### PR TITLE
Remove `paged_allocator.h` include from `message_queue.h`.

### DIFF
--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -31,6 +31,7 @@
 #include "message_queue.h"
 
 #include "core/config/project_settings.h"
+#include "core/templates/paged_allocator.h" // IWYU pragma: keep. PagedAllocator is aliased as CallQueue::Allocator.
 
 #include <cstdio>
 
@@ -55,6 +56,14 @@
 	if (this != MessageQueue::thread_singleton) { \
 		mutex.unlock(); \
 	}
+
+_FORCE_INLINE_ void CallQueue::_ensure_first_page() {
+	if (unlikely(pages.is_empty())) {
+		pages.push_back(allocator->alloc());
+		page_bytes.push_back(0);
+		pages_used = 1;
+	}
+}
 
 void CallQueue::_add_page() {
 	if (pages_used == page_bytes.size()) {

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -33,10 +33,11 @@
 #include "core/object/object_id.h"
 #include "core/os/mutex.h"
 #include "core/templates/local_vector.h"
-#include "core/templates/paged_allocator.h"
 #include "core/variant/variant.h"
 
 class Object;
+template <typename T, bool, uint32_t>
+class PagedAllocator;
 
 class CallQueue {
 	friend class MessageQueue;
@@ -52,7 +53,7 @@ public:
 
 	// Needs to be public to be able to define it outside the class.
 	// Needs to lock because there can be multiple of these allocators in several threads.
-	typedef PagedAllocator<Page, true> Allocator;
+	typedef PagedAllocator<Page, true, PAGE_SIZE_BYTES> Allocator;
 
 private:
 	enum {
@@ -89,13 +90,7 @@ private:
 		};
 	};
 
-	_FORCE_INLINE_ void _ensure_first_page() {
-		if (unlikely(pages.is_empty())) {
-			pages.push_back(allocator->alloc());
-			page_bytes.push_back(0);
-			pages_used = 1;
-		}
-	}
+	void _ensure_first_page();
 
 	void _add_page();
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -42,6 +42,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
 #include "core/profiling/profiling.h"
+#include "core/templates/paged_allocator.h" // IWYU pragma: keep. PagedAllocator is aliased as CallQueue::Allocator.
 #include "scene/animation/tween.h"
 #include "scene/debugger/scene_debugger.h"
 #include "scene/gui/control.h"


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Addresses https://github.com/godotengine/godot/issues/111218

`CallQueue::Allocator` is only accessed via a pointer, so it is possible to convert it into a forward declaration. The inline function `CallQueue::_ensure_first_page()`'s definition (which allocates from the Allocator) is moved to `message_queue.cpp` as it is a private function that is only ever called there anyway. (Which means there's no issue of duplicate definition that comes with forward-declaring inline functions)

EDIT: `paged_allocator.h` is also removed from `variant.h` by isolating the Variant pools into a separate compilation unit.