### PR TITLE
Add ability to use 3D physics engine in 2D

### DIFF
--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -644,6 +644,16 @@
 				Substitutes a given body shape by another. The old shape is selected by its index, the new one by its [RID].
 			</description>
 		</method>
+		<method name="body_set_shape_as_one_way_collision">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enable" type="bool" />
+			<param index="3" name="margin" type="float" />
+			<description>
+				Sets the one-way collision properties of the body's shape with the given index. If [param enable] is [code]true[/code], the Y axis in the shape's local space (that is [code]body_get_shape_transform(body, shape_idx).y.normalized()[/code] in the body's local space) will be used to ignore collisions with the shape in the opposite direction, and to ensure depenetration of kinematic bodies happens in this direction.
+			</description>
+		</method>
 		<method name="body_set_shape_disabled">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -650,8 +650,9 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="enable" type="bool" />
 			<param index="3" name="margin" type="float" />
+			<param index="4" name="direction" type="Vector3" />
 			<description>
-				Sets the one-way collision properties of the body's shape with the given index. If [param enable] is [code]true[/code], the Y axis in the shape's local space (that is [code]body_get_shape_transform(body, shape_idx).y.normalized()[/code] in the body's local space) will be used to ignore collisions with the shape in the opposite direction, and to ensure depenetration of kinematic bodies happens in this direction.
+				Sets the one-way collision properties of the body's shape with the given index. If [param enable] is [code]true[/code], the one-way collision direction given by [param direction] in the shape's local space (that is [code]body_get_shape_transform(body, shape_idx).basis.xform(direction).normalized()[/code] in the body's local space) will be used to ignore collisions with the shape in the opposite direction, and to ensure depenetration of kinematic bodies happens in this direction.
 			</description>
 		</method>
 		<method name="body_set_shape_disabled">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -556,6 +556,15 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_set_shape_as_one_way_collision" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enabled" type="bool" />
+			<param index="3" name="margin" type="float" />
+			<description>
+			</description>
+		</method>
 		<method name="_body_set_shape_disabled" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -562,6 +562,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="enabled" type="bool" />
 			<param index="3" name="margin" type="float" />
+			<param index="4" name="direction" type="Vector3" />
 			<description>
 			</description>
 		</method>

--- a/modules/godot_physics_3d/godot_body_pair_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_pair_3d.cpp
@@ -239,7 +239,7 @@ bool GodotBodyPair3D::_test_ccd(real_t p_step, GodotBody3D *p_A, int p_shape_A, 
 
 	// Check one-way collision based on motion direction.
 	if (p_A->get_shape(p_shape_A)->allows_one_way_collision() && p_B->is_shape_set_as_one_way_collision(p_shape_B)) {
-		Vector3 direction = -predicted_xform_B.basis[1].normalized();
+		Vector3 direction = predicted_xform_B.basis.xform(p_B->get_shape_one_way_collision_direction(p_shape_B)).normalized();
 		if (direction.dot(mnormal) < CMP_EPSILON) {
 			collided = false;
 			oneway_disabled = true;
@@ -330,7 +330,7 @@ bool GodotBodyPair3D::setup(real_t p_step) {
 
 	if (!prev_collided) {
 		if (shape_B_ptr->allows_one_way_collision() && A->is_shape_set_as_one_way_collision(shape_A)) {
-			Vector3 direction = -xform_A.basis[1].normalized();
+			Vector3 direction = xform_A.basis.xform(A->get_shape_one_way_collision_direction(shape_A)).normalized();
 			bool valid = false;
 			for (int i = 0; i < contact_count; i++) {
 				Contact &c = contacts[i];
@@ -348,7 +348,7 @@ bool GodotBodyPair3D::setup(real_t p_step) {
 		}
 
 		if (shape_A_ptr->allows_one_way_collision() && B->is_shape_set_as_one_way_collision(shape_B)) {
-			Vector3 direction = -xform_B.basis[1].normalized();
+			Vector3 direction = xform_B.basis.xform(B->get_shape_one_way_collision_direction(shape_B)).normalized();
 			bool valid = false;
 			for (int i = 0; i < contact_count; i++) {
 				Contact &c = contacts[i];

--- a/modules/godot_physics_3d/godot_body_pair_3d.h
+++ b/modules/godot_physics_3d/godot_body_pair_3d.h
@@ -89,6 +89,7 @@ class GodotBodyPair3D : public GodotBodyContact3D {
 	bool collide_A = false;
 	bool collide_B = false;
 
+	bool oneway_disabled = false;
 	bool report_contacts_only = false;
 
 	Vector3 offset_B; //use local A coordinates to avoid numerical issues on collision detection

--- a/modules/godot_physics_3d/godot_collision_object_3d.h
+++ b/modules/godot_physics_3d/godot_collision_object_3d.h
@@ -68,6 +68,8 @@ private:
 		real_t area_cache = 0.0;
 		GodotShape3D *shape = nullptr;
 		bool disabled = false;
+		bool one_way_collision = false;
+		real_t one_way_collision_margin = 0.0;
 	};
 
 	Vector<Shape> shapes;
@@ -151,6 +153,21 @@ public:
 	_FORCE_INLINE_ bool is_shape_disabled(int p_idx) const {
 		ERR_FAIL_INDEX_V(p_idx, shapes.size(), false);
 		return shapes[p_idx].disabled;
+	}
+
+	_FORCE_INLINE_ void set_shape_as_one_way_collision(int p_idx, bool p_one_way_collision, real_t p_margin) {
+		CRASH_BAD_INDEX(p_idx, shapes.size());
+		shapes.write[p_idx].one_way_collision = p_one_way_collision;
+		shapes.write[p_idx].one_way_collision_margin = p_margin;
+	}
+	_FORCE_INLINE_ bool is_shape_set_as_one_way_collision(int p_idx) const {
+		CRASH_BAD_INDEX(p_idx, shapes.size());
+		return shapes[p_idx].one_way_collision;
+	}
+
+	_FORCE_INLINE_ real_t get_shape_one_way_collision_margin(int p_idx) const {
+		CRASH_BAD_INDEX(p_idx, shapes.size());
+		return shapes[p_idx].one_way_collision_margin;
 	}
 
 	_FORCE_INLINE_ void set_collision_layer(uint32_t p_layer) {

--- a/modules/godot_physics_3d/godot_collision_object_3d.h
+++ b/modules/godot_physics_3d/godot_collision_object_3d.h
@@ -70,6 +70,7 @@ private:
 		bool disabled = false;
 		bool one_way_collision = false;
 		real_t one_way_collision_margin = 0.0;
+		Vector3 one_way_collision_direction = Vector3(0, -1, 0);
 	};
 
 	Vector<Shape> shapes;
@@ -155,10 +156,11 @@ public:
 		return shapes[p_idx].disabled;
 	}
 
-	_FORCE_INLINE_ void set_shape_as_one_way_collision(int p_idx, bool p_one_way_collision, real_t p_margin) {
+	_FORCE_INLINE_ void set_shape_as_one_way_collision(int p_idx, bool p_one_way_collision, real_t p_margin, const Vector3 &p_direction) {
 		CRASH_BAD_INDEX(p_idx, shapes.size());
 		shapes.write[p_idx].one_way_collision = p_one_way_collision;
 		shapes.write[p_idx].one_way_collision_margin = p_margin;
+		shapes.write[p_idx].one_way_collision_direction = p_direction;
 	}
 	_FORCE_INLINE_ bool is_shape_set_as_one_way_collision(int p_idx) const {
 		CRASH_BAD_INDEX(p_idx, shapes.size());
@@ -168,6 +170,11 @@ public:
 	_FORCE_INLINE_ real_t get_shape_one_way_collision_margin(int p_idx) const {
 		CRASH_BAD_INDEX(p_idx, shapes.size());
 		return shapes[p_idx].one_way_collision_margin;
+	}
+
+	_FORCE_INLINE_ Vector3 get_shape_one_way_collision_direction(int p_idx) const {
+		CRASH_BAD_INDEX(p_idx, shapes.size());
+		return shapes[p_idx].one_way_collision_direction;
 	}
 
 	_FORCE_INLINE_ void set_collision_layer(uint32_t p_layer) {

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -542,13 +542,13 @@ void GodotPhysicsServer3D::body_set_shape_disabled(RID p_body, int p_shape_idx, 
 	body->set_shape_disabled(p_shape_idx, p_disabled);
 }
 
-void GodotPhysicsServer3D::body_set_shape_as_one_way_collision(RID p_body, int p_shape_idx, bool p_enable, real_t p_margin) {
+void GodotPhysicsServer3D::body_set_shape_as_one_way_collision(RID p_body, int p_shape_idx, bool p_enable, real_t p_margin, const Vector3 &p_direction) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
 	FLUSH_QUERY_CHECK(body);
 
-	body->set_shape_as_one_way_collision(p_shape_idx, p_enable, p_margin);
+	body->set_shape_as_one_way_collision(p_shape_idx, p_enable, p_margin, p_direction);
 }
 
 Transform3D GodotPhysicsServer3D::body_get_shape_transform(RID p_body, int p_shape_idx) const {

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -71,8 +71,12 @@ class GodotPhysicsServer3D : public PhysicsServer3D {
 
 public:
 	struct CollCbkData {
-		int max;
-		int amount;
+		Vector3 valid_dir;
+		real_t valid_depth;
+		int max = 0;
+		int amount = 0;
+		int passed = 0;
+		int invalid_by_dir = 0;
 		Vector3 *ptr = nullptr;
 	};
 
@@ -178,6 +182,7 @@ public:
 	virtual Transform3D body_get_shape_transform(RID p_body, int p_shape_idx) const override;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override;
+	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) override;
 
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) override;
 	virtual void body_clear_shapes(RID p_body) override;

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -182,7 +182,7 @@ public:
 	virtual Transform3D body_get_shape_transform(RID p_body, int p_shape_idx) const override;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override;
-	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) override;
+	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0, const Vector3 &p_direction = Vector3(0, -1, 0)) override;
 
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) override;
 	virtual void body_clear_shapes(RID p_body) override;

--- a/modules/godot_physics_3d/godot_shape_3d.h
+++ b/modules/godot_physics_3d/godot_shape_3d.h
@@ -73,6 +73,8 @@ public:
 	_FORCE_INLINE_ const AABB &get_aabb() const { return aabb; }
 	_FORCE_INLINE_ bool is_configured() const { return configured; }
 
+	virtual bool allows_one_way_collision() const { return true; }
+
 	virtual bool is_concave() const { return false; }
 
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const = 0;
@@ -145,6 +147,8 @@ class GodotSeparationRayShape3D : public GodotShape3D {
 public:
 	real_t get_length() const;
 	bool get_slide_on_slope() const;
+
+	virtual bool allows_one_way_collision() const override { return false; }
 
 	virtual real_t get_volume() const override { return 0.0; }
 	virtual PhysicsServer3D::ShapeType get_type() const override { return PhysicsServer3D::SHAPE_SEPARATION_RAY; }

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -755,7 +755,7 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 					Transform3D col_obj_shape_xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 
 					if (body_shape->allows_one_way_collision() && col_obj->is_shape_set_as_one_way_collision(shape_idx)) {
-						cbk.valid_dir = -col_obj_shape_xform.basis[1].normalized(); // TODO + or -?
+						cbk.valid_dir = col_obj_shape_xform.basis.xform(col_obj->get_shape_one_way_collision_direction(shape_idx)).normalized();
 
 						real_t owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);
 						cbk.valid_depth = MAX(owc_margin, margin); //user specified, but never less than actual margin or it won't work
@@ -975,7 +975,7 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 					cbk.amount = 0;
 					cbk.passed = 0;
 					cbk.ptr = cd;
-					cbk.valid_dir = -col_obj_shape_xform.basis[1].normalized(); // TODO + or -?
+					cbk.valid_dir = col_obj_shape_xform.basis.xform(col_obj->get_shape_one_way_collision_direction(shape_idx)).normalized();
 
 					cbk.valid_depth = 10e20;
 
@@ -1073,7 +1073,7 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 				Transform3D col_obj_shape_xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 
 				if (body_shape->allows_one_way_collision() && col_obj->is_shape_set_as_one_way_collision(shape_idx)) {
-					rcd.valid_dir = -col_obj_shape_xform.basis[1].normalized(); // TODO + or -?
+					rcd.valid_dir = col_obj_shape_xform.basis.xform(col_obj->get_shape_one_way_collision_direction(shape_idx)).normalized();
 
 					real_t owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);
 					rcd.valid_depth = MAX(owc_margin, margin); //user specified, but never less than actual margin or it won't work

--- a/modules/godot_physics_3d/godot_space_3d.h
+++ b/modules/godot_physics_3d/godot_space_3d.h
@@ -68,6 +68,12 @@ public:
 	};
 
 private:
+	struct ExcludedShapeSW {
+		GodotShape3D *local_shape = nullptr;
+		const GodotCollisionObject3D *against_object = nullptr;
+		int against_shape_index = 0;
+	};
+
 	uint64_t elapsed_time[ELAPSED_TIME_MAX] = {};
 
 	GodotPhysicsDirectSpaceState3D *direct_access = nullptr;

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -647,6 +647,13 @@ void JoltPhysicsServer3D::body_set_shape_disabled(RID p_body, int p_shape_idx, b
 	body->set_shape_disabled(p_shape_idx, p_disabled);
 }
 
+void JoltPhysicsServer3D::body_set_shape_as_one_way_collision(RID p_body, int p_shape_idx, bool p_enabled, real_t p_margin) {
+	JoltBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_shape_as_one_way_collision(p_shape_idx, p_enabled, p_margin);
+}
+
 void JoltPhysicsServer3D::body_attach_object_instance_id(RID p_body, ObjectID p_id) {
 	if (JoltBody3D *body = body_owner.get_or_null(p_body)) {
 		body->set_instance_id(p_id);

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -647,11 +647,11 @@ void JoltPhysicsServer3D::body_set_shape_disabled(RID p_body, int p_shape_idx, b
 	body->set_shape_disabled(p_shape_idx, p_disabled);
 }
 
-void JoltPhysicsServer3D::body_set_shape_as_one_way_collision(RID p_body, int p_shape_idx, bool p_enabled, real_t p_margin) {
+void JoltPhysicsServer3D::body_set_shape_as_one_way_collision(RID p_body, int p_shape_idx, bool p_enabled, real_t p_margin, const Vector3 &p_direction) {
 	JoltBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	body->set_shape_as_one_way_collision(p_shape_idx, p_enabled, p_margin);
+	body->set_shape_as_one_way_collision(p_shape_idx, p_enabled, p_margin, p_direction);
 }
 
 void JoltPhysicsServer3D::body_attach_object_instance_id(RID p_body, ObjectID p_id) {

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -221,6 +221,7 @@ public:
 	virtual Transform3D body_get_shape_transform(RID p_body, int p_shape_idx) const override;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override;
+	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) override;
 
 	virtual int body_get_shape_count(RID p_body) const override;
 

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -221,7 +221,7 @@ public:
 	virtual Transform3D body_get_shape_transform(RID p_body, int p_shape_idx) const override;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override;
-	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) override;
+	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0, const Vector3 &p_direction = Vector3(0, -1, 0)) override;
 
 	virtual int body_get_shape_count(RID p_body) const override;
 

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
@@ -456,3 +456,33 @@ void JoltShapedObject3D::set_shape_disabled(int p_index, bool p_disabled) {
 
 	_shapes_changed();
 }
+
+bool JoltShapedObject3D::is_shape_set_as_one_way_collision(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, (int)shapes.size(), false);
+	return shapes[p_index].is_set_as_one_way_collision();
+}
+
+void JoltShapedObject3D::set_shape_as_one_way_collision(int p_index, bool p_enabled, real_t p_margin) {
+	ERR_FAIL_INDEX(p_index, (int)shapes.size());
+
+	JoltShapeInstance3D &shape = shapes[p_index];
+
+	if (shape.is_set_as_one_way_collision() == p_enabled && shape.get_one_way_collision_margin() == p_margin) {
+		return;
+	}
+
+	if (shape.is_set_as_one_way_collision() && !p_enabled) {
+		one_way_collision_shape_count--;
+	} else if (!shape.is_set_as_one_way_collision() && p_enabled) {
+		one_way_collision_shape_count++;
+	}
+
+	shape.set_as_one_way_collision(p_enabled, p_margin);
+
+	//_shapes_changed(); // TODO check
+}
+
+real_t JoltShapedObject3D::get_shape_one_way_collision_margin(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, (int)shapes.size(), 0.0f);
+	return shapes[p_index].get_one_way_collision_margin();
+}

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
@@ -462,12 +462,12 @@ bool JoltShapedObject3D::is_shape_set_as_one_way_collision(int p_index) const {
 	return shapes[p_index].is_set_as_one_way_collision();
 }
 
-void JoltShapedObject3D::set_shape_as_one_way_collision(int p_index, bool p_enabled, real_t p_margin) {
+void JoltShapedObject3D::set_shape_as_one_way_collision(int p_index, bool p_enabled, real_t p_margin, const Vector3 &p_direction) {
 	ERR_FAIL_INDEX(p_index, (int)shapes.size());
 
 	JoltShapeInstance3D &shape = shapes[p_index];
 
-	if (shape.is_set_as_one_way_collision() == p_enabled && shape.get_one_way_collision_margin() == p_margin) {
+	if (shape.is_set_as_one_way_collision() == p_enabled && shape.get_one_way_collision_margin() == p_margin && shape.get_one_way_collision_direction() == p_direction) {
 		return;
 	}
 
@@ -477,7 +477,7 @@ void JoltShapedObject3D::set_shape_as_one_way_collision(int p_index, bool p_enab
 		one_way_collision_shape_count++;
 	}
 
-	shape.set_as_one_way_collision(p_enabled, p_margin);
+	shape.set_as_one_way_collision(p_enabled, p_margin, p_direction);
 
 	//_shapes_changed(); // TODO check
 }
@@ -485,4 +485,9 @@ void JoltShapedObject3D::set_shape_as_one_way_collision(int p_index, bool p_enab
 real_t JoltShapedObject3D::get_shape_one_way_collision_margin(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, (int)shapes.size(), 0.0f);
 	return shapes[p_index].get_one_way_collision_margin();
+}
+
+Vector3 JoltShapedObject3D::get_shape_one_way_collision_direction(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, (int)shapes.size(), Vector3(0, -1, 0));
+	return shapes[p_index].get_one_way_collision_direction();
 }

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.h
@@ -45,6 +45,7 @@ class JoltShapedObject3D : public JoltObject3D {
 protected:
 	SelfList<JoltShapedObject3D> shapes_changed_element;
 	SelfList<JoltShapedObject3D> needs_optimization_element;
+	int one_way_collision_shape_count = 0;
 
 	Vector3 scale = Vector3(1, 1, 1);
 
@@ -127,4 +128,9 @@ public:
 
 	bool is_shape_disabled(int p_index) const;
 	void set_shape_disabled(int p_index, bool p_disabled);
+
+	bool has_one_way_collision_shapes() const { return one_way_collision_shape_count > 0; }
+	bool is_shape_set_as_one_way_collision(int p_index) const;
+	void set_shape_as_one_way_collision(int p_index, bool p_enabled, real_t p_margin);
+	real_t get_shape_one_way_collision_margin(int p_index) const;
 };

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.h
@@ -131,6 +131,7 @@ public:
 
 	bool has_one_way_collision_shapes() const { return one_way_collision_shape_count > 0; }
 	bool is_shape_set_as_one_way_collision(int p_index) const;
-	void set_shape_as_one_way_collision(int p_index, bool p_enabled, real_t p_margin);
+	void set_shape_as_one_way_collision(int p_index, bool p_enabled, real_t p_margin, const Vector3 &p_direction);
 	real_t get_shape_one_way_collision_margin(int p_index) const;
+	Vector3 get_shape_one_way_collision_direction(int p_index) const;
 };

--- a/modules/jolt_physics/shapes/jolt_separation_ray_shape_3d.h
+++ b/modules/jolt_physics/shapes/jolt_separation_ray_shape_3d.h
@@ -41,6 +41,7 @@ class JoltSeparationRayShape3D final : public JoltShape3D {
 public:
 	virtual ShapeType get_type() const override { return ShapeType::SHAPE_SEPARATION_RAY; }
 	virtual bool is_convex() const override { return true; }
+	virtual bool allows_one_way_collision() const override { return false; }
 
 	virtual Variant get_data() const override;
 	virtual void set_data(const Variant &p_data) override;

--- a/modules/jolt_physics/shapes/jolt_shape_3d.h
+++ b/modules/jolt_physics/shapes/jolt_shape_3d.h
@@ -63,6 +63,7 @@ public:
 
 	virtual ShapeType get_type() const = 0;
 	virtual bool is_convex() const = 0;
+	virtual bool allows_one_way_collision() const { return true; }
 
 	virtual Variant get_data() const = 0;
 	virtual void set_data(const Variant &p_data) = 0;

--- a/modules/jolt_physics/shapes/jolt_shape_instance_3d.h
+++ b/modules/jolt_physics/shapes/jolt_shape_instance_3d.h
@@ -67,6 +67,8 @@ class JoltShapeInstance3D {
 	JPH::ShapeRefC jolt_ref;
 	uint32_t id = next_id++;
 	bool disabled = false;
+	bool one_way_collision = false;
+	real_t one_way_collision_margin = 0.0;
 
 public:
 	JoltShapeInstance3D() = default;
@@ -94,6 +96,13 @@ public:
 
 	void enable() { disabled = false; }
 	void disable() { disabled = true; }
+
+	void set_as_one_way_collision(bool p_enabled, real_t p_margin) {
+		one_way_collision = p_enabled;
+		one_way_collision_margin = p_margin;
+	}
+	bool is_set_as_one_way_collision() const { return one_way_collision; }
+	real_t get_one_way_collision_margin() const { return one_way_collision_margin; }
 
 	bool try_build();
 };

--- a/modules/jolt_physics/shapes/jolt_shape_instance_3d.h
+++ b/modules/jolt_physics/shapes/jolt_shape_instance_3d.h
@@ -69,6 +69,7 @@ class JoltShapeInstance3D {
 	bool disabled = false;
 	bool one_way_collision = false;
 	real_t one_way_collision_margin = 0.0;
+	Vector3 one_way_collision_direction = Vector3(0, -1, 0);
 
 public:
 	JoltShapeInstance3D() = default;
@@ -97,12 +98,14 @@ public:
 	void enable() { disabled = false; }
 	void disable() { disabled = true; }
 
-	void set_as_one_way_collision(bool p_enabled, real_t p_margin) {
+	void set_as_one_way_collision(bool p_enabled, real_t p_margin, const Vector3 &p_direction) {
 		one_way_collision = p_enabled;
 		one_way_collision_margin = p_margin;
+		one_way_collision_direction = p_direction;
 	}
 	bool is_set_as_one_way_collision() const { return one_way_collision; }
 	real_t get_one_way_collision_margin() const { return one_way_collision_margin; }
+	Vector3 get_one_way_collision_direction() const { return one_way_collision_direction; }
 
 	bool try_build();
 };

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
@@ -68,14 +68,14 @@ JPH::ValidateResult JoltContactListener3D::OnContactValidate(const JPH::Body &p_
 	Vector3 contact_normal = to_godot(-p_collision_result.mPenetrationAxis.Normalized());
 
 	if (shape2->allows_one_way_collision() && body1->is_shape_set_as_one_way_collision(shape1_idx)) {
-		Vector3 direction = -body1->get_shape_transform_scaled(shape1_idx).basis[1].normalized();
+		Vector3 direction = body1->get_shape_transform_unscaled(shape1_idx).basis.xform(body1->get_shape_one_way_collision_direction(shape1_idx)).normalized();
 		if (contact_normal.dot(direction) < CMP_EPSILON) {
 			return JPH::ValidateResult::RejectContact;
 		}
 	}
 
 	if (shape1->allows_one_way_collision() && body2->is_shape_set_as_one_way_collision(shape2_idx)) {
-		Vector3 direction = -body2->get_shape_transform_scaled(shape2_idx).basis[1].normalized();
+		Vector3 direction = body2->get_shape_transform_unscaled(shape2_idx).basis.xform(body2->get_shape_one_way_collision_direction(shape2_idx)).normalized();
 		if (contact_normal.dot(direction) > -CMP_EPSILON) {
 			return JPH::ValidateResult::RejectContact;
 		}

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
@@ -35,10 +35,54 @@
 #include "../objects/jolt_area_3d.h"
 #include "../objects/jolt_body_3d.h"
 #include "../objects/jolt_soft_body_3d.h"
+#include "../shapes/jolt_shape_3d.h"
 #include "jolt_space_3d.h"
 
+#include "Jolt/Physics/Collision/CollideShape.h"
 #include "Jolt/Physics/Collision/EstimateCollisionResponse.h"
 #include "Jolt/Physics/SoftBody/SoftBodyManifold.h"
+
+JPH::ValidateResult JoltContactListener3D::OnContactValidate(const JPH::Body &p_body1, const JPH::Body &p_body2, JPH::RVec3Arg p_base_offset, const JPH::CollideShapeResult &p_collision_result) {
+	const JoltBody3D *body1 = reinterpret_cast<JoltBody3D *>(p_body1.GetUserData());
+	const JoltBody3D *body2 = reinterpret_cast<JoltBody3D *>(p_body2.GetUserData());
+
+	if (!body1 || !body2) {
+		return JPH::ValidateResult::AcceptContact;
+	}
+
+	// Optimization to avoid the find_shape_index calls below.
+	if (!body1->has_one_way_collision_shapes() && !body2->has_one_way_collision_shapes()) {
+		return JPH::ValidateResult::AcceptContact;
+	}
+
+	const int shape1_idx = body1->find_shape_index(p_collision_result.mSubShapeID1);
+	const int shape2_idx = body2->find_shape_index(p_collision_result.mSubShapeID2);
+
+	if (shape1_idx == -1 || shape2_idx == -1) {
+		return JPH::ValidateResult::AcceptContact;
+	}
+
+	const JoltShape3D *shape1 = body1->get_shape(shape1_idx);
+	const JoltShape3D *shape2 = body2->get_shape(shape2_idx);
+
+	Vector3 contact_normal = to_godot(-p_collision_result.mPenetrationAxis.Normalized());
+
+	if (shape2->allows_one_way_collision() && body1->is_shape_set_as_one_way_collision(shape1_idx)) {
+		Vector3 direction = -body1->get_shape_transform_scaled(shape1_idx).basis[1].normalized();
+		if (contact_normal.dot(direction) < CMP_EPSILON) {
+			return JPH::ValidateResult::RejectContact;
+		}
+	}
+
+	if (shape1->allows_one_way_collision() && body2->is_shape_set_as_one_way_collision(shape2_idx)) {
+		Vector3 direction = -body2->get_shape_transform_scaled(shape2_idx).basis[1].normalized();
+		if (contact_normal.dot(direction) > -CMP_EPSILON) {
+			return JPH::ValidateResult::RejectContact;
+		}
+	}
+
+	return JPH::ValidateResult::AcceptContact;
+}
 
 void JoltContactListener3D::OnContactAdded(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold, JPH::ContactSettings &p_settings) {
 	_try_override_collision_response(p_body1, p_body2, p_settings);

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
@@ -99,6 +99,7 @@ class JoltContactListener3D final
 	std::atomic_int debug_contact_count = 0;
 #endif
 
+	virtual JPH::ValidateResult OnContactValidate(const JPH::Body &p_body1, const JPH::Body &p_body2, JPH::RVec3Arg p_base_offset, const JPH::CollideShapeResult &p_collision_result) override;
 	virtual void OnContactAdded(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold, JPH::ContactSettings &p_settings) override;
 	virtual void OnContactPersisted(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold, JPH::ContactSettings &p_settings) override;
 	virtual void OnContactRemoved(const JPH::SubShapeIDPair &p_shape_pair) override;

--- a/servers/physics_2d/physics_server_2d_in_3d.h
+++ b/servers/physics_2d/physics_server_2d_in_3d.h
@@ -1,0 +1,1243 @@
+/**************************************************************************/
+/*  physics_server_2d_in_3d.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+// TODO: Make it a module.
+
+#include "core/math/geometry_2d.h"
+#include "physics_server_2d.h"
+#include "servers/physics_3d/physics_server_3d.h"
+
+static constexpr float SCALE_2D_TO_3D = 0.1f;
+static constexpr float SCALE_3D_TO_2D = 1.0f / SCALE_2D_TO_3D;
+static constexpr float DEPTH_ORTHOGONAL_TO_2D_PLANE = 20.0f; // in pixels
+static constexpr Vector3 PLANE_NORMAL_3D = Vector3(0, 0, 1);
+
+#define VECTOR2TO3(m_vec2) (SCALE_2D_TO_3D * Vector3(m_vec2.x, m_vec2.y, 0))
+#define VECTOR2TO3_FRONT(m_vec2) (SCALE_2D_TO_3D * Vector3(m_vec2.x, m_vec2.y, 0.5 * DEPTH_ORTHOGONAL_TO_2D_PLANE))
+#define VECTOR2TO3_BACK(m_vec2) (SCALE_2D_TO_3D * Vector3(m_vec2.x, m_vec2.y, -0.5 * DEPTH_ORTHOGONAL_TO_2D_PLANE))
+#define VECTOR3TO2(m_vec3) (SCALE_3D_TO_2D * Vector2(m_vec3.x, m_vec3.y))
+#define VECTOR2TO3_UNSCALED(m_vec2) (Vector3(m_vec2.x, m_vec2.y, 0))
+#define VECTOR3TO2_UNSCALED(m_vec3) (Vector2(m_vec3.x, m_vec3.y))
+#define SIZE2TO3(m_size2) (SCALE_2D_TO_3D * Vector3(m_size2.x, m_size2.y, DEPTH_ORTHOGONAL_TO_2D_PLANE))
+#define SIZE3TO2(m_size3) (SCALE_3D_TO_2D * Vector2(m_size3.x, m_size3.y))
+#define ANGLE2TO3(m_angle2) (Vector3(0, 0, m_angle2))
+#define ANGLE3TO2(m_angles3) (m_angles3.z)
+#define ANGLE2TOBASIS(m_angle2) (Basis(PLANE_NORMAL_3D, m_angle2))
+#define BASISTOANGLE2(m_basis) (m_basis.get_euler().z)
+
+class PhysicsDirectBodyState2Din3D : public PhysicsDirectBodyState2D {
+	GDCLASS(PhysicsDirectBodyState2Din3D, PhysicsDirectBodyState2D);
+
+	PhysicsDirectBodyState3D *state_3d;
+
+public:
+	virtual Vector2 get_total_gravity() const override {
+		Vector3 gravity_3d = state_3d->get_total_gravity();
+		return VECTOR3TO2(gravity_3d);
+	}
+	virtual real_t get_total_linear_damp() const override { return state_3d->get_total_linear_damp(); }
+	virtual real_t get_total_angular_damp() const override { return state_3d->get_total_angular_damp(); }
+
+	virtual Vector2 get_center_of_mass() const override {
+		Vector3 com = state_3d->get_center_of_mass();
+		return VECTOR3TO2(com);
+	}
+	virtual Vector2 get_center_of_mass_local() const override {
+		Vector3 com = state_3d->get_center_of_mass_local();
+		return VECTOR3TO2(com);
+	}
+	virtual real_t get_inverse_mass() const override { return state_3d->get_inverse_mass(); } // TODO check, wrong?
+	virtual real_t get_inverse_inertia() const override { return state_3d->get_inverse_inertia().z; } // TODO check, wrong?
+
+	virtual void set_linear_velocity(const Vector2 &p_velocity) override { state_3d->set_linear_velocity(VECTOR2TO3(p_velocity)); }
+	virtual Vector2 get_linear_velocity() const override {
+		Vector3 velocity_3d = state_3d->get_linear_velocity();
+		return VECTOR3TO2(velocity_3d);
+	}
+
+	virtual void set_angular_velocity(real_t p_velocity) override { state_3d->set_angular_velocity(ANGLE2TO3(p_velocity)); }
+	virtual real_t get_angular_velocity() const override { return ANGLE3TO2(state_3d->get_angular_velocity()); }
+
+	virtual void set_transform(const Transform2D &p_transform) override {
+		Vector2 origin = p_transform.get_origin();
+		state_3d->set_transform(Transform3D(ANGLE2TOBASIS(p_transform.get_rotation()), VECTOR2TO3(origin)));
+	}
+	virtual Transform2D get_transform() const override {
+		Transform3D xform_3d = state_3d->get_transform();
+		Vector3 origin = xform_3d.get_origin();
+		return Transform2D(BASISTOANGLE2(xform_3d.basis), VECTOR3TO2(origin));
+	}
+
+	virtual Vector2 get_velocity_at_local_position(const Vector2 &p_position) const override {
+		Vector3 velocity = state_3d->get_velocity_at_local_position(VECTOR2TO3(p_position));
+		return VECTOR3TO2(velocity);
+	}
+
+	virtual void apply_central_impulse(const Vector2 &p_impulse) override { state_3d->apply_central_impulse(VECTOR2TO3(p_impulse)); }
+	virtual void apply_torque_impulse(real_t p_torque) override { state_3d->apply_torque_impulse(ANGLE2TO3(p_torque)); }
+	virtual void apply_impulse(const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override { state_3d->apply_impulse(VECTOR2TO3(p_impulse), VECTOR2TO3(p_position)); }
+
+	virtual void apply_central_force(const Vector2 &p_force) override { state_3d->apply_central_force(VECTOR2TO3(p_force)); }
+	virtual void apply_force(const Vector2 &p_force, const Vector2 &p_position = Vector2()) override { state_3d->apply_force(VECTOR2TO3(p_force), VECTOR2TO3(p_position)); }
+	virtual void apply_torque(real_t p_torque) override { state_3d->apply_torque(ANGLE2TO3(p_torque)); }
+
+	virtual void add_constant_central_force(const Vector2 &p_force) override { state_3d->add_constant_central_force(VECTOR2TO3(p_force)); }
+	virtual void add_constant_force(const Vector2 &p_force, const Vector2 &p_position = Vector2()) override { state_3d->add_constant_force(VECTOR2TO3(p_force), VECTOR2TO3(p_position)); }
+	virtual void add_constant_torque(real_t p_torque) override { state_3d->add_constant_torque(ANGLE2TO3(p_torque)); }
+
+	virtual void set_constant_force(const Vector2 &p_force) override { state_3d->set_constant_force(VECTOR2TO3(p_force)); }
+	virtual Vector2 get_constant_force() const override {
+		Vector3 force = state_3d->get_constant_force();
+		return VECTOR3TO2(force);
+	}
+
+	virtual void set_constant_torque(real_t p_torque) override { state_3d->set_constant_torque(ANGLE2TO3(p_torque)); }
+	virtual real_t get_constant_torque() const override { return ANGLE3TO2(state_3d->get_constant_torque()); }
+
+	virtual void set_sleep_state(bool p_enable) override { state_3d->set_sleep_state(p_enable); }
+	virtual bool is_sleeping() const override { return state_3d->is_sleeping(); }
+
+	virtual void set_collision_layer(uint32_t p_layer) override { state_3d->set_collision_layer(p_layer); }
+	virtual uint32_t get_collision_layer() const override { return state_3d->get_collision_layer(); }
+
+	virtual void set_collision_mask(uint32_t p_mask) override { state_3d->set_collision_mask(p_mask); }
+	virtual uint32_t get_collision_mask() const override { return state_3d->get_collision_mask(); }
+
+	virtual int get_contact_count() const override { return state_3d->get_contact_count(); } // TODO fix. filter orthogonal to the plane and duplicates?
+
+	virtual Vector2 get_contact_local_position(int p_contact_idx) const override {
+		Vector3 pos = state_3d->get_contact_local_position(p_contact_idx);
+		return VECTOR3TO2(pos);
+	}
+	virtual Vector2 get_contact_local_normal(int p_contact_idx) const override {
+		Vector3 normal = state_3d->get_contact_local_normal(p_contact_idx);
+		return VECTOR3TO2(normal).normalized(); // TODO good enough?
+	}
+	virtual int get_contact_local_shape(int p_contact_idx) const override { return state_3d->get_contact_local_shape(p_contact_idx); }
+	virtual Vector2 get_contact_local_velocity_at_position(int p_contact_idx) const override {
+		Vector3 velocity = state_3d->get_contact_local_velocity_at_position(p_contact_idx);
+		return VECTOR3TO2(velocity);
+	}
+
+	virtual RID get_contact_collider(int p_contact_idx) const override { return state_3d->get_contact_collider(p_contact_idx); }
+	virtual Vector2 get_contact_collider_position(int p_contact_idx) const override {
+		Vector3 pos = state_3d->get_contact_collider_position(p_contact_idx);
+		return VECTOR3TO2(pos);
+	}
+	virtual ObjectID get_contact_collider_id(int p_contact_idx) const override { return state_3d->get_contact_collider_id(p_contact_idx); }
+	virtual Object *get_contact_collider_object(int p_contact_idx) const override { return state_3d->get_contact_collider_object(p_contact_idx); }
+	virtual int get_contact_collider_shape(int p_contact_idx) const override { return state_3d->get_contact_collider_shape(p_contact_idx); }
+	virtual Vector2 get_contact_collider_velocity_at_position(int p_contact_idx) const override {
+		Vector3 velocity = state_3d->get_contact_collider_velocity_at_position(p_contact_idx);
+		return VECTOR3TO2(velocity);
+	}
+	virtual Vector2 get_contact_impulse(int p_contact_idx) const override {
+		Vector3 impulse = state_3d->get_contact_impulse(p_contact_idx);
+		return VECTOR3TO2(impulse);
+	}
+
+	virtual real_t get_step() const override { return state_3d->get_step(); }
+	virtual void integrate_forces() override { state_3d->integrate_forces(); }
+
+	virtual RequiredResult<PhysicsDirectSpaceState2D> get_space_state() override { return nullptr; } // TODO
+
+	PhysicsDirectBodyState2Din3D(PhysicsDirectBodyState3D *p_state) :
+			state_3d(p_state) {}
+};
+
+class PhysicsDirectSpaceState2Din3D : public PhysicsDirectSpaceState2D {
+	GDCLASS(PhysicsDirectSpaceState2Din3D, PhysicsDirectSpaceState2D);
+
+	PhysicsDirectSpaceState3D *state_3d;
+
+public:
+	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
+		PhysicsDirectSpaceState3D::RayParameters params;
+		params.from = VECTOR2TO3(p_parameters.from);
+		params.to = VECTOR2TO3(p_parameters.to);
+		params.exclude = p_parameters.exclude;
+		params.collision_mask = p_parameters.collision_mask;
+		params.collide_with_bodies = p_parameters.collide_with_bodies;
+		params.collide_with_areas = p_parameters.collide_with_areas;
+		params.hit_from_inside = p_parameters.hit_from_inside;
+		PhysicsDirectSpaceState3D::RayResult result;
+		int ret = state_3d->intersect_ray(params, result);
+		r_result.position = VECTOR3TO2(result.position);
+		r_result.normal = VECTOR3TO2(result.normal).normalized();
+		r_result.rid = result.rid;
+		r_result.collider_id = result.collider_id;
+		r_result.collider = result.collider;
+		r_result.shape = result.shape;
+		return ret;
+	}
+
+	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override {
+		PhysicsDirectSpaceState3D::PointParameters params;
+		params.position = VECTOR2TO3(p_parameters.position);
+		params.exclude = p_parameters.exclude;
+		params.collision_mask = p_parameters.collision_mask;
+		params.collide_with_bodies = p_parameters.collide_with_bodies;
+		params.collide_with_areas = p_parameters.collide_with_areas;
+		return state_3d->intersect_point(params, (PhysicsDirectSpaceState3D::ShapeResult *)r_results, p_result_max); // NOTE: ShapeResult in 2D and 3D are compatible.
+	}
+
+	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override {
+		PhysicsDirectSpaceState3D::ShapeParameters params;
+		params.shape_rid = p_parameters.shape_rid;
+		params.transform = Transform3D(ANGLE2TOBASIS(p_parameters.transform.get_rotation()), VECTOR2TO3(p_parameters.transform.get_origin()));
+		params.motion = VECTOR2TO3(p_parameters.motion);
+		params.margin = SCALE_2D_TO_3D * p_parameters.margin;
+		params.exclude = p_parameters.exclude;
+		params.collision_mask = p_parameters.collision_mask;
+		params.collide_with_bodies = p_parameters.collide_with_bodies;
+		params.collide_with_areas = p_parameters.collide_with_areas;
+		return state_3d->intersect_shape(params, (PhysicsDirectSpaceState3D::ShapeResult *)r_results, p_result_max); // NOTE: ShapeResult in 2D and 3D are compatible.
+	}
+	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe) override {
+		PhysicsDirectSpaceState3D::ShapeParameters params;
+		params.shape_rid = p_parameters.shape_rid;
+		params.transform = Transform3D(ANGLE2TOBASIS(p_parameters.transform.get_rotation()), VECTOR2TO3(p_parameters.transform.get_origin()));
+		params.motion = VECTOR2TO3(p_parameters.motion);
+		params.margin = SCALE_2D_TO_3D * p_parameters.margin;
+		params.exclude = p_parameters.exclude;
+		params.collision_mask = p_parameters.collision_mask;
+		params.collide_with_bodies = p_parameters.collide_with_bodies;
+		params.collide_with_areas = p_parameters.collide_with_areas;
+		return state_3d->cast_motion(params, p_closest_safe, p_closest_unsafe); // NOTE: Fractions need no conversion.
+	}
+	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector2 *r_results, int p_result_max, int &r_result_count) override {
+		PhysicsDirectSpaceState3D::ShapeParameters params;
+		params.shape_rid = p_parameters.shape_rid;
+		params.transform = Transform3D(ANGLE2TOBASIS(p_parameters.transform.get_rotation()), VECTOR2TO3(p_parameters.transform.get_origin()));
+		params.motion = VECTOR2TO3(p_parameters.motion);
+		params.margin = SCALE_2D_TO_3D * p_parameters.margin;
+		params.exclude = p_parameters.exclude;
+		params.collision_mask = p_parameters.collision_mask;
+		params.collide_with_bodies = p_parameters.collide_with_bodies;
+		params.collide_with_areas = p_parameters.collide_with_areas;
+		// TODO: Handle r_results == nullptr?
+		Vector3 results[32]; // TODO: Enough? alloca?
+		bool ret = state_3d->collide_shape(params, results, p_result_max, r_result_count);
+		for (int i = 0; i < r_result_count; i++) {
+			r_results[i] = VECTOR3TO2(results[i]);
+		}
+		return ret;
+	}
+	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) override {
+		PhysicsDirectSpaceState3D::ShapeParameters params;
+		params.shape_rid = p_parameters.shape_rid;
+		params.transform = Transform3D(ANGLE2TOBASIS(p_parameters.transform.get_rotation()), VECTOR2TO3(p_parameters.transform.get_origin()));
+		params.motion = VECTOR2TO3(p_parameters.motion);
+		params.margin = SCALE_2D_TO_3D * p_parameters.margin;
+		params.exclude = p_parameters.exclude;
+		params.collision_mask = p_parameters.collision_mask;
+		params.collide_with_bodies = p_parameters.collide_with_bodies;
+		params.collide_with_areas = p_parameters.collide_with_areas;
+		bool ret;
+		if (r_info == nullptr) {
+			ret = state_3d->rest_info(params, nullptr);
+		} else {
+			PhysicsDirectSpaceState3D::ShapeRestInfo rest_info;
+			ret = state_3d->rest_info(params, &rest_info);
+			r_info->point = VECTOR3TO2(rest_info.point);
+			r_info->normal = VECTOR3TO2(rest_info.normal).normalized();
+			r_info->rid = rest_info.rid;
+			r_info->collider_id = rest_info.collider_id;
+			r_info->shape = rest_info.shape;
+			r_info->linear_velocity = VECTOR3TO2(rest_info.linear_velocity);
+		}
+		return ret;
+	}
+
+	PhysicsDirectSpaceState2Din3D(PhysicsDirectSpaceState3D *p_state) :
+			state_3d(p_state) {}
+};
+
+class PhysicsServer2Din3D : public PhysicsServer2D {
+	GDCLASS(PhysicsServer2Din3D, PhysicsServer2D);
+
+	PhysicsServer3D *physics_server_3d;
+	HashMap<RID, PhysicsDirectSpaceState2Din3D *> space_state;
+	HashMap<RID, PhysicsDirectBodyState2Din3D *> body_state;
+
+public:
+	virtual RID world_boundary_shape_create() override { return physics_server_3d->world_boundary_shape_create(); }
+	virtual RID separation_ray_shape_create() override { return physics_server_3d->separation_ray_shape_create(); }
+	virtual RID segment_shape_create() override { ERR_FAIL_V(RID()); } // TODO
+	virtual RID circle_shape_create() override { return physics_server_3d->sphere_shape_create(); }
+	virtual RID rectangle_shape_create() override { return physics_server_3d->box_shape_create(); }
+	virtual RID capsule_shape_create() override { return physics_server_3d->capsule_shape_create(); }
+	virtual RID convex_polygon_shape_create() override { return physics_server_3d->convex_polygon_shape_create(); }
+	virtual RID concave_polygon_shape_create() override { return physics_server_3d->concave_polygon_shape_create(); }
+
+	virtual void shape_set_data(RID p_shape, const Variant &p_data) override {
+		ShapeType shape_type = PhysicsServer2D::get_singleton()->shape_get_type(p_shape);
+		switch (shape_type) {
+			case ShapeType::SHAPE_RECTANGLE: {
+				Vector2 extents = p_data;
+				physics_server_3d->shape_set_data(p_shape, SIZE2TO3(extents));
+			} break;
+			case ShapeType::SHAPE_CAPSULE: {
+				float height, radius;
+				if (p_data.get_type() == Variant::Type::VECTOR2) {
+					Vector2 params = p_data;
+					radius = params.x;
+					height = params.y;
+				} else if (p_data.get_type() == Variant::Type::ARRAY) {
+					Array params = p_data;
+					ERR_FAIL_COND(params.size() != 2);
+					height = params[0];
+					radius = params[1];
+				} else {
+					ERR_FAIL();
+				}
+				Dictionary data;
+				data["height"] = SCALE_2D_TO_3D * height;
+				data["radius"] = SCALE_2D_TO_3D * radius;
+				physics_server_3d->shape_set_data(p_shape, data);
+			} break;
+			case ShapeType::SHAPE_CONVEX_POLYGON: {
+				if (p_data.get_type() != Variant::Type::PACKED_VECTOR2_ARRAY) {
+					ERR_FAIL();
+				}
+				// TODO: Also handle PackedFloat32Array
+				PackedVector2Array points = p_data;
+				PackedVector3Array points_3d_array;
+				points_3d_array.resize(points.size() * 2);
+				Vector3 *points_3d = points_3d_array.ptrw();
+				for (int i = 0; i < points.size(); i++) {
+					points_3d[2 * i] = VECTOR2TO3_FRONT(points[i]);
+					points_3d[2 * i + 1] = VECTOR2TO3_BACK(points[i]);
+				}
+				physics_server_3d->shape_set_data(p_shape, points_3d_array);
+			} break;
+			case ShapeType::SHAPE_CIRCLE: {
+				float radius = p_data;
+				physics_server_3d->shape_set_data(p_shape, SCALE_2D_TO_3D * radius);
+			} break;
+			case ShapeType::SHAPE_SEPARATION_RAY: {
+				Dictionary params_2d = p_data;
+				float length_2d = params_2d["length"];
+				Dictionary params_3d;
+				params_3d["length"] = SCALE_2D_TO_3D * length_2d;
+				params_3d["slide_on_slope"] = params_2d["slide_on_slope"];
+				physics_server_3d->shape_set_data(p_shape, params_3d);
+			} break;
+			case ShapeType::SHAPE_WORLD_BOUNDARY: {
+				Array params = p_data;
+				if (params[0].get_type() != Variant::Type::VECTOR2 || params[1].get_type() != Variant::Type::FLOAT) {
+					ERR_FAIL();
+				}
+				Vector2 normal = params[0];
+				real_t d = params[1];
+				Plane p(VECTOR2TO3(normal), SCALE_2D_TO_3D * d);
+				physics_server_3d->shape_set_data(p_shape, p);
+			} break;
+			case ShapeType::SHAPE_CONCAVE_POLYGON: {
+				PackedVector2Array segments = p_data;
+				int num_segments = segments.size() / 2;
+				PackedVector3Array faces;
+				faces.resize(num_segments * 3);
+				Vector3 *faces_3d = faces.ptrw();
+				// TODO: Make it so that other shapes are not balancing on the edge?
+				for (int i = 0; i < num_segments; i++) {
+					faces_3d[3 * i] = VECTOR2TO3_FRONT(segments[2 * i]);
+					faces_3d[3 * i + 1] = VECTOR2TO3_FRONT(segments[2 * i + 1]);
+					faces_3d[3 * i + 2] = VECTOR2TO3_BACK(0.5 * (segments[2 * i] + segments[2 * i + 1]));
+				}
+				Dictionary data;
+				data["faces"] = faces;
+				data["backface_collision"] = true;
+				physics_server_3d->shape_set_data(p_shape, data);
+			} break;
+			// TODO cases
+			default: {
+				// Don't know this shape.
+				ERR_FAIL();
+			} break;
+		}
+	}
+
+	virtual Variant shape_get_data(RID p_shape) const override {
+		ShapeType shape_type = PhysicsServer2D::get_singleton()->shape_get_type(p_shape);
+		Variant data_3d = physics_server_3d->shape_get_data(p_shape);
+		switch (shape_type) {
+			case ShapeType::SHAPE_RECTANGLE: {
+				Vector3 extents_3d = data_3d;
+				return SIZE3TO2(extents_3d);
+			} break;
+			case ShapeType::SHAPE_CAPSULE: {
+				Dictionary dict_3d = data_3d;
+				float height = dict_3d["height"];
+				float radius = dict_3d["radius"];
+				Dictionary data_2d;
+				data_2d["height"] = SCALE_3D_TO_2D * height;
+				data_2d["radius"] = SCALE_3D_TO_2D * radius;
+				return data_2d;
+			} break;
+			case ShapeType::SHAPE_CONVEX_POLYGON: {
+				PackedVector3Array points_3d = data_3d;
+				PackedVector2Array points_2d_array;
+				// If shape_set_data in 3D wouldn't modify the data, then it would be as easy as this:
+				/*
+				points_2d_array.resize(points_3d.size() / 2);
+				Vector2 *points_2d = points_2d_array.ptrw();
+				for (int i = 0; i < points_3d.size() / 2; i++) {
+					points_2d[i] = VECTOR3TO2(points_3d[2 * i]);
+				}
+				return points_2d_array;
+				*/
+				// NOTE: Workaround for shape_set_data in 3D (in Godot Physics) modifying the data.
+				points_2d_array.resize(points_3d.size());
+				Vector2 *points_2d = points_2d_array.ptrw();
+				for (int i = 0; i < points_3d.size(); i++) {
+					points_2d[i] = VECTOR3TO2(points_3d[i]);
+				}
+				return Geometry2D::convex_hull(points_2d_array);
+			} break;
+			case ShapeType::SHAPE_CIRCLE: {
+				float radius_3d = data_3d;
+				return SCALE_3D_TO_2D * radius_3d;
+			} break;
+			case ShapeType::SHAPE_SEPARATION_RAY: {
+				Dictionary dict_3d = data_3d;
+				float length_3d = dict_3d["length"];
+				Dictionary data_2d;
+				data_2d["length"] = SCALE_3D_TO_2D * length_3d;
+				data_2d["slide_on_slope"] = dict_3d["slide_on_slope"];
+				return data_2d;
+			} break;
+			case ShapeType::SHAPE_WORLD_BOUNDARY: {
+				Plane plane_3d = data_3d;
+				Array data_2d;
+				data_2d.push_back(VECTOR3TO2(plane_3d.normal));
+				data_2d.push_back(SCALE_3D_TO_2D * -plane_3d.d);
+				return data_2d;
+			} break;
+			case ShapeType::SHAPE_CONCAVE_POLYGON: {
+				Dictionary dict_3d = data_3d;
+				PackedVector3Array faces_3d = dict_3d["faces"];
+				PackedVector2Array segments_2d_array;
+				segments_2d_array.resize(faces_3d.size() / 3);
+				Vector2 *segments_2d = segments_2d_array.ptrw();
+				for (int i = 0; i < faces_3d.size() / 3; i++) {
+					segments_2d[i] = VECTOR3TO2(faces_3d[3 * i]);
+				}
+				return segments_2d_array;
+			} break;
+			// TODO cases
+			default: {
+				// Don't know this shape.
+				ERR_FAIL_V(Variant());
+			} break;
+		}
+		// FIXME: error: control reaches end of non-void function [-Werror=return-type]
+		ERR_FAIL_V(Variant());
+	}
+
+	virtual void shape_set_custom_solver_bias(RID p_shape, real_t p_bias) override { physics_server_3d->shape_set_custom_solver_bias(p_shape, p_bias); }
+	virtual real_t shape_get_custom_solver_bias(RID p_shape) const override { return physics_server_3d->shape_get_custom_solver_bias(p_shape); }
+
+	virtual ShapeType shape_get_type(RID p_shape) const override {
+		PhysicsServer3D::ShapeType shape_type = physics_server_3d->shape_get_type(p_shape);
+		switch (shape_type) {
+			case PhysicsServer3D::ShapeType::SHAPE_BOX:
+				return ShapeType::SHAPE_RECTANGLE;
+			case PhysicsServer3D::ShapeType::SHAPE_CAPSULE:
+				return ShapeType::SHAPE_CAPSULE;
+			case PhysicsServer3D::ShapeType::SHAPE_CONVEX_POLYGON:
+				return ShapeType::SHAPE_CONVEX_POLYGON;
+			case PhysicsServer3D::ShapeType::SHAPE_SPHERE:
+				return ShapeType::SHAPE_CIRCLE;
+			case PhysicsServer3D::ShapeType::SHAPE_SEPARATION_RAY:
+				return ShapeType::SHAPE_SEPARATION_RAY;
+			case PhysicsServer3D::ShapeType::SHAPE_WORLD_BOUNDARY:
+				return ShapeType::SHAPE_WORLD_BOUNDARY;
+			case PhysicsServer3D::ShapeType::SHAPE_CONCAVE_POLYGON:
+				return ShapeType::SHAPE_CONCAVE_POLYGON;
+			// TODO cases
+			default:
+				return ShapeType::SHAPE_CIRCLE;
+		}
+	}
+
+	virtual bool shape_collide(RID p_shape_A, const Transform2D &p_xform_A, const Vector2 &p_motion_A, RID p_shape_B, const Transform2D &p_xform_B, const Vector2 &p_motion_B, Vector2 *r_results, int p_result_max, int &r_result_count) override { return false; } // TODO
+
+	/* SPACE API */
+
+	virtual RID space_create() override { return physics_server_3d->space_create(); }
+	virtual void space_set_active(RID p_space, bool p_active) override { physics_server_3d->space_set_active(p_space, p_active); }
+	virtual bool space_is_active(RID p_space) const override { return physics_server_3d->space_is_active(p_space); }
+
+	virtual void space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) override {
+		switch (p_param) {
+			case SpaceParameter::SPACE_PARAM_CONTACT_RECYCLE_RADIUS: {
+				physics_server_3d->space_set_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_CONTACT_RECYCLE_RADIUS, 0.1 * SCALE_2D_TO_3D * p_value); // TODO: Okay to match defaults like this?
+			} break;
+			case SpaceParameter::SPACE_PARAM_CONTACT_MAX_SEPARATION: {
+				physics_server_3d->space_set_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_CONTACT_MAX_SEPARATION, SCALE_2D_TO_3D * p_value / 3.0); // TODO: Okay to match defaults like this?
+			} break;
+			case SpaceParameter::SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION: {
+				physics_server_3d->space_set_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION, SCALE_2D_TO_3D * p_value / 3.0); // TODO: Okay to match defaults like this?
+			} break;
+			case SpaceParameter::SPACE_PARAM_CONTACT_DEFAULT_BIAS: {
+				physics_server_3d->space_set_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_CONTACT_DEFAULT_BIAS, p_value); // TODO: Same unit?
+			} break;
+			case SpaceParameter::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD: {
+				physics_server_3d->space_set_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD, SCALE_2D_TO_3D * p_value / 2.0); // TODO: Okay to match defaults like this?
+			} break;
+			case SpaceParameter::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD: {
+				physics_server_3d->space_set_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD, p_value); // TODO: Same unit?
+			} break;
+			case SpaceParameter::SPACE_PARAM_BODY_TIME_TO_SLEEP: {
+				physics_server_3d->space_set_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_BODY_TIME_TO_SLEEP, p_value); // NOTE: Time is time, no scale.
+			} break;
+			case SpaceParameter::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS: {
+				// TODO: No way?
+			} break;
+			case SpaceParameter::SPACE_PARAM_SOLVER_ITERATIONS: {
+				physics_server_3d->space_set_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_SOLVER_ITERATIONS, p_value);
+			} break;
+			default: {
+				ERR_FAIL();
+			} break;
+		}
+	}
+	virtual real_t space_get_param(RID p_space, SpaceParameter p_param) const override {
+		switch (p_param) {
+			case SpaceParameter::SPACE_PARAM_CONTACT_RECYCLE_RADIUS: {
+				return 10.0 * SCALE_3D_TO_2D * physics_server_3d->space_get_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_CONTACT_RECYCLE_RADIUS);
+			} break;
+			case SpaceParameter::SPACE_PARAM_CONTACT_MAX_SEPARATION: {
+				return 3.0 * SCALE_3D_TO_2D * physics_server_3d->space_get_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_CONTACT_MAX_SEPARATION);
+			} break;
+			case SpaceParameter::SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION: {
+				return 3.0 * SCALE_3D_TO_2D * physics_server_3d->space_get_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION);
+			} break;
+			case SpaceParameter::SPACE_PARAM_CONTACT_DEFAULT_BIAS: {
+				return physics_server_3d->space_get_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_CONTACT_DEFAULT_BIAS);
+			} break;
+			case SpaceParameter::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD: {
+				return 2.0 * SCALE_3D_TO_2D * physics_server_3d->space_get_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD);
+			} break;
+			case SpaceParameter::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD: {
+				return physics_server_3d->space_get_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD);
+			} break;
+			case SpaceParameter::SPACE_PARAM_BODY_TIME_TO_SLEEP: {
+				return physics_server_3d->space_get_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_BODY_TIME_TO_SLEEP);
+			} break;
+			case SpaceParameter::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS: {
+				// TODO: No way?
+				return (real_t)0;
+			} break;
+			case SpaceParameter::SPACE_PARAM_SOLVER_ITERATIONS: {
+				return physics_server_3d->space_get_param(p_space, PhysicsServer3D::SpaceParameter::SPACE_PARAM_SOLVER_ITERATIONS);
+			} break;
+			default: {
+				ERR_FAIL_V(0.0);
+			} break;
+		}
+	}
+
+	virtual PhysicsDirectSpaceState2D *space_get_direct_state(RID p_space) override {
+		PhysicsDirectSpaceState3D *state_3d = physics_server_3d->space_get_direct_state(p_space);
+		if (!state_3d) {
+			return nullptr;
+		}
+		PhysicsDirectSpaceState2Din3D *state_2d = nullptr;
+		if (space_state.has(p_space)) {
+			state_2d = space_state.get(p_space);
+		} else {
+			state_2d = memnew(PhysicsDirectSpaceState2Din3D(state_3d));
+			space_state.insert(p_space, state_2d);
+		}
+		return state_2d;
+	}
+
+	virtual void space_set_debug_contacts(RID p_space, int p_max_contacts) override { physics_server_3d->space_set_debug_contacts(p_space, p_max_contacts); }
+	virtual Vector<Vector2> space_get_contacts(RID p_space) const override {
+		Vector<Vector3> contacts_3d = physics_server_3d->space_get_contacts(p_space);
+		Vector<Vector2> contacts_2d_array;
+		contacts_2d_array.resize(contacts_3d.size());
+		Vector2 *contacts_2d = contacts_2d_array.ptrw();
+		for (int i = 0; i < contacts_3d.size(); i++) {
+			contacts_2d[i] = VECTOR3TO2(contacts_3d[i]);
+		}
+		return contacts_2d_array;
+	}
+	virtual int space_get_contact_count(RID p_space) const override { return physics_server_3d->space_get_contact_count(p_space); }
+
+	/* AREA API */
+
+	virtual RID area_create() override { return physics_server_3d->area_create(); }
+
+	virtual void area_set_space(RID p_area, RID p_space) override { physics_server_3d->area_set_space(p_area, p_space); }
+	virtual RID area_get_space(RID p_area) const override { return physics_server_3d->area_get_space(p_area); }
+
+	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) override {
+		Vector2 origin = p_transform.get_origin();
+		Transform3D xform_3d = Transform3D(ANGLE2TOBASIS(p_transform.get_rotation()), VECTOR2TO3(origin));
+		physics_server_3d->area_add_shape(p_area, p_shape, xform_3d, p_disabled);
+	}
+	virtual void area_set_shape(RID p_area, int p_shape_idx, RID p_shape) override { physics_server_3d->area_set_shape(p_area, p_shape_idx, p_shape); }
+	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform) override {
+		Vector2 origin = p_transform.get_origin();
+		Transform3D xform_3d = Transform3D(ANGLE2TOBASIS(p_transform.get_rotation()), VECTOR2TO3(origin));
+		physics_server_3d->area_set_shape_transform(p_area, p_shape_idx, xform_3d);
+	}
+
+	virtual int area_get_shape_count(RID p_area) const override { return physics_server_3d->area_get_shape_count(p_area); }
+	virtual RID area_get_shape(RID p_area, int p_shape_idx) const override { return physics_server_3d->area_get_shape(p_area, p_shape_idx); }
+	virtual Transform2D area_get_shape_transform(RID p_area, int p_shape_idx) const override {
+		Transform3D xform_3d = physics_server_3d->area_get_shape_transform(p_area, p_shape_idx);
+		Vector3 origin = xform_3d.get_origin();
+		return Transform2D(BASISTOANGLE2(xform_3d.basis), VECTOR3TO2(origin));
+	}
+
+	virtual void area_remove_shape(RID p_area, int p_shape_idx) override { physics_server_3d->area_remove_shape(p_area, p_shape_idx); }
+	virtual void area_clear_shapes(RID p_area) override { physics_server_3d->area_clear_shapes(p_area); }
+
+	virtual void area_set_shape_disabled(RID p_area, int p_shape, bool p_disabled) override { physics_server_3d->area_set_shape_disabled(p_area, p_shape, p_disabled); }
+
+	virtual void area_attach_object_instance_id(RID p_area, ObjectID p_id) override { physics_server_3d->area_attach_object_instance_id(p_area, p_id); }
+	virtual ObjectID area_get_object_instance_id(RID p_area) const override { return physics_server_3d->area_get_object_instance_id(p_area); }
+
+	virtual void area_attach_canvas_instance_id(RID p_area, ObjectID p_id) override {} // TODO hmmm
+	virtual ObjectID area_get_canvas_instance_id(RID p_area) const override { return ObjectID(); } // TODO hmmm
+
+	virtual void area_set_param(RID p_area, AreaParameter p_param, const Variant &p_value) override {
+		switch (p_param) {
+			case AREA_PARAM_GRAVITY: {
+				float gravity = p_value;
+				physics_server_3d->area_set_param(p_area, PhysicsServer3D::AreaParameter::AREA_PARAM_GRAVITY, SCALE_2D_TO_3D * gravity);
+			} break;
+			case AREA_PARAM_GRAVITY_VECTOR: {
+				Vector2 gravity = p_value;
+				// NOTE: No scale to avoid double scaling.
+				physics_server_3d->area_set_param(p_area, PhysicsServer3D::AreaParameter::AREA_PARAM_GRAVITY_VECTOR, VECTOR2TO3_UNSCALED(gravity));
+			} break;
+			case AREA_PARAM_GRAVITY_POINT_UNIT_DISTANCE: {
+				float unit_distance = p_value;
+				physics_server_3d->area_set_param(p_area, PhysicsServer3D::AreaParameter::AREA_PARAM_GRAVITY_POINT_UNIT_DISTANCE, SCALE_2D_TO_3D * unit_distance);
+			} break;
+			// NOTE: AreaSpaceOverrideMode in 2D and 3D are compatible.
+			case AREA_PARAM_GRAVITY_OVERRIDE_MODE:
+			case AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE:
+			case AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE:
+			// NOTE: Booleans in 2D and 3D are compatible.
+			case AREA_PARAM_GRAVITY_IS_POINT:
+			// NOTE: Priority numbers in 2D and 3D are compatible.
+			case AREA_PARAM_PRIORITY:
+			// NOTE: Damping factors in 2D and 3D are compatible.
+			case AREA_PARAM_LINEAR_DAMP:
+			case AREA_PARAM_ANGULAR_DAMP: {
+				// NOTE: AreaParameter constants in 2D and 3D are compatible.
+				physics_server_3d->area_set_param(p_area, (PhysicsServer3D::AreaParameter)p_param, p_value);
+			} break;
+			default: {
+				// Don't know what.
+				ERR_FAIL();
+			} break;
+		}
+	}
+	virtual void area_set_transform(RID p_area, const Transform2D &p_transform) override {
+		Vector2 origin = p_transform.get_origin();
+		Transform3D xform_3d = Transform3D(ANGLE2TOBASIS(p_transform.get_rotation()), VECTOR2TO3(origin));
+		physics_server_3d->area_set_transform(p_area, xform_3d);
+	}
+
+	virtual Variant area_get_param(RID p_area, AreaParameter p_param) const override {
+		switch (p_param) {
+			case AREA_PARAM_GRAVITY: {
+				float gravity = physics_server_3d->area_get_param(p_area, PhysicsServer3D::AreaParameter::AREA_PARAM_GRAVITY);
+				return SCALE_3D_TO_2D * gravity;
+			} break;
+			case AREA_PARAM_GRAVITY_VECTOR: {
+				Vector3 gravity = physics_server_3d->area_get_param(p_area, PhysicsServer3D::AreaParameter::AREA_PARAM_GRAVITY_VECTOR);
+				// NOTE: No scale to avoid double scaling.
+				return VECTOR3TO2_UNSCALED(gravity);
+			} break;
+			case AREA_PARAM_GRAVITY_POINT_UNIT_DISTANCE: {
+				float unit_distance = physics_server_3d->area_get_param(p_area, PhysicsServer3D::AreaParameter::AREA_PARAM_GRAVITY_POINT_UNIT_DISTANCE);
+				return SCALE_3D_TO_2D * unit_distance;
+			} break;
+			// NOTE: AreaParameter constants and parameter values in 2D and 3D are compatible in the following cases.
+			case AREA_PARAM_GRAVITY_OVERRIDE_MODE:
+			case AREA_PARAM_GRAVITY_IS_POINT:
+			case AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE:
+			case AREA_PARAM_LINEAR_DAMP:
+			case AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE:
+			case AREA_PARAM_ANGULAR_DAMP:
+			case AREA_PARAM_PRIORITY: {
+				return physics_server_3d->area_get_param(p_area, (PhysicsServer3D::AreaParameter)p_param);
+			} break;
+			default: {
+				// Don't know what.
+				ERR_FAIL_V(Variant());
+			} break;
+		}
+	}
+	virtual Transform2D area_get_transform(RID p_area) const override {
+		Transform3D xform_3d = physics_server_3d->area_get_transform(p_area);
+		Vector3 origin = xform_3d.get_origin();
+		return Transform2D(BASISTOANGLE2(xform_3d.basis), VECTOR3TO2(origin));
+	}
+
+	virtual void area_set_collision_layer(RID p_area, uint32_t p_layer) override { physics_server_3d->area_set_collision_layer(p_area, p_layer); }
+	virtual uint32_t area_get_collision_layer(RID p_area) const override { return physics_server_3d->area_get_collision_layer(p_area); }
+
+	virtual void area_set_collision_mask(RID p_area, uint32_t p_mask) override { physics_server_3d->area_set_collision_mask(p_area, p_mask); }
+	virtual uint32_t area_get_collision_mask(RID p_area) const override { return physics_server_3d->area_get_collision_mask(p_area); }
+
+	virtual void area_set_monitorable(RID p_area, bool p_monitorable) override { physics_server_3d->area_set_monitorable(p_area, p_monitorable); }
+	virtual void area_set_pickable(RID p_area, bool p_pickable) override { physics_server_3d->area_set_ray_pickable(p_area, p_pickable); }
+
+	virtual void area_set_monitor_callback(RID p_area, const Callable &p_callback) override { physics_server_3d->area_set_monitor_callback(p_area, p_callback); } // NOTE: Callback signature compatible with 3D.
+	virtual void area_set_area_monitor_callback(RID p_area, const Callable &p_callback) override { physics_server_3d->area_set_area_monitor_callback(p_area, p_callback); } // NOTE: Callback signature compatible with 3D.
+
+	/* BODY API */
+
+	virtual RID body_create() override {
+		RID body = physics_server_3d->body_create();
+		physics_server_3d->body_set_axis_lock(body, PhysicsServer3D::BodyAxis::BODY_AXIS_LINEAR_Z, true);
+		physics_server_3d->body_set_axis_lock(body, PhysicsServer3D::BodyAxis::BODY_AXIS_ANGULAR_X, true);
+		physics_server_3d->body_set_axis_lock(body, PhysicsServer3D::BodyAxis::BODY_AXIS_ANGULAR_Y, true);
+		return body;
+	}
+
+	virtual void body_set_space(RID p_body, RID p_space) override { physics_server_3d->body_set_space(p_body, p_space); }
+	virtual RID body_get_space(RID p_body) const override { return physics_server_3d->body_get_space(p_body); }
+
+	virtual void body_set_mode(RID p_body, BodyMode p_mode) override { physics_server_3d->body_set_mode(p_body, (PhysicsServer3D::BodyMode)p_mode); }
+	virtual BodyMode body_get_mode(RID p_body) const override { return (BodyMode)physics_server_3d->body_get_mode(p_body); }
+
+	virtual void body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) override {
+		Vector2 origin = p_transform.get_origin();
+		Transform3D xform_3d = Transform3D(ANGLE2TOBASIS(p_transform.get_rotation()), VECTOR2TO3(origin));
+		physics_server_3d->body_add_shape(p_body, p_shape, xform_3d, p_disabled);
+	}
+	virtual void body_set_shape(RID p_body, int p_shape_idx, RID p_shape) override { physics_server_3d->body_set_shape(p_body, p_shape_idx, p_shape); }
+	virtual void body_set_shape_transform(RID p_body, int p_shape_idx, const Transform2D &p_transform) override {
+		Vector2 origin = p_transform.get_origin();
+		Transform3D xform_3d = Transform3D(ANGLE2TOBASIS(p_transform.get_rotation()), VECTOR2TO3(origin));
+		physics_server_3d->body_set_shape_transform(p_body, p_shape_idx, xform_3d);
+	}
+
+	virtual int body_get_shape_count(RID p_body) const override { return physics_server_3d->body_get_shape_count(p_body); }
+	virtual RID body_get_shape(RID p_body, int p_shape_idx) const override { return physics_server_3d->body_get_shape(p_body, p_shape_idx); }
+	virtual Transform2D body_get_shape_transform(RID p_body, int p_shape_idx) const override {
+		Transform3D xform_3d = physics_server_3d->body_get_shape_transform(p_body, p_shape_idx);
+		Vector3 origin = xform_3d.get_origin();
+		return Transform2D(BASISTOANGLE2(xform_3d.basis), VECTOR3TO2(origin));
+	}
+
+	virtual void body_set_shape_disabled(RID p_body, int p_shape, bool p_disabled) override { physics_server_3d->body_set_shape_disabled(p_body, p_shape, p_disabled); }
+	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0, const Vector2 &p_direction = Vector2(0, 1)) override {
+		real_t margin = SCALE_2D_TO_3D * p_margin;
+		physics_server_3d->body_set_shape_as_one_way_collision(p_body, p_shape, p_enabled, margin, VECTOR2TO3(p_direction));
+	}
+
+	virtual void body_remove_shape(RID p_body, int p_shape_idx) override { physics_server_3d->body_remove_shape(p_body, p_shape_idx); }
+	virtual void body_clear_shapes(RID p_body) override { physics_server_3d->body_clear_shapes(p_body); }
+
+	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) override { physics_server_3d->body_attach_object_instance_id(p_body, p_id); }
+	virtual ObjectID body_get_object_instance_id(RID p_body) const override { return physics_server_3d->body_get_object_instance_id(p_body); }
+
+	virtual void body_attach_canvas_instance_id(RID p_body, ObjectID p_id) override {} // TODO hmmm
+	virtual ObjectID body_get_canvas_instance_id(RID p_body) const override { return ObjectID(); } // TODO hmmm
+
+	virtual void body_set_continuous_collision_detection_mode(RID p_body, CCDMode p_mode) override { physics_server_3d->body_set_enable_continuous_collision_detection(p_body, p_mode != CCDMode::CCD_MODE_DISABLED); }
+	virtual CCDMode body_get_continuous_collision_detection_mode(RID p_body) const override { return physics_server_3d->body_is_continuous_collision_detection_enabled(p_body) ? CCDMode::CCD_MODE_CAST_RAY : CCDMode::CCD_MODE_DISABLED; } // TODO: what represents true better? cast ray or shape?
+
+	virtual void body_set_collision_layer(RID p_body, uint32_t p_layer) override { physics_server_3d->body_set_collision_layer(p_body, p_layer); }
+	virtual uint32_t body_get_collision_layer(RID p_body) const override { return physics_server_3d->body_get_collision_layer(p_body); }
+
+	virtual void body_set_collision_mask(RID p_body, uint32_t p_mask) override { physics_server_3d->body_set_collision_mask(p_body, p_mask); }
+	virtual uint32_t body_get_collision_mask(RID p_body) const override { return physics_server_3d->body_get_collision_mask(p_body); }
+
+	virtual void body_set_collision_priority(RID p_body, real_t p_priority) override { physics_server_3d->body_set_collision_priority(p_body, p_priority); }
+	virtual real_t body_get_collision_priority(RID p_body) const override { return physics_server_3d->body_get_collision_priority(p_body); }
+
+	virtual void body_set_param(RID p_body, BodyParameter p_param, const Variant &p_value) override {
+		switch (p_param) {
+			case BODY_PARAM_MASS: {
+				real_t mass = p_value;
+				physics_server_3d->body_set_param(p_body, PhysicsServer3D::BodyParameter::BODY_PARAM_MASS, mass); // TODO: Scale correct?
+			} break;
+			case BODY_PARAM_INERTIA: {
+				real_t inertia_2d = p_value;
+				Vector3 inertia_3d;
+				if (inertia_2d > 0) {
+					inertia_3d = Vector3(1, 1, inertia_2d); // TODO: Check. Scale?
+				}
+				physics_server_3d->body_set_param(p_body, PhysicsServer3D::BodyParameter::BODY_PARAM_INERTIA, inertia_3d);
+			} break;
+			case BODY_PARAM_CENTER_OF_MASS: {
+				Vector2 com = p_value;
+				physics_server_3d->body_set_param(p_body, PhysicsServer3D::BodyParameter::BODY_PARAM_CENTER_OF_MASS, VECTOR2TO3(com));
+			} break;
+			// NOTE: BodyParameter in 2D and 3D are compatible, and the following parameters are compatible.
+			case BODY_PARAM_BOUNCE:
+			case BODY_PARAM_FRICTION:
+			case BODY_PARAM_GRAVITY_SCALE:
+			case BODY_PARAM_LINEAR_DAMP_MODE:
+			case BODY_PARAM_ANGULAR_DAMP_MODE:
+			// NOTE: No scale on damp.
+			case BODY_PARAM_LINEAR_DAMP:
+			case BODY_PARAM_ANGULAR_DAMP: {
+				physics_server_3d->body_set_param(p_body, (PhysicsServer3D::BodyParameter)p_param, p_value);
+			} break;
+			default: {
+				ERR_FAIL();
+			} break;
+		}
+	}
+	virtual Variant body_get_param(RID p_body, BodyParameter p_param) const override {
+		switch (p_param) {
+			case BODY_PARAM_MASS: {
+				real_t mass = physics_server_3d->body_get_param(p_body, PhysicsServer3D::BodyParameter::BODY_PARAM_MASS);
+				return mass; // TODO: Scale correct?
+			} break;
+			case BODY_PARAM_INERTIA: {
+				Vector3 inertia = physics_server_3d->body_get_param(p_body, PhysicsServer3D::BodyParameter::BODY_PARAM_INERTIA);
+				return inertia.z; // TODO: Scale or no?
+			} break;
+			case BODY_PARAM_CENTER_OF_MASS: {
+				Vector3 com = physics_server_3d->body_get_param(p_body, PhysicsServer3D::BodyParameter::BODY_PARAM_CENTER_OF_MASS);
+				return VECTOR3TO2(com);
+			} break;
+			// NOTE: BodyParameter in 2D and 3D are compatible, and the following parameters are compatible.
+			case BODY_PARAM_BOUNCE:
+			case BODY_PARAM_FRICTION:
+			case BODY_PARAM_GRAVITY_SCALE:
+			case BODY_PARAM_LINEAR_DAMP_MODE:
+			case BODY_PARAM_ANGULAR_DAMP_MODE:
+			// NOTE: No scale on damp.
+			case BODY_PARAM_LINEAR_DAMP:
+			case BODY_PARAM_ANGULAR_DAMP: {
+				return physics_server_3d->body_get_param(p_body, (PhysicsServer3D::BodyParameter)p_param);
+			} break;
+			default: {
+				ERR_FAIL_V(Variant());
+			} break;
+		}
+	}
+
+	virtual void body_reset_mass_properties(RID p_body) override { physics_server_3d->body_reset_mass_properties(p_body); }
+
+	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) override {
+		switch (p_state) {
+			case BodyState::BODY_STATE_TRANSFORM: {
+				Transform2D xform_2d = p_variant;
+				Vector2 origin = xform_2d.get_origin();
+				Transform3D xform = Transform3D(ANGLE2TOBASIS(xform_2d.get_rotation()), VECTOR2TO3(origin));
+				physics_server_3d->body_set_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_TRANSFORM, xform);
+			} break;
+			case BodyState::BODY_STATE_LINEAR_VELOCITY: {
+				Vector2 velocity_2d = p_variant;
+				Vector3 velocity = VECTOR2TO3(velocity_2d);
+				physics_server_3d->body_set_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_LINEAR_VELOCITY, velocity);
+			} break;
+			case BodyState::BODY_STATE_ANGULAR_VELOCITY: {
+				real_t angular_velocity_2d = p_variant;
+				Vector3 angular_velocity = ANGLE2TO3(angular_velocity_2d);
+				physics_server_3d->body_set_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_ANGULAR_VELOCITY, angular_velocity);
+			} break;
+			case BodyState::BODY_STATE_CAN_SLEEP: {
+				bool can_sleep = p_variant;
+				physics_server_3d->body_set_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_CAN_SLEEP, can_sleep);
+			} break;
+			case BodyState::BODY_STATE_SLEEPING: {
+				bool sleeping = p_variant;
+				physics_server_3d->body_set_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_SLEEPING, sleeping);
+			} break;
+			default: {
+				ERR_FAIL();
+			} break;
+		}
+	}
+	virtual Variant body_get_state(RID p_body, BodyState p_state) const override {
+		switch (p_state) {
+			case BodyState::BODY_STATE_TRANSFORM: {
+				Transform3D xform_3d = physics_server_3d->body_get_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_TRANSFORM);
+				Vector3 origin = xform_3d.get_origin();
+				return Transform2D(BASISTOANGLE2(xform_3d.basis), VECTOR3TO2(origin));
+			} break;
+			case BodyState::BODY_STATE_LINEAR_VELOCITY: {
+				Vector3 velocity_3d = physics_server_3d->body_get_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_LINEAR_VELOCITY);
+				return VECTOR3TO2(velocity_3d);
+			} break;
+			case BodyState::BODY_STATE_ANGULAR_VELOCITY: {
+				Vector3 velocity_3d = physics_server_3d->body_get_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_ANGULAR_VELOCITY);
+				return ANGLE3TO2(velocity_3d);
+			} break;
+			case BodyState::BODY_STATE_CAN_SLEEP: {
+				return physics_server_3d->body_get_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_CAN_SLEEP);
+			} break;
+			case BodyState::BODY_STATE_SLEEPING: {
+				return physics_server_3d->body_get_state(p_body, PhysicsServer3D::BodyState::BODY_STATE_SLEEPING);
+			} break;
+			default: {
+				ERR_FAIL_V(Variant());
+			} break;
+		}
+	}
+
+	virtual void body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) override { physics_server_3d->body_apply_central_impulse(p_body, VECTOR2TO3(p_impulse)); }
+	virtual void body_apply_torque_impulse(RID p_body, real_t p_torque) override { physics_server_3d->body_apply_torque_impulse(p_body, ANGLE2TO3(p_torque)); }
+	virtual void body_apply_impulse(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override { physics_server_3d->body_apply_impulse(p_body, VECTOR2TO3(p_impulse), VECTOR2TO3(p_position)); }
+
+	virtual void body_apply_central_force(RID p_body, const Vector2 &p_force) override { physics_server_3d->body_apply_central_force(p_body, VECTOR2TO3(p_force)); }
+	virtual void body_apply_force(RID p_body, const Vector2 &p_force, const Vector2 &p_position = Vector2()) override { physics_server_3d->body_apply_force(p_body, VECTOR2TO3(p_force), VECTOR2TO3(p_position)); }
+	virtual void body_apply_torque(RID p_body, real_t p_torque) override { physics_server_3d->body_apply_torque(p_body, ANGLE2TO3(p_torque)); }
+
+	virtual void body_add_constant_central_force(RID p_body, const Vector2 &p_force) override { physics_server_3d->body_add_constant_central_force(p_body, VECTOR2TO3(p_force)); }
+	virtual void body_add_constant_force(RID p_body, const Vector2 &p_force, const Vector2 &p_position = Vector2()) override { physics_server_3d->body_add_constant_force(p_body, VECTOR2TO3(p_force), VECTOR2TO3(p_position)); }
+	virtual void body_add_constant_torque(RID p_body, real_t p_torque) override { physics_server_3d->body_add_constant_torque(p_body, ANGLE2TO3(p_torque)); }
+
+	virtual void body_set_constant_force(RID p_body, const Vector2 &p_force) override { physics_server_3d->body_set_constant_force(p_body, VECTOR2TO3(p_force)); }
+	virtual Vector2 body_get_constant_force(RID p_body) const override {
+		Vector3 force = physics_server_3d->body_get_constant_force(p_body);
+		return VECTOR3TO2(force);
+	}
+
+	virtual void body_set_constant_torque(RID p_body, real_t p_torque) override { physics_server_3d->body_set_constant_torque(p_body, ANGLE2TO3(p_torque)); }
+	virtual real_t body_get_constant_torque(RID p_body) const override { return ANGLE3TO2(physics_server_3d->body_get_constant_torque(p_body)); }
+
+	virtual void body_set_axis_velocity(RID p_body, const Vector2 &p_axis_velocity) override { physics_server_3d->body_set_axis_velocity(p_body, VECTOR2TO3(p_axis_velocity)); }
+
+	virtual void body_add_collision_exception(RID p_body, RID p_body_b) override { physics_server_3d->body_add_collision_exception(p_body, p_body_b); }
+	virtual void body_remove_collision_exception(RID p_body, RID p_body_b) override { physics_server_3d->body_remove_collision_exception(p_body, p_body_b); }
+	virtual void body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) override { physics_server_3d->body_get_collision_exceptions(p_body, p_exceptions); }
+
+	virtual void body_set_max_contacts_reported(RID p_body, int p_contacts) override { physics_server_3d->body_set_max_contacts_reported(p_body, p_contacts); }
+	virtual int body_get_max_contacts_reported(RID p_body) const override { return physics_server_3d->body_get_max_contacts_reported(p_body); }
+
+	virtual void body_set_contacts_reported_depth_threshold(RID p_body, real_t p_threshold) override { physics_server_3d->body_set_contacts_reported_depth_threshold(p_body, SCALE_2D_TO_3D * p_threshold); }
+	virtual real_t body_get_contacts_reported_depth_threshold(RID p_body) const override { return SCALE_3D_TO_2D * physics_server_3d->body_get_contacts_reported_depth_threshold(p_body); }
+
+	virtual void body_set_omit_force_integration(RID p_body, bool p_omit) override { physics_server_3d->body_set_omit_force_integration(p_body, p_omit); }
+	virtual bool body_is_omitting_force_integration(RID p_body) const override { return physics_server_3d->body_is_omitting_force_integration(p_body); }
+
+	void body_state_sync_callback_3d(PhysicsDirectBodyState3D *p_state_3d, RID p_body, const Callable &p_callable_2d) {
+		PhysicsDirectBodyState2Din3D *state_2d = nullptr;
+		if (body_state.has(p_body)) {
+			state_2d = body_state.get(p_body);
+		} else {
+			state_2d = memnew(PhysicsDirectBodyState2Din3D(p_state_3d));
+			body_state.insert(p_body, state_2d);
+		}
+		p_callable_2d.call(state_2d);
+	}
+	virtual void body_set_state_sync_callback(RID p_body, const Callable &p_callable) override { physics_server_3d->body_set_state_sync_callback(p_body, callable_mp(this, &PhysicsServer2Din3D::body_state_sync_callback_3d).bind(p_body, p_callable)); }
+
+	void body_force_integration_callback_3d(PhysicsDirectBodyState3D *p_state_3d, const Variant &p_udata, RID p_body, const Callable &p_callable_2d) {
+		PhysicsDirectBodyState2Din3D *state_2d = nullptr;
+		if (body_state.has(p_body)) {
+			state_2d = body_state.get(p_body);
+		} else {
+			state_2d = memnew(PhysicsDirectBodyState2Din3D(p_state_3d));
+			body_state.insert(p_body, state_2d);
+		}
+		p_callable_2d.call(state_2d, p_udata);
+	}
+	virtual void body_set_force_integration_callback(RID p_body, const Callable &p_callable, const Variant &p_udata = Variant()) override { physics_server_3d->body_set_force_integration_callback(p_body, callable_mp(this, &PhysicsServer2Din3D::body_force_integration_callback_3d).bind(p_body, p_callable), p_udata); }
+
+	virtual bool body_collide_shape(RID p_body, int p_body_shape, RID p_shape, const Transform2D &p_shape_xform, const Vector2 &p_motion, Vector2 *r_results, int p_result_max, int &r_result_count) override { return false; } // TODO
+
+	virtual void body_set_pickable(RID p_body, bool p_pickable) override { physics_server_3d->body_set_ray_pickable(p_body, p_pickable); }
+
+	virtual PhysicsDirectBodyState2D *body_get_direct_state(RID p_body) override {
+		PhysicsDirectBodyState3D *state_3d = physics_server_3d->body_get_direct_state(p_body);
+		if (!state_3d) {
+			return nullptr;
+		}
+		PhysicsDirectBodyState2Din3D *state_2d = nullptr;
+		if (body_state.has(p_body)) {
+			state_2d = body_state.get(p_body);
+		} else {
+			state_2d = memnew(PhysicsDirectBodyState2Din3D(state_3d));
+			body_state.insert(p_body, state_2d);
+		}
+		return state_2d;
+	}
+
+	virtual bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
+		PhysicsServer3D::MotionResult motion_result;
+		PhysicsServer3D::MotionParameters motion_params;
+		Vector2 origin_2d = p_parameters.from.get_origin();
+		motion_params.from = Transform3D(ANGLE2TOBASIS(p_parameters.from.get_rotation()), VECTOR2TO3(origin_2d));
+		motion_params.motion = VECTOR2TO3(p_parameters.motion);
+		motion_params.margin = SCALE_2D_TO_3D * p_parameters.margin / 8.0f; // TODO: OK to match defaults like this? 0.08 in 2D -> 0.001 in 3D.
+		motion_params.max_collisions = 1; // TODO: ?
+		motion_params.collide_separation_ray = p_parameters.collide_separation_ray;
+		motion_params.exclude_bodies = p_parameters.exclude_bodies;
+		motion_params.exclude_objects = p_parameters.exclude_objects;
+		motion_params.recovery_as_collision = p_parameters.recovery_as_collision;
+		bool collided = physics_server_3d->body_test_motion(p_body, motion_params, r_result ? &motion_result : nullptr);
+		if (r_result) {
+			r_result->travel = VECTOR3TO2(motion_result.travel);
+			r_result->remainder = VECTOR3TO2(motion_result.remainder);
+			r_result->collision_depth = SCALE_3D_TO_2D * motion_result.collision_depth;
+			r_result->collision_safe_fraction = motion_result.collision_safe_fraction;
+			r_result->collision_unsafe_fraction = motion_result.collision_unsafe_fraction;
+			if (motion_result.collision_count > 0) {
+				// TODO: Handle multiple?
+				PhysicsServer3D::MotionCollision &collision = motion_result.collisions[0];
+				r_result->collision_point = VECTOR3TO2(collision.position);
+				r_result->collision_normal = VECTOR3TO2(collision.normal).normalized();
+				r_result->collider_velocity = VECTOR3TO2(collision.collider_velocity);
+				r_result->collision_local_shape = collision.local_shape;
+				r_result->collider_id = collision.collider_id;
+				r_result->collider = collision.collider;
+				r_result->collider_shape = collision.collider_shape;
+			}
+		}
+		return collided;
+	}
+
+	/* JOINT API */
+
+	virtual RID joint_create() override { return physics_server_3d->joint_create(); }
+
+	virtual void joint_clear(RID p_joint) override { physics_server_3d->joint_clear(p_joint); }
+
+	virtual void joint_set_param(RID p_joint, JointParam p_param, real_t p_value) override {
+		JointType type = joint_get_type(p_joint);
+		switch (p_param) {
+			case JointParam::JOINT_PARAM_BIAS: {
+				switch (type) {
+					case JointType::JOINT_TYPE_PIN: {
+						physics_server_3d->pin_joint_set_param(p_joint, PhysicsServer3D::PinJointParam::PIN_JOINT_BIAS, p_value);
+					} break;
+					default: {
+						ERR_FAIL_MSG("PhysicsServer2Din3D does not support joint bias for joints other than pin joints.");
+					} break;
+				}
+			} break;
+			case JointParam::JOINT_PARAM_MAX_BIAS: {
+				ERR_FAIL_MSG("PhysicsServer2Din3D does not support joint max bias.");
+			} break;
+			case JointParam::JOINT_PARAM_MAX_FORCE: {
+				ERR_FAIL_MSG("PhysicsServer2Din3D does not support joint max force.");
+			} break;
+			default: {
+				ERR_FAIL();
+			} break;
+		}
+	}
+	virtual real_t joint_get_param(RID p_joint, JointParam p_param) const override {
+		JointType type = joint_get_type(p_joint);
+		switch (p_param) {
+			case JointParam::JOINT_PARAM_BIAS: {
+				switch (type) {
+					case JointType::JOINT_TYPE_PIN: {
+						return physics_server_3d->pin_joint_get_param(p_joint, PhysicsServer3D::PinJointParam::PIN_JOINT_BIAS);
+					} break;
+					default: {
+						ERR_FAIL_V((real_t)0); // TODO check
+					} break;
+				}
+			} break;
+			case JointParam::JOINT_PARAM_MAX_BIAS: {
+				ERR_FAIL_V_MSG(0, "PhysicsServer2Din3D does not support joint max bias."); // TODO check
+			} break;
+			case JointParam::JOINT_PARAM_MAX_FORCE: {
+				ERR_FAIL_V_MSG(0, "PhysicsServer2Din3D does not support joint max force."); // TODO check
+			} break;
+			default: {
+				ERR_FAIL_V((real_t)0);
+			} break;
+		}
+	}
+
+	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) override { physics_server_3d->joint_disable_collisions_between_bodies(p_joint, p_disable); }
+	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const override { return physics_server_3d->joint_is_disabled_collisions_between_bodies(p_joint); }
+
+	virtual void joint_make_pin(RID p_joint, const Vector2 &p_anchor, RID p_body_a, RID p_body_b = RID()) override {
+		Vector3 anchor = VECTOR2TO3(p_anchor);
+		Transform3D xform_a = physics_server_3d->body_get_state(p_body_a, PhysicsServer3D::BodyState::BODY_STATE_TRANSFORM);
+		Transform3D xform_b = physics_server_3d->body_get_state(p_body_b, PhysicsServer3D::BodyState::BODY_STATE_TRANSFORM);
+		Vector3 local_a = xform_a.xform_inv(anchor);
+		Vector3 local_b = xform_b.xform_inv(anchor);
+		// TODO: Reset z = 0 too?
+		physics_server_3d->joint_make_pin(p_joint, p_body_a, local_a, p_body_b, local_b);
+	}
+	virtual void joint_make_groove(RID p_joint, const Vector2 &p_a_groove1, const Vector2 &p_a_groove2, const Vector2 &p_b_anchor, RID p_body_a, RID p_body_b) override {
+		Transform3D xform_a = physics_server_3d->body_get_state(p_body_a, PhysicsServer3D::BodyState::BODY_STATE_TRANSFORM);
+		Transform3D xform_b = physics_server_3d->body_get_state(p_body_b, PhysicsServer3D::BodyState::BODY_STATE_TRANSFORM);
+		// TODO: Correct? Probably not in general.
+		Transform3D local_ref_a = Transform3D().translated(xform_a.xform_inv(VECTOR2TO3(p_a_groove1)));
+		Transform3D local_ref_b = Transform3D().translated(xform_b.xform_inv(VECTOR2TO3(p_b_anchor)));
+		// TODO: Set limits based on p_a_groove_1, p_a_groove_2.
+		real_t limit_length = SCALE_2D_TO_3D * p_a_groove1.distance_to(p_a_groove2); // TODO: Right?
+		physics_server_3d->joint_make_generic_6dof(p_joint, p_body_a, local_ref_a, p_body_b, local_ref_b);
+		physics_server_3d->generic_6dof_joint_set_flag(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisFlag::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT, true);
+		physics_server_3d->generic_6dof_joint_set_param(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_LINEAR_LOWER_LIMIT, -limit_length);
+		physics_server_3d->generic_6dof_joint_set_param(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_LINEAR_UPPER_LIMIT, (real_t)0);
+		// NOTE: Use an unused dummy parameter to store that this is a groove joint (and not a damped spring joint).
+		real_t flag_param = 0;
+		physics_server_3d->generic_6dof_joint_set_param(p_joint, Vector3::Axis::AXIS_Z, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_ANGULAR_MOTOR_FORCE_LIMIT, flag_param);
+	}
+	virtual void joint_make_damped_spring(RID p_joint, const Vector2 &p_anchor_a, const Vector2 &p_anchor_b, RID p_body_a, RID p_body_b = RID()) override {
+		Transform3D xform_a = physics_server_3d->body_get_state(p_body_a, PhysicsServer3D::BodyState::BODY_STATE_TRANSFORM);
+		Transform3D xform_b;
+		if (p_body_b.is_valid()) {
+			xform_b = physics_server_3d->body_get_state(p_body_b, PhysicsServer3D::BodyState::BODY_STATE_TRANSFORM);
+		}
+		// TODO: Correct? Probably not in general.
+		Transform3D local_ref_a = Transform3D().translated(xform_a.xform_inv(VECTOR2TO3(p_anchor_a)));
+		Transform3D local_ref_b = Transform3D().translated(xform_b.xform_inv(VECTOR2TO3(p_anchor_b)));
+		physics_server_3d->joint_make_generic_6dof(p_joint, p_body_a, local_ref_a, p_body_b, local_ref_b);
+		physics_server_3d->generic_6dof_joint_set_flag(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisFlag::G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING, true);
+		// TODO: Fix this. Damped spring not working as is.
+		physics_server_3d->generic_6dof_joint_set_flag(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisFlag::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT, false);
+		// NOTE: Use an unused dummy parameter to store that this is a damped spring joint (and not a groove joint).
+		real_t flag_param = 1;
+		physics_server_3d->generic_6dof_joint_set_param(p_joint, Vector3::Axis::AXIS_Z, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_ANGULAR_MOTOR_FORCE_LIMIT, flag_param);
+	}
+
+	virtual void pin_joint_set_param(RID p_joint, PinJointParam p_param, real_t p_value) override {
+		switch (p_param) {
+			case PinJointParam::PIN_JOINT_SOFTNESS: {
+				ERR_FAIL_COND_MSG(p_value != 0, "PhysicsServer2Din3D does not support pin joint softness.");
+			} break;
+			case PinJointParam::PIN_JOINT_LIMIT_UPPER:
+			case PinJointParam::PIN_JOINT_LIMIT_LOWER: {
+				ERR_FAIL_COND_MSG(p_value != 0, "PhysicsServer2Din3D does not support pin joint limits.");
+			} break;
+			case PinJointParam::PIN_JOINT_MOTOR_TARGET_VELOCITY: {
+				ERR_FAIL_COND_MSG(p_value != 0, "PhysicsServer2Din3D does not support pin joint motor target velocity.");
+			} break;
+			default: {
+				ERR_FAIL();
+			} break;
+		}
+	}
+	virtual real_t pin_joint_get_param(RID p_joint, PinJointParam p_param) const override { ERR_FAIL_V_MSG(0, "PhysicsServer2Din3D does not support pin joint parameters."); }
+
+	virtual void pin_joint_set_flag(RID p_joint, PinJointFlag p_flag, bool p_enabled) override { ERR_FAIL_COND_MSG(p_enabled, "PhysicsServer2Din3D does not support pin joint flags."); }
+	virtual bool pin_joint_get_flag(RID p_joint, PinJointFlag p_flag) const override { ERR_FAIL_V_MSG(false, "PhysicsServer2Din3D does not support pin joint flags."); }
+
+	virtual void damped_spring_joint_set_param(RID p_joint, DampedSpringParam p_param, real_t p_value) override {
+		switch (p_param) {
+			case DampedSpringParam::DAMPED_SPRING_REST_LENGTH: {
+				real_t rest_length = p_value;
+				physics_server_3d->generic_6dof_joint_set_param(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT, SCALE_2D_TO_3D * rest_length);
+			} break;
+			case DampedSpringParam::DAMPED_SPRING_STIFFNESS: {
+				// TODO: No scale?
+				physics_server_3d->generic_6dof_joint_set_param(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_LINEAR_SPRING_STIFFNESS, 100 * p_value);
+			} break;
+			case DampedSpringParam::DAMPED_SPRING_DAMPING: {
+				// TODO: No scale?
+				physics_server_3d->generic_6dof_joint_set_param(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_LINEAR_SPRING_DAMPING, 100 * p_value);
+			} break;
+			default: {
+				ERR_FAIL();
+			} break;
+		}
+	}
+	virtual real_t damped_spring_joint_get_param(RID p_joint, DampedSpringParam p_param) const override {
+		switch (p_param) {
+			case DampedSpringParam::DAMPED_SPRING_REST_LENGTH: {
+				real_t equilibrium_point = physics_server_3d->generic_6dof_joint_get_param(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT);
+				return SCALE_3D_TO_2D * equilibrium_point;
+			} break;
+			case DampedSpringParam::DAMPED_SPRING_STIFFNESS: {
+				// TODO: No scale?
+				return physics_server_3d->generic_6dof_joint_get_param(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_LINEAR_SPRING_STIFFNESS) / 100;
+			} break;
+			case DampedSpringParam::DAMPED_SPRING_DAMPING: {
+				// TODO: No scale?
+				return physics_server_3d->generic_6dof_joint_get_param(p_joint, Vector3::Axis::AXIS_Y, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_LINEAR_SPRING_DAMPING) / 100;
+			} break;
+			default: {
+				ERR_FAIL_V((real_t)0);
+			} break;
+		}
+	}
+
+	virtual JointType joint_get_type(RID p_joint) const override {
+		PhysicsServer3D::JointType type_3d = physics_server_3d->joint_get_type(p_joint);
+		switch (type_3d) {
+			case PhysicsServer3D::JointType::JOINT_TYPE_PIN: {
+				return JointType::JOINT_TYPE_PIN;
+			} break;
+			case PhysicsServer3D::JointType::JOINT_TYPE_6DOF: {
+				real_t flag_param = physics_server_3d->generic_6dof_joint_get_param(p_joint, Vector3::Axis::AXIS_Z, PhysicsServer3D::G6DOFJointAxisParam::G6DOF_JOINT_ANGULAR_MOTOR_FORCE_LIMIT);
+				return flag_param ? JointType::JOINT_TYPE_GROOVE : JointType::JOINT_TYPE_DAMPED_SPRING;
+			} break;
+			default: {
+				return JointType::JOINT_TYPE_MAX;
+			} break;
+		}
+	}
+
+	/* MISC */
+
+	virtual void free_rid(RID p_rid) override {
+		if (space_state.has(p_rid)) {
+			memdelete(space_state.get(p_rid));
+			space_state.erase(p_rid);
+			physics_server_3d->free_rid(p_rid);
+		} else if (body_state.has(p_rid)) {
+			memdelete(body_state.get(p_rid));
+			body_state.erase(p_rid);
+			physics_server_3d->free_rid(p_rid);
+		} else {
+			// TODO: Don't return null RIDs in the server, so this check can be removed.
+			if (p_rid.is_valid()) {
+				physics_server_3d->free_rid(p_rid);
+			}
+		}
+	}
+
+	// TODO: Wrap and actually call these methods.
+	virtual void set_active(bool p_active) override { physics_server_3d->set_active(p_active); }
+	virtual void init() override {}
+	virtual void step(real_t p_step) override {}
+	virtual void sync() override {}
+	virtual void flush_queries() override {}
+	virtual void end_sync() override {}
+	virtual void finish() override {}
+
+	virtual bool is_flushing_queries() const override { return false; }
+
+	virtual int get_process_info(ProcessInfo p_info) override {
+		// NOTE: ProcessInfo in 2D and 3D are compatible.
+		return physics_server_3d->get_process_info((PhysicsServer3D::ProcessInfo)p_info);
+	}
+
+	PhysicsServer2Din3D() :
+			physics_server_3d(PhysicsServer3D::get_singleton()) {}
+};

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -780,7 +780,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_shape", "body", "shape_idx", "shape"), &PhysicsServer3D::body_set_shape);
 	ClassDB::bind_method(D_METHOD("body_set_shape_transform", "body", "shape_idx", "transform"), &PhysicsServer3D::body_set_shape_transform);
 	ClassDB::bind_method(D_METHOD("body_set_shape_disabled", "body", "shape_idx", "disabled"), &PhysicsServer3D::body_set_shape_disabled);
