### PR TITLE
Check that ColorPickerButton popup is currently open in `_modal_closed()`

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2442,12 +2442,14 @@ void ColorPickerButton::_color_changed(const Color &p_color) {
 }
 
 void ColorPickerButton::_modal_closed() {
-	if (Input::get_singleton()->is_action_just_pressed(SNAME("ui_cancel"))) {
-		set_pick_color(picker->get_old_color());
-		emit_signal(SNAME("color_changed"), color);
+	if (picker->is_visible_in_tree()) {
+		if (Input::get_singleton()->is_action_just_pressed(SNAME("ui_cancel"))) {
+			set_pick_color(picker->get_old_color());
+			emit_signal(SNAME("color_changed"), color);
+		}
+		emit_signal(SNAME("popup_closed"));
+		set_pressed(false);
 	}
-	emit_signal(SNAME("popup_closed"));
-	set_pressed(false);
 	if (!get_tree()->get_root()->is_embedding_subwindows()) {
 		get_viewport()->set_disable_input(false);
 	}


### PR DESCRIPTION
Fixes #111245 

This is my first time contributing here so please let me know if I've done something wrong.

Currently the `_modal_closed()` method checks if `ui_cancel` was just pressed so it can revert the color to the old one before closing. This wasn't an issue before as previously this method was only called when the popup was closed, but after #109824 it is also possible for this method to be called when the ```ColorPickerButton``` exits the scene tree, regardless of if the popup was already open; and since `ui_cancel` can deselect the current node from the inspector it is possible for `_modal_closed()` to be called on the same frame as `ui_cancel` without the popup previously being open.

I've fixed this by just adding a check to see if the popup is currently visible in the scene tree, which seems to work from my testing but there might be some edge cases where the popup is hidden before `_modal_closed()` is called, so let me know if there is a more robust solution this. This also fixes another potential issue where the `popup_closed` signal would be called on scene tree exit too, even while it was already closed. 

I have also tested the MRP from the issue that #109824 was fixing and confirmed that it still works.