### PR TITLE
Add side menu support to FileDialog

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -29,6 +29,15 @@
 				[param default_value_index] should be an index of the value in the [param values]. If [param values] is empty it should be either [code]1[/code] (checked), or [code]0[/code] (unchecked).
 			</description>
 		</method>
+		<method name="add_side_menu">
+			<return type="void" />
+			<param index="0" name="menu" type="Control" />
+			<param index="1" name="title" type="String" default="&quot;&quot;" />
+			<description>
+				Adds a control to the side of the [FileDialog] that can add custom options to the dialog. If [param title] is not empty, a header label will be added above the control. Only one side menu can be added to the [FileDialog] at a time. The menu can be removed with [method remove_side_menu].
+				If [member use_native_dialog] is enabled, the [FileDialog] will appear with full-size side menu and then open the native dialog once accepted.
+			</description>
+		</method>
 		<method name="clear_filename_filter">
 			<return type="void" />
 			<description>
@@ -113,6 +122,12 @@
 			<param index="0" name="flag" type="int" enum="FileDialog.Customization" />
 			<description>
 				Returns [code]true[/code] if the provided [param flag] is enabled.
+			</description>
+		</method>
+		<method name="remove_side_menu">
+			<return type="void" />
+			<description>
+				Removes the side menu. The menu node is automatically freed. Prints an error if the side menu was not added via [method add_side_menu].
 			</description>
 		</method>
 		<method name="set_customization_flag_enabled">

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -37,6 +37,7 @@ class DirAccess;
 class FlowContainer;
 class GridContainer;
 class HBoxContainer;
+class HSplitContainer;
 class ItemList;
 class LineEdit;
 class MenuButton;
@@ -218,6 +219,11 @@ private:
 	Button *show_filename_filter_button = nullptr;
 	MenuButton *file_sort_button = nullptr;
 
+	HSplitContainer *main_split = nullptr;
+	HBoxContainer *top_toolbar = nullptr;
+	HSplitContainer *left_center_split = nullptr;
+	VBoxContainer *side_vbox = nullptr;
+
 	VBoxContainer *favorite_vbox = nullptr;
 	Button *fav_up_button = nullptr;
 	Button *fav_down_button = nullptr;
@@ -331,10 +337,12 @@ private:
 	void _invalidate();
 	void _setup_button(Button *p_button, const Ref<Texture2D> &p_icon);
 	void _update_make_dir_visible();
+	void _update_side_menu_visibility(bool p_native_dialog);
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	bool _can_use_native_popup();
+	bool _should_use_native_popup();
 	void _native_popup();
 	void _native_dialog_cb(bool p_ok, const Vector<String> &p_files, int p_filter);
 	void _native_dialog_cb_with_options(bool p_ok, const Vector<String> &p_files, int p_filter, const Dictionary &p_selected_options);
@@ -361,7 +369,6 @@ protected:
 
 public:
 	virtual void set_visible(bool p_visible) override;
-	virtual void popup(const Rect2i &p_rect = Rect2i()) override;
 
 	void popup_file_dialog();
 	void clear_filters();
@@ -395,6 +402,9 @@ public:
 	int get_option_count() const;
 
 	Dictionary get_selected_options() const;
+
+	void add_side_menu(Control *p_menu, const String &p_title = String());
+	void remove_side_menu();
 
 	void set_root_subfolder(const String &p_root);
 	String get_root_subfolder() const;


### PR DESCRIPTION
Last major feature required for https://github.com/godotengine/godot-proposals/issues/6831
This adds the side menu support that exists in EditorFileDialog.

https://github.com/user-attachments/assets/9897b3eb-6344-4aab-9167-fb492c7d1b92