-	ClassDB::bind_method(D_METHOD("body_set_shape_as_one_way_collision", "body", "shape_idx", "enable", "margin"), &PhysicsServer3D::body_set_shape_as_one_way_collision);
+	ClassDB::bind_method(D_METHOD("body_set_shape_as_one_way_collision", "body", "shape_idx", "enable", "margin", "direction"), &PhysicsServer3D::body_set_shape_as_one_way_collision);
 
 	ClassDB::bind_method(D_METHOD("body_get_shape_count", "body"), &PhysicsServer3D::body_get_shape_count);
 	ClassDB::bind_method(D_METHOD("body_get_shape", "body", "shape_idx"), &PhysicsServer3D::body_get_shape);

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -780,6 +780,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_shape", "body", "shape_idx", "shape"), &PhysicsServer3D::body_set_shape);
 	ClassDB::bind_method(D_METHOD("body_set_shape_transform", "body", "shape_idx", "transform"), &PhysicsServer3D::body_set_shape_transform);
 	ClassDB::bind_method(D_METHOD("body_set_shape_disabled", "body", "shape_idx", "disabled"), &PhysicsServer3D::body_set_shape_disabled);
+	ClassDB::bind_method(D_METHOD("body_set_shape_as_one_way_collision", "body", "shape_idx", "enable", "margin"), &PhysicsServer3D::body_set_shape_as_one_way_collision);
 
 	ClassDB::bind_method(D_METHOD("body_get_shape_count", "body"), &PhysicsServer3D::body_get_shape_count);
 	ClassDB::bind_method(D_METHOD("body_get_shape", "body", "shape_idx"), &PhysicsServer3D::body_get_shape);

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -418,6 +418,7 @@ public:
 	virtual void body_clear_shapes(RID p_body) = 0;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) = 0;
