### PR TITLE
Fix LineEdit Unicode code-point/control character insertion failing to emit `text_changed`

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -819,6 +819,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	if ((!k->is_pressed() && alt_start && k->get_keycode() == Key::ALT) || (alt_start_no_hold && (k->is_action("ui_text_submit", true) || k->is_action("ui_accept", true)))) {
 		alt_start = false;
 		alt_start_no_hold = false;
+		int prev_len = text.length();
 		if ((alt_code > 0x31 && alt_code < 0xd800) || (alt_code > 0xdfff)) {
 			ime_text = String();
 			ime_selection = Vector2i();
@@ -845,6 +846,13 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 			alt_mode = ALT_INPUT_NONE;
+			// Mirror paste behavior: defer _text_changed once per frame while emitting text_changed signal.
+			if (!text_changed_dirty) {
+				if (is_inside_tree() && text.length() != prev_len) {
+					callable_mp(this, &LineEdit::_text_changed).call_deferred();
+				}
+				text_changed_dirty = true;
+			}
 		} else {
 			ime_text = String();
 			ime_selection = Vector2i();
@@ -2589,6 +2597,8 @@ bool LineEdit::is_text_field() const {
 }
 
 void LineEdit::menu_option(int p_option) {
+	int prev_len = text.length();
+	bool inserted_control_char = false;
 	switch (p_option) {
 		case MENU_CUT: {
 			if (editable) {
@@ -2639,86 +2649,110 @@ void LineEdit::menu_option(int p_option) {
 		case MENU_INSERT_LRM: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x200E));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_RLM: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x200F));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_LRE: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x202A));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_RLE: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x202B));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_LRO: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x202D));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_RLO: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x202E));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_PDF: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x202C));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_ALM: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x061C));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_LRI: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x2066));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_RLI: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x2067));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_FSI: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x2068));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_PDI: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x2069));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_ZWJ: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x200D));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_ZWNJ: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x200C));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_WJ: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x2060));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_INSERT_SHY: {
 			if (editable) {
 				insert_text_at_caret(String::chr(0x00AD));
+				inserted_control_char = true;
 			}
 		} break;
 		case MENU_EMOJI_AND_SYMBOL: {
 			show_emoji_and_symbol_picker();
 		} break;
+	}
+
+	// Mirror paste/drag behavior, emit text_changed signal if a control character was inserted.
+	if (inserted_control_char && !text_changed_dirty) {
+		if (is_inside_tree() && text.length() != prev_len) {
+			callable_mp(this, &LineEdit::_text_changed).call_deferred();
+		}
+		text_changed_dirty = true;
 	}
 }
 


### PR DESCRIPTION
### Summary
`LineEdit` did not emit `text_changed` when text was inserted via Unicode code-point input and the “Insert Control Character” menu. This would break UI logic that depends on `text_changed`.

### Reproduction
Minimal scene with a single `LineEdit` element and the following attached script:

```Python
extends LineEdit
func _ready():
    text_changed.connect(func(new_text):
        print("text_changed:", new_text))
```

Pressing ctrl + shift + u and typing `2020` then pressing enter inserts the dagger character (†) but does not trigger `text_changed` i.e. no print statement is written to the console.

Right click + Insert Control Character (pick any) also inserts but does **not** trigger `text_changed`.

https://github.com/user-attachments/assets/7b3ac2a4-2b5b-4b6c-adad-1ac9fc9d4ea1

### Fix
After performing the two aforementioned insertions, defer `_text_changed()` and set the `text_changed_dirty` guard (exact same process used in `paste_text()` ). Regular typing and paste behavior remains unaffected. `set_text()` is unchanged and still does **not** emit, as per the documentation. This is a small, localized fix in `scene/gui/line_edit.cpp`

https://github.com/user-attachments/assets/6d11362b-e9e6-4047-97b9-8e55f7624c5b

### Testing
Verified fix on a Windows dev build, code-point submission and control character insertion now print once to the console and update any bound UI elements. Regular typing, paste, and deletions have been verified to still emit exactly once.

Formatting: clang-format 17

Fixes #110809

Note: There is an overlapping PR #110988 that instead moves the `text_changed` emission logic to the core function `insert_text_at_caret()` while removing `text.length() != prev_len` checks to determine whether to emit `text_changed` or not. Let me know if this more general change to a core function is preferred, as the changes in my PR attempt to fix two specific bugs without altering core functions while aligning with the existing architecture. A previous PR #84382 also attempted to alter `insert_text_at_caret()` directly which resulted in duplicate signals.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
