### PR TITLE
Fix off-by-one bug for line 1 in EditorInterface::edit_script()

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -683,7 +683,13 @@ void EditorInterface::edit_node(Node *p_node) {
 }
 
 void EditorInterface::edit_script(const Ref<Script> &p_script, int p_line, int p_col, bool p_grab_focus) {
-	ScriptEditor::get_singleton()->edit(p_script, p_line - 1, p_col - 1, p_grab_focus);
+	if(p_line > 0){
+		p_line -= 1;
+	}
+	if(p_col > 0){
+		p_col -= 1;
+	}
+	ScriptEditor::get_singleton()->edit(p_script, p_line, p_col, p_grab_focus);
 }
 
 void EditorInterface::open_scene_from_path(const String &scene_path, bool p_set_inherited) {


### PR DESCRIPTION
I fixed the issue #110136 where When calling EditorInterface::edit_script() with line = 1, the script editor doesn’t jump to the first line. It works correctly with line 2 or higher, but not line 1.
I corrected this off-by-one error by addign if statement in the edit_script() function.
