### PR TITLE
`Polygon2DEditor`: Reorganize/fix UI to make it fit in editor at its minimum size

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9086,6 +9086,7 @@ EditorNode::EditorNode() {
 	{
 		Dictionary offsets;
 		offsets["Audio"] = -450;
+		offsets["Polygon"] = -300;
 		default_layout->set_value(EDITOR_NODE_CONFIG_SECTION, "bottom_panel_offsets", offsets);
 	}
 

--- a/editor/scene/2d/polygon_2d_editor_plugin.h
+++ b/editor/scene/2d/polygon_2d_editor_plugin.h
@@ -93,6 +93,11 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	Button *b_snap_grid = nullptr;
 	MenuButton *edit_menu = nullptr;
 
+	HBoxContainer *action_points_hb = nullptr;
+	HBoxContainer *action_transform_hb = nullptr;
+	HBoxContainer *action_polygon_hb = nullptr;
+	HBoxContainer *action_bones_hb = nullptr;
+
 	Control *canvas = nullptr;
 	Panel *canvas_background = nullptr;
 	Polygon2D *preview_polygon = nullptr;


### PR DESCRIPTION
- Addresses https://github.com/godotengine/godot/issues/26835, but only for `Polygon2DEditor`.

- This PR is based on, is a continuation of, and a part of https://github.com/godotengine/godot/pull/102301 (I decided to split changes into several PRs for easier review).

---

**Before:** The editor goes out of screen because `Polygon2DEditor` is too wide and tall. This is especially noticeable on small screens and/or on phones.

https://github.com/user-attachments/assets/584b3460-d2e7-4e9f-a74a-3f935aca504d

**After:** Everything fits just fine.
`Polygon2DEditor` tries to open at the same horizontal size as before this PR. If this fails, then it does not push other controls off the screen.

https://github.com/user-attachments/assets/b7712ad5-7443-44a7-af7b-9fe3459fd65b

