### PR TITLE
Expose `is_valid()` from `AnimationPlayer` to make detecting paused animations possible.

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -93,6 +93,17 @@
 				Returns [code]true[/code] if an animation is currently playing with a section.
 			</description>
 		</method>
+		<method name="is_animation_active" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the an animation is currently active. An animation is active if it was played by calling [method play] and was not finished yet, or was stopped by calling [method stop].
+				This can be used to check whether an animation is currently paused or stopped.
+				[codeblock]
+				var is_paused = not is_playing() and is_animation_active()
+				var is_stopped = not is_playing() and not is_animation_active()
+				[/codeblock]
+			</description>
+		</method>
 		<method name="is_playing" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -977,6 +977,7 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("pause"), &AnimationPlayer::pause);
 	ClassDB::bind_method(D_METHOD("stop", "keep_state"), &AnimationPlayer::stop, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimationPlayer::is_playing);
+	ClassDB::bind_method(D_METHOD("is_animation_active"), &AnimationPlayer::is_valid);
 
 	ClassDB::bind_method(D_METHOD("set_current_animation", "animation"), &AnimationPlayer::set_current_animation);
 	ClassDB::bind_method(D_METHOD("get_current_animation"), &AnimationPlayer::get_current_animation);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13208