### PR TITLE
Optimize `Node::is_ancestor_of` for nodes in tree

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2150,12 +2150,23 @@ Window *Node::get_last_exclusive_window() const {
 
 bool Node::is_ancestor_of(RequiredParam<const Node> rp_node) const {
 	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, false);
-	Node *p = p_node->data.parent;
-	while (p) {
-		if (p == this) {
+
+	const Node *n = p_node;
+
+	if (is_inside_tree() && p_node->data.tree == data.tree) {
+		const int depth = data.depth;
+		while (n->data.depth > depth) {
+			n = n->data.parent;
+		}
+		return n == this;
+	}
+
+	n = p_node->data.parent;
+	while (n) {
+		if (n == this) {
 			return true;
 		}
-		p = p->data.parent;
+		n = n->data.parent;
 	}
 
 	return false;


### PR DESCRIPTION
Should not make any difference if the node actually is an ancestor (the benchmark focuses on cases were this is not the case), but if not this change prevents iterating up to the root and instead terminates early using the cached depth information.

<details>
<summary>Benchmarked using this script (on a node with depth 50)</summary>

```gdscript
extends Node


# Called when the node enters the scene tree for the first time.
func _ready() -> void:
	for i in [2, 100]:
		benchmark_balanced(i)
		benchmark_unbalanced(i, true)
		benchmark_unbalanced(i, false)

func benchmark_unbalanced(nodes: int, is_ancestor: bool = true):
	var shallow_node = self
	if not is_ancestor:
		shallow_node = Node.new()
		self.add_child(shallow_node)
	var deep_node = self
	for i in range(nodes - 1):
		var new = Node.new()
		deep_node.add_child(new)
		deep_node = new
	
	var t1 = Time.get_ticks_usec()
	for i in range(1000):
		shallow_node.is_ancestor_of(deep_node)
	var t2 = Time.get_ticks_usec()
	
	var t3 = Time.get_ticks_usec()
	for i in range(1000):
		deep_node.is_ancestor_of(shallow_node)
	var t4 = Time.get_ticks_usec()
	
	print(str(nodes) + "; " + str(is_ancestor) + "; shallow ancestor of deep;" + str(t2 - t1))
	print(str(nodes) + "; " + str(is_ancestor) + "; deep ancestor of shallow;" + str(t4 - t3))

func benchmark_balanced(nodes: int):
	var left = self
	var right = self
	for i in range(int(nodes / 2)):
		var nl = Node.new()
		var nr = Node.new()
		left.add_child(nl)
		right.add_child(nr)
		left = nl
		right = nr
	var t1 = Time.get_ticks_usec()
	for i in range(1000):
		left.is_ancestor_of(right)
	var t2 = Time.get_ticks_usec()
	print(str(nodes) + "; ; balanced; " + str(t2 - t1))
```

</details>

Benchmark:

|n (proximity)  | Tree structure and request | expected result  | Before (3 samples) | After (3 samples) | %
|-- | -- | -- | -- | -- | --
| 2 | balanced  | FALSE | 327.67 | 283.67 | 13.43
|  | shallow ancestor of deep?  | TRUE | 358.67 | 321.33 | 10.41
|  | deep ancestor of shallow?  | FALSE | 332.00 | 282.00 | 15.06
|  | shallow ancestor of deep?  | FALSE | 366.00 | 279.33 | 23.68
|  | deep ancestor of shallow?  | FALSE | 347.33 | 283.33 | 18.43
| 100 |  balanced | FALSE | 437.67 | 281.00 | 35.80
|  | shallow ancestor of deep? | TRUE | 417.33 | 403.00 | 3.43
|  | deep ancestor of shallow?  | FALSE | 339.00 | 280.33 | 17.31
|  | shallow ancestor of deep?  | FALSE | 470.67 | 369.00 | 21.60
|  | deep ancestor of shallow? |  FALSE | 339.00 | 281.67 | 16.91

<sub>(Don't mind the duplicate results for "deep ancestor of shallow?". They result from running one time were shallow is an ancestor of deep and one time were shallow is no ancestor of deep. Only noticed that this should make no difference after making the table.)</sub>

I don't fully trust the results for proximity 2, because there _should_ be no difference when the expected result is TRUE, maybe some oddities with my background load :shrug:

