### PR TITLE
Add Math::pitch_scale_to_semitones and its inverse

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -622,6 +622,22 @@ _ALWAYS_INLINE_ float db_to_linear(float p_db) {
 	return exp(p_db * (float)0.11512925464970228420089957273422);
 }
 
+// log(2) / 12
+const double LOG_SEMITONE = 0.05776226504666210911810267678818;
+_ALWAYS_INLINE_ double semitones_to_pitch_scale(double semitones) {
+	return exp(LOG_SEMITONE * semitones);
+}
+_ALWAYS_INLINE_ float semitones_to_pitch_scale(float semitones) {
+	return exp((float)LOG_SEMITONE * semitones);
+}
+
+_ALWAYS_INLINE_ double pitch_scale_to_semitones(double pitch_scale) {
+	return log(pitch_scale) / LOG_SEMITONE;
+}
+_ALWAYS_INLINE_ float pitch_scale_to_semitones(float pitch_scale) {
+	return log(pitch_scale) / (float)LOG_SEMITONE;
+}
+
 _ALWAYS_INLINE_ double round(double p_val) {
 	return std::round(p_val);
 }

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -582,6 +582,14 @@ double VariantUtilityFunctions::db_to_linear(double db) {
 	return Math::db_to_linear(db);
 }
 
