### PR TITLE
Fix CharacterBody2D `move_and_slide()` treats wall as floor

### DIFF
--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -345,7 +345,10 @@ void CharacterBody2D::_apply_floor_snap(bool p_wall_as_floor) {
 	real_t length = MAX(floor_snap_length, margin);
 
 	PhysicsServer2D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
-	parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
+	// Ignore recovery when treating wall as floor. Recovery happens
+	// only if we cancelled an earlier recovery motion, in which case
+	// it may report a collision with vertical wall unexpectedly.
+	parameters.recovery_as_collision = !p_wall_as_floor;
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer2D::MotionResult result;


### PR DESCRIPTION
Fixes #111059

https://github.com/godotengine/godot/blob/8d8041bd4dab30e51ecf5be21dc7bf1f6a26c039/scene/2d/physics/character_body_2d.cpp#L183-L200

Line 188-193 may cancel a recovery motion, so that another recovery collision would be reported in line 195 `_snap_on_floor(true, false, true)`, which may eventually treat a vertical wall as floor, just as the issue shown. 

Furthermore, I think recovery collision is not necessary in this case. Since we have called `move_and_collide` before, it should be safe in theory. That is, ignoring recovery collision here will resolve the issue.

I'm not sure whether this solution will affect anything else, let me know if it will, thanks!