### PR TITLE
GDScript: Add support for `@read_only` annotation

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -782,6 +782,15 @@
 				[/codeblock]
 			</description>
 		</annotation>
+		<annotation name="@read_only">
+			<return type="void" />
+			<description>
+				Mark the following property as read-only. Read-only properties can only be assigned a value once, either at declaration or in the constructor ([method Object._init]). Any further assignment will result in an error.
+				[codeblock]
+				@read_only var size = 10
+				[/codeblock]
+			</description>
+		</annotation>
 		<annotation name="@rpc">
 			<return type="void" />
 			<param index="0" name="mode" type="String" default="&quot;authority&quot;" />

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1435,6 +1435,37 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 		}
 	}
 
+	// Verify that read-only variables are assigned only once, either inline or in the constructor.
+	GDScriptParser::FunctionNode *constructor = p_class->has_function("_init") ? p_class->get_member("_init").function : nullptr;
+	for (int i = 0; i < p_class->members.size(); i++) {
+		GDScriptParser::ClassNode::Member member = p_class->members[i];
+		if (member.type != GDScriptParser::ClassNode::Member::VARIABLE || !member.variable->readonly) {
+			continue;
+		}
+		if (!constructor) {
+			if (member.variable->initializer == nullptr) {
+				push_error(vformat(R"(The read-only variable "%s" must be assigned a value inline or in the constructor.)", member.variable->identifier->name), member.variable);
+			}
+			continue;
+		}
+		int assignment_result = check_readonly_assignments(constructor->body, member.variable->identifier->name);
+		if (member.variable->initializer != nullptr) {
+			if (assignment_result > 0) {
+				push_error(vformat(R"(The read-only variable "%s" is assigned inline and in the constructor; only one assignment is allowed.)", member.variable->identifier->name), member.variable);
+			}
+		} else {
+			if (assignment_result == -1) {
+				push_error(vformat(R"(The read-only variable "%s" must be assigned a value inline or in the constructor.)", member.variable->identifier->name), member.variable);
+			} else if (assignment_result == 0) {
+				push_error(vformat(R"(The read-only variable "%s" must be definitely assigned in all code paths of the constructor.)", member.variable->identifier->name), member.variable);
+			} else if (assignment_result == 2) {
+				push_error(vformat(R"(The read-only variable "%s" is assigned more than once in the constructor; only one assignment is allowed.)", member.variable->identifier->name), member.variable);
+			} else if (assignment_result == 1) {
+				member.variable->assignments++;
+			}
+		}
+	}
+
 	// Check unused variables and datatypes of property getters and setters.
 	for (int i = 0; i < p_class->members.size(); i++) {
 		GDScriptParser::ClassNode::Member member = p_class->members[i];
@@ -2860,6 +2891,32 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 	}
 #endif // DEBUG_ENABLED
 
+	// If we're assigning to a read-only member in the base constructor, count the assignment
+	// before reducing the assignee so we don't mis-diagnose the LHS as a read-before-assign read.
+	{
+		auto early_increment_member_assignment = [&](const StringName &p_name) {
+			if (!parser->current_class->has_member(p_name)) {
+				return;
+			}
+			GDScriptParser::ClassNode::Member found_member = parser->current_class->get_member(p_name);
+			if (found_member.type == GDScriptParser::ClassNode::Member::VARIABLE && found_member.variable && found_member.variable->readonly) {
+				found_member.variable->assignments++;
+			}
+		};
+
+		if (parser->current_function && parser->current_function->identifier && parser->current_function->identifier->name == SNAME("_init") && p_assignment->assignee) {
+			if (p_assignment->assignee->type == GDScriptParser::Node::IDENTIFIER) {
+				GDScriptParser::IdentifierNode *id = static_cast<GDScriptParser::IdentifierNode *>(p_assignment->assignee);
+				early_increment_member_assignment(id->name);
+			} else if (p_assignment->assignee->type == GDScriptParser::Node::SUBSCRIPT) {
+				GDScriptParser::SubscriptNode *sub = static_cast<GDScriptParser::SubscriptNode *>(p_assignment->assignee);
+				if (sub->is_attribute && sub->base->type == GDScriptParser::Node::SELF) {
+					early_increment_member_assignment(sub->attribute->name);
+				}
+			}
+		}
+	}
+
 	reduce_expression(p_assignment->assignee);
 
 #ifdef DEBUG_ENABLED
