### PR TITLE
FTI - Fix physics body resets when using `sync_to_physics`

### DIFF
--- a/scene/2d/physics/animatable_body_2d.cpp
+++ b/scene/2d/physics/animatable_body_2d.cpp
@@ -71,6 +71,7 @@ void AnimatableBody2D::_body_state_changed(PhysicsDirectBodyState2D *p_state) {
 	set_notify_local_transform(false);
 	set_global_transform(last_valid_transform);
 	set_notify_local_transform(true);
+	_on_physics_callback();
 }
 
 void AnimatableBody2D::_notification(int p_what) {

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -76,6 +76,10 @@ void CollisionObject2D::_notification(int p_what) {
 			_update_pickable();
 		} break;
 
+		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
+			_fti_physics_reset_requested = true;
+		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (only_update_transform_changes) {
 				return;
@@ -539,6 +543,13 @@ void CollisionObject2D::_mouse_shape_enter(int p_shape) {
 void CollisionObject2D::_mouse_shape_exit(int p_shape) {
 	GDVIRTUAL_CALL(_mouse_shape_exit, p_shape);
 	emit_signal(SceneStringName(mouse_shape_exited), p_shape);
+}
+
+void CollisionObject2D::_on_physics_callback() {
+	if (_fti_physics_reset_requested) {
+		reset_physics_interpolation();
+		_fti_physics_reset_requested = false;
+	}
 }
 
 void CollisionObject2D::set_only_update_transform_changes(bool p_enable) {

--- a/scene/2d/physics/collision_object_2d.h
+++ b/scene/2d/physics/collision_object_2d.h
@@ -81,6 +81,10 @@ private:
 	RBMap<uint32_t, ShapeData> shapes;
 	bool only_update_transform_changes = false; // This is used for sync to physics.
 
+	// Physics bodies using sync to physics defer setting global xform until callbacks from the physics.
+	// In these cases, resets should also be deferred until the callback, because global_xforms will be stale.
+	bool _fti_physics_reset_requested = false;
+
 	void _apply_disabled();
 	void _apply_enabled();
 
@@ -104,6 +108,8 @@ protected:
 
 	void _mouse_shape_enter(int p_shape);
 	void _mouse_shape_exit(int p_shape);
+
+	void _on_physics_callback();
 
 	void set_only_update_transform_changes(bool p_enable);
 	bool is_only_update_transform_changes_enabled() const;

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -256,6 +256,7 @@ void RigidBody2D::_body_state_changed(PhysicsDirectBodyState2D *p_state) {
 	}
 
 	unlock_callback();
+	_on_physics_callback();
 }
 
 void RigidBody2D::_apply_body_mode() {

--- a/scene/3d/physics/animatable_body_3d.cpp
+++ b/scene/3d/physics/animatable_body_3d.cpp
@@ -80,7 +80,7 @@ void AnimatableBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 	set_notify_local_transform(false);
 	set_global_transform(last_valid_transform);
 	set_notify_local_transform(true);
-	_on_transform_changed();
+	_on_transform_changed(true);
 }
 
 void AnimatableBody3D::_notification(int p_what) {
@@ -110,7 +110,7 @@ void AnimatableBody3D::_notification(int p_what) {
 			set_notify_local_transform(false);
 			set_global_transform(last_valid_transform);
 			set_notify_local_transform(true);
-			_on_transform_changed();
+			_on_transform_changed(false);
 		} break;
 	}
 }

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -83,6 +83,10 @@ void CollisionObject3D::_notification(int p_what) {
 			_update_pickable();
 		} break;
 
+		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
+			_fti_physics_reset_requested = true;
+		} break;
+
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			update_configuration_warnings();
 		} break;
@@ -98,7 +102,7 @@ void CollisionObject3D::_notification(int p_what) {
 				PhysicsServer3D::get_singleton()->body_set_state(rid, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
 			}
 
-			_on_transform_changed();
+			_on_transform_changed(false);
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -429,7 +433,7 @@ void CollisionObject3D::_clear_debug_shapes() {
 	debug_shapes_count = 0;
 }
 
-void CollisionObject3D::_on_transform_changed() {
+void CollisionObject3D::_on_transform_changed(bool p_in_physics_callback) {
 	if (debug_shapes_count > 0 && !debug_shape_old_transform.is_equal_approx(get_global_transform())) {
 		debug_shape_old_transform = get_global_transform();
 		for (KeyValue<uint32_t, ShapeData> &E : shapes) {
@@ -445,6 +449,11 @@ void CollisionObject3D::_on_transform_changed() {
 				RS::get_singleton()->instance_set_transform(shape_bases[i].debug_shape, debug_shape_old_transform * shapedata.xform);
 			}
 		}
+	}
+
+	if (p_in_physics_callback && _fti_physics_reset_requested) {
+		reset_physics_interpolation();
+		_fti_physics_reset_requested = false;
 	}
 }
 

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -81,6 +81,10 @@ private:
 	bool capture_input_on_drag = false;
 	bool ray_pickable = true;
 
+	// Physics bodies using sync to physics defer setting global xform until callbacks from the physics.
+	// In these cases, resets should also be deferred until the callback, because global_xforms will be stale.
+	bool _fti_physics_reset_requested = false;
+
 	HashSet<uint32_t> debug_shapes_to_update;
 	int debug_shapes_count = 0;
 	Transform3D debug_shape_old_transform;
@@ -108,7 +112,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	void _on_transform_changed();
+	void _on_transform_changed(bool p_in_physics_callback);
 
 	friend class Viewport;
 	virtual void _input_event_call(Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -814,7 +814,7 @@ void PhysicalBone3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 	}
 
 	_sync_body_state(p_state);
-	_on_transform_changed();
+	_on_transform_changed(true);
 
 	Transform3D global_transform(p_state->get_transform());
 

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -176,7 +176,7 @@ void RigidBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 	}
 
 	_sync_body_state(p_state);
-	_on_transform_changed();
+	_on_transform_changed(true);
 
 	if (contact_monitor) {
 		contact_monitor->locked = true;


### PR DESCRIPTION
Fix for deferred xforms when `sync_to_physics` is set on physics bodies.

Fixes #111040
Forward port of #111069

While investigating the issue it turns out that `reset_physics_interpolation()` doesn't work correctly for (other) physics objects when `sync_to_physics` is selected.

This happens because `sync_to_physics` uses a hack to avoid setting the global xform immediately, and stores it in `last_valid_transform` until a callback from the physics where it is actually set on the `Node`. This means that any call to `reset` after setting `global_xform` will reset based on the _prior_ stale global_xform, and not the new pending xform.

This class of bug seems to occur for several physics objects (slightly different in 3.x and 4.x) so I'm attempting to fix them all (that I can find) in one PR here.

## Discussion
There is one downside to this simple technique - because the set / reset process is happening out of order, and only one `global_xform` can be queued, it is not possible to set up a moving start for FTI with these physics objects when `sync_to_physics` is selected.

If this is a problem in practice, we can look to additional methods to solve this, but the state after this PR should be considerably more usable than before (where `reset` was functionally being ignored).

## Notes
* These nodes (and their children) will effectively be reset _twice_, the first unnecessarily. This is unlikely to be a performance problem but it's possible we can do a follow up to prevent the first reset.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
