### PR TITLE
Fix color text's tooltip not being updated when the intensity is more than 0

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1425,12 +1425,14 @@ void ColorPicker::_update_text_value() {
 		text_type->set_disabled(!is_color_valid_hex(color));
 		hex_label->set_text(ETR("Expr"));
 		c_text->set_text(t);
+		c_text->set_tooltip_text(RTR("Execute an expression as a color."));
 	} else {
 		text_type->set_text("#");
 		text_type->set_button_icon(nullptr);
 		text_type->set_disabled(false);
 		hex_label->set_text(ETR("Hex"));
 		c_text->set_text(color.to_html(edit_alpha && color.a < 1));
+		c_text->set_tooltip_text(ETR("Enter a hex code (\"#ff0000\") or named color (\"red\")."));
 	}
 }
 


### PR DESCRIPTION
Before, the tooltip would **only** change when pressing the "#" button in the editor, but it would never change at runtime or in the editor when changing the intensity.

Before:
<img width="391" height="134" alt="image" src="https://github.com/user-attachments/assets/0704a285-6150-4bbc-839f-ad1295b8a892" />


Now:
<img width="269" height="136" alt="image" src="https://github.com/user-attachments/assets/70e2c8a0-b4ea-4b85-86db-442761fcab3e" />

