### PR TITLE
Group together 2D camera override functions

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -225,39 +225,6 @@ Error SceneDebugger::_msg_override_cameras(const Array &p_args) {
 	return OK;
 }
 
-Error SceneDebugger::_msg_transform_camera_2d(const Array &p_args) {
-	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
-	ERR_FAIL_COND_V(!SceneTree::get_singleton()->get_root()->is_camera_2d_override_enabled(), ERR_BUG);
-	Transform2D transform = p_args[0];
-	Camera2D *override_camera = SceneTree::get_singleton()->get_root()->get_override_camera_2d();
-	override_camera->set_offset(transform.affine_inverse().get_origin());
-	override_camera->set_zoom(transform.get_scale());
-	RuntimeNodeSelect::get_singleton()->_queue_selection_update();
-	return OK;
-}
-
-#ifndef _3D_DISABLED
-Error SceneDebugger::_msg_transform_camera_3d(const Array &p_args) {
-	ERR_FAIL_COND_V(p_args.size() < 5, ERR_INVALID_DATA);
-	ERR_FAIL_COND_V(!SceneTree::get_singleton()->get_root()->is_camera_3d_override_enabled(), ERR_BUG);
-	Transform3D transform = p_args[0];
-	bool is_perspective = p_args[1];
-	float size_or_fov = p_args[2];
-	float depth_near = p_args[3];
-	float depth_far = p_args[4];
-
-	Camera3D *override_camera = SceneTree::get_singleton()->get_root()->get_override_camera_3d();
-	if (is_perspective) {
-		override_camera->set_perspective(size_or_fov, depth_near, depth_far);
-	} else {
-		override_camera->set_orthogonal(size_or_fov, depth_near, depth_far);
-	}
-	override_camera->set_transform(transform);
-	RuntimeNodeSelect::get_singleton()->_queue_selection_update();
-	return OK;
-}
-#endif // _3D_DISABLED
-
 Error SceneDebugger::_msg_set_object_property(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);
 	_set_object_property(p_args[0], p_args[1], p_args[2]);
@@ -443,9 +410,41 @@ Error SceneDebugger::_msg_runtime_node_select_reset_camera_2d(const Array &p_arg
 	RuntimeNodeSelect::get_singleton()->_reset_camera_2d();
 	return OK;
 }
+
+Error SceneDebugger::_msg_transform_camera_2d(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
+	ERR_FAIL_COND_V(!SceneTree::get_singleton()->get_root()->is_camera_2d_override_enabled(), ERR_BUG);
+	Transform2D transform = p_args[0];
+	Camera2D *override_camera = SceneTree::get_singleton()->get_root()->get_override_camera_2d();
+	override_camera->set_offset(transform.affine_inverse().get_origin());
+	override_camera->set_zoom(transform.get_scale());
+	RuntimeNodeSelect::get_singleton()->_queue_selection_update();
+	return OK;
+}
+
 #ifndef _3D_DISABLED
 Error SceneDebugger::_msg_runtime_node_select_reset_camera_3d(const Array &p_args) {
 	RuntimeNodeSelect::get_singleton()->_reset_camera_3d();
+	return OK;
+}
+
+Error SceneDebugger::_msg_transform_camera_3d(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.size() < 5, ERR_INVALID_DATA);
+	ERR_FAIL_COND_V(!SceneTree::get_singleton()->get_root()->is_camera_3d_override_enabled(), ERR_BUG);
+	Transform3D transform = p_args[0];
+	bool is_perspective = p_args[1];
+	float size_or_fov = p_args[2];
+	float depth_near = p_args[3];
+	float depth_far = p_args[4];
+
+	Camera3D *override_camera = SceneTree::get_singleton()->get_root()->get_override_camera_3d();
+	if (is_perspective) {
+		override_camera->set_perspective(size_or_fov, depth_near, depth_far);
+	} else {
+		override_camera->set_orthogonal(size_or_fov, depth_near, depth_far);
+	}
+	override_camera->set_transform(transform);
+	RuntimeNodeSelect::get_singleton()->_queue_selection_update();
 	return OK;
 }
 #endif // _3D_DISABLED