+	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) = 0;
 
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) = 0;
 	virtual ObjectID body_get_object_instance_id(RID p_body) const = 0;

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -418,7 +418,7 @@ public:
 	virtual void body_clear_shapes(RID p_body) = 0;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) = 0;
-	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) = 0;
+	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0, const Vector3 &p_direction = Vector3(0, -1, 0)) = 0;
 
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) = 0;
 	virtual ObjectID body_get_object_instance_id(RID p_body) const = 0;

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -236,6 +236,7 @@ public:
 	virtual void body_clear_shapes(RID p_body) override {}
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override {}
+	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) override {}
 
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) override {}
 	virtual ObjectID body_get_object_instance_id(RID p_body) const override { return ObjectID(); }

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -236,7 +236,7 @@ public:
 	virtual void body_clear_shapes(RID p_body) override {}
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override {}
-	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0) override {}
+	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape, bool p_enabled, real_t p_margin = 0, const Vector3 &p_direction = Vector3(0, -1, 0)) override {}
 
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) override {}
 	virtual ObjectID body_get_object_instance_id(RID p_body) const override { return ObjectID(); }

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -230,6 +230,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_body_set_shape, "body", "shape_idx", "shape");
 	GDVIRTUAL_BIND(_body_set_shape_transform, "body", "shape_idx", "transform");
 	GDVIRTUAL_BIND(_body_set_shape_disabled, "body", "shape_idx", "disabled");
