### PR TITLE
CI: Bump SCons version [4.9.0→4.10.0]

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: x64
   scons-version:
     description: The SCons version to use.
-    default: 4.9.0
+    default: 4.10.0
 
 runs:
   using: composite


### PR DESCRIPTION
Newest version released yesterday, so we should make sure our CI works with it