@@ -534,7 +533,7 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["transform_camera_2d"] = _msg_transform_camera_2d;
 #ifndef _3D_DISABLED
 	message_handlers["transform_camera_3d"] = _msg_transform_camera_3d;
-#endif
+#endif // _3D_DISABLED
 	message_handlers["set_object_property"] = _msg_set_object_property;
 	message_handlers["set_object_property_field"] = _msg_set_object_property_field;
 	message_handlers["reload_cached_files"] = _msg_reload_cached_files;

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -91,10 +91,6 @@ private:
 	static Error _msg_next_frame(const Array &p_args);
 	static Error _msg_debug_mute_audio(const Array &p_args);
 	static Error _msg_override_cameras(const Array &p_args);
-	static Error _msg_transform_camera_2d(const Array &p_args);
-#ifndef _3D_DISABLED
-	static Error _msg_transform_camera_3d(const Array &p_args);
-#endif
 	static Error _msg_set_object_property(const Array &p_args);
 	static Error _msg_set_object_property_field(const Array &p_args);
 	static Error _msg_reload_cached_files(const Array &p_args);
@@ -118,11 +114,14 @@ private:
 	static Error _msg_runtime_node_select_set_type(const Array &p_args);
 	static Error _msg_runtime_node_select_set_mode(const Array &p_args);
 	static Error _msg_runtime_node_select_set_visible(const Array &p_args);
+	static Error _msg_rq_screenshot(const Array &p_args);
+
 	static Error _msg_runtime_node_select_reset_camera_2d(const Array &p_args);
+	static Error _msg_transform_camera_2d(const Array &p_args);
 #ifndef _3D_DISABLED
 	static Error _msg_runtime_node_select_reset_camera_3d(const Array &p_args);
-#endif
-	static Error _msg_rq_screenshot(const Array &p_args);
+	static Error _msg_transform_camera_3d(const Array &p_args);
+#endif // _3D_DISABLED
 
 public:
 	static Error parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -34,8 +34,6 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/templates/pair.h"
 #include "core/templates/sort_array.h"
-#include "scene/2d/audio_listener_2d.h"
-#include "scene/2d/camera_2d.h"
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/popup.h"
@@ -49,6 +47,10 @@
 #include "scene/resources/world_2d.h"
 #include "servers/audio_server.h"
 #include "servers/rendering/rendering_server_globals.h"
+
+// 2D.
+#include "scene/2d/audio_listener_2d.h"
+#include "scene/2d/camera_2d.h"
 
 #ifndef _3D_DISABLED
 #include "scene/3d/audio_listener_3d.h"
@@ -1204,35 +1206,6 @@ void Viewport::canvas_parent_mark_dirty(Node *p_node) {
 		callable_mp(this, &Viewport::_process_dirty_canvas_parent_orders).call_deferred();
 	}
 }
-
-#if DEBUG_ENABLED
-void Viewport::enable_camera_2d_override(bool p_enable) {
-	ERR_MAIN_THREAD_GUARD;
-
-	if (p_enable) {
-		camera_2d_override.enable(this, camera_2d);
-	} else {
-		camera_2d_override.disable(camera_2d);
-	}
-}
-
-bool Viewport::is_camera_2d_override_enabled() const {
-	ERR_READ_THREAD_GUARD_V(false);
-	return camera_2d_override.is_enabled();
-}
-
-Camera2D *Viewport::get_overridden_camera_2d() const {
-	ERR_READ_THREAD_GUARD_V(nullptr);
-	ERR_FAIL_COND_V(!camera_2d_override.is_enabled(), nullptr);
-	return camera_2d_override.get_overridden_camera();
-}
-
-Camera2D *Viewport::get_override_camera_2d() const {
-	ERR_READ_THREAD_GUARD_V(nullptr);
-	ERR_FAIL_COND_V(!camera_2d_override.is_enabled(), nullptr);
-	return camera_2d_override.is_enabled() ? get_camera_2d() : nullptr;
-}
-#endif // DEBUG_ENABLED
 
 void Viewport::set_canvas_transform(const Transform2D &p_transform) {
 	ERR_MAIN_THREAD_GUARD;
@@ -4399,6 +4372,35 @@ void Viewport::assign_next_enabled_camera_2d(const StringName &p_camera_group) {
 		set_canvas_transform(Transform2D());
 	}
 }
