### PR TITLE
Make `InputEvent` subclasses' `to_string()` respect overrides from scripts and GDExtension

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -278,6 +278,10 @@ String InputEventWithModifiers::as_text() const {
 }
 
 String InputEventWithModifiers::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	return as_text();
 }
 
@@ -489,6 +493,10 @@ String InputEventKey::as_text() const {
 }
 
 String InputEventKey::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	String p = is_pressed() ? "true" : "false";
 	String e = is_echo() ? "true" : "false";
 
@@ -849,6 +857,10 @@ String InputEventMouseButton::as_text() const {
 }
 
 String InputEventMouseButton::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	String p = is_pressed() ? "true" : "false";
 	String canceled_state = is_canceled() ? "true" : "false";
 	String d = double_click ? "true" : "false";
@@ -989,6 +1001,10 @@ String InputEventMouseMotion::as_text() const {
 }
 
 String InputEventMouseMotion::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	BitField<MouseButtonMask> mouse_button_mask = get_button_mask();
 	String button_mask_string = itos((int64_t)mouse_button_mask);
 
@@ -1185,6 +1201,10 @@ String InputEventJoypadMotion::as_text() const {
 }
 
 String InputEventJoypadMotion::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	return vformat("InputEventJoypadMotion: axis=%d, axis_value=%.2f", axis, axis_value);
 }
 
@@ -1303,6 +1323,10 @@ String InputEventJoypadButton::as_text() const {
 }
 
 String InputEventJoypadButton::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	String p = is_pressed() ? "true" : "false";
 	return vformat("InputEventJoypadButton: button_index=%d, pressed=%s, pressure=%.2f", button_index, p, pressure);
 }
@@ -1385,6 +1409,10 @@ String InputEventScreenTouch::as_text() const {
 }
 
 String InputEventScreenTouch::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	String p = pressed ? "true" : "false";
 	String canceled_state = canceled ? "true" : "false";
 	String double_tap_string = double_tap ? "true" : "false";
@@ -1513,6 +1541,10 @@ String InputEventScreenDrag::as_text() const {
 }
 
 String InputEventScreenDrag::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	return vformat("InputEventScreenDrag: index=%d, position=(%s), relative=(%s), velocity=(%s), pressure=%.2f, tilt=(%s), pen_inverted=(%s)", index, String(get_position()), String(get_relative()), String(get_velocity()), get_pressure(), String(get_tilt()), get_pen_inverted());
 }
 
@@ -1655,6 +1687,10 @@ String InputEventAction::as_text() const {
 }
 
 String InputEventAction::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	String p = is_pressed() ? "true" : "false";
 	return vformat("InputEventAction: action=\"%s\", pressed=%s", action, p);
 }
@@ -1726,6 +1762,10 @@ String InputEventMagnifyGesture::as_text() const {
 }
 
 String InputEventMagnifyGesture::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	return vformat("InputEventMagnifyGesture: factor=%.2f, position=(%s)", factor, String(get_position()));
 }
 
@@ -1768,6 +1808,10 @@ String InputEventPanGesture::as_text() const {
 }
 
 String InputEventPanGesture::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	return vformat("InputEventPanGesture: delta=(%s), position=(%s)", String(get_delta()), String(get_position()));
 }
 
@@ -1850,6 +1894,9 @@ String InputEventMIDI::as_text() const {
 
 String InputEventMIDI::to_string() {
 	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	switch (message) {
 		case MIDIMessage::NOTE_ON:
 			ret = vformat("Note On: channel=%d, pitch=%d, velocity=%d", channel, pitch, velocity);
@@ -1925,6 +1972,10 @@ String InputEventShortcut::as_text() const {
 }
 
 String InputEventShortcut::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
+	}
 	ERR_FAIL_COND_V(shortcut.is_null(), "None");
 
 	return vformat("InputEventShortcut: shortcut=%s", shortcut->get_as_text());

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -965,13 +965,13 @@ void Object::_notification_backward(int p_notification) {
 	_notification_backwardv(p_notification);
 }
 
-String Object::to_string() {
-	// Keep this method in sync with `Node::to_string`.
+bool Object::_try_get_override_to_string(String &r_result) const {
 	if (script_instance) {
 		bool valid;
 		String ret = script_instance->to_string(&valid);
 		if (valid) {
-			return ret;
+			r_result = ret;
+			return true;
 		}
 	}
 	if (_extension && _extension->to_string) {
@@ -979,8 +979,17 @@ String Object::to_string() {
 		GDExtensionBool is_valid;
 		_extension->to_string(_extension_instance, &is_valid, &ret);
 		if (is_valid) {
-			return ret;
+			r_result = ret;
+			return true;
 		}
+	}
+	return false;
+}
+
+String Object::to_string() {
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
 	}
 	return "<" + get_class() + "#" + itos(get_instance_id()) + ">";
 }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -797,6 +797,8 @@ protected:
 
 	virtual bool _uses_signal_mutex() const;
 
+	bool _try_get_override_to_string(String &r_result) const;
+
 #ifdef TOOLS_ENABLED
 	struct VirtualMethodTracker {
 		void **method;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2738,22 +2738,10 @@ void Node::get_storable_properties(HashSet<StringName> &r_storable_properties) c
 }
 
 String Node::to_string() {
-	// Keep this method in sync with `Object::to_string`.
 	ERR_THREAD_GUARD_V(String());
-	if (get_script_instance()) {
-		bool valid;
-		String ret = get_script_instance()->to_string(&valid);
-		if (valid) {
-			return ret;
-		}
-	}
-	if (_get_extension() && _get_extension()->to_string) {
-		String ret;
-		GDExtensionBool is_valid;
-		_get_extension()->to_string(_get_extension_instance(), &is_valid, &ret);
-		if (is_valid) {
-			return ret;
-		}
+	String ret;
+	if (_try_get_override_to_string(ret)) {
+		return ret;
 	}
 	return (get_name() ? String(get_name()) + ":" : "") + Object::to_string();
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/110338

I've also taken this opportunity to add a new method `Object::_try_get_override_to_string()` so the same implementation can be used by `Node::to_string()`, `Object::to_string()`.

For consistency within the same file, other `InputAction` subclasses also have the issue mentioned above fixed.