### PR TITLE
macOS: Move includes inside `#ifdef` so OpenGL can be disabled

### DIFF
--- a/platform/macos/embedded_gl_manager.mm
+++ b/platform/macos/embedded_gl_manager.mm
@@ -30,10 +30,10 @@
 
 #import "embedded_gl_manager.h"
 
+#if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
+
 #import "drivers/gles3/storage/texture_storage.h"
 #import "platform_gl.h"
-
-#if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 
 #import <QuartzCore/QuartzCore.h>
 #include <dlfcn.h>


### PR DESCRIPTION
# Summary

Ensures OpenGL can be correctly disabled on MacOS builds

Closes #111275