### PR TITLE
Unix: Don't print an error if `bind` fails

### DIFF
--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -429,20 +429,16 @@ Error NetSocketUnix::bind(NetSocket::Address p_addr) {
 	ERR_FAIL_COND_V(_family != p_addr.get_family(), ERR_INVALID_PARAMETER);
 	switch (p_addr.get_family()) {
 		case Family::INET: {
-			Error res = _inet_bind(p_addr.ip(), p_addr.port());
-			ERR_FAIL_COND_V(res != OK, res);
-		} break;
+			return _inet_bind(p_addr.ip(), p_addr.port());
+		}
 		case Family::UNIX: {
 			_unix_path = p_addr.get_path();
-			Error res = _unix_bind(_unix_path);
-			ERR_FAIL_COND_V(res != OK, res);
-		} break;
+			return _unix_bind(_unix_path);
+		}
 		case Family::NONE:
 		default:
 			return ERR_INVALID_PARAMETER;
 	}
-
-	return OK;
 }
 
 Error NetSocketUnix::listen(int p_max_pending) {


### PR DESCRIPTION
# Summary

Remove unnecessary `ERR_COND_FAIL_V` check, as the remainder of the function only returns the value.

Partially addresses #111261; as Godot should also consider not trying to bind the port every frame.