### PR TITLE
[3.x] FTI - Fix physics body resets when using `sync_to_physics`

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -69,6 +69,11 @@ void CollisionObject2D::_notification(int p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			_update_pickable();
 		} break;
+
+		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
+			_fti_physics_reset_requested = true;
+		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (only_update_transform_changes) {
 				return;
@@ -400,6 +405,13 @@ void CollisionObject2D::_mouse_exit() {
 		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_exit);
 	}
 	emit_signal(SceneStringNames::get_singleton()->mouse_exited);
+}
+
+void CollisionObject2D::_on_physics_callback() {
+	if (_fti_physics_reset_requested) {
+		reset_physics_interpolation();
+		_fti_physics_reset_requested = false;
+	}
 }
 
 void CollisionObject2D::set_only_update_transform_changes(bool p_enable) {

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -70,6 +70,10 @@ class CollisionObject2D : public Node2D {
 	Map<uint32_t, ShapeData> shapes;
 	bool only_update_transform_changes; //this is used for sync physics in KinematicBody
 
+	// Physics bodies using sync to physics defer setting global xform to callbacks from the physics.
+	// In these cases, resets should also be deferred until the callback, because global_xforms will be stale.
+	bool _fti_physics_reset_requested = false;
+
 protected:
 	CollisionObject2D(RID p_rid, bool p_area);
 
@@ -83,6 +87,7 @@ protected:
 	void _mouse_exit();
 
 	void set_only_update_transform_changes(bool p_enable);
+	void _on_physics_callback();
 
 public:
 	static constexpr AncestralClass static_ancestral_class = AncestralClass::COLLISION_OBJECT_2D;

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -474,6 +474,7 @@ void RigidBody2D::_direct_state_changed(Object *p_state) {
 	}
 
 	state = nullptr;
+	_on_physics_callback();
 }
 
 void RigidBody2D::set_mode(Mode p_mode) {
@@ -1428,6 +1429,8 @@ void KinematicBody2D::_direct_state_changed(Object *p_state) {
 	set_notify_local_transform(false);
 	set_global_transform(last_valid_transform);
 	set_notify_local_transform(true);
+
+	_on_physics_callback();
 }
 
 void KinematicBody2D::_notification(int p_what) {

--- a/scene/3d/collision_object.h
+++ b/scene/3d/collision_object.h
@@ -67,6 +67,10 @@ class CollisionObject : public Spatial {
 	Map<uint32_t, ShapeData> shapes;
 	bool only_update_transform_changes = false; //this is used for sync physics in KinematicBody
 
+	// Physics bodies using sync to physics defer setting global xform to callbacks from the physics.
+	// In these cases, resets should also be deferred until the callback, because global_xforms will be stale.
+	bool _fti_physics_reset_requested = false;
+
 	bool capture_input_on_drag;
 	bool ray_pickable;
 
@@ -94,7 +98,7 @@ protected:
 
 	void set_only_update_transform_changes(bool p_enable);
 
-	void _on_transform_changed();
+	void _on_transform_changed(bool p_in_physics_callback);
 
 public:
 	static constexpr AncestralClass static_ancestral_class = AncestralClass::COLLISION_OBJECT;

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -383,7 +383,7 @@ void RigidBody::_direct_state_changed(Object *p_state) {
 		get_script_instance()->call("_integrate_forces", state);
 	}
 	set_ignore_transform_notification(false);
-	_on_transform_changed();
+	_on_transform_changed(true);
 
 	if (contact_monitor) {
 		contact_monitor->locked = true;
@@ -1451,7 +1451,7 @@ void KinematicBody::_direct_state_changed(Object *p_state) {
 	set_notify_local_transform(false);
 	set_global_transform(last_valid_transform);
 	set_notify_local_transform(true);
-	_on_transform_changed();
+	_on_transform_changed(true);
 }
 
 void KinematicBody::_notification(int p_what) {
@@ -1476,7 +1476,7 @@ void KinematicBody::_notification(int p_what) {
 		set_notify_local_transform(false);
 		set_global_transform(last_valid_transform);
 		set_notify_local_transform(true);
-		_on_transform_changed();
+		_on_transform_changed(false);
 	}
 }
 
@@ -2361,7 +2361,7 @@ void PhysicalBone::_direct_state_changed(Object *p_state) {
 	set_ignore_transform_notification(true);
 	set_global_transform(global_transform);
 	set_ignore_transform_notification(false);
-	_on_transform_changed();
+	_on_transform_changed(true);
 
 	// Update skeleton
 	if (parent_skeleton) {


### PR DESCRIPTION
## Introduction
When investigating #111040 it turns out that `reset_physics_interpolation()` doesn't work correctly for physics objects when `sync_to_physics` is selected.

This happens because `sync_to_physics` uses a hack to avoid setting the global xform immediately, and stores it in `last_valid_transform` until a callback from the physics where it is actually set on the `Node`. This means that any call to `reset` after setting `global_xform` will reset based on the _prior_ stale global_xform, and not the new pending xform.

This class of bug seems to occur for several physics objects (slightly different in 3.x and 4.x) so I'm attempting to fix them all (that I can find) in one PR here for 3.x.

## Discussion
There is one downside to this simple technique - because the set / reset process is happening out of order, and only one `global_xform` can be queued, it is not possible to set up a moving start for FTI with these physics objects when `sync_to_physics` is selected.

If this is a problem in practice, we can look to additional methods to solve this, but the state after this PR should be considerably more usable than before (where `reset` was functionally being ignored).

### Test Project
Run before and after the PR. Before the PR, the reset is ignored, after it works correctly.
[origin_shifting.zip](https://github.com/user-attachments/files/22619476/origin_shifting.zip)

## Notes
* These nodes (and their children) will effectively be reset _twice_, the first unnecessarily. This is unlikely to be a performance problem but it's possible we can do a follow up to prevent the first reset.
* Still todo for 4.x.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
