### PR TITLE
Remove side menu functionality in `EditorFileDialog`

### DIFF
--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -30,12 +30,12 @@
 				[param default_value_index] should be an index of the value in the [param values]. If [param values] is empty it should be either [code]1[/code] (checked), or [code]0[/code] (unchecked).
 			</description>
 		</method>
-		<method name="add_side_menu">
+		<method name="add_side_menu" deprecated="This feature is no longer supported.">
 			<return type="void" />
 			<param index="0" name="menu" type="Control" />
 			<param index="1" name="title" type="String" default="&quot;&quot;" />
 			<description>
-				Adds the given [param menu] to the side of the file dialog with the given [param title] text on top. Only one side menu is allowed.
+				This method is kept for compatibility and does nothing. As an alternative, you can display another dialog after showing the file dialog.
 			</description>
 		</method>
 		<method name="clear_filename_filter">

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -122,7 +122,6 @@ private:
 	ConfirmationDialog *confirm_save = nullptr;
 	DependencyRemoveDialog *dep_remove_dialog = nullptr;
 	ConfirmationDialog *global_remove_dialog = nullptr;
-	VBoxContainer *side_vbox = nullptr;
 	VBoxContainer *vbc = nullptr;
 	HBoxContainer *pathhb = nullptr;
 
@@ -280,8 +279,6 @@ private:
 
 	bool _is_open_should_be_disabled();
 
-	void _update_side_menu_visibility(bool p_native_dlg);
-
 	void _native_popup();
 	void _native_dialog_cb(bool p_ok, const Vector<String> &p_files, int p_filter, const Dictionary &p_selected_options);
 
@@ -367,7 +364,9 @@ public:
 	void set_previews_enabled(bool p_enabled);
 	bool are_previews_enabled();
 
