### PR TITLE
Clean up SceneExporterGLTFPlugin

### DIFF
--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_scene_exporter_gltf_plugin.h"
 
+#include "../gltf_document.h"
 #include "editor_scene_exporter_gltf_settings.h"
 
 #include "editor/editor_node.h"
@@ -40,38 +41,32 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/dialogs.h"
 
-String SceneExporterGLTFPlugin::get_plugin_name() const {
-	return "ConvertGLTF2";
-}
-
-bool SceneExporterGLTFPlugin::has_main_screen() const {
-	return false;
-}
-
 SceneExporterGLTFPlugin::SceneExporterGLTFPlugin() {
 	_gltf_document.instantiate();
+	_export_settings.instantiate();
+
 	// Set up the file dialog.
 	_file_dialog = memnew(EditorFileDialog);
 	_file_dialog->connect("file_selected", callable_mp(this, &SceneExporterGLTFPlugin::_popup_gltf_settings_dialog));
-	_file_dialog->set_title(TTR("Export Library"));
+	_file_dialog->set_title(TTRC("Export Library"));
 	_file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	_file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
-	_file_dialog->clear_filters();
 	_file_dialog->add_filter("*.glb");
 	_file_dialog->add_filter("*.gltf");
-	_file_dialog->set_title(TTR("Export Scene to glTF 2.0 File"));
+	_file_dialog->set_title(TTRC("Export Scene to glTF 2.0 File"));
 	EditorNode::get_singleton()->get_gui_base()->add_child(_file_dialog);
+
 	// Set up the export settings menu.
 	_config_dialog = memnew(ConfirmationDialog);
 	_config_dialog->set_title(TTRC("Export Settings"));
 	EditorNode::get_singleton()->get_gui_base()->add_child(_config_dialog);
 	_config_dialog->connect(SceneStringName(confirmed), callable_mp(this, &SceneExporterGLTFPlugin::_export_scene_as_gltf));
 
-	_export_settings.instantiate();
-	_export_settings->generate_property_list(_gltf_document);
 	_settings_inspector = memnew(EditorInspector);
 	_settings_inspector->set_custom_minimum_size(Size2(350, 300) * EDSCALE);
+	_settings_inspector->edit(_export_settings.ptr());
 	_config_dialog->add_child(_settings_inspector);
+
 	// Add a button to the Scene -> Export menu to pop up the settings dialog.
 	PopupMenu *menu = get_export_as_menu();
 	int idx = menu->get_item_count();
@@ -84,10 +79,11 @@ void SceneExporterGLTFPlugin::_popup_gltf_settings_dialog(const String &p_select
 
 	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
 	ERR_FAIL_NULL(root);
+
 	// Generate and refresh the export settings.
 	_export_settings->generate_property_list(_gltf_document, root);
-	_settings_inspector->edit(nullptr);
-	_settings_inspector->edit(_export_settings.ptr());
+	_settings_inspector->update_tree();
+
 	// Show the config dialog.
 	_config_dialog->popup_centered();
 }
@@ -104,6 +100,7 @@ void SceneExporterGLTFPlugin::_popup_gltf_export_dialog() {
 		filename = root->get_name();
 	}
 	_file_dialog->set_current_file(filename + String(".gltf"));
+
 	// Show the file dialog.
 	_file_dialog->popup_file_dialog();
 }
@@ -111,17 +108,20 @@ void SceneExporterGLTFPlugin::_popup_gltf_export_dialog() {
 void SceneExporterGLTFPlugin::_export_scene_as_gltf() {
 	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
 	ERR_FAIL_NULL(root);
+
 	List<String> deps;
 	Ref<GLTFState> state;
+	int32_t flags = EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS;
+
 	state.instantiate();
 	state->set_copyright(_export_settings->get_copyright());
-	int32_t flags = 0;
-	flags |= EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS;
 	state->set_bake_fps(_export_settings->get_bake_fps());
+
 	Error err = _gltf_document->append_from_scene(root, state, flags);
 	if (err != OK) {
 		ERR_PRINT(vformat("glTF2 save scene error %s.", itos(err)));
 	}
+
 	err = _gltf_document->write_to_filesystem(state, export_path);
 	if (err != OK) {
 		ERR_PRINT(vformat("glTF2 save scene error %s.", itos(err)));

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
@@ -30,14 +30,13 @@
 
 #pragma once
 
-#include "../gltf_document.h"
-#include "editor_scene_exporter_gltf_settings.h"
-
 #include "editor/plugins/editor_plugin.h"
 
 class ConfirmationDialog;
 class EditorFileDialog;
 class EditorInspector;
+class GLTFDocument;
+class EditorSceneExporterGLTFSettings;
 
 class SceneExporterGLTFPlugin : public EditorPlugin {
 	GDCLASS(SceneExporterGLTFPlugin, EditorPlugin);
@@ -55,7 +54,5 @@ class SceneExporterGLTFPlugin : public EditorPlugin {
 	void _export_scene_as_gltf();
 
 public:
-	virtual String get_plugin_name() const override;
-	bool has_main_screen() const override;
 	SceneExporterGLTFPlugin();
 };


### PR DESCRIPTION
Various improvements I spotted when making #111162
- Remove unnecessary code.
- Improve code style.
- Replace some wrong method calls.
- Switch to TTRC where applicable.

The dialog/export should function the same as before.