### PR TITLE
[3.x] Android: Set minsdk to 21, workaround `fseeko` error in Opus.

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -21,7 +21,7 @@ def get_opts():
 
     return [
         ("ANDROID_SDK_ROOT", "Path to the Android SDK", get_env_android_sdk_root()),
-        ("ndk_platform", 'Target platform (android-<api>, e.g. "android-24")', "android-24"),
+        ("ndk_platform", 'Target platform (android-<api>, e.g. "android-21")', "android-21"),
         EnumVariable("android_arch", "Target architecture", "armv7", ("armv7", "arm64v8", "x86", "x86_64")),
         BoolVariable("android_neon", "Enable NEON support (armv7 only)", True),
         BoolVariable("store_release", "Editor build for Google Play Store (for official builds only)", False),
@@ -176,7 +176,9 @@ def configure(env):
         CCFLAGS="-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing".split()
     )
     env.Append(CPPDEFINES=["NO_STATVFS", "GLES_ENABLED"])
-    env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
+
+    if get_min_sdk_version(env["ndk_platform"]) >= 24:
+        env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
 
     env["neon_enabled"] = False
     if env["android_arch"] == "x86":

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -226,7 +226,7 @@ static const int EXPORT_FORMAT_AAB = 1;
 static const char *APK_ASSETS_DIRECTORY = "res://android/build/assets";
 static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPackInstallTime/src/main/assets";
 
-static const int DEFAULT_MIN_SDK_VERSION = 24; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
+static const int DEFAULT_MIN_SDK_VERSION = 21; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
 static const int DEFAULT_TARGET_SDK_VERSION = 35; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
 
 #ifndef ANDROID_ENABLED

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,7 +1,7 @@
 ext.versions = [
     androidGradlePlugin: '8.6.1',
     compileSdk         : 35,
-    minSdk             : 24, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
+    minSdk             : 21, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
     targetSdk          : 35, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     buildTools         : '35.0.0',
     kotlinVersion      : '2.1.20',

--- a/thirdparty/opus/patches/android-api-21-support.patch
+++ b/thirdparty/opus/patches/android-api-21-support.patch
@@ -1,0 +1,24 @@
+diff --git a/thirdparty/opus/stream.c b/thirdparty/opus/stream.c
+index 0238a6b31b..ef1667a7b6 100644
+--- a/thirdparty/opus/stream.c
++++ b/thirdparty/opus/stream.c
+@@ -96,6 +96,9 @@ static int op_fseek(void *_stream,opus_int64 _offset,int _whence){
+   if(pos<0||_offset<-pos||_offset>OP_INT64_MAX-pos)return -1;
+   pos+=_offset;
+   return fsetpos((FILE *)_stream,(fpos_t *)&pos);
++#elif defined(__ANDROID__) && __ANDROID_API__ < 24
++  /*fseeko is not available on Android API < 24, use 32-bit fseek instead.*/
++  return fseek((FILE *)_stream,(long)_offset,_whence);
+ #else
+   /*This function actually conforms to the SUSv2 and POSIX.1-2001, so we prefer
+      it except on Windows.*/
+@@ -111,6 +114,9 @@ static opus_int64 op_ftell(void *_stream){
+   opus_int64 pos;
+   OP_ASSERT(sizeof(pos)==sizeof(fpos_t));
+   return fgetpos((FILE *)_stream,(fpos_t *)&pos)?-1:pos;
++#elif defined(__ANDROID__) && __ANDROID_API__ < 24
++  /*ftello is not available on Android API < 24, use 32-bit ftell instead.*/
++  return ftell((FILE *)_stream);
+ #else
+   /*This function actually conforms to the SUSv2 and POSIX.1-2001, so we prefer
+      it except on Windows.*/

--- a/thirdparty/opus/stream.c
+++ b/thirdparty/opus/stream.c
@@ -96,6 +96,9 @@ static int op_fseek(void *_stream,opus_int64 _offset,int _whence){
   if(pos<0||_offset<-pos||_offset>OP_INT64_MAX-pos)return -1;
   pos+=_offset;
   return fsetpos((FILE *)_stream,(fpos_t *)&pos);
+#elif defined(__ANDROID__) && __ANDROID_API__ < 24
+  /*fseeko is not available on Android API < 24, use 32-bit fseek instead.*/
+  return fseek((FILE *)_stream,(long)_offset,_whence);
 #else
   /*This function actually conforms to the SUSv2 and POSIX.1-2001, so we prefer
      it except on Windows.*/
@@ -111,6 +114,9 @@ static opus_int64 op_ftell(void *_stream){
   opus_int64 pos;
   OP_ASSERT(sizeof(pos)==sizeof(fpos_t));
   return fgetpos((FILE *)_stream,(fpos_t *)&pos)?-1:pos;
+#elif defined(__ANDROID__) && __ANDROID_API__ < 24
+  /*ftello is not available on Android API < 24, use 32-bit ftell instead.*/
+  return ftell((FILE *)_stream);
 #else
   /*This function actually conforms to the SUSv2 and POSIX.1-2001, so we prefer
      it except on Windows.*/


### PR DESCRIPTION
Min SDK to 21.

this change seems to fix the `fseeko` on https://github.com/godotengine/godot/pull/108433#issuecomment-3164882813.


Also,
Can we please release 3.6.2 with just the changes so we can upload the apps to Play Console. 