@@ -2902,6 +2959,39 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 
 	if (p_assignment->assigned_value == nullptr || p_assignment->assignee == nullptr) {
 		return;
+	}
+
+	// Enforce: class read-only variables can only be assigned in the base constructor (_init of the class that declares the variable).
+	{
+		bool in_constructor = parser->current_function && parser->current_function->identifier && parser->current_function->identifier->name == SNAME("_init");
+
+		auto check_readonly_assignment = [&](const GDScriptParser::IdentifierNode *id, bool allow_reference_types) {
+			using Src = GDScriptParser::IdentifierNode::Source;
+			if (id && (id->source == Src::MEMBER_VARIABLE || id->source == Src::INHERITED_VARIABLE) && id->variable_source && id->variable_source->readonly && (!in_constructor || !parser->current_class->has_member(id->name))) {
+				const GDScriptParser::DataType &id_type = id->datatype;
+				if (allow_reference_types && (id_type.kind == GDScriptParser::DataType::CLASS || id_type.builtin_type == Variant::ARRAY || id_type.builtin_type == Variant::DICTIONARY || id_type.builtin_type == Variant::OBJECT)) {
+					return;
+				}
+				push_error(vformat(R"(The read-only variable "%s" can only be assigned inline or in the base constructor.)", id->name), p_assignment->assignee);
+			}
+		};
+
+		if (p_assignment->assignee->type == GDScriptParser::Node::IDENTIFIER) {
+			check_readonly_assignment(static_cast<const GDScriptParser::IdentifierNode *>(p_assignment->assignee), false);
+		} else if (p_assignment->assignee->type == GDScriptParser::Node::SUBSCRIPT) {
+			GDScriptParser::SubscriptNode *sub = static_cast<GDScriptParser::SubscriptNode *>(p_assignment->assignee);
+			if (sub->is_attribute) {
+				check_readonly_assignment(sub->attribute, false);
+			}
+			if (sub->base->type == GDScriptParser::Node::IDENTIFIER) {
+				check_readonly_assignment(static_cast<const GDScriptParser::IdentifierNode *>(sub->base), true);
+			} else if (sub->base->type == GDScriptParser::Node::SUBSCRIPT) {
+				const GDScriptParser::SubscriptNode *base = static_cast<const GDScriptParser::SubscriptNode *>(sub->base);
+				if (base->is_attribute) {
+					check_readonly_assignment(base->attribute, true);
+				}
+			}
+		}
 	}
 
 	GDScriptParser::DataType assignee_type = p_assignment->assignee->get_datatype();
@@ -3702,6 +3792,43 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		}
 #endif // DEBUG_ENABLED
 
