### PR TITLE
System-provided ENet warning

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -244,6 +244,9 @@ def configure(env: "SConsEnvironment"):
 
     if not env["builtin_enet"]:
         env.ParseConfig("pkg-config libenet --cflags --libs")
+        print_warning(
+            "System-provided ENet has its functionality limited to IPv4 only and no DTLS support, unless patched for Godot."
+        )
 
     if not env["builtin_zstd"]:
         env.ParseConfig("pkg-config libzstd --cflags --libs")


### PR DESCRIPTION
Codifies warning from documentation: https://github.com/godotengine/godot/tree/master/thirdparty#enet