### PR TITLE
Fix RichTextLabel Focus Box

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2788,7 +2788,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 			menu->set_position(get_screen_transform().xform(b->get_position()));
 			menu->reset_size();
 			menu->popup();
-			grab_focus();
+			menu->grab_focus();
 		}
 	}
 


### PR DESCRIPTION
Fix the focus box that should not appear when right-clicking on a RichTextLabel.