### PR TITLE
Move file filter when filesystem dock is in the bottom panel

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -489,7 +489,11 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 				button_toggle_display_mode->set_button_icon(get_editor_theme_icon(SNAME("Panels1")));
 				tree->show();
 				tree->set_v_size_flags(SIZE_EXPAND_FILL);
-				toolbar2_hbc->show();
+				if (horizontal) {
+					toolbar2_hbc->hide();
+				} else {
+					toolbar2_hbc->show();
+				}
 
 				_update_tree(get_uncollapsed_paths());
 				file_list_vb->hide();
@@ -4019,12 +4023,14 @@ MenuButton *FileSystemDock::_create_file_menu_button() {
 }
 
 void FileSystemDock::update_layout(EditorDock::DockLayout p_layout) {
-	bool horizontal = p_layout == EditorDock::DOCK_LAYOUT_HORIZONTAL;
+	horizontal = p_layout == EditorDock::DOCK_LAYOUT_HORIZONTAL;
 	if (button_dock_placement->is_visible() == horizontal) {
 		return;
 	}
 
 	if (horizontal) {
+		path_hb->reparent(toolbar_hbc, false);
+		toolbar_hbc->move_child(path_hb, 2);
 		set_meta("_dock_display_mode", get_display_mode());
 		set_meta("_dock_file_display_mode", get_file_list_display_mode());
 
@@ -4035,6 +4041,8 @@ void FileSystemDock::update_layout(EditorDock::DockLayout p_layout) {
 		set_file_list_display_mode(new_file_display_mode);
 		set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	} else {
+		path_hb->reparent(file_list_vb);
+		file_list_vb->move_child(path_hb, 0);
 		set_meta("_bottom_display_mode", get_display_mode());
 		set_meta("_bottom_file_display_mode", get_file_list_display_mode());
 
@@ -4180,7 +4188,7 @@ FileSystemDock::FileSystemDock() {
 	VBoxContainer *top_vbc = memnew(VBoxContainer);
 	main_vb->add_child(top_vbc);
 
-	HBoxContainer *toolbar_hbc = memnew(HBoxContainer);
+	toolbar_hbc = memnew(HBoxContainer);
 	top_vbc->add_child(toolbar_hbc);
 
 	HBoxContainer *nav_hbc = memnew(HBoxContainer);
@@ -4276,6 +4284,7 @@ FileSystemDock::FileSystemDock() {
 	split_box->add_child(file_list_vb);
 
 	path_hb = memnew(HBoxContainer);
+	path_hb->set_h_size_flags(SIZE_EXPAND_FILL);
 	file_list_vb->add_child(path_hb);
 
 	file_list_search_box = memnew(LineEdit);

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -165,6 +165,7 @@ private:
 	Button *button_hist_prev = nullptr;
 	LineEdit *current_path_line_edit = nullptr;
 
+	HBoxContainer *toolbar_hbc = nullptr;
 	HBoxContainer *toolbar2_hbc = nullptr;
 	LineEdit *tree_search_box = nullptr;
 	MenuButton *tree_button_sort = nullptr;
@@ -181,6 +182,8 @@ private:
 	FileListDisplayMode file_list_display_mode;
 	DisplayMode display_mode;
 	DisplayMode old_display_mode;
+
+	bool horizontal = false;
 
 	PopupMenu *file_list_popup = nullptr;
 	PopupMenu *tree_popup = nullptr;


### PR DESCRIPTION
There is extra room next to the current folder LineEdit when the filesystem dock is docked in the bottom panel.

This change moves the file filter LineEdit to be horizontal with the current folder more effectively uses the vertical space of the bottom panel.

Closes https://github.com/godotengine/godot-proposals/issues/12579

Before changes:
<img width="2583" height="498" alt="image" src="https://github.com/user-attachments/assets/a2b5f9ca-acfb-41c5-8d16-759c62b600f1" />

After changes:
<img width="2888" height="525" alt="image" src="https://github.com/user-attachments/assets/80a1e286-0dce-4880-ae84-9e58a1f0fa7e" />

Docking on the side is unchanged:
<img width="268" height="664" alt="image" src="https://github.com/user-attachments/assets/69676d58-922b-4dfb-8cfb-aa4ace823d00" />

