### PR TITLE
Add the ExternalLink icon to the "Update available" text

### DIFF
--- a/editor/project_manager/engine_update_label.cpp
+++ b/editor/project_manager/engine_update_label.cpp
@@ -199,6 +199,7 @@ void EngineUpdateLabel::_set_status(UpdateStatus p_status) {
 			set_disabled(false);
 			set_accessibility_live(DisplayServer::AccessibilityLiveMode::LIVE_POLITE);
 			set_tooltip_text(TTR("Click to open download page."));
+			emit_signal("update_available");
 		} break;
 
 		default: {
@@ -275,6 +276,7 @@ void EngineUpdateLabel::_notification(int p_what) {
 
 void EngineUpdateLabel::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("offline_clicked"));
+	ADD_SIGNAL(MethodInfo("update_available"));
 }
 
 void EngineUpdateLabel::pressed() {

--- a/editor/project_manager/engine_update_label.h
+++ b/editor/project_manager/engine_update_label.h
@@ -93,8 +93,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void pressed() override;
-
 public:
+	void pressed() override;
+
 	EngineUpdateLabel();
 };

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -291,6 +291,11 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 		// Dialogs
 		migration_guide_button->set_button_icon(get_editor_theme_icon(SNAME("ExternalLink")));
 
+#ifdef ENGINE_UPDATE_CHECK_ENABLED
+		// Footer
+		external_link_icon->set_texture_normal(get_editor_theme_icon("ExternalLink"));
+#endif // ENGINE_UPDATE_CHECK_ENABLED
+
 		// Asset library popup.
 		if (asset_library) {
 			// Removes extra border margins.
@@ -926,6 +931,16 @@ void ProjectManager::_on_search_term_submitted(const String &p_text) {
 
 	_open_selected_projects_check_recovery_mode();
 }
+
+#ifdef ENGINE_UPDATE_CHECK_ENABLED
+void ProjectManager::_on_update_available() {
+	external_link_icon->show();
+}
+
+void ProjectManager::_on_external_link_icon_pressed() {
+	update_label->pressed();
+}
+#endif
 
 LineEdit *ProjectManager::get_search_box() {
 	return search_box;
@@ -1671,9 +1686,18 @@ ProjectManager::ProjectManager() {
 		main_vbox->add_child(footer_bar);
 
 #ifdef ENGINE_UPDATE_CHECK_ENABLED
-		EngineUpdateLabel *update_label = memnew(EngineUpdateLabel);
-		footer_bar->add_child(update_label);
+		HBoxContainer *update_container = memnew(HBoxContainer);
+		footer_bar->add_child(update_container);
+
+		update_label = memnew(EngineUpdateLabel);
+		update_container->add_child(update_label);
 		update_label->connect("offline_clicked", callable_mp(this, &ProjectManager::_show_quick_settings));
+		update_label->connect("update_available", callable_mp(this, &ProjectManager::_on_update_available));
+
+		external_link_icon = memnew(TextureButton);
+		external_link_icon->connect("pressed", callable_mp(this, &ProjectManager::_on_external_link_icon_pressed));
+		external_link_icon->hide();
+		update_container->add_child(external_link_icon);
 #endif
 
 		EditorVersionButton *version_btn = memnew(EditorVersionButton(EditorVersionButton::FORMAT_WITH_BUILD));

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -38,6 +38,7 @@ class EditorAbout;
 class EditorAssetLibrary;
 class EditorFileDialog;
 class EditorTitleBar;
+class EngineUpdateLabel;
 class HFlowContainer;
 class LineEdit;
 class MarginContainer;
@@ -49,6 +50,7 @@ class ProjectList;
 class QuickSettingsDialog;
 class RichTextLabel;
 class TabContainer;
+class TextureRect;
 class VBoxContainer;
 
 class ProjectManager : public Control {
@@ -113,6 +115,11 @@ class ProjectManager : public Control {
 
 	VBoxContainer *local_projects_vb = nullptr;
 	EditorAssetLibrary *asset_library = nullptr;
+
+#ifdef ENGINE_UPDATE_CHECK_ENABLED
+	EngineUpdateLabel *update_label = nullptr;
+	TextureButton *external_link_icon = nullptr;
+#endif
 
 	EditorAbout *about_dialog = nullptr;
 
@@ -212,6 +219,11 @@ class ProjectManager : public Control {
 	void _on_order_option_changed(int p_idx);
 	void _on_search_term_changed(const String &p_term);
 	void _on_search_term_submitted(const String &p_text);
+
+#ifdef ENGINE_UPDATE_CHECK_ENABLED
+	void _on_update_available();
+	void _on_external_link_icon_pressed();
+#endif
 
 	// Project tag management.
 


### PR DESCRIPTION
<img width="462" height="107" alt="image" src="https://github.com/user-attachments/assets/b0e5aab9-e0b7-4829-ad61-7a5d71379572" />

(Here I have the minor version set to 5, but it shows my version as being 4.6, I don't know why this happens, but it doesn't change the bahavior of this PR as its an unrelated bug.)

It only shows up when an update is available (aka when clicking it opens a link). It works by using a `HBoxContainer` and then adding the `EngineUpdateLabel` and a `TextureButton` to it. The `EngineUpdateLabel` is the text that normally shows up and the `TextureButton` holds the ExternalLink icon.

The Icon can be clicked, and does the same as clicking on the `EngineUpdateLabel`.

You can test this feature by doing one of the following:
- Changing `version.py`'s minor to 5 to make the "Update available" text show up
- Changing `version.py`'s minor to 4 to make the "Offline mode" text show up

Closes godotengine/godot-proposals#13161
