### PR TITLE
Allow extracting translation strings without generating POT

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -587,6 +587,7 @@
 			<param index="0" name="parser" type="EditorTranslationParserPlugin" />
 			<description>
 				Registers a custom translation parser plugin for extracting translatable strings from custom files.
+				[b]Note:[/b] A custom parser added earlier takes precedence over one added later. Processing the same file extension by multiple custom parsers is not supported.
 			</description>
 		</method>
 		<method name="add_undo_redo_inspector_hook_callback">

--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		[EditorTranslationParserPlugin] is invoked when a file is being parsed to extract strings that require translation. To define the parsing and string extraction logic, override the [method _parse_file] method in script.
-		The return value should be an [Array] of [PackedStringArray]s, one for each extracted translatable string. Each entry should contain [code][msgid, msgctxt, msgid_plural, comment, source_line][/code], where all except [code]msgid[/code] are optional. Empty strings will be ignored.
 		The extracted strings will be written into a translation template file selected by user under "Template Generation" in "Localization" tab in "Project Settings" menu.
 		Below shows an example of a custom parser that extracts strings from a CSV file to write into a template.
 		[codeblocks]
@@ -106,7 +105,7 @@
 		<method name="_get_recognized_extensions" qualifiers="virtual const">
 			<return type="PackedStringArray" />
 			<description>
-				Gets the list of file extensions to associate with this parser, e.g. [code]["csv"][/code].
+				Override this method to provide the list of file extensions to associate with this parser, e.g. [code]["csv"][/code].
 			</description>
 		</method>
 		<method name="_parse_file" qualifiers="virtual">
@@ -114,6 +113,24 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Override this method to define a custom parsing logic to extract the translatable strings.
+				The return value should be an array of [PackedStringArray]s, one for each extracted translatable string. Each entry should contain [code][msgid, msgctxt, msgid_plural, comment, source_line][/code], where all except [code]msgid[/code] are optional. Empty strings will be ignored.
+			</description>
+		</method>
+		<method name="get_all_recognized_extensions" qualifiers="static">
+			<return type="PackedStringArray" />
+			<description>
+				Returns a list of all file extensions supported by any translation parser, both standard and custom.
+				[b]Note:[/b] This is a static method intended to be called externally. It must [b]not[/b] be called from [method _get_recognized_extensions].
+			</description>
+		</method>
+		<method name="parse" qualifiers="static">
+			<return type="PackedStringArray[]" />
+			<param index="0" name="paths" type="PackedStringArray" />
+			<param index="1" name="add_builtin" type="bool" />
+			<description>
+				Returns strings parsed from files located in [param paths]. Built-in extractable strings are included if [param add_builtin] is [code]true[/code].
+				The returned value is an array of extracted string information. Each entry is an array of five strings: [code][msgid, msgctxt, msgid_plural, comment, source_line][/code].
+				[b]Note:[/b] This is a static method intended to be called externally. It must [b]not[/b] be called from [method _parse_file].
 			</description>
 		</method>
 	</methods>

--- a/editor/translations/editor_translation_parser.h
+++ b/editor/translations/editor_translation_parser.h
@@ -37,6 +37,12 @@
 class EditorTranslationParserPlugin : public RefCounted {
 	GDCLASS(EditorTranslationParserPlugin, RefCounted);
 
+	// These static methods were added since this class is exposed, but the singleton `EditorTranslationParser` is not.
+	// The `add_parser()` and `remove_parser()` methods are exposed through `EditorPlugin`, but there's no point
+	// in cluttering it with more unrelated methods.
+	static TypedArray<PackedStringArray> parse(const PackedStringArray &p_paths, bool p_add_builtin);
+	static PackedStringArray get_all_recognized_extensions();
+
 protected:
 	static void _bind_methods();
 
@@ -53,22 +59,27 @@ public:
 };
 
 class EditorTranslationParser {
-	static EditorTranslationParser *singleton;
-
 public:
 	enum ParserType {
-		STANDARD, // GDScript, CSharp, ...
-		CUSTOM // User-defined parser plugins. This will override standard parsers if the same extension type is defined.
+		STANDARD, // Built-in parser plugins.
+		CUSTOM, // User-defined parser plugins. This will override standard parsers if the same file extension is used.
 	};
 
-	static EditorTranslationParser *get_singleton();
+private:
+	static EditorTranslationParser *singleton;
 
 	Vector<Ref<EditorTranslationParserPlugin>> standard_parsers;
 	Vector<Ref<EditorTranslationParserPlugin>> custom_parsers;
 
+public:
+	static EditorTranslationParser *get_singleton();
+
+	Vector<Vector<String>> parse(const Vector<String> &p_paths, bool p_add_builtin) const;
+
 	void get_recognized_extensions(List<String> *r_extensions) const;
 	bool can_parse(const String &p_extension) const;
 	Ref<EditorTranslationParserPlugin> get_parser(const String &p_extension) const;
+
 	void add_parser(const Ref<EditorTranslationParserPlugin> &p_parser, ParserType p_type);
 	void remove_parser(const Ref<EditorTranslationParserPlugin> &p_parser, ParserType p_type);
 	void clean_parsers();


### PR DESCRIPTION
The POT generation feature has the advantage of automatically extracting translatable strings from various sources (scenes, scripts, and other resources via custom `EditorTranslationParserPlugin`s).

However, not all users like `gettext` workflow; some prefer the out-of-the-box supported CSV translation feature or even implement their own formats (the `Translation` class has a corresponding API for customization). The inability to access standard parsers makes this inconvenient and forces the use of POT generation.

This PR exposes access to standard parsers. Since the `EditorTranslationParser` singleton isn't exposed, access to its methods is provided through static `EditorTranslationParserPlugin` methods. An alternative would be to do this through `EditorPlugin` (as with the `add_parser()` and `remove_parser()` methods), but I think it would be a bad idea to clutter the rather generic `EditorPlugin` with unrelated methods. Also, `EditorTranslationParserPlugin` seems like a pretty expected place for these methods.

Additionally, this PR provides access to the list of built-in strings, which corresponds to the "Add Built-in Strings to POT" checkbox in the editor interface.

This PR slightly breaks compatibility: now custom plugins added later have priority, not earlier ones. On the other hand, this could be considered a bug fix.