### PR TITLE
Make LineEdit::insert_text_at_caret emit text_changed

### DIFF
--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -68,6 +68,9 @@ int TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::get_id() const {
 }
 
 bool TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::_set(const StringName &p_name, const Variant &p_value) {
+	if (tile_set_atlas_source.is_null()) {
+		return false;
+	}
 	if (p_name == "id") {
 		set_id(p_value);
 		return true;

--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -62,6 +62,9 @@ int TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::get
 }
 
 bool TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::_set(const StringName &p_name, const Variant &p_value) {
+	if (!tile_set_scenes_collection_source) {
+		return false;
+	}
 	String name = p_name;
 	if (name == "name") {
 		// Use the resource_name property to store the source's name.

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -384,11 +384,7 @@ void LineEdit::unhandled_key_input(const Ref<InputEvent> &p_event) {
 		if (has_focus() && editable && (k->get_unicode() >= 32)) {
 			selection_delete();
 			char32_t ucodestr[2] = { (char32_t)k->get_unicode(), 0 };
-			int prev_len = text.length();
 			insert_text_at_caret(ucodestr);
-			if (text.length() != prev_len) {
-				_text_changed();
-			}
 			accept_event();
 		}
 	}
@@ -438,13 +434,6 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 			if (!paste_buffer.is_empty()) {
 				insert_text_at_caret(paste_buffer);
-
-				if (!text_changed_dirty) {
-					if (is_inside_tree()) {
-						callable_mp(this, &LineEdit::_text_changed).call_deferred();
-					}
-					text_changed_dirty = true;
-				}
 			}
 			accept_event();
 			return;
@@ -1009,16 +998,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		// Handle Unicode if no modifiers are active.
 		selection_delete();
 		char32_t ucodestr[2] = { (char32_t)k->get_unicode(), 0 };
-		int prev_len = text.length();
 		insert_text_at_caret(ucodestr);
-		if (text.length() != prev_len) {
-			if (!text_changed_dirty) {
-				if (is_inside_tree()) {
-					callable_mp(this, &LineEdit::_text_changed).call_deferred();
-				}
-				text_changed_dirty = true;
-			}
-		}
 		accept_event();
 		return;
 	}
@@ -1706,18 +1686,10 @@ void LineEdit::paste_text() {
 	String paste_buffer = DisplayServer::get_singleton()->clipboard_get().strip_escapes();
 
 	if (!paste_buffer.is_empty()) {
-		int prev_len = text.length();
 		if (selection.enabled) {
 			selection_delete();
 		}
 		insert_text_at_caret(paste_buffer);
-
-		if (!text_changed_dirty) {
-			if (is_inside_tree() && text.length() != prev_len) {
-				callable_mp(this, &LineEdit::_text_changed).call_deferred();
-			}
-			text_changed_dirty = true;
-		}
 	}
 }
 
@@ -2359,6 +2331,13 @@ void LineEdit::insert_text_at_caret(String p_text) {
 
 	if (!ime_text.is_empty()) {
 		_shape();
+	}
+
+	if (p_text.length() > 0) {
+		if (!text_changed_dirty && is_inside_tree()) {
+			text_changed_dirty = true;
+			callable_mp(this, &LineEdit::_text_changed).call_deferred();
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes #84377 and #110809 

`LineEdit:insert_text_at_caret` now emits `text_changed` if the text was changed. This is the same behavior as `TextEdit`. 

I also added null checks to `TileSetAtlasSourceProxyObject::_set` and `TileSetCollectionProxyObject::_set` similar to their respective `_get` methods. Without these, when the editor boots up, it attempts to call `set` on a null pointer. This only happens when I call `_text_changed` deferred. I don't know exactly why this happens, and I do not know if this fix breaks anything tilemap related, but everything seems to work as expected.