### PR TITLE
Delete "Activate now?" button

### DIFF
--- a/editor/plugins/plugin_config_dialog.cpp
+++ b/editor/plugins/plugin_config_dialog.cpp
@@ -98,7 +98,6 @@ void PluginConfigDialog::_create_script_for_plugin(const String &p_plugin_path, 
 		scr->set_path(script_path, true);
 		ResourceSaver::save(scr);
 		p_config_file->save(p_plugin_path.path_join("plugin.cfg"));
-		emit_signal(SNAME("plugin_ready"), scr.ptr(), active_edit->is_pressed() ? _to_absolute_plugin_path(_get_subfolder()) : "");
 	}
 }
 
@@ -131,15 +130,6 @@ void PluginConfigDialog::_on_required_text_changed() {
 	String ext = language->get_extension();
 	if ((!script_edit->get_text().get_extension().is_empty() && script_edit->get_text().get_extension() != ext) || script_edit->get_text().ends_with(".")) {
 		validation_panel->set_message(MSG_ID_SCRIPT, vformat(TTR("Script extension must match chosen language extension (.%s)."), ext), EditorValidationPanel::MSG_ERROR);
-	}
-	if (active_edit->is_visible()) {
-		if (language->get_name() == "C#") {
-			active_edit->set_pressed(false);
-			active_edit->set_disabled(true);
-			validation_panel->set_message(MSG_ID_ACTIVE, TTR("C# doesn't support activating the plugin on creation because the project must be built first."), EditorValidationPanel::MSG_WARNING);
-		} else {
-			active_edit->set_disabled(false);
-		}
 	}
 }
 
@@ -316,19 +306,6 @@ PluginConfigDialog::PluginConfigDialog() {
 	script_edit->set_accessibility_name(TTRC("Script Name:"));
 	script_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(script_edit);
-
-	// Activate now checkbox
-	Label *active_label = memnew(Label);
-	active_label->set_text(TTR("Activate now?"));
-	active_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
-	grid->add_child(active_label);
-	plugin_edit_hidden_controls.push_back(active_label);
-
-	active_edit = memnew(CheckBox);
-	active_edit->set_pressed(true);
-	active_edit->set_accessibility_name(TTRC("Activate now?"));
-	grid->add_child(active_edit);
-	plugin_edit_hidden_controls.push_back(active_edit);
 
 	Control *spacing = memnew(Control);
 	vbox->add_child(spacing);

--- a/editor/plugins/plugin_config_dialog.h
+++ b/editor/plugins/plugin_config_dialog.h
@@ -56,7 +56,6 @@ class PluginConfigDialog : public ConfirmationDialog {
 	LineEdit *version_edit = nullptr;
 	OptionButton *script_option_edit = nullptr;
 	LineEdit *script_edit = nullptr;
-	CheckBox *active_edit = nullptr;
 
 	LocalVector<Control *> plugin_edit_hidden_controls;
 


### PR DESCRIPTION
Give one reason why it should stay.
|Before|After|
|-|-|
|<img width="523" height="584" alt="image" src="https://github.com/user-attachments/assets/86378986-d21c-41fa-bdc5-e1cc38d2a6a1" />|<img width="521" height="552" alt="image" src="https://github.com/user-attachments/assets/253467db-d8b4-4e66-9beb-e737c1e64e95" />|

Typical plugin creation workflow: you open the Plugins tab, select Create New Plugin, type name and optionally other stuff, confirm. The addon is created, you edit the script and do something like
```GDScript
extends EditorPlugin
var dock: Control
func _enter_tree():
	dock = load("dock_scene.tscn")
	add_dock(dock)

func _exit_tree():
	remove_dock(dock)
```
Then go to Plugins tab again, disable your newly created addon and then enable again so the dock is added.
But now you have an error in your Output: `Error: p_dock is null, in remove_dock()`. That's because your plugin was activated while it had no code and tried to deinitialize when you disabled it. However `dock` only exists when you enable the plugin _and_ it actually creates the dock.

There is zero reason to activate the plugin immediately. `add_control_to_dock()`, `add_export_plugin()`, `add_context_menu_plugin()` etc. all typically run in `_enter_tree()`, but when your script is just created, this code does not exist yet, so to register your new docks/plugins you have to run `_enter_tree()` again, which means disabling and enabling the script. If you have to disable it to do anything then why even enable it beforehand? It would be maybe fine if it was harmless, but if you deactivate a plugin that wasn't initialized, you end up with useless errors.