### PR TITLE
Use `AHashMap` for `classes` in `ClassDB`

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1649,7 +1649,7 @@ static GDExtensionObjectPtr gdextension_classdb_construct_object2(GDExtensionCon
 
 static void *gdextension_classdb_get_class_tag(GDExtensionConstStringNamePtr p_classname) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
-	ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(classname);
+	ClassDB::ClassInfo *class_info = deref_or_null(ClassDB::classes.getptr(classname));
 	return class_info ? class_info->class_ptr : nullptr;
 }
 

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -37,6 +37,7 @@
 // Makes callable_mp readily available in all classes connecting signals.
 // Needs to come after method_bind and object have been included.
 #include "core/object/callable_method_pointer.h"
+#include "core/templates/a_hash_map.h"
 #include "core/templates/hash_set.h"
 
 #include <type_traits>
@@ -202,7 +203,7 @@ public:
 		};
 	};
 
-	static HashMap<StringName, ClassInfo> classes;
+	static AHashMap<StringName, ClassInfo *> classes;
 	static HashMap<StringName, StringName> resource_base_extensions;
 	static HashMap<StringName, StringName> compat_classes;
 
@@ -252,7 +253,7 @@ public:
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
-		ClassInfo *t = classes.getptr(T::get_class_static());
+		ClassInfo *t = deref_or_null(classes.getptr(T::get_class_static()));
 		ERR_FAIL_NULL(t);
 		t->creation_func = &creator<T>;
 		t->exposed = true;
@@ -267,7 +268,7 @@ public:
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
-		ClassInfo *t = classes.getptr(T::get_class_static());
+		ClassInfo *t = deref_or_null(classes.getptr(T::get_class_static()));
 		ERR_FAIL_NULL(t);
 		t->exposed = true;
 		t->class_ptr = T::get_class_ptr_static();
@@ -280,7 +281,7 @@ public:
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
-		ClassInfo *t = classes.getptr(T::get_class_static());
+		ClassInfo *t = deref_or_null(classes.getptr(T::get_class_static()));
 		ERR_FAIL_NULL(t);
 		t->creation_func = &creator<T>;
 		t->exposed = false;
@@ -295,7 +296,7 @@ public:
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
-		ClassInfo *t = classes.getptr(T::get_class_static());
+		ClassInfo *t = deref_or_null(classes.getptr(T::get_class_static()));
 		ERR_FAIL_NULL(t);
 		ERR_FAIL_COND_MSG(t->inherits_ptr && !t->inherits_ptr->creation_func, vformat("Cannot register runtime class '%s' that descends from an abstract parent class.", T::get_class_static()));
 		t->creation_func = &creator<T>;
@@ -320,7 +321,7 @@ public:
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
-		ClassInfo *t = classes.getptr(T::get_class_static());
+		ClassInfo *t = deref_or_null(classes.getptr(T::get_class_static()));
 		ERR_FAIL_NULL(t);
 		t->creation_func = &_create_ptr_func<T>;
 		t->exposed = true;

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -144,6 +144,11 @@ constexpr auto CLAMP(const T m_a, const T2 m_min, const T3 m_max) {
 #define SWAP(m_x, m_y) std::swap((m_x), (m_y))
 #endif // SWAP
 
+template <typename T>
+_FORCE_INLINE_ T *deref_or_null(T **p_ptr) {
+	return p_ptr ? *p_ptr : nullptr;
+}
+
 /* Functions to handle powers of 2 and shifting. */
 
 // Returns `true` if a positive integer is a power of 2, `false` otherwise.

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1638,7 +1638,7 @@ void ScriptTextEditor::_update_connected_methods() {
 					}
 				}
 
