### PR TITLE
Speed up `GDScript::get_script_property_list` by not using an intermediate Vector

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -315,7 +315,6 @@ void GDScript::get_script_method_list(List<MethodInfo> *r_list) const {
 
 void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const {
 	const GDScript *sptr = this;
-	List<PropertyInfo> props;
 
 	while (sptr) {
 		Vector<_GDScriptMemberSort> msort;
@@ -330,24 +329,19 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 		}
 
 		msort.sort();
-		msort.reverse();
-		for (int i = 0; i < msort.size(); i++) {
-			props.push_front(sptr->member_indices[msort[i].name].property_info);
-		}
 
 #ifdef TOOLS_ENABLED
 		r_list->push_back(sptr->get_class_category());
 #endif // TOOLS_ENABLED
 
-		for (const PropertyInfo &E : props) {
-			r_list->push_back(E);
+		for (const _GDScriptMemberSort &member : msort) {
+			r_list->push_back(sptr->member_indices[member.name].property_info);
 		}
 
 		if (!p_include_base) {
 			break;
 		}
 
-		props.clear();
 		sptr = sptr->base.ptr();
 	}
 }


### PR DESCRIPTION
The code would reverse the original sorted vector, just to reverse it again into an intermediate vector using `push_front`. Now it uses `push_back` and the sorted vector directly.

<details>
<summary>Benchmarked using these scripts</summary>

```gdscript
extends Node
class_name PropA

var a1
var a2
var a3
var a4
var a5
var a6
var a7
var a8
var a9
var a10
```

```gdscript
extends PropA
class_name PropB

var b1
var b2
var b3
var b4
var b5
var b6
var b7
var b8
var b9
var b10
```

```gdscript
func _ready() -> void:
	const Props: Script = preload("b.gd")
	
	var t1 = Time.get_ticks_usec()
	for i in range(1000):
		Props.get_script_property_list()
	var t2 = Time.get_ticks_usec()
	print("Took " + str(t2 - t1) + " usec")
```

</details>

Benchmark (two separate runs, since some background task must have kicked in at some point):

|                   | Before | After | %     |
|-------------------|--------|-------|-------|
| Run 1 (4 samples) | 77759  | 74832 | ~3.7% |
| Run 2 (4 samples) | 78043  | 76048 | ~2.6% |

> Note: While the speedup here is only around 3%, it's worth noting that this benchmark uses the GDScript version which also converts all results to `Dictionary`.


