### PR TITLE
[iOS, 3.x] Switch window creation to UIScene.

### DIFF
--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -59,5 +59,19 @@
 	$additional_plist_content
 	$plist_launch_screen_name
 	<key>CADisableMinimumFrameDurationOnPhone</key><true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key><false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -14,6 +14,7 @@ iphone_lib = [
     "tts_ios.mm",
     "display_layer.mm",
     "godot_app_delegate.m",
+    "godot_scene_delegate.m",
     "godot_view_renderer.mm",
     "device_metrics.m",
     "keyboard_input_view.mm",

--- a/platform/iphone/godot_app_delegate.m
+++ b/platform/iphone/godot_app_delegate.m
@@ -31,6 +31,7 @@
 #import "godot_app_delegate.h"
 
 #import "app_delegate.h"
+#import "godot_scene_delegate.h"
 
 @interface GodotApplicalitionDelegate ()
 
@@ -46,7 +47,7 @@ static NSMutableArray<ApplicationDelegateService *> *services = nil;
 
 + (void)load {
 	services = [NSMutableArray new];
-	[services addObject:[AppDelegate new]];
+	[services addObject:[AppDelegate getSingleton]];
 }
 
 + (void)addService:(ApplicationDelegateService *)service {
@@ -63,15 +64,29 @@ static NSMutableArray<ApplicationDelegateService *> *services = nil;
 - (UIWindow *)window {
 	UIWindow *result = nil;
 
-	for (ApplicationDelegateService *service in services) {
-		if (![service respondsToSelector:_cmd]) {
-			continue;
+	if (@available(iOS 13, tvOS 13, *)) {
+		for (SceneDelegateService *service in [SceneDelegate services]) {
+			if (![service respondsToSelector:_cmd]) {
+				continue;
+			}
+
+			UIWindow *value = [service window];
+
+			if (value) {
+				result = value;
+			}
 		}
+	} else {
+		for (ApplicationDelegateService *service in services) {
+			if (![service respondsToSelector:_cmd]) {
+				continue;
+			}
 
-		UIWindow *value = [service window];
+			UIWindow *value = [service window];
 
-		if (value) {
-			result = value;
+			if (value) {
+				result = value;
+			}
 		}
 	}
 
@@ -456,12 +471,15 @@ static NSMutableArray<ApplicationDelegateService *> *services = nil;
 	}
 }
 
-/* Handled By Info.plist file for now
-
 // MARK: Interface Geometry
 
-- (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {}
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options API_AVAILABLE(ios(13.0), tvos(13.0)) {
+	UISceneConfiguration *config = [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+	config.delegateClass = [SceneDelegate class];
+	return config;
+}
 
-*/
+- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions API_AVAILABLE(ios(13.0), tvos(13.0)) {
+}
 
 @end

--- a/platform/iphone/godot_scene_delegate.h
+++ b/platform/iphone/godot_scene_delegate.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  app_delegate.h                                                        */
+/*  godot_scene_delegate.h                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,13 +30,13 @@
 
 #import <UIKit/UIKit.h>
 
-@class ViewController;
+typedef NSObject<UIWindowSceneDelegate> SceneDelegateService API_AVAILABLE(ios(13.0), tvos(13.0));
 
-@interface AppDelegate : NSObject <UIApplicationDelegate, UIWindowSceneDelegate>
+API_AVAILABLE(ios(13.0), tvos(13.0))
+@interface SceneDelegate : NSObject <UIWindowSceneDelegate>
 
-+ (AppDelegate *)getSingleton;
+@property(class, readonly, strong) NSArray<SceneDelegateService *> *services;
 
-@property(strong, nonatomic) UIWindow *window;
-@property(strong, class, readonly, nonatomic) ViewController *viewController;
++ (void)addService:(SceneDelegateService *)service;
 
 @end

--- a/platform/iphone/godot_scene_delegate.m
+++ b/platform/iphone/godot_scene_delegate.m
@@ -1,0 +1,122 @@
+/**************************************************************************/
+/*  godot_scene_delegate.m                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#import "godot_scene_delegate.h"
+
+#import "app_delegate.h"
+
+@implementation SceneDelegate
+
+API_AVAILABLE(ios(13.0), tvos(13.0))
+static NSMutableArray<SceneDelegateService *> *services = nil;
+
++ (NSArray<SceneDelegateService *> *)services API_AVAILABLE(ios(13.0), tvos(13.0)) {
+	return services;
+}
+
++ (void)load {
+	if (@available(iOS 13, tvOS 13, *)) {
+		services = [NSMutableArray new];
+		[services addObject:[AppDelegate getSingleton]];
+	}
+}
+
++ (void)addService:(SceneDelegateService *)service API_AVAILABLE(ios(13.0), tvos(13.0)) {
+	if (!services || !service) {
+		return;
+	}
+	[services addObject:service];
+}
+
+// MARK: Scene
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions API_AVAILABLE(ios(13.0), tvos(13.0)) {
+	for (SceneDelegateService *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service scene:scene willConnectToSession:session options:connectionOptions];
+	}
+}
+
+// MARK: Life-Cycle
+
+- (void)sceneDidDisconnect:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0)) {
+	for (SceneDelegateService *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneDidDisconnect:scene];
+	}
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0)) {
+	for (SceneDelegateService *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneDidBecomeActive:scene];
+	}
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0)) {
+	for (SceneDelegateService *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneWillResignActive:scene];
+	}
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0)) {
+	for (SceneDelegateService *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneDidEnterBackground:scene];
+	}
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0)) {
+	for (SceneDelegateService *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneWillEnterForeground:scene];
+	}
+}
+
+@end


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/107615, but for 3.x

Using UIScene will be required starting from the next iOS release (in iOS 26 it's just causing a warning in the log).