### PR TITLE
Unify FileDialog context menus

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -207,6 +207,9 @@
 		<member name="current_path" type="String" setter="set_current_path" getter="get_current_path">
 			The currently selected file path of the file dialog.
 		</member>
+		<member name="deleting_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
+			If [code]true[/code], the context menu will show the "Delete" option, which allows moving files and folders to trash.
+		</member>
 		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" overrides="AcceptDialog" default="false" />
 		<member name="display_mode" type="int" setter="set_display_mode" getter="get_display_mode" enum="FileDialog.DisplayMode" default="0">
 			Display mode of the dialog's file list.
@@ -232,7 +235,7 @@
 			[b]Note:[/b] Embedded file dialog and Windows file dialog support only file extensions, while Android, Linux, and macOS file dialogs also support MIME types.
 		</member>
 		<member name="folder_creation_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
-			If [code]true[/code], shows the button for creating new directories (when using [constant FILE_MODE_OPEN_DIR], [constant FILE_MODE_OPEN_ANY], or [constant FILE_MODE_SAVE_FILE]).
+			If [code]true[/code], shows the button for creating new directories (when using [constant FILE_MODE_OPEN_DIR], [constant FILE_MODE_OPEN_ANY], or [constant FILE_MODE_SAVE_FILE]), and the context menu will have the "New Folder..." option.
 		</member>
 		<member name="hidden_files_toggle_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
 			If [code]true[/code], shows the toggle hidden files button.
@@ -358,6 +361,10 @@
 		<constant name="CUSTOMIZATION_OVERWRITE_WARNING" value="7" enum="Customization">
 			If enabled, the [FileDialog] will warn the user before overwriting files in save mode.
 			Equivalent to [member overwrite_warning_enabled].
+		</constant>
+		<constant name="CUSTOMIZATION_DELETE" value="8" enum="Customization">
+			If enabled, the context menu will show the "Delete" option, which allows moving files and folders to trash.
+			Equivalent to [member deleting_enabled].
 		</constant>
 	</constants>
 	<theme_items>

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -131,6 +131,9 @@ public:
 
 	enum ItemMenu {
 		ITEM_MENU_COPY_PATH,
+		ITEM_MENU_DELETE,
+		ITEM_MENU_REFRESH,
+		ITEM_MENU_NEW_FOLDER,
 		ITEM_MENU_SHOW_IN_EXPLORER,
 		ITEM_MENU_SHOW_BUNDLE_CONTENT,
 	};
@@ -144,6 +147,7 @@ public:
 		CUSTOMIZATION_RECENT,
 		CUSTOMIZATION_LAYOUT,
 		CUSTOMIZATION_OVERWRITE_WARNING,
+		CUSTOMIZATION_DELETE,
 		CUSTOMIZATION_MAX
 	};
 
@@ -163,6 +167,7 @@ private:
 	static inline DisplayMode default_display_mode = DISPLAY_THUMBNAILS;
 	bool show_hidden_files = false;
 	bool use_native_dialog = false;
+	bool can_create_folders = true;
 	bool customization_flags[CUSTOMIZATION_MAX]; // Initialized to true in the constructor.
 
 	inline static LocalVector<String> global_favorites;
@@ -241,6 +246,7 @@ private:
 	FlowContainer *flow_checkbox_options = nullptr;
 	GridContainer *grid_select_options = nullptr;
 
+	ConfirmationDialog *delete_dialog = nullptr;
 	ConfirmationDialog *make_dir_dialog = nullptr;
 	LineEdit *new_dir_name = nullptr;
 	AcceptDialog *mkdirerr = nullptr;
@@ -289,10 +295,12 @@ private:
 	void _item_menu_id_pressed(int p_option);
 	void _empty_clicked(const Vector2 &p_pos, MouseButton p_button);
 	void _item_clicked(int p_item, const Vector2 &p_pos, MouseButton p_button);
+	void _popup_menu(const Vector2 &p_pos, int p_for_item);
 
 	void _focus_file_text();
 
 	int _get_selected_file_idx();
+	String _get_item_path(int p_idx) const;
 	void _file_list_multi_selected(int p_item, bool p_selected);
 	void _file_list_selected(int p_item);
 	void _file_list_item_activated(int p_item);
@@ -307,6 +315,7 @@ private:
 	void _filename_filter_changed();
 	void _filename_filter_selected();
 	void _file_list_select_first();
+	void _delete_confirm();
 	void _make_dir();
 	void _make_dir_confirm();
 	void _go_up();


### PR DESCRIPTION
Part of https://github.com/godotengine/godot-proposals/issues/6831

This PR adds missing context menu options to FileDialog, which existed in EditorFileDialog.
- Fixed ITEM_MENU_COPY_PATH being unused
- Added ITEM_MENU_DELETE
  - Moves file/folder to trash, after confirmation
  - Can be disabled with new customization flag
- Added ITEM_MENU_REFRESH
- Added ITEM_MENU_NEW_FOLDER
  - Same as New Folder button, and also can be disabled by the same customization flag
- Text for ITEM_MENU_SHOW_IN_EXPLORER changes depending whether file or folder is clicked
- Menu creation is unified into single method

https://github.com/user-attachments/assets/652d7b75-20ad-4b10-9159-0abcb66ac9e0

The items are missing icons and shortcuts, I will add them in a follow-up.