### PR TITLE
[3.x] FTI - Optimize non-interpolated 2D items

### DIFF
--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1218,7 +1218,6 @@ public:
 				memdelete(skinning_data);
 				skinning_data = nullptr;
 			}
-			on_interpolate_transform_list = false;
 		}
 		Item() {
 			light_mask = 1;

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -381,7 +381,7 @@ void VisualServerCanvas::_render_canvas_item_cull_by_item(Item *p_canvas_item, c
 	Rect2 rect = ci->get_rect();
 
 	Transform2D final_xform;
-	if (!_interpolation_data.interpolation_enabled || !ci->interpolated) {
+	if (!_interpolation_data.interpolation_enabled || !ci->interpolated || !ci->on_interpolate_transform_list) {
 		final_xform = ci->xform_curr;
 	} else {
 		real_t f = Engine::get_singleton()->get_physics_interpolation_fraction();
@@ -528,7 +528,7 @@ void VisualServerCanvas::_render_canvas_item_cull_by_node(Item *p_canvas_item, c
 	Rect2 rect = ci->get_rect();
 
 	Transform2D final_xform;
-	if (!_interpolation_data.interpolation_enabled || !ci->interpolated) {
+	if (!_interpolation_data.interpolation_enabled || !ci->interpolated || !ci->on_interpolate_transform_list) {
 		final_xform = ci->xform_curr;
 	} else {
 		real_t f = Engine::get_singleton()->get_physics_interpolation_fraction();


### PR DESCRIPTION
Avoids interpolation calculations for non-moving items.

Fixes #111177

It turned out this change was possible to check by the numbers, by `DEV_ASSERT`ing that prev and curr xform were the same when `on_interpolate_transform_list` was false (and the new shortcut was taken).

This testing showed that it wasn't correct to set `on_interpolate_transform_list` to false on `clear()` in 3.x, as this function rather confusingly isn't used to do a total clear. The xforms are preserved, and this is relied on for some behaviour which is demonstrable in jetpaca. (This is unlikely to have resulted in any visible bugs previously, but it is more correct by the numbers not to set the flag to false during clear.)

_It might at some later stage be worth doing a `reset` during `clear()`, but that is outside the scope of this PR, and we've not had any issues reporting this as a problem._

4.x already doesn't set `on_interpolated_transform_list` to false during `clear()`, so no changes were needed in that version of the PR.

## Notes
* This isn't much of a bottleneck in 3.x, but in 4.x can be, and it is likely just a case of checking a flag
* It is *just possible* I forgot to add this to the culling code
* Also applicable to 4.x

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
