### PR TITLE
[Tree] Add alternate rows for readability.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -320,6 +320,9 @@
 		<member name="docks/scene_tree/hide_filtered_out_parents" type="bool" setter="" getter="">
 			If [code]true[/code], the scene tree dock will only show nodes that match the filter, without showing parents that don't. This settings can also be changed in the Scene dock's top menu.
 		</member>
+		<member name="docks/scene_tree/show_row_stripes" type="bool" setter="" getter="">
+			If [code]true[/code], the scene tree dock will draw striped rows to improve readability.
+		</member>
 		<member name="docks/scene_tree/start_create_dialog_fully_expanded" type="bool" setter="" getter="">
 			If [code]true[/code], the Create dialog (Create New Node/Create New Resource) will start with all its sections expanded. Otherwise, sections will be collapsed until the user starts searching (which will automatically expand sections as needed).
 		</member>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -326,6 +326,9 @@
 		<member name="docks/scene_tree/hide_filtered_out_parents" type="bool" setter="" getter="">
 			If [code]true[/code], the scene tree dock will only show nodes that match the filter, without showing parents that don't. This settings can also be changed in the Scene dock's top menu.
 		</member>
+		<member name="docks/scene_tree/show_row_stripes" type="bool" setter="" getter="">
+			If [code]true[/code], the Scene dock will draw striped rows to improve readability. See also [member interface/theme/strip_alpha].
+		</member>
 		<member name="docks/scene_tree/start_create_dialog_fully_expanded" type="bool" setter="" getter="">
 			If [code]true[/code], the Create dialog (Create New Node/Create New Resource) will start with all its sections expanded. Otherwise, sections will be collapsed until the user starts searching (which will automatically expand sections as needed).
 		</member>
@@ -1285,6 +1288,9 @@
 		</member>
 		<member name="interface/theme/spacing_preset" type="String" setter="" getter="">
 			The editor theme spacing preset to use. See also [member interface/theme/base_spacing] and [member interface/theme/additional_spacing].
+		</member>
+		<member name="interface/theme/strip_alpha" type="float" setter="" getter="">
+			The opacity to use when drawing striped rows for any interface based on [Tree] in the editor, such as the Scene dock. If set to [code]0.0[/code], no stripes will be drawn. See also [member docks/scene_tree/show_row_stripes].
 		</member>
 		<member name="interface/theme/style" type="String" setter="" getter="">
 			The editor theme style to use.

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -393,6 +393,9 @@
 		<member name="hide_root" type="bool" setter="set_hide_root" getter="is_root_hidden" default="false">
 			If [code]true[/code], the tree's root is hidden.
 		</member>
+		<member name="row_stripes_visible" type="bool" setter="set_row_stripes_visible" getter="are_row_stripes_visible" default="false">
+			If [code]true[/code], draws the [theme_item row_stripes] style box behind every second row to improve readability. Useful when the [Tree] has multiple columns.
+		</member>
 		<member name="scroll_hint_mode" type="int" setter="set_scroll_hint_mode" getter="get_scroll_hint_mode" enum="Tree.ScrollHintMode" default="0">
 			The way which scroll hints (indicators that show that the content can still be scrolled in a certain direction) will be shown.
 		</member>
@@ -760,6 +763,9 @@
 		</theme_item>
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The background style for the [Tree].
+		</theme_item>
+		<theme_item name="row_stripes" data_type="style" type="StyleBox">
+			[StyleBox] drawn behind every second row when [member row_stripes_visible] is [code]true[/code].
 		</theme_item>
 		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is not being focused.

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -614,6 +614,9 @@
 		<theme_item name="draw_relationship_lines" data_type="constant" type="int" default="0">
 			Draws the relationship lines if not zero, this acts as a boolean. Relationship lines are drawn at the start of child items to show hierarchy.
 		</theme_item>
+		<theme_item name="row_stripes_visible" data_type="constant" type="int" default="0">
+			Draws the [theme_item row_stripes] style box behind every second row if not zero, this acts as a boolean. Useful when the [Tree] has multiple columns to improve readability.
+		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between item cells. This is also used as the margin at the start of an item when folding is disabled.
 		</theme_item>
@@ -767,6 +770,9 @@
 		</theme_item>
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The background style for the [Tree].
+		</theme_item>
+		<theme_item name="row_stripes" data_type="style" type="StyleBox">
+			[StyleBox] drawn behind every second row when [theme_item row_stripes_visible] is not zero.
 		</theme_item>
 		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is not being focused.

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -777,6 +777,7 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_custom_minimum_width(2, 50 * EDSCALE);
 	variables->set_theme_type_variation("TreeSecondary");
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
+	variables->set_row_stripes_visible(true);
 
 	graph = memnew(TextureRect);
 	graph->set_custom_minimum_size(Size2(250 * EDSCALE, 0));

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -794,6 +794,7 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_clip_content(2, true);
 	variables->set_column_custom_minimum_width(2, 50 * EDSCALE);
 	variables->set_theme_type_variation("TreeSecondary");
+	variables->add_theme_constant_override("row_stripes_visible", 1);
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
 	variables->connect("item_collapsed", callable_mp(this, &EditorProfiler::_item_collapsed));
 

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -864,6 +864,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->set_column_clip_content(2, true);
 	variables->set_column_custom_minimum_width(2, 75 * EDSCALE);
 	variables->set_theme_type_variation("TreeSecondary");
+	variables->set_row_stripes_visible(true);
 	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
 	variables->connect("item_collapsed", callable_mp(this, &EditorVisualProfiler::_item_collapsed));
 

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -874,6 +874,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->set_column_clip_content(2, true);
 	variables->set_column_custom_minimum_width(2, 75 * EDSCALE);
 	variables->set_theme_type_variation("TreeSecondary");
+	variables->add_theme_constant_override("row_stripes_visible", 1);
 	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
 	variables->connect("item_collapsed", callable_mp(this, &EditorVisualProfiler::_item_collapsed));
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2420,6 +2420,7 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		vmem_vb->add_child(mc);
 
 		vmem_tree = memnew(Tree);
+		vmem_tree->set_row_stripes_visible(true);
 		vmem_vb->set_name(TTRC("Video RAM"));
 		vmem_tree->set_columns(4);
 		vmem_tree->set_column_titles_visible(true);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2439,6 +2439,7 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		vmem_vb->add_child(vmem_mc);
 
 		vmem_tree = memnew(Tree);
