### PR TITLE
Move deprecated `has_named_classes` from `ScriptLanguage` to `ScriptLanguageExtension`

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -273,9 +273,6 @@ public:
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptError> *r_errors = nullptr, List<Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const = 0;
 	virtual String validate_path(const String &p_path) const { return ""; }
 	virtual Script *create_script() const = 0;
-#ifndef DISABLE_DEPRECATED
-	virtual bool has_named_classes() const = 0;
-#endif
 	virtual bool supports_builtin_mode() const = 0;
 	virtual bool supports_documentation() const { return false; }
 	virtual bool can_inherit_from_file() const { return false; }

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -370,7 +370,7 @@ public:
 		return Object::cast_to<Script>(ret);
 	}
 #ifndef DISABLE_DEPRECATED
-	EXBIND0RC(bool, has_named_classes)
+	GDVIRTUAL0RC(bool, _has_named_classes)
 #endif
 	EXBIND0RC(bool, supports_builtin_mode)
 	EXBIND0RC(bool, supports_documentation)

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -215,7 +215,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_has_named_classes" qualifiers="virtual required const" deprecated="This method is not called by the engine.">
+		<method name="_has_named_classes" qualifiers="virtual const" deprecated="This method is not called by the engine.">
 			<return type="bool" />
 			<description>
 			</description>

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -608,9 +608,6 @@ public:
 	virtual Vector<ScriptTemplate> get_built_in_templates(const StringName &p_object) override;
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const override;
 	virtual Script *create_script() const override;
-#ifndef DISABLE_DEPRECATED
-	virtual bool has_named_classes() const override { return false; }
-#endif
 	virtual bool supports_builtin_mode() const override;
 	virtual bool supports_documentation() const override;
 	virtual bool can_inherit_from_file() const override { return true; }

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -513,9 +513,6 @@ public:
 	}
 	String validate_path(const String &p_path) const override;
 	Script *create_script() const override;
-#ifndef DISABLE_DEPRECATED
-	virtual bool has_named_classes() const override { return false; }
-#endif
 	bool supports_builtin_mode() const override;
 	/* TODO? */ int find_function(const String &p_function, const String &p_code) const override {
 		return -1;


### PR DESCRIPTION
`ScriptLanguage` is unexposed, the only reason to keep dummy implementations of this deprecated method around was, so that `ScriptLanguageExtension` can use the `EXBIND0RC` macro which binds an existing virtual method to GDExtension. This has been converted to `GDVIRTUAL0RC` which can keep the gdvirtual without having a method in C++.