### PR TITLE
Fix folder sorting in file dialogs for all sort options

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -863,9 +863,7 @@ void FileDialog::update_file_list() {
 			DirInfo di;
 			di.name = dir_name;
 			di.bundle = bundle;
-			if (file_sort == FileSortOption::MODIFIED_TIME || file_sort == FileSortOption::MODIFIED_TIME_REVERSE) {
-				di.modified_time = FileAccess::get_modified_time(base_dir.path_join(dir_name));
-			}
+			di.modified_time = FileAccess::get_modified_time(base_dir.path_join(dir_name));
 			filtered_dirs.push_back(di);
 		}
 	}
@@ -876,7 +874,7 @@ void FileDialog::update_file_list() {
 		filtered_dirs.sort_custom<DirInfo::NameComparator>();
 	}
 
-	if (file_sort == FileSortOption::NAME_REVERSE || file_sort == FileSortOption::MODIFIED_TIME_REVERSE) {
+	if (file_sort == FileSortOption::NAME_REVERSE || file_sort == FileSortOption::TYPE_REVERSE || file_sort == FileSortOption::MODIFIED_TIME_REVERSE) {
 		filtered_dirs.reverse();
 	}
 


### PR DESCRIPTION
# PR Description: Directory Sorting Fixes and Improvements

This PR addresses several long-standing issues related to directory sorting within Godot's file dialogs, ensuring more consistent and correct behavior.

### Key Changes:

*   **Fixes Directory Sorting Inconsistencies:**
    *   Corrected the issue where `TYPE_REVERSE` sorting was not properly applied to directories.
    *   Resolved the problem where `MODIFIED_TIME` sorting always defaulted to name-based sorting for directories.
    *   Introduced proper, robust modified time-based sorting for directories.
    *   Ensured that all reverse sort options (e.g., `TYPE_REVERSE`, `MODIFIED_TIME` with reverse) now function correctly for directories.
*   **Architectural Enhancements:**
    *   Implemented a new `DirInfo` structure within `EditorFileDialog` to efficiently handle and store necessary information for time-based sorting.
    *   Refactored and cleaned up the overall sorting logic, leading to improved code consistency and maintainability.

### Issues Addressed:

Prior to this PR, users experienced the following problems when sorting folders in file dialogs:

*   When `Type (Descending)` sort was selected, folders were not correctly reversed in their order.
*   Even when `Modified Time` sort was chosen, folders would consistently be sorted by their name instead of their modification timestamp.
*   There was inconsistent sorting behavior observed between the main Editor file dialog and the Scene file dialog.

### Modified Files:

*   `scene/gui/file_dialog.cpp`:
    *   Modified to always collect the `modified_time` for directories.
    *   Adjusted reverse sorting conditions to ensure correct application.
*   `editor/gui/editor_file_dialog.cpp`:
    *   Added the new `DirInfo` structure.
    *   Implemented the core logic for time-based directory sorting using the new structure.



<table>
  <tr>
    <th>AS-IS</th>
    <th>TO-BE</th>
  </tr>
  <tr>
<td>
      <img src="" width=300 />
      <video src="https://github.com/user-attachments/assets/35249c7f-f657-46f0-8cdd-e7c5d0287a0a" width=300 />
</td>
<td>
      <img src="" width=300 />
      <video src="https://github.com/user-attachments/assets/2f53672a-b4dd-4c29-a235-9b4a7cbb70e4" width=300 />
</td>
  </tr>
</table>

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/111036*