### PR TITLE
Use const ref parameters in the GLTF module

### DIFF
--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -2021,7 +2021,7 @@ void FBXDocument::_process_mesh_instances(Ref<FBXState> p_state, Node *p_scene_r
 	}
 }
 
-Error FBXDocument::_parse(Ref<FBXState> p_state, String p_path, Ref<FileAccess> p_file) {
+Error FBXDocument::_parse(Ref<FBXState> p_state, const String &p_path, Ref<FileAccess> p_file) {
 	p_state->scene.reset();
 
 	Error err = ERR_INVALID_DATA;
@@ -2164,7 +2164,7 @@ Node *FBXDocument::generate_scene(Ref<GLTFState> p_state, float p_bake_fps, bool
 	return root;
 }
 
-Error FBXDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> p_state, uint32_t p_flags) {
+Error FBXDocument::append_from_buffer(const PackedByteArray &p_bytes, const String &p_base_path, Ref<GLTFState> p_state, uint32_t p_flags) {
 	Ref<FBXState> state = p_state;
 	ERR_FAIL_COND_V(state.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_NULL_V(p_bytes.ptr(), ERR_INVALID_DATA);
@@ -2259,7 +2259,7 @@ Error FBXDocument::_parse_fbx_state(Ref<FBXState> p_state, const String &p_searc
 	return OK;
 }
 
-Error FBXDocument::append_from_file(String p_path, Ref<GLTFState> p_state, uint32_t p_flags, String p_base_path) {
+Error FBXDocument::append_from_file(const String &p_path, Ref<GLTFState> p_state, uint32_t p_flags, const String &p_base_path) {
 	Ref<FBXState> state = p_state;
 	ERR_FAIL_COND_V(state.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_path.is_empty(), ERR_FILE_NOT_FOUND);

--- a/modules/fbx/fbx_document.h
+++ b/modules/fbx/fbx_document.h
@@ -54,8 +54,8 @@ public:
 	static String _gen_unique_name(HashSet<String> &unique_names, const String &p_name);
 
 public:
-	Error append_from_file(String p_path, Ref<GLTFState> p_state, uint32_t p_flags = 0, String p_base_path = String()) override;
-	Error append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> p_state, uint32_t p_flags = 0) override;
+	Error append_from_file(const String &p_path, Ref<GLTFState> p_state, uint32_t p_flags = 0, const String &p_base_path = String()) override;
+	Error append_from_buffer(const PackedByteArray &p_bytes, const String &p_base_path, Ref<GLTFState> p_state, uint32_t p_flags = 0) override;
 	Error append_from_scene(Node *p_node, Ref<GLTFState> p_state, uint32_t p_flags = 0) override;
 
 	Node *generate_scene(Ref<GLTFState> p_state, float p_bake_fps = 30.0f, bool p_trimming = false, bool p_remove_immutable_tracks = true) override;
@@ -101,5 +101,5 @@ public:
 	void _generate_skeleton_bone_node(Ref<FBXState> p_state, const GLTFNodeIndex p_node_index, Node *p_scene_parent, Node *p_scene_root);
 	void _import_animation(Ref<FBXState> p_state, AnimationPlayer *p_animation_player,
 			const GLTFAnimationIndex p_index, const bool p_trimming, const bool p_remove_immutable_tracks);
-	Error _parse(Ref<FBXState> p_state, String p_path, Ref<FileAccess> p_file);
+	Error _parse(Ref<FBXState> p_state, const String &p_path, Ref<FileAccess> p_file);
 };

--- a/modules/gltf/extensions/gltf_document_extension.cpp
+++ b/modules/gltf/extensions/gltf_document_extension.cpp
@@ -59,7 +59,7 @@ void GLTFDocumentExtension::_bind_methods() {
 }
 
 // Import process.
-Error GLTFDocumentExtension::import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) {
+Error GLTFDocumentExtension::import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) {
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_import_preflight, p_state, p_extensions, err);
@@ -72,11 +72,11 @@ Vector<String> GLTFDocumentExtension::get_supported_extensions() {
 	return ret;
 }
 
-Error GLTFDocumentExtension::parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &p_extensions) {
+Error GLTFDocumentExtension::parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions) {
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_gltf_node.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
-	GDVIRTUAL_CALL(_parse_node_extensions, p_state, p_gltf_node, p_extensions, err);
+	GDVIRTUAL_CALL(_parse_node_extensions, p_state, p_gltf_node, Dictionary(p_extensions), err);
 	return err;
 }
 
@@ -98,7 +98,7 @@ Error GLTFDocumentExtension::parse_texture_json(Ref<GLTFState> p_state, const Di
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(r_gltf_texture.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
-	GDVIRTUAL_CALL(_parse_texture_json, p_state, p_texture_json, r_gltf_texture, err);
+	GDVIRTUAL_CALL(_parse_texture_json, p_state, Dictionary(p_texture_json), r_gltf_texture, err);
 	return err;
 }
 
@@ -136,7 +136,7 @@ Error GLTFDocumentExtension::import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p
 	ERR_FAIL_COND_V(p_gltf_node.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_NULL_V(p_node, ERR_INVALID_PARAMETER);
 	Error err = OK;
-	GDVIRTUAL_CALL(_import_node, p_state, p_gltf_node, r_dict, p_node, err);
+	GDVIRTUAL_CALL(_import_node, p_state, p_gltf_node, Dictionary(r_dict), p_node, err);
 	return err;
 }
 
@@ -193,11 +193,11 @@ Vector<String> GLTFDocumentExtension::get_saveable_image_formats() {
 	return ret;
 }
 
-PackedByteArray GLTFDocumentExtension::serialize_image_to_bytes(Ref<GLTFState> p_state, Ref<Image> p_image, Dictionary p_image_dict, const String &p_image_format, float p_lossy_quality) {
+PackedByteArray GLTFDocumentExtension::serialize_image_to_bytes(Ref<GLTFState> p_state, Ref<Image> p_image, Dictionary &r_image_dict, const String &p_image_format, float p_lossy_quality) {
 	PackedByteArray ret;
 	ERR_FAIL_COND_V(p_state.is_null(), ret);
 	ERR_FAIL_COND_V(p_image.is_null(), ret);
-	GDVIRTUAL_CALL(_serialize_image_to_bytes, p_state, p_image, p_image_dict, p_image_format, p_lossy_quality, ret);
+	GDVIRTUAL_CALL(_serialize_image_to_bytes, p_state, p_image, Dictionary(r_image_dict), p_image_format, p_lossy_quality, ret);
 	return ret;
 }
 
@@ -209,11 +209,11 @@ Error GLTFDocumentExtension::save_image_at_path(Ref<GLTFState> p_state, Ref<Imag
 	return ret;
 }
 
-Error GLTFDocumentExtension::serialize_texture_json(Ref<GLTFState> p_state, Dictionary p_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format) {
+Error GLTFDocumentExtension::serialize_texture_json(Ref<GLTFState> p_state, Dictionary &r_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format) {
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_gltf_texture.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
-	GDVIRTUAL_CALL(_serialize_texture_json, p_state, p_texture_json, p_gltf_texture, p_image_format, err);
+	GDVIRTUAL_CALL(_serialize_texture_json, p_state, Dictionary(r_texture_json), p_gltf_texture, p_image_format, err);
 	return err;
 }
 
@@ -221,7 +221,7 @@ Error GLTFDocumentExtension::export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_gltf_node.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
-	GDVIRTUAL_CALL(_export_node, p_state, p_gltf_node, r_dict, p_node, err);
+	GDVIRTUAL_CALL(_export_node, p_state, p_gltf_node, Dictionary(r_dict), p_node, err);
 	return err;
 }
 

--- a/modules/gltf/extensions/gltf_document_extension.h
+++ b/modules/gltf/extensions/gltf_document_extension.h
@@ -42,9 +42,9 @@ protected:
 
 public:
 	// Import process.
-	virtual Error import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions);
+	virtual Error import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions);
 	virtual Vector<String> get_supported_extensions();
-	virtual Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &p_extensions);
+	virtual Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions);
 	virtual Error parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image);
 	virtual String get_image_file_extension();
 	virtual Error parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture);
@@ -61,9 +61,9 @@ public:
 	virtual Error export_preserialize(Ref<GLTFState> p_state);
 	virtual Ref<GLTFObjectModelProperty> export_object_model_property(Ref<GLTFState> p_state, const NodePath &p_node_path, const Node *p_godot_node, GLTFNodeIndex p_gltf_node_index, const Object *p_target_object, int p_target_depth);
 	virtual Vector<String> get_saveable_image_formats();
-	virtual PackedByteArray serialize_image_to_bytes(Ref<GLTFState> p_state, Ref<Image> p_image, Dictionary p_image_dict, const String &p_image_format, float p_lossy_quality);
+	virtual PackedByteArray serialize_image_to_bytes(Ref<GLTFState> p_state, Ref<Image> p_image, Dictionary &r_image_dict, const String &p_image_format, float p_lossy_quality);
 	virtual Error save_image_at_path(Ref<GLTFState> p_state, Ref<Image> p_image, const String &p_file_path, const String &p_image_format, float p_lossy_quality);
