### PR TITLE
Core: Clean up headers in `core/config`, forward-declare `MainLoop` in `OS`

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -30,9 +30,12 @@
 
 #pragma once
 
-#include "core/os/main_loop.h"
-#include "core/string/ustring.h"
+#include "core/string/string_name.h"
+#include "core/templates/hash_map.h"
 #include "core/templates/list.h"
+
+class Object;
+class Dictionary;
 
 template <typename T>
 class TypedArray;

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
 #include "core/templates/rb_map.h"
 
 template <typename T>

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -40,6 +40,7 @@
 #include "core/math/geometry_2d.h"
 #include "core/math/geometry_3d.h"
 #include "core/os/keyboard.h"
+#include "core/os/main_loop.h"
 #include "core/os/thread_safe.h"
 #include "core/variant/typed_array.h"
 

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -31,6 +31,7 @@
 #include "local_debugger.h"
 
 #include "core/debugger/script_debugger.h"
+#include "core/os/main_loop.h"
 #include "core/os/os.h"
 
 struct LocalDebugger::ScriptsProfiler {

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -37,6 +37,7 @@
 #include "core/io/file_access_encrypted.h"
 #include "core/io/file_access_pack.h"
 #include "core/io/marshalls.h"
+#include "core/io/resource_uid.h"
 #include "core/os/os.h"
 #include "core/os/time.h"
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -566,6 +566,7 @@ public:                                              \
                                                      \
 private:
 
+class ClassDB;
 class ScriptInstance;
 
 class Object {
@@ -781,7 +782,7 @@ protected:
 
 	void _clear_internal_resource_paths(const Variant &p_var);
 
-	friend class ClassDB;
+	friend class ::ClassDB;
 	friend class PlaceholderExtensionInstance;
 
 	static void _add_class_to_classdb(const StringName &p_class, const StringName &p_inherits);

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -39,6 +39,7 @@
 #include "core/templates/paged_allocator.h"
 #include "core/templates/rid.h"
 #include "core/templates/safe_refcount.h"
+#include "core/templates/self_list.h"
 
 class WorkerThreadPool : public Object {
 	GDCLASS(WorkerThreadPool, Object)

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -30,9 +30,8 @@
 
 #pragma once
 
-#include "core/input/input_event.h"
 #include "core/object/gdvirtual.gen.inc"
-#include "core/object/ref_counted.h"
+#include "core/object/object.h"
 
 class MainLoop : public Object {
 	GDCLASS(MainLoop, Object);

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -40,6 +40,8 @@
 
 #include <cstdlib>
 
+class MainLoop;
+
 class OS {
 	static OS *singleton;
 	static uint64_t target_ticks;
@@ -223,6 +225,7 @@ public:
 
 	void ensure_user_data_dir();
 
+	// NOTE: MainLoop is forward-declared in OS and should be included to use this.
 	virtual MainLoop *get_main_loop() const = 0;
 
 	virtual void yield();

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -33,6 +33,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
+#include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/string/locales.h"
 

--- a/drivers/apple_embedded/app_delegate_service.mm
+++ b/drivers/apple_embedded/app_delegate_service.mm
@@ -35,6 +35,7 @@
 #import "os_apple_embedded.h"
 
 #include "core/config/project_settings.h"
+#include "core/os/main_loop.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #include "main/main.h"
 

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -40,6 +40,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/os/main_loop.h"
 #import "drivers/apple/os_log_logger.h"
 #include "main/main.h"
 

--- a/modules/jolt_physics/jolt_project_settings.cpp
+++ b/modules/jolt_physics/jolt_project_settings.cpp
@@ -31,6 +31,7 @@
 #include "jolt_project_settings.h"
 
 #include "core/config/project_settings.h"
+#include "core/object/callable_method_pointer.h"
 
 void JoltProjectSettings::register_settings() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/jolt_physics_3d/simulation/velocity_steps", PROPERTY_HINT_RANGE, U"2,16,or_greater"), 10);

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -48,6 +48,7 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
+#include "core/os/main_loop.h"
 #include "main/main.h"
 #include "servers/rendering/rendering_server.h"
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -41,6 +41,7 @@
 #include "core/config/project_settings.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/io/xml_parser.h"
+#include "core/os/main_loop.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #ifdef TOOLS_ENABLED

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/script_language.h"
+#include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -33,6 +33,7 @@
 #include "core/io/certs_compressed.gen.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/os/main_loop.h"
 #ifdef SDL_ENABLED
 #include "drivers/sdl/joypad_sdl.h"
 #endif

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -39,6 +39,7 @@
 #define DEBUG_LOG_WAYLAND(...)
 #endif
 
+#include "core/os/main_loop.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #ifdef VULKAN_ENABLED

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -38,6 +38,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "core/math/math_funcs.h"
+#include "core/os/main_loop.h"
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
 #include "core/version.h"

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/script_language.h"
+#include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -55,6 +55,7 @@
 #import "core/config/project_settings.h"
 #import "core/debugger/engine_debugger.h"
 #import "core/io/marshalls.h"
+#import "core/os/main_loop.h"
 
 DisplayServerEmbedded::DisplayServerEmbedded(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error) {
 	EmbeddedDebugger::initialize(this);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -49,6 +49,7 @@
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/os/keyboard.h"
+#include "core/os/main_loop.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
 #include "scene/resources/image_texture.h"

--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -34,6 +34,7 @@
 #include "platform/macos/display_server_macos.h"
 
 #include "core/input/input_event_codec.h"
+#include "core/os/main_loop.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"

--- a/platform/macos/embedded_debugger.mm
+++ b/platform/macos/embedded_debugger.mm
@@ -34,6 +34,7 @@
 
 #include "core/debugger/engine_debugger.h"
 #include "core/input/input_event_codec.h"
+#include "core/os/main_loop.h"
 
 #ifdef DEBUG_ENABLED
 HashMap<String, EmbeddedDebugger::ParseMessageFunc> EmbeddedDebugger::parse_message_handlers;

--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -35,6 +35,7 @@
 #import "native_menu_macos.h"
 #import "os_macos.h"
 
+#import "core/os/main_loop.h"
 #import "main/main.h"
 
 #import <Carbon/Carbon.h>

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -40,6 +40,7 @@
 
 #include "core/crypto/crypto_core.h"
 #include "core/io/file_access.h"
+#include "core/os/main_loop.h"
 #include "core/version_generated.gen.h"
 #include "drivers/apple/os_log_logger.h"
 #include "main/main.h"

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -36,6 +36,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/callable_method_pointer.h"
+#include "core/os/main_loop.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #ifdef GLES3_ENABLED

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -39,6 +39,7 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/io/file_access.h"
+#include "core/os/main_loop.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #include "main/main.h"

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/script_language.h"
+#include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/script_language.h"
+#include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -39,6 +39,7 @@
 #include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/io/xml_parser.h"
+#include "core/os/main_loop.h"
 #include "core/version.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -38,6 +38,7 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "core/io/marshalls.h"
+#include "core/os/main_loop.h"
 #include "core/version_generated.gen.h"
 #include "drivers/windows/dir_access_windows.h"
 #include "drivers/windows/file_access_windows.h"

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/math/math_funcs.h"
+#include "core/os/main_loop.h"
 #include "scene/resources/theme.h"
 #include "scene/theme/theme_db.h"
 #include "servers/rendering/rendering_server.h"

--- a/servers/text/text_server.cpp
+++ b/servers/text/text_server.cpp
@@ -32,6 +32,7 @@
 #include "text_server.compat.inc"
 
 #include "core/config/project_settings.h"
+#include "core/os/main_loop.h"
 #include "core/variant/typed_array.h"
 #include "servers/rendering/rendering_server.h"
 


### PR DESCRIPTION
- Helps address #111218

Tackles scope reduction for two files: `core/config/engine.h` aand `core/config/project_settings.h`. The latter was inconsequential, but the former revealed several dependency chains for `core/os/main_loop.h`, despite neither it *nor the compilation file* using `MainLoop` in any way.