### PR TITLE
Add `shape_code` function to `CodeEdit` node

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -484,6 +484,12 @@
 				Sets the symbol emitted by [signal symbol_validate] as a valid lookup.
 			</description>
 		</method>
+		<method name="shape_code">
+			<return type="void" />
+			<description>
+				Redefines the indentations of each line, if [member auto_indent] is[code]true[/code] and according to the current indentation settings.
+			</description>
+		</method>
 		<method name="toggle_foldable_line">
 			<return type="void" />
 			<param index="0" name="line" type="int" />

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -484,6 +484,12 @@
 				Sets the symbol emitted by [signal symbol_validate] as a valid lookup.
 			</description>
 		</method>
+		<method name="shape_code">
+			<return type="void" />
+			<description>
+				Redefines the indentations of each line, if [member indent_automatic] is[code]true[/code] and according to the current indentation settings.
+			</description>
+		</method>
 		<method name="toggle_foldable_line">
 			<return type="void" />
 			<param index="0" name="line" type="int" />

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2704,6 +2704,57 @@ void CodeEdit::duplicate_lines() {
 	end_complex_operation();
 }
 
+void CodeEdit::shape_code() {
+	if (!is_editable() || !is_auto_indent_enabled()) {
+		return;
+	}
+
+	int indent_level = 0;
+	const int line_count = get_line_count();
+
+	begin_complex_operation();
+
+	for (int i = 0; i < line_count; i++) {
+		String line = get_line(i);
+		String trimmed_line = line.strip_edges();
+		TypedArray<String> auto_indent_prefixes_list = get_auto_indent_prefixes();
+
+		if (trimmed_line.is_empty()) {
+			if (line.is_empty()) {
+				indent_level = 0;
+				continue;
+			} else {
+				continue;
+			}
+		}
+
+		for (int j = 0; j < auto_brace_completion_pairs.size(); j++) {
+			if (trimmed_line.begins_with(auto_brace_completion_pairs[j].close_key) && auto_indent_prefixes_list.has(auto_brace_completion_pairs[j].open_key)) {
+				indent_level = MAX(indent_level - 1, 0);
+				break;
+			}
+		}
+
+		String correct_indentation = "";
+		if (is_indent_using_spaces()) {
+			correct_indentation = String(" ").repeat(indent_level * get_indent_size());
+		} else {
+			correct_indentation = String("\t").repeat(indent_level);
+		}
+		line = correct_indentation + trimmed_line;
+		set_line(i, line);
+
+		for (int j = 0; j < auto_indent_prefixes_list.size(); j++) {
+			if (trimmed_line.ends_with(auto_indent_prefixes_list[j])) {
+				indent_level++;
+				break;
+			}
+		}
+	}
+
+	end_complex_operation();
+}
+
 /* Visual */
 Color CodeEdit::_get_brace_mismatch_color() const {
 	return theme_cache.brace_mismatch_color;
@@ -2914,6 +2965,7 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("delete_lines"), &CodeEdit::delete_lines);
 	ClassDB::bind_method(D_METHOD("duplicate_selection"), &CodeEdit::duplicate_selection);
 	ClassDB::bind_method(D_METHOD("duplicate_lines"), &CodeEdit::duplicate_lines);
+	ClassDB::bind_method(D_METHOD("shape_code"), &CodeEdit::shape_code);
 
 	/* Inspector */
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "symbol_lookup_on_click"), "set_symbol_lookup_on_click_enabled", "is_symbol_lookup_on_click_enabled");

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -203,7 +203,7 @@ private:
 	bool code_hint_draw_below = true;
 	int code_hint_xpos = -0xFFFF;
 
-	/* Code Completion */
+	/* Code Completion */ 
 	bool code_completion_enabled = false;
 	bool code_completion_forced = false;
 
@@ -521,6 +521,7 @@ public:
 	void delete_lines();
 	void duplicate_selection();
 	void duplicate_lines();
+	void shape_code();
 
 	CodeEdit();
 	~CodeEdit();

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -521,6 +521,7 @@ public:
 	void delete_lines();
 	void duplicate_selection();
 	void duplicate_lines();
+	void shape_code();
 
 	CodeEdit();
 	~CodeEdit();


### PR DESCRIPTION
Related to https://github.com/godotengine/godot-proposals/issues/13177

Add the `shape_code` function that puts the code in shape according to the automatic indentation parameters.
The function need `indent_automatic` to be true to work and will take count of `indent_use_spaces`, `indent_size` and `indent_automatic_prefixes`.

| Before | After |
| ------ | ------ |
| <img width="1127" height="389" alt="image" src="https://github.com/user-attachments/assets/818c95bf-de08-45bf-ac4e-9d6a2c099eb8" /> |<img width="1133" height="415" alt="image" src="https://github.com/user-attachments/assets/27407ffd-3e72-4c88-88eb-d94b1420b282" /> |
| <img width="1141" height="490" alt="image" src="https://github.com/user-attachments/assets/2e0e9c26-9341-41fb-8c38-d98570d21719" /> | <img width="1144" height="420" alt="image" src="https://github.com/user-attachments/assets/89512890-3f64-44ce-a802-3c60ccd8269a" /> |
| <img width="1148" height="395" alt="image" src="https://github.com/user-attachments/assets/038db252-4f1d-4dd7-9639-53661f90e283" /> | <img width="1146" height="396" alt="image" src="https://github.com/user-attachments/assets/7938f6c2-c2c8-454f-b977-f9a3d1fe7a24" /> |

The function is very easy to use, it's just a call we need to add in the code:

<img width="366" height="198" alt="image" src="https://github.com/user-attachments/assets/4298d172-2578-4256-9198-936fc814b980" />