+		vmem_tree->add_theme_constant_override("row_stripes_visible", 1);
 		vmem_vb->set_name(TTRC("Video RAM"));
 		vmem_tree->set_columns(4);
 		vmem_tree->set_column_titles_visible(true);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1780,6 +1780,11 @@ void SceneTreeDock::_notification(int p_what) {
 				scene_tree->set_auto_expand_selected(EDITOR_GET("docks/scene_tree/auto_expand_to_selected"), false);
 				scene_tree->set_hide_filtered_out_parents(EDITOR_GET("docks/scene_tree/hide_filtered_out_parents"), false);
 				scene_tree->set_accessibility_warnings(EDITOR_GET("docks/scene_tree/accessibility_warnings"), false);
+				bool show_row_stripes = EDITOR_GET("docks/scene_tree/show_row_stripes");
+				scene_tree->get_scene_tree()->set_row_stripes_visible(show_row_stripes);
+				if (remote_tree) {
+					remote_tree->set_row_stripes_visible(show_row_stripes);
+				}
 			}
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/timers")) {
 				inspect_hovered_node_delay->set_wait_time(EDITOR_GET("interface/editor/timers/dragging_hover_wait_seconds"));
@@ -4607,6 +4612,7 @@ void SceneTreeDock::add_remote_tree_editor(Tree *p_remote) {
 	ERR_FAIL_COND(remote_tree != nullptr);
 	main_mc->add_child(p_remote);
 	remote_tree = p_remote;
+	remote_tree->set_row_stripes_visible(EDITOR_GET("docks/scene_tree/show_row_stripes"));
 	remote_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	remote_tree->hide();
 	remote_tree->connect("open", callable_mp(this, &SceneTreeDock::_load_request));
@@ -5081,6 +5087,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	create_root_dialog->hide();
 
 	scene_tree = memnew(SceneTreeEditor(false, true, true));
+	scene_tree->get_scene_tree()->set_row_stripes_visible(EDITOR_GET("docks/scene_tree/show_row_stripes"));
 	main_mc->add_child(scene_tree);
 	scene_tree->get_scene_tree()->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	scene_tree->connect("rmb_pressed", callable_mp(this, &SceneTreeDock::_tree_rmb));

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1820,6 +1820,11 @@ void SceneTreeDock::_notification(int p_what) {
 				scene_tree->set_auto_expand_selected(EDITOR_GET("docks/scene_tree/auto_expand_to_selected"), false);
 				scene_tree->set_hide_filtered_out_parents(EDITOR_GET("docks/scene_tree/hide_filtered_out_parents"), false);
 				scene_tree->set_accessibility_warnings(EDITOR_GET("docks/scene_tree/accessibility_warnings"), false);
+				bool show_row_stripes = EDITOR_GET("docks/scene_tree/show_row_stripes");
+				scene_tree->get_scene_tree()->add_theme_constant_override("row_stripes_visible", show_row_stripes ? 1 : 0);
+				if (remote_tree) {
+					remote_tree->add_theme_constant_override("row_stripes_visible", show_row_stripes ? 1 : 0);
+				}
 			}
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/timers")) {
 				inspect_hovered_node_delay->set_wait_time(EDITOR_GET("interface/editor/timers/dragging_hover_wait_seconds"));
@@ -4735,6 +4740,7 @@ void SceneTreeDock::add_remote_tree_editor(Tree *p_remote) {
 	ERR_FAIL_COND(remote_tree != nullptr);
 	main_mc->add_child(p_remote);
 	remote_tree = p_remote;
+	remote_tree->add_theme_constant_override("row_stripes_visible", EDITOR_GET("docks/scene_tree/show_row_stripes") ? 1 : 0);
 	remote_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	remote_tree->hide();
 	remote_tree->connect("open", callable_mp(this, &SceneTreeDock::_load_request));
@@ -5219,6 +5225,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	create_root_dialog->hide();
 
 	scene_tree = memnew(SceneTreeEditor(false, true, true));
+	scene_tree->get_scene_tree()->add_theme_constant_override("row_stripes_visible", EDITOR_GET("docks/scene_tree/show_row_stripes") ? 1 : 0);
 	main_mc->add_child(scene_tree);
 	scene_tree->get_scene_tree()->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	scene_tree->connect("rmb_pressed", callable_mp(this, &SceneTreeDock::_tree_rmb));

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -251,6 +251,7 @@ EditorPluginSettings::EditorPluginSettings() {
 	add_child(title_hb);
 
 	plugin_list = memnew(Tree);
+	plugin_list->set_row_stripes_visible(true);
 	plugin_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	plugin_list->set_theme_type_variation("TreeTable");
 	plugin_list->set_hide_folding(true);

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -251,6 +251,7 @@ EditorPluginSettings::EditorPluginSettings() {
 	add_child(title_hb);
 
 	plugin_list = memnew(Tree);
+	plugin_list->add_theme_constant_override("row_stripes_visible", 1);
 	plugin_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	plugin_list->set_theme_type_variation("TreeTable");
 	plugin_list->set_hide_folding(true);

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -533,6 +533,7 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	add_child(mc);
 
 	tree = memnew(Tree);
+	tree->set_row_stripes_visible(true);
 	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tree->set_hide_root(true);
 	tree->set_select_mode(Tree::SELECT_SINGLE);

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -533,6 +533,7 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	add_child(mc);
 
 	tree = memnew(Tree);
+	tree->add_theme_constant_override("row_stripes_visible", 1);
 	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tree->set_hide_root(true);
 	tree->set_select_mode(Tree::SELECT_SINGLE);

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -45,7 +45,6 @@
 #include "scene/gui/button.h"
 #include "scene/gui/tree.h"
 #include "scene/main/scene_tree.h"
-#include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 
 #define PREVIEW_LIST_MAX_SIZE 10
@@ -907,6 +906,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	add_child(mc);
 
 	tree = memnew(Tree);
+	tree->set_row_stripes_visible(true);
 	tree->set_accessibility_name(TTRC("Autoloads"));
 	tree->set_hide_root(true);
 	tree->set_select_mode(Tree::SELECT_MULTI);

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -915,6 +915,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	add_child(mc);
 
 	tree = memnew(Tree);
+	tree->add_theme_constant_override("row_stripes_visible", 1);
 	tree->set_accessibility_name(TTRC("Autoloads"));
 	tree->set_hide_root(true);
 	tree->set_select_mode(Tree::SELECT_MULTI);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -709,6 +709,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/scene_tree/center_node_on_reparent", false);
 	_initial_set("docks/scene_tree/hide_filtered_out_parents", true);
 	_initial_set("docks/scene_tree/accessibility_warnings", false);
+	_initial_set("docks/scene_tree/show_row_stripes", false);
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,128,16")

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -629,6 +629,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/icon_saturation", 2.0, "0,2,0.01")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/theme/draw_relationship_lines", (int32_t)EditorThemeManager::RELATIONSHIP_SELECTED_ONLY, "None,Selected Only,All")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/relationship_line_opacity", 0.1, "0.00,1,0.01")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/strip_alpha", 0.05, "0.00,1,0.01")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/border_size", 0, "0,2,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/corner_radius", 4, "0,6,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/base_spacing", 4, "0,8,1")
@@ -725,6 +726,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/scene_tree/center_node_on_reparent", false);
 	_initial_set("docks/scene_tree/hide_filtered_out_parents", true);
 	_initial_set("docks/scene_tree/accessibility_warnings", false);
+	_initial_set("docks/scene_tree/show_row_stripes", false);
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,224,16")

--- a/editor/settings/gdextension/project_settings_gdextension.cpp
+++ b/editor/settings/gdextension/project_settings_gdextension.cpp
@@ -113,6 +113,7 @@ ProjectSettingsGDExtension::ProjectSettingsGDExtension() {
 	add_child(title_hb);
 	// Create the tree.
 	extension_list = memnew(Tree);
+	extension_list->set_row_stripes_visible(true);
 	extension_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	extension_list->set_hide_root(true);
 	extension_list->set_theme_type_variation("TreeTable");

--- a/editor/settings/gdextension/project_settings_gdextension.cpp
+++ b/editor/settings/gdextension/project_settings_gdextension.cpp
@@ -113,6 +113,7 @@ ProjectSettingsGDExtension::ProjectSettingsGDExtension() {
 	add_child(title_hb);
 	// Create the tree.
 	extension_list = memnew(Tree);
+	extension_list->add_theme_constant_override("row_stripes_visible", 1);
 	extension_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	extension_list->set_hide_root(true);
 	extension_list->set_theme_type_variation("TreeTable");

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -76,6 +76,7 @@ uint32_t EditorThemeManager::ThemeConfiguration::hash() {
 
 	hash = hash_murmur3_one_32((int)draw_extra_borders, hash);
 	hash = hash_murmur3_one_float(relationship_line_opacity, hash);
+	hash = hash_murmur3_one_float(strip_alpha, hash);
 	hash = hash_murmur3_one_32(thumb_size, hash);
 	hash = hash_murmur3_one_32(class_icon_size, hash);
 	hash = hash_murmur3_one_32((int)enable_touch_optimizations, hash);
@@ -262,6 +263,7 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 	config.draw_extra_borders = EDITOR_GET("interface/theme/draw_extra_borders");
 	config.draw_relationship_lines = EDITOR_GET("interface/theme/draw_relationship_lines");
 	config.relationship_line_opacity = EDITOR_GET("interface/theme/relationship_line_opacity");
+	config.strip_alpha = EDITOR_GET("interface/theme/strip_alpha");
 	config.thumb_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
 	config.class_icon_size = 16 * EDSCALE;
 	config.enable_touch_optimizations = EDITOR_GET("interface/touchscreen/enable_touch_optimizations");

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -73,6 +73,7 @@ public:
 		bool draw_extra_borders = false;
 		int draw_relationship_lines;
 		float relationship_line_opacity = 1.0;
+		float strip_alpha = 0.05;
 		int thumb_size = 16;
 		int class_icon_size = 16;
 		bool enable_touch_optimizations = false;

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -580,7 +580,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 		Ref<StyleBoxFlat> style_tree_selected = style_tree_focus->duplicate();
 
-		const Color guide_color = p_config.mono_color * Color(1, 1, 1, 0.05);
+		const Color guide_color = p_config.mono_color * Color(1, 1, 1, p_config.dark_theme ? 0.025 : 0.075);
 
 		// Tree.
 		{
@@ -601,6 +601,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_stylebox("custom_button", "Tree", EditorThemeManager::make_empty_stylebox());
 			p_theme->set_stylebox("custom_button_pressed", "Tree", EditorThemeManager::make_empty_stylebox());
 			p_theme->set_stylebox("custom_button_hover", "Tree", p_config.button_style);
+			p_theme->set_stylebox("row_stripes", "Tree", EditorThemeManager::make_flat_stylebox(guide_color, 0, 0, 0, 0, p_config.corner_radius));
 
 			p_theme->set_color("custom_button_font_highlight", "Tree", p_config.font_hover_color);
 			p_theme->set_color(SceneStringName(font_color), "Tree", p_config.font_color);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -590,7 +590,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 		Ref<StyleBoxFlat> style_tree_selected = style_tree_focus->duplicate();
 
-		const Color guide_color = p_config.mono_color * Color(1, 1, 1, 0.05);
+		const Color guide_color = p_config.mono_color * Color(1, 1, 1, p_config.strip_alpha);
 
 		// Tree.
 		{
@@ -611,6 +611,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_stylebox("custom_button", "Tree", EditorThemeManager::make_empty_stylebox());
 			p_theme->set_stylebox("custom_button_pressed", "Tree", EditorThemeManager::make_empty_stylebox());
 			p_theme->set_stylebox("custom_button_hover", "Tree", p_config.button_style);
+			p_theme->set_stylebox("row_stripes", "Tree", EditorThemeManager::make_flat_stylebox(guide_color, 0, 0, 0, 0, p_config.corner_radius));
 
 			p_theme->set_color("custom_button_font_highlight", "Tree", p_config.font_hover_color);
 			p_theme->set_color(SceneStringName(font_color), "Tree", p_config.font_color);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -600,6 +600,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 	// Tree & ItemList.
 	{
+		const Color guide_color = p_config.mono_color * Color(1, 1, 1, p_config.dark_theme ? 0.025 : 0.075);
+
 		// Tree.
 		{
 			// Use empty stylebox for trees to avoid drawing unnecessary borders in docks.
@@ -626,6 +628,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_stylebox("button_pressed", "Tree", style_button_pressed);
 			p_theme->set_stylebox("custom_button", "Tree", p_config.flat_button);
 			p_theme->set_stylebox("custom_button_pressed", "Tree", style_button_pressed);
+			p_theme->set_stylebox("row_stripes", "Tree", EditorThemeManager::make_flat_stylebox(guide_color, 0, 0, 0, 0, p_config.corner_radius));
 
 			p_theme->set_color("custom_button_font_highlight", "Tree", p_config.font_hover_color);
 			p_theme->set_color(SceneStringName(font_color), "Tree", p_config.font_color);
@@ -684,7 +687,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_color("children_hl_line_color", "Tree", relationship_line_color);
 			p_theme->set_color("drop_on_item_color", "Tree", p_config.accent_color);
 			p_theme->set_color("drop_position_color", "Tree", p_config.icon_normal_color);
-			p_theme->set_color("guide_color", "Tree", Color(1, 1, 1, 0));
+			p_theme->set_color("guide_color", "Tree", guide_color);
 			p_theme->set_color("scroll_hint_color", "Tree", Color(0, 0, 0, p_config.dark_theme ? 1.0 : 0.5));
 
 			Ref<StyleBoxFlat> style_tree_hover = p_config.flat_button_hover->duplicate();
@@ -743,7 +746,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_stylebox("focus", "ProjectList", p_config.focus_style);
 
 			p_theme->set_color(SceneStringName(font_color), "ProjectList", p_config.font_color);
-			p_theme->set_color("guide_color", "ProjectList", Color(1, 1, 1, 0));
+			p_theme->set_color("guide_color", "ProjectList", guide_color);
 		}
 
 		// ItemList.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -610,6 +610,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 	// Tree & ItemList.
 	{
+		const Color guide_color = p_config.mono_color * Color(1, 1, 1, p_config.strip_alpha);
+
 		// Tree.
 		{
 			// Use empty stylebox for trees to avoid drawing unnecessary borders in docks.
@@ -636,6 +638,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_stylebox("button_pressed", "Tree", style_button_pressed);
 			p_theme->set_stylebox("custom_button", "Tree", p_config.flat_button);
 			p_theme->set_stylebox("custom_button_pressed", "Tree", style_button_pressed);
+			p_theme->set_stylebox("row_stripes", "Tree", EditorThemeManager::make_flat_stylebox(guide_color, 0, 0, 0, 0, p_config.corner_radius));
 
 			p_theme->set_color("custom_button_font_highlight", "Tree", p_config.font_hover_color);
 			p_theme->set_color(SceneStringName(font_color), "Tree", p_config.font_color);
@@ -695,7 +698,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_color("children_hl_line_color", "Tree", relationship_line_color);
 			p_theme->set_color("drop_on_item_color", "Tree", p_config.accent_color);
 			p_theme->set_color("drop_position_color", "Tree", p_config.mono_color * Color(1, 1, 1, 0.9));
-			p_theme->set_color("guide_color", "Tree", Color(1, 1, 1, 0));
+			p_theme->set_color("guide_color", "Tree", guide_color);
 			p_theme->set_color("scroll_hint_color", "Tree", Color(0, 0, 0, p_config.dark_theme ? 1.0 : 0.5));
 
 			Ref<StyleBoxFlat> style_tree_hover = p_config.flat_button_hover->duplicate();
@@ -754,7 +757,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_stylebox("focus", "ProjectList", p_config.focus_style);
 
 			p_theme->set_color(SceneStringName(font_color), "ProjectList", p_config.font_color);
-			p_theme->set_color("guide_color", "ProjectList", Color(1, 1, 1, 0));
+			p_theme->set_color("guide_color", "ProjectList", guide_color);
 		}
 
 		// ItemList.

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -776,6 +776,7 @@ LocalizationEditor::LocalizationEditor() {
 
 		translation_list = memnew(Tree);
 		translation_list->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
+		translation_list->set_row_stripes_visible(true);
 		mc->add_child(translation_list);
 		trees.push_back(translation_list);
 		tree_data_types[translation_list] = "localization_editor_translation_item";
@@ -816,6 +817,7 @@ LocalizationEditor::LocalizationEditor() {
 		translation_remap->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 		translation_remap->connect("cell_selected", callable_mp(this, &LocalizationEditor::_translation_res_select));
 		translation_remap->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_res_delete));
+		translation_remap->set_row_stripes_visible(true);
 		mc->add_child(translation_remap);
 
 		translation_res_file_open_dialog = memnew(EditorFileDialog);
@@ -856,6 +858,7 @@ LocalizationEditor::LocalizationEditor() {
 		translation_remap_options->connect("item_edited", callable_mp(this, &LocalizationEditor::_translation_res_option_changed));
 		translation_remap_options->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_res_option_delete));
 		translation_remap_options->connect("custom_popup_edited", callable_mp(this, &LocalizationEditor::_translation_res_option_popup));
+		translation_remap_options->set_row_stripes_visible(true);
 		mc->add_child(translation_remap_options);
 
 		translation_res_option_file_open_dialog = memnew(EditorFileDialog);
@@ -891,6 +894,7 @@ LocalizationEditor::LocalizationEditor() {
 
 		template_source_list = memnew(Tree);
 		template_source_list->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
+		template_source_list->set_row_stripes_visible(true);
 		mc->add_child(template_source_list);
 		trees.push_back(template_source_list);
 		tree_data_types[template_source_list] = "localization_editor_pot_item";

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -793,6 +793,7 @@ LocalizationEditor::LocalizationEditor() {
 
 		translation_list = memnew(Tree);
 		translation_list->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
+		translation_list->add_theme_constant_override("row_stripes_visible", 1);
 		mc->add_child(translation_list);
 		trees.push_back(translation_list);
 		tree_data_types[translation_list] = "localization_editor_translation_item";
@@ -833,6 +834,7 @@ LocalizationEditor::LocalizationEditor() {
 		translation_remap->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 		translation_remap->connect("cell_selected", callable_mp(this, &LocalizationEditor::_translation_res_select));
 		translation_remap->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_res_delete));
+		translation_remap->add_theme_constant_override("row_stripes_visible", 1);
 		mc->add_child(translation_remap);
 
 		translation_res_file_open_dialog = memnew(EditorFileDialog);
@@ -873,6 +875,7 @@ LocalizationEditor::LocalizationEditor() {
 		translation_remap_options->connect("item_edited", callable_mp(this, &LocalizationEditor::_translation_res_option_changed));
 		translation_remap_options->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_res_option_delete));
 		translation_remap_options->connect("custom_popup_edited", callable_mp(this, &LocalizationEditor::_translation_res_option_popup));
+		translation_remap_options->add_theme_constant_override("row_stripes_visible", 1);
 		mc->add_child(translation_remap_options);
 
 		translation_res_option_file_open_dialog = memnew(EditorFileDialog);
@@ -912,6 +915,7 @@ LocalizationEditor::LocalizationEditor() {
 
 		template_source_list = memnew(Tree);
 		template_source_list->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
+		template_source_list->add_theme_constant_override("row_stripes_visible", 1);
 		mc->add_child(template_source_list);
 		trees.push_back(template_source_list);
 		tree_data_types[template_source_list] = "localization_editor_pot_item";

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -408,6 +408,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	counters_display->set_column_clip_content(2, true);
 	counters_display->set_theme_type_variation("TreeSecondary");
 	counters_display->set_column_custom_minimum_width(2, 120 * EDSCALE);
+	counters_display->set_row_stripes_visible(true);
 	sc->add_child(counters_display);
 
 	// Replication
@@ -441,6 +442,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	replication_display->set_column_custom_minimum_width(4, 80 * EDSCALE);
 	replication_display->set_theme_type_variation("TreeSecondary");
 	replication_display->connect("button_clicked", callable_mp(this, &EditorNetworkProfiler::_replication_button_clicked));
+	replication_display->set_row_stripes_visible(true);
 	sc->add_child(replication_display);
 
 	refresh_timer = memnew(Timer);

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -407,6 +407,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	counters_display->set_column_clip_content(2, true);
 	counters_display->set_theme_type_variation("TreeSecondary");
 	counters_display->set_column_custom_minimum_width(2, 120 * EDSCALE);
+	counters_display->add_theme_constant_override("row_stripes_visible", 1);
 	sc->add_child(counters_display);
 
 	// Replication
@@ -440,6 +441,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	replication_display->set_column_custom_minimum_width(4, 80 * EDSCALE);
 	replication_display->set_theme_type_variation("TreeSecondary");
 	replication_display->connect("button_clicked", callable_mp(this, &EditorNetworkProfiler::_replication_button_clicked));
+	replication_display->add_theme_constant_override("row_stripes_visible", 1);
 	sc->add_child(replication_display);
 
 	refresh_timer = memnew(Timer);

--- a/modules/objectdb_profiler/editor/data_viewers/class_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/class_view.cpp
@@ -187,6 +187,7 @@ Tree *SnapshotClassView::_make_object_list_tree(const String &p_column_name) {
 	list->set_column_expand(0, true);
 	list->set_theme_type_variation("TreeSecondary");
 	list->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotClassView::_object_selected).bind(list));
+	list->set_row_stripes_visible(true);
 	list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	return list;

--- a/modules/objectdb_profiler/editor/data_viewers/class_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/class_view.cpp
@@ -187,6 +187,7 @@ Tree *SnapshotClassView::_make_object_list_tree(const String &p_column_name) {
 	list->set_column_expand(0, true);
 	list->set_theme_type_variation("TreeSecondary");
 	list->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotClassView::_object_selected).bind(list));
+	list->add_theme_constant_override("row_stripes_visible", 1);
 	list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	return list;

--- a/modules/objectdb_profiler/editor/data_viewers/object_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/object_view.cpp
@@ -109,6 +109,7 @@ void SnapshotObjectView::show_snapshot(GameStateSnapshot *p_data, GameStateSnaps
 	object_list->set_column_title_tooltip_text(offset + 3, TTRC("Number of outbound references"));
 	object_list->set_column_custom_minimum_width(offset + 2, 30 * EDSCALE);
 	object_list->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotObjectView::_object_selected));
+	object_list->set_row_stripes_visible(true);
 	object_list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	object_list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 
@@ -258,6 +259,7 @@ Tree *SnapshotObjectView::_make_references_list(Control *p_container, const Stri
 	tree->set_column_clip_content(1, false);
 	tree->set_column_title_tooltip_text(1, p_col_2_tooltip);
 	tree->set_v_scroll_enabled(false);
+	tree->set_row_stripes_visible(true);
 	tree->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 
 	return tree;

--- a/modules/objectdb_profiler/editor/data_viewers/object_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/object_view.cpp
@@ -109,6 +109,7 @@ void SnapshotObjectView::show_snapshot(GameStateSnapshot *p_data, GameStateSnaps
 	object_list->set_column_title_tooltip_text(offset + 3, TTRC("Number of outbound references"));
 	object_list->set_column_custom_minimum_width(offset + 2, 30 * EDSCALE);
 	object_list->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotObjectView::_object_selected));
+	object_list->add_theme_constant_override("row_stripes_visible", 1);
 	object_list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	object_list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 
@@ -258,6 +259,7 @@ Tree *SnapshotObjectView::_make_references_list(Control *p_container, const Stri
 	tree->set_column_clip_content(1, false);
 	tree->set_column_title_tooltip_text(1, p_col_2_tooltip);
 	tree->set_v_scroll_enabled(false);
+	tree->add_theme_constant_override("row_stripes_visible", 1);
 	tree->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 
 	return tree;

--- a/modules/objectdb_profiler/editor/data_viewers/refcounted_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/refcounted_view.cpp
@@ -118,6 +118,7 @@ void SnapshotRefCountedView::show_snapshot(GameStateSnapshot *p_data, GameStateS
 	refs_list->set_column_title_tooltip_text(offset + 5, TTRC("Cycles detected in the ObjectDB"));
 
 	refs_list->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotRefCountedView::_refcounted_selected));
+	refs_list->set_row_stripes_visible(true);
 	refs_list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	refs_list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 
@@ -263,6 +264,7 @@ void SnapshotRefCountedView::_refcounted_selected() {
 		inbound_tree->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 		inbound_tree->set_v_scroll_enabled(false);
 		inbound_tree->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotRefCountedView::_ref_selected).bind(inbound_tree));
+		inbound_tree->set_row_stripes_visible(true);
 
 		// The same reference can exist as multiple properties of an object (for example, gdscript `@export` properties exist twice).
 		// We flag for the user if a property is exposed multiple times so it's clearer why there are more references in the list
@@ -302,6 +304,7 @@ void SnapshotRefCountedView::_refcounted_selected() {
 		cycles_tree->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 		cycles_tree->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 		cycles_tree->set_v_scroll_enabled(false);
+		cycles_tree->set_row_stripes_visible(true);
 
 		TreeItem *root = cycles_tree->create_item();
 		for (const Variant &cycle : ref_cycles) {

--- a/modules/objectdb_profiler/editor/data_viewers/refcounted_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/refcounted_view.cpp
@@ -118,6 +118,7 @@ void SnapshotRefCountedView::show_snapshot(GameStateSnapshot *p_data, GameStateS
 	refs_list->set_column_title_tooltip_text(offset + 5, TTRC("Cycles detected in the ObjectDB"));
 
 	refs_list->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotRefCountedView::_refcounted_selected));
+	refs_list->add_theme_constant_override("row_stripes_visible", 1);
 	refs_list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	refs_list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 
@@ -263,6 +264,7 @@ void SnapshotRefCountedView::_refcounted_selected() {
 		inbound_tree->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 		inbound_tree->set_v_scroll_enabled(false);
 		inbound_tree->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotRefCountedView::_ref_selected).bind(inbound_tree));
+		inbound_tree->add_theme_constant_override("row_stripes_visible", 1);
 
 		// The same reference can exist as multiple properties of an object (for example, gdscript `@export` properties exist twice).
 		// We flag for the user if a property is exposed multiple times so it's clearer why there are more references in the list
@@ -302,6 +304,7 @@ void SnapshotRefCountedView::_refcounted_selected() {
 		cycles_tree->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 		cycles_tree->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 		cycles_tree->set_v_scroll_enabled(false);
+		cycles_tree->add_theme_constant_override("row_stripes_visible", 1);
 
 		TreeItem *root = cycles_tree->create_item();
 		for (const Variant &cycle : ref_cycles) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2319,7 +2319,7 @@ void Tree::update_item_cache(TreeItem *p_item) const {
 	}
 }
 
-int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height) {
+int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height, int &r_row_idx) {
 	const real_t bottom_margin = theme_cache.panel_style->get_margin(SIDE_BOTTOM); // Extra stylebox space below the content
 	const real_t draw_height = p_draw_size.height + bottom_margin; // Visible height including bottom margin
 
@@ -2346,6 +2346,8 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 		// Draw separation.
 
 		ERR_FAIL_COND_V(theme_cache.font.is_null(), -1);
+
+		r_row_idx++;
 
 		int ofs = p_pos.x + ((p_item->disable_folding || hide_folding) ? theme_cache.h_separation : theme_cache.item_margin);
 		int skip2 = 0;
@@ -2435,33 +2437,39 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				cell_rect.size.x += theme_cache.h_separation;
 			}
 
-			if (i == 0 && select_mode == SELECT_ROW) {
-				if (p_item->cells[0].selected || is_row_hovered) {
-					const Rect2 content_rect = _get_content_rect();
-					Rect2i row_rect = Rect2i(Point2i(content_rect.position.x, item_rect.position.y), Size2i(content_rect.size.x, item_rect.size.y));
-					row_rect = convert_rtl_rect(row_rect);
+			if (i == 0) {
+				const Rect2 content_rect = _get_content_rect();
+				Rect2i row_rect = Rect2i(Point2i(content_rect.position.x, item_rect.position.y), Size2i(content_rect.size.x, item_rect.size.y));
+				row_rect = convert_rtl_rect(row_rect);
 
-					if (p_item->cells[0].selected) {
-						if (is_row_hovered) {
-							if (has_focus(true)) {
-								theme_cache.hovered_selected_focus->draw(stylebox_ci, row_rect);
+				if (select_mode == SELECT_ROW) {
+					if (p_item->cells[0].selected || is_row_hovered) {
+						if (p_item->cells[0].selected) {
+							if (is_row_hovered) {
+								if (has_focus(true)) {
+									theme_cache.hovered_selected_focus->draw(stylebox_ci, row_rect);
+								} else {
+									theme_cache.hovered_selected->draw(stylebox_ci, row_rect);
+								}
 							} else {
-								theme_cache.hovered_selected->draw(stylebox_ci, row_rect);
+								if (has_focus(true)) {
+									theme_cache.selected_focus->draw(stylebox_ci, row_rect);
+								} else {
+									theme_cache.selected->draw(stylebox_ci, row_rect);
+								}
 							}
-						} else {
-							if (has_focus(true)) {
-								theme_cache.selected_focus->draw(stylebox_ci, row_rect);
+						} else if (!drop_mode_flags) {
+							if (is_cell_button_hovered) {
+								theme_cache.hovered_dimmed->draw(stylebox_ci, row_rect);
 							} else {
-								theme_cache.selected->draw(stylebox_ci, row_rect);
+								theme_cache.hovered->draw(stylebox_ci, row_rect);
 							}
-						}
-					} else if (!drop_mode_flags) {
-						if (is_cell_button_hovered) {
-							theme_cache.hovered_dimmed->draw(stylebox_ci, row_rect);
-						} else {
-							theme_cache.hovered->draw(stylebox_ci, row_rect);
 						}
 					}
+				}
+
+				if (show_row_stripes && (r_row_idx % 2 != 0)) {
+					theme_cache.row_stripes->draw(ci, row_rect);
 				}
 			}
 
@@ -2823,7 +2831,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			int child_h = -1;
 			int child_self_height = 0;
 			if (htotal >= 0) {
-				child_h = draw_item(children_pos, p_draw_ofs, p_draw_size, c, child_self_height);
+				child_h = draw_item(children_pos, p_draw_ofs, p_draw_size, c, child_self_height, r_row_idx);
 				child_self_height += theme_cache.v_separation;
 			}
 
@@ -5256,7 +5264,8 @@ void Tree::_notification(int p_what) {
 
 			if (root && get_size().x > 0 && get_size().y > 0) {
 				int self_height = 0; // Just to pass a reference, we don't need the root's `self_height`.
-				draw_item(Point2(), draw_ofs, draw_size, root, self_height);
+				int row_idx = -1;
+				draw_item(Point2(), draw_ofs, draw_size, root, self_height, row_idx);
 
 				// Draw drop indicator.
 				if (drop_mode_flags && drop_mode_over) {
@@ -6275,6 +6284,19 @@ bool Tree::are_column_titles_visible() const {
 	return show_column_titles;
 }
 
+void Tree::set_row_stripes_visible(bool p_show) {
+	if (show_row_stripes == p_show) {
+		return;
+	}
+
+	show_row_stripes = p_show;
+	queue_redraw();
+}
+
+bool Tree::are_row_stripes_visible() const {
+	return show_row_stripes;
+}
+
 void Tree::set_column_title(int p_column, const String &p_title) {
 	ERR_FAIL_INDEX(p_column, columns.size());
 
@@ -7229,6 +7251,9 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_column_titles_visible", "visible"), &Tree::set_column_titles_visible);
 	ClassDB::bind_method(D_METHOD("are_column_titles_visible"), &Tree::are_column_titles_visible);
 
+	ClassDB::bind_method(D_METHOD("set_row_stripes_visible", "visible"), &Tree::set_row_stripes_visible);
+	ClassDB::bind_method(D_METHOD("are_row_stripes_visible"), &Tree::are_row_stripes_visible);
+
 	ClassDB::bind_method(D_METHOD("set_column_title", "column", "title"), &Tree::set_column_title);
 	ClassDB::bind_method(D_METHOD("get_column_title", "column"), &Tree::get_column_title);
 
@@ -7285,6 +7310,7 @@ void Tree::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "columns"), "set_columns", "get_columns");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "column_titles_visible"), "set_column_titles_visible", "are_column_titles_visible");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "row_stripes_visible"), "set_row_stripes_visible", "are_row_stripes_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_rmb_select"), "set_allow_rmb_select", "get_allow_rmb_select");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_search"), "set_allow_search", "get_allow_search");
@@ -7348,6 +7374,7 @@ void Tree::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, Tree, cursor_unfocus, "cursor_unfocused");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, button_hover);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, button_pressed);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, row_stripes);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, Tree, checked);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, Tree, unchecked);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2321,7 +2321,7 @@ void Tree::update_item_cache(TreeItem *p_item) const {
 	}
 }
 
