### PR TITLE
Dont warning await on abstract method

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5856,7 +5856,7 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 		}
 		r_return_type = p_is_constructor ? p_base_type : found_function->get_datatype();
 		r_return_type.is_meta_type = false;
-		r_return_type.is_coroutine = found_function->is_coroutine;
+		r_return_type.is_coroutine = found_function->is_coroutine || found_function->is_abstract;
 
 		return true;
 	}


### PR DESCRIPTION
https://github.com/godotengine/godot/issues/110961#issuecomment-3341529471

**Issue Description**

When method is abstract, do not report warning for await.

Currently, there is only one parameter `is_coroutine` to determine whether this method can be handled by await. If we want more meanful in this situation, we could add a parameter likes `is_abstract` to `DataType`.