### PR TITLE
CI: Add pre-commit hook for XML linting

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -35,9 +35,3 @@ jobs:
         uses: pre-commit/action@v3.0.1
         with:
           extra_args: --files ${{ env.CHANGED_FILES }}
-
-      - name: Class reference schema checks
-        run: |
-          sudo apt-get update
-          sudo apt-get install libxml2-utils
-          xmllint --quiet --noout --schema doc/class.xsd doc/classes/*.xml modules/*/doc_classes/*.xml platform/*/doc_classes/*.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,16 +64,6 @@ repos:
         files: ^core/extension/gdextension_interface\.json$
         args: ["--schemafile", "core/extension/gdextension_interface.schema.json"]
 
-  ### Requires Docker; look into alternative implementation.
-  # - repo: https://github.com/comkieffer/pre-commit-xmllint.git
-  #   rev: 1.0.0
-  #   hooks:
-  #     - id: xmllint
-  #       language: docker
-  #       types_or: [text]
-  #       files: ^(doc/classes|.*/doc_classes)/.*\.xml$
-  #       args: [--schema, doc/class.xsd]
-
   - repo: local
     hooks:
       - id: make-rst
@@ -98,6 +88,13 @@ repos:
         entry: python tests/python_build/validate_builders.py
         pass_filenames: false
         files: ^(gles3|glsl)_builders\.py$
+
+      - id: validate-xml
+        name: validate-xml
+        language: python
+        entry: python misc/scripts/validate_xml.py
+        files: ^(doc/classes|.*/doc_classes)/.*\.xml$
+        additional_dependencies: [xmlschema]
 
       - id: eslint
         name: eslint

--- a/misc/scripts/validate_xml.py
+++ b/misc/scripts/validate_xml.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+if __name__ != "__main__":
+    raise SystemExit(f'Utility script "{__file__}" should not be used as a module!')
+
+import argparse
+import sys
+
+import xmlschema  # Third-party module. Automatically installed in associated pre-commit hook.
+
+sys.path.insert(0, "./")
+
+try:
+    from methods import print_error
+except ImportError:
+    raise SystemExit(f"Utility script {__file__} must be run from repository root!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate XML documents against `doc/class.xsd`")
+    parser.add_argument("files", nargs="+", help="A list of XML files to parse")
+    args = parser.parse_args()
+
+    SCHEMA = xmlschema.XMLSchema("doc/class.xsd")
+    ret = 0
+
+    for file in args.files:
+        try:
+            SCHEMA.validate(file)
+        except xmlschema.validators.exceptions.XMLSchemaValidationError as err:
+            print_error(f'Validation failed for "{file}"!\n\n{err}')
+            ret += 1
+
+    return ret
+
+
+try:
+    raise SystemExit(main())
+except KeyboardInterrupt:
+    import os
+    import signal
+
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    os.kill(os.getpid(), signal.SIGINT)


### PR DESCRIPTION
Replaces one of the last remaining legacy hooks with a pre-commit equivalent. This enables XML validation locally, and should speed up the validation process by only parsing whatever XML files were actually changed