### PR TITLE
Fix invalid reported joypad presses

### DIFF
--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -228,6 +228,12 @@ void JoypadSDL::process_events() {
 				case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
 					SKIP_EVENT_FOR_GAMEPAD;
 
+					// Some devices report pressing buttons with indices like 232+, 241+, etc. that are not valid,
+					// so we ignore them here.
+					if (sdl_event.jbutton.button >= (int)JoyButton::MAX) {
+						continue;
+					}
+
 					Input::get_singleton()->joy_button(
 							joy_id,
 							static_cast<JoyButton>(sdl_event.jbutton.button), // Godot button constants are intentionally the same as SDL's, so we can just straight up use them


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108753 , but it does NOT fix several other issues reported there, such as duplicate joypad devices or crashes when some joypads are disconnected (see https://github.com/godotengine/godot/issues/108753#issuecomment-3291422376 )

The reason these strange button presses are recognized is most likely because the devices have slightly broken HID descriptors (see https://github.com/libsdl-org/SDL/issues/13913#issuecomment-3289983243 ).