### PR TITLE
Build: Fix container build path for swift

### DIFF
--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -25,6 +25,7 @@ def get_opts():
 
     return [
         ("vulkan_sdk_path", "Path to the Vulkan SDK", ""),
+        ("SWIFT_FRONTEND", "Path to the swift-frontend binary", ""),
         # APPLE_TOOLCHAIN_PATH Example: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain
         (("APPLE_TOOLCHAIN_PATH", "IOS_TOOLCHAIN_PATH"), "Path to the Apple toolchain", ""),
         (("APPLE_SDK_PATH", "IOS_SDK_PATH"), "Path to the iOS SDK", ""),

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -29,6 +29,7 @@ def get_opts():
 
     return [
         ("osxcross_sdk", "OSXCross SDK version", "darwin16"),
+        ("SWIFT_FRONTEND", "Path to the swift-frontend binary", ""),
         ("MACOS_SDK_PATH", "Path to the macOS SDK", ""),
         ("vulkan_sdk_path", "Path to the Vulkan SDK", ""),
         EnumVariable("macports_clang", "Build using Clang from MacPorts", "no", ["no", "5.0", "devel"], ignorecase=2),

--- a/platform/visionos/detect.py
+++ b/platform/visionos/detect.py
@@ -24,6 +24,7 @@ def get_opts():
     from SCons.Variables import BoolVariable
 
     return [
+        ("SWIFT_FRONTEND", "Path to the swift-frontend binary", ""),
         # APPLE_TOOLCHAIN_PATH Example: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain
         ("APPLE_TOOLCHAIN_PATH", "Path to the Apple toolchain", ""),
         (("APPLE_SDK_PATH", "VISIONOS_SDK_PATH"), "Path to the visionOS SDK", ""),


### PR DESCRIPTION
# Summary

Ensures release builds using osxcross paths when using `swiftc`.

Depends on:

- godotengine/build-containers/pull/155
- godotengine/godot-build-scripts/pull/129