### PR TITLE
Store `ThemeOwner` owner directly as `Node*`

### DIFF
--- a/scene/theme/theme_owner.h
+++ b/scene/theme/theme_owner.h
@@ -43,8 +43,7 @@ class ThemeOwner : public Object {
 
 	Node *holder = nullptr;
 
-	Control *owner_control = nullptr;
-	Window *owner_window = nullptr;
+	Node *owner_node = nullptr;
 	ThemeContext *owner_context = nullptr;
 
 	void _owner_context_changed();
@@ -57,8 +56,8 @@ public:
 	// Theme owner node.
 
 	void set_owner_node(Node *p_node);
-	Node *get_owner_node() const;
-	bool has_owner_node() const;
+	Node *get_owner_node() const { return owner_node; }
+	bool has_owner_node() const { return owner_node != nullptr; }
 
 	void set_owner_context(ThemeContext *p_context, bool p_propagate = true);
 


### PR DESCRIPTION
At the moment `ThemeOwner` stores its owner node casted to either `Control` or `Window`. Those casted pointers are never really used and all public methods just use `Node *` so we can store the pointer directly without casting.

Main benefit is just to remove some noise from the code. I was looking a bit into the theming system and it took me way to long to realize that those methods and members don't really do anything relevant.