### PR TITLE
Check color backbuffer is initialized when copying screen

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -3461,6 +3461,8 @@ void TextureStorage::render_target_copy_to_back_buffer(RID p_render_target, cons
 
 	if (rt->backbuffer_fbo == 0) {
 		_create_render_target_backbuffer(rt);
+	} else if (rt->backbuffer == 0) {
+		check_backbuffer(rt, true, false);
 	}
 
 	Rect2i region;
@@ -3522,6 +3524,8 @@ void TextureStorage::render_target_gen_back_buffer_mipmaps(RID p_render_target, 
 
 	if (rt->backbuffer_fbo == 0) {
 		_create_render_target_backbuffer(rt);
+	} else if (rt->backbuffer == 0) {
+		check_backbuffer(rt, true, false);
 	}
 
 	Rect2i region;


### PR DESCRIPTION
Before copying the screen, we test if the fbo is initialized but not the colour buffer. It is possible for the scene to initialize only the depth buffer and not the colour buffer causing issues when rendering the canvas so this needs to be tested as well.

This could instead be done once right before rendering the canvas if that makes more sense, but given that we are already setting up the fbo if it isn't initalized I felt that this was better.

Fixes https://github.com/godotengine/godot/issues/97728