### PR TITLE
Fix editor run bar not stopping when game view crashes

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -308,6 +308,7 @@ void EditorDebuggerNode::stop(bool p_force) {
 
 		server.unref();
 	}
+	EditorRunBar::get_singleton()->stop_playing();
 
 	// Also close all debugging sessions.
 	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
@@ -322,6 +323,12 @@ void EditorDebuggerNode::stop(bool p_force) {
 }
 
 void EditorDebuggerNode::_notification(int p_what) {
+	if (broken) {
+		broken = false;
+		stop();
+		return;
+	}
+
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (!EditorThemeManager::is_generated_theme_outdated()) {
@@ -551,6 +558,9 @@ void EditorDebuggerNode::_break_state_changed() {
 	const bool can_debug = get_current_debugger()->is_debuggable();
 	if (breaked) { // Show debugger.
 		EditorNode::get_bottom_panel()->make_item_visible(this);
+		if (!can_debug) {
+			broken = true;
+		}
 	}
 
 	// Update script menu.

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -99,6 +99,7 @@ private:
 	Ref<Script> stack_script; // Why?!?
 
 	bool initializing = true;
+	bool broken = false;
 	int last_error_count = 0;
 	int last_warning_count = 0;
 


### PR DESCRIPTION
When the game view crashes or is closed with the X button the editor run bar still showed the game running. In order to run the game (or scene) again the user needs to press stop before pressing run.

This change now correctly stops the editor run bar upon game view closing or crashing.

*Bugsquad edit:* closes #44738
