### PR TITLE
Improve Move/Duplicate dialog

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2550,7 +2550,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			}
 			if (to_move.size() > 0) {
 				move_dialog->config(p_selected);
-				move_dialog->popup_centered_ratio(0.5);
+				move_dialog->popup_centered(Vector2i(260 * EDSCALE, DisplayServer::get_singleton()->screen_get_size().y * 0.6));
 			}
 		} break;
 

--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -99,6 +99,7 @@ void EditorDirDialog::config(const Vector<String> &p_paths) {
 		// TRANSLATORS: %d is the number of files that will be moved or duplicated.
 		set_title(vformat(TTRN("Move/Duplicate %d Item", "Move/Duplicate %d Items", p_paths.size()), p_paths.size()));
 	}
+	base_directory_path = p_paths[0].get_base_dir();
 }
 
 void EditorDirDialog::reload(const String &p_path) {
@@ -129,8 +130,39 @@ void EditorDirDialog::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (must_reload && is_visible()) {
-				reload();
+			if (is_visible()) {
+				if (must_reload) {
+					reload();
+				}
+
+				tree->deselect_all();
+				const PackedStringArray parts = base_directory_path.trim_prefix("res://").split("/");
+				if (parts.is_empty()) {
+					break;
+				}
+
+				int i = 0;
+				TreeItem *item = tree->get_root();
+				while (i < parts.size()) {
+					const String &folder = parts[i];
+					for (TreeItem *child = item->get_first_child(); child; child = child->get_next()) {
+						if (child->get_text(0) == folder) {
+							i++;
+							if (i == parts.size()) {
+								TreeItem *parent_item = child->get_parent();
+								while (parent_item) {
+									parent_item->set_collapsed(false);
+									parent_item = parent_item->get_parent();
+								}
+								child->select(0);
+								tree->ensure_cursor_is_visible();
+							} else {
+								item = child;
+							}
+							break;
+						}
+					}
+				}
 			}
 		} break;
 	}
@@ -178,7 +210,7 @@ void EditorDirDialog::_make_dir() {
 	TreeItem *ti = tree->get_selected();
 	ERR_FAIL_NULL(ti);
 	const String &directory = ti->get_metadata(0);
-	makedialog->config(directory, callable_mp(this, &EditorDirDialog::_make_dir_confirm).bind(directory), DirectoryCreateDialog::MODE_DIRECTORY, "new folder");
+	makedialog->config(directory, callable_mp(this, &EditorDirDialog::_make_dir_confirm).bind(directory), DirectoryCreateDialog::MODE_DIRECTORY, TTR("Create Folder"), "new folder");
 	makedialog->popup_centered();
 }
 

--- a/editor/gui/editor_dir_dialog.h
+++ b/editor/gui/editor_dir_dialog.h
@@ -46,6 +46,7 @@ class EditorDirDialog : public ConfirmationDialog {
 	Button *copy = nullptr;
 	HashSet<String> opened_paths;
 	String new_dir_path;
+	String base_directory_path;
 
 	Tree *tree = nullptr;
 	bool updating = false;


### PR DESCRIPTION
Small improvements to the Move/Duplicate dialog from FileSystem dock.
- Fix Create Directory dialog's title
- When moving a file, automatically navigate to its parent directory
  - This makes it easy to quickly find the source location. The directory you want to move to is usually close

https://github.com/user-attachments/assets/ff4a564e-1b1a-4e3d-9f43-f5b0037eabd1

EDIT:
Also made the dialog less wide:
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/3e0ab43b-d7fb-4dc2-9b79-d872e9330df3" />
