### PR TITLE
PackedScene: Avoid saving connections twice 

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2603,6 +2603,31 @@ String Node::get_tree_string() {
 	return _get_tree_string(this);
 }
 
+void Node::add_connection_owner(Node *p_owner, Node *p_to_node, const StringName &p_signal_name, const Callable &p_callable, bool is_inherited) {
+	uint32_t hash = HashMapHasherDefault::hash(p_to_node) ^ p_signal_name.hash() ^ p_callable.get_method().hash();
+	if (is_inherited) {
+		data.inherited_connections.insert(hash);
+	} else {
+		data.connection_owners[hash] = p_owner;
+	}
+}
+
+// Returns true if the connection data comes from a scene this node inherits.
+bool Node::is_connection_inherited(Node *p_to_node, const StringName &p_signal_name, const Callable &p_callable) const {
+	uint32_t hash = HashMapHasherDefault::hash(p_to_node) ^ p_signal_name.hash() ^ p_callable.get_method().hash();
+	return data.inherited_connections.has(hash);
+}
+
+Node *Node::get_connection_owner(Node *p_to_node, const StringName &p_signal_name, const Callable &p_callable) const {
+	for (const KeyValue<uint32_t, Node *> &E : data.connection_owners) {
+		uint32_t hash = HashMapHasherDefault::hash(p_to_node) ^ p_signal_name.hash() ^ p_callable.get_method().hash();
+		if (E.key == hash) {
+			return E.value;
+		}
+	}
+	return nullptr; // The connection was just added (not instantiated) so it doesn't have an owner.
+}
+
 void Node::propagate_notification(int p_notification) {
 	ERR_THREAD_GUARD
 	data.blocked++;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -217,6 +217,8 @@ private:
 		int blocked = 0; // Safeguard that throws an error when attempting to modify the tree in a harmful way while being traversed.
 		StringName name;
 		SceneTree *tree = nullptr;
+		HashMap<uint32_t, Node *> connection_owners; // Maintain the level at which signals were connected so connections can be packed correctly.
+		HashSet<uint32_t> inherited_connections; // Connections that come from a scene this node inherits.
 
 		String editor_description;
 
@@ -650,6 +652,15 @@ public:
 	void propagate_notification(int p_notification);
 
 	void propagate_call(const StringName &p_method, const Array &p_args = Array(), const bool p_parent_first = false);
+
+	/* USED ONLY BY PACKED SCENE */
+
+	// A connection is owned by the root node of the scene it is first saved
+	// in. Maintaining this data when instantiating scenes allows for correct
+	// packing of connections later.
+	void add_connection_owner(Node *p_owner, Node *p_to_node, const StringName &p_signal_name, const Callable &p_callable, bool is_inherited);
+	bool is_connection_inherited(Node *p_to_node, const StringName &p_signal_name, const Callable &p_callable) const;
+	Node *get_connection_owner(Node *p_to_node, const StringName &p_signal_name, const Callable &p_callable) const;
 
 	/* PROCESSING */
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -719,8 +719,13 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 		}
 	}
 
-	//do connections
+	NODE_FROM_ID(conn_owner, 0); // root node of scene.
 
+	// If there are already connections on this node, then they must be from an inherited scene.
+	// Add inherited=true to existing connection owner data.
+	_add_inheritance_to_connections_owned_by(conn_owner, conn_owner);
+
+	// Add the connections that belong to this scene.
 	int cc = connections.size();
 	const ConnectionData *cdata = connections.ptr();
 
@@ -753,9 +758,14 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 		}
 
 		cfrom->connect(snames[c.signal], callable, CONNECT_PERSIST | c.flags | (p_edit_state == GEN_EDIT_STATE_MAIN ? 0 : CONNECT_INHERITED));
-	}
 
-	//Node *s = ret_nodes[0];
+		// Above check for inherited connections works in most cases, this is needed when creating a new inherited scene in the editor.
+		if (p_edit_state == GEN_EDIT_STATE_MAIN_INHERITED) {
+			cfrom->add_connection_owner(conn_owner, cto, snames[c.signal], callable, true);
+		} else {
+			cfrom->add_connection_owner(conn_owner, cto, snames[c.signal], callable, false);
+		}
+	}
 
 	//remove nodes that could not be added, likely as a result that
 	while (stray_instances.size()) {
@@ -771,6 +781,28 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	}
 
 	return ret_nodes[0];
