### PR TITLE
Refine ObjectDB Profiler

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -701,6 +701,10 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 
 		// PanelContainer.
 		p_theme->set_stylebox(SceneStringName(panel), "PanelContainer", p_config.panel_container_style);
+		p_theme->set_type_variation("PanelContainerFlat", "PanelContainer");
+		p_theme->set_stylebox(SceneStringName(panel), "PanelContainerFlat", make_flat_stylebox(p_config.dark_color_1));
+		p_theme->set_type_variation("PanelContainerDarkFlat", "PanelContainer");
+		p_theme->set_stylebox(SceneStringName(panel), "PanelContainerDarkFlat", make_flat_stylebox(p_config.dark_color_3));
 
 		// TooltipPanel & TooltipLabel.
 		{

--- a/modules/objectdb_profiler/editor/data_viewers/node_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/node_view.cpp
@@ -43,11 +43,8 @@ SnapshotNodeView::SnapshotNodeView() {
 void SnapshotNodeView::show_snapshot(GameStateSnapshot *p_data, GameStateSnapshot *p_diff_data) {
 	SnapshotView::show_snapshot(p_data, p_diff_data);
 
-	set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-
 	HSplitContainer *diff_sides = memnew(HSplitContainer);
-	diff_sides->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
+	diff_sides->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
 	add_child(diff_sides);
 
 	main_tree = _make_node_tree(diff_data && !combined_diff_view ? TTRC("A Nodes") : TTRC("Nodes"));
@@ -87,12 +84,13 @@ void SnapshotNodeView::show_snapshot(GameStateSnapshot *p_data, GameStateSnapsho
 NodeTreeElements SnapshotNodeView::_make_node_tree(const String &p_tree_name) {
 	NodeTreeElements elements;
 	elements.root = memnew(VBoxContainer);
-	elements.root->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
+	elements.root->set_h_size_flags(SIZE_EXPAND_FILL);
 	elements.tree = memnew(Tree);
+	elements.tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	elements.filter_bar = memnew(TreeSortAndFilterBar(elements.tree, TTRC("Filter Nodes")));
 	elements.root->add_child(elements.filter_bar);
-	elements.tree->set_select_mode(Tree::SelectMode::SELECT_ROW);
-	elements.tree->set_custom_minimum_size(Size2(150, 0) * EDSCALE);
+	elements.tree->set_select_mode(Tree::SELECT_ROW);
+	elements.tree->set_custom_minimum_size(Size2(150 * EDSCALE, 0));
 	elements.tree->set_hide_folding(false);
 	elements.root->add_child(elements.tree);
 	elements.tree->set_hide_root(true);
@@ -104,9 +102,7 @@ NodeTreeElements SnapshotNodeView::_make_node_tree(const String &p_tree_name) {
 	elements.tree->set_column_clip_content(0, false);
 	elements.tree->set_column_custom_minimum_width(0, 150 * EDSCALE);
 	elements.tree->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotNodeView::_node_selected).bind(elements.tree));
-	elements.tree->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	elements.tree->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	elements.tree->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
+	elements.tree->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	elements.tree->create_item();
 

--- a/modules/objectdb_profiler/editor/data_viewers/refcounted_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/refcounted_view.cpp
@@ -45,15 +45,12 @@ void SnapshotRefCountedView::show_snapshot(GameStateSnapshot *p_data, GameStateS
 	item_data_map.clear();
 	data_item_map.clear();
 
-	set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-
 	refs_view = memnew(HSplitContainer);
+	refs_view->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
 	add_child(refs_view);
-	refs_view->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
 
 	VBoxContainer *refs_column = memnew(VBoxContainer);
-	refs_column->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
+	refs_column->set_h_size_flags(SIZE_EXPAND_FILL);
 	refs_view->add_child(refs_column);
 
 	// Tree of Refs.
@@ -63,25 +60,24 @@ void SnapshotRefCountedView::show_snapshot(GameStateSnapshot *p_data, GameStateS
 	refs_column->add_child(filter_bar);
 	int offset = diff_data ? 1 : 0;
 	if (diff_data) {
-		filter_bar->add_sort_option(TTRC("Snapshot"), TreeSortAndFilterBar::SortType::ALPHA_SORT, 0);
+		filter_bar->add_sort_option(TTRC("Snapshot"), TreeSortAndFilterBar::SORT_TYPE_ALPHA, 0);
 	}
-	filter_bar->add_sort_option(TTRC("Class"), TreeSortAndFilterBar::SortType::ALPHA_SORT, offset + 0);
-	filter_bar->add_sort_option(TTRC("Name"), TreeSortAndFilterBar::SortType::ALPHA_SORT, offset + 1);
-	TreeSortAndFilterBar::SortOptionIndexes default_sort = filter_bar->add_sort_option(
-			TTRC("Native Refs"),
-			TreeSortAndFilterBar::SortType::NUMERIC_SORT,
-			offset + 2);
-	filter_bar->add_sort_option(TTRC("ObjectDB Refs"), TreeSortAndFilterBar::SortType::NUMERIC_SORT, offset + 3);
-	filter_bar->add_sort_option(TTRC("Total Refs"), TreeSortAndFilterBar::SortType::NUMERIC_SORT, offset + 4);
-	filter_bar->add_sort_option(TTRC("ObjectDB Cycles"), TreeSortAndFilterBar::SortType::NUMERIC_SORT, offset + 5);
 
-	refs_list->set_select_mode(Tree::SelectMode::SELECT_ROW);
-	refs_list->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
-	refs_list->set_hide_folding(false);
-	refs_column->add_child(refs_list);
+	TreeSortAndFilterBar::SortOptionIndexes default_sort;
+	filter_bar->add_sort_option(TTRC("Class Name"), TreeSortAndFilterBar::SORT_TYPE_ALPHA, offset + 0);
+	filter_bar->add_sort_option(TTRC("Object Name"), TreeSortAndFilterBar::SORT_TYPE_ALPHA, offset + 1);
+	filter_bar->add_sort_option(TTRC("Refs"), TreeSortAndFilterBar::SORT_TYPE_NUMERIC, offset + 2);
+	default_sort = filter_bar->add_sort_option(TTRC("Native Refs"), TreeSortAndFilterBar::SORT_TYPE_NUMERIC, offset + 3);
+	filter_bar->add_sort_option(TTRC("Total Refs"), TreeSortAndFilterBar::SORT_TYPE_NUMERIC, offset + 4);
+	filter_bar->add_sort_option(TTRC("Cycles"), TreeSortAndFilterBar::SORT_TYPE_NUMERIC, offset + 5);
+
+	refs_list->set_select_mode(Tree::SELECT_ROW);
+	refs_list->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+	refs_list->set_hide_folding(true);
 	refs_list->set_hide_root(true);
 	refs_list->set_columns(diff_data ? 7 : 6);
 	refs_list->set_column_titles_visible(true);
+	refs_column->add_child(refs_list);
 
 	if (diff_data) {
 		refs_list->set_column_title(0, TTRC("Snapshot"));
@@ -89,41 +85,43 @@ void SnapshotRefCountedView::show_snapshot(GameStateSnapshot *p_data, GameStateS
 		refs_list->set_column_title_tooltip_text(0, "A: " + snapshot_data->name + ", B: " + diff_data->name);
 	}
 
-	refs_list->set_column_title(offset + 0, TTRC("Class"));
+	refs_list->set_column_title(offset + 0, TTRC("Class Name"));
 	refs_list->set_column_expand(offset + 0, true);
 	refs_list->set_column_title_tooltip_text(offset + 0, TTRC("Object's class"));
 
-	refs_list->set_column_title(offset + 1, TTRC("Name"));
+	refs_list->set_column_title(offset + 1, TTRC("Object Name"));
 	refs_list->set_column_expand(offset + 1, true);
 	refs_list->set_column_expand_ratio(offset + 1, 2);
 	refs_list->set_column_title_tooltip_text(offset + 1, TTRC("Object's name"));
 
-	refs_list->set_column_title(offset + 2, TTRC("Native Refs"));
+	refs_list->set_column_title(offset + 2, TTRC("Refs"));
+	refs_list->set_column_custom_minimum_width(offset + 2, 50 * EDSCALE);
 	refs_list->set_column_expand(offset + 2, false);
-	refs_list->set_column_title_tooltip_text(offset + 2, TTRC("References not owned by the ObjectDB"));
+	refs_list->set_column_title_tooltip_text(offset + 2, TTRC("References owned by the ObjectDB"));
 
-	refs_list->set_column_title(offset + 3, TTRC("ObjectDB Refs"));
+	refs_list->set_column_title(offset + 3, TTRC("Native Refs"));
+	refs_list->set_column_custom_minimum_width(offset + 3, 50 * EDSCALE);
 	refs_list->set_column_expand(offset + 3, false);
-	refs_list->set_column_title_tooltip_text(offset + 3, TTRC("References owned by the ObjectDB"));
+	refs_list->set_column_title_tooltip_text(offset + 3, TTRC("References not owned by the ObjectDB"));
 
 	refs_list->set_column_title(offset + 4, TTRC("Total Refs"));
+	refs_list->set_column_custom_minimum_width(offset + 4, 50 * EDSCALE);
 	refs_list->set_column_expand(offset + 4, false);
 	refs_list->set_column_title_tooltip_text(offset + 4, TTRC("ObjectDB References + Native References"));
 
-	refs_list->set_column_title(offset + 5, TTRC("ObjectDB Cycles"));
+	refs_list->set_column_title(offset + 5, TTRC("Cycles"));
+	refs_list->set_column_custom_minimum_width(offset + 5, 50 * EDSCALE);
 	refs_list->set_column_expand(offset + 5, false);
 	refs_list->set_column_title_tooltip_text(offset + 5, TTRC("Cycles detected in the ObjectDB"));
 
 	refs_list->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotRefCountedView::_refcounted_selected));
-	refs_list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	refs_list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	refs_list->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	// View of the selected refcounted.
 	ref_details = memnew(VBoxContainer);
-	ref_details->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	ref_details->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+	ref_details->set_h_size_flags(SIZE_EXPAND_FILL);
 	refs_view->add_child(ref_details);
-	ref_details->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	ref_details->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 
 	refs_list->create_item();
 	_insert_data(snapshot_data, TTRC("A"));
@@ -171,9 +169,13 @@ void SnapshotRefCountedView::_insert_data(GameStateSnapshot *p_snapshot, const S
 		item->set_text(offset + 1, pair.value->get_name());
 		item->set_auto_translate_mode(offset + 1, AUTO_TRANSLATE_MODE_DISABLED);
 		item->set_text(offset + 2, String::num_uint64(native_refs));
+		item->set_text_alignment(offset + 2, HORIZONTAL_ALIGNMENT_CENTER);
 		item->set_text(offset + 3, String::num_uint64(objectdb_refs));
+		item->set_text_alignment(offset + 3, HORIZONTAL_ALIGNMENT_CENTER);
 		item->set_text(offset + 4, String::num_uint64(total_refs));
+		item->set_text_alignment(offset + 4, HORIZONTAL_ALIGNMENT_CENTER);
 		item->set_text(offset + 5, String::num_uint64(ref_cycles.size())); // Compute cycles and attach it to refcounted object.
+		item->set_text_alignment(offset + 5, HORIZONTAL_ALIGNMENT_CENTER);
 
 		if (total_refs == ref_cycles.size()) {
 			// Often, references are held by the engine so we can't know if we're stuck in a cycle or not
@@ -192,29 +194,23 @@ void SnapshotRefCountedView::_refcounted_selected() {
 	SnapshotDataObject *d = item_data_map[refs_list->get_selected()];
 	EditorNode::get_singleton()->push_item(static_cast<Object *>(d));
 
-	DarkPanelContainer *refcounted_panel = memnew(DarkPanelContainer);
-	VBoxContainer *refcounted_panel_content = memnew(VBoxContainer);
-	refcounted_panel_content->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	refcounted_panel_content->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	PanelContainer *refcounted_panel = memnew(PanelContainer);
+	refcounted_panel->set_theme_type_variation("PanelContainerFlat");
+	refcounted_panel->set_v_size_flags(SIZE_EXPAND_FILL);
 	ref_details->add_child(refcounted_panel);
+	VBoxContainer *refcounted_panel_content = memnew(VBoxContainer);
 	refcounted_panel->add_child(refcounted_panel_content);
 	refcounted_panel_content->add_child(memnew(SpanningHeader(d->get_name())));
 
 	ScrollContainer *properties_scroll = memnew(ScrollContainer);
 	properties_scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
-	properties_scroll->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_AUTO);
-	properties_scroll->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	properties_scroll->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	properties_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
 	refcounted_panel_content->add_child(properties_scroll);
 
 	VBoxContainer *properties_container = memnew(VBoxContainer);
-	properties_container->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	properties_container->set_h_size_flags(SIZE_EXPAND_FILL);
+	properties_container->add_theme_constant_override("separation", 4 * EDSCALE);
 	properties_scroll->add_child(properties_container);
-	properties_container->add_theme_constant_override("separation", 5);
-	properties_container->add_theme_constant_override("margin_left", 2);
-	properties_container->add_theme_constant_override("margin_right", 2);
-	properties_container->add_theme_constant_override("margin_top", 2);
-	properties_container->add_theme_constant_override("margin_bottom", 2);
 
 	int total_refs = d->extra_debug_data.has("ref_count") ? (uint64_t)d->extra_debug_data["ref_count"] : 0;
 	int objectdb_refs = d->get_unique_inbound_references().size();
@@ -241,7 +237,7 @@ void SnapshotRefCountedView::_refcounted_selected() {
 		Tree *inbound_tree = memnew(Tree);
 		inbound_tree->set_hide_folding(true);
 		properties_container->add_child(inbound_tree);
-		inbound_tree->set_select_mode(Tree::SelectMode::SELECT_ROW);
+		inbound_tree->set_select_mode(Tree::SELECT_ROW);
 		inbound_tree->set_hide_root(true);
 		inbound_tree->set_columns(3);
 		inbound_tree->set_column_titles_visible(true);
@@ -256,8 +252,7 @@ void SnapshotRefCountedView::_refcounted_selected() {
 		inbound_tree->set_column_title(2, TTRC("Duplicate?"));
 		inbound_tree->set_column_expand(2, false);
 		inbound_tree->set_column_title_tooltip_text(2, TTRC("Was the same reference returned by multiple getters on the source object?"));
-		inbound_tree->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-		inbound_tree->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+		inbound_tree->set_v_size_flags(SIZE_EXPAND_FILL);
 		inbound_tree->set_v_scroll_enabled(false);
 		inbound_tree->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotRefCountedView::_ref_selected).bind(inbound_tree));
 
@@ -289,22 +284,21 @@ void SnapshotRefCountedView::_refcounted_selected() {
 		properties_container->add_child(memnew(SpanningHeader(TTRC("ObjectDB Cycles"))));
 		Tree *cycles_tree = memnew(Tree);
 		cycles_tree->set_hide_folding(true);
-		properties_container->add_child(cycles_tree);
-		cycles_tree->set_select_mode(Tree::SelectMode::SELECT_ROW);
+		cycles_tree->set_select_mode(Tree::SELECT_ROW);
 		cycles_tree->set_hide_root(true);
 		cycles_tree->set_columns(1);
 		cycles_tree->set_column_titles_visible(false);
 		cycles_tree->set_column_expand(0, true);
 		cycles_tree->set_column_clip_content(0, false);
-		cycles_tree->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-		cycles_tree->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+		cycles_tree->set_v_size_flags(SIZE_EXPAND_FILL);
 		cycles_tree->set_v_scroll_enabled(false);
+		properties_container->add_child(cycles_tree);
 
 		TreeItem *root = cycles_tree->create_item();
 		for (const Variant &cycle : ref_cycles) {
 			TreeItem *i = cycles_tree->create_item(root);
 			i->set_text(0, cycle);
-			i->set_text_overrun_behavior(0, TextServer::OverrunBehavior::OVERRUN_NO_TRIMMING);
+			i->set_text_overrun_behavior(0, TextServer::OVERRUN_NO_TRIMMING);
 		}
 	}
 }

--- a/modules/objectdb_profiler/editor/data_viewers/shared_controls.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/shared_controls.cpp
@@ -36,27 +36,14 @@
 #include "scene/gui/label.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
-#include "scene/resources/style_box_flat.h"
 
 SpanningHeader::SpanningHeader(const String &p_text) {
-	Ref<StyleBoxFlat> title_sbf;
-	title_sbf.instantiate();
-	title_sbf->set_bg_color(EditorNode::get_singleton()->get_editor_theme()->get_color("dark_color_3", "Editor"));
-	add_theme_style_override(SceneStringName(panel), title_sbf);
-	set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	set_theme_type_variation("PanelContainerDarkFlat");
+	set_h_size_flags(SIZE_EXPAND_FILL);
 	Label *title = memnew(Label(p_text));
 	add_child(title);
-	title->set_horizontal_alignment(HorizontalAlignment::HORIZONTAL_ALIGNMENT_CENTER);
-	title->set_vertical_alignment(VerticalAlignment::VERTICAL_ALIGNMENT_CENTER);
-}
-
-DarkPanelContainer::DarkPanelContainer() {
-	set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	Ref<StyleBoxFlat> content_wrapper_sbf;
-	content_wrapper_sbf.instantiate();
-	content_wrapper_sbf->set_bg_color(EditorNode::get_singleton()->get_editor_theme()->get_color("dark_color_2", "Editor"));
-	add_theme_style_override(SceneStringName(panel), content_wrapper_sbf);
+	title->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	title->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 }
 
 void TreeSortAndFilterBar::_apply_filter(TreeItem *p_current_node) {
@@ -127,17 +114,17 @@ void TreeSortAndFilterBar::_apply_sort() {
 			items.push_back(TreeItemColumn(to_sort->get_child(i), sort.column));
 		}
 
-		if (sort.type == ALPHA_SORT && sort.ascending == true) {
+		if (sort.type == SORT_TYPE_ALPHA && sort.ascending == true) {
 			items.sort_custom<TreeItemAlphaComparator>();
 		}
-		if (sort.type == ALPHA_SORT && sort.ascending == false) {
+		if (sort.type == SORT_TYPE_ALPHA && sort.ascending == false) {
 			items.sort_custom<TreeItemAlphaComparator>();
 			items.reverse();
 		}
-		if (sort.type == NUMERIC_SORT && sort.ascending == true) {
+		if (sort.type == SORT_TYPE_NUMERIC && sort.ascending == true) {
 			items.sort_custom<TreeItemNumericComparator>();
 		}
-		if (sort.type == NUMERIC_SORT && sort.ascending == false) {
+		if (sort.type == SORT_TYPE_NUMERIC && sort.ascending == false) {
 			items.sort_custom<TreeItemNumericComparator>();
 			items.reverse();
 		}
@@ -166,11 +153,11 @@ void TreeSortAndFilterBar::_filter_changed(const String &p_filter) {
 
 TreeSortAndFilterBar::TreeSortAndFilterBar(Tree *p_managed_tree, const String &p_filter_placeholder_text) :
 		managed_tree(p_managed_tree) {
-	set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	set_h_size_flags(SIZE_EXPAND_FILL);
 	add_theme_constant_override("h_separation", 10 * EDSCALE);
 	filter_edit = memnew(LineEdit);
 	filter_edit->set_clear_button_enabled(true);
-	filter_edit->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	filter_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter_edit->set_placeholder(p_filter_placeholder_text);
 	add_child(filter_edit);
 	filter_edit->connect(SceneStringName(text_changed), callable_mp(this, &TreeSortAndFilterBar::_filter_changed));

--- a/modules/objectdb_profiler/editor/data_viewers/shared_controls.h
+++ b/modules/objectdb_profiler/editor/data_viewers/shared_controls.h
@@ -44,13 +44,6 @@ public:
 	SpanningHeader(const String &p_text);
 };
 
-class DarkPanelContainer : public PanelContainer {
-	GDCLASS(DarkPanelContainer, PanelContainer);
-
-public:
-	DarkPanelContainer();
-};
-
 // Utility class that creates a filter text box and a sort menu.
 // Takes a reference to a tree and applies the sort and filter to the tree.
 class TreeSortAndFilterBar : public HBoxContainer {
@@ -59,8 +52,8 @@ class TreeSortAndFilterBar : public HBoxContainer {
 public:
 	// The ways a column can be sorted, either alphabetically or numerically.
 	enum SortType {
-		NUMERIC_SORT = 0,
-		ALPHA_SORT,
+		SORT_TYPE_NUMERIC,
+		SORT_TYPE_ALPHA,
 		SORT_TYPE_MAX
 	};
 
@@ -80,7 +73,7 @@ protected:
 				id(p_id), label(p_label), type(p_type), ascending(p_ascending), column(p_column) {}
 		int id = 0;
 		String label;
-		SortType type = SortType::NUMERIC_SORT;
+		SortType type = SORT_TYPE_NUMERIC;
 		bool ascending = false;
 		int column = 0;
 	};

--- a/modules/objectdb_profiler/editor/data_viewers/summary_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/summary_view.cpp
@@ -36,71 +36,51 @@
 #include "scene/gui/label.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/rich_text_label.h"
-#include "scene/resources/style_box_flat.h"
 
 SnapshotSummaryView::SnapshotSummaryView() {
 	set_name(TTRC("Summary"));
 
-	set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-
-	MarginContainer *mc = memnew(MarginContainer);
-	mc->add_theme_constant_override("margin_left", 5);
-	mc->add_theme_constant_override("margin_right", 5);
-	mc->add_theme_constant_override("margin_top", 5);
-	mc->add_theme_constant_override("margin_bottom", 5);
-	mc->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
+	MarginContainer *margin = memnew(MarginContainer);
+	margin->add_theme_constant_override("margin_left", 5);
+	margin->add_theme_constant_override("margin_right", 5);
+	margin->add_theme_constant_override("margin_top", 5);
+	margin->add_theme_constant_override("margin_bottom", 5);
 	PanelContainer *content_wrapper = memnew(PanelContainer);
-	content_wrapper->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
-	Ref<StyleBoxFlat> content_wrapper_sbf;
-	content_wrapper_sbf.instantiate();
-	content_wrapper_sbf->set_bg_color(EditorNode::get_singleton()->get_editor_theme()->get_color("dark_color_2", "Editor"));
-	content_wrapper->add_theme_style_override(SceneStringName(panel), content_wrapper_sbf);
-	content_wrapper->add_child(mc);
-	add_child(content_wrapper);
+	content_wrapper->set_theme_type_variation("PanelContainerDarkFlat");
+	content_wrapper->add_child(margin);
 
 	VBoxContainer *content = memnew(VBoxContainer);
-	mc->add_child(content);
-	content->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
+	margin->add_child(content);
+	content_wrapper->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	add_child(content_wrapper);
 
-	PanelContainer *pc = memnew(PanelContainer);
-	Ref<StyleBoxFlat> sbf;
-	sbf.instantiate();
-	sbf->set_bg_color(EditorNode::get_singleton()->get_editor_theme()->get_color("dark_color_3", "Editor"));
-	pc->add_theme_style_override("panel", sbf);
-	content->add_child(pc);
-	pc->set_anchors_preset(LayoutPreset::PRESET_TOP_WIDE);
+	PanelContainer *panel = memnew(PanelContainer);
+	panel->set_theme_type_variation("PanelContainerDarkFlat");
+	content->add_child(panel);
 	Label *title = memnew(Label(TTRC("ObjectDB Snapshot Summary")));
-	pc->add_child(title);
-	title->set_horizontal_alignment(HorizontalAlignment::HORIZONTAL_ALIGNMENT_CENTER);
-	title->set_vertical_alignment(VerticalAlignment::VERTICAL_ALIGNMENT_CENTER);
+	panel->add_child(title);
+	title->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	title->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 
 	explainer_text = memnew(CenterContainer);
-	explainer_text->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	explainer_text->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	explainer_text->set_v_size_flags(SIZE_EXPAND_FILL);
 	content->add_child(explainer_text);
 	VBoxContainer *explainer_lines = memnew(VBoxContainer);
 	explainer_text->add_child(explainer_lines);
-	Label *l1 = memnew(Label(TTRC("Press 'Take ObjectDB Snapshot' to snapshot the ObjectDB.")));
-	Label *l2 = memnew(Label(TTRC("Memory in Godot is either owned natively by the engine or owned by the ObjectDB.")));
-	Label *l3 = memnew(Label(TTRC("ObjectDB Snapshots capture only memory owned by the ObjectDB.")));
-	l1->set_horizontal_alignment(HorizontalAlignment::HORIZONTAL_ALIGNMENT_CENTER);
-	l2->set_horizontal_alignment(HorizontalAlignment::HORIZONTAL_ALIGNMENT_CENTER);
-	l3->set_horizontal_alignment(HorizontalAlignment::HORIZONTAL_ALIGNMENT_CENTER);
-	explainer_lines->add_child(l1);
-	explainer_lines->add_child(l2);
-	explainer_lines->add_child(l3);
+	Label *label = memnew(Label());
+	label->set_text(TTRC("Press 'Take ObjectDB Snapshot' to snapshot the ObjectDB.\n\nMemory in Godot is either owned natively by the engine or owned by the ObjectDB.\n\nObjectDB Snapshots capture only memory owned by the ObjectDB."));
+	label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	explainer_lines->add_child(label);
 
-	ScrollContainer *sc = memnew(ScrollContainer);
-	sc->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
-	sc->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	sc->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	content->add_child(sc);
+	ScrollContainer *scroll = memnew(ScrollContainer);
+	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	content->add_child(scroll);
 
 	blurb_list = memnew(VBoxContainer);
-	sc->add_child(blurb_list);
-	blurb_list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
-	blurb_list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	scroll->add_child(blurb_list);
+	blurb_list->set_v_size_flags(SIZE_EXPAND_FILL);
+	blurb_list->set_h_size_flags(SIZE_EXPAND_FILL);
 }
 
 void SnapshotSummaryView::show_snapshot(GameStateSnapshot *p_data, GameStateSnapshot *p_diff_data) {
@@ -142,14 +122,14 @@ void SnapshotSummaryView::clear_snapshot() {
 }
 
 SummaryBlurb::SummaryBlurb(const String &p_title, const String &p_rtl_content) {
-	add_theme_constant_override("margin_left", 2);
-	add_theme_constant_override("margin_right", 2);
-	add_theme_constant_override("margin_top", 2);
-	add_theme_constant_override("margin_bottom", 2);
+	add_theme_constant_override("margin_left", 2 * EDSCALE);
+	add_theme_constant_override("margin_right", 2 * EDSCALE);
+	add_theme_constant_override("margin_top", 2 * EDSCALE);
+	add_theme_constant_override("margin_bottom", 2 * EDSCALE);
 
 	label = memnew(RichTextLabel);
 	label->add_theme_constant_override(SceneStringName(line_separation), 6);
-	label->set_text_direction(Control::TEXT_DIRECTION_INHERITED);
+	label->set_text_direction(TEXT_DIRECTION_INHERITED);
 	label->set_fit_content(true);
 	label->set_use_bbcode(true);
 	label->add_newline();

--- a/modules/objectdb_profiler/editor/objectdb_profiler_panel.h
+++ b/modules/objectdb_profiler/editor/objectdb_profiler_panel.h
@@ -46,10 +46,10 @@ class ObjectDBProfilerPanel : public Control {
 protected:
 	static constexpr int SNAPSHOT_CACHE_MAX_SIZE = 10;
 
-	enum OdbProfilerMenuOptions {
-		ODB_MENU_RENAME,
-		ODB_MENU_SHOW_IN_FOLDER,
-		ODB_MENU_DELETE,
+	enum MenuOptions {
+		OPTION_RENAME,
+		OPTION_SHOW_IN_FOLDER,
+		OPTION_DELETE,
 	};
 
 	struct PartialSnapshot {

--- a/modules/objectdb_profiler/editor/objectdb_profiler_plugin.cpp
+++ b/modules/objectdb_profiler/editor/objectdb_profiler_plugin.cpp
@@ -56,10 +56,10 @@ ObjectDBProfilerPlugin::ObjectDBProfilerPlugin() {
 
 void ObjectDBProfilerPlugin::_notification(int p_what) {
 	switch (p_what) {
-		case Node::NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_ENTER_TREE: {
 			add_debugger_plugin(debugger);
 		} break;
-		case Node::NOTIFICATION_EXIT_TREE: {
+		case NOTIFICATION_EXIT_TREE: {
 			remove_debugger_plugin(debugger);
 		}
 	}

--- a/modules/objectdb_profiler/editor/snapshot_data.cpp
+++ b/modules/objectdb_profiler/editor/snapshot_data.cpp
@@ -212,8 +212,8 @@ HashSet<ObjectID> SnapshotDataObject::get_unique_inbound_references() {
 void GameStateSnapshot::_get_outbound_references(Variant &p_var, HashMap<String, ObjectID> &r_ret_val, const String &p_current_path) {
 	String path_divider = p_current_path.size() > 0 ? "/" : ""; // Make sure we don't start with a /.
 	switch (p_var.get_type()) {
-		case Variant::Type::INT:
-		case Variant::Type::OBJECT: { // Means ObjectID.
+		case Variant::INT:
+		case Variant::OBJECT: { // Means ObjectID.
 			ObjectID as_id = ObjectID((uint64_t)p_var);
 			if (!objects.has(as_id)) {
 				return;
@@ -221,7 +221,7 @@ void GameStateSnapshot::_get_outbound_references(Variant &p_var, HashMap<String,
 			r_ret_val[p_current_path] = as_id;
 			break;
 		}
-		case Variant::Type::DICTIONARY: {
+		case Variant::DICTIONARY: {
 			Dictionary dict = (Dictionary)p_var;
 			LocalVector<Variant> keys = dict.get_key_list();
 			for (Variant &k : keys) {
@@ -232,7 +232,7 @@ void GameStateSnapshot::_get_outbound_references(Variant &p_var, HashMap<String,
 			}
 			break;
 		}
-		case Variant::Type::ARRAY: {
+		case Variant::ARRAY: {
 			Array arr = (Array)p_var;
 			int i = 0;
 			for (Variant &v : arr) {


### PR DESCRIPTION
Changes:
- Remove unused code.
- Follow Godot c++ style.
- Fix few visual issues.
- Editor: Add `PanelContainerFlat` and `PanelContainerDarkFlat` theme type variation instead of creating a new `DarkPanelContainer` class to change `PanelContainer` default transparent style.
- <s>Fix Tree column tooltip crash from using columns[i -1] when column i == 0 (ie. columns are empty).</s> Should be fixed by https://github.com/godotengine/godot/pull/111292.

Also Tried to give some space for names and reduce the snapshots left panel width.

Before:
<img width="1077" height="606" alt="Screenshot From 2025-10-05 05-59-15" src="https://github.com/user-attachments/assets/6f6bc658-57a4-4c46-9bed-0ed4b7cec8c6" />

After:
<img width="1077" height="606" alt="Screenshot From 2025-10-05 06-11-06" src="https://github.com/user-attachments/assets/cefb99c5-c664-45f7-b555-790127c3bb81" />

