### PR TITLE
Apply luminance multiplier when not drawing sky in Compatibility

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2601,6 +2601,10 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 					GLES3::MaterialStorage::get_singleton()->material_set_param(sky_globals.fog_material, "clear_color", Variant(clear_color));
 				}
 
+				clear_color.r *= render_data.luminance_multiplier;
+				clear_color.g *= render_data.luminance_multiplier;
+				clear_color.b *= render_data.luminance_multiplier;
+
 				clear_color = clear_color.srgb_to_linear();
 				clear_color.r *= bg_energy_multiplier;
 				clear_color.g *= bg_energy_multiplier;


### PR DESCRIPTION
When the background mode is set to clear color or color and fog is disabled, similar to the background energy multiplier the luminance multiplier also needs to be pre-multiplied into the background colour because the sky will not be drawn.

Fixes https://github.com/godotengine/godot/issues/106702