### PR TITLE
Fix warning about `await` on abstract function

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -149,6 +149,7 @@ class GDScriptAnalyzer {
 	Ref<GDScriptParserRef> find_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, const Ref<GDScriptParserRef> &p_dependant_parser);
 	Ref<GDScriptParserRef> find_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, GDScriptParser *p_dependant_parser);
 	Ref<GDScript> get_depended_shallow_script(const String &p_path, Error &r_error);
+	bool awaited_is_of_abstract_function(GDScriptParser::AwaitNode *p_await);
 #ifdef DEBUG_ENABLED
 	void is_shadowing(GDScriptParser::IdentifierNode *p_identifier, const String &p_context, const bool p_in_local_scope);
 #endif

--- a/modules/gdscript/tests/scripts/analyzer/warnings/await_method.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/await_method.gd
@@ -1,0 +1,17 @@
+extends RefCounted
+
+@abstract class ClassA extends Node:
+	@abstract func simulate() -> ClassA
+
+	func coroutine() -> void:
+		@warning_ignore("redundant_await")
+		await 0
+
+class ClassAImpl extends ClassA:
+	func simulate() -> ClassA:
+		await coroutine()
+		return self
+
+func test() -> void:
+	var a: ClassA = ClassAImpl.new()
+	await a.simulate()

--- a/modules/gdscript/tests/scripts/analyzer/warnings/await_method.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/await_method.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Following #110961, this PR fixes a bug in which using the `await` keyword on an `@abstract` function will print a warning, even though there is not enough information to conclude this from the `@abstract` class.