### PR TITLE
Fix incorrect docs example in `Dictionary.set` description

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -508,7 +508,7 @@
 			<param index="0" name="key" type="Variant" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Sets the value of the element at the given [param key] to the given [param value]. This is the same as using the [code][][/code] operator ([code]array[index] = value[/code]).
+				Sets the value of the element at the given [param key] to the given [param value]. This is the same as using the [code][][/code] operator ([code]dict[key] = value[/code]).
 			</description>
 		</method>
 		<method name="size" qualifiers="const">


### PR DESCRIPTION
The example in the Dictionary.set method description is incorrect. It shows (array[index] = value), which is the syntax for Array, not Dictionary.

This pull request corrects the example to (dict[key] = value).

