### PR TITLE
Add notification to update theme of the build button

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -692,6 +692,11 @@ namespace GodotTools
 
                 RiderPathManager.InitializeIfNeeded(editor);
             }
+
+            if (changedSettings.Contains(_editorSettings.NotificationThemeChanged))
+            {
+                UpdateTheme();
+            }
         }
 
         protected override void Dispose(bool disposing)
@@ -722,18 +727,6 @@ namespace GodotTools
             base.Dispose(disposing);
         }
 
-        public override void _Notification(int what)
-        {
-            base._Notification(what);
-
-            UpdateTheme();
-
-            //if (what == NotificationThemeChanged)
-            //{
-
-            //}
-        }
-
         private void UpdateTheme()
         {
             // Nodes will be null until _Ready is called.
@@ -742,6 +735,7 @@ namespace GodotTools
 
             _toolBarBuildButton.Icon = EditorInterface.Singleton.GetEditorTheme().GetIcon("BuildCSharp", "EditorIcons");
         }
+
         public void OnBeforeSerialize()
         {
         }

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -722,6 +722,26 @@ namespace GodotTools
             base.Dispose(disposing);
         }
 
+        public override void _Notification(int what)
+        {
+            base._Notification(what);
+
+            UpdateTheme();
+
+            //if (what == NotificationThemeChanged)
+            //{
+
+            //}
+        }
+
+        private void UpdateTheme()
+        {
+            // Nodes will be null until _Ready is called.
+            if (_toolBarBuildButton == null)
+                return;
+
+            _toolBarBuildButton.Icon = EditorInterface.Singleton.GetEditorTheme().GetIcon("BuildCSharp", "EditorIcons");
+        }
         public void OnBeforeSerialize()
         {
         }

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -693,7 +693,7 @@ namespace GodotTools
                 RiderPathManager.InitializeIfNeeded(editor);
             }
 
-            if (changedSettings.Contains(_editorSettings.NotificationThemeChanged))
+            if (changedSettings.Contains("interface/theme/preset"))
             {
                 UpdateTheme();
             }


### PR DESCRIPTION
This PR addresses an issue in the mono version of godot where the build button would not update when the theme is changed

Key Changes:

    Added Notification function to GodotSharpEditor.cs that updates the _toolbarbuildbutton Icon

Issues Addressed:
    This PR addresses the bug mentioned in issue #108485 

Modified Files:

    modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs:
        Added notification and update theme functions to update the build button's theme

Current Issues:

(error CS0103: The name 'NotificationThemeChanged' does not exist in the current context) is given everytime I try using the theme changed notification enum used in 3 other files meaning the update theme function is called everytime there is an engine notification. I need help figuring out why this is so if you can help, it would be greatly appreciated.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/108485*