### PR TITLE
Fix Quick Open history

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -521,18 +521,28 @@ void QuickOpenResultContainer::update_results() {
 }
 
 void QuickOpenResultContainer::_use_default_candidates() {
+	HashSet<String> existing_paths;
 	Vector<QuickOpenResultCandidate> *history = _get_history();
 	if (history) {
 		candidates.append_array(*history);
+		for (const QuickOpenResultCandidate &candi : *history) {
+			existing_paths.insert(candi.file_path);
+		}
 	}
+	int i = candidates.size();
+
 	candidates.resize(MIN(max_total_results, filepaths.size()));
+	QuickOpenResultCandidate *candidates_w = candidates.ptrw();
 	int count = candidates.size();
-	int i = 0;
+
 	for (const String &filepath : filepaths) {
 		if (i >= count) {
 			break;
 		}
-		_setup_candidate(candidates.write[i++], filepath);
+		if (existing_paths.has(filepath)) {
+			continue;
+		}
+		_setup_candidate(candidates_w[i++], filepath);
 	}
 }
 


### PR DESCRIPTION
I don't know if it was like that from the beginning or if it broke at some point, but the EditorQuickOpenDialog's handling of item history was completely wrong.

The idea was that when you open the dialog, it setups the default entries by first appending the recently used ones and then all files. However there were 2 major problems there :D
- The "all files" did not account for the items added from history and were overwriting them
- If a history item was not overwritten, it was possible to have it appear twice (because nothing was checking if a file was already added)

I recently noticed that the quick open history wasn't working properly, and as I investigated, I discovered these 2 funny bugs. This PR fixes them.