### PR TITLE
Fix crash when calling `move_and_collide` with a null `jolt_body`

### DIFF
--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -861,6 +861,10 @@ Vector3 JoltPhysicsDirectSpaceState3D::get_closest_point_to_object_volume(RID p_
 bool JoltPhysicsDirectSpaceState3D::body_test_motion(const JoltBody3D &p_body, const PhysicsServer3D::MotionParameters &p_parameters, PhysicsServer3D::MotionResult *r_result) const {
 	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "body_test_motion (maybe from move_and_slide?) must not be called while the physics space is being stepped.");
 
+	if (!p_body.in_space()) {
+		return false;
+	}
+
 	space->flush_pending_objects();
 
 	const float margin = MAX((float)p_parameters.margin, 0.0001f);


### PR DESCRIPTION
Fixes #110963.

This addresses a crash when using Jolt Physics as the 3D physics engine, that occurs when calling `move_and_collide`, `move_and_slide` or `body_test_motion` on a physics body that has failed to allocate its `jolt_body`, which can happen when the maximum number of bodies (as configured through `physics/jolt_physics_3d/limits/max_bodies`) has been exceeded.

This PR fixes this by simply doing an early-out in `body_test_motion` if the body is not considered to be in a valid space, which includes checking for a non-null `jolt_body` pointer (or invalid `jolt_id` in the case of 4.4).