### PR TITLE
Replace `std::size` usage with `std_size` to avoid `<iterator>` include.

### DIFF
--- a/core/error/error_list.cpp
+++ b/core/error/error_list.cpp
@@ -30,7 +30,7 @@
 
 #include "error_list.h"
 
-#include <iterator>
+#include "core/typedefs.h"
 
 const char *error_names[] = {
 	"OK", // OK
@@ -84,4 +84,4 @@ const char *error_names[] = {
 	"Printer on fire", // ERR_PRINTER_ON_FIRE
 };
 
-static_assert(std::size(error_names) == ERR_MAX);
+static_assert(std_size(error_names) == ERR_MAX);

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -415,7 +415,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 };
 
 String InputMap::get_builtin_display_name(const String &p_name) const {
-	constexpr int len = std::size(_builtin_action_display_names);
+	constexpr int len = std_size(_builtin_action_display_names);
 
 	for (int i = 0; i < len; i++) {
 		if (_builtin_action_display_names[i].name == p_name) {

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -445,7 +445,7 @@ class CharBuffer {
 public:
 	_FORCE_INLINE_ CharBuffer() :
 			buffer(stack_buffer),
-			capacity(std::size(stack_buffer)) {
+			capacity(std_size(stack_buffer)) {
 	}
 
 	_FORCE_INLINE_ void push_back(char c) {

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -47,7 +47,7 @@ String ResourceUID::get_cache_file() {
 }
 
 static constexpr uint8_t uuid_characters[] = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', '0', '1', '2', '3', '4', '5', '6', '7', '8' };
-static constexpr uint32_t uuid_characters_element_count = std::size(uuid_characters);
+static constexpr uint32_t uuid_characters_element_count = std_size(uuid_characters);
 static constexpr uint8_t max_uuid_number_length = 13; // Max 0x7FFFFFFFFFFFFFFF (uid://d4n4ub6itg400) size is 13 characters.
 
 String ResourceUID::id_to_text(ID p_id) const {

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -432,7 +432,7 @@ int Color::find_named_color(const String &p_name) {
 }
 
 int Color::get_named_color_count() {
-	return std::size(named_colors);
+	return std_size(named_colors);
 }
 
 String Color::get_named_color_name(int p_idx) {

--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -34,14 +34,12 @@
 
 #include "char_range.inc"
 
-#include <iterator>
-
 static constexpr char hex_char_table_upper[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 static constexpr char hex_char_table_lower[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
 #define BSEARCH_CHAR_RANGE(m_array)                \
 	int low = 0;                                   \
-	int high = std::size(m_array) - 1;             \
+	int high = std_size(m_array) - 1;              \
 	int middle = (low + high) / 2;                 \
                                                    \
 	while (low <= high) {                          \

--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -182,7 +182,7 @@ const char32_t *TranslationDomain::_get_accented_version(char32_t p_character) c
 		return nullptr;
 	}
 
-	for (unsigned int i = 0; i < std::size(_character_to_accented); i++) {
+	for (unsigned int i = 0; i < std_size(_character_to_accented); i++) {
 		if (_character_to_accented[i].character == p_character) {
 			return _character_to_accented[i].accented_character;
 		}

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -144,6 +144,12 @@ constexpr auto CLAMP(const T m_a, const T2 m_min, const T3 m_max) {
 #define SWAP(m_x, m_y) std::swap((m_x), (m_y))
 #endif // SWAP
 
+// Like std::size, but without requiring any additional includes.
+template <typename T, size_t SIZE>
+constexpr size_t std_size(const T (&)[SIZE]) {
+	return SIZE;
+}
+
 /* Functions to handle powers of 2 and shifting. */
 
 // Returns `true` if a positive integer is a power of 2, `false` otherwise.

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -52,7 +52,7 @@
 
 using Microsoft::WRL::ComPtr;
 
-#define ARRAY_SIZE(a) std::size(a)
+#define ARRAY_SIZE(a) std_size(a)
 
 class RenderingContextDriverD3D12 : public RenderingContextDriver {
 	ComPtr<ID3D12DeviceFactory> device_factory;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3845,7 +3845,7 @@ void RasterizerSceneGLES3::_render_uv2(const PagedArray<RenderGeometryInstance *
 			GL_COLOR_ATTACHMENT2,
 			GL_COLOR_ATTACHMENT3
 		};
-		glDrawBuffers(std::size(draw_buffers), draw_buffers);
+		glDrawBuffers(std_size(draw_buffers), draw_buffers);
 
 		glClearColor(0.0, 0.0, 0.0, 0.0);
 		RasterizerGLES3::clear_depth(0.0);

--- a/drivers/metal/inflection_map.h
+++ b/drivers/metal/inflection_map.h
@@ -33,6 +33,8 @@
 #include "core/templates/hash_map.h"
 #include "core/templates/local_vector.h"
 
+#include <iterator>
+
 /// An unordered map that splits elements between a fast-access vector of LinearCount consecutively
 /// indexed elements, and a slower-access map holding sparse indexes larger than LinearCount.
 ///

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -36,8 +36,6 @@
 #include "core/os/time.h"
 #include "core/variant/dictionary.h"
 
-#include <iterator>
-
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_events.h>

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -46,7 +46,7 @@
 #include "thirdparty/swappy-frame-pacing/swappyVk.h"
 #endif
 
-#define ARRAY_SIZE(a) std::size(a)
+#define ARRAY_SIZE(a) std_size(a)
 
 #define PRINT_NATIVE_COMMANDS 0
 

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -873,7 +873,7 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 		state_machine_draw->draw_line(p_from, p_from.lerp(p_to, p_fade_ratio), fade_line_color, 2);
 	}
 
-	const int ICON_COUNT = std::size(theme_cache.transition_icons);
+	const int ICON_COUNT = std_size(theme_cache.transition_icons);
 	int icon_index = p_mode + (p_auto_advance ? ICON_COUNT / 2 : 0);
 	ERR_FAIL_COND(icon_index >= ICON_COUNT);
 	Ref<Texture2D> icon = theme_cache.transition_icons[icon_index];

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8466,7 +8466,7 @@ EditorNode::EditorNode() {
 	default_layout->set_value(docks_section, "dock_5", "Inspector,Node,History");
 
 	int hsplits[] = { 0, 270, -270, 0 };
-	DEV_ASSERT((int)std::size(hsplits) == editor_dock_manager->get_hsplit_count());
+	DEV_ASSERT((int)std_size(hsplits) == editor_dock_manager->get_hsplit_count());
 	for (int i = 0; i < editor_dock_manager->get_hsplit_count(); i++) {
 		default_layout->set_value(docks_section, "dock_hsplit_" + itos(i + 1), hsplits[i]);
 	}

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -321,7 +321,7 @@ void EditorExportPlatformAppleEmbedded::get_export_options(List<ExportOption> *r
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/photolibrary_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need access to the photo library"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "privacy/photolibrary_usage_description_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary()));
 
-	for (uint64_t i = 0; i < std::size(api_info); ++i) {
+	for (uint64_t i = 0; i < std_size(api_info); ++i) {
 		String prop_name = vformat("privacy/%s_access_reasons", api_info[i].prop_name);
 		String hint;
 		for (int j = 0; j < api_info[i].prop_flag_value.size(); j++) {
@@ -338,13 +338,13 @@ void EditorExportPlatformAppleEmbedded::get_export_options(List<ExportOption> *r
 
 	{
 		String hint;
-		for (uint64_t i = 0; i < std::size(data_collect_purpose_info); ++i) {
+		for (uint64_t i = 0; i < std_size(data_collect_purpose_info); ++i) {
 			if (i != 0) {
 				hint += ",";
 			}
 			hint += vformat("%s:%d", data_collect_purpose_info[i].prop_name, (1 << i));
 		}
-		for (uint64_t i = 0; i < std::size(data_collect_type_info); ++i) {
+		for (uint64_t i = 0; i < std_size(data_collect_type_info); ++i) {
 			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("privacy/collected_data/%s/collected", data_collect_type_info[i].prop_name)), false));
 			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("privacy/collected_data/%s/linked_to_user", data_collect_type_info[i].prop_name)), false));
 			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("privacy/collected_data/%s/used_for_tracking", data_collect_type_info[i].prop_name)), false));
@@ -669,7 +669,7 @@ String EditorExportPlatformAppleEmbedded::_process_config_file_line(const Ref<Ed
 		strnew += p_line.replace("$swift_runtime_build_phase", value) + "\n";
 	} else if (p_line.contains("$priv_collection")) {
 		bool section_opened = false;
-		for (uint64_t j = 0; j < std::size(data_collect_type_info); ++j) {
+		for (uint64_t j = 0; j < std_size(data_collect_type_info); ++j) {
 			bool data_collected = p_preset->get(vformat("privacy/collected_data/%s/collected", data_collect_type_info[j].prop_name));
 			bool linked = p_preset->get(vformat("privacy/collected_data/%s/linked_to_user", data_collect_type_info[j].prop_name));
 			bool tracking = p_preset->get(vformat("privacy/collected_data/%s/used_for_tracking", data_collect_type_info[j].prop_name));
@@ -698,7 +698,7 @@ String EditorExportPlatformAppleEmbedded::_process_config_file_line(const Ref<Ed
 				if (purposes != 0) {
 					strnew += "\t\t\t\t<key>NSPrivacyCollectedDataTypePurposes</key>\n";
 					strnew += "\t\t\t\t<array>\n";
-					for (uint64_t k = 0; k < std::size(data_collect_purpose_info); ++k) {
+					for (uint64_t k = 0; k < std_size(data_collect_purpose_info); ++k) {
 						if (purposes & (1 << k)) {
 							strnew += vformat("\t\t\t\t\t<string>%s</string>\n", data_collect_purpose_info[k].type_name);
 						}
@@ -730,7 +730,7 @@ String EditorExportPlatformAppleEmbedded::_process_config_file_line(const Ref<Ed
 		}
 	} else if (p_line.contains("$priv_api_types")) {
 		strnew += "\t<array>\n";
-		for (uint64_t j = 0; j < std::size(api_info); ++j) {
+		for (uint64_t j = 0; j < std_size(api_info); ++j) {
 			int api_access = p_preset->get(vformat("privacy/%s_access_reasons", api_info[j].prop_name));
 			if (api_access != 0) {
 				strnew += "\t\t<dict>\n";

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1968,7 +1968,7 @@ CodeTextEditor::CodeTextEditor() {
 	zoom_button->set_accessibility_name(TTRC("Zoom Factor"));
 
 	PopupMenu *zoom_menu = zoom_button->get_popup();
-	constexpr int preset_count = std::size(ZOOM_FACTOR_PRESETS);
+	constexpr int preset_count = std_size(ZOOM_FACTOR_PRESETS);
 
 	for (int i = 0; i < preset_count; i++) {
 		float z = ZOOM_FACTOR_PRESETS[i];

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -92,7 +92,7 @@ static FloatConstantDef float_constant_defs[] = {
 	{ "Sqrt2", Math::SQRT2, TTRC("Sqrt2 constant (1.414214). Square root of 2.") }
 };
 
-constexpr int MAX_FLOAT_CONST_DEFS = std::size(float_constant_defs);
+constexpr int MAX_FLOAT_CONST_DEFS = std_size(float_constant_defs);
 
 ///////////////////
 

--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -159,7 +159,7 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	String noto_cjk_path;
 	String noto_cjk_bold_path;
 	String var_suffix[] = { "HK", "KR", "SC", "TC", "JP" }; // Note: All Noto Sans CJK versions support all glyph variations, it should not match current locale.
-	for (size_t i = 0; i < std::size(var_suffix); i++) {
+	for (size_t i = 0; i < std_size(var_suffix); i++) {
 		if (noto_cjk_path.is_empty()) {
 			noto_cjk_path = OS::get_singleton()->get_system_font_path("Noto Sans CJK " + var_suffix[i], 400, 100);
 		}

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -220,7 +220,7 @@ String Performance::get_monitor_name(Monitor p_monitor) const {
 		PNAME("navigation_3d/obstacles"),
 #endif // NAVIGATION_3D_DISABLED
 	};
-	static_assert(std::size(names) == MONITOR_MAX);
+	static_assert(std_size(names) == MONITOR_MAX);
 
 	return names[p_monitor];
 }

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4241,7 +4241,7 @@ GDScriptParser::ParseRule *GDScriptParser::get_rule(GDScriptTokenizer::Token::Ty
 	};
 	/* clang-format on */
 	// Avoid desync.
-	static_assert(std::size(rules) == GDScriptTokenizer::Token::TK_MAX, "Amount of parse rules don't match the amount of token types.");
+	static_assert(std_size(rules) == GDScriptTokenizer::Token::TK_MAX, "Amount of parse rules don't match the amount of token types.");
 
 	// Let's assume this is never invalid, since nothing generates a TK_MAX.
 	return &rules[p_token_type];

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -158,7 +158,7 @@ static const char *token_names[] = {
 };
 
 // Avoid desync.
-static_assert(std::size(token_names) == GDScriptTokenizer::Token::TK_MAX, "Amount of token names don't match the amount of token types.");
+static_assert(std_size(token_names) == GDScriptTokenizer::Token::TK_MAX, "Amount of token names don't match the amount of token types.");
 
 const char *GDScriptTokenizer::Token::get_name() const {
 	ERR_FAIL_INDEX_V_MSG(type, TK_MAX, "<error>", "Using token type out of the enum.");

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -411,7 +411,7 @@ void (*type_init_function_table[])(Variant *) = {
 		&&OPCODE_LINE,                                   \
 		&&OPCODE_END                                     \
 	};                                                   \
-	static_assert(std::size(switch_table_ops) == (OPCODE_END + 1), "Opcodes in jump table aren't the same as opcodes in enum.");
+	static_assert(std_size(switch_table_ops) == (OPCODE_END + 1), "Opcodes in jump table aren't the same as opcodes in enum.");
 
 #define OPCODE(m_op) \
 	m_op:

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -248,7 +248,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 #endif
 	};
 
-	static_assert(std::size(names) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");
+	static_assert(std_size(names) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");
 
 	return names[(int)p_code];
 }

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -155,7 +155,7 @@ public:
 #endif
 	};
 
-	static_assert(std::size(default_warning_levels) == WARNING_MAX, "Amount of default levels does not match the amount of warnings.");
+	static_assert(std_size(default_warning_levels) == WARNING_MAX, "Amount of default levels does not match the amount of warnings.");
 
 	Code code = WARNING_MAX;
 	int start_line = -1, end_line = -1;

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -260,7 +260,7 @@ String _get_gles_tag() {
 String _get_screen_sizes_tag(const Ref<EditorExportPreset> &p_preset) {
 	String manifest_screen_sizes = "    <supports-screens \n        tools:node=\"replace\"";
 	String sizes[] = { "small", "normal", "large", "xlarge" };
-	constexpr size_t num_sizes = std::size(sizes);
+	constexpr size_t num_sizes = std_size(sizes);
 	for (size_t i = 0; i < num_sizes; i++) {
 		String feature_name = vformat("screen/support_%s", sizes[i]);
 		String feature_support = bool_to_string(p_preset->get(feature_name));

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -94,7 +94,7 @@ void OS_LinuxBSD::alert(const String &p_alert, const String &p_title) {
 	String program;
 
 	for (int i = 0; i < path_elems.size(); i++) {
-		for (uint64_t k = 0; k < std::size(message_programs); k++) {
+		for (uint64_t k = 0; k < std_size(message_programs); k++) {
 			String tested_path = path_elems[i].path_join(message_programs[k]);
 
 			if (FileAccess::exists(tested_path)) {
@@ -776,7 +776,7 @@ Vector<String> OS_LinuxBSD::get_system_font_path_for_text(const String &p_font_n
 
 	Vector<String> ret;
 	static const char *allowed_formats[] = { "TrueType", "CFF" };
-	for (size_t i = 0; i < std::size(allowed_formats); i++) {
+	for (size_t i = 0; i < std_size(allowed_formats); i++) {
 		FcPattern *pattern = FcPatternCreate();
 		if (pattern) {
 			FcPatternAddBool(pattern, FC_SCALABLE, FcTrue);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4199,7 +4199,7 @@ Atom DisplayServerX11::_process_selection_request_target(Atom p_target, Window p
 				32,
 				PropModeReplace,
 				(unsigned char *)&data,
-				std::size(data));
+				std_size(data));
 		return p_property;
 	} else if (p_target == XInternAtom(x11_display, "SAVE_TARGETS", 0)) {
 		// Request to check if SAVE_TARGETS is supported, nothing special to do.

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -583,13 +583,13 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 
 	{
 		String hint;
-		for (uint64_t i = 0; i < std::size(data_collect_purpose_info); ++i) {
+		for (uint64_t i = 0; i < std_size(data_collect_purpose_info); ++i) {
 			if (i != 0) {
 				hint += ",";
 			}
 			hint += vformat("%s:%d", data_collect_purpose_info[i].prop_name, (1 << i));
 		}
-		for (uint64_t i = 0; i < std::size(data_collect_type_info); ++i) {
+		for (uint64_t i = 0; i < std_size(data_collect_type_info); ++i) {
 			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("privacy/collected_data/%s/collected", data_collect_type_info[i].prop_name)), false));
 			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("privacy/collected_data/%s/linked_to_user", data_collect_type_info[i].prop_name)), false));
 			r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("privacy/collected_data/%s/used_for_tracking", data_collect_type_info[i].prop_name)), false));
@@ -693,7 +693,7 @@ void EditorExportPlatformMacOS::_make_icon(const Ref<EditorExportPreset> &p_pres
 		{ "is32", "s8mk", false, 16 } //16×16 24-bit RLE + 8-bit uncompressed mask
 	};
 
-	for (uint64_t i = 0; i < std::size(icon_infos); ++i) {
+	for (uint64_t i = 0; i < std_size(icon_infos); ++i) {
 		Ref<Image> copy = p_icon->duplicate();
 		copy->convert(Image::FORMAT_RGBA8);
 		copy->resize(icon_infos[i].size, icon_infos[i].size, (Image::Interpolation)(p_preset->get("application/icon_interpolation").operator int()));
@@ -764,7 +764,7 @@ void EditorExportPlatformMacOS::_fix_privacy_manifest(const Ref<EditorExportPres
 	for (int i = 0; i < lines.size(); i++) {
 		if (lines[i].find("$priv_collection") != -1) {
 			bool section_opened = false;
-			for (uint64_t j = 0; j < std::size(data_collect_type_info); ++j) {
+			for (uint64_t j = 0; j < std_size(data_collect_type_info); ++j) {
 				bool data_collected = p_preset->get(vformat("privacy/collected_data/%s/collected", data_collect_type_info[j].prop_name));
 				bool linked = p_preset->get(vformat("privacy/collected_data/%s/linked_to_user", data_collect_type_info[j].prop_name));
 				bool tracking = p_preset->get(vformat("privacy/collected_data/%s/used_for_tracking", data_collect_type_info[j].prop_name));
@@ -793,7 +793,7 @@ void EditorExportPlatformMacOS::_fix_privacy_manifest(const Ref<EditorExportPres
 					if (purposes != 0) {
 						strnew += "\t\t\t\t<key>NSPrivacyCollectedDataTypePurposes</key>\n";
 						strnew += "\t\t\t\t<array>\n";
-						for (uint64_t k = 0; k < std::size(data_collect_purpose_info); ++k) {
+						for (uint64_t k = 0; k < std_size(data_collect_purpose_info); ++k) {
 							if (purposes & (1 << k)) {
 								strnew += vformat("\t\t\t\t\t<string>%s</string>\n", data_collect_purpose_info[k].type_name);
 							}

--- a/platform/macos/key_mapping_macos.mm
+++ b/platform/macos/key_mapping_macos.mm
@@ -390,7 +390,7 @@ Key KeyMappingMacOS::remap_key(unsigned int p_key, unsigned int p_state, bool p_
 			LMGetKbdType(),
 			kUCKeyTranslateNoDeadKeysBit,
 			&keys_down,
-			std::size(chars),
+			std_size(chars),
 			&real_length,
 			chars);
 

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -43,7 +43,6 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
-#include <iterator>
 #include <string>
 #include <vector>
 

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -120,7 +120,7 @@ Error EditorExportPlatformWindows::_process_icon(const Ref<EditorExportPreset> &
 		Ref<Image> src_image = _load_icon_or_splash_image(p_src_path, &err);
 		ERR_FAIL_COND_V(err != OK || src_image.is_null() || src_image->is_empty(), ERR_CANT_OPEN);
 
-		for (size_t i = 0; i < std::size(icon_size); ++i) {
+		for (size_t i = 0; i < std_size(icon_size); ++i) {
 			int size = (icon_size[i] == 0) ? 256 : icon_size[i];
 
 			Ref<Image> res_image = src_image->duplicate();
@@ -131,7 +131,7 @@ Error EditorExportPlatformWindows::_process_icon(const Ref<EditorExportPreset> &
 	}
 
 	uint16_t valid_icon_count = 0;
-	for (size_t i = 0; i < std::size(icon_size); ++i) {
+	for (size_t i = 0; i < std_size(icon_size); ++i) {
 		if (images.has(icon_size[i])) {
 			valid_icon_count++;
 		} else {
@@ -153,7 +153,7 @@ Error EditorExportPlatformWindows::_process_icon(const Ref<EditorExportPreset> &
 
 	// Write ICONDIRENTRY.
 	uint32_t img_offset = 6 + 16 * valid_icon_count;
-	for (size_t i = 0; i < std::size(icon_size); ++i) {
+	for (size_t i = 0; i < std_size(icon_size); ++i) {
 		if (images.has(icon_size[i])) {
 			const IconData &di = images[icon_size[i]];
 			fw->store_8(icon_size[i]); // Width in pixels.
@@ -170,7 +170,7 @@ Error EditorExportPlatformWindows::_process_icon(const Ref<EditorExportPreset> &
 	}
 
 	// Write image data.
-	for (size_t i = 0; i < std::size(icon_size); ++i) {
+	for (size_t i = 0; i < std_size(icon_size); ++i) {
 		if (images.has(icon_size[i])) {
 			const IconData &di = images[icon_size[i]];
 			fw->store_buffer(di.data.ptr(), di.data.size());

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -851,7 +851,7 @@ bool OS_Windows::get_user_prefers_integrated_gpu() const {
 			GetCurrentApplicationUserModelIdPtr GetCurrentApplicationUserModelId = (GetCurrentApplicationUserModelIdPtr)(void *)GetProcAddress(kernel32, "GetCurrentApplicationUserModelId");
 
 			if (GetCurrentApplicationUserModelId) {
-				UINT32 length = std::size(value_name);
+				UINT32 length = std_size(value_name);
 				LONG result = GetCurrentApplicationUserModelId(&length, value_name);
 				if (result == ERROR_SUCCESS) {
 					is_packaged = true;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -4190,7 +4190,7 @@ void Control::_bind_methods() {
 	StringBuilder builder;
 	builder.append(TTRC("Custom"));
 	builder.append(":-1");
-	for (size_t i = 0; i < std::size(anchors_presets); i++) {
+	for (size_t i = 0; i < std_size(anchors_presets); i++) {
 		builder.append(",");
 		builder.append(anchors_presets[i].name);
 		builder.append(":");

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -5282,7 +5282,7 @@ ShaderLanguage::DataType ShaderLanguage::get_scalar_type(DataType p_type) {
 		TYPE_VOID,
 	};
 
-	static_assert(std::size(scalar_types) == TYPE_MAX);
+	static_assert(std_size(scalar_types) == TYPE_MAX);
 
 	return scalar_types[p_type];
 }
@@ -5324,7 +5324,7 @@ int ShaderLanguage::get_cardinality(DataType p_type) {
 		1,
 	};
 
-	static_assert(std::size(cardinality_table) == TYPE_MAX);
+	static_assert(std_size(cardinality_table) == TYPE_MAX);
 
 	return cardinality_table[p_type];
 }
@@ -11369,7 +11369,7 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 #ifdef DEBUG_ENABLED
 	// Adds context keywords.
 	if (keyword_completion_context != CF_UNSPECIFIED) {
-		constexpr int sz = std::size(keyword_list);
+		constexpr int sz = std_size(keyword_list);
 		for (int i = 0; i < sz; i++) {
 			if (keyword_list[i].flags == CF_UNSPECIFIED) {
 				break; // Ignore hint keywords (parsed below).

--- a/servers/rendering/shader_warnings.cpp
+++ b/servers/rendering/shader_warnings.cpp
@@ -97,7 +97,7 @@ String ShaderWarning::get_name_from_code(Code p_code) {
 		PNAME("MAGIC_POSITION_WRITE"),
 	};
 
-	static_assert(std::size(names) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");
+	static_assert(std_size(names) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");
 
 	return names[(int)p_code];
 }

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1997,7 +1997,7 @@ TEST_CASE("[String] Is_*") {
 	static bool isflt[] = { true, true, true, false, true, true, false, false, false, false, false, false, false, true, true };
 	static bool isaid[] = { false, false, false, false, false, false, false, false, true, true, false, false, false, false, false };
 	static bool isuid[] = { false, false, false, false, false, false, false, false, true, true, false, false, true, false, false };
-	for (unsigned int i = 0; i < std::size(data); i++) {
+	for (unsigned int i = 0; i < std_size(data); i++) {
 		String s = String::utf8(data[i]);
 		CHECK(s.is_numeric() == isnum[i]);
 		CHECK(s.is_valid_int() == isint[i]);

--- a/tests/core/templates/test_vector.h
+++ b/tests/core/templates/test_vector.h
@@ -220,7 +220,7 @@ TEST_CASE("[Vector] To byte array (variant call)") {
 		PackedInt32Array vector[] = { { 0, -1, 2008 }, {} };
 		PackedByteArray out[] = { { /* 0 */ 0x00, 0x00, 0x00, 0x00, /* -1 */ 0xFF, 0xFF, 0xFF, 0xFF, /* 2008 */ 0xD8, 0x07, 0x00, 0x00 }, {} };
 
-		for (size_t i = 0; i < std::size(vector); i++) {
+		for (size_t i = 0; i < std_size(vector); i++) {
 			Callable::CallError err;
 			Variant v_ret;
 			Variant v_vector = vector[i];
@@ -235,7 +235,7 @@ TEST_CASE("[Vector] To byte array (variant call)") {
 		PackedInt64Array vector[] = { { 0, -1, 2008 }, {} };
 		PackedByteArray out[] = { { /* 0 */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* -1 */ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, /* 2008 */ 0xD8, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, {} };
 
-		for (size_t i = 0; i < std::size(vector); i++) {
+		for (size_t i = 0; i < std_size(vector); i++) {
 			Callable::CallError err;
 			Variant v_ret;
 			Variant v_vector = vector[i];
@@ -250,7 +250,7 @@ TEST_CASE("[Vector] To byte array (variant call)") {
 		PackedFloat32Array vector[] = { { 0.0, -1.0, 200e24 }, {} };
 		PackedByteArray out[] = { { /* 0.0 */ 0x00, 0x00, 0x00, 0x00, /* -1.0 */ 0x00, 0x00, 0x80, 0xBF, /* 200e24 */ 0xA6, 0x6F, 0x25, 0x6B }, {} };
 
-		for (size_t i = 0; i < std::size(vector); i++) {
+		for (size_t i = 0; i < std_size(vector); i++) {
 			Callable::CallError err;
 			Variant v_ret;
 			Variant v_vector = vector[i];
@@ -264,7 +264,7 @@ TEST_CASE("[Vector] To byte array (variant call)") {
 		PackedFloat64Array vector[] = { { 0.0, -1.0, 200e24 }, {} };
 		PackedByteArray out[] = { { /* 0.0 */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* -1.0 */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xBF, /* 200e24 */ 0x35, 0x03, 0x32, 0xB7, 0xF4, 0xAD, 0x64, 0x45 }, {} };
 
-		for (size_t i = 0; i < std::size(vector); i++) {
+		for (size_t i = 0; i < std_size(vector); i++) {
 			Callable::CallError err;
 			Variant v_ret;
 			Variant v_vector = vector[i];
@@ -279,7 +279,7 @@ TEST_CASE("[Vector] To byte array (variant call)") {
 		PackedStringArray vector[] = { { "test", "string" }, {}, { "", "test" } };
 		PackedByteArray out[] = { { /* test */ 0x74, 0x65, 0x73, 0x74, /* null */ 0x00, /* string */ 0x73, 0x74, 0x72, 0x69, 0x6E, 0x67, /* null */ 0x00 }, {}, { /* null */ 0x00, /* test */ 0x74, 0x65, 0x73, 0x74, /* null */ 0x00 } };
 
-		for (size_t i = 0; i < std::size(vector); i++) {
+		for (size_t i = 0; i < std_size(vector); i++) {
 			Callable::CallError err;
 			Variant v_ret;
 			Variant v_vector = vector[i];
@@ -298,7 +298,7 @@ TEST_CASE("[Vector] To byte array (variant call)") {
 		PackedByteArray out[] = { { /* X=0.0 */ 0x00, 0x00, 0x00, 0x00, /* Y=0.0 */ 0x00, 0x00, 0x00, 0x00, /* X=1.0 */ 0x00, 0x00, 0x80, 0x3F, /* Y=-1.0 */ 0x00, 0x00, 0x80, 0xBF }, {} };
 #endif
 
-		for (size_t i = 0; i < std::size(vector); i++) {
+		for (size_t i = 0; i < std_size(vector); i++) {
 			Callable::CallError err;
 			Variant v_ret;
 			Variant v_vector = vector[i];
@@ -317,7 +317,7 @@ TEST_CASE("[Vector] To byte array (variant call)") {
 		PackedByteArray out[] = { { /* X=0.0 */ 0x00, 0x00, 0x00, 0x00, /* Y=0.0 */ 0x00, 0x00, 0x00, 0x00, /* Z=0.0 */ 0x00, 0x00, 0x00, 0x00, /* X=1.0 */ 0x00, 0x00, 0x80, 0x3F, /* Y=1.0 */ 0x00, 0x00, 0x80, 0x3F, /* Z=-1.0 */ 0x00, 0x00, 0x80, 0xBF }, {} };
 #endif
 
-		for (size_t i = 0; i < std::size(vector); i++) {
+		for (size_t i = 0; i < std_size(vector); i++) {
 			Callable::CallError err;
 			Variant v_ret;
 			Variant v_vector = vector[i];
@@ -332,7 +332,7 @@ TEST_CASE("[Vector] To byte array (variant call)") {
 		PackedColorArray vector[] = { { Color(), Color(1, 1, 1) }, {} };
 		PackedByteArray out[] = { { /* R=0.0 */ 0x00, 0x00, 0x00, 0x00, /* G=0.0 */ 0x00, 0x00, 0x00, 0x00, /* B=0.0 */ 0x00, 0x00, 0x00, 0x00, /* A=1.0 */ 0x00, 0x00, 0x80, 0x3F, /* R=1.0 */ 0x00, 0x00, 0x80, 0x3F, /* G=1.0 */ 0x00, 0x00, 0x80, 0x3F, /* B=1.0 */ 0x00, 0x00, 0x80, 0x3F, /* A=1.0 */ 0x00, 0x00, 0x80, 0x3F }, {} };
 
-		for (size_t i = 0; i < std::size(vector); i++) {
+		for (size_t i = 0; i < std_size(vector); i++) {
 			Callable::CallError err;
 			Variant v_ret;
 			Variant v_vector = vector[i];
@@ -351,7 +351,7 @@ TEST_CASE("[Vector] To byte array (variant call)") {
 		PackedByteArray out[] = { { /* X=0.0 */ 0x00, 0x00, 0x00, 0x00, /* Y=0.0 */ 0x00, 0x00, 0x00, 0x00, /* Z=0.0 */ 0x00, 0x00, 0x00, 0x00, /* W 0.0 */ 0x00, 0x00, 0x00, 0x00, /* X 1.0 */ 0x00, 0x00, 0x80, 0x3F, /* Y=-1.0 */ 0x00, 0x00, 0x80, 0xBF, /* Z=1.0 */ 0x00, 0x00, 0x80, 0x3F, /* W=-1.0 */ 0x00, 0x00, 0x80, 0xBF }, {} };
 #endif
 
-		for (size_t i = 0; i < std::size(vector); i++) {
+		for (size_t i = 0; i < std_size(vector); i++) {
 			Callable::CallError err;
 			Variant v_ret;
 			Variant v_vector = vector[i];

--- a/tests/core/test_crypto.h
+++ b/tests/core/test_crypto.h
@@ -59,8 +59,8 @@ PackedByteArray raw_to_pba(const uint8_t *arr, size_t len) {
 TEST_CASE("[Crypto] PackedByteArray constant time compare") {
 	const uint8_t hm1[] = { 144, 140, 176, 38, 88, 113, 101, 45, 71, 105, 10, 91, 248, 16, 117, 244, 189, 30, 238, 29, 219, 134, 82, 130, 212, 114, 161, 166, 188, 169, 200, 106 };
 	const uint8_t hm2[] = { 80, 30, 144, 228, 108, 38, 188, 125, 150, 64, 165, 127, 221, 118, 144, 232, 45, 100, 15, 248, 193, 244, 245, 34, 116, 147, 132, 200, 110, 27, 38, 75 };
-	PackedByteArray p1 = raw_to_pba(hm1, std::size(hm1));
-	PackedByteArray p2 = raw_to_pba(hm2, std::size(hm2));
+	PackedByteArray p1 = raw_to_pba(hm1, std_size(hm1));
+	PackedByteArray p2 = raw_to_pba(hm2, std_size(hm2));
 	_MockCrypto crypto;
 	bool equal = crypto.constant_time_compare(p1, p1);
 	CHECK(equal);

--- a/tests/servers/test_text_server.h
+++ b/tests/servers/test_text_server.h
@@ -497,7 +497,7 @@ TEST_SUITE("[TextServer]") {
 						{ U"test\r test", { 0, 5, 5, 10 } },
 						{ U"test\r test \r test", { 0, 5, 5, 12, 12, 17 } },
 					};
-					for (size_t j = 0; j < std::size(cases); j++) {
+					for (size_t j = 0; j < std_size(cases); j++) {
 						RID ctx = ts->create_shaped_text();
 						CHECK_FALSE_MESSAGE(ctx == RID(), "Creating text buffer failed.");
 						bool ok = ts->shaped_text_add_string(ctx, cases[j].text, font, 16);


### PR DESCRIPTION
- Helps address https://github.com/godotengine/godot/issues/111218

We're using `std::size` in the codebase because it's a useful function that helps avoid using magic numbers.
Unfortunately, there's no easy way to use `std::size` without also including a bunch of other definitions and headers. The 'cheapest' way to include it is considered to be `<iterator>`. But even `<iterator>` makes a lot of declarations, and even nesting includes, on my OS. This probably contributes to it appearing in the includes centrality top 100 (https://github.com/godotengine/godot/issues/111218).

`std::size` should really have been a language feature. But since there's no cheap way to include it, I've re-declared the function as `std_size` (alluding to its normal definition) in `typedefs.h`.