+		// Check for attempts to use .set() or .set_deferred() on read-only variables.
+		if ((p_call->function_name == SNAME("set") || p_call->function_name == SNAME("set_deferred")) && !p_call->arguments.is_empty()) {
+			const GDScriptParser::ExpressionNode *property_arg = p_call->arguments[0];
+			if (property_arg) {
+				StringName property_name;
+				bool has_property_name = false;
+
+				if (property_arg->is_constant && property_arg->reduced_value.get_type() == Variant::STRING) {
+					property_name = property_arg->reduced_value;
+					has_property_name = true;
+				} else if (property_arg->type == GDScriptParser::Node::LITERAL) {
+					const GDScriptParser::LiteralNode *literal = static_cast<const GDScriptParser::LiteralNode *>(property_arg);
+					if (literal->value.get_type() == Variant::STRING) {
+						property_name = literal->value;
+						has_property_name = true;
+					}
+				}
+
+				if (has_property_name && base_type.kind == GDScriptParser::DataType::CLASS && base_type.class_type != nullptr) {
+					List<GDScriptParser::ClassNode *> script_classes;
+					get_class_node_current_scope_classes(base_type.class_type, &script_classes, p_call);
+
+					for (GDScriptParser::ClassNode *script_class : script_classes) {
+						if (script_class->has_member(property_name)) {
+							resolve_class_member(script_class, property_name, p_call);
+							const GDScriptParser::ClassNode::Member &member = script_class->get_member(property_name);
+
+							if (member.type == GDScriptParser::ClassNode::Member::VARIABLE && member.variable && member.variable->readonly) {
+								push_error(vformat(R"*(Cannot use "%s()" to modify read-only variable "%s".)*", p_call->function_name, property_name), p_call);
+							}
+							break;
+						}
+					}
+				}
+			}
+		}
+
 		call_type = return_type;
 	} else {
 		bool found = false;
@@ -4464,6 +4591,10 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 		const bool source_is_instance_function = p_identifier->source == GDScriptParser::IdentifierNode::MEMBER_FUNCTION && !p_identifier->function_source_is_static;
 		const bool source_is_signal = p_identifier->source == GDScriptParser::IdentifierNode::MEMBER_SIGNAL;
 
+		if (source_is_instance_variable && p_identifier->variable_source && p_identifier->variable_source->readonly && p_identifier->variable_source->assignments == 0) {
+			push_error(vformat(R"(The read-only variable "%s" must be assigned a value inline or in the constructor before it can be read.)", p_identifier->name), p_identifier);
+		}
+
 		if (static_context && (source_is_instance_variable || source_is_instance_function || source_is_signal)) {
 			// Get the parent function above any lambda.
 			GDScriptParser::FunctionNode *parent_function = parser->current_function;
@@ -4848,6 +4979,13 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 			reduce_identifier_from_base(p_subscript->attribute, &base_type);
 			GDScriptParser::DataType attr_type = p_subscript->attribute->get_datatype();
 			if (attr_type.is_set()) {
+				if (p_subscript->base && p_subscript->base->type == GDScriptParser::Node::SELF) {
+					GDScriptParser::IdentifierNode *attr = p_subscript->attribute;
+					using Src = GDScriptParser::IdentifierNode::Source;
+					if ((attr->source == Src::MEMBER_VARIABLE || attr->source == Src::INHERITED_VARIABLE) && attr->variable_source && attr->variable_source->readonly && attr->variable_source->assignments == 0) {
+						push_error(vformat(R"(The read-only variable "%s" must be assigned a value before it can be read.)", attr->name), attr);
+					}
+				}
 				if (base_type.builtin_type == Variant::DICTIONARY && base_type.has_container_element_types()) {
 					Variant::Type key_type = base_type.get_container_element_type_or_variant(0).builtin_type;
 					valid = key_type == Variant::NIL || key_type == Variant::STRING || key_type == Variant::STRING_NAME;
@@ -5509,6 +5647,94 @@ Variant GDScriptAnalyzer::make_variable_default_value(GDScriptParser::VariableNo
 	}
 
 	return result;
+}
+
+int GDScriptAnalyzer::check_readonly_assignments(const GDScriptParser::Node *p_node, const StringName &p_var_name) {
+	switch (p_node->type) {
+		case GDScriptParser::Node::ASSIGNMENT: {
+			const GDScriptParser::AssignmentNode *assignment = static_cast<const GDScriptParser::AssignmentNode *>(p_node);
+			const GDScriptParser::ExpressionNode *lhs = assignment->assignee;
+			bool assigns_target = false;
+
+			if (lhs && lhs->type == GDScriptParser::Node::IDENTIFIER) {
+				const GDScriptParser::IdentifierNode *id = static_cast<const GDScriptParser::IdentifierNode *>(lhs);
+				assigns_target = (id->name == p_var_name && id->source == GDScriptParser::IdentifierNode::Source::MEMBER_VARIABLE);
+			} else if (lhs && lhs->type == GDScriptParser::Node::SUBSCRIPT) {
+				const GDScriptParser::SubscriptNode *sub = static_cast<const GDScriptParser::SubscriptNode *>(lhs);
+				assigns_target = (sub->is_attribute && sub->attribute->name == p_var_name && sub->base && sub->base->type == GDScriptParser::Node::SELF);
+			}
+			return assigns_target ? 1 : -1;
+			break;
+		}
+		case GDScriptParser::Node::IF: {
+			const GDScriptParser::IfNode *if_node = static_cast<const GDScriptParser::IfNode *>(p_node);
+			int true_result = check_readonly_assignments(if_node->true_block, p_var_name);
+			int false_result = if_node->false_block ? check_readonly_assignments(if_node->false_block, p_var_name) : -1;
+			if (true_result == 1 && false_result == 1) {
+				return 1;
+			} else if (true_result == 2 || false_result == 2) {
+				return 2;
+			} else if (true_result > 0 || false_result > 0) {
+				return 0;
+			}
+			return -1;
+			break;
+		}
+		case GDScriptParser::Node::MATCH: {
+			const GDScriptParser::MatchNode *match_node = static_cast<const GDScriptParser::MatchNode *>(p_node);
+			if (match_node->branches.is_empty()) {
+				return -1;
+			}
+			bool all_assign = true;
+			bool any_multiple = false;
+			bool has_wildcard = false;
+			for (const GDScriptParser::MatchBranchNode *branch : match_node->branches) {
+				if (branch->has_wildcard) {
+					has_wildcard = true;
+				}
+				int branch_result = check_readonly_assignments(branch->block, p_var_name);
+				if (branch_result < 1) {
+					all_assign = false;
+				} else if (branch_result == 2) {
+					any_multiple = true;
+				}
+			}
+			if (has_wildcard && all_assign) {
+				return any_multiple ? 2 : 1;
+			} else if (!all_assign && (any_multiple || match_node->branches.size() > 0)) {
+				for (const GDScriptParser::MatchBranchNode *branch : match_node->branches) {
+					if (check_readonly_assignments(branch->block, p_var_name) > 0) {
+						return any_multiple ? 2 : 0;
+					}
+				}
+			}
+			return -1;
+			break;
+		}
+		case GDScriptParser::Node::SUITE: {
+			const GDScriptParser::SuiteNode *suite = static_cast<const GDScriptParser::SuiteNode *>(p_node);
+			int total_assignments = 0;
+			bool definitely_assigned = false;
+
+			for (int i = 0; i < suite->statements.size(); ++i) {
+				int result = check_readonly_assignments(suite->statements[i], p_var_name);
+				if (result == 1) {
+					total_assignments++;
+					definitely_assigned = true;
+				} else if (result == 2) {
+					return 2;
+				} else if (result == 0 && !definitely_assigned) {
+					return 0;
+				} else if (total_assignments > 1) {
+					return 2;
+				}
+			}
+			return definitely_assigned ? 1 : -1;
+			break;
+		}
+		default:
+			return -1;
+	}
 }
 
 GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source) {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -141,10 +141,12 @@ class GDScriptAnalyzer {
 	void push_error(const String &p_message, const GDScriptParser::Node *p_origin = nullptr);
 	void mark_node_unsafe(const GDScriptParser::Node *p_node);
 	void downgrade_node_type_source(GDScriptParser::Node *p_node);
+	void find_declaring_class_and_member(const StringName &p_name, const GDScriptParser::ClassNode *&r_declaring_class, GDScriptParser::ClassNode::Member &r_member);
 	void mark_lambda_use_self();
 	void resolve_pending_lambda_bodies();
 	bool class_exists(const StringName &p_class) const;
 	void reduce_identifier_from_base_set_class(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType p_identifier_datatype);
+	int check_readonly_assignments(const GDScriptParser::Node *p_node, const StringName &p_var_name);
 	Ref<GDScriptParserRef> ensure_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, const GDScriptParser::ClassNode *p_from_class, const char *p_context, const GDScriptParser::Node *p_source);
 	Ref<GDScriptParserRef> find_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, const Ref<GDScriptParserRef> &p_dependant_parser);
 	Ref<GDScriptParserRef> find_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, GDScriptParser *p_dependant_parser);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -99,6 +99,8 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@abstract"), AnnotationInfo::SCRIPT | AnnotationInfo::CLASS | AnnotationInfo::FUNCTION, &GDScriptParser::abstract_annotation);
 		// Onready annotation.
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
+		// Read-only annotation.
+		register_annotation(MethodInfo("@read_only"), AnnotationInfo::VARIABLE, &GDScriptParser::readonly_annotation);
 		// Export annotations.
 		register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
 		register_annotation(MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_ENUM, Variant::NIL>, varray(), true);
@@ -4416,6 +4418,26 @@ bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_ta
 	}
 	variable->onready = true;
 	current_class->onready_used = true;
