### PR TITLE
Fix GDScript translation parser for `FileDialog.add_filter()` two-parameter format

### DIFF
--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -383,9 +383,14 @@ void GDScriptEditorTranslationParserPlugin::_assess_call(const GDScriptParser::C
 			_add_id(p_call->arguments[1]->reduced_value, p_call->arguments[1]->start_line);
 		}
 	} else if (function_name == fd_add_filter) {
-		// Extract the 'JPE Images' in this example - get_node("FileDialog").add_filter("*.jpg; JPE Images").
-		if (!p_call->arguments.is_empty()) {
+		if (p_call->arguments.size() == 1) {
+			// The first parameter may contain a description, like `"*.jpg; JPEG Images"`.
 			_extract_fd_filter_string(p_call->arguments[0], p_call->arguments[0]->start_line);
+		} else if (p_call->arguments.size() >= 2) {
+			// The second optional parameter can be a description.
+			if (_is_constant_string(p_call->arguments[1])) {
+				_add_id(p_call->arguments[1]->reduced_value, p_call->arguments[1]->start_line);
+			}
 		}
 	} else if (function_name == fd_set_filter) {
 		// Extract from `get_node("FileDialog").set_filters(<filter array>)`.
@@ -396,11 +401,16 @@ void GDScriptEditorTranslationParserPlugin::_assess_call(const GDScriptParser::C
 }
 
 void GDScriptEditorTranslationParserPlugin::_extract_fd_filter_string(const GDScriptParser::ExpressionNode *p_expression, int p_line) {
-	// Extract the name in "extension ; name".
+	// Extract the description from `"filter; Description"` format.
+	// The description part is optional, so we skip if it's missing or empty.
 	if (_is_constant_string(p_expression)) {
-		PackedStringArray arr = p_expression->reduced_value.operator String().split(";", true);
-		ERR_FAIL_COND_MSG(arr.size() != 2, "Argument for setting FileDialog has bad format.");
-		_add_id(arr[1].strip_edges(), p_line);
+		const PackedStringArray arr = p_expression->reduced_value.operator String().split(";", true, 1);
+		if (arr.size() >= 2) {
+			const String description = arr[1].strip_edges();
+			if (!description.is_empty()) {
+				_add_id(description, p_line);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes: [GDScript translation parser bug with FileDialog #111286
](https://github.com/godotengine/godot/issues/111286)

The translation parser was only handling the single-parameter format of `add_filter("*.jpg; JPE Images")` and would throw an error when you used the two-parameter format `add_filter("*.jpg", "JPE Images")`.

This fix checks for the second parameter first before trying to parse the semicolon format, so both ways work now, and translatable filter names get extracted properly.