-int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height, const RID &p_ci) {
+int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height, const RID &p_ci, int &r_row_idx) {
 	const real_t bottom_margin = theme_cache.panel_style->get_margin(SIDE_BOTTOM); // Extra stylebox space below the content
 	const real_t draw_height = p_draw_size.height + bottom_margin; // Visible height including bottom margin
 
@@ -2350,6 +2350,12 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 		// Draw separation.
 
 		ERR_FAIL_COND_V(theme_cache.font.is_null(), -1);
+
+		r_row_idx++;
+
+		if (p_ci == content_ci) {
+			p_item->cached_strip_index = r_row_idx;
+		}
 
 		int ofs = p_pos.x + ((p_item->disable_folding || hide_folding) ? theme_cache.h_separation : theme_cache.item_margin);
 		int skip2 = 0;
@@ -2440,34 +2446,41 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				cell_rect.size.x += theme_cache.h_separation;
 			}
 
-			if (should_draw_row_rect) {
-				if (p_item->cells[0].selected || is_row_hovered) {
-					const Rect2 content_rect = _get_content_rect();
-					Rect2i row_rect = Rect2i(Point2i(content_rect.position.x, item_rect.position.y), Size2i(content_rect.size.x, item_rect.size.y));
-					row_rect = convert_rtl_rect(row_rect);
+			if (i == 0) {
+				const Rect2 content_rect = _get_content_rect();
+				Rect2i row_rect = Rect2i(Point2i(content_rect.position.x, item_rect.position.y), Size2i(content_rect.size.x, item_rect.size.y));
+				row_rect = convert_rtl_rect(row_rect);
 
-					if (p_item->cells[0].selected) {
-						if (is_row_hovered) {
-							if (has_focus(true)) {
-								theme_cache.hovered_selected_focus->draw(sb_ci, row_rect);
+				if (should_draw_row_rect) {
+					if (p_item->cells[0].selected || is_row_hovered) {
+						if (p_item->cells[0].selected) {
+							if (is_row_hovered) {
+								if (has_focus(true)) {
+									theme_cache.hovered_selected_focus->draw(sb_ci, row_rect);
+								} else {
+									theme_cache.hovered_selected->draw(sb_ci, row_rect);
+								}
 							} else {
-								theme_cache.hovered_selected->draw(sb_ci, row_rect);
+								if (has_focus(true)) {
+									theme_cache.selected_focus->draw(sb_ci, row_rect);
+								} else {
+									theme_cache.selected->draw(sb_ci, row_rect);
+								}
 							}
-						} else {
-							if (has_focus(true)) {
-								theme_cache.selected_focus->draw(sb_ci, row_rect);
+						} else if (!drop_mode_flags) {
+							if (is_cell_button_hovered) {
+								theme_cache.hovered_dimmed->draw(sb_ci, row_rect);
 							} else {
-								theme_cache.selected->draw(sb_ci, row_rect);
+								theme_cache.hovered->draw(sb_ci, row_rect);
 							}
-						}
-					} else if (!drop_mode_flags) {
-						if (is_cell_button_hovered) {
-							theme_cache.hovered_dimmed->draw(sb_ci, row_rect);
-						} else {
-							theme_cache.hovered->draw(sb_ci, row_rect);
 						}
 					}
 				}
+
+				if (theme_cache.row_stripes_visible && (r_row_idx % 2 != 0)) {
+					theme_cache.row_stripes->draw(ci, row_rect);
+				}
+
 				should_draw_row_rect = false;
 			}
 
@@ -2830,7 +2843,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			int child_h = -1;
 			int child_self_height = 0;
 			if (htotal >= 0) {
-				child_h = draw_item(children_pos, p_draw_ofs, p_draw_size, c, child_self_height, ci);
+				child_h = draw_item(children_pos, p_draw_ofs, p_draw_size, c, child_self_height, ci, r_row_idx);
 				child_self_height += theme_cache.v_separation;
 			}
 
@@ -5399,7 +5412,8 @@ void Tree::_notification(int p_what) {
 			sticky_candidates.clear();
 			if (root && get_size().x > 0 && get_size().y > 0) {
 				int self_height = 0; // Just to pass a reference, we don't need the root's `self_height`.
-				draw_item(Point2(), draw_ofs, draw_size, root, self_height, content_ci);
+				int row_idx = -1;
+				draw_item(Point2(), draw_ofs, draw_size, root, self_height, content_ci, row_idx);
 
 				// Draw drop indicator.
 				if (drop_mode_flags && drop_mode_over) {
@@ -5691,7 +5705,8 @@ void Tree::_notification(int p_what) {
 					Point2 old_offset = theme_cache.offset;
 					theme_cache.offset.y = 0;
 					int self_height = 0;
-					draw_item(item->sticky_offset, draw_ofs, draw_size, item, self_height, is_last ? last_sticky_ci : header_ci);
+					int row_idx = item->cached_strip_index > 0 ? item->cached_strip_index - 1 : -1;
+					draw_item(item->sticky_offset, draw_ofs, draw_size, item, self_height, is_last ? last_sticky_ci : header_ci, row_idx);
 					theme_cache.offset = old_offset;
 				}
 
@@ -7582,6 +7597,7 @@ void Tree::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, Tree, cursor_unfocus, "cursor_unfocused");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, button_hover);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, button_pressed);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, row_stripes);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, Tree, checked);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, Tree, unchecked);
@@ -7626,6 +7642,7 @@ void Tree::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_CONSTANT, Tree, font_outline_size, "outline_size");
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, draw_guides);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, row_stripes_visible);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, guide_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, draw_relationship_lines);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, relationship_line_width);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -553,6 +553,7 @@ private:
 	};
 
 	bool show_column_titles = false;
