### PR TITLE
Avoid unnecessary `CowData::resize` calls.

### DIFF
--- a/core/crypto/aes_context.cpp
+++ b/core/crypto/aes_context.cpp
@@ -39,7 +39,7 @@ Error AESContext::start(Mode p_mode, const PackedByteArray &p_key, const PackedB
 	// Initialization vector.
 	if (p_mode == MODE_CBC_ENCRYPT || p_mode == MODE_CBC_DECRYPT) {
 		ERR_FAIL_COND_V_MSG(p_iv.size() != 16, ERR_INVALID_PARAMETER, "The initialization vector (IV) must be exactly 16 bytes.");
-		iv.resize(0);
+		iv.clear();
 		iv.append_array(p_iv);
 	}
 	// Encryption/decryption key.
@@ -96,7 +96,7 @@ PackedByteArray AESContext::get_iv_state() {
 
 void AESContext::finish() {
 	mode = MODE_MAX;
-	iv.resize(0);
+	iv.clear();
 }
 
 void AESContext::_bind_methods() {

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -102,7 +102,7 @@ Error PacketPeer::put_var(const Variant &p_packet, bool p_full_objects) {
 	ERR_FAIL_COND_V_MSG(len > encode_buffer_max_size, ERR_OUT_OF_MEMORY, "Failed to encode variant, encode size is bigger then encode_buffer_max_size. Consider raising it via 'set_encode_buffer_max_size'.");
 
 	if (unlikely(encode_buffer.size() < len)) {
-		encode_buffer.resize(0); // Avoid realloc
+		encode_buffer.clear(); // Avoid realloc
 		encode_buffer.resize(next_power_of_2((uint32_t)len));
 	}
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -188,7 +188,7 @@ public:
 
 	/// Resizes the string. The given size must include the null terminator.
 	/// New characters are not initialized, and should be set by the caller.
-	_FORCE_INLINE_ Error resize_uninitialized(int64_t p_size) { return _cowdata.template resize<false>(p_size); }
+	_FORCE_INLINE_ Error resize_uninitialized(int64_t p_size) { return (p_size == size()) ? OK : _cowdata.template resize<false>(p_size); }
 
 	_FORCE_INLINE_ T get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
@@ -315,7 +315,7 @@ public:
 
 	/// Resizes the string. The given size must include the null terminator.
 	/// New characters are not initialized, and should be set by the caller.
-	Error resize_uninitialized(int64_t p_size) { return _cowdata.resize<false>(p_size); }
+	_FORCE_INLINE_ Error resize_uninitialized(int64_t p_size) { return (p_size == size()) ? OK : _cowdata.resize<false>(p_size); }
 
 	Error reserve(int64_t p_size) {
 		ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -396,11 +396,6 @@ Error CowData<T>::resize(Size p_size) {
 	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
 
 	const Size prev_size = size();
-	if (p_size == prev_size) {
-		// Caller wants to stay the same size, so we do nothing.
-		return OK;
-	}
-
 	if (p_size > prev_size) {
 		// Caller wants to grow.
 

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -105,20 +105,20 @@ public:
 	/// Resize the vector.
 	/// Elements are initialized (or not) depending on what the default C++ behavior for this type is.
 	_FORCE_INLINE_ Error resize(Size p_size) {
-		return _cowdata.template resize<!std::is_trivially_constructible_v<T>>(p_size);
+		return (p_size == size()) ? OK : _cowdata.template resize<!std::is_trivially_constructible_v<T>>(p_size);
 	}
 
 	/// Resize and set all values to 0 / false / nullptr.
 	/// This is only available for zero constructible types.
 	_FORCE_INLINE_ Error resize_initialized(Size p_size) {
-		return _cowdata.template resize<true>(p_size);
+		return (p_size == size()) ? OK : _cowdata.template resize<true>(p_size);
 	}
 
 	/// Resize and set all values to 0 / false / nullptr.
 	/// This is only available for trivially destructible types (otherwise, trivial resize might be UB).
 	_FORCE_INLINE_ Error resize_uninitialized(Size p_size) {
 		// resize() statically asserts that T is compatible, no need to do it ourselves.
-		return _cowdata.template resize<false>(p_size);
+		return (p_size == size()) ? OK : _cowdata.template resize<false>(p_size);
 	}
 
 	Error reserve(Size p_size) {

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -1083,8 +1083,8 @@ void GodotConvexPolygonShape3D::_setup(const Vector<Vector3> &p_vertices) {
 	if (err != OK) {
 		ERR_PRINT("Failed to build convex hull");
 	}
-	extreme_vertices.resize(0);
-	vertex_neighbors.resize(0);
+	extreme_vertices.clear();
+	vertex_neighbors.clear();
 
 	AABB _aabb;
 

--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
@@ -414,7 +414,7 @@ void NavMeshGenerator2D::generator_bake_from_source_geometry_data(Ref<Navigation
 	if (!empty_projected_obstructions) {
 		RWLockRead read_lock(p_source_geometry_data->geometry_rwlock);
 		const Vector<NavigationMeshSourceGeometryData2D::ProjectedObstruction> &projected_obstructions = p_source_geometry_data->_projected_obstructions;
-		obstruction_polygon_paths.resize(0);
+		obstruction_polygon_paths.clear();
 		for (const NavigationMeshSourceGeometryData2D::ProjectedObstruction &projected_obstruction : projected_obstructions) {
 			if (!projected_obstruction.carve) {
 				continue;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2065,7 +2065,7 @@ void TextServerAdvanced::_font_set_data_ptr(const RID &p_font_rid, const uint8_t
 
 	MutexLock lock(fd->mutex);
 	_font_clear_cache(fd);
-	fd->data.resize(0);
+	fd->data.clear();
 	fd->data_ptr = p_data_ptr;
 	fd->data_size = p_data_size;
 }

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1148,7 +1148,7 @@ void TextServerFallback::_font_set_data_ptr(const RID &p_font_rid, const uint8_t
 
 	MutexLock lock(fd->mutex);
 	_font_clear_cache(fd);
-	fd->data.resize(0);
+	fd->data.clear();
 	fd->data_ptr = p_data_ptr;
 	fd->data_size = p_data_size;
 }

--- a/modules/webrtc/webrtc_data_channel_js.cpp
+++ b/modules/webrtc/webrtc_data_channel_js.cpp
@@ -84,7 +84,7 @@ void WebRTCDataChannelJS::_on_message(void *p_obj, const uint8_t *p_data, int p_
 }
 
 void WebRTCDataChannelJS::close() {
-	in_buffer.resize(0);
+	in_buffer.clear();
 	queue_count = 0;
 	_was_string = false;
 	godot_js_rtc_datachannel_close(_js_id);

--- a/modules/websocket/packet_buffer.h
+++ b/modules/websocket/packet_buffer.h
@@ -112,8 +112,8 @@ public:
 	}
 
 	void clear() {
-		_payload.resize(0);
-		_packets.resize(0);
+		_payload.clear();
+		_packets.clear();
 		_read_pos = 0;
 		_write_pos = 0;
 		_queued = 0;

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -863,7 +863,7 @@ void WSLPeer::close(int p_code, const String &p_reason) {
 	if (ready_state == STATE_CLOSED) {
 		heartbeat_waiting = false;
 		in_buffer.clear();
-		packet_buffer.resize(0);
+		packet_buffer.clear();
 		pending_message.clear();
 	}
 }

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -572,7 +572,7 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 		// Message is supplied by the subroutine method.
 		return err;
 	}
-	html.resize(0);
+	html.clear();
 
 	// Export splash (why?)
 	Ref<Image> splash = _get_project_splash(p_preset);

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -113,8 +113,8 @@ void HTTPClientWeb::close() {
 	use_tls = false;
 	status = STATUS_DISCONNECTED;
 	polled_response_code = 0;
-	response_headers.resize(0);
-	response_buffer.resize(0);
+	response_headers.clear();
+	response_buffer.clear();
 	if (js_id) {
 		godot_js_fetch_free(js_id);
 		js_id = 0;

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -60,7 +60,7 @@ void SoftBodyRenderingServerHandler::prepare(RID p_mesh, int p_surface) {
 }
 
 void SoftBodyRenderingServerHandler::clear() {
-	buffer.resize(0);
+	buffer.clear();
 	stride = 0;
 	normal_stride = 0;
 	offset_vertices = 0;

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1774,7 +1774,7 @@ void Curve3D::_bake() const {
 	}
 
 	if (!up_vector_enabled) {
-		baked_up_vector_cache.resize(0);
+		baked_up_vector_cache.clear();
 		return;
 	}
 

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -514,7 +514,7 @@ bool RenderingLightCuller::prepare_camera(const Transform3D &p_cam_transform, co
 	data.regular_rejected_count = 0;
 #endif
 
-	data.directional_cull_planes.resize(0);
+	data.directional_cull_planes.clear();
 
 #ifdef LIGHT_CULLER_DEBUG_LOGGING
 	if (is_logging()) {


### PR DESCRIPTION
Return early before calling CowData::resize when the requested size matches the current size.
This prevents redundant calls, which occur thousands of times during editor startup and project loading, saving unnecessary overhead.