+	GDVIRTUAL_BIND(_body_set_shape_as_one_way_collision, "body", "shape_idx", "enabled", "margin");
 
 	GDVIRTUAL_BIND(_body_get_shape_count, "body");
 	GDVIRTUAL_BIND(_body_get_shape, "body", "shape_idx");

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -230,7 +230,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_body_set_shape, "body", "shape_idx", "shape");
 	GDVIRTUAL_BIND(_body_set_shape_transform, "body", "shape_idx", "transform");
 	GDVIRTUAL_BIND(_body_set_shape_disabled, "body", "shape_idx", "disabled");
-	GDVIRTUAL_BIND(_body_set_shape_as_one_way_collision, "body", "shape_idx", "enabled", "margin");
+	GDVIRTUAL_BIND(_body_set_shape_as_one_way_collision, "body", "shape_idx", "enabled", "margin", "direction");
 
 	GDVIRTUAL_BIND(_body_get_shape_count, "body");
 	GDVIRTUAL_BIND(_body_get_shape, "body", "shape_idx");

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -303,6 +303,7 @@ public:
 	EXBIND3(body_set_shape, RID, int, RID)
 	EXBIND3(body_set_shape_transform, RID, int, const Transform3D &)
 	EXBIND3(body_set_shape_disabled, RID, int, bool)