-	virtual Error serialize_texture_json(Ref<GLTFState> p_state, Dictionary p_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format);
+	virtual Error serialize_texture_json(Ref<GLTFState> p_state, Dictionary &r_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format);
 	virtual Error export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node);
 	virtual Error export_post(Ref<GLTFState> p_state);
 

--- a/modules/gltf/extensions/gltf_document_extension_texture_ktx.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_texture_ktx.cpp
@@ -31,7 +31,7 @@
 #include "gltf_document_extension_texture_ktx.h"
 
 // Import process.
-Error GLTFDocumentExtensionTextureKTX::import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) {
+Error GLTFDocumentExtensionTextureKTX::import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) {
 	if (!p_extensions.has("KHR_texture_basisu")) {
 		return ERR_SKIP;
 	}

--- a/modules/gltf/extensions/gltf_document_extension_texture_ktx.h
+++ b/modules/gltf/extensions/gltf_document_extension_texture_ktx.h
@@ -37,7 +37,7 @@ class GLTFDocumentExtensionTextureKTX : public GLTFDocumentExtension {
 
 public:
 	// Import process.
-	Error import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) override;
+	Error import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) override;
 	Vector<String> get_supported_extensions() override;
 	Error parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image) override;
 	Error parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture) override;

--- a/modules/gltf/extensions/gltf_document_extension_texture_webp.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_texture_webp.cpp
@@ -31,7 +31,7 @@
 #include "gltf_document_extension_texture_webp.h"
 
 // Import process.
-Error GLTFDocumentExtensionTextureWebP::import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) {
+Error GLTFDocumentExtensionTextureWebP::import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) {
 	if (!p_extensions.has("EXT_texture_webp")) {
 		return ERR_SKIP;
 	}
@@ -76,12 +76,12 @@ Vector<String> GLTFDocumentExtensionTextureWebP::get_saveable_image_formats() {
 	return ret;
 }
 
-PackedByteArray GLTFDocumentExtensionTextureWebP::serialize_image_to_bytes(Ref<GLTFState> p_state, Ref<Image> p_image, Dictionary p_image_dict, const String &p_image_format, float p_lossy_quality) {
+PackedByteArray GLTFDocumentExtensionTextureWebP::serialize_image_to_bytes(Ref<GLTFState> p_state, Ref<Image> p_image, Dictionary &r_image_dict, const String &p_image_format, float p_lossy_quality) {
 	if (p_image_format == "Lossless WebP") {
-		p_image_dict["mimeType"] = "image/webp";
+		r_image_dict["mimeType"] = "image/webp";
 		return p_image->save_webp_to_buffer(false);
 	} else if (p_image_format == "Lossy WebP") {
-		p_image_dict["mimeType"] = "image/webp";
+		r_image_dict["mimeType"] = "image/webp";
 		return p_image->save_webp_to_buffer(true, p_lossy_quality);
 	}
 	ERR_FAIL_V(PackedByteArray());
@@ -98,12 +98,12 @@ Error GLTFDocumentExtensionTextureWebP::save_image_at_path(Ref<GLTFState> p_stat
 	return ERR_INVALID_PARAMETER;
 }
 
-Error GLTFDocumentExtensionTextureWebP::serialize_texture_json(Ref<GLTFState> p_state, Dictionary p_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format) {
+Error GLTFDocumentExtensionTextureWebP::serialize_texture_json(Ref<GLTFState> p_state, Dictionary &r_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format) {
 	Dictionary ext_texture_webp;
 	ext_texture_webp["source"] = p_gltf_texture->get_src_image();
 	Dictionary texture_extensions;
 	texture_extensions["EXT_texture_webp"] = ext_texture_webp;
-	p_texture_json["extensions"] = texture_extensions;
+	r_texture_json["extensions"] = texture_extensions;
 	p_state->add_used_extension("EXT_texture_webp", true);
 	return OK;
 }

--- a/modules/gltf/extensions/gltf_document_extension_texture_webp.h
+++ b/modules/gltf/extensions/gltf_document_extension_texture_webp.h
@@ -37,14 +37,14 @@ class GLTFDocumentExtensionTextureWebP : public GLTFDocumentExtension {
 
 public:
 	// Import process.
-	Error import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) override;
+	Error import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) override;
 	Vector<String> get_supported_extensions() override;
 	Error parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image) override;
 	String get_image_file_extension() override;
 	Error parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture) override;
 	// Export process.
 	Vector<String> get_saveable_image_formats() override;
-	PackedByteArray serialize_image_to_bytes(Ref<GLTFState> p_state, Ref<Image> p_image, Dictionary p_image_dict, const String &p_image_format, float p_lossy_quality) override;
+	PackedByteArray serialize_image_to_bytes(Ref<GLTFState> p_state, Ref<Image> p_image, Dictionary &r_image_dict, const String &p_image_format, float p_lossy_quality) override;
 	Error save_image_at_path(Ref<GLTFState> p_state, Ref<Image> p_image, const String &p_full_path, const String &p_image_format, float p_lossy_quality) override;
-	Error serialize_texture_json(Ref<GLTFState> p_state, Dictionary p_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format) override;
+	Error serialize_texture_json(Ref<GLTFState> p_state, Dictionary &r_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format) override;
 };

--- a/modules/gltf/extensions/gltf_light.cpp
+++ b/modules/gltf/extensions/gltf_light.cpp
@@ -186,7 +186,7 @@ Light3D *GLTFLight::to_node() const {
 	return light;
 }
 
-Ref<GLTFLight> GLTFLight::from_dictionary(const Dictionary p_dictionary) {
+Ref<GLTFLight> GLTFLight::from_dictionary(const Dictionary &p_dictionary) {
 	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFLight>(), "Failed to parse glTF light, missing required field 'type'.");
 	Ref<GLTFLight> light;
 	light.instantiate();

--- a/modules/gltf/extensions/gltf_light.h
+++ b/modules/gltf/extensions/gltf_light.h
@@ -77,7 +77,7 @@ public:
 	static Ref<GLTFLight> from_node(const Light3D *p_light);
 	Light3D *to_node() const;
 
-	static Ref<GLTFLight> from_dictionary(const Dictionary p_dictionary);
+	static Ref<GLTFLight> from_dictionary(const Dictionary &p_dictionary);
 	Dictionary to_dictionary() const;
 
 	Variant get_additional_data(const StringName &p_extension_name);

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -37,7 +37,7 @@
 using GLTFShapeIndex = int64_t;
 
 // Import process.
-Error GLTFDocumentExtensionPhysics::import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) {
+Error GLTFDocumentExtensionPhysics::import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) {
 	if (!p_extensions.has("OMI_collider") && !p_extensions.has("OMI_physics_body") && !p_extensions.has("OMI_physics_shape")) {
 		return ERR_SKIP;
 	}
@@ -83,7 +83,7 @@ Vector<String> GLTFDocumentExtensionPhysics::get_supported_extensions() {
 	return ret;
 }
 
-Error GLTFDocumentExtensionPhysics::parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &p_extensions) {
+Error GLTFDocumentExtensionPhysics::parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions) {
 #ifndef DISABLE_DEPRECATED
 	if (p_extensions.has("OMI_collider")) {
 		Dictionary node_collider_ext = p_extensions["OMI_collider"];

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.h
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.h
@@ -39,9 +39,9 @@ class GLTFDocumentExtensionPhysics : public GLTFDocumentExtension {
 
 public:
 	// Import process.
-	Error import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) override;
+	Error import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) override;
 	Vector<String> get_supported_extensions() override;
-	Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &p_extensions) override;
+	Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions) override;
 	Ref<GLTFObjectModelProperty> import_object_model_property(Ref<GLTFState> p_state, const PackedStringArray &p_split_json_pointer, const TypedArray<NodePath> &p_partial_paths) override;
 	Node3D *generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent) override;
 	// Export process.

--- a/modules/gltf/extensions/physics/gltf_physics_body.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_body.cpp
@@ -94,7 +94,7 @@ String GLTFPhysicsBody::get_body_type() const {
 	return "rigid";
 }
 