+}
+
+void SceneState::_add_inheritance_to_connections_owned_by(Node *p_owner, Node *p_node) const {
+	List<MethodInfo> _signals;
+	p_node->get_signal_list(&_signals);
+	for (const MethodInfo &E : _signals) {
+		List<Node::Connection> conns;
+		p_node->get_signal_connection_list(E.name, &conns);
+
+		for (const Node::Connection &F : conns) {
+			const Node::Connection &c = F;
+			Node *target = Object::cast_to<Node>(c.callable.get_object());
+
+			// overwrite the connection owner data with is_inherited=true.
+			p_node->add_connection_owner(p_owner, target, E.name, c.callable, true);
+		}
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		Node *child = p_node->get_child(i);
+		_add_inheritance_to_connections_owned_by(p_owner, child);
+	}
 }
 
 Variant SceneState::make_local_resource(Variant &p_value, const SceneState::NodeData &p_node_data, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
@@ -1269,95 +1301,20 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 				base_callable = c.callable;
 			}
 
-			//find if this connection already exists
-			Node *common_parent = target->find_common_parent_with(p_node);
-
-			ERR_CONTINUE(!common_parent);
-
-			if (common_parent != p_owner && !common_parent->is_instance()) {
-				common_parent = common_parent->get_owner();
-			}
-
-			bool exists = false;
-
-			//go through ownership chain to see if this exists
-			while (common_parent) {
-				Ref<SceneState> ps;
-
-				if (common_parent == p_owner) {
-					ps = common_parent->get_scene_inherited_state();
-				} else {
-					ps = common_parent->get_scene_instance_state();
-				}
-
-				if (ps.is_valid()) {
-					NodePath signal_from = common_parent->get_path_to(p_node);
-					NodePath signal_to = common_parent->get_path_to(target);
-
-					if (ps->has_connection(signal_from, c.signal.get_name(), signal_to, base_callable.get_method())) {
-						exists = true;
-						break;
-					}
-				}
-
-				if (common_parent == p_owner) {
-					break;
-				} else {
-					common_parent = common_parent->get_owner();
-				}
-			}
-
-			if (exists) { //already exists (comes from instance or inheritance), so don't save
+			// Don't save connection if it is from an inherited scene.
+			if (p_node->is_connection_inherited(target, E.name, base_callable)) {
 				continue;
 			}
 
-			{
-				Node *nl = p_node;
-
-				bool exists2 = false;
-
-				while (nl) {
-					if (nl == p_owner) {
-						Ref<SceneState> state = nl->get_scene_inherited_state();
-						if (state.is_valid()) {
-							int from_node = state->find_node_by_path(nl->get_path_to(p_node));
-							int to_node = state->find_node_by_path(nl->get_path_to(target));
-
-							if (from_node >= 0 && to_node >= 0) {
-								//this one has state for this node, save
-								if (state->is_connection(from_node, c.signal.get_name(), to_node, base_callable.get_method())) {
-									exists2 = true;
-									break;
-								}
-							}
-						}
-
-						nl = nullptr;
-					} else {
-						if (nl->is_instance()) {
-							Ref<SceneState> state = nl->get_scene_instance_state();
-							if (state.is_valid()) {
-								int from_node = state->find_node_by_path(nl->get_path_to(p_node));
-								int to_node = state->find_node_by_path(nl->get_path_to(target));
-
-								if (from_node >= 0 && to_node >= 0) {
-									//this one has state for this node, save
-									if (state->is_connection(from_node, c.signal.get_name(), to_node, base_callable.get_method())) {
-										exists2 = true;
-										break;
-									}
-								}
-							}
-						}
-						nl = nl->get_owner();
-					}
-				}
-
-				if (exists2) {
-					continue;
-				}
+			// Don't save connection if it is part of a scene instance.
+			Node *conn_owner = p_node->get_connection_owner(target, E.name, base_callable);
+			bool owned_by_node_in_tree = p_node == conn_owner || (conn_owner != nullptr && p_owner->find_child(conn_owner->get_name(), true)); // Need to check this so that connections of reparented nodes not in the scenetree will be saved.
+			bool owned_by_main_scene = (conn_owner == p_owner || conn_owner == nullptr); // nullptr means the connection was just added and wasn't connected during node instantiation.
+			if (!owned_by_main_scene && owned_by_node_in_tree) {
+				continue;
 			}
 
+			// Pack the connection!
 			int src_id;
 
 			if (node_map.has(p_node)) {
@@ -1691,39 +1648,6 @@ bool SceneState::disable_placeholders = false;
 
 void SceneState::set_disable_placeholders(bool p_disable) {
 	disable_placeholders = p_disable;
-}
-
-bool SceneState::is_connection(int p_node, const StringName &p_signal, int p_to_node, const StringName &p_to_method) const {
-	ERR_FAIL_COND_V(p_node < 0, false);
-	ERR_FAIL_COND_V(p_to_node < 0, false);
-
-	if (p_node < nodes.size() && p_to_node < nodes.size()) {
-		int signal_idx = -1;
-		int method_idx = -1;
-		for (int i = 0; i < names.size(); i++) {
-			if (names[i] == p_signal) {
-				signal_idx = i;
-			} else if (names[i] == p_to_method) {
-				method_idx = i;
-			}
-		}
-
-		if (signal_idx >= 0 && method_idx >= 0) {
-			//signal and method strings are stored..
-
-			for (int i = 0; i < connections.size(); i++) {
-				if (connections[i].from == p_node && connections[i].to == p_to_node && connections[i].signal == signal_idx && connections[i].method == method_idx) {
-					return true;
-				}
-			}
-		}
-	}
-
-	if (base_scene_node_remap.has(p_node) && base_scene_node_remap.has(p_to_node)) {
-		return get_base_scene_state()->is_connection(base_scene_node_remap[p_node], p_signal, base_scene_node_remap[p_to_node], p_to_method);
-	}
-
-	return false;
 }
 
 void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -94,6 +94,7 @@ class SceneState : public RefCounted {
 
 	Error _parse_node(Node *p_owner, Node *p_node, int p_parent_idx, HashMap<StringName, int> &name_map, HashMap<Variant, int> &variant_map, HashMap<Node *, int> &node_map, HashMap<Node *, int> &nodepath_map, HashSet<int32_t> &ids_saved);
 	Error _parse_connections(Node *p_owner, Node *p_node, HashMap<StringName, int> &name_map, HashMap<Variant, int> &variant_map, HashMap<Node *, int> &node_map, HashMap<Node *, int> &nodepath_map);
+	void _add_inheritance_to_connections_owned_by(Node *p_owner, Node *p_node) const;
 
 	String path;
 
@@ -148,7 +149,6 @@ public:
 	int find_node_by_path(const NodePath &p_node) const;
 	Variant get_property_value(int p_node, const StringName &p_property, bool &r_found, bool &r_node_deferred) const;
 	bool is_node_in_group(int p_node, const StringName &p_group) const;
-	bool is_connection(int p_node, const StringName &p_signal, int p_to_node, const StringName &p_to_method) const;
 
 	void set_bundled_scene(const Dictionary &p_dictionary);
 	Dictionary get_bundled_scene() const;

--- a/tests/scene/test_packed_scene.cpp
+++ b/tests/scene/test_packed_scene.cpp
@@ -56,34 +56,105 @@ TEST_CASE("[PackedScene] Pack Scene and Retrieve State") {
 	memdelete(scene);
 }
 
-TEST_CASE("[PackedScene] Signals Preserved when Packing Scene") {
-	// Create main scene
+TEST_CASE("[PackedScene] Connections Preserved when Packing Scene with connections on reparented nodes") {
+	Node *main_scene_root = memnew(Node);
+	main_scene_root->set_name("some_name"); // setting name prevents an error when "find_node" is called in pack
+	Node *sub_node = memnew(Node);
+	Node *sub_node_2 = memnew(Node);
+
+	main_scene_root->add_child(sub_node);
+	main_scene_root->add_child(sub_node_2);
+	sub_node->set_owner(main_scene_root);
+	sub_node_2->set_owner(main_scene_root);
+
+	Callable call = Callable(sub_node_2, "is_ready");
+	sub_node->connect("ready", call, Object::CONNECT_PERSIST);
+
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+	const Error err = packed_scene->pack(main_scene_root);
+	CHECK(err == OK);
+
+	Ref<SceneState> state = packed_scene->get_state();
+	CHECK_EQ(state->get_connection_count(), 1);
+
+	// Take child nodes from the main scene and reparent to a node not in the tree
+	Node *new_root = packed_scene->instantiate();
+	Node *dangling_root = memnew(Node);
+
+	Node *node = new_root->get_child(0);
+	Node *node_2 = new_root->get_child(1);
+	node->set_owner(nullptr);
+	node_2->set_owner(nullptr);
+	node->reparent(dangling_root);
+	node_2->reparent(dangling_root);
+	node->set_owner(dangling_root);
+	node_2->set_owner(dangling_root);
+
+	const Error err2 = packed_scene->pack(dangling_root);
+	CHECK(err2 == OK);
+
+	// Ensure connection is still packed in the new "dangling" scene
+	Ref<SceneState> new_state = packed_scene->get_state();
+	CHECK_EQ(new_state->get_connection_count(), 1);
+
+	memdelete(new_root);
+	memdelete(main_scene_root);
+	memdelete(dangling_root);
+}
+
+TEST_CASE("[PackedScene] Connections Preserved when Packing Scene") {
+	// Create main scene for testing all connection possibilities
+	//
 	// root
 	// `- sub_node (local)
 	// `- sub_scene (instance of another scene)
 	//    `- sub_scene_node (owned by sub_scene)
+	// `- sub_scene_editable (instance of another scene with editable children set)
+	//    `- sub_scene_node (owned by sub_scene_editable)
+	//    `- sub_scene_node_2 (owned by sub_scene_editable)
+	//
 	Node *main_scene_root = memnew(Node);
 	Node *sub_node = memnew(Node);
 	Node *sub_scene_root = memnew(Node);
 	Node *sub_scene_node = memnew(Node);
+	Node *sub_scene_editable_root = memnew(Node);
+	Node *sub_scene_editable_node = memnew(Node);
 
 	main_scene_root->add_child(sub_node);
 	sub_node->set_owner(main_scene_root);
 
+	// non-editable subscene
 	sub_scene_root->add_child(sub_scene_node);
 	sub_scene_node->set_owner(sub_scene_root);
 
 	main_scene_root->add_child(sub_scene_root);
-	sub_scene_root->set_owner(main_scene_root);
+	main_scene_root->add_child(sub_scene_editable_root);
 
-	SUBCASE("Signals that should be saved") {
-		int main_flags = Object::CONNECT_PERSIST;
-		// sub node to a node in main scene
-		sub_node->connect("ready", callable_mp(main_scene_root, &Node::is_ready), main_flags);
-		// subscene root to a node in main scene
-		sub_scene_root->connect("ready", callable_mp(main_scene_root, &Node::is_ready), main_flags);
-		//subscene root to subscene root (connected within main scene)
-		sub_scene_root->connect("ready", callable_mp(sub_scene_root, &Node::is_ready), main_flags);
+	// editable subscene
+	sub_scene_editable_root->add_child(sub_scene_editable_node);
+	main_scene_root->set_editable_instance(sub_scene_editable_root, true);
+	main_scene_root->set_editable_instance(sub_scene_editable_node, true);
+	sub_scene_editable_node->set_owner(sub_scene_editable_root);
+	sub_scene_editable_node->set_name("editable_node");
+
+	sub_scene_root->set_owner(main_scene_root);
+	sub_scene_editable_root->set_owner(main_scene_root);
+	CHECK(main_scene_root->is_editable_instance(sub_scene_editable_node) == true);
+
+	int flags = Object::CONNECT_PERSIST;
+
+	SUBCASE("Connections that should be saved") {
+		// Sub node to a node in main scene
+		sub_node->connect("ready", callable_mp(main_scene_root, &Node::is_ready), flags);
+		// Subscene root to a node in main scene
+		sub_scene_root->connect("ready", callable_mp(main_scene_root, &Node::is_ready), flags);
+		// Subscene root to subscene root (connected within main scene)
+		sub_scene_root->connect("ready", callable_mp(sub_scene_root, &Node::is_ready), flags);
+
+		// Editable Subscene child to editable Subscene root (connected within main scene)
+		Callable call = Callable(sub_scene_editable_root, "is_ready");
+		sub_scene_editable_node->connect("ready", call, flags);
 
 		// Pack the scene.
 		Ref<PackedScene> packed_scene;
@@ -91,21 +162,27 @@ TEST_CASE("[PackedScene] Signals Preserved when Packing Scene") {
 		const Error err = packed_scene->pack(main_scene_root);
 		CHECK(err == OK);
 
-		// Make sure the right connections are in packed scene.
+		// Make sure that all connections were saved
 		Ref<SceneState> state = packed_scene->get_state();
-		CHECK_EQ(state->get_connection_count(), 3);
+		CHECK_EQ(state->get_connection_count(), 4);
 	}
 
-	/*
-	// FIXME: This subcase requires GH-48064 to be fixed.
-	SUBCASE("Signals that should not be saved") {
-		int subscene_flags = Object::CONNECT_PERSIST | Object::CONNECT_INHERITED;
-		// subscene node to itself
-		sub_scene_node->connect("ready", callable_mp(sub_scene_node, &Node::is_ready), subscene_flags);
-		// subscene node to subscene root
-		sub_scene_node->connect("ready", callable_mp(sub_scene_root, &Node::is_ready), subscene_flags);
-		//subscene root to subscene root (connected within sub scene)
-		sub_scene_root->connect("ready", callable_mp(sub_scene_root, &Node::is_ready), subscene_flags);
+	SUBCASE("Connections that should not be saved") {
+		// Subscene node to itself
+		sub_scene_node->connect("ready", callable_mp(sub_scene_node, &Node::is_ready), flags);
+
+		// Subscene node to subscene root
+		sub_scene_node->connect("ready", callable_mp(sub_scene_root, &Node::is_ready), flags);
+
+		// Subscene root to subscene root (connected within sub scene)
+		Callable call = Callable(sub_scene_root, "is_ready");
+		sub_scene_root->connect("ready", call, flags);
+		sub_scene_root->add_connection_owner(sub_scene_root, sub_scene_root, "ready", call, false);
+
+		// Editable Subscene child to editable Subscene root (belonging to subscene)
+		Callable call2 = Callable(sub_scene_editable_root, "is_ready");
+		sub_scene_editable_node->connect("ready", call2, flags);
+		sub_scene_editable_node->add_connection_owner(sub_scene_editable_root, sub_scene_editable_root, "ready", call2, false);
 
 		// Pack the scene.
 		Ref<PackedScene> packed_scene;
@@ -113,11 +190,10 @@ TEST_CASE("[PackedScene] Signals Preserved when Packing Scene") {
 		const Error err = packed_scene->pack(main_scene_root);
 		CHECK(err == OK);
 
-		// Make sure the right connections are in packed scene.
+		// Make sure that no connections were saved.
 		Ref<SceneState> state = packed_scene->get_state();
 		CHECK_EQ(state->get_connection_count(), 0);
 	}
-	*/
 
 	memdelete(main_scene_root);
 }


### PR DESCRIPTION
This PR is a redo of #100965

Fixes #48064 fixes #86532 fixes #85372 (variations of the same issue)

### The Problem
When packing a PackedScene from a script that contained instances of other scenes, signal connections within those instances were also getting saved in some circumstances (they should all be ignored because they are already saved in the scene that was instanced). This causes "duplicate signal" errors whenever the scenes were instantiated as the editor would try to connect the signals more than once. As some of the issues point out, you can open a `tscn` file and plainly see that connections are saved where they shouldn't be. The errors can quickly overwhelm the rest of the output and obfuscate real problems.

### What this PR does
This PR fixes the issues by giving connections "owners" when they are instantiated and checking the owners when packing them to ensure they remain only in the scenes that own them. The owner of a node is the scene it belongs to, but the root node of a scene instance will belong to the scene containing it. The new "connection owner" I have added is different because a connection from the root node of a scene instance (that belongs to the scene) should still be owned by the root node of the instance, not the root node of the containing scene.

Adding this new scheme made most of the previous connection finding code irrelevant, and I believe this method makes the whole connection packing and instantiation more straightforward.