+	EXBIND4(body_set_shape_as_one_way_collision, RID, int, bool, real_t)
 
 	EXBIND1RC(int, body_get_shape_count, RID)
 	EXBIND2RC(RID, body_get_shape, RID, int)

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -303,7 +303,7 @@ public:
 	EXBIND3(body_set_shape, RID, int, RID)
 	EXBIND3(body_set_shape_transform, RID, int, const Transform3D &)
 	EXBIND3(body_set_shape_disabled, RID, int, bool)
-	EXBIND4(body_set_shape_as_one_way_collision, RID, int, bool, real_t)
+	EXBIND5(body_set_shape_as_one_way_collision, RID, int, bool, real_t, const Vector3 &)
 
 	EXBIND1RC(int, body_get_shape_count, RID)
 	EXBIND2RC(RID, body_get_shape, RID, int)

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -195,6 +195,7 @@ public:
 	FUNC2RC(RID, body_get_shape, RID, int);
 
 	FUNC3(body_set_shape_disabled, RID, int, bool);
+	FUNC4(body_set_shape_as_one_way_collision, RID, int, bool, real_t);
 
 	FUNC2(body_remove_shape, RID, int);
 	FUNC1(body_clear_shapes, RID);

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -195,7 +195,7 @@ public:
 	FUNC2RC(RID, body_get_shape, RID, int);
 
 	FUNC3(body_set_shape_disabled, RID, int, bool);
