### PR TITLE
CI: Fix `CODEOWNERS` inconsistencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,8 +45,6 @@
 # Editor
 
 /editor/                                      @godotengine/docks
-/editor/script/                               @godotengine/script-editor
-/editor/shader/                               @godotengine/script-editor @godotengine/shaders
 /editor/animation/                            @godotengine/animation
 /editor/audio/                                @godotengine/audio
 /editor/debugger/                             @godotengine/debugger
@@ -57,10 +55,12 @@
 /editor/import/                               @godotengine/import
 /editor/inspector/                            @godotengine/docks
 /editor/scene/2d/                             @godotengine/2d-editor
-/editor/scene/2d/physics                      @godotengine/2d-editor @godotengine/physics
+/editor/scene/2d/physics/                     @godotengine/2d-editor @godotengine/physics
 /editor/scene/3d/                             @godotengine/3d-editor
-/editor/scene/3d/physics                      @godotengine/3d-editor @godotengine/physics
+/editor/scene/3d/physics/                     @godotengine/3d-editor @godotengine/physics
 /editor/scene/gui/                            @godotengine/gui-nodes
+/editor/script/                               @godotengine/script-editor
+/editor/shader/                               @godotengine/script-editor @godotengine/shaders
 /editor/themes/                               @godotengine/usability @godotengine/gui-nodes
 /editor/translations/                         @godotengine/usability
 
@@ -205,9 +205,12 @@
 # Scene
 
 /scene/2d/                                    @godotengine/2d-nodes
+/scene/2d/navigation/                         @godotengine/2d-nodes @godotengine/navigation
 /scene/2d/physics/                            @godotengine/2d-nodes @godotengine/physics
 /scene/3d/                                    @godotengine/3d-nodes
+/scene/3d/navigation/                         @godotengine/3d-nodes @godotengine/navigation
 /scene/3d/physics/                            @godotengine/3d-nodes @godotengine/physics
+/scene/3d/xr/                                 @godotengine/3d-nodes @godotengine/xr
 /scene/animation/                             @godotengine/animation
 /scene/audio/                                 @godotengine/audio
 /scene/debugger/                              @godotengine/debugger
@@ -227,18 +230,13 @@
 
 # Servers
 
-/servers/**/audio_*                           @godotengine/audio
-/servers/**/camera_*                          @godotengine/xr
-/servers/**/debugger_*                        @godotengine/debugger
-/servers/**/navigation_*                      @godotengine/navigation
-/servers/**/physics_*                         @godotengine/physics
-/servers/**/rendering_*                       @godotengine/rendering
-/servers/**/text_*                            @godotengine/gui-nodes
-/servers/**/xr_*                              @godotengine/xr
 /servers/audio/                               @godotengine/audio
 /servers/camera/                              @godotengine/xr
 /servers/debugger/                            @godotengine/debugger
-/servers/navigation/                          @godotengine/navigation
+/servers/navigation_2d/                       @godotengine/navigation
+/servers/navigation_3d/                       @godotengine/navigation
+/servers/physics_2d/                          @godotengine/physics
+/servers/physics_3d/                          @godotengine/physics
 /servers/rendering/                           @godotengine/rendering
 /servers/text/                                @godotengine/gui-nodes
 /servers/xr/                                  @godotengine/xr


### PR DESCRIPTION
There've been a number of structural changes to the repo, but not all of these are currently reflected in the `CODEOWNERS` file. While eventually we should have some kind of tool that ratifies/generates this sort of thing, manual adjustments like this get the job done (for now)