### PR TITLE
Remove `timer.h` include from `control.h`.

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -45,6 +45,7 @@
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/gui/separator.h"
+#include "scene/main/timer.h"
 #include "scene/resources/font.h"
 #include "servers/audio/audio_server.h"
 

--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -47,6 +47,7 @@
 
 class EditorAudioBuses;
 class EditorFileDialog;
+class Timer;
 
 class EditorAudioBus : public PanelContainer {
 	GDCLASS(EditorAudioBus, PanelContainer);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -42,6 +42,7 @@
 #include "editor/themes/editor_scale.h"
 #include "modules/regex/regex.h"
 #include "scene/gui/separator.h"
+#include "scene/main/timer.h"
 #include "scene/resources/font.h"
 
 void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type) {

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -36,6 +36,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/rich_text_label.h"
 
+class Timer;
 class UndoRedo;
 
 class EditorLog : public HBoxContainer {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -61,6 +61,7 @@
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/tab_container.h"
+#include "scene/main/timer.h"
 #include "scene/main/window.h"
 #include "scene/property_utils.h"
 #include "scene/resources/image_texture.h"

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -55,6 +55,7 @@ class PanelContainer;
 class RichTextLabel;
 class SubViewport;
 class TextureProgressBar;
+class Timer;
 class Translation;
 class Tree;
 class VBoxContainer;

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "editor/settings/editor_settings.h"
+#include "scene/main/timer.h"
 
 EditorExport *EditorExport::singleton = nullptr;
 

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -42,6 +42,7 @@
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/gui/subviewport_container.h"
+#include "scene/main/timer.h"
 #include "scene/resources/3d/importer_mesh.h"
 #include "scene/resources/surface_tool.h"
 

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -49,6 +49,7 @@
 class EditorFileDialog;
 class EditorInspector;
 class SceneImportSettingsData;
+class Timer;
 
 class SceneImportSettingsDialog : public ConfirmationDialog {
 	GDCLASS(SceneImportSettingsDialog, ConfirmationDialog)

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -53,6 +53,7 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/texture_rect.h"
+#include "scene/main/timer.h"
 #include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
 #include "scene/resources/style_box_flat.h"

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -50,6 +50,7 @@ class PopupMenu;
 class SpinBox;
 class StyleBoxFlat;
 class TextureRect;
+class Timer;
 
 class EditorPropertyRevert {
 public:

--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "editor/editor_string_names.h"
+#include "scene/main/timer.h"
 #include "scene/main/window.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/theme/theme_db.h"

--- a/editor/run/embedded_process.h
+++ b/editor/run/embedded_process.h
@@ -33,6 +33,7 @@
 #include "scene/gui/control.h"
 
 class ScriptEditorDebugger;
+class Timer;
 
 class EmbeddedProcessBase : public Control {
 	GDCLASS(EmbeddedProcessBase, Control);

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
@@ -37,6 +37,7 @@
 #include "scene/3d/physics/joints/hinge_joint_3d.h"
 #include "scene/3d/physics/joints/pin_joint_3d.h"
 #include "scene/3d/physics/joints/slider_joint_3d.h"
+#include "scene/main/timer.h"
 
 #define BODY_A_RADIUS 0.25
 #define BODY_B_RADIUS 0.27

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
@@ -32,6 +32,8 @@
 
 #include "editor/scene/3d/node_3d_editor_gizmos.h"
 
+class Timer;
+
 class Joint3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(Joint3DGizmoPlugin, EditorNode3DGizmoPlugin);
 

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -37,6 +37,7 @@
 #include "scene/gui/check_box.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/line_edit.h"
+#include "scene/main/timer.h"
 
 void EditorNetworkProfiler::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));

--- a/modules/multiplayer/editor/editor_network_profiler.h
+++ b/modules/multiplayer/editor/editor_network_profiler.h
@@ -39,6 +39,8 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
 
+class Timer;
+
 class EditorNetworkProfiler : public VBoxContainer {
 	GDCLASS(EditorNetworkProfiler, VBoxContainer)
 

--- a/modules/navigation_2d/editor/navigation_region_2d_editor_plugin.cpp
+++ b/modules/navigation_2d/editor/navigation_region_2d_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/settings/editor_settings.h"
 #include "scene/2d/navigation/navigation_region_2d.h"
 #include "scene/gui/dialogs.h"
+#include "scene/main/timer.h"
 
 Ref<NavigationPolygon> NavigationRegion2DEditor::_ensure_navpoly() const {
 	Ref<NavigationPolygon> navpoly = node->get_navigation_polygon();

--- a/modules/navigation_2d/editor/navigation_region_2d_editor_plugin.h
+++ b/modules/navigation_2d/editor/navigation_region_2d_editor_plugin.h
@@ -37,6 +37,7 @@ class AcceptDialog;
 class HBoxContainer;
 class NavigationPolygon;
 class NavigationRegion2D;
+class Timer;
 
 class NavigationRegion2DEditor : public AbstractPolygon2DEditor {
 	friend class NavigationRegion2DEditorPlugin;

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "scene/gui/label.h"
+#include "scene/main/timer.h"
 #include "scene/main/window.h"
 
 void BaseButton::_unpress_group() {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -34,6 +34,7 @@
 #include "scene/gui/control.h"
 
 class ButtonGroup;
+class Timer;
 
 class BaseButton : public Control {
 	GDCLASS(BaseButton, Control);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -33,7 +33,6 @@
 #include "core/math/transform_2d.h"
 #include "core/object/gdvirtual.gen.inc"
 #include "scene/main/canvas_item.h"
-#include "scene/main/timer.h"
 #include "scene/resources/theme.h"
 
 class Viewport;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -37,6 +37,7 @@
 #include "core/os/os.h"
 #include "scene/gui/menu_bar.h"
 #include "scene/gui/panel_container.h"
+#include "scene/main/timer.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/theme/theme_db.h"
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -37,6 +37,7 @@
 #include "scene/resources/text_line.h"
 
 class PanelContainer;
+class Timer;
 
 class PopupMenu : public Popup {
 	GDCLASS(PopupMenu, Popup);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -37,6 +37,7 @@
 #include "core/os/os.h"
 #include "scene/gui/label.h"
 #include "scene/gui/rich_text_effect.h"
+#include "scene/main/timer.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/display_server.h"

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -42,6 +42,7 @@
 #include "scene/gui/scroll_bar.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/text_edit.h"
+#include "scene/main/timer.h"
 #include "scene/main/window.h"
 #include "scene/theme/theme_db.h"
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -40,6 +40,7 @@ class LineEdit;
 class Popup;
 class PopupMenu;
 class TextEdit;
+class Timer;
 class Tree;
 class VScrollBar;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Addresses https://github.com/godotengine/godot/issues/111218

An unexpected one: nowhere in `Control` is the `Timer` class used, even though only a handful of all Control subclasses actually uses Timers internally.