### PR TITLE
Remove unused members from `Viewport`

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -260,11 +260,8 @@ private:
 	RID contact_3d_debug_multimesh;
 	RID contact_3d_debug_instance;
 
-	Rect2 last_vp_rect;
-
 	bool transparent_bg = false;
 	bool use_hdr_2d = false;
-	bool gen_mipmaps = false;
 
 	bool snap_controls_to_pixels = true;
 	bool snap_2d_transforms_to_pixel = false;


### PR DESCRIPTION
- `gen_mipmaps` seems to be a relic from Godot 2: https://docs.godotengine.org/en/2.1/classes/class_viewport.html#class-viewport-set-render-target-gen-mipmaps
- Not sure about `last_vp_rect`, but blame points to e82dc402052a47b44bb3bcf50ee4801257f92778