### PR TITLE
Add Auto update check mode

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1253,8 +1253,9 @@
 		<member name="network/connection/check_for_updates" type="int" setter="" getter="">
 			Specifies how the engine should check for updates.
 			- [b]Disable Update Checks[/b] will block the engine from checking updates (see also [member network/connection/network_mode]).
-			- [b]Check Newest Preview[/b] (default for preview versions) will check for the newest available development snapshot.
-			- [b]Check Newest Stable[/b] (default for stable versions) will check for the newest available stable version.
+			- [b]Auto[/b] (default) will check for newest stable or unstable version, depending on which version are you currently using. Switch to another option if you want to lock in.
+			- [b]Check Newest Preview[/b] will check for the newest available development snapshot.
+			- [b]Check Newest Stable[/b] will check for the newest available stable version.
 			- [b]Check Newest Patch[/b] will check for the latest available stable version, but only within the same minor version. E.g. if your version is [code]4.3.stable[/code], you will be notified about [code]4.3.1.stable[/code], but not [code]4.4.stable[/code].
 			All update modes will ignore builds with different major versions (e.g. Godot 4 -&gt; Godot 5).
 		</member>

--- a/editor/project_manager/engine_update_label.h
+++ b/editor/project_manager/engine_update_label.h
@@ -40,6 +40,7 @@ class EngineUpdateLabel : public LinkButton {
 public:
 	enum class UpdateMode {
 		DISABLED,
+		AUTO,
 		NEWEST_UNSTABLE,
 		NEWEST_STABLE,
 		NEWEST_PATCH,
@@ -86,7 +87,7 @@ private:
 	void _set_message(const String &p_message, const Color &p_color);
 	void _set_status(UpdateStatus p_status);
 
-	VersionType _get_version_type(const String &p_string, int *r_index) const;
+	VersionType _get_version_type(const String &p_string, int *r_index = nullptr) const;
 	String _extract_sub_string(const String &p_line) const;
 
 protected:

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -480,11 +480,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/project_manager_screen", EditorSettings::InitialScreen::INITIAL_SCREEN_PRIMARY, project_manager_screen_hints)
 
 	{
-		EngineUpdateLabel::UpdateMode default_update_mode = EngineUpdateLabel::UpdateMode::NEWEST_UNSTABLE;
-		if (String(GODOT_VERSION_STATUS) == String("stable")) {
-			default_update_mode = EngineUpdateLabel::UpdateMode::NEWEST_STABLE;
-		}
-		EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "network/connection/check_for_updates", int(default_update_mode), "Disable Update Checks,Check Newest Preview,Check Newest Stable,Check Newest Patch"); // Uses EngineUpdateLabel::UpdateMode.
+		const String update_hint = vformat("Disable Update Checks,Auto (%s),Check Newest Preview,Check Newest Stable,Check Newest Patch", (str_compare(GODOT_VERSION_STATUS, "stable") == 0) ? "Stable" : "Preview");
+		EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "network/connection/check_for_updates", EngineUpdateLabel::UpdateMode::AUTO, update_hint);
 	}
 
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/use_embedded_menu", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_BASIC_SETTING)


### PR DESCRIPTION
Should resolve #111161

Currently the `check_for_updates` has an awkward "default" that changes depending on whether you use stable version or not. Which means if you switch between versions, the setting might get reset or get some invalid value or whatever.

This PR adds an explicit Auto version check mode, which is also the new default.

<img width="455" height="205" alt="image" src="https://github.com/user-attachments/assets/02729b0c-5ad3-4dbe-85ce-d9df40a845a6" />

The name changes depending on whether you use stable and it works like the current default, but if you change `check_for_updates` to e.g. Newest Stable, it will stay like that even if you use a preview version.

I also replaced `get_version_info()` in EngineUpdateLabel with proper `version.h` usage.