### PR TITLE
Make ThemeOwner a struct and don't store it separately from `Control`

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2890,7 +2890,7 @@ bool Control::is_clipping_contents() {
 
 void Control::_theme_changed() {
 	if (is_inside_tree()) {
-		data.theme_owner->propagate_theme_changed(this, this, true, false);
+		data.theme_owner.propagate_theme_changed(this, this, true, false);
 	}
 }
 
@@ -2915,22 +2915,22 @@ void Control::_update_theme_item_cache() {
 
 void Control::set_theme_owner_node(Node *p_node) {
 	ERR_MAIN_THREAD_GUARD;
-	data.theme_owner->set_owner_node(p_node);
+	data.theme_owner.set_owner_node(p_node);
 }
 
 Node *Control::get_theme_owner_node() const {
 	ERR_READ_THREAD_GUARD_V(nullptr);
-	return data.theme_owner->get_owner_node();
+	return data.theme_owner.get_owner_node();
 }
 
 bool Control::has_theme_owner_node() const {
 	ERR_READ_THREAD_GUARD_V(false);
-	return data.theme_owner->has_owner_node();
+	return data.theme_owner.has_owner_node();
 }
 
 void Control::set_theme_context(ThemeContext *p_context, bool p_propagate) {
 	ERR_MAIN_THREAD_GUARD;
-	data.theme_owner->set_owner_context(p_context, p_propagate);
+	data.theme_owner.set_owner_context(p_context, p_propagate);
 }
 
 void Control::set_theme(const Ref<Theme> &p_theme) {
@@ -2945,24 +2945,24 @@ void Control::set_theme(const Ref<Theme> &p_theme) {
 
 	data.theme = p_theme;
 	if (data.theme.is_valid()) {
-		data.theme_owner->propagate_theme_changed(this, this, is_inside_tree(), true);
+		data.theme_owner.propagate_theme_changed(this, this, is_inside_tree(), true);
 		data.theme->connect_changed(callable_mp(this, &Control::_theme_changed), CONNECT_DEFERRED);
 		return;
 	}
 
 	Control *parent_c = Object::cast_to<Control>(get_parent());
 	if (parent_c && parent_c->has_theme_owner_node()) {
-		data.theme_owner->propagate_theme_changed(this, parent_c->get_theme_owner_node(), is_inside_tree(), true);
+		data.theme_owner.propagate_theme_changed(this, parent_c->get_theme_owner_node(), is_inside_tree(), true);
 		return;
 	}
 
 	Window *parent_w = cast_to<Window>(get_parent());
 	if (parent_w && parent_w->has_theme_owner_node()) {
-		data.theme_owner->propagate_theme_changed(this, parent_w->get_theme_owner_node(), is_inside_tree(), true);
+		data.theme_owner.propagate_theme_changed(this, parent_w->get_theme_owner_node(), is_inside_tree(), true);
 		return;
 	}
 
-	data.theme_owner->propagate_theme_changed(this, nullptr, is_inside_tree(), true);
+	data.theme_owner.propagate_theme_changed(this, nullptr, is_inside_tree(), true);
 }
 
 Ref<Theme> Control::get_theme() const {
@@ -3006,8 +3006,8 @@ Ref<Texture2D> Control::get_theme_icon(const StringName &p_name, const StringNam
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	Ref<Texture2D> icon = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<Texture2D> icon = data.theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
 	data.theme_icon_cache[p_theme_type][p_name] = icon;
 	return icon;
 }
@@ -3030,8 +3030,8 @@ Ref<StyleBox> Control::get_theme_stylebox(const StringName &p_name, const String
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	Ref<StyleBox> style = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<StyleBox> style = data.theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
 	data.theme_style_cache[p_theme_type][p_name] = style;
 	return style;
 }
@@ -3054,8 +3054,8 @@ Ref<Font> Control::get_theme_font(const StringName &p_name, const StringName &p_
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	Ref<Font> font = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<Font> font = data.theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
 	data.theme_font_cache[p_theme_type][p_name] = font;
 	return font;
 }
@@ -3078,8 +3078,8 @@ int Control::get_theme_font_size(const StringName &p_name, const StringName &p_t
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	int font_size = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	int font_size = data.theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
 	data.theme_font_size_cache[p_theme_type][p_name] = font_size;
 	return font_size;
 }
@@ -3102,8 +3102,8 @@ Color Control::get_theme_color(const StringName &p_name, const StringName &p_the
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	Color color = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Color color = data.theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
 	data.theme_color_cache[p_theme_type][p_name] = color;
 	return color;
 }
@@ -3126,8 +3126,8 @@ int Control::get_theme_constant(const StringName &p_name, const StringName &p_th
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	int constant = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	int constant = data.theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 	data.theme_constant_cache[p_theme_type][p_name] = constant;
 	return constant;
 }
@@ -3210,8 +3210,8 @@ bool Control::has_theme_icon(const StringName &p_name, const StringName &p_theme
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return data.theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
 }
 
 bool Control::has_theme_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
@@ -3227,8 +3227,8 @@ bool Control::has_theme_stylebox(const StringName &p_name, const StringName &p_t
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return data.theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
 }
 
 bool Control::has_theme_font(const StringName &p_name, const StringName &p_theme_type) const {
@@ -3244,8 +3244,8 @@ bool Control::has_theme_font(const StringName &p_name, const StringName &p_theme
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return data.theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
 }
 
 bool Control::has_theme_font_size(const StringName &p_name, const StringName &p_theme_type) const {
@@ -3261,8 +3261,8 @@ bool Control::has_theme_font_size(const StringName &p_name, const StringName &p_
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return data.theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
 }
 
 bool Control::has_theme_color(const StringName &p_name, const StringName &p_theme_type) const {
@@ -3278,8 +3278,8 @@ bool Control::has_theme_color(const StringName &p_name, const StringName &p_them
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return data.theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
 }
 
 bool Control::has_theme_constant(const StringName &p_name, const StringName &p_theme_type) const {
@@ -3295,8 +3295,8 @@ bool Control::has_theme_constant(const StringName &p_name, const StringName &p_t
 	}
 
 	Vector<StringName> theme_types;
-	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
+	data.theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return data.theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 }
 
 /// Local property overrides.
@@ -3446,17 +3446,17 @@ bool Control::has_theme_constant_override(const StringName &p_name) const {
 
 float Control::get_theme_default_base_scale() const {
 	ERR_READ_THREAD_GUARD_V(0);
-	return data.theme_owner->get_theme_default_base_scale();
+	return data.theme_owner.get_theme_default_base_scale();
 }
 
 Ref<Font> Control::get_theme_default_font() const {
 	ERR_READ_THREAD_GUARD_V(Ref<Font>());
-	return data.theme_owner->get_theme_default_font();
+	return data.theme_owner.get_theme_default_font();
 }
 
 int Control::get_theme_default_font_size() const {
 	ERR_READ_THREAD_GUARD_V(0);
-	return data.theme_owner->get_theme_default_font_size();
+	return data.theme_owner.get_theme_default_font_size();
 }
 
 /// Bulk actions.
@@ -3788,7 +3788,7 @@ void Control::_notification(int p_notification) {
 			data.parent_control = Object::cast_to<Control>(parent_node);
 			data.parent_window = Object::cast_to<Window>(parent_node);
 
-			data.theme_owner->assign_theme_on_parented(this);
+			data.theme_owner.assign_theme_on_parented(this);
 
 			_update_layout_mode();
 
@@ -3800,7 +3800,7 @@ void Control::_notification(int p_notification) {
 			data.parent_control = nullptr;
 			data.parent_window = nullptr;
 
-			data.theme_owner->clear_theme_on_unparented(this);
+			data.theme_owner.clear_theme_on_unparented(this);
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -4399,16 +4399,13 @@ void Control::_bind_methods() {
 }
 
 Control::Control() {
+	data.theme_owner.holder = this;
 	_define_ancestry(AncestralClass::CONTROL);
-
-	data.theme_owner = memnew(ThemeOwner(this));
 
 	set_physics_interpolation_mode(Node::PHYSICS_INTERPOLATION_MODE_OFF);
 }
 
 Control::~Control() {
-	memdelete(data.theme_owner);
-
 	// Resources need to be disconnected.
 	for (KeyValue<StringName, Ref<Texture2D>> &E : data.theme_icon_override) {
 		E.value->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -34,11 +34,11 @@
 #include "core/object/gdvirtual.gen.inc"
 #include "scene/main/canvas_item.h"
 #include "scene/resources/theme.h"
+#include "scene/theme/theme_owner.h"
 
 class Viewport;
 class Label;
 class Panel;
-class ThemeOwner;
 class ThemeContext;
 
 class Control : public CanvasItem {
@@ -264,7 +264,7 @@ private:
 
 		// Theming.
 
-		ThemeOwner *theme_owner = nullptr;
+		ThemeOwner theme_owner;
 		Ref<Theme> theme;
 		StringName theme_type_variation;
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1473,11 +1473,11 @@ void Window::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_PARENTED: {
-			theme_owner->assign_theme_on_parented(this);
+			theme_owner.assign_theme_on_parented(this);
 		} break;
 
 		case NOTIFICATION_UNPARENTED: {
-			theme_owner->clear_theme_on_unparented(this);
+			theme_owner.clear_theme_on_unparented(this);
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -2274,22 +2274,22 @@ void Window::remove_child_notify(Node *p_child) {
 
 void Window::set_theme_owner_node(Node *p_node) {
 	ERR_MAIN_THREAD_GUARD;
-	theme_owner->set_owner_node(p_node);
+	theme_owner.set_owner_node(p_node);
 }
 
 Node *Window::get_theme_owner_node() const {
 	ERR_READ_THREAD_GUARD_V(nullptr);
-	return theme_owner->get_owner_node();
+	return theme_owner.get_owner_node();
 }
 
 bool Window::has_theme_owner_node() const {
 	ERR_READ_THREAD_GUARD_V(false);
-	return theme_owner->has_owner_node();
+	return theme_owner.has_owner_node();
 }
 
 void Window::set_theme_context(ThemeContext *p_context, bool p_propagate) {
 	ERR_MAIN_THREAD_GUARD;
-	theme_owner->set_owner_context(p_context, p_propagate);
+	theme_owner.set_owner_context(p_context, p_propagate);
 }
 
 void Window::set_theme(const Ref<Theme> &p_theme) {
@@ -2304,24 +2304,24 @@ void Window::set_theme(const Ref<Theme> &p_theme) {
 
 	theme = p_theme;
 	if (theme.is_valid()) {
-		theme_owner->propagate_theme_changed(this, this, is_inside_tree(), true);
+		theme_owner.propagate_theme_changed(this, this, is_inside_tree(), true);
 		theme->connect_changed(callable_mp(this, &Window::_theme_changed), CONNECT_DEFERRED);
 		return;
 	}
 
 	Control *parent_c = Object::cast_to<Control>(get_parent());
 	if (parent_c && parent_c->has_theme_owner_node()) {
-		theme_owner->propagate_theme_changed(this, parent_c->get_theme_owner_node(), is_inside_tree(), true);
+		theme_owner.propagate_theme_changed(this, parent_c->get_theme_owner_node(), is_inside_tree(), true);
 		return;
 	}
 
 	Window *parent_w = cast_to<Window>(get_parent());
 	if (parent_w && parent_w->has_theme_owner_node()) {
-		theme_owner->propagate_theme_changed(this, parent_w->get_theme_owner_node(), is_inside_tree(), true);
+		theme_owner.propagate_theme_changed(this, parent_w->get_theme_owner_node(), is_inside_tree(), true);
 		return;
 	}
 
-	theme_owner->propagate_theme_changed(this, nullptr, is_inside_tree(), true);
+	theme_owner.propagate_theme_changed(this, nullptr, is_inside_tree(), true);
 }
 
 Ref<Theme> Window::get_theme() const {
@@ -2331,7 +2331,7 @@ Ref<Theme> Window::get_theme() const {
 
 void Window::_theme_changed() {
 	if (is_inside_tree()) {
-		theme_owner->propagate_theme_changed(this, this, true, false);
+		theme_owner.propagate_theme_changed(this, this, true, false);
 	}
 }
 
@@ -2408,8 +2408,8 @@ Ref<Texture2D> Window::get_theme_icon(const StringName &p_name, const StringName
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	Ref<Texture2D> icon = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<Texture2D> icon = theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
 	theme_icon_cache[p_theme_type][p_name] = icon;
 	return icon;
 }
@@ -2432,8 +2432,8 @@ Ref<StyleBox> Window::get_theme_stylebox(const StringName &p_name, const StringN
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	Ref<StyleBox> style = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<StyleBox> style = theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
 	theme_style_cache[p_theme_type][p_name] = style;
 	return style;
 }
@@ -2456,8 +2456,8 @@ Ref<Font> Window::get_theme_font(const StringName &p_name, const StringName &p_t
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	Ref<Font> font = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<Font> font = theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
 	theme_font_cache[p_theme_type][p_name] = font;
 	return font;
 }
@@ -2480,8 +2480,8 @@ int Window::get_theme_font_size(const StringName &p_name, const StringName &p_th
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	int font_size = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	int font_size = theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
 	theme_font_size_cache[p_theme_type][p_name] = font_size;
 	return font_size;
 }
@@ -2504,8 +2504,8 @@ Color Window::get_theme_color(const StringName &p_name, const StringName &p_them
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	Color color = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Color color = theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
 	theme_color_cache[p_theme_type][p_name] = color;
 	return color;
 }
@@ -2528,8 +2528,8 @@ int Window::get_theme_constant(const StringName &p_name, const StringName &p_the
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	int constant = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	int constant = theme_owner.get_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 	theme_constant_cache[p_theme_type][p_name] = constant;
 	return constant;
 }
@@ -2586,8 +2586,8 @@ bool Window::has_theme_icon(const StringName &p_name, const StringName &p_theme_
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_ICON, p_name, theme_types);
 }
 
 bool Window::has_theme_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
@@ -2603,8 +2603,8 @@ bool Window::has_theme_stylebox(const StringName &p_name, const StringName &p_th
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
 }
 
 bool Window::has_theme_font(const StringName &p_name, const StringName &p_theme_type) const {
@@ -2620,8 +2620,8 @@ bool Window::has_theme_font(const StringName &p_name, const StringName &p_theme_
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_FONT, p_name, theme_types);
 }
 
 bool Window::has_theme_font_size(const StringName &p_name, const StringName &p_theme_type) const {
@@ -2637,8 +2637,8 @@ bool Window::has_theme_font_size(const StringName &p_name, const StringName &p_t
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_FONT_SIZE, p_name, theme_types);
 }
 
 bool Window::has_theme_color(const StringName &p_name, const StringName &p_theme_type) const {
@@ -2654,8 +2654,8 @@ bool Window::has_theme_color(const StringName &p_name, const StringName &p_theme
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_COLOR, p_name, theme_types);
 }
 
 bool Window::has_theme_constant(const StringName &p_name, const StringName &p_theme_type) const {
@@ -2671,8 +2671,8 @@ bool Window::has_theme_constant(const StringName &p_name, const StringName &p_th
 	}
 
 	Vector<StringName> theme_types;
-	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
-	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
+	theme_owner.get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return theme_owner.has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 }
 
 /// Local property overrides.
@@ -2822,17 +2822,17 @@ bool Window::has_theme_constant_override(const StringName &p_name) const {
 
 float Window::get_theme_default_base_scale() const {
 	ERR_READ_THREAD_GUARD_V(0);
-	return theme_owner->get_theme_default_base_scale();
+	return theme_owner.get_theme_default_base_scale();
 }
 
 Ref<Font> Window::get_theme_default_font() const {
 	ERR_READ_THREAD_GUARD_V(Ref<Font>());
-	return theme_owner->get_theme_default_font();
+	return theme_owner.get_theme_default_font();
 }
 
 int Window::get_theme_default_font_size() const {
 	ERR_READ_THREAD_GUARD_V(0);
-	return theme_owner->get_theme_default_font_size();
+	return theme_owner.get_theme_default_font_size();
 }
 
 /// Bulk actions.
@@ -3469,13 +3469,13 @@ void Window::_bind_methods() {
 }
 
 Window::Window() {
+	theme_owner.holder = this;
 	RenderingServer *rendering_server = RenderingServer::get_singleton();
 	if (rendering_server) {
 		max_size = rendering_server->get_maximum_viewport_size();
 		max_size_used = max_size; // Update max_size_used.
 	}
 
-	theme_owner = memnew(ThemeOwner(this));
 	RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_DISABLED);
 }
 
@@ -3483,7 +3483,6 @@ Window::~Window() {
 	if (focused_window == this) {
 		focused_window = nullptr;
 	}
-	memdelete(theme_owner);
 
 	// Resources need to be disconnected.
 	for (KeyValue<StringName, Ref<Texture2D>> &E : theme_icon_override) {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -32,12 +32,12 @@
 
 #include "scene/main/viewport.h"
 #include "scene/resources/theme.h"
+#include "scene/theme/theme_owner.h"
 #include "servers/display/display_server.h"
 
 class Font;
 class Shortcut;
 class StyleBox;
-class ThemeOwner;
 class ThemeContext;
 
 class Window : public Viewport {
@@ -191,7 +191,7 @@ private:
 
 	static Window *focused_window;
 
-	ThemeOwner *theme_owner = nullptr;
+	ThemeOwner theme_owner;
 	Ref<Theme> theme;
 	StringName theme_type_variation;
 

--- a/scene/theme/theme_owner.h
+++ b/scene/theme/theme_owner.h
@@ -38,21 +38,19 @@ class Node;
 class ThemeContext;
 class Window;
 
-class ThemeOwner : public Object {
-	GDSOFTCLASS(ThemeOwner, Object);
-
-	Node *holder = nullptr;
-
+struct ThemeOwner {
+private:
 	Node *owner_node = nullptr;
 	ThemeContext *owner_context = nullptr;
 
-	void _owner_context_changed();
+	static void _owner_context_changed(Node *p_node);
 	ThemeContext *_get_active_owner_context() const;
 
 	Node *_get_next_owner_node(Node *p_from_node) const;
 	Ref<Theme> _get_owner_node_theme(Node *p_owner_node) const;
 
 public:
+	Node *holder = nullptr;
 	// Theme owner node.
 
 	void set_owner_node(Node *p_node);
@@ -71,12 +69,10 @@ public:
 
 	void get_theme_type_dependencies(const Node *p_for_node, const StringName &p_theme_type, Vector<StringName> &r_result) const;
 
-	Variant get_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const Vector<StringName> &p_theme_types);
-	bool has_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const Vector<StringName> &p_theme_types);
+	Variant get_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const Vector<StringName> &p_theme_types) const;
+	bool has_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, const Vector<StringName> &p_theme_types) const;
 
-	float get_theme_default_base_scale();
-	Ref<Font> get_theme_default_font();
-	int get_theme_default_font_size();
-
-	ThemeOwner(Node *p_holder) { holder = p_holder; }
+	float get_theme_default_base_scale() const;
+	Ref<Font> get_theme_default_font() const;
+	int get_theme_default_font_size() const;
 };


### PR DESCRIPTION
`ThemeOwner` was introduced to unify some shared code between `Control` and `Window` which both support theming. When it was addded it was created as a separate heap allocated `Object`.

This PR converts it into a struct which gets embedded into the nodes which support theming. The main reason for it to be an object in the first place seems to be the necessity to connect to some signals on theme related stuff. To deal with that, this PR introduces a `CallableCustom` which is bound to an object but calls a static method with the object as argument instead of a member function of the object.

Benefits are:
- reduces the memory footprint of plain `Control` by around 8% in my testing (using the static memory monitor, not real OS memory usage)
- Also tested with my [kanban board application](https://github.com/HolonProduction/godot_kanban_tasks) as real usecase. Reduces the memory footprint reported by the OS by around 4%
- Paves the way for moving ownership of the Theme into `ThemeOwner` which would allow unifying more code which is currently present in both `Control` and `Window`

Not sure if it's worth the additional `CallableCustom` though. So I'll just leave this up as a draft for now.

~Also currently includes https://github.com/godotengine/godot/pull/111249~ Has been merged

To my knowledge currently blocked on https://github.com/godotengine/godot/pull/112682 as alternative to the custom callable