### PR TITLE
LSP: Fix repeated restart attempts

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -56,7 +56,8 @@ void GDScriptLanguageServer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			if (!started && EditorNode::get_singleton()->is_editor_ready()) {
+			if (!start_attempted && EditorNode::get_singleton()->is_editor_ready()) {
+				start_attempted = true;
 				start();
 			}
 

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -41,6 +41,8 @@ class GDScriptLanguageServer : public EditorPlugin {
 
 	Thread thread;
 	bool thread_running = false;
+	// There is no notification when the editor is initialized. We need to poll till we attempted to start the server.
+	bool start_attempted = false;
 	bool started = false;
 	bool use_thread = false;
 	String host = "127.0.0.1";


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/111261

The error will still print once but that's kinda expected. If two separate Godot instances try to start the language server on the same port there exists a conflict.

However now the language server will not try to restart every frame if the port is taken.

With this PR the behavior is the same as in 4.4, however in 4.4 it would fail silently and not print an error at all. This must be some change in the networking layer I guess.