### PR TITLE
Change `Memory` from a class into a namespace.

### DIFF
--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -57,8 +57,8 @@ void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_d
 #endif
 
 #ifdef DEBUG_ENABLED
-SafeNumeric<uint64_t> Memory::mem_usage;
-SafeNumeric<uint64_t> Memory::max_usage;
+static SafeNumeric<uint64_t> _current_mem_usage;
+static SafeNumeric<uint64_t> _max_mem_usage;
 #endif
 
 void *Memory::alloc_aligned_static(size_t p_bytes, size_t p_alignment) {
@@ -117,8 +117,8 @@ void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 		*s = p_bytes;
 
 #ifdef DEBUG_ENABLED
-		uint64_t new_mem_usage = mem_usage.add(p_bytes);
-		max_usage.exchange_if_greater(new_mem_usage);
+		uint64_t new_mem_usage = _current_mem_usage.add(p_bytes);
+		_max_mem_usage.exchange_if_greater(new_mem_usage);
 #endif
 		return s8 + DATA_OFFSET;
 	} else {
@@ -148,10 +148,10 @@ void *Memory::realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align) {
 
 #ifdef DEBUG_ENABLED
 		if (p_bytes > *s) {
-			uint64_t new_mem_usage = mem_usage.add(p_bytes - *s);
-			max_usage.exchange_if_greater(new_mem_usage);
+			uint64_t new_mem_usage = _current_mem_usage.add(p_bytes - *s);
+			_max_mem_usage.exchange_if_greater(new_mem_usage);
 		} else {
-			mem_usage.sub(*s - p_bytes);
+			_current_mem_usage.sub(*s - p_bytes);
 		}
 #endif
 
@@ -195,7 +195,7 @@ void Memory::free_static(void *p_ptr, bool p_pad_align) {
 
 #ifdef DEBUG_ENABLED
 		uint64_t *s = (uint64_t *)(mem + SIZE_OFFSET);
-		mem_usage.sub(*s);
+		_current_mem_usage.sub(*s);
 #endif
 
 		free(mem);
@@ -210,7 +210,7 @@ uint64_t Memory::get_mem_available() {
 
 uint64_t Memory::get_mem_usage() {
 #ifdef DEBUG_ENABLED
-	return mem_usage.get();
+	return _current_mem_usage.get();
 #else
 	return 0;
 #endif
@@ -218,7 +218,7 @@ uint64_t Memory::get_mem_usage() {
 
 uint64_t Memory::get_mem_max_usage() {
 #ifdef DEBUG_ENABLED
-	return max_usage.get();
+	return _max_mem_usage.get();
 #else
 	return 0;
 #endif


### PR DESCRIPTION
- Helps address https://github.com/godotengine/godot/issues/111218

`Memory` is currently a class. This is a bad fit because it is not meant to be constructed.

Changing it into a `namespace` does not solve any problems (except for some stylistic workarounds). But it communicates the intent better, may _very slightly_ improve compile time, and allows us to split declarations into separate headers in the future if needed.

I also took the opportunity to rename the memory usage properties, to make the names clearer. This is also what helps address https://github.com/godotengine/godot/issues/111218, by removing the `safe_ref_count.h` include.