### PR TITLE
Fix editor log search ignoring BBCode formatting in messages

### DIFF
--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -140,6 +140,9 @@ private:
 	Button *show_search_button = nullptr;
 	LineEdit *search_box = nullptr;
 
+	// Reusable RichTextLabel for BBCode parsing during search
+	RichTextLabel *bbcode_parser = nullptr;
+
 	// Reference to the "Output" button on the toolbar so we can update its icon when warnings or errors are encountered.
 	Button *tool_button = nullptr;
 


### PR DESCRIPTION
When searching in the editor output log, messages with BBCode formatting (like [color=red]text[/color]) would not be found when searching for the plain text content. For example, searching for "Example is" in a message "[color=blue]EXAMPLE[/color] is super cool" would fail to find the match.

Resolves https://github.com/godotengine/godot/issues/110967



Before searching:
<img width="1916" height="1080" alt="image" src="https://github.com/user-attachments/assets/147b2790-1501-40c8-b953-2116a6ac1d4a" />

After searching:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/83f481a9-76dd-402d-b37d-a45f1bd4da71" />

Search still works for searching specifically with bbcode syntax, and string literals representing bbcode syntax:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/22137a20-7bc7-49de-b725-1d1bfceca571" />






