### PR TITLE
Speed up `Node::get_path_to` when inside tree

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2345,27 +2345,39 @@ NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_
 		return NodePath(".");
 	}
 
-	HashSet<const Node *> visited;
-
 	const Node *n = this;
-
-	while (n) {
-		visited.insert(n);
-		n = n->data.parent;
-	}
-
 	const Node *common_parent = p_node;
-
-	while (common_parent) {
-		if (visited.has(common_parent)) {
-			break;
+	if (is_inside_tree() && p_node->data.tree == data.tree) {
+		// Nodes inside the tree can use their depth.
+		while (common_parent->data.depth > data.depth) {
+			common_parent = common_parent->data.parent;
 		}
-		common_parent = common_parent->data.parent;
+
+		while (n->data.depth > common_parent->data.depth) {
+			n = n->data.parent;
+		}
+
+		while (common_parent != n) {
+			common_parent = common_parent->data.parent;
+			n = n->data.parent;
+		}
+	} else {
+		HashSet<const Node *> visited;
+
+		while (n) {
+			visited.insert(n);
+			n = n->data.parent;
+		}
+
+		while (common_parent) {
+			if (visited.has(common_parent)) {
+				break;
+			}
+			common_parent = common_parent->data.parent;
+		}
 	}
 
 	ERR_FAIL_NULL_V_MSG(common_parent, NodePath(), vformat("No path can be resolved between the nodes %s and %s as they share no common ancestor.", get_description(true), p_node->get_description(true)));
-
-	visited.clear();
 
 	Vector<StringName> path;
 	StringName up = String("..");
@@ -2405,6 +2417,32 @@ NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_
 			if (!detected_name.is_empty()) {
 				path.push_back(UNIQUE_NODE_PREFIX + detected_name);
 			}
+
+			path.reverse();
+		}
+	} else if (is_inside_tree() && data.tree == p_node->data.tree) {
+		// Nodes inside the tree can use their depth.
+
+		const int32_t this_branch_depth = (data.depth - common_parent->data.depth);
+		const int32_t other_branch_depth = (p_node->data.depth - common_parent->data.depth);
+
+		path.resize(this_branch_depth + other_branch_depth);
+
+		int i = 0;
+		n = this;
+		StringName *ptrw = path.ptrw();
+		while (n != common_parent) {
+			ptrw[i] = up;
+			i++;
+			n = n->data.parent;
+		}
+
+		n = p_node;
+		i = this_branch_depth + other_branch_depth - 1;
+		while (n != common_parent) {
+			ptrw[i] = n->get_name();
+			i--;
+			n = n->data.parent;
 		}
 	} else {
 		n = p_node;
@@ -2420,9 +2458,9 @@ NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_
 			path.push_back(up);
 			n = n->data.parent;
 		}
-	}
 
-	path.reverse();
+		path.reverse();
+	}
 
 	return NodePath(path, false);
 }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2374,27 +2374,39 @@ NodePath Node::get_path_to(RequiredParam<const Node> p_node, bool p_use_unique_p
 		return NodePath(".");
 	}
 
-	HashSet<const Node *> visited;
-
 	const Node *n = this;
-
-	while (n) {
-		visited.insert(n);
-		n = n->data.parent;
-	}
-
 	const Node *common_parent = node;
-
-	while (common_parent) {
-		if (visited.has(common_parent)) {
-			break;
+	if (is_inside_tree() && node->data.tree == data.tree) {
+		// Nodes inside the tree can use their depth.
+		while (common_parent->data.depth > data.depth) {
+			common_parent = common_parent->data.parent;
 		}
-		common_parent = common_parent->data.parent;
+
+		while (n->data.depth > common_parent->data.depth) {
+			n = n->data.parent;
+		}
+
+		while (common_parent != n) {
+			common_parent = common_parent->data.parent;
+			n = n->data.parent;
+		}
+	} else {
+		HashSet<const Node *> visited;
+
+		while (n) {
+			visited.insert(n);
+			n = n->data.parent;
+		}
+
+		while (common_parent) {
+			if (visited.has(common_parent)) {
+				break;
+			}
+			common_parent = common_parent->data.parent;
+		}
 	}
 
 	ERR_FAIL_NULL_V_MSG(common_parent, NodePath(), vformat("No path can be resolved between the nodes %s and %s as they share no common ancestor.", get_description(true), node->get_description(true)));
-
-	visited.clear();
 
 	Vector<StringName> path;
 	StringName up = String("..");
@@ -2434,6 +2446,32 @@ NodePath Node::get_path_to(RequiredParam<const Node> p_node, bool p_use_unique_p
 			if (!detected_name.is_empty()) {
 				path.push_back(UNIQUE_NODE_PREFIX + detected_name);
 			}
+
+			path.reverse();
+		}
+	} else if (is_inside_tree() && data.tree == node->data.tree) {
+		// Nodes inside the tree can use their depth.
+
+		const int32_t this_branch_depth = (data.depth - common_parent->data.depth);
+		const int32_t other_branch_depth = (node->data.depth - common_parent->data.depth);
+
+		path.resize(this_branch_depth + other_branch_depth);
+
+		int i = 0;
+		n = this;
+		StringName *ptrw = path.ptrw();
+		while (n != common_parent) {
+			ptrw[i] = up;
+			i++;
+			n = n->data.parent;
+		}
+
+		n = node;
+		i = this_branch_depth + other_branch_depth - 1;
+		while (n != common_parent) {
+			ptrw[i] = n->get_name();
+			i--;
+			n = n->data.parent;
 		}
 	} else {
 		n = node;
@@ -2449,9 +2487,9 @@ NodePath Node::get_path_to(RequiredParam<const Node> p_node, bool p_use_unique_p
 			path.push_back(up);
 			n = n->data.parent;
 		}
-	}
 
-	path.reverse();
+		path.reverse();
+	}
 
 	return NodePath(path, false);
 }


