### PR TITLE
Remove `Node3D::viewport` use `Node::viewport` instead

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -243,14 +243,6 @@ void Node3D::_notification(int p_what) {
 			ERR_MAIN_THREAD_GUARD;
 
 			data.inside_world = true;
-			data.viewport = nullptr;
-			Node *parent = get_parent();
-			while (parent && !data.viewport) {
-				data.viewport = Object::cast_to<Viewport>(parent);
-				parent = parent->get_parent();
-			}
-
-			ERR_FAIL_NULL(data.viewport);
 
 #ifdef TOOLS_ENABLED
 			if (is_part_of_edited_scene() && !data.gizmos_requested) {
@@ -267,7 +259,6 @@ void Node3D::_notification(int p_what) {
 			clear_gizmos();
 #endif
 
-			data.viewport = nullptr;
 			data.inside_world = false;
 		} break;
 
@@ -1074,9 +1065,9 @@ bool Node3D::is_set_as_top_level() const {
 Ref<World3D> Node3D::get_world_3d() const {
 	ERR_READ_THREAD_GUARD_V(Ref<World3D>()); // World3D can only be set from main thread, so it's safe to obtain on threads.
 	ERR_FAIL_COND_V(!is_inside_world(), Ref<World3D>());
-	ERR_FAIL_NULL_V(data.viewport, Ref<World3D>());
+	ERR_FAIL_NULL_V(get_viewport(), Ref<World3D>());
 
-	return data.viewport->find_world_3d();
+	return get_viewport()->find_world_3d();
 }
 
 void Node3D::_propagate_visibility_changed() {

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -123,8 +123,6 @@ private:
 
 		mutable MTNumeric<uint32_t> dirty;
 
-		Viewport *viewport = nullptr;
-
 		bool top_level : 1;
 		bool inside_world : 1;
 


### PR DESCRIPTION
`Node3D` has been tracking it's viewport since https://github.com/godotengine/godot/commit/0b806ee0fc9097fa7bda7ac0109191c9c5e0a1ac, however since https://github.com/godotengine/godot/commit/7ea3e8267afaf626256c84a9a3dc61e2954fc6a2 `Node` is also tracking its viewport. At the moment this means, that each `Node3D` contains two pointers to its viewport.

This PR removes the tracking from `Node3D` and uses the viewport pointer from `Node` instead. `Node3D::viewport` is initialized in `NOTIFICATION_ENTER_WORLD` and `Node::viewport` in `NOTIFICATION_ENTER_TREE`, the later runs before the former, so `Node::viewport` is initialized at all points in time when `Node3D::viewport` would have been valid. So this PR _should_ not break anything.
