### PR TITLE
Fix Tree column title tooltip crash.

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -6403,14 +6403,15 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 		// Walk forwards until we know which column we're in.
 		int next_edge = 0;
 		int i = 0;
-		for (; i < columns.size(); i++) {
+		for (const ColumnInfo &column : columns) {
+			next_edge += get_column_width(i++);
+
 			if (pos_x < next_edge) {
+				if (!column.title_tooltip.is_empty()) {
+					return column.title_tooltip;
+				}
 				break;
 			}
-			next_edge += get_column_width(i);
-		}
-		if (!columns[i - 1].title_tooltip.is_empty()) {
-			return columns[i - 1].title_tooltip;
 		}
 
 		// If the column has no tooltip, use the default.


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/111291

* Introduced in: https://github.com/godotengine/godot/pull/97210