### PR TITLE
X11: Fix minimization of maximized windows

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1915,9 +1915,22 @@ void DisplayServerX11::show_window(WindowID p_id) {
 
 	DEBUG_LOG_X11("show_window: %lu (%u) \n", wd.x11_window, p_id);
 
+	// Setup initial minimize/maximize state.
+	// `_NET_WM_STATE` can be set directly when the window is unmapped.
+	LocalVector<Atom> hints;
+	if (wd.maximized) {
+		hints.push_back(XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_VERT", False));
+		hints.push_back(XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_HORZ", False));
+	}
+	if (wd.minimized) {
+		hints.push_back(XInternAtom(x11_display, "_NET_WM_STATE_HIDDEN", False));
+	}
+	XChangeProperty(x11_display, wd.x11_window, XInternAtom(x11_display, "_NET_WM_STATE", False), XA_ATOM, 32, PropModeReplace, (unsigned char *)hints.ptr(), hints.size());
+
 	XMapWindow(x11_display, wd.x11_window);
 	XSync(x11_display, False);
-	_validate_mode_on_map(p_id);
+
+	_validate_fullscreen_on_map(p_id);
 
 	if (p_id == MAIN_WINDOW_ID) {
 		// Get main window size for boot splash drawing.
@@ -2446,6 +2459,52 @@ void DisplayServerX11::_update_actions_hints(WindowID p_window) {
 	}
 }
 
+void DisplayServerX11::_update_wm_state_hints(WindowID p_window) {
+	WindowData &wd = windows[p_window];
+
+	Atom type;
+	int format;
+	unsigned long len;
+	unsigned long remaining;
+	unsigned char *data = nullptr;
+
+	int result = XGetWindowProperty(
+			x11_display,
+			wd.x11_window,
+			XInternAtom(x11_display, "_NET_WM_STATE", False),
+			0,
+			1024,
+			False,
+			XA_ATOM,
+			&type,
+			&format,
+			&len,
+			&remaining,
+			&data);
+	if (result != Success) {
+		return;
+	}
+
+	LocalVector<Atom> hints;
+	if (data) {
+		hints.resize(len);
+		Atom *atoms = (Atom *)data;
+		for (unsigned long i = 0; i < len; i++) {
+			hints[i] = atoms[i];
+		}
+		XFree(data);
+	}
+
+	Atom fullscreen_atom = XInternAtom(x11_display, "_NET_WM_STATE_FULLSCREEN", False);
+	Atom maximized_horz_atom = XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_HORZ", False);
+	Atom maximized_vert_atom = XInternAtom(x11_display, "_NET_WM_STATE_MAXIMIZED_VERT", False);
+	Atom hidden_atom = XInternAtom(x11_display, "_NET_WM_STATE_HIDDEN", False);
+
+	wd.fullscreen = hints.has(fullscreen_atom);
+	wd.maximized = hints.has(maximized_horz_atom) && hints.has(maximized_vert_atom);
+	wd.minimized = hints.has(hidden_atom);
+}
+
 Point2i DisplayServerX11::window_get_position(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
@@ -2853,15 +2912,11 @@ bool DisplayServerX11::_window_fullscreen_check(WindowID p_window) const {
 	return retval;
 }
 
-void DisplayServerX11::_validate_mode_on_map(WindowID p_window) {
+void DisplayServerX11::_validate_fullscreen_on_map(WindowID p_window) {
 	// Check if we applied any window modes that didn't take effect while unmapped
 	const WindowData &wd = windows[p_window];
 	if (wd.fullscreen && !_window_fullscreen_check(p_window)) {
 		_set_wm_fullscreen(p_window, true, wd.exclusive_fullscreen);
-	} else if (wd.maximized && !_window_maximize_check(p_window, "_NET_WM_STATE")) {
-		_set_wm_maximized(p_window, true);
-	} else if (wd.minimized && !_window_minimize_check(p_window)) {
-		_set_wm_minimized(p_window, true);
 	}
 
 	if (wd.on_top) {
@@ -3060,13 +3115,15 @@ void DisplayServerX11::window_set_mode(WindowMode p_mode, WindowID p_window) {
 
 		} break;
 		case WINDOW_MODE_MAXIMIZED: {
-			_set_wm_maximized(p_window, false);
+			// Varies between target modes, so do nothing here.
 		} break;
 	}
 
 	switch (p_mode) {
 		case WINDOW_MODE_WINDOWED: {
-			//do nothing
+			if (wd.maximized) {
+				_set_wm_maximized(p_window, false);
+			}
 		} break;
 		case WINDOW_MODE_MINIMIZED: {
 			_set_wm_minimized(p_window, true);
@@ -3100,27 +3157,20 @@ DisplayServer::WindowMode DisplayServerX11::window_get_mode(WindowID p_window) c
 	ERR_FAIL_COND_V(!windows.has(p_window), WINDOW_MODE_WINDOWED);
 	const WindowData &wd = windows[p_window];
 
-	if (wd.fullscreen) { //if fullscreen, it's not in another mode
-		if (wd.exclusive_fullscreen) {
-			return WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
-		} else {
-			return WINDOW_MODE_FULLSCREEN;
-		}
+	if (_window_minimize_check(p_window)) {
+		return WINDOW_MODE_MINIMIZED;
 	}
 
-	// Test maximized.
-	// Using EWMH -- Extended Window Manager Hints
+	if (wd.fullscreen) {
+		if (wd.exclusive_fullscreen) {
+			return WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+		}
+		return WINDOW_MODE_FULLSCREEN;
+	}
+
 	if (_window_maximize_check(p_window, "_NET_WM_STATE")) {
 		return WINDOW_MODE_MAXIMIZED;
 	}
-
-	{
-		if (_window_minimize_check(p_window)) {
-			return WINDOW_MODE_MINIMIZED;
-		}
-	}
-
-	// All other discarded, return windowed.
 
 	return WINDOW_MODE_WINDOWED;
 }
@@ -4400,11 +4450,6 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 		return;
 	}
 
-	// Query display server about a possible new window state.
-	wd.fullscreen = _window_fullscreen_check(window_id);
-	wd.maximized = _window_maximize_check(window_id, "_NET_WM_STATE") && !wd.fullscreen;
-	wd.minimized = _window_minimize_check(window_id) && !wd.fullscreen && !wd.maximized;
-
 	// Readjusting the window position if the window is being reparented by the window manager for decoration
 	Window root, parent, *children;
 	unsigned int nchildren;
@@ -5035,7 +5080,7 @@ void DisplayServerX11::process_events() {
 				}
 
 				// Have we failed to set fullscreen while the window was unmapped?
-				_validate_mode_on_map(window_id);
+				_validate_fullscreen_on_map(window_id);
 
 				// On KDE Plasma, when the parent window of an embedded process is restored after being minimized,
 				// only the embedded window receives the Map notification, causing it to
@@ -5054,24 +5099,6 @@ void DisplayServerX11::process_events() {
 				windows[window_id].fullscreen = _window_fullscreen_check(window_id);
 
 				Main::force_redraw();
-			} break;
-
-			case NoExpose: {
-				DEBUG_LOG_X11("[%u] NoExpose drawable=%lu (%u) \n", frame, event.xnoexpose.drawable, window_id);
-				if (ime_window_event) {
-					break;
-				}
-
-				windows[window_id].minimized = true;
-			} break;
-
-			case VisibilityNotify: {
-				DEBUG_LOG_X11("[%u] VisibilityNotify window=%lu (%u), state=%u \n", frame, event.xvisibility.window, window_id, event.xvisibility.state);
-				if (ime_window_event) {
-					break;
-				}
-
-				windows[window_id].minimized = _window_minimize_check(window_id);
 			} break;
 
 			case LeaveNotify: {
@@ -5215,6 +5242,12 @@ void DisplayServerX11::process_events() {
 				}
 
 				_window_changed(&event);
+			} break;
+
+			case PropertyNotify: {
+				if (event.xproperty.atom == XInternAtom(x11_display, "_NET_WM_STATE", False)) {
+					_update_wm_state_hints(window_id);
+				}
 			} break;
 
 			case ButtonPress:

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -352,9 +352,10 @@ class DisplayServerX11 : public DisplayServer {
 	bool _window_maximize_check(WindowID p_window, const char *p_atom_name) const;
 	bool _window_fullscreen_check(WindowID p_window) const;
 	bool _window_minimize_check(WindowID p_window) const;
-	void _validate_mode_on_map(WindowID p_window);
+	void _validate_fullscreen_on_map(WindowID p_window);
 	void _update_size_hints(WindowID p_window);
 	void _update_actions_hints(WindowID p_window);
+	void _update_wm_state_hints(WindowID p_window);
 	void _set_wm_fullscreen(WindowID p_window, bool p_enabled, bool p_exclusive);
 	void _set_wm_maximized(WindowID p_window, bool p_enabled);
 	void _set_wm_minimized(WindowID p_window, bool p_enabled);


### PR DESCRIPTION
Currently, when a maximized window is minimized by...

- Clicking the minimize button on the title bar or the window button on task bar:
    `get_window().mode` still returns `WINDOW_MODE_MAXIMIZED`.
- Changing the window mode via code:
    Unminimizing the window by clicking the window button on task bar does not work for the first time, i.e., you have to click the button twice to see the window.

The first case is simple: "minimized" currently has less priority than other modes. Maximized and minimized are independent states for window managers and are not mutually exclusive. So reordering the checks solves the problem.

https://github.com/godotengine/godot/blob/b4472f4670a0b7fd34137d18f1e080e3319e3819/platform/linuxbsd/x11/display_server_x11.cpp#L3101-L3121

The second case is more or less messed up I think. I reverted some of the modifications in:

- #76868
    This one confuses window states stored in `WindowData` (minimized, maximized, fullscreen, etc.) with window modes. The former models states in window managers, while the latter is a Godot concept. It's a wrong fix for the issue it trys to solve, the problem still exists in another form.
- #65107
    This one is trying to fix the problem of initial window state not being honoured. But it's done by changing window states in `MapNotify`, i.e., whenever the window appears on the screen. This includes when the window is unminimized. This is the root cause of the problem.

The minimize / maximize states should use `_NET_WM_STATE`:

- Initial values are set using `XChangeProperty` before `XMapWindow`.
- Updates are received in `PropertyNotify`. We don't need to remember the window's state before minimization ourselves. After the user manually cancels minimization, the window manager will update the `_NET_WM_STATE` to the correct state, be it maximized or fullscreen.

I also removed the minimization state update logic in [`NoExpose`](https://tronche.com/gui/x/xlib/events/exposure/graphics-expose-and-no-expose.html) and [`VisibilityNotify`](https://tronche.com/gui/x/xlib/events/window-state-change/visibility.html). These two events are not related to window states at all. The former can only be received during `XCopyArea` or `XCopyPlane` calls which Godot does not use. The latter is about the window being obscured by other windows instead of the "visibility" in Godot term.

p.s. The fullscreen state may also have similar problems that have accumulated over the years. I took a quick look and it seems to be more complex, with mixed old and new code. Let's fix the problems one step at a time.