### PR TITLE
Optimize initial `Node::get_path` call by avoiding `Vector::reverse`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2396,13 +2396,13 @@ NodePath Node::get_path() const {
 	const Node *n = this;
 
 	Vector<StringName> path;
+	path.resize(data.depth);
 
+	StringName *ptrw = path.ptrw();
 	while (n) {
-		path.push_back(n->get_name());
+		ptrw[n->data.depth - 1] = n->get_name();
 		n = n->data.parent;
 	}
-
-	path.reverse();
 
 	data.path_cache = memnew(NodePath(path, true));
 


### PR DESCRIPTION
Tested using this script:
```gdscript
func _ready() -> void:
	var t1 = Time.get_ticks_usec()
	for i in range(1000):
		get_path()
	var t2 = Time.get_ticks_usec()
	var delta = t2 - t1
	print("Took " + str(delta) + " usec")
```
On a 20 deep node and on a 5 deep node.

Since the result is cached internally I also removed the cache lookup for testing:
```diff
-if (data.path_cache) {
-		return *data.path_cache;
-}
```

This project contains the 20 deep setup: [get_path_test.zip](https://github.com/user-attachments/files/22645464/get_path_test.zip)

Benchmark:

|                     | before     | after      |
|---------------------|------------|------------|
| 5 deep (3 samples)  | ~1464 usec | ~625 usec  |
| 20 deep (2 samples) | ~3086 usec | ~1398 usec |



