### PR TITLE
Filter out metadata of excluded files on export

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -35,6 +35,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/io/stream_peer.h"
 #include "core/math/random_pcg.h"
 #include "core/object/class_db.h"
 
@@ -248,6 +249,21 @@ String ResourceUID::ensure_path(const String &p_uid_or_path) {
 	return p_uid_or_path;
 }
 
+Vector<uint8_t> ResourceUID::encode_binary_cache(const Vector<Pair<ID, String>> &p_entries) {
+	Ref<StreamPeerBuffer> buffer;
+	buffer.instantiate();
+	buffer->put_u32(p_entries.size());
+
+	for (const Pair<ID, String> &entry : p_entries) {
+		buffer->put_u64(uint64_t(entry.first));
+		CharString cs = entry.second.utf8();
+		buffer->put_u32(cs.length());
+		buffer->put_data((const uint8_t *)cs.ptr(), cs.length());
+	}
+
+	return buffer->get_data_array();
+}
+
 Error ResourceUID::save_to_cache() {
 	String cache_file = get_cache_file();
 	if (!FileAccess::exists(cache_file)) {
@@ -261,18 +277,19 @@ Error ResourceUID::save_to_cache() {
 	}
 
 	MutexLock l(mutex);
-	f->store_32(unique_ids.size());
 
+	Vector<Pair<ID, String>> entries;
+	entries.reserve(unique_ids.size());
 	cache_entries = 0;
 
 	for (KeyValue<ID, Cache> &E : unique_ids) {
-		f->store_64(uint64_t(E.key));
-		uint32_t s = E.value.cs.length();
-		f->store_32(s);
-		f->store_buffer((const uint8_t *)E.value.cs.ptr(), s);
+		entries.push_back(Pair<ID, String>(E.key, String::utf8(E.value.cs.ptr(), E.value.cs.length())));
 		E.value.saved_to_cache = true;
 		cache_entries++;
 	}
+
+	Vector<uint8_t> data = encode_binary_cache(entries);
+	f->store_buffer(data.ptr(), data.size());
 
 	changed = false;
 	return OK;

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -88,6 +88,7 @@ public:
 	Error save_to_cache();
 	Error update_cache();
 	static String get_path_from_cache(Ref<FileAccess> &p_cache_file, const String &p_uid_string);
+	static Vector<uint8_t> encode_binary_cache(const Vector<Pair<ID, String>> &p_entries);
 
 	void enable_reverse_cache() { use_reverse_cache = true; }
 	void clear();

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1247,10 +1247,6 @@ Vector<String> EditorExportPlatform::get_forced_export_files(const Ref<EditorExp
 	if (!splash.is_empty() && FileAccess::exists(splash) && icon != splash) {
 		files.push_back(splash);
 	}
-	String resource_cache_file = ResourceUID::get_cache_file();
-	if (FileAccess::exists(resource_cache_file)) {
-		files.push_back(resource_cache_file);
-	}
 
 	String extension_list_config_file = GDExtension::get_extension_list_config_file();
 	if (FileAccess::exists(extension_list_config_file)) {
@@ -1788,21 +1784,34 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		}
 	}
 
+	const FilteredCache filtered_cache = _get_filtered_cache(paths);
+
 	Vector<String> forced_export = get_forced_export_files(p_preset);
-	for (int i = 0; i < forced_export.size(); i++) {
+	for (const String &file : forced_export) {
 		Vector<uint8_t> array;
-		if (GDExtension::get_extension_list_config_file() == forced_export[i]) {
-			array = _filter_extension_list_config_file(forced_export[i], paths);
-			if (array.is_empty()) {
-				continue;
-			}
+
+		if (file == GDExtension::get_extension_list_config_file()) {
+			array = filtered_cache.extension_list;
+		} else if (file == ProjectSettings::get_singleton()->get_global_class_list_path()) {
+			array = filtered_cache.global_class_list;
 		} else {
-			array = FileAccess::get_file_as_bytes(forced_export[i]);
+			array = FileAccess::get_file_as_bytes(file);
 		}
-		err = save_proxy.save_file(p_preset, p_udata, forced_export[i], array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+
+		if (array.is_empty()) {
+			continue;
+		}
+
+		err = save_proxy.save_file(p_preset, p_udata, file, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 		if (err != OK) {
 			return err;
 		}
+	}
+
+	String uid_cache_file_path = ResourceUID::get_cache_file();
+	err = save_proxy.save_file(p_preset, p_udata, uid_cache_file_path, filtered_cache.uids, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+	if (err != OK) {
+		return err;
 	}
 
 	Dictionary int_export = get_internal_export_files(p_preset, p_debug);
@@ -1841,20 +1850,69 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	return OK;
 }
 
-Vector<uint8_t> EditorExportPlatform::_filter_extension_list_config_file(const String &p_config_path, const HashSet<String> &p_paths) {
-	Ref<FileAccess> f = FileAccess::open(p_config_path, FileAccess::READ);
-	if (f.is_null()) {
-		ERR_FAIL_V_MSG(Vector<uint8_t>(), "Can't open file from path '" + String(p_config_path) + "'.");
-	}
-	Vector<uint8_t> data;
-	while (!f->eof_reached()) {
-		String l = f->get_line().strip_edges();
-		if (p_paths.has(l)) {
-			data.append_array(l.to_utf8_buffer());
-			data.append('\n');
+// Used by the main export function to filter excluded global classes, extensions
+// and UIDs based on excluded resources configured in the export preset.
+EditorExportPlatform::FilteredCache EditorExportPlatform::_get_filtered_cache(const HashSet<String> &p_paths) {
+	FilteredCache result;
+
+	HashSet<String> extension_list_lines;
+	Ref<FileAccess> ext_file = FileAccess::open(GDExtension::get_extension_list_config_file(), FileAccess::READ);
+	if (ext_file.is_valid()) {
+		while (!ext_file->eof_reached()) {
+			String line = ext_file->get_line().strip_edges();
+			extension_list_lines.insert(line);
 		}
 	}
-	return data;
+
+	HashMap<String, Dictionary> class_by_path;
+	Ref<ConfigFile> global_class_cf;
+	global_class_cf.instantiate();
+	if (global_class_cf->load(ProjectSettings::get_singleton()->get_global_class_list_path()) == OK) {
+		Array original_list = global_class_cf->get_value("", "list", Array());
+		class_by_path.reserve(original_list.size());
+		for (const Variant &item : original_list) {
+			const Dictionary &class_dict = item;
+			ERR_CONTINUE(!class_dict.has("path"));
+			class_by_path[class_dict["path"]] = class_dict;
+		}
+	}
+
+	Vector<String> extension_lines;
+	Array global_class_list;
+	Vector<Pair<ResourceUID::ID, String>> uid_entries;
+	extension_lines.reserve(extension_list_lines.size());
+	global_class_list.reserve(class_by_path.size());
+	uid_entries.reserve(p_paths.size());
+
+	for (const String &path : p_paths) {
+		if (extension_list_lines.has(path)) {
+			extension_lines.push_back(path);
+		}
+		if (class_by_path.has(path)) {
+			global_class_list.push_back(class_by_path[path]);
+		}
+		ResourceUID::ID uid = EditorFileSystem::get_singleton()->get_file_uid(path);
+		if (uid != ResourceUID::INVALID_ID) {
+			uid_entries.push_back(Pair<ResourceUID::ID, String>(uid, path));
+		}
+	}
+
+	// Encode extensions.
+	for (const String &line : extension_lines) {
+		result.extension_list.append_array(line.to_utf8_buffer());
+		result.extension_list.append('\n');
+	}
+
+	// Encode global classes.
+	if (!global_class_list.is_empty()) {
+		global_class_cf->set_value("", "list", global_class_list);
+		result.global_class_list = global_class_cf->encode_to_text().to_utf8_buffer();
+	}
+
+	// Encode UIDs.
+	result.uids = ResourceUID::encode_binary_cache(uid_entries);
+
+	return result;
 }
 
 Error EditorExportPlatform::_pack_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -146,7 +146,13 @@ private:
 	void _edit_files_with_filter(Ref<DirAccess> &da, const Vector<String> &p_filters, HashSet<String> &r_list, bool exclude);
 	void _edit_filter_list(HashSet<String> &r_list, const String &p_filter, bool exclude);
 
-	static Vector<uint8_t> _filter_extension_list_config_file(const String &p_config_path, const HashSet<String> &p_paths);
+	struct FilteredCache {
+		Vector<uint8_t> extension_list;
+		Vector<uint8_t> global_class_list;
+		Vector<uint8_t> uids;
+	};
+
+	static FilteredCache _get_filtered_cache(const HashSet<String> &p_paths);
 
 	struct FileExportCache {
 		uint64_t source_modified_time = 0;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12701
Closes https://github.com/godotengine/godot/issues/116110

Excludes metadata of excluded files from pck. Generates the UID cache for exported files instead of force-exporting the entire `uid_cache.bin` and filters the contents of `global_script_class_cache.cfg`

Example project: [exportfilter.zip](https://github.com/user-attachments/files/22710612/exportfilter.zip)

Export config:

<img src="https://github.com/user-attachments/assets/7912b05a-23d6-4c89-819b-48337c131e18" width=500><br>

Occurences of "unreleased" in pck:

| Master: `4` | PR: `0` |
|--------|--------|
| ![a](https://github.com/user-attachments/assets/2e378652-fd74-41c9-85a2-4de7507bb6af) | ![b](https://github.com/user-attachments/assets/c39d6a7b-e59e-45cd-9dd5-22656410ac07) |