+double VariantUtilityFunctions::pitch_scale_to_semitones(double pitch_scale) {
+	return Math::pitch_scale_to_semitones(pitch_scale);
+}
+
+double VariantUtilityFunctions::semitones_to_pitch_scale(double semitones) {
+	return Math::semitones_to_pitch_scale(semitones);
+}
+
 Variant VariantUtilityFunctions::wrap(const Variant &p_x, const Variant &p_min, const Variant &p_max, Callable::CallError &r_error) {
 	Variant::Type x_type = p_x.get_type();
 	if (x_type != Variant::INT && x_type != Variant::FLOAT) {
@@ -1712,6 +1720,8 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(rad_to_deg, sarray("rad"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(linear_to_db, sarray("lin"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(db_to_linear, sarray("db"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(pitch_scale_to_semitones, sarray("scale"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(semitones_to_pitch_scale, sarray("semitones"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR3(wrap, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(wrapi, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -100,6 +100,8 @@ struct VariantUtilityFunctions {
 	static double rad_to_deg(double angle_rad);
 	static double linear_to_db(double linear);
 	static double db_to_linear(double db);
+	static double pitch_scale_to_semitones(double pitch_scale);
+	static double semitones_to_pitch_scale(double semitones);
 	static Variant wrap(const Variant &p_x, const Variant &p_min, const Variant &p_max, Callable::CallError &r_error);
 	static int64_t wrapi(int64_t value, int64_t min, int64_t max);
 	static double wrapf(double value, double min, double max);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -806,6 +806,13 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="pitch_scale_to_semitones">
+			<return type="float" />
+			<param index="0" name="scale" type="float" />
+			<description>
+				Converts from pitch scale multipliers to semitones.
+			</description>
+		</method>
 		<method name="posmod">
 			<return type="int" />
 			<param index="0" name="x" type="int" />
@@ -1182,6 +1189,17 @@
 				// a and b are now identical
 				[/csharp]
 				[/codeblocks]
+			</description>
+		</method>
+		<method name="semitones_to_pitch_scale">
+			<return type="float" />
+			<param index="0" name="semitones" type="float" />
+			<description>
+				Converts a number of semitones to a pitch scale multiplier.
+				[b]Example:[/b] Tune an [AudioStreamPlayer] down a major third, in equal temperament:
+				[codeblock]
+				player.pitch_scale = semitones_to_pitch_scale(-4)
+				[/codeblock]
 			</description>
 		</method>
 		<method name="sign">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -1183,6 +1183,52 @@ namespace Godot
             return Math.Log(linear) * 8.6858896380650365530225783783321;
         }
 
+        private const double LogSemitone = 0.05776226504666210911810267678818d;
+
+        /// <summary>
+        /// Converts from pitch scale multipliers to semitones.
+        /// </summary>
+        /// <seealso cref="SemitonesToPitchScale(double)"/>
+        /// <param name="scale">The pitch scale multiplier to convert to semitones.</param>
+        /// <returns>Number of semitones represented by scaling speed by the given scale factor.</returns>
+        public static double PitchScaleToSemitones(double scale)
+        {
+            return Math.Log(scale) / LogSemitone;
+        }
+
+        /// <summary>
+        /// Converts from pitch scale multipliers to semitones.
+        /// </summary>
+        /// <seealso cref="SemitonesToPitchScale(double)"/>
+        /// <param name="scale">The pitch scale multiplier to convert to semitones.</param>
+        /// <returns>Number of semitones represented by scaling speed by the given scale factor.</returns>
+        public static float PitchScaleToSemitones(float scale)
+        {
+            return MathF.Log(scale) / (float)LogSemitone;
+        }
+
+        /// <summary>
+        /// Converts from semitones to a pitch scale multiplier.
+        /// </summary>
+        /// <seealso cref="PitchScaleToSemitones(double)"/>
+        /// <param name="semitones">The number of semitones</param>
+        /// <returns>A number by which to scale the speed of a sample to achieve the given semitone distance.</returns>
+        public static double SemitonesToPitchScale(double semitones)
+        {
+            return Math.Exp(semitones * LogSemitone);
+        }
+
+        /// <summary>
+        /// Converts from semitones to a pitch scale multiplier.
+        /// </summary>
+        /// <seealso cref="PitchScaleToSemitones(double)"/>
+        /// <param name="semitones">The number of semitones</param>
+        /// <returns>A number by which to scale the speed of a sample to achieve the given semitone distance.</returns>
+        public static float SemitonesToPitchScale(float semitones)
+        {
+            return MathF.Exp(semitones * (float)LogSemitone);
+        }
+
         /// <summary>
         /// Natural logarithm. The amount of time needed to reach a certain level of continuous growth.
         ///

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -311,6 +311,20 @@ TEST_CASE_TEMPLATE("[Math] db_to_linear", T, float, double) {
 	CHECK(Math::db_to_linear((T)-20.0) == doctest::Approx((T)0.1));
 }
 
+TEST_CASE_TEMPLATE("[Math] semitones_to_pitch_scale", T, float, double) {
+	CHECK(Math::semitones_to_pitch_scale((T)0.0) == doctest::Approx((T)1.0));
+	CHECK(Math::semitones_to_pitch_scale((T)12.0) == doctest::Approx((T)2.0));
+	CHECK(Math::semitones_to_pitch_scale((T)-12.0) == doctest::Approx((T)0.5));
+}
+
+TEST_CASE_TEMPLATE("[Math] pitch_scale_to_semitones", T, float, double) {
+	CHECK(Math::pitch_scale_to_semitones((T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::pitch_scale_to_semitones((T)2.0) == doctest::Approx((T)12.0));
+	CHECK(Math::pitch_scale_to_semitones((T)0.5) == doctest::Approx((T)-12.0));
+	CHECK(Math::is_inf(Math::pitch_scale_to_semitones((T)0.0)));
+	CHECK(Math::is_nan(Math::pitch_scale_to_semitones((T)-20.0)));
+}
+
 TEST_CASE_TEMPLATE("[Math] step_decimals", T, float, double) {
 	CHECK(Math::step_decimals((T)-0.5) == 1);
 	CHECK(Math::step_decimals((T)0) == 0);


### PR DESCRIPTION
Several audio components modulate pitch based on a speed scaling factor. Similar to `db_to_linear` and `linear_to_db`, it would be convenient to have functions that convert between semitone space and scaling factors.

Closes: https://github.com/godotengine/godot-proposals/issues/13320