### PR TITLE
Drop the experimental label for the Jolt Physics integration

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2533,7 +2533,7 @@
 			Sets which physics engine to use for 3D physics.
 			[b]DEFAULT[/b] is currently equivalent to [b]GodotPhysics3D[/b], but may change in future releases. Select an explicit implementation if you want to ensure that your project stays on the same engine.
 			[b]GodotPhysics3D[/b] is Godot's internal 3D physics engine.
-			[b]Jolt Physics[/b] is an alternative physics engine that is generally faster and more reliable than [b]GodotPhysics3D[/b]. As it was recently implemented, it is currently considered experimental and its behavior may change in future releases. Jolt Physics is the default for projects created starting in Godot 4.6.
+			[b]Jolt Physics[/b] is an alternative physics engine that is generally faster and more reliable than [b]GodotPhysics3D[/b]. Jolt Physics is the default for projects created starting in Godot 4.6.
 			[b]Dummy[/b] is a 3D physics server that does nothing and returns only dummy values, effectively disabling all 3D physics functionality.
 			Third-party extensions and modules can add other physics engines to select with this setting.
 		</member>


### PR DESCRIPTION
Related to godotengine/godot-proposals#12289.

Since Jolt Physics is now the default 3D physics engine for newly created projects starting with Godot 4.6 (#105737), I don't think it makes much sense to have its integration be labeled as experimental anymore.

The experimental label was something I declared when the integration was first merged for the following reasons:

1. It was highly likely that there would be regressions as a result of the port from the Godot Jolt extension.
2. I had several large refactorings planned that could potentially introduce new (and potentially severe) regressions or changes in behavior.
3. We did not have full feature/performance parity with Godot Physics.

Point 1 is likely resolved at this point. None of the open issues are (as far as I'm aware) a result of mistakes from the porting process.

Point 2 is mostly done at this point, with big refactorings like #100983, #101189 and #105748 behind us. I had a few more things planned, but I don't think they justify keeping the experimental label around for another release.

Point 3 is a bit more contentious I guess. This hasn't really changed at all since the integration was first merged, short of a few minor additions. The bigger feature/performance parity issues that I had in mind originally were:

1. The node interfaces for the joints still being largely designed for Bullet, which means that things like soft limits can't be achieved with Jolt currently, because the interface for it can't reasonably be mapped to Jolt's.
    - Some argue that we should just change the joint interfaces from Bullet's to Jolt's and be done with it, which would obviously resolve this, but I'm not a fan of that idea personally. I would argue that we'd be "pulling up the ladder behind us" and making things more difficult for physics extensions.
    - I had a small prototype for allowing the physics server to modify the physics node interfaces as they saw fit, which I still think is worth exploring, but I haven't prioritized it yet.
    - In any case, I would probably argue that the joints as they currently behave in Godot Physics are unstable to the point of being unusable, which makes this more of a theoretical parity issue rather than a practical one.
2. Mutating compound shapes (i.e. bodies with multiple shapes) can be incredibly slow when using Jolt.
    - Any change to one of multiple shapes, after their body has entered the scene tree, will force costly rebuilds due to design decisions I made early on in the development of Godot Jolt.
    - This is currently prominently seen in the [Voxel Game](https://github.com/godotengine/godot-demo-projects/tree/master/3d/voxel) demo project, where the "Flat Grass" level stutters heavily as it streams in the world chunks, even on the most high-end PC.
    - The refactoring needed for this is known but scary.
    - In any case, I have seen very few mentions of this problem since the integration was merged, which might suggest that it's not that big of a deal for the vast majority of projects out there.

So yes, we still don't have feature/performance parity with Godot Physics, but I would argue it's not significant enough to warrant a scary experimental label.