+	return true;
+}
+
+bool GDScriptParser::readonly_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, R"("@readonly" annotation can only be applied to class variables.)");
+
+	VariableNode *variable = static_cast<VariableNode *>(p_target);
+	if (variable->is_static) {
+		push_error(R"("@readonly" annotation cannot be applied to a static variable.)", p_annotation);
+		return false;
+	}
+	if (variable->readonly) {
+		push_error(R"("@readonly" annotation can only be used once per variable.)", p_annotation);
+		return false;
+	}
+	if (variable->setter_pointer != nullptr) {
+		push_error(R"("@readonly" annotation cannot be used with a variable that has a setter.)", p_annotation);
+		return false;
+	}
+	variable->readonly = true;
 	return true;
 }
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1260,6 +1260,7 @@ public:
 
 		bool exported = false;
 		bool onready = false;
+		bool readonly = false;
 		PropertyInfo export_info;
 		int assignments = 0;
 		bool is_static = false;
@@ -1535,6 +1536,7 @@ private:
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_custom_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_tool_button_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool readonly_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyUsageFlags t_usage>
 	bool export_group_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool warning_ignore_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/tests/scripts/analyzer/errors/readonly_variable.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/readonly_variable.gd
@@ -1,0 +1,81 @@
+class A:
+	@read_only var a: bool = true # Case: initialized inline
+	@read_only var b: bool # Case: initialized in constructor
+	@read_only var c: bool # Case: not initialized	 														NOT ALLOWED
+	@read_only var d: bool # Case: initialized in constructor by non-pure initializer
+	var e: bool = true # Control case (regression check)
+	var f: bool # Control case
+	@read_only var g: bool = true: # Case: has setter		 												NOT ALLOWED
+		set(value):
+			g = value
+	@read_only var h: bool = true: # Case: has getter
+		get():
+			return h
+	var i: bool = b # Case: accessing before initialized													NOT ALLOWED
+	@read_only var j: bool # Case: initialized in all branches in constructor
+	@read_only var k: bool # Case: initialized in not all branches in constructor							NOT ALLOWED
+
+	func _init(d_val: bool) -> void:
+		print(a) # Case: accessing inline initialized
+
+		a = false # Case: reinitializing inline initialized 												NOT ALLOWED
+
+		print(b) # Case: accessing beore initializing														NOT ALLOWED
+		print(self.b) # Case: same as bove but with self.													NOT ALLOWED
+
+		b = true # Case: initializing in constructor
+		b = false # Case: reinitializing constructor initialized											NOT ALLOWED
+
+		d = d_val # Case: non-pure initializing in constructor
+
+		if a:
+			j = true
+			k = true
+		else:
+			match b:
+				true:
+					j = true
+				_:
+					j = false
+
+	func test() -> void:
+		a = false # Case: give value to read-only															NOT ALLOWED
+		print(b) # Case: access after initialization
+		e = false # Control case
+
+class B extends A:
+	func _init() -> void:
+		b = false # Case: initializing in NOT base constructor												NOT ALLOWED
+		self.b = true  # Case: same as above but with self.													NOT ALLOWED
+
+		super._init(true) # Case: initializing through constructor parameter
+
+class C:
+	var a:= A.new(true)
+	@read_only var b:= B.new()
+	@read_only var c:= [1,2,3]
+	@read_only var d:= Vector2.ZERO
+	@read_only var e: bool # Case: not initialized, no constructor											NOT ALLOWED
+
+class D:
+	var c:= C.new()
+	@read_only var c2:= C.new()
+
+class E:
+	var d:= D.new()
+
+func test():
+	var a:= A.new(true)
+	a.a = false # Case: give value to read-only in subscript												NOT ALLOWED
+	a.set("a", false) # Case: set read-only via .set()														NOT ALLOWED
+	a.e = false # Control case
+
+	var c := C.new()
+	c.a.a = false # Case: give value to read-only in nested subscript										NOT ALLOWED
+	c.c = [3,2,1] # Case: give value to pass-by-ref read-only												NOT ALLOWED
+	c.c[0] = 0 # Case: Modifying array value (pass by ref)
+	c.d.x = 1 # Case: Modifying vector value (pass by value)												NOT ALLOWED
+
+	var e := E.new()
+	e.d.c.d.x = 1 # Case: same as above, deep																NOT ALLOWED
+	e.d.c2.a.e = false # Case: read-only pass-by-ref in chain but not last