-	void add_side_menu(Control *p_menu, const String &p_title = "");
+#ifndef DISABLE_DEPRECATED
+	void add_side_menu(Control *p_menu, const String &p_title = "") { ERR_FAIL_MSG("add_side_menu() is kept for compatibility and does nothing. For similar functionality, you can show another dialog after file dialog."); }
+#endif
 
 	EditorFileDialog();
 	~EditorFileDialog();

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -38,6 +38,7 @@
 #include "editor/import/3d/scene_import_settings.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/dialogs.h"
 
 String SceneExporterGLTFPlugin::get_plugin_name() const {
 	return "ConvertGLTF2";
@@ -51,7 +52,7 @@ SceneExporterGLTFPlugin::SceneExporterGLTFPlugin() {
 	_gltf_document.instantiate();
 	// Set up the file dialog.
 	_file_dialog = memnew(EditorFileDialog);
-	_file_dialog->connect("file_selected", callable_mp(this, &SceneExporterGLTFPlugin::_export_scene_as_gltf));
+	_file_dialog->connect("file_selected", callable_mp(this, &SceneExporterGLTFPlugin::_popup_gltf_settings_dialog));
 	_file_dialog->set_title(TTR("Export Library"));
 	_file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	_file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
@@ -61,11 +62,16 @@ SceneExporterGLTFPlugin::SceneExporterGLTFPlugin() {
 	_file_dialog->set_title(TTR("Export Scene to glTF 2.0 File"));
 	EditorNode::get_singleton()->get_gui_base()->add_child(_file_dialog);
 	// Set up the export settings menu.
+	_config_dialog = memnew(ConfirmationDialog);
+	_config_dialog->set_title(TTRC("Export Settings"));
+	EditorNode::get_singleton()->get_gui_base()->add_child(_config_dialog);
+	_config_dialog->connect(SceneStringName(confirmed), callable_mp(this, &SceneExporterGLTFPlugin::_export_scene_as_gltf));
+
 	_export_settings.instantiate();
 	_export_settings->generate_property_list(_gltf_document);
 	_settings_inspector = memnew(EditorInspector);
 	_settings_inspector->set_custom_minimum_size(Size2(350, 300) * EDSCALE);
-	_file_dialog->add_side_menu(_settings_inspector, TTR("Export Settings:"));
+	_config_dialog->add_child(_settings_inspector);
 	// Add a button to the Scene -> Export menu to pop up the settings dialog.
 	PopupMenu *menu = get_export_as_menu();
 	int idx = menu->get_item_count();
@@ -73,10 +79,23 @@ SceneExporterGLTFPlugin::SceneExporterGLTFPlugin() {
 	menu->set_item_metadata(idx, callable_mp(this, &SceneExporterGLTFPlugin::_popup_gltf_export_dialog));
 }
 
+void SceneExporterGLTFPlugin::_popup_gltf_settings_dialog(const String &p_selected_path) {
+	export_path = p_selected_path;
+
+	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
+	ERR_FAIL_NULL(root);
+	// Generate and refresh the export settings.
+	_export_settings->generate_property_list(_gltf_document, root);
+	_settings_inspector->edit(nullptr);
+	_settings_inspector->edit(_export_settings.ptr());
+	// Show the config dialog.
+	_config_dialog->popup_centered();
+}
+
 void SceneExporterGLTFPlugin::_popup_gltf_export_dialog() {
 	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
 	if (!root) {
-		EditorNode::get_singleton()->show_accept(TTR("This operation can't be done without a scene."), TTR("OK"));
+		EditorNode::get_singleton()->show_warning(TTR("This operation can't be done without a scene."));
 		return;
 	}
 	// Set the file dialog's file name to the scene name.
@@ -85,20 +104,13 @@ void SceneExporterGLTFPlugin::_popup_gltf_export_dialog() {
 		filename = root->get_name();
 	}
 	_file_dialog->set_current_file(filename + String(".gltf"));
-	// Generate and refresh the export settings.
-	_export_settings->generate_property_list(_gltf_document, root);
-	_settings_inspector->edit(nullptr);
-	_settings_inspector->edit(_export_settings.ptr());
 	// Show the file dialog.
-	_file_dialog->popup_centered_ratio();
+	_file_dialog->popup_file_dialog();
 }
 
-void SceneExporterGLTFPlugin::_export_scene_as_gltf(const String &p_file_path) {
+void SceneExporterGLTFPlugin::_export_scene_as_gltf() {
 	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
-	if (!root) {
-		EditorNode::get_singleton()->show_accept(TTR("This operation can't be done without a scene."), TTR("OK"));
-		return;
-	}
+	ERR_FAIL_NULL(root);
 	List<String> deps;
 	Ref<GLTFState> state;
 	state.instantiate();
@@ -110,7 +122,7 @@ void SceneExporterGLTFPlugin::_export_scene_as_gltf(const String &p_file_path) {
 	if (err != OK) {
 		ERR_PRINT(vformat("glTF2 save scene error %s.", itos(err)));
 	}
-	err = _gltf_document->write_to_filesystem(state, p_file_path);
+	err = _gltf_document->write_to_filesystem(state, export_path);
 	if (err != OK) {
 		ERR_PRINT(vformat("glTF2 save scene error %s.", itos(err)));
 	}

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
@@ -35,6 +35,7 @@
 
 #include "editor/plugins/editor_plugin.h"
 
+class ConfirmationDialog;
 class EditorFileDialog;
 class EditorInspector;
 
@@ -43,10 +44,15 @@ class SceneExporterGLTFPlugin : public EditorPlugin {
 
 	Ref<GLTFDocument> _gltf_document;
 	Ref<EditorSceneExporterGLTFSettings> _export_settings;
+	String export_path;
+
 	EditorInspector *_settings_inspector = nullptr;
+	ConfirmationDialog *_config_dialog = nullptr;
 	EditorFileDialog *_file_dialog = nullptr;
+
+	void _popup_gltf_settings_dialog(const String &p_selected_path);
 	void _popup_gltf_export_dialog();
-	void _export_scene_as_gltf(const String &p_file_path);
+	void _export_scene_as_gltf();
 
 public:
 	virtual String get_plugin_name() const override;


### PR DESCRIPTION
Alternative to #111120
This deprecates `add_side_menu()` and replaces the only usage with an additional dialog.

https://github.com/user-attachments/assets/65bb66fe-e3c1-4f93-966c-84bb994b5ae3

It's similar to what was already happening when native dialogs were enabled, but the config dialog is more compact.