-	FUNC4(body_set_shape_as_one_way_collision, RID, int, bool, real_t);
+	FUNC5(body_set_shape_as_one_way_collision, RID, int, bool, real_t, const Vector3 &);
 
 	FUNC2(body_remove_shape, RID, int);
 	FUNC1(body_clear_shapes, RID);

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -87,6 +87,9 @@
 #ifndef PHYSICS_2D_DISABLED
 #include "servers/physics_2d/physics_server_2d.h"
 #include "servers/physics_2d/physics_server_2d_dummy.h"
+#ifndef PHYSICS_3D_DISABLED
+#include "servers/physics_2d/physics_server_2d_in_3d.h"
+#endif
 #include "servers/physics_2d/physics_server_2d_extension.h"
 #endif // PHYSICS_2D_DISABLED
 
@@ -116,6 +119,11 @@ ShaderTypes *shader_types = nullptr;
 static PhysicsServer2D *_create_dummy_physics_server_2d() {
 	return memnew(PhysicsServer2DDummy);
 }
+#ifndef PHYSICS_3D_DISABLED
+static PhysicsServer2D *_create_physics_server_2d_in_3d() {
+	return memnew(PhysicsServer2Din3D);
+}
+#endif // PHYSICS_3D_DISABLED
 #endif // PHYSICS_2D_DISABLED
 
 #ifndef PHYSICS_3D_DISABLED
