### PR TITLE
Remove unused `multiplayer` member from `Node`

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -264,8 +264,6 @@ private:
 
 	} data;
 
-	Ref<MultiplayerAPI> multiplayer;
-
 	String _get_tree_string_pretty(const String &p_prefix, bool p_last);
 	String _get_tree_string(const Node *p_node);
 


### PR DESCRIPTION
The member is not used anymore. Per node multiplayers are stored directly with the scene tree since https://github.com/godotengine/godot/pull/57647. The exposed `get_multiplayer` method (and associated property) are retrieving the multiplayer ref from the scene tree and ignore the member.