### PR TITLE
Always show settings to enable DOF near + far

### DIFF
--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -259,8 +259,8 @@ void CameraAttributesPractical::_validate_property(PropertyInfo &p_property) con
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		return;
 	}
-	if ((!dof_blur_far_enabled && p_property.name.begins_with("dof_blur_far_")) ||
-			(!dof_blur_near_enabled && p_property.name.begins_with("dof_blur_near_"))) {
+	if ((p_property.name != "dof_blur_far_enabled" && !dof_blur_far_enabled && p_property.name.begins_with("dof_blur_far_")) ||
+			(p_property.name != "dof_blur_near_enabled" && !dof_blur_near_enabled && p_property.name.begins_with("dof_blur_near_"))) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/108254 changed the behaviour of ```_validate_property``` in CameraAttributes to simplify the logic. The problem is that it also disables the enable buttons so if the settings get disabled the buttons to re-enable them also disappear.