### PR TITLE
Apply MSDF to Animation Blend Tree Editor

### DIFF
--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -40,6 +40,7 @@
 #include "editor/inspector/editor_properties.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "editor/themes/editor_theme_manager.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/grid_container.h"
@@ -145,6 +146,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 	for (const StringName &E : nodes) {
 		GraphNode *node = memnew(GraphNode);
 		graph->add_child(node);
+		node->set_theme(blend_msdf_fonts_theme);
 
 		node->set_draggable(!read_only);
 
@@ -1183,6 +1185,18 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	singleton = this;
 	updating = false;
 	use_position_from_popup_menu = false;
+
+	//////////
+	blend_msdf_fonts_theme.instantiate();
+
+	Ref<Font> label_font = EditorNode::get_singleton()->get_editor_theme()->get_font("main_msdf", EditorStringName(EditorFonts));
+	Ref<Font> label_bold_font = EditorNode::get_singleton()->get_editor_theme()->get_font("main_bold_msdf", EditorStringName(EditorFonts));
+
+	blend_msdf_fonts_theme->set_font(SceneStringName(font), "Label", label_font);
+	blend_msdf_fonts_theme->set_font(SceneStringName(font), "GraphNodeTitleLabel", label_bold_font);
+	blend_msdf_fonts_theme->set_font(SceneStringName(font), "LineEdit", label_font);
+	blend_msdf_fonts_theme->set_font(SceneStringName(font), "Button", label_font);
+	//////////
 
 	graph = memnew(GraphEdit);
 	add_child(graph);

--- a/editor/animation/animation_blend_tree_editor_plugin.h
+++ b/editor/animation/animation_blend_tree_editor_plugin.h
@@ -52,6 +52,8 @@ class EditorInspectorPluginAnimationNodeAnimation;
 class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendTreeEditor, AnimationTreeNodeEditorPlugin);
 
+	Ref<Theme> blend_msdf_fonts_theme;
+
 	Ref<AnimationNodeBlendTree> blend_tree;
 
 	bool read_only = false;


### PR DESCRIPTION
-Created a Ref<Theme> variable in the AnimationNodeBlendTreeEditor definition. -Instantiate MSDF theme variable in constructor.
-Use the same structure from the Visual Shader Editor to set font specifications -Set Theme of each node in update_graph()

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
