### PR TITLE
Fix LightmapGI not being correctly applied to objects

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -844,7 +844,7 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 
 		RenderElementInfo &element_info = rl->element_info[p_offset + i];
 
-		element_info.value = uint32_t(surface->sort.sort_key2 & 0x0FFF00000000);
+		element_info.value = uint32_t((surface->sort.sort_key2 & 0x0FFF00000000) >> 32u);
 
 		if (cant_repeat) {
 			prev_surface = nullptr;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1976,7 +1976,7 @@ void RenderForwardMobile::_fill_instance_data(RenderListType p_render_list, uint
 		RenderElementInfo &element_info = rl->element_info[p_offset + i];
 
 		// Sets lod_index and uses_lightmap at once.
-		element_info.value = uint32_t(surface->sort.sort_key2 & 0x01FF00000000);
+		element_info.value = uint32_t((surface->sort.sort_key2 & 0x01FF00000000) >> 32u);
 	}
 
 	if (p_update_buffer) {


### PR DESCRIPTION
Fixes #111123

Adds a bitshift to make the sorting key's value align with the render element's data.