### PR TITLE
Fix openGL depthbuffer attachment using wrong type

### DIFF
--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -504,9 +504,9 @@ void RenderSceneBuffersGLES3::check_backbuffer(bool p_need_color, bool p_need_de
 		glBindTexture(texture_target, backbuffer3d.depth);
 
 		if (use_multiview) {
-			glTexImage3D(texture_target, 0, depth_format, internal_size.x, internal_size.y, view_count, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT, nullptr);
+			glTexImage3D(texture_target, 0, depth_format, internal_size.x, internal_size.y, view_count, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
 		} else {
-			glTexImage2D(texture_target, 0, depth_format, internal_size.x, internal_size.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT, nullptr);
+			glTexImage2D(texture_target, 0, depth_format, internal_size.x, internal_size.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
 		}
 
 		glTexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);


### PR DESCRIPTION
Fixes a small issue I mentioned in https://github.com/godotengine/godot/issues/97728#issuecomment-3364009779 .

This bug was causing some issues using depth/screen textures together on my hardware; should be safe to fix this param since texture storage sets it up in exactly this way (and seems to be the preferred type to use when using a depth+stencil buffer)

https://github.com/godotengine/godot/blob/1af4472bf20a37a562fa2d995fdd5f96c0047055/drivers/gles3/storage/texture_storage.cpp#L2191-L2195