### PR TITLE
Fix cases where `LineEdit` can still show focus with mouse events

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -82,8 +82,9 @@
 		</method>
 		<method name="edit">
 			<return type="void" />
+			<param index="0" name="hide_focus" type="bool" default="false" />
 			<description>
-				Allows entering edit mode whether the [LineEdit] is focused or not.
+				Allows entering edit mode whether the [LineEdit] is focused or not. If [param hide_focus] is [code]true[/code], the focused state will not be shown (see [method Control.grab_focus]).
 				See also [member keep_editing_on_text_submit].
 			</description>
 		</method>

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -33,3 +33,10 @@ GH-110867
 ERROR: Validate extension JSON: Missing field in current API 'classes/FileAccess/methods/get_as_text': arguments. This is a bug.
 
 Optional argument removed. Compatibility method registered.
+
+
+GH-111117
+---------
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/LineEdit/methods/edit': arguments
+
+Optional argument added. Compatibility method registered.

--- a/scene/gui/line_edit.compat.inc
+++ b/scene/gui/line_edit.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  line_edit.compat.inc                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void LineEdit::_edit_bind_compat_111117() {
+	edit(false);
+}
+
+void LineEdit::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("edit"), &LineEdit::_edit_bind_compat_111117);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "line_edit.h"
+#include "line_edit.compat.inc"
 
 #include "core/input/input_map.h"
 #include "core/os/keyboard.h"
@@ -45,17 +46,17 @@
 #include "editor/settings/editor_settings.h"
 #endif
 
-void LineEdit::edit() {
-	_edit(true);
+void LineEdit::edit(bool p_hide_focus) {
+	_edit(true, p_hide_focus);
 }
 
-void LineEdit::_edit(bool p_show_virtual_keyboard) {
+void LineEdit::_edit(bool p_show_virtual_keyboard, bool p_hide_focus) {
 	if (!is_inside_tree()) {
 		return;
 	}
 
 	if (!has_focus()) {
-		grab_focus();
+		grab_focus(p_hide_focus);
 		return;
 	}
 
@@ -415,7 +416,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			if (editable && !editing) {
-				edit();
+				edit(true);
 				emit_signal(SNAME("editing_toggled"), true);
 			}
 
@@ -432,7 +433,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			set_caret_at_pixel_pos(b->get_position().x);
 
 			if (!editing) {
-				edit();
+				edit(true);
 				emit_signal(SNAME("editing_toggled"), true);
 			}
 
@@ -535,7 +536,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			if (editable && !editing) {
-				edit();
+				edit(true);
 				emit_signal(SNAME("editing_toggled"), true);
 				return;
 			}
@@ -1099,10 +1100,10 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 			selection_delete();
 			set_caret_column(caret_column_tmp);
 			insert_text_at_caret(p_data);
-			grab_focus();
+			grab_focus(true);
 		} else {
 			insert_text_at_caret(p_data);
-			grab_focus();
+			grab_focus(true);
 		}
 		select(caret_column_tmp, caret_column);
 		if (!text_changed_dirty) {
@@ -3196,7 +3197,7 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_horizontal_alignment", "alignment"), &LineEdit::set_horizontal_alignment);
 	ClassDB::bind_method(D_METHOD("get_horizontal_alignment"), &LineEdit::get_horizontal_alignment);
 
-	ClassDB::bind_method(D_METHOD("edit"), &LineEdit::edit);
+	ClassDB::bind_method(D_METHOD("edit", "hide_focus"), &LineEdit::edit, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("unedit"), &LineEdit::unedit);
 	ClassDB::bind_method(D_METHOD("is_editing"), &LineEdit::is_editing);
 	ClassDB::bind_method(D_METHOD("set_keep_editing_on_text_submit", "enable"), &LineEdit::set_keep_editing_on_text_submit);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -263,7 +263,7 @@ private:
 	void _delete(bool p_word = false, bool p_all_to_right = false);
 	void _texture_changed();
 
-	void _edit(bool p_show_virtual_keyboard = true);
+	void _edit(bool p_show_virtual_keyboard = true, bool p_hide_focus = false);
 
 protected:
 	bool _is_over_clear_button(const Point2 &p_pos) const;
@@ -274,6 +274,11 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	void _edit_bind_compat_111117();
+	static void _bind_compatibility_methods();
+#endif
+
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
@@ -283,7 +288,7 @@ protected:
 	void _accessibility_action_menu(const Variant &p_data);
 
 public:
-	void edit();
+	void edit(bool p_hide_focus = false);
 	void unedit();
 	bool is_editing() const;
 	void set_keep_editing_on_text_submit(bool p_enabled);


### PR DESCRIPTION
- Right-clicking to open the context menu (https://github.com/godotengine/godot/pull/110250#issuecomment-3355761345).
- Dragging text to it.