### PR TITLE
Add a new editor theme

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1107,6 +1107,9 @@
 		<member name="interface/theme/border_size" type="int" setter="" getter="">
 			The border size to use for interface elements (in pixels).
 		</member>
+		<member name="interface/theme/color_preset" type="String" setter="" getter="">
+			The editor color preset to use.
+		</member>
 		<member name="interface/theme/contrast" type="float" setter="" getter="">
 			The contrast factor to use when deriving the editor theme's base color (see [member interface/theme/base_color]). When using a positive values, the derived colors will be [i]darker[/i] than the base color. This contrast factor can be set to a negative value, which will make the derived colors [i]brighter[/i] than the base color. Negative contrast rates often look better for light themes.
 		</member>
@@ -1118,6 +1121,12 @@
 		</member>
 		<member name="interface/theme/draw_extra_borders" type="bool" setter="" getter="">
 			If [code]true[/code], draws additional borders around interactive UI elements in the editor. This is automatically enabled when using the [b]Black (OLED)[/b] theme preset, as this theme preset uses a fully black background.
+		</member>
+		<member name="interface/theme/draw_relationship_lines" type="int" setter="" getter="">
+			What relationship lines to draw in the editor's [Tree]-based GUIs (such as the Scene tree dock).
+			- [b]None[/b] will make it so that no relationship lines are drawn.
+			- [b]Selected Only[/b] will only draw them for selected items.
+			- [b]All[/b] will always draw them for all items.
 		</member>
 		<member name="interface/theme/follow_system_theme" type="bool" setter="" getter="">
 			If [code]true[/code], the editor theme preset will attempt to automatically match the system theme.
@@ -1132,14 +1141,14 @@
 			The saturation to use for editor icons. Higher values result in more vibrant colors.
 			[b]Note:[/b] The default editor icon saturation was increased by 30% in Godot 4.0 and later. To get Godot 3.x's icon saturation back, set [member interface/theme/icon_saturation] to [code]0.77[/code].
 		</member>
-		<member name="interface/theme/preset" type="String" setter="" getter="">
-			The editor theme preset to use.
-		</member>
 		<member name="interface/theme/relationship_line_opacity" type="float" setter="" getter="">
 			The opacity to use when drawing relationship lines in the editor's [Tree]-based GUIs (such as the Scene tree dock).
 		</member>
 		<member name="interface/theme/spacing_preset" type="String" setter="" getter="">
 			The editor theme spacing preset to use. See also [member interface/theme/base_spacing] and [member interface/theme/additional_spacing].
+		</member>
+		<member name="interface/theme/style" type="String" setter="" getter="">
+			The editor theme style to use.
 		</member>
 		<member name="interface/theme/use_system_accent_color" type="bool" setter="" getter="">
 			If [code]true[/code], set accent color based on system settings.

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -47,6 +47,7 @@
 #include "scene/gui/separator.h"
 #include "scene/main/timer.h"
 #include "scene/resources/font.h"
+#include "scene/resources/style_box_flat.h"
 #include "servers/audio/audio_server.h"
 
 void EditorAudioBus::_update_visible_channels() {
@@ -87,10 +88,11 @@ void EditorAudioBus::_notification(int p_what) {
 
 			disabled_vu = get_editor_theme_icon(SNAME("BusVuFrozen"));
 
-			Color solo_color = EditorThemeManager::is_dark_theme() ? Color(1.0, 0.89, 0.22) : Color(1.9, 1.74, 0.83);
-			Color mute_color = EditorThemeManager::is_dark_theme() ? Color(1.0, 0.16, 0.16) : Color(2.35, 1.03, 1.03);
-			Color bypass_color = EditorThemeManager::is_dark_theme() ? Color(0.13, 0.8, 1.0) : Color(1.03, 2.04, 2.35);
-			float darkening_factor = EditorThemeManager::is_dark_theme() ? 0.15 : 0.65;
+			bool dark_icon_and_font = EditorThemeManager::is_dark_icon_and_font();
+			Color solo_color = dark_icon_and_font ? Color(1.0, 0.89, 0.22) : Color(1.9, 1.74, 0.83);
+			Color mute_color = dark_icon_and_font ? Color(1.0, 0.16, 0.16) : Color(2.35, 1.03, 1.03);
+			Color bypass_color = dark_icon_and_font ? Color(0.13, 0.8, 1.0) : Color(1.03, 2.04, 2.35);
+			float darkening_factor = dark_icon_and_font ? 0.15 : 0.65;
 			Color solo_color_darkened = solo_color.darkened(darkening_factor);
 			Color mute_color_darkened = mute_color.darkened(darkening_factor);
 			Color bypass_color_darkened = bypass_color.darkened(darkening_factor);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -236,8 +236,8 @@ void FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 
 	if (has_custom_color) {
-		subdirectory_item->set_icon_modulate(0, editor_is_dark_theme ? custom_color : custom_color * ITEM_COLOR_SCALE);
-		subdirectory_item->set_custom_bg_color(0, Color(custom_color, editor_is_dark_theme ? ITEM_ALPHA_MIN : ITEM_ALPHA_MAX));
+		subdirectory_item->set_icon_modulate(0, editor_is_dark_icon_and_font ? custom_color : custom_color * ITEM_COLOR_SCALE);
+		subdirectory_item->set_custom_bg_color(0, Color(custom_color, editor_is_dark_icon_and_font ? ITEM_ALPHA_MIN : ITEM_ALPHA_MAX));
 	} else {
 		TreeItem *parent = subdirectory_item->get_parent();
 		if (parent) {
@@ -630,9 +630,9 @@ void FileSystemDock::_notification(int p_what) {
 			// Update editor dark theme & always show folders states from editor settings, redraw if needed.
 			bool do_redraw = false;
 
-			bool new_editor_is_dark_theme = EditorThemeManager::is_dark_theme();
-			if (new_editor_is_dark_theme != editor_is_dark_theme) {
-				editor_is_dark_theme = new_editor_is_dark_theme;
+			bool new_editor_is_dark_icon_and_font = EditorThemeManager::is_dark_icon_and_font();
+			if (new_editor_is_dark_icon_and_font != editor_is_dark_icon_and_font) {
+				editor_is_dark_icon_and_font = new_editor_is_dark_icon_and_font;
 				do_redraw = true;
 			}
 
@@ -1080,7 +1080,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 
 					files->set_item_metadata(-1, bd);
 					files->set_item_selectable(-1, false);
-					if (!editor_is_dark_theme && inherited_folder_color != default_folder_color) {
+					if (!editor_is_dark_icon_and_font && inherited_folder_color != default_folder_color) {
 						files->set_item_icon_modulate(-1, inherited_folder_color * ITEM_COLOR_SCALE);
 					} else {
 						files->set_item_icon_modulate(-1, inherited_folder_color);
@@ -1098,7 +1098,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 					files->add_item(dname, folder_icon, true);
 					files->set_item_metadata(-1, dpath);
 					Color this_folder_color = has_custom_color ? folder_colors[assigned_folder_colors[dpath]] : inherited_folder_color;
-					if (!editor_is_dark_theme && this_folder_color != default_folder_color) {
+					if (!editor_is_dark_icon_and_font && this_folder_color != default_folder_color) {
 						this_folder_color *= ITEM_COLOR_SCALE;
 					}
 					files->set_item_icon_modulate(-1, this_folder_color);
@@ -3393,7 +3393,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 			for (const KeyValue<String, Color> &E : folder_colors) {
 				folder_colors_menu->add_icon_item(get_editor_theme_icon(SNAME("Folder")), E.key.capitalize());
 
-				folder_colors_menu->set_item_icon_modulate(-1, editor_is_dark_theme ? E.value : E.value * 2);
+				folder_colors_menu->set_item_icon_modulate(-1, editor_is_dark_icon_and_font ? E.value : E.value * 2);
 				folder_colors_menu->set_item_metadata(-1, E.key);
 			}
 		}
@@ -4226,7 +4226,7 @@ FileSystemDock::FileSystemDock() {
 
 	assigned_folder_colors = ProjectSettings::get_singleton()->get_setting("file_customization/folder_colors");
 
-	editor_is_dark_theme = EditorThemeManager::is_dark_theme();
+	editor_is_dark_icon_and_font = EditorThemeManager::is_dark_icon_and_font();
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -211,7 +211,7 @@ private:
 	bool always_show_folders = false;
 	int thumbnail_size_setting = 0;
 
-	bool editor_is_dark_theme = false;
+	bool editor_is_dark_icon_and_font = false;
 
 	class FileOrFolder {
 	public:

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1096,8 +1096,8 @@ void EditorNode::_update_update_spinner() {
 		// as this feature should only be enabled for troubleshooting purposes.
 		// Make the icon modulate color overbright because icons are not completely white on a dark theme.
 		// On a light theme, icons are dark, so we need to modulate them with an even brighter color.
-		const bool dark_theme = EditorThemeManager::is_dark_theme();
-		update_spinner->set_self_modulate(theme->get_color(SNAME("error_color"), EditorStringName(Editor)) * (dark_theme ? Color(1.1, 1.1, 1.1) : Color(4.25, 4.25, 4.25)));
+		const bool dark_icon_and_font = EditorThemeManager::is_dark_icon_and_font();
+		update_spinner->set_self_modulate(theme->get_color(SNAME("error_color"), EditorStringName(Editor)) * (dark_icon_and_font ? Color(1.1, 1.1, 1.1) : Color(4.25, 4.25, 4.25)));
 	} else {
 		update_spinner->set_tooltip_text(TTRC("Spins when the editor window redraws."));
 		update_spinner->set_self_modulate(Color(1, 1, 1));

--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -38,7 +38,7 @@
 #include "scene/gui/tree.h"
 #include "servers/display/display_server.h"
 
-void EditorDirDialog::_update_dir(const Color &p_default_folder_color, const Dictionary &p_assigned_folder_colors, const HashMap<String, Color> &p_folder_colors, bool p_is_dark_theme, TreeItem *p_item, EditorFileSystemDirectory *p_dir, const String &p_select_path) {
+void EditorDirDialog::_update_dir(const Color &p_default_folder_color, const Dictionary &p_assigned_folder_colors, const HashMap<String, Color> &p_folder_colors, bool p_is_dark_icon_and_font, TreeItem *p_item, EditorFileSystemDirectory *p_dir, const String &p_select_path) {
 	updating = true;
 
 	const String path = p_dir->get_path();
@@ -58,8 +58,8 @@ void EditorDirDialog::_update_dir(const Color &p_default_folder_color, const Dic
 
 		if (p_assigned_folder_colors.has(path)) {
 			const Color &folder_color = p_folder_colors[p_assigned_folder_colors[path]];
-			p_item->set_icon_modulate(0, p_is_dark_theme ? folder_color : folder_color * FileSystemDock::ITEM_COLOR_SCALE);
-			p_item->set_custom_bg_color(0, Color(folder_color, p_is_dark_theme ? FileSystemDock::ITEM_ALPHA_MIN : FileSystemDock::ITEM_ALPHA_MAX));
+			p_item->set_icon_modulate(0, p_is_dark_icon_and_font ? folder_color : folder_color * FileSystemDock::ITEM_COLOR_SCALE);
+			p_item->set_custom_bg_color(0, Color(folder_color, p_is_dark_icon_and_font ? FileSystemDock::ITEM_ALPHA_MIN : FileSystemDock::ITEM_ALPHA_MAX));
 		} else {
 			TreeItem *parent_item = p_item->get_parent();
 			Color parent_bg_color = parent_item->get_custom_bg_color(0);
@@ -79,7 +79,7 @@ void EditorDirDialog::_update_dir(const Color &p_default_folder_color, const Dic
 	updating = false;
 	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
 		TreeItem *ti = tree->create_item(p_item);
-		_update_dir(p_default_folder_color, p_assigned_folder_colors, p_folder_colors, p_is_dark_theme, ti, p_dir->get_subdir(i));
+		_update_dir(p_default_folder_color, p_assigned_folder_colors, p_folder_colors, p_is_dark_icon_and_font, ti, p_dir->get_subdir(i));
 	}
 }
 
@@ -107,7 +107,7 @@ void EditorDirDialog::reload(const String &p_path) {
 
 	tree->clear();
 	TreeItem *root = tree->create_item();
-	_update_dir(tree->get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")), FileSystemDock::get_singleton()->get_assigned_folder_colors(), FileSystemDock::get_singleton()->get_folder_colors(), EditorThemeManager::is_dark_theme(), root, EditorFileSystem::get_singleton()->get_filesystem(), p_path);
+	_update_dir(tree->get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")), FileSystemDock::get_singleton()->get_assigned_folder_colors(), FileSystemDock::get_singleton()->get_folder_colors(), EditorThemeManager::is_dark_icon_and_font(), root, EditorFileSystem::get_singleton()->get_filesystem(), p_path);
 	_item_collapsed(root);
 	new_dir_path.clear();
 	must_reload = false;

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -208,9 +208,8 @@ EditorObjectSelector::EditorObjectSelector(EditorSelectionHistory *p_history) {
 	history = p_history;
 
 	MarginContainer *main_mc = memnew(MarginContainer);
+	main_mc->set_theme_type_variation("ObjectSelectorMargin");
 	main_mc->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
-	main_mc->add_theme_constant_override("margin_left", 4 * EDSCALE);
-	main_mc->add_theme_constant_override("margin_right", 6 * EDSCALE);
 	add_child(main_mc);
 
 	HBoxContainer *main_hb = memnew(HBoxContainer);

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1978,6 +1978,8 @@ void EditorInspectorSection::_notification(int p_what) {
 
 			bg_color = theme_cache.prop_subsection;
 			bg_color.a /= level;
+
+			vbox->add_theme_constant_override("separation", theme_cache.vertical_separation);
 		} break;
 
 		case NOTIFICATION_SORT_CHILDREN: {
@@ -3552,7 +3554,7 @@ void EditorInspector::initialize_section_theme(EditorInspectorSection::ThemeCach
 	}
 
 	p_cache.horizontal_separation = p_control->get_theme_constant(SNAME("h_separation"), SNAME("EditorInspectorSection"));
-	p_cache.vertical_separation = p_control->get_theme_constant(SNAME("v_separation"), SNAME("Tree"));
+	p_cache.vertical_separation = p_control->get_theme_constant(SNAME("v_separation"), SNAME("EditorInspector"));
 	p_cache.inspector_margin = p_control->get_theme_constant(SNAME("inspector_margin"), EditorStringName(Editor));
 	p_cache.indent_size = p_control->get_theme_constant(SNAME("indent_size"), SNAME("EditorInspectorSection"));
 	p_cache.key_padding_size = int(EDITOR_GET("interface/theme/base_spacing")) * 2;
@@ -3591,7 +3593,7 @@ void EditorInspector::initialize_category_theme(EditorInspectorCategory::ThemeCa
 	}
 
 	p_cache.horizontal_separation = p_control->get_theme_constant(SNAME("h_separation"), SNAME("Tree"));
-	p_cache.vertical_separation = p_control->get_theme_constant(SNAME("v_separation"), SNAME("Tree"));
+	p_cache.vertical_separation = p_control->get_theme_constant(SNAME("v_separation"), SNAME("EditorInspector"));
 	p_cache.class_icon_size = p_control->get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 
 	p_cache.font_color = p_control->get_theme_color(SceneStringName(font_color), SNAME("Tree"));
@@ -3806,8 +3808,7 @@ void EditorInspector::_add_section_in_tree(EditorInspectorSection *p_section, VB
 	}
 	if (!container) {
 		container = memnew(VBoxContainer);
-		int separation = get_theme_constant(SNAME("v_separation"), SNAME("EditorInspector"));
-		container->add_theme_constant_override("separation", separation);
+		container->add_theme_constant_override("separation", theme_cache.vertical_separation);
 		p_current_vbox->add_child(container);
 	}
 	container->add_child(p_section);
@@ -4209,6 +4210,7 @@ void EditorInspector::update_tree() {
 		// Recreate the category vbox if it was reset.
 		if (category_vbox == nullptr) {
 			category_vbox = memnew(VBoxContainer);
+			category_vbox->add_theme_constant_override("separation", theme_cache.vertical_separation);
 			category_vbox->hide();
 			main_vbox->add_child(category_vbox);
 		}

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -232,7 +232,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 		main_vbox->add_theme_constant_override("separation", top_bar_separation);
 
 		background_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox("Background", EditorStringName(EditorStyles)));
-		main_view_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), "TabContainer"));
+		main_view_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox("panel_container", "ProjectManager"));
 
 		title_bar_logo->set_button_icon(get_editor_theme_icon("TitleBarLogo"));
 

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -59,7 +59,7 @@ void QuickSettingsDialog::_fetch_setting_values() {
 #ifndef ANDROID_ENABLED
 				editor_languages = pi.hint_string.split(";", false);
 #endif
-			} else if (pi.name == "interface/theme/preset") {
+			} else if (pi.name == "interface/theme/color_preset") {
 				editor_themes = pi.hint_string.split(",");
 			} else if (pi.name == "interface/editor/display_scale") {
 				editor_scales = pi.hint_string.split(",");
@@ -93,7 +93,7 @@ void QuickSettingsDialog::_update_current_values() {
 
 	// Theme options.
 	{
-		const String current_theme = EDITOR_GET("interface/theme/preset");
+		const String current_theme = EDITOR_GET("interface/theme/color_preset");
 
 		for (int i = 0; i < editor_themes.size(); i++) {
 			const String &theme_value = editor_themes[i];
@@ -185,7 +185,7 @@ void QuickSettingsDialog::_language_selected(int p_id) {
 
 void QuickSettingsDialog::_theme_selected(int p_id) {
 	const String selected_theme = theme_option_button->get_item_text(p_id);
-	_set_setting_value("interface/theme/preset", selected_theme);
+	_set_setting_value("interface/theme/color_preset", selected_theme);
 
 	custom_theme_label->set_visible(selected_theme == "Custom");
 }
@@ -241,7 +241,7 @@ void QuickSettingsDialog::update_size_limits(const Size2 &p_max_popup_size) {
 void QuickSettingsDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			settings_list_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("Background"), EditorStringName(EditorStyles)));
+			settings_list_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("quick_settings_panel"), SNAME("ProjectManager")));
 
 			restart_required_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 			custom_theme_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("font_placeholder_color"), EditorStringName(Editor)));
@@ -307,7 +307,7 @@ QuickSettingsDialog::QuickSettingsDialog() {
 				theme_option_button->add_item(theme_value, i);
 			}
 
-			_add_setting_control(TTRC("Interface Theme"), theme_option_button);
+			_add_setting_control(TTRC("Color Preset"), theme_option_button);
 
 			custom_theme_label = memnew(Label(TTRC("Custom preset can be further configured in the editor.")));
 			custom_theme_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -1125,12 +1125,8 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	window_wrapper = p_wrapper;
 	embedded_process = p_embedded_process;
 
-	// Add some margin to the sides for better aesthetics.
-	// This prevents the first button's hover/pressed effect from "touching" the panel's border,
-	// which looks ugly.
 	MarginContainer *toolbar_margin = memnew(MarginContainer);
-	toolbar_margin->add_theme_constant_override("margin_left", 4 * EDSCALE);
-	toolbar_margin->add_theme_constant_override("margin_right", 4 * EDSCALE);
+	toolbar_margin->set_theme_type_variation("MainToolBarMargin");
 	add_child(toolbar_margin);
 
 	HBoxContainer *main_menu_hbox = memnew(HBoxContainer);

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -370,7 +370,7 @@ void TileSetEditor::_notification(int p_what) {
 			source_sort_button->set_button_icon(get_editor_theme_icon(SNAME("Sort")));
 			sources_advanced_menu_button->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
 			missing_texture_texture = get_editor_theme_icon(SNAME("TileSet"));
-			expanded_area->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), "Tree"));
+			expanded_area->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("expand_panel"), SNAME("TileSetEditor")));
 			_update_sources_list();
 		} break;
 

--- a/editor/scene/3d/bone_map_editor_plugin.cpp
+++ b/editor/scene/3d/bone_map_editor_plugin.cpp
@@ -55,7 +55,7 @@ void BoneMapperButton::fetch_textures() {
 	set_offset(SIDE_BOTTOM, 0);
 
 	// Hack to avoid handle color darkening...
-	set_modulate(EditorThemeManager::is_dark_theme() ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25));
+	set_modulate(EditorThemeManager::is_dark_icon_and_font() ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25));
 
 	circle = memnew(TextureRect);
 	circle->set_texture(get_editor_theme_icon(SNAME("BoneMapperHandleCircle")));

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -9600,12 +9600,8 @@ Node3DEditor::Node3DEditor() {
 	snap_key_enabled = false;
 	tool_mode = TOOL_MODE_SELECT;
 
-	// Add some margin to the sides for better aesthetics.
-	// This prevents the first button's hover/pressed effect from "touching" the panel's border,
-	// which looks ugly.
 	MarginContainer *toolbar_margin = memnew(MarginContainer);
-	toolbar_margin->add_theme_constant_override("margin_left", 4 * EDSCALE);
-	toolbar_margin->add_theme_constant_override("margin_right", 4 * EDSCALE);
+	toolbar_margin->set_theme_type_variation("MainToolBarMargin");
 	vbc->add_child(toolbar_margin);
 
 	// A fluid container for all toolbars.

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -4245,7 +4245,7 @@ void CanvasItemEditor::_update_editor_settings() {
 	// to distinguish from the other key icons at the top. On a light theme,
 	// the icon will be dark, so we need to lighten it before blending it
 	// with the red color.
-	const Color key_auto_color = EditorThemeManager::is_dark_theme() ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25);
+	const Color key_auto_color = EditorThemeManager::is_dark_icon_and_font() ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25);
 	key_auto_insert_button->add_theme_color_override("icon_pressed_color", key_auto_color.lerp(Color(1, 0, 0), 0.55));
 	animation_menu->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
 
@@ -5439,12 +5439,8 @@ CanvasItemEditor::CanvasItemEditor() {
 	SceneTreeDock::get_singleton()->connect("node_created", callable_mp(this, &CanvasItemEditor::_adjust_new_node_position));
 	SceneTreeDock::get_singleton()->connect("add_node_used", callable_mp(this, &CanvasItemEditor::_reset_create_position));
 
-	// Add some margin to the sides for better aesthetics.
-	// This prevents the first button's hover/pressed effect from "touching" the panel's border,
-	// which looks ugly.
 	MarginContainer *toolbar_margin = memnew(MarginContainer);
-	toolbar_margin->add_theme_constant_override("margin_left", 4 * EDSCALE);
-	toolbar_margin->add_theme_constant_override("margin_right", 4 * EDSCALE);
+	toolbar_margin->set_theme_type_variation("MainToolBarMargin");
 	add_child(toolbar_margin);
 
 	// A fluid container for all toolbars.

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -49,6 +49,7 @@
 #include "editor/file_system/editor_paths.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/project_manager/engine_update_label.h"
+#include "editor/themes/editor_theme_manager.h"
 #include "editor/translations/editor_translation.h"
 #include "main/main.h"
 #include "modules/regex/regex.h"
@@ -582,18 +583,20 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Theme
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_ENUM, "interface/theme/follow_system_theme", false, "")
-	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", "Default", "Default,Breeze Dark,Godot 2,Gray,Light,Solarized (Dark),Solarized (Light),Black (OLED),Custom")
+	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/style", "Modern", "Modern,Classic")
+	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/color_preset", "Default", "Default,Breeze Dark,Godot 2,Godot 3,Gray,Light,Solarized (Dark),Solarized (Light),Black (OLED),Custom")
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/spacing_preset", "Default", "Compact,Default,Spacious,Custom")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/theme/icon_and_font_color", 0, "Auto,Dark,Light")
-	EDITOR_SETTING_BASIC(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/base_color", Color(0.2, 0.23, 0.31), "")
-	EDITOR_SETTING_BASIC(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/accent_color", Color(0.41, 0.61, 0.91), "")
+	EDITOR_SETTING_BASIC(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/base_color", Color(0.14, 0.14, 0.14), "")
+	EDITOR_SETTING_BASIC(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/accent_color", Color(0.34, 0.62, 1.0), "")
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/theme/use_system_accent_color", false, "")
 	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/contrast", 0.3, "-1,1,0.01")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/theme/draw_extra_borders", false, "")
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/icon_saturation", 1.0, "0,2,0.01")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/icon_saturation", 2.0, "0,2,0.01")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/theme/draw_relationship_lines", (int32_t)EditorThemeManager::RELATIONSHIP_SELECTED_ONLY, "None,Selected Only,All")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/relationship_line_opacity", 0.1, "0.00,1,0.01")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/border_size", 0, "0,2,1")
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/corner_radius", 3, "0,6,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/corner_radius", 4, "0,6,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/base_spacing", 4, "0,8,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/additional_spacing", 0, "0,8,1")
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "interface/theme/custom_theme", "", "*.res,*.tres,*.theme", PROPERTY_USAGE_DEFAULT)
@@ -1209,6 +1212,7 @@ const String EditorSettings::_get_project_metadata_path() const {
 
 #ifndef DISABLE_DEPRECATED
 void EditorSettings::_remove_deprecated_settings() {
+	erase("interface/theme/preset");
 	erase("network/connection/engine_version_update_mode");
 	erase("run/output/always_open_output_on_play");
 	erase("run/output/always_close_output_on_stop");

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -70,8 +70,8 @@ void EditorSettingsDialog::_settings_property_edited(const String &p_name) {
 
 	// Set theme presets to Custom when controlled settings change.
 
-	if (full_name == "interface/theme/accent_color" || full_name == "interface/theme/base_color" || full_name == "interface/theme/contrast" || full_name == "interface/theme/draw_extra_borders") {
-		EditorSettings::get_singleton()->set_manually("interface/theme/preset", "Custom");
+	if (full_name == "interface/theme/accent_color" || full_name == "interface/theme/base_color" || full_name == "interface/theme/contrast" || full_name == "interface/theme/draw_extra_borders" || full_name == "interface/theme/icon_saturation" || full_name == "interface/theme/draw_relationship_lines" || full_name == "interface/theme/corner_radius") {
+		EditorSettings::get_singleton()->set_manually("interface/theme/color_preset", "Custom");
 	} else if (full_name == "interface/theme/base_spacing" || full_name == "interface/theme/additional_spacing") {
 		EditorSettings::get_singleton()->set_manually("interface/theme/spacing_preset", "Custom");
 	} else if (full_name.begins_with("text_editor/theme/highlighting")) {

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -573,7 +573,7 @@ void VisualShaderGraphPlugin::update_theme() {
 	Ref<Font> label_bold_font = EditorNode::get_singleton()->get_editor_theme()->get_font("main_bold_msdf", EditorStringName(EditorFonts));
 	vs_msdf_fonts_theme->set_font(SceneStringName(font), "Label", label_font);
 	vs_msdf_fonts_theme->set_font(SceneStringName(font), "GraphNodeTitleLabel", label_bold_font);
-	if (!EditorThemeManager::is_dark_theme()) {
+	if (!EditorThemeManager::is_dark_icon_and_font()) {
 		// Override the color to white for light themes.
 		vs_msdf_fonts_theme->set_color(SceneStringName(font_color), "GraphNodeTitleLabel", Color(1, 1, 1));
 	}

--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -39,8 +39,8 @@
 
 #include "modules/svg/image_loader_svg.h"
 
-void editor_configure_icons(bool p_dark_theme) {
-	if (p_dark_theme) {
+void editor_configure_icons(bool p_dark_icon_and_font) {
+	if (p_dark_icon_and_font) {
 		ImageLoaderSVG::set_forced_color_map(HashMap<Color, Color>());
 	} else {
 		ImageLoaderSVG::set_forced_color_map(EditorColorMap::get_color_conversion_map());

--- a/editor/themes/editor_icons.h
+++ b/editor/themes/editor_icons.h
@@ -32,7 +32,7 @@
 
 #include "scene/resources/theme.h"
 
-void editor_configure_icons(bool p_dark_theme);
+void editor_configure_icons(bool p_dark_icon_and_font);
 void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p_icon_saturation, int p_thumb_size, float p_gizmo_handle_scale);
 void editor_copy_icons(const Ref<Theme> &p_theme, const Ref<Theme> &p_old_theme);
 

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -40,13 +40,14 @@
 #include "editor/themes/editor_icons.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme.h"
-#include "scene/gui/graph_edit.h"
-#include "scene/resources/dpi_texture.h"
-#include "scene/resources/image_texture.h"
+#include "editor/themes/theme_classic.h"
+#include "editor/themes/theme_modern.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_line.h"
 #include "scene/resources/style_box_texture.h"
 #include "scene/resources/texture.h"
+#include "scene/scene_string_names.h"
+#include "servers/display/display_server.h"
 
 // Theme configuration.
 
@@ -55,6 +56,7 @@ uint32_t EditorThemeManager::ThemeConfiguration::hash() {
 
 	// Basic properties.
 
+	hash = hash_murmur3_one_32(style.hash(), hash);
 	hash = hash_murmur3_one_32(preset.hash(), hash);
 	hash = hash_murmur3_one_32(spacing_preset.hash(), hash);
 
@@ -84,6 +86,7 @@ uint32_t EditorThemeManager::ThemeConfiguration::hash() {
 	// Generated properties.
 
 	hash = hash_murmur3_one_32((int)dark_theme, hash);
+	hash = hash_murmur3_one_32((int)dark_icon_and_font, hash);
 
 	return hash;
 }
@@ -105,7 +108,7 @@ uint32_t EditorThemeManager::ThemeConfiguration::hash_icons() {
 	hash = hash_murmur3_one_32(thumb_size, hash);
 	hash = hash_murmur3_one_float(gizmo_handle_scale, hash);
 
-	hash = hash_murmur3_one_32((int)dark_theme, hash);
+	hash = hash_murmur3_one_32((int)dark_icon_and_font, hash);
 
 	return hash;
 }
@@ -124,7 +127,7 @@ String EditorThemeManager::get_benchmark_key() {
 
 // Generation helper methods.
 
-Ref<StyleBoxTexture> make_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, bool p_draw_center = true) {
+Ref<StyleBoxTexture> EditorThemeManager::make_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left, float p_margin_top, float p_margin_right, float p_margin_bottom, bool p_draw_center) {
 	Ref<StyleBoxTexture> style(memnew(StyleBoxTexture));
 	style->set_texture(p_texture);
 	style->set_texture_margin_individual(p_left * EDSCALE, p_top * EDSCALE, p_right * EDSCALE, p_bottom * EDSCALE);
@@ -133,25 +136,23 @@ Ref<StyleBoxTexture> make_stylebox(Ref<Texture2D> p_texture, float p_left, float
 	return style;
 }
 
-Ref<StyleBoxEmpty> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {
+Ref<StyleBoxEmpty> EditorThemeManager::make_empty_stylebox(float p_margin_left, float p_margin_top, float p_margin_right, float p_margin_bottom) {
 	Ref<StyleBoxEmpty> style(memnew(StyleBoxEmpty));
 	style->set_content_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
 	return style;
 }
 
-Ref<StyleBoxFlat> make_flat_stylebox(Color p_color, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, int p_corner_width = 0) {
+Ref<StyleBoxFlat> EditorThemeManager::make_flat_stylebox(Color p_color, float p_margin_left, float p_margin_top, float p_margin_right, float p_margin_bottom, int p_corner_width) {
 	Ref<StyleBoxFlat> style(memnew(StyleBoxFlat));
 	style->set_bg_color(p_color);
 	// Adjust level of detail based on the corners' effective sizes.
 	style->set_corner_detail(Math::ceil(0.8 * p_corner_width * EDSCALE));
 	style->set_corner_radius_all(p_corner_width * EDSCALE);
 	style->set_content_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
-	// Work around issue about antialiased edges being blurrier (GH-35279).
-	style->set_anti_aliased(false);
 	return style;
 }
 
-Ref<StyleBoxLine> make_line_stylebox(Color p_color, int p_thickness = 1, float p_grow_begin = 1, float p_grow_end = 1, bool p_vertical = false) {
+Ref<StyleBoxLine> EditorThemeManager::make_line_stylebox(Color p_color, int p_thickness, float p_grow_begin, float p_grow_end, bool p_vertical) {
 	Ref<StyleBoxLine> style(memnew(StyleBoxLine));
 	style->set_color(p_color);
 	style->set_grow_begin(p_grow_begin);
@@ -174,14 +175,19 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 
 	print_verbose(vformat("EditorTheme: Generating new theme for the config '%d'.", theme->get_generated_hash()));
 
-	_create_shared_styles(theme, config);
+	bool is_default_style = config.style == "Modern";
+	if (is_default_style) {
+		ThemeModern::populate_shared_styles(theme, config);
+	} else {
+		ThemeClassic::populate_shared_styles(theme, config);
+	}
 
 	// Register icons.
 	{
 		OS::get_singleton()->benchmark_begin_measure(get_benchmark_key(), "Register Icons");
 
 		// External functions, see editor_icons.cpp.
-		editor_configure_icons(config.dark_theme);
+		editor_configure_icons(config.dark_icon_and_font);
 
 		// If settings are comparable to the old theme, then just copy existing icons over.
 		// Otherwise, regenerate them.
@@ -191,7 +197,7 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 			editor_copy_icons(theme, p_old_theme);
 		} else {
 			print_verbose("EditorTheme: Generating new icons.");
-			editor_register_icons(theme, config.dark_theme, config.icon_saturation, config.thumb_size, config.gizmo_handle_scale);
+			editor_register_icons(theme, config.dark_icon_and_font, config.icon_saturation, config.thumb_size, config.gizmo_handle_scale);
 		}
 
 		OS::get_singleton()->benchmark_end_measure(get_benchmark_key(), "Register Icons");
@@ -213,8 +219,15 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 	// TODO: Check if existing style definitions from the old theme are usable and copy them.
 
 	print_verbose("EditorTheme: Generating new styles.");
-	_populate_standard_styles(theme, config);
-	_populate_editor_styles(theme, config);
+
+	if (is_default_style) {
+		ThemeModern::populate_standard_styles(theme, config);
+		ThemeModern::populate_editor_styles(theme, config);
+	} else {
+		ThemeClassic::populate_standard_styles(theme, config);
+		ThemeClassic::populate_editor_styles(theme, config);
+	}
+
 	_populate_text_editor_styles(theme, config);
 	_populate_visual_shader_styles(theme, config);
 
@@ -227,13 +240,15 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 
 	// Basic properties.
 
-	config.preset = EDITOR_GET("interface/theme/preset");
+	config.style = EDITOR_GET("interface/theme/style");
+	config.preset = EDITOR_GET("interface/theme/color_preset");
 	config.spacing_preset = EDITOR_GET("interface/theme/spacing_preset");
 
 	config.base_color = EDITOR_GET("interface/theme/base_color");
 	config.accent_color = EDITOR_GET("interface/theme/accent_color");
 	config.contrast = EDITOR_GET("interface/theme/contrast");
 	config.icon_saturation = EDITOR_GET("interface/theme/icon_saturation");
+	config.corner_radius = EDITOR_GET("interface/theme/corner_radius");
 
 	// Extra properties.
 
@@ -241,9 +256,9 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 	config.extra_spacing = EDITOR_GET("interface/theme/additional_spacing");
 	// Ensure borders are visible when using an editor scale below 100%.
 	config.border_width = CLAMP((int)EDITOR_GET("interface/theme/border_size"), 0, 2) * MAX(1, EDSCALE);
-	config.corner_radius = CLAMP((int)EDITOR_GET("interface/theme/corner_radius"), 0, 6);
 
 	config.draw_extra_borders = EDITOR_GET("interface/theme/draw_extra_borders");
+	config.draw_relationship_lines = EDITOR_GET("interface/theme/draw_relationship_lines");
 	config.relationship_line_opacity = EDITOR_GET("interface/theme/relationship_line_opacity");
 	config.thumb_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
 	config.class_icon_size = 16 * EDSCALE;
@@ -251,10 +266,27 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 	config.gizmo_handle_scale = EDITOR_GET("interface/touchscreen/scale_gizmo_handles");
 	config.color_picker_button_height = 28 * EDSCALE;
 	config.subresource_hue_tint = EDITOR_GET("docks/property_editor/subresource_hue_tint");
+	config.dragging_hover_wait_msec = (float)EDITOR_GET("interface/editor/dragging_hover_wait_seconds") * 1000;
 
-	config.default_contrast = 0.3; // Make sure to keep this in sync with the editor settings definition.
+	// Handle theme style.
+	if (config.preset != "Custom") {
+		if (config.style == "Classic") {
+			config.draw_relationship_lines = RELATIONSHIP_ALL;
+			config.corner_radius = 3;
+		} else { // Default
+			config.draw_relationship_lines = config.default_relationship_lines;
+			config.corner_radius = config.default_corner_radius;
+		}
 
-	// Handle main theme preset.
+		EditorSettings::get_singleton()->set_initial_value("interface/theme/draw_relationship_lines", config.draw_relationship_lines);
+		EditorSettings::get_singleton()->set_initial_value("interface/theme/corner_radius", config.corner_radius);
+
+		// Enforce values in case they were adjusted or overridden.
+		EditorSettings::get_singleton()->set_manually("interface/theme/draw_relationship_lines", config.draw_relationship_lines);
+		EditorSettings::get_singleton()->set_manually("interface/theme/corner_radius", config.corner_radius);
+	}
+
+	// Handle color preset.
 	{
 		const bool follow_system_theme = EDITOR_GET("interface/theme/follow_system_theme");
 		const bool use_system_accent_color = EDITOR_GET("interface/theme/use_system_accent_color");
@@ -282,27 +314,36 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 		if (config.preset != "Custom") {
 			Color preset_accent_color;
 			Color preset_base_color;
-			float preset_contrast = 0;
+			float preset_contrast = config.default_contrast;
 			bool preset_draw_extra_borders = false;
+			float preset_icon_saturation = config.default_icon_saturation;
 
-			// Please use alphabetical order if you're adding a new theme here.
-			if (config.preset == "Breeze Dark") {
+			// Please use alphabetical order if you're adding a new color preset here.
+			if (config.preset == "Black (OLED)") {
+				preset_accent_color = Color(0.45, 0.75, 1.0);
+				preset_base_color = Color(0, 0, 0);
+				// The contrast rate value is irrelevant on a fully black theme.
+				preset_contrast = 0.0;
+				preset_draw_extra_borders = true;
+			} else if (config.preset == "Breeze Dark") {
 				preset_accent_color = Color(0.239, 0.682, 0.914);
 				preset_base_color = Color(0.1255, 0.1373, 0.149);
-				preset_contrast = config.default_contrast;
 			} else if (config.preset == "Godot 2") {
 				preset_accent_color = Color(0.53, 0.67, 0.89);
 				preset_base_color = Color(0.24, 0.23, 0.27);
-				preset_contrast = config.default_contrast;
+				preset_icon_saturation = 1;
+			} else if (config.preset == "Godot 3") {
+				preset_accent_color = Color(0.44, 0.73, 0.98);
+				preset_base_color = Color(0.21, 0.24, 0.29);
+				preset_icon_saturation = 1;
 			} else if (config.preset == "Gray") {
 				preset_accent_color = Color(0.44, 0.73, 0.98);
 				preset_base_color = Color(0.24, 0.24, 0.24);
-				preset_contrast = config.default_contrast;
 			} else if (config.preset == "Light") {
 				preset_accent_color = Color(0.18, 0.50, 1.00);
 				preset_base_color = Color(0.9, 0.9, 0.9);
 				// A negative contrast rate looks better for light themes, since it better follows the natural order of UI "elevation".
-				preset_contrast = -0.06;
+				preset_contrast = -0.4;
 			} else if (config.preset == "Solarized (Dark)") {
 				preset_accent_color = Color(0.15, 0.55, 0.82);
 				preset_base_color = Color(0.03, 0.21, 0.26);
@@ -311,28 +352,23 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 				preset_accent_color = Color(0.15, 0.55, 0.82);
 				preset_base_color = Color(0.89, 0.86, 0.79);
 				// A negative contrast rate looks better for light themes, since it better follows the natural order of UI "elevation".
-				preset_contrast = -0.06;
-			} else if (config.preset == "Black (OLED)") {
-				preset_accent_color = Color(0.45, 0.75, 1.0);
-				preset_base_color = Color(0, 0, 0);
-				// The contrast rate value is irrelevant on a fully black theme.
-				preset_contrast = 0.0;
-				preset_draw_extra_borders = true;
+				preset_contrast = -0.4;
 			} else { // Default
-				preset_accent_color = Color(0.44, 0.73, 0.98);
-				preset_base_color = Color(0.21, 0.24, 0.29);
-				preset_contrast = config.default_contrast;
+				preset_accent_color = Color(0.337, 0.62, 1.0);
+				preset_base_color = Color(0.145, 0.145, 0.145);
 			}
 
 			config.accent_color = preset_accent_color;
 			config.base_color = preset_base_color;
 			config.contrast = preset_contrast;
 			config.draw_extra_borders = preset_draw_extra_borders;
+			config.icon_saturation = preset_icon_saturation;
 
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/accent_color", config.accent_color);
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/base_color", config.base_color);
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/contrast", config.contrast);
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/draw_extra_borders", config.draw_extra_borders);
+			EditorSettings::get_singleton()->set_initial_value("interface/theme/icon_saturation", config.icon_saturation);
 		}
 
 		if (follow_system_theme && system_base_color != Color(0, 0, 0, 0)) {
@@ -346,11 +382,12 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 		}
 
 		// Enforce values in case they were adjusted or overridden.
-		EditorSettings::get_singleton()->set_manually("interface/theme/preset", config.preset);
+		EditorSettings::get_singleton()->set_manually("interface/theme/color_preset", config.preset);
 		EditorSettings::get_singleton()->set_manually("interface/theme/accent_color", config.accent_color);
 		EditorSettings::get_singleton()->set_manually("interface/theme/base_color", config.base_color);
 		EditorSettings::get_singleton()->set_manually("interface/theme/contrast", config.contrast);
 		EditorSettings::get_singleton()->set_manually("interface/theme/draw_extra_borders", config.draw_extra_borders);
+		EditorSettings::get_singleton()->set_manually("interface/theme/icon_saturation", config.icon_saturation);
 	}
 
 	// Handle theme spacing preset.
@@ -361,8 +398,8 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 			Size2 preset_dialogs_buttons_min_size;
 
 			if (config.spacing_preset == "Compact") {
-				preset_base_spacing = 0;
-				preset_extra_spacing = 4;
+				preset_base_spacing = 2;
+				preset_extra_spacing = 2;
 				preset_dialogs_buttons_min_size = Size2(90, 26);
 			} else if (config.spacing_preset == "Spacious") {
 				preset_base_spacing = 6;
@@ -391,14 +428,15 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 	// Generated properties.
 
 	config.dark_theme = is_dark_theme();
+	config.dark_icon_and_font = is_dark_icon_and_font();
 
 	config.base_margin = config.base_spacing;
-	config.increased_margin = config.base_spacing + config.extra_spacing;
+	config.increased_margin = config.base_spacing + config.extra_spacing * 0.75;
 	config.separation_margin = (config.base_spacing + config.extra_spacing / 2) * EDSCALE;
 	config.popup_margin = config.base_margin * 2.4 * EDSCALE;
 	// Make sure content doesn't stick to window decorations; this can be fixed in future with layout changes.
-	config.window_border_margin = MAX(1, config.base_margin * 2);
-	config.top_bar_separation = config.base_margin * 2 * EDSCALE;
+	config.window_border_margin = MAX(1, config.base_margin * EDSCALE);
+	config.top_bar_separation = MAX(1, config.base_margin * EDSCALE);
 
 	// Force the v_separation to be even so that the spacing on top and bottom is even.
 	// If the vsep is odd and cannot be split into 2 even groups (of pixels), then it will be lopsided.
@@ -407,2248 +445,6 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 	config.forced_even_separation = separation_base + (separation_base % 2);
 
 	return config;
-}
-
-void EditorThemeManager::_create_shared_styles(const Ref<EditorTheme> &p_theme, ThemeConfiguration &p_config) {
-	// Colors.
-	{
-		// Base colors.
-
-		p_theme->set_color("base_color", EditorStringName(Editor), p_config.base_color);
-		p_theme->set_color("accent_color", EditorStringName(Editor), p_config.accent_color);
-
-		// White (dark theme) or black (light theme), will be used to generate the rest of the colors
-		p_config.mono_color = p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0);
-
-		// Ensure base colors are in the 0..1 luminance range to avoid 8-bit integer overflow or text rendering issues.
-		// Some places in the editor use 8-bit integer colors.
-		p_config.dark_color_1 = p_config.base_color.lerp(Color(0, 0, 0, 1), p_config.contrast).clamp();
-		p_config.dark_color_2 = p_config.base_color.lerp(Color(0, 0, 0, 1), p_config.contrast * 1.5).clamp();
-		p_config.dark_color_3 = p_config.base_color.lerp(Color(0, 0, 0, 1), p_config.contrast * 2).clamp();
-
-		p_config.contrast_color_1 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast, p_config.default_contrast));
-		p_config.contrast_color_2 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast * 1.5, p_config.default_contrast * 1.5));
-
-		p_config.highlight_color = Color(p_config.accent_color.r, p_config.accent_color.g, p_config.accent_color.b, 0.275);
-		p_config.highlight_disabled_color = p_config.highlight_color.lerp(p_config.dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.5);
-
-		p_config.success_color = Color(0.45, 0.95, 0.5);
-		p_config.warning_color = Color(1, 0.87, 0.4);
-		p_config.error_color = Color(1, 0.47, 0.42);
-		if (!p_config.dark_theme) {
-			// Darken some colors to be readable on a light background.
-			p_config.success_color = p_config.success_color.lerp(p_config.mono_color, 0.35);
-			p_config.warning_color = Color(0.82, 0.56, 0.1);
-			p_config.error_color = Color(0.8, 0.22, 0.22);
-		}
-
-		p_theme->set_color("mono_color", EditorStringName(Editor), p_config.mono_color);
-		p_theme->set_color("dark_color_1", EditorStringName(Editor), p_config.dark_color_1);
-		p_theme->set_color("dark_color_2", EditorStringName(Editor), p_config.dark_color_2);
-		p_theme->set_color("dark_color_3", EditorStringName(Editor), p_config.dark_color_3);
-		p_theme->set_color("contrast_color_1", EditorStringName(Editor), p_config.contrast_color_1);
-		p_theme->set_color("contrast_color_2", EditorStringName(Editor), p_config.contrast_color_2);
-		p_theme->set_color("highlight_color", EditorStringName(Editor), p_config.highlight_color);
-		p_theme->set_color("highlight_disabled_color", EditorStringName(Editor), p_config.highlight_disabled_color);
-		p_theme->set_color("success_color", EditorStringName(Editor), p_config.success_color);
-		p_theme->set_color("warning_color", EditorStringName(Editor), p_config.warning_color);
-		p_theme->set_color("error_color", EditorStringName(Editor), p_config.error_color);
-#ifndef DISABLE_DEPRECATED // Used before 4.3.
-		p_theme->set_color("disabled_highlight_color", EditorStringName(Editor), p_config.highlight_disabled_color);
-#endif
-
-		// Only used when the Draw Extra Borders editor setting is enabled.
-		p_config.extra_border_color_1 = Color(0.5, 0.5, 0.5);
-		p_config.extra_border_color_2 = p_config.dark_theme ? Color(0.3, 0.3, 0.3) : Color(0.7, 0.7, 0.7);
-
-		p_theme->set_color("extra_border_color_1", EditorStringName(Editor), p_config.extra_border_color_1);
-		p_theme->set_color("extra_border_color_2", EditorStringName(Editor), p_config.extra_border_color_2);
-
-		// Font colors.
-
-		p_config.font_color = p_config.mono_color.lerp(p_config.base_color, 0.25);
-		p_config.font_focus_color = p_config.mono_color.lerp(p_config.base_color, 0.125);
-		p_config.font_hover_color = p_config.mono_color.lerp(p_config.base_color, 0.125);
-		p_config.font_pressed_color = p_config.accent_color;
-		p_config.font_hover_pressed_color = p_config.font_hover_color.lerp(p_config.accent_color, 0.74);
-		p_config.font_disabled_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.35);
-		p_config.font_readonly_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.65);
-		p_config.font_placeholder_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.5);
-		p_config.font_outline_color = Color(0, 0, 0, 0);
-
-		p_theme->set_color(SceneStringName(font_color), EditorStringName(Editor), p_config.font_color);
-		p_theme->set_color("font_focus_color", EditorStringName(Editor), p_config.font_focus_color);
-		p_theme->set_color("font_hover_color", EditorStringName(Editor), p_config.font_hover_color);
-		p_theme->set_color("font_pressed_color", EditorStringName(Editor), p_config.font_pressed_color);
-		p_theme->set_color("font_hover_pressed_color", EditorStringName(Editor), p_config.font_hover_pressed_color);
-		p_theme->set_color("font_disabled_color", EditorStringName(Editor), p_config.font_disabled_color);
-		p_theme->set_color("font_readonly_color", EditorStringName(Editor), p_config.font_readonly_color);
-		p_theme->set_color("font_placeholder_color", EditorStringName(Editor), p_config.font_placeholder_color);
-		p_theme->set_color("font_outline_color", EditorStringName(Editor), p_config.font_outline_color);
-#ifndef DISABLE_DEPRECATED // Used before 4.3.
-		p_theme->set_color("readonly_font_color", EditorStringName(Editor), p_config.font_readonly_color);
-		p_theme->set_color("disabled_font_color", EditorStringName(Editor), p_config.font_disabled_color);
-		p_theme->set_color("readonly_color", EditorStringName(Editor), p_config.font_readonly_color);
-		p_theme->set_color("highlighted_font_color", EditorStringName(Editor), p_config.font_hover_color); // Closest equivalent.
-#endif
-
-		// Icon colors.
-
-		p_config.icon_normal_color = Color(1, 1, 1);
-		p_config.icon_focus_color = p_config.icon_normal_color * (p_config.dark_theme ? 1.15 : 1.45);
-		p_config.icon_focus_color.a = 1.0;
-		p_config.icon_hover_color = p_config.icon_focus_color;
-		// Make the pressed icon color overbright because icons are not completely white on a dark theme.
-		// On a light theme, icons are dark, so we need to modulate them with an even brighter color.
-		p_config.icon_pressed_color = p_config.accent_color * (p_config.dark_theme ? 1.15 : 3.5);
-		p_config.icon_pressed_color.a = 1.0;
-		p_config.icon_disabled_color = Color(p_config.icon_normal_color, 0.4);
-
-		p_theme->set_color("icon_normal_color", EditorStringName(Editor), p_config.icon_normal_color);
-		p_theme->set_color("icon_focus_color", EditorStringName(Editor), p_config.icon_focus_color);
-		p_theme->set_color("icon_hover_color", EditorStringName(Editor), p_config.icon_hover_color);
-		p_theme->set_color("icon_pressed_color", EditorStringName(Editor), p_config.icon_pressed_color);
-		p_theme->set_color("icon_disabled_color", EditorStringName(Editor), p_config.icon_disabled_color);
-
-		// Additional GUI colors.
-
-		p_config.shadow_color = Color(0, 0, 0, p_config.dark_theme ? 0.3 : 0.1);
-		p_config.selection_color = p_config.accent_color * Color(1, 1, 1, 0.4);
-		p_config.disabled_border_color = p_config.mono_color.inverted().lerp(p_config.base_color, 0.7);
-		p_config.disabled_bg_color = p_config.mono_color.inverted().lerp(p_config.base_color, 0.9);
-		p_config.separator_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.1);
-
-		p_theme->set_color("selection_color", EditorStringName(Editor), p_config.selection_color);
-		p_theme->set_color("disabled_border_color", EditorStringName(Editor), p_config.disabled_border_color);
-		p_theme->set_color("disabled_bg_color", EditorStringName(Editor), p_config.disabled_bg_color);
-		p_theme->set_color("separator_color", EditorStringName(Editor), p_config.separator_color);
-
-		// Additional editor colors.
-
-		p_theme->set_color("box_selection_fill_color", EditorStringName(Editor), p_config.accent_color * Color(1, 1, 1, 0.3));
-		p_theme->set_color("box_selection_stroke_color", EditorStringName(Editor), p_config.accent_color * Color(1, 1, 1, 0.8));
-
-		p_theme->set_color("axis_x_color", EditorStringName(Editor), Color(0.96, 0.20, 0.32));
-		p_theme->set_color("axis_y_color", EditorStringName(Editor), Color(0.53, 0.84, 0.01));
-		p_theme->set_color("axis_z_color", EditorStringName(Editor), Color(0.16, 0.55, 0.96));
-		p_theme->set_color("axis_w_color", EditorStringName(Editor), Color(0.55, 0.55, 0.55));
-
-		const float prop_color_saturation = p_config.accent_color.get_s() * 0.75;
-		const float prop_color_value = p_config.accent_color.get_v();
-
-		p_theme->set_color("property_color_x", EditorStringName(Editor), Color::from_hsv(0.0 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
-		p_theme->set_color("property_color_y", EditorStringName(Editor), Color::from_hsv(1.0 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
-		p_theme->set_color("property_color_z", EditorStringName(Editor), Color::from_hsv(2.0 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
-		p_theme->set_color("property_color_w", EditorStringName(Editor), Color::from_hsv(1.5 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
-
-		// Special colors for rendering methods.
-
-		p_theme->set_color("forward_plus_color", EditorStringName(Editor), Color::hex(0x5d8c3fff));
-		p_theme->set_color("mobile_color", EditorStringName(Editor), Color::hex(0xa5557dff));
-		p_theme->set_color("gl_compatibility_color", EditorStringName(Editor), Color::hex(0x5586a4ff));
-
-		if (p_config.dark_theme) {
-			p_theme->set_color("highend_color", EditorStringName(Editor), Color(1.0, 0.0, 0.0));
-		} else {
-			p_theme->set_color("highend_color", EditorStringName(Editor), Color::hex(0xad1128ff));
-		}
-	}
-
-	// Constants.
-	{
-		// Can't save single float in theme, so using Color.
-		p_theme->set_color("icon_saturation", EditorStringName(Editor), Color(p_config.icon_saturation, p_config.icon_saturation, p_config.icon_saturation));
-
-		// Controls may rely on the scale for their internal drawing logic.
-		p_theme->set_default_base_scale(EDSCALE);
-		p_theme->set_constant("scale", EditorStringName(Editor), EDSCALE);
-
-		p_theme->set_constant("thumb_size", EditorStringName(Editor), p_config.thumb_size);
-		p_theme->set_constant("class_icon_size", EditorStringName(Editor), p_config.class_icon_size);
-		p_theme->set_constant("color_picker_button_height", EditorStringName(Editor), p_config.color_picker_button_height);
-		p_theme->set_constant("gizmo_handle_scale", EditorStringName(Editor), p_config.gizmo_handle_scale);
-
-		p_theme->set_constant("base_margin", EditorStringName(Editor), p_config.base_margin);
-		p_theme->set_constant("increased_margin", EditorStringName(Editor), p_config.increased_margin);
-		p_theme->set_constant("window_border_margin", EditorStringName(Editor), p_config.window_border_margin);
-		p_theme->set_constant("top_bar_separation", EditorStringName(Editor), p_config.top_bar_separation);
-
-		p_theme->set_constant("dark_theme", EditorStringName(Editor), p_config.dark_theme);
-	}
-
-	// Styleboxes.
-	{
-		// This is the basic stylebox, used as a base for most other styleboxes (through `duplicate()`).
-		p_config.base_style = make_flat_stylebox(p_config.base_color, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.corner_radius);
-		p_config.base_style->set_border_width_all(p_config.border_width);
-		p_config.base_style->set_border_color(p_config.base_color);
-
-		p_config.base_empty_style = make_empty_stylebox(p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
-
-		// Button styles.
-		{
-			p_config.widget_margin = Vector2(p_config.increased_margin + 2, p_config.increased_margin + 1) * EDSCALE;
-
-			p_config.button_style = p_config.base_style->duplicate();
-			p_config.button_style->set_content_margin_individual(p_config.widget_margin.x, p_config.widget_margin.y, p_config.widget_margin.x, p_config.widget_margin.y);
-			p_config.button_style->set_bg_color(p_config.dark_color_1);
-			if (p_config.draw_extra_borders) {
-				p_config.button_style->set_border_width_all(Math::round(EDSCALE));
-				p_config.button_style->set_border_color(p_config.extra_border_color_1);
-			} else {
-				p_config.button_style->set_border_color(p_config.dark_color_2);
-			}
-
-			p_config.button_style_disabled = p_config.button_style->duplicate();
-			p_config.button_style_disabled->set_bg_color(p_config.disabled_bg_color);
-			if (p_config.draw_extra_borders) {
-				p_config.button_style_disabled->set_border_color(p_config.extra_border_color_2);
-			} else {
-				p_config.button_style_disabled->set_border_color(p_config.disabled_border_color);
-			}
-
-			p_config.button_style_focus = p_config.button_style->duplicate();
-			p_config.button_style_focus->set_draw_center(false);
-			p_config.button_style_focus->set_border_width_all(Math::round(2 * MAX(1, EDSCALE)));
-			p_config.button_style_focus->set_border_color(p_config.accent_color);
-
-			p_config.button_style_pressed = p_config.button_style->duplicate();
-			p_config.button_style_pressed->set_bg_color(p_config.dark_color_1.darkened(0.125));
-
-			p_config.button_style_hover = p_config.button_style->duplicate();
-			p_config.button_style_hover->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.11));
-			if (p_config.draw_extra_borders) {
-				p_config.button_style_hover->set_border_color(p_config.extra_border_color_1);
-			} else {
-				p_config.button_style_hover->set_border_color(p_config.mono_color * Color(1, 1, 1, 0.05));
-			}
-		}
-
-		// Windows and popups.
-		{
-			p_config.popup_style = p_config.base_style->duplicate();
-			p_config.popup_style->set_content_margin_all(p_config.popup_margin);
-			p_config.popup_style->set_border_color(p_config.contrast_color_1);
-			p_config.popup_style->set_shadow_color(p_config.shadow_color);
-			p_config.popup_style->set_shadow_size(4 * EDSCALE);
-			// Popups are separate windows by default in the editor. Windows currently don't support per-pixel transparency
-			// in 4.0, and even if it was, it may not always work in practice (e.g. running with compositing disabled).
-			p_config.popup_style->set_corner_radius_all(0);
-
-			p_config.popup_border_style = p_config.popup_style->duplicate();
-			p_config.popup_border_style->set_content_margin_all(MAX(Math::round(EDSCALE), p_config.border_width) + 2 + (p_config.base_margin * 1.5) * EDSCALE);
-			// Always display a border for popups like PopupMenus so they can be distinguished from their background.
-			p_config.popup_border_style->set_border_width_all(MAX(Math::round(EDSCALE), p_config.border_width));
-			if (p_config.draw_extra_borders) {
-				p_config.popup_border_style->set_border_color(p_config.extra_border_color_2);
-			} else {
-				p_config.popup_border_style->set_border_color(p_config.dark_color_2);
-			}
-
-			p_config.window_style = p_config.popup_style->duplicate();
-			p_config.window_style->set_border_color(p_config.base_color);
-			p_config.window_style->set_border_width(SIDE_TOP, 24 * EDSCALE);
-			p_config.window_style->set_expand_margin(SIDE_TOP, 24 * EDSCALE);
-
-			// Prevent corner artifacts between window title and body.
-			p_config.dialog_style = p_config.base_style->duplicate();
-			p_config.dialog_style->set_corner_radius(CORNER_TOP_LEFT, 0);
-			p_config.dialog_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
-			p_config.dialog_style->set_content_margin_all(p_config.popup_margin);
-			// Prevent visible line between window title and body.
-			p_config.dialog_style->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
-		}
-
-		// Panels.
-		{
-			p_config.panel_container_style = p_config.button_style->duplicate();
-			p_config.panel_container_style->set_draw_center(false);
-			p_config.panel_container_style->set_border_width_all(0);
-
-			// Content panel for tabs and similar containers.
-
-			// Compensate for the border.
-			const int content_panel_margin = p_config.base_margin * EDSCALE + p_config.border_width;
-
-			p_config.content_panel_style = p_config.base_style->duplicate();
-			p_config.content_panel_style->set_border_color(p_config.dark_color_3);
-			p_config.content_panel_style->set_border_width_all(p_config.border_width);
-			p_config.content_panel_style->set_border_width(Side::SIDE_TOP, 0);
-			p_config.content_panel_style->set_corner_radius(CORNER_TOP_LEFT, 0);
-			p_config.content_panel_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
-			p_config.content_panel_style->set_content_margin_individual(content_panel_margin, 2 * EDSCALE + content_panel_margin, content_panel_margin, content_panel_margin);
-
-			// Trees and similarly inset panels.
-
-			p_config.tree_panel_style = p_config.base_style->duplicate();
-			// Make Trees easier to distinguish from other controls by using a darker background color.
-			p_config.tree_panel_style->set_bg_color(p_config.dark_color_1.lerp(p_config.dark_color_2, 0.5));
-			if (p_config.draw_extra_borders) {
-				p_config.tree_panel_style->set_border_width_all(Math::round(EDSCALE));
-				p_config.tree_panel_style->set_border_color(p_config.extra_border_color_2);
-			} else {
-				p_config.tree_panel_style->set_border_color(p_config.dark_color_3);
-			}
-		}
-	}
-}
-
-void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_theme, ThemeConfiguration &p_config) {
-	// Panels.
-	{
-		// Panel.
-		p_theme->set_stylebox(SceneStringName(panel), "Panel", make_flat_stylebox(p_config.dark_color_1, 6, 4, 6, 4, p_config.corner_radius));
-
-		// PanelContainer.
-		p_theme->set_stylebox(SceneStringName(panel), "PanelContainer", p_config.panel_container_style);
-
-		// TooltipPanel & TooltipLabel.
-		{
-			// TooltipPanel is also used for custom tooltips, while TooltipLabel
-			// is only relevant for default tooltips.
-
-			p_theme->set_color(SceneStringName(font_color), "TooltipLabel", p_config.font_hover_color);
-			p_theme->set_color("font_shadow_color", "TooltipLabel", Color(0, 0, 0, 0));
-
-			Ref<StyleBoxFlat> style_tooltip = p_config.popup_style->duplicate();
-			style_tooltip->set_shadow_size(0);
-			style_tooltip->set_content_margin_all(p_config.base_margin * EDSCALE * 0.5);
-			style_tooltip->set_bg_color(p_config.dark_color_3 * Color(0.8, 0.8, 0.8, 0.9));
-			if (p_config.draw_extra_borders) {
-				style_tooltip->set_border_width_all(Math::round(EDSCALE));
-				style_tooltip->set_border_color(p_config.extra_border_color_2);
-			} else {
-				style_tooltip->set_border_width_all(0);
-			}
-			p_theme->set_stylebox(SceneStringName(panel), "TooltipPanel", style_tooltip);
-		}
-
-		// PopupPanel
-		p_theme->set_stylebox(SceneStringName(panel), "PopupPanel", p_config.popup_border_style);
-	}
-
-	// Buttons.
-	{
-		// Button.
-
-		p_theme->set_stylebox(CoreStringName(normal), "Button", p_config.button_style);
-		p_theme->set_stylebox(SceneStringName(hover), "Button", p_config.button_style_hover);
-		p_theme->set_stylebox(SceneStringName(pressed), "Button", p_config.button_style_pressed);
-		p_theme->set_stylebox("focus", "Button", p_config.button_style_focus);
-		p_theme->set_stylebox("disabled", "Button", p_config.button_style_disabled);
-
-		p_theme->set_color(SceneStringName(font_color), "Button", p_config.font_color);
-		p_theme->set_color("font_hover_color", "Button", p_config.font_hover_color);
-		p_theme->set_color("font_hover_pressed_color", "Button", p_config.font_hover_pressed_color);
-		p_theme->set_color("font_focus_color", "Button", p_config.font_focus_color);
-		p_theme->set_color("font_pressed_color", "Button", p_config.font_pressed_color);
-		p_theme->set_color("font_disabled_color", "Button", p_config.font_disabled_color);
-		p_theme->set_color("font_outline_color", "Button", p_config.font_outline_color);
-
-		p_theme->set_color("icon_normal_color", "Button", p_config.icon_normal_color);
-		p_theme->set_color("icon_hover_color", "Button", p_config.icon_hover_color);
-		p_theme->set_color("icon_focus_color", "Button", p_config.icon_focus_color);
-		p_theme->set_color("icon_hover_pressed_color", "Button", p_config.icon_pressed_color);
-		p_theme->set_color("icon_pressed_color", "Button", p_config.icon_pressed_color);
-		p_theme->set_color("icon_disabled_color", "Button", p_config.icon_disabled_color);
-
-		p_theme->set_constant("h_separation", "Button", 4 * EDSCALE);
-		p_theme->set_constant("outline_size", "Button", 0);
-
-		p_theme->set_constant("align_to_largest_stylebox", "Button", 1); // Enabled.
-
-		// MenuButton.
-
-		p_theme->set_stylebox(CoreStringName(normal), "MenuButton", p_config.panel_container_style);
-		p_theme->set_stylebox(SceneStringName(hover), "MenuButton", p_config.button_style_hover);
-		p_theme->set_stylebox(SceneStringName(pressed), "MenuButton", p_config.panel_container_style);
-		p_theme->set_stylebox("focus", "MenuButton", p_config.panel_container_style);
-		p_theme->set_stylebox("disabled", "MenuButton", p_config.panel_container_style);
-
-		p_theme->set_color(SceneStringName(font_color), "MenuButton", p_config.font_color);
-		p_theme->set_color("font_hover_color", "MenuButton", p_config.font_hover_color);
-		p_theme->set_color("font_hover_pressed_color", "MenuButton", p_config.font_hover_pressed_color);
-		p_theme->set_color("font_focus_color", "MenuButton", p_config.font_focus_color);
-		p_theme->set_color("font_outline_color", "MenuButton", p_config.font_outline_color);
-
-		p_theme->set_constant("outline_size", "MenuButton", 0);
-
-		// MenuBar.
-
-		p_theme->set_stylebox(CoreStringName(normal), "MenuBar", p_config.button_style);
-		p_theme->set_stylebox(SceneStringName(hover), "MenuBar", p_config.button_style_hover);
-		p_theme->set_stylebox(SceneStringName(pressed), "MenuBar", p_config.button_style_pressed);
-		p_theme->set_stylebox("disabled", "MenuBar", p_config.button_style_disabled);
-
-		p_theme->set_color(SceneStringName(font_color), "MenuBar", p_config.font_color);
-		p_theme->set_color("font_hover_color", "MenuBar", p_config.font_hover_color);
-		p_theme->set_color("font_hover_pressed_color", "MenuBar", p_config.font_hover_pressed_color);
-		p_theme->set_color("font_focus_color", "MenuBar", p_config.font_focus_color);
-		p_theme->set_color("font_pressed_color", "MenuBar", p_config.font_pressed_color);
-		p_theme->set_color("font_disabled_color", "MenuBar", p_config.font_disabled_color);
-		p_theme->set_color("font_outline_color", "MenuBar", p_config.font_outline_color);
-
-		p_theme->set_color("icon_normal_color", "MenuBar", p_config.icon_normal_color);
-		p_theme->set_color("icon_hover_color", "MenuBar", p_config.icon_hover_color);
-		p_theme->set_color("icon_focus_color", "MenuBar", p_config.icon_focus_color);
-		p_theme->set_color("icon_pressed_color", "MenuBar", p_config.icon_pressed_color);
-		p_theme->set_color("icon_disabled_color", "MenuBar", p_config.icon_disabled_color);
-
-		p_theme->set_constant("h_separation", "MenuBar", 4 * EDSCALE);
-		p_theme->set_constant("outline_size", "MenuBar", 0);
-
-		// OptionButton.
-		{
-			Ref<StyleBoxFlat> option_button_focus_style = p_config.button_style_focus->duplicate();
-			Ref<StyleBoxFlat> option_button_normal_style = p_config.button_style->duplicate();
-			Ref<StyleBoxFlat> option_button_hover_style = p_config.button_style_hover->duplicate();
-			Ref<StyleBoxFlat> option_button_pressed_style = p_config.button_style_pressed->duplicate();
-			Ref<StyleBoxFlat> option_button_disabled_style = p_config.button_style_disabled->duplicate();
-
-			option_button_focus_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
-			option_button_normal_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
-			option_button_hover_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
-			option_button_pressed_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
-			option_button_disabled_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
-
-			p_theme->set_stylebox("focus", "OptionButton", option_button_focus_style);
-			p_theme->set_stylebox(CoreStringName(normal), "OptionButton", p_config.button_style);
-			p_theme->set_stylebox(SceneStringName(hover), "OptionButton", p_config.button_style_hover);
-			p_theme->set_stylebox(SceneStringName(pressed), "OptionButton", p_config.button_style_pressed);
-			p_theme->set_stylebox("disabled", "OptionButton", p_config.button_style_disabled);
-
-			p_theme->set_stylebox("normal_mirrored", "OptionButton", option_button_normal_style);
-			p_theme->set_stylebox("hover_mirrored", "OptionButton", option_button_hover_style);
-			p_theme->set_stylebox("pressed_mirrored", "OptionButton", option_button_pressed_style);
-			p_theme->set_stylebox("disabled_mirrored", "OptionButton", option_button_disabled_style);
-
-			p_theme->set_color(SceneStringName(font_color), "OptionButton", p_config.font_color);
-			p_theme->set_color("font_hover_color", "OptionButton", p_config.font_hover_color);
-			p_theme->set_color("font_hover_pressed_color", "OptionButton", p_config.font_hover_pressed_color);
-			p_theme->set_color("font_focus_color", "OptionButton", p_config.font_focus_color);
-			p_theme->set_color("font_pressed_color", "OptionButton", p_config.font_pressed_color);
-			p_theme->set_color("font_disabled_color", "OptionButton", p_config.font_disabled_color);
-			p_theme->set_color("font_outline_color", "OptionButton", p_config.font_outline_color);
-
-			p_theme->set_color("icon_normal_color", "OptionButton", p_config.icon_normal_color);
-			p_theme->set_color("icon_hover_color", "OptionButton", p_config.icon_hover_color);
-			p_theme->set_color("icon_focus_color", "OptionButton", p_config.icon_focus_color);
-			p_theme->set_color("icon_pressed_color", "OptionButton", p_config.icon_pressed_color);
-			p_theme->set_color("icon_disabled_color", "OptionButton", p_config.icon_disabled_color);
-
-			p_theme->set_icon("arrow", "OptionButton", p_theme->get_icon(SNAME("GuiOptionArrow"), EditorStringName(EditorIcons)));
-			p_theme->set_constant("arrow_margin", "OptionButton", p_config.widget_margin.x - 2 * EDSCALE);
-			p_theme->set_constant("modulate_arrow", "OptionButton", true);
-			p_theme->set_constant("h_separation", "OptionButton", 4 * EDSCALE);
-			p_theme->set_constant("outline_size", "OptionButton", 0);
-		}
-
-		// CheckButton.
-
-		p_theme->set_stylebox(CoreStringName(normal), "CheckButton", p_config.panel_container_style);
-		p_theme->set_stylebox(SceneStringName(pressed), "CheckButton", p_config.panel_container_style);
-		p_theme->set_stylebox("disabled", "CheckButton", p_config.panel_container_style);
-		p_theme->set_stylebox(SceneStringName(hover), "CheckButton", p_config.panel_container_style);
-		p_theme->set_stylebox("hover_pressed", "CheckButton", p_config.panel_container_style);
-
-		p_theme->set_icon("checked", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOn"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("checked_disabled", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOnDisabled"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("unchecked", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOff"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("unchecked_disabled", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffDisabled"), EditorStringName(EditorIcons)));
-
-		p_theme->set_icon("checked_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOnMirrored"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("checked_disabled_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOnDisabledMirrored"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("unchecked_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffMirrored"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("unchecked_disabled_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffDisabledMirrored"), EditorStringName(EditorIcons)));
-
-		p_theme->set_color(SceneStringName(font_color), "CheckButton", p_config.font_color);
-		p_theme->set_color("font_hover_color", "CheckButton", p_config.font_hover_color);
-		p_theme->set_color("font_hover_pressed_color", "CheckButton", p_config.font_hover_pressed_color);
-		p_theme->set_color("font_focus_color", "CheckButton", p_config.font_focus_color);
-		p_theme->set_color("font_pressed_color", "CheckButton", p_config.font_pressed_color);
-		p_theme->set_color("font_disabled_color", "CheckButton", p_config.font_disabled_color);
-		p_theme->set_color("font_outline_color", "CheckButton", p_config.font_outline_color);
-
-		p_theme->set_color("icon_normal_color", "CheckButton", p_config.icon_normal_color);
-		p_theme->set_color("icon_hover_color", "CheckButton", p_config.icon_hover_color);
-		p_theme->set_color("icon_focus_color", "CheckButton", p_config.icon_focus_color);
-		p_theme->set_color("icon_pressed_color", "CheckButton", p_config.icon_pressed_color);
-		p_theme->set_color("icon_disabled_color", "CheckButton", p_config.icon_disabled_color);
-
-		p_theme->set_constant("h_separation", "CheckButton", 8 * EDSCALE);
-		p_theme->set_constant("check_v_offset", "CheckButton", 0);
-		p_theme->set_constant("outline_size", "CheckButton", 0);
-
-		// CheckBox.
-		{
-			Ref<StyleBoxFlat> checkbox_style = p_config.panel_container_style->duplicate();
-
-			p_theme->set_stylebox(CoreStringName(normal), "CheckBox", checkbox_style);
-			p_theme->set_stylebox(SceneStringName(pressed), "CheckBox", checkbox_style);
-			p_theme->set_stylebox("disabled", "CheckBox", checkbox_style);
-			p_theme->set_stylebox(SceneStringName(hover), "CheckBox", checkbox_style);
-			p_theme->set_stylebox("hover_pressed", "CheckBox", checkbox_style);
-			p_theme->set_icon("checked", "CheckBox", p_theme->get_icon(SNAME("GuiChecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("unchecked", "CheckBox", p_theme->get_icon(SNAME("GuiUnchecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("radio_checked", "CheckBox", p_theme->get_icon(SNAME("GuiRadioChecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("radio_unchecked", "CheckBox", p_theme->get_icon(SNAME("GuiRadioUnchecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("checked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiCheckedDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("unchecked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiUncheckedDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("radio_checked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiRadioCheckedDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("radio_unchecked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), EditorStringName(EditorIcons)));
-
-			p_theme->set_color(SceneStringName(font_color), "CheckBox", p_config.font_color);
-			p_theme->set_color("font_hover_color", "CheckBox", p_config.font_hover_color);
-			p_theme->set_color("font_hover_pressed_color", "CheckBox", p_config.font_hover_pressed_color);
-			p_theme->set_color("font_focus_color", "CheckBox", p_config.font_focus_color);
-			p_theme->set_color("font_pressed_color", "CheckBox", p_config.font_pressed_color);
-			p_theme->set_color("font_disabled_color", "CheckBox", p_config.font_disabled_color);
-			p_theme->set_color("font_outline_color", "CheckBox", p_config.font_outline_color);
-
-			p_theme->set_color("icon_normal_color", "CheckBox", p_config.icon_normal_color);
-			p_theme->set_color("icon_hover_color", "CheckBox", p_config.icon_hover_color);
-			p_theme->set_color("icon_focus_color", "CheckBox", p_config.icon_focus_color);
-			p_theme->set_color("icon_pressed_color", "CheckBox", p_config.icon_pressed_color);
-			p_theme->set_color("icon_disabled_color", "CheckBox", p_config.icon_disabled_color);
-
-			p_theme->set_constant("h_separation", "CheckBox", 8 * EDSCALE);
-			p_theme->set_constant("check_v_offset", "CheckBox", 0);
-			p_theme->set_constant("outline_size", "CheckBox", 0);
-		}
-
-		// LinkButton.
-
-		p_theme->set_stylebox("focus", "LinkButton", p_config.base_empty_style);
-		p_theme->set_color(SceneStringName(font_color), "LinkButton", p_config.font_color);
-		p_theme->set_color("font_hover_color", "LinkButton", p_config.font_hover_color);
-		p_theme->set_color("font_hover_pressed_color", "LinkButton", p_config.font_hover_pressed_color);
-		p_theme->set_color("font_focus_color", "LinkButton", p_config.font_focus_color);
-		p_theme->set_color("font_pressed_color", "LinkButton", p_config.font_pressed_color);
-		p_theme->set_color("font_disabled_color", "LinkButton", p_config.font_disabled_color);
-		p_theme->set_color("font_outline_color", "LinkButton", p_config.font_outline_color);
-
-		p_theme->set_constant("outline_size", "LinkButton", 0);
-	}
-
-	// Tree & ItemList.
-	{
-		Ref<StyleBoxFlat> style_tree_focus = p_config.base_style->duplicate();
-		style_tree_focus->set_bg_color(p_config.highlight_color);
-		style_tree_focus->set_border_width_all(0);
-
-		Ref<StyleBoxFlat> style_tree_selected = style_tree_focus->duplicate();
-
-		const Color guide_color = p_config.mono_color * Color(1, 1, 1, 0.05);
-
-		// Tree.
-		{
-			p_theme->set_icon("checked", "Tree", p_theme->get_icon(SNAME("GuiChecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("checked_disabled", "Tree", p_theme->get_icon(SNAME("GuiCheckedDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("indeterminate", "Tree", p_theme->get_icon(SNAME("GuiIndeterminate"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("indeterminate_disabled", "Tree", p_theme->get_icon(SNAME("GuiIndeterminateDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("unchecked", "Tree", p_theme->get_icon(SNAME("GuiUnchecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("unchecked_disabled", "Tree", p_theme->get_icon(SNAME("GuiUncheckedDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("arrow", "Tree", p_theme->get_icon(SNAME("GuiTreeArrowDown"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("arrow_collapsed", "Tree", p_theme->get_icon(SNAME("GuiTreeArrowRight"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("arrow_collapsed_mirrored", "Tree", p_theme->get_icon(SNAME("GuiTreeArrowLeft"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("updown", "Tree", p_theme->get_icon(SNAME("GuiTreeUpdown"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("select_arrow", "Tree", p_theme->get_icon(SNAME("GuiDropdown"), EditorStringName(EditorIcons)));
-
-			p_theme->set_stylebox(SceneStringName(panel), "Tree", p_config.tree_panel_style);
-			p_theme->set_stylebox("focus", "Tree", p_config.button_style_focus);
-			p_theme->set_stylebox("custom_button", "Tree", make_empty_stylebox());
-			p_theme->set_stylebox("custom_button_pressed", "Tree", make_empty_stylebox());
-			p_theme->set_stylebox("custom_button_hover", "Tree", p_config.button_style);
-
-			p_theme->set_color("custom_button_font_highlight", "Tree", p_config.font_hover_color);
-			p_theme->set_color(SceneStringName(font_color), "Tree", p_config.font_color);
-			p_theme->set_color("font_hovered_color", "Tree", p_config.mono_color);
-			p_theme->set_color("font_hovered_dimmed_color", "Tree", p_config.font_color);
-			p_theme->set_color("font_hovered_selected_color", "Tree", p_config.mono_color);
-			p_theme->set_color("font_selected_color", "Tree", p_config.mono_color);
-			p_theme->set_color("font_disabled_color", "Tree", p_config.font_disabled_color);
-			p_theme->set_color("font_outline_color", "Tree", p_config.font_outline_color);
-			p_theme->set_color("title_button_color", "Tree", p_config.font_color);
-			p_theme->set_color("drop_position_color", "Tree", p_config.accent_color);
-
-			p_theme->set_constant("v_separation", "Tree", p_config.separation_margin);
-			p_theme->set_constant("h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
-			p_theme->set_constant("guide_width", "Tree", p_config.border_width);
-			p_theme->set_constant("item_margin", "Tree", MAX(3 * p_config.increased_margin * EDSCALE, 12 * EDSCALE));
-			p_theme->set_constant("inner_item_margin_top", "Tree", p_config.separation_margin);
-			p_theme->set_constant("inner_item_margin_bottom", "Tree", p_config.separation_margin);
-			p_theme->set_constant("inner_item_margin_left", "Tree", p_config.increased_margin * EDSCALE);
-			p_theme->set_constant("inner_item_margin_right", "Tree", p_config.increased_margin * EDSCALE);
-			p_theme->set_constant("button_margin", "Tree", p_config.base_margin * EDSCALE);
-			p_theme->set_constant("dragging_unfold_wait_msec", "Tree", (float)EDITOR_GET("interface/editor/dragging_hover_wait_seconds") * 1000);
-			p_theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
-			p_theme->set_constant("scroll_speed", "Tree", 12);
-			p_theme->set_constant("outline_size", "Tree", 0);
-			p_theme->set_constant("scrollbar_margin_left", "Tree", 0);
-			p_theme->set_constant("scrollbar_margin_top", "Tree", 0);
-			p_theme->set_constant("scrollbar_margin_right", "Tree", 0);
-			p_theme->set_constant("scrollbar_margin_bottom", "Tree", 0);
-			p_theme->set_constant("scrollbar_h_separation", "Tree", 1 * EDSCALE);
-			p_theme->set_constant("scrollbar_v_separation", "Tree", 1 * EDSCALE);
-
-			Color relationship_line_color = p_config.mono_color * Color(1, 1, 1, p_config.relationship_line_opacity);
-
-			p_theme->set_constant("draw_guides", "Tree", p_config.relationship_line_opacity < 0.01);
-			p_theme->set_color("guide_color", "Tree", guide_color);
-
-			int relationship_line_width = 1;
-			Color parent_line_color = p_config.mono_color * Color(1, 1, 1, CLAMP(p_config.relationship_line_opacity + 0.45, 0.0, 1.0));
-			Color children_line_color = p_config.mono_color * Color(1, 1, 1, CLAMP(p_config.relationship_line_opacity + 0.25, 0.0, 1.0));
-
-			p_theme->set_constant("draw_relationship_lines", "Tree", p_config.relationship_line_opacity >= 0.01);
-			p_theme->set_constant("relationship_line_width", "Tree", relationship_line_width);
-			p_theme->set_constant("parent_hl_line_width", "Tree", relationship_line_width * 2);
-			p_theme->set_constant("children_hl_line_width", "Tree", relationship_line_width);
-			p_theme->set_constant("parent_hl_line_margin", "Tree", relationship_line_width * 3);
-			p_theme->set_color("relationship_line_color", "Tree", relationship_line_color);
-			p_theme->set_color("parent_hl_line_color", "Tree", parent_line_color);
-			p_theme->set_color("children_hl_line_color", "Tree", children_line_color);
-			p_theme->set_color("drop_position_color", "Tree", p_config.accent_color);
-
-			Ref<StyleBoxFlat> style_tree_btn = p_config.base_style->duplicate();
-			style_tree_btn->set_bg_color(p_config.highlight_color);
-			style_tree_btn->set_border_width_all(0);
-			p_theme->set_stylebox("button_pressed", "Tree", style_tree_btn);
-
-			Ref<StyleBoxFlat> style_tree_hover = p_config.base_style->duplicate();
-			style_tree_hover->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 0.4));
-			style_tree_hover->set_border_width_all(0);
-			p_theme->set_stylebox("hovered", "Tree", style_tree_hover);
-			p_theme->set_stylebox("button_hover", "Tree", style_tree_hover);
-
-			Ref<StyleBoxFlat> style_tree_hover_dimmed = p_config.base_style->duplicate();
-			style_tree_hover_dimmed->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 0.2));
-			style_tree_hover_dimmed->set_border_width_all(0);
-			p_theme->set_stylebox("hovered_dimmed", "Tree", style_tree_hover_dimmed);
-
-			Ref<StyleBoxFlat> style_tree_hover_selected = style_tree_selected->duplicate();
-			style_tree_hover_selected->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 1.2));
-			style_tree_hover_selected->set_border_width_all(0);
-
-			p_theme->set_stylebox("hovered_selected", "Tree", style_tree_hover_selected);
-			p_theme->set_stylebox("hovered_selected_focus", "Tree", style_tree_hover_selected);
-
-			p_theme->set_stylebox("selected_focus", "Tree", style_tree_focus);
-			p_theme->set_stylebox("selected", "Tree", style_tree_selected);
-
-			Ref<StyleBoxFlat> style_tree_cursor = p_config.base_style->duplicate();
-			style_tree_cursor->set_draw_center(false);
-			style_tree_cursor->set_border_width_all(MAX(1, p_config.border_width));
-			style_tree_cursor->set_border_color(p_config.contrast_color_1);
-
-			Ref<StyleBoxFlat> style_tree_title = p_config.base_style->duplicate();
-			style_tree_title->set_bg_color(p_config.dark_color_3);
-			style_tree_title->set_border_width_all(0);
-			p_theme->set_stylebox("cursor", "Tree", style_tree_cursor);
-			p_theme->set_stylebox("cursor_unfocused", "Tree", style_tree_cursor);
-			p_theme->set_stylebox("title_button_normal", "Tree", style_tree_title);
-			p_theme->set_stylebox("title_button_hover", "Tree", style_tree_title);
-			p_theme->set_stylebox("title_button_pressed", "Tree", style_tree_title);
-		}
-
-		// ItemList.
-		{
-			Ref<StyleBoxFlat> style_itemlist_bg = p_config.base_style->duplicate();
-			style_itemlist_bg->set_content_margin_all(p_config.separation_margin);
-			style_itemlist_bg->set_bg_color(p_config.dark_color_1);
-
-			if (p_config.draw_extra_borders) {
-				style_itemlist_bg->set_border_width_all(Math::round(EDSCALE));
-				style_itemlist_bg->set_border_color(p_config.extra_border_color_2);
-			} else {
-				style_itemlist_bg->set_border_width_all(p_config.border_width);
-				style_itemlist_bg->set_border_color(p_config.dark_color_3);
-			}
-
-			Ref<StyleBoxFlat> style_itemlist_cursor = p_config.base_style->duplicate();
-			style_itemlist_cursor->set_draw_center(false);
-			style_itemlist_cursor->set_border_width_all(MAX(1 * EDSCALE, p_config.border_width));
-			style_itemlist_cursor->set_border_color(p_config.highlight_color);
-
-			Ref<StyleBoxFlat> style_itemlist_hover = style_tree_selected->duplicate();
-			style_itemlist_hover->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 0.3));
-			style_itemlist_hover->set_border_width_all(0);
-
-			Ref<StyleBoxFlat> style_itemlist_hover_selected = style_tree_selected->duplicate();
-			style_itemlist_hover_selected->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 1.2));
-			style_itemlist_hover_selected->set_border_width_all(0);
-
-			p_theme->set_stylebox(SceneStringName(panel), "ItemList", style_itemlist_bg);
-			p_theme->set_stylebox("focus", "ItemList", p_config.button_style_focus);
-			p_theme->set_stylebox("cursor", "ItemList", style_itemlist_cursor);
-			p_theme->set_stylebox("cursor_unfocused", "ItemList", style_itemlist_cursor);
-			p_theme->set_stylebox("selected_focus", "ItemList", style_tree_focus);
-			p_theme->set_stylebox("selected", "ItemList", style_tree_selected);
-			p_theme->set_stylebox("hovered", "ItemList", style_itemlist_hover);
-			p_theme->set_stylebox("hovered_selected", "ItemList", style_itemlist_hover_selected);
-			p_theme->set_stylebox("hovered_selected_focus", "ItemList", style_itemlist_hover_selected);
-			p_theme->set_color(SceneStringName(font_color), "ItemList", p_config.font_color);
-			p_theme->set_color("font_hovered_color", "ItemList", p_config.mono_color);
-			p_theme->set_color("font_hovered_selected_color", "ItemList", p_config.mono_color);
-			p_theme->set_color("font_selected_color", "ItemList", p_config.mono_color);
-			p_theme->set_color("font_outline_color", "ItemList", p_config.font_outline_color);
-			p_theme->set_color("guide_color", "ItemList", Color(1, 1, 1, 0));
-			p_theme->set_constant("v_separation", "ItemList", p_config.forced_even_separation * EDSCALE);
-			p_theme->set_constant("h_separation", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
-			p_theme->set_constant("icon_margin", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
-			p_theme->set_constant(SceneStringName(line_separation), "ItemList", p_config.separation_margin);
-			p_theme->set_constant("outline_size", "ItemList", 0);
-		}
-	}
-
-	// TabBar & TabContainer.
-	{
-		Ref<StyleBoxFlat> style_tab_base = p_config.button_style->duplicate();
-
-		style_tab_base->set_border_width_all(0);
-		// Don't round the top corners to avoid creating a small blank space between the tabs and the main panel.
-		// This also makes the top highlight look better.
-		style_tab_base->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-		style_tab_base->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-
-		// When using a border width greater than 0, visually line up the left of the selected tab with the underlying panel.
-		style_tab_base->set_expand_margin(SIDE_LEFT, -p_config.border_width);
-
-		style_tab_base->set_content_margin(SIDE_LEFT, p_config.widget_margin.x + 5 * EDSCALE);
-		style_tab_base->set_content_margin(SIDE_RIGHT, p_config.widget_margin.x + 5 * EDSCALE);
-		style_tab_base->set_content_margin(SIDE_BOTTOM, p_config.widget_margin.y);
-		style_tab_base->set_content_margin(SIDE_TOP, p_config.widget_margin.y);
-
-		Ref<StyleBoxFlat> style_tab_selected = style_tab_base->duplicate();
-
-		style_tab_selected->set_bg_color(p_config.base_color);
-		// Add a highlight line at the top of the selected tab.
-		style_tab_selected->set_border_width(SIDE_TOP, Math::round(2 * EDSCALE));
-		// Make the highlight line prominent, but not too prominent as to not be distracting.
-		Color tab_highlight = p_config.dark_color_2.lerp(p_config.accent_color, 0.75);
-		style_tab_selected->set_border_color(tab_highlight);
-		style_tab_selected->set_corner_radius_all(0);
-
-		Ref<StyleBoxFlat> style_tab_hovered = style_tab_base->duplicate();
-
-		style_tab_hovered->set_bg_color(p_config.dark_color_1.lerp(p_config.base_color, 0.4));
-		// Hovered tab has a subtle highlight between normal and selected states.
-		style_tab_hovered->set_corner_radius_all(0);
-
-		Ref<StyleBoxFlat> style_tab_unselected = style_tab_base->duplicate();
-		style_tab_unselected->set_expand_margin(SIDE_BOTTOM, 0);
-		style_tab_unselected->set_bg_color(p_config.dark_color_1);
-		// Add some spacing between unselected tabs to make them easier to distinguish from each other
-		style_tab_unselected->set_border_color(Color(0, 0, 0, 0));
-
-		Ref<StyleBoxFlat> style_tab_disabled = style_tab_base->duplicate();
-		style_tab_disabled->set_expand_margin(SIDE_BOTTOM, 0);
-		style_tab_disabled->set_bg_color(p_config.disabled_bg_color);
-		style_tab_disabled->set_border_color(p_config.disabled_bg_color);
-
-		Ref<StyleBoxFlat> style_tab_focus = p_config.button_style_focus->duplicate();
-
-		Ref<StyleBoxFlat> style_tabbar_background = make_flat_stylebox(p_config.dark_color_1, 0, 0, 0, 0, p_config.corner_radius);
-		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-		p_theme->set_stylebox("tabbar_background", "TabContainer", style_tabbar_background);
-		p_theme->set_stylebox(SceneStringName(panel), "TabContainer", p_config.content_panel_style);
-
-		p_theme->set_stylebox("tab_selected", "TabContainer", style_tab_selected);
-		p_theme->set_stylebox("tab_hovered", "TabContainer", style_tab_hovered);
-		p_theme->set_stylebox("tab_unselected", "TabContainer", style_tab_unselected);
-		p_theme->set_stylebox("tab_disabled", "TabContainer", style_tab_disabled);
-		p_theme->set_stylebox("tab_focus", "TabContainer", style_tab_focus);
-		p_theme->set_stylebox("tab_selected", "TabBar", style_tab_selected);
-		p_theme->set_stylebox("tab_hovered", "TabBar", style_tab_hovered);
-		p_theme->set_stylebox("tab_unselected", "TabBar", style_tab_unselected);
-		p_theme->set_stylebox("tab_disabled", "TabBar", style_tab_disabled);
-		p_theme->set_stylebox("tab_focus", "TabBar", style_tab_focus);
-		p_theme->set_stylebox("button_pressed", "TabBar", p_config.panel_container_style);
-		p_theme->set_stylebox("button_highlight", "TabBar", p_config.panel_container_style);
-
-		p_theme->set_color("font_selected_color", "TabContainer", p_config.font_color);
-		p_theme->set_color("font_hovered_color", "TabContainer", p_config.font_color);
-		p_theme->set_color("font_unselected_color", "TabContainer", p_config.font_disabled_color);
-		p_theme->set_color("font_outline_color", "TabContainer", p_config.font_outline_color);
-		p_theme->set_color("font_selected_color", "TabBar", p_config.font_color);
-		p_theme->set_color("font_hovered_color", "TabBar", p_config.font_color);
-		p_theme->set_color("font_unselected_color", "TabBar", p_config.font_disabled_color);
-		p_theme->set_color("font_outline_color", "TabBar", p_config.font_outline_color);
-		p_theme->set_color("drop_mark_color", "TabContainer", tab_highlight);
-		p_theme->set_color("drop_mark_color", "TabBar", tab_highlight);
-
-		Color icon_color = Color(1, 1, 1);
-		p_theme->set_color("icon_selected_color", "TabContainer", icon_color);
-		p_theme->set_color("icon_hovered_color", "TabContainer", icon_color);
-		p_theme->set_color("icon_unselected_color", "TabContainer", icon_color);
-		p_theme->set_color("icon_selected_color", "TabBar", icon_color);
-		p_theme->set_color("icon_hovered_color", "TabBar", icon_color);
-		p_theme->set_color("icon_unselected_color", "TabBar", icon_color);
-
-		p_theme->set_icon("menu", "TabContainer", p_theme->get_icon(SNAME("GuiTabMenu"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("menu_highlight", "TabContainer", p_theme->get_icon(SNAME("GuiTabMenuHl"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("close", "TabBar", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("increment", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowRight"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("decrement", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowLeft"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("increment", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowRight"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("decrement", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowLeft"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("increment_highlight", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowRightHl"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("decrement_highlight", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowLeftHl"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("increment_highlight", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowRightHl"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("decrement_highlight", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowLeftHl"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("drop_mark", "TabContainer", p_theme->get_icon(SNAME("GuiTabDropMark"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("drop_mark", "TabBar", p_theme->get_icon(SNAME("GuiTabDropMark"), EditorStringName(EditorIcons)));
-
-		p_theme->set_constant("side_margin", "TabContainer", 0);
-		p_theme->set_constant("outline_size", "TabContainer", 0);
-		p_theme->set_constant("h_separation", "TabBar", 4 * EDSCALE);
-		p_theme->set_constant("outline_size", "TabBar", 0);
-		p_theme->set_constant("hover_switch_wait_msec", "TabBar", (float)EDITOR_GET("interface/editor/dragging_hover_wait_seconds") * 1000);
-	}
-
-	// Separators.
-	p_theme->set_stylebox("separator", "HSeparator", make_line_stylebox(p_config.separator_color, MAX(Math::round(EDSCALE), p_config.border_width)));
-	p_theme->set_stylebox("separator", "VSeparator", make_line_stylebox(p_config.separator_color, MAX(Math::round(EDSCALE), p_config.border_width), 0, 0, true));
-
-	// LineEdit & TextEdit.
-	{
-		Ref<StyleBoxFlat> text_editor_style = p_config.button_style->duplicate();
-
-		// Don't round the bottom corners to make the line look sharper.
-		text_editor_style->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-		text_editor_style->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-
-		if (p_config.draw_extra_borders) {
-			text_editor_style->set_border_width_all(Math::round(EDSCALE));
-			text_editor_style->set_border_color(p_config.extra_border_color_1);
-		} else {
-			// Add a bottom line to make LineEdits more visible, especially in sectioned inspectors
-			// such as the Project Settings.
-			text_editor_style->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
-			text_editor_style->set_border_color(p_config.dark_color_2);
-		}
-
-		Ref<StyleBoxFlat> text_editor_disabled_style = text_editor_style->duplicate();
-		text_editor_disabled_style->set_border_color(p_config.disabled_border_color);
-		text_editor_disabled_style->set_bg_color(p_config.disabled_bg_color);
-
-		// LineEdit.
-
-		p_theme->set_stylebox(CoreStringName(normal), "LineEdit", text_editor_style);
-		p_theme->set_stylebox("focus", "LineEdit", p_config.button_style_focus);
-		p_theme->set_stylebox("read_only", "LineEdit", text_editor_disabled_style);
-
-		p_theme->set_icon("clear", "LineEdit", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
-
-		p_theme->set_color(SceneStringName(font_color), "LineEdit", p_config.font_color);
-		p_theme->set_color("font_selected_color", "LineEdit", p_config.mono_color);
-		p_theme->set_color("font_uneditable_color", "LineEdit", p_config.font_readonly_color);
-		p_theme->set_color("font_placeholder_color", "LineEdit", p_config.font_placeholder_color);
-		p_theme->set_color("font_outline_color", "LineEdit", p_config.font_outline_color);
-		p_theme->set_color("caret_color", "LineEdit", p_config.font_color);
-		p_theme->set_color("selection_color", "LineEdit", p_config.selection_color);
-		p_theme->set_color("clear_button_color", "LineEdit", p_config.font_color);
-		p_theme->set_color("clear_button_color_pressed", "LineEdit", p_config.accent_color);
-
-		p_theme->set_constant("minimum_character_width", "LineEdit", 4);
-		p_theme->set_constant("outline_size", "LineEdit", 0);
-		p_theme->set_constant("caret_width", "LineEdit", 1);
-
-		// TextEdit.
-
-		p_theme->set_stylebox(CoreStringName(normal), "TextEdit", text_editor_style);
-		p_theme->set_stylebox("focus", "TextEdit", p_config.button_style_focus);
-		p_theme->set_stylebox("read_only", "TextEdit", text_editor_disabled_style);
-
-		p_theme->set_icon("tab", "TextEdit", p_theme->get_icon(SNAME("GuiTab"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("space", "TextEdit", p_theme->get_icon(SNAME("GuiSpace"), EditorStringName(EditorIcons)));
-
-		p_theme->set_color(SceneStringName(font_color), "TextEdit", p_config.font_color);
-		p_theme->set_color("font_readonly_color", "TextEdit", p_config.font_readonly_color);
-		p_theme->set_color("font_placeholder_color", "TextEdit", p_config.font_placeholder_color);
-		p_theme->set_color("font_outline_color", "TextEdit", p_config.font_outline_color);
-		p_theme->set_color("caret_color", "TextEdit", p_config.font_color);
-		p_theme->set_color("selection_color", "TextEdit", p_config.selection_color);
-		p_theme->set_color("background_color", "TextEdit", Color(0, 0, 0, 0));
-
-		p_theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
-		p_theme->set_constant("outline_size", "TextEdit", 0);
-		p_theme->set_constant("caret_width", "TextEdit", 1);
-	}
-
-	// Containers.
-	{
-		p_theme->set_constant("separation", "BoxContainer", p_config.separation_margin);
-		p_theme->set_constant("separation", "HBoxContainer", p_config.separation_margin);
-		p_theme->set_constant("separation", "VBoxContainer", p_config.separation_margin);
-		p_theme->set_constant("margin_left", "MarginContainer", 0);
-		p_theme->set_constant("margin_top", "MarginContainer", 0);
-		p_theme->set_constant("margin_right", "MarginContainer", 0);
-		p_theme->set_constant("margin_bottom", "MarginContainer", 0);
-		p_theme->set_constant("h_separation", "GridContainer", p_config.separation_margin);
-		p_theme->set_constant("v_separation", "GridContainer", p_config.separation_margin);
-		p_theme->set_constant("h_separation", "FlowContainer", p_config.separation_margin);
-		p_theme->set_constant("v_separation", "FlowContainer", p_config.separation_margin);
-		p_theme->set_constant("h_separation", "HFlowContainer", p_config.separation_margin);
-		p_theme->set_constant("v_separation", "HFlowContainer", p_config.separation_margin);
-		p_theme->set_constant("h_separation", "VFlowContainer", p_config.separation_margin);
-		p_theme->set_constant("v_separation", "VFlowContainer", p_config.separation_margin);
-
-		// SplitContainer.
-
-		p_theme->set_icon("h_grabber", "SplitContainer", p_theme->get_icon(SNAME("GuiHsplitter"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("v_grabber", "SplitContainer", p_theme->get_icon(SNAME("GuiVsplitter"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("grabber", "VSplitContainer", p_theme->get_icon(SNAME("GuiVsplitter"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("grabber", "HSplitContainer", p_theme->get_icon(SNAME("GuiHsplitter"), EditorStringName(EditorIcons)));
-
-		p_theme->set_constant("separation", "SplitContainer", p_config.separation_margin);
-		p_theme->set_constant("separation", "HSplitContainer", p_config.separation_margin);
-		p_theme->set_constant("separation", "VSplitContainer", p_config.separation_margin);
-
-		p_theme->set_constant("minimum_grab_thickness", "SplitContainer", p_config.increased_margin * EDSCALE);
-		p_theme->set_constant("minimum_grab_thickness", "HSplitContainer", p_config.increased_margin * EDSCALE);
-		p_theme->set_constant("minimum_grab_thickness", "VSplitContainer", p_config.increased_margin * EDSCALE);
-
-		// GridContainer.
-		p_theme->set_constant("v_separation", "GridContainer", Math::round(p_config.widget_margin.y - 2 * EDSCALE));
-
-		// FoldableContainer
-
-		Ref<StyleBoxFlat> foldable_container_title = make_flat_stylebox(p_config.dark_color_1.darkened(0.125), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
-		foldable_container_title->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-		foldable_container_title->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-		p_theme->set_stylebox("title_panel", "FoldableContainer", foldable_container_title);
-		Ref<StyleBoxFlat> foldable_container_hover = make_flat_stylebox(p_config.dark_color_1.lerp(p_config.base_color, 0.4), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
-		foldable_container_hover->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-		foldable_container_hover->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-		p_theme->set_stylebox("title_hover_panel", "FoldableContainer", foldable_container_hover);
-		p_theme->set_stylebox("title_collapsed_panel", "FoldableContainer", make_flat_stylebox(p_config.dark_color_1.darkened(0.125), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
-		p_theme->set_stylebox("title_collapsed_hover_panel", "FoldableContainer", make_flat_stylebox(p_config.dark_color_1.lerp(p_config.base_color, 0.4), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
-		Ref<StyleBoxFlat> foldable_container_panel = make_flat_stylebox(p_config.dark_color_1, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
-		foldable_container_panel->set_corner_radius(CORNER_TOP_LEFT, 0);
-		foldable_container_panel->set_corner_radius(CORNER_TOP_RIGHT, 0);
-		p_theme->set_stylebox(SceneStringName(panel), "FoldableContainer", foldable_container_panel);
-		p_theme->set_stylebox("focus", "FoldableContainer", p_config.button_style_focus);
-
-		p_theme->set_font(SceneStringName(font), "FoldableContainer", p_theme->get_font(SceneStringName(font), SNAME("HeaderSmall")));
-		p_theme->set_font_size(SceneStringName(font_size), "FoldableContainer", p_theme->get_font_size(SceneStringName(font_size), SNAME("HeaderSmall")));
-
-		p_theme->set_color(SceneStringName(font_color), "FoldableContainer", p_config.font_color);
-		p_theme->set_color("hover_font_color", "FoldableContainer", p_config.font_hover_color);
-		p_theme->set_color("collapsed_font_color", "FoldableContainer", p_config.font_pressed_color);
-		p_theme->set_color("font_outline_color", "FoldableContainer", p_config.font_outline_color);
-
-		p_theme->set_icon("expanded_arrow", "FoldableContainer", p_theme->get_icon(SNAME("GuiTreeArrowDown"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("expanded_arrow_mirrored", "FoldableContainer", p_theme->get_icon(SNAME("GuiArrowUp"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("folded_arrow", "FoldableContainer", p_theme->get_icon(SNAME("GuiTreeArrowRight"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("folded_arrow_mirrored", "FoldableContainer", p_theme->get_icon(SNAME("GuiTreeArrowLeft"), EditorStringName(EditorIcons)));
-
-		p_theme->set_constant("outline_size", "FoldableContainer", 0);
-		p_theme->set_constant("h_separation", "FoldableContainer", p_config.separation_margin);
-	}
-
-	// Window and dialogs.
-	{
-		// Window.
-
-		p_theme->set_stylebox("embedded_border", "Window", p_config.window_style);
-		p_theme->set_stylebox("embedded_unfocused_border", "Window", p_config.window_style);
-
-		p_theme->set_color("title_color", "Window", p_config.font_color);
-		p_theme->set_icon("close", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("close_pressed", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
-		p_theme->set_constant("close_h_offset", "Window", 22 * EDSCALE);
-		p_theme->set_constant("close_v_offset", "Window", 20 * EDSCALE);
-		p_theme->set_constant("title_height", "Window", 24 * EDSCALE);
-		p_theme->set_constant("resize_margin", "Window", 4 * EDSCALE);
-		p_theme->set_font("title_font", "Window", p_theme->get_font(SNAME("title"), EditorStringName(EditorFonts)));
-		p_theme->set_font_size("title_font_size", "Window", p_theme->get_font_size(SNAME("title_size"), EditorStringName(EditorFonts)));
-
-		// AcceptDialog.
-		p_theme->set_stylebox(SceneStringName(panel), "AcceptDialog", p_config.dialog_style);
-		p_theme->set_constant("buttons_separation", "AcceptDialog", 8 * EDSCALE);
-		// Make buttons with short texts such as "OK" easier to click/tap.
-		p_theme->set_constant("buttons_min_width", "AcceptDialog", p_config.dialogs_buttons_min_size.x * EDSCALE);
-		p_theme->set_constant("buttons_min_height", "AcceptDialog", p_config.dialogs_buttons_min_size.y * EDSCALE);
-
-		// FileDialog.
-		p_theme->set_icon("folder", "FileDialog", p_theme->get_icon(SNAME("Folder"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("parent_folder", "FileDialog", p_theme->get_icon(SNAME("ArrowUp"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("back_folder", "FileDialog", p_theme->get_icon(SNAME("Back"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("forward_folder", "FileDialog", p_theme->get_icon(SNAME("Forward"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("reload", "FileDialog", p_theme->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("toggle_hidden", "FileDialog", p_theme->get_icon(SNAME("GuiVisibilityVisible"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("create_folder", "FileDialog", p_theme->get_icon(SNAME("FolderCreate"), EditorStringName(EditorIcons)));
-		// Use a different color for folder icons to make them easier to distinguish from files.
-		// On a light theme, the icon will be dark, so we need to lighten it before blending it with the accent color.
-		p_theme->set_color("folder_icon_color", "FileDialog", (p_config.dark_theme ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(p_config.accent_color, 0.7));
-		p_theme->set_color("file_disabled_color", "FileDialog", p_config.font_disabled_color);
-
-		// PopupDialog.
-		p_theme->set_stylebox(SceneStringName(panel), "PopupDialog", p_config.popup_style);
-
-		// PopupMenu.
-		{
-			Ref<StyleBoxFlat> style_popup_menu = p_config.popup_border_style->duplicate();
-			// Use 1 pixel for the sides, since if 0 is used, the highlight of hovered items is drawn
-			// on top of the popup border. This causes a 'gap' in the panel border when an item is highlighted,
-			// and it looks weird. 1px solves this.
-			style_popup_menu->set_content_margin_individual(Math::round(EDSCALE), 2 * EDSCALE, Math::round(EDSCALE), 2 * EDSCALE);
-			p_theme->set_stylebox(SceneStringName(panel), "PopupMenu", style_popup_menu);
-
-			Ref<StyleBoxFlat> style_menu_hover = p_config.button_style_hover->duplicate();
-			// Don't use rounded corners for hover highlights since the StyleBox touches the PopupMenu's edges.
-			style_menu_hover->set_corner_radius_all(0);
-			p_theme->set_stylebox(SceneStringName(hover), "PopupMenu", style_menu_hover);
-
-			Ref<StyleBoxLine> style_popup_separator(memnew(StyleBoxLine));
-			style_popup_separator->set_color(p_config.separator_color);
-			style_popup_separator->set_grow_begin(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
-			style_popup_separator->set_grow_end(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
-			style_popup_separator->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
-
-			Ref<StyleBoxLine> style_popup_labeled_separator_left(memnew(StyleBoxLine));
-			style_popup_labeled_separator_left->set_grow_begin(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
-			style_popup_labeled_separator_left->set_color(p_config.separator_color);
-			style_popup_labeled_separator_left->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
-
-			Ref<StyleBoxLine> style_popup_labeled_separator_right(memnew(StyleBoxLine));
-			style_popup_labeled_separator_right->set_grow_end(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
-			style_popup_labeled_separator_right->set_color(p_config.separator_color);
-			style_popup_labeled_separator_right->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
-
-			p_theme->set_stylebox("separator", "PopupMenu", style_popup_separator);
-			p_theme->set_stylebox("labeled_separator_left", "PopupMenu", style_popup_labeled_separator_left);
-			p_theme->set_stylebox("labeled_separator_right", "PopupMenu", style_popup_labeled_separator_right);
-
-			p_theme->set_color(SceneStringName(font_color), "PopupMenu", p_config.font_color);
-			p_theme->set_color("font_hover_color", "PopupMenu", p_config.font_hover_color);
-			p_theme->set_color("font_accelerator_color", "PopupMenu", p_config.font_disabled_color);
-			p_theme->set_color("font_disabled_color", "PopupMenu", p_config.font_disabled_color);
-			p_theme->set_color("font_separator_color", "PopupMenu", p_config.font_disabled_color);
-			p_theme->set_color("font_outline_color", "PopupMenu", p_config.font_outline_color);
-
-			p_theme->set_icon("checked", "PopupMenu", p_theme->get_icon(SNAME("GuiChecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("unchecked", "PopupMenu", p_theme->get_icon(SNAME("GuiUnchecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("radio_checked", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioChecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("radio_unchecked", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioUnchecked"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("checked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiCheckedDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("unchecked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiUncheckedDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("radio_checked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioCheckedDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("radio_unchecked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("submenu", "PopupMenu", p_theme->get_icon(SNAME("ArrowRight"), EditorStringName(EditorIcons)));
-			p_theme->set_icon("submenu_mirrored", "PopupMenu", p_theme->get_icon(SNAME("ArrowLeft"), EditorStringName(EditorIcons)));
-
-			p_theme->set_constant("v_separation", "PopupMenu", p_config.forced_even_separation * EDSCALE);
-			p_theme->set_constant("outline_size", "PopupMenu", 0);
-			p_theme->set_constant("item_start_padding", "PopupMenu", p_config.separation_margin);
-			p_theme->set_constant("item_end_padding", "PopupMenu", p_config.separation_margin);
-		}
-	}
-
-	// Sliders and scrollbars.
-	{
-		Ref<Texture2D> empty_icon = memnew(ImageTexture);
-
-		// HScrollBar.
-
-		if (p_config.enable_touch_optimizations) {
-			p_theme->set_stylebox("scroll", "HScrollBar", make_line_stylebox(p_config.separator_color, 50));
-		} else {
-			p_theme->set_stylebox("scroll", "HScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, -5, 1, -5, 1));
-		}
-		p_theme->set_stylebox("scroll_focus", "HScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
-		p_theme->set_stylebox("grabber", "HScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabber"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
-		p_theme->set_stylebox("grabber_highlight", "HScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberHl"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
-		p_theme->set_stylebox("grabber_pressed", "HScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberPressed"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
-
-		p_theme->set_icon("increment", "HScrollBar", empty_icon);
-		p_theme->set_icon("increment_highlight", "HScrollBar", empty_icon);
-		p_theme->set_icon("increment_pressed", "HScrollBar", empty_icon);
-		p_theme->set_icon("decrement", "HScrollBar", empty_icon);
-		p_theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
-		p_theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
-
-		// VScrollBar.
-
-		if (p_config.enable_touch_optimizations) {
-			p_theme->set_stylebox("scroll", "VScrollBar", make_line_stylebox(p_config.separator_color, 50, 1, 1, true));
-		} else {
-			p_theme->set_stylebox("scroll", "VScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, -5, 1, -5));
-		}
-		p_theme->set_stylebox("scroll_focus", "VScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
-		p_theme->set_stylebox("grabber", "VScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabber"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
-		p_theme->set_stylebox("grabber_highlight", "VScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberHl"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
-		p_theme->set_stylebox("grabber_pressed", "VScrollBar", make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberPressed"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
-
-		p_theme->set_icon("increment", "VScrollBar", empty_icon);
-		p_theme->set_icon("increment_highlight", "VScrollBar", empty_icon);
-		p_theme->set_icon("increment_pressed", "VScrollBar", empty_icon);
-		p_theme->set_icon("decrement", "VScrollBar", empty_icon);
-		p_theme->set_icon("decrement_highlight", "VScrollBar", empty_icon);
-		p_theme->set_icon("decrement_pressed", "VScrollBar", empty_icon);
-
-		// Slider
-		const int background_margin = MAX(2, p_config.base_margin / 2);
-
-		// HSlider.
-		p_theme->set_icon("grabber_highlight", "HSlider", p_theme->get_icon(SNAME("GuiSliderGrabberHl"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("grabber", "HSlider", p_theme->get_icon(SNAME("GuiSliderGrabber"), EditorStringName(EditorIcons)));
-		p_theme->set_stylebox("slider", "HSlider", make_flat_stylebox(p_config.dark_color_3, 0, background_margin, 0, background_margin, p_config.corner_radius));
-		p_theme->set_stylebox("grabber_area", "HSlider", make_flat_stylebox(p_config.contrast_color_1, 0, background_margin, 0, background_margin, p_config.corner_radius));
-		p_theme->set_stylebox("grabber_area_highlight", "HSlider", make_flat_stylebox(p_config.contrast_color_1, 0, background_margin, 0, background_margin));
-		p_theme->set_constant("center_grabber", "HSlider", 0);
-		p_theme->set_constant("grabber_offset", "HSlider", 0);
-
-		// VSlider.
-		p_theme->set_icon("grabber", "VSlider", p_theme->get_icon(SNAME("GuiSliderGrabber"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("grabber_highlight", "VSlider", p_theme->get_icon(SNAME("GuiSliderGrabberHl"), EditorStringName(EditorIcons)));
-		p_theme->set_stylebox("slider", "VSlider", make_flat_stylebox(p_config.dark_color_3, background_margin, 0, background_margin, 0, p_config.corner_radius));
-		p_theme->set_stylebox("grabber_area", "VSlider", make_flat_stylebox(p_config.contrast_color_1, background_margin, 0, background_margin, 0, p_config.corner_radius));
-		p_theme->set_stylebox("grabber_area_highlight", "VSlider", make_flat_stylebox(p_config.contrast_color_1, background_margin, 0, background_margin, 0));
-		p_theme->set_constant("center_grabber", "VSlider", 0);
-		p_theme->set_constant("grabber_offset", "VSlider", 0);
-	}
-
-	// Labels.
-	{
-		// RichTextLabel.
-
-		p_theme->set_stylebox(CoreStringName(normal), "RichTextLabel", p_config.tree_panel_style);
-		p_theme->set_stylebox("focus", "RichTextLabel", make_empty_stylebox());
-
-		p_theme->set_color("default_color", "RichTextLabel", p_config.font_color);
-		p_theme->set_color("font_shadow_color", "RichTextLabel", Color(0, 0, 0, 0));
-		p_theme->set_color("font_outline_color", "RichTextLabel", p_config.font_outline_color);
-		p_theme->set_color("selection_color", "RichTextLabel", p_config.selection_color);
-
-		p_theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
-		p_theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
-		p_theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * EDSCALE);
-		p_theme->set_constant("outline_size", "RichTextLabel", 0);
-
-		// Label.
-
-		p_theme->set_stylebox(CoreStringName(normal), "Label", p_config.base_empty_style);
-		p_theme->set_stylebox("focus", "Label", p_config.button_style_focus);
-
-		p_theme->set_color(SceneStringName(font_color), "Label", p_config.font_color);
-		p_theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
-		p_theme->set_color("font_outline_color", "Label", p_config.font_outline_color);
-
-		p_theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
-		p_theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
-		p_theme->set_constant("shadow_outline_size", "Label", 1 * EDSCALE);
-		p_theme->set_constant("line_spacing", "Label", 3 * EDSCALE);
-		p_theme->set_constant("outline_size", "Label", 0);
-	}
-
-	// SpinBox.
-	{
-		Ref<Texture2D> empty_icon = memnew(ImageTexture);
-		p_theme->set_icon("updown", "SpinBox", empty_icon);
-		p_theme->set_icon("up", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("up_hover", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("up_pressed", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("up_disabled", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("down", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("down_hover", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("down_pressed", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("down_disabled", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
-
-		p_theme->set_stylebox("up_background", "SpinBox", make_empty_stylebox());
-		p_theme->set_stylebox("up_background_hovered", "SpinBox", p_config.button_style_hover);
-		p_theme->set_stylebox("up_background_pressed", "SpinBox", p_config.button_style_pressed);
-		p_theme->set_stylebox("up_background_disabled", "SpinBox", make_empty_stylebox());
-		p_theme->set_stylebox("down_background", "SpinBox", make_empty_stylebox());
-		p_theme->set_stylebox("down_background_hovered", "SpinBox", p_config.button_style_hover);
-		p_theme->set_stylebox("down_background_pressed", "SpinBox", p_config.button_style_pressed);
-		p_theme->set_stylebox("down_background_disabled", "SpinBox", make_empty_stylebox());
-
-		p_theme->set_color("up_icon_modulate", "SpinBox", p_config.font_color);
-		p_theme->set_color("up_hover_icon_modulate", "SpinBox", p_config.font_hover_color);
-		p_theme->set_color("up_pressed_icon_modulate", "SpinBox", p_config.font_pressed_color);
-		p_theme->set_color("up_disabled_icon_modulate", "SpinBox", p_config.font_disabled_color);
-		p_theme->set_color("down_icon_modulate", "SpinBox", p_config.font_color);
-		p_theme->set_color("down_hover_icon_modulate", "SpinBox", p_config.font_hover_color);
-		p_theme->set_color("down_pressed_icon_modulate", "SpinBox", p_config.font_pressed_color);
-		p_theme->set_color("down_disabled_icon_modulate", "SpinBox", p_config.font_disabled_color);
-
-		p_theme->set_stylebox("field_and_buttons_separator", "SpinBox", make_empty_stylebox());
-		p_theme->set_stylebox("up_down_buttons_separator", "SpinBox", make_empty_stylebox());
-
-		p_theme->set_constant("buttons_vertical_separation", "SpinBox", 0);
-		p_theme->set_constant("field_and_buttons_separation", "SpinBox", 2);
-		p_theme->set_constant("buttons_width", "SpinBox", 16);
-#ifndef DISABLE_DEPRECATED
-		p_theme->set_constant("set_min_buttons_width_from_icons", "SpinBox", 1);
-#endif
-	}
-
-	// ProgressBar.
-	p_theme->set_stylebox("background", "ProgressBar", make_stylebox(p_theme->get_icon(SNAME("GuiProgressBar"), EditorStringName(EditorIcons)), 4, 4, 4, 4, 0, 0, 0, 0));
-	p_theme->set_stylebox("fill", "ProgressBar", make_stylebox(p_theme->get_icon(SNAME("GuiProgressFill"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 2, 1, 2, 1));
-	p_theme->set_color(SceneStringName(font_color), "ProgressBar", p_config.font_color);
-	p_theme->set_color("font_outline_color", "ProgressBar", p_config.font_outline_color);
-	p_theme->set_constant("outline_size", "ProgressBar", 0);
-
-	// GraphEdit and related nodes.
-	{
-		// GraphEdit.
-
-		p_theme->set_stylebox(SceneStringName(panel), "GraphEdit", p_config.tree_panel_style);
-		p_theme->set_stylebox("panel_focus", "GraphEdit", p_config.button_style_focus);
-		p_theme->set_stylebox("menu_panel", "GraphEdit", make_flat_stylebox(p_config.dark_color_1 * Color(1, 1, 1, 0.6), 4, 2, 4, 2, 3));
-
-		float grid_base_brightness = p_config.dark_theme ? 1.0 : 0.0;
-		GraphEdit::GridPattern grid_pattern = (GraphEdit::GridPattern) int(EDITOR_GET("editors/visual_editors/grid_pattern"));
-		switch (grid_pattern) {
-			case GraphEdit::GRID_PATTERN_LINES:
-				p_theme->set_color("grid_major", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.10));
-				p_theme->set_color("grid_minor", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.05));
-				break;
-			case GraphEdit::GRID_PATTERN_DOTS:
-				p_theme->set_color("grid_major", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.07));
-				p_theme->set_color("grid_minor", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.07));
-				break;
-			default:
-				WARN_PRINT("Unknown grid pattern.");
-				break;
-		}
-
-		p_theme->set_color("selection_fill", "GraphEdit", p_theme->get_color(SNAME("box_selection_fill_color"), EditorStringName(Editor)));
-		p_theme->set_color("selection_stroke", "GraphEdit", p_theme->get_color(SNAME("box_selection_stroke_color"), EditorStringName(Editor)));
-		p_theme->set_color("activity", "GraphEdit", p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0));
-
-		p_theme->set_color("connection_hover_tint_color", "GraphEdit", p_config.dark_theme ? Color(0, 0, 0, 0.3) : Color(1, 1, 1, 0.3));
-		p_theme->set_constant("connection_hover_thickness", "GraphEdit", 0);
-		p_theme->set_color("connection_valid_target_tint_color", "GraphEdit", p_config.dark_theme ? Color(1, 1, 1, 0.4) : Color(0, 0, 0, 0.4));
-		p_theme->set_color("connection_rim_color", "GraphEdit", p_config.tree_panel_style->get_bg_color());
-
-		p_theme->set_icon("zoom_out", "GraphEdit", p_theme->get_icon(SNAME("ZoomLess"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("zoom_in", "GraphEdit", p_theme->get_icon(SNAME("ZoomMore"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("zoom_reset", "GraphEdit", p_theme->get_icon(SNAME("ZoomReset"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("grid_toggle", "GraphEdit", p_theme->get_icon(SNAME("GridToggle"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("minimap_toggle", "GraphEdit", p_theme->get_icon(SNAME("GridMinimap"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("snapping_toggle", "GraphEdit", p_theme->get_icon(SNAME("SnapGrid"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("layout", "GraphEdit", p_theme->get_icon(SNAME("GridLayout"), EditorStringName(EditorIcons)));
-
-		// GraphEditMinimap.
-		{
-			Ref<StyleBoxFlat> style_minimap_bg = make_flat_stylebox(p_config.dark_color_1, 0, 0, 0, 0);
-			style_minimap_bg->set_border_color(p_config.dark_color_3);
-			style_minimap_bg->set_border_width_all(1);
-			p_theme->set_stylebox(SceneStringName(panel), "GraphEditMinimap", style_minimap_bg);
-
-			Ref<StyleBoxFlat> style_minimap_camera;
-			Ref<StyleBoxFlat> style_minimap_node;
-			if (p_config.dark_theme) {
-				style_minimap_camera = make_flat_stylebox(Color(0.65, 0.65, 0.65, 0.2), 0, 0, 0, 0);
-				style_minimap_camera->set_border_color(Color(0.65, 0.65, 0.65, 0.45));
-				style_minimap_node = make_flat_stylebox(Color(1, 1, 1), 0, 0, 0, 0);
-			} else {
-				style_minimap_camera = make_flat_stylebox(Color(0.38, 0.38, 0.38, 0.2), 0, 0, 0, 0);
-				style_minimap_camera->set_border_color(Color(0.38, 0.38, 0.38, 0.45));
-				style_minimap_node = make_flat_stylebox(Color(0, 0, 0), 0, 0, 0, 0);
-			}
-			style_minimap_camera->set_border_width_all(1);
-			style_minimap_node->set_anti_aliased(false);
-			p_theme->set_stylebox("camera", "GraphEditMinimap", style_minimap_camera);
-			p_theme->set_stylebox("node", "GraphEditMinimap", style_minimap_node);
-
-			const Color minimap_resizer_color = p_config.dark_theme ? Color(1, 1, 1, 0.65) : Color(0, 0, 0, 0.65);
-			p_theme->set_icon("resizer", "GraphEditMinimap", p_theme->get_icon(SNAME("GuiResizerTopLeft"), EditorStringName(EditorIcons)));
-			p_theme->set_color("resizer_color", "GraphEditMinimap", minimap_resizer_color);
-		}
-
-		// GraphElement, GraphNode & GraphFrame.
-		{
-			const int gn_margin_top = 2;
-			const int gn_margin_side = 2;
-			const int gn_margin_bottom = 2;
-
-			const int gn_corner_radius = 3;
-
-			const Color gn_bg_color = p_config.dark_theme ? p_config.dark_color_3 : p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
-			const Color gn_selected_border_color = p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0);
-			const Color gn_frame_bg = gn_bg_color.lerp(p_config.tree_panel_style->get_bg_color(), 0.3);
-
-			const bool high_contrast_borders = p_config.draw_extra_borders && p_config.dark_theme;
-
-			Ref<StyleBoxFlat> gn_panel_style = make_flat_stylebox(gn_frame_bg, gn_margin_side, gn_margin_top, gn_margin_side, gn_margin_bottom, p_config.corner_radius);
-			gn_panel_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
-			gn_panel_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_panel_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
-			gn_panel_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
-			gn_panel_style->set_corner_radius_individual(0, 0, gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE);
-			gn_panel_style->set_anti_aliased(true);
-
-			Ref<StyleBoxFlat> gn_panel_selected_style = gn_panel_style->duplicate();
-			gn_panel_selected_style->set_bg_color(p_config.dark_theme ? gn_bg_color.lightened(0.15) : gn_bg_color.darkened(0.15));
-			gn_panel_selected_style->set_border_width(SIDE_TOP, 0);
-			gn_panel_selected_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
-			gn_panel_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_panel_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
-			gn_panel_selected_style->set_border_color(gn_selected_border_color);
-
-			const int gn_titlebar_margin_top = 8;
-			const int gn_titlebar_margin_side = 12;
-			const int gn_titlebar_margin_bottom = 8;
-
-			Ref<StyleBoxFlat> gn_titlebar_style = make_flat_stylebox(gn_bg_color, gn_titlebar_margin_side, gn_titlebar_margin_top, gn_titlebar_margin_side, gn_titlebar_margin_bottom, p_config.corner_radius);
-			gn_titlebar_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
-			gn_titlebar_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_titlebar_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
-			gn_titlebar_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
-			gn_titlebar_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
-			gn_titlebar_style->set_corner_radius_individual(gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE, 0, 0);
-			gn_titlebar_style->set_anti_aliased(true);
-
-			Ref<StyleBoxFlat> gn_titlebar_selected_style = gn_titlebar_style->duplicate();
-			gn_titlebar_selected_style->set_border_color(gn_selected_border_color);
-			gn_titlebar_selected_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
-			gn_titlebar_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_titlebar_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
-			gn_titlebar_selected_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
-
-			Color gn_decoration_color = p_config.dark_color_1.inverted();
-
-			// GraphElement.
-
-			p_theme->set_stylebox(SceneStringName(panel), "GraphElement", gn_panel_style);
-			p_theme->set_stylebox("panel_selected", "GraphElement", gn_panel_selected_style);
-			p_theme->set_stylebox("titlebar", "GraphElement", gn_titlebar_style);
-			p_theme->set_stylebox("titlebar_selected", "GraphElement", gn_titlebar_selected_style);
-
-			p_theme->set_color("resizer_color", "GraphElement", gn_decoration_color);
-			p_theme->set_icon("resizer", "GraphElement", p_theme->get_icon(SNAME("GuiResizer"), EditorStringName(EditorIcons)));
-
-			// GraphNode.
-
-			Ref<StyleBoxEmpty> gn_slot_style = make_empty_stylebox(12, 0, 12, 0);
-
-			p_theme->set_stylebox(SceneStringName(panel), "GraphNode", gn_panel_style);
-			p_theme->set_stylebox("panel_selected", "GraphNode", gn_panel_selected_style);
-			p_theme->set_stylebox("panel_focus", "GraphNode", p_config.button_style_focus);
-			p_theme->set_stylebox("titlebar", "GraphNode", gn_titlebar_style);
-			p_theme->set_stylebox("titlebar_selected", "GraphNode", gn_titlebar_selected_style);
-			p_theme->set_stylebox("slot", "GraphNode", gn_slot_style);
-			p_theme->set_stylebox("slot_selected", "GraphNode", p_config.button_style_focus);
-
-			p_theme->set_color("resizer_color", "GraphNode", gn_decoration_color);
-
-			p_theme->set_constant("port_h_offset", "GraphNode", 1);
-			p_theme->set_constant("separation", "GraphNode", 1 * EDSCALE);
-
-			Ref<DPITexture> port_icon = p_theme->get_icon(SNAME("GuiGraphNodePort"), EditorStringName(EditorIcons));
-			// The true size is 24x24 This is necessary for sharp port icons at high zoom levels in GraphEdit (up to ~200%).
-			port_icon->set_size_override(Size2(12, 12));
-			p_theme->set_icon("port", "GraphNode", port_icon);
-
-			// GraphNode's title Label.
-			p_theme->set_type_variation("GraphNodeTitleLabel", "Label");
-			p_theme->set_stylebox(CoreStringName(normal), "GraphNodeTitleLabel", make_empty_stylebox(0, 0, 0, 0));
-			p_theme->set_color("font_shadow_color", "GraphNodeTitleLabel", p_config.shadow_color);
-			p_theme->set_constant("shadow_outline_size", "GraphNodeTitleLabel", 4);
-			p_theme->set_constant("shadow_offset_x", "GraphNodeTitleLabel", 0);
-			p_theme->set_constant("shadow_offset_y", "GraphNodeTitleLabel", 1);
-			p_theme->set_constant("line_spacing", "GraphNodeTitleLabel", 3 * EDSCALE);
-
-			// GraphFrame.
-
-			const int gf_corner_width = 7 * EDSCALE;
-			const int gf_border_width = 2 * MAX(1, EDSCALE);
-
-			Ref<StyleBoxFlat> graphframe_sb = make_flat_stylebox(Color(0.0, 0.0, 0.0, 0.2), gn_margin_side, gn_margin_side, gn_margin_side, gn_margin_bottom, gf_corner_width);
-			graphframe_sb->set_expand_margin(SIDE_TOP, 38 * EDSCALE);
-			graphframe_sb->set_border_width_all(gf_border_width);
-			graphframe_sb->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
-			graphframe_sb->set_shadow_size(8 * EDSCALE);
-			graphframe_sb->set_shadow_color(Color(p_config.shadow_color, p_config.shadow_color.a * 0.25));
-			graphframe_sb->set_anti_aliased(true);
-
-			Ref<StyleBoxFlat> graphframe_sb_selected = graphframe_sb->duplicate();
-			graphframe_sb_selected->set_border_color(gn_selected_border_color);
-
-			p_theme->set_stylebox(SceneStringName(panel), "GraphFrame", graphframe_sb);
-			p_theme->set_stylebox("panel_selected", "GraphFrame", graphframe_sb_selected);
-			p_theme->set_stylebox("titlebar", "GraphFrame", make_empty_stylebox(4, 4, 4, 4));
-			p_theme->set_stylebox("titlebar_selected", "GraphFrame", make_empty_stylebox(4, 4, 4, 4));
-			p_theme->set_color("resizer_color", "GraphFrame", gn_decoration_color);
-
-			// GraphFrame's title Label.
-			p_theme->set_type_variation("GraphFrameTitleLabel", "Label");
-			p_theme->set_stylebox(CoreStringName(normal), "GraphFrameTitleLabel", memnew(StyleBoxEmpty));
-			p_theme->set_font_size(SceneStringName(font_size), "GraphFrameTitleLabel", 22 * EDSCALE);
-			p_theme->set_color(SceneStringName(font_color), "GraphFrameTitleLabel", Color(1, 1, 1));
-			p_theme->set_color("font_shadow_color", "GraphFrameTitleLabel", Color(0, 0, 0, 0));
-			p_theme->set_color("font_outline_color", "GraphFrameTitleLabel", Color(1, 1, 1));
-			p_theme->set_constant("shadow_offset_x", "GraphFrameTitleLabel", 1 * EDSCALE);
-			p_theme->set_constant("shadow_offset_y", "GraphFrameTitleLabel", 1 * EDSCALE);
-			p_theme->set_constant("outline_size", "GraphFrameTitleLabel", 0);
-			p_theme->set_constant("shadow_outline_size", "GraphFrameTitleLabel", 1 * EDSCALE);
-			p_theme->set_constant("line_spacing", "GraphFrameTitleLabel", 3 * EDSCALE);
-		}
-
-		// VisualShader reroute node.
-		{
-			Ref<StyleBox> vs_reroute_panel_style = make_empty_stylebox();
-			Ref<StyleBox> vs_reroute_titlebar_style = vs_reroute_panel_style->duplicate();
-			vs_reroute_titlebar_style->set_content_margin_all(16 * EDSCALE);
-			p_theme->set_stylebox(SceneStringName(panel), "VSRerouteNode", vs_reroute_panel_style);
-			p_theme->set_stylebox("panel_selected", "VSRerouteNode", vs_reroute_panel_style);
-			p_theme->set_stylebox("titlebar", "VSRerouteNode", vs_reroute_titlebar_style);
-			p_theme->set_stylebox("titlebar_selected", "VSRerouteNode", vs_reroute_titlebar_style);
-			p_theme->set_stylebox("slot", "VSRerouteNode", make_empty_stylebox());
-
-			p_theme->set_color("drag_background", "VSRerouteNode", p_config.dark_theme ? Color(0.19, 0.21, 0.24) : Color(0.8, 0.8, 0.8));
-			p_theme->set_color("selected_rim_color", "VSRerouteNode", p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0));
-		}
-	}
-
-	// ColorPicker and related nodes.
-	{
-		// ColorPicker.
-		p_config.circle_style_focus = p_config.button_style_focus->duplicate();
-		p_config.circle_style_focus->set_corner_radius_all(256 * EDSCALE);
-		p_config.circle_style_focus->set_corner_detail(32 * EDSCALE);
-
-		p_theme->set_constant("margin", "ColorPicker", p_config.base_margin);
-		p_theme->set_constant("sv_width", "ColorPicker", 256 * EDSCALE);
-		p_theme->set_constant("sv_height", "ColorPicker", 256 * EDSCALE);
-		p_theme->set_constant("h_width", "ColorPicker", 30 * EDSCALE);
-		p_theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
-		p_theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
-
-		p_theme->set_stylebox("sample_focus", "ColorPicker", p_config.button_style_focus);
-		p_theme->set_stylebox("picker_focus_rectangle", "ColorPicker", p_config.button_style_focus);
-		p_theme->set_stylebox("picker_focus_circle", "ColorPicker", p_config.circle_style_focus);
-		p_theme->set_color("focused_not_editing_cursor_color", "ColorPicker", p_config.highlight_color);
-
-		p_theme->set_icon("screen_picker", "ColorPicker", p_theme->get_icon(SNAME("ColorPick"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("shape_circle", "ColorPicker", p_theme->get_icon(SNAME("PickerShapeCircle"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("shape_rect", "ColorPicker", p_theme->get_icon(SNAME("PickerShapeRectangle"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("shape_rect_wheel", "ColorPicker", p_theme->get_icon(SNAME("PickerShapeRectangleWheel"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("add_preset", "ColorPicker", p_theme->get_icon(SNAME("Add"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("sample_bg", "ColorPicker", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("sample_revert", "ColorPicker", p_theme->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("overbright_indicator", "ColorPicker", p_theme->get_icon(SNAME("OverbrightIndicator"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("bar_arrow", "ColorPicker", p_theme->get_icon(SNAME("ColorPickerBarArrow"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("picker_cursor", "ColorPicker", p_theme->get_icon(SNAME("PickerCursor"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("picker_cursor_bg", "ColorPicker", p_theme->get_icon(SNAME("PickerCursorBg"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("color_script", "ColorPicker", p_theme->get_icon(SNAME("Script"), EditorStringName(EditorIcons)));
-
-		// ColorPickerButton.
-		p_theme->set_icon("bg", "ColorPickerButton", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));
-
-		// ColorPresetButton.
-		p_theme->set_stylebox("preset_fg", "ColorPresetButton", make_flat_stylebox(Color(1, 1, 1), 2, 2, 2, 2, 2));
-		p_theme->set_icon("preset_bg", "ColorPresetButton", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("overbright_indicator", "ColorPresetButton", p_theme->get_icon(SNAME("OverbrightIndicator"), EditorStringName(EditorIcons)));
-	}
-}
-
-void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme, ThemeConfiguration &p_config) {
-	// Project manager.
-	{
-		p_theme->set_stylebox("project_list", "ProjectManager", p_config.tree_panel_style);
-		p_theme->set_constant("sidebar_button_icon_separation", "ProjectManager", int(6 * EDSCALE));
-		p_theme->set_icon("browse_folder", "ProjectManager", p_theme->get_icon(SNAME("FolderBrowse"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("browse_file", "ProjectManager", p_theme->get_icon(SNAME("FileBrowse"), EditorStringName(EditorIcons)));
-
-		// ProjectTag.
-		{
-			p_theme->set_type_variation("ProjectTagButton", "Button");
-
-			Ref<StyleBoxFlat> tag = p_config.button_style->duplicate();
-			tag->set_bg_color(p_config.dark_theme ? tag->get_bg_color().lightened(0.2) : tag->get_bg_color().darkened(0.2));
-			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
-			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
-			p_theme->set_stylebox(CoreStringName(normal), "ProjectTagButton", tag);
-
-			tag = p_config.button_style_hover->duplicate();
-			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
-			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
-			p_theme->set_stylebox(SceneStringName(hover), "ProjectTagButton", tag);
-
-			tag = p_config.button_style_pressed->duplicate();
-			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
-			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
-			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
-		}
-	}
-
-	// Editor and main screen.
-	{
-		// Editor background.
-		Color background_color_opaque = p_config.dark_color_2;
-		background_color_opaque.a = 1.0;
-		p_theme->set_color("background", EditorStringName(Editor), background_color_opaque);
-		p_theme->set_stylebox("Background", EditorStringName(EditorStyles), make_flat_stylebox(background_color_opaque, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
-
-		Ref<StyleBoxFlat> editor_panel_foreground = p_config.base_style->duplicate();
-		editor_panel_foreground->set_corner_radius_all(0);
-		p_theme->set_stylebox("PanelForeground", EditorStringName(EditorStyles), editor_panel_foreground);
-
-		// Editor focus.
-		p_theme->set_stylebox("Focus", EditorStringName(EditorStyles), p_config.button_style_focus);
-
-		Ref<StyleBoxFlat> style_widget_focus_viewport = p_config.button_style_focus->duplicate();
-		// Use a less opaque color to be less distracting for the 2D and 3D editor viewports.
-		style_widget_focus_viewport->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.5));
-		p_theme->set_stylebox("FocusViewport", EditorStringName(EditorStyles), style_widget_focus_viewport);
-
-		Ref<StyleBoxFlat> style_widget_scroll_container = p_config.button_style_focus->duplicate();
-		p_theme->set_stylebox("focus", "ScrollContainer", style_widget_scroll_container);
-
-		// This stylebox is used in 3d and 2d viewports (no borders).
-		Ref<StyleBoxFlat> style_content_panel_vp = p_config.content_panel_style->duplicate();
-		style_content_panel_vp->set_content_margin_individual(p_config.border_width * 2, p_config.base_margin * EDSCALE, p_config.border_width * 2, p_config.border_width * 2);
-		p_theme->set_stylebox("Content", EditorStringName(EditorStyles), style_content_panel_vp);
-
-		// 3D/Spatial editor.
-		Ref<StyleBoxFlat> style_info_3d_viewport = p_config.base_style->duplicate();
-		style_info_3d_viewport->set_bg_color(style_info_3d_viewport->get_bg_color() * Color(1, 1, 1, 0.5));
-		style_info_3d_viewport->set_border_width_all(0);
-		p_theme->set_stylebox("Information3dViewport", EditorStringName(EditorStyles), style_info_3d_viewport);
-
-		// 2D and 3D contextual toolbar.
-		// Use a custom stylebox to make contextual menu items stand out from the rest.
-		// This helps with editor usability as contextual menu items change when selecting nodes,
-		// even though it may not be immediately obvious at first.
-		Ref<StyleBoxFlat> toolbar_stylebox = memnew(StyleBoxFlat);
-		toolbar_stylebox->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
-		toolbar_stylebox->set_anti_aliased(false);
-		// Add an underline to the StyleBox, but prevent its minimum vertical size from changing.
-		toolbar_stylebox->set_border_color(p_config.accent_color);
-		toolbar_stylebox->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
-		toolbar_stylebox->set_content_margin(SIDE_BOTTOM, 0);
-		toolbar_stylebox->set_expand_margin_individual(4 * EDSCALE, 2 * EDSCALE, 4 * EDSCALE, 4 * EDSCALE);
-		p_theme->set_stylebox("ContextualToolbar", EditorStringName(EditorStyles), toolbar_stylebox);
-
-		// Script editor.
-		p_theme->set_stylebox("ScriptEditorPanel", EditorStringName(EditorStyles), make_empty_stylebox(p_config.base_margin, 0, p_config.base_margin, p_config.base_margin));
-		p_theme->set_stylebox("ScriptEditorPanelFloating", EditorStringName(EditorStyles), make_empty_stylebox(0, 0, 0, 0));
-		p_theme->set_stylebox("ScriptEditor", EditorStringName(EditorStyles), make_empty_stylebox(0, 0, 0, 0));
-
-		// Game view.
-		p_theme->set_type_variation("GamePanel", "Panel");
-		Ref<StyleBoxFlat> game_panel = p_theme->get_stylebox(SceneStringName(panel), SNAME("Panel"))->duplicate();
-		game_panel->set_corner_radius_all(0);
-		p_theme->set_stylebox(SceneStringName(panel), "GamePanel", game_panel);
-
-		// Main menu.
-		Ref<StyleBoxFlat> menu_transparent_style = p_config.button_style->duplicate();
-		menu_transparent_style->set_bg_color(Color(1, 1, 1, 0));
-		menu_transparent_style->set_border_width_all(0);
-		Ref<StyleBoxFlat> main_screen_button_hover = p_config.button_style_hover->duplicate();
-		for (int i = 0; i < 4; i++) {
-			menu_transparent_style->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
-			main_screen_button_hover->set_content_margin((Side)i, p_config.button_style_hover->get_content_margin((Side)i));
-		}
-		p_theme->set_stylebox(CoreStringName(normal), "MainScreenButton", menu_transparent_style);
-		p_theme->set_stylebox("normal_mirrored", "MainScreenButton", menu_transparent_style);
-		p_theme->set_stylebox(SceneStringName(pressed), "MainScreenButton", menu_transparent_style);
-		p_theme->set_stylebox("pressed_mirrored", "MainScreenButton", menu_transparent_style);
-		p_theme->set_stylebox(SceneStringName(hover), "MainScreenButton", main_screen_button_hover);
-		p_theme->set_stylebox("hover_mirrored", "MainScreenButton", main_screen_button_hover);
-		p_theme->set_stylebox("hover_pressed", "MainScreenButton", main_screen_button_hover);
-		p_theme->set_stylebox("hover_pressed_mirrored", "MainScreenButton", main_screen_button_hover);
-
-		p_theme->set_type_variation("MainMenuBar", "FlatMenuButton");
-		p_theme->set_stylebox(CoreStringName(normal), "MainMenuBar", menu_transparent_style);
-		p_theme->set_stylebox(SceneStringName(pressed), "MainMenuBar", main_screen_button_hover);
-		p_theme->set_stylebox(SceneStringName(hover), "MainMenuBar", main_screen_button_hover);
-		p_theme->set_stylebox("hover_pressed", "MainMenuBar", main_screen_button_hover);
-
-		// Run bar.
-		p_theme->set_type_variation("RunBarButton", "FlatMenuButton");
-		p_theme->set_stylebox("disabled", "RunBarButton", menu_transparent_style);
-		p_theme->set_stylebox(SceneStringName(pressed), "RunBarButton", menu_transparent_style);
-
-		p_theme->set_type_variation("RunBarButtonMovieMakerDisabled", "RunBarButton");
-		p_theme->set_color("icon_normal_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.7));
-		p_theme->set_color("icon_pressed_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.84));
-		p_theme->set_color("icon_hover_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.9));
-		p_theme->set_color("icon_hover_pressed_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.84));
-
-		p_theme->set_type_variation("RunBarButtonMovieMakerEnabled", "RunBarButton");
-		p_theme->set_color("icon_normal_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.7));
-		p_theme->set_color("icon_pressed_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.84));
-		p_theme->set_color("icon_hover_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.9));
-		p_theme->set_color("icon_hover_pressed_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.84));
-
-		// Bottom panel.
-		Ref<StyleBoxFlat> style_bottom_panel = p_config.content_panel_style->duplicate();
-		style_bottom_panel->set_corner_radius_all(p_config.corner_radius * EDSCALE);
-		p_theme->set_stylebox("BottomPanel", EditorStringName(EditorStyles), style_bottom_panel);
-		p_theme->set_type_variation("BottomPanelButton", "FlatMenuButton");
-		p_theme->set_stylebox(CoreStringName(normal), "BottomPanelButton", menu_transparent_style);
-		p_theme->set_stylebox(SceneStringName(pressed), "BottomPanelButton", menu_transparent_style);
-		p_theme->set_stylebox("hover_pressed", "BottomPanelButton", main_screen_button_hover);
-		p_theme->set_stylebox(SceneStringName(hover), "BottomPanelButton", main_screen_button_hover);
-		// Don't tint the icon even when in "pressed" state.
-		p_theme->set_color("icon_pressed_color", "BottomPanelButton", Color(1, 1, 1, 1));
-		Color icon_hover_color = p_config.icon_normal_color * (p_config.dark_theme ? 1.15 : 1.0);
-		icon_hover_color.a = 1.0;
-		p_theme->set_color("icon_hover_color", "BottomPanelButton", icon_hover_color);
-		p_theme->set_color("icon_hover_pressed_color", "BottomPanelButton", icon_hover_color);
-
-		// Audio bus.
-		p_theme->set_stylebox("normal", "EditorAudioBus", style_bottom_panel);
-		p_theme->set_stylebox("master", "EditorAudioBus", p_config.button_style_disabled);
-		p_theme->set_stylebox("focus", "EditorAudioBus", p_config.button_style_focus);
-	}
-
-	// Editor GUI widgets.
-	{
-		// EditorSpinSlider.
-		p_theme->set_color("label_color", "EditorSpinSlider", p_config.font_color);
-		p_theme->set_color("read_only_label_color", "EditorSpinSlider", p_config.font_readonly_color);
-
-		Ref<StyleBoxFlat> editor_spin_label_bg = p_config.base_style->duplicate();
-		editor_spin_label_bg->set_bg_color(p_config.dark_color_3);
-		editor_spin_label_bg->set_border_width_all(0);
-		p_theme->set_stylebox("label_bg", "EditorSpinSlider", editor_spin_label_bg);
-
-		// TODO Use separate arrows instead like on SpinBox. Planned for a different PR.
-		p_theme->set_icon("updown", "EditorSpinSlider", p_theme->get_icon(SNAME("GuiSpinboxUpdown"), EditorStringName(EditorIcons)));
-		p_theme->set_icon("updown_disabled", "EditorSpinSlider", p_theme->get_icon(SNAME("GuiSpinboxUpdownDisabled"), EditorStringName(EditorIcons)));
-
-		// Launch Pad and Play buttons.
-		Ref<StyleBoxFlat> style_launch_pad = make_flat_stylebox(p_config.dark_color_1, 2 * EDSCALE, 0, 2 * EDSCALE, 0, p_config.corner_radius);
-		style_launch_pad->set_corner_radius_all(p_config.corner_radius * EDSCALE);
-		p_theme->set_stylebox("LaunchPadNormal", EditorStringName(EditorStyles), style_launch_pad);
-		Ref<StyleBoxFlat> style_launch_pad_movie = style_launch_pad->duplicate();
-		style_launch_pad_movie->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
-		style_launch_pad_movie->set_border_color(p_config.accent_color);
-		style_launch_pad_movie->set_border_width_all(Math::round(2 * EDSCALE));
-		p_theme->set_stylebox("LaunchPadMovieMode", EditorStringName(EditorStyles), style_launch_pad_movie);
-		Ref<StyleBoxFlat> style_launch_pad_recovery_mode = style_launch_pad->duplicate();
-		style_launch_pad_recovery_mode->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
-		style_launch_pad_recovery_mode->set_border_color(p_config.warning_color);
-		style_launch_pad_recovery_mode->set_border_width_all(Math::round(2 * EDSCALE));
-		p_theme->set_stylebox("LaunchPadRecoveryMode", EditorStringName(EditorStyles), style_launch_pad_recovery_mode);
-
-		p_theme->set_stylebox("MovieWriterButtonNormal", EditorStringName(EditorStyles), make_empty_stylebox(0, 0, 0, 0));
-		Ref<StyleBoxFlat> style_write_movie_button = p_config.button_style_pressed->duplicate();
-		style_write_movie_button->set_bg_color(p_config.accent_color);
-		style_write_movie_button->set_corner_radius_all(p_config.corner_radius * EDSCALE);
-		style_write_movie_button->set_content_margin(SIDE_TOP, 0);
-		style_write_movie_button->set_content_margin(SIDE_BOTTOM, 0);
-		style_write_movie_button->set_content_margin(SIDE_LEFT, 0);
-		style_write_movie_button->set_content_margin(SIDE_RIGHT, 0);
-		style_write_movie_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
-		p_theme->set_stylebox("MovieWriterButtonPressed", EditorStringName(EditorStyles), style_write_movie_button);
-
-		// Profiler autostart indicator panel.
-		Ref<StyleBoxFlat> style_profiler_autostart = style_launch_pad->duplicate();
-		style_profiler_autostart->set_bg_color(Color(1, 0.867, 0.396));
-		p_theme->set_type_variation("ProfilerAutostartIndicator", "Button");
-		p_theme->set_stylebox(CoreStringName(normal), "ProfilerAutostartIndicator", style_profiler_autostart);
-		p_theme->set_stylebox(SceneStringName(pressed), "ProfilerAutostartIndicator", style_profiler_autostart);
-		p_theme->set_stylebox("hover", "ProfilerAutostartIndicator", style_profiler_autostart);
-
-		// Recovery mode button style
-		Ref<StyleBoxFlat> style_recovery_mode_button = p_config.button_style_pressed->duplicate();
-		style_recovery_mode_button->set_bg_color(p_config.warning_color);
-		style_recovery_mode_button->set_corner_radius_all(p_config.corner_radius * EDSCALE);
-		style_recovery_mode_button->set_content_margin_all(0);
-		// Recovery mode button is implicitly styled from the panel's background.
-		// So, remove any existing borders. (e.g. from draw_extra_borders config)
-		style_recovery_mode_button->set_border_width_all(0);
-		style_recovery_mode_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
-		p_theme->set_stylebox("RecoveryModeButton", EditorStringName(EditorStyles), style_recovery_mode_button);
-	}
-
-	// Standard GUI variations.
-	{
-		// Custom theme type for MarginContainer with 4px margins.
-		p_theme->set_type_variation("MarginContainer4px", "MarginContainer");
-		p_theme->set_constant("margin_left", "MarginContainer4px", 4 * EDSCALE);
-		p_theme->set_constant("margin_top", "MarginContainer4px", 4 * EDSCALE);
-		p_theme->set_constant("margin_right", "MarginContainer4px", 4 * EDSCALE);
-		p_theme->set_constant("margin_bottom", "MarginContainer4px", 4 * EDSCALE);
-
-		// Header LinkButton variation.
-		p_theme->set_type_variation("HeaderSmallLink", "LinkButton");
-		p_theme->set_font(SceneStringName(font), "HeaderSmallLink", p_theme->get_font(SceneStringName(font), SNAME("HeaderSmall")));
-		p_theme->set_font_size(SceneStringName(font_size), "HeaderSmallLink", p_theme->get_font_size(SceneStringName(font_size), SNAME("HeaderSmall")));
-
-		// Flat button variations.
-		{
-			Ref<StyleBoxEmpty> style_flat_button = make_empty_stylebox();
-			Ref<StyleBoxFlat> style_flat_button_hover = p_config.button_style_hover->duplicate();
-			Ref<StyleBoxFlat> style_flat_button_pressed = p_config.button_style_pressed->duplicate();
-
-			for (int i = 0; i < 4; i++) {
-				style_flat_button->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
-				style_flat_button_hover->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
-				style_flat_button_pressed->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
-			}
-			Color flat_pressed_color = p_config.dark_color_1.lightened(0.24).lerp(p_config.accent_color, 0.2) * Color(0.8, 0.8, 0.8, 0.85);
-			if (p_config.dark_theme) {
-				flat_pressed_color = p_config.dark_color_1.lerp(p_config.accent_color, 0.12) * Color(0.6, 0.6, 0.6, 0.85);
-			}
-			style_flat_button_pressed->set_bg_color(flat_pressed_color);
-
-			p_theme->set_stylebox(CoreStringName(normal), SceneStringName(FlatButton), style_flat_button);
-			p_theme->set_stylebox(SceneStringName(hover), SceneStringName(FlatButton), style_flat_button_hover);
-			p_theme->set_stylebox(SceneStringName(pressed), SceneStringName(FlatButton), style_flat_button_pressed);
-			p_theme->set_stylebox("disabled", SceneStringName(FlatButton), style_flat_button);
-
-			p_theme->set_stylebox(CoreStringName(normal), "FlatMenuButton", style_flat_button);
-			p_theme->set_stylebox(SceneStringName(hover), "FlatMenuButton", style_flat_button_hover);
-			p_theme->set_stylebox(SceneStringName(pressed), "FlatMenuButton", style_flat_button_pressed);
-			p_theme->set_stylebox("disabled", "FlatMenuButton", style_flat_button);
-
-			// Variation for Editor Log filter buttons.
-
-			p_theme->set_type_variation("EditorLogFilterButton", "Button");
-			// When pressed, don't tint the icons with the accent color, just leave them normal.
-			p_theme->set_color("icon_pressed_color", "EditorLogFilterButton", p_config.icon_normal_color);
-			// When unpressed, dim the icons.
-			Color icon_normal_color = Color(p_config.icon_normal_color, (p_config.dark_theme ? 0.4 : 0.8));
-			p_theme->set_color("icon_normal_color", "EditorLogFilterButton", icon_normal_color);
-			Color icon_hover_color = p_config.icon_normal_color * (p_config.dark_theme ? 1.15 : 1.0);
-			icon_hover_color.a = 1.0;
-			p_theme->set_color("icon_hover_color", "EditorLogFilterButton", icon_hover_color);
-			p_theme->set_color("icon_hover_pressed_color", "EditorLogFilterButton", icon_hover_color);
-
-			// When pressed, add a small bottom border to the buttons to better show their active state,
-			// similar to active tabs.
-			Ref<StyleBoxFlat> editor_log_button_pressed = style_flat_button_pressed->duplicate();
-			editor_log_button_pressed->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
-			editor_log_button_pressed->set_border_color(p_config.accent_color);
-			if (!p_config.dark_theme) {
-				editor_log_button_pressed->set_bg_color(flat_pressed_color.lightened(0.5));
-			}
-			p_theme->set_stylebox(CoreStringName(normal), "EditorLogFilterButton", style_flat_button);
-			p_theme->set_stylebox(SceneStringName(hover), "EditorLogFilterButton", style_flat_button_hover);
-			p_theme->set_stylebox(SceneStringName(pressed), "EditorLogFilterButton", editor_log_button_pressed);
-		}
-
-		// Buttons styles that stand out against the panel background (e.g. AssetLib).
-		{
-			p_theme->set_type_variation("PanelBackgroundButton", "Button");
-
-			Ref<StyleBoxFlat> panel_button_style = p_config.button_style->duplicate();
-			panel_button_style->set_bg_color(p_config.base_color.lerp(p_config.mono_color, 0.08));
-
-			Ref<StyleBoxFlat> panel_button_style_hover = p_config.button_style_hover->duplicate();
-			panel_button_style_hover->set_bg_color(p_config.base_color.lerp(p_config.mono_color, 0.16));
-
-			Ref<StyleBoxFlat> panel_button_style_pressed = p_config.button_style_pressed->duplicate();
-			panel_button_style_pressed->set_bg_color(p_config.base_color.lerp(p_config.mono_color, 0.20));
-
-			Ref<StyleBoxFlat> panel_button_style_disabled = p_config.button_style_disabled->duplicate();
-			panel_button_style_disabled->set_bg_color(p_config.disabled_bg_color);
-
-			p_theme->set_stylebox(CoreStringName(normal), "PanelBackgroundButton", panel_button_style);
-			p_theme->set_stylebox(SceneStringName(hover), "PanelBackgroundButton", panel_button_style_hover);
-			p_theme->set_stylebox(SceneStringName(pressed), "PanelBackgroundButton", panel_button_style_pressed);
-			p_theme->set_stylebox("disabled", "PanelBackgroundButton", panel_button_style_disabled);
-		}
-
-		// Top bar selectors.
-		{
-			p_theme->set_type_variation("TopBarOptionButton", "OptionButton");
-			p_theme->set_font(SceneStringName(font), "TopBarOptionButton", p_theme->get_font(SNAME("bold"), EditorStringName(EditorFonts)));
-			p_theme->set_font_size(SceneStringName(font_size), "TopBarOptionButton", p_theme->get_font_size(SNAME("bold_size"), EditorStringName(EditorFonts)));
-		}
-
-		// Complex editor windows.
-		{
-			Ref<StyleBoxFlat> style_complex_window = p_config.window_style->duplicate();
-			style_complex_window->set_bg_color(p_config.dark_color_2);
-			style_complex_window->set_border_color(p_config.dark_color_2);
-			p_theme->set_stylebox(SceneStringName(panel), "EditorSettingsDialog", style_complex_window);
-			p_theme->set_stylebox(SceneStringName(panel), "ProjectSettingsEditor", style_complex_window);
-			p_theme->set_stylebox(SceneStringName(panel), "EditorAbout", style_complex_window);
-		}
-
-		// InspectorActionButton.
-		{
-			p_theme->set_type_variation("InspectorActionButton", "Button");
-
-			const float action_extra_margin = 32 * EDSCALE;
-			p_theme->set_constant("h_separation", "InspectorActionButton", action_extra_margin);
-
-			Color color_inspector_action = p_config.dark_color_1.lerp(p_config.mono_color, 0.12);
-			color_inspector_action.a = 0.5;
-			Ref<StyleBoxFlat> style_inspector_action = p_config.button_style->duplicate();
-			style_inspector_action->set_bg_color(color_inspector_action);
-			style_inspector_action->set_content_margin(SIDE_RIGHT, action_extra_margin);
-			p_theme->set_stylebox(CoreStringName(normal), "InspectorActionButton", style_inspector_action);
-
-			style_inspector_action = p_config.button_style->duplicate();
-			style_inspector_action->set_bg_color(color_inspector_action);
-			style_inspector_action->set_content_margin(SIDE_LEFT, action_extra_margin);
-			p_theme->set_stylebox("normal_mirrored", "InspectorActionButton", style_inspector_action);
-
-			style_inspector_action = p_config.button_style_hover->duplicate();
-			style_inspector_action->set_content_margin(SIDE_RIGHT, action_extra_margin);
-			p_theme->set_stylebox(SceneStringName(hover), "InspectorActionButton", style_inspector_action);
-
-			style_inspector_action = p_config.button_style_hover->duplicate();
-			style_inspector_action->set_content_margin(SIDE_LEFT, action_extra_margin);
-			p_theme->set_stylebox("hover_mirrored", "InspectorActionButton", style_inspector_action);
-
-			style_inspector_action = p_config.button_style_pressed->duplicate();
-			style_inspector_action->set_content_margin(SIDE_RIGHT, action_extra_margin);
-			p_theme->set_stylebox(SceneStringName(pressed), "InspectorActionButton", style_inspector_action);
-
-			style_inspector_action = p_config.button_style_pressed->duplicate();
-			style_inspector_action->set_content_margin(SIDE_LEFT, action_extra_margin);
-			p_theme->set_stylebox("pressed_mirrored", "InspectorActionButton", style_inspector_action);
-
-			style_inspector_action = p_config.button_style_disabled->duplicate();
-			style_inspector_action->set_content_margin(SIDE_RIGHT, action_extra_margin);
-			p_theme->set_stylebox("disabled", "InspectorActionButton", style_inspector_action);
-
-			style_inspector_action = p_config.button_style_disabled->duplicate();
-			style_inspector_action->set_content_margin(SIDE_LEFT, action_extra_margin);
-			p_theme->set_stylebox("disabled_mirrored", "InspectorActionButton", style_inspector_action);
-		}
-
-		// Buttons in material previews.
-		{
-			const Color dim_light_color = p_config.icon_normal_color.darkened(0.24);
-			const Color dim_light_highlighted_color = p_config.icon_normal_color.darkened(0.18);
-			Ref<StyleBox> sb_empty_borderless = make_empty_stylebox();
-
-			p_theme->set_type_variation("PreviewLightButton", "Button");
-			// When pressed, don't use the accent color tint. When unpressed, dim the icon.
-			p_theme->set_color("icon_normal_color", "PreviewLightButton", dim_light_color);
-			p_theme->set_color("icon_focus_color", "PreviewLightButton", dim_light_color);
-			p_theme->set_color("icon_pressed_color", "PreviewLightButton", p_config.icon_normal_color);
-			p_theme->set_color("icon_hover_pressed_color", "PreviewLightButton", p_config.icon_normal_color);
-			// Unpressed icon is dim, so use a dim highlight.
-			p_theme->set_color("icon_hover_color", "PreviewLightButton", dim_light_highlighted_color);
-
-			p_theme->set_stylebox(CoreStringName(normal), "PreviewLightButton", sb_empty_borderless);
-			p_theme->set_stylebox(SceneStringName(hover), "PreviewLightButton", sb_empty_borderless);
-			p_theme->set_stylebox("focus", "PreviewLightButton", sb_empty_borderless);
-			p_theme->set_stylebox(SceneStringName(pressed), "PreviewLightButton", sb_empty_borderless);
-		}
-
-		// TabContainerOdd variation.
-		{
-			// Can be used on tabs against the base color background (e.g. nested tabs).
-			p_theme->set_type_variation("TabContainerOdd", "TabContainer");
-
-			Ref<StyleBoxFlat> style_tab_selected_odd = p_theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->duplicate();
-			style_tab_selected_odd->set_bg_color(p_config.disabled_bg_color);
-			p_theme->set_stylebox("tab_selected", "TabContainerOdd", style_tab_selected_odd);
-
-			Ref<StyleBoxFlat> style_content_panel_odd = p_config.content_panel_style->duplicate();
-			style_content_panel_odd->set_bg_color(p_config.disabled_bg_color);
-			p_theme->set_stylebox(SceneStringName(panel), "TabContainerOdd", style_content_panel_odd);
-		}
-
-		// EditorValidationPanel.
-		p_theme->set_stylebox(SceneStringName(panel), "EditorValidationPanel", p_config.tree_panel_style);
-
-		// Secondary trees and item lists.
-		p_theme->set_type_variation("TreeSecondary", "Tree");
-		p_theme->set_type_variation("ItemListSecondary", "ItemList");
-	}
-
-	// Editor inspector.
-	{
-		// Panel.
-		Ref<StyleBoxFlat> editor_inspector_panel = p_config.tree_panel_style->duplicate();
-		editor_inspector_panel->set_border_width_all(0);
-		editor_inspector_panel->set_content_margin_all(0);
-		p_theme->set_stylebox(SceneStringName(panel), "EditorInspector", editor_inspector_panel);
-
-		// Vertical separation between inspector categories and sections.
-		p_theme->set_constant("v_separation", "EditorInspector", 0);
-
-		// EditorProperty.
-
-		Ref<StyleBoxFlat> style_property_bg = p_config.base_style->duplicate();
-		style_property_bg->set_bg_color(p_config.highlight_color);
-		style_property_bg->set_border_width_all(0);
-
-		Ref<StyleBoxFlat> style_property_child_bg = p_config.base_style->duplicate();
-		style_property_child_bg->set_bg_color(p_config.dark_color_2);
-		style_property_child_bg->set_border_width_all(0);
-
-		p_theme->set_stylebox("bg", "EditorProperty", memnew(StyleBoxEmpty));
-		p_theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg);
-		p_theme->set_stylebox("child_bg", "EditorProperty", style_property_child_bg);
-		p_theme->set_constant("font_offset", "EditorProperty", 8 * EDSCALE);
-		p_theme->set_constant("v_separation", "EditorProperty", p_config.increased_margin * EDSCALE);
-
-		const Color property_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
-		const Color readonly_color = property_color.lerp(p_config.dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
-		const Color readonly_warning_color = p_config.error_color.lerp(p_config.dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
-
-		p_theme->set_color("property_color", "EditorProperty", property_color);
-		p_theme->set_color("readonly_color", "EditorProperty", readonly_color);
-		p_theme->set_color("warning_color", "EditorProperty", p_config.warning_color);
-		p_theme->set_color("readonly_warning_color", "EditorProperty", readonly_warning_color);
-
-		Ref<StyleBoxFlat> style_property_group_note = p_config.base_style->duplicate();
-		Color property_group_note_color = p_config.accent_color;
-		property_group_note_color.a = 0.1;
-		style_property_group_note->set_bg_color(property_group_note_color);
-		p_theme->set_stylebox("bg_group_note", "EditorProperty", style_property_group_note);
-
-		// EditorInspectorSection.
-
-		Color inspector_section_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.35);
-		p_theme->set_color(SceneStringName(font_color), "EditorInspectorSection", inspector_section_color);
-
-		Color inspector_indent_color = p_config.accent_color;
-		inspector_indent_color.a = 0.2;
-		Ref<StyleBoxFlat> inspector_indent_style = make_flat_stylebox(inspector_indent_color, 2.0 * EDSCALE, 0, 2.0 * EDSCALE, 0);
-		p_theme->set_stylebox("indent_box", "EditorInspectorSection", inspector_indent_style);
-		p_theme->set_constant("indent_size", "EditorInspectorSection", 6.0 * EDSCALE);
-		p_theme->set_constant("h_separation", "EditorInspectorSection", 2.0 * EDSCALE);
-
-		Color prop_category_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.12);
-		Color prop_section_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
-		Color prop_subsection_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.06);
-
-		p_theme->set_color("prop_category", EditorStringName(Editor), prop_category_color);
-		p_theme->set_color("prop_section", EditorStringName(Editor), prop_section_color);
-		p_theme->set_color("prop_subsection", EditorStringName(Editor), prop_subsection_color);
-#ifndef DISABLE_DEPRECATED // Used before 4.3.
-		p_theme->set_color("property_color", EditorStringName(Editor), prop_category_color);
-#endif
-
-		// EditorInspectorCategory.
-
-		Ref<StyleBoxFlat> category_bg = p_config.base_style->duplicate();
-		category_bg->set_bg_color(prop_category_color);
-		category_bg->set_border_color(prop_category_color);
-		category_bg->set_content_margin_all(0);
-		p_theme->set_stylebox("bg", "EditorInspectorCategory", category_bg);
-
-		p_theme->set_constant("inspector_margin", EditorStringName(Editor), 12 * EDSCALE);
-
-		// Colored EditorProperty.
-		for (int i = 0; i < 16; i++) {
-			Color si_base_color = p_config.accent_color;
-
-			float hue_rotate = (i * 2 % 16) / 16.0;
-			si_base_color.set_hsv(Math::fmod(float(si_base_color.get_h() + hue_rotate), float(1.0)), si_base_color.get_s(), si_base_color.get_v());
-			si_base_color = p_config.accent_color.lerp(si_base_color, p_config.subresource_hue_tint);
-
-			// Sub-inspector background.
-			Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
-			sub_inspector_bg->set_bg_color(p_config.dark_color_1.lerp(si_base_color, 0.08));
-			sub_inspector_bg->set_border_width_all(2 * EDSCALE);
-			sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
-			sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
-			sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
-			sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
-
-			p_theme->set_stylebox("sub_inspector_bg" + itos(i + 1), EditorStringName(EditorStyles), sub_inspector_bg);
-
-			// EditorProperty background while it has a sub-inspector open.
-			Ref<StyleBoxFlat> bg_color = make_flat_stylebox(si_base_color * Color(0.7, 0.7, 0.7, 0.8), 0, 0, 0, 0, p_config.corner_radius);
-			bg_color->set_anti_aliased(false);
-			bg_color->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			bg_color->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-
-			p_theme->set_stylebox("sub_inspector_property_bg" + itos(i + 1), EditorStringName(EditorStyles), bg_color);
-
-			// Dictionary editor add item.
-			// Expand to the left and right by 4px to compensate for the dictionary editor margins.
-
-			Color style_dictionary_bg_color = p_config.dark_color_3.lerp(si_base_color, 0.08);
-			Ref<StyleBoxFlat> style_dictionary_add_item = make_flat_stylebox(style_dictionary_bg_color, 0, 4, 0, 4, p_config.corner_radius);
-			style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 2 * EDSCALE);
-			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
-			p_theme->set_stylebox("DictionaryAddItem" + itos(i + 1), EditorStringName(EditorStyles), style_dictionary_add_item);
-		}
-		Color si_base_color = p_config.accent_color;
-
-		// Sub-inspector background.
-		Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
-		sub_inspector_bg->set_bg_color(Color(1, 1, 1, 0));
-		sub_inspector_bg->set_border_width_all(2 * EDSCALE);
-		sub_inspector_bg->set_border_color(p_config.dark_color_1.lerp(si_base_color, 0.15));
-		sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
-		sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
-		sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
-
-		p_theme->set_stylebox("sub_inspector_bg0", EditorStringName(EditorStyles), sub_inspector_bg);
-
-		// Sub-inspector background no border.
-
-		Ref<StyleBoxFlat> sub_inspector_bg_no_border = p_config.base_style->duplicate();
-		sub_inspector_bg_no_border->set_content_margin_all(2 * EDSCALE);
-		sub_inspector_bg_no_border->set_bg_color(p_config.dark_color_2.lerp(p_config.dark_color_3, 0.15));
-		p_theme->set_stylebox("sub_inspector_bg_no_border", EditorStringName(EditorStyles), sub_inspector_bg_no_border);
-
-		// EditorProperty background while it has a sub-inspector open.
-		Ref<StyleBoxFlat> bg_color = make_flat_stylebox(p_config.dark_color_1.lerp(si_base_color, 0.15), 0, 0, 0, 0, p_config.corner_radius);
-		bg_color->set_anti_aliased(false);
-		bg_color->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-		bg_color->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-
-		p_theme->set_stylebox("sub_inspector_property_bg0", EditorStringName(EditorStyles), bg_color);
-
-		p_theme->set_color("sub_inspector_property_color", EditorStringName(EditorStyles), p_config.dark_theme ? Color(1, 1, 1, 1) : Color(0, 0, 0, 1));
-
-		// Dictionary editor.
-
-		// Expand to the left and right by 4px to compensate for the dictionary editor margins.
-		Ref<StyleBoxFlat> style_dictionary_add_item = make_flat_stylebox(prop_subsection_color, 0, 4, 0, 4, p_config.corner_radius);
-		style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 2 * EDSCALE);
-		style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
-		p_theme->set_stylebox("DictionaryAddItem0", EditorStringName(EditorStyles), style_dictionary_add_item);
-	}
-
-	// Animation Editor.
-	{
-		// Timeline general.
-		p_theme->set_constant("timeline_v_separation", "AnimationTrackEditor", 0);
-		p_theme->set_constant("track_v_separation", "AnimationTrackEditor", 0);
-
-		// AnimationTimelineEdit.
-		// "primary" is used for integer timeline values, "secondary" for decimals.
-
-		Ref<StyleBoxFlat> style_time_unavailable = make_flat_stylebox(p_config.dark_color_2, 0, 0, 0, 0, 0);
-		Ref<StyleBoxFlat> style_time_available = make_flat_stylebox(p_config.font_color * Color(1, 1, 1, 0.2), 0, 0, 0, 0, 0);
-
-		p_theme->set_stylebox("time_unavailable", "AnimationTimelineEdit", style_time_unavailable);
-		p_theme->set_stylebox("time_available", "AnimationTimelineEdit", style_time_available);
-
-		p_theme->set_color("v_line_primary_color", "AnimationTimelineEdit", p_config.font_color * Color(1, 1, 1, 0.2));
-		p_theme->set_color("v_line_secondary_color", "AnimationTimelineEdit", p_config.font_color * Color(1, 1, 1, 0.2));
-		p_theme->set_color("h_line_color", "AnimationTimelineEdit", p_config.font_color * Color(1, 1, 1, 0.2));
-		p_theme->set_color("font_primary_color", "AnimationTimelineEdit", p_config.font_color);
-		p_theme->set_color("font_secondary_color", "AnimationTimelineEdit", p_config.font_color * Color(1, 1, 1, 0.5));
-
-		p_theme->set_constant("v_line_primary_margin", "AnimationTimelineEdit", 0);
-		p_theme->set_constant("v_line_secondary_margin", "AnimationTimelineEdit", 0);
-		p_theme->set_constant("v_line_primary_width", "AnimationTimelineEdit", 1 * EDSCALE);
-		p_theme->set_constant("v_line_secondary_width", "AnimationTimelineEdit", 1 * EDSCALE);
-		p_theme->set_constant("text_primary_margin", "AnimationTimelineEdit", 3 * EDSCALE);
-		p_theme->set_constant("text_secondary_margin", "AnimationTimelineEdit", 3 * EDSCALE);
-
-		// AnimationTrackEdit.
-
-		Ref<StyleBoxFlat> style_animation_track_odd = make_flat_stylebox(Color(0.5, 0.5, 0.5, 0.05), 0, 0, 0, 0, p_config.corner_radius);
-		Ref<StyleBoxFlat> style_animation_track_hover = make_flat_stylebox(Color(0.5, 0.5, 0.5, 0.1), 0, 0, 0, 0, p_config.corner_radius);
-
-		p_theme->set_stylebox("odd", "AnimationTrackEdit", style_animation_track_odd);
-		p_theme->set_stylebox(SceneStringName(hover), "AnimationTrackEdit", style_animation_track_hover);
-		p_theme->set_stylebox("focus", "AnimationTrackEdit", p_config.button_style_focus);
-
-		p_theme->set_color("h_line_color", "AnimationTrackEdit", p_config.font_color * Color(1, 1, 1, 0.2));
-
-		p_theme->set_constant("h_separation", "AnimationTrackEdit", (p_config.increased_margin + 2) * EDSCALE);
-		p_theme->set_constant("outer_margin", "AnimationTrackEdit", p_config.increased_margin * 6 * EDSCALE);
-
-		// AnimationTrackEditGroup.
-
-		Ref<StyleBoxFlat> style_animation_track_header = make_flat_stylebox(p_config.dark_color_2 * Color(1, 1, 1, 0.6), p_config.increased_margin * 3, 0, 0, 0, p_config.corner_radius);
-
-		p_theme->set_stylebox("header", "AnimationTrackEditGroup", style_animation_track_header);
-
-		p_theme->set_color("h_line_color", "AnimationTrackEditGroup", p_config.font_color * Color(1, 1, 1, 0.2));
-		p_theme->set_color("v_line_color", "AnimationTrackEditGroup", p_config.font_color * Color(1, 1, 1, 0.2));
-
-		p_theme->set_constant("h_separation", "AnimationTrackEditGroup", (p_config.increased_margin + 2) * EDSCALE);
-		p_theme->set_constant("v_separation", "AnimationTrackEditGroup", 0);
-
-		// AnimationBezierTrackEdit.
-
-		p_theme->set_color("focus_color", "AnimationBezierTrackEdit", p_config.accent_color * Color(1, 1, 1, 0.7));
-		p_theme->set_color("track_focus_color", "AnimationBezierTrackEdit", p_config.accent_color * Color(1, 1, 1, 0.5));
-		p_theme->set_color("h_line_color", "AnimationBezierTrackEdit", p_config.font_color * Color(1, 1, 1, 0.2));
-		p_theme->set_color("v_line_color", "AnimationBezierTrackEdit", p_config.font_color * Color(1, 1, 1, 0.2));
-
-		p_theme->set_constant("h_separation", "AnimationBezierTrackEdit", (p_config.increased_margin + 2) * EDSCALE);
-		p_theme->set_constant("v_separation", "AnimationBezierTrackEdit", p_config.forced_even_separation * EDSCALE);
-	}
-
-	// Editor help.
-	{
-		Ref<StyleBoxFlat> style_editor_help = p_config.base_style->duplicate();
-		style_editor_help->set_bg_color(p_config.dark_color_2);
-		style_editor_help->set_border_color(p_config.dark_color_3);
-		p_theme->set_stylebox("background", "EditorHelp", style_editor_help);
-
-		const Color kbd_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
-
-		p_theme->set_color("title_color", "EditorHelp", p_config.accent_color);
-		p_theme->set_color("headline_color", "EditorHelp", p_config.mono_color);
-		p_theme->set_color("text_color", "EditorHelp", p_config.font_color);
-		p_theme->set_color("comment_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
-		p_theme->set_color("symbol_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
-		p_theme->set_color("value_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
-		p_theme->set_color("qualifier_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.8));
-		p_theme->set_color("type_color", "EditorHelp", p_config.accent_color.lerp(p_config.font_color, 0.5));
-		p_theme->set_color("override_color", "EditorHelp", p_config.warning_color);
-		p_theme->set_color("selection_color", "EditorHelp", p_config.selection_color);
-		p_theme->set_color("link_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color, 0.8));
-		p_theme->set_color("code_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color, 0.6));
-		p_theme->set_color("kbd_color", "EditorHelp", p_config.accent_color.lerp(kbd_color, 0.6));
-		p_theme->set_color("code_bg_color", "EditorHelp", p_config.dark_color_3);
-		p_theme->set_color("kbd_bg_color", "EditorHelp", p_config.dark_color_1);
-		p_theme->set_color("param_bg_color", "EditorHelp", p_config.dark_color_1);
-		p_theme->set_constant(SceneStringName(line_separation), "EditorHelp", Math::round(6 * EDSCALE));
-		p_theme->set_constant("table_h_separation", "EditorHelp", 16 * EDSCALE);
-		p_theme->set_constant("table_v_separation", "EditorHelp", 6 * EDSCALE);
-		p_theme->set_constant("text_highlight_h_padding", "EditorHelp", 1 * EDSCALE);
-		p_theme->set_constant("text_highlight_v_padding", "EditorHelp", 2 * EDSCALE);
-	}
-
-	// EditorHelpBitTitle.
-	{
-		Ref<StyleBoxFlat> style = p_config.tree_panel_style->duplicate();
-		style->set_bg_color(p_config.dark_theme ? style->get_bg_color().lightened(0.04) : style->get_bg_color().darkened(0.04));
-		style->set_border_color(p_config.dark_theme ? style->get_border_color().lightened(0.04) : style->get_border_color().darkened(0.04));
-		if (p_config.draw_extra_borders) {
-			// A tooltip border is already drawn for all tooltips when Draw Extra Borders is enabled.
-			// Hide borders that don't serve in drawing a line between the title and content to prevent the border from being doubled.
-			style->set_border_width(SIDE_TOP, 0);
-			style->set_border_width(SIDE_LEFT, 0);
-			style->set_border_width(SIDE_RIGHT, 0);
-		}
-		style->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-		style->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-
-		p_theme->set_type_variation("EditorHelpBitTitle", "RichTextLabel");
-		p_theme->set_stylebox(CoreStringName(normal), "EditorHelpBitTitle", style);
-	}
-
-	// EditorHelpBitContent.
-	{
-		Ref<StyleBoxFlat> style = p_config.tree_panel_style->duplicate();
-		if (p_config.draw_extra_borders) {
-			// A tooltip border is already drawn for all tooltips when Draw Extra Borders is enabled.
-			// Hide borders that don't serve in drawing a line between the title and content to prevent the border from being doubled.
-			style->set_border_width(SIDE_BOTTOM, 0);
-			style->set_border_width(SIDE_LEFT, 0);
-			style->set_border_width(SIDE_RIGHT, 0);
-		}
-		style->set_corner_radius(CORNER_TOP_LEFT, 0);
-		style->set_corner_radius(CORNER_TOP_RIGHT, 0);
-
-		p_theme->set_type_variation("EditorHelpBitContent", "RichTextLabel");
-		p_theme->set_stylebox(CoreStringName(normal), "EditorHelpBitContent", style);
-	}
-
-	// Asset Library.
-	p_theme->set_stylebox("bg", "AssetLib", p_config.base_empty_style);
-	p_theme->set_stylebox(SceneStringName(panel), "AssetLib", p_config.content_panel_style);
-	p_theme->set_color("status_color", "AssetLib", Color(0.5, 0.5, 0.5)); // FIXME: Use a defined color instead.
-	p_theme->set_icon("dismiss", "AssetLib", p_theme->get_icon(SNAME("Close"), EditorStringName(EditorIcons)));
-
-	// Debugger.
-	{
-		Ref<StyleBoxFlat> debugger_panel_style = p_config.content_panel_style->duplicate();
-		debugger_panel_style->set_border_width(SIDE_BOTTOM, 0);
-		p_theme->set_stylebox("DebuggerPanel", EditorStringName(EditorStyles), debugger_panel_style);
-	}
-
-	// Resource and node editors.
-	{
-		// TextureRegion editor.
-		Ref<StyleBoxFlat> style_texture_region_bg = p_config.tree_panel_style->duplicate();
-		style_texture_region_bg->set_content_margin_all(0);
-		p_theme->set_stylebox("TextureRegionPreviewBG", EditorStringName(EditorStyles), style_texture_region_bg);
-		p_theme->set_stylebox("TextureRegionPreviewFG", EditorStringName(EditorStyles), make_empty_stylebox(0, 0, 0, 0));
-
-		// Theme editor.
-		{
-			p_theme->set_color("preview_picker_overlay_color", "ThemeEditor", Color(0.1, 0.1, 0.1, 0.25));
-
-			Color theme_preview_picker_bg_color = p_config.accent_color;
-			theme_preview_picker_bg_color.a = 0.2;
-			Ref<StyleBoxFlat> theme_preview_picker_sb = make_flat_stylebox(theme_preview_picker_bg_color, 0, 0, 0, 0);
-			theme_preview_picker_sb->set_border_color(p_config.accent_color);
-			theme_preview_picker_sb->set_border_width_all(1.0 * EDSCALE);
-			p_theme->set_stylebox("preview_picker_overlay", "ThemeEditor", theme_preview_picker_sb);
-
-			Color theme_preview_picker_label_bg_color = p_config.accent_color;
-			theme_preview_picker_label_bg_color.set_v(0.5);
-			Ref<StyleBoxFlat> theme_preview_picker_label_sb = make_flat_stylebox(theme_preview_picker_label_bg_color, 4.0, 1.0, 4.0, 3.0);
-			p_theme->set_stylebox("preview_picker_label", "ThemeEditor", theme_preview_picker_label_sb);
-
-			Ref<StyleBoxFlat> style_theme_preview_tab = p_theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainerOdd"))->duplicate();
-			style_theme_preview_tab->set_expand_margin(SIDE_BOTTOM, 5 * EDSCALE);
-			p_theme->set_stylebox("ThemeEditorPreviewFG", EditorStringName(EditorStyles), style_theme_preview_tab);
-
-			Ref<StyleBoxFlat> style_theme_preview_bg_tab = p_theme->get_stylebox(SNAME("tab_unselected"), SNAME("TabContainer"))->duplicate();
-			style_theme_preview_bg_tab->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
-			p_theme->set_stylebox("ThemeEditorPreviewBG", EditorStringName(EditorStyles), style_theme_preview_bg_tab);
-		}
-
-		// VisualShader editor.
-		p_theme->set_stylebox("label_style", "VShaderEditor", make_empty_stylebox(4, 6, 4, 6));
-
-		// StateMachine graph.
-		{
-			p_theme->set_stylebox(SceneStringName(panel), "GraphStateMachine", p_config.tree_panel_style);
-			p_theme->set_stylebox("error_panel", "GraphStateMachine", p_config.tree_panel_style);
-			p_theme->set_color("error_color", "GraphStateMachine", p_config.error_color);
-
-			const int sm_margin_side = 10 * EDSCALE;
-			const int sm_margin_bottom = 2;
-			const Color sm_bg_color = p_config.dark_theme ? p_config.dark_color_3 : p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
-
-			Ref<StyleBoxFlat> sm_node_style = make_flat_stylebox(p_config.dark_color_3 * Color(1, 1, 1, 0.7), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
-			sm_node_style->set_border_width_all(p_config.border_width);
-			sm_node_style->set_border_color(sm_bg_color);
-
-			Ref<StyleBoxFlat> sm_node_selected_style = make_flat_stylebox(sm_bg_color * Color(1, 1, 1, 0.9), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
-			sm_node_selected_style->set_border_width_all(2 * EDSCALE + p_config.border_width);
-			sm_node_selected_style->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.9));
-			sm_node_selected_style->set_shadow_size(8 * EDSCALE);
-			sm_node_selected_style->set_shadow_color(p_config.shadow_color);
-
-			Ref<StyleBoxFlat> sm_node_playing_style = sm_node_selected_style->duplicate();
-			sm_node_playing_style->set_border_color(p_config.warning_color);
-			sm_node_playing_style->set_shadow_color(p_config.warning_color * Color(1, 1, 1, 0.2));
-			sm_node_playing_style->set_draw_center(false);
-
-			p_theme->set_stylebox("node_frame", "GraphStateMachine", sm_node_style);
-			p_theme->set_stylebox("node_frame_selected", "GraphStateMachine", sm_node_selected_style);
-			p_theme->set_stylebox("node_frame_playing", "GraphStateMachine", sm_node_playing_style);
-
-			Ref<StyleBoxFlat> sm_node_start_style = sm_node_style->duplicate();
-			sm_node_start_style->set_border_width_all(1 * EDSCALE);
-			sm_node_start_style->set_border_color(p_config.success_color.lightened(0.24));
-			p_theme->set_stylebox("node_frame_start", "GraphStateMachine", sm_node_start_style);
-
-			Ref<StyleBoxFlat> sm_node_end_style = sm_node_style->duplicate();
-			sm_node_end_style->set_border_width_all(1 * EDSCALE);
-			sm_node_end_style->set_border_color(p_config.error_color);
-			p_theme->set_stylebox("node_frame_end", "GraphStateMachine", sm_node_end_style);
-
-			p_theme->set_font("node_title_font", "GraphStateMachine", p_theme->get_font(SceneStringName(font), SNAME("Label")));
-			p_theme->set_font_size("node_title_font_size", "GraphStateMachine", p_theme->get_font_size(SceneStringName(font_size), SNAME("Label")));
-			p_theme->set_color("node_title_font_color", "GraphStateMachine", p_config.font_color);
-
-			p_theme->set_color("transition_color", "GraphStateMachine", p_config.font_color);
-			p_theme->set_color("transition_disabled_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.2));
-			p_theme->set_color("transition_icon_color", "GraphStateMachine", Color(1, 1, 1));
-			p_theme->set_color("transition_icon_disabled_color", "GraphStateMachine", Color(1, 1, 1, 0.2));
-			p_theme->set_color("highlight_color", "GraphStateMachine", p_config.accent_color);
-			p_theme->set_color("highlight_disabled_color", "GraphStateMachine", p_config.accent_color * Color(1, 1, 1, 0.6));
-			p_theme->set_color("focus_color", "GraphStateMachine", p_config.accent_color);
-			p_theme->set_color("guideline_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
-
-			p_theme->set_color("playback_color", "GraphStateMachine", p_config.font_color);
-			p_theme->set_color("playback_background_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
-		}
-	}
 }
 
 void _load_text_editor_theme() {
@@ -2700,19 +496,19 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 			const Color alpha3 = Color(mono_value, mono_value, mono_value, 0.27);
 
 			// Syntax highlight token colors.
-			colors["text_editor/theme/highlighting/symbol_color"] = p_config.dark_theme ? Color(0.67, 0.79, 1) : Color(0, 0, 0.61);
-			colors["text_editor/theme/highlighting/keyword_color"] = p_config.dark_theme ? Color(1.0, 0.44, 0.52) : Color(0.9, 0.135, 0.51);
-			colors["text_editor/theme/highlighting/control_flow_keyword_color"] = p_config.dark_theme ? Color(1.0, 0.55, 0.8) : Color(0.743, 0.12, 0.8);
-			colors["text_editor/theme/highlighting/base_type_color"] = p_config.dark_theme ? Color(0.26, 1.0, 0.76) : Color(0, 0.6, 0.2);
-			colors["text_editor/theme/highlighting/engine_type_color"] = p_config.dark_theme ? Color(0.56, 1, 0.86) : Color(0.11, 0.55, 0.4);
-			colors["text_editor/theme/highlighting/user_type_color"] = p_config.dark_theme ? Color(0.78, 1, 0.93) : Color(0.18, 0.45, 0.4);
-			colors["text_editor/theme/highlighting/comment_color"] = p_config.dark_theme ? dim_color : Color(0.08, 0.08, 0.08, 0.5);
-			colors["text_editor/theme/highlighting/doc_comment_color"] = p_config.dark_theme ? Color(0.6, 0.7, 0.8, 0.8) : Color(0.15, 0.15, 0.4, 0.7);
-			colors["text_editor/theme/highlighting/string_color"] = p_config.dark_theme ? Color(1, 0.93, 0.63) : Color(0.6, 0.42, 0);
+			colors["text_editor/theme/highlighting/symbol_color"] = p_config.dark_icon_and_font ? Color(0.67, 0.79, 1) : Color(0, 0, 0.61);
+			colors["text_editor/theme/highlighting/keyword_color"] = p_config.dark_icon_and_font ? Color(1.0, 0.44, 0.52) : Color(0.9, 0.135, 0.51);
+			colors["text_editor/theme/highlighting/control_flow_keyword_color"] = p_config.dark_icon_and_font ? Color(1.0, 0.55, 0.8) : Color(0.743, 0.12, 0.8);
+			colors["text_editor/theme/highlighting/base_type_color"] = p_config.dark_icon_and_font ? Color(0.26, 1.0, 0.76) : Color(0, 0.6, 0.2);
+			colors["text_editor/theme/highlighting/engine_type_color"] = p_config.dark_icon_and_font ? Color(0.56, 1, 0.86) : Color(0.11, 0.55, 0.4);
+			colors["text_editor/theme/highlighting/user_type_color"] = p_config.dark_icon_and_font ? Color(0.78, 1, 0.93) : Color(0.18, 0.45, 0.4);
+			colors["text_editor/theme/highlighting/comment_color"] = p_config.dark_icon_and_font ? dim_color : Color(0.08, 0.08, 0.08, 0.5);
+			colors["text_editor/theme/highlighting/doc_comment_color"] = p_config.dark_icon_and_font ? Color(0.6, 0.7, 0.8, 0.8) : Color(0.15, 0.15, 0.4, 0.7);
+			colors["text_editor/theme/highlighting/string_color"] = p_config.dark_icon_and_font ? Color(1, 0.93, 0.63) : Color(0.6, 0.42, 0);
 
 			// Use the brightest background color on a light theme (which generally uses a negative contrast rate).
-			colors["text_editor/theme/highlighting/background_color"] = p_config.dark_theme ? p_config.dark_color_2 : p_config.dark_color_3;
-			colors["text_editor/theme/highlighting/completion_background_color"] = p_config.dark_theme ? p_config.base_color : p_config.dark_color_2;
+			colors["text_editor/theme/highlighting/background_color"] = p_config.dark_icon_and_font ? p_config.dark_color_2 : p_config.dark_color_3;
+			colors["text_editor/theme/highlighting/completion_background_color"] = p_config.dark_icon_and_font ? p_config.base_color : p_config.dark_color_2;
 			colors["text_editor/theme/highlighting/completion_selected_color"] = alpha1;
 			colors["text_editor/theme/highlighting/completion_existing_color"] = alpha2;
 			// Same opacity as the scroll grabber editor icon.
@@ -2721,29 +517,29 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 			colors["text_editor/theme/highlighting/completion_font_color"] = p_config.font_color;
 			colors["text_editor/theme/highlighting/text_color"] = p_config.font_color;
 			colors["text_editor/theme/highlighting/line_number_color"] = dim_color;
-			colors["text_editor/theme/highlighting/safe_line_number_color"] = p_config.dark_theme ? (dim_color * Color(1, 1.2, 1, 1.5)) : Color(0, 0.4, 0, 0.75);
+			colors["text_editor/theme/highlighting/safe_line_number_color"] = p_config.dark_icon_and_font ? (dim_color * Color(1, 1.2, 1, 1.5)) : Color(0, 0.4, 0, 0.75);
 			colors["text_editor/theme/highlighting/caret_color"] = p_config.mono_color;
 			colors["text_editor/theme/highlighting/caret_background_color"] = p_config.mono_color.inverted();
 			colors["text_editor/theme/highlighting/text_selected_color"] = Color(0, 0, 0, 0);
 			colors["text_editor/theme/highlighting/selection_color"] = p_config.selection_color;
-			colors["text_editor/theme/highlighting/brace_mismatch_color"] = p_config.dark_theme ? p_config.error_color : Color(1, 0.08, 0, 1);
+			colors["text_editor/theme/highlighting/brace_mismatch_color"] = p_config.dark_icon_and_font ? p_config.error_color : Color(1, 0.08, 0, 1);
 			colors["text_editor/theme/highlighting/current_line_color"] = alpha1;
-			colors["text_editor/theme/highlighting/line_length_guideline_color"] = p_config.dark_theme ? p_config.base_color : p_config.dark_color_2;
+			colors["text_editor/theme/highlighting/line_length_guideline_color"] = p_config.dark_icon_and_font ? p_config.base_color : p_config.dark_color_2;
 			colors["text_editor/theme/highlighting/word_highlighted_color"] = alpha1;
-			colors["text_editor/theme/highlighting/number_color"] = p_config.dark_theme ? Color(0.63, 1, 0.88) : Color(0, 0.55, 0.28, 1);
-			colors["text_editor/theme/highlighting/function_color"] = p_config.dark_theme ? Color(0.34, 0.7, 1.0) : Color(0, 0.225, 0.9, 1);
-			colors["text_editor/theme/highlighting/member_variable_color"] = p_config.dark_theme ? Color(0.34, 0.7, 1.0).lerp(p_config.mono_color, 0.6) : Color(0, 0.4, 0.68, 1);
+			colors["text_editor/theme/highlighting/number_color"] = p_config.dark_icon_and_font ? Color(0.63, 1, 0.88) : Color(0, 0.55, 0.28, 1);
+			colors["text_editor/theme/highlighting/function_color"] = p_config.dark_icon_and_font ? Color(0.34, 0.7, 1.0) : Color(0, 0.225, 0.9, 1);
+			colors["text_editor/theme/highlighting/member_variable_color"] = p_config.dark_icon_and_font ? Color(0.34, 0.7, 1.0).lerp(p_config.mono_color, 0.6) : Color(0, 0.4, 0.68, 1);
 			colors["text_editor/theme/highlighting/mark_color"] = Color(p_config.error_color.r, p_config.error_color.g, p_config.error_color.b, 0.3);
 			colors["text_editor/theme/highlighting/warning_color"] = Color(p_config.warning_color.r, p_config.warning_color.g, p_config.warning_color.b, 0.15);
 			colors["text_editor/theme/highlighting/bookmark_color"] = Color(0.08, 0.49, 0.98);
-			colors["text_editor/theme/highlighting/breakpoint_color"] = p_config.dark_theme ? p_config.error_color : Color(1, 0.27, 0.2, 1);
+			colors["text_editor/theme/highlighting/breakpoint_color"] = p_config.dark_icon_and_font ? p_config.error_color : Color(1, 0.27, 0.2, 1);
 			colors["text_editor/theme/highlighting/executing_line_color"] = Color(0.98, 0.89, 0.27);
 			colors["text_editor/theme/highlighting/code_folding_color"] = alpha3;
 			colors["text_editor/theme/highlighting/folded_code_region_color"] = Color(0.68, 0.46, 0.77, 0.2);
 			colors["text_editor/theme/highlighting/search_result_color"] = alpha1;
-			colors["text_editor/theme/highlighting/search_result_border_color"] = p_config.dark_theme ? Color(0.41, 0.61, 0.91, 0.38) : Color(0, 0.4, 1, 0.38);
+			colors["text_editor/theme/highlighting/search_result_border_color"] = p_config.dark_icon_and_font ? Color(0.41, 0.61, 0.91, 0.38) : Color(0, 0.4, 1, 0.38);
 
-			if (p_config.dark_theme) {
+			if (p_config.dark_icon_and_font) {
 				colors["text_editor/theme/highlighting/gdscript/function_definition_color"] = Color(0.4, 0.9, 1.0);
 				colors["text_editor/theme/highlighting/gdscript/global_function_color"] = Color(0.64, 0.64, 0.96);
 				colors["text_editor/theme/highlighting/gdscript/node_path_color"] = Color(0.72, 0.77, 0.49);
@@ -2938,12 +734,14 @@ bool EditorThemeManager::is_generated_theme_outdated() {
 }
 
 bool EditorThemeManager::is_dark_theme() {
-	// Light color mode for icons and fonts means it's a dark theme, and vice versa.
-	int icon_font_color_setting = EDITOR_GET("interface/theme/icon_and_font_color");
+	Color base_color = EDITOR_GET("interface/theme/base_color");
+	return base_color.get_luminance() < 0.5;
+}
 
+bool EditorThemeManager::is_dark_icon_and_font() {
+	int icon_font_color_setting = EDITOR_GET("interface/theme/icon_and_font_color");
 	if (icon_font_color_setting == ColorMode::AUTO_COLOR) {
-		Color base_color = EDITOR_GET("interface/theme/base_color");
-		return base_color.get_luminance() < 0.5;
+		return is_dark_theme();
 	}
 
 	return icon_font_color_setting == ColorMode::LIGHT_COLOR;

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -31,7 +31,10 @@
 #pragma once
 
 #include "editor/themes/editor_theme.h"
-#include "scene/resources/style_box_flat.h"
+
+class StyleBoxFlat;
+class StyleBoxLine;
+class StyleBoxTexture;
 
 class EditorThemeManager {
 	static int benchmark_run;
@@ -46,9 +49,11 @@ class EditorThemeManager {
 		LIGHT_COLOR,
 	};
 
+public:
 	struct ThemeConfiguration {
 		// Basic properties.
 
+		String style;
 		String preset;
 		String spacing_preset;
 
@@ -66,6 +71,7 @@ class EditorThemeManager {
 		int corner_radius = 3;
 
 		bool draw_extra_borders = false;
+		int draw_relationship_lines;
 		float relationship_line_opacity = 1.0;
 		int thumb_size = 16;
 		int class_icon_size = 16;
@@ -73,12 +79,18 @@ class EditorThemeManager {
 		float gizmo_handle_scale = 1.0;
 		int color_picker_button_height = 28;
 		float subresource_hue_tint = 0.0;
+		float dragging_hover_wait_msec = 0;
 
-		float default_contrast = 1.0;
+		// Make sure to keep those in sync with the definitions in the editor settings.
+		const float default_icon_saturation = 2.0;
+		const int default_relationship_lines = RELATIONSHIP_SELECTED_ONLY;
+		const float default_contrast = 0.3;
+		const int default_corner_radius = 4;
 
 		// Generated properties.
 
 		bool dark_theme = false;
+		bool dark_icon_and_font = false;
 
 		int base_margin = 4;
 		int increased_margin = 4;
@@ -89,6 +101,8 @@ class EditorThemeManager {
 		int forced_even_separation = 0;
 
 		Color mono_color;
+		Color mono_color_icon_and_font;
+		Color mono_color_inv;
 		Color dark_color_1;
 		Color dark_color_2;
 		Color dark_color_3;
@@ -103,6 +117,7 @@ class EditorThemeManager {
 		Color extra_border_color_2;
 
 		Color font_color;
+		Color font_secondary_color;
 		Color font_focus_color;
 		Color font_hover_color;
 		Color font_pressed_color;
@@ -113,10 +128,27 @@ class EditorThemeManager {
 		Color font_outline_color;
 
 		Color icon_normal_color;
+		Color icon_secondary_color;
 		Color icon_focus_color;
 		Color icon_hover_color;
 		Color icon_pressed_color;
 		Color icon_disabled_color;
+
+		Color surface_lowest_color;
+		Color surface_lower_color;
+		Color surface_low_color;
+		Color surface_base_color;
+		Color surface_high_color;
+		Color surface_higher_color;
+		Color surface_highest_color;
+
+		Color button_normal_color;
+		Color button_hover_color;
+		Color button_pressed_color;
+		Color button_disabled_color;
+		Color button_border_normal_color;
+		Color button_border_hover_color;
+		Color button_border_pressed_color;
 
 		Color shadow_color;
 		Color selection_color;
@@ -125,7 +157,9 @@ class EditorThemeManager {
 		Color separator_color;
 
 		Ref<StyleBoxFlat> base_style;
+		Ref<StyleBoxFlat> focus_style;
 		Ref<StyleBoxEmpty> base_empty_style;
+		Ref<StyleBoxEmpty> base_empty_wide_style;
 
 		Ref<StyleBoxFlat> button_style;
 		Ref<StyleBoxFlat> button_style_disabled;
@@ -133,11 +167,15 @@ class EditorThemeManager {
 		Ref<StyleBoxFlat> button_style_pressed;
 		Ref<StyleBoxFlat> button_style_hover;
 
-		Ref<StyleBoxFlat> circle_style_focus;
+		Ref<StyleBoxFlat> flat_button;
+		Ref<StyleBoxFlat> flat_button_pressed;
+		Ref<StyleBoxFlat> flat_button_hover;
 
 		Ref<StyleBoxFlat> popup_style;
 		Ref<StyleBoxFlat> popup_border_style;
+		Ref<StyleBoxFlat> popup_panel_style;
 		Ref<StyleBoxFlat> window_style;
+		Ref<StyleBoxFlat> window_complex_style;
 		Ref<StyleBoxFlat> dialog_style;
 		Ref<StyleBoxFlat> panel_container_style;
 		Ref<StyleBoxFlat> content_panel_style;
@@ -150,12 +188,15 @@ class EditorThemeManager {
 		uint32_t hash_icons();
 	};
 
+	enum RelationshipLinesMode {
+		RELATIONSHIP_NONE,
+		RELATIONSHIP_SELECTED_ONLY,
+		RELATIONSHIP_ALL,
+	};
+
+private:
 	static Ref<EditorTheme> _create_base_theme(const Ref<EditorTheme> &p_old_theme = nullptr);
 	static ThemeConfiguration _create_theme_config(const Ref<EditorTheme> &p_theme);
-
-	static void _create_shared_styles(const Ref<EditorTheme> &p_theme, ThemeConfiguration &p_config);
-	static void _populate_standard_styles(const Ref<EditorTheme> &p_theme, ThemeConfiguration &p_config);
-	static void _populate_editor_styles(const Ref<EditorTheme> &p_theme, ThemeConfiguration &p_config);
 
 	static void _populate_text_editor_styles(const Ref<EditorTheme> &p_theme, ThemeConfiguration &p_config);
 	static void _populate_visual_shader_styles(const Ref<EditorTheme> &p_theme, ThemeConfiguration &p_config);
@@ -163,10 +204,16 @@ class EditorThemeManager {
 	static void _reset_dirty_flag();
 
 public:
+	static Ref<StyleBoxFlat> make_flat_stylebox(Color p_color, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, int p_corner_width = 0);
+	static Ref<StyleBoxEmpty> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1);
+	static Ref<StyleBoxTexture> make_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, bool p_draw_center = true);
+	static Ref<StyleBoxLine> make_line_stylebox(Color p_color, int p_thickness = 1, float p_grow_begin = 1, float p_grow_end = 1, bool p_vertical = false);
+
 	static Ref<EditorTheme> generate_theme(const Ref<EditorTheme> &p_old_theme = nullptr);
 	static bool is_generated_theme_outdated();
 
 	static bool is_dark_theme();
+	static bool is_dark_icon_and_font();
 
 	static void initialize();
 	static void finalize();

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1,0 +1,2299 @@
+/**************************************************************************/
+/*  theme_classic.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "theme_classic.h"
+
+#include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
+#include "editor/themes/editor_scale.h"
+#include "editor/themes/editor_theme_manager.h"
+#include "scene/gui/graph_edit.h"
+#include "scene/resources/dpi_texture.h"
+#include "scene/resources/image_texture.h"
+#include "scene/resources/style_box_flat.h"
+#include "scene/resources/style_box_line.h"
+#include "scene/resources/style_box_texture.h"
+
+void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config) {
+	// Colors.
+	{
+		// Base colors.
+
+		p_theme->set_color("base_color", EditorStringName(Editor), p_config.base_color);
+		p_theme->set_color("accent_color", EditorStringName(Editor), p_config.accent_color);
+
+		// White (dark theme) or black (light theme), will be used to generate the rest of the colors
+		p_config.mono_color = p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0);
+		p_config.mono_color_icon_and_font = p_config.dark_icon_and_font ? Color(1, 1, 1) : Color(0, 0, 0);
+
+		// Ensure base colors are in the 0..1 luminance range to avoid 8-bit integer overflow or text rendering issues.
+		// Some places in the editor use 8-bit integer colors.
+		p_config.dark_color_1 = p_config.base_color.lerp(Color(0, 0, 0, 1), p_config.contrast).clamp();
+		p_config.dark_color_2 = p_config.base_color.lerp(Color(0, 0, 0, 1), p_config.contrast * 1.5).clamp();
+		p_config.dark_color_3 = p_config.base_color.lerp(Color(0, 0, 0, 1), p_config.contrast * 2).clamp();
+
+		p_config.contrast_color_1 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast, p_config.default_contrast));
+		p_config.contrast_color_2 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast * 1.5, p_config.default_contrast * 1.5));
+
+		p_config.highlight_color = Color(p_config.accent_color.r, p_config.accent_color.g, p_config.accent_color.b, 0.275);
+		p_config.highlight_disabled_color = p_config.highlight_color.lerp(p_config.dark_icon_and_font ? Color(0, 0, 0) : Color(1, 1, 1), 0.5);
+
+		p_config.success_color = Color(0.45, 0.95, 0.5);
+		p_config.warning_color = Color(1, 0.87, 0.4);
+		p_config.error_color = Color(1, 0.47, 0.42);
+		if (!p_config.dark_icon_and_font) {
+			// Darken some colors to be readable on a light background.
+			p_config.success_color = p_config.success_color.lerp(p_config.mono_color_icon_and_font, 0.35);
+			p_config.warning_color = Color(0.82, 0.56, 0.1);
+			p_config.error_color = Color(0.8, 0.22, 0.22);
+		}
+
+		p_theme->set_color("mono_color", EditorStringName(Editor), p_config.mono_color);
+		p_theme->set_color("dark_color_1", EditorStringName(Editor), p_config.dark_color_1);
+		p_theme->set_color("dark_color_2", EditorStringName(Editor), p_config.dark_color_2);
+		p_theme->set_color("dark_color_3", EditorStringName(Editor), p_config.dark_color_3);
+		p_theme->set_color("contrast_color_1", EditorStringName(Editor), p_config.contrast_color_1);
+		p_theme->set_color("contrast_color_2", EditorStringName(Editor), p_config.contrast_color_2);
+		p_theme->set_color("highlight_color", EditorStringName(Editor), p_config.highlight_color);
+		p_theme->set_color("highlight_disabled_color", EditorStringName(Editor), p_config.highlight_disabled_color);
+		p_theme->set_color("success_color", EditorStringName(Editor), p_config.success_color);
+		p_theme->set_color("warning_color", EditorStringName(Editor), p_config.warning_color);
+		p_theme->set_color("error_color", EditorStringName(Editor), p_config.error_color);
+#ifndef DISABLE_DEPRECATED // Used before 4.3.
+		p_theme->set_color("disabled_highlight_color", EditorStringName(Editor), p_config.highlight_disabled_color);
+#endif
+
+		// Only used when the Draw Extra Borders editor setting is enabled.
+		p_config.extra_border_color_1 = Color(0.5, 0.5, 0.5);
+		p_config.extra_border_color_2 = p_config.dark_theme ? Color(0.3, 0.3, 0.3) : Color(0.7, 0.7, 0.7);
+
+		p_theme->set_color("extra_border_color_1", EditorStringName(Editor), p_config.extra_border_color_1);
+		p_theme->set_color("extra_border_color_2", EditorStringName(Editor), p_config.extra_border_color_2);
+
+		// Font colors.
+
+		p_config.font_color = p_config.mono_color_icon_and_font.lerp(p_config.base_color, 0.25);
+		p_config.font_focus_color = p_config.mono_color_icon_and_font.lerp(p_config.base_color, 0.125);
+		p_config.font_hover_color = p_config.mono_color_icon_and_font.lerp(p_config.base_color, 0.125);
+		p_config.font_pressed_color = p_config.accent_color;
+		p_config.font_hover_pressed_color = p_config.font_hover_color.lerp(p_config.accent_color, 0.74);
+		p_config.font_disabled_color = Color(p_config.mono_color_icon_and_font.r, p_config.mono_color_icon_and_font.g, p_config.mono_color_icon_and_font.b, 0.35);
+		p_config.font_readonly_color = Color(p_config.mono_color_icon_and_font.r, p_config.mono_color_icon_and_font.g, p_config.mono_color_icon_and_font.b, 0.65);
+		p_config.font_placeholder_color = Color(p_config.mono_color_icon_and_font.r, p_config.mono_color_icon_and_font.g, p_config.mono_color_icon_and_font.b, 0.5);
+		p_config.font_outline_color = Color(0, 0, 0, 0);
+
+		p_theme->set_color(SceneStringName(font_color), EditorStringName(Editor), p_config.font_color);
+		p_theme->set_color("font_focus_color", EditorStringName(Editor), p_config.font_focus_color);
+		p_theme->set_color("font_hover_color", EditorStringName(Editor), p_config.font_hover_color);
+		p_theme->set_color("font_pressed_color", EditorStringName(Editor), p_config.font_pressed_color);
+		p_theme->set_color("font_hover_pressed_color", EditorStringName(Editor), p_config.font_hover_pressed_color);
+		p_theme->set_color("font_disabled_color", EditorStringName(Editor), p_config.font_disabled_color);
+		p_theme->set_color("font_readonly_color", EditorStringName(Editor), p_config.font_readonly_color);
+		p_theme->set_color("font_placeholder_color", EditorStringName(Editor), p_config.font_placeholder_color);
+		p_theme->set_color("font_outline_color", EditorStringName(Editor), p_config.font_outline_color);
+#ifndef DISABLE_DEPRECATED // Used before 4.3.
+		p_theme->set_color("readonly_font_color", EditorStringName(Editor), p_config.font_readonly_color);
+		p_theme->set_color("disabled_font_color", EditorStringName(Editor), p_config.font_disabled_color);
+		p_theme->set_color("readonly_color", EditorStringName(Editor), p_config.font_readonly_color);
+		p_theme->set_color("highlighted_font_color", EditorStringName(Editor), p_config.font_hover_color); // Closest equivalent.
+#endif
+
+		// Icon colors.
+
+		p_config.icon_normal_color = Color(1, 1, 1);
+		p_config.icon_focus_color = p_config.icon_normal_color * (p_config.dark_icon_and_font ? 1.15 : 1.45);
+		p_config.icon_focus_color.a = 1.0;
+		p_config.icon_hover_color = p_config.icon_focus_color;
+		// Make the pressed icon color overbright because icons are not completely white on a dark theme.
+		// On a light theme, icons are dark, so we need to modulate them with an even brighter color.
+		p_config.icon_pressed_color = p_config.accent_color * (p_config.dark_icon_and_font ? 1.15 : 3.5);
+		p_config.icon_pressed_color.a = 1.0;
+		p_config.icon_disabled_color = Color(p_config.icon_normal_color, 0.4);
+
+		p_theme->set_color("icon_normal_color", EditorStringName(Editor), p_config.icon_normal_color);
+		p_theme->set_color("icon_focus_color", EditorStringName(Editor), p_config.icon_focus_color);
+		p_theme->set_color("icon_hover_color", EditorStringName(Editor), p_config.icon_hover_color);
+		p_theme->set_color("icon_pressed_color", EditorStringName(Editor), p_config.icon_pressed_color);
+		p_theme->set_color("icon_disabled_color", EditorStringName(Editor), p_config.icon_disabled_color);
+
+		// Additional GUI colors.
+
+		p_config.shadow_color = Color(0, 0, 0, p_config.dark_theme ? 0.3 : 0.1);
+		p_config.selection_color = p_config.accent_color * Color(1, 1, 1, 0.4);
+		p_config.disabled_border_color = p_config.mono_color.inverted().lerp(p_config.base_color, 0.7);
+		p_config.disabled_bg_color = p_config.mono_color.inverted().lerp(p_config.base_color, 0.9);
+		p_config.separator_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.1);
+
+		p_theme->set_color("selection_color", EditorStringName(Editor), p_config.selection_color);
+		p_theme->set_color("disabled_border_color", EditorStringName(Editor), p_config.disabled_border_color);
+		p_theme->set_color("disabled_bg_color", EditorStringName(Editor), p_config.disabled_bg_color);
+		p_theme->set_color("separator_color", EditorStringName(Editor), p_config.separator_color);
+
+		// Additional editor colors.
+
+		p_theme->set_color("box_selection_fill_color", EditorStringName(Editor), p_config.accent_color * Color(1, 1, 1, 0.3));
+		p_theme->set_color("box_selection_stroke_color", EditorStringName(Editor), p_config.accent_color * Color(1, 1, 1, 0.8));
+
+		p_theme->set_color("axis_x_color", EditorStringName(Editor), Color(0.96, 0.20, 0.32));
+		p_theme->set_color("axis_y_color", EditorStringName(Editor), Color(0.53, 0.84, 0.01));
+		p_theme->set_color("axis_z_color", EditorStringName(Editor), Color(0.16, 0.55, 0.96));
+		p_theme->set_color("axis_w_color", EditorStringName(Editor), Color(0.55, 0.55, 0.55));
+
+		const float prop_color_saturation = p_config.accent_color.get_s() * 0.75;
+		const float prop_color_value = p_config.accent_color.get_v();
+
+		p_theme->set_color("property_color_x", EditorStringName(Editor), Color::from_hsv(0.0 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
+		p_theme->set_color("property_color_y", EditorStringName(Editor), Color::from_hsv(1.0 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
+		p_theme->set_color("property_color_z", EditorStringName(Editor), Color::from_hsv(2.0 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
+		p_theme->set_color("property_color_w", EditorStringName(Editor), Color::from_hsv(1.5 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
+
+		// Special colors for rendering methods.
+
+		p_theme->set_color("forward_plus_color", EditorStringName(Editor), Color::hex(0x5d8c3fff));
+		p_theme->set_color("mobile_color", EditorStringName(Editor), Color::hex(0xa5557dff));
+		p_theme->set_color("gl_compatibility_color", EditorStringName(Editor), Color::hex(0x5586a4ff));
+
+		if (p_config.dark_theme) {
+			p_theme->set_color("highend_color", EditorStringName(Editor), Color(1.0, 0.0, 0.0));
+		} else {
+			p_theme->set_color("highend_color", EditorStringName(Editor), Color::hex(0xad1128ff));
+		}
+	}
+
+	// Constants.
+	{
+		// Can't save single float in theme, so using Color.
+		p_theme->set_color("icon_saturation", EditorStringName(Editor), Color(p_config.icon_saturation, p_config.icon_saturation, p_config.icon_saturation));
+
+		// Controls may rely on the scale for their internal drawing logic.
+		p_theme->set_default_base_scale(EDSCALE);
+		p_theme->set_constant("scale", EditorStringName(Editor), EDSCALE);
+
+		p_theme->set_constant("thumb_size", EditorStringName(Editor), p_config.thumb_size);
+		p_theme->set_constant("class_icon_size", EditorStringName(Editor), p_config.class_icon_size);
+		p_theme->set_constant("color_picker_button_height", EditorStringName(Editor), p_config.color_picker_button_height);
+		p_theme->set_constant("gizmo_handle_scale", EditorStringName(Editor), p_config.gizmo_handle_scale);
+
+		p_theme->set_constant("base_margin", EditorStringName(Editor), p_config.base_margin);
+		p_theme->set_constant("increased_margin", EditorStringName(Editor), p_config.increased_margin);
+		p_theme->set_constant("window_border_margin", EditorStringName(Editor), p_config.window_border_margin);
+		p_theme->set_constant("top_bar_separation", EditorStringName(Editor), p_config.top_bar_separation);
+
+		p_theme->set_constant("dark_theme", EditorStringName(Editor), p_config.dark_theme);
+	}
+
+	// Styleboxes.
+	{
+		// This is the basic stylebox, used as a base for most other styleboxes (through `duplicate()`).
+		p_config.base_style = EditorThemeManager::make_flat_stylebox(p_config.base_color, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.corner_radius);
+		p_config.base_style->set_border_width_all(p_config.border_width);
+		p_config.base_style->set_border_color(p_config.base_color);
+
+		p_config.base_empty_style = EditorThemeManager::make_empty_stylebox(p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
+
+		// Button styles.
+		{
+			p_config.widget_margin = Vector2(p_config.increased_margin + 2, p_config.increased_margin + 1) * EDSCALE;
+
+			p_config.button_style = p_config.base_style->duplicate();
+			p_config.button_style->set_content_margin_individual(p_config.widget_margin.x, p_config.widget_margin.y, p_config.widget_margin.x, p_config.widget_margin.y);
+			p_config.button_style->set_bg_color(p_config.dark_color_1);
+			if (p_config.draw_extra_borders) {
+				p_config.button_style->set_border_width_all(Math::round(EDSCALE));
+				p_config.button_style->set_border_color(p_config.extra_border_color_1);
+			} else {
+				p_config.button_style->set_border_color(p_config.dark_color_2);
+			}
+
+			p_config.button_style_disabled = p_config.button_style->duplicate();
+			p_config.button_style_disabled->set_bg_color(p_config.disabled_bg_color);
+			if (p_config.draw_extra_borders) {
+				p_config.button_style_disabled->set_border_color(p_config.extra_border_color_2);
+			} else {
+				p_config.button_style_disabled->set_border_color(p_config.disabled_border_color);
+			}
+
+			p_config.button_style_focus = p_config.button_style->duplicate();
+			p_config.button_style_focus->set_draw_center(false);
+			p_config.button_style_focus->set_border_width_all(Math::round(2 * MAX(1, EDSCALE)));
+			p_config.button_style_focus->set_border_color(p_config.accent_color);
+
+			p_config.button_style_pressed = p_config.button_style->duplicate();
+			p_config.button_style_pressed->set_bg_color(p_config.dark_color_1.darkened(0.125));
+
+			p_config.button_style_hover = p_config.button_style->duplicate();
+			p_config.button_style_hover->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.11));
+			if (p_config.draw_extra_borders) {
+				p_config.button_style_hover->set_border_color(p_config.extra_border_color_1);
+			} else {
+				p_config.button_style_hover->set_border_color(p_config.mono_color * Color(1, 1, 1, 0.05));
+			}
+		}
+
+		// Windows and popups.
+		{
+			p_config.popup_style = p_config.base_style->duplicate();
+			p_config.popup_style->set_content_margin_all(p_config.popup_margin);
+			p_config.popup_style->set_border_color(p_config.contrast_color_1);
+			p_config.popup_style->set_shadow_color(p_config.shadow_color);
+			p_config.popup_style->set_shadow_size(4 * EDSCALE);
+			// Popups are separate windows by default in the editor. Windows currently don't support per-pixel transparency
+			// in 4.0, and even if it was, it may not always work in practice (e.g. running with compositing disabled).
+			p_config.popup_style->set_corner_radius_all(0);
+
+			p_config.popup_border_style = p_config.popup_style->duplicate();
+			p_config.popup_border_style->set_content_margin_all(MAX(Math::round(EDSCALE), p_config.border_width) + 2 + (p_config.base_margin * 1.5) * EDSCALE);
+			// Always display a border for popups like PopupMenus so they can be distinguished from their background.
+			p_config.popup_border_style->set_border_width_all(MAX(Math::round(EDSCALE), p_config.border_width));
+			if (p_config.draw_extra_borders) {
+				p_config.popup_border_style->set_border_color(p_config.extra_border_color_2);
+			} else {
+				p_config.popup_border_style->set_border_color(p_config.dark_color_2);
+			}
+
+			p_config.window_style = p_config.popup_style->duplicate();
+			p_config.window_style->set_border_color(p_config.base_color);
+			p_config.window_style->set_border_width(SIDE_TOP, 24 * EDSCALE);
+			p_config.window_style->set_expand_margin(SIDE_TOP, 24 * EDSCALE);
+
+			// Prevent corner artifacts between window title and body.
+			p_config.dialog_style = p_config.base_style->duplicate();
+			p_config.dialog_style->set_corner_radius(CORNER_TOP_LEFT, 0);
+			p_config.dialog_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
+			p_config.dialog_style->set_content_margin_all(p_config.popup_margin);
+			// Prevent visible line between window title and body.
+			p_config.dialog_style->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
+		}
+
+		// Panels.
+		{
+			p_config.panel_container_style = p_config.button_style->duplicate();
+			p_config.panel_container_style->set_draw_center(false);
+			p_config.panel_container_style->set_border_width_all(0);
+
+			// Content panel for tabs and similar containers.
+
+			// Compensate for the border.
+			const int content_panel_margin = p_config.base_margin * EDSCALE + p_config.border_width;
+
+			p_config.content_panel_style = p_config.base_style->duplicate();
+			p_config.content_panel_style->set_border_color(p_config.dark_color_3);
+			p_config.content_panel_style->set_border_width_all(p_config.border_width);
+			p_config.content_panel_style->set_border_width(Side::SIDE_TOP, 0);
+			p_config.content_panel_style->set_corner_radius(CORNER_TOP_LEFT, 0);
+			p_config.content_panel_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
+			p_config.content_panel_style->set_content_margin_individual(content_panel_margin, 2 * EDSCALE + content_panel_margin, content_panel_margin, content_panel_margin);
+
+			// Trees and similarly inset panels.
+
+			p_config.tree_panel_style = p_config.base_style->duplicate();
+			// Make Trees easier to distinguish from other controls by using a darker background color.
+			p_config.tree_panel_style->set_bg_color(p_config.dark_color_1.lerp(p_config.dark_color_2, 0.5));
+			if (p_config.draw_extra_borders) {
+				p_config.tree_panel_style->set_border_width_all(Math::round(EDSCALE));
+				p_config.tree_panel_style->set_border_color(p_config.extra_border_color_2);
+			} else {
+				p_config.tree_panel_style->set_border_color(p_config.dark_color_3);
+			}
+		}
+	}
+}
+
+void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config) {
+	// Panels.
+	{
+		// Panel.
+		p_theme->set_stylebox(SceneStringName(panel), "Panel", EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 6, 4, 6, 4, p_config.corner_radius));
+
+		// PanelContainer.
+		p_theme->set_stylebox(SceneStringName(panel), "PanelContainer", p_config.panel_container_style);
+
+		// TooltipPanel & TooltipLabel.
+		{
+			// TooltipPanel is also used for custom tooltips, while TooltipLabel
+			// is only relevant for default tooltips.
+
+			p_theme->set_color(SceneStringName(font_color), "TooltipLabel", p_config.font_hover_color);
+			p_theme->set_color("font_shadow_color", "TooltipLabel", Color(0, 0, 0, 0));
+
+			Ref<StyleBoxFlat> style_tooltip = p_config.popup_style->duplicate();
+			style_tooltip->set_shadow_size(0);
+			style_tooltip->set_content_margin_all(p_config.base_margin * EDSCALE * 0.5);
+			style_tooltip->set_bg_color(p_config.dark_color_3 * Color(0.8, 0.8, 0.8, 0.9));
+			if (p_config.draw_extra_borders) {
+				style_tooltip->set_border_width_all(Math::round(EDSCALE));
+				style_tooltip->set_border_color(p_config.extra_border_color_2);
+			} else {
+				style_tooltip->set_border_width_all(0);
+			}
+			p_theme->set_stylebox(SceneStringName(panel), "TooltipPanel", style_tooltip);
+		}
+
+		// PopupPanel
+		p_theme->set_stylebox(SceneStringName(panel), "PopupPanel", p_config.popup_border_style);
+	}
+
+	// Buttons.
+	{
+		// Button.
+
+		p_theme->set_stylebox(CoreStringName(normal), "Button", p_config.button_style);
+		p_theme->set_stylebox(SceneStringName(hover), "Button", p_config.button_style_hover);
+		p_theme->set_stylebox(SceneStringName(pressed), "Button", p_config.button_style_pressed);
+		p_theme->set_stylebox("focus", "Button", p_config.button_style_focus);
+		p_theme->set_stylebox("disabled", "Button", p_config.button_style_disabled);
+
+		p_theme->set_color(SceneStringName(font_color), "Button", p_config.font_color);
+		p_theme->set_color("font_hover_color", "Button", p_config.font_hover_color);
+		p_theme->set_color("font_hover_pressed_color", "Button", p_config.font_hover_pressed_color);
+		p_theme->set_color("font_focus_color", "Button", p_config.font_focus_color);
+		p_theme->set_color("font_pressed_color", "Button", p_config.font_pressed_color);
+		p_theme->set_color("font_disabled_color", "Button", p_config.font_disabled_color);
+		p_theme->set_color("font_outline_color", "Button", p_config.font_outline_color);
+
+		p_theme->set_color("icon_normal_color", "Button", p_config.icon_normal_color);
+		p_theme->set_color("icon_hover_color", "Button", p_config.icon_hover_color);
+		p_theme->set_color("icon_focus_color", "Button", p_config.icon_focus_color);
+		p_theme->set_color("icon_hover_pressed_color", "Button", p_config.icon_pressed_color);
+		p_theme->set_color("icon_pressed_color", "Button", p_config.icon_pressed_color);
+		p_theme->set_color("icon_disabled_color", "Button", p_config.icon_disabled_color);
+
+		p_theme->set_constant("h_separation", "Button", 4 * EDSCALE);
+		p_theme->set_constant("outline_size", "Button", 0);
+
+		p_theme->set_constant("align_to_largest_stylebox", "Button", 1); // Enabled.
+
+		// MenuButton.
+
+		p_theme->set_stylebox(CoreStringName(normal), "MenuButton", p_config.panel_container_style);
+		p_theme->set_stylebox(SceneStringName(hover), "MenuButton", p_config.button_style_hover);
+		p_theme->set_stylebox(SceneStringName(pressed), "MenuButton", p_config.panel_container_style);
+		p_theme->set_stylebox("focus", "MenuButton", p_config.panel_container_style);
+		p_theme->set_stylebox("disabled", "MenuButton", p_config.panel_container_style);
+
+		p_theme->set_color(SceneStringName(font_color), "MenuButton", p_config.font_color);
+		p_theme->set_color("font_hover_color", "MenuButton", p_config.font_hover_color);
+		p_theme->set_color("font_hover_pressed_color", "MenuButton", p_config.font_hover_pressed_color);
+		p_theme->set_color("font_focus_color", "MenuButton", p_config.font_focus_color);
+		p_theme->set_color("font_outline_color", "MenuButton", p_config.font_outline_color);
+
+		p_theme->set_constant("outline_size", "MenuButton", 0);
+
+		// MenuBar.
+
+		p_theme->set_stylebox(CoreStringName(normal), "MenuBar", p_config.button_style);
+		p_theme->set_stylebox(SceneStringName(hover), "MenuBar", p_config.button_style_hover);
+		p_theme->set_stylebox(SceneStringName(pressed), "MenuBar", p_config.button_style_pressed);
+		p_theme->set_stylebox("disabled", "MenuBar", p_config.button_style_disabled);
+
+		p_theme->set_color(SceneStringName(font_color), "MenuBar", p_config.font_color);
+		p_theme->set_color("font_hover_color", "MenuBar", p_config.font_hover_color);
+		p_theme->set_color("font_hover_pressed_color", "MenuBar", p_config.font_hover_pressed_color);
+		p_theme->set_color("font_focus_color", "MenuBar", p_config.font_focus_color);
+		p_theme->set_color("font_pressed_color", "MenuBar", p_config.font_pressed_color);
+		p_theme->set_color("font_disabled_color", "MenuBar", p_config.font_disabled_color);
+		p_theme->set_color("font_outline_color", "MenuBar", p_config.font_outline_color);
+
+		p_theme->set_constant("h_separation", "MenuBar", 4 * EDSCALE);
+		p_theme->set_constant("outline_size", "MenuBar", 0);
+
+		// OptionButton.
+		{
+			Ref<StyleBoxFlat> option_button_focus_style = p_config.button_style_focus->duplicate();
+			Ref<StyleBoxFlat> option_button_normal_style = p_config.button_style->duplicate();
+			Ref<StyleBoxFlat> option_button_hover_style = p_config.button_style_hover->duplicate();
+			Ref<StyleBoxFlat> option_button_pressed_style = p_config.button_style_pressed->duplicate();
+			Ref<StyleBoxFlat> option_button_disabled_style = p_config.button_style_disabled->duplicate();
+
+			option_button_focus_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+			option_button_normal_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+			option_button_hover_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+			option_button_pressed_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+			option_button_disabled_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+
+			p_theme->set_stylebox("focus", "OptionButton", option_button_focus_style);
+			p_theme->set_stylebox(CoreStringName(normal), "OptionButton", p_config.button_style);
+			p_theme->set_stylebox(SceneStringName(hover), "OptionButton", p_config.button_style_hover);
+			p_theme->set_stylebox(SceneStringName(pressed), "OptionButton", p_config.button_style_pressed);
+			p_theme->set_stylebox("disabled", "OptionButton", p_config.button_style_disabled);
+
+			p_theme->set_stylebox("normal_mirrored", "OptionButton", option_button_normal_style);
+			p_theme->set_stylebox("hover_mirrored", "OptionButton", option_button_hover_style);
+			p_theme->set_stylebox("pressed_mirrored", "OptionButton", option_button_pressed_style);
+			p_theme->set_stylebox("disabled_mirrored", "OptionButton", option_button_disabled_style);
+
+			p_theme->set_color(SceneStringName(font_color), "OptionButton", p_config.font_color);
+			p_theme->set_color("font_hover_color", "OptionButton", p_config.font_hover_color);
+			p_theme->set_color("font_hover_pressed_color", "OptionButton", p_config.font_hover_pressed_color);
+			p_theme->set_color("font_focus_color", "OptionButton", p_config.font_focus_color);
+			p_theme->set_color("font_pressed_color", "OptionButton", p_config.font_pressed_color);
+			p_theme->set_color("font_disabled_color", "OptionButton", p_config.font_disabled_color);
+			p_theme->set_color("font_outline_color", "OptionButton", p_config.font_outline_color);
+
+			p_theme->set_color("icon_normal_color", "OptionButton", p_config.icon_normal_color);
+			p_theme->set_color("icon_hover_color", "OptionButton", p_config.icon_hover_color);
+			p_theme->set_color("icon_focus_color", "OptionButton", p_config.icon_focus_color);
+			p_theme->set_color("icon_pressed_color", "OptionButton", p_config.icon_pressed_color);
+			p_theme->set_color("icon_disabled_color", "OptionButton", p_config.icon_disabled_color);
+
+			p_theme->set_icon("arrow", "OptionButton", p_theme->get_icon(SNAME("GuiOptionArrow"), EditorStringName(EditorIcons)));
+			p_theme->set_constant("arrow_margin", "OptionButton", p_config.widget_margin.x - 2 * EDSCALE);
+			p_theme->set_constant("modulate_arrow", "OptionButton", true);
+			p_theme->set_constant("h_separation", "OptionButton", 4 * EDSCALE);
+			p_theme->set_constant("outline_size", "OptionButton", 0);
+		}
+
+		// CheckButton.
+
+		p_theme->set_stylebox(CoreStringName(normal), "CheckButton", p_config.panel_container_style);
+		p_theme->set_stylebox(SceneStringName(pressed), "CheckButton", p_config.panel_container_style);
+		p_theme->set_stylebox("disabled", "CheckButton", p_config.panel_container_style);
+		p_theme->set_stylebox(SceneStringName(hover), "CheckButton", p_config.panel_container_style);
+		p_theme->set_stylebox("hover_pressed", "CheckButton", p_config.panel_container_style);
+
+		p_theme->set_icon("checked", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOn"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("checked_disabled", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOnDisabled"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("unchecked", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOff"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("unchecked_disabled", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffDisabled"), EditorStringName(EditorIcons)));
+
+		p_theme->set_icon("checked_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOnMirrored"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("checked_disabled_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOnDisabledMirrored"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("unchecked_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffMirrored"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("unchecked_disabled_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffDisabledMirrored"), EditorStringName(EditorIcons)));
+
+		p_theme->set_color(SceneStringName(font_color), "CheckButton", p_config.font_color);
+		p_theme->set_color("font_hover_color", "CheckButton", p_config.font_hover_color);
+		p_theme->set_color("font_hover_pressed_color", "CheckButton", p_config.font_hover_pressed_color);
+		p_theme->set_color("font_focus_color", "CheckButton", p_config.font_focus_color);
+		p_theme->set_color("font_pressed_color", "CheckButton", p_config.font_pressed_color);
+		p_theme->set_color("font_disabled_color", "CheckButton", p_config.font_disabled_color);
+		p_theme->set_color("font_outline_color", "CheckButton", p_config.font_outline_color);
+
+		p_theme->set_color("icon_normal_color", "CheckButton", p_config.icon_normal_color);
+		p_theme->set_color("icon_hover_color", "CheckButton", p_config.icon_hover_color);
+		p_theme->set_color("icon_focus_color", "CheckButton", p_config.icon_focus_color);
+		p_theme->set_color("icon_pressed_color", "CheckButton", p_config.icon_pressed_color);
+		p_theme->set_color("icon_disabled_color", "CheckButton", p_config.icon_disabled_color);
+
+		p_theme->set_constant("h_separation", "CheckButton", 8 * EDSCALE);
+		p_theme->set_constant("check_v_offset", "CheckButton", 0);
+		p_theme->set_constant("outline_size", "CheckButton", 0);
+
+		// CheckBox.
+		{
+			Ref<StyleBoxFlat> checkbox_style = p_config.panel_container_style->duplicate();
+
+			p_theme->set_stylebox(CoreStringName(normal), "CheckBox", checkbox_style);
+			p_theme->set_stylebox(SceneStringName(pressed), "CheckBox", checkbox_style);
+			p_theme->set_stylebox("disabled", "CheckBox", checkbox_style);
+			p_theme->set_stylebox(SceneStringName(hover), "CheckBox", checkbox_style);
+			p_theme->set_stylebox("hover_pressed", "CheckBox", checkbox_style);
+
+			p_theme->set_icon("checked", "CheckBox", p_theme->get_icon(SNAME("GuiChecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked", "CheckBox", p_theme->get_icon(SNAME("GuiUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_checked", "CheckBox", p_theme->get_icon(SNAME("GuiRadioChecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_unchecked", "CheckBox", p_theme->get_icon(SNAME("GuiRadioUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("checked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiUncheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_checked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiRadioCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_unchecked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), EditorStringName(EditorIcons)));
+
+			p_theme->set_color(SceneStringName(font_color), "CheckBox", p_config.font_color);
+			p_theme->set_color("font_hover_color", "CheckBox", p_config.font_hover_color);
+			p_theme->set_color("font_hover_pressed_color", "CheckBox", p_config.font_hover_pressed_color);
+			p_theme->set_color("font_focus_color", "CheckBox", p_config.font_focus_color);
+			p_theme->set_color("font_pressed_color", "CheckBox", p_config.font_pressed_color);
+			p_theme->set_color("font_disabled_color", "CheckBox", p_config.font_disabled_color);
+			p_theme->set_color("font_outline_color", "CheckBox", p_config.font_outline_color);
+
+			p_theme->set_color("icon_normal_color", "CheckBox", p_config.icon_normal_color);
+			p_theme->set_color("icon_hover_color", "CheckBox", p_config.icon_hover_color);
+			p_theme->set_color("icon_focus_color", "CheckBox", p_config.icon_focus_color);
+			p_theme->set_color("icon_pressed_color", "CheckBox", p_config.icon_pressed_color);
+			p_theme->set_color("icon_disabled_color", "CheckBox", p_config.icon_disabled_color);
+
+			p_theme->set_constant("h_separation", "CheckBox", 8 * EDSCALE);
+			p_theme->set_constant("check_v_offset", "CheckBox", 0);
+			p_theme->set_constant("outline_size", "CheckBox", 0);
+		}
+
+		// LinkButton.
+
+		p_theme->set_stylebox("focus", "LinkButton", p_config.base_empty_style);
+
+		p_theme->set_color(SceneStringName(font_color), "LinkButton", p_config.font_color);
+		p_theme->set_color("font_hover_color", "LinkButton", p_config.font_hover_color);
+		p_theme->set_color("font_hover_pressed_color", "LinkButton", p_config.font_hover_pressed_color);
+		p_theme->set_color("font_focus_color", "LinkButton", p_config.font_focus_color);
+		p_theme->set_color("font_pressed_color", "LinkButton", p_config.font_pressed_color);
+		p_theme->set_color("font_disabled_color", "LinkButton", p_config.font_disabled_color);
+		p_theme->set_color("font_outline_color", "LinkButton", p_config.font_outline_color);
+
+		p_theme->set_constant("outline_size", "LinkButton", 0);
+	}
+
+	// Tree & ItemList.
+	{
+		Ref<StyleBoxFlat> style_tree_focus = p_config.base_style->duplicate();
+		style_tree_focus->set_bg_color(p_config.highlight_color);
+		style_tree_focus->set_border_width_all(0);
+
+		Ref<StyleBoxFlat> style_tree_selected = style_tree_focus->duplicate();
+
+		const Color guide_color = p_config.mono_color * Color(1, 1, 1, 0.05);
+
+		// Tree.
+		{
+			p_theme->set_icon("checked", "Tree", p_theme->get_icon(SNAME("GuiChecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("checked_disabled", "Tree", p_theme->get_icon(SNAME("GuiCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("indeterminate", "Tree", p_theme->get_icon(SNAME("GuiIndeterminate"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("indeterminate_disabled", "Tree", p_theme->get_icon(SNAME("GuiIndeterminateDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked", "Tree", p_theme->get_icon(SNAME("GuiUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked_disabled", "Tree", p_theme->get_icon(SNAME("GuiUncheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("arrow", "Tree", p_theme->get_icon(SNAME("GuiTreeArrowDown"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("arrow_collapsed", "Tree", p_theme->get_icon(SNAME("GuiTreeArrowRight"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("arrow_collapsed_mirrored", "Tree", p_theme->get_icon(SNAME("GuiTreeArrowLeft"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("updown", "Tree", p_theme->get_icon(SNAME("GuiTreeUpdown"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("select_arrow", "Tree", p_theme->get_icon(SNAME("GuiDropdown"), EditorStringName(EditorIcons)));
+
+			p_theme->set_stylebox(SceneStringName(panel), "Tree", p_config.tree_panel_style);
+			p_theme->set_stylebox("focus", "Tree", p_config.button_style_focus);
+			p_theme->set_stylebox("custom_button", "Tree", EditorThemeManager::make_empty_stylebox());
+			p_theme->set_stylebox("custom_button_pressed", "Tree", EditorThemeManager::make_empty_stylebox());
+			p_theme->set_stylebox("custom_button_hover", "Tree", p_config.button_style);
+
+			p_theme->set_color("custom_button_font_highlight", "Tree", p_config.font_hover_color);
+			p_theme->set_color(SceneStringName(font_color), "Tree", p_config.font_color);
+			p_theme->set_color("font_hovered_color", "Tree", p_config.mono_color_icon_and_font);
+			p_theme->set_color("font_hovered_dimmed_color", "Tree", p_config.font_color);
+			p_theme->set_color("font_hovered_selected_color", "Tree", p_config.mono_color_icon_and_font);
+			p_theme->set_color("font_selected_color", "Tree", p_config.mono_color_icon_and_font);
+			p_theme->set_color("font_disabled_color", "Tree", p_config.font_disabled_color);
+			p_theme->set_color("font_outline_color", "Tree", p_config.font_outline_color);
+			p_theme->set_color("title_button_color", "Tree", p_config.font_color);
+			p_theme->set_color("drop_position_color", "Tree", p_config.accent_color);
+
+			p_theme->set_constant("v_separation", "Tree", p_config.separation_margin);
+			p_theme->set_constant("h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("guide_width", "Tree", p_config.border_width);
+			p_theme->set_constant("item_margin", "Tree", MAX(3 * p_config.increased_margin * EDSCALE, 12 * EDSCALE));
+			p_theme->set_constant("inner_item_margin_top", "Tree", p_config.separation_margin);
+			p_theme->set_constant("inner_item_margin_bottom", "Tree", p_config.separation_margin);
+			p_theme->set_constant("inner_item_margin_left", "Tree", p_config.increased_margin * EDSCALE);
+			p_theme->set_constant("inner_item_margin_right", "Tree", p_config.increased_margin * EDSCALE);
+			p_theme->set_constant("button_margin", "Tree", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("dragging_unfold_wait_msec", "Tree", p_config.dragging_hover_wait_msec);
+			p_theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
+			p_theme->set_constant("scroll_speed", "Tree", 12);
+			p_theme->set_constant("outline_size", "Tree", 0);
+			p_theme->set_constant("scrollbar_margin_left", "Tree", 0);
+			p_theme->set_constant("scrollbar_margin_top", "Tree", 0);
+			p_theme->set_constant("scrollbar_margin_right", "Tree", 0);
+			p_theme->set_constant("scrollbar_margin_bottom", "Tree", 0);
+			p_theme->set_constant("scrollbar_h_separation", "Tree", 1 * EDSCALE);
+			p_theme->set_constant("scrollbar_v_separation", "Tree", 1 * EDSCALE);
+
+			Color relationship_line_color = p_config.mono_color * Color(1, 1, 1, p_config.relationship_line_opacity);
+
+			int draw_relationship_lines = 0;
+			int relationship_line_width = 0;
+			int highlighted_line_width = 2;
+			if (p_config.draw_relationship_lines == EditorThemeManager::RELATIONSHIP_ALL) {
+				draw_relationship_lines = 1;
+				relationship_line_width = highlighted_line_width;
+			} else if (p_config.draw_relationship_lines == EditorThemeManager::RELATIONSHIP_SELECTED_ONLY) {
+				draw_relationship_lines = 1;
+			}
+
+			p_theme->set_constant("draw_guides", "Tree", !draw_relationship_lines || p_config.relationship_line_opacity < 0.01);
+			p_theme->set_color("guide_color", "Tree", guide_color);
+
+			Color parent_line_color = p_config.mono_color * Color(1, 1, 1, CLAMP(p_config.relationship_line_opacity + 0.45, 0.0, 1.0));
+			Color children_line_color = p_config.mono_color * Color(1, 1, 1, CLAMP(p_config.relationship_line_opacity + 0.25, 0.0, 1.0));
+
+			p_theme->set_constant("draw_relationship_lines", "Tree", draw_relationship_lines && p_config.relationship_line_opacity >= 0.01);
+			p_theme->set_constant("relationship_line_width", "Tree", relationship_line_width);
+			p_theme->set_constant("parent_hl_line_width", "Tree", highlighted_line_width);
+			p_theme->set_constant("children_hl_line_width", "Tree", highlighted_line_width / 2);
+			p_theme->set_constant("parent_hl_line_margin", "Tree", 3);
+			p_theme->set_color("relationship_line_color", "Tree", relationship_line_color);
+			p_theme->set_color("parent_hl_line_color", "Tree", parent_line_color);
+			p_theme->set_color("children_hl_line_color", "Tree", children_line_color);
+			p_theme->set_color("drop_position_color", "Tree", p_config.accent_color);
+
+			Ref<StyleBoxFlat> style_tree_btn = p_config.base_style->duplicate();
+			style_tree_btn->set_bg_color(p_config.highlight_color);
+			style_tree_btn->set_border_width_all(0);
+			p_theme->set_stylebox("button_pressed", "Tree", style_tree_btn);
+
+			Ref<StyleBoxFlat> style_tree_hover = p_config.base_style->duplicate();
+			style_tree_hover->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 0.4));
+			style_tree_hover->set_border_width_all(0);
+			p_theme->set_stylebox("hovered", "Tree", style_tree_hover);
+			p_theme->set_stylebox("button_hover", "Tree", style_tree_hover);
+
+			Ref<StyleBoxFlat> style_tree_hover_dimmed = p_config.base_style->duplicate();
+			style_tree_hover_dimmed->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 0.2));
+			style_tree_hover_dimmed->set_border_width_all(0);
+			p_theme->set_stylebox("hovered_dimmed", "Tree", style_tree_hover_dimmed);
+
+			Ref<StyleBoxFlat> style_tree_hover_selected = style_tree_selected->duplicate();
+			style_tree_hover_selected->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 1.2));
+			style_tree_hover_selected->set_border_width_all(0);
+
+			p_theme->set_stylebox("hovered_selected", "Tree", style_tree_hover_selected);
+			p_theme->set_stylebox("hovered_selected_focus", "Tree", style_tree_hover_selected);
+
+			p_theme->set_stylebox("selected_focus", "Tree", style_tree_focus);
+			p_theme->set_stylebox("selected", "Tree", style_tree_selected);
+
+			Ref<StyleBoxFlat> style_tree_cursor = p_config.base_style->duplicate();
+			style_tree_cursor->set_draw_center(false);
+			style_tree_cursor->set_border_width_all(MAX(1, p_config.border_width));
+			style_tree_cursor->set_border_color(p_config.contrast_color_1);
+
+			Ref<StyleBoxFlat> style_tree_title = p_config.base_style->duplicate();
+			style_tree_title->set_bg_color(p_config.dark_color_3);
+			style_tree_title->set_border_width_all(0);
+			p_theme->set_stylebox("cursor", "Tree", style_tree_cursor);
+			p_theme->set_stylebox("cursor_unfocused", "Tree", style_tree_cursor);
+			p_theme->set_stylebox("title_button_normal", "Tree", style_tree_title);
+			p_theme->set_stylebox("title_button_hover", "Tree", style_tree_title);
+			p_theme->set_stylebox("title_button_pressed", "Tree", style_tree_title);
+		}
+
+		// ItemList.
+		{
+			Ref<StyleBoxFlat> style_itemlist_bg = p_config.base_style->duplicate();
+			style_itemlist_bg->set_content_margin_all(p_config.separation_margin);
+			style_itemlist_bg->set_bg_color(p_config.dark_color_1);
+
+			if (p_config.draw_extra_borders) {
+				style_itemlist_bg->set_border_width_all(Math::round(EDSCALE));
+				style_itemlist_bg->set_border_color(p_config.extra_border_color_2);
+			} else {
+				style_itemlist_bg->set_border_width_all(p_config.border_width);
+				style_itemlist_bg->set_border_color(p_config.dark_color_3);
+			}
+
+			Ref<StyleBoxFlat> style_itemlist_cursor = p_config.base_style->duplicate();
+			style_itemlist_cursor->set_draw_center(false);
+			style_itemlist_cursor->set_border_width_all(MAX(1 * EDSCALE, p_config.border_width));
+			style_itemlist_cursor->set_border_color(p_config.highlight_color);
+
+			Ref<StyleBoxFlat> style_itemlist_hover = style_tree_selected->duplicate();
+			style_itemlist_hover->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 0.3));
+			style_itemlist_hover->set_border_width_all(0);
+
+			Ref<StyleBoxFlat> style_itemlist_hover_selected = style_tree_selected->duplicate();
+			style_itemlist_hover_selected->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 1.2));
+			style_itemlist_hover_selected->set_border_width_all(0);
+
+			p_theme->set_stylebox(SceneStringName(panel), "ItemList", style_itemlist_bg);
+			p_theme->set_stylebox("focus", "ItemList", p_config.button_style_focus);
+			p_theme->set_stylebox("cursor", "ItemList", style_itemlist_cursor);
+			p_theme->set_stylebox("cursor_unfocused", "ItemList", style_itemlist_cursor);
+			p_theme->set_stylebox("selected_focus", "ItemList", style_tree_focus);
+			p_theme->set_stylebox("selected", "ItemList", style_tree_selected);
+			p_theme->set_stylebox("hovered", "ItemList", style_itemlist_hover);
+			p_theme->set_stylebox("hovered_selected", "ItemList", style_itemlist_hover_selected);
+			p_theme->set_stylebox("hovered_selected_focus", "ItemList", style_itemlist_hover_selected);
+			p_theme->set_color(SceneStringName(font_color), "ItemList", p_config.font_color);
+			p_theme->set_color("font_hovered_color", "ItemList", p_config.mono_color_icon_and_font);
+			p_theme->set_color("font_hovered_selected_color", "ItemList", p_config.mono_color_icon_and_font);
+			p_theme->set_color("font_selected_color", "ItemList", p_config.mono_color_icon_and_font);
+			p_theme->set_color("font_outline_color", "ItemList", p_config.font_outline_color);
+			p_theme->set_color("guide_color", "ItemList", Color(1, 1, 1, 0));
+			p_theme->set_constant("v_separation", "ItemList", p_config.forced_even_separation * EDSCALE);
+			p_theme->set_constant("h_separation", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("icon_margin", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant(SceneStringName(line_separation), "ItemList", p_config.separation_margin);
+			p_theme->set_constant("outline_size", "ItemList", 0);
+		}
+	}
+
+	// TabBar & TabContainer.
+	{
+		Ref<StyleBoxFlat> style_tab_base = p_config.button_style->duplicate();
+
+		style_tab_base->set_border_width_all(0);
+		// Don't round the top corners to avoid creating a small blank space between the tabs and the main panel.
+		// This also makes the top highlight look better.
+		style_tab_base->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		style_tab_base->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+
+		// When using a border width greater than 0, visually line up the left of the selected tab with the underlying panel.
+		style_tab_base->set_expand_margin(SIDE_LEFT, -p_config.border_width);
+
+		style_tab_base->set_content_margin(SIDE_LEFT, p_config.widget_margin.x + 5 * EDSCALE);
+		style_tab_base->set_content_margin(SIDE_RIGHT, p_config.widget_margin.x + 5 * EDSCALE);
+		style_tab_base->set_content_margin(SIDE_BOTTOM, p_config.widget_margin.y);
+		style_tab_base->set_content_margin(SIDE_TOP, p_config.widget_margin.y);
+
+		Ref<StyleBoxFlat> style_tab_selected = style_tab_base->duplicate();
+
+		style_tab_selected->set_bg_color(p_config.base_color);
+		// Add a highlight line at the top of the selected tab.
+		style_tab_selected->set_border_width(SIDE_TOP, Math::round(2 * EDSCALE));
+		// Make the highlight line prominent, but not too prominent as to not be distracting.
+		Color tab_highlight = p_config.dark_color_2.lerp(p_config.accent_color, 0.75);
+		style_tab_selected->set_border_color(tab_highlight);
+		style_tab_selected->set_corner_radius_all(0);
+
+		Ref<StyleBoxFlat> style_tab_hovered = style_tab_base->duplicate();
+
+		style_tab_hovered->set_bg_color(p_config.dark_color_1.lerp(p_config.base_color, 0.4));
+		// Hovered tab has a subtle highlight between normal and selected states.
+		style_tab_hovered->set_corner_radius_all(0);
+
+		Ref<StyleBoxFlat> style_tab_unselected = style_tab_base->duplicate();
+		style_tab_unselected->set_expand_margin(SIDE_BOTTOM, 0);
+		style_tab_unselected->set_bg_color(p_config.dark_color_1);
+		// Add some spacing between unselected tabs to make them easier to distinguish from each other
+		style_tab_unselected->set_border_color(Color(0, 0, 0, 0));
+
+		Ref<StyleBoxFlat> style_tab_disabled = style_tab_base->duplicate();
+		style_tab_disabled->set_expand_margin(SIDE_BOTTOM, 0);
+		style_tab_disabled->set_bg_color(p_config.disabled_bg_color);
+		style_tab_disabled->set_border_color(p_config.disabled_bg_color);
+
+		Ref<StyleBoxFlat> style_tab_focus = p_config.button_style_focus->duplicate();
+
+		Ref<StyleBoxFlat> style_tabbar_background = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 0, 0, 0, 0, p_config.corner_radius);
+		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+		p_theme->set_stylebox("tabbar_background", "TabContainer", style_tabbar_background);
+		p_theme->set_stylebox(SceneStringName(panel), "TabContainer", p_config.content_panel_style);
+
+		p_theme->set_stylebox("tab_selected", "TabContainer", style_tab_selected);
+		p_theme->set_stylebox("tab_hovered", "TabContainer", style_tab_hovered);
+		p_theme->set_stylebox("tab_unselected", "TabContainer", style_tab_unselected);
+		p_theme->set_stylebox("tab_disabled", "TabContainer", style_tab_disabled);
+		p_theme->set_stylebox("tab_focus", "TabContainer", style_tab_focus);
+		p_theme->set_stylebox("tab_selected", "TabBar", style_tab_selected);
+		p_theme->set_stylebox("tab_hovered", "TabBar", style_tab_hovered);
+		p_theme->set_stylebox("tab_unselected", "TabBar", style_tab_unselected);
+		p_theme->set_stylebox("tab_disabled", "TabBar", style_tab_disabled);
+		p_theme->set_stylebox("tab_focus", "TabBar", style_tab_focus);
+		p_theme->set_stylebox("button_pressed", "TabBar", p_config.panel_container_style);
+		p_theme->set_stylebox("button_highlight", "TabBar", p_config.panel_container_style);
+
+		p_theme->set_color("font_selected_color", "TabContainer", p_config.font_color);
+		p_theme->set_color("font_hovered_color", "TabContainer", p_config.font_color);
+		p_theme->set_color("font_unselected_color", "TabContainer", p_config.font_disabled_color);
+		p_theme->set_color("font_outline_color", "TabContainer", p_config.font_outline_color);
+		p_theme->set_color("font_selected_color", "TabBar", p_config.font_color);
+		p_theme->set_color("font_hovered_color", "TabBar", p_config.font_color);
+		p_theme->set_color("font_unselected_color", "TabBar", p_config.font_disabled_color);
+		p_theme->set_color("font_outline_color", "TabBar", p_config.font_outline_color);
+		p_theme->set_color("drop_mark_color", "TabContainer", tab_highlight);
+		p_theme->set_color("drop_mark_color", "TabBar", tab_highlight);
+
+		Color icon_color = Color(1, 1, 1);
+		p_theme->set_color("icon_selected_color", "TabContainer", icon_color);
+		p_theme->set_color("icon_hovered_color", "TabContainer", icon_color);
+		p_theme->set_color("icon_unselected_color", "TabContainer", icon_color);
+		p_theme->set_color("icon_selected_color", "TabBar", icon_color);
+		p_theme->set_color("icon_hovered_color", "TabBar", icon_color);
+		p_theme->set_color("icon_unselected_color", "TabBar", icon_color);
+
+		p_theme->set_icon("menu", "TabContainer", p_theme->get_icon(SNAME("GuiTabMenu"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("menu_highlight", "TabContainer", p_theme->get_icon(SNAME("GuiTabMenuHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("close", "TabBar", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("increment", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowRight"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("decrement", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowLeft"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("increment", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowRight"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("decrement", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowLeft"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("increment_highlight", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowRightHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("decrement_highlight", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowLeftHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("increment_highlight", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowRightHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("decrement_highlight", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowLeftHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("drop_mark", "TabContainer", p_theme->get_icon(SNAME("GuiTabDropMark"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("drop_mark", "TabBar", p_theme->get_icon(SNAME("GuiTabDropMark"), EditorStringName(EditorIcons)));
+
+		p_theme->set_constant("side_margin", "TabContainer", 0);
+		p_theme->set_constant("outline_size", "TabContainer", 0);
+		p_theme->set_constant("h_separation", "TabBar", 4 * EDSCALE);
+		p_theme->set_constant("outline_size", "TabBar", 0);
+		p_theme->set_constant("hover_switch_wait_msec", "TabBar", p_config.dragging_hover_wait_msec);
+	}
+
+	// Separators.
+	p_theme->set_stylebox("separator", "HSeparator", EditorThemeManager::make_line_stylebox(p_config.separator_color, MAX(Math::round(EDSCALE), p_config.border_width)));
+	p_theme->set_stylebox("separator", "VSeparator", EditorThemeManager::make_line_stylebox(p_config.separator_color, MAX(Math::round(EDSCALE), p_config.border_width), 0, 0, true));
+
+	// LineEdit & TextEdit.
+	{
+		Ref<StyleBoxFlat> text_editor_style = p_config.button_style->duplicate();
+
+		// Don't round the bottom corners to make the line look sharper.
+		text_editor_style->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		text_editor_style->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+
+		if (p_config.draw_extra_borders) {
+			text_editor_style->set_border_width_all(Math::round(EDSCALE));
+			text_editor_style->set_border_color(p_config.extra_border_color_1);
+		} else {
+			// Add a bottom line to make LineEdits more visible, especially in sectioned inspectors
+			// such as the Project Settings.
+			text_editor_style->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
+			text_editor_style->set_border_color(p_config.dark_color_2);
+		}
+
+		Ref<StyleBoxFlat> text_editor_disabled_style = text_editor_style->duplicate();
+		text_editor_disabled_style->set_border_color(p_config.disabled_border_color);
+		text_editor_disabled_style->set_bg_color(p_config.disabled_bg_color);
+
+		// LineEdit.
+
+		p_theme->set_stylebox(CoreStringName(normal), "LineEdit", text_editor_style);
+		p_theme->set_stylebox("focus", "LineEdit", p_config.button_style_focus);
+		p_theme->set_stylebox("read_only", "LineEdit", text_editor_disabled_style);
+
+		p_theme->set_icon("clear", "LineEdit", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
+
+		p_theme->set_color(SceneStringName(font_color), "LineEdit", p_config.font_color);
+		p_theme->set_color("font_selected_color", "LineEdit", p_config.mono_color_icon_and_font);
+		p_theme->set_color("font_uneditable_color", "LineEdit", p_config.font_readonly_color);
+		p_theme->set_color("font_placeholder_color", "LineEdit", p_config.font_placeholder_color);
+		p_theme->set_color("font_outline_color", "LineEdit", p_config.font_outline_color);
+		p_theme->set_color("caret_color", "LineEdit", p_config.font_color);
+		p_theme->set_color("selection_color", "LineEdit", p_config.selection_color);
+		p_theme->set_color("clear_button_color", "LineEdit", p_config.font_color);
+		p_theme->set_color("clear_button_color_pressed", "LineEdit", p_config.accent_color);
+
+		p_theme->set_constant("minimum_character_width", "LineEdit", 4);
+		p_theme->set_constant("outline_size", "LineEdit", 0);
+		p_theme->set_constant("caret_width", "LineEdit", 1);
+
+		// TextEdit.
+
+		p_theme->set_stylebox(CoreStringName(normal), "TextEdit", text_editor_style);
+		p_theme->set_stylebox("focus", "TextEdit", p_config.button_style_focus);
+		p_theme->set_stylebox("read_only", "TextEdit", text_editor_disabled_style);
+
+		p_theme->set_icon("tab", "TextEdit", p_theme->get_icon(SNAME("GuiTab"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("space", "TextEdit", p_theme->get_icon(SNAME("GuiSpace"), EditorStringName(EditorIcons)));
+
+		p_theme->set_color(SceneStringName(font_color), "TextEdit", p_config.font_color);
+		p_theme->set_color("font_readonly_color", "TextEdit", p_config.font_readonly_color);
+		p_theme->set_color("font_placeholder_color", "TextEdit", p_config.font_placeholder_color);
+		p_theme->set_color("font_outline_color", "TextEdit", p_config.font_outline_color);
+		p_theme->set_color("caret_color", "TextEdit", p_config.font_color);
+		p_theme->set_color("selection_color", "TextEdit", p_config.selection_color);
+		p_theme->set_color("background_color", "TextEdit", Color(0, 0, 0, 0));
+
+		p_theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
+		p_theme->set_constant("outline_size", "TextEdit", 0);
+		p_theme->set_constant("caret_width", "TextEdit", 1);
+	}
+
+	// Containers.
+	{
+		p_theme->set_constant("separation", "BoxContainer", p_config.separation_margin);
+		p_theme->set_constant("separation", "HBoxContainer", p_config.separation_margin);
+		p_theme->set_constant("separation", "VBoxContainer", p_config.separation_margin);
+		p_theme->set_constant("margin_left", "MarginContainer", 0);
+		p_theme->set_constant("margin_top", "MarginContainer", 0);
+		p_theme->set_constant("margin_right", "MarginContainer", 0);
+		p_theme->set_constant("margin_bottom", "MarginContainer", 0);
+		p_theme->set_constant("h_separation", "GridContainer", p_config.separation_margin);
+		p_theme->set_constant("v_separation", "GridContainer", p_config.separation_margin);
+		p_theme->set_constant("h_separation", "FlowContainer", p_config.separation_margin);
+		p_theme->set_constant("v_separation", "FlowContainer", p_config.separation_margin);
+		p_theme->set_constant("h_separation", "HFlowContainer", p_config.separation_margin);
+		p_theme->set_constant("v_separation", "HFlowContainer", p_config.separation_margin);
+		p_theme->set_constant("h_separation", "VFlowContainer", p_config.separation_margin);
+		p_theme->set_constant("v_separation", "VFlowContainer", p_config.separation_margin);
+
+		// SplitContainer.
+
+		p_theme->set_icon("h_grabber", "SplitContainer", p_theme->get_icon(SNAME("GuiHsplitter"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("v_grabber", "SplitContainer", p_theme->get_icon(SNAME("GuiVsplitter"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grabber", "VSplitContainer", p_theme->get_icon(SNAME("GuiVsplitter"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grabber", "HSplitContainer", p_theme->get_icon(SNAME("GuiHsplitter"), EditorStringName(EditorIcons)));
+
+		p_theme->set_constant("separation", "SplitContainer", p_config.separation_margin);
+		p_theme->set_constant("separation", "HSplitContainer", p_config.separation_margin);
+		p_theme->set_constant("separation", "VSplitContainer", p_config.separation_margin);
+
+		p_theme->set_constant("minimum_grab_thickness", "SplitContainer", p_config.increased_margin * EDSCALE);
+		p_theme->set_constant("minimum_grab_thickness", "HSplitContainer", p_config.increased_margin * EDSCALE);
+		p_theme->set_constant("minimum_grab_thickness", "VSplitContainer", p_config.increased_margin * EDSCALE);
+
+		// GridContainer.
+		p_theme->set_constant("v_separation", "GridContainer", Math::round(p_config.widget_margin.y - 2 * EDSCALE));
+
+		// FoldableContainer
+
+		Ref<StyleBoxFlat> foldable_container_title = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.darkened(0.125), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
+		foldable_container_title->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		foldable_container_title->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+		p_theme->set_stylebox("title_panel", "FoldableContainer", foldable_container_title);
+		Ref<StyleBoxFlat> foldable_container_hover = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.lerp(p_config.base_color, 0.4), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
+		foldable_container_hover->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		foldable_container_hover->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+		p_theme->set_stylebox("title_hover_panel", "FoldableContainer", foldable_container_hover);
+		p_theme->set_stylebox("title_collapsed_panel", "FoldableContainer", EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.darkened(0.125), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
+		p_theme->set_stylebox("title_collapsed_hover_panel", "FoldableContainer", EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.lerp(p_config.base_color, 0.4), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
+		Ref<StyleBoxFlat> foldable_container_panel = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
+		foldable_container_panel->set_corner_radius(CORNER_TOP_LEFT, 0);
+		foldable_container_panel->set_corner_radius(CORNER_TOP_RIGHT, 0);
+		p_theme->set_stylebox(SceneStringName(panel), "FoldableContainer", foldable_container_panel);
+		p_theme->set_stylebox("focus", "FoldableContainer", p_config.button_style_focus);
+
+		p_theme->set_font(SceneStringName(font), "FoldableContainer", p_theme->get_font(SceneStringName(font), SNAME("HeaderSmall")));
+		p_theme->set_font_size(SceneStringName(font_size), "FoldableContainer", p_theme->get_font_size(SceneStringName(font_size), SNAME("HeaderSmall")));
+
+		p_theme->set_color(SceneStringName(font_color), "FoldableContainer", p_config.font_color);
+		p_theme->set_color("hover_font_color", "FoldableContainer", p_config.font_hover_color);
+		p_theme->set_color("collapsed_font_color", "FoldableContainer", p_config.font_pressed_color);
+		p_theme->set_color("font_outline_color", "FoldableContainer", p_config.font_outline_color);
+
+		p_theme->set_icon("expanded_arrow", "FoldableContainer", p_theme->get_icon(SNAME("GuiTreeArrowDown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("expanded_arrow_mirrored", "FoldableContainer", p_theme->get_icon(SNAME("GuiArrowUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("folded_arrow", "FoldableContainer", p_theme->get_icon(SNAME("GuiTreeArrowRight"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("folded_arrow_mirrored", "FoldableContainer", p_theme->get_icon(SNAME("GuiTreeArrowLeft"), EditorStringName(EditorIcons)));
+
+		p_theme->set_constant("outline_size", "FoldableContainer", 0);
+		p_theme->set_constant("h_separation", "FoldableContainer", p_config.separation_margin);
+	}
+
+	// Window and dialogs.
+	{
+		// Window.
+
+		p_theme->set_stylebox("embedded_border", "Window", p_config.window_style);
+		p_theme->set_stylebox("embedded_unfocused_border", "Window", p_config.window_style);
+
+		p_theme->set_color("title_color", "Window", p_config.font_color);
+		p_theme->set_icon("close", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("close_pressed", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
+		p_theme->set_constant("close_h_offset", "Window", 22 * EDSCALE);
+		p_theme->set_constant("close_v_offset", "Window", 20 * EDSCALE);
+		p_theme->set_constant("title_height", "Window", 24 * EDSCALE);
+		p_theme->set_constant("resize_margin", "Window", 4 * EDSCALE);
+		p_theme->set_font("title_font", "Window", p_theme->get_font(SNAME("title"), EditorStringName(EditorFonts)));
+		p_theme->set_font_size("title_font_size", "Window", p_theme->get_font_size(SNAME("title_size"), EditorStringName(EditorFonts)));
+
+		// AcceptDialog.
+		p_theme->set_stylebox(SceneStringName(panel), "AcceptDialog", p_config.dialog_style);
+		p_theme->set_constant("buttons_separation", "AcceptDialog", 8 * EDSCALE);
+		// Make buttons with short texts such as "OK" easier to click/tap.
+		p_theme->set_constant("buttons_min_width", "AcceptDialog", p_config.dialogs_buttons_min_size.x * EDSCALE);
+		p_theme->set_constant("buttons_min_height", "AcceptDialog", p_config.dialogs_buttons_min_size.y * EDSCALE);
+
+		// FileDialog.
+		p_theme->set_icon("folder", "FileDialog", p_theme->get_icon(SNAME("Folder"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("parent_folder", "FileDialog", p_theme->get_icon(SNAME("ArrowUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("back_folder", "FileDialog", p_theme->get_icon(SNAME("Back"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("forward_folder", "FileDialog", p_theme->get_icon(SNAME("Forward"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("reload", "FileDialog", p_theme->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("toggle_hidden", "FileDialog", p_theme->get_icon(SNAME("GuiVisibilityVisible"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("create_folder", "FileDialog", p_theme->get_icon(SNAME("FolderCreate"), EditorStringName(EditorIcons)));
+		// Use a different color for folder icons to make them easier to distinguish from files.
+		// On a light theme, the icon will be dark, so we need to lighten it before blending it with the accent color.
+		p_theme->set_color("folder_icon_color", "FileDialog", (p_config.dark_icon_and_font ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(p_config.accent_color, 0.7));
+		p_theme->set_color("file_disabled_color", "FileDialog", p_config.font_disabled_color);
+
+		// PopupDialog.
+		p_theme->set_stylebox(SceneStringName(panel), "PopupDialog", p_config.popup_style);
+
+		// PopupMenu.
+		{
+			Ref<StyleBoxFlat> style_popup_menu = p_config.popup_border_style->duplicate();
+			// Use 1 pixel for the sides, since if 0 is used, the highlight of hovered items is drawn
+			// on top of the popup border. This causes a 'gap' in the panel border when an item is highlighted,
+			// and it looks weird. 1px solves this.
+			style_popup_menu->set_content_margin_individual(Math::round(EDSCALE), 2 * EDSCALE, Math::round(EDSCALE), 2 * EDSCALE);
+			p_theme->set_stylebox(SceneStringName(panel), "PopupMenu", style_popup_menu);
+
+			Ref<StyleBoxFlat> style_menu_hover = p_config.button_style_hover->duplicate();
+			// Don't use rounded corners for hover highlights since the StyleBox touches the PopupMenu's edges.
+			style_menu_hover->set_corner_radius_all(0);
+			p_theme->set_stylebox(SceneStringName(hover), "PopupMenu", style_menu_hover);
+
+			Ref<StyleBoxLine> style_popup_separator(memnew(StyleBoxLine));
+			style_popup_separator->set_color(p_config.separator_color);
+			style_popup_separator->set_grow_begin(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_separator->set_grow_end(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_separator->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
+
+			Ref<StyleBoxLine> style_popup_labeled_separator_left(memnew(StyleBoxLine));
+			style_popup_labeled_separator_left->set_grow_begin(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_labeled_separator_left->set_color(p_config.separator_color);
+			style_popup_labeled_separator_left->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
+
+			Ref<StyleBoxLine> style_popup_labeled_separator_right(memnew(StyleBoxLine));
+			style_popup_labeled_separator_right->set_grow_end(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_labeled_separator_right->set_color(p_config.separator_color);
+			style_popup_labeled_separator_right->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
+
+			p_theme->set_stylebox("separator", "PopupMenu", style_popup_separator);
+			p_theme->set_stylebox("labeled_separator_left", "PopupMenu", style_popup_labeled_separator_left);
+			p_theme->set_stylebox("labeled_separator_right", "PopupMenu", style_popup_labeled_separator_right);
+
+			p_theme->set_color(SceneStringName(font_color), "PopupMenu", p_config.font_color);
+			p_theme->set_color("font_hover_color", "PopupMenu", p_config.font_hover_color);
+			p_theme->set_color("font_accelerator_color", "PopupMenu", p_config.font_disabled_color);
+			p_theme->set_color("font_disabled_color", "PopupMenu", p_config.font_disabled_color);
+			p_theme->set_color("font_separator_color", "PopupMenu", p_config.font_disabled_color);
+			p_theme->set_color("font_outline_color", "PopupMenu", p_config.font_outline_color);
+
+			p_theme->set_icon("checked", "PopupMenu", p_theme->get_icon(SNAME("GuiChecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked", "PopupMenu", p_theme->get_icon(SNAME("GuiUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_checked", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioChecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_unchecked", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("checked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiUncheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_checked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_unchecked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("submenu", "PopupMenu", p_theme->get_icon(SNAME("ArrowRight"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("submenu_mirrored", "PopupMenu", p_theme->get_icon(SNAME("ArrowLeft"), EditorStringName(EditorIcons)));
+
+			p_theme->set_constant("v_separation", "PopupMenu", p_config.forced_even_separation * EDSCALE);
+			p_theme->set_constant("outline_size", "PopupMenu", 0);
+			p_theme->set_constant("item_start_padding", "PopupMenu", p_config.separation_margin);
+			p_theme->set_constant("item_end_padding", "PopupMenu", p_config.separation_margin);
+		}
+	}
+
+	// Sliders and scrollbars.
+	{
+		Ref<Texture2D> empty_icon = memnew(ImageTexture);
+
+		// HScrollBar.
+
+		if (p_config.enable_touch_optimizations) {
+			p_theme->set_stylebox("scroll", "HScrollBar", EditorThemeManager::make_line_stylebox(p_config.separator_color, 50));
+		} else {
+			p_theme->set_stylebox("scroll", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, -5, 1, -5, 1));
+		}
+		p_theme->set_stylebox("scroll_focus", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
+		p_theme->set_stylebox("grabber", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabber"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
+		p_theme->set_stylebox("grabber_highlight", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberHl"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
+		p_theme->set_stylebox("grabber_pressed", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberPressed"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
+
+		p_theme->set_icon("increment", "HScrollBar", empty_icon);
+		p_theme->set_icon("increment_highlight", "HScrollBar", empty_icon);
+		p_theme->set_icon("increment_pressed", "HScrollBar", empty_icon);
+		p_theme->set_icon("decrement", "HScrollBar", empty_icon);
+		p_theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
+		p_theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
+
+		// VScrollBar.
+
+		if (p_config.enable_touch_optimizations) {
+			p_theme->set_stylebox("scroll", "VScrollBar", EditorThemeManager::make_line_stylebox(p_config.separator_color, 50, 1, 1, true));
+		} else {
+			p_theme->set_stylebox("scroll", "VScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, -5, 1, -5));
+		}
+		p_theme->set_stylebox("scroll_focus", "VScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
+		p_theme->set_stylebox("grabber", "VScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabber"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
+		p_theme->set_stylebox("grabber_highlight", "VScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberHl"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
+		p_theme->set_stylebox("grabber_pressed", "VScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberPressed"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
+
+		p_theme->set_icon("increment", "VScrollBar", empty_icon);
+		p_theme->set_icon("increment_highlight", "VScrollBar", empty_icon);
+		p_theme->set_icon("increment_pressed", "VScrollBar", empty_icon);
+		p_theme->set_icon("decrement", "VScrollBar", empty_icon);
+		p_theme->set_icon("decrement_highlight", "VScrollBar", empty_icon);
+		p_theme->set_icon("decrement_pressed", "VScrollBar", empty_icon);
+
+		// Slider
+		const int background_margin = MAX(2, p_config.base_margin / 2);
+
+		// HSlider.
+		p_theme->set_icon("grabber_highlight", "HSlider", p_theme->get_icon(SNAME("GuiSliderGrabberHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grabber", "HSlider", p_theme->get_icon(SNAME("GuiSliderGrabber"), EditorStringName(EditorIcons)));
+		p_theme->set_stylebox("slider", "HSlider", EditorThemeManager::make_flat_stylebox(p_config.dark_color_3, 0, background_margin, 0, background_margin, p_config.corner_radius));
+		p_theme->set_stylebox("grabber_area", "HSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, 0, background_margin, 0, background_margin, p_config.corner_radius));
+		p_theme->set_stylebox("grabber_area_highlight", "HSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, 0, background_margin, 0, background_margin));
+		p_theme->set_constant("center_grabber", "HSlider", 0);
+		p_theme->set_constant("grabber_offset", "HSlider", 0);
+
+		// VSlider.
+		p_theme->set_icon("grabber", "VSlider", p_theme->get_icon(SNAME("GuiSliderGrabber"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grabber_highlight", "VSlider", p_theme->get_icon(SNAME("GuiSliderGrabberHl"), EditorStringName(EditorIcons)));
+		p_theme->set_stylebox("slider", "VSlider", EditorThemeManager::make_flat_stylebox(p_config.dark_color_3, background_margin, 0, background_margin, 0, p_config.corner_radius));
+		p_theme->set_stylebox("grabber_area", "VSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, background_margin, 0, background_margin, 0, p_config.corner_radius));
+		p_theme->set_stylebox("grabber_area_highlight", "VSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, background_margin, 0, background_margin, 0));
+		p_theme->set_constant("center_grabber", "VSlider", 0);
+		p_theme->set_constant("grabber_offset", "VSlider", 0);
+	}
+
+	// Labels.
+	{
+		// RichTextLabel.
+
+		p_theme->set_stylebox(CoreStringName(normal), "RichTextLabel", p_config.tree_panel_style);
+		p_theme->set_stylebox("focus", "RichTextLabel", EditorThemeManager::make_empty_stylebox());
+
+		p_theme->set_color("default_color", "RichTextLabel", p_config.font_color);
+		p_theme->set_color("font_shadow_color", "RichTextLabel", Color(0, 0, 0, 0));
+		p_theme->set_color("font_outline_color", "RichTextLabel", p_config.font_outline_color);
+		p_theme->set_color("selection_color", "RichTextLabel", p_config.selection_color);
+
+		p_theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
+		p_theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
+		p_theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * EDSCALE);
+		p_theme->set_constant("outline_size", "RichTextLabel", 0);
+
+		// Label.
+
+		p_theme->set_stylebox(CoreStringName(normal), "Label", p_config.base_empty_style);
+		p_theme->set_stylebox("focus", "Label", p_config.button_style_focus);
+
+		p_theme->set_color(SceneStringName(font_color), "Label", p_config.font_color);
+		p_theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
+		p_theme->set_color("font_outline_color", "Label", p_config.font_outline_color);
+
+		p_theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
+		p_theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
+		p_theme->set_constant("shadow_outline_size", "Label", 1 * EDSCALE);
+		p_theme->set_constant("line_spacing", "Label", 3 * EDSCALE);
+		p_theme->set_constant("outline_size", "Label", 0);
+	}
+
+	// SpinBox.
+	{
+		Ref<Texture2D> empty_icon = memnew(ImageTexture);
+		p_theme->set_icon("updown", "SpinBox", empty_icon);
+		p_theme->set_icon("up", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("up_hover", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("up_pressed", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("up_disabled", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("down", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("down_hover", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("down_pressed", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("down_disabled", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
+
+		p_theme->set_stylebox("up_background", "SpinBox", EditorThemeManager::make_empty_stylebox());
+		p_theme->set_stylebox("up_background_hovered", "SpinBox", p_config.button_style_hover);
+		p_theme->set_stylebox("up_background_pressed", "SpinBox", p_config.button_style_pressed);
+		p_theme->set_stylebox("up_background_disabled", "SpinBox", EditorThemeManager::make_empty_stylebox());
+		p_theme->set_stylebox("down_background", "SpinBox", EditorThemeManager::make_empty_stylebox());
+		p_theme->set_stylebox("down_background_hovered", "SpinBox", p_config.button_style_hover);
+		p_theme->set_stylebox("down_background_pressed", "SpinBox", p_config.button_style_pressed);
+		p_theme->set_stylebox("down_background_disabled", "SpinBox", EditorThemeManager::make_empty_stylebox());
+
+		p_theme->set_color("up_icon_modulate", "SpinBox", p_config.font_color);
+		p_theme->set_color("up_hover_icon_modulate", "SpinBox", p_config.font_hover_color);
+		p_theme->set_color("up_pressed_icon_modulate", "SpinBox", p_config.font_pressed_color);
+		p_theme->set_color("up_disabled_icon_modulate", "SpinBox", p_config.font_disabled_color);
+		p_theme->set_color("down_icon_modulate", "SpinBox", p_config.font_color);
+		p_theme->set_color("down_hover_icon_modulate", "SpinBox", p_config.font_hover_color);
+		p_theme->set_color("down_pressed_icon_modulate", "SpinBox", p_config.font_pressed_color);
+		p_theme->set_color("down_disabled_icon_modulate", "SpinBox", p_config.font_disabled_color);
+
+		p_theme->set_stylebox("field_and_buttons_separator", "SpinBox", EditorThemeManager::make_empty_stylebox());
+		p_theme->set_stylebox("up_down_buttons_separator", "SpinBox", EditorThemeManager::make_empty_stylebox());
+
+		p_theme->set_constant("buttons_vertical_separation", "SpinBox", 0);
+		p_theme->set_constant("field_and_buttons_separation", "SpinBox", 2);
+		p_theme->set_constant("buttons_width", "SpinBox", 16);
+#ifndef DISABLE_DEPRECATED
+		p_theme->set_constant("set_min_buttons_width_from_icons", "SpinBox", 1);
+#endif
+	}
+
+	// ProgressBar.
+	p_theme->set_stylebox("background", "ProgressBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiProgressBar"), EditorStringName(EditorIcons)), 4, 4, 4, 4, 0, 0, 0, 0));
+	p_theme->set_stylebox("fill", "ProgressBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiProgressFill"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 2, 1, 2, 1));
+	p_theme->set_color(SceneStringName(font_color), "ProgressBar", p_config.font_color);
+	p_theme->set_color("font_outline_color", "ProgressBar", p_config.font_outline_color);
+	p_theme->set_constant("outline_size", "ProgressBar", 0);
+
+	// GraphEdit and related nodes.
+	{
+		// GraphEdit.
+
+		p_theme->set_stylebox(SceneStringName(panel), "GraphEdit", p_config.tree_panel_style);
+		p_theme->set_stylebox("panel_focus", "GraphEdit", p_config.button_style_focus);
+		p_theme->set_stylebox("menu_panel", "GraphEdit", EditorThemeManager::make_flat_stylebox(p_config.dark_color_1 * Color(1, 1, 1, 0.6), 4, 2, 4, 2, 3));
+
+		float grid_base_brightness = p_config.dark_theme ? 1.0 : 0.0;
+		GraphEdit::GridPattern grid_pattern = (GraphEdit::GridPattern) int(EDITOR_GET("editors/visual_editors/grid_pattern"));
+		switch (grid_pattern) {
+			case GraphEdit::GRID_PATTERN_LINES:
+				p_theme->set_color("grid_major", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.10));
+				p_theme->set_color("grid_minor", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.05));
+				break;
+			case GraphEdit::GRID_PATTERN_DOTS:
+				p_theme->set_color("grid_major", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.07));
+				p_theme->set_color("grid_minor", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.07));
+				break;
+			default:
+				WARN_PRINT("Unknown grid pattern.");
+				break;
+		}
+
+		p_theme->set_color("selection_fill", "GraphEdit", p_theme->get_color(SNAME("box_selection_fill_color"), EditorStringName(Editor)));
+		p_theme->set_color("selection_stroke", "GraphEdit", p_theme->get_color(SNAME("box_selection_stroke_color"), EditorStringName(Editor)));
+		p_theme->set_color("activity", "GraphEdit", p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0));
+
+		p_theme->set_color("connection_hover_tint_color", "GraphEdit", p_config.dark_theme ? Color(0, 0, 0, 0.3) : Color(1, 1, 1, 0.3));
+		p_theme->set_constant("connection_hover_thickness", "GraphEdit", 0);
+		p_theme->set_color("connection_valid_target_tint_color", "GraphEdit", p_config.dark_theme ? Color(1, 1, 1, 0.4) : Color(0, 0, 0, 0.4));
+		p_theme->set_color("connection_rim_color", "GraphEdit", p_config.tree_panel_style->get_bg_color());
+
+		p_theme->set_icon("zoom_out", "GraphEdit", p_theme->get_icon(SNAME("ZoomLess"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("zoom_in", "GraphEdit", p_theme->get_icon(SNAME("ZoomMore"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("zoom_reset", "GraphEdit", p_theme->get_icon(SNAME("ZoomReset"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grid_toggle", "GraphEdit", p_theme->get_icon(SNAME("GridToggle"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("minimap_toggle", "GraphEdit", p_theme->get_icon(SNAME("GridMinimap"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("snapping_toggle", "GraphEdit", p_theme->get_icon(SNAME("SnapGrid"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("layout", "GraphEdit", p_theme->get_icon(SNAME("GridLayout"), EditorStringName(EditorIcons)));
+
+		// GraphEditMinimap.
+		{
+			Ref<StyleBoxFlat> style_minimap_bg = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 0, 0, 0, 0);
+			style_minimap_bg->set_border_color(p_config.dark_color_3);
+			style_minimap_bg->set_border_width_all(1);
+			p_theme->set_stylebox(SceneStringName(panel), "GraphEditMinimap", style_minimap_bg);
+
+			Ref<StyleBoxFlat> style_minimap_camera;
+			Ref<StyleBoxFlat> style_minimap_node;
+			if (p_config.dark_theme) {
+				style_minimap_camera = EditorThemeManager::make_flat_stylebox(Color(0.65, 0.65, 0.65, 0.2), 0, 0, 0, 0);
+				style_minimap_camera->set_border_color(Color(0.65, 0.65, 0.65, 0.45));
+				style_minimap_node = EditorThemeManager::make_flat_stylebox(Color(1, 1, 1), 0, 0, 0, 0);
+			} else {
+				style_minimap_camera = EditorThemeManager::make_flat_stylebox(Color(0.38, 0.38, 0.38, 0.2), 0, 0, 0, 0);
+				style_minimap_camera->set_border_color(Color(0.38, 0.38, 0.38, 0.45));
+				style_minimap_node = EditorThemeManager::make_flat_stylebox(Color(0, 0, 0), 0, 0, 0, 0);
+			}
+			style_minimap_camera->set_border_width_all(1);
+			style_minimap_node->set_anti_aliased(false);
+			p_theme->set_stylebox("camera", "GraphEditMinimap", style_minimap_camera);
+			p_theme->set_stylebox("node", "GraphEditMinimap", style_minimap_node);
+
+			const Color minimap_resizer_color = p_config.dark_theme ? Color(1, 1, 1, 0.65) : Color(0, 0, 0, 0.65);
+			p_theme->set_icon("resizer", "GraphEditMinimap", p_theme->get_icon(SNAME("GuiResizerTopLeft"), EditorStringName(EditorIcons)));
+			p_theme->set_color("resizer_color", "GraphEditMinimap", minimap_resizer_color);
+		}
+
+		// GraphElement, GraphNode & GraphFrame.
+		{
+			const int gn_margin_top = 2;
+			const int gn_margin_side = 2;
+			const int gn_margin_bottom = 2;
+
+			const int gn_corner_radius = 3;
+
+			const Color gn_bg_color = p_config.dark_theme ? p_config.dark_color_3 : p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
+			const Color gn_selected_border_color = p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0);
+			const Color gn_frame_bg = gn_bg_color.lerp(p_config.tree_panel_style->get_bg_color(), 0.3);
+
+			const bool high_contrast_borders = p_config.draw_extra_borders && p_config.dark_theme;
+
+			Ref<StyleBoxFlat> gn_panel_style = EditorThemeManager::make_flat_stylebox(gn_frame_bg, gn_margin_side, gn_margin_top, gn_margin_side, gn_margin_bottom, p_config.corner_radius);
+			gn_panel_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
+			gn_panel_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
+			gn_panel_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_panel_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
+			gn_panel_style->set_corner_radius_individual(0, 0, gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE);
+			gn_panel_style->set_anti_aliased(true);
+
+			Ref<StyleBoxFlat> gn_panel_selected_style = gn_panel_style->duplicate();
+			gn_panel_selected_style->set_bg_color(p_config.dark_theme ? gn_bg_color.lightened(0.15) : gn_bg_color.darkened(0.15));
+			gn_panel_selected_style->set_border_width(SIDE_TOP, 0);
+			gn_panel_selected_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
+			gn_panel_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
+			gn_panel_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_panel_selected_style->set_border_color(gn_selected_border_color);
+
+			const int gn_titlebar_margin_top = 8;
+			const int gn_titlebar_margin_side = 12;
+			const int gn_titlebar_margin_bottom = 8;
+
+			Ref<StyleBoxFlat> gn_titlebar_style = EditorThemeManager::make_flat_stylebox(gn_bg_color, gn_titlebar_margin_side, gn_titlebar_margin_top, gn_titlebar_margin_side, gn_titlebar_margin_bottom, p_config.corner_radius);
+			gn_titlebar_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
+			gn_titlebar_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
+			gn_titlebar_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_titlebar_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
+			gn_titlebar_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
+			gn_titlebar_style->set_corner_radius_individual(gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE, 0, 0);
+			gn_titlebar_style->set_anti_aliased(true);
+
+			Ref<StyleBoxFlat> gn_titlebar_selected_style = gn_titlebar_style->duplicate();
+			gn_titlebar_selected_style->set_border_color(gn_selected_border_color);
+			gn_titlebar_selected_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
+			gn_titlebar_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
+			gn_titlebar_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_titlebar_selected_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
+
+			Color gn_decoration_color = p_config.dark_color_1.inverted();
+
+			// GraphElement.
+
+			p_theme->set_stylebox(SceneStringName(panel), "GraphElement", gn_panel_style);
+			p_theme->set_stylebox("panel_selected", "GraphElement", gn_panel_selected_style);
+			p_theme->set_stylebox("titlebar", "GraphElement", gn_titlebar_style);
+			p_theme->set_stylebox("titlebar_selected", "GraphElement", gn_titlebar_selected_style);
+
+			p_theme->set_color("resizer_color", "GraphElement", gn_decoration_color);
+			p_theme->set_icon("resizer", "GraphElement", p_theme->get_icon(SNAME("GuiResizer"), EditorStringName(EditorIcons)));
+
+			// GraphNode.
+
+			Ref<StyleBoxEmpty> gn_slot_style = EditorThemeManager::make_empty_stylebox(12, 0, 12, 0);
+
+			p_theme->set_stylebox(SceneStringName(panel), "GraphNode", gn_panel_style);
+			p_theme->set_stylebox("panel_selected", "GraphNode", gn_panel_selected_style);
+			p_theme->set_stylebox("panel_focus", "GraphNode", p_config.button_style_focus);
+			p_theme->set_stylebox("titlebar", "GraphNode", gn_titlebar_style);
+			p_theme->set_stylebox("titlebar_selected", "GraphNode", gn_titlebar_selected_style);
+			p_theme->set_stylebox("slot", "GraphNode", gn_slot_style);
+			p_theme->set_stylebox("slot_selected", "GraphNode", p_config.button_style_focus);
+
+			p_theme->set_color("resizer_color", "GraphNode", gn_decoration_color);
+
+			p_theme->set_constant("port_h_offset", "GraphNode", 1);
+			p_theme->set_constant("separation", "GraphNode", 1 * EDSCALE);
+
+			Ref<DPITexture> port_icon = p_theme->get_icon(SNAME("GuiGraphNodePort"), EditorStringName(EditorIcons));
+			// The true size is 24x24 This is necessary for sharp port icons at high zoom levels in GraphEdit (up to ~200%).
+			port_icon->set_size_override(Size2(12, 12));
+			p_theme->set_icon("port", "GraphNode", port_icon);
+
+			// GraphNode's title Label.
+			p_theme->set_type_variation("GraphNodeTitleLabel", "Label");
+			p_theme->set_stylebox(CoreStringName(normal), "GraphNodeTitleLabel", EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+			p_theme->set_color("font_shadow_color", "GraphNodeTitleLabel", p_config.shadow_color);
+			p_theme->set_constant("shadow_outline_size", "GraphNodeTitleLabel", 4);
+			p_theme->set_constant("shadow_offset_x", "GraphNodeTitleLabel", 0);
+			p_theme->set_constant("shadow_offset_y", "GraphNodeTitleLabel", 1);
+			p_theme->set_constant("line_spacing", "GraphNodeTitleLabel", 3 * EDSCALE);
+
+			// GraphFrame.
+
+			const int gf_corner_width = 7 * EDSCALE;
+			const int gf_border_width = 2 * MAX(1, EDSCALE);
+
+			Ref<StyleBoxFlat> graphframe_sb = EditorThemeManager::make_flat_stylebox(Color(0.0, 0.0, 0.0, 0.2), gn_margin_side, gn_margin_side, gn_margin_side, gn_margin_bottom, gf_corner_width);
+			graphframe_sb->set_expand_margin(SIDE_TOP, 38 * EDSCALE);
+			graphframe_sb->set_border_width_all(gf_border_width);
+			graphframe_sb->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
+			graphframe_sb->set_shadow_size(8 * EDSCALE);
+			graphframe_sb->set_shadow_color(Color(p_config.shadow_color, p_config.shadow_color.a * 0.25));
+			graphframe_sb->set_anti_aliased(true);
+
+			Ref<StyleBoxFlat> graphframe_sb_selected = graphframe_sb->duplicate();
+			graphframe_sb_selected->set_border_color(gn_selected_border_color);
+
+			p_theme->set_stylebox(SceneStringName(panel), "GraphFrame", graphframe_sb);
+			p_theme->set_stylebox("panel_selected", "GraphFrame", graphframe_sb_selected);
+			p_theme->set_stylebox("titlebar", "GraphFrame", EditorThemeManager::make_empty_stylebox(4, 4, 4, 4));
+			p_theme->set_stylebox("titlebar_selected", "GraphFrame", EditorThemeManager::make_empty_stylebox(4, 4, 4, 4));
+			p_theme->set_color("resizer_color", "GraphFrame", gn_decoration_color);
+
+			// GraphFrame's title Label.
+			p_theme->set_type_variation("GraphFrameTitleLabel", "Label");
+			p_theme->set_stylebox(CoreStringName(normal), "GraphFrameTitleLabel", memnew(StyleBoxEmpty));
+			p_theme->set_font_size(SceneStringName(font_size), "GraphFrameTitleLabel", 22 * EDSCALE);
+			p_theme->set_color(SceneStringName(font_color), "GraphFrameTitleLabel", Color(1, 1, 1));
+			p_theme->set_color("font_shadow_color", "GraphFrameTitleLabel", Color(0, 0, 0, 0));
+			p_theme->set_color("font_outline_color", "GraphFrameTitleLabel", Color(1, 1, 1));
+			p_theme->set_constant("shadow_offset_x", "GraphFrameTitleLabel", 1 * EDSCALE);
+			p_theme->set_constant("shadow_offset_y", "GraphFrameTitleLabel", 1 * EDSCALE);
+			p_theme->set_constant("outline_size", "GraphFrameTitleLabel", 0);
+			p_theme->set_constant("shadow_outline_size", "GraphFrameTitleLabel", 1 * EDSCALE);
+			p_theme->set_constant("line_spacing", "GraphFrameTitleLabel", 3 * EDSCALE);
+		}
+
+		// VisualShader reroute node.
+		{
+			Ref<StyleBox> vs_reroute_panel_style = EditorThemeManager::make_empty_stylebox();
+			Ref<StyleBox> vs_reroute_titlebar_style = vs_reroute_panel_style->duplicate();
+			vs_reroute_titlebar_style->set_content_margin_all(16 * EDSCALE);
+			p_theme->set_stylebox(SceneStringName(panel), "VSRerouteNode", vs_reroute_panel_style);
+			p_theme->set_stylebox("panel_selected", "VSRerouteNode", vs_reroute_panel_style);
+			p_theme->set_stylebox("titlebar", "VSRerouteNode", vs_reroute_titlebar_style);
+			p_theme->set_stylebox("titlebar_selected", "VSRerouteNode", vs_reroute_titlebar_style);
+			p_theme->set_stylebox("slot", "VSRerouteNode", EditorThemeManager::make_empty_stylebox());
+
+			p_theme->set_color("drag_background", "VSRerouteNode", p_config.dark_theme ? Color(0.19, 0.21, 0.24) : Color(0.8, 0.8, 0.8));
+			p_theme->set_color("selected_rim_color", "VSRerouteNode", p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0));
+		}
+	}
+
+	// ColorPicker and related nodes.
+	{
+		// ColorPicker.
+		Ref<StyleBoxFlat> circle_style_focus = p_config.button_style_focus->duplicate();
+		circle_style_focus->set_corner_radius_all(256 * EDSCALE);
+		circle_style_focus->set_corner_detail(32 * EDSCALE);
+
+		p_theme->set_constant("margin", "ColorPicker", p_config.base_margin);
+		p_theme->set_constant("sv_width", "ColorPicker", 256 * EDSCALE);
+		p_theme->set_constant("sv_height", "ColorPicker", 256 * EDSCALE);
+		p_theme->set_constant("h_width", "ColorPicker", 30 * EDSCALE);
+		p_theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
+		p_theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
+
+		p_theme->set_stylebox("sample_focus", "ColorPicker", p_config.button_style_focus);
+		p_theme->set_stylebox("picker_focus_rectangle", "ColorPicker", p_config.button_style_focus);
+		p_theme->set_stylebox("picker_focus_circle", "ColorPicker", circle_style_focus);
+		p_theme->set_color("focused_not_editing_cursor_color", "ColorPicker", p_config.highlight_color);
+
+		p_theme->set_icon("screen_picker", "ColorPicker", p_theme->get_icon(SNAME("ColorPick"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("shape_circle", "ColorPicker", p_theme->get_icon(SNAME("PickerShapeCircle"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("shape_rect", "ColorPicker", p_theme->get_icon(SNAME("PickerShapeRectangle"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("shape_rect_wheel", "ColorPicker", p_theme->get_icon(SNAME("PickerShapeRectangleWheel"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("add_preset", "ColorPicker", p_theme->get_icon(SNAME("Add"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("sample_bg", "ColorPicker", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("sample_revert", "ColorPicker", p_theme->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("overbright_indicator", "ColorPicker", p_theme->get_icon(SNAME("OverbrightIndicator"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("bar_arrow", "ColorPicker", p_theme->get_icon(SNAME("ColorPickerBarArrow"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("picker_cursor", "ColorPicker", p_theme->get_icon(SNAME("PickerCursor"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("picker_cursor_bg", "ColorPicker", p_theme->get_icon(SNAME("PickerCursorBg"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("color_script", "ColorPicker", p_theme->get_icon(SNAME("Script"), EditorStringName(EditorIcons)));
+
+		// ColorPickerButton.
+		p_theme->set_icon("bg", "ColorPickerButton", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));
+
+		// ColorPresetButton.
+		p_theme->set_stylebox("preset_fg", "ColorPresetButton", EditorThemeManager::make_flat_stylebox(Color(1, 1, 1), 2, 2, 2, 2, 2));
+		p_theme->set_icon("preset_bg", "ColorPresetButton", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("overbright_indicator", "ColorPresetButton", p_theme->get_icon(SNAME("OverbrightIndicator"), EditorStringName(EditorIcons)));
+	}
+}
+
+void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config) {
+	// Project manager.
+	{
+		Ref<StyleBoxFlat> style_panel_container = p_theme->get_stylebox(SceneStringName(panel), SNAME("TabContainer"))->duplicate();
+		style_panel_container->set_corner_radius(CORNER_TOP_LEFT, style_panel_container->get_corner_radius(CORNER_BOTTOM_LEFT));
+		style_panel_container->set_corner_radius(CORNER_TOP_RIGHT, style_panel_container->get_corner_radius(CORNER_BOTTOM_RIGHT));
+
+		p_theme->set_stylebox("panel_container", "ProjectManager", style_panel_container);
+		p_theme->set_stylebox("project_list", "ProjectManager", p_config.tree_panel_style);
+		p_theme->set_constant("sidebar_button_icon_separation", "ProjectManager", int(6 * EDSCALE));
+		p_theme->set_icon("browse_folder", "ProjectManager", p_theme->get_icon(SNAME("FolderBrowse"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("browse_file", "ProjectManager", p_theme->get_icon(SNAME("FileBrowse"), EditorStringName(EditorIcons)));
+
+		// ProjectTag.
+		{
+			p_theme->set_type_variation("ProjectTagButton", "Button");
+
+			Ref<StyleBoxFlat> tag = p_config.button_style->duplicate();
+			tag->set_bg_color(p_config.dark_theme ? tag->get_bg_color().lightened(0.2) : tag->get_bg_color().darkened(0.2));
+			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(CoreStringName(normal), "ProjectTagButton", tag);
+
+			tag = p_config.button_style_hover->duplicate();
+			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(SceneStringName(hover), "ProjectTagButton", tag);
+
+			tag = p_config.button_style_pressed->duplicate();
+			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
+		}
+	}
+
+	// Editor and main screen.
+	{
+		// Editor background.
+		Color background_color_opaque = p_config.dark_color_2;
+		background_color_opaque.a = 1.0;
+		p_theme->set_color("background", EditorStringName(Editor), background_color_opaque);
+		p_theme->set_stylebox("Background", EditorStringName(EditorStyles), EditorThemeManager::make_flat_stylebox(background_color_opaque, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
+
+		Ref<StyleBoxFlat> editor_panel_foreground = p_config.base_style->duplicate();
+		editor_panel_foreground->set_corner_radius_all(0);
+		p_theme->set_stylebox("PanelForeground", EditorStringName(EditorStyles), editor_panel_foreground);
+
+		// Editor focus.
+		p_theme->set_stylebox("Focus", EditorStringName(EditorStyles), p_config.button_style_focus);
+
+		Ref<StyleBoxFlat> style_widget_focus_viewport = p_config.button_style_focus->duplicate();
+		// Use a less opaque color to be less distracting for the 2D and 3D editor viewports.
+		style_widget_focus_viewport->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.5));
+		p_theme->set_stylebox("FocusViewport", EditorStringName(EditorStyles), style_widget_focus_viewport);
+
+		Ref<StyleBoxFlat> style_widget_scroll_container = p_config.button_style_focus->duplicate();
+		p_theme->set_stylebox("focus", "ScrollContainer", style_widget_scroll_container);
+
+		// This stylebox is used in 3d and 2d viewports (no borders).
+		Ref<StyleBoxFlat> style_content_panel_vp = p_config.content_panel_style->duplicate();
+		style_content_panel_vp->set_content_margin_individual(p_config.border_width * 2, p_config.base_margin * EDSCALE, p_config.border_width * 2, p_config.border_width * 2);
+		p_theme->set_stylebox("Content", EditorStringName(EditorStyles), style_content_panel_vp);
+
+		// 3D/Spatial editor.
+		Ref<StyleBoxFlat> style_info_3d_viewport = p_config.base_style->duplicate();
+		style_info_3d_viewport->set_bg_color(style_info_3d_viewport->get_bg_color() * Color(1, 1, 1, 0.5));
+		style_info_3d_viewport->set_border_width_all(0);
+		p_theme->set_stylebox("Information3dViewport", EditorStringName(EditorStyles), style_info_3d_viewport);
+
+		// 2D, 3D, and Game toolbar.
+		p_theme->set_type_variation("MainToolBarMargin", "MarginContainer");
+		p_theme->set_constant("margin_left", "MainToolBarMargin", 4 * EDSCALE);
+		p_theme->set_constant("margin_right", "MainToolBarMargin", 4 * EDSCALE);
+
+		// 2D and 3D contextual toolbar.
+		// Use a custom stylebox to make contextual menu items stand out from the rest.
+		// This helps with editor usability as contextual menu items change when selecting nodes,
+		// even though it may not be immediately obvious at first.
+		Ref<StyleBoxFlat> toolbar_stylebox = memnew(StyleBoxFlat);
+		toolbar_stylebox->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
+		toolbar_stylebox->set_anti_aliased(false);
+		// Add an underline to the StyleBox, but prevent its minimum vertical size from changing.
+		toolbar_stylebox->set_border_color(p_config.accent_color);
+		toolbar_stylebox->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
+		toolbar_stylebox->set_content_margin(SIDE_BOTTOM, 0);
+		toolbar_stylebox->set_expand_margin_individual(4 * EDSCALE, 2 * EDSCALE, 4 * EDSCALE, 4 * EDSCALE);
+		p_theme->set_stylebox("ContextualToolbar", EditorStringName(EditorStyles), toolbar_stylebox);
+
+		// Script editor.
+		p_theme->set_stylebox("ScriptEditorPanel", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(p_config.base_margin, 0, p_config.base_margin, p_config.base_margin));
+		p_theme->set_stylebox("ScriptEditorPanelFloating", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+		p_theme->set_stylebox("ScriptEditor", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+
+		// Game view.
+		p_theme->set_type_variation("GamePanel", "Panel");
+		Ref<StyleBoxFlat> game_panel = p_theme->get_stylebox(SceneStringName(panel), SNAME("Panel"))->duplicate();
+		game_panel->set_corner_radius_all(0);
+		p_theme->set_stylebox(SceneStringName(panel), "GamePanel", game_panel);
+
+		// Main menu.
+		Ref<StyleBoxFlat> menu_transparent_style = p_config.button_style->duplicate();
+		menu_transparent_style->set_bg_color(Color(1, 1, 1, 0));
+		menu_transparent_style->set_border_width_all(0);
+		Ref<StyleBoxFlat> main_screen_button_hover = p_config.button_style_hover->duplicate();
+		for (int i = 0; i < 4; i++) {
+			menu_transparent_style->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
+			main_screen_button_hover->set_content_margin((Side)i, p_config.button_style_hover->get_content_margin((Side)i));
+		}
+		p_theme->set_stylebox(CoreStringName(normal), "MainScreenButton", menu_transparent_style);
+		p_theme->set_stylebox("normal_mirrored", "MainScreenButton", menu_transparent_style);
+		p_theme->set_stylebox(SceneStringName(pressed), "MainScreenButton", menu_transparent_style);
+		p_theme->set_stylebox("pressed_mirrored", "MainScreenButton", menu_transparent_style);
+		p_theme->set_stylebox(SceneStringName(hover), "MainScreenButton", main_screen_button_hover);
+		p_theme->set_stylebox("hover_mirrored", "MainScreenButton", main_screen_button_hover);
+		p_theme->set_stylebox("hover_pressed", "MainScreenButton", main_screen_button_hover);
+		p_theme->set_stylebox("hover_pressed_mirrored", "MainScreenButton", main_screen_button_hover);
+
+		p_theme->set_type_variation("MainMenuBar", "FlatMenuButton");
+		p_theme->set_stylebox(CoreStringName(normal), "MainMenuBar", menu_transparent_style);
+		p_theme->set_stylebox(SceneStringName(pressed), "MainMenuBar", main_screen_button_hover);
+		p_theme->set_stylebox(SceneStringName(hover), "MainMenuBar", main_screen_button_hover);
+		p_theme->set_stylebox("hover_pressed", "MainMenuBar", main_screen_button_hover);
+
+		// Run bar.
+		p_theme->set_type_variation("RunBarButton", "FlatMenuButton");
+		p_theme->set_stylebox("disabled", "RunBarButton", menu_transparent_style);
+		p_theme->set_stylebox(SceneStringName(pressed), "RunBarButton", menu_transparent_style);
+
+		p_theme->set_type_variation("RunBarButtonMovieMakerDisabled", "RunBarButton");
+		p_theme->set_color("icon_normal_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.7));
+		p_theme->set_color("icon_pressed_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.84));
+		p_theme->set_color("icon_hover_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.9));
+		p_theme->set_color("icon_hover_pressed_color", "RunBarButtonMovieMakerDisabled", Color(1, 1, 1, 0.84));
+
+		p_theme->set_type_variation("RunBarButtonMovieMakerEnabled", "RunBarButton");
+		p_theme->set_color("icon_normal_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.7));
+		p_theme->set_color("icon_pressed_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.84));
+		p_theme->set_color("icon_hover_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.9));
+		p_theme->set_color("icon_hover_pressed_color", "RunBarButtonMovieMakerEnabled", Color(0, 0, 0, 0.84));
+
+		// Bottom panel.
+		Ref<StyleBoxFlat> style_bottom_panel = p_config.content_panel_style->duplicate();
+		style_bottom_panel->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		p_theme->set_stylebox("BottomPanel", EditorStringName(EditorStyles), style_bottom_panel);
+		p_theme->set_type_variation("BottomPanelButton", "FlatMenuButton");
+		p_theme->set_stylebox(CoreStringName(normal), "BottomPanelButton", menu_transparent_style);
+		p_theme->set_stylebox(SceneStringName(pressed), "BottomPanelButton", menu_transparent_style);
+		p_theme->set_stylebox("hover_pressed", "BottomPanelButton", main_screen_button_hover);
+		p_theme->set_stylebox(SceneStringName(hover), "BottomPanelButton", main_screen_button_hover);
+		// Don't tint the icon even when in "pressed" state.
+		p_theme->set_color("icon_pressed_color", "BottomPanelButton", Color(1, 1, 1, 1));
+		Color icon_hover_color = p_config.icon_normal_color * (p_config.dark_icon_and_font ? 1.15 : 1.0);
+		icon_hover_color.a = 1.0;
+		p_theme->set_color("icon_hover_color", "BottomPanelButton", icon_hover_color);
+		p_theme->set_color("icon_hover_pressed_color", "BottomPanelButton", icon_hover_color);
+
+		// Audio bus.
+		p_theme->set_stylebox(CoreStringName(normal), "EditorAudioBus", style_bottom_panel);
+		p_theme->set_stylebox("master", "EditorAudioBus", p_config.button_style_disabled);
+		p_theme->set_stylebox("focus", "EditorAudioBus", p_config.button_style_focus);
+	}
+
+	// Editor GUI widgets.
+	{
+		// EditorSpinSlider.
+		p_theme->set_color("label_color", "EditorSpinSlider", p_config.font_color);
+		p_theme->set_color("read_only_label_color", "EditorSpinSlider", p_config.font_readonly_color);
+
+		Ref<StyleBoxFlat> editor_spin_label_bg = p_config.base_style->duplicate();
+		editor_spin_label_bg->set_bg_color(p_config.dark_color_3);
+		editor_spin_label_bg->set_border_width_all(0);
+		p_theme->set_stylebox("label_bg", "EditorSpinSlider", editor_spin_label_bg);
+
+		// TODO Use separate arrows instead like on SpinBox. Planned for a different PR.
+		p_theme->set_icon("updown", "EditorSpinSlider", p_theme->get_icon(SNAME("GuiSpinboxUpdown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("updown_disabled", "EditorSpinSlider", p_theme->get_icon(SNAME("GuiSpinboxUpdownDisabled"), EditorStringName(EditorIcons)));
+
+		// Launch Pad and Play buttons.
+		Ref<StyleBoxFlat> style_launch_pad = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 2 * EDSCALE, 0, 2 * EDSCALE, 0, p_config.corner_radius);
+		style_launch_pad->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		p_theme->set_stylebox("LaunchPadNormal", EditorStringName(EditorStyles), style_launch_pad);
+		Ref<StyleBoxFlat> style_launch_pad_movie = style_launch_pad->duplicate();
+		style_launch_pad_movie->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
+		style_launch_pad_movie->set_border_color(p_config.accent_color);
+		style_launch_pad_movie->set_border_width_all(Math::round(2 * EDSCALE));
+		p_theme->set_stylebox("LaunchPadMovieMode", EditorStringName(EditorStyles), style_launch_pad_movie);
+		Ref<StyleBoxFlat> style_launch_pad_recovery_mode = style_launch_pad->duplicate();
+		style_launch_pad_recovery_mode->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
+		style_launch_pad_recovery_mode->set_border_color(p_config.warning_color);
+		style_launch_pad_recovery_mode->set_border_width_all(Math::round(2 * EDSCALE));
+		p_theme->set_stylebox("LaunchPadRecoveryMode", EditorStringName(EditorStyles), style_launch_pad_recovery_mode);
+
+		p_theme->set_stylebox("MovieWriterButtonNormal", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+		Ref<StyleBoxFlat> style_write_movie_button = p_config.button_style_pressed->duplicate();
+		style_write_movie_button->set_bg_color(p_config.accent_color);
+		style_write_movie_button->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_write_movie_button->set_content_margin(SIDE_TOP, 0);
+		style_write_movie_button->set_content_margin(SIDE_BOTTOM, 0);
+		style_write_movie_button->set_content_margin(SIDE_LEFT, 0);
+		style_write_movie_button->set_content_margin(SIDE_RIGHT, 0);
+		style_write_movie_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+		p_theme->set_stylebox("MovieWriterButtonPressed", EditorStringName(EditorStyles), style_write_movie_button);
+
+		// Profiler autostart indicator panel.
+		Ref<StyleBoxFlat> style_profiler_autostart = style_launch_pad->duplicate();
+		style_profiler_autostart->set_bg_color(Color(1, 0.867, 0.396));
+		p_theme->set_type_variation("ProfilerAutostartIndicator", "Button");
+		p_theme->set_stylebox(CoreStringName(normal), "ProfilerAutostartIndicator", style_profiler_autostart);
+		p_theme->set_stylebox(SceneStringName(pressed), "ProfilerAutostartIndicator", style_profiler_autostart);
+		p_theme->set_stylebox(SceneStringName(hover), "ProfilerAutostartIndicator", style_profiler_autostart);
+
+		// Recovery mode button style
+		Ref<StyleBoxFlat> style_recovery_mode_button = p_config.button_style_pressed->duplicate();
+		style_recovery_mode_button->set_bg_color(p_config.warning_color);
+		style_recovery_mode_button->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_recovery_mode_button->set_content_margin_all(0);
+		// Recovery mode button is implicitly styled from the panel's background.
+		// So, remove any existing borders. (e.g. from draw_extra_borders config)
+		style_recovery_mode_button->set_border_width_all(0);
+		style_recovery_mode_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+		p_theme->set_stylebox("RecoveryModeButton", EditorStringName(EditorStyles), style_recovery_mode_button);
+	}
+
+	// Standard GUI variations.
+	{
+		// Custom theme type for MarginContainer with 4px margins.
+		p_theme->set_type_variation("MarginContainer4px", "MarginContainer");
+		p_theme->set_constant("margin_left", "MarginContainer4px", 4 * EDSCALE);
+		p_theme->set_constant("margin_top", "MarginContainer4px", 4 * EDSCALE);
+		p_theme->set_constant("margin_right", "MarginContainer4px", 4 * EDSCALE);
+		p_theme->set_constant("margin_bottom", "MarginContainer4px", 4 * EDSCALE);
+
+		// Header LinkButton variation.
+		p_theme->set_type_variation("HeaderSmallLink", "LinkButton");
+		p_theme->set_font(SceneStringName(font), "HeaderSmallLink", p_theme->get_font(SceneStringName(font), SNAME("HeaderSmall")));
+		p_theme->set_font_size(SceneStringName(font_size), "HeaderSmallLink", p_theme->get_font_size(SceneStringName(font_size), SNAME("HeaderSmall")));
+
+		// Flat button variations.
+		{
+			Ref<StyleBoxEmpty> style_flat_button = EditorThemeManager::make_empty_stylebox();
+			Ref<StyleBoxFlat> style_flat_button_hover = p_config.button_style_hover->duplicate();
+			Ref<StyleBoxFlat> style_flat_button_pressed = p_config.button_style_pressed->duplicate();
+
+			for (int i = 0; i < 4; i++) {
+				style_flat_button->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
+				style_flat_button_hover->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
+				style_flat_button_pressed->set_content_margin((Side)i, p_config.button_style->get_content_margin((Side)i));
+			}
+			Color flat_pressed_color = p_config.dark_color_1.lightened(0.24).lerp(p_config.accent_color, 0.2) * Color(0.8, 0.8, 0.8, 0.85);
+			if (p_config.dark_theme) {
+				flat_pressed_color = p_config.dark_color_1.lerp(p_config.accent_color, 0.12) * Color(0.6, 0.6, 0.6, 0.85);
+			}
+			style_flat_button_pressed->set_bg_color(flat_pressed_color);
+
+			p_theme->set_stylebox(CoreStringName(normal), SceneStringName(FlatButton), style_flat_button);
+			p_theme->set_stylebox(SceneStringName(hover), SceneStringName(FlatButton), style_flat_button_hover);
+			p_theme->set_stylebox(SceneStringName(pressed), SceneStringName(FlatButton), style_flat_button_pressed);
+			p_theme->set_stylebox("disabled", SceneStringName(FlatButton), style_flat_button);
+
+			p_theme->set_stylebox(CoreStringName(normal), "FlatMenuButton", style_flat_button);
+			p_theme->set_stylebox(SceneStringName(hover), "FlatMenuButton", style_flat_button_hover);
+			p_theme->set_stylebox(SceneStringName(pressed), "FlatMenuButton", style_flat_button_pressed);
+			p_theme->set_stylebox("disabled", "FlatMenuButton", style_flat_button);
+
+			// Variation for Editor Log filter buttons.
+
+			p_theme->set_type_variation("EditorLogFilterButton", "Button");
+			// When pressed, don't tint the icons with the accent color, just leave them normal.
+			p_theme->set_color("icon_pressed_color", "EditorLogFilterButton", p_config.icon_normal_color);
+			// When unpressed, dim the icons.
+			Color icon_normal_color = Color(p_config.icon_normal_color, (p_config.dark_icon_and_font ? 0.4 : 0.8));
+			p_theme->set_color("icon_normal_color", "EditorLogFilterButton", icon_normal_color);
+			Color icon_hover_color = p_config.icon_normal_color * (p_config.dark_icon_and_font ? 1.15 : 1.0);
+			icon_hover_color.a = 1.0;
+			p_theme->set_color("icon_hover_color", "EditorLogFilterButton", icon_hover_color);
+			p_theme->set_color("icon_hover_pressed_color", "EditorLogFilterButton", icon_hover_color);
+
+			// When pressed, add a small bottom border to the buttons to better show their active state,
+			// similar to active tabs.
+			Ref<StyleBoxFlat> editor_log_button_pressed = style_flat_button_pressed->duplicate();
+			editor_log_button_pressed->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
+			editor_log_button_pressed->set_border_color(p_config.accent_color);
+			if (!p_config.dark_theme) {
+				editor_log_button_pressed->set_bg_color(flat_pressed_color.lightened(0.5));
+			}
+			p_theme->set_stylebox(CoreStringName(normal), "EditorLogFilterButton", style_flat_button);
+			p_theme->set_stylebox(SceneStringName(hover), "EditorLogFilterButton", style_flat_button_hover);
+			p_theme->set_stylebox(SceneStringName(pressed), "EditorLogFilterButton", editor_log_button_pressed);
+		}
+
+		// Buttons styles that stand out against the panel background (e.g. AssetLib).
+		{
+			p_theme->set_type_variation("PanelBackgroundButton", "Button");
+
+			Ref<StyleBoxFlat> panel_button_style = p_config.button_style->duplicate();
+			panel_button_style->set_bg_color(p_config.base_color.lerp(p_config.mono_color, 0.08));
+
+			Ref<StyleBoxFlat> panel_button_style_hover = p_config.button_style_hover->duplicate();
+			panel_button_style_hover->set_bg_color(p_config.base_color.lerp(p_config.mono_color, 0.16));
+
+			Ref<StyleBoxFlat> panel_button_style_pressed = p_config.button_style_pressed->duplicate();
+			panel_button_style_pressed->set_bg_color(p_config.base_color.lerp(p_config.mono_color, 0.20));
+
+			Ref<StyleBoxFlat> panel_button_style_disabled = p_config.button_style_disabled->duplicate();
+			panel_button_style_disabled->set_bg_color(p_config.disabled_bg_color);
+
+			p_theme->set_stylebox(CoreStringName(normal), "PanelBackgroundButton", panel_button_style);
+			p_theme->set_stylebox(SceneStringName(hover), "PanelBackgroundButton", panel_button_style_hover);
+			p_theme->set_stylebox(SceneStringName(pressed), "PanelBackgroundButton", panel_button_style_pressed);
+			p_theme->set_stylebox("disabled", "PanelBackgroundButton", panel_button_style_disabled);
+		}
+
+		// Top bar selectors.
+		{
+			p_theme->set_type_variation("TopBarOptionButton", "OptionButton");
+			p_theme->set_font(SceneStringName(font), "TopBarOptionButton", p_theme->get_font(SNAME("bold"), EditorStringName(EditorFonts)));
+			p_theme->set_font_size(SceneStringName(font_size), "TopBarOptionButton", p_theme->get_font_size(SNAME("bold_size"), EditorStringName(EditorFonts)));
+		}
+
+		// Complex editor windows.
+		{
+			Ref<StyleBoxFlat> style_complex_window = p_config.window_style->duplicate();
+			style_complex_window->set_bg_color(p_config.dark_color_2);
+			style_complex_window->set_border_color(p_config.dark_color_2);
+			p_theme->set_stylebox(SceneStringName(panel), "EditorSettingsDialog", style_complex_window);
+			p_theme->set_stylebox(SceneStringName(panel), "ProjectSettingsEditor", style_complex_window);
+			p_theme->set_stylebox(SceneStringName(panel), "EditorAbout", style_complex_window);
+		}
+
+		// InspectorActionButton.
+		{
+			p_theme->set_type_variation("InspectorActionButton", "Button");
+
+			const float action_extra_margin = 32 * EDSCALE;
+			p_theme->set_constant("h_separation", "InspectorActionButton", action_extra_margin);
+
+			Color color_inspector_action = p_config.dark_color_1.lerp(p_config.mono_color, 0.12);
+			color_inspector_action.a = 0.5;
+			Ref<StyleBoxFlat> style_inspector_action = p_config.button_style->duplicate();
+			style_inspector_action->set_bg_color(color_inspector_action);
+			style_inspector_action->set_content_margin(SIDE_RIGHT, action_extra_margin);
+			p_theme->set_stylebox(CoreStringName(normal), "InspectorActionButton", style_inspector_action);
+
+			style_inspector_action = p_config.button_style->duplicate();
+			style_inspector_action->set_bg_color(color_inspector_action);
+			style_inspector_action->set_content_margin(SIDE_LEFT, action_extra_margin);
+			p_theme->set_stylebox("normal_mirrored", "InspectorActionButton", style_inspector_action);
+
+			style_inspector_action = p_config.button_style_hover->duplicate();
+			style_inspector_action->set_content_margin(SIDE_RIGHT, action_extra_margin);
+			p_theme->set_stylebox(SceneStringName(hover), "InspectorActionButton", style_inspector_action);
+
+			style_inspector_action = p_config.button_style_hover->duplicate();
+			style_inspector_action->set_content_margin(SIDE_LEFT, action_extra_margin);
+			p_theme->set_stylebox("hover_mirrored", "InspectorActionButton", style_inspector_action);
+
+			style_inspector_action = p_config.button_style_pressed->duplicate();
+			style_inspector_action->set_content_margin(SIDE_RIGHT, action_extra_margin);
+			p_theme->set_stylebox(SceneStringName(pressed), "InspectorActionButton", style_inspector_action);
+
+			style_inspector_action = p_config.button_style_pressed->duplicate();
+			style_inspector_action->set_content_margin(SIDE_LEFT, action_extra_margin);
+			p_theme->set_stylebox("pressed_mirrored", "InspectorActionButton", style_inspector_action);
+
+			style_inspector_action = p_config.button_style_disabled->duplicate();
+			style_inspector_action->set_content_margin(SIDE_RIGHT, action_extra_margin);
+			p_theme->set_stylebox("disabled", "InspectorActionButton", style_inspector_action);
+
+			style_inspector_action = p_config.button_style_disabled->duplicate();
+			style_inspector_action->set_content_margin(SIDE_LEFT, action_extra_margin);
+			p_theme->set_stylebox("disabled_mirrored", "InspectorActionButton", style_inspector_action);
+		}
+
+		// Buttons in material previews.
+		{
+			const Color dim_light_color = p_config.icon_normal_color.darkened(0.24);
+			const Color dim_light_highlighted_color = p_config.icon_normal_color.darkened(0.18);
+			Ref<StyleBox> sb_empty_borderless = EditorThemeManager::make_empty_stylebox();
+
+			p_theme->set_type_variation("PreviewLightButton", "Button");
+			// When pressed, don't use the accent color tint. When unpressed, dim the icon.
+			p_theme->set_color("icon_normal_color", "PreviewLightButton", dim_light_color);
+			p_theme->set_color("icon_focus_color", "PreviewLightButton", dim_light_color);
+			p_theme->set_color("icon_pressed_color", "PreviewLightButton", p_config.icon_normal_color);
+			p_theme->set_color("icon_hover_pressed_color", "PreviewLightButton", p_config.icon_normal_color);
+			// Unpressed icon is dim, so use a dim highlight.
+			p_theme->set_color("icon_hover_color", "PreviewLightButton", dim_light_highlighted_color);
+
+			p_theme->set_stylebox(CoreStringName(normal), "PreviewLightButton", sb_empty_borderless);
+			p_theme->set_stylebox(SceneStringName(hover), "PreviewLightButton", sb_empty_borderless);
+			p_theme->set_stylebox("focus", "PreviewLightButton", sb_empty_borderless);
+			p_theme->set_stylebox(SceneStringName(pressed), "PreviewLightButton", sb_empty_borderless);
+		}
+
+		// TabContainerOdd variation.
+		{
+			// Can be used on tabs against the base color background (e.g. nested tabs).
+			p_theme->set_type_variation("TabContainerOdd", "TabContainer");
+
+			Ref<StyleBoxFlat> style_tab_selected_odd = p_theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->duplicate();
+			style_tab_selected_odd->set_bg_color(p_config.disabled_bg_color);
+			p_theme->set_stylebox("tab_selected", "TabContainerOdd", style_tab_selected_odd);
+
+			Ref<StyleBoxFlat> style_content_panel_odd = p_config.content_panel_style->duplicate();
+			style_content_panel_odd->set_bg_color(p_config.disabled_bg_color);
+			p_theme->set_stylebox(SceneStringName(panel), "TabContainerOdd", style_content_panel_odd);
+		}
+
+		// EditorValidationPanel.
+		p_theme->set_stylebox(SceneStringName(panel), "EditorValidationPanel", p_config.tree_panel_style);
+
+		// Secondary trees and item lists.
+		p_theme->set_type_variation("TreeSecondary", "Tree");
+		p_theme->set_type_variation("ItemListSecondary", "ItemList");
+	}
+
+	// Editor inspector.
+	{
+		// Panel.
+		Ref<StyleBoxFlat> editor_inspector_panel = p_config.tree_panel_style->duplicate();
+		editor_inspector_panel->set_border_width_all(0);
+		editor_inspector_panel->set_content_margin_all(0);
+		p_theme->set_stylebox(SceneStringName(panel), "EditorInspector", editor_inspector_panel);
+
+		// Vertical separation between inspector categories and sections.
+		p_theme->set_constant("v_separation", "EditorInspector", 0);
+
+		// EditorProperty.
+
+		Ref<StyleBoxFlat> style_property_bg = p_config.base_style->duplicate();
+		style_property_bg->set_bg_color(p_config.highlight_color);
+		style_property_bg->set_border_width_all(0);
+
+		Ref<StyleBoxFlat> style_property_child_bg = p_config.base_style->duplicate();
+		style_property_child_bg->set_bg_color(p_config.dark_color_2);
+		style_property_child_bg->set_border_width_all(0);
+
+		p_theme->set_stylebox("bg", "EditorProperty", memnew(StyleBoxEmpty));
+		p_theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg);
+		p_theme->set_stylebox("child_bg", "EditorProperty", style_property_child_bg);
+		p_theme->set_constant("font_offset", "EditorProperty", 8 * EDSCALE);
+		p_theme->set_constant("v_separation", "EditorProperty", p_config.increased_margin * EDSCALE);
+
+		const Color property_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
+		const Color readonly_color = property_color.lerp(p_config.dark_icon_and_font ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
+		const Color readonly_warning_color = p_config.error_color.lerp(p_config.dark_icon_and_font ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
+
+		p_theme->set_color("property_color", "EditorProperty", property_color);
+		p_theme->set_color("readonly_color", "EditorProperty", readonly_color);
+		p_theme->set_color("warning_color", "EditorProperty", p_config.warning_color);
+		p_theme->set_color("readonly_warning_color", "EditorProperty", readonly_warning_color);
+
+		Ref<StyleBoxFlat> style_property_group_note = p_config.base_style->duplicate();
+		Color property_group_note_color = p_config.accent_color;
+		property_group_note_color.a = 0.1;
+		style_property_group_note->set_bg_color(property_group_note_color);
+		p_theme->set_stylebox("bg_group_note", "EditorProperty", style_property_group_note);
+
+		// EditorInspectorSection.
+
+		Color inspector_section_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.35);
+		p_theme->set_color(SceneStringName(font_color), "EditorInspectorSection", inspector_section_color);
+
+		Color inspector_indent_color = p_config.accent_color;
+		inspector_indent_color.a = 0.2;
+		Ref<StyleBoxFlat> inspector_indent_style = EditorThemeManager::make_flat_stylebox(inspector_indent_color, 2.0 * EDSCALE, 0, 2.0 * EDSCALE, 0);
+		p_theme->set_stylebox("indent_box", "EditorInspectorSection", inspector_indent_style);
+		p_theme->set_constant("indent_size", "EditorInspectorSection", 6.0 * EDSCALE);
+		p_theme->set_constant("h_separation", "EditorInspectorSection", 2.0 * EDSCALE);
+
+		Color prop_category_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.12);
+		Color prop_subsection_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.06);
+
+		p_theme->set_color("prop_subsection", EditorStringName(Editor), prop_subsection_color);
+#ifndef DISABLE_DEPRECATED // Used before 4.3.
+		p_theme->set_color("property_color", EditorStringName(Editor), prop_category_color);
+#endif
+
+		// EditorInspectorCategory.
+
+		Ref<StyleBoxFlat> category_bg = p_config.base_style->duplicate();
+		category_bg->set_bg_color(prop_category_color);
+		category_bg->set_border_color(prop_category_color);
+		category_bg->set_content_margin_all(0);
+		p_theme->set_stylebox("bg", "EditorInspectorCategory", category_bg);
+
+		p_theme->set_constant("inspector_margin", EditorStringName(Editor), 12 * EDSCALE);
+
+		// Colored EditorProperty.
+		for (int i = 0; i < 16; i++) {
+			Color si_base_color = p_config.accent_color;
+
+			float hue_rotate = (i * 2 % 16) / 16.0;
+			si_base_color.set_hsv(Math::fmod(float(si_base_color.get_h() + hue_rotate), float(1.0)), si_base_color.get_s(), si_base_color.get_v());
+			si_base_color = p_config.accent_color.lerp(si_base_color, p_config.subresource_hue_tint);
+
+			// Sub-inspector background.
+			Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
+			sub_inspector_bg->set_bg_color(p_config.dark_color_1.lerp(si_base_color, 0.08));
+			sub_inspector_bg->set_border_width_all(2 * EDSCALE);
+			sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
+			sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+			sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
+			sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
+
+			p_theme->set_stylebox("sub_inspector_bg" + itos(i + 1), EditorStringName(EditorStyles), sub_inspector_bg);
+
+			// EditorProperty background while it has a sub-inspector open.
+			Ref<StyleBoxFlat> bg_color = EditorThemeManager::make_flat_stylebox(si_base_color * Color(0.7, 0.7, 0.7, 0.8), 0, 0, 0, 0, p_config.corner_radius);
+			bg_color->set_anti_aliased(false);
+			bg_color->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			bg_color->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+
+			p_theme->set_stylebox("sub_inspector_property_bg" + itos(i + 1), EditorStringName(EditorStyles), bg_color);
+
+			// Dictionary editor add item.
+			// Expand to the left and right by 4px to compensate for the dictionary editor margins.
+			Color style_dictionary_bg_color = p_config.dark_color_3.lerp(si_base_color, 0.08);
+			Ref<StyleBoxFlat> style_dictionary_add_item = EditorThemeManager::make_flat_stylebox(style_dictionary_bg_color, 0, 4, 0, 4, p_config.corner_radius);
+			style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 2 * EDSCALE);
+			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+			p_theme->set_stylebox("DictionaryAddItem" + itos(i + 1), EditorStringName(EditorStyles), style_dictionary_add_item);
+
+			// Object selector;
+			p_theme->set_type_variation("ObjectSelectorMargin", "MarginContainer");
+			p_theme->set_constant("margin_left", "ObjectSelectorMargin", 4 * EDSCALE);
+			p_theme->set_constant("margin_right", "ObjectSelectorMargin", 6 * EDSCALE);
+		}
+		Color si_base_color = p_config.accent_color;
+
+		// Sub-inspector background.
+		Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
+		sub_inspector_bg->set_bg_color(Color(1, 1, 1, 0));
+		sub_inspector_bg->set_border_width_all(2 * EDSCALE);
+		sub_inspector_bg->set_border_color(p_config.dark_color_1.lerp(si_base_color, 0.15));
+		sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+		sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
+		sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
+
+		p_theme->set_stylebox("sub_inspector_bg0", EditorStringName(EditorStyles), sub_inspector_bg);
+
+		// Sub-inspector background no border.
+
+		Ref<StyleBoxFlat> sub_inspector_bg_no_border = p_config.base_style->duplicate();
+		sub_inspector_bg_no_border->set_content_margin_all(2 * EDSCALE);
+		sub_inspector_bg_no_border->set_bg_color(p_config.dark_color_2.lerp(p_config.dark_color_3, 0.15));
+		p_theme->set_stylebox("sub_inspector_bg_no_border", EditorStringName(EditorStyles), sub_inspector_bg_no_border);
+
+		// EditorProperty background while it has a sub-inspector open.
+		Ref<StyleBoxFlat> bg_color = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.lerp(si_base_color, 0.15), 0, 0, 0, 0, p_config.corner_radius);
+		bg_color->set_anti_aliased(false);
+		bg_color->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		bg_color->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+
+		p_theme->set_stylebox("sub_inspector_property_bg0", EditorStringName(EditorStyles), bg_color);
+
+		p_theme->set_color("sub_inspector_property_color", EditorStringName(EditorStyles), p_config.dark_icon_and_font ? Color(1, 1, 1, 1) : Color(0, 0, 0, 1));
+
+		// Dictionary editor.
+
+		// Expand to the left and right by 4px to compensate for the dictionary editor margins.
+		Ref<StyleBoxFlat> style_dictionary_add_item = EditorThemeManager::make_flat_stylebox(prop_subsection_color, 0, 4, 0, 4, p_config.corner_radius);
+		style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 2 * EDSCALE);
+		style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+		p_theme->set_stylebox("DictionaryAddItem0", EditorStringName(EditorStyles), style_dictionary_add_item);
+	}
+
+	// Animation Editor.
+	{
+		// Timeline general.
+		p_theme->set_constant("timeline_v_separation", "AnimationTrackEditor", 0);
+		p_theme->set_constant("track_v_separation", "AnimationTrackEditor", 0);
+
+		// AnimationTimelineEdit.
+		// "primary" is used for integer timeline values, "secondary" for decimals.
+
+		Ref<StyleBoxFlat> style_time_unavailable = EditorThemeManager::make_flat_stylebox(p_config.dark_color_2, 0, 0, 0, 0, 0);
+		Ref<StyleBoxFlat> style_time_available = EditorThemeManager::make_flat_stylebox(p_config.font_color * Color(1, 1, 1, 0.2), 0, 0, 0, 0, 0);
+
+		p_theme->set_stylebox("time_unavailable", "AnimationTimelineEdit", style_time_unavailable);
+		p_theme->set_stylebox("time_available", "AnimationTimelineEdit", style_time_available);
+
+		p_theme->set_color("v_line_primary_color", "AnimationTimelineEdit", p_config.font_color * Color(1, 1, 1, 0.2));
+		p_theme->set_color("v_line_secondary_color", "AnimationTimelineEdit", p_config.font_color * Color(1, 1, 1, 0.2));
+		p_theme->set_color("h_line_color", "AnimationTimelineEdit", p_config.font_color * Color(1, 1, 1, 0.2));
+		p_theme->set_color("font_primary_color", "AnimationTimelineEdit", p_config.font_color);
+		p_theme->set_color("font_secondary_color", "AnimationTimelineEdit", p_config.font_color * Color(1, 1, 1, 0.5));
+
+		p_theme->set_constant("v_line_primary_margin", "AnimationTimelineEdit", 0);
+		p_theme->set_constant("v_line_secondary_margin", "AnimationTimelineEdit", 0);
+		p_theme->set_constant("v_line_primary_width", "AnimationTimelineEdit", 1 * EDSCALE);
+		p_theme->set_constant("v_line_secondary_width", "AnimationTimelineEdit", 1 * EDSCALE);
+		p_theme->set_constant("text_primary_margin", "AnimationTimelineEdit", 3 * EDSCALE);
+		p_theme->set_constant("text_secondary_margin", "AnimationTimelineEdit", 3 * EDSCALE);
+
+		// AnimationTrackEdit.
+
+		Ref<StyleBoxFlat> style_animation_track_odd = EditorThemeManager::make_flat_stylebox(Color(0.5, 0.5, 0.5, 0.05), 0, 0, 0, 0, p_config.corner_radius);
+		Ref<StyleBoxFlat> style_animation_track_hover = EditorThemeManager::make_flat_stylebox(Color(0.5, 0.5, 0.5, 0.1), 0, 0, 0, 0, p_config.corner_radius);
+
+		p_theme->set_stylebox("odd", "AnimationTrackEdit", style_animation_track_odd);
+		p_theme->set_stylebox(SceneStringName(hover), "AnimationTrackEdit", style_animation_track_hover);
+		p_theme->set_stylebox("focus", "AnimationTrackEdit", p_config.button_style_focus);
+
+		p_theme->set_color("h_line_color", "AnimationTrackEdit", p_config.font_color * Color(1, 1, 1, 0.2));
+
+		p_theme->set_constant("h_separation", "AnimationTrackEdit", (p_config.increased_margin + 2) * EDSCALE);
+		p_theme->set_constant("outer_margin", "AnimationTrackEdit", p_config.increased_margin * 6 * EDSCALE);
+
+		// AnimationTrackEditGroup.
+
+		Ref<StyleBoxFlat> style_animation_track_header = EditorThemeManager::make_flat_stylebox(p_config.dark_color_2 * Color(1, 1, 1, 0.6), p_config.increased_margin * 3, 0, 0, 0, p_config.corner_radius);
+
+		p_theme->set_stylebox("header", "AnimationTrackEditGroup", style_animation_track_header);
+
+		p_theme->set_color("h_line_color", "AnimationTrackEditGroup", p_config.font_color * Color(1, 1, 1, 0.2));
+		p_theme->set_color("v_line_color", "AnimationTrackEditGroup", p_config.font_color * Color(1, 1, 1, 0.2));
+
+		p_theme->set_constant("h_separation", "AnimationTrackEditGroup", (p_config.increased_margin + 2) * EDSCALE);
+		p_theme->set_constant("v_separation", "AnimationTrackEditGroup", 0);
+
+		// AnimationBezierTrackEdit.
+
+		p_theme->set_color("focus_color", "AnimationBezierTrackEdit", p_config.accent_color * Color(1, 1, 1, 0.7));
+		p_theme->set_color("track_focus_color", "AnimationBezierTrackEdit", p_config.accent_color * Color(1, 1, 1, 0.5));
+		p_theme->set_color("h_line_color", "AnimationBezierTrackEdit", p_config.font_color * Color(1, 1, 1, 0.2));
+		p_theme->set_color("v_line_color", "AnimationBezierTrackEdit", p_config.font_color * Color(1, 1, 1, 0.2));
+
+		p_theme->set_constant("h_separation", "AnimationBezierTrackEdit", (p_config.increased_margin + 2) * EDSCALE);
+		p_theme->set_constant("v_separation", "AnimationBezierTrackEdit", p_config.forced_even_separation * EDSCALE);
+	}
+
+	// Editor help.
+	{
+		Ref<StyleBoxFlat> style_editor_help = p_config.base_style->duplicate();
+		style_editor_help->set_bg_color(p_config.dark_color_2);
+		style_editor_help->set_border_color(p_config.dark_color_3);
+		p_theme->set_stylebox("background", "EditorHelp", style_editor_help);
+
+		const Color kbd_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
+
+		p_theme->set_color("title_color", "EditorHelp", p_config.accent_color);
+		p_theme->set_color("headline_color", "EditorHelp", p_config.mono_color_icon_and_font);
+		p_theme->set_color("text_color", "EditorHelp", p_config.font_color);
+		p_theme->set_color("comment_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
+		p_theme->set_color("symbol_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
+		p_theme->set_color("value_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
+		p_theme->set_color("qualifier_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.8));
+		p_theme->set_color("type_color", "EditorHelp", p_config.accent_color.lerp(p_config.font_color, 0.5));
+		p_theme->set_color("override_color", "EditorHelp", p_config.warning_color);
+		p_theme->set_color("selection_color", "EditorHelp", p_config.selection_color);
+		p_theme->set_color("link_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color_icon_and_font, 0.8));
+		p_theme->set_color("code_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color_icon_and_font, 0.6));
+		p_theme->set_color("kbd_color", "EditorHelp", p_config.accent_color.lerp(kbd_color, 0.6));
+		p_theme->set_color("code_bg_color", "EditorHelp", p_config.dark_color_3);
+		p_theme->set_color("kbd_bg_color", "EditorHelp", p_config.dark_color_1);
+		p_theme->set_color("param_bg_color", "EditorHelp", p_config.dark_color_1);
+		p_theme->set_constant(SceneStringName(line_separation), "EditorHelp", Math::round(6 * EDSCALE));
+		p_theme->set_constant("table_h_separation", "EditorHelp", 16 * EDSCALE);
+		p_theme->set_constant("table_v_separation", "EditorHelp", 6 * EDSCALE);
+		p_theme->set_constant("text_highlight_h_padding", "EditorHelp", 1 * EDSCALE);
+		p_theme->set_constant("text_highlight_v_padding", "EditorHelp", 2 * EDSCALE);
+	}
+
+	// EditorHelpBitTitle.
+	{
+		Ref<StyleBoxFlat> style = p_config.tree_panel_style->duplicate();
+		style->set_bg_color(p_config.dark_theme ? style->get_bg_color().lightened(0.04) : style->get_bg_color().darkened(0.04));
+		style->set_border_color(p_config.dark_theme ? style->get_border_color().lightened(0.04) : style->get_border_color().darkened(0.04));
+		if (p_config.draw_extra_borders) {
+			// A tooltip border is already drawn for all tooltips when Draw Extra Borders is enabled.
+			// Hide borders that don't serve in drawing a line between the title and content to prevent the border from being doubled.
+			style->set_border_width(SIDE_TOP, 0);
+			style->set_border_width(SIDE_LEFT, 0);
+			style->set_border_width(SIDE_RIGHT, 0);
+		}
+		style->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		style->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+
+		p_theme->set_type_variation("EditorHelpBitTitle", "RichTextLabel");
+		p_theme->set_stylebox(CoreStringName(normal), "EditorHelpBitTitle", style);
+	}
+
+	// EditorHelpBitContent.
+	{
+		Ref<StyleBoxFlat> style = p_config.tree_panel_style->duplicate();
+		if (p_config.draw_extra_borders) {
+			// A tooltip border is already drawn for all tooltips when Draw Extra Borders is enabled.
+			// Hide borders that don't serve in drawing a line between the title and content to prevent the border from being doubled.
+			style->set_border_width(SIDE_BOTTOM, 0);
+			style->set_border_width(SIDE_LEFT, 0);
+			style->set_border_width(SIDE_RIGHT, 0);
+		}
+		style->set_corner_radius(CORNER_TOP_LEFT, 0);
+		style->set_corner_radius(CORNER_TOP_RIGHT, 0);
+
+		p_theme->set_type_variation("EditorHelpBitContent", "RichTextLabel");
+		p_theme->set_stylebox(CoreStringName(normal), "EditorHelpBitContent", style);
+	}
+
+	// Asset Library.
+	p_theme->set_stylebox("bg", "AssetLib", p_config.base_empty_style);
+	p_theme->set_stylebox(SceneStringName(panel), "AssetLib", p_config.content_panel_style);
+	p_theme->set_color("status_color", "AssetLib", Color(0.5, 0.5, 0.5)); // FIXME: Use a defined color instead.
+	p_theme->set_icon("dismiss", "AssetLib", p_theme->get_icon(SNAME("Close"), EditorStringName(EditorIcons)));
+
+	// Debugger.
+	Ref<StyleBoxFlat> debugger_panel_style = p_config.content_panel_style->duplicate();
+	debugger_panel_style->set_border_width(SIDE_BOTTOM, 0);
+	p_theme->set_stylebox("DebuggerPanel", EditorStringName(EditorStyles), debugger_panel_style);
+
+	// Resource and node editors.
+	{
+		// TextureRegion editor.
+		Ref<StyleBoxFlat> style_texture_region_bg = p_config.tree_panel_style->duplicate();
+		style_texture_region_bg->set_content_margin_all(0);
+		p_theme->set_stylebox("TextureRegionPreviewBG", EditorStringName(EditorStyles), style_texture_region_bg);
+		p_theme->set_stylebox("TextureRegionPreviewFG", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+
+		// Theme editor.
+		{
+			p_theme->set_color("preview_picker_overlay_color", "ThemeEditor", Color(0.1, 0.1, 0.1, 0.25));
+
+			Color theme_preview_picker_bg_color = p_config.accent_color;
+			theme_preview_picker_bg_color.a = 0.2;
+			Ref<StyleBoxFlat> theme_preview_picker_sb = EditorThemeManager::make_flat_stylebox(theme_preview_picker_bg_color, 0, 0, 0, 0);
+			theme_preview_picker_sb->set_border_color(p_config.accent_color);
+			theme_preview_picker_sb->set_border_width_all(1.0 * EDSCALE);
+			p_theme->set_stylebox("preview_picker_overlay", "ThemeEditor", theme_preview_picker_sb);
+
+			Color theme_preview_picker_label_bg_color = p_config.accent_color;
+			theme_preview_picker_label_bg_color.set_v(0.5);
+			Ref<StyleBoxFlat> theme_preview_picker_label_sb = EditorThemeManager::make_flat_stylebox(theme_preview_picker_label_bg_color, 4.0, 1.0, 4.0, 3.0);
+			p_theme->set_stylebox("preview_picker_label", "ThemeEditor", theme_preview_picker_label_sb);
+
+			Ref<StyleBoxFlat> style_theme_preview_tab = p_theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainerOdd"))->duplicate();
+			style_theme_preview_tab->set_expand_margin(SIDE_BOTTOM, 5 * EDSCALE);
+			p_theme->set_stylebox("ThemeEditorPreviewFG", EditorStringName(EditorStyles), style_theme_preview_tab);
+
+			Ref<StyleBoxFlat> style_theme_preview_bg_tab = p_theme->get_stylebox(SNAME("tab_unselected"), SNAME("TabContainer"))->duplicate();
+			style_theme_preview_bg_tab->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
+			p_theme->set_stylebox("ThemeEditorPreviewBG", EditorStringName(EditorStyles), style_theme_preview_bg_tab);
+		}
+
+		// VisualShader editor.
+		p_theme->set_stylebox("label_style", "VShaderEditor", EditorThemeManager::make_empty_stylebox(4, 6, 4, 6));
+
+		// StateMachine graph.
+		{
+			p_theme->set_stylebox(SceneStringName(panel), "GraphStateMachine", p_config.tree_panel_style);
+			p_theme->set_stylebox("error_panel", "GraphStateMachine", p_config.tree_panel_style);
+			p_theme->set_color("error_color", "GraphStateMachine", p_config.error_color);
+
+			const int sm_margin_side = 10 * EDSCALE;
+			const int sm_margin_bottom = 2;
+			const Color sm_bg_color = p_config.dark_theme ? p_config.dark_color_3 : p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
+
+			Ref<StyleBoxFlat> sm_node_style = EditorThemeManager::make_flat_stylebox(p_config.dark_color_3 * Color(1, 1, 1, 0.7), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
+			sm_node_style->set_border_width_all(p_config.border_width);
+			sm_node_style->set_border_color(sm_bg_color);
+
+			Ref<StyleBoxFlat> sm_node_selected_style = EditorThemeManager::make_flat_stylebox(sm_bg_color * Color(1, 1, 1, 0.9), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
+			sm_node_selected_style->set_border_width_all(2 * EDSCALE + p_config.border_width);
+			sm_node_selected_style->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.9));
+			sm_node_selected_style->set_shadow_size(8 * EDSCALE);
+			sm_node_selected_style->set_shadow_color(p_config.shadow_color);
+
+			Ref<StyleBoxFlat> sm_node_playing_style = sm_node_selected_style->duplicate();
+			sm_node_playing_style->set_border_color(p_config.warning_color);
+			sm_node_playing_style->set_shadow_color(p_config.warning_color * Color(1, 1, 1, 0.2));
+			sm_node_playing_style->set_draw_center(false);
+
+			p_theme->set_stylebox("node_frame", "GraphStateMachine", sm_node_style);
+			p_theme->set_stylebox("node_frame_selected", "GraphStateMachine", sm_node_selected_style);
+			p_theme->set_stylebox("node_frame_playing", "GraphStateMachine", sm_node_playing_style);
+
+			Ref<StyleBoxFlat> sm_node_start_style = sm_node_style->duplicate();
+			sm_node_start_style->set_border_width_all(1 * EDSCALE);
+			sm_node_start_style->set_border_color(p_config.success_color.lightened(0.24));
+			p_theme->set_stylebox("node_frame_start", "GraphStateMachine", sm_node_start_style);
+
+			Ref<StyleBoxFlat> sm_node_end_style = sm_node_style->duplicate();
+			sm_node_end_style->set_border_width_all(1 * EDSCALE);
+			sm_node_end_style->set_border_color(p_config.error_color);
+			p_theme->set_stylebox("node_frame_end", "GraphStateMachine", sm_node_end_style);
+
+			p_theme->set_font("node_title_font", "GraphStateMachine", p_theme->get_font(SceneStringName(font), SNAME("Label")));
+			p_theme->set_font_size("node_title_font_size", "GraphStateMachine", p_theme->get_font_size(SceneStringName(font_size), SNAME("Label")));
+			p_theme->set_color("node_title_font_color", "GraphStateMachine", p_config.font_color);
+
+			p_theme->set_color("transition_color", "GraphStateMachine", p_config.font_color);
+			p_theme->set_color("transition_disabled_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.2));
+			p_theme->set_color("transition_icon_color", "GraphStateMachine", Color(1, 1, 1));
+			p_theme->set_color("transition_icon_disabled_color", "GraphStateMachine", Color(1, 1, 1, 0.2));
+			p_theme->set_color("highlight_color", "GraphStateMachine", p_config.accent_color);
+			p_theme->set_color("highlight_disabled_color", "GraphStateMachine", p_config.accent_color * Color(1, 1, 1, 0.6));
+			p_theme->set_color("focus_color", "GraphStateMachine", p_config.accent_color);
+			p_theme->set_color("guideline_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
+
+			p_theme->set_color("playback_color", "GraphStateMachine", p_config.font_color);
+			p_theme->set_color("playback_background_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
+		}
+	}
+}

--- a/editor/themes/theme_classic.h
+++ b/editor/themes/theme_classic.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_dir_dialog.h                                                   */
+/*  theme_classic.h                                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,45 +30,11 @@
 
 #pragma once
 
-#include "scene/gui/dialogs.h"
+#include "editor/themes/editor_theme_manager.h"
 
-class DirectoryCreateDialog;
-class EditorFileSystemDirectory;
-class Tree;
-class TreeItem;
-
-class EditorDirDialog : public ConfirmationDialog {
-	GDCLASS(EditorDirDialog, ConfirmationDialog);
-
-	DirectoryCreateDialog *makedialog = nullptr;
-
-	Button *makedir = nullptr;
-	Button *copy = nullptr;
-	HashSet<String> opened_paths;
-	String new_dir_path;
-
-	Tree *tree = nullptr;
-	bool updating = false;
-
-	void _item_collapsed(Object *p_item);
-	void _item_activated();
-	void _update_dir(const Color &p_default_folder_color, const Dictionary &p_assigned_folder_colors, const HashMap<String, Color> &p_folder_colors, bool p_is_dark_icon_and_font, TreeItem *p_item, EditorFileSystemDirectory *p_dir, const String &p_select_path = String());
-
-	void _make_dir();
-	void _make_dir_confirm(const String &p_path, const String &p_base_dir);
-
-	void _copy_pressed();
-	void ok_pressed() override;
-
-	bool must_reload = false;
-
-protected:
-	void _notification(int p_what);
-	static void _bind_methods();
-
+class ThemeClassic {
 public:
-	void config(const Vector<String> &p_paths);
-	void reload(const String &p_path = "");
-
-	EditorDirDialog();
+	static void populate_shared_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config);
+	static void populate_standard_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config);
+	static void populate_editor_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config);
 };

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1,0 +1,2278 @@
+/**************************************************************************/
+/*  theme_modern.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "theme_modern.h"
+
+#include "core/math/math_defs.h"
+#include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
+#include "editor/themes/editor_scale.h"
+#include "editor/themes/editor_theme_manager.h"
+#include "scene/gui/graph_edit.h"
+#include "scene/resources/dpi_texture.h"
+#include "scene/resources/image_texture.h"
+#include "scene/resources/style_box_flat.h"
+#include "scene/resources/style_box_line.h"
+
+// Helper.
+static Color _get_base_color(EditorThemeManager::ThemeConfiguration &p_config, float p_brightness_ofs = 0.0, float p_saturation_mult = 1.0) {
+	const bool is_dark = p_brightness_ofs >= 0.0 ? p_config.dark_theme : !p_config.dark_theme;
+	Color color = p_config.base_color;
+	color.set_v(CLAMP(Math::lerp(color.get_v(), is_dark ? 1 : 0, Math::abs(p_config.contrast * p_brightness_ofs)), 0, 1));
+	color.set_s(color.get_s() * p_saturation_mult);
+
+	return color;
+}
+
+void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config) {
+	// Colors.
+	{
+		// Base colors.
+
+		p_theme->set_color("base_color", EditorStringName(Editor), p_config.base_color);
+		p_theme->set_color("accent_color", EditorStringName(Editor), p_config.accent_color);
+
+		// White (dark theme) or black (light theme), will be used to generate the rest of the colors
+		p_config.mono_color = p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0);
+		p_config.mono_color_icon_and_font = p_config.dark_icon_and_font ? Color(1, 1, 1) : Color(0, 0, 0);
+		p_config.mono_color_inv = p_config.dark_theme ? Color(0, 0, 0) : Color(1, 1, 1);
+
+		// Ensure base colors are in the 0..1 luminance range to avoid 8-bit integer overflow or text rendering issues.
+		// Some places in the editor use 8-bit integer colors.
+		p_config.dark_color_1 = p_config.base_color.lerp(Color(0, 0, 0, 1), p_config.contrast).clamp();
+		p_config.dark_color_2 = p_config.dark_theme ? Color(0, 0, 0, 0.3) : Color(1, 1, 1, 0.3);
+		p_config.dark_color_3 = _get_base_color(p_config, p_config.dark_theme ? -0.95 : -1.8, 0.9);
+
+		p_config.contrast_color_1 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast, p_config.default_contrast));
+		p_config.contrast_color_2 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast * 1.5, p_config.default_contrast * 1.5));
+
+		p_config.highlight_color = Color(p_config.accent_color.r, p_config.accent_color.g, p_config.accent_color.b, 0.275);
+		p_config.highlight_disabled_color = p_config.highlight_color.lerp(p_config.dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.5);
+
+		p_config.success_color = Color(0.45, 0.95, 0.5);
+		p_config.warning_color = Color(0.83, 0.78, 0.62);
+		p_config.error_color = Color(1, 0.47, 0.42);
+		if (!p_config.dark_icon_and_font) {
+			// Darken some colors to be readable on a light background.
+			p_config.success_color = p_config.success_color.lerp(p_config.mono_color_icon_and_font, 0.35);
+			p_config.warning_color = Color(0.83, 0.49, 0.01);
+			p_config.error_color = Color(0.8, 0.22, 0.22);
+		}
+
+		p_theme->set_color("mono_color", EditorStringName(Editor), p_config.mono_color);
+		p_theme->set_color("dark_color_1", EditorStringName(Editor), p_config.dark_color_1);
+		p_theme->set_color("dark_color_2", EditorStringName(Editor), p_config.dark_color_2);
+		p_theme->set_color("dark_color_3", EditorStringName(Editor), p_config.dark_color_3);
+		p_theme->set_color("contrast_color_1", EditorStringName(Editor), p_config.contrast_color_1);
+		p_theme->set_color("contrast_color_2", EditorStringName(Editor), p_config.contrast_color_2);
+		p_theme->set_color("highlight_color", EditorStringName(Editor), p_config.highlight_color);
+		p_theme->set_color("highlight_disabled_color", EditorStringName(Editor), p_config.highlight_disabled_color);
+		p_theme->set_color("success_color", EditorStringName(Editor), p_config.success_color);
+		p_theme->set_color("warning_color", EditorStringName(Editor), p_config.warning_color);
+		p_theme->set_color("error_color", EditorStringName(Editor), p_config.error_color);
+#ifndef DISABLE_DEPRECATED // Used before 4.3.
+		p_theme->set_color("disabled_highlight_color", EditorStringName(Editor), p_config.highlight_disabled_color);
+#endif
+
+		// Only used when the Draw Extra Borders editor setting is enabled.
+		p_config.extra_border_color_1 = p_config.dark_theme ? Color(1, 1, 1, 0.4) : Color(0, 0, 0, 0.4);
+		p_config.extra_border_color_2 = p_config.dark_theme ? Color(1, 1, 1, 0.2) : Color(0, 0, 0, 0.2);
+
+		p_theme->set_color("extra_border_color_1", EditorStringName(Editor), p_config.extra_border_color_1);
+		p_theme->set_color("extra_border_color_2", EditorStringName(Editor), p_config.extra_border_color_2);
+
+		// Font colors.
+
+		p_config.font_color = p_config.mono_color_icon_and_font * Color(1, 1, 1, 0.7);
+		p_config.font_secondary_color = p_config.mono_color_icon_and_font * Color(1, 1, 1, 0.45);
+		p_config.font_focus_color = p_config.mono_color_icon_and_font;
+		p_config.font_hover_color = p_config.mono_color_icon_and_font;
+		p_config.font_pressed_color = p_config.mono_color_icon_and_font;
+		p_config.font_hover_pressed_color = p_config.mono_color_icon_and_font;
+		p_config.font_disabled_color = p_config.mono_color_icon_and_font * Color(1, 1, 1, p_config.dark_icon_and_font ? 0.35 : 0.5);
+		p_config.font_readonly_color = Color(p_config.mono_color_icon_and_font.r, p_config.mono_color_icon_and_font.g, p_config.mono_color_icon_and_font.b, 0.65);
+		p_config.font_placeholder_color = p_config.font_disabled_color;
+		p_config.font_outline_color = Color(1, 1, 1, 0);
+
+		p_theme->set_color(SceneStringName(font_color), EditorStringName(Editor), p_config.font_color);
+		p_theme->set_color("font_focus_color", EditorStringName(Editor), p_config.font_focus_color);
+		p_theme->set_color("font_hover_color", EditorStringName(Editor), p_config.font_hover_color);
+		p_theme->set_color("font_pressed_color", EditorStringName(Editor), p_config.font_pressed_color);
+		p_theme->set_color("font_hover_pressed_color", EditorStringName(Editor), p_config.font_hover_pressed_color);
+		p_theme->set_color("font_disabled_color", EditorStringName(Editor), p_config.font_disabled_color);
+		p_theme->set_color("font_readonly_color", EditorStringName(Editor), p_config.font_readonly_color);
+		p_theme->set_color("font_placeholder_color", EditorStringName(Editor), p_config.font_placeholder_color);
+		p_theme->set_color("font_outline_color", EditorStringName(Editor), p_config.font_outline_color);
+#ifndef DISABLE_DEPRECATED // Used before 4.3.
+		p_theme->set_color("readonly_font_color", EditorStringName(Editor), p_config.font_readonly_color);
+		p_theme->set_color("disabled_font_color", EditorStringName(Editor), p_config.font_disabled_color);
+		p_theme->set_color("readonly_color", EditorStringName(Editor), p_config.font_readonly_color);
+		p_theme->set_color("highlighted_font_color", EditorStringName(Editor), p_config.font_hover_color); // Closest equivalent.
+#endif
+
+		// Icon colors.
+
+		p_config.icon_normal_color = p_config.mono_color_icon_and_font * Color(1, 1, 1, 0.7);
+		p_config.icon_secondary_color = p_config.mono_color_icon_and_font * Color(1, 1, 1, 0.45);
+		p_config.icon_focus_color = p_config.mono_color_icon_and_font;
+		p_config.icon_hover_color = p_config.mono_color_icon_and_font;
+		p_config.icon_pressed_color = p_config.mono_color_icon_and_font;
+		p_config.icon_disabled_color = p_config.mono_color_icon_and_font * Color(1, 1, 1, p_config.dark_icon_and_font ? 0.35 : 0.5);
+
+		p_theme->set_color("icon_normal_color", EditorStringName(Editor), p_config.icon_normal_color);
+		p_theme->set_color("icon_focus_color", EditorStringName(Editor), p_config.icon_focus_color);
+		p_theme->set_color("icon_hover_color", EditorStringName(Editor), p_config.icon_hover_color);
+		p_theme->set_color("icon_pressed_color", EditorStringName(Editor), p_config.icon_pressed_color);
+		p_theme->set_color("icon_disabled_color", EditorStringName(Editor), p_config.icon_disabled_color);
+
+		// Additional GUI colors.
+
+		p_config.surface_lowest_color = _get_base_color(p_config, p_config.dark_theme ? -1.3 : -2.2, 0.9);
+		p_config.surface_lower_color = p_config.dark_color_3;
+		p_config.surface_low_color = _get_base_color(p_config, p_config.dark_theme ? -0.6 : -0.9);
+		p_config.surface_base_color = _get_base_color(p_config, -0.2);
+		p_config.surface_high_color = _get_base_color(p_config, 0.2, 0.8);
+		p_config.surface_higher_color = _get_base_color(p_config, 0.35, 0.8);
+		p_config.surface_highest_color = _get_base_color(p_config, 0.55, 0.6);
+
+		p_config.button_normal_color = _get_base_color(p_config, 0.35, 0.85);
+		p_config.button_hover_color = _get_base_color(p_config, 0.55, 0.75);
+		p_config.button_pressed_color = _get_base_color(p_config, 0.75, 0.75);
+		p_config.button_disabled_color = _get_base_color(p_config, 0.2, 0.75);
+		p_config.button_border_normal_color = _get_base_color(p_config, 0.45, 0.75);
+		p_config.button_border_hover_color = _get_base_color(p_config, 0.65, 0.75);
+		p_config.button_border_pressed_color = _get_base_color(p_config, 0.85, 0.75);
+
+		p_config.shadow_color = Color(0, 0, 0, p_config.dark_theme ? 0.3 : 0.1);
+		p_config.selection_color = p_config.accent_color * Color(1, 1, 1, 0.4);
+		p_config.disabled_border_color = p_config.mono_color.inverted().lerp(p_config.base_color, 0.7);
+		p_config.disabled_bg_color = p_config.mono_color.inverted().lerp(p_config.base_color, 0.9);
+		p_config.separator_color = p_config.dark_theme ? Color(0, 0, 0, 0.3) : Color(0, 0, 0, 0.1);
+
+		p_theme->set_color("selection_color", EditorStringName(Editor), p_config.selection_color);
+		p_theme->set_color("disabled_border_color", EditorStringName(Editor), p_config.disabled_border_color);
+		p_theme->set_color("disabled_bg_color", EditorStringName(Editor), p_config.disabled_bg_color);
+		p_theme->set_color("separator_color", EditorStringName(Editor), p_config.separator_color);
+
+		// Additional editor colors.
+
+		p_theme->set_color("box_selection_fill_color", EditorStringName(Editor), p_config.mono_color * Color(1, 1, 1, 0.12));
+		p_theme->set_color("box_selection_stroke_color", EditorStringName(Editor), p_config.mono_color * Color(1, 1, 1, 0.4));
+
+		p_theme->set_color("axis_x_color", EditorStringName(Editor), Color(0.96, 0.20, 0.32));
+		p_theme->set_color("axis_y_color", EditorStringName(Editor), Color(0.53, 0.84, 0.01));
+		p_theme->set_color("axis_z_color", EditorStringName(Editor), Color(0.16, 0.55, 0.96));
+		p_theme->set_color("axis_w_color", EditorStringName(Editor), Color(0.55, 0.55, 0.55));
+
+		p_theme->set_color("property_color_x", EditorStringName(Editor), p_config.dark_icon_and_font ? Color(0.88, 0.38, 0.47) : Color(0.40, 0.04, 0.09));
+		p_theme->set_color("property_color_y", EditorStringName(Editor), p_config.dark_icon_and_font ? Color(0.76, 0.93, 0.40) : Color(0.27, 0.37, 0.06));
+		p_theme->set_color("property_color_z", EditorStringName(Editor), p_config.dark_icon_and_font ? Color(0.42, 0.67, 0.96) : Color(0.08, 0.22, 0.38));
+		p_theme->set_color("property_color_w", EditorStringName(Editor), p_config.font_color);
+
+		// Special colors for rendering methods.
+
+		p_theme->set_color("forward_plus_color", EditorStringName(Editor), Color(0.55, 0.75, 0.39));
+		p_theme->set_color("mobile_color", EditorStringName(Editor), Color(0.45, 0.70, 0.89));
+		p_theme->set_color("gl_compatibility_color", EditorStringName(Editor), Color(0.86, 0.48, 0.58));
+
+		if (p_config.dark_theme) {
+			p_theme->set_color("highend_color", EditorStringName(Editor), Color(1.0, 0.0, 0.0));
+		} else {
+			p_theme->set_color("highend_color", EditorStringName(Editor), Color::hex(0xad1128ff));
+		}
+	}
+
+	// Constants.
+	{
+		// Can't save single float in theme, so using Color.
+		p_theme->set_color("icon_saturation", EditorStringName(Editor), Color(p_config.icon_saturation, p_config.icon_saturation, p_config.icon_saturation));
+
+		// Controls may rely on the scale for their internal drawing logic.
+		p_theme->set_default_base_scale(EDSCALE);
+		p_theme->set_constant("scale", EditorStringName(Editor), EDSCALE);
+
+		p_theme->set_constant("thumb_size", EditorStringName(Editor), p_config.thumb_size);
+		p_theme->set_constant("class_icon_size", EditorStringName(Editor), p_config.class_icon_size);
+		p_theme->set_constant("color_picker_button_height", EditorStringName(Editor), p_config.color_picker_button_height);
+		p_theme->set_constant("gizmo_handle_scale", EditorStringName(Editor), p_config.gizmo_handle_scale);
+
+		p_theme->set_constant("base_margin", EditorStringName(Editor), p_config.base_margin);
+		p_theme->set_constant("increased_margin", EditorStringName(Editor), p_config.increased_margin);
+		p_theme->set_constant("window_border_margin", EditorStringName(Editor), p_config.window_border_margin);
+		p_theme->set_constant("top_bar_separation", EditorStringName(Editor), p_config.top_bar_separation);
+
+		p_theme->set_constant("dark_theme", EditorStringName(Editor), p_config.dark_theme);
+	}
+
+	// Styleboxes.
+	{
+		// This is the basic stylebox, used as a base for most other styleboxes (through `duplicate()`).
+		p_config.base_style = EditorThemeManager::make_flat_stylebox(p_config.base_color, p_config.increased_margin * 1.5, p_config.increased_margin * 1.5, p_config.increased_margin * 1.5, p_config.increased_margin * 1.5, p_config.corner_radius);
+
+		p_config.focus_style = p_config.base_style->duplicate();
+		p_config.focus_style->set_draw_center(false);
+		p_config.focus_style->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.8));
+		p_config.focus_style->set_border_width_all(2);
+
+		p_config.base_empty_style = EditorThemeManager::make_empty_stylebox();
+
+		p_config.base_empty_wide_style = EditorThemeManager::make_empty_stylebox();
+		// Ensure minimum margin for wide flat buttons otherwise the topbar looks broken.
+		float base_empty_wide_margin = MAX(p_config.base_margin, 3.0);
+		p_config.base_empty_wide_style->set_content_margin_individual(base_empty_wide_margin * 1.5 * EDSCALE, base_empty_wide_margin * EDSCALE, base_empty_wide_margin * 1.5 * EDSCALE, base_empty_wide_margin * EDSCALE);
+
+		// Button styles.
+		{
+			p_config.widget_margin = Vector2(p_config.increased_margin + 2, p_config.increased_margin + 1) * EDSCALE;
+
+			p_config.button_style = p_config.base_style->duplicate();
+			p_config.button_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE);
+			p_config.button_style->set_bg_color(p_config.button_normal_color);
+			p_config.button_style->set_border_width_all(Math::round(EDSCALE));
+			p_config.button_style->set_shadow_color(p_config.dark_theme ? Color(0, 0, 0, 0.005) : Color(1, 1, 1, 0.005));
+			p_config.button_style->set_shadow_size(Math::ceil(8 * EDSCALE));
+			p_config.button_style->set_shadow_offset(Vector2(0, 4) * EDSCALE);
+			if (p_config.draw_extra_borders) {
+				p_config.button_style->set_border_color(p_config.extra_border_color_1);
+			} else {
+				p_config.button_style->set_border_color(p_config.button_border_normal_color);
+			}
+
+			p_config.button_style_disabled = p_config.button_style->duplicate();
+			p_config.button_style_disabled->set_bg_color(p_config.button_disabled_color);
+			if (p_config.draw_extra_borders) {
+				p_config.button_style_disabled->set_border_color(p_config.extra_border_color_2 * Color(1, 1, 1, 0.5));
+			} else {
+				p_config.button_style_disabled->set_border_width_all(0);
+			}
+
+			p_config.button_style_pressed = p_config.button_style->duplicate();
+			p_config.button_style_pressed->set_bg_color(p_config.button_pressed_color);
+			if (p_config.draw_extra_borders) {
+				p_config.button_style_pressed->set_border_color(p_config.extra_border_color_1);
+			} else {
+				p_config.button_style_pressed->set_border_color(p_config.button_border_pressed_color);
+			}
+
+			p_config.button_style_hover = p_config.button_style->duplicate();
+			p_config.button_style_hover->set_bg_color(p_config.button_hover_color);
+			if (p_config.draw_extra_borders) {
+				p_config.button_style_pressed->set_border_color(p_config.extra_border_color_1);
+			} else {
+				p_config.button_style_hover->set_border_color(p_config.button_border_hover_color);
+			}
+
+			p_config.flat_button_hover = p_config.base_style->duplicate();
+			// Use the normal variation here and the hover one in the pressed state to lessen contrast.
+			p_config.flat_button_hover->set_bg_color(p_config.button_normal_color);
+			// This affects buttons in Tree so top and bottom margins should be kept low.
+			p_config.flat_button_hover->set_content_margin_individual(p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 0.9 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 0.9 * EDSCALE);
+			if (p_config.draw_extra_borders) {
+				p_config.button_style_hover->set_border_color(p_config.extra_border_color_1);
+			}
+
+			p_config.flat_button_pressed = p_config.flat_button_hover->duplicate();
+			p_config.flat_button_pressed->set_bg_color(p_config.button_hover_color);
+			if (p_config.draw_extra_borders) {
+				p_config.flat_button_pressed->set_border_color(p_config.extra_border_color_1);
+			}
+
+			p_config.flat_button = p_config.flat_button_hover->duplicate();
+			p_config.flat_button->set_draw_center(false);
+		}
+
+		// Windows and popups.
+		{
+			p_config.popup_panel_style = p_config.base_style->duplicate();
+			p_config.popup_panel_style->set_bg_color(_get_base_color(p_config, -0.8, 0.9));
+			p_config.popup_panel_style->set_shadow_color(Color(0, 0, 0, 0.3));
+			p_config.popup_panel_style->set_shadow_size(p_config.base_margin * 0.75 * EDSCALE);
+			p_config.popup_panel_style->set_content_margin_all(p_config.popup_margin * EDSCALE);
+			p_config.popup_panel_style->set_corner_radius_all(0);
+			if (p_config.draw_extra_borders) {
+				p_config.popup_panel_style->set_border_width_all(Math::round(EDSCALE));
+				p_config.popup_panel_style->set_border_color(p_config.extra_border_color_2);
+			}
+
+			p_config.window_style = p_config.base_style->duplicate();
+			p_config.window_style->set_content_margin_all(p_config.popup_margin);
+			p_config.window_style->set_shadow_color(p_config.shadow_color);
+			p_config.window_style->set_shadow_size(4 * EDSCALE);
+			p_config.window_style->set_border_color(p_config.base_color);
+			p_config.window_style->set_border_width(SIDE_TOP, 24 * EDSCALE);
+			p_config.window_style->set_expand_margin(SIDE_TOP, 24 * EDSCALE);
+			p_config.window_style->set_corner_radius_all(0);
+
+			p_config.window_complex_style = p_config.window_style->duplicate();
+			p_config.window_complex_style->set_bg_color(p_config.surface_lowest_color);
+
+			p_config.dialog_style = p_config.base_style->duplicate();
+			p_config.dialog_style->set_content_margin_all(p_config.popup_margin);
+			p_config.dialog_style->set_corner_radius_all(0);
+		}
+
+		// Panels.
+		{
+			p_config.panel_container_style = p_config.button_style->duplicate();
+			p_config.panel_container_style->set_draw_center(false);
+			p_config.panel_container_style->set_border_width_all(0);
+
+			// Content panel for tabs and similar containers.
+
+			// Compensate for the border.
+			const int content_panel_margin = p_config.base_margin * EDSCALE + p_config.border_width;
+
+			p_config.content_panel_style = p_config.base_style->duplicate();
+			p_config.content_panel_style->set_border_color(p_config.dark_color_3);
+			p_config.content_panel_style->set_border_width_all(p_config.border_width);
+			p_config.content_panel_style->set_border_width(Side::SIDE_TOP, 0);
+			p_config.content_panel_style->set_corner_radius(CORNER_TOP_LEFT, 0);
+			p_config.content_panel_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
+			p_config.content_panel_style->set_content_margin_individual(content_panel_margin, 2 * EDSCALE + content_panel_margin, content_panel_margin, content_panel_margin);
+
+			// Trees and similarly inset panels.
+
+			p_config.tree_panel_style = p_config.base_style->duplicate();
+			// Make Trees easier to distinguish from other controls by using a darker background color.
+			p_config.tree_panel_style->set_bg_color(p_config.dark_color_1.lerp(p_config.dark_color_2, 0.5));
+			if (p_config.draw_extra_borders) {
+				p_config.tree_panel_style->set_border_width_all(Math::round(EDSCALE));
+				p_config.tree_panel_style->set_border_color(p_config.extra_border_color_2);
+			} else {
+				p_config.tree_panel_style->set_border_color(p_config.dark_color_3);
+			}
+		}
+	}
+}
+
+void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config) {
+	// Panels.
+	{
+		// Panel.
+		p_theme->set_stylebox(SceneStringName(panel), "Panel", EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 6, 4, 6, 4, p_config.corner_radius));
+
+		// PanelContainer.
+		p_theme->set_stylebox(SceneStringName(panel), "PanelContainer", p_config.base_empty_wide_style);
+
+		// TooltipPanel & TooltipLabel.
+		{
+			// TooltipPanel is also used for custom tooltips, while TooltipLabel
+			// is only relevant for default tooltips.
+
+			p_theme->set_color(SceneStringName(font_color), "TooltipLabel", p_config.font_hover_color);
+			p_theme->set_color("font_shadow_color", "TooltipLabel", Color(1, 1, 1, 0));
+
+			Ref<StyleBoxFlat> tooltip_style = p_config.base_style->duplicate();
+			tooltip_style->set_bg_color(p_config.surface_lower_color);
+			tooltip_style->set_content_margin_all(0);
+			tooltip_style->set_corner_radius_all(0);
+			if (p_config.draw_extra_borders) {
+				tooltip_style->set_border_width_all(Math::round(EDSCALE));
+				tooltip_style->set_border_color(p_config.extra_border_color_2);
+			}
+			p_theme->set_stylebox(SceneStringName(panel), "TooltipPanel", tooltip_style);
+		}
+
+		// PopupPanel
+		Ref<StyleBoxFlat> popup_panel_style = p_config.base_style->duplicate();
+		popup_panel_style->set_bg_color(p_config.surface_lower_color);
+		popup_panel_style->set_shadow_color(Color(0, 0, 0, 0.3));
+		popup_panel_style->set_shadow_size(p_config.base_margin * 0.75 * EDSCALE);
+		popup_panel_style->set_content_margin_all(p_config.popup_margin);
+		popup_panel_style->set_corner_radius_all(0);
+		if (p_config.draw_extra_borders) {
+			popup_panel_style->set_border_width_all(Math::round(EDSCALE));
+			popup_panel_style->set_border_color(p_config.extra_border_color_2);
+		}
+		p_theme->set_stylebox(SceneStringName(panel), "PopupPanel", p_config.popup_panel_style);
+	}
+
+	// Buttons.
+	{
+		// Button.
+
+		p_theme->set_stylebox(CoreStringName(normal), "Button", p_config.button_style);
+		p_theme->set_stylebox(SceneStringName(hover), "Button", p_config.button_style_hover);
+		p_theme->set_stylebox(SceneStringName(pressed), "Button", p_config.button_style_pressed);
+		p_theme->set_stylebox("hover_pressed", "Button", p_config.button_style_pressed);
+		p_theme->set_stylebox("focus", "Button", p_config.focus_style);
+		p_theme->set_stylebox("disabled", "Button", p_config.button_style_disabled);
+
+		p_theme->set_color(SceneStringName(font_color), "Button", p_config.font_color);
+		p_theme->set_color("font_hover_color", "Button", p_config.font_hover_color);
+		p_theme->set_color("font_hover_pressed_color", "Button", p_config.font_hover_pressed_color);
+		p_theme->set_color("font_focus_color", "Button", p_config.font_focus_color);
+		p_theme->set_color("font_pressed_color", "Button", p_config.font_pressed_color);
+		p_theme->set_color("font_disabled_color", "Button", p_config.font_disabled_color);
+		p_theme->set_color("font_outline_color", "Button", p_config.font_outline_color);
+
+		p_theme->set_color("icon_normal_color", "Button", p_config.icon_normal_color);
+		p_theme->set_color("icon_hover_color", "Button", p_config.icon_hover_color);
+		p_theme->set_color("icon_focus_color", "Button", p_config.icon_focus_color);
+		p_theme->set_color("icon_hover_pressed_color", "Button", p_config.accent_color);
+		p_theme->set_color("icon_pressed_color", "Button", p_config.accent_color);
+		p_theme->set_color("icon_disabled_color", "Button", p_config.icon_disabled_color);
+
+		p_theme->set_constant("h_separation", "Button", 4 * EDSCALE);
+		p_theme->set_constant("outline_size", "Button", 0);
+
+		p_theme->set_constant("outline_size", "Button", 0);
+		p_theme->set_constant("align_to_largest_stylebox", "Button", 1); // Enabled.
+
+		// MenuButton.
+
+		p_theme->set_stylebox(CoreStringName(normal), "MenuButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox(SceneStringName(hover), "MenuButton", p_config.flat_button_hover);
+		p_theme->set_stylebox(SceneStringName(pressed), "MenuButton", p_config.flat_button_pressed);
+		p_theme->set_stylebox("focus", "MenuButton", p_config.focus_style);
+		p_theme->set_stylebox("disabled", "MenuButton", p_config.base_empty_wide_style);
+
+		p_theme->set_constant("outline_size", "MenuButton", 0);
+
+		// MenuBar.
+
+		p_theme->set_stylebox(CoreStringName(normal), "MenuBar", p_config.button_style);
+		p_theme->set_stylebox(SceneStringName(hover), "MenuBar", p_config.button_style_hover);
+		p_theme->set_stylebox(SceneStringName(pressed), "MenuBar", p_config.button_style_pressed);
+		p_theme->set_stylebox("disabled", "MenuBar", p_config.button_style_disabled);
+
+		p_theme->set_color(SceneStringName(font_color), "MenuBar", p_config.font_color);
+		p_theme->set_color("font_hover_color", "MenuBar", p_config.font_hover_color);
+		p_theme->set_color("font_hover_pressed_color", "MenuBar", p_config.font_hover_pressed_color);
+		p_theme->set_color("font_focus_color", "MenuBar", p_config.font_focus_color);
+		p_theme->set_color("font_pressed_color", "MenuBar", p_config.font_pressed_color);
+		p_theme->set_color("font_disabled_color", "MenuBar", p_config.font_disabled_color);
+		p_theme->set_color("font_outline_color", "MenuBar", p_config.font_outline_color);
+
+		p_theme->set_constant("h_separation", "MenuBar", 4 * EDSCALE);
+		p_theme->set_constant("outline_size", "MenuBar", 0);
+
+		// OptionButton.
+
+		p_theme->set_stylebox("focus", "OptionButton", p_config.focus_style);
+		p_theme->set_stylebox(CoreStringName(normal), "OptionButton", p_config.button_style);
+		p_theme->set_stylebox(SceneStringName(hover), "OptionButton", p_config.button_style_hover);
+		p_theme->set_stylebox(SceneStringName(pressed), "OptionButton", p_config.button_style_pressed);
+		p_theme->set_stylebox("disabled", "OptionButton", p_config.button_style_disabled);
+
+		p_theme->set_icon("arrow", "OptionButton", p_theme->get_icon(SNAME("GuiOptionArrow"), EditorStringName(EditorIcons)));
+		p_theme->set_constant("arrow_margin", "OptionButton", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("modulate_arrow", "OptionButton", true);
+		p_theme->set_constant("h_separation", "OptionButton", 4 * EDSCALE);
+		p_theme->set_constant("outline_size", "OptionButton", 0);
+
+		// CheckButton.
+
+		p_theme->set_stylebox(CoreStringName(normal), "CheckButton", p_config.panel_container_style);
+		p_theme->set_stylebox(SceneStringName(pressed), "CheckButton", p_config.panel_container_style);
+		p_theme->set_stylebox("disabled", "CheckButton", p_config.panel_container_style);
+		p_theme->set_stylebox(SceneStringName(hover), "CheckButton", p_config.panel_container_style);
+		p_theme->set_stylebox("hover_pressed", "CheckButton", p_config.panel_container_style);
+
+		p_theme->set_icon("checked", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOn"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("checked_disabled", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOnDisabled"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("unchecked", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOff"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("unchecked_disabled", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffDisabled"), EditorStringName(EditorIcons)));
+
+		p_theme->set_icon("checked_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOnMirrored"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("checked_disabled_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOnDisabledMirrored"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("unchecked_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffMirrored"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("unchecked_disabled_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffDisabledMirrored"), EditorStringName(EditorIcons)));
+
+		p_theme->set_constant("h_separation", "CheckButton", 8 * EDSCALE);
+		p_theme->set_constant("check_v_offset", "CheckButton", 0);
+		p_theme->set_constant("outline_size", "CheckButton", 0);
+
+		// CheckBox.
+		{
+			Ref<StyleBoxFlat> checkbox_style = p_config.panel_container_style->duplicate();
+			Ref<StyleBoxFlat> checkbox_style_normal = p_config.base_style->duplicate();
+			checkbox_style_normal->set_content_margin_individual(p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 0.5 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 0.5 * EDSCALE);
+			checkbox_style_normal->set_draw_center(false);
+
+			p_theme->set_stylebox(CoreStringName(normal), "CheckBox", checkbox_style_normal);
+			p_theme->set_stylebox(SceneStringName(pressed), "CheckBox", checkbox_style);
+			p_theme->set_stylebox("disabled", "CheckBox", checkbox_style);
+			p_theme->set_stylebox(SceneStringName(hover), "CheckBox", checkbox_style);
+			p_theme->set_stylebox("hover_pressed", "CheckBox", checkbox_style);
+
+			p_theme->set_icon("checked", "CheckBox", p_theme->get_icon(SNAME("GuiChecked"), EditorStringName(EditorIcons)));
+
+			p_theme->set_icon("unchecked", "CheckBox", p_theme->get_icon(SNAME("GuiUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_checked", "CheckBox", p_theme->get_icon(SNAME("GuiRadioChecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_unchecked", "CheckBox", p_theme->get_icon(SNAME("GuiRadioUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("checked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiUncheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_checked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiRadioCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_unchecked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), EditorStringName(EditorIcons)));
+
+			p_theme->set_constant("h_separation", "CheckBox", 8 * EDSCALE);
+			p_theme->set_constant("check_v_offset", "CheckBox", 0);
+			p_theme->set_constant("outline_size", "CheckBox", 0);
+		}
+
+		// LinkButton.
+
+		p_theme->set_stylebox("focus", "LinkButton", p_config.base_empty_style);
+
+		p_theme->set_color(SceneStringName(font), "LinkButton", p_config.font_color);
+		p_theme->set_color("font_hover_color", "LinkButton", p_config.font_hover_color);
+		p_theme->set_color("font_hover_pressed_color", "LinkButton", p_config.font_hover_pressed_color);
+		p_theme->set_color("font_focus_color", "LinkButton", p_config.font_focus_color);
+		p_theme->set_color("font_pressed_color", "LinkButton", p_config.font_pressed_color);
+		p_theme->set_color("font_disabled_color", "LinkButton", p_config.font_disabled_color);
+		p_theme->set_color("font_outline_color", "LinkButton", p_config.font_outline_color);
+
+		p_theme->set_constant("outline_size", "LinkButton", 0);
+	}
+
+	// Tree & ItemList.
+	{
+		// Tree.
+		{
+			// Use empty stylebox for trees to avoid drawing unnecessary borders in docks.
+			Ref<StyleBoxEmpty> style_tree_panel = p_config.base_empty_style->duplicate();
+			style_tree_panel->set_content_margin_individual(p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 2.5 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 2.5 * EDSCALE);
+
+			Ref<StyleBoxFlat> style_button_pressed = p_config.flat_button_pressed->duplicate();
+			style_button_pressed->set_content_margin_individual(p_config.base_margin, 0, p_config.base_margin, 0);
+
+			p_theme->set_icon("checked", "Tree", p_theme->get_icon(SNAME("GuiChecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("checked_disabled", "Tree", p_theme->get_icon(SNAME("GuiCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("indeterminate", "Tree", p_theme->get_icon(SNAME("GuiIndeterminate"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("indeterminate_disabled", "Tree", p_theme->get_icon(SNAME("GuiIndeterminateDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked", "Tree", p_theme->get_icon(SNAME("GuiUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked_disabled", "Tree", p_theme->get_icon(SNAME("GuiUncheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("arrow", "Tree", p_theme->get_icon(SNAME("GuiTreeArrowDown"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("arrow_collapsed", "Tree", p_theme->get_icon(SNAME("GuiTreeArrowRight"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("arrow_collapsed_mirrored", "Tree", p_theme->get_icon(SNAME("GuiTreeArrowLeft"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("updown", "Tree", p_theme->get_icon(SNAME("GuiTreeUpdown"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("select_arrow", "Tree", p_theme->get_icon(SNAME("GuiDropdown"), EditorStringName(EditorIcons)));
+
+			p_theme->set_stylebox(SceneStringName(panel), "Tree", style_tree_panel);
+			p_theme->set_stylebox("focus", "Tree", p_config.focus_style);
+			p_theme->set_stylebox("button_pressed", "Tree", style_button_pressed);
+			p_theme->set_stylebox("custom_button", "Tree", p_config.flat_button);
+			p_theme->set_stylebox("custom_button_pressed", "Tree", style_button_pressed);
+
+			p_theme->set_color("custom_button_font_highlight", "Tree", p_config.font_hover_color);
+			p_theme->set_color(SceneStringName(font_color), "Tree", p_config.font_color);
+			p_theme->set_color("font_hovered_color", "Tree", p_config.font_hover_color);
+			p_theme->set_color("font_hovered_dimmed_color", "Tree", p_config.font_hover_color);
+			p_theme->set_color("font_hovered_selected_color", "Tree", p_config.font_hover_color);
+			p_theme->set_color("font_selected_color", "Tree", p_config.font_pressed_color);
+			p_theme->set_color("font_disabled_color", "Tree", p_config.font_disabled_color);
+			p_theme->set_color("font_outline_color", "Tree", p_config.font_outline_color);
+			p_theme->set_color("title_button_color", "Tree", p_config.font_color);
+			p_theme->set_color("drop_position_color", "Tree", p_config.accent_color);
+
+			p_theme->set_constant("v_separation", "Tree", Math::pow(p_config.base_margin * 0.2 * EDSCALE, 3));
+			p_theme->set_constant("h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("guide_width", "Tree", p_config.border_width);
+			p_theme->set_constant("item_margin", "Tree", MAX(3 * p_config.increased_margin * EDSCALE, 12 * EDSCALE));
+			p_theme->set_constant("inner_item_margin_top", "Tree", p_config.separation_margin);
+			p_theme->set_constant("inner_item_margin_bottom", "Tree", p_config.separation_margin);
+			p_theme->set_constant("inner_item_margin_left", "Tree", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("inner_item_margin_right", "Tree", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("button_margin", "Tree", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("dragging_unfold_wait_msec", "Tree", p_config.dragging_hover_wait_msec);
+			p_theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
+			p_theme->set_constant("scroll_speed", "Tree", 12);
+			p_theme->set_constant("outline_size", "Tree", 0);
+			p_theme->set_constant("scrollbar_margin_left", "Tree", 0);
+			p_theme->set_constant("scrollbar_margin_top", "Tree", 0);
+			p_theme->set_constant("scrollbar_margin_right", "Tree", 0);
+			p_theme->set_constant("scrollbar_margin_bottom", "Tree", 0);
+			p_theme->set_constant("scrollbar_h_separation", "Tree", 1 * EDSCALE);
+			p_theme->set_constant("scrollbar_v_separation", "Tree", 1 * EDSCALE);
+
+			Color relationship_line_color = p_config.mono_color * Color(1, 1, 1, p_config.relationship_line_opacity);
+			Color highlight_line_color = p_config.mono_color * Color(1, 1, 1, p_config.relationship_line_opacity * 2);
+
+			int draw_relationship_lines = 0;
+			int relationship_line_width = 0;
+			int highlighted_line_width = Math::ceil(EDSCALE);
+			if (p_config.draw_relationship_lines == EditorThemeManager::RELATIONSHIP_ALL) {
+				draw_relationship_lines = 1;
+				relationship_line_width = 1;
+			} else if (p_config.draw_relationship_lines == EditorThemeManager::RELATIONSHIP_SELECTED_ONLY) {
+				draw_relationship_lines = 1;
+			}
+
+			p_theme->set_constant("draw_guides", "Tree", 0);
+			p_theme->set_constant("draw_relationship_lines", "Tree", draw_relationship_lines && p_config.relationship_line_opacity >= 0.01);
+			p_theme->set_constant("relationship_line_width", "Tree", relationship_line_width);
+			p_theme->set_constant("parent_hl_line_width", "Tree", highlighted_line_width);
+			p_theme->set_constant("children_hl_line_width", "Tree", 1);
+			p_theme->set_constant("parent_hl_line_margin", "Tree", 3);
+			p_theme->set_color("relationship_line_color", "Tree", relationship_line_color);
+			p_theme->set_color("parent_hl_line_color", "Tree", highlight_line_color);
+			p_theme->set_color("children_hl_line_color", "Tree", relationship_line_color);
+			p_theme->set_color("drop_position_color", "Tree", p_config.icon_normal_color);
+			p_theme->set_color("guide_color", "Tree", Color(1, 1, 1, 0));
+
+			Ref<StyleBoxFlat> style_tree_hover = p_config.flat_button_hover->duplicate();
+			style_tree_hover->set_bg_color(p_config.button_disabled_color);
+			style_tree_hover->set_content_margin_all(0);
+
+			p_theme->set_stylebox("button_hover", "Tree", style_tree_hover);
+			p_theme->set_stylebox("hovered", "Tree", style_tree_hover);
+			p_theme->set_stylebox("hovered_dimmed", "Tree", style_tree_hover);
+			p_theme->set_stylebox("custom_button_hover", "Tree", style_tree_hover);
+			p_theme->set_stylebox("selected", "Tree", style_tree_hover);
+			p_theme->set_stylebox("selected_focus", "Tree", p_config.focus_style);
+
+			Ref<StyleBoxFlat> style_tree_hover_selected = style_tree_hover->duplicate();
+			style_tree_hover_selected->set_bg_color(p_config.button_normal_color);
+
+			p_theme->set_stylebox("hovered_selected", "Tree", style_tree_hover_selected);
+			p_theme->set_stylebox("hovered_selected_focus", "Tree", p_config.focus_style);
+
+			// Cursor is drawn on top of the item so it needs to be transparent.
+			Ref<StyleBoxFlat> style_tree_cursor = p_config.base_style->duplicate();
+			style_tree_cursor->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.04));
+
+			Ref<StyleBoxFlat> style_tree_title = p_config.base_style->duplicate();
+			style_tree_title->set_bg_color(p_config.surface_lowest_color);
+			// Use a transparent border to separate rounded column titles.
+			style_tree_title->set_border_color(Color(p_config.surface_lowest_color, 0));
+			style_tree_title->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_tree_title->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+
+			p_theme->set_stylebox("cursor", "Tree", style_tree_cursor);
+			p_theme->set_stylebox("cursor_unfocused", "Tree", style_tree_cursor);
+			p_theme->set_stylebox("title_button_normal", "Tree", style_tree_title);
+			p_theme->set_stylebox("title_button_hover", "Tree", style_tree_title);
+			p_theme->set_stylebox("title_button_pressed", "Tree", style_tree_title);
+		}
+
+		// ItemList.
+		{
+			Ref<StyleBoxFlat> style_itemlist_bg = p_config.base_style->duplicate();
+			style_itemlist_bg->set_content_margin_all(p_config.base_margin * 2 * EDSCALE);
+			Ref<StyleBoxFlat> style_itemlist_cursor = p_config.base_style->duplicate();
+			style_itemlist_cursor->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.04));
+
+			p_theme->set_stylebox(SceneStringName(panel), "ItemList", style_itemlist_bg);
+			p_theme->set_stylebox("focus", "ItemList", p_config.focus_style);
+			p_theme->set_stylebox("cursor", "ItemList", style_itemlist_cursor);
+			p_theme->set_stylebox("cursor_unfocused", "ItemList", style_itemlist_cursor);
+			p_theme->set_stylebox("selected_focus", "ItemList", p_config.focus_style);
+			p_theme->set_stylebox("selected", "ItemList", p_config.flat_button_hover);
+			p_theme->set_stylebox("hovered", "ItemList", p_config.flat_button_hover);
+			p_theme->set_stylebox("hovered_selected", "ItemList", p_config.flat_button_hover);
+			p_theme->set_stylebox("hovered_selected_focus", "ItemList", p_config.focus_style);
+			p_theme->set_color(SceneStringName(font_color), "ItemList", p_config.font_color);
+			p_theme->set_color("font_hovered_color", "ItemList", p_config.font_hover_color);
+			p_theme->set_color("font_hovered_selected_color", "ItemList", p_config.font_hover_pressed_color);
+			p_theme->set_color("font_selected_color", "ItemList", p_config.font_pressed_color);
+			p_theme->set_color("font_outline_color", "ItemList", p_config.font_outline_color);
+			p_theme->set_color("guide_color", "ItemList", Color(1, 1, 1, 0));
+			p_theme->set_constant("v_separation", "ItemList", p_config.base_margin * 1.5 * EDSCALE);
+			p_theme->set_constant("h_separation", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("icon_margin", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant(SceneStringName(line_separation), "ItemList", p_config.separation_margin);
+			p_theme->set_constant("outline_size", "ItemList", 0);
+		}
+	}
+
+	// TabBar & TabContainer.
+	{
+		Ref<StyleBoxFlat> style_tab_selected = p_config.base_style->duplicate();
+		style_tab_selected->set_content_margin_individual(p_config.base_margin * 4 * EDSCALE, p_config.base_margin * 2.1 * EDSCALE, p_config.base_margin * 4 * EDSCALE, p_config.base_margin * 2.1 * EDSCALE);
+		style_tab_selected->set_corner_radius_individual(p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE, 0, 0);
+
+		Ref<StyleBoxFlat> style_tab_focus = style_tab_selected->duplicate();
+		style_tab_focus->set_bg_color(p_config.base_color);
+		style_tab_focus->set_border_color(p_config.accent_color);
+
+		Ref<StyleBoxFlat> style_tab_unselected = style_tab_selected->duplicate();
+		style_tab_unselected->set_bg_color(p_config.surface_lowest_color);
+		style_tab_unselected->set_border_width_all(0);
+
+		Ref<StyleBoxFlat> style_tab_hovered = style_tab_unselected->duplicate();
+		style_tab_hovered->set_bg_color(p_config.surface_base_color * Color(1, 1, 1, 0.8));
+
+		Color drop_mark_color = p_config.dark_color_2.lerp(p_config.accent_color, 0.75);
+
+		Ref<StyleBoxFlat> style_tabbar_background = p_config.base_style->duplicate();
+		style_tabbar_background->set_bg_color(p_config.surface_lowest_color);
+		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+		style_tabbar_background->set_content_margin_individual(0, 0, p_config.base_margin * 0.25 * EDSCALE, 0);
+
+		Ref<StyleBoxFlat> style_panel = p_config.base_style->duplicate();
+		style_panel->set_content_margin_all(p_config.increased_margin * 1.5 * EDSCALE);
+		style_panel->set_corner_radius_individual(0, 0, p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE);
+
+		p_theme->set_stylebox("tabbar_background", "TabContainer", style_tabbar_background);
+		p_theme->set_stylebox(SceneStringName(panel), "TabContainer", style_panel);
+
+		p_theme->set_stylebox("tab_selected", "TabContainer", style_tab_selected);
+		p_theme->set_stylebox("tab_hovered", "TabContainer", style_tab_hovered);
+		p_theme->set_stylebox("tab_unselected", "TabContainer", style_tab_unselected);
+		p_theme->set_stylebox("tab_disabled", "TabContainer", style_tab_unselected);
+		p_theme->set_stylebox("tab_focus", "TabContainer", p_config.focus_style);
+		p_theme->set_stylebox("tab_selected", "TabBar", style_tab_selected);
+		p_theme->set_stylebox("tab_hovered", "TabBar", style_tab_hovered);
+		p_theme->set_stylebox("tab_unselected", "TabBar", style_tab_unselected);
+		p_theme->set_stylebox("tab_disabled", "TabBar", style_tab_unselected);
+		p_theme->set_stylebox("tab_focus", "TabBar", p_config.focus_style);
+		p_theme->set_stylebox("button_pressed", "TabBar", p_config.panel_container_style);
+		p_theme->set_stylebox("button_highlight", "TabBar", p_config.panel_container_style);
+
+		p_theme->set_color("font_selected_color", "TabContainer", p_config.font_color);
+		p_theme->set_color("font_hovered_color", "TabContainer", p_config.font_hover_color);
+		p_theme->set_color("font_unselected_color", "TabContainer", p_config.font_secondary_color);
+		p_theme->set_color("font_disabled_color", "TabContainer", p_config.font_disabled_color * Color(1, 1, 1, 0.55));
+		p_theme->set_color("font_outline_color", "TabContainer", p_config.font_outline_color);
+		p_theme->set_color("font_selected_color", "TabBar", p_config.font_color);
+		p_theme->set_color("font_hovered_color", "TabBar", p_config.font_hover_color);
+		p_theme->set_color("font_unselected_color", "TabBar", p_config.font_secondary_color);
+		p_theme->set_color("font_disabled_color", "TabBar", p_config.font_disabled_color * Color(1, 1, 1, 0.55));
+		p_theme->set_color("font_outline_color", "TabBar", p_config.font_outline_color);
+		p_theme->set_color("drop_mark_color", "TabContainer", drop_mark_color);
+		p_theme->set_color("drop_mark_color", "TabBar", drop_mark_color);
+
+		p_theme->set_color("icon_selected_color", "TabContainer", p_config.icon_normal_color);
+		p_theme->set_color("icon_hovered_color", "TabContainer", p_config.icon_hover_color);
+		p_theme->set_color("icon_unselected_color", "TabContainer", p_config.icon_secondary_color);
+		p_theme->set_color("icon_disabled_color", "TabContainer", p_config.icon_disabled_color * Color(1, 1, 1, 0.55));
+		p_theme->set_color("icon_selected_color", "TabBar", p_config.icon_normal_color);
+		p_theme->set_color("icon_hovered_color", "TabBar", p_config.icon_hover_color);
+		p_theme->set_color("icon_unselected_color", "TabBar", p_config.icon_secondary_color);
+		p_theme->set_color("icon_disabled_color", "TabBar", p_config.icon_disabled_color * Color(1, 1, 1, 0.55));
+
+		p_theme->set_icon("menu", "TabContainer", p_theme->get_icon(SNAME("GuiTabMenu"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("menu_highlight", "TabContainer", p_theme->get_icon(SNAME("GuiTabMenuHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("close", "TabBar", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("increment", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowRight"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("decrement", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowLeft"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("increment", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowRight"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("decrement", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowLeft"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("increment_highlight", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowRightHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("decrement_highlight", "TabBar", p_theme->get_icon(SNAME("GuiScrollArrowLeftHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("increment_highlight", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowRightHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("decrement_highlight", "TabContainer", p_theme->get_icon(SNAME("GuiScrollArrowLeftHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("drop_mark", "TabContainer", p_theme->get_icon(SNAME("GuiTabDropMark"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("drop_mark", "TabBar", p_theme->get_icon(SNAME("GuiTabDropMark"), EditorStringName(EditorIcons)));
+
+		p_theme->set_constant("side_margin", "TabContainer", 0);
+		p_theme->set_constant("outline_size", "TabContainer", 0);
+		p_theme->set_constant("h_separation", "TabBar", 4 * EDSCALE);
+		p_theme->set_constant("outline_size", "TabBar", 0);
+		p_theme->set_constant("hover_switch_wait_msec", "TabBar", p_config.dragging_hover_wait_msec);
+	}
+
+	// Separators.
+	{
+		Ref<StyleBoxLine> style_h_separator = EditorThemeManager::make_line_stylebox(p_config.separator_color, Math::round(2 * EDSCALE), p_config.base_margin * -1 * EDSCALE, p_config.base_margin * -1 * EDSCALE);
+		p_theme->set_stylebox("separator", "HSeparator", style_h_separator);
+
+		Ref<StyleBoxLine> style_v_separator = style_h_separator->duplicate();
+		style_v_separator->set_vertical(true);
+		p_theme->set_stylebox("separator", "VSeparator", style_v_separator);
+
+		p_theme->set_constant("separation", "Separator", p_config.base_margin * 2 * EDSCALE);
+	}
+
+	// LineEdit & TextEdit.
+	{
+		Ref<StyleBoxFlat> text_editor_style = p_config.base_style->duplicate();
+		text_editor_style->set_bg_color(p_config.surface_lower_color);
+		text_editor_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 0.75 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 0.75 * EDSCALE);
+		if (p_config.draw_extra_borders) {
+			text_editor_style->set_border_width_all(Math::round(EDSCALE));
+			text_editor_style->set_border_color(p_config.extra_border_color_1);
+		}
+
+		Ref<StyleBoxFlat> text_editor_disabled_style = text_editor_style->duplicate();
+		// Using transparent background for readonly otherwise it looks bad in the master audio bus.
+		text_editor_disabled_style->set_bg_color(p_config.dark_theme ? Color(0, 0, 0, 0.2) : Color(1, 1, 1, 0.5));
+
+		// LineEdit.
+
+		p_theme->set_stylebox(CoreStringName(normal), "LineEdit", text_editor_style);
+		p_theme->set_stylebox("focus", "LineEdit", p_config.focus_style);
+		p_theme->set_stylebox("read_only", "LineEdit", text_editor_disabled_style);
+
+		p_theme->set_icon("clear", "LineEdit", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
+
+		p_theme->set_color(SceneStringName(font_color), "LineEdit", p_config.font_color);
+		p_theme->set_color("font_selected_color", "LineEdit", p_config.font_pressed_color);
+		p_theme->set_color("font_uneditable_color", "LineEdit", p_config.font_readonly_color);
+		p_theme->set_color("font_placeholder_color", "LineEdit", p_config.font_placeholder_color);
+		p_theme->set_color("font_outline_color", "LineEdit", p_config.font_outline_color);
+		p_theme->set_color("caret_color", "LineEdit", p_config.font_color);
+		p_theme->set_color("selection_color", "LineEdit", p_config.selection_color);
+		p_theme->set_color("clear_button_color", "LineEdit", p_config.font_color);
+		p_theme->set_color("clear_button_color_pressed", "LineEdit", p_config.accent_color);
+
+		p_theme->set_constant("minimum_character_width", "LineEdit", 4);
+		p_theme->set_constant("outline_size", "LineEdit", 0);
+		p_theme->set_constant("caret_width", "LineEdit", 1);
+
+		// TextEdit.
+
+		p_theme->set_stylebox(CoreStringName(normal), "TextEdit", text_editor_style);
+		p_theme->set_stylebox("focus", "TextEdit", p_config.focus_style);
+		p_theme->set_stylebox("read_only", "TextEdit", text_editor_disabled_style);
+
+		p_theme->set_icon("tab", "TextEdit", p_theme->get_icon(SNAME("GuiTab"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("space", "TextEdit", p_theme->get_icon(SNAME("GuiSpace"), EditorStringName(EditorIcons)));
+
+		p_theme->set_color(SceneStringName(font_color), "TextEdit", p_config.font_color);
+		p_theme->set_color("font_readonly_color", "TextEdit", p_config.font_readonly_color);
+		p_theme->set_color("font_placeholder_color", "TextEdit", p_config.font_placeholder_color);
+		p_theme->set_color("font_outline_color", "TextEdit", p_config.font_outline_color);
+		p_theme->set_color("caret_color", "TextEdit", p_config.font_color);
+		p_theme->set_color("selection_color", "TextEdit", p_config.selection_color);
+		p_theme->set_color("background_color", "TextEdit", Color(1, 1, 1, 0));
+
+		p_theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
+		p_theme->set_constant("outline_size", "TextEdit", 0);
+		p_theme->set_constant("caret_width", "TextEdit", 1);
+	}
+
+	// Containers.
+	{
+		p_theme->set_constant("separation", "BoxContainer", p_config.separation_margin);
+		p_theme->set_constant("separation", "HBoxContainer", p_config.separation_margin);
+		p_theme->set_constant("separation", "VBoxContainer", p_config.separation_margin);
+		p_theme->set_constant("margin_left", "MarginContainer", 0);
+		p_theme->set_constant("margin_top", "MarginContainer", 0);
+		p_theme->set_constant("margin_right", "MarginContainer", 0);
+		p_theme->set_constant("margin_bottom", "MarginContainer", 0);
+		p_theme->set_constant("h_separation", "GridContainer", p_config.separation_margin);
+		p_theme->set_constant("v_separation", "GridContainer", p_config.separation_margin);
+		p_theme->set_constant("h_separation", "FlowContainer", p_config.separation_margin);
+		p_theme->set_constant("v_separation", "FlowContainer", p_config.separation_margin);
+		p_theme->set_constant("h_separation", "HFlowContainer", p_config.separation_margin);
+		p_theme->set_constant("v_separation", "HFlowContainer", p_config.separation_margin);
+		p_theme->set_constant("h_separation", "VFlowContainer", p_config.separation_margin);
+		p_theme->set_constant("v_separation", "VFlowContainer", p_config.separation_margin);
+
+		// SplitContainer.
+
+		p_theme->set_icon("h_grabber", "SplitContainer", p_theme->get_icon(SNAME("GuiHsplitter"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("v_grabber", "SplitContainer", p_theme->get_icon(SNAME("GuiVsplitter"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grabber", "VSplitContainer", p_theme->get_icon(SNAME("GuiVsplitter"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grabber", "HSplitContainer", p_theme->get_icon(SNAME("GuiHsplitter"), EditorStringName(EditorIcons)));
+
+		p_theme->set_constant("separation", "SplitContainer", p_config.base_margin * 0.75 * EDSCALE);
+		p_theme->set_constant("separation", "HSplitContainer", p_config.base_margin * 0.75 * EDSCALE);
+		p_theme->set_constant("separation", "VSplitContainer", p_config.base_margin * 0.75 * EDSCALE);
+
+		p_theme->set_constant("autohide", "SplitContainer", 1);
+		p_theme->set_constant("autohide", "HSplitContainer", 1);
+		p_theme->set_constant("autohide", "VSplitContainer", 1);
+
+		p_theme->set_constant("minimum_grab_thickness", "SplitContainer", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("minimum_grab_thickness", "HSplitContainer", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("minimum_grab_thickness", "VSplitContainer", p_config.base_margin * 2 * EDSCALE);
+
+		// GridContainer.
+		p_theme->set_constant("v_separation", "GridContainer", Math::round(p_config.widget_margin.y - 2 * EDSCALE));
+
+		// FoldableContainer
+
+		Ref<StyleBoxFlat> foldable_container_title = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.darkened(0.125), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
+		foldable_container_title->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		foldable_container_title->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+		p_theme->set_stylebox("title_panel", "FoldableContainer", foldable_container_title);
+		Ref<StyleBoxFlat> foldable_container_hover = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.lerp(p_config.base_color, 0.4), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
+		foldable_container_hover->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		foldable_container_hover->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+		p_theme->set_stylebox("title_hover_panel", "FoldableContainer", foldable_container_hover);
+		p_theme->set_stylebox("title_collapsed_panel", "FoldableContainer", EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.darkened(0.125), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
+		p_theme->set_stylebox("title_collapsed_hover_panel", "FoldableContainer", EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.lerp(p_config.base_color, 0.4), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
+		Ref<StyleBoxFlat> foldable_container_panel = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
+		foldable_container_panel->set_corner_radius(CORNER_TOP_LEFT, 0);
+		foldable_container_panel->set_corner_radius(CORNER_TOP_RIGHT, 0);
+		p_theme->set_stylebox(SceneStringName(panel), "FoldableContainer", foldable_container_panel);
+		p_theme->set_stylebox("focus", "FoldableContainer", p_config.focus_style);
+
+		p_theme->set_font(SceneStringName(font), "FoldableContainer", p_theme->get_font(SceneStringName(font), SNAME("HeaderSmall")));
+		p_theme->set_font_size(SceneStringName(font_size), "FoldableContainer", p_theme->get_font_size(SceneStringName(font_size), SNAME("HeaderSmall")));
+
+		p_theme->set_color(SceneStringName(font_color), "FoldableContainer", p_config.font_color);
+		p_theme->set_color("hover_font_color", "FoldableContainer", p_config.font_hover_color);
+		p_theme->set_color("collapsed_font_color", "FoldableContainer", p_config.font_pressed_color);
+		p_theme->set_color("font_outline_color", "FoldableContainer", p_config.font_outline_color);
+
+		p_theme->set_icon("expanded_arrow", "FoldableContainer", p_theme->get_icon(SNAME("GuiTreeArrowDown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("expanded_arrow_mirrored", "FoldableContainer", p_theme->get_icon(SNAME("GuiArrowUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("folded_arrow", "FoldableContainer", p_theme->get_icon(SNAME("GuiTreeArrowRight"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("folded_arrow_mirrored", "FoldableContainer", p_theme->get_icon(SNAME("GuiTreeArrowLeft"), EditorStringName(EditorIcons)));
+
+		p_theme->set_constant("outline_size", "FoldableContainer", 0);
+		p_theme->set_constant("h_separation", "FoldableContainer", p_config.separation_margin);
+	}
+
+	// Window and dialogs.
+	{
+		// Window.
+
+		p_theme->set_stylebox("embedded_border", "Window", p_config.window_style);
+		p_theme->set_stylebox("embedded_unfocused_border", "Window", p_config.window_style);
+
+		p_theme->set_color("title_color", "Window", p_config.font_color);
+		p_theme->set_icon("close", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("close_pressed", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
+		p_theme->set_constant("close_h_offset", "Window", 22 * EDSCALE);
+		p_theme->set_constant("close_v_offset", "Window", 20 * EDSCALE);
+		p_theme->set_constant("title_height", "Window", 24 * EDSCALE);
+		p_theme->set_constant("resize_margin", "Window", 4 * EDSCALE);
+		p_theme->set_font("title_font", "Window", p_theme->get_font(SNAME("title"), EditorStringName(EditorFonts)));
+		p_theme->set_font_size("title_font_size", "Window", p_theme->get_font_size(SNAME("title_size"), EditorStringName(EditorFonts)));
+
+		// AcceptDialog.
+		p_theme->set_stylebox(SceneStringName(panel), "AcceptDialog", p_config.dialog_style);
+		p_theme->set_constant("buttons_separation", "AcceptDialog", 8 * EDSCALE);
+		// Make buttons with short texts such as "OK" easier to click/tap.
+		p_theme->set_constant("buttons_min_width", "AcceptDialog", p_config.dialogs_buttons_min_size.x * EDSCALE);
+		p_theme->set_constant("buttons_min_height", "AcceptDialog", p_config.dialogs_buttons_min_size.y * EDSCALE);
+
+		// FileDialog.
+		p_theme->set_icon("folder", "FileDialog", p_theme->get_icon(SNAME("Folder"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("parent_folder", "FileDialog", p_theme->get_icon(SNAME("ArrowUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("back_folder", "FileDialog", p_theme->get_icon(SNAME("Back"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("forward_folder", "FileDialog", p_theme->get_icon(SNAME("Forward"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("reload", "FileDialog", p_theme->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("toggle_hidden", "FileDialog", p_theme->get_icon(SNAME("GuiVisibilityVisible"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("create_folder", "FileDialog", p_theme->get_icon(SNAME("FolderCreate"), EditorStringName(EditorIcons)));
+		// Use a different color for folder icons to make them easier to distinguish from files.
+		// On a light theme, the icon will be dark, so we need to lighten it before blending it with the accent color.
+		p_theme->set_color("folder_icon_color", "FileDialog", (p_config.dark_icon_and_font ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(p_config.accent_color, 0.7));
+		p_theme->set_color("file_disabled_color", "FileDialog", p_config.font_disabled_color);
+
+		// PopupDialog.
+		p_theme->set_stylebox(SceneStringName(panel), "PopupDialog", p_config.dialog_style);
+
+		// PopupMenu.
+		{
+			Ref<StyleBoxFlat> style_popup_menu = p_config.base_style->duplicate();
+			style_popup_menu->set_bg_color(p_config.surface_lower_color);
+			style_popup_menu->set_content_margin_all(p_config.popup_margin);
+			style_popup_menu->set_corner_radius_all(0);
+			if (p_config.draw_extra_borders) {
+				style_popup_menu->set_border_width_all(Math::round(EDSCALE));
+				style_popup_menu->set_border_color(p_config.extra_border_color_2);
+			}
+			p_theme->set_stylebox(SceneStringName(panel), "PopupMenu", style_popup_menu);
+
+			p_theme->set_stylebox(SceneStringName(hover), "PopupMenu", p_config.flat_button_hover);
+
+			Ref<StyleBoxLine> style_popup_separator = EditorThemeManager::make_line_stylebox(Color(0, 0, 0, p_config.dark_theme ? 0.2 : 0.1), Math::round(2 * EDSCALE), p_config.base_margin * -1.5 * EDSCALE, p_config.base_margin * -1.5 * EDSCALE);
+
+			p_theme->set_stylebox("separator", "PopupMenu", style_popup_separator);
+			p_theme->set_stylebox("labeled_separator_left", "PopupMenu", style_popup_separator);
+			p_theme->set_stylebox("labeled_separator_right", "PopupMenu", style_popup_separator);
+
+			p_theme->set_color(SceneStringName(font_color), "PopupMenu", p_config.font_color);
+			p_theme->set_color("font_hover_color", "PopupMenu", p_config.font_hover_color);
+			p_theme->set_color("font_accelerator_color", "PopupMenu", p_config.font_disabled_color);
+			p_theme->set_color("font_disabled_color", "PopupMenu", p_config.font_disabled_color);
+			p_theme->set_color("font_separator_color", "PopupMenu", p_config.font_disabled_color);
+			p_theme->set_color("font_outline_color", "PopupMenu", p_config.font_outline_color);
+
+			p_theme->set_icon("checked", "PopupMenu", p_theme->get_icon(SNAME("GuiChecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked", "PopupMenu", p_theme->get_icon(SNAME("GuiUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_checked", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioChecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_unchecked", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioUnchecked"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("checked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("unchecked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiUncheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_checked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioCheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("radio_unchecked_disabled", "PopupMenu", p_theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("submenu", "PopupMenu", p_theme->get_icon(SNAME("ArrowRight"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("submenu_mirrored", "PopupMenu", p_theme->get_icon(SNAME("ArrowLeft"), EditorStringName(EditorIcons)));
+
+			p_theme->set_constant("h_separation", "PopupMenu", p_config.base_margin * 1.75 * EDSCALE);
+			p_theme->set_constant("v_separation", "PopupMenu", p_config.base_margin * 1.75 * EDSCALE);
+			p_theme->set_constant("outline_size", "PopupMenu", 0);
+			p_theme->set_constant("item_start_padding", "PopupMenu", p_config.popup_margin);
+			p_theme->set_constant("item_end_padding", "PopupMenu", p_config.popup_margin);
+		}
+	}
+
+	// Sliders and scrollbars.
+	{
+		Ref<Texture2D> empty_icon = memnew(ImageTexture);
+
+		Ref<StyleBoxFlat> grabber_style = p_config.base_style->duplicate();
+		grabber_style->set_bg_color(_get_base_color(p_config, 0.5, 0.6));
+		grabber_style->set_border_color(p_config.base_color * Color(1, 1, 1, 0));
+		grabber_style->set_border_width_all(3 * EDSCALE);
+
+		Ref<StyleBoxFlat> grabber_hl_style = p_config.base_style->duplicate();
+		grabber_hl_style->set_bg_color(_get_base_color(p_config, 1.4, 0.5));
+		grabber_hl_style->set_border_color(_get_base_color(p_config) * Color(1, 1, 1, 0));
+		grabber_hl_style->set_border_width_all(2.5 * EDSCALE);
+
+		int scroll_margin = (p_config.enable_touch_optimizations ? 12 : 6) * EDSCALE;
+
+		// HScrollBar.
+
+		Ref<StyleBoxEmpty> h_scroll_style = p_config.base_empty_style->duplicate();
+		h_scroll_style->set_content_margin_individual(0, scroll_margin, 0, scroll_margin);
+
+		p_theme->set_stylebox("scroll", "HScrollBar", h_scroll_style);
+		p_theme->set_stylebox("scroll_focus", "HScrollBar", p_config.focus_style);
+		p_theme->set_stylebox("grabber", "HScrollBar", grabber_style);
+		p_theme->set_stylebox("grabber_highlight", "HScrollBar", grabber_hl_style);
+		p_theme->set_stylebox("grabber_pressed", "HScrollBar", grabber_hl_style);
+
+		p_theme->set_icon("increment", "HScrollBar", empty_icon);
+		p_theme->set_icon("increment_highlight", "HScrollBar", empty_icon);
+		p_theme->set_icon("increment_pressed", "HScrollBar", empty_icon);
+		p_theme->set_icon("decrement", "HScrollBar", empty_icon);
+		p_theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
+		p_theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
+
+		// VScrollBar.
+
+		Ref<StyleBoxEmpty> v_scroll_style = p_config.base_empty_style->duplicate();
+		v_scroll_style->set_content_margin_individual(scroll_margin, 0, scroll_margin, 0);
+
+		p_theme->set_stylebox("scroll", "VScrollBar", v_scroll_style);
+		p_theme->set_stylebox("scroll_focus", "VScrollBar", p_config.focus_style);
+		p_theme->set_stylebox("grabber", "VScrollBar", grabber_style);
+		p_theme->set_stylebox("grabber_highlight", "VScrollBar", grabber_hl_style);
+		p_theme->set_stylebox("grabber_pressed", "VScrollBar", grabber_hl_style);
+
+		p_theme->set_icon("increment", "VScrollBar", empty_icon);
+		p_theme->set_icon("increment_highlight", "VScrollBar", empty_icon);
+		p_theme->set_icon("increment_pressed", "VScrollBar", empty_icon);
+		p_theme->set_icon("decrement", "VScrollBar", empty_icon);
+		p_theme->set_icon("decrement_highlight", "VScrollBar", empty_icon);
+		p_theme->set_icon("decrement_pressed", "VScrollBar", empty_icon);
+
+		// Slider
+		const int background_margin = MAX(2, p_config.base_margin / 2);
+
+		Ref<StyleBoxFlat> style_h_slider = p_config.base_style->duplicate();
+		style_h_slider->set_bg_color(p_config.mono_color_inv * Color(1, 1, 1, 0.35));
+		style_h_slider->set_content_margin_individual(0, 2 * EDSCALE, 0, 2 * EDSCALE);
+
+		// HSlider.
+		p_theme->set_icon("grabber_highlight", "HSlider", p_theme->get_icon(SNAME("GuiSliderGrabberHl"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grabber", "HSlider", p_theme->get_icon(SNAME("GuiSliderGrabber"), EditorStringName(EditorIcons)));
+		p_theme->set_stylebox("slider", "HSlider", style_h_slider);
+		p_theme->set_stylebox("grabber_area", "HSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, 0, background_margin, 0, background_margin, p_config.corner_radius));
+		p_theme->set_stylebox("grabber_area_highlight", "HSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, 0, background_margin, 0, background_margin));
+		p_theme->set_constant("center_grabber", "HSlider", 0);
+		p_theme->set_constant("grabber_offset", "HSlider", 0);
+
+		Ref<StyleBoxFlat> style_v_slider = style_h_slider->duplicate();
+		style_v_slider->set_content_margin_individual(2 * EDSCALE, 0, 2 * EDSCALE, 0);
+
+		// VSlider.
+		p_theme->set_icon("grabber", "VSlider", p_theme->get_icon(SNAME("GuiSliderGrabber"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grabber_highlight", "VSlider", p_theme->get_icon(SNAME("GuiSliderGrabberHl"), EditorStringName(EditorIcons)));
+		p_theme->set_stylebox("slider", "VSlider", style_v_slider);
+		p_theme->set_stylebox("grabber_area", "VSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, background_margin, 0, background_margin, 0, p_config.corner_radius));
+		p_theme->set_stylebox("grabber_area_highlight", "VSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, background_margin, 0, background_margin, 0));
+		p_theme->set_constant("center_grabber", "VSlider", 0);
+		p_theme->set_constant("grabber_offset", "VSlider", 0);
+	}
+
+	// Labels.
+	{
+		// RichTextLabel.
+
+		Ref<StyleBoxFlat> rich_text_style = p_config.base_style->duplicate();
+		rich_text_style->set_bg_color(p_config.surface_low_color);
+		rich_text_style->set_content_margin_all(p_config.base_margin * 2 * EDSCALE);
+
+		p_theme->set_stylebox(CoreStringName(normal), "RichTextLabel", rich_text_style);
+		p_theme->set_stylebox("focus", "RichTextLabel", EditorThemeManager::make_empty_stylebox());
+
+		p_theme->set_color("default_color", "RichTextLabel", p_config.font_color);
+		p_theme->set_color("font_shadow_color", "RichTextLabel", Color(1, 1, 1, 0));
+		p_theme->set_color("font_outline_color", "RichTextLabel", p_config.font_outline_color);
+		p_theme->set_color("selection_color", "RichTextLabel", p_config.selection_color);
+
+		p_theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
+		p_theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
+		p_theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * EDSCALE);
+		p_theme->set_constant("outline_size", "RichTextLabel", 0);
+
+		// Label.
+
+		Ref<StyleBoxEmpty> label_style = p_config.base_empty_style->duplicate();
+		label_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE);
+
+		p_theme->set_stylebox(CoreStringName(normal), "Label", label_style);
+		p_theme->set_stylebox("focus", "Label", p_config.focus_style);
+
+		p_theme->set_color(SceneStringName(font_color), "Label", p_config.font_color);
+		p_theme->set_color("font_shadow_color", "Label", Color(1, 1, 1, 0));
+		p_theme->set_color("font_outline_color", "Label", p_config.font_outline_color);
+
+		p_theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
+		p_theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
+		p_theme->set_constant("shadow_outline_size", "Label", 1 * EDSCALE);
+		p_theme->set_constant("line_spacing", "Label", 3 * EDSCALE);
+		p_theme->set_constant("outline_size", "Label", 0);
+	}
+
+	// SpinBox.
+	{
+		Ref<Texture2D> empty_icon = memnew(ImageTexture);
+		p_theme->set_icon("updown", "SpinBox", empty_icon);
+		p_theme->set_icon("up", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("up_hover", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("up_pressed", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("up_disabled", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxUp"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("down", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("down_hover", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("down_pressed", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("down_disabled", "SpinBox", p_theme->get_icon(SNAME("GuiSpinboxDown"), EditorStringName(EditorIcons)));
+
+		p_theme->set_stylebox("up_background", "SpinBox", EditorThemeManager::make_empty_stylebox());
+		p_theme->set_stylebox("up_background_hovered", "SpinBox", p_config.button_style_hover);
+		p_theme->set_stylebox("up_background_pressed", "SpinBox", p_config.button_style_pressed);
+		p_theme->set_stylebox("up_background_disabled", "SpinBox", EditorThemeManager::make_empty_stylebox());
+		p_theme->set_stylebox("down_background", "SpinBox", EditorThemeManager::make_empty_stylebox());
+		p_theme->set_stylebox("down_background_hovered", "SpinBox", p_config.button_style_hover);
+		p_theme->set_stylebox("down_background_pressed", "SpinBox", p_config.button_style_pressed);
+		p_theme->set_stylebox("down_background_disabled", "SpinBox", EditorThemeManager::make_empty_stylebox());
+
+		p_theme->set_color("up_icon_modulate", "SpinBox", p_config.icon_normal_color);
+		p_theme->set_color("up_hover_icon_modulate", "SpinBox", p_config.icon_hover_color);
+		p_theme->set_color("up_pressed_icon_modulate", "SpinBox", p_config.icon_pressed_color);
+		p_theme->set_color("up_disabled_icon_modulate", "SpinBox", p_config.icon_disabled_color);
+		p_theme->set_color("down_icon_modulate", "SpinBox", p_config.icon_normal_color);
+		p_theme->set_color("down_hover_icon_modulate", "SpinBox", p_config.icon_hover_color);
+		p_theme->set_color("down_pressed_icon_modulate", "SpinBox", p_config.icon_pressed_color);
+		p_theme->set_color("down_disabled_icon_modulate", "SpinBox", p_config.icon_disabled_color);
+
+		p_theme->set_stylebox("field_and_buttons_separator", "SpinBox", EditorThemeManager::make_empty_stylebox());
+		p_theme->set_stylebox("up_down_buttons_separator", "SpinBox", EditorThemeManager::make_empty_stylebox());
+
+		p_theme->set_constant("buttons_vertical_separation", "SpinBox", 0);
+		p_theme->set_constant("field_and_buttons_separation", "SpinBox", 2);
+		p_theme->set_constant("buttons_width", "SpinBox", 16);
+#ifndef DISABLE_DEPRECATED
+		p_theme->set_constant("set_min_buttons_width_from_icons", "SpinBox", 1);
+#endif
+	}
+
+	// ProgressBar.
+
+	Ref<StyleBoxFlat> progress_bar_style = p_config.base_style->duplicate();
+	progress_bar_style->set_bg_color(p_config.surface_lowest_color);
+	progress_bar_style->set_expand_margin(SIDE_TOP, p_config.base_margin * 0.5 * EDSCALE);
+	progress_bar_style->set_expand_margin(SIDE_BOTTOM, p_config.base_margin * 0.5 * EDSCALE);
+	progress_bar_style->set_content_margin_all(p_config.base_margin * EDSCALE);
+	if (p_config.draw_extra_borders) {
+		progress_bar_style->set_border_width_all(Math::round(EDSCALE));
+		progress_bar_style->set_border_color(p_config.extra_border_color_2);
+	}
+
+	Ref<StyleBoxFlat> progress_fill_style = progress_bar_style->duplicate();
+	progress_fill_style->set_bg_color(p_config.button_normal_color);
+	if (p_config.draw_extra_borders) {
+		progress_fill_style->set_border_color(p_config.extra_border_color_1);
+	}
+
+	p_theme->set_stylebox("background", "ProgressBar", progress_bar_style);
+	p_theme->set_stylebox("fill", "ProgressBar", progress_fill_style);
+	p_theme->set_color(SceneStringName(font_color), "ProgressBar", p_config.font_color);
+	p_theme->set_color("font_outline_color", "ProgressBar", p_config.font_outline_color);
+	p_theme->set_constant("outline_size", "ProgressBar", 0);
+
+	// GraphEdit and related nodes.
+	{
+		// GraphEdit.
+
+		Ref<StyleBoxFlat> graph_panel_focus = p_config.base_style->duplicate();
+		graph_panel_focus->set_border_color(p_config.mono_color * Color(1, 1, 1, 0.07));
+		graph_panel_focus->set_border_width_all(Math::round(2 * EDSCALE));
+
+		p_theme->set_stylebox(SceneStringName(panel), "GraphEdit", p_config.tree_panel_style);
+		p_theme->set_stylebox("panel_focus", "GraphEdit", graph_panel_focus);
+		p_theme->set_stylebox("menu_panel", "GraphEdit", EditorThemeManager::make_flat_stylebox(p_config.dark_color_1 * Color(1, 1, 1, 0.6), 4, 2, 4, 2, 3));
+
+		float grid_base_brightness = p_config.dark_theme ? 1.0 : 0.0;
+		GraphEdit::GridPattern grid_pattern = (GraphEdit::GridPattern) int(EDITOR_GET("editors/visual_editors/grid_pattern"));
+		switch (grid_pattern) {
+			case GraphEdit::GRID_PATTERN_LINES:
+				p_theme->set_color("grid_major", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.10));
+				p_theme->set_color("grid_minor", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.05));
+				break;
+			case GraphEdit::GRID_PATTERN_DOTS:
+				p_theme->set_color("grid_major", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.07));
+				p_theme->set_color("grid_minor", "GraphEdit", Color(grid_base_brightness, grid_base_brightness, grid_base_brightness, 0.07));
+				break;
+			default:
+				WARN_PRINT("Unknown grid pattern.");
+				break;
+		}
+
+		p_theme->set_color("selection_fill", "GraphEdit", p_theme->get_color(SNAME("box_selection_fill_color"), EditorStringName(Editor)));
+		p_theme->set_color("selection_stroke", "GraphEdit", p_theme->get_color(SNAME("box_selection_stroke_color"), EditorStringName(Editor)));
+		p_theme->set_color("activity", "GraphEdit", p_config.mono_color);
+
+		p_theme->set_color("connection_hover_tint_color", "GraphEdit", p_config.dark_color_2);
+		p_theme->set_constant("connection_hover_thickness", "GraphEdit", 0);
+		p_theme->set_color("connection_valid_target_tint_color", "GraphEdit", p_config.extra_border_color_1);
+		p_theme->set_color("connection_rim_color", "GraphEdit", p_config.tree_panel_style->get_bg_color());
+
+		p_theme->set_icon("zoom_out", "GraphEdit", p_theme->get_icon(SNAME("ZoomLess"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("zoom_in", "GraphEdit", p_theme->get_icon(SNAME("ZoomMore"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("zoom_reset", "GraphEdit", p_theme->get_icon(SNAME("ZoomReset"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("grid_toggle", "GraphEdit", p_theme->get_icon(SNAME("GridToggle"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("minimap_toggle", "GraphEdit", p_theme->get_icon(SNAME("GridMinimap"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("snapping_toggle", "GraphEdit", p_theme->get_icon(SNAME("SnapGrid"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("layout", "GraphEdit", p_theme->get_icon(SNAME("GridLayout"), EditorStringName(EditorIcons)));
+
+		// GraphEditMinimap.
+		{
+			Ref<StyleBoxFlat> style_minimap_bg = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 0, 0, 0, 0);
+			style_minimap_bg->set_border_color(p_config.dark_color_3);
+			style_minimap_bg->set_border_width_all(1);
+			p_theme->set_stylebox(SceneStringName(panel), "GraphEditMinimap", style_minimap_bg);
+
+			Ref<StyleBoxFlat> style_minimap_camera;
+			Ref<StyleBoxFlat> style_minimap_node;
+			if (p_config.dark_theme) {
+				style_minimap_camera = EditorThemeManager::make_flat_stylebox(Color(0.65, 0.65, 0.65, 0.2), 0, 0, 0, 0);
+				style_minimap_camera->set_border_color(Color(0.65, 0.65, 0.65, 0.45));
+				style_minimap_node = EditorThemeManager::make_flat_stylebox(Color(1, 1, 1), 0, 0, 0, 0);
+			} else {
+				style_minimap_camera = EditorThemeManager::make_flat_stylebox(Color(0.38, 0.38, 0.38, 0.2), 0, 0, 0, 0);
+				style_minimap_camera->set_border_color(Color(0.38, 0.38, 0.38, 0.45));
+				style_minimap_node = EditorThemeManager::make_flat_stylebox(Color(0, 0, 0), 0, 0, 0, 0);
+			}
+			style_minimap_camera->set_border_width_all(1);
+			style_minimap_node->set_anti_aliased(false);
+			p_theme->set_stylebox("camera", "GraphEditMinimap", style_minimap_camera);
+			p_theme->set_stylebox("node", "GraphEditMinimap", style_minimap_node);
+
+			const Color minimap_resizer_color = p_config.dark_theme ? Color(1, 1, 1, 0.65) : Color(0, 0, 0, 0.65);
+			p_theme->set_icon("resizer", "GraphEditMinimap", p_theme->get_icon(SNAME("GuiResizerTopLeft"), EditorStringName(EditorIcons)));
+			p_theme->set_color("resizer_color", "GraphEditMinimap", minimap_resizer_color);
+		}
+
+		// GraphElement, GraphNode & GraphFrame.
+		{
+			const int gn_margin_top = 2;
+			const int gn_margin_side = 2;
+			const int gn_margin_bottom = 2;
+
+			const int gn_corner_radius = 3;
+
+			const Color gn_bg_color = p_config.dark_theme ? p_config.dark_color_3 : p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
+			const Color gn_frame_bg = gn_bg_color.lerp(p_config.tree_panel_style->get_bg_color(), 0.3);
+
+			const bool high_contrast_borders = p_config.draw_extra_borders && p_config.dark_theme;
+
+			Ref<StyleBoxFlat> gn_panel_style = EditorThemeManager::make_flat_stylebox(gn_frame_bg, gn_margin_side, gn_margin_top, gn_margin_side, gn_margin_bottom, p_config.corner_radius);
+			gn_panel_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
+			gn_panel_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
+			gn_panel_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_panel_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
+			gn_panel_style->set_corner_radius_individual(0, 0, gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE);
+			gn_panel_style->set_anti_aliased(true);
+
+			Ref<StyleBoxFlat> gn_panel_selected_style = gn_panel_style->duplicate();
+			gn_panel_selected_style->set_bg_color(p_config.dark_theme ? gn_bg_color.lightened(0.15) : gn_bg_color.darkened(0.15));
+			gn_panel_selected_style->set_border_width(SIDE_TOP, 0);
+			gn_panel_selected_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
+			gn_panel_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
+			gn_panel_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_panel_selected_style->set_border_color(p_config.mono_color);
+
+			const int gn_titlebar_margin_top = 8;
+			const int gn_titlebar_margin_side = 12;
+			const int gn_titlebar_margin_bottom = 8;
+
+			Ref<StyleBoxFlat> gn_titlebar_style = EditorThemeManager::make_flat_stylebox(gn_bg_color, gn_titlebar_margin_side, gn_titlebar_margin_top, gn_titlebar_margin_side, gn_titlebar_margin_bottom, p_config.corner_radius);
+			gn_titlebar_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
+			gn_titlebar_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
+			gn_titlebar_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_titlebar_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
+			gn_titlebar_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
+			gn_titlebar_style->set_corner_radius_individual(gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE, 0, 0);
+			gn_titlebar_style->set_anti_aliased(true);
+
+			Ref<StyleBoxFlat> gn_titlebar_selected_style = gn_titlebar_style->duplicate();
+			gn_titlebar_selected_style->set_border_color(p_config.mono_color);
+			gn_titlebar_selected_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
+			gn_titlebar_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
+			gn_titlebar_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_titlebar_selected_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
+
+			Color gn_decoration_color = p_config.dark_color_1.inverted();
+
+			// GraphElement.
+
+			p_theme->set_stylebox(SceneStringName(panel), "GraphElement", gn_panel_style);
+			p_theme->set_stylebox("panel_selected", "GraphElement", gn_panel_selected_style);
+			p_theme->set_stylebox("titlebar", "GraphElement", gn_titlebar_style);
+			p_theme->set_stylebox("titlebar_selected", "GraphElement", gn_titlebar_selected_style);
+
+			p_theme->set_color("resizer_color", "GraphElement", gn_decoration_color);
+			p_theme->set_icon("resizer", "GraphElement", p_theme->get_icon(SNAME("GuiResizer"), EditorStringName(EditorIcons)));
+
+			// GraphNode.
+
+			Ref<StyleBoxEmpty> gn_slot_style = EditorThemeManager::make_empty_stylebox(12, 0, 12, 0);
+
+			p_theme->set_stylebox(SceneStringName(panel), "GraphNode", gn_panel_style);
+			p_theme->set_stylebox("panel_selected", "GraphNode", gn_panel_selected_style);
+			p_theme->set_stylebox("panel_focus", "GraphNode", p_config.focus_style);
+			p_theme->set_stylebox("titlebar", "GraphNode", gn_titlebar_style);
+			p_theme->set_stylebox("titlebar_selected", "GraphNode", gn_titlebar_selected_style);
+			p_theme->set_stylebox("slot", "GraphNode", gn_slot_style);
+			p_theme->set_stylebox("slot_selected", "GraphNode", p_config.focus_style);
+
+			p_theme->set_color("resizer_color", "GraphNode", gn_decoration_color);
+
+			p_theme->set_constant("port_h_offset", "GraphNode", 1);
+			p_theme->set_constant("separation", "GraphNode", 1 * EDSCALE);
+
+			Ref<DPITexture> port_icon = p_theme->get_icon(SNAME("GuiGraphNodePort"), EditorStringName(EditorIcons));
+			// The true size is 24x24 This is necessary for sharp port icons at high zoom levels in GraphEdit (up to ~200%).
+			port_icon->set_size_override(Size2(12, 12));
+			p_theme->set_icon("port", "GraphNode", port_icon);
+
+			// GraphNode's title Label.
+			p_theme->set_type_variation("GraphNodeTitleLabel", "Label");
+			p_theme->set_stylebox(CoreStringName(normal), "GraphNodeTitleLabel", EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+			p_theme->set_color("font_shadow_color", "GraphNodeTitleLabel", p_config.shadow_color);
+			p_theme->set_constant("shadow_outline_size", "GraphNodeTitleLabel", 4);
+			p_theme->set_constant("shadow_offset_x", "GraphNodeTitleLabel", 0);
+			p_theme->set_constant("shadow_offset_y", "GraphNodeTitleLabel", 1);
+			p_theme->set_constant("line_spacing", "GraphNodeTitleLabel", 3 * EDSCALE);
+
+			// GraphFrame.
+
+			const int gf_corner_width = 7 * EDSCALE;
+			const int gf_border_width = 2 * MAX(1, EDSCALE);
+
+			Ref<StyleBoxFlat> graphframe_sb = EditorThemeManager::make_flat_stylebox(Color(0.0, 0.0, 0.0, 0.2), gn_margin_side, gn_margin_side, gn_margin_side, gn_margin_bottom, gf_corner_width);
+			graphframe_sb->set_expand_margin(SIDE_TOP, 38 * EDSCALE);
+			graphframe_sb->set_border_width_all(gf_border_width);
+			graphframe_sb->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
+			graphframe_sb->set_shadow_size(8 * EDSCALE);
+			graphframe_sb->set_shadow_color(Color(p_config.shadow_color, p_config.shadow_color.a * 0.25));
+			graphframe_sb->set_anti_aliased(true);
+
+			Ref<StyleBoxFlat> graphframe_sb_selected = graphframe_sb->duplicate();
+			graphframe_sb_selected->set_border_color(p_config.mono_color);
+
+			p_theme->set_stylebox(SceneStringName(panel), "GraphFrame", graphframe_sb);
+			p_theme->set_stylebox("panel_selected", "GraphFrame", graphframe_sb_selected);
+			p_theme->set_stylebox("titlebar", "GraphFrame", EditorThemeManager::make_empty_stylebox(4, 4, 4, 4));
+			p_theme->set_stylebox("titlebar_selected", "GraphFrame", EditorThemeManager::make_empty_stylebox(4, 4, 4, 4));
+			p_theme->set_color("resizer_color", "GraphFrame", gn_decoration_color);
+
+			// GraphFrame's title Label.
+			p_theme->set_type_variation("GraphFrameTitleLabel", "Label");
+			p_theme->set_stylebox(CoreStringName(normal), "GraphFrameTitleLabel", memnew(StyleBoxEmpty));
+			p_theme->set_font_size(SceneStringName(font_size), "GraphFrameTitleLabel", 22 * EDSCALE);
+			p_theme->set_color(SceneStringName(font_color), "GraphFrameTitleLabel", Color(1, 1, 1));
+			p_theme->set_color("font_shadow_color", "GraphFrameTitleLabel", Color(1, 1, 1, 0));
+			p_theme->set_color("font_outline_color", "GraphFrameTitleLabel", Color(1, 1, 1));
+			p_theme->set_constant("shadow_offset_x", "GraphFrameTitleLabel", 1 * EDSCALE);
+			p_theme->set_constant("shadow_offset_y", "GraphFrameTitleLabel", 1 * EDSCALE);
+			p_theme->set_constant("outline_size", "GraphFrameTitleLabel", 0);
+			p_theme->set_constant("shadow_outline_size", "GraphFrameTitleLabel", 1 * EDSCALE);
+			p_theme->set_constant("line_spacing", "GraphFrameTitleLabel", 3 * EDSCALE);
+		}
+
+		// VisualShader reroute node.
+		{
+			Ref<StyleBox> vs_reroute_panel_style = EditorThemeManager::make_empty_stylebox();
+			Ref<StyleBox> vs_reroute_titlebar_style = vs_reroute_panel_style->duplicate();
+			vs_reroute_titlebar_style->set_content_margin_all(16 * EDSCALE);
+			p_theme->set_stylebox(SceneStringName(panel), "VSRerouteNode", vs_reroute_panel_style);
+			p_theme->set_stylebox("panel_selected", "VSRerouteNode", vs_reroute_panel_style);
+			p_theme->set_stylebox("titlebar", "VSRerouteNode", vs_reroute_titlebar_style);
+			p_theme->set_stylebox("titlebar_selected", "VSRerouteNode", vs_reroute_titlebar_style);
+			p_theme->set_stylebox("slot", "VSRerouteNode", EditorThemeManager::make_empty_stylebox());
+
+			p_theme->set_color("drag_background", "VSRerouteNode", p_config.dark_theme ? Color(0.19, 0.21, 0.24) : Color(0.8, 0.8, 0.8));
+			p_theme->set_color("selected_rim_color", "VSRerouteNode", p_config.mono_color);
+		}
+	}
+
+	// ColorPicker and related nodes.
+	{
+		// ColorPicker.
+		Ref<StyleBoxFlat> circle_style_focus = p_config.base_style->duplicate();
+		circle_style_focus->set_border_color(p_config.mono_color * Color(1, 1, 1, 0.3));
+		circle_style_focus->set_draw_center(false);
+		circle_style_focus->set_corner_radius_all(256 * EDSCALE);
+		circle_style_focus->set_corner_detail(32 * EDSCALE);
+
+		p_theme->set_constant("margin", "ColorPicker", p_config.base_margin);
+		p_theme->set_constant("sv_width", "ColorPicker", 256 * EDSCALE);
+		p_theme->set_constant("sv_height", "ColorPicker", 256 * EDSCALE);
+		p_theme->set_constant("h_width", "ColorPicker", 30 * EDSCALE);
+		p_theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
+		p_theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
+
+		p_theme->set_stylebox("sample_focus", "ColorPicker", p_config.focus_style);
+		p_theme->set_stylebox("picker_focus_rectangle", "ColorPicker", p_config.focus_style);
+		p_theme->set_stylebox("picker_focus_circle", "ColorPicker", circle_style_focus);
+		p_theme->set_color("focused_not_editing_cursor_color", "ColorPicker", p_config.highlight_color);
+
+		p_theme->set_icon("screen_picker", "ColorPicker", p_theme->get_icon(SNAME("ColorPick"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("shape_circle", "ColorPicker", p_theme->get_icon(SNAME("PickerShapeCircle"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("shape_rect", "ColorPicker", p_theme->get_icon(SNAME("PickerShapeRectangle"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("shape_rect_wheel", "ColorPicker", p_theme->get_icon(SNAME("PickerShapeRectangleWheel"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("add_preset", "ColorPicker", p_theme->get_icon(SNAME("Add"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("sample_bg", "ColorPicker", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("sample_revert", "ColorPicker", p_theme->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("overbright_indicator", "ColorPicker", p_theme->get_icon(SNAME("OverbrightIndicator"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("bar_arrow", "ColorPicker", p_theme->get_icon(SNAME("ColorPickerBarArrow"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("picker_cursor", "ColorPicker", p_theme->get_icon(SNAME("PickerCursor"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("picker_cursor_bg", "ColorPicker", p_theme->get_icon(SNAME("PickerCursorBg"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("color_script", "ColorPicker", p_theme->get_icon(SNAME("Script"), EditorStringName(EditorIcons)));
+
+		// ColorPickerButton.
+		p_theme->set_icon("bg", "ColorPickerButton", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));
+
+		// ColorPresetButton.
+		p_theme->set_stylebox("preset_fg", "ColorPresetButton", EditorThemeManager::make_flat_stylebox(Color(1, 1, 1), 2, 2, 2, 2, 2));
+		p_theme->set_icon("preset_bg", "ColorPresetButton", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("overbright_indicator", "ColorPresetButton", p_theme->get_icon(SNAME("OverbrightIndicator"), EditorStringName(EditorIcons)));
+	}
+}
+
+void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config) {
+	// Project manager.
+	{
+		Ref<StyleBoxFlat> style_panel_container = p_theme->get_stylebox(SceneStringName(panel), SNAME("TabContainer"))->duplicate();
+		style_panel_container->set_corner_radius(CORNER_TOP_LEFT, style_panel_container->get_corner_radius(CORNER_BOTTOM_LEFT));
+		style_panel_container->set_corner_radius(CORNER_TOP_RIGHT, style_panel_container->get_corner_radius(CORNER_BOTTOM_RIGHT));
+
+		Ref<StyleBoxFlat> style_project_list = p_config.base_style->duplicate();
+		style_project_list->set_bg_color(p_config.surface_low_color);
+
+		p_theme->set_stylebox("panel_container", "ProjectManager", style_panel_container);
+		p_theme->set_stylebox("project_list", "ProjectManager", style_project_list);
+		p_theme->set_stylebox("quick_settings_panel", "ProjectManager", style_project_list);
+		p_theme->set_constant("sidebar_button_icon_separation", "ProjectManager", int(6 * EDSCALE));
+		p_theme->set_icon("browse_folder", "ProjectManager", p_theme->get_icon(SNAME("FolderBrowse"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("browse_file", "ProjectManager", p_theme->get_icon(SNAME("FileBrowse"), EditorStringName(EditorIcons)));
+
+		// ProjectTag.
+		{
+			p_theme->set_type_variation("ProjectTagButton", "Button");
+
+			Ref<StyleBoxFlat> tag = p_config.button_style->duplicate();
+			tag->set_bg_color(p_config.dark_theme ? tag->get_bg_color().lightened(0.2) : tag->get_bg_color().darkened(0.2));
+			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(CoreStringName(normal), "ProjectTagButton", tag);
+
+			tag = p_config.button_style_hover->duplicate();
+			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(SceneStringName(hover), "ProjectTagButton", tag);
+
+			tag = p_config.button_style_pressed->duplicate();
+			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
+		}
+	}
+
+	// Editor and main screen.
+	{
+		// Editor background.
+		Color background_color = p_config.surface_lowest_color; //_get_base_color(p_config, -1.5);
+		p_theme->set_color("background", EditorStringName(Editor), background_color);
+		Ref<StyleBoxFlat> style_bg = p_config.base_style->duplicate();
+		style_bg->set_bg_color(background_color);
+		style_bg->set_content_margin_all(0);
+		style_bg->set_corner_radius_all(0);
+		p_theme->set_stylebox("Background", EditorStringName(EditorStyles), style_bg);
+
+		Ref<StyleBoxFlat> editor_panel_foreground = p_config.base_style->duplicate();
+		editor_panel_foreground->set_corner_radius_all(0);
+		p_theme->set_stylebox("PanelForeground", EditorStringName(EditorStyles), editor_panel_foreground);
+
+		// Editor focus.
+		p_theme->set_stylebox("Focus", EditorStringName(EditorStyles), p_config.focus_style);
+
+		Ref<StyleBoxFlat> style_widget_focus_viewport = p_config.base_style->duplicate();
+		style_widget_focus_viewport->set_corner_radius_all(0);
+		style_widget_focus_viewport->set_border_width_all(2);
+		style_widget_focus_viewport->set_border_color(p_config.mono_color * Color(1, 1, 1, 0.07));
+		style_widget_focus_viewport->set_draw_center(false);
+		p_theme->set_stylebox("FocusViewport", EditorStringName(EditorStyles), style_widget_focus_viewport);
+
+		p_theme->set_stylebox(SceneStringName(panel), "ScrollContainer", p_config.base_empty_style);
+		p_theme->set_stylebox("focus", "ScrollContainer", p_config.focus_style);
+
+		// This stylebox is used in 3d and 2d viewports (no borders).
+		Ref<StyleBoxFlat> style_content_panel_vp = p_config.content_panel_style->duplicate();
+		style_content_panel_vp->set_content_margin_individual(p_config.border_width * 2, p_config.base_margin * EDSCALE, p_config.border_width * 2, p_config.border_width * 2);
+		p_theme->set_stylebox("Content", EditorStringName(EditorStyles), style_content_panel_vp);
+
+		// 3D/Spatial editor.
+		Ref<StyleBoxFlat> style_info_3d_viewport = p_config.base_style->duplicate();
+		style_info_3d_viewport->set_bg_color(p_config.dark_color_2);
+		style_info_3d_viewport->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE);
+		p_theme->set_stylebox("Information3dViewport", EditorStringName(EditorStyles), style_info_3d_viewport);
+
+		// 2D, 3D, and Game toolbar.
+		p_theme->set_type_variation("MainToolBarMargin", "MarginContainer");
+		p_theme->set_constant("margin_left", "MainToolBarMargin", 4 * EDSCALE);
+		p_theme->set_constant("margin_right", "MainToolBarMargin", 4 * EDSCALE);
+		p_theme->set_constant("margin_top", "MainToolBarMargin", p_config.base_margin * 0.5 * EDSCALE);
+		p_theme->set_constant("margin_bottom", "MainToolBarMargin", p_config.base_margin * 0.5 * EDSCALE);
+
+		// 2D and 3D contextual toolbar.
+		// Use a custom stylebox to make contextual menu items stand out from the rest.
+		// This helps with editor usability as contextual menu items change when selecting nodes,
+		// even though it may not be immediately obvious at first.
+		Ref<StyleBoxFlat> toolbar_stylebox = p_config.base_style->duplicate();
+		toolbar_stylebox->set_bg_color(p_config.surface_higher_color);
+		toolbar_stylebox->set_content_margin_all(0);
+		p_theme->set_stylebox("ContextualToolbar", EditorStringName(EditorStyles), toolbar_stylebox);
+
+		// Script editor.
+		p_theme->set_stylebox("ScriptEditorPanel", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(p_config.base_margin, 0, p_config.base_margin, p_config.base_margin));
+		p_theme->set_stylebox("ScriptEditorPanelFloating", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+		p_theme->set_stylebox("ScriptEditor", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+
+		// Game view.
+		p_theme->set_type_variation("GamePanel", "Panel");
+		Ref<StyleBoxFlat> game_panel = p_theme->get_stylebox(SceneStringName(panel), SNAME("Panel"))->duplicate();
+		game_panel->set_corner_radius_all(0);
+		p_theme->set_stylebox(SceneStringName(panel), "GamePanel", game_panel);
+
+		// Main menu.
+		p_theme->set_stylebox(CoreStringName(normal), "MainScreenButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox("normal_mirrored", "MainScreenButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox(SceneStringName(pressed), "MainScreenButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox("pressed_mirrored", "MainScreenButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox(SceneStringName(hover), "MainScreenButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox("hover_mirrored", "MainScreenButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox("hover_pressed", "MainScreenButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox("hover_pressed_mirrored", "MainScreenButton", p_config.base_empty_wide_style);
+
+		p_theme->set_type_variation("MainMenuBar", "FlatMenuButton");
+		p_theme->set_stylebox(CoreStringName(normal), "MainMenuBar", p_config.flat_button);
+		p_theme->set_stylebox(SceneStringName(pressed), "MainMenuBar", p_config.flat_button_pressed);
+		p_theme->set_stylebox(SceneStringName(hover), "MainMenuBar", p_config.flat_button_hover);
+		p_theme->set_stylebox("hover_pressed", "MainMenuBar", p_config.flat_button_hover);
+
+		// Run bar.
+		Ref<StyleBoxFlat> run_bar_hover = p_config.base_style->duplicate();
+		run_bar_hover->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.1));
+		run_bar_hover->set_content_margin_all(0);
+
+		p_theme->set_type_variation("RunBarButton", "FlatMenuButton");
+		p_theme->set_stylebox("disabled", "RunBarButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox(SceneStringName(pressed), "RunBarButton", p_config.base_empty_wide_style);
+		p_theme->set_stylebox(SceneStringName(hover), "RunBarButton", run_bar_hover);
+
+		// FIXME: Decide if the faded color should be used in the modern theme as well.
+		p_theme->set_type_variation("RunBarButtonMovieMakerDisabled", "RunBarButton");
+
+		p_theme->set_type_variation("RunBarButtonMovieMakerEnabled", "RunBarButton");
+		// The icon will be surrounded by the accent color, no need to colorize it.
+		p_theme->set_color("icon_pressed_color", "RunBarButtonMovieMakerEnabled", p_config.icon_pressed_color);
+		p_theme->set_color("icon_hover_pressed_color", "RunBarButtonMovieMakerEnabled", p_config.icon_pressed_color);
+
+		// Bottom panel.
+		Ref<StyleBoxFlat> style_bottom_panel = p_config.content_panel_style->duplicate();
+		style_bottom_panel->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		p_theme->set_stylebox("BottomPanel", EditorStringName(EditorStyles), style_bottom_panel);
+
+		p_theme->set_type_variation("BottomPanelButton", "FlatMenuButton");
+
+		// Use bigger margin for buttons in bottom panel to make them easier to press.
+		Ref<StyleBoxEmpty> bottom_panel_button = p_config.base_empty_style->duplicate();
+		bottom_panel_button->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE);
+		p_theme->set_stylebox(CoreStringName(normal), "BottomPanelButton", bottom_panel_button);
+
+		Ref<StyleBoxFlat> bottom_panel_button_hover = p_config.flat_button_hover->duplicate();
+		bottom_panel_button_hover->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE);
+		p_theme->set_stylebox(SceneStringName(hover), "BottomPanelButton", bottom_panel_button_hover);
+		p_theme->set_stylebox(SceneStringName(pressed), "BottomPanelButton", bottom_panel_button_hover);
+
+		Ref<StyleBoxFlat> bottom_panel_button_pressed = p_config.flat_button_hover->duplicate();
+		bottom_panel_button_pressed->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE);
+		p_theme->set_stylebox("hover_pressed", "BottomPanelButton", bottom_panel_button_pressed);
+
+		// Don't tint the icon even when in "pressed" state.
+		p_theme->set_color("icon_pressed_color", "BottomPanelButton", Color(1, 1, 1, 1));
+		Color icon_hover_color = p_config.icon_normal_color * (p_config.dark_icon_and_font ? 1.15 : 1.0);
+		icon_hover_color.a = 1.0;
+		p_theme->set_color("icon_hover_color", "BottomPanelButton", icon_hover_color);
+		p_theme->set_color("icon_hover_pressed_color", "BottomPanelButton", icon_hover_color);
+
+		// Audio bus.
+		Ref<StyleBoxFlat> audio_bus = p_config.base_style->duplicate();
+		audio_bus->set_bg_color(p_config.surface_high_color);
+		p_theme->set_stylebox(CoreStringName(normal), "EditorAudioBus", audio_bus);
+		p_theme->set_stylebox("focus", "EditorAudioBus", p_config.focus_style);
+		Ref<StyleBoxFlat> audio_bus_master = p_config.base_style->duplicate();
+		audio_bus_master->set_bg_color(p_config.surface_higher_color);
+		p_theme->set_stylebox("master", "EditorAudioBus", audio_bus_master);
+	}
+
+	// Editor GUI widgets.
+	{
+		// EditorSpinSlider.
+		p_theme->set_color("label_color", "EditorSpinSlider", p_config.font_color);
+		p_theme->set_color("read_only_label_color", "EditorSpinSlider", p_config.font_readonly_color);
+
+		Ref<StyleBoxFlat> editor_spin_label_bg = p_config.base_style->duplicate();
+		editor_spin_label_bg->set_bg_color(p_config.surface_lower_color);
+		editor_spin_label_bg->set_content_margin_all(p_config.base_margin * EDSCALE);
+		p_theme->set_stylebox("label_bg", "EditorSpinSlider", editor_spin_label_bg);
+
+		// TODO Use separate arrows instead like on SpinBox. Planned for a different PR.
+		p_theme->set_icon("updown", "EditorSpinSlider", p_theme->get_icon(SNAME("GuiSpinboxUpdown"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("updown_disabled", "EditorSpinSlider", p_theme->get_icon(SNAME("GuiSpinboxUpdownDisabled"), EditorStringName(EditorIcons)));
+
+		// Launch Pad and Play buttons.
+		Ref<StyleBoxFlat> style_launch_pad_movie = p_config.base_style->duplicate();
+		style_launch_pad_movie->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.2));
+		style_launch_pad_movie->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.8));
+		style_launch_pad_movie->set_border_width_all(Math::round(2 * EDSCALE));
+		p_theme->set_stylebox("LaunchPadMovieMode", EditorStringName(EditorStyles), style_launch_pad_movie);
+
+		int pad_normal_margin = style_launch_pad_movie->get_minimum_size().width / 2;
+		Ref<StyleBoxEmpty> style_launch_pad = memnew(StyleBoxEmpty);
+		style_launch_pad->set_content_margin_all(pad_normal_margin);
+		p_theme->set_stylebox("LaunchPadNormal", EditorStringName(EditorStyles), style_launch_pad);
+
+		Ref<StyleBoxFlat> style_launch_pad_recovery_mode = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 2 * EDSCALE, 0, 2 * EDSCALE, 0, p_config.corner_radius);
+		style_launch_pad_recovery_mode->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
+		style_launch_pad_recovery_mode->set_border_color(p_config.warning_color);
+		style_launch_pad_recovery_mode->set_border_width_all(Math::round(2 * EDSCALE));
+		style_launch_pad_recovery_mode->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		p_theme->set_stylebox("LaunchPadRecoveryMode", EditorStringName(EditorStyles), style_launch_pad_recovery_mode);
+
+		p_theme->set_stylebox("MovieWriterButtonNormal", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+		Ref<StyleBoxFlat> style_write_movie_button = p_config.base_style->duplicate();
+		style_write_movie_button->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.8));
+		style_write_movie_button->set_content_margin_all(0);
+		p_theme->set_stylebox("MovieWriterButtonPressed", EditorStringName(EditorStyles), style_write_movie_button);
+
+		// Profiler autostart indicator panel.
+		Ref<StyleBoxFlat> style_profiler_autostart = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 2 * EDSCALE, 0, 2 * EDSCALE, 0, p_config.corner_radius);
+		style_profiler_autostart->set_bg_color(Color(1, 0.867, 0.396));
+		style_profiler_autostart->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		p_theme->set_type_variation("ProfilerAutostartIndicator", "Button");
+		p_theme->set_stylebox(CoreStringName(normal), "ProfilerAutostartIndicator", style_profiler_autostart);
+		p_theme->set_stylebox(SceneStringName(pressed), "ProfilerAutostartIndicator", style_profiler_autostart);
+		p_theme->set_stylebox(SceneStringName(hover), "ProfilerAutostartIndicator", style_profiler_autostart);
+
+		// Recovery mode button style
+		Ref<StyleBoxFlat> style_recovery_mode_button = p_config.button_style_pressed->duplicate();
+		style_recovery_mode_button->set_bg_color(p_config.warning_color);
+		style_recovery_mode_button->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_recovery_mode_button->set_content_margin_all(0);
+		// Recovery mode button is implicitly styled from the panel's background.
+		// So, remove any existing borders. (e.g. from draw_extra_borders config)
+		style_recovery_mode_button->set_border_width_all(0);
+		style_recovery_mode_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+		p_theme->set_stylebox("RecoveryModeButton", EditorStringName(EditorStyles), style_recovery_mode_button);
+	}
+
+	// Standard GUI variations.
+	{
+		// Custom theme type for MarginContainer with 4px margins.
+		p_theme->set_type_variation("MarginContainer4px", "MarginContainer");
+		p_theme->set_constant("margin_left", "MarginContainer4px", 4 * EDSCALE);
+		p_theme->set_constant("margin_top", "MarginContainer4px", 4 * EDSCALE);
+		p_theme->set_constant("margin_right", "MarginContainer4px", 4 * EDSCALE);
+		p_theme->set_constant("margin_bottom", "MarginContainer4px", 4 * EDSCALE);
+
+		// Header LinkButton variation.
+		p_theme->set_type_variation("HeaderSmallLink", "LinkButton");
+		p_theme->set_font(SceneStringName(font), "HeaderSmallLink", p_theme->get_font(SceneStringName(font), SNAME("HeaderSmall")));
+		p_theme->set_font_size(SceneStringName(font_size), "HeaderSmallLink", p_theme->get_font_size(SceneStringName(font_size), SNAME("HeaderSmall")));
+
+		// Flat button variations.
+		{
+			p_theme->set_stylebox(CoreStringName(normal), SceneStringName(FlatButton), p_config.base_empty_wide_style);
+			p_theme->set_stylebox(SceneStringName(hover), SceneStringName(FlatButton), p_config.flat_button_hover);
+			p_theme->set_stylebox(SceneStringName(pressed), SceneStringName(FlatButton), p_config.flat_button_pressed);
+			p_theme->set_stylebox("hover_pressed", SceneStringName(FlatButton), p_config.flat_button_pressed);
+			p_theme->set_stylebox("disabled", SceneStringName(FlatButton), p_config.base_empty_wide_style);
+
+			p_theme->set_stylebox(CoreStringName(normal), "FlatMenuButton", p_config.base_empty_wide_style);
+			p_theme->set_stylebox(SceneStringName(hover), "FlatMenuButton", p_config.flat_button_hover);
+			p_theme->set_stylebox(SceneStringName(pressed), "FlatMenuButton", p_config.flat_button_pressed);
+			p_theme->set_stylebox("hover_pressed", "FlatMenuButton", p_config.flat_button_pressed);
+			p_theme->set_stylebox("disabled", "FlatMenuButton", p_config.base_empty_wide_style);
+
+			// Variation for Editor Log filter buttons.
+
+			p_theme->set_type_variation("EditorLogFilterButton", "Button");
+			// When pressed, don't tint the icons with the accent color, just leave them normal.
+			p_theme->set_color("icon_pressed_color", "EditorLogFilterButton", p_config.icon_pressed_color);
+			// When unpressed, dim the icons.
+			p_theme->set_color("icon_normal_color", "EditorLogFilterButton", p_config.icon_disabled_color);
+			p_theme->set_color("icon_hover_color", "EditorLogFilterButton", p_config.icon_hover_color);
+			p_theme->set_color("icon_hover_pressed_color", "EditorLogFilterButton", p_config.icon_hover_color);
+
+			// Hover and pressed styles are swapped for toggle buttons on purpose.
+			p_theme->set_stylebox(CoreStringName(normal), "EditorLogFilterButton", p_config.base_empty_style);
+			p_theme->set_stylebox(SceneStringName(hover), "EditorLogFilterButton", p_config.flat_button_pressed);
+			p_theme->set_stylebox(SceneStringName(pressed), "EditorLogFilterButton", p_config.flat_button_hover);
+		}
+
+		// Buttons styles that stand out against the panel background (e.g. AssetLib).
+		{
+			p_theme->set_type_variation("PanelBackgroundButton", "Button");
+
+			Ref<StyleBoxFlat> panel_button_style = p_config.button_style->duplicate();
+			panel_button_style->set_bg_color(p_config.base_color.lerp(p_config.mono_color, 0.08));
+
+			Ref<StyleBoxFlat> panel_button_style_hover = p_config.button_style_hover->duplicate();
+			panel_button_style_hover->set_bg_color(p_config.base_color.lerp(p_config.mono_color, 0.16));
+
+			Ref<StyleBoxFlat> panel_button_style_pressed = p_config.button_style_pressed->duplicate();
+			panel_button_style_pressed->set_bg_color(p_config.base_color.lerp(p_config.mono_color, 0.20));
+
+			Ref<StyleBoxFlat> panel_button_style_disabled = p_config.button_style_disabled->duplicate();
+			panel_button_style_disabled->set_bg_color(p_config.disabled_bg_color);
+
+			p_theme->set_stylebox(CoreStringName(normal), "PanelBackgroundButton", panel_button_style);
+			p_theme->set_stylebox(SceneStringName(hover), "PanelBackgroundButton", panel_button_style_hover);
+			p_theme->set_stylebox(SceneStringName(pressed), "PanelBackgroundButton", panel_button_style_pressed);
+			p_theme->set_stylebox("disabled", "PanelBackgroundButton", panel_button_style_disabled);
+		}
+
+		// Top bar selectors.
+		p_theme->set_type_variation("TopBarOptionButton", "OptionButton");
+		p_theme->set_font(SceneStringName(font), "TopBarOptionButton", p_theme->get_font(SNAME("bold"), EditorStringName(EditorFonts)));
+		p_theme->set_font_size(SceneStringName(font_size), "TopBarOptionButton", p_theme->get_font_size(SNAME("bold_size"), EditorStringName(EditorFonts)));
+
+		// Complex editor windows.
+		p_theme->set_stylebox(SceneStringName(panel), "EditorSettingsDialog", p_config.window_complex_style);
+		p_theme->set_stylebox(SceneStringName(panel), "ProjectSettingsEditor", p_config.window_complex_style);
+		p_theme->set_stylebox(SceneStringName(panel), "ProjectExportDialog", p_config.window_complex_style);
+		p_theme->set_stylebox(SceneStringName(panel), "SceneImportSettingsDialog", p_config.window_complex_style);
+		p_theme->set_stylebox(SceneStringName(panel), "EditorAbout", p_config.window_complex_style);
+		p_theme->set_stylebox(SceneStringName(panel), "ThemeItemEditorDialog", p_config.window_complex_style);
+
+		// InspectorActionButton.
+		p_theme->set_type_variation("InspectorActionButton", "Button");
+		p_theme->set_constant("h_separation", "InspectorActionButton", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_stylebox(CoreStringName(normal), "InspectorActionButton", p_config.button_style);
+		p_theme->set_stylebox(SceneStringName(hover), "InspectorActionButton", p_config.button_style_hover);
+		p_theme->set_stylebox(SceneStringName(pressed), "InspectorActionButton", p_config.button_style_pressed);
+		p_theme->set_stylebox("disabled", "InspectorActionButton", p_config.button_style_disabled);
+
+		// Buttons in material previews.
+		{
+			const Color dim_light_color = p_config.icon_normal_color.darkened(0.24);
+			const Color dim_light_highlighted_color = p_config.icon_normal_color.darkened(0.18);
+			Ref<StyleBox> sb_empty_borderless = EditorThemeManager::make_empty_stylebox();
+
+			p_theme->set_type_variation("PreviewLightButton", "Button");
+			// When pressed, don't use the accent color tint. When unpressed, dim the icon.
+			p_theme->set_color("icon_normal_color", "PreviewLightButton", dim_light_color);
+			p_theme->set_color("icon_focus_color", "PreviewLightButton", dim_light_color);
+			p_theme->set_color("icon_pressed_color", "PreviewLightButton", p_config.icon_normal_color);
+			p_theme->set_color("icon_hover_pressed_color", "PreviewLightButton", p_config.icon_normal_color);
+			// Unpressed icon is dim, so use a dim highlight.
+			p_theme->set_color("icon_hover_color", "PreviewLightButton", dim_light_highlighted_color);
+
+			p_theme->set_stylebox(CoreStringName(normal), "PreviewLightButton", sb_empty_borderless);
+			p_theme->set_stylebox(SceneStringName(hover), "PreviewLightButton", sb_empty_borderless);
+			p_theme->set_stylebox("focus", "PreviewLightButton", sb_empty_borderless);
+			p_theme->set_stylebox(SceneStringName(pressed), "PreviewLightButton", sb_empty_borderless);
+		}
+
+		// TabContainerOdd variation.
+		{
+			// Can be used on tabs against the base color background (e.g. nested tabs).
+			p_theme->set_type_variation("TabContainerOdd", "TabContainer");
+
+			Ref<StyleBoxFlat> style_tab_selected_odd = p_theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->duplicate();
+			style_tab_selected_odd->set_bg_color(p_config.surface_base_color);
+			p_theme->set_stylebox("tab_selected", "TabContainerOdd", style_tab_selected_odd);
+
+			Ref<StyleBoxFlat> style_panel_odd = p_theme->get_stylebox(SceneStringName(panel), SNAME("TabContainer"))->duplicate();
+			style_panel_odd->set_bg_color(p_config.surface_base_color);
+			p_theme->set_stylebox(SceneStringName(panel), "TabContainerOdd", style_panel_odd);
+
+			p_theme->set_stylebox("tabbar_background", "TabContainerOdd", p_theme->get_stylebox(SNAME("tabbar_background"), SNAME("TabContainer")));
+		}
+
+		// EditorValidationPanel.
+		Ref<StyleBoxFlat> editor_validation_panel = p_config.base_style->duplicate();
+		editor_validation_panel->set_bg_color(p_config.surface_low_color);
+		editor_validation_panel->set_content_margin_individual(p_config.base_margin * EDSCALE, p_config.base_margin * 0.5 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 0.5 * EDSCALE);
+		p_theme->set_stylebox(SceneStringName(panel), "EditorValidationPanel", editor_validation_panel);
+
+		// Sidebars.
+		{
+			p_theme->set_type_variation("TreeSecondary", "Tree");
+			p_theme->set_type_variation("ItemListSecondary", "ItemList");
+
+			Ref<StyleBoxFlat> style_sidebar = p_config.base_style->duplicate();
+			style_sidebar->set_bg_color(p_config.surface_low_color);
+			if (p_config.draw_extra_borders) {
+				style_sidebar->set_border_width_all(1 * EDSCALE);
+				style_sidebar->set_border_color(p_config.extra_border_color_2);
+			}
+
+			p_theme->set_stylebox(SceneStringName(panel), "TreeSecondary", style_sidebar);
+			p_theme->set_stylebox(SceneStringName(panel), "ItemListSecondary", style_sidebar);
+			// Use it for EditorDebuggerInspector in StackTrace to keep the default 3-column layout,
+			// as the debugger inspector is too small to be considered a main area.
+			p_theme->set_stylebox(SceneStringName(panel), "EditorDebuggerInspector", style_sidebar);
+		}
+	}
+
+	// Editor inspector.
+	{
+		// Panel.
+		Ref<StyleBoxEmpty> editor_inspector_panel = p_config.base_empty_style->duplicate();
+		editor_inspector_panel->set_content_margin_all(p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_stylebox(SceneStringName(panel), "EditorInspector", editor_inspector_panel);
+
+		// Vertical separation between inspector categories and sections.
+		p_theme->set_constant("v_separation", "EditorInspector", Math::ceil(p_config.base_margin * 0.5 * EDSCALE));
+
+		// EditorProperty.
+
+		Ref<StyleBoxFlat> style_property_bg = p_config.base_style->duplicate();
+		style_property_bg->set_bg_color(p_config.highlight_color);
+		style_property_bg->set_border_width_all(0);
+
+		Ref<StyleBoxFlat> style_property_bg_selected = p_config.base_style->duplicate();
+		style_property_bg_selected->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.03));
+
+		Ref<StyleBoxFlat> style_property_child_bg = p_config.base_style->duplicate();
+		style_property_child_bg->set_bg_color(p_config.surface_lower_color);
+		style_property_child_bg->set_content_margin_all(p_config.base_margin * EDSCALE);
+
+		p_theme->set_stylebox("bg", "EditorProperty", p_config.base_empty_style);
+		p_theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg_selected);
+		p_theme->set_stylebox("child_bg", "EditorProperty", style_property_child_bg);
+		p_theme->set_constant("font_offset", "EditorProperty", 8 * EDSCALE);
+		p_theme->set_constant("v_separation", "EditorProperty", p_config.increased_margin * EDSCALE);
+
+		const Color property_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
+		const Color readonly_color = property_color.lerp(p_config.dark_icon_and_font ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
+		const Color readonly_warning_color = p_config.error_color.lerp(p_config.dark_icon_and_font ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
+
+		p_theme->set_color("property_color", "EditorProperty", p_config.font_color);
+		p_theme->set_color("readonly_color", "EditorProperty", readonly_color);
+		p_theme->set_color("warning_color", "EditorProperty", p_config.warning_color);
+		p_theme->set_color("readonly_warning_color", "EditorProperty", readonly_warning_color);
+
+		Ref<StyleBoxFlat> style_property_group_note = p_config.base_style->duplicate();
+		Color property_group_note_color = p_config.accent_color;
+		property_group_note_color.a = 0.1;
+		style_property_group_note->set_bg_color(property_group_note_color);
+		p_theme->set_stylebox("bg_group_note", "EditorProperty", style_property_group_note);
+
+		// EditorInspectorSection.
+
+		Color inspector_section_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.35);
+		p_theme->set_color(SceneStringName(font_color), "EditorInspectorSection", inspector_section_color);
+
+		Color inspector_indent_color = p_config.accent_color;
+		inspector_indent_color.a = 0.2;
+		Ref<StyleBoxFlat> inspector_indent_style = EditorThemeManager::make_flat_stylebox(inspector_indent_color, 2.0 * EDSCALE, 0, 2.0 * EDSCALE, 0);
+		p_theme->set_stylebox("indent_box", "EditorInspectorSection", inspector_indent_style);
+		p_theme->set_constant("indent_size", "EditorInspectorSection", 6.0 * EDSCALE);
+		p_theme->set_constant("h_separation", "EditorInspectorSection", p_config.base_margin * EDSCALE);
+
+		p_theme->set_color("prop_subsection", EditorStringName(Editor), Color(1, 1, 1, 0));
+#ifndef DISABLE_DEPRECATED // Used before 4.3.
+		p_theme->set_color("property_color", EditorStringName(Editor), p_config.dark_color_1.lerp(p_config.mono_color_icon_and_font, 0.12));
+#endif
+
+		// EditorInspectorCategory.
+
+		Ref<StyleBoxFlat> category_bg = p_config.base_style->duplicate();
+		category_bg->set_bg_color(p_config.surface_high_color);
+		category_bg->set_content_margin_individual(0, p_config.base_margin * EDSCALE, 0, p_config.base_margin * EDSCALE);
+		if (p_config.draw_extra_borders) {
+			category_bg->set_border_width_all(1);
+			category_bg->set_border_color(p_config.extra_border_color_2);
+		}
+		p_theme->set_stylebox("bg", "EditorInspectorCategory", category_bg);
+
+		p_theme->set_constant("inspector_margin", EditorStringName(Editor), 12 * EDSCALE);
+
+		// Colored EditorProperty.
+		for (int i = 0; i < 16; i++) {
+			Color si_base_color = p_config.accent_color;
+
+			float hue_rotate = (i * 2 % 16) / 16.0;
+			si_base_color.set_hsv(Math::fmod(float(si_base_color.get_h() + hue_rotate), float(1.0)), si_base_color.get_s(), si_base_color.get_v());
+			si_base_color = p_config.accent_color.lerp(si_base_color, p_config.subresource_hue_tint);
+
+			// Sub-inspector background.
+			Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
+			sub_inspector_bg->set_bg_color(p_config.dark_color_1.lerp(si_base_color, 0.08));
+			sub_inspector_bg->set_border_width_all(2 * EDSCALE);
+			sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
+			sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+			sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
+			sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
+
+			p_theme->set_stylebox("sub_inspector_bg" + itos(i + 1), EditorStringName(EditorStyles), sub_inspector_bg);
+
+			// EditorProperty background while it has a sub-inspector open.
+			Ref<StyleBoxFlat> bg_color = EditorThemeManager::make_flat_stylebox(si_base_color * Color(0.7, 0.7, 0.7, 0.8), 0, 0, 0, 0, p_config.corner_radius);
+			bg_color->set_anti_aliased(false);
+			bg_color->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			bg_color->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+
+			p_theme->set_stylebox("sub_inspector_property_bg" + itos(i + 1), EditorStringName(EditorStyles), bg_color);
+
+			// Dictionary editor add item.
+			// Expand to the left and right by 4px to compensate for the dictionary editor margins.
+
+			Color style_dictionary_bg_color = p_config.dark_color_3.lerp(si_base_color, 0.08);
+			Ref<StyleBoxFlat> style_dictionary_add_item = EditorThemeManager::make_flat_stylebox(style_dictionary_bg_color, 0, 4, 0, 4, p_config.corner_radius);
+			style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 2 * EDSCALE);
+			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+			p_theme->set_stylebox("DictionaryAddItem" + itos(i + 1), EditorStringName(EditorStyles), style_dictionary_add_item);
+		}
+		Color si_base_color = p_config.accent_color;
+
+		// Sub-inspector background.
+		Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
+		sub_inspector_bg->set_bg_color(Color(1, 1, 1, 0));
+		sub_inspector_bg->set_border_width_all(2 * EDSCALE);
+		sub_inspector_bg->set_border_color(p_config.dark_color_1.lerp(si_base_color, 0.15));
+		sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+		sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
+		sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
+
+		p_theme->set_stylebox("sub_inspector_bg0", EditorStringName(EditorStyles), sub_inspector_bg);
+
+		// Sub-inspector background no border.
+
+		Ref<StyleBoxFlat> sub_inspector_bg_no_border = p_config.base_style->duplicate();
+		sub_inspector_bg_no_border->set_content_margin_all(2 * EDSCALE);
+		sub_inspector_bg_no_border->set_bg_color(p_config.dark_color_2.lerp(p_config.dark_color_3, 0.15));
+		p_theme->set_stylebox("sub_inspector_bg_no_border", EditorStringName(EditorStyles), sub_inspector_bg_no_border);
+
+		// EditorProperty background while it has a sub-inspector open.
+		Ref<StyleBoxFlat> bg_color = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.lerp(si_base_color, 0.15), 0, 0, 0, 0, p_config.corner_radius);
+		bg_color->set_anti_aliased(false);
+		bg_color->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		bg_color->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+
+		p_theme->set_stylebox("sub_inspector_property_bg0", EditorStringName(EditorStyles), bg_color);
+
+		p_theme->set_color("sub_inspector_property_color", EditorStringName(EditorStyles), p_config.dark_icon_and_font ? Color(1, 1, 1, 1) : Color(0, 0, 0, 1));
+
+		// Dictionary editor.
+		// Expand to the left and right by 4px to compensate for the dictionary editor margins.
+		Ref<StyleBoxEmpty> style_dictionary_add_item = EditorThemeManager::make_empty_stylebox(0, 4, 0, 4);
+		p_theme->set_stylebox("DictionaryAddItem0", EditorStringName(EditorStyles), style_dictionary_add_item);
+
+		// Object selector;
+		p_theme->set_type_variation("ObjectSelectorMargin", "MarginContainer");
+		p_theme->set_constant("margin_left", "ObjectSelectorMargin", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("margin_right", "ObjectSelectorMargin", p_config.base_margin * 2.5 * EDSCALE);
+	}
+
+	// Animation Editor.
+	{
+		// Timeline general.
+		p_theme->set_constant("timeline_v_separation", "AnimationTrackEditor", 0);
+		p_theme->set_constant("track_v_separation", "AnimationTrackEditor", 0);
+
+		// AnimationTimelineEdit.
+		// "primary" is used for integer timeline values, "secondary" for decimals.
+
+		Ref<StyleBoxFlat> style_time_available = p_config.base_style->duplicate();
+		style_time_available->set_bg_color(p_config.surface_highest_color);
+		if (p_config.draw_extra_borders) {
+			style_time_available->set_border_width_all(Math::round(EDSCALE));
+			style_time_available->set_border_color(p_config.extra_border_color_1);
+		}
+
+		Ref<StyleBoxFlat> style_time_unavailable = p_config.base_style->duplicate();
+		style_time_unavailable->set_bg_color(p_config.surface_high_color);
+
+		p_theme->set_stylebox("time_available", "AnimationTimelineEdit", style_time_available);
+		p_theme->set_stylebox("time_unavailable", "AnimationTimelineEdit", style_time_unavailable);
+
+		p_theme->set_color("v_line_primary_color", "AnimationTimelineEdit", p_config.mono_color * Color(1, 1, 1, 0.4));
+		p_theme->set_color("v_line_secondary_color", "AnimationTimelineEdit", p_config.mono_color * Color(1, 1, 1, 0.08));
+		p_theme->set_color("h_line_color", "AnimationTimelineEdit", Color(1, 1, 1, 0));
+		p_theme->set_color("font_primary_color", "AnimationTimelineEdit", p_config.font_color);
+		p_theme->set_color("font_secondary_color", "AnimationTimelineEdit", p_config.font_disabled_color);
+
+		p_theme->set_constant("v_line_primary_margin", "AnimationTimelineEdit", p_config.base_margin * EDSCALE);
+		p_theme->set_constant("v_line_secondary_margin", "AnimationTimelineEdit", p_config.base_margin * 1.5 * EDSCALE);
+		p_theme->set_constant("v_line_primary_width", "AnimationTimelineEdit", Math::ceil(2 * EDSCALE));
+		p_theme->set_constant("v_line_secondary_width", "AnimationTimelineEdit", Math::ceil(EDSCALE));
+		p_theme->set_constant("text_primary_margin", "AnimationTimelineEdit", p_config.base_margin * 0.75 * EDSCALE);
+		p_theme->set_constant("text_secondary_margin", "AnimationTimelineEdit", p_config.base_margin * 0.5 * EDSCALE);
+
+		// AnimationTrackEdit.
+
+		Ref<StyleBoxFlat> style_animation_track_odd = p_config.base_style->duplicate();
+		style_animation_track_odd->set_bg_color(p_config.surface_base_color);
+
+		Ref<StyleBoxFlat> style_animation_track_hover = p_config.base_style->duplicate();
+		style_animation_track_hover->set_bg_color(p_config.surface_high_color);
+
+		Ref<StyleBoxFlat> style_animation_track_focus = p_config.base_style->duplicate();
+		style_animation_track_focus->set_content_margin_individual(p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * EDSCALE);
+		style_animation_track_focus->set_border_width_all(2);
+		style_animation_track_focus->set_border_color(p_config.surface_high_color);
+		style_animation_track_focus->set_draw_center(false);
+
+		p_theme->set_stylebox("odd", "AnimationTrackEdit", style_animation_track_odd);
+		p_theme->set_stylebox(SceneStringName(hover), "AnimationTrackEdit", style_animation_track_hover);
+		p_theme->set_stylebox("focus", "AnimationTrackEdit", style_animation_track_focus);
+
+		p_theme->set_color("h_line_color", "AnimationTrackEdit", Color(1, 1, 1, 0));
+
+		p_theme->set_constant("h_separation", "AnimationTrackEdit", p_config.base_margin * 1.5 * EDSCALE);
+		p_theme->set_constant("outer_margin", "AnimationTrackEdit", p_config.increased_margin * 6 * EDSCALE);
+
+		// AnimationTrackEditGroup.
+
+		Ref<StyleBoxFlat> style_animation_track_header = p_config.base_style->duplicate();
+		style_animation_track_header->set_bg_color(p_config.surface_low_color);
+		style_animation_track_header->set_content_margin_individual(p_config.base_margin * 4 * EDSCALE, p_config.base_margin * EDSCALE, 0, p_config.base_margin * EDSCALE);
+
+		p_theme->set_stylebox("header", "AnimationTrackEditGroup", style_animation_track_header);
+
+		p_theme->set_color("bg_color", "AnimationTrackEditGroup", p_config.surface_base_color);
+		p_theme->set_color("h_line_color", "AnimationTrackEditGroup", Color(1, 1, 1, 0));
+		p_theme->set_color("v_line_color", "AnimationTrackEditGroup", Color(1, 1, 1, 0));
+
+		p_theme->set_constant("h_separation", "AnimationTrackEditGroup", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("v_separation", "AnimationTrackEditGroup", 0);
+
+		// AnimationBezierTrackEdit.
+
+		p_theme->set_color("focus_color", "AnimationBezierTrackEdit", p_config.accent_color * Color(1, 1, 1, 0.8));
+		p_theme->set_color("track_focus_color", "AnimationBezierTrackEdit", p_config.mono_color * Color(1, 1, 1, 0.1));
+		p_theme->set_color("h_line_color", "AnimationBezierTrackEdit", p_config.mono_color * Color(1, 1, 1, 0.12));
+		p_theme->set_color("v_line_color", "AnimationBezierTrackEdit", Color(1, 1, 1, 0));
+
+		p_theme->set_constant("h_separation", "AnimationBezierTrackEdit", (p_config.increased_margin + 2) * EDSCALE);
+		p_theme->set_constant("v_separation", "AnimationBezierTrackEdit", p_config.forced_even_separation * EDSCALE);
+	}
+
+	// Editor help.
+	{
+		Ref<StyleBoxFlat> style_editor_help = p_config.base_style->duplicate();
+		style_editor_help->set_bg_color(p_config.dark_color_2);
+		style_editor_help->set_border_color(p_config.dark_color_3);
+		p_theme->set_stylebox("background", "EditorHelp", style_editor_help);
+
+		const Color kbd_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
+
+		p_theme->set_color("title_color", "EditorHelp", p_config.accent_color);
+		p_theme->set_color("headline_color", "EditorHelp", p_config.mono_color_icon_and_font);
+		p_theme->set_color("text_color", "EditorHelp", p_config.font_color);
+		p_theme->set_color("comment_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
+		p_theme->set_color("symbol_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
+		p_theme->set_color("value_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.6));
+		p_theme->set_color("qualifier_color", "EditorHelp", p_config.font_color * Color(1, 1, 1, 0.8));
+		p_theme->set_color("type_color", "EditorHelp", p_config.accent_color.lerp(p_config.font_color, 0.5));
+		p_theme->set_color("override_color", "EditorHelp", p_config.warning_color);
+		p_theme->set_color("selection_color", "EditorHelp", p_config.selection_color);
+		p_theme->set_color("link_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color_icon_and_font, 0.8));
+		p_theme->set_color("code_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color_icon_and_font, 0.6));
+		p_theme->set_color("kbd_color", "EditorHelp", p_config.accent_color.lerp(kbd_color, 0.6));
+		p_theme->set_color("code_bg_color", "EditorHelp", p_config.dark_color_3);
+		p_theme->set_color("kbd_bg_color", "EditorHelp", p_config.dark_color_1);
+		p_theme->set_color("param_bg_color", "EditorHelp", p_config.dark_color_1);
+		p_theme->set_constant(SceneStringName(line_separation), "EditorHelp", Math::round(6 * EDSCALE));
+		p_theme->set_constant("table_h_separation", "EditorHelp", 16 * EDSCALE);
+		p_theme->set_constant("table_v_separation", "EditorHelp", 6 * EDSCALE);
+		p_theme->set_constant("text_highlight_h_padding", "EditorHelp", 1 * EDSCALE);
+		p_theme->set_constant("text_highlight_v_padding", "EditorHelp", 2 * EDSCALE);
+	}
+
+	// EditorHelpBitTitle.
+	{
+		Ref<StyleBoxFlat> editor_help_title_style = p_config.base_style->duplicate();
+		editor_help_title_style->set_bg_color(_get_base_color(p_config, p_config.dark_theme ? -0.55 : -0.9));
+		editor_help_title_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE);
+		editor_help_title_style->set_corner_radius_individual(0, 0, p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE);
+		if (p_config.draw_extra_borders) {
+			editor_help_title_style->set_border_width_all(Math::round(EDSCALE));
+			editor_help_title_style->set_border_color(p_config.extra_border_color_2);
+		}
+
+		p_theme->set_type_variation("EditorHelpBitTitle", "RichTextLabel");
+		p_theme->set_stylebox(CoreStringName(normal), "EditorHelpBitTitle", editor_help_title_style);
+	}
+
+	// EditorHelpBitContent.
+	{
+		Ref<StyleBoxFlat> editor_help_content_style = p_config.base_style->duplicate();
+		editor_help_content_style->set_bg_color(p_config.surface_low_color);
+		editor_help_content_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE);
+		editor_help_content_style->set_corner_radius_individual(0, 0, p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE);
+		if (p_config.draw_extra_borders) {
+			editor_help_content_style->set_border_width_all(Math::round(EDSCALE));
+			editor_help_content_style->set_border_color(p_config.extra_border_color_2);
+		}
+
+		p_theme->set_type_variation("EditorHelpBitContent", "RichTextLabel");
+		p_theme->set_stylebox(CoreStringName(normal), "EditorHelpBitContent", editor_help_content_style);
+	}
+
+	// Asset Library.
+	Ref<StyleBoxFlat> assetlib_panel_style = p_config.base_style->duplicate();
+	assetlib_panel_style->set_bg_color(p_config.surface_low_color);
+	assetlib_panel_style->set_content_margin_all(p_config.base_margin * 2 * EDSCALE);
+
+	p_theme->set_stylebox("bg", "AssetLib", EditorThemeManager::make_empty_stylebox(p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
+	p_theme->set_stylebox(SceneStringName(panel), "AssetLib", assetlib_panel_style);
+	p_theme->set_color("status_color", "AssetLib", Color(0.5, 0.5, 0.5)); // FIXME: Use a defined color instead.
+	p_theme->set_icon("dismiss", "AssetLib", p_theme->get_icon(SNAME("Close"), EditorStringName(EditorIcons)));
+
+	// Debugger.
+	Ref<StyleBoxFlat> debugger_panel_style = p_config.content_panel_style->duplicate();
+	debugger_panel_style->set_border_width(SIDE_BOTTOM, 0);
+	p_theme->set_stylebox("DebuggerPanel", EditorStringName(EditorStyles), debugger_panel_style);
+
+	// Resource and node editors.
+	{
+		// TextureRegion editor.
+		Ref<StyleBoxFlat> style_texture_region_bg = p_config.tree_panel_style->duplicate();
+		style_texture_region_bg->set_content_margin_all(0);
+		p_theme->set_stylebox("TextureRegionPreviewBG", EditorStringName(EditorStyles), style_texture_region_bg);
+		p_theme->set_stylebox("TextureRegionPreviewFG", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
+
+		// Theme editor.
+		{
+			p_theme->set_color("preview_picker_overlay_color", "ThemeEditor", Color(0.1, 0.1, 0.1, 0.25));
+
+			Color theme_preview_picker_bg_color = p_config.accent_color;
+			theme_preview_picker_bg_color.a = 0.2;
+			Ref<StyleBoxFlat> theme_preview_picker_sb = EditorThemeManager::make_flat_stylebox(theme_preview_picker_bg_color, 0, 0, 0, 0);
+			theme_preview_picker_sb->set_border_color(p_config.accent_color);
+			theme_preview_picker_sb->set_border_width_all(1.0 * EDSCALE);
+			p_theme->set_stylebox("preview_picker_overlay", "ThemeEditor", theme_preview_picker_sb);
+
+			Color theme_preview_picker_label_bg_color = p_config.accent_color;
+			theme_preview_picker_label_bg_color.set_v(0.5);
+			Ref<StyleBoxFlat> theme_preview_picker_label_sb = EditorThemeManager::make_flat_stylebox(theme_preview_picker_label_bg_color, 4.0, 1.0, 4.0, 3.0);
+			p_theme->set_stylebox("preview_picker_label", "ThemeEditor", theme_preview_picker_label_sb);
+
+			Ref<StyleBoxFlat> style_theme_preview_tab = p_theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->duplicate();
+			style_theme_preview_tab->set_expand_margin(SIDE_BOTTOM, 5 * EDSCALE);
+			p_theme->set_stylebox("ThemeEditorPreviewFG", EditorStringName(EditorStyles), style_theme_preview_tab);
+
+			Ref<StyleBoxFlat> style_theme_preview_bg_tab = p_theme->get_stylebox(SNAME("tab_unselected"), SNAME("TabContainer"))->duplicate();
+			style_theme_preview_bg_tab->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
+			p_theme->set_stylebox("ThemeEditorPreviewBG", EditorStringName(EditorStyles), style_theme_preview_bg_tab);
+		}
+
+		// VisualShader editor.
+		p_theme->set_stylebox("label_style", "VShaderEditor", EditorThemeManager::make_empty_stylebox(4, 6, 4, 6));
+
+		// StateMachine graph.
+		{
+			p_theme->set_stylebox(SceneStringName(panel), "GraphStateMachine", p_config.tree_panel_style);
+			p_theme->set_stylebox("error_panel", "GraphStateMachine", p_config.tree_panel_style);
+			p_theme->set_color("error_color", "GraphStateMachine", p_config.error_color);
+
+			const int sm_margin_side = 10 * EDSCALE;
+			const int sm_margin_bottom = 2;
+			const Color sm_bg_color = p_config.dark_theme ? p_config.dark_color_3 : p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
+
+			Ref<StyleBoxFlat> sm_node_style = EditorThemeManager::make_flat_stylebox(p_config.dark_color_3 * Color(1, 1, 1, 0.7), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
+			sm_node_style->set_border_width_all(p_config.border_width);
+			sm_node_style->set_border_color(sm_bg_color);
+
+			Ref<StyleBoxFlat> sm_node_selected_style = EditorThemeManager::make_flat_stylebox(sm_bg_color * Color(1, 1, 1, 0.9), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
+			sm_node_selected_style->set_border_width_all(2 * EDSCALE + p_config.border_width);
+			sm_node_selected_style->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.9));
+			sm_node_selected_style->set_shadow_size(8 * EDSCALE);
+			sm_node_selected_style->set_shadow_color(p_config.shadow_color);
+
+			Ref<StyleBoxFlat> sm_node_playing_style = sm_node_selected_style->duplicate();
+			sm_node_playing_style->set_border_color(p_config.warning_color);
+			sm_node_playing_style->set_shadow_color(p_config.warning_color * Color(1, 1, 1, 0.2));
+			sm_node_playing_style->set_draw_center(false);
+
+			p_theme->set_stylebox("node_frame", "GraphStateMachine", sm_node_style);
+			p_theme->set_stylebox("node_frame_selected", "GraphStateMachine", sm_node_selected_style);
+			p_theme->set_stylebox("node_frame_playing", "GraphStateMachine", sm_node_playing_style);
+
+			Ref<StyleBoxFlat> sm_node_start_style = sm_node_style->duplicate();
+			sm_node_start_style->set_border_width_all(1 * EDSCALE);
+			sm_node_start_style->set_border_color(p_config.success_color.lightened(0.24));
+			p_theme->set_stylebox("node_frame_start", "GraphStateMachine", sm_node_start_style);
+
+			Ref<StyleBoxFlat> sm_node_end_style = sm_node_style->duplicate();
+			sm_node_end_style->set_border_width_all(1 * EDSCALE);
+			sm_node_end_style->set_border_color(p_config.error_color);
+			p_theme->set_stylebox("node_frame_end", "GraphStateMachine", sm_node_end_style);
+
+			p_theme->set_font("node_title_font", "GraphStateMachine", p_theme->get_font(SceneStringName(font), SNAME("Label")));
+			p_theme->set_font_size("node_title_font_size", "GraphStateMachine", p_theme->get_font_size(SceneStringName(font_size), SNAME("Label")));
+			p_theme->set_color("node_title_font_color", "GraphStateMachine", p_config.font_color);
+
+			p_theme->set_color("transition_color", "GraphStateMachine", p_config.font_color);
+			p_theme->set_color("transition_disabled_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.2));
+			p_theme->set_color("transition_icon_color", "GraphStateMachine", Color(1, 1, 1));
+			p_theme->set_color("transition_icon_disabled_color", "GraphStateMachine", Color(1, 1, 1, 0.2));
+			p_theme->set_color("highlight_color", "GraphStateMachine", p_config.accent_color);
+			p_theme->set_color("highlight_disabled_color", "GraphStateMachine", p_config.accent_color * Color(1, 1, 1, 0.6));
+			p_theme->set_color("focus_color", "GraphStateMachine", p_config.accent_color * Color(1, 1, 1, 0.8));
+			p_theme->set_color("guideline_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
+
+			p_theme->set_color("playback_color", "GraphStateMachine", p_config.font_color);
+			p_theme->set_color("playback_background_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
+		}
+
+		// TileSet editor.
+		// This editor is using Tree panel for the panel container of expanded view, while the theme
+		// needs trees to be transparent, so it needs to have its own style.
+		Ref<StyleBoxFlat> tile_expand_style = p_config.base_style->duplicate();
+		tile_expand_style->set_corner_radius_all(0);
+		p_theme->set_stylebox("expand_panel", "TileSetEditor", tile_expand_style);
+	}
+}

--- a/editor/themes/theme_modern.h
+++ b/editor/themes/theme_modern.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_dir_dialog.h                                                   */
+/*  theme_modern.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,45 +30,11 @@
 
 #pragma once
 
-#include "scene/gui/dialogs.h"
+#include "editor/themes/editor_theme_manager.h"
 
-class DirectoryCreateDialog;
-class EditorFileSystemDirectory;
-class Tree;
-class TreeItem;
-
-class EditorDirDialog : public ConfirmationDialog {
-	GDCLASS(EditorDirDialog, ConfirmationDialog);
-
-	DirectoryCreateDialog *makedialog = nullptr;
-
-	Button *makedir = nullptr;
-	Button *copy = nullptr;
-	HashSet<String> opened_paths;
-	String new_dir_path;
-
-	Tree *tree = nullptr;
-	bool updating = false;
-
-	void _item_collapsed(Object *p_item);
-	void _item_activated();
-	void _update_dir(const Color &p_default_folder_color, const Dictionary &p_assigned_folder_colors, const HashMap<String, Color> &p_folder_colors, bool p_is_dark_icon_and_font, TreeItem *p_item, EditorFileSystemDirectory *p_dir, const String &p_select_path = String());
-
-	void _make_dir();
-	void _make_dir_confirm(const String &p_path, const String &p_base_dir);
-
-	void _copy_pressed();
-	void ok_pressed() override;
-
-	bool must_reload = false;
-
-protected:
-	void _notification(int p_what);
-	static void _bind_methods();
-
+class ThemeModern {
 public:
-	void config(const Vector<String> &p_paths);
-	void reload(const String &p_path = "");
-
-	EditorDirDialog();
+	static void populate_shared_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config);
+	static void populate_standard_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config);
+	static void populate_editor_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config);
 };


### PR DESCRIPTION
<img width="1920" height="1128" alt="Screenshot_20251023_132202" src="https://github.com/user-attachments/assets/3f95136f-58ee-4b66-a117-415cf83719df" />
<br><br>

Is with great pleasure that I present you, Godot's soon-to-be new default theme!

This is a 1:1 port of @passivestar's [Minimal Theme](https://github.com/passivestar/godot-minimal-theme?tab=readme-ov-file), with himself also helping us behind the curtains in order to facilitate the porting work. The editor font used is now [Inter](https://rsms.me/inter/), and the new theme also changes the editor's base color and accent. While the blue tint had become a staple of Godot’s look over the past years, it caused issues such as distorting the perceived white balance of the viewport. Switching to a neutral gray resolves this.

But for those who still liked the older look better, fret not, As **the old theme and color preset is still available**, for you to pick! They can be accessed by choosing "Classic" in the `interface/theme/style` and `interface/theme/preset` settings.

While this PR is in a merge-able state, some small things still need to be worked on:
- <s>Nested `TabContainer`s blend with each other.</s>
- <s>The disabled tab style is a placeholder, while waiting for passive to implement it.</s>
- `PopupMenu`s still look very squarish, as #106324 still needs to be resolved.

Feedback is more than welcome, but please, keep it civil. Topics involving theming and design are very subjective, so the more objective information you can provide about your issues the easier it will be to address them in future PRs. 