### PR TITLE
Add Experimental Support for RISC-V for Android

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -67,6 +67,9 @@ elif env["arch"] == "x86_32":
 elif env["arch"] == "x86_64":
     lib_arch_dir = "x86_64"
     triple_target_dir = "x86_64-linux-android"
+elif env["arch"] == "rv64":
+    lib_arch_dir = "riscv64"
+    triple_target_dir = "riscv64-linux-android"
 else:
     print_warning("Architecture not suitable for embedding into APK; keeping .so at \\bin")
 

--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -27,6 +27,9 @@
 		<member name="architectures/armeabi-v7a" type="bool" setter="" getter="">
 			If [code]true[/code], [code]arm32[/code] binaries are included into exported project.
 		</member>
+		<member name="architectures/riscv64" type="bool" setter="" getter="">
+			If [code]true[/code], [code]rv64[/code] binaries are included into exported project.
+		</member>
 		<member name="architectures/x86" type="bool" setter="" getter="">
 			If [code]true[/code], [code]x86_32[/code] binaries are included into exported project.
 		</member>

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -672,6 +672,7 @@ Vector<EditorExportPlatformAndroid::ABI> EditorExportPlatformAndroid::get_abis()
 	abis.push_back(ABI("arm64-v8a", "arm64"));
 	abis.push_back(ABI("x86", "x86_32"));
 	abis.push_back(ABI("x86_64", "x86_64"));
+	abis.push_back(ABI("riscv64", "rv64"));
 	return abis;
 }
 

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -147,6 +147,7 @@ android {
         pickFirst 'lib/x86_64/libc++_shared.so'
         pickFirst 'lib/armeabi-v7a/libc++_shared.so'
         pickFirst 'lib/arm64-v8a/libc++_shared.so'
+        pickFirst 'lib/riscv64/libc++_shared.so'
     }
 
     signingConfigs {

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -13,7 +13,7 @@ ext.versions = [
     nexusPublishVersion: '1.3.0',
     javaVersion        : JavaVersion.VERSION_17,
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
-    ndkVersion         : '28.1.13356709',
+    ndkVersion         : '29.0.14033849',
     splashscreenVersion: '1.0.1',
     openxrVendorsVersion: '4.1.1-stable'
 
@@ -186,7 +186,7 @@ final String VALUE_SEPARATOR_REGEX = "\\|"
 ext.getExportEnabledABIs = { ->
     String enabledABIs = project.hasProperty("export_enabled_abis") ? project.property("export_enabled_abis") : ""
     if (enabledABIs == null || enabledABIs.isEmpty()) {
-        enabledABIs = "armeabi-v7a|arm64-v8a|x86|x86_64|"
+        enabledABIs = "armeabi-v7a|arm64-v8a|x86|x86_64|riscv64|"
     }
     Set<String> exportAbiFilter = []
     for (String abi_name : enabledABIs.split(VALUE_SEPARATOR_REGEX)) {

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -23,7 +23,7 @@ allprojects {
 }
 
 ext {
-    supportedAbis = ["arm32", "arm64", "x86_32", "x86_64"]
+    supportedAbis = ["arm32", "arm64", "x86_32", "x86_64", "rv64"]
     supportedFlavors = ["editor", "template"]
     supportedAndroidDistributions = ["android", "horizonos", "picoos"]
     supportedFlavorsBuildTypes = [


### PR DESCRIPTION
Closes [godot-proposals/#13300](https://github.com/godotengine/godot-proposals/issues/13300)

Edit: see [this comment](https://github.com/godotengine/godot/pull/111034#issuecomment-3349048433).

So far I haven't done testing beyond building. But for those that can test, you can download the binaries [here](https://drive.google.com/drive/folders/1EqSKvUvi3179OatuPtoJj8-p6t-2ZTB1?usp=sharing).

It is complete with `editor` and `templates`, both with `riscv-only` and `fat` binaries + debug symbols for each.
