### PR TITLE
Editor: Fix 'More Info…' link in Export/Encryption

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -584,7 +584,7 @@ void ProjectExportDialog::_enc_filters_changed(const String &p_filters) {
 }
 
 void ProjectExportDialog::_open_key_help_link() {
-	OS::get_singleton()->shell_open(vformat("%s/contributing/development/compiling/compiling_with_script_encryption_key.html", GODOT_VERSION_DOCS_URL));
+	OS::get_singleton()->shell_open(vformat("%s/engine_details/development/compiling/compiling_with_script_encryption_key.html", GODOT_VERSION_DOCS_URL));
 }
 
 void ProjectExportDialog::_enc_pck_changed(bool p_pressed) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Problem
The More Info… button in Project → Export → [any preset] → Encryption opens a 404.
The link still points to the old docs path:
.../contributing/development/compiling/compiling_with_script_encryption_key.html

Solution
Update the path to the current location in the docs:
.../engine_details/development/compiling/compiling_with_script_encryption_key.html

The URL is built with GODOT_VERSION_DOCS_URL, so it resolves to the running editor’s version (e.g. en/latest for dev builds, or en/4.5 for stable).

Changed file

editor/export/project_export.cpp (1 line)

Testing
- Built the editor on Windows.
- Opened any project → Project → Export… → Add… → Windows Desktop → Encryption tab → More Info….
- Browser opens the “Compiling with PCK encryption key” page under engine_details/....
- Verified both dev (en/latest) and stable (en/4.x) builds resolve correctly.

Risk
Very low; editor-only change, no runtime impact.

Fixes
Fixes #111108.