+	bool show_row_stripes = false;
 
 	bool popup_edit_committed = true;
 	RID accessibility_scroll_element;
@@ -588,7 +589,7 @@ private:
 	void update_item_cell(TreeItem *p_item, int p_col) const;
 	void update_item_cache(TreeItem *p_item) const;
 	void draw_item_rect(const TreeItem::Cell &p_cell, const Rect2i &p_rect, const Color &p_color, const Color &p_icon_color, int p_ol_size, const Color &p_ol_color) const;
-	int draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height);
+	int draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height, int &r_row_idx);
 	void select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_col, TreeItem *p_prev = nullptr, bool *r_in_range = nullptr, bool p_force_deselect = false);
 	int propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int x_limit, bool p_double_click, TreeItem *p_item, MouseButton p_button, const Ref<InputEventWithModifiers> &p_mod);
 	void _line_editor_submit(String p_text);
@@ -634,6 +635,7 @@ private:
 		Ref<StyleBox> custom_button;
 		Ref<StyleBox> custom_button_hover;
 		Ref<StyleBox> custom_button_pressed;
+		Ref<StyleBox> row_stripes;
 
 		Color title_button_color;
 
@@ -905,6 +907,9 @@ public:
 
 	void set_column_titles_visible(bool p_show);
 	bool are_column_titles_visible() const;
