### PR TITLE
Remaining FileDialog changes before unification

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -246,6 +246,9 @@
 		<member name="option_count" type="int" setter="set_option_count" getter="get_option_count" default="0">
 			The number of additional [OptionButton]s and [CheckBox]es in the dialog.
 		</member>
+		<member name="overwrite_warning_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
+			If [code]true[/code], the [FileDialog] will warn the user before overwriting files in save mode.
+		</member>
 		<member name="recent_list_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
 			If [code]true[/code], shows the recent directories list on the left side of the dialog.
 		</member>
@@ -351,6 +354,10 @@
 		<constant name="CUSTOMIZATION_LAYOUT" value="6" enum="Customization">
 			If enabled, shows the layout switch buttons (list/thumbnails).
 			Equivalent to [member layout_toggle_enabled].
+		</constant>
+		<constant name="CUSTOMIZATION_OVERWRITE_WARNING" value="7" enum="Customization">
+			If enabled, the [FileDialog] will warn the user before overwriting files in save mode.
+			Equivalent to [member overwrite_warning_enabled].
 		</constant>
 	</constants>
 	<theme_items>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -980,6 +980,7 @@ void EditorNode::_notification(int p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("filesystem/file_dialog")) {
 				FileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
+				FileDialog::set_default_display_mode(EDITOR_GET("filesystem/file_dialog/display_mode"));
 				EditorFileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
 				EditorFileDialog::set_default_display_mode((EditorFileDialog::DisplayMode)EDITOR_GET("filesystem/file_dialog/display_mode").operator int());
 			}
@@ -7703,6 +7704,8 @@ EditorNode::EditorNode() {
 		DisplayServer::get_singleton()->window_set_min_size(minimum_size);
 	}
 
+	FileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
+	FileDialog::set_default_display_mode(EDITOR_GET("filesystem/file_dialog/display_mode"));
 	EditorFileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
 	EditorFileDialog::set_default_display_mode((EditorFileDialog::DisplayMode)EDITOR_GET("filesystem/file_dialog/display_mode").operator int());
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -540,7 +540,7 @@ void FileDialog::_action_pressed() {
 			return;
 		}
 
-		if (dir_access->file_exists(f) || dir_access->is_bundle(f)) {
+		if (customization_flags[CUSTOMIZATION_OVERWRITE_WARNING] && (dir_access->file_exists(f) || dir_access->is_bundle(f))) {
 			confirm_save->set_text(vformat(atr(ETR("File \"%s\" already exists.\nDo you want to overwrite it?")), f));
 			confirm_save->popup_centered(Size2(250, 80));
 		} else {
@@ -2057,6 +2057,7 @@ void FileDialog::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "favorites_enabled"), "set_customization_flag_enabled", "is_customization_flag_enabled", CUSTOMIZATION_FAVORITES);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "recent_list_enabled"), "set_customization_flag_enabled", "is_customization_flag_enabled", CUSTOMIZATION_RECENT);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "layout_toggle_enabled"), "set_customization_flag_enabled", "is_customization_flag_enabled", CUSTOMIZATION_LAYOUT);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "overwrite_warning_enabled"), "set_customization_flag_enabled", "is_customization_flag_enabled", CUSTOMIZATION_OVERWRITE_WARNING);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "current_dir", PROPERTY_HINT_DIR, "", PROPERTY_USAGE_NONE), "set_current_dir", "get_current_dir");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "current_file", PROPERTY_HINT_FILE_PATH, "*", PROPERTY_USAGE_NONE), "set_current_file", "get_current_file");
@@ -2087,6 +2088,7 @@ void FileDialog::_bind_methods() {
 	BIND_ENUM_CONSTANT(CUSTOMIZATION_FAVORITES);
 	BIND_ENUM_CONSTANT(CUSTOMIZATION_RECENT);
 	BIND_ENUM_CONSTANT(CUSTOMIZATION_LAYOUT);
+	BIND_ENUM_CONSTANT(CUSTOMIZATION_OVERWRITE_WARNING);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, FileDialog, thumbnail_size);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, FileDialog, parent_folder);
@@ -2169,6 +2171,10 @@ void FileDialog::set_default_show_hidden_files(bool p_show) {
 	default_show_hidden_files = p_show;
 }
 
+void FileDialog::set_default_display_mode(DisplayMode p_mode) {
+	default_display_mode = p_mode;
+}
+
 void FileDialog::set_get_icon_callback(const Callable &p_callback) {
 	get_icon_callback = p_callback;
 }
@@ -2209,6 +2215,7 @@ FileDialog::FileDialog() {
 	}
 
 	show_hidden_files = default_show_hidden_files;
+	display_mode = default_display_mode;
 	dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 
 	main_vbox = memnew(VBoxContainer);
@@ -2315,6 +2322,7 @@ FileDialog::FileDialog() {
 		favorite_list = memnew(ItemList);
 		favorite_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		favorite_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+		favorite_list->set_theme_type_variation("ItemListSecondary");
 		favorite_list->set_accessibility_name(ETR("Favorites:"));
 		favorite_vbox->add_child(favorite_list);
 		favorite_list->connect(SceneStringName(item_selected), callable_mp(this, &FileDialog::_favorite_selected));
@@ -2331,6 +2339,7 @@ FileDialog::FileDialog() {
 		recent_list = memnew(ItemList);
 		recent_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		recent_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+		recent_list->set_theme_type_variation("ItemListSecondary");
 		recent_list->set_accessibility_name(ETR("Recent:"));
 		recent_vbox->add_child(recent_list);
 		recent_list->connect(SceneStringName(item_selected), callable_mp(this, &FileDialog::_recent_selected));

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -143,6 +143,7 @@ public:
 		CUSTOMIZATION_FAVORITES,
 		CUSTOMIZATION_RECENT,
 		CUSTOMIZATION_LAYOUT,
+		CUSTOMIZATION_OVERWRITE_WARNING,
 		CUSTOMIZATION_MAX
 	};
 
@@ -159,6 +160,7 @@ private:
 	PropertyListHelper property_helper;
 
 	inline static bool default_show_hidden_files = false;
+	static inline DisplayMode default_display_mode = DISPLAY_THUMBNAILS;
 	bool show_hidden_files = false;
 	bool use_native_dialog = false;
 	bool customization_flags[CUSTOMIZATION_MAX]; // Initialized to true in the constructor.
@@ -432,6 +434,7 @@ public:
 	bool get_show_filename_filter() const;
 
 	static void set_default_show_hidden_files(bool p_show);
+	static void set_default_display_mode(DisplayMode p_mode);
 
 	static void set_get_icon_callback(const Callable &p_callback);
 	static void set_get_thumbnail_callback(const Callable &p_callback);


### PR DESCRIPTION
Some misc changes as part of https://github.com/godotengine/godot-proposals/issues/6831
- Added `disable_overwrite_warning` property
- Added static `default_display_mode` (not exposed, set in the editor)
- Assigned `ItemListSecondary` to side ItemLists (does not affect default theme)

I plan to finally merge the classes in the next PR.