### PR TITLE
Document link between `Node2D.look_at()` and `Node2D.get_angle_to()`

### DIFF
--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -19,11 +19,11 @@
 				Multiplies the current scale by the [param ratio] vector.
 			</description>
 		</method>
-		<method name="get_angle_to" qualifiers="const">
+		<method name="get_angle_to" qualifiers="const" keywords="look_at">
 			<return type="float" />
 			<param index="0" name="point" type="Vector2" />
 			<description>
-				Returns the angle between the node and the [param point] in radians.
+				Returns the angle between the node and the [param point] in radians. See also [method look_at].
 				[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/node2d_get_angle_to.png]Illustration of the returned angle.[/url]
 			</description>
 		</method>
@@ -45,7 +45,7 @@
 			<return type="void" />
 			<param index="0" name="point" type="Vector2" />
 			<description>
-				Rotates the node so that its local +X axis points towards the [param point], which is expected to use global coordinates.
+				Rotates the node so that its local +X axis points towards the [param point], which is expected to use global coordinates. This method is a combination of both [method rotate] and [method get_angle_to].
 				[param point] should not be the same as the node's position, otherwise the node always looks to the right.
 			</description>
 		</method>
@@ -69,7 +69,7 @@
 			<return type="void" />
 			<param index="0" name="radians" type="float" />
 			<description>
-				Applies a rotation to the node, in radians, starting from its current rotation.
+				Applies a rotation to the node, in radians, starting from its current rotation. This is equivalent to [code]rotation += radians[/code].
 			</description>
 		</method>
 		<method name="to_global" qualifiers="const">
@@ -90,7 +90,7 @@
 			<return type="void" />
 			<param index="0" name="offset" type="Vector2" />
 			<description>
-				Translates the node by the given [param offset] in local coordinates.
+				Translates the node by the given [param offset] in local coordinates. This is equivalent to [code]position += offset[/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
These methods are closely related, as `Node2D.get_angle_to()` can be used to get the rotation value that is being applied to `look_at()` without actually applying it to the node.

- See https://github.com/godotengine/godot-proposals/issues/13312.
