### PR TITLE
[GDScript]: Resolve autocomplete for chained calls after GET_NODE.

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1906,6 +1906,17 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 				r_type = _type_from_variant(literal->value, p_context);
 				found = true;
 			} break;
+			case GDScriptParser::Node::GET_NODE: {
+				// Resolves chained calls after %/$ to their concrete node type from the current scene.
+				const GDScriptParser::GetNodeNode *gn = static_cast<const GDScriptParser::GetNodeNode *>(p_expression);
+				const Node *base = Object::cast_to<Node>(p_context.base);
+				const Node *node = base ? base->get_node_or_null(gn->full_path) : nullptr;
+				if (node != nullptr) {
+					r_type = _type_from_variant(node, p_context);
+					found = true;
+					break;
+				}
+			} break;
 			case GDScriptParser::Node::SELF: {
 				if (p_context.current_class) {
 					r_type.type = p_context.current_class->get_datatype();

--- a/modules/gdscript/tests/scripts/completion/get_node/method_chain/unique_animation_queue_chain.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/method_chain/unique_animation_queue_chain.cfg
@@ -1,0 +1,7 @@
+[input]
+scene="res://completion/get_node/get_node.tscn"
+
+[output]
+include=[
+    {"display": "size()"},
+]

--- a/modules/gdscript/tests/scripts/completion/get_node/method_chain/unique_animation_queue_chain.gd
+++ b/modules/gdscript/tests/scripts/completion/get_node/method_chain/unique_animation_queue_chain.gd
@@ -1,0 +1,5 @@
+extends Node
+
+func _ready():
+	%UniqueAnimationPlayer.get_queue().➡
+	pass


### PR DESCRIPTION
With this PR you can get autocomplete for as many calls after a `$GetNode` as you like:

<img width="626" height="120" alt="image" src="https://github.com/user-attachments/assets/193d3068-da32-4fdd-82b6-4390eb8cf4b9" />

Without this PR: 💨