### PR TITLE
Emit `format_changed` on CameraFeed datatype change

### DIFF
--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -188,6 +188,14 @@ void CameraFeed::set_rgb_image(const Ref<Image> &p_rgb_img) {
 		int new_width = p_rgb_img->get_width();
 		int new_height = p_rgb_img->get_height();
 
+		// Emit `format_changed` signal if feed datatype or frame size is changed.
+		// The signal is deferred to ensure:
+		// - They are emitted on Godot's main thread.
+		// - Both datatype and frame size are updated before the emission.
+		if (datatype != CameraFeed::FEED_RGB || (base_width != new_width) || (base_height != new_height)) {
+			call_deferred("emit_signal", format_changed_signal_name);
+		}
+
 		if ((base_width != new_width) || (base_height != new_height)) {
 			// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 			base_width = new_width;
@@ -195,10 +203,6 @@ void CameraFeed::set_rgb_image(const Ref<Image> &p_rgb_img) {
 
 			RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_rgb_img);
 			RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_RGBA_IMAGE], new_texture);
-
-			// Defer `format_changed` signals to ensure they are emitted on Godot's main thread.
-			// This also makes sure the datatype of the feed is updated before the emission.
-			call_deferred("emit_signal", format_changed_signal_name);
 		} else {
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_RGBA_IMAGE], p_rgb_img);
 		}
@@ -216,6 +220,14 @@ void CameraFeed::set_ycbcr_image(const Ref<Image> &p_ycbcr_img) {
 		int new_width = p_ycbcr_img->get_width();
 		int new_height = p_ycbcr_img->get_height();
 
+		// Emit `format_changed` signal if feed datatype or frame size is changed.
+		// The signal is deferred to ensure:
+		// - They are emitted on Godot's main thread.
+		// - Both datatype and frame size are updated before the emission.
+		if (datatype != CameraFeed::FEED_YCBCR || (base_width != new_width) || (base_height != new_height)) {
+			call_deferred("emit_signal", format_changed_signal_name);
+		}
+
 		if ((base_width != new_width) || (base_height != new_height)) {
 			// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 			base_width = new_width;
@@ -223,10 +235,6 @@ void CameraFeed::set_ycbcr_image(const Ref<Image> &p_ycbcr_img) {
 
 			RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_ycbcr_img);
 			RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_RGBA_IMAGE], new_texture);
-
-			// Defer `format_changed` signals to ensure they are emitted on Godot's main thread.
-			// This also makes sure the datatype of the feed is updated before the emission.
-			call_deferred("emit_signal", format_changed_signal_name);
 		} else {
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_RGBA_IMAGE], p_ycbcr_img);
 		}
@@ -249,6 +257,14 @@ void CameraFeed::set_ycbcr_images(const Ref<Image> &p_y_img, const Ref<Image> &p
 		int new_y_width = p_y_img->get_width();
 		int new_y_height = p_y_img->get_height();
 
+		// Emit `format_changed` signal if feed datatype or frame size is changed.
+		// The signal is deferred to ensure:
+		// - They are emitted on Godot's main thread.
+		// - Both datatype and frame size are updated before the emission.
+		if (datatype != CameraFeed::FEED_YCBCR_SEP || (base_width != new_y_width) || (base_height != new_y_height)) {
+			call_deferred("emit_signal", format_changed_signal_name);
+		}
+
 		if ((base_width != new_y_width) || (base_height != new_y_height)) {
 			// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 			base_width = new_y_width;
@@ -261,10 +277,6 @@ void CameraFeed::set_ycbcr_images(const Ref<Image> &p_y_img, const Ref<Image> &p
 				RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_cbcr_img);
 				RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_CBCR_IMAGE], new_texture);
 			}
-
-			// Defer `format_changed` signals to ensure they are emitted on Godot's main thread.
-			// This also makes sure the datatype of the feed is updated before the emission.
-			call_deferred("emit_signal", format_changed_signal_name);
 		} else {
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_Y_IMAGE], p_y_img);
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_CBCR_IMAGE], p_cbcr_img);
@@ -278,6 +290,14 @@ void CameraFeed::set_ycbcr_images(const Ref<Image> &p_y_img, const Ref<Image> &p
 }
 
 void CameraFeed::set_external(int p_width, int p_height) {
+	// Emit `format_changed` signal if feed datatype or frame size is changed.
+	// The signal is deferred to ensure:
+	// - They are emitted on Godot's main thread.
+	// - Both datatype and frame size are updated before the emission.
+	if (datatype != CameraFeed::FEED_EXTERNAL || (base_width != p_width) || (base_height != p_height)) {
+		call_deferred("emit_signal", format_changed_signal_name);
+	}
+
 	if ((base_width != p_width) || (base_height != p_height)) {
 		// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 		base_width = p_width;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
`format_changed` signal in CameraFeed is emitted when camera frame size changed, but when camera feed datatype is changed with the same frame size (e.g. from 640x480 FEED_YCBCR to 640x480 FEED_YCBCR_SEP), the signal is not emitted and users will not aware of the datatype change.

This PR check camera feed datatype and frame size changes beforehand, and defer `format_changed` signal to ensure both datatype and frame size are updated before signal emission.