### PR TITLE
Add auto-apply option for external scene changes

### DIFF
--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -516,7 +516,7 @@
 		<member name="h" type="float" setter="" getter="" default="0.0">
 			The HSV hue of this color, on the range 0 to 1.
 		</member>
-		<member name="ok_hsl_h" type="float" setter="" getter="" default="0.0">
+		<member name="ok_hsl_h" type="float" setter="" getter="" default="2.9802322e-08">
 			The OKHSL hue of this color, on the range 0 to 1.
 		</member>
 		<member name="ok_hsl_l" type="float" setter="" getter="" default="0.0">

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -516,7 +516,7 @@
 		<member name="h" type="float" setter="" getter="" default="0.0">
 			The HSV hue of this color, on the range 0 to 1.
 		</member>
-		<member name="ok_hsl_h" type="float" setter="" getter="" default="2.9802322e-08">
+		<member name="ok_hsl_h" type="float" setter="" getter="" default="0.0">
 			The OKHSL hue of this color, on the range 0 to 1.
 		</member>
 		<member name="ok_hsl_l" type="float" setter="" getter="" default="0.0">

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -831,6 +831,9 @@
 			- [b]Cancel First[/b] forces the ordering Cancel/OK.
 			- [b]OK First[/b] forces the ordering OK/Cancel.
 		</member>
+		<member name="interface/editor/auto_apply_external_scene_changes" type="bool" setter="" getter="">
+			If [code]true[/code], automatically reloads scenes and project settings when they are modified externally (by another program). If [code]false[/code], a dialog will be shown asking the user what to do.
+		</member>
 		<member name="interface/editor/automatically_open_screenshots" type="bool" setter="" getter="">
 			If [code]true[/code], automatically opens screenshots with the default program associated to [code].png[/code] files after a screenshot is taken using the [b]Editor &gt; Take Screenshot[/b] action.
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -530,6 +530,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/unfocused_low_processor_mode_sleep_usec", 100000, "1,1000000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/import_resources_when_unfocused", false, "")
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/auto_apply_external_scene_changes", false, "")
 
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/vsync_mode", 1, "Disabled,Enabled,Adaptive,Mailbox")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/update_continuously", false, "")


### PR DESCRIPTION
The reason this option is needed is because when generating scenes via AI, pop-ups get in the way.

### Changes:
- Add new editor setting "interface/editor/auto_apply_external_scene_changes"
- Implement automatic reloading of externally modified scenes and project settings
- Skip dialog UI preparation when auto-apply is enabled
- Automatically reload scenes and project settings when changes are detected
- Maintain existing dialog-based workflow when auto-apply is disabled

This feature allows developers to automatically apply external changes to scenes without manual confirmation, improving workflow efficiency.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
