### PR TITLE
Remove `hash_map.h` include from `a_hash_map.h`, and remove cross conversion operators

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -30,9 +30,14 @@
 
 #pragma once
 
-#include "core/string/ustring.h"
-#include "core/templates/hash_map.h"
+#include "core/os/memory.h"
+#include "core/string/print_string.h"
+#include "core/templates/hashfuncs.h"
+#include "core/templates/pair.h"
 
+#include <initializer_list>
+
+class String;
 class StringName;
 class Variant;
 
@@ -182,8 +187,7 @@ private:
 			if (_metadata[meta_idx].hash == EMPTY_HASH) {
 #ifdef DEV_ENABLED
 				if (unlikely(distance > 12)) {
-					WARN_PRINT("Excessive collision count (" +
-							itos(distance) + "), is the right hash function being used?");
+					WARN_PRINT("Excessive collision count, is the right hash function being used?");
 				}
 #endif
 				_metadata[meta_idx] = metadata;
@@ -657,16 +661,20 @@ public:
 
 	/* Constructors */
 
-	AHashMap(const AHashMap &p_other) {
-		_init_from(p_other);
+	AHashMap(AHashMap &&p_other) {
+		_elements = p_other._elements;
+		_metadata = p_other._metadata;
+		_capacity_mask = p_other._capacity_mask;
+		_size = p_other._size;
+
+		p_other._elements = nullptr;
+		p_other._metadata = nullptr;
+		p_other._capacity_mask = 0;
+		p_other._size = 0;
 	}
 
-	AHashMap(const HashMap<TKey, TValue> &p_other) {
-		reserve(p_other.size());
-		for (const KeyValue<TKey, TValue> &E : p_other) {
-			uint32_t hash = _hash(E.key);
-			_insert_element(E.key, E.value, hash);
-		}
+	AHashMap(const AHashMap &p_other) {
+		_init_from(p_other);
 	}
 
 	void operator=(const AHashMap &p_other) {
@@ -677,15 +685,6 @@ public:
 		reset();
 
 		_init_from(p_other);
-	}
-
-	void operator=(const HashMap<TKey, TValue> &p_other) {
-		reset();
-		reserve(p_other.size());
-		for (const KeyValue<TKey, TValue> &E : p_other) {
-			uint32_t hash = _hash(E.key);
-			_insert_element(E.key, E.value, hash);
-		}
 	}
 
 	AHashMap(uint32_t p_initial_capacity) {

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2508,7 +2508,7 @@ void AnimatedValuesBackup::set_data(const AHashMap<Animation::TypeHash, Animatio
 }
 
 AHashMap<Animation::TypeHash, AnimationMixer::TrackCache *, HashHasher> AnimatedValuesBackup::get_data() const {
-	HashMap<Animation::TypeHash, AnimationMixer::TrackCache *> ret;
+	AHashMap<Animation::TypeHash, AnimationMixer::TrackCache *, HashHasher> ret;
 	for (const KeyValue<Animation::TypeHash, AnimationMixer::TrackCache *> &E : data) {
 		AnimationMixer::TrackCache *track = get_cache_copy(E.value);
 		ERR_CONTINUE(!track); // Backup shouldn't contain tracks that cannot be copied, this is a mistake.


### PR DESCRIPTION
- Helps address https://github.com/godotengine/godot/issues/111218

`AHashMap` currently includes `HashMap`. The reason is the conversion operator between the two.
I have found that the conversion operator was used only in a single place. I managed to fix the code by using `AHashMap` without conversions. I've also added a move constructor, to avoid the `AHashMap` copying anyway on return.

I have then removed the no longer needed conversion operators, and removed the `HashMap` include, reducing the header to the actual includes needed (same as `HashMap`).