### PR TITLE
Fix snap Polygon2D editor

### DIFF
--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -794,7 +794,7 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 				} break;
 				case ACTION_EDIT_POINT: {
 					Vector<Vector2> uv_new = editing_points;
-					uv_new.set(point_drag_index, uv_new[point_drag_index] + drag);
+					uv_new.set(point_drag_index, mtx.affine_inverse().xform(snap_point(mm->get_position())));
 
 					if (current_mode == MODE_UV) {
 						node->set_uv(uv_new);


### PR DESCRIPTION
* *fixes: https://github.com/godotengine/godot/issues/110966*

**Issue Description**

When we drag a vertex of a Polygon from polygon editor.

- Pressed mouse left key, record mouse position as `drag_from`
- Drag to somewhere and release mouse, get mouse position as `drag_to`, depending on `grid snap` configuration, we will calculate with `snap_point()` to let mouse position snap to the grid
- The problem is we used `drag_to - drag_from` as distance to update points of polygon, that caused very hard to drag  a vertex to snap the grid correctly. It should use snapped mouse position directly.

e.g.

- vertex position (1, 1)
- grid (10, 10)
- original mouse position (5, 5), we pressed mouse on (5,5)
- target mouse position (10, 10), we released mouse on (10, 10). Maybe real position is (9,9) or (11,11), it will be snapped to (10, 10) as grid configuration.
- The the distance is (10, 10) - (5, 5) = (5,5)
- Finally, vertex will move to (1, 1) + (5,5) = (6,6), which is not snapped on grid.
- We should let vertext move to (10, 10) directly.