-				ClassDB::ClassInfo *base_class_ptr = ClassDB::classes.getptr(base_class)->inherits_ptr;
+				ClassDB::ClassInfo *base_class_ptr = ClassDB::classes.get(base_class)->inherits_ptr;
 				if (base_class_ptr == nullptr) {
 					break;
 				}

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -240,7 +240,7 @@ void GDScriptLanguageProtocol::initialized(const Variant &p_params) {
 		LSP::GodotNativeClassInfo gdclass;
 		gdclass.name = E.value.name;
 		gdclass.class_doc = &(E.value);
-		if (ClassDB::ClassInfo *ptr = ClassDB::classes.getptr(StringName(E.value.name))) {
+		if (ClassDB::ClassInfo *ptr = deref_or_null(ClassDB::classes.getptr(StringName(E.value.name)))) {
 			gdclass.class_info = ptr;
 		}
 		capabilities.native_classes.push_back(gdclass);

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -44,7 +44,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 	ClassDB::get_class_list(class_list);
 
 	for (const StringName &class_name : class_list) {
-		ClassDB::ClassInfo *t = ClassDB::classes.getptr(class_name);
+		ClassDB::ClassInfo *t = deref_or_null(ClassDB::classes.getptr(class_name));
 		ERR_FAIL_NULL(t);
 		if (t->api != p_api || !t->exposed) {
 			continue;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1147,7 +1147,7 @@ bool CSharpLanguage::setup_csharp_script_binding(CSharpScriptBinding &r_script_b
 
 	StringName type_name = p_object->get_class_name();
 
-	const ClassDB::ClassInfo *classinfo = ClassDB::classes.getptr(type_name);
+	const ClassDB::ClassInfo *classinfo = deref_or_null(ClassDB::classes.getptr(type_name));
 
 	// This skipping of GDExtension classes, as well as whatever classes are in this list of ignored types, is a
 	// workaround to allow GDExtension classes to be used from C# so long as they're only used through base classes that

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -3883,7 +3883,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			continue;
 		}
 
-		ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(type_cname);
+		ClassDB::ClassInfo *class_info = deref_or_null(ClassDB::classes.getptr(type_cname));
 
 		TypeInterface itype = TypeInterface::create_object_type(type_cname, pascal_to_pascal_case(type_cname), api_type);
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -73,7 +73,7 @@ MethodBind *godotsharp_method_bind_get_method_with_compatibility(const StringNam
 }
 
 godotsharp_class_creation_func godotsharp_get_class_constructor(const StringName *p_classname) {
-	ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(*p_classname);
+	ClassDB::ClassInfo *class_info = deref_or_null(ClassDB::classes.getptr(*p_classname));
 	if (class_info) {
 		return class_info->creation_func;
 	}

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -538,7 +538,7 @@ void add_exposed_classes(Context &r_context) {
 			continue;
 		}
 
-		ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(class_name);
+		ClassDB::ClassInfo *class_info = deref_or_null(ClassDB::classes.getptr(class_name));
 
 		ExposedClass exposed_class;
 		exposed_class.name = class_name;


### PR DESCRIPTION
`classes` is a major bottleneck for `ClassDB`, and much `Object` related functionality. A "proper" type system could correct this problem (https://github.com/godotengine/godot-proposals/issues/12323).

Eventually, `ClassDB` will not own class types (instead, `Object` subtypes will own them statically, and only register them in the `ClassDB`). To work towards this, this PR changes ownership from `HashMap` managed ownership to explicit allocations and deallocations.

As a side effect, lookups receive slightly improved efficiency (see benchmark).

## Benchmark

I used the same property benchmark as in https://github.com/godotengine/godot/pull/106646. While not nearly effective here as in that PR, we still see a ~3% improvement from GDScript (and the two are mutually compatible).

```gdscript
extends Camera3D

func _ready() -> void:
	var start := Time.get_ticks_usec()
	for i in range(5000000):
		editor_description = editor_description
		editor_description = editor_description
		editor_description = editor_description
		editor_description = editor_description
	var end := Time.get_ticks_usec()
	print((end - start) / 1000, "ms")
```

I ran the test 3 times (due to slight fluctuations):

```
before: 1856ms + 1862ms + 1871ms = 5.589
after: 1824ms + 1799ms + 1811ms = 5.434
```

## Notes

To work around the `classes` value type change easily, I introduce `deref_or_null`. It saves us from introducing `get_or_default` on `AHashMap`, which would be less efficient and less versatile.
There are also some minor performance improvements in `ClassDB` functionality, avoiding the "if has() then get()" antipattern, in exchange for `getptr`.