### PR TITLE
Remove automatic capacity shrinking from `CowData` (`String`, `Vector`, and `Array`)

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -316,7 +316,10 @@ public:
 
 	void remove_at(int p_index) { _cowdata.remove_at(p_index); }
 
-	_FORCE_INLINE_ void clear() { resize_uninitialized(0); }
+	// Removes all characters from the string, but keeps the current capacity.
+	_FORCE_INLINE_ void clear() { _cowdata.clear(); }
+	// Removes all characters from the array, and resets the capacity to 0.
+	_FORCE_INLINE_ void reset() { _cowdata.reset(); }
 
 	_FORCE_INLINE_ char32_t get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const char32_t &p_elem) { _cowdata.set(p_index, p_elem); }

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -91,12 +91,16 @@ public:
 	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ Size size() const { return _cowdata.size(); }
 	_FORCE_INLINE_ USize capacity() const { return _cowdata.capacity(); }
+	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
 
 	_FORCE_INLINE_ operator Span<T>() const { return _cowdata.span(); }
 	_FORCE_INLINE_ Span<T> span() const { return _cowdata.span(); }
 
+	// Removes all items from the vector, but keeps the current capacity.
 	_FORCE_INLINE_ void clear() { _cowdata.clear(); }
-	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
+	// Removes all items from the vector, and resets the capacity to 0.
+	// If this was the last reference to the underlying data, the memory is freed.
+	_FORCE_INLINE_ void reset() { _cowdata.reset(); }
 
 	_FORCE_INLINE_ T get(Size p_index) { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ const T &get(Size p_index) const { return _cowdata.get(p_index); }

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -126,6 +126,11 @@ void Array::clear() {
 	_p->array.clear();
 }
 
+void Array::reset() {
+	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	_p->array.reset();
+}
+
 bool Array::operator==(const Array &p_array) const {
 	return recursive_equal(p_array, 0);
 }

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -108,6 +108,7 @@ public:
 	int size() const;
 	bool is_empty() const;
 	void clear();
+	void reset();
 
 	bool operator==(const Array &p_array) const;
 	bool operator!=(const Array &p_array) const;

--- a/tests/core/templates/test_hash_set.h
+++ b/tests/core/templates/test_hash_set.h
@@ -140,7 +140,7 @@ TEST_CASE("[HashSet] Insert, iterate and remove many strings") {
 		CHECK(set.has(elems_still_valid[i]));
 	}
 
-	elems_still_valid.clear();
+	elems_still_valid.reset();
 	set.reset();
 
 	CHECK(Memory::get_mem_usage() == pre_mem);


### PR DESCRIPTION
Currently, `CowData` based types (`Array`, `Packed*Array`, and `String`) will automatically reduce their own capacity if element counts fall below some threshold.
With this change, backing buffers will keep the peak needed capacity forever. This was discussed at the last Core meeting, and deemed desirable to be merged for early 4.6.

This change will eliminate performance problems when removing and adding elements from arrays often. In particular, the buffers were previously allowed to shrink automatically, which would necessitate another allocation in the future. In very unlucky circumstances, this can have major performance impact.

Most of the time, dynamic arrays that grow to some peak capacity are expected to grow to that capacity again. 
However, rarely, vectors can grow to some capacity, shrink to some vastly smaller size, and then never (or rarely) grow again. In this case, the `CowData` becomes an unnecessary memory hog. To mitigate this, users can construct a new `Array`, `Packed*Array`, `Vector`, or `String`, and use `append_array` (or similar) on it, to transfer the elements without transferring the capacity.
Still, it is likely that we want to add a dedicated method for capacity shrinking in the future.

## Alternative

An alternative might be to _decrease_ the shrinking behavior instead. For example, we could shrink the buffer automatically only if 1/8 of the current capacity was reached, and then we'd shrink it up to 1/2 of the current capacity.
However, it's unlikely users will construct and manage large enough arrays to have considerable RAM impact. Most will therefore never need to think about shrinking their buffers "by hand".
While no auto shrinking can be worked around, auto shrinking cannot. Therefore, I would favour removing it altogether.

## Future work

It's likely this PR will introduce at least _some_ RAM regressions. We should keep a close eye on projects during the 4.6 dev cycle, and fix any emerging RAM concerns by either shrinking buffers, or exposing methods to let users shrink buffers.