### PR TITLE
Automatically include text server data if project includes translations requiring it.

### DIFF
--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1160,6 +1160,13 @@
 				Returns [code]true[/code] if locale is right-to-left.
 			</description>
 		</method>
+		<method name="is_locale_using_support_data" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="locale" type="String" />
+			<description>
+				Returns [code]true[/code] if the locale requires text server support data for line/word breaking.
+			</description>
+		</method>
 		<method name="is_valid_identifier" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="string" type="String" />

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -1137,6 +1137,13 @@
 				Returns [code]true[/code] if locale is right-to-left.
 			</description>
 		</method>
+		<method name="_is_locale_using_support_data" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="locale" type="String" />
+			<description>
+				Returns [code]true[/code] if the locale requires text server support data for line/word breaking.
+			</description>
+		</method>
 		<method name="_is_valid_identifier" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="string" type="String" />

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -522,6 +522,15 @@ PackedByteArray TextServerAdvanced::_get_support_data() const {
 #endif
 }
 
+bool TextServerAdvanced::_is_locale_using_support_data(const String &p_locale) const {
+	String l = p_locale.get_slicec('_', 0);
+	if ((l == "my") || (l == "zh") || (l == "ja") || (l == "ko") || (l == "km") || (l == "lo") || (l == "th")) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 bool TextServerAdvanced::_is_locale_right_to_left(const String &p_locale) const {
 	String l = p_locale.get_slicec('_', 0);
 	if ((l == "ar") || (l == "dv") || (l == "he") || (l == "fa") || (l == "ff") || (l == "ku") || (l == "ur")) {
@@ -5727,6 +5736,7 @@ RID TextServerAdvanced::_find_sys_font_for_text(const RID &p_fdef, const String 
 
 	String locale = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
 	PackedStringArray fallback_font_name = OS::get_singleton()->get_system_font_path_for_text(font_name, p_text, locale, p_script_code, font_weight, font_stretch, font_style & TextServer::FONT_ITALIC);
+	print_line("sysf x ", p_text, " --> ", fallback_font_name);
 #ifdef GDEXTENSION
 	for (int fb = 0; fb < fallback_font_name.size(); fb++) {
 		const String &E = fallback_font_name[fb];

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -833,6 +833,7 @@ public:
 	MODBIND0RC(String, get_support_data_info);
 	MODBIND1RC(bool, save_support_data, const String &);
 	MODBIND0RC(PackedByteArray, get_support_data);
+	MODBIND1RC(bool, is_locale_using_support_data, const String &);
 
 	MODBIND1RC(bool, is_locale_right_to_left, const String &);
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -183,6 +183,10 @@ PackedByteArray TextServerFallback::_get_support_data() const {
 	return PackedByteArray(); // No extra data used.
 }
 
+bool TextServerFallback::_is_locale_using_support_data(const String &p_locale) const {
+	return false; // No data support.
+}
+
 bool TextServerFallback::_is_locale_right_to_left(const String &p_locale) const {
 	return false; // No RTL support.
 }

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -616,6 +616,7 @@ public:
 	MODBIND0RC(String, get_support_data_info);
 	MODBIND1RC(bool, save_support_data, const String &);
 	MODBIND0RC(PackedByteArray, get_support_data);
+	MODBIND1RC(bool, is_locale_using_support_data, const String &);
 
 	MODBIND1RC(bool, is_locale_right_to_left, const String &);
 

--- a/servers/text/text_server.cpp
+++ b/servers/text/text_server.cpp
@@ -205,6 +205,7 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_support_data_info"), &TextServer::get_support_data_info);
 	ClassDB::bind_method(D_METHOD("save_support_data", "filename"), &TextServer::save_support_data);
 	ClassDB::bind_method(D_METHOD("get_support_data"), &TextServer::get_support_data);
+	ClassDB::bind_method(D_METHOD("is_locale_using_support_data", "locale"), &TextServer::is_locale_using_support_data);
 
 	ClassDB::bind_method(D_METHOD("is_locale_right_to_left", "locale"), &TextServer::is_locale_right_to_left);
 

--- a/servers/text/text_server.h
+++ b/servers/text/text_server.h
@@ -261,6 +261,7 @@ public:
 	virtual String get_support_data_info() const = 0;
 	virtual bool save_support_data(const String &p_filename) const = 0;
 	virtual PackedByteArray get_support_data() const = 0;
+	virtual bool is_locale_using_support_data(const String &p_locale) const { return false; }
 
 	virtual bool is_locale_right_to_left(const String &p_locale) const = 0;
 

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -43,6 +43,7 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_support_data_info);
 	GDVIRTUAL_BIND(_save_support_data, "filename");
 	GDVIRTUAL_BIND(_get_support_data);
+	GDVIRTUAL_BIND(_is_locale_using_support_data, "locale");
 
 	GDVIRTUAL_BIND(_is_locale_right_to_left, "locale");
 
@@ -445,6 +446,12 @@ bool TextServerExtension::save_support_data(const String &p_filename) const {
 PackedByteArray TextServerExtension::get_support_data() const {
 	PackedByteArray ret;
 	GDVIRTUAL_CALL(_get_support_data, ret);
+	return ret;
+}
+
+bool TextServerExtension::is_locale_using_support_data(const String &p_locale) const {
+	bool ret = false;
+	GDVIRTUAL_CALL(_is_locale_using_support_data, p_locale, ret);
 	return ret;
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -67,6 +67,8 @@ public:
 	GDVIRTUAL0RC(String, _get_support_data_info);
 	GDVIRTUAL1RC(bool, _save_support_data, const String &);
 	GDVIRTUAL0RC(PackedByteArray, _get_support_data);
+	virtual bool is_locale_using_support_data(const String &p_locale) const override;
+	GDVIRTUAL1RC(bool, _is_locale_using_support_data, const String &);
 
 	virtual bool is_locale_right_to_left(const String &p_locale) const override;
 	GDVIRTUAL1RC(bool, _is_locale_right_to_left, const String &);


### PR DESCRIPTION
Should prevent issues like https://github.com/godotengine/godot/issues/110109 by automatically including data is specific translations/fallback language are used.