### PR TITLE
CI: Add `changed-files` GitHub Action

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,6 +1,11 @@
 name: 🐧 Linux Builds
 on:
   workflow_call:
+    inputs:
+      changed-files:
+        description: A list of changed files.
+        required: true
+        type: string
   workflow_dispatch:
 
 # Global Settings
@@ -115,21 +120,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-          fetch-depth: 2 # 2 needed for Get changed files; no trivial way to conditionally use 1
-
-      # Keep in sync with static_checks.yml
-      - name: Get changed files
-        if: matrix.clang-tidy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r HEAD^1..HEAD 2> /dev/null || true)
-          elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.forced }}" == "false" -a "${{ github.event.created }}" == "false" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null || true)
-          fi
-          files=$(echo "$files" | xargs -I {} sh -c 'echo "\"./{}\""' | tr '\n' ' ')
-          echo "CHANGED_FILES=$files" >> $GITHUB_ENV
 
       - name: Setup dependencies
         run: |
@@ -201,7 +191,7 @@ jobs:
         if: matrix.clang-tidy
         uses: pre-commit/action@v3.0.1
         with:
-          extra_args: --files ${{ env.CHANGED_FILES }} --hook-stage manual clang-tidy
+          extra_args: --files ${{ inputs.changed-files }} --hook-stage manual clang-tidy
 
       - name: Compilation (godot-cpp)
         uses: ./.github/actions/godot-cpp-build

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -29,6 +29,8 @@ jobs:
     name: 🐧 Linux
     needs: static-checks
     uses: ./.github/workflows/linux_builds.yml
+    with:
+      changed-files: ${{ needs.static-checks.outputs.changed-files }}
 
   macos-build:
     name: 🍎 macOS

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,6 +1,10 @@
 name: 📊 Static Checks
 on:
   workflow_call:
+    outputs:
+      changed-files:
+        description: A list of changed files.
+        value: ${{ jobs.static-checks.outputs.changed-files }}
   workflow_dispatch:
 
 jobs:
@@ -8,31 +12,31 @@ jobs:
     name: Code style, file formatting, and docs
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    outputs:
+      changed-files: '"${{ steps.changed-files.outputs.all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0 # Treeless clone. Slightly less performant than a shallow clone, but makes finding diffs instantaneous.
+          filter: tree:0 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
 
       # This needs to happen before Python and npm execution; it must happen before any extra files are written.
       - name: .gitignore checks (gitignore_check.sh)
         run: |
           bash ./misc/scripts/gitignore_check.sh
 
-      # Keep in sync with linux_builds.yml
       - name: Get changed files
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r HEAD^1..HEAD 2> /dev/null || true)
-          elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.forced }}" == "false" -a "${{ github.event.created }}" == "false" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null || true)
-          fi
-          files=$(echo "$files" | xargs -I {} sh -c 'echo "\"./{}\""' | tr '\n' ' ')
-          echo "CHANGED_FILES=$files" >> $GITHUB_ENV
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          safe_output: false # Output passed to environment variable to avoid command injection.
+          separator: '" "' # To account for paths with spaces, ensure our items are split by quotes internally.
+          skip_initial_fetch: true
 
       - name: Style checks via pre-commit
         uses: pre-commit/action@v3.0.1
+        env:
+          CHANGED_FILES: '"${{ steps.changed-files.outputs.all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
         with:
           extra_args: --files ${{ env.CHANGED_FILES }}


### PR DESCRIPTION
Replaces our existing shell solution for determining changed files with a dedicated action: [changed-files](https://github.com/tj-actions/changed-files). While this process takes slightly longer than the shell script, it appears to have a much higher consistency with actually gathering the files. Most notably: this enables static checks on forks!