--- a/modules/gdscript/tests/scripts/analyzer/errors/readonly_variable.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/readonly_variable.out
@@ -1,0 +1,19 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 8: "@readonly" annotation cannot be used with a variable that has a setter.
+>> ERROR at line 14: The read-only variable "b" must be assigned a value inline or in the constructor before it can be read.
+>> ERROR at line 69: The read-only variable "a" can only be assigned inline or in the base constructor.
+>> ERROR at line 70: Cannot use "set()" to modify read-only variable "a".
+>> ERROR at line 74: The read-only variable "a" can only be assigned inline or in the base constructor.
+>> ERROR at line 75: The read-only variable "c" can only be assigned inline or in the base constructor.
+>> ERROR at line 77: The read-only variable "d" can only be assigned inline or in the base constructor.
+>> ERROR at line 80: The read-only variable "d" can only be assigned inline or in the base constructor.
+>> ERROR at line 23: The read-only variable "b" must be assigned a value inline or in the constructor before it can be read.
+>> ERROR at line 24: The read-only variable "b" must be assigned a value before it can be read.
+>> ERROR at line 42: The read-only variable "a" can only be assigned inline or in the base constructor.
+>> ERROR at line 2: The read-only variable "a" is assigned inline and in the constructor; only one assignment is allowed.
+>> ERROR at line 3: The read-only variable "b" is assigned more than once in the constructor; only one assignment is allowed.
+>> ERROR at line 4: The read-only variable "c" must be assigned a value inline or in the constructor.
+>> ERROR at line 16: The read-only variable "k" must be definitely assigned in all code paths of the constructor.
+>> ERROR at line 48: The read-only variable "b" can only be assigned inline or in the base constructor.
+>> ERROR at line 49: The read-only variable "b" can only be assigned inline or in the base constructor.
+>> ERROR at line 58: The read-only variable "e" must be assigned a value inline or in the constructor.

