### PR TITLE
Remove `Array` include from `dictionary.h` and `ustring.h`.

### DIFF
--- a/core/extension/gdextension_special_compat_hashes.h
+++ b/core/extension/gdextension_special_compat_hashes.h
@@ -36,6 +36,8 @@
 #include "core/templates/hash_map.h"
 #include "core/templates/local_vector.h"
 
+class Array;
+
 // Note: In most situations, compatibility methods should be registered via ClassDB::bind_compatibility_method().
 //       This class is only meant to be used in exceptional circumstances, for example, when Godot's hashing
 //       algorithm changes and registering compatibility methods for all affect methods would be onerous.

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -33,6 +33,8 @@
 #include "core/string/string_name.h"
 #include "core/string/ustring.h"
 
+#include <climits>
+
 class [[nodiscard]] NodePath {
 	struct Data {
 		SafeRefCount refcount;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -31,6 +31,7 @@
 #include "ustring.h"
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Dictionary);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Array);
 
 #include "core/crypto/crypto_core.h"
 #include "core/math/color.h"

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -37,7 +37,6 @@
 #include "core/templates/hashfuncs.h"
 #include "core/templates/vector.h"
 #include "core/typedefs.h"
-#include "core/variant/array.h"
 
 class String;
 template <typename T>

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -33,6 +33,7 @@
 #include "core/object/object_id.h"
 #include "core/string/string_name.h"
 
+class Array;
 class Object;
 class Variant;
 class CallableCustom;

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -30,6 +30,8 @@
 
 #include "dictionary.h"
 
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Array);
+
 #include "core/templates/hash_map.h"
 #include "core/templates/safe_refcount.h"
 #include "core/variant/container_type_validate.h"

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -30,15 +30,14 @@
 
 #pragma once
 
-#include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/pair.h"
-#include "core/variant/array.h"
 #include "core/variant/variant_deep_duplicate.h"
 
+class Array;
+class StringName;
 class Variant;
-
 struct ContainerType;
 struct ContainerTypeValidate;
 struct DictionaryPrivate;


### PR DESCRIPTION
- Follow-up of #107587 

Decreases coupling within core by removing `array.h` include from `dictionary.h` and `ustring.h`. 
Most modules will include it anyway, since many are working with `variant.h`, which includes pretty much everything.

Still, this should improve compile time for _some_ modules, and pave the way for the eventual `variant.h` includes refactor.