### PR TITLE
Scons option to enable CVTT and Betsy compression in export templates

### DIFF
--- a/modules/betsy/config.py
+++ b/modules/betsy/config.py
@@ -1,5 +1,17 @@
 def can_build(env, platform):
-    return env.editor_build
+    return env.editor_build or env["betsy_export_templates"]
+
+
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable(
+            "betsy_export_templates",
+            "Enable Betsy image compression in export template builds (increases binary size)",
+            False,
+        ),
+    ]
 
 
 def configure(env):

--- a/modules/cvtt/config.py
+++ b/modules/cvtt/config.py
@@ -1,5 +1,17 @@
 def can_build(env, platform):
-    return env.editor_build
+    return env.editor_build or env["cvtt_export_templates"]
+
+
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable(
+            "cvtt_export_templates",
+            "Enable CVTT image compression in export template builds (increases binary size)",
+            False,
+        ),
+    ]
 
 
 def configure(env):

--- a/modules/cvtt/register_types.cpp
+++ b/modules/cvtt/register_types.cpp
@@ -30,8 +30,6 @@
 
 #include "register_types.h"
 
-#ifdef TOOLS_ENABLED
-
 #include "image_compress_cvtt.h"
 
 void initialize_cvtt_module(ModuleInitializationLevel p_level) {
@@ -47,5 +45,3 @@ void uninitialize_cvtt_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 }
-
-#endif // TOOLS_ENABLED

--- a/modules/cvtt/register_types.h
+++ b/modules/cvtt/register_types.h
@@ -30,11 +30,7 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "modules/register_module_types.h"
 
 void initialize_cvtt_module(ModuleInitializationLevel p_level);
 void uninitialize_cvtt_module(ModuleInitializationLevel p_level);
-
-#endif // TOOLS_ENABLED


### PR DESCRIPTION
Adresses https://github.com/godotengine/godot-proposals/issues/13297

This PR adds a `cvtt_export_templates=yes` and `betsy_export_templates=yes` scons options that allows to use some (probably not all) texture compression in export templates

Sorry if I didn't do something correctly

<details>
<summary>File sizes for comparison</summary>

`scons platform=windows target=template_release`
<img width="344" height="208" alt="default" src="https://github.com/user-attachments/assets/fcc8a614-d76d-4792-99f4-e6b33461fd4b" />

`scons platform=windows target=template_release cvtt_export_templates=yes`
<img width="331" height="189" alt="cvtt" src="https://github.com/user-attachments/assets/6fdebea4-56ea-465b-bba4-0fc02120233b" />

`scons platform=windows target=template_release betsy_export_templates=yes`
<img width="336" height="201" alt="betsy" src="https://github.com/user-attachments/assets/740fce7e-7750-4fcb-93db-c8f04cbf3762" />

`scons platform=windows target=template_release cvtt_export_templates=yes betsy_export_templates=yes`
<img width="335" height="204" alt="both" src="https://github.com/user-attachments/assets/541453ba-736c-45cf-8e15-b51679f7b9e4" />
</details>

This pull request makes the MRP in https://github.com/godotengine/godot/issues/110992 work for me