### PR TITLE
FTI - Optimize non-interpolated 2D items

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -116,7 +116,7 @@ void RendererCanvasCull::_collect_ysort_children(RendererCanvasCull::Item *p_can
 				// To y-sort according to the item's final position, physics interpolation
 				// and transform snapping need to be applied before y-sorting.
 				Transform2D child_xform;
-				if (!_interpolation_data.interpolation_enabled || !child_items[i]->interpolated) {
+				if (!_interpolation_data.interpolation_enabled || !child_items[i]->interpolated || !child_items[i]->on_interpolate_transform_list) {
 					child_xform = child_items[i]->xform_curr;
 				} else {
 					real_t f = Engine::get_singleton()->get_physics_interpolation_fraction();
@@ -348,7 +348,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		// and is passed as `p_parent_xform` afterwards. No need to recalculate.
 		final_xform = p_parent_xform;
 	} else {
-		if (!_interpolation_data.interpolation_enabled || !ci->interpolated) {
+		if (!_interpolation_data.interpolation_enabled || !ci->interpolated || !ci->on_interpolate_transform_list) {
 			self_xform = ci->xform_curr;
 		} else {
 			real_t f = Engine::get_singleton()->get_physics_interpolation_fraction();

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -602,7 +602,7 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 			}
 
 			Transform2D final_xform;
-			if (!RSG::canvas->_interpolation_data.interpolation_enabled || !l->interpolated) {
+			if (!RSG::canvas->_interpolation_data.interpolation_enabled || !l->interpolated || !l->on_interpolate_transform_list) {
 				final_xform = l->xform_curr;
 			} else {
 				real_t f = Engine::get_singleton()->get_physics_interpolation_fraction();


### PR DESCRIPTION
Avoids interpolation calculations for non-moving items.

Fixes #111177
Forward port of #111195

## Notes
* This isn't much of a bottleneck in 3.x, but in 4.x can be, and it is likely just a case of checking a flag
* It is *just possible* I simply forgot to add this
* I've now double checked this by the numbers with the 3.x PR and it should be fine.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
