### PR TITLE
Fix game `Camera2D` override from editor and 2D debug templates building.

### DIFF
--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -284,6 +284,7 @@ private:
 	RID sel_drag_ci;
 
 	bool camera_override = false;
+	bool camera_first_override = true;
 
 	// Values taken from EditorZoomWidget.
 	const float VIEW_2D_MIN_ZOOM = 1.0 / 128;
@@ -326,7 +327,6 @@ private:
 	const float CAMERA_MIN_FOV_SCALE = 0.1;
 	const float CAMERA_MAX_FOV_SCALE = 2.5;
 
-	bool camera_first_override = true;
 	bool camera_freelook = false;
 
 	real_t camera_fov = 0;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5603,5 +5603,7 @@ T *Viewport::CameraOverride<T>::get_overridden_camera() const {
 // Explicit template instantiation to allow template definitions inside cpp file
 // and prevent instantiation using other than the desired camera types.
 template class Viewport::CameraOverride<Camera2D>;
+#ifndef _3D_DISABLED
 template class Viewport::CameraOverride<Camera3D>;
+#endif // _3D_DISABLED
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/111151
* Fixes: https://github.com/godotengine/godot/issues/111155