### PR TITLE
Add custom tooltip project setting and custom tooltip option to viewport

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1227,6 +1227,14 @@
 		<member name="filesystem/import/fbx2gltf/enabled.web" type="bool" setter="" getter="" default="false">
 			Override for [member filesystem/import/fbx2gltf/enabled] on the Web where FBX2glTF can't easily be accessed from Godot.
 		</member>
+		<member name="gui/common/custom_tooltip_scene" type="String" setter="" getter="" default="&quot;&quot;">
+			Path to the scene that should be used for tooltips. Custom tooltips for specific [Control] nodes can still be set with [method Control._make_custom_tooltip] or for a whole [Viewport] with [method Viewport.set_custom_tooltip].
+			[b]Note:[/b] The root class of the scene provided must be a [Control] or Control-derived node.
+			Tooltip text will be passed to the custom scene by setting the root node's [member Control.tooltip_text] property directly.
+		</member>
+		<member name="gui/common/custom_tooltip_scene.editor_hint" type="String" setter="" getter="" default="&quot;&quot;">
+			Path to the scene that should be used for tooltips in the editor.
+		</member>
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.
 		</member>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -282,6 +282,16 @@
 				Set/clear individual bits on the rendering layer mask. This simplifies editing this [Viewport]'s layers.
 			</description>
 		</method>
+		<method name="set_custom_tooltip">
+			<return type="void" />
+			<param index="0" name="custom_tooltip_scene" type="PackedScene" />
+			<description>
+				Sets a custom tooltip scene to be used for any tooltips if no custom tooltip was already set using [method Control._make_custom_tooltip].
+				[b]Note:[/b] The root class of the scene provided must be a [Control] or Control-derived node.
+				Tooltip text will be passed to the custom scene by setting the root node's [member Control.tooltip_text] property directly.
+				Setting this will override the [member ProjectSettings.gui/common/custom_tooltip_scene] property for this [Viewport].
+			</description>
+		</method>
 		<method name="set_input_as_handled">
 			<return type="void" />
 			<description>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -37,6 +37,8 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/input/input.h"
+#include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/templates/pair.h"
@@ -51,6 +53,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "scene/main/window.h"
 #include "scene/resources/dpi_texture.h"
 #include "scene/resources/mesh.h"
+#include "scene/resources/packed_scene.h"
 #include "scene/resources/text_line.h"
 #include "servers/audio/audio_server.h"
 #include "servers/display/display_server.h"
@@ -1666,6 +1669,20 @@ void Viewport::_gui_show_tooltip_at(const Point2i &p_pos) {
 		return;
 	}
 
+	// If no custom tooltip is set on the control, check if the viewport has one set
+	if (!base_tooltip && gui.custom_tooltip.is_valid()) {
+		Node *scene = gui.custom_tooltip->instantiate();
+		Control *scene_as_control = Object::cast_to<Control>(scene);
+		if (scene_as_control) {
+			base_tooltip = scene_as_control;
+			// Set tooltip text of the root node so we can pass the text into the scene
+			base_tooltip->set_tooltip_text(gui.tooltip_text);
+		} else {
+			ERR_FAIL_EDMSG("Invalid scene for Viewport Custom Tooltip. Root node should extend Control.");
+			scene->queue_free();
+		}
+	}
+
 	// Popup window which houses the tooltip content.
 	PopupPanel *panel = memnew(PopupPanel);
 	panel->set_theme_type_variation(SNAME("TooltipPanel"));
@@ -1744,6 +1761,29 @@ void Viewport::_gui_show_tooltip_at(const Point2i &p_pos) {
 		gui.tooltip_popup->popup(r);
 	}
 	gui.tooltip_popup->child_controls_changed();
