### PR TITLE
Fix small code layout issue in persistence scope initialization

### DIFF
--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
@@ -364,8 +364,8 @@ void OpenXRSpatialAnchorCapability::on_instance_created(const XrInstance p_insta
 		if (xr_result != XR_SUCCESS) {
 			// Check for stores for compatibility with beta runtimes.
 			// Lucky for us, related structs and enums are compatible.
-			print_verbose("OpenXR: xrEnumerateSpatialPersistenceScopesEXT is not supported, falling back to xrEnumerateSpatialPersistenceStoresEXT!")
-					xr_result = openxr_api->get_instance_proc_addr("xrEnumerateSpatialPersistenceStoresEXT", (PFN_xrVoidFunction *)&xrEnumerateSpatialPersistenceScopesEXT_ptr);
+			print_verbose("OpenXR: xrEnumerateSpatialPersistenceScopesEXT is not supported, falling back to xrEnumerateSpatialPersistenceStoresEXT!");
+			xr_result = openxr_api->get_instance_proc_addr("xrEnumerateSpatialPersistenceStoresEXT", (PFN_xrVoidFunction *)&xrEnumerateSpatialPersistenceScopesEXT_ptr);
 		}
 		ERR_FAIL_COND(XR_FAILED(xr_result));
 		//EXT_INIT_XR_FUNC(xrEnumerateSpatialPersistenceScopesEXT);


### PR DESCRIPTION
Tiny layout fix @aaronfranke pointed out in #107391 but which was missed before merging.

Note that this code block at some point in the future should be removed, but not yet. We haven't confirmed runtimes have fixed up this last minute renames in the API before the spec went public.