### PR TITLE
Add parameter to preview a translation on startup

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -385,6 +385,14 @@ String TranslationServer::get_fallback_locale() const {
 	return fallback;
 }
 
+void TranslationServer::set_default_preview(const String &p_locale) {
+	default_preview = p_locale;
+}
+
+String TranslationServer::get_default_preview() const {
+	return default_preview;
+}
+
 PackedStringArray TranslationServer::get_loaded_locales() const {
 	return main_domain->get_loaded_locales();
 }
@@ -451,6 +459,7 @@ void TranslationServer::setup() {
 	}
 
 	fallback = GLOBAL_DEF("internationalization/locale/fallback", "en");
+	default_preview = GLOBAL_DEF("internationalization/locale/default_preview", "");
 	main_domain->set_pseudolocalization_enabled(GLOBAL_DEF("internationalization/pseudolocalization/use_pseudolocalization", false));
 	main_domain->set_pseudolocalization_accents_enabled(GLOBAL_DEF("internationalization/pseudolocalization/replace_with_accents", true));
 	main_domain->set_pseudolocalization_double_vowels_enabled(GLOBAL_DEF("internationalization/pseudolocalization/double_vowels", false));
@@ -464,6 +473,7 @@ void TranslationServer::setup() {
 #ifdef TOOLS_ENABLED
 	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "internationalization/locale/test", PROPERTY_HINT_LOCALE_ID, ""));
 	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "internationalization/locale/fallback", PROPERTY_HINT_LOCALE_ID, ""));
+	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "internationalization/locale/default_preview", PROPERTY_HINT_LOCALE_ID, ""));
 #endif
 }
 

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -38,6 +38,7 @@ class TranslationServer : public Object {
 
 	String locale = "en";
 	String fallback;
+	String default_preview;
 
 	Ref<TranslationDomain> main_domain;
 	Ref<TranslationDomain> editor_domain;
@@ -101,6 +102,8 @@ public:
 	String get_locale() const;
 	void set_fallback_locale(const String &p_locale);
 	String get_fallback_locale() const;
+	void set_default_preview(const String &p_locale);
+	String get_default_preview() const;
 	Ref<Translation> get_translation_object(const String &p_locale);
 
 	Vector<String> get_all_languages() const;

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1631,6 +1631,9 @@
 		<member name="input_devices/sensors/enable_magnetometer" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the magnetometer sensor is enabled and [method Input.get_magnetometer] returns valid data.
 		</member>
+		<member name="internationalization/locale/default_preview" type="String" setter="" getter="" default="&quot;&quot;">
+			If non-empty, this locale will be automatically previewed on project open if available.
+		</member>
 		<member name="internationalization/locale/fallback" type="String" setter="" getter="" default="&quot;en&quot;">
 			The locale to fall back to if a translation isn't available in a given language. If left empty, [code]en[/code] (English) will be used.
 			[b]Note:[/b] Not to be confused with [TextServerFallback].

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -924,6 +924,15 @@ void EditorNode::_notification(int p_what) {
 				EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Editor functionality has been restricted."), EditorToaster::SEVERITY_WARNING);
 			}
 
+			// Preview your default translation, if available.
+			String default_preview = TranslationServer::get_singleton()->get_default_preview();
+			if (!default_preview.is_empty()) {
+				Vector<String> locales = TranslationServer::get_singleton()->get_loaded_locales();
+				if (locales.has(default_preview)) {
+					set_preview_locale(default_preview);
+				}
+			}
+
 			/* DO NOT LOAD SCENES HERE, WAIT FOR FILE SCANNING AND REIMPORT TO COMPLETE */
 		} break;
 


### PR DESCRIPTION
Something small I personally experienced was when reopening a project often, having to set your translation preview over and over got kind of annoying...

This pull request adds a **Default Preview** project setting that automatically previews a locale when you open the project, granted it exists in your current localizations:
<img width="1189" height="292" alt="image" src="https://github.com/user-attachments/assets/04f671f1-589d-4ad4-98ed-2fcd50988f2f" />

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/13309.*