### PR TITLE
Fix syntax highlighting for enum keys in enum declaration

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -63,6 +63,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 	bool is_bin_notation = false;
 	bool in_member_variable = false;
 	bool in_lambda = false;
+	static bool in_enum = false;
 
 	bool in_function_name = false; // Any call.
 	bool in_function_declaration = false; // Only declaration.
@@ -423,7 +424,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 						col = global_function_color;
 					}
 				}
-			} else if (class_names.has(word)) {
+			} else if (class_names.has(word) && !in_enum) {
 				col = class_names[word];
 			} else if (reserved_keywords.has(word)) {
 				col = reserved_keywords[word];
@@ -449,6 +450,10 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 				if (!in_member_variable && col != Color()) {
 					in_keyword = true;
 					keyword_color = col;
+
+					if (word == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::ENUM)) {
+						in_enum = true;
+					}
 				}
 			}
 		}
@@ -522,6 +527,9 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 						break;
 					case '}':
 						in_declaration_param_dicts -= 1;
+						if (in_enum && in_declaration_param_dicts == 0) {
+							in_enum = false;
+						}
 						break;
 				}
 			} else if ((is_after_func_signal_declaration || prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC)) && str[j] == '(') {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/87825.

Not happy with the current implementation because it uses a stateful variable in an otherwise mostly stateless function(at least in the part we are changing), seems very hacky. It does work though.

I couldn't really figure out a way to get more context about if we are inside an enum or not without checking other lines. If anyone has any suggestions feel free.