### PR TITLE
Speed up `Node::is_greater_than` by avoiding `alloca`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2102,59 +2102,40 @@ bool Node::is_ancestor_of(const Node *p_node) const {
 }
 
 bool Node::is_greater_than(const Node *p_node) const {
+	// parent->get_child(1) > parent->get_child(0) > parent
+
 	ERR_FAIL_NULL_V(p_node, false);
 	ERR_FAIL_COND_V(!data.tree, false);
-	ERR_FAIL_COND_V(!p_node->data.tree, false);
+	ERR_FAIL_COND_V(p_node->data.tree != data.tree, false);
 
 	ERR_FAIL_COND_V(data.depth < 0, false);
 	ERR_FAIL_COND_V(p_node->data.depth < 0, false);
 
 	_update_children_cache();
 
-	int *this_stack = (int *)alloca(sizeof(int) * data.depth);
-	int *that_stack = (int *)alloca(sizeof(int) * p_node->data.depth);
+	bool this_is_deeper = this->data.depth > p_node->data.depth;
 
-	const Node *n = this;
-
-	int idx = data.depth - 1;
-	while (n) {
-		ERR_FAIL_INDEX_V(idx, data.depth, false);
-		this_stack[idx--] = n->get_index();
-		n = n->data.parent;
+	const Node *deep = this;
+	const Node *shallow = p_node;
+	if (!this_is_deeper) {
+		deep = p_node;
+		shallow = this;
 	}
 
-	ERR_FAIL_COND_V(idx != -1, false);
-	n = p_node;
-	idx = p_node->data.depth - 1;
-	while (n) {
-		ERR_FAIL_INDEX_V(idx, p_node->data.depth, false);
-		that_stack[idx--] = n->get_index();
-
-		n = n->data.parent;
-	}
-	ERR_FAIL_COND_V(idx != -1, false);
-	idx = 0;
-
-	bool res;
-	while (true) {
-		// using -2 since out-of-tree or nonroot nodes have -1
-		int this_idx = (idx >= data.depth) ? -2 : this_stack[idx];
-		int that_idx = (idx >= p_node->data.depth) ? -2 : that_stack[idx];
-
-		if (this_idx > that_idx) {
-			res = true;
-			break;
-		} else if (this_idx < that_idx) {
-			res = false;
-			break;
-		} else if (this_idx == -2) {
-			res = false; // equal
-			break;
-		}
-		idx++;
+	while (deep->data.depth > shallow->data.depth) {
+		deep = deep->data.parent;
 	}
 
-	return res;
+	if (deep == shallow) { // Shallow is ancestor of deep.
+		return this_is_deeper;
+	}
+
+	while (deep->data.parent != shallow->data.parent) {
+		deep = deep->data.parent;
+		shallow = shallow->data.parent;
+	}
+
+	return (deep->get_index() > shallow->get_index()) == this_is_deeper;
 }
 
 void Node::get_owned_by(Node *p_by, List<Node *> *p_owned) {


### PR DESCRIPTION
The old impl would stack allocate lists to store the index of all ancestor up to the root node. This impl avoids that by finding a common ancestor and only comparing the indizes for that ancestor. This also makes the implementation independent of depth in the tree, performance is now only influenced by proximity of the nodes.

<details>
<summary>Benchmarked using this script</summary>

```gdscript
func _ready() -> void:
	for i in [2, 100]:
		benchmark_balanced(i)
		benchmark_unbalanced(i, true)
		benchmark_unbalanced(i, false)

func benchmark_unbalanced(nodes: int, first_deep: bool):
	var shallow_node = Node.new()
	if not first_deep:
		self.add_child(shallow_node)
	var deep_node = self
	for i in range(nodes - 1):
		var new = Node.new()
		deep_node.add_child(new)
		deep_node = new
	if first_deep:
		self.add_child(shallow_node)
	
	var t1 = Time.get_ticks_usec()
	for i in range(1000):
		shallow_node.is_greater_than(deep_node)
	var t2 = Time.get_ticks_usec()
	print("Unbalanced n=" + str(nodes) + " first_deep = " + str(first_deep))
	print("\tshallow > deep: " + str(t2 - t1))
	
	var t3 = Time.get_ticks_usec()
	for i in range(1000):
		deep_node.is_greater_than(shallow_node)
	var t4 = Time.get_ticks_usec()
	print("\tdeep > shallow: " + str(t4 - t3))

func benchmark_balanced(nodes: int):
	var left = self
	var right = self
	for i in range(int(nodes / 2)):
		var nl = Node.new()
		var nr = Node.new()
		left.add_child(nl)
		right.add_child(nr)
		left = nl
		right = nr
	var t1 = Time.get_ticks_usec()
	for i in range(1000):
		left.is_greater_than(right)
	var t2 = Time.get_ticks_usec()
	print("Balanced n=" + str(nodes) + ": " + str(t2 - t1))
	print("\tfirst > last: " + str(t2 - t1))
	
	var t3 = Time.get_ticks_usec()
	for i in range(1000):
		right.is_greater_than(left)
	var t4 = Time.get_ticks_usec()
	print("\tlast > first: " + str(t4 - t3))
```

</details>

Benchmarked once with the script attached to a node that was close to the scene tree root and once with the script attached to a node that had a depth of around 50. For the impl from this PR there is no significant difference, for the old impl there is.

Benchmark:

deep | n (proximity) |   | Before (usec) 3 samples | After (usec) 3 samples | %
-- | -- | -- | -- | -- | --
FALSE | 2 | balanced, first > last | 344.33 | 315.00 | 8.52
  |   | balanced, last > first | 346.00 | 315.00 | 8.96
  |   | first deep, shallow > deep | 342.00 | 308.33 | 9.84
  |   | first deep, deep > shallow | 342.67 | 309.67 | 9.63
  |   | last deep, shallow > deep | 344.00 | 312.33 | 9.21
  |   | last deep, deep > shallow | 337.67 | 307.00 | 9.08
  | 100 | balanced, first > last | 811.67 | 386.67 | 52.36
  |   | balanced, last > first | 799.67 | 382.67 | 52.15
  |   | first deep, shallow > deep | 809.67 | 450.67 | 44.34
  |   | first deep, deep > shallow | 811.00 | 445.00 | 45.13
  |   | last deep, shallow > deep | 823.67 | 397.00 | 51.80
  |   | last deep, deep > shallow | 815.00 | 392.00 | 51.90
TRUE | 2 | balanced, first > last | 977.33 | 310.33 | 68.25
  |   | balanced, last > first | 905.33 | 308.00 | 65.98
  |   | first deep, shallow > deep | 904.33 | 308.00 | 65.94
  |   | first deep, deep > shallow | 905.00 | 307.00 | 66.08
  |   | last deep, shallow > deep | 906.67 | 311.33 | 65.66
  |   | last deep, deep > shallow | 918.33 | 311.00 | 66.13
  | 100 | balanced, first > last | 1424.33 | 375.33 | 73.65
  |   | balanced, last > first | 1430.00 | 379.67 | 73.45
  |   | first deep, shallow > deep | 1388.00 | 394.00 | 71.61
  |   | first deep, deep > shallow | 1393.67 | 397.33 | 71.49
  |   | last deep, shallow > deep | 1472.00 | 390.67 | 73.46
  |   | last deep, deep > shallow | 1396.33 | 391.33 | 71.97
