### PR TITLE
Use const ref parameters in the Web modules

### DIFF
--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -187,20 +187,20 @@ MultiplayerPeer::ConnectionStatus WebRTCMultiplayerPeer::get_connection_status()
 	return connection_status;
 }
 
-Error WebRTCMultiplayerPeer::create_server(Array p_channels_config) {
+Error WebRTCMultiplayerPeer::create_server(const Array &p_channels_config) {
 	return _initialize(1, MODE_SERVER, p_channels_config);
 }
 
-Error WebRTCMultiplayerPeer::create_client(int p_self_id, Array p_channels_config) {
+Error WebRTCMultiplayerPeer::create_client(int p_self_id, const Array &p_channels_config) {
 	ERR_FAIL_COND_V_MSG(p_self_id == 1, ERR_INVALID_PARAMETER, "Clients cannot have ID 1.");
 	return _initialize(p_self_id, MODE_CLIENT, p_channels_config);
 }
 
-Error WebRTCMultiplayerPeer::create_mesh(int p_self_id, Array p_channels_config) {
+Error WebRTCMultiplayerPeer::create_mesh(int p_self_id, const Array &p_channels_config) {
 	return _initialize(p_self_id, MODE_MESH, p_channels_config);
 }
 
-Error WebRTCMultiplayerPeer::_initialize(int p_self_id, NetworkMode p_mode, Array p_channels_config) {
+Error WebRTCMultiplayerPeer::_initialize(int p_self_id, NetworkMode p_mode, const Array &p_channels_config) {
 	ERR_FAIL_COND_V(p_self_id < 1 || p_self_id > ~(1 << 31), ERR_INVALID_PARAMETER);
 	channels_config.clear();
 	channels_modes.clear();
@@ -254,7 +254,7 @@ int WebRTCMultiplayerPeer::get_unique_id() const {
 	return unique_id;
 }
 
-void WebRTCMultiplayerPeer::_peer_to_dict(Ref<ConnectedPeer> p_connected_peer, Dictionary &r_dict) {
+void WebRTCMultiplayerPeer::_peer_to_dict(const Ref<ConnectedPeer> &p_connected_peer, Dictionary &r_dict) {
 	Array channels;
 	for (Ref<WebRTCDataChannel> &F : p_connected_peer->channels) {
 		channels.push_back(F);
@@ -285,7 +285,7 @@ Dictionary WebRTCMultiplayerPeer::get_peers() {
 	return out;
 }
 
-Error WebRTCMultiplayerPeer::add_peer(Ref<WebRTCPeerConnection> p_peer, int p_peer_id, int p_unreliable_lifetime) {
+Error WebRTCMultiplayerPeer::add_peer(const Ref<WebRTCPeerConnection> &p_peer, int p_peer_id, int p_unreliable_lifetime) {
 	ERR_FAIL_COND_V(network_mode == MODE_NONE, ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(network_mode == MODE_CLIENT && p_peer_id != 1, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(network_mode == MODE_SERVER && p_peer_id == 1, ERR_INVALID_PARAMETER);

--- a/modules/webrtc/webrtc_multiplayer_peer.h
+++ b/modules/webrtc/webrtc_multiplayer_peer.h
@@ -81,19 +81,19 @@ private:
 	List<TransferMode> channels_modes;
 	List<Dictionary> channels_config;
 
-	void _peer_to_dict(Ref<ConnectedPeer> p_connected_peer, Dictionary &r_dict);
+	void _peer_to_dict(const Ref<ConnectedPeer> &p_connected_peer, Dictionary &r_dict);
 	void _find_next_peer();
 	Ref<ConnectedPeer> _get_next_peer();
-	Error _initialize(int p_self_id, NetworkMode p_mode, Array p_channels_config = Array());
+	Error _initialize(int p_self_id, NetworkMode p_mode, const Array &p_channels_config = Array());
 
 public:
 	WebRTCMultiplayerPeer() {}
 	~WebRTCMultiplayerPeer();
 
-	Error create_server(Array p_channels_config = Array());
-	Error create_client(int p_self_id, Array p_channels_config = Array());
-	Error create_mesh(int p_self_id, Array p_channels_config = Array());
-	Error add_peer(Ref<WebRTCPeerConnection> p_peer, int p_peer_id, int p_unreliable_lifetime = 1);
+	Error create_server(const Array &p_channels_config = Array());
+	Error create_client(int p_self_id, const Array &p_channels_config = Array());
+	Error create_mesh(int p_self_id, const Array &p_channels_config = Array());
+	Error add_peer(const Ref<WebRTCPeerConnection> &p_peer, int p_peer_id, int p_unreliable_lifetime = 1);
 	void remove_peer(int p_peer_id);
 	bool has_peer(int p_peer_id);
 	Dictionary get_peer(int p_peer_id);

--- a/modules/webrtc/webrtc_peer_connection.h
+++ b/modules/webrtc/webrtc_peer_connection.h
@@ -73,12 +73,12 @@ public:
 	virtual GatheringState get_gathering_state() const = 0;
 	virtual SignalingState get_signaling_state() const = 0;
 
-	virtual Error initialize(Dictionary p_config = Dictionary()) = 0;
-	virtual Ref<WebRTCDataChannel> create_data_channel(String p_label, Dictionary p_options = Dictionary()) = 0;
+	virtual Error initialize(const Dictionary &p_config = Dictionary()) = 0;
+	virtual Ref<WebRTCDataChannel> create_data_channel(const String &p_label, const Dictionary &p_options = Dictionary()) = 0;
 	virtual Error create_offer() = 0;
-	virtual Error set_remote_description(String type, String sdp) = 0;
-	virtual Error set_local_description(String type, String sdp) = 0;
-	virtual Error add_ice_candidate(String sdpMidName, int sdpMlineIndexName, String sdpName) = 0;
+	virtual Error set_remote_description(const String &p_type, const String &p_sdp) = 0;
+	virtual Error set_local_description(const String &p_type, const String &p_sdp) = 0;
+	virtual Error add_ice_candidate(const String &p_sdp_mid_name, int p_sdp_mline_index_name, const String &p_sdp_name) = 0;
 	virtual Error poll() = 0;
 	virtual void close() = 0;
 

--- a/modules/webrtc/webrtc_peer_connection_extension.h
+++ b/modules/webrtc/webrtc_peer_connection_extension.h
@@ -46,12 +46,12 @@ public:
 	EXBIND0RC(ConnectionState, get_connection_state);
 	EXBIND0RC(GatheringState, get_gathering_state);
 	EXBIND0RC(SignalingState, get_signaling_state);
-	EXBIND1R(Error, initialize, Dictionary);
-	EXBIND2R(Ref<WebRTCDataChannel>, create_data_channel, String, Dictionary);
+	EXBIND1R(Error, initialize, const Dictionary &);
+	EXBIND2R(Ref<WebRTCDataChannel>, create_data_channel, const String &, const Dictionary &);
 	EXBIND0R(Error, create_offer);
-	EXBIND2R(Error, set_remote_description, String, String);
-	EXBIND2R(Error, set_local_description, String, String);
-	EXBIND3R(Error, add_ice_candidate, String, int, String);
+	EXBIND2R(Error, set_remote_description, const String &, const String &);
+	EXBIND2R(Error, set_local_description, const String &, const String &);
+	EXBIND3R(Error, add_ice_candidate, const String &, int, const String &);
 	EXBIND0R(Error, poll);
 	EXBIND0(close);
 

--- a/modules/webrtc/webrtc_peer_connection_js.cpp
+++ b/modules/webrtc/webrtc_peer_connection_js.cpp
@@ -83,26 +83,26 @@ Error WebRTCPeerConnectionJS::create_offer() {
 	return OK;
 }
 
-Error WebRTCPeerConnectionJS::set_local_description(String type, String sdp) {
-	godot_js_rtc_pc_local_description_set(_js_id, type.utf8().get_data(), sdp.utf8().get_data(), this, &_on_error);
+Error WebRTCPeerConnectionJS::set_local_description(const String &p_type, const String &p_sdp) {
+	godot_js_rtc_pc_local_description_set(_js_id, p_type.utf8().get_data(), p_sdp.utf8().get_data(), this, &_on_error);
 	return OK;
 }
 
-Error WebRTCPeerConnectionJS::set_remote_description(String type, String sdp) {
-	if (type == "offer") {
+Error WebRTCPeerConnectionJS::set_remote_description(const String &p_type, const String &p_sdp) {
+	if (p_type == "offer") {
 		ERR_FAIL_COND_V(_conn_state != STATE_NEW, FAILED);
 		_conn_state = STATE_CONNECTING;
 	}
-	godot_js_rtc_pc_remote_description_set(_js_id, type.utf8().get_data(), sdp.utf8().get_data(), this, &_on_session_created, &_on_error);
+	godot_js_rtc_pc_remote_description_set(_js_id, p_type.utf8().get_data(), p_sdp.utf8().get_data(), this, &_on_session_created, &_on_error);
 	return OK;
 }
 
-Error WebRTCPeerConnectionJS::add_ice_candidate(String sdpMidName, int sdpMlineIndexName, String sdpName) {
-	godot_js_rtc_pc_ice_candidate_add(_js_id, sdpMidName.utf8().get_data(), sdpMlineIndexName, sdpName.utf8().get_data());
+Error WebRTCPeerConnectionJS::add_ice_candidate(const String &p_sdp_mid_name, int p_sdp_mline_index_name, const String &p_sdp_name) {
+	godot_js_rtc_pc_ice_candidate_add(_js_id, p_sdp_mid_name.utf8().get_data(), p_sdp_mline_index_name, p_sdp_name.utf8().get_data());
 	return OK;
 }
 
-Error WebRTCPeerConnectionJS::initialize(Dictionary p_config) {
+Error WebRTCPeerConnectionJS::initialize(const Dictionary &p_config) {
 	if (_js_id) {
 		godot_js_rtc_pc_destroy(_js_id);
 		_js_id = 0;
@@ -114,7 +114,7 @@ Error WebRTCPeerConnectionJS::initialize(Dictionary p_config) {
 	return _js_id ? OK : FAILED;
 }
 
-Ref<WebRTCDataChannel> WebRTCPeerConnectionJS::create_data_channel(String p_channel, Dictionary p_channel_config) {
+Ref<WebRTCDataChannel> WebRTCPeerConnectionJS::create_data_channel(const String &p_channel, const Dictionary &p_channel_config) {
 	ERR_FAIL_COND_V(_conn_state != STATE_NEW, nullptr);
 
 	String config = Variant(p_channel_config).to_json_string();

--- a/modules/webrtc/webrtc_peer_connection_js.h
+++ b/modules/webrtc/webrtc_peer_connection_js.h
@@ -74,12 +74,12 @@ public:
 	virtual GatheringState get_gathering_state() const override;
 	virtual SignalingState get_signaling_state() const override;
 
-	virtual Error initialize(Dictionary configuration = Dictionary()) override;
-	virtual Ref<WebRTCDataChannel> create_data_channel(String p_channel_name, Dictionary p_channel_config = Dictionary()) override;
+	virtual Error initialize(const Dictionary &p_config = Dictionary()) override;
+	virtual Ref<WebRTCDataChannel> create_data_channel(const String &p_channel_name, const Dictionary &p_channel_config = Dictionary()) override;
 	virtual Error create_offer() override;
-	virtual Error set_remote_description(String type, String sdp) override;
-	virtual Error set_local_description(String type, String sdp) override;
-	virtual Error add_ice_candidate(String sdpMidName, int sdpMlineIndexName, String sdpName) override;
+	virtual Error set_remote_description(const String &p_type, const String &p_sdp) override;
+	virtual Error set_local_description(const String &p_type, const String &p_sdp) override;
+	virtual Error add_ice_candidate(const String &p_sdp_mid_name, int p_sdp_mline_index_name, const String &p_sdp_name) override;
 	virtual Error poll() override;
 	virtual void close() override;
 

--- a/modules/websocket/editor/editor_debugger_server_websocket.h
+++ b/modules/websocket/editor/editor_debugger_server_websocket.h
@@ -47,7 +47,7 @@ private:
 public:
 	static EditorDebuggerServer *create(const String &p_protocol);
 
-	void _peer_connected(int p_peer, String p_protocol);
+	void _peer_connected(int p_peer, const String &p_protocol);
 	void _peer_disconnected(int p_peer, bool p_was_clean);
 
 	virtual void poll() override;

--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -60,7 +60,7 @@ void EMWSPeer::_esws_on_close(void *p_obj, int p_code, const char *p_reason, int
 	peer->ready_state = STATE_CLOSED;
 }
 
-Error EMWSPeer::connect_to_url(const String &p_url, Ref<TLSOptions> p_tls_options) {
+Error EMWSPeer::connect_to_url(const String &p_url, const Ref<TLSOptions> &p_tls_options) {
 	ERR_FAIL_COND_V(p_url.is_empty(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_tls_options.is_valid() && p_tls_options->is_server(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(ready_state != STATE_CLOSED && ready_state != STATE_CLOSING, ERR_ALREADY_IN_USE);
@@ -112,7 +112,7 @@ Error EMWSPeer::connect_to_url(const String &p_url, Ref<TLSOptions> p_tls_option
 	return OK;
 }
 
-Error EMWSPeer::accept_stream(Ref<StreamPeer> p_stream) {
+Error EMWSPeer::accept_stream(const Ref<StreamPeer> &p_stream) {
 	WARN_PRINT_ONCE("Acting as WebSocket server is not supported in Web platforms.");
 	return ERR_UNAVAILABLE;
 }
@@ -179,7 +179,7 @@ void EMWSPeer::_clear() {
 	packet_buffer.clear();
 }
 
-void EMWSPeer::close(int p_code, String p_reason) {
+void EMWSPeer::close(int p_code, const String &p_reason) {
 	if (p_code < 0) {
 		if (peer_sock != -1) {
 			godot_js_websocket_destroy(peer_sock);

--- a/modules/websocket/emws_peer.h
+++ b/modules/websocket/emws_peer.h
@@ -86,9 +86,9 @@ public:
 
 	// WebSocketPeer
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) override;
-	virtual Error connect_to_url(const String &p_url, Ref<TLSOptions> p_tls_client_options) override;
-	virtual Error accept_stream(Ref<StreamPeer> p_stream) override;
-	virtual void close(int p_code = 1000, String p_reason = "") override;
+	virtual Error connect_to_url(const String &p_url, const Ref<TLSOptions> &p_tls_client_options) override;
+	virtual Error accept_stream(const Ref<StreamPeer> &p_stream) override;
+	virtual void close(int p_code = 1000, const String &p_reason = "") override;
 	virtual void poll() override;
 
 	virtual State get_ready_state() const override;

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -74,7 +74,7 @@ void RemoteDebuggerPeerWebSocket::poll() {
 	}
 
 	while (ws_peer->get_ready_state() == WebSocketPeer::STATE_OPEN && out_queue.size() > 0) {
-		Array var = out_queue.front()->get();
+		const Array var = out_queue.front()->get();
 		Error err = ws_peer->put_var(var);
 		ERR_BREAK(err != OK); // Peer buffer full?
 		out_queue.pop_front();
@@ -92,7 +92,7 @@ bool RemoteDebuggerPeerWebSocket::has_message() {
 
 Array RemoteDebuggerPeerWebSocket::get_message() {
 	ERR_FAIL_COND_V(in_queue.is_empty(), Array());
-	Array msg = in_queue.front()->get();
+	const Array msg = in_queue.front()->get();
 	in_queue.pop_front();
 	return msg;
 }
@@ -119,7 +119,7 @@ bool RemoteDebuggerPeerWebSocket::can_block() const {
 #endif
 }
 
-RemoteDebuggerPeerWebSocket::RemoteDebuggerPeerWebSocket(Ref<WebSocketPeer> p_peer) {
+RemoteDebuggerPeerWebSocket::RemoteDebuggerPeerWebSocket(const Ref<WebSocketPeer> &p_peer) {
 	max_queued_messages = (int)GLOBAL_GET("network/limits/debugger/max_queued_messages");
 	ws_peer = p_peer;
 	if (ws_peer.is_valid()) {

--- a/modules/websocket/remote_debugger_peer_websocket.h
+++ b/modules/websocket/remote_debugger_peer_websocket.h
@@ -57,5 +57,5 @@ public:
 	void poll() override;
 	bool can_block() const override;
 
-	RemoteDebuggerPeerWebSocket(Ref<WebSocketPeer> p_peer = Ref<WebSocketPeer>());
+	RemoteDebuggerPeerWebSocket(const Ref<WebSocketPeer> &p_peer = Ref<WebSocketPeer>());
 };

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -178,7 +178,7 @@ int WebSocketMultiplayerPeer::get_max_packet_size() const {
 	return get_outbound_buffer_size() - PROTO_SIZE;
 }
 
-Error WebSocketMultiplayerPeer::create_server(int p_port, IPAddress p_bind_ip, Ref<TLSOptions> p_options) {
+Error WebSocketMultiplayerPeer::create_server(int p_port, IPAddress p_bind_ip, const Ref<TLSOptions> &p_options) {
 	ERR_FAIL_COND_V(get_connection_status() != CONNECTION_DISCONNECTED, ERR_ALREADY_IN_USE);
 	ERR_FAIL_COND_V(p_options.is_valid() && !p_options->is_server(), ERR_INVALID_PARAMETER);
 	_clear();
@@ -194,7 +194,7 @@ Error WebSocketMultiplayerPeer::create_server(int p_port, IPAddress p_bind_ip, R
 	return OK;
 }
 
-Error WebSocketMultiplayerPeer::create_client(const String &p_url, Ref<TLSOptions> p_options) {
+Error WebSocketMultiplayerPeer::create_client(const String &p_url, const Ref<TLSOptions> &p_options) {
 	ERR_FAIL_COND_V(get_connection_status() != CONNECTION_DISCONNECTED, ERR_ALREADY_IN_USE);
 	ERR_FAIL_COND_V(p_options.is_valid() && p_options->is_server(), ERR_INVALID_PARAMETER);
 	_clear();

--- a/modules/websocket/websocket_multiplayer_peer.h
+++ b/modules/websocket/websocket_multiplayer_peer.h
@@ -111,8 +111,8 @@ public:
 	/* WebSocketPeer */
 	virtual Ref<WebSocketPeer> get_peer(int p_peer_id) const;
 
-	Error create_client(const String &p_url, Ref<TLSOptions> p_options);
-	Error create_server(int p_port, IPAddress p_bind_ip, Ref<TLSOptions> p_options);
+	Error create_client(const String &p_url, const Ref<TLSOptions> &p_options);
+	Error create_server(int p_port, IPAddress p_bind_ip, const Ref<TLSOptions> &p_options);
 
 	void set_supported_protocols(const Vector<String> &p_protocols);
 	Vector<String> get_supported_protocols() const;

--- a/modules/websocket/websocket_peer.h
+++ b/modules/websocket/websocket_peer.h
@@ -80,11 +80,11 @@ public:
 		return _create(p_notify_postinitialize);
 	}
 
-	virtual Error connect_to_url(const String &p_url, Ref<TLSOptions> p_options = Ref<TLSOptions>()) = 0;
-	virtual Error accept_stream(Ref<StreamPeer> p_stream) = 0;
+	virtual Error connect_to_url(const String &p_url, const Ref<TLSOptions> &p_options = Ref<TLSOptions>()) = 0;
+	virtual Error accept_stream(const Ref<StreamPeer> &p_stream) = 0;
 
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) = 0;
-	virtual void close(int p_code = 1000, String p_reason = "") = 0;
+	virtual void close(int p_code = 1000, const String &p_reason = "") = 0;
 
 	virtual IPAddress get_connected_host() const = 0;
 	virtual uint16_t get_connected_port() const = 0;

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -80,7 +80,7 @@ void WSLPeer::Resolver::stop() {
 	port = 0;
 }
 
-void WSLPeer::Resolver::try_next_candidate(Ref<StreamPeerTCP> &p_tcp) {
+void WSLPeer::Resolver::try_next_candidate(const Ref<StreamPeerTCP> &p_tcp) {
 	// Check if we still need resolving.
 	if (resolver_id != IP::RESOLVER_INVALID_ID) {
 		IP::ResolverStatus ip_status = IP::get_singleton()->get_resolve_item_status(resolver_id);
@@ -124,7 +124,7 @@ void WSLPeer::Resolver::try_next_candidate(Ref<StreamPeerTCP> &p_tcp) {
 ///
 /// Server functions
 ///
-Error WSLPeer::accept_stream(Ref<StreamPeer> p_stream) {
+Error WSLPeer::accept_stream(const Ref<StreamPeer> &p_stream) {
 	ERR_FAIL_COND_V(p_stream.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(ready_state != STATE_CLOSED && ready_state != STATE_CLOSING, ERR_ALREADY_IN_USE);
 
@@ -474,7 +474,7 @@ bool WSLPeer::_verify_server_response() {
 	return true;
 }
 
-Error WSLPeer::connect_to_url(const String &p_url, Ref<TLSOptions> p_options) {
+Error WSLPeer::connect_to_url(const String &p_url, const Ref<TLSOptions> &p_options) {
 	ERR_FAIL_COND_V(p_url.is_empty(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_options.is_valid() && p_options->is_server(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(ready_state != STATE_CLOSED && ready_state != STATE_CLOSING, ERR_ALREADY_IN_USE);
@@ -688,7 +688,7 @@ String WSLPeer::_generate_key() {
 	return CryptoCore::b64_encode_str(bkey.ptrw(), len);
 }
 
-String WSLPeer::_compute_key_response(String p_key) {
+String WSLPeer::_compute_key_response(const String &p_key) {
 	String key = p_key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"; // Magic UUID as per RFC
 	Vector<uint8_t> sha = key.sha1_buffer();
 	return CryptoCore::b64_encode_str(sha.ptr(), sha.size());
@@ -840,7 +840,7 @@ int WSLPeer::get_current_outbound_buffered_amount() const {
 	return wslay_event_get_queued_msg_length(wsl_ctx);
 }
 
-void WSLPeer::close(int p_code, String p_reason) {
+void WSLPeer::close(int p_code, const String &p_reason) {
 	if (p_code < 0) {
 		// Force immediate close.
 		ready_state = STATE_CLOSED;

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -59,7 +59,7 @@ private:
 	static wslay_event_callbacks _wsl_callbacks;
 
 	// Helpers
-	static String _compute_key_response(String p_key);
+	static String _compute_key_response(const String &p_key);
 	static String _generate_key();
 
 	// Client IP resolver.
@@ -73,7 +73,7 @@ private:
 			return ip_candidates.size() > 0 || resolver_id != IP::RESOLVER_INVALID_ID;
 		}
 
-		void try_next_candidate(Ref<StreamPeerTCP> &p_tcp);
+		void try_next_candidate(const Ref<StreamPeerTCP> &p_tcp);
 		void start(const String &p_host, int p_port);
 		void stop();
 		Resolver() {}
@@ -143,9 +143,9 @@ public:
 
 	// WebSocketPeer
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) override;
-	virtual Error connect_to_url(const String &p_url, Ref<TLSOptions> p_options = Ref<TLSOptions>()) override;
-	virtual Error accept_stream(Ref<StreamPeer> p_stream) override;
-	virtual void close(int p_code = 1000, String p_reason = "") override;
+	virtual Error connect_to_url(const String &p_url, const Ref<TLSOptions> &p_options = Ref<TLSOptions>()) override;
+	virtual Error accept_stream(const Ref<StreamPeer> &p_stream) override;
+	virtual void close(int p_code = 1000, const String &p_reason = "") override;
 	virtual void poll() override;
 
 	virtual State get_ready_state() const override { return ready_state; }

--- a/modules/webxr/webxr_interface.h
+++ b/modules/webxr/webxr_interface.h
@@ -57,13 +57,13 @@ public:
 	};
 
 	virtual void is_session_supported(const String &p_session_mode) = 0;
-	virtual void set_session_mode(String p_session_mode) = 0;
+	virtual void set_session_mode(const String &p_session_mode) = 0;
 	virtual String get_session_mode() const = 0;
-	virtual void set_required_features(String p_required_features) = 0;
+	virtual void set_required_features(const String &p_required_features) = 0;
 	virtual String get_required_features() const = 0;
-	virtual void set_optional_features(String p_optional_features) = 0;
+	virtual void set_optional_features(const String &p_optional_features) = 0;
 	virtual String get_optional_features() const = 0;
-	virtual void set_requested_reference_space_types(String p_requested_reference_space_types) = 0;
+	virtual void set_requested_reference_space_types(const String &p_requested_reference_space_types) = 0;
 	virtual String get_requested_reference_space_types() const = 0;
 	virtual String get_reference_space_type() const = 0;
 	virtual String get_enabled_features() const = 0;

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -121,7 +121,7 @@ void WebXRInterfaceJS::is_session_supported(const String &p_session_mode) {
 	godot_webxr_is_session_supported(p_session_mode.utf8().get_data(), &_emwebxr_on_session_supported);
 }
 
-void WebXRInterfaceJS::set_session_mode(String p_session_mode) {
+void WebXRInterfaceJS::set_session_mode(const String &p_session_mode) {
 	session_mode = p_session_mode;
 }
 
@@ -129,7 +129,7 @@ String WebXRInterfaceJS::get_session_mode() const {
 	return session_mode;
 }
 
-void WebXRInterfaceJS::set_required_features(String p_required_features) {
+void WebXRInterfaceJS::set_required_features(const String &p_required_features) {
 	required_features = p_required_features;
 }
 
@@ -137,7 +137,7 @@ String WebXRInterfaceJS::get_required_features() const {
 	return required_features;
 }
 
-void WebXRInterfaceJS::set_optional_features(String p_optional_features) {
+void WebXRInterfaceJS::set_optional_features(const String &p_optional_features) {
 	optional_features = p_optional_features;
 }
 
@@ -145,7 +145,7 @@ String WebXRInterfaceJS::get_optional_features() const {
 	return optional_features;
 }
 
-void WebXRInterfaceJS::set_requested_reference_space_types(String p_requested_reference_space_types) {
+void WebXRInterfaceJS::set_requested_reference_space_types(const String &p_requested_reference_space_types) {
 	requested_reference_space_types = p_requested_reference_space_types;
 }
 
@@ -251,7 +251,7 @@ bool WebXRInterfaceJS::set_environment_blend_mode(EnvironmentBlendMode p_new_env
 	return false;
 }
 
-void WebXRInterfaceJS::_set_environment_blend_mode(String p_blend_mode_string) {
+void WebXRInterfaceJS::_set_environment_blend_mode(const String &p_blend_mode_string) {
 	if (p_blend_mode_string == "opaque") {
 		environment_blend_mode = XRInterface::XR_ENV_BLEND_MODE_OPAQUE;
 	} else if (p_blend_mode_string == "additive") {

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -94,13 +94,13 @@ private:
 
 public:
 	virtual void is_session_supported(const String &p_session_mode) override;
-	virtual void set_session_mode(String p_session_mode) override;
+	virtual void set_session_mode(const String &p_session_mode) override;
 	virtual String get_session_mode() const override;
-	virtual void set_required_features(String p_required_features) override;
+	virtual void set_required_features(const String &p_required_features) override;
 	virtual String get_required_features() const override;
-	virtual void set_optional_features(String p_optional_features) override;
+	virtual void set_optional_features(const String &p_optional_features) override;
 	virtual String get_optional_features() const override;
-	virtual void set_requested_reference_space_types(String p_requested_reference_space_types) override;
+	virtual void set_requested_reference_space_types(const String &p_requested_reference_space_types) override;
 	virtual String get_requested_reference_space_types() const override;
 	virtual String get_reference_space_type() const override;
 	virtual String get_enabled_features() const override;
@@ -142,9 +142,9 @@ public:
 	void _on_input_event(int p_event_type, int p_input_source_id);
 
 	// Internal setters used by callbacks from Emscripten.
-	inline void _set_reference_space_type(String p_reference_space_type) { reference_space_type = p_reference_space_type; }
-	inline void _set_enabled_features(String p_enabled_features) { enabled_features = p_enabled_features; }
-	void _set_environment_blend_mode(String p_blend_mode_string);
+	inline void _set_reference_space_type(const String &p_reference_space_type) { reference_space_type = p_reference_space_type; }
+	inline void _set_enabled_features(const String &p_enabled_features) { enabled_features = p_enabled_features; }
+	void _set_environment_blend_mode(const String &p_blend_mode_string);
 
 	WebXRInterfaceJS();
 	~WebXRInterfaceJS();


### PR DESCRIPTION
This PR changes parameters in the WebRTC, WebSocket, and WebXR modules to const refs: `const Type &`. This change prevents making unnecessary copies of parameters when calling functions, including when the bindings call the functions.

Motivation: I tried changing the copy constructors of container types like Array to explicit, but this creates a problem for non-const-ref parameters of container types in the bindings. Right now, the bindings are implicitly making copies of this data, and the bindings do not compile anymore if this is changed to explicit. See the discussions in PR #107377 and PR #110912 for more information.

Only doing this for container types would be sufficient for that purpose, but that would be a massive change throughout the entire codebase. I think it would be better for reviewability if I open multiple PRs targeting specific parts of the codebase, so for example, this PR can be reviewed by the maintainers of the web platform. And, while I'm at it, I also made this change for types such as `String` and `Ref<>` to fix up those too.

This PR also contains a small number of other changes to parameters, such as using snake_case names consistently.