### PR TITLE
Tree: Prevent auto-scrolling from dragging and dropping targets

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -489,7 +489,7 @@ void ScrollContainer::_notification(int p_what) {
 			if (scroll_on_drag_hover && get_viewport()->gui_is_dragging()) {
 				Point2 mouse_position = get_viewport()->get_mouse_position() - get_global_position();
 				Transform2D xform = get_transform();
-				if (Rect2(Point2(), xform.get_scale() * get_size()).grow(scroll_border).has_point(mouse_position)) {
+				if (Rect2(Point2(), xform.get_scale() * get_size()).grow(scroll_border).has_point(mouse_position) && can_drop_data(mouse_position, get_viewport()->gui_get_drag_data())) {
 					Point2 point;
 
 					if ((Math::abs(mouse_position.x) < Math::abs(mouse_position.x - get_size().width)) && (Math::abs(mouse_position.x) < scroll_border)) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5040,7 +5040,7 @@ void Tree::_notification(int p_what) {
 			}
 
 			Point2 mouse_position = get_viewport()->get_mouse_position() - get_global_position();
-			if (scrolling && get_rect().grow(theme_cache.scroll_border).has_point(mouse_position)) {
+			if (scrolling && get_rect().grow(theme_cache.scroll_border).has_point(mouse_position) && can_drop_data(mouse_position, get_viewport()->gui_get_drag_data())) {
 				Point2 point;
 
 				if ((Math::abs(mouse_position.x) < Math::abs(mouse_position.x - get_size().width)) && (Math::abs(mouse_position.x) < theme_cache.scroll_border)) {


### PR DESCRIPTION
- Fixes #93755
- Fixes #111005
- *Bugsquad edit:* Fixes #113670 according to [this comment](https://github.com/godotengine/godot/issues/113670#issuecomment-3667858641)

**Current Behavior**

When any object for example ui dock tab or  a invalid file type is near the tree control system , then the tree starts to auto scroll (File System Dock or Scene Manager Dock) , even if the dock cannot accept the drop .

**New Behavior**

if the Tree is a valid target for the currently dragged object . This fix the auto scroll movement of the tree control systems.

**Testing the fix**
1.Open a new project.
2. Move the filesystem dock above the scene manager dock .
3. Make sure the filesystem has multiple files.
4. Try to hover any file or a ui dock name (Scene or Import or Filesystem )  near or over the Scene Manager or vice versa check.
5. The auto scroll should not happen if not respective Tree Drop area are present.

**MRP from the issue and added some scenes in the scene manager**

[MRP-filesystem-scroll.zip](https://github.com/user-attachments/files/22636509/MRP-filesystem-scroll.zip)

**Video Demonstration**
New Video
[Screencast_20251004_213629.webm](https://github.com/user-attachments/assets/f30e3e1e-0936-49e1-91ab-0c18faa1a761)

Updated Video
[Screencast_20251225_203452.webm](https://github.com/user-attachments/assets/ed7edd40-1e1a-43ee-8bc1-8907431831d3)