+
+	void set_row_stripes_visible(bool p_show);
+	bool are_row_stripes_visible() const;
 
 	RID get_custom_drawing_canvas_item() const { return custom_ci; }
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -159,6 +159,7 @@ private:
 	int cached_start = 0;
 	int cached_label_height = 0;
 	int cached_total_end = 0;
+	int cached_strip_index = -1;
 	Point2 sticky_offset;
 
 	LocalVector<TreeItem *> children_cache;
@@ -602,7 +603,7 @@ private:
 	void update_item_cell(TreeItem *p_item, int p_col) const;
 	void update_item_cache(TreeItem *p_item) const;
 	void draw_item_rect(const TreeItem::Cell &p_cell, const Rect2i &p_rect, const Color &p_color, const Color &p_icon_color, int p_ol_size, const Color &p_ol_color, const RID &p_ci) const;
-	int draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height, const RID &p_ci);
+	int draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height, const RID &p_ci, int &r_row_idx);
 	void select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_col, TreeItem *p_prev = nullptr, bool *r_in_range = nullptr, bool p_force_deselect = false);
 	int propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int x_limit, bool p_double_click, TreeItem *p_item, MouseButton p_button, const Ref<InputEventWithModifiers> &p_mod, bool p_first_call = true, bool p_skip_children = false);
 	void _line_editor_submit(String p_text);
