### PR TITLE
Add null check when getting motion vector fbo

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2495,7 +2495,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 
 	scene_state.reset_gl_state();
 
-	GLuint motion_vectors_fbo = rt->overridden.velocity_fbo;
+	GLuint motion_vectors_fbo = rt ? rt->overridden.velocity_fbo : 0;
 	if (motion_vectors_fbo != 0 && GLES3::Config::get_singleton()->max_vertex_attribs >= 22) {
 		RENDER_TIMESTAMP("Motion Vectors Pass");
 		glBindFramebuffer(GL_FRAMEBUFFER, motion_vectors_fbo);


### PR DESCRIPTION
A [comment](https://github.com/godotengine/godot/pull/97151#issuecomment-3368418690) brought to my attention that this line of code can throw null pointer exceptions. This appears to be caused by reflection probes, and after this fix I'm not seeing issues with them.