### PR TITLE
Remove `file_access.h` and `script_backtrace.h` includes from `logger.h`.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -35,6 +35,7 @@
 #include "core/crypto/crypto_core.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
+#include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/geometry_3d.h"

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -31,6 +31,7 @@
 #include "json.h"
 
 #include "core/config/engine.h"
+#include "core/io/file_access.h"
 #include "core/object/script_language.h"
 #include "core/variant/container_type_validate.h"
 

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -32,6 +32,8 @@
 
 #include "core/core_globals.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/object/script_backtrace.h"
 #include "core/os/time.h"
 #include "core/templates/rb_set.h"
 

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -30,14 +30,15 @@
 
 #pragma once
 
-#include "core/io/file_access.h"
-#include "core/object/script_backtrace.h"
+#include "core/object/ref_counted.h"
 #include "core/string/ustring.h"
 #include "core/templates/vector.h"
 
 #include <cstdarg>
 
+class FileAccess;
 class RegEx;
+class ScriptBacktrace;
 
 class Logger {
 protected:

--- a/drivers/accesskit/accessibility_driver_accesskit.cpp
+++ b/drivers/accesskit/accessibility_driver_accesskit.cpp
@@ -33,6 +33,7 @@
 #include "accessibility_driver_accesskit.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/file_access.h"
 #include "core/version.h"
 
 #include "servers/text/text_server.h"

--- a/drivers/apple/os_log_logger.cpp
+++ b/drivers/apple/os_log_logger.cpp
@@ -30,6 +30,7 @@
 
 #include "os_log_logger.h"
 
+#include "core/object/script_backtrace.h"
 #include "core/string/print_string.h"
 
 #include <cstdlib> // For malloc/free

--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -32,6 +32,7 @@
 
 #include "core/crypto/crypto_core.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "drivers/gles3/rasterizer_gles3.h"
 
 #ifdef EGL_ENABLED

--- a/drivers/metal/rendering_shader_container_metal.mm
+++ b/drivers/metal/rendering_shader_container_metal.mm
@@ -32,6 +32,7 @@
 
 #import "metal_utils.h"
 
+#import "core/io/file_access.h"
 #import "core/io/marshalls.h"
 #import "servers/rendering/rendering_device.h"
 

--- a/editor/file_system/editor_paths.cpp
+++ b/editor/file_system/editor_paths.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/os/os.h"
 #include "main/main.h"
 

--- a/modules/jpg/movie_writer_mjpeg.cpp
+++ b/modules/jpg/movie_writer_mjpeg.cpp
@@ -30,6 +30,7 @@
 
 #include "movie_writer_mjpeg.h"
 #include "core/config/project_settings.h"
+#include "core/io/file_access.h"
 
 uint32_t MovieWriterMJPEG::get_audio_mix_rate() const {
 	return mix_rate;

--- a/modules/mbedtls/tests/test_crypto_mbedtls.cpp
+++ b/modules/mbedtls/tests/test_crypto_mbedtls.cpp
@@ -32,6 +32,7 @@
 
 #include "../crypto_mbedtls.h"
 
+#include "core/io/file_access.h"
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -33,6 +33,7 @@
 #define MINIMP3_NO_STDIO
 
 #include "audio_stream_mp3.h"
+#include "core/io/file_access.h"
 
 int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	if (!active) {

--- a/modules/objectdb_profiler/editor/snapshot_data.cpp
+++ b/modules/objectdb_profiler/editor/snapshot_data.cpp
@@ -31,6 +31,7 @@
 #include "snapshot_data.h"
 
 #include "core/core_bind.h"
+#include "core/io/compression.h"
 #include "core/object/script_language.h"
 #include "scene/debugger/scene_debugger.h"
 

--- a/modules/objectdb_profiler/snapshot_collector.cpp
+++ b/modules/objectdb_profiler/snapshot_collector.cpp
@@ -32,6 +32,7 @@
 
 #include "core/core_bind.h"
 #include "core/debugger/engine_debugger.h"
+#include "core/io/compression.h"
 #include "core/os/time.h"
 #include "core/version.h"
 #include "scene/main/node.h"

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -49,6 +49,7 @@ using namespace godot;
 
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
+#include "core/io/file_access.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/string/translation_server.h"
 #include "scene/resources/image_texture.h"

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -51,6 +51,7 @@ using namespace godot;
 
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
+#include "core/io/file_access.h"
 #include "core/string/print_string.h"
 #include "core/string/translation_server.h"
 

--- a/modules/theora/editor/movie_writer_ogv.cpp
+++ b/modules/theora/editor/movie_writer_ogv.cpp
@@ -31,6 +31,7 @@
 #include "movie_writer_ogv.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/file_access.h"
 #include "rgb2yuv.h"
 
 void MovieWriterOGV::push_audio(const int32_t *p_audio_data) {

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "audio_stream_ogg_vorbis.h"
+#include "core/io/file_access.h"
 
 #include <ogg/ogg.h>
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/certs_compressed.gen.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #ifdef SDL_ENABLED
 #include "drivers/sdl/joypad_sdl.h"
 #endif

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -46,6 +46,7 @@
 #endif
 
 #ifdef GLES3_ENABLED
+#include "core/io/file_access.h"
 #include "detect_prime_egl.h"
 #include "drivers/gles3/rasterizer_gles3.h"
 #include "wayland/egl_manager_wayland.h"

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -36,6 +36,7 @@
 #include "x11/key_mapping_x11.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/file_access.h"
 #include "core/math/math_funcs.h"
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -45,6 +45,7 @@
 #import "os_macos.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/os/keyboard.h"

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -39,6 +39,7 @@
 #import "godot_application_delegate.h"
 
 #include "core/crypto/crypto_core.h"
+#include "core/io/file_access.h"
 #include "core/version_generated.gen.h"
 #include "drivers/apple/os_log_logger.h"
 #include "main/main.h"

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -38,6 +38,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
+#include "core/io/file_access.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #include "main/main.h"

--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -33,6 +33,7 @@
 #include "os_web.h"
 
 #include "core/config/engine.h"
+#include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "main/main.h"
 #include "scene/main/scene_tree.h"

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -36,6 +36,7 @@
 #include "wgl_detect_version.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/io/xml_parser.h"
 #include "core/version.h"

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -30,6 +30,7 @@
 
 #include "windows_terminal_logger.h"
 
+#include "core/object/script_backtrace.h"
 #include "core/os/os.h"
 
 #ifdef WINDOWS_ENABLED

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/os/keyboard.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -30,6 +30,7 @@
 
 #include "http_request.h"
 
+#include "core/io/file_access.h"
 #include "scene/main/timer.h"
 
 Error HTTPRequest::_request() {

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -30,6 +30,7 @@
 
 #include "compressed_texture.h"
 
+#include "core/io/file_access.h"
 #include "scene/resources/bit_map.h"
 
 Error CompressedTexture2D::_load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit) {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -31,6 +31,7 @@
 #include "packed_scene.h"
 
 #include "core/config/engine.h"
+#include "core/io/file_access.h"
 #include "core/io/missing_resource.h"
 #include "core/io/resource_loader.h"
 #include "core/templates/local_vector.h"

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_include.h"
 
+#include "core/io/file_access.h"
 #include "servers/rendering/shader_preprocessor.h"
 
 void ShaderInclude::_dependency_changed() {

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -30,6 +30,7 @@
 
 #include "text_file.h"
 
+#include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 
 bool TextFile::has_text() const {

--- a/servers/movie_writer/movie_writer_pngwav.cpp
+++ b/servers/movie_writer/movie_writer_pngwav.cpp
@@ -31,6 +31,7 @@
 #include "movie_writer_pngwav.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 
 uint32_t MovieWriterPNGWAV::get_audio_mix_rate() const {
 	return mix_rate;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -36,6 +36,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "modules/modules_enabled.gen.h"
 #include "servers/rendering/rendering_shader_container.h"
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Addresses https://github.com/godotengine/godot/issues/111218

While `logger.h` is rarely included directly, `os.h` (which includes `logger.h`) is included by a plethora of core classes, most of which don't use `FileAccess` or `ScriptBacktrace` directly, so this should improve compile times somewhat.