### PR TITLE
Joypad: Support raw input, skipping gamepad mapping

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -144,6 +144,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vector", "negative_x", "positive_x", "negative_y", "positive_y", "deadzone"), &Input::get_vector, DEFVAL(-1.0f));
 	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &Input::remove_joy_mapping);
+	ClassDB::bind_method(D_METHOD("set_joy_raw", "device", "raw"), &Input::set_joy_raw);
+	ClassDB::bind_method(D_METHOD("get_joy_raw", "device"), &Input::get_joy_raw);
 	ClassDB::bind_method(D_METHOD("is_joy_known", "device"), &Input::is_joy_known);
 	ClassDB::bind_method(D_METHOD("get_joy_axis", "device", "axis"), &Input::get_joy_axis);
 	ClassDB::bind_method(D_METHOD("get_joy_name", "device"), &Input::get_joy_name);
@@ -1663,7 +1665,8 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 		return;
 	}
 	joy.last_buttons[(size_t)p_button] = p_pressed;
-	if (joy.mapping == -1) {
+
+	if (joy.raw || joy.mapping == -1) {
 		_button_event(p_device, p_button, p_pressed);
 		return;
 	}
@@ -1698,7 +1701,7 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 
 	joy.last_axis[(size_t)p_axis] = p_value;
 
-	if (joy.mapping == -1) {
+	if (joy.raw || joy.mapping == -1) {
 		_axis_event(p_device, p_axis, p_value);
 		return;
 	}
@@ -2246,6 +2249,16 @@ void Input::remove_joy_mapping(const String &p_guid) {
 			}
 		}
 	}
