### PR TITLE
Fix warning about `await` on abstract function

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3102,7 +3102,15 @@ void GDScriptAnalyzer::reduce_await(GDScriptParser::AwaitNode *p_await) {
 #ifdef DEBUG_ENABLED
 	GDScriptParser::DataType to_await_type = p_await->to_await->get_datatype();
 	if (!to_await_type.is_coroutine && !to_await_type.is_variant() && to_await_type.builtin_type != Variant::SIGNAL) {
-		parser->push_warning(p_await, GDScriptWarning::REDUNDANT_AWAIT);
+		if (p_await->to_await->type != GDScriptParser::Node::CALL) {
+			parser->push_warning(p_await, GDScriptWarning::REDUNDANT_AWAIT);
+		} else {
+			GDScriptParser::CallNode *call = static_cast<GDScriptParser::CallNode *>(p_await->to_await);
+
+			if (!call->is_abstract) {
+				parser->push_warning(p_await, GDScriptWarning::REDUNDANT_AWAIT);
+			}
+		}
 	}
 #endif // DEBUG_ENABLED
 }
@@ -3652,6 +3660,8 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			} else if (method_flags.has_flag(METHOD_FLAG_VIRTUAL_REQUIRED)) {
 				push_error(vformat(R"*(Cannot call the parent class' abstract function "%s()" because it hasn't been defined.)*", p_call->function_name), p_call);
 			}
+		} else {
+			p_call->is_abstract = method_flags.has_flag(METHOD_FLAG_VIRTUAL_REQUIRED);
 		}
 
 		// If the function requires typed arrays we must make literals be typed.

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -511,6 +511,7 @@ public:
 		StringName function_name;
 		bool is_super = false;
 		bool is_static = false;
+		bool is_abstract = false;
 
 		CallNode() {
 			type = CALL;

--- a/modules/gdscript/tests/scripts/analyzer/warnings/abc.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/abc.notest.gd
@@ -1,0 +1,10 @@
+@abstract class_name ABC extends RefCounted
+
+@abstract func simulate() -> void
+
+func coroutine() -> void:
+	@warning_ignore("redundant_await")
+	await 0
+
+func other_method() -> void:
+	await simulate()

--- a/modules/gdscript/tests/scripts/analyzer/warnings/abc_child.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/abc_child.notest.gd
@@ -1,0 +1,3 @@
+@abstract class_name ABCChild extends ABC
+
+# Deliberately empty.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/await_abstract_method.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/await_abstract_method.gd
@@ -1,0 +1,39 @@
+extends RefCounted
+
+@abstract class ABCLocal:
+	@abstract func simulate() -> void
+
+	func coroutine() -> void:
+		@warning_ignore("redundant_await")
+		await 0
+
+	func other_method() -> void:
+		await simulate()
+
+class ImplLocal extends ABCLocal:
+	func simulate() -> void:
+		await coroutine()
+
+class Impl extends ABC:
+	func simulate() -> void:
+		await coroutine()
+
+class ImplChild extends ABCChild:
+	func simulate() -> void:
+		await coroutine()
+
+func test() -> void:
+	# Local file.
+	var l: ABCLocal = ImplLocal.new()
+	await l.simulate()
+	await l.other_method()
+
+	# Direct child.
+	var a: ABC = Impl.new()
+	await a.simulate()
+	await a.other_method()
+
+	# Indirect child.
+	var b: ABCChild = ImplChild.new()
+	await b.simulate()
+	await b.other_method()

--- a/modules/gdscript/tests/scripts/analyzer/warnings/await_abstract_method.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/await_abstract_method.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Following #110961, this PR fixes a bug in which using the `await` keyword on a call of an `@abstract` function will print a warning, even though there is not enough information to conclude this from the `@abstract` class.

This PR surfaces whether a call is of a method annotated with `@abstract`, then never fires the error if this is the case.

Please note that:

1. This is a copy of a previous PR (#110981), that was prematurely closed due to my reading of a mis-communication (cc @dalexeev)
2. I have listed @xuhuisheng as co-author, since they collaborated on the issue