-void GLTFPhysicsBody::set_body_type(String p_body_type) {
+void GLTFPhysicsBody::set_body_type(const String &p_body_type) {
 	if (p_body_type == "static") {
 		body_type = PhysicsBodyType::STATIC;
 	} else if (p_body_type == "animatable") {
@@ -132,7 +132,7 @@ Vector3 GLTFPhysicsBody::get_linear_velocity() const {
 	return linear_velocity;
 }
 
-void GLTFPhysicsBody::set_linear_velocity(Vector3 p_linear_velocity) {
+void GLTFPhysicsBody::set_linear_velocity(const Vector3 &p_linear_velocity) {
 	linear_velocity = p_linear_velocity;
 }
 
@@ -140,7 +140,7 @@ Vector3 GLTFPhysicsBody::get_angular_velocity() const {
 	return angular_velocity;
 }
 
-void GLTFPhysicsBody::set_angular_velocity(Vector3 p_angular_velocity) {
+void GLTFPhysicsBody::set_angular_velocity(const Vector3 &p_angular_velocity) {
 	angular_velocity = p_angular_velocity;
 }
 
@@ -173,7 +173,7 @@ Basis GLTFPhysicsBody::get_inertia_tensor() const {
 	return Basis::from_scale(inertia_diagonal);
 }
 
-void GLTFPhysicsBody::set_inertia_tensor(Basis p_inertia_tensor) {
+void GLTFPhysicsBody::set_inertia_tensor(const Basis &p_inertia_tensor) {
 	inertia_diagonal = p_inertia_tensor.get_main_diagonal();
 }
 #endif // DISABLE_DEPRECATED
@@ -250,7 +250,7 @@ CollisionObject3D *GLTFPhysicsBody::to_node() const {
 	return nullptr;
 }
 
-Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_dictionary(const Dictionary p_dictionary) {
+Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_dictionary(const Dictionary &p_dictionary) {
 	Ref<GLTFPhysicsBody> physics_body;
 	physics_body.instantiate();
 	Dictionary motion;

--- a/modules/gltf/extensions/physics/gltf_physics_body.h
+++ b/modules/gltf/extensions/physics/gltf_physics_body.h
@@ -68,7 +68,7 @@ private:
 
 public:
 	String get_body_type() const;
-	void set_body_type(String p_body_type);
+	void set_body_type(const String &p_body_type);
 
 	PhysicsBodyType get_physics_body_type() const;
 	void set_physics_body_type(PhysicsBodyType p_body_type);
@@ -77,10 +77,10 @@ public:
 	void set_mass(real_t p_mass);
 
 	Vector3 get_linear_velocity() const;
-	void set_linear_velocity(Vector3 p_linear_velocity);
+	void set_linear_velocity(const Vector3 &p_linear_velocity);
 
 	Vector3 get_angular_velocity() const;
-	void set_angular_velocity(Vector3 p_angular_velocity);
+	void set_angular_velocity(const Vector3 &p_angular_velocity);
 
 	Vector3 get_center_of_mass() const;
 	void set_center_of_mass(const Vector3 &p_center_of_mass);
@@ -93,12 +93,12 @@ public:
 
 #ifndef DISABLE_DEPRECATED
 	Basis get_inertia_tensor() const;
-	void set_inertia_tensor(Basis p_inertia_tensor);
+	void set_inertia_tensor(const Basis &p_inertia_tensor);
 #endif // DISABLE_DEPRECATED
 
 	static Ref<GLTFPhysicsBody> from_node(const CollisionObject3D *p_body_node);
 	CollisionObject3D *to_node() const;
 
-	static Ref<GLTFPhysicsBody> from_dictionary(const Dictionary p_dictionary);
+	static Ref<GLTFPhysicsBody> from_dictionary(const Dictionary &p_dictionary);
 	Dictionary to_dictionary() const;
 };

--- a/modules/gltf/extensions/physics/gltf_physics_shape.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_shape.cpp
@@ -80,7 +80,7 @@ String GLTFPhysicsShape::get_shape_type() const {
 	return shape_type;
 }
 
-void GLTFPhysicsShape::set_shape_type(String p_shape_type) {
+void GLTFPhysicsShape::set_shape_type(const String &p_shape_type) {
 	shape_type = p_shape_type;
 }
 
@@ -88,7 +88,7 @@ Vector3 GLTFPhysicsShape::get_size() const {
 	return size;
 }
 
-void GLTFPhysicsShape::set_size(Vector3 p_size) {
+void GLTFPhysicsShape::set_size(const Vector3 &p_size) {
 	size = p_size;
 }
 
@@ -128,7 +128,7 @@ Ref<ImporterMesh> GLTFPhysicsShape::get_importer_mesh() const {
 	return importer_mesh;
 }
 
-void GLTFPhysicsShape::set_importer_mesh(Ref<ImporterMesh> p_importer_mesh) {
+void GLTFPhysicsShape::set_importer_mesh(const Ref<ImporterMesh> &p_importer_mesh) {
 	importer_mesh = p_importer_mesh;
 }
 
@@ -267,7 +267,7 @@ Ref<Shape3D> GLTFPhysicsShape::to_resource(bool p_cache_shapes) {
 	return _shape_cache;
 }
 
-Ref<GLTFPhysicsShape> GLTFPhysicsShape::from_dictionary(const Dictionary p_dictionary) {
+Ref<GLTFPhysicsShape> GLTFPhysicsShape::from_dictionary(const Dictionary &p_dictionary) {
 	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFPhysicsShape>(), "Failed to parse GLTFPhysicsShape, missing required field 'type'.");
 	Ref<GLTFPhysicsShape> gltf_shape;
 	gltf_shape.instantiate();

--- a/modules/gltf/extensions/physics/gltf_physics_shape.h
+++ b/modules/gltf/extensions/physics/gltf_physics_shape.h
@@ -59,10 +59,10 @@ private:
 
 public:
 	String get_shape_type() const;
-	void set_shape_type(String p_shape_type);
+	void set_shape_type(const String &p_shape_type);
 
 	Vector3 get_size() const;
-	void set_size(Vector3 p_size);
+	void set_size(const Vector3 &p_size);
 
 	real_t get_radius() const;
 	void set_radius(real_t p_radius);
@@ -77,7 +77,7 @@ public:
 	void set_mesh_index(GLTFMeshIndex p_mesh_index);
 
 	Ref<ImporterMesh> get_importer_mesh() const;
-	void set_importer_mesh(Ref<ImporterMesh> p_importer_mesh);
+	void set_importer_mesh(const Ref<ImporterMesh> &p_importer_mesh);
 
 	static Ref<GLTFPhysicsShape> from_node(const CollisionShape3D *p_shape_node);
 	CollisionShape3D *to_node(bool p_cache_shapes = false);
@@ -85,6 +85,6 @@ public:
 	static Ref<GLTFPhysicsShape> from_resource(const Ref<Shape3D> &p_shape_resource);
 	Ref<Shape3D> to_resource(bool p_cache_shapes = false);
 
-	static Ref<GLTFPhysicsShape> from_dictionary(const Dictionary p_dictionary);
+	static Ref<GLTFPhysicsShape> from_dictionary(const Dictionary &p_dictionary);
 	Dictionary to_dictionary() const;
 };

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -1606,7 +1606,7 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 		if (import_mesh.is_null()) {
 			continue;
 		}
-		Array instance_materials = gltf_mesh->get_instance_materials();
+		const Array &instance_materials = gltf_mesh->get_instance_materials();
 		Array primitives;
 		Dictionary mesh_dict;
 		Array target_names;
@@ -4013,7 +4013,7 @@ Error GLTFDocument::_create_skins(Ref<GLTFState> p_state) {
 	return OK;
 }
 
-bool GLTFDocument::_skins_are_same(const Ref<Skin> p_skin_a, const Ref<Skin> p_skin_b) {
+bool GLTFDocument::_skins_are_same(const Ref<Skin> &p_skin_a, const Ref<Skin> &p_skin_b) {
 	if (p_skin_a->get_bind_count() != p_skin_b->get_bind_count()) {
 		return false;
 	}
@@ -4926,7 +4926,7 @@ void GLTFDocument::_convert_grid_map_to_gltf(GridMap *p_grid_map, GLTFNodeIndex 
 #ifndef MODULE_GRIDMAP_ENABLED
 	ERR_FAIL_MSG("gridmap module is disabled.");
 #else
-	Array cells = p_grid_map->get_used_cells();
+	const Array &cells = p_grid_map->get_used_cells();
 	for (int32_t k = 0; k < cells.size(); k++) {
 		GLTFNode *new_gltf_node = memnew(GLTFNode);
 		p_gltf_node->children.push_back(p_state->nodes.size());
@@ -5647,7 +5647,7 @@ T GLTFDocument::_interpolate_track(const Vector<double> &p_times, const Vector<T
 	ERR_FAIL_V(p_values[0]);
 }
 
-NodePath GLTFDocument::_find_material_node_path(Ref<GLTFState> p_state, Ref<Material> p_material) {
+NodePath GLTFDocument::_find_material_node_path(Ref<GLTFState> p_state, const Ref<Material> &p_material) {
 	int mesh_index = 0;
 	for (Ref<GLTFMesh> gltf_mesh : p_state->meshes) {
 		TypedArray<Material> materials = gltf_mesh->get_instance_materials();
@@ -7163,7 +7163,7 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> p_state, AnimationPlayer *p
 	}
 }
 
-Error GLTFDocument::_parse(Ref<GLTFState> p_state, String p_path, Ref<FileAccess> p_file) {
+Error GLTFDocument::_parse(Ref<GLTFState> p_state, const String &p_path, Ref<FileAccess> p_file) {
 	Error err;
 	if (p_file.is_null()) {
 		return FAILED;
@@ -7231,14 +7231,14 @@ Dictionary _serialize_texture_transform_uv(Vector2 p_offset, Vector2 p_scale) {
 	return extension;
 }
 
-Dictionary GLTFDocument::_serialize_texture_transform_uv1(Ref<BaseMaterial3D> p_material) {
+Dictionary GLTFDocument::_serialize_texture_transform_uv1(const Ref<BaseMaterial3D> &p_material) {
 	ERR_FAIL_COND_V(p_material.is_null(), Dictionary());
 	Vector3 offset = p_material->get_uv1_offset();
 	Vector3 scale = p_material->get_uv1_scale();
 	return _serialize_texture_transform_uv(Vector2(offset.x, offset.y), Vector2(scale.x, scale.y));
 }
 
-Dictionary GLTFDocument::_serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_material) {
+Dictionary GLTFDocument::_serialize_texture_transform_uv2(const Ref<BaseMaterial3D> &p_material) {
 	ERR_FAIL_COND_V(p_material.is_null(), Dictionary());
 	Vector3 offset = p_material->get_uv2_offset();
 	Vector3 scale = p_material->get_uv2_scale();
@@ -7789,7 +7789,7 @@ Error GLTFDocument::append_from_scene(Node *p_node, Ref<GLTFState> p_state, uint
 	return OK;
 }
 
-Error GLTFDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> p_state, uint32_t p_flags) {
+Error GLTFDocument::append_from_buffer(const PackedByteArray &p_bytes, const String &p_base_path, Ref<GLTFState> p_state, uint32_t p_flags) {
 	Ref<GLTFState> state = p_state;
 	ERR_FAIL_COND_V(state.is_null(), FAILED);
 	// TODO Add missing texture and missing .bin file paths to r_missing_deps 2021-09-10 fire
@@ -7813,7 +7813,7 @@ Error GLTFDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_pa
 	return OK;
 }
 
-Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> p_state, uint32_t p_flags, String p_base_path) {
+Error GLTFDocument::append_from_file(const String &p_path, Ref<GLTFState> p_state, uint32_t p_flags, const String &p_base_path) {
 	Ref<GLTFState> state = p_state;
 	// TODO Add missing texture and missing .bin file paths to r_missing_deps 2021-09-10 fire
 	if (state == Ref<GLTFState>()) {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -86,7 +86,7 @@ public:
 	static Vector<String> get_supported_gltf_extensions();
 	static HashSet<String> get_supported_gltf_extensions_hashset();
 
-	static NodePath _find_material_node_path(Ref<GLTFState> p_state, Ref<Material> p_material);
+	static NodePath _find_material_node_path(Ref<GLTFState> p_state, const Ref<Material> &p_material);
 	static Ref<GLTFObjectModelProperty> import_object_model_property(Ref<GLTFState> p_state, const String &p_json_pointer);
 	static Ref<GLTFObjectModelProperty> export_object_model_property(Ref<GLTFState> p_state, const NodePath &p_node_path, const Node *p_godot_node, GLTFNodeIndex p_gltf_node_index);
 
@@ -202,7 +202,7 @@ private:
 	Error _parse_skins(Ref<GLTFState> p_state);
 	Error _serialize_skins(Ref<GLTFState> p_state);
 	Error _create_skins(Ref<GLTFState> p_state);
-	bool _skins_are_same(const Ref<Skin> p_skin_a, const Ref<Skin> p_skin_b);
+	bool _skins_are_same(const Ref<Skin> &p_skin_a, const Ref<Skin> &p_skin_b);
 	void _remove_duplicate_skins(Ref<GLTFState> p_state);
 	Error _serialize_cameras(Ref<GLTFState> p_state);
 	Error _parse_cameras(Ref<GLTFState> p_state);
@@ -233,8 +233,8 @@ private:
 	Error _encode_buffer_bins(Ref<GLTFState> p_state, const String &p_path);
 	Error _encode_buffer_glb(Ref<GLTFState> p_state, const String &p_path);
 	PackedByteArray _serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err);
-	Dictionary _serialize_texture_transform_uv1(Ref<BaseMaterial3D> p_material);
-	Dictionary _serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_material);
+	Dictionary _serialize_texture_transform_uv1(const Ref<BaseMaterial3D> &p_material);
+	Dictionary _serialize_texture_transform_uv2(const Ref<BaseMaterial3D> &p_material);
 	Error _serialize_asset_header(Ref<GLTFState> p_state);
 	Error _serialize_file(Ref<GLTFState> p_state, const String p_path);
 	Error _serialize_gltf_extensions(Ref<GLTFState> p_state) const;
@@ -256,8 +256,8 @@ private:
 	static float get_max_component(const Color &p_color);
 
 public:
-	virtual Error append_from_file(String p_path, Ref<GLTFState> p_state, uint32_t p_flags = 0, String p_base_path = String());
-	virtual Error append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> p_state, uint32_t p_flags = 0);
+	virtual Error append_from_file(const String &p_path, Ref<GLTFState> p_state, uint32_t p_flags = 0, const String &p_base_path = String());
+	virtual Error append_from_buffer(const PackedByteArray &p_bytes, const String &p_base_path, Ref<GLTFState> p_state, uint32_t p_flags = 0);
 	virtual Error append_from_scene(Node *p_node, Ref<GLTFState> p_state, uint32_t p_flags = 0);
 
 	virtual Node *generate_scene(Ref<GLTFState> p_state, float p_bake_fps = 30.0f, bool p_trimming = false, bool p_remove_immutable_tracks = true);
@@ -326,7 +326,7 @@ public:
 	void _convert_animation(Ref<GLTFState> p_state, AnimationPlayer *p_animation_player, const String &p_animation_track_name);
 
 	Error _serialize(Ref<GLTFState> p_state);
-	Error _parse(Ref<GLTFState> p_state, String p_path, Ref<FileAccess> p_file);
+	Error _parse(Ref<GLTFState> p_state, const String &p_path, Ref<FileAccess> p_file);
 };
 
 VARIANT_ENUM_CAST(GLTFDocument::RootNodeMode);

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -162,11 +162,11 @@ void GLTFState::add_used_extension(const String &p_extension_name, bool p_requir
 }
 
 Dictionary GLTFState::get_json() {
-	return json;
+	return Dictionary(json);
 }
 
-void GLTFState::set_json(Dictionary p_json) {
-	json = p_json;
+void GLTFState::set_json(const Dictionary &p_json) {
+	json = Dictionary(p_json);
 }
 
 int GLTFState::get_major_version() {
@@ -194,11 +194,11 @@ void GLTFState::set_copyright(const String &p_copyright) {
 }
 
 Vector<uint8_t> GLTFState::get_glb_data() {
-	return glb_data;
+	return Vector<uint8_t>(glb_data);
 }
 
-void GLTFState::set_glb_data(Vector<uint8_t> p_glb_data) {
-	glb_data = p_glb_data;
+void GLTFState::set_glb_data(const Vector<uint8_t> &p_glb_data) {
+	glb_data = Vector<uint8_t>(p_glb_data);
 }
 
 bool GLTFState::get_use_named_skin_binds() {
@@ -213,7 +213,7 @@ TypedArray<GLTFNode> GLTFState::get_nodes() {
 	return GLTFTemplateConvert::to_array(nodes);
 }
 
-void GLTFState::set_nodes(TypedArray<GLTFNode> p_nodes) {
+void GLTFState::set_nodes(const TypedArray<GLTFNode> &p_nodes) {
 	GLTFTemplateConvert::set_from_array(nodes, p_nodes);
 }
 
@@ -221,7 +221,7 @@ TypedArray<PackedByteArray> GLTFState::get_buffers() {
 	return GLTFTemplateConvert::to_array(buffers);
 }
 
-void GLTFState::set_buffers(TypedArray<PackedByteArray> p_buffers) {
+void GLTFState::set_buffers(const TypedArray<PackedByteArray> &p_buffers) {
 	GLTFTemplateConvert::set_from_array(buffers, p_buffers);
 }
 
@@ -229,7 +229,7 @@ TypedArray<GLTFBufferView> GLTFState::get_buffer_views() {
 	return GLTFTemplateConvert::to_array(buffer_views);
 }
 
-void GLTFState::set_buffer_views(TypedArray<GLTFBufferView> p_buffer_views) {
+void GLTFState::set_buffer_views(const TypedArray<GLTFBufferView> &p_buffer_views) {
 	GLTFTemplateConvert::set_from_array(buffer_views, p_buffer_views);
 }
 
@@ -237,7 +237,7 @@ TypedArray<GLTFAccessor> GLTFState::get_accessors() {
 	return GLTFTemplateConvert::to_array(accessors);
 }
 
-void GLTFState::set_accessors(TypedArray<GLTFAccessor> p_accessors) {
+void GLTFState::set_accessors(const TypedArray<GLTFAccessor> &p_accessors) {
 	GLTFTemplateConvert::set_from_array(accessors, p_accessors);
 }
 
@@ -245,7 +245,7 @@ TypedArray<GLTFMesh> GLTFState::get_meshes() {
 	return GLTFTemplateConvert::to_array(meshes);
 }
 
-void GLTFState::set_meshes(TypedArray<GLTFMesh> p_meshes) {
+void GLTFState::set_meshes(const TypedArray<GLTFMesh> &p_meshes) {
 	GLTFTemplateConvert::set_from_array(meshes, p_meshes);
 }
 
@@ -253,7 +253,7 @@ TypedArray<Material> GLTFState::get_materials() {
 	return GLTFTemplateConvert::to_array(materials);
 }
 
-void GLTFState::set_materials(TypedArray<Material> p_materials) {
+void GLTFState::set_materials(const TypedArray<Material> &p_materials) {
 	GLTFTemplateConvert::set_from_array(materials, p_materials);
 }
 
@@ -261,7 +261,7 @@ String GLTFState::get_scene_name() {
 	return scene_name;
 }
 
-void GLTFState::set_scene_name(String p_scene_name) {
+void GLTFState::set_scene_name(const String &p_scene_name) {
 	scene_name = p_scene_name;
 }
 
@@ -269,15 +269,15 @@ PackedInt32Array GLTFState::get_root_nodes() {
 	return root_nodes;
 }
 
-void GLTFState::set_root_nodes(PackedInt32Array p_root_nodes) {
-	root_nodes = p_root_nodes;
+void GLTFState::set_root_nodes(const PackedInt32Array &p_root_nodes) {
+	root_nodes = PackedInt32Array(p_root_nodes);
 }
 
 TypedArray<GLTFTexture> GLTFState::get_textures() {
 	return GLTFTemplateConvert::to_array(textures);
 }
 
-void GLTFState::set_textures(TypedArray<GLTFTexture> p_textures) {
+void GLTFState::set_textures(const TypedArray<GLTFTexture> &p_textures) {
 	GLTFTemplateConvert::set_from_array(textures, p_textures);
 }
 
@@ -285,7 +285,7 @@ TypedArray<GLTFTextureSampler> GLTFState::get_texture_samplers() {
 	return GLTFTemplateConvert::to_array(texture_samplers);
 }
 
-void GLTFState::set_texture_samplers(TypedArray<GLTFTextureSampler> p_texture_samplers) {
+void GLTFState::set_texture_samplers(const TypedArray<GLTFTextureSampler> &p_texture_samplers) {
 	GLTFTemplateConvert::set_from_array(texture_samplers, p_texture_samplers);
 }
 
@@ -293,7 +293,7 @@ TypedArray<Texture2D> GLTFState::get_images() {
 	return GLTFTemplateConvert::to_array(images);
 }
 
-void GLTFState::set_images(TypedArray<Texture2D> p_images) {
+void GLTFState::set_images(const TypedArray<Texture2D> &p_images) {
 	GLTFTemplateConvert::set_from_array(images, p_images);
 }
 
@@ -301,7 +301,7 @@ TypedArray<GLTFSkin> GLTFState::get_skins() {
 	return GLTFTemplateConvert::to_array(skins);
 }
 
-void GLTFState::set_skins(TypedArray<GLTFSkin> p_skins) {
+void GLTFState::set_skins(const TypedArray<GLTFSkin> &p_skins) {
 	GLTFTemplateConvert::set_from_array(skins, p_skins);
 }
 
@@ -309,7 +309,7 @@ TypedArray<GLTFCamera> GLTFState::get_cameras() {
 	return GLTFTemplateConvert::to_array(cameras);
 }
 
-void GLTFState::set_cameras(TypedArray<GLTFCamera> p_cameras) {
+void GLTFState::set_cameras(const TypedArray<GLTFCamera> &p_cameras) {
 	GLTFTemplateConvert::set_from_array(cameras, p_cameras);
 }
 
@@ -317,7 +317,7 @@ TypedArray<GLTFLight> GLTFState::get_lights() {
 	return GLTFTemplateConvert::to_array(lights);
 }
 
-void GLTFState::set_lights(TypedArray<GLTFLight> p_lights) {
+void GLTFState::set_lights(const TypedArray<GLTFLight> &p_lights) {
 	GLTFTemplateConvert::set_from_array(lights, p_lights);
 }
 
@@ -325,7 +325,7 @@ TypedArray<String> GLTFState::get_unique_names() {
 	return GLTFTemplateConvert::to_array(unique_names);
 }
 
-void GLTFState::set_unique_names(TypedArray<String> p_unique_names) {
+void GLTFState::set_unique_names(const TypedArray<String> &p_unique_names) {
 	GLTFTemplateConvert::set_from_array(unique_names, p_unique_names);
 }
 
@@ -333,7 +333,7 @@ TypedArray<String> GLTFState::get_unique_animation_names() {
 	return GLTFTemplateConvert::to_array(unique_animation_names);
 }
 
-void GLTFState::set_unique_animation_names(TypedArray<String> p_unique_animation_names) {
+void GLTFState::set_unique_animation_names(const TypedArray<String> &p_unique_animation_names) {
 	GLTFTemplateConvert::set_from_array(unique_animation_names, p_unique_animation_names);
 }
 
@@ -341,7 +341,7 @@ TypedArray<GLTFSkeleton> GLTFState::get_skeletons() {
 	return GLTFTemplateConvert::to_array(skeletons);
 }
 
-void GLTFState::set_skeletons(TypedArray<GLTFSkeleton> p_skeletons) {
+void GLTFState::set_skeletons(const TypedArray<GLTFSkeleton> &p_skeletons) {
 	GLTFTemplateConvert::set_from_array(skeletons, p_skeletons);
 }
 
@@ -365,7 +365,7 @@ TypedArray<GLTFAnimation> GLTFState::get_animations() {
 	return GLTFTemplateConvert::to_array(animations);
 }
 
-void GLTFState::set_animations(TypedArray<GLTFAnimation> p_animations) {
+void GLTFState::set_animations(const TypedArray<GLTFAnimation> &p_animations) {
 	GLTFTemplateConvert::set_from_array(animations, p_animations);
 }
 

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -150,7 +150,7 @@ public:
 	void set_handle_binary_image_mode(HandleBinaryImageMode p_handle_binary_image) { handle_binary_image_mode = p_handle_binary_image; }
 
 	Dictionary get_json();
-	void set_json(Dictionary p_json);
+	void set_json(const Dictionary &p_json);
 
 	int get_major_version();
 	void set_major_version(int p_major_version);
@@ -162,7 +162,7 @@ public:
 	void set_copyright(const String &p_copyright);
 
 	Vector<uint8_t> get_glb_data();
-	void set_glb_data(Vector<uint8_t> p_glb_data);
+	void set_glb_data(const Vector<uint8_t> &p_glb_data);
 
 	bool get_use_named_skin_binds();
 	void set_use_named_skin_binds(bool p_use_named_skin_binds);
@@ -180,25 +180,25 @@ public:
 	void set_discard_meshes_and_materials(bool p_discard_meshes_and_materials);
 
 	TypedArray<GLTFNode> get_nodes();
-	void set_nodes(TypedArray<GLTFNode> p_nodes);
+	void set_nodes(const TypedArray<GLTFNode> &p_nodes);
 
 	TypedArray<PackedByteArray> get_buffers();
-	void set_buffers(TypedArray<PackedByteArray> p_buffers);
+	void set_buffers(const TypedArray<PackedByteArray> &p_buffers);
 
 	TypedArray<GLTFBufferView> get_buffer_views();
-	void set_buffer_views(TypedArray<GLTFBufferView> p_buffer_views);
+	void set_buffer_views(const TypedArray<GLTFBufferView> &p_buffer_views);
 
 	TypedArray<GLTFAccessor> get_accessors();
-	void set_accessors(TypedArray<GLTFAccessor> p_accessors);
+	void set_accessors(const TypedArray<GLTFAccessor> &p_accessors);
 
 	TypedArray<GLTFMesh> get_meshes();
-	void set_meshes(TypedArray<GLTFMesh> p_meshes);
+	void set_meshes(const TypedArray<GLTFMesh> &p_meshes);
 
 	TypedArray<Material> get_materials();
-	void set_materials(TypedArray<Material> p_materials);
+	void set_materials(const TypedArray<Material> &p_materials);
 
 	String get_scene_name();
-	void set_scene_name(String p_scene_name);
+	void set_scene_name(const String &p_scene_name);
 
 	String get_base_path();
 	void set_base_path(const String &p_base_path);
@@ -213,34 +213,34 @@ public:
 	void set_filename(const String &p_filename);
 
 	PackedInt32Array get_root_nodes();
-	void set_root_nodes(PackedInt32Array p_root_nodes);
+	void set_root_nodes(const PackedInt32Array &p_root_nodes);
 
 	TypedArray<GLTFTexture> get_textures();
-	void set_textures(TypedArray<GLTFTexture> p_textures);
+	void set_textures(const TypedArray<GLTFTexture> &p_textures);
 
 	TypedArray<GLTFTextureSampler> get_texture_samplers();
-	void set_texture_samplers(TypedArray<GLTFTextureSampler> p_texture_samplers);
+	void set_texture_samplers(const TypedArray<GLTFTextureSampler> &p_texture_samplers);
 
 	TypedArray<Texture2D> get_images();
-	void set_images(TypedArray<Texture2D> p_images);
+	void set_images(const TypedArray<Texture2D> &p_images);
 
 	TypedArray<GLTFSkin> get_skins();
-	void set_skins(TypedArray<GLTFSkin> p_skins);
+	void set_skins(const TypedArray<GLTFSkin> &p_skins);
 
 	TypedArray<GLTFCamera> get_cameras();
-	void set_cameras(TypedArray<GLTFCamera> p_cameras);
+	void set_cameras(const TypedArray<GLTFCamera> &p_cameras);
 
 	TypedArray<GLTFLight> get_lights();
-	void set_lights(TypedArray<GLTFLight> p_lights);
+	void set_lights(const TypedArray<GLTFLight> &p_lights);
 
 	TypedArray<String> get_unique_names();
-	void set_unique_names(TypedArray<String> p_unique_names);
+	void set_unique_names(const TypedArray<String> &p_unique_names);
 
 	TypedArray<String> get_unique_animation_names();
-	void set_unique_animation_names(TypedArray<String> p_unique_names);
+	void set_unique_animation_names(const TypedArray<String> &p_unique_names);
 
 	TypedArray<GLTFSkeleton> get_skeletons();
-	void set_skeletons(TypedArray<GLTFSkeleton> p_skeletons);
+	void set_skeletons(const TypedArray<GLTFSkeleton> &p_skeletons);
 
 	bool get_create_animations();
 	void set_create_animations(bool p_create_animations);
@@ -249,7 +249,7 @@ public:
 	void set_import_as_skeleton_bones(bool p_import_as_skeleton_bones);
 
 	TypedArray<GLTFAnimation> get_animations();
-	void set_animations(TypedArray<GLTFAnimation> p_animations);
+	void set_animations(const TypedArray<GLTFAnimation> &p_animations);
 
 	Node *get_scene_node(GLTFNodeIndex idx);
 	GLTFNodeIndex get_node_index(Node *p_node);

--- a/modules/gltf/gltf_template_convert.h
+++ b/modules/gltf/gltf_template_convert.h
@@ -37,8 +37,8 @@
 
 namespace GLTFTemplateConvert {
 template <typename T>
-static Array to_array(const Vector<T> &p_inp) {
-	Array ret;
+static TypedArray<T> to_array(const Vector<T> &p_inp) {
+	TypedArray<T> ret;
 	for (int i = 0; i < p_inp.size(); i++) {
 		ret.push_back(p_inp[i]);
 	}

--- a/modules/gltf/structures/gltf_accessor.cpp
+++ b/modules/gltf/structures/gltf_accessor.cpp
@@ -165,19 +165,19 @@ void GLTFAccessor::set_type(int p_accessor_type) {
 }
 
 Vector<double> GLTFAccessor::get_min() const {
-	return min;
+	return Vector<double>(min);
 }
 
-void GLTFAccessor::set_min(Vector<double> p_min) {
-	min = p_min;
+void GLTFAccessor::set_min(const Vector<double> &p_min) {
+	min = Vector<double>(p_min);
 }
 
 Vector<double> GLTFAccessor::get_max() const {
-	return max;
+	return Vector<double>(max);
 }
 
-void GLTFAccessor::set_max(Vector<double> p_max) {
-	max = p_max;
+void GLTFAccessor::set_max(const Vector<double> &p_max) {
+	max = Vector<double>(p_max);
 }
 
 int64_t GLTFAccessor::get_sparse_count() const {

--- a/modules/gltf/structures/gltf_accessor.h
+++ b/modules/gltf/structures/gltf_accessor.h
@@ -146,10 +146,10 @@ public:
 	void set_type(int p_accessor_type);
 
 	Vector<double> get_min() const;
-	void set_min(Vector<double> p_min);
+	void set_min(const Vector<double> &p_min);
 
 	Vector<double> get_max() const;
-	void set_max(Vector<double> p_max);
+	void set_max(const Vector<double> &p_max);
 
 	int64_t get_sparse_count() const;
 	void set_sparse_count(int64_t p_sparse_count);

--- a/modules/gltf/structures/gltf_animation.cpp
+++ b/modules/gltf/structures/gltf_animation.cpp
@@ -74,7 +74,7 @@ String GLTFAnimation::get_original_name() {
 	return original_name;
 }
 
-void GLTFAnimation::set_original_name(String p_name) {
+void GLTFAnimation::set_original_name(const String &p_name) {
 	original_name = p_name;
 }
 

--- a/modules/gltf/structures/gltf_animation.h
+++ b/modules/gltf/structures/gltf_animation.h
@@ -71,7 +71,7 @@ public:
 	static Animation::InterpolationType gltf_to_godot_interpolation(Interpolation p_gltf_interpolation);
 
 	String get_original_name();
-	void set_original_name(String p_name);
+	void set_original_name(const String &p_name);
 
 	bool get_loop() const;
 	void set_loop(bool p_val);

--- a/modules/gltf/structures/gltf_camera.cpp
+++ b/modules/gltf/structures/gltf_camera.cpp
@@ -99,7 +99,7 @@ Camera3D *GLTFCamera::to_node() const {
 	return camera;
 }
 
-Ref<GLTFCamera> GLTFCamera::from_dictionary(const Dictionary p_dictionary) {
+Ref<GLTFCamera> GLTFCamera::from_dictionary(const Dictionary &p_dictionary) {
 	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFCamera>(), "Failed to parse glTF camera, missing required field 'type'.");
 	Ref<GLTFCamera> camera;
 	camera.instantiate();

--- a/modules/gltf/structures/gltf_camera.h
+++ b/modules/gltf/structures/gltf_camera.h
@@ -70,6 +70,6 @@ public:
 	static Ref<GLTFCamera> from_node(const Camera3D *p_camera);
 	Camera3D *to_node() const;
 
-	static Ref<GLTFCamera> from_dictionary(const Dictionary p_dictionary);
+	static Ref<GLTFCamera> from_dictionary(const Dictionary &p_dictionary);
 	virtual Dictionary to_dictionary() const;
 };

--- a/modules/gltf/structures/gltf_mesh.cpp
+++ b/modules/gltf/structures/gltf_mesh.cpp
@@ -54,7 +54,7 @@ String GLTFMesh::get_original_name() {
 	return original_name;
 }
 
-void GLTFMesh::set_original_name(String p_name) {
+void GLTFMesh::set_original_name(const String &p_name) {
 	original_name = p_name;
 }
 
@@ -62,24 +62,24 @@ Ref<ImporterMesh> GLTFMesh::get_mesh() {
 	return mesh;
 }
 
-void GLTFMesh::set_mesh(Ref<ImporterMesh> p_mesh) {
+void GLTFMesh::set_mesh(const Ref<ImporterMesh> &p_mesh) {
 	mesh = p_mesh;
 }
 
 TypedArray<Material> GLTFMesh::get_instance_materials() {
-	return instance_materials;
+	return TypedArray<Material>(instance_materials);
 }
 
-void GLTFMesh::set_instance_materials(TypedArray<Material> p_instance_materials) {
-	instance_materials = p_instance_materials;
+void GLTFMesh::set_instance_materials(const TypedArray<Material> &p_instance_materials) {
+	instance_materials = TypedArray<Material>(p_instance_materials);
 }
 
 Vector<float> GLTFMesh::get_blend_weights() {
-	return blend_weights;
+	return Vector<float>(blend_weights);
 }
 
-void GLTFMesh::set_blend_weights(Vector<float> p_blend_weights) {
-	blend_weights = p_blend_weights;
+void GLTFMesh::set_blend_weights(const Vector<float> &p_blend_weights) {
+	blend_weights = Vector<float>(p_blend_weights);
 }
 
 Variant GLTFMesh::get_additional_data(const StringName &p_extension_name) {

--- a/modules/gltf/structures/gltf_mesh.h
+++ b/modules/gltf/structures/gltf_mesh.h
@@ -49,13 +49,13 @@ protected:
 
 public:
 	String get_original_name();
-	void set_original_name(String p_name);
+	void set_original_name(const String &p_name);
 	Ref<ImporterMesh> get_mesh();
-	void set_mesh(Ref<ImporterMesh> p_mesh);
+	void set_mesh(const Ref<ImporterMesh> &p_mesh);
 	Vector<float> get_blend_weights();
-	void set_blend_weights(Vector<float> p_blend_weights);
+	void set_blend_weights(const Vector<float> &p_blend_weights);
 	TypedArray<Material> get_instance_materials();
-	void set_instance_materials(TypedArray<Material> p_instance_materials);
+	void set_instance_materials(const TypedArray<Material> &p_instance_materials);
 	Variant get_additional_data(const StringName &p_extension_name);
 	void set_additional_data(const StringName &p_extension_name, Variant p_additional_data);
 };

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -85,7 +85,7 @@ void GLTFNode::_bind_methods() {
 String GLTFNode::get_original_name() {
 	return original_name;
 }
-void GLTFNode::set_original_name(String p_name) {
+void GLTFNode::set_original_name(const String &p_name) {
 	original_name = p_name;
 }
 
@@ -109,7 +109,7 @@ Transform3D GLTFNode::get_xform() {
 	return transform;
 }
 
-void GLTFNode::set_xform(Transform3D p_xform) {
+void GLTFNode::set_xform(const Transform3D &p_xform) {
 	transform = p_xform;
 }
 
@@ -149,7 +149,7 @@ Vector3 GLTFNode::get_position() {
 	return transform.origin;
 }
 
-void GLTFNode::set_position(Vector3 p_position) {
+void GLTFNode::set_position(const Vector3 &p_position) {
 	transform.origin = p_position;
 }
 
@@ -157,7 +157,7 @@ Quaternion GLTFNode::get_rotation() {
 	return transform.basis.get_rotation_quaternion();
 }
 
-void GLTFNode::set_rotation(Quaternion p_rotation) {
+void GLTFNode::set_rotation(const Quaternion &p_rotation) {
 	transform.basis.set_quaternion_scale(p_rotation, transform.basis.get_scale());
 }
 
@@ -165,16 +165,16 @@ Vector3 GLTFNode::get_scale() {
 	return transform.basis.get_scale();
 }
 
-void GLTFNode::set_scale(Vector3 p_scale) {
+void GLTFNode::set_scale(const Vector3 &p_scale) {
 	transform.basis = transform.basis.orthonormalized() * Basis::from_scale(p_scale);
 }
 
 Vector<int> GLTFNode::get_children() {
-	return children;
+	return Vector<int>(children);
 }
 
-void GLTFNode::set_children(Vector<int> p_children) {
-	children = p_children;
+void GLTFNode::set_children(const Vector<int> &p_children) {
+	children = Vector<int>(p_children);
 }
 
 void GLTFNode::append_child_index(int p_child_index) {

--- a/modules/gltf/structures/gltf_node.h
+++ b/modules/gltf/structures/gltf_node.h
@@ -60,7 +60,7 @@ protected:
 
 public:
 	String get_original_name();
-	void set_original_name(String p_name);
+	void set_original_name(const String &p_name);
 
 	GLTFNodeIndex get_parent();
 	void set_parent(GLTFNodeIndex p_parent);
@@ -69,10 +69,10 @@ public:
 	void set_height(int p_height);
 
 	Transform3D get_xform();
-	void set_xform(Transform3D p_xform);
+	void set_xform(const Transform3D &p_xform);
 
 	Transform3D get_rest_xform();
-	void set_rest_xform(Transform3D p_rest_xform);
+	void set_rest_xform(const Transform3D &p_rest_xform);
 
 	GLTFMeshIndex get_mesh();
 	void set_mesh(GLTFMeshIndex p_mesh);
@@ -87,16 +87,16 @@ public:
 	void set_skeleton(GLTFSkeletonIndex p_skeleton);
 
 	Vector3 get_position();
-	void set_position(Vector3 p_position);
+	void set_position(const Vector3 &p_position);
 
 	Quaternion get_rotation();
-	void set_rotation(Quaternion p_rotation);
+	void set_rotation(const Quaternion &p_rotation);
 
 	Vector3 get_scale();
-	void set_scale(Vector3 p_scale);
+	void set_scale(const Vector3 &p_scale);
 
 	Vector<int> get_children();
-	void set_children(Vector<int> p_children);
+	void set_children(const Vector<int> &p_children);
 	void append_child_index(int p_child_index);
 
 	GLTFLightIndex get_light();

--- a/modules/gltf/structures/gltf_object_model_property.cpp
+++ b/modules/gltf/structures/gltf_object_model_property.cpp
@@ -107,7 +107,7 @@ Ref<Expression> GLTFObjectModelProperty::get_gltf_to_godot_expression() const {
 	return gltf_to_godot_expr;
 }
 
-void GLTFObjectModelProperty::set_gltf_to_godot_expression(Ref<Expression> p_gltf_to_godot_expr) {
+void GLTFObjectModelProperty::set_gltf_to_godot_expression(const Ref<Expression> &p_gltf_to_godot_expr) {
 	gltf_to_godot_expr = p_gltf_to_godot_expr;
 }
 
@@ -115,20 +115,20 @@ Ref<Expression> GLTFObjectModelProperty::get_godot_to_gltf_expression() const {
 	return godot_to_gltf_expr;
 }
 
-void GLTFObjectModelProperty::set_godot_to_gltf_expression(Ref<Expression> p_godot_to_gltf_expr) {
+void GLTFObjectModelProperty::set_godot_to_gltf_expression(const Ref<Expression> &p_godot_to_gltf_expr) {
 	godot_to_gltf_expr = p_godot_to_gltf_expr;
 }
 
 TypedArray<NodePath> GLTFObjectModelProperty::get_node_paths() const {
-	return node_paths;
+	return TypedArray<NodePath>(node_paths);
 }
 
 bool GLTFObjectModelProperty::has_node_paths() const {
 	return !node_paths.is_empty();
 }
 
-void GLTFObjectModelProperty::set_node_paths(TypedArray<NodePath> p_node_paths) {
-	node_paths = p_node_paths;
+void GLTFObjectModelProperty::set_node_paths(const TypedArray<NodePath> &p_node_paths) {
+	node_paths = TypedArray<NodePath>(p_node_paths);
 }
 
 GLTFObjectModelProperty::GLTFObjectModelType GLTFObjectModelProperty::get_object_model_type() const {

--- a/modules/gltf/structures/gltf_object_model_property.h
+++ b/modules/gltf/structures/gltf_object_model_property.h
@@ -73,14 +73,14 @@ public:
 	GLTFAccessor::GLTFAccessorType get_accessor_type() const;
 
 	Ref<Expression> get_gltf_to_godot_expression() const;
-	void set_gltf_to_godot_expression(Ref<Expression> p_gltf_to_godot_expr);
+	void set_gltf_to_godot_expression(const Ref<Expression> &p_gltf_to_godot_expr);
 
 	Ref<Expression> get_godot_to_gltf_expression() const;
-	void set_godot_to_gltf_expression(Ref<Expression> p_godot_to_gltf_expr);
+	void set_godot_to_gltf_expression(const Ref<Expression> &p_godot_to_gltf_expr);
 
 	TypedArray<NodePath> get_node_paths() const;
 	bool has_node_paths() const;
-	void set_node_paths(TypedArray<NodePath> p_node_paths);
+	void set_node_paths(const TypedArray<NodePath> &p_node_paths);
 
 	GLTFObjectModelType get_object_model_type() const;
 	void set_object_model_type(GLTFObjectModelType p_type);

--- a/modules/gltf/structures/gltf_skeleton.cpp
+++ b/modules/gltf/structures/gltf_skeleton.cpp
@@ -54,19 +54,19 @@ void GLTFSkeleton::_bind_methods() {
 }
 
 Vector<GLTFNodeIndex> GLTFSkeleton::get_joints() {
-	return joints;
+	return Vector<GLTFNodeIndex>(joints);
 }
 
-void GLTFSkeleton::set_joints(Vector<GLTFNodeIndex> p_joints) {
-	joints = p_joints;
+void GLTFSkeleton::set_joints(const Vector<GLTFNodeIndex> &p_joints) {
+	joints = Vector<GLTFNodeIndex>(p_joints);
 }
 
 Vector<GLTFNodeIndex> GLTFSkeleton::get_roots() {
-	return roots;
+	return Vector<GLTFNodeIndex>(roots);
 }
 
-void GLTFSkeleton::set_roots(Vector<GLTFNodeIndex> p_roots) {
-	roots = p_roots;
+void GLTFSkeleton::set_roots(const Vector<GLTFNodeIndex> &p_roots) {
+	roots = Vector<GLTFNodeIndex>(p_roots);
 }
 
 Skeleton3D *GLTFSkeleton::get_godot_skeleton() {
@@ -77,7 +77,7 @@ TypedArray<String> GLTFSkeleton::get_unique_names() {
 	return GLTFTemplateConvert::to_array(unique_names);
 }
 
-void GLTFSkeleton::set_unique_names(TypedArray<String> p_unique_names) {
+void GLTFSkeleton::set_unique_names(const TypedArray<String> &p_unique_names) {
 	GLTFTemplateConvert::set_from_array(unique_names, p_unique_names);
 }
 
@@ -85,7 +85,7 @@ Dictionary GLTFSkeleton::get_godot_bone_node() {
 	return GLTFTemplateConvert::to_dictionary(godot_bone_node);
 }
 
-void GLTFSkeleton::set_godot_bone_node(Dictionary p_indict) {
+void GLTFSkeleton::set_godot_bone_node(const Dictionary &p_indict) {
 	GLTFTemplateConvert::set_from_dictionary(godot_bone_node, p_indict);
 }
 

--- a/modules/gltf/structures/gltf_skeleton.h
+++ b/modules/gltf/structures/gltf_skeleton.h
@@ -65,10 +65,10 @@ protected:
 
 public:
 	Vector<GLTFNodeIndex> get_joints();
-	void set_joints(Vector<GLTFNodeIndex> p_joints);
+	void set_joints(const Vector<GLTFNodeIndex> &p_joints);
 
 	Vector<GLTFNodeIndex> get_roots();
-	void set_roots(Vector<GLTFNodeIndex> p_roots);
+	void set_roots(const Vector<GLTFNodeIndex> &p_roots);
 
 	Skeleton3D *get_godot_skeleton();
 
@@ -80,7 +80,7 @@ public:
 	// }
 
 	TypedArray<String> get_unique_names();
-	void set_unique_names(TypedArray<String> p_unique_names);
+	void set_unique_names(const TypedArray<String> &p_unique_names);
 
 	//RBMap<int32_t, GLTFNodeIndex> get_godot_bone_node() {
 	//	return godot_bone_node;
@@ -89,7 +89,7 @@ public:
 	//	godot_bone_node = p_godot_bone_node;
 	//}
 	Dictionary get_godot_bone_node();
-	void set_godot_bone_node(Dictionary p_indict);
+	void set_godot_bone_node(const Dictionary &p_indict);
 
 	//Dictionary get_godot_bone_node() {
 	//	return VariantConversion::to_dict(godot_bone_node);

--- a/modules/gltf/structures/gltf_skin.cpp
+++ b/modules/gltf/structures/gltf_skin.cpp
@@ -81,15 +81,15 @@ Vector<GLTFNodeIndex> GLTFSkin::get_joints_original() {
 	return joints_original;
 }
 
-void GLTFSkin::set_joints_original(Vector<GLTFNodeIndex> p_joints_original) {
-	joints_original = p_joints_original;
+void GLTFSkin::set_joints_original(const Vector<GLTFNodeIndex> &p_joints_original) {
+	joints_original = Vector<GLTFNodeIndex>(p_joints_original);
 }
 
 TypedArray<Transform3D> GLTFSkin::get_inverse_binds() {
 	return GLTFTemplateConvert::to_array(inverse_binds);
 }
 
-void GLTFSkin::set_inverse_binds(TypedArray<Transform3D> p_inverse_binds) {
+void GLTFSkin::set_inverse_binds(const TypedArray<Transform3D> &p_inverse_binds) {
 	GLTFTemplateConvert::set_from_array(inverse_binds, p_inverse_binds);
 }
 
@@ -97,24 +97,24 @@ Vector<GLTFNodeIndex> GLTFSkin::get_joints() {
 	return joints;
 }
 
-void GLTFSkin::set_joints(Vector<GLTFNodeIndex> p_joints) {
-	joints = p_joints;
+void GLTFSkin::set_joints(const Vector<GLTFNodeIndex> &p_joints) {
+	joints = Vector<GLTFNodeIndex>(p_joints);
 }
 
 Vector<GLTFNodeIndex> GLTFSkin::get_non_joints() {
 	return non_joints;
 }
 
-void GLTFSkin::set_non_joints(Vector<GLTFNodeIndex> p_non_joints) {
-	non_joints = p_non_joints;
+void GLTFSkin::set_non_joints(const Vector<GLTFNodeIndex> &p_non_joints) {
+	non_joints = Vector<GLTFNodeIndex>(p_non_joints);
 }
 
 Vector<GLTFNodeIndex> GLTFSkin::get_roots() {
 	return roots;
 }
 
-void GLTFSkin::set_roots(Vector<GLTFNodeIndex> p_roots) {
-	roots = p_roots;
+void GLTFSkin::set_roots(const Vector<GLTFNodeIndex> &p_roots) {
+	roots = Vector<GLTFNodeIndex>(p_roots);
 }
 
 int GLTFSkin::get_skeleton() {
@@ -129,7 +129,7 @@ Dictionary GLTFSkin::get_joint_i_to_bone_i() {
 	return GLTFTemplateConvert::to_dictionary(joint_i_to_bone_i);
 }
 
-void GLTFSkin::set_joint_i_to_bone_i(Dictionary p_joint_i_to_bone_i) {
+void GLTFSkin::set_joint_i_to_bone_i(const Dictionary &p_joint_i_to_bone_i) {
 	GLTFTemplateConvert::set_from_dictionary(joint_i_to_bone_i, p_joint_i_to_bone_i);
 }
 
@@ -143,7 +143,7 @@ Dictionary GLTFSkin::get_joint_i_to_name() {
 	return ret;
 }
 
-void GLTFSkin::set_joint_i_to_name(Dictionary p_joint_i_to_name) {
+void GLTFSkin::set_joint_i_to_name(const Dictionary &p_joint_i_to_name) {
 	joint_i_to_name = HashMap<int, StringName>();
 	for (const KeyValue<Variant, Variant> &kv : p_joint_i_to_name) {
 		joint_i_to_name[kv.key] = kv.value;
@@ -154,7 +154,7 @@ Ref<Skin> GLTFSkin::get_godot_skin() {
 	return godot_skin;
 }
 
-void GLTFSkin::set_godot_skin(Ref<Skin> p_godot_skin) {
+void GLTFSkin::set_godot_skin(const Ref<Skin> &p_godot_skin) {
 	godot_skin = p_godot_skin;
 }
 

--- a/modules/gltf/structures/gltf_skin.h
+++ b/modules/gltf/structures/gltf_skin.h
@@ -86,31 +86,31 @@ public:
 	void set_skin_root(GLTFNodeIndex p_skin_root);
 
 	Vector<GLTFNodeIndex> get_joints_original();
-	void set_joints_original(Vector<GLTFNodeIndex> p_joints_original);
+	void set_joints_original(const Vector<GLTFNodeIndex> &p_joints_original);
 
 	TypedArray<Transform3D> get_inverse_binds();
-	void set_inverse_binds(TypedArray<Transform3D> p_inverse_binds);
+	void set_inverse_binds(const TypedArray<Transform3D> &p_inverse_binds);
 
 	Vector<GLTFNodeIndex> get_joints();
-	void set_joints(Vector<GLTFNodeIndex> p_joints);
+	void set_joints(const Vector<GLTFNodeIndex> &p_joints);
 
 	Vector<GLTFNodeIndex> get_non_joints();
-	void set_non_joints(Vector<GLTFNodeIndex> p_non_joints);
+	void set_non_joints(const Vector<GLTFNodeIndex> &p_non_joints);
 
 	Vector<GLTFNodeIndex> get_roots();
-	void set_roots(Vector<GLTFNodeIndex> p_roots);
+	void set_roots(const Vector<GLTFNodeIndex> &p_roots);
 
 	int get_skeleton();
 	void set_skeleton(int p_skeleton);
 
 	Dictionary get_joint_i_to_bone_i();
-	void set_joint_i_to_bone_i(Dictionary p_joint_i_to_bone_i);
+	void set_joint_i_to_bone_i(const Dictionary &p_joint_i_to_bone_i);
 
 	Dictionary get_joint_i_to_name();
-	void set_joint_i_to_name(Dictionary p_joint_i_to_name);
+	void set_joint_i_to_name(const Dictionary &p_joint_i_to_name);
 
 	Ref<Skin> get_godot_skin();
-	void set_godot_skin(Ref<Skin> p_godot_skin);
+	void set_godot_skin(const Ref<Skin> &p_godot_skin);
 
 	Dictionary to_dictionary();
 	Error from_dictionary(const Dictionary &dict);


### PR DESCRIPTION
This PR changes parameters in the GLTF module to const refs: `const Type &`. This change prevents making unnecessary copies of parameters when calling functions, including when the bindings call the functions.

Motivation: I tried changing the copy constructors of container types like Array to explicit, but this creates a problem for non-const-ref parameters of container types in the bindings. Right now, the bindings are implicitly making copies of this data, and the bindings do not compile anymore if this is changed to explicit. See the discussions in PR #107377 and PR #110912 for more information.

Only doing this for container types would be sufficient for that purpose, but that would be a massive change throughout the entire codebase. I think it would be better for reviewability if I open multiple PRs targeting specific parts of the codebase, so for example, this PR can be reviewed by the Import team. And, while I'm at it, I also made this change for types such as `String` and `Ref<>` to fix up those too.

This PR also contains a small number of other changes to parameters, such as using `p_` and `r_` consistently, a few changes to use explicit copy constructors, and changing GLTFTemplateConvert to use TypedArray instead of Array (the functions calling this already use TypedArray anyway, so this just avoids an extra conversion).