+
+#if DEBUG_ENABLED
+void Viewport::enable_camera_2d_override(bool p_enable) {
+	ERR_MAIN_THREAD_GUARD;
+
+	if (p_enable) {
+		camera_2d_override.enable(this, camera_2d);
+	} else {
+		camera_2d_override.disable(camera_2d);
+	}
+}
+
+bool Viewport::is_camera_2d_override_enabled() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return camera_2d_override.is_enabled();
+}
+
+Camera2D *Viewport::get_overridden_camera_2d() const {
+	ERR_READ_THREAD_GUARD_V(nullptr);
+	ERR_FAIL_COND_V(!camera_2d_override.is_enabled(), nullptr);
+	return camera_2d_override.get_overridden_camera();
+}
+
+Camera2D *Viewport::get_override_camera_2d() const {
+	ERR_READ_THREAD_GUARD_V(nullptr);
+	ERR_FAIL_COND_V(!camera_2d_override.is_enabled(), nullptr);
+	return camera_2d_override.is_enabled() ? get_camera_2d() : nullptr;
+}
+#endif // DEBUG_ENABLED
 
 #ifndef _3D_DISABLED
 AudioListener3D *Viewport::get_audio_listener_3d() const {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -534,13 +534,6 @@ public:
 	Ref<World2D> get_world_2d() const;
 	Ref<World2D> find_world_2d() const;
 
-#if DEBUG_ENABLED
-	void enable_camera_2d_override(bool p_enable);
-	bool is_camera_2d_override_enabled() const;
-	Camera2D *get_overridden_camera_2d() const;
-	Camera2D *get_override_camera_2d() const;
-#endif // DEBUG_ENABLED
-
 	void set_canvas_transform(const Transform2D &p_transform);
 	Transform2D get_canvas_transform() const;
 
@@ -766,11 +759,18 @@ private:
 
 	friend class Camera2D; // Needs _camera_2d_set
 	Camera2D *camera_2d = nullptr;
+	void _camera_2d_set(Camera2D *p_camera_2d);
 #if DEBUG_ENABLED
 	CameraOverride<Camera2D> camera_2d_override;
-#endif // DEBUG_ENABLED
-	void _camera_2d_set(Camera2D *p_camera_2d);
 
+public:
+	void enable_camera_2d_override(bool p_enable);
+	bool is_camera_2d_override_enabled() const;
+	Camera2D *get_overridden_camera_2d() const;
+	Camera2D *get_override_camera_2d() const;
+#endif // DEBUG_ENABLED
+
+private:
 #ifndef PHYSICS_2D_DISABLED
 	// Collider to frame
 	HashMap<ObjectID, uint64_t> physics_2d_mouseover;


### PR DESCRIPTION
This PR is a sort of follow-up to PR #79183 and PR #52285.

PR #52285 merged for Godot 4.6 cleaned up the camera override API, but now the 2D camera override was separated from the rest of the 2D camera functions. This PR moves them together. This is good for organization, but the motivation behind this PR is that this helps with my other PR for disabling compiling with 2D enabled (PR #47054).

This PR also adds a missing `#ifndef _3D_DISABLED` around `template class Viewport::CameraOverride<Camera3D>;` and groups together sets of 2D and 3D functions in `SceneDebugger`.