### PR TITLE
Fix: move initialization of `KeyMappingMacOS` to `DisplayServerMacOSBase`

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3721,8 +3721,6 @@ bool DisplayServerMacOS::mouse_process_popups(bool p_close) {
 }
 
 DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
-	KeyMappingMacOS::initialize();
-
 	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
 
 	r_error = OK;

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -302,6 +302,8 @@ void DisplayServerMacOSBase::show_emoji_and_symbol_picker() const {
 }
 
 DisplayServerMacOSBase::DisplayServerMacOSBase() {
+	KeyMappingMacOS::initialize();
+
 	// Init TTS
 	bool tts_enabled = GLOBAL_GET("audio/general/text_to_speech");
 	if (tts_enabled) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes #110751.

After 350b1936eefeed583a7befe4e92e9adac9bd9764, several methods - including `keyboard_get_keycode_from_physical()` - were moved from `DisplayServerMacOSBase` to `DisplayServerMacOS`. However! The `KeyMappingMacOS::initialize()` call was not moved as well, meaning it is now inaccessible to the base class, where the methods newly reside.

[MRP](https://github.com/user-attachments/files/22582895/issue-110751.zip) - which now prints anything except `0` on any keypress when run.