--- a/modules/gdscript/tests/scripts/runtime/features/readonly_variable.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/readonly_variable.gd
@@ -1,0 +1,30 @@
+class A:
+	@read_only var a: int = 1
+	@read_only var b: int
+	@read_only var c: int
+
+	func _init(c_val: int) -> void:
+		b = 2
+		c = c_val
+
+class B extends A:
+	@read_only var d: int = 4
+
+	func _init() -> void:
+		super._init(12)
+
+func test():
+	var a:= A.new(3)
+	print("A values")
+	print("A.a: ", a.a)
+	print("A.b: ", a.b)
+	print("A.c: ", a.c)
+	print("--")
+
+	var b:= B.new()
+	print("B values")
+	print("B.a: ", b.a)
+	print("B.b: ", b.b)
+	print("B.c: ", b.c)
+	print("B.d: ", b.d)
+	print("--")

--- a/modules/gdscript/tests/scripts/runtime/features/readonly_variable.out
+++ b/modules/gdscript/tests/scripts/runtime/features/readonly_variable.out
@@ -1,0 +1,12 @@
+GDTEST_OK
+A values
+A.a: 1
+A.b: 2
+A.c: 3
+--
+B values
+B.a: 1
+B.b: 2
+B.c: 12
+B.d: 4
+--


### PR DESCRIPTION
* closes https://github.com/godotengine/godot-proposals/issues/13285
* requires #85481 (sort of, see below)
* Merge notes: contains overlapping/duplicated code in `GDScriptAnalyzer::reduce_call` and `GDScriptAnalyzer::reduce_assignment` with #111089 

The user can define a class variable as `@read_only`. 
* That variable must then be given a value, either in-line or in the constructor. 
  * Constructor assignment without #85481 would be "unsafe", as the base constructor will not necessarily be called, resulting in a "not initialized" (i.e. default value) variable
* Constructor assignment is only possible in the constructor of the class where the variable is declared. 
* This supports non-pure initializers, as GDScript does. 
* This variable cannot be accessed before being initialized in constructor if not initialized inline
  * Same caveat applies as above in event where base constructor is not called
* This variable cannot have a setter defined (would be useless) but can have a getter defined

If the user wishes to give it a value at a child class level, this is achieved by passing it as an argument to the base class' constructor. 


See example in proposal. 

TO-DO:
- [x] Improve the constructor check. Currently it doesn't take into account if/match statements, which may result in unassigned variables

~

For immutable variables (similar, but can only be assigned in-line and cannot have a getter), see #111089 
Those can also be used as locals and parameters to functions