@@ -649,6 +650,7 @@ private:
 		Ref<StyleBox> custom_button;
 		Ref<StyleBox> custom_button_hover;
 		Ref<StyleBox> custom_button_pressed;
+		Ref<StyleBox> row_stripes;
 
 		Color title_button_color;
 
@@ -703,6 +705,7 @@ private:
 		int children_hl_line_width = 0;
 		int parent_hl_line_margin = 0;
 		int draw_guides = 0;
+		int row_stripes_visible = 0;
 
 		int dragging_unfold_wait_msec = 500;
 

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -890,6 +890,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("custom_button", "Tree", button_normal);
 	theme->set_stylebox("custom_button_pressed", "Tree", button_pressed);
 	theme->set_stylebox("custom_button_hover", "Tree", button_hover);
+	theme->set_stylebox("row_stripes", "Tree", make_flat_stylebox(Color(0.7, 0.7, 0.7, 0.25), 0, 0, 0, 0, 0));
 
 	theme->set_icon("checked", "Tree", icons["checked"]);
 	theme->set_icon("checked_disabled", "Tree", icons["checked_disabled"]);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -898,6 +898,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("custom_button", "Tree", button_normal);
 	theme->set_stylebox("custom_button_pressed", "Tree", button_pressed);
 	theme->set_stylebox("custom_button_hover", "Tree", button_hover);
+	theme->set_stylebox("row_stripes", "Tree", make_flat_stylebox(Color(0.7, 0.7, 0.7, 0.25), 0, 0, 0, 0, 0));
 
 	theme->set_icon("checked", "Tree", icons["checked"]);
 	theme->set_icon("checked_disabled", "Tree", icons["checked_disabled"]);
@@ -950,6 +951,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("children_hl_line_width", "Tree", 1);
 	theme->set_constant("parent_hl_line_margin", "Tree", 0);
 	theme->set_constant("draw_guides", "Tree", 1);
+	theme->set_constant("row_stripes_visible", "Tree", 0);
 	theme->set_constant("dragging_unfold_wait_msec", "Tree", 500);
 	theme->set_constant("scroll_border", "Tree", Math::round(4 * scale));
 	theme->set_constant("scroll_speed", "Tree", 12);


### PR DESCRIPTION
Implements: https://github.com/godotengine/godot/pull/111268#issuecomment-3368760141

<img width="1919" height="1070" alt="image" src="https://github.com/user-attachments/assets/3de23536-b296-4c23-adf5-ecd775bbb242" />

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/9376