### PR TITLE
Remove unused `GDScript::member_default_values`

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -137,7 +137,6 @@ private:
 	void _restore_old_static_data();
 
 	HashMap<StringName, int> member_lines;
-	HashMap<StringName, Variant> member_default_values;
 	List<PropertyInfo> members_cache;
 	HashMap<StringName, Variant> member_default_values_cache;
 	Ref<GDScript> base_cache;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2908,15 +2908,6 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 					p_script->member_indices[name] = minfo;
 					p_script->members.insert(name);
 				}
-
-#ifdef TOOLS_ENABLED
-				if (variable->initializer != nullptr && variable->initializer->is_constant) {
-					p_script->member_default_values[name] = variable->initializer->reduced_value;
-					GDScriptCompiler::convert_to_initializer_type(p_script->member_default_values[name], variable);
-				} else {
-					p_script->member_default_values.erase(name);
-				}
-#endif
 			} break;
 
 			case GDScriptParser::ClassNode::Member::CONSTANT: {
@@ -3099,20 +3090,6 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 
 	p_script->valid = true;
 	return OK;
-}
-
-void GDScriptCompiler::convert_to_initializer_type(Variant &p_variant, const GDScriptParser::VariableNode *p_node) {
-	// Set p_variant to the value of p_node's initializer, with the type of p_node's variable.
-	GDScriptParser::DataType member_t = p_node->type_constraint;
-	GDScriptParser::DataType init_t = p_node->initializer->type_constraint;
-	if (member_t.is_hard_type() && init_t.is_hard_type() &&
-			member_t.kind == GDScriptParser::DataType::BUILTIN && init_t.kind == GDScriptParser::DataType::BUILTIN) {
-		if (Variant::can_convert_strict(init_t.builtin_type, member_t.builtin_type)) {
-			const Variant *v = &p_node->initializer->reduced_value;
-			Callable::CallError ce;
-			Variant::construct(member_t.builtin_type, p_variant, &v, 1, ce);
-		}
-	}
 }
 
 void GDScriptCompiler::make_scripts(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state) {

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -174,7 +174,6 @@ class GDScriptCompiler {
 	bool has_static_data = false;
 
 public:
-	static void convert_to_initializer_type(Variant &p_variant, const GDScriptParser::VariableNode *p_node);
 	static void make_scripts(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
 	Error compile(const GDScriptParser *p_parser, GDScript *p_script, bool p_keep_state = false);
 


### PR DESCRIPTION
Not entirely sure what this was used for at some point, but at the moment is never read (except once, but that's only for updating the member and does not have side effects). Given that there exists `member_default_values_cache` I'd assume that whatever used this at some point is now using the later.