@@ -299,6 +307,9 @@ void register_server_types() {
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, PhysicsServer2DManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"), "DEFAULT");
 
 	PhysicsServer2DManager::get_singleton()->register_server("Dummy", callable_mp_static(_create_dummy_physics_server_2d));
+#ifndef PHYSICS_3D_DISABLED
+	PhysicsServer2DManager::get_singleton()->register_server("Use 3D Physics Engine", callable_mp_static(_create_physics_server_2d_in_3d));
+#endif
 #endif // PHYSICS_2D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED


### PR DESCRIPTION
Adds a new option for the 2D physics engine:

<img width="1493" height="430" alt="image" src="https://github.com/user-attachments/assets/63acee16-a6f5-49b1-b6d0-f9f89ceb228f" />

This allows e.g. using Jolt Physics in 2D. Something like this can be desirable e.g. for stability compared to GodotPhysics2D.

Internally it just locks the bodies to a plane and adds some thickness to the shapes, etc.

Needs some more work, it's still a bit janky ~~and is missing some features like one-way collisions, joints, character bodies~~.

In the current state the [2D Physics Platformer Demo](https://github.com/godotengine/godot-demo-projects/tree/master/2d/physics_platformer) and the [2D Platformer Demo](https://github.com/godotengine/godot-demo-projects/tree/master/2d/platformer) are already playable.

- Closes https://github.com/godotengine/godot-proposals/issues/13313

*This PR is sponsored by My Spare Time™.*