### PR TITLE
Sort render list correctly in RD renderers

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -841,7 +841,7 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 
 		RenderElementInfo &element_info = rl->element_info[p_offset + i];
 
-		element_info.value = uint32_t(surface->sort.sort_key1 & 0xFFF);
+		element_info.value = uint32_t(surface->sort.sort_key2 & 0x0FFF00000000);
 
 		if (cant_repeat) {
 			prev_surface = nullptr;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -494,6 +494,10 @@ private:
 				uint64_t sort_key2;
 			};
 			struct {
+				uint64_t geometry_id : 32;
+				uint64_t material_id : 32;
+
+				uint64_t shader_id : 32;
 				uint64_t lod_index : 8;
 				uint64_t uses_softshadow : 1;
 				uint64_t uses_projector : 1;
@@ -502,10 +506,6 @@ private:
 				uint64_t depth_layer : 4;
 				uint64_t surface_index : 8;
 				uint64_t priority : 8;
-				uint64_t geometry_id : 32;
-
-				uint64_t material_id : 32;
-				uint64_t shader_id : 32;
 			};
 		} sort;
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1973,7 +1973,7 @@ void RenderForwardMobile::_fill_instance_data(RenderListType p_render_list, uint
 		RenderElementInfo &element_info = rl->element_info[p_offset + i];
 
 		// Sets lod_index and uses_lightmap at once.
-		element_info.value = uint32_t(surface->sort.sort_key1 & 0x1FF);
+		element_info.value = uint32_t(surface->sort.sort_key2 & 0x01FF00000000);
 	}
 
 	if (p_update_buffer) {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -474,16 +474,16 @@ protected:
 				uint64_t sort_key2;
 			};
 			struct {
+				uint64_t geometry_id : 32;
+				uint64_t material_id : 32;
+
+				uint64_t shader_id : 32;
 				uint64_t lod_index : 8;
 				uint64_t uses_lightmap : 1;
 				uint64_t pad : 3;
 				uint64_t depth_layer : 4;
 				uint64_t surface_index : 8;
 				uint64_t priority : 8;
-				uint64_t geometry_id : 32;
-
-				uint64_t material_id : 32;
-				uint64_t shader_id : 32;
 			};
 		} sort;
 


### PR DESCRIPTION
"priority" needs to be the last bits in its key in order to properly determine the order to sort the render list in.

Closes https://github.com/godotengine/godot/issues/110962
