### PR TITLE
Editor: Add splitter to "Create New Node" dialog

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -4533,6 +4533,7 @@ EditorHelpBit::EditorHelpBit(const String &p_symbol, const String &p_prologue, b
 	content = memnew(RichTextLabel);
 	content->set_theme_type_variation("EditorHelpBitContent");
 	content->set_custom_minimum_size(Size2(640 * EDSCALE, content_min_height));
+	content->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	content->set_selection_enabled(p_allow_selection);
 	content->set_context_menu_enabled(p_allow_selection);
 	content->set_selection_modifier(callable_mp_static(_replace_nbsp_with_space));

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -863,6 +863,9 @@ CreateDialog::CreateDialog() {
 	VSplitContainer *vsc = memnew(VSplitContainer);
 	hsc->add_child(vsc);
 
+	VSplitContainer *vsc_right = memnew(VSplitContainer);
+	hsc->add_child(vsc_right);
+
 	VBoxContainer *fav_vb = memnew(VBoxContainer);
 	fav_vb->set_custom_minimum_size(Size2(150, 100) * EDSCALE);
 	fav_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -899,7 +902,8 @@ CreateDialog::CreateDialog() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	vbc->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
 	vbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	hsc->add_child(vbc);
+	vbc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	vsc_right->add_child(vbc);
 
 	search_box = memnew(LineEdit);
 	search_box->set_accessibility_name(TTRC("Search"));
@@ -928,9 +932,15 @@ CreateDialog::CreateDialog() {
 
 	help_bit = memnew(EditorHelpBit);
 	help_bit->set_accessibility_name(TTRC("Description:"));
+	help_bit->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	help_bit->set_content_height_limits(80 * EDSCALE, 80 * EDSCALE);
 	help_bit->connect("request_hide", callable_mp(this, &CreateDialog::_hide_requested));
-	vbc->add_margin_child(TTR("Description:"), help_bit);
+
+	VBoxContainer *vbc_desc = memnew(VBoxContainer);
+	vbc_desc->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
+	vbc_desc->add_margin_child(TTR("Description:"), help_bit, true);
+
+	vsc_right->add_child(vbc_desc);
 
 	register_text_enter(search_box);
 	set_hide_on_ok(false);


### PR DESCRIPTION
Adds a new splitter to the Create New Node dialog between the Matches and Description panes. The description text is often crowded which hinders node discoverability.

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/12517 Supersedes #106956