### PR TITLE
Expose ScriptEditor::is_editor_floating() to GDScript

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -83,6 +83,12 @@
 				Goes to the specified line in the current script.
 			</description>
 		</method>
+		<method name="is_editor_floating">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the Script Editor is floating, i.e. the Script Editor is running in a separate window.
+			</description>
+		</method>
 		<method name="open_script_create_dialog">
 			<return type="void" />
 			<param index="0" name="base_name" type="String" />

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -4203,6 +4203,8 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("update_docs_from_script", "script"), &ScriptEditor::update_docs_from_script);
 	ClassDB::bind_method(D_METHOD("clear_docs_from_script", "script"), &ScriptEditor::clear_docs_from_script);
 
+	ClassDB::bind_method(D_METHOD("is_editor_floating"), &ScriptEditor::is_editor_floating);
+
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 }


### PR DESCRIPTION
A very simple PR(my first) to expose the `is_editor_floating()` method to GDScript for use by `EditorPlugin`s. I'm using it for a plugin to add VIM-like behavior to the Script Editor.

This is necessary because when the Script Editor is floating, it will still receive shortcuts from an `EditorPlugin` even if it doesn't have focus. Having access to `is_editor_floating()` allows me to flip the processing logic of the `NOTIFICATION_WM_WINDOW_FOCUS_OUT`/`IN` notifications to reliably handle or not handle shortcuts in the floating Script Editor window since there don't appear to be any dedicated notifications for the floating window itself.