### PR DESCRIPTION
This PR adds two additional codepaths to `Node::get_path_to` which use the cached depth information, if the node is in the tree. This allows to:
- avoid using a HashSet for finding a common ancestor
- know the size of the `Vector<StringName>` beforehand, which is used to resize the vector and prevent using `Vector::revert`

<details>
<summary>Benchmarked using the following script</summary>

```gdscript
extends Node


# Called when the node enters the scene tree for the first time.
func _ready() -> void:
	for i in range(2, 19, 4):
		benchmark_balanced(i)
		benchmark_unbalanced(i)

func benchmark_unbalanced(nodes: int):
	var deep_node = self
	for i in range(nodes - 1):
		var new = Node.new()
		deep_node.add_child(new)
		deep_node = new
	var shallow_node = Node.new()
	self.add_child(shallow_node)
	
	var t1 = Time.get_ticks_usec()
	for i in range(1000):
		shallow_node.get_path_to(deep_node)
	var t2 = Time.get_ticks_usec()
	print("Unbalanced n=" + str(nodes))
	print("\tshallow->deep: " + str(t2 - t1) + " usec")
	
	var t3 = Time.get_ticks_usec()
	for i in range(1000):
		deep_node.get_path_to(shallow_node)
	var t4 = Time.get_ticks_usec()
	print("\tdeep->shallow: " + str(t4 - t3) + " usec")

func benchmark_balanced(nodes: int):
	var left = self
	var right = self
	for i in range(int(nodes / 2)):
		var nl = Node.new()
		var nr = Node.new()
		left.add_child(nl)
		right.add_child(nr)
		left = nl
		right = nr
	var t1 = Time.get_ticks_usec()
	for i in range(1000):
		left.get_path_to(right)
	var t2 = Time.get_ticks_usec()
	print("Balanced n=" + str(nodes) + ": " + str(t2 - t1))

```
</details>

Benchmark (usec) 2 samples

| n  |               | before    | optimize common ancestor | optimize push_back | both     |
|----|---------------|-----------|----------------------|-------------|----------|
| 2  | Balanced      | 1417      | 1291                 | 1431        | 959      |
|    | shallow->deep | 1450      | 1235                 | 1260        | 1004     |
|    | deep->shallow | 1460      | 1222                 | 1237        | 955      |
| 18 | Balanced      | 4093      | 3419                 | 2508        | 1841     |
|    | shallow->deep | 3832      | 3499                 | 2280        | 1870     |
|    | deep->shallow | 4639      | 3531                 | 3104        | 1800     |

<!--| 6  | Balanced      | 2087      | 1894                 | 1539        | 1192     |
|    | shallow->deep | 2130      | 1927                 | 1506        | 1194     |
|    | deep->shallow | 2150      | 1894                 | 1524        | 1206     |
| 10 | Balanced      | 2937      | 2426                 | 1866        | 1419     |
|    | shallow->deep | 2759      | 2740                 | 1765        | 1583     |
|    | deep->shallow | 2969      | 2587                 | 1935        | 1398     |
| 14 | Balanced      | 3440      | 2963                 | 2491        | 1638     |
|    | shallow->deep | 3202      | 2886                 | 2072        | 1640     |
|    | deep->shallow | 3774      | 3014                 | 2402        | 1588     |-->
