### PR TITLE
Fix warning spam in Compatibility when using depth texture

### DIFF
--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -504,9 +504,9 @@ void RenderSceneBuffersGLES3::check_backbuffer(bool p_need_color, bool p_need_de
 		glBindTexture(texture_target, backbuffer3d.depth);
 
 		if (use_multiview) {
-			glTexImage3D(texture_target, 0, depth_format, internal_size.x, internal_size.y, view_count, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT, nullptr);
+			glTexImage3D(texture_target, 0, depth_format, internal_size.x, internal_size.y, view_count, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
 		} else {
-			glTexImage2D(texture_target, 0, depth_format, internal_size.x, internal_size.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT, nullptr);
+			glTexImage2D(texture_target, 0, depth_format, internal_size.x, internal_size.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
 		}
 
 		glTexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);


### PR DESCRIPTION
Using the depth texture in Compatibility at the same time as 3d scaling causes a warning spam. The depth texture still seems to work though, it must be getting set up again elsewhere.

Whether 3d scaling is on or off changes the code path for setting up the buffers: https://github.com/godotengine/godot/blob/06827c91c6ee98068a48c66be0cc067ebb434a2f/drivers/gles3/rasterizer_scene_gles3.cpp#L2729-L2742 This pr just copies the same ```type``` value found in the other code path when using ```GL_DEPTH_STENCIL```: https://github.com/godotengine/godot/blob/06827c91c6ee98068a48c66be0cc067ebb434a2f/drivers/gles3/storage/texture_storage.cpp#L2589-L2594 Aside from this one value all of the others are already the same, so I am assuming that this was a mistake in the first place.