### PR TITLE
Add `TextServer.get_short_name()` and use it in `--text-driver`

### DIFF
--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1111,6 +1111,12 @@
 				Returns the name of the server interface.
 			</description>
 		</method>
+		<method name="get_short_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the short name of the server interface. This short name can be used as a value for the [code]--text-driver[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url] (the full name is also supported for compatibility, but it must be quoted if it contains spaces).
+			</description>
+		</method>
 		<method name="get_support_data" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -1090,6 +1090,12 @@
 				Returns the name of the server interface.
 			</description>
 		</method>
+		<method name="_get_short_name" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				Returns the short name of the server interface. By convention, this should return a lowercase string that follows the [code]snake_case[/code] naming scheme.
+			</description>
+		</method>
 		<method name="_get_support_data" qualifiers="virtual const">
 			<return type="PackedByteArray" />
 			<description>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3584,7 +3584,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 		if (!text_driver.is_empty()) {
 			/* Load user selected text server. */
 			for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
-				if (TextServerManager::get_singleton()->get_interface(i)->get_name() == text_driver) {
+				if (TextServerManager::get_singleton()->get_interface(i)->get_short_name() == text_driver || TextServerManager::get_singleton()->get_interface(i)->get_name() == text_driver) {
 					text_driver_idx = i;
 					break;
 				}

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -387,6 +387,10 @@ String TextServerAdvanced::_get_name() const {
 #endif
 }
 
+String TextServerAdvanced::_get_short_name() const {
+	return "advanced";
+}
+
 int64_t TextServerAdvanced::_get_features() const {
 	int64_t interface_features = FEATURE_SIMPLE_LAYOUT | FEATURE_BIDI_LAYOUT | FEATURE_VERTICAL_LAYOUT | FEATURE_SHAPING | FEATURE_KASHIDA_JUSTIFICATION | FEATURE_BREAK_ITERATORS | FEATURE_FONT_BITMAP | FEATURE_FONT_VARIABLE | FEATURE_CONTEXT_SENSITIVE_CASE_CONVERSION | FEATURE_USE_SUPPORT_DATA;
 #ifdef MODULE_FREETYPE_ENABLED

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -817,6 +817,7 @@ protected:
 public:
 	MODBIND1RC(bool, has_feature, Feature);
 	MODBIND0RC(String, get_name);
+	MODBIND0RC(String, get_short_name);
 	MODBIND0RC(int64_t, get_features);
 
 	MODBIND1(free_rid, const RID &);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -111,6 +111,10 @@ String TextServerFallback::_get_name() const {
 #endif
 }
 
+String TextServerFallback::_get_short_name() const {
+	return "fallback";
+}
+
 int64_t TextServerFallback::_get_features() const {
 	int64_t interface_features = FEATURE_SIMPLE_LAYOUT | FEATURE_FONT_BITMAP;
 #ifdef MODULE_FREETYPE_ENABLED

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -606,6 +606,7 @@ protected:
 public:
 	MODBIND1RC(bool, has_feature, Feature);
 	MODBIND0RC(String, get_name);
+	MODBIND0RC(String, get_short_name);
 	MODBIND0RC(int64_t, get_features);
 
 	MODBIND1(free_rid, const RID &);

--- a/servers/text/text_server.cpp
+++ b/servers/text/text_server.cpp
@@ -68,7 +68,7 @@ void TextServerManager::add_interface(const Ref<TextServer> &p_interface) {
 	};
 
 	interfaces.push_back(p_interface);
-	print_verbose("TextServer: Added interface \"" + p_interface->get_name() + "\"");
+	print_verbose("TextServer: Added interface \"" + p_interface->get_name() + "\" (" + p_interface->get_short_name() + ")");
 	emit_signal(SNAME("interface_added"), p_interface->get_name());
 }
 
@@ -85,7 +85,7 @@ void TextServerManager::remove_interface(const Ref<TextServer> &p_interface) {
 	};
 
 	ERR_FAIL_COND_MSG(idx == -1, "Interface not found.");
-	print_verbose("TextServer: Removed interface \"" + p_interface->get_name() + "\"");
+	print_verbose("TextServer: Removed interface \"" + p_interface->get_name() + "\" (" + p_interface->get_short_name() + ")");
 	emit_signal(SNAME("interface_removed"), p_interface->get_name());
 	interfaces.remove_at(idx);
 }
@@ -120,6 +120,7 @@ TypedArray<Dictionary> TextServerManager::get_interfaces() const {
 
 		iface_info["id"] = i;
 		iface_info["name"] = interfaces[i]->get_name();
+		iface_info["short_name"] = interfaces[i]->get_short_name();
 
 		ret.push_back(iface_info);
 	};
@@ -133,7 +134,7 @@ void TextServerManager::set_primary_interface(const Ref<TextServer> &p_primary_i
 		primary_interface.unref();
 	} else {
 		primary_interface = p_primary_interface;
-		print_verbose("TextServer: Primary interface set to: \"" + primary_interface->get_name() + "\".");
+		print_verbose("TextServer: Primary interface set to: \"" + primary_interface->get_name() + "\" (" + primary_interface->get_short_name() + ").");
 
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TEXT_SERVER_CHANGED);
@@ -198,6 +199,7 @@ double TextServer::vp_oversampling = 0.0;
 void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_feature", "feature"), &TextServer::has_feature);
 	ClassDB::bind_method(D_METHOD("get_name"), &TextServer::get_name);
+	ClassDB::bind_method(D_METHOD("get_short_name"), &TextServer::get_short_name);
 	ClassDB::bind_method(D_METHOD("get_features"), &TextServer::get_features);
 	ClassDB::bind_method(D_METHOD("load_support_data", "filename"), &TextServer::load_support_data);
 

--- a/servers/text/text_server.h
+++ b/servers/text/text_server.h
@@ -251,6 +251,7 @@ public:
 
 	virtual bool has_feature(Feature p_feature) const = 0;
 	virtual String get_name() const = 0;
+	virtual String get_short_name() const = 0;
 	virtual int64_t get_features() const = 0;
 
 	virtual void free_rid(const RID &p_rid) = 0;

--- a/servers/text/text_server_dummy.h
+++ b/servers/text/text_server_dummy.h
@@ -41,6 +41,7 @@ class TextServerDummy : public TextServerExtension {
 public:
 	virtual bool has_feature(Feature p_feature) const override { return false; }
 	virtual String get_name() const override { return "Dummy"; }
+	virtual String get_short_name() const override { return "dummy"; }
 	virtual int64_t get_features() const override { return 0; }
 	virtual void free_rid(const RID &p_rid) override {}
 	virtual bool has(const RID &p_rid) override { return false; }

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -33,6 +33,7 @@
 void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_has_feature, "feature");
 	GDVIRTUAL_BIND(_get_name);
+	GDVIRTUAL_BIND(_get_short_name);
 	GDVIRTUAL_BIND(_get_features);
 
 	GDVIRTUAL_BIND(_free_rid, "rid");
@@ -399,6 +400,16 @@ bool TextServerExtension::has_feature(Feature p_feature) const {
 String TextServerExtension::get_name() const {
 	String ret = "Unknown";
 	GDVIRTUAL_CALL(_get_name, ret);
+	return ret;
+}
+
+String TextServerExtension::get_short_name() const {
+	String ret = "unknown";
+	GDVIRTUAL_CALL(_get_short_name, ret);
+	if (ret == "unknown") {
+		// Fall back to a simplified version of the full name if not overridden.
+		ret = get_name().to_lower().replace_char(' ', '_');
+	}
 	return ret;
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -47,9 +47,11 @@ protected:
 public:
 	virtual bool has_feature(Feature p_feature) const override;
 	virtual String get_name() const override;
+	virtual String get_short_name() const override;
 	virtual int64_t get_features() const override;
 	GDVIRTUAL1RC_REQUIRED(bool, _has_feature, Feature);
 	GDVIRTUAL0RC_REQUIRED(String, _get_name);
+	GDVIRTUAL0RC(String, _get_short_name);
 	GDVIRTUAL0RC_REQUIRED(int64_t, _get_features);
 
 	virtual void free_rid(const RID &p_rid) override;


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-proposals/issues/13725.
- See https://github.com/godotengine/godot/pull/111014#pullrequestreview-3281345157.