+}
+
+void Viewport::set_custom_tooltip(Ref<PackedScene> p_custom_tooltip_scene) {
+	ERR_MAIN_THREAD_GUARD;
+	if (p_custom_tooltip_scene.is_valid()) {
+		// Check if it extends Control
+		Ref<SceneState> scene_state = p_custom_tooltip_scene->get_state();
+		String type;
+		while (scene_state.is_valid() && type.is_empty()) {
+			// Make sure we have a root node. Supposed to be at 0 index because find_node_by_path() does not seem to work.
+			ERR_FAIL_COND(scene_state->get_node_count() < 1);
+
+			type = scene_state->get_node_type(0);
+			scene_state = scene_state->get_base_scene_state();
+		}
+		ERR_FAIL_COND_EDMSG(type.is_empty(), vformat("Invalid PackedScene for Viewport Custom Tooltip: %s. Could not get the type of the root node.", p_custom_tooltip_scene->get_path()));
+		bool extends_correct_class = ClassDB::is_parent_class(type, "Control");
+		ERR_FAIL_COND_EDMSG(!extends_correct_class, vformat("Invalid PackedScene for Viewport Custom Tooltip: %s. Root node should extend Control. Found %s instead.", p_custom_tooltip_scene->get_path(), type));
+
+		gui.custom_tooltip = p_custom_tooltip_scene;
+	} else {
+		gui.custom_tooltip = Ref<PackedScene>();
+	}
 }
 
 void Viewport::_gui_call_input(Control *p_control, const Ref<InputEvent> &p_input) {
@@ -5202,6 +5242,8 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_texture"), &Viewport::get_texture);
 
+	ClassDB::bind_method(D_METHOD("set_custom_tooltip", "custom_tooltip_scene"), &Viewport::set_custom_tooltip);
+
 #if !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
 	ClassDB::bind_method(D_METHOD("set_physics_object_picking", "enable"), &Viewport::set_physics_object_picking);
 	ClassDB::bind_method(D_METHOD("get_physics_object_picking"), &Viewport::get_physics_object_picking);
@@ -5525,6 +5567,11 @@ void Viewport::_bind_methods() {
 	BIND_ENUM_CONSTANT(VRS_UPDATE_ONCE);
 	BIND_ENUM_CONSTANT(VRS_UPDATE_ALWAYS);
 	BIND_ENUM_CONSTANT(VRS_UPDATE_MAX);
+
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "gui/common/custom_tooltip_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res"), "");
+#ifdef TOOLS_ENABLED
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "gui/common/custom_tooltip_scene.editor_hint", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res"), "");
+#endif
 }
 
 void Viewport::_validate_property(PropertyInfo &p_property) const {
@@ -5572,6 +5619,10 @@ Viewport::Viewport() {
 
 	// Window tooltip.
 	gui.tooltip_delay = GLOBAL_GET("gui/timers/tooltip_delay_sec");
+	String custom_tooltip_setting = GLOBAL_GET("gui/common/custom_tooltip_scene");
+	if (!custom_tooltip_setting.is_empty() && FileAccess::exists(custom_tooltip_setting) && ResourceLoader::get_resource_type(custom_tooltip_setting) == "PackedScene") {
+		set_custom_tooltip(ResourceLoader::load(custom_tooltip_setting));
+	}
 
 #ifndef _3D_DISABLED
 	set_scaling_3d_mode((Viewport::Scaling3DMode)(int)GLOBAL_GET("rendering/scaling_3d/mode"));

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/main/node.h"
+#include "scene/resources/packed_scene.h"
 #include "scene/resources/texture.h"
 #include "servers/display/display_server_enums.h"
 #include "servers/rendering/rendering_server_enums.h"
@@ -385,6 +386,7 @@ private:
 		Window *subwindow_over = nullptr; // mouse_over and subwindow_over are mutually exclusive. At all times at least one of them is nullptr.
 		Window *windowmanager_window_over = nullptr; // Only used in root Viewport.
 		Control *drag_mouse_over = nullptr;
+		Ref<PackedScene> custom_tooltip;
 		Control *tooltip_control = nullptr;
 		Window *tooltip_popup = nullptr;
 		Label *tooltip_label = nullptr;
@@ -540,6 +542,7 @@ public:
 
 	void cancel_tooltip();
 	void show_tooltip(Control *p_control);
+	void set_custom_tooltip(Ref<PackedScene> p_custom_tooltip_scene);
 
 	void update_canvas_items();
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Adds the `gui/common/custom_tooltip_scene` ProjectSetting that can be used to define a scene to be used for tooltips project wide. This will more easily permit the use of tooltips, especially in cases where the `Control` node generating tooltips uses a `Window` in some way (such as the `OptionButton`'s popup menu) as in those cases just overridding `_make_custom_tooltip` for the button does not do it.

Whenever a `Viewport` is created, it will set its `gui.custom_tooltip` to the project setting. 

Additionally, `Viewport` now has the `set_custom_tooltip` function to change the tooltips for that `Viewport`. As a note this will not affect any controls like `OptionButton`'s popup menu though, as `Window` has it's own separate viewport, that's why the project setting exists.

This allows the use of custom tooltips with much less friction, removing the need to either make class implementations that override `_make_custom_tooltip` for many nodes (and more serious work for those like `OptionButton` or `Tree`/`ItemList` to handle the internal controls) or the need to apply a script to *every single control* that you want to use your custom tooltip.

Now you can just set a project setting. Or if you have a viewport that should have specific types of tooltips, you can set it for that viewport with one line of code.

As a note the logic in viewport for what tooltip is generated is now:

1) Call `_make_custom_tooltip` on the requesting control
2) If above did not return anything, check if the viewport has one defined in `gui.custom_tooltip` set either to the project setting if it has a value when the viewport was created, or when the user calls `set_custom_tooltip`
3) If the above did not set it, default to the engine provided label.

This means you can still use `_make_custom_tooltip` if you wish, and this PR does not change any existing behaviour.

Closes: https://github.com/godotengine/godot-proposals/issues/13325

# Example:
**Download:**  [custom-tooltip-eval-project.zip](https://github.com/user-attachments/files/22688803/custom-tooltip-eval-project.zip)

<img width="1210" height="457" alt="Screenshot_20251003_155052" src="https://github.com/user-attachments/assets/bddfe21e-fdc3-4108-8bbe-12a3564a8324" />

There is an editor setting override, as without it the editor will also use those custom tooltips which may be undesired. This also means you could set custom editor tooltips easily if you wanted. The current editor tooltips (where used) don't have a saved scene though and are constructed purely in code.


Video:



https://github.com/user-attachments/assets/d7a9fc1f-5a0e-490a-91c6-4b212b88756e


The tooltip with a squid icon is the scene that the `gui/common/custom_tooltip_scene` is set to in this demo project. The scene that the "Set custom tooltip" CheckButton enables is just a RichTextLabel with no icon. The one icon that says "A custom tooltip set" uses a godot logo icon instead of the squid, set using `_make_custom_tooltip` to demonstrate that takes priority.

The "Set custom tooltip" CheckButton, when toggled off, calls `set_custom_tooltip` with null, which reverts back to default engine behavior of providing the base label. The fallback checkbox changes it to use the project setting scene instead. Since the viewport sets it's value to the project setting only when constructed, if you ever override it you would need to handle setting it back to that project setting if you wanted it back to using that.

I have also tested using C# in a separate project, but the provided demo only uses gdscript for ease of review.