+}
+
+void Input::set_joy_raw(int p_device, bool p_raw) {
+	_THREAD_SAFE_METHOD_
+	joy_names[p_device].raw = p_raw;
+}
+
+bool Input::get_joy_raw(int p_device) const {
+	_THREAD_SAFE_METHOD_
+	return joy_names[p_device].raw;
 }
 
 void Input::_set_joypad_mapping(Joypad &p_js, int p_map_index) {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -217,6 +217,7 @@ private:
 		HatMask last_hat = HatMask::CENTER;
 		int mapping = -1;
 		int hat_current = 0;
+		bool raw = false;
 		Dictionary info;
 		bool has_light = false;
 		bool has_vibration = false;
@@ -460,6 +461,8 @@ public:
 
 	void add_joy_mapping(const String &p_mapping, bool p_update_existing = false);
 	void remove_joy_mapping(const String &p_guid);
+	void set_joy_raw(int p_device, bool p_raw);
+	bool get_joy_raw(int p_device) const;
 
 	int get_unused_joy_id();
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -217,6 +217,14 @@
 				Returns the name of the joypad at the specified device index, e.g. [code]PS4 Controller[/code]. Godot uses the [url=https://github.com/gabomdq/SDL_GameControllerDB]SDL2 game controller database[/url] to determine gamepad names.
 			</description>
 		</method>
+		<method name="get_joy_raw" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<description>
+				Returns whether or not raw input is enabled for this joystick.
+				When enabled, raw input skips gamepad mappings. This is useful, for example, with flight simulation hardware such as flight joysticks, throttles, or rudder pedals.
+			</description>
+		</method>
 		<method name="get_joy_vibration_duration">
 			<return type="float" />
 			<param index="0" name="device" type="int" />
@@ -528,6 +536,15 @@
 			<description>
 				Sets the value of the rotation rate of the gyroscope sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
+			</description>
+		</method>
+		<method name="set_joy_raw">
+			<return type="void" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="raw" type="bool" />
+			<description>
+				Enable or disable raw input for this joystick.
+				When enabled, raw input skips gamepad mappings. This is useful, for example, with flight simulation hardware such as flight joysticks, throttles, or rudder pedals.
 			</description>
 		</method>
 		<method name="set_joy_light">

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -44,9 +44,14 @@
 
 // Macro to skip the SDL joystick event handling if the device is an SDL gamepad, because
 // there are separate events for SDL gamepads
-#define SKIP_EVENT_FOR_GAMEPAD \
-	if (SDL_IsGamepad(sdl_event.jdevice.which)) { \
-		continue; \
+#define SKIP_JOYSTICK_EVENT_WHEN_NOT_RAW                \
+	if (!Input::get_singleton()->get_joy_raw(joy_id)) { \
+		continue;                                       \
+	}
+
+#define SKIP_GAMEPAD_EVENT_WHEN_RAW                    \
+	if (Input::get_singleton()->get_joy_raw(joy_id)) { \
+		continue;                                      \
 	}
 
 JoypadSDL::~JoypadSDL() {
@@ -221,7 +226,7 @@ void JoypadSDL::process_events() {
 					break;
 
 				case SDL_EVENT_JOYSTICK_AXIS_MOTION:
-					SKIP_EVENT_FOR_GAMEPAD;
+					SKIP_JOYSTICK_EVENT_WHEN_NOT_RAW;
 
 					Input::get_singleton()->joy_axis(
 							joy_id,
@@ -231,7 +236,7 @@ void JoypadSDL::process_events() {
 
 				case SDL_EVENT_JOYSTICK_BUTTON_UP:
 				case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
-					SKIP_EVENT_FOR_GAMEPAD;
+					SKIP_JOYSTICK_EVENT_WHEN_NOT_RAW;
 
 					// Some devices report pressing buttons with indices like 232+, 241+, etc. that are not valid,
 					// so we ignore them here.
@@ -246,8 +251,6 @@ void JoypadSDL::process_events() {
 					break;
 
 				case SDL_EVENT_JOYSTICK_HAT_MOTION:
-					SKIP_EVENT_FOR_GAMEPAD;
-
 					Input::get_singleton()->joy_hat(
 							joy_id,
 							(HatMask)sdl_event.jhat.value // Godot hat masks are identical to SDL hat masks, so we can just use them as-is.
@@ -255,6 +258,8 @@ void JoypadSDL::process_events() {
 					break;
 
 				case SDL_EVENT_GAMEPAD_AXIS_MOTION: {
+					SKIP_GAMEPAD_EVENT_WHEN_RAW;
+
 					float axis_value;
 
 					if (sdl_event.gaxis.axis == SDL_GAMEPAD_AXIS_LEFT_TRIGGER || sdl_event.gaxis.axis == SDL_GAMEPAD_AXIS_RIGHT_TRIGGER) {
@@ -275,6 +280,8 @@ void JoypadSDL::process_events() {
 				// Do note SDL gamepads do not have separate events for the dpad
 				case SDL_EVENT_GAMEPAD_BUTTON_UP:
 				case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
+					SKIP_GAMEPAD_EVENT_WHEN_RAW;
+
 					Input::get_singleton()->joy_button(
 							joy_id,
 							static_cast<JoyButton>(sdl_event.gbutton.button), // Godot button constants are intentionally the same as SDL's, so we can just straight up use them


### PR DESCRIPTION
See #111231 for motivation. This may not be implemented in the best way, so I am certainly open to feedback, and I apologize if I'm somehow skipping any steps in the contribution process.

This adds a method `Input.set_joy_raw(device, raw)` which enables/disables "raw input" for a specific joystick device, completely bypassing gamepad mappings and using the axis/button numbers directly taken from SDL. `Input.get_joy_raw(device)` also returns the status of this flag for a given device. The raw input flag is by default set to false, meaning that the existing gamepad mapping behaviour is retained except for code that explicitly opts in.

For non-SDL platforms (Apple/Android/Web), mappings are also skipped and the values taken directly from the platform-specific input layer. I recommend, for this reason, that raw mode only be used if a proper configuration interface is given to users to allow setting up these inputs properly.

- *Bugsquad edit:* This PR should fix https://github.com/godotengine/godot/issues/111231 .