### PR TITLE
Fix backward/pingpong root motion in AnimationTree

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -268,7 +268,7 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 		AnimationMixer::PlaybackInfo pi = p_playback_info;
 		pi.start = 0.0;
 		pi.end = cur_len;
-		if (play_mode == PLAY_MODE_FORWARD) {
+		if (node_backward ? cur_backward : !cur_backward) {
 			pi.time = cur_playback_time;
 			pi.delta = cur_delta;
 		} else {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/110813

This issue is regression by https://github.com/godotengine/godot/pull/87171. We need to retrieve not only the NodeAnimation settings but also the actual playback direction after processing. Since root motion is calculated based on the positive or negative delta in NodeTimeInfo, modifying this branch should be the correct fix.