### PR TITLE
Implement a `@meta` annotation

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -159,80 +159,38 @@ PropertyInfo Script::get_class_category() const {
 
 #endif // TOOLS_ENABLED
 
-bool Script::has_class_meta(const StringName &p_name) const {
-	return script_metadata.has(p_name);
+Dictionary ScriptMetadata::to_dictionary() const {
+	Dictionary result;
+	result[StringName("target_container")] = target_container;
+	result[StringName("target_name")] = target_name;
+	result[StringName("target_type")] = target_type;
+	result[StringName("value")] = value;
+	return result;
 }
 
-void Script::set_class_meta(const StringName &p_name, const Variant &p_value) {
-	script_metadata[p_name] = p_value;
-}
-
-void Script::remove_class_meta(const StringName &p_name) {
-	script_metadata.erase(p_name);
-}
-
-Variant Script::get_class_meta(const StringName &p_name, const Variant &p_default) const {
-	if (!script_metadata.has(p_name)) {
-		if (p_default != Variant()) {
-			return p_default;
-		} else {
-			ERR_FAIL_V_MSG(Variant(), vformat("The script does not have any 'meta' values with the key '%s'.", p_name));
+TypedArray<Dictionary> Script::get_script_meta(const StringName &p_name) const {
+	Array result;
+	if (script_metadata.has(p_name)) {
+		for (const auto& meta : script_metadata[p_name]) {
+			result.append(meta.to_dictionary());
 		}
-	}
-	return script_metadata[p_name];
-}
-
-TypedArray<StringName> Script::get_class_meta_list() const {
-	TypedArray<StringName> result;
-	for (const auto &[key, _] : script_metadata) {
-		result.append(key);
 	}
 	return result;
 }
 
-bool Script::has_member_meta(const StringName &p_member, const StringName &p_name) const {
-	return member_metadata.has(p_name);
-}
-
-void Script::set_member_meta(const StringName &p_member, const StringName &p_name, const Variant &p_value) {
-	if (!member_metadata.has(p_member)) {
-		member_metadata.insert(p_member, HashMap<StringName, Variant>());
-	}
-	member_metadata[p_member][p_name] = p_value;
-}
-
-void Script::remove_member_meta(const StringName &p_member, const StringName &p_name) {
-	if (member_metadata.has(p_member)) {
-		member_metadata.erase(p_name);
-	}
-}
-
-Variant Script::get_member_meta(const StringName &p_member, const StringName &p_name, const Variant &p_default) const {
-	if (member_metadata.has(p_member)) {
-		if (!member_metadata[p_member].has(p_name)) {
-			if (p_default != Variant()) {
-				return p_default;
-			} else {
-				ERR_FAIL_V_MSG(Variant(), vformat("The member does not have any 'meta' values with the key '%s'.", p_name));
-			}
-		}
-		return member_metadata[p_member][p_name];
-	}
-	if (p_default != Variant()) {
-		return p_default;
-	} else {
-		ERR_FAIL_V_MSG(Variant(), vformat("The script does not have a member '%s' with 'meta' values.", p_member));
-	}
-}
-
-TypedArray<StringName> Script::get_member_meta_list(const StringName &p_member) const {
-	TypedArray<StringName> result;
-	if (member_metadata.has(p_member)) {
-		for (const auto &[key, _] : member_metadata[p_member]) {
-			result.append(key);
-		}
+PackedStringArray Script::get_script_meta_list() const {
+	PackedStringArray result;
+	for (const auto &[meta_name, _] : script_metadata) {
+		result.append(meta_name);
 	}
 	return result;
+}
+
+void Script::copy_script_meta_from(const HashMap<StringName, Vector<ScriptMetadata>> &p_source) {
+	script_metadata.clear();
+	for (const auto &[key, value] : p_source) {
+		script_metadata.insert(key, value);
+	}
 }
 
 void Script::_bind_methods() {
@@ -261,18 +219,17 @@ void Script::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_rpc_config"), &Script::_get_rpc_config_bind);
 
-	ClassDB::bind_method(D_METHOD("has_class_meta", "name"), &Script::has_class_meta);
-	ClassDB::bind_method(D_METHOD("set_class_meta", "name", "value"), &Script::set_class_meta);
-	ClassDB::bind_method(D_METHOD("remove_class_meta", "name"), &Script::remove_class_meta);
-	ClassDB::bind_method(D_METHOD("get_class_meta", "name", "default"), &Script::get_class_meta, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("get_class_meta_list"), &Script::get_class_meta_list);
-	ClassDB::bind_method(D_METHOD("has_member_meta", "name"), &Script::has_member_meta);
-	ClassDB::bind_method(D_METHOD("set_member_meta", "name", "value"), &Script::set_member_meta);
-	ClassDB::bind_method(D_METHOD("remove_member_meta", "name"), &Script::remove_member_meta);
-	ClassDB::bind_method(D_METHOD("get_member_meta", "name", "default"), &Script::get_member_meta, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("get_member_meta_list"), &Script::get_member_meta_list);
+	ClassDB::bind_method(D_METHOD("get_script_meta", "name"), &Script::get_script_meta);
+	ClassDB::bind_method(D_METHOD("get_script_meta_list"), &Script::get_script_meta_list);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
+
+	// TODO: Figure out why BIND_ENUM_CONSTANT doesn't work here.
+	ClassDB::bind_integer_constant(get_class_static(), StringName("MetaTargetType"), "META_TARGET_CLASS", META_TARGET_CLASS);
+	ClassDB::bind_integer_constant(get_class_static(), StringName("MetaTargetType"), "META_TARGET_VARIABLE", META_TARGET_VARIABLE);
+	ClassDB::bind_integer_constant(get_class_static(), StringName("MetaTargetType"), "META_TARGET_CONSTANT", META_TARGET_CONSTANT);
+	ClassDB::bind_integer_constant(get_class_static(), StringName("MetaTargetType"), "META_TARGET_SIGNAL", META_TARGET_SIGNAL);
+	ClassDB::bind_integer_constant(get_class_static(), StringName("MetaTargetType"), "META_TARGET_FUNCTION", META_TARGET_FUNCTION);
 }
 
 void Script::reload_from_file() {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -171,7 +171,7 @@ Dictionary ScriptMetadata::to_dictionary() const {
 TypedArray<Dictionary> Script::get_script_meta(const StringName &p_name) const {
 	Array result;
 	if (script_metadata.has(p_name)) {
-		for (const auto& meta : script_metadata[p_name]) {
+		for (const auto &meta : script_metadata[p_name]) {
 			result.append(meta.to_dictionary());
 		}
 	}

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -159,6 +159,82 @@ PropertyInfo Script::get_class_category() const {
 
 #endif // TOOLS_ENABLED
 
+bool Script::has_class_meta(const StringName &p_name) const {
+	return script_metadata.has(p_name);
+}
+
+void Script::set_class_meta(const StringName &p_name, const Variant &p_value) {
+	script_metadata[p_name] = p_value;
+}
+
+void Script::remove_class_meta(const StringName &p_name) {
+	script_metadata.erase(p_name);
+}
+
+Variant Script::get_class_meta(const StringName &p_name, const Variant &p_default) const {
+	if (!script_metadata.has(p_name)) {
+		if (p_default != Variant()) {
+			return p_default;
+		} else {
+			ERR_FAIL_V_MSG(Variant(), vformat("The script does not have any 'meta' values with the key '%s'.", p_name));
+		}
+	}
+	return script_metadata[p_name];
+}
+
+TypedArray<StringName> Script::get_class_meta_list() const {
+	TypedArray<StringName> result;
+	for (const auto &[key, _] : script_metadata) {
+		result.append(key);
+	}
+	return result;
+}
+
+bool Script::has_member_meta(const StringName &p_member, const StringName &p_name) const {
+	return member_metadata.has(p_name);
+}
+
+void Script::set_member_meta(const StringName &p_member, const StringName &p_name, const Variant &p_value) {
+	if (!member_metadata.has(p_member)) {
+		member_metadata.insert(p_member, HashMap<StringName, Variant>());
+	}
+	member_metadata[p_member][p_name] = p_value;
+}
+
+void Script::remove_member_meta(const StringName &p_member, const StringName &p_name) {
+	if (member_metadata.has(p_member)) {
+		member_metadata.erase(p_name);
+	}
+}
+
+Variant Script::get_member_meta(const StringName &p_member, const StringName &p_name, const Variant &p_default) const {
+	if (member_metadata.has(p_member)) {
+		if (!member_metadata[p_member].has(p_name)) {
+			if (p_default != Variant()) {
+				return p_default;
+			} else {
+				ERR_FAIL_V_MSG(Variant(), vformat("The member does not have any 'meta' values with the key '%s'.", p_name));
+			}
+		}
+		return member_metadata[p_member][p_name];
+	}
+	if (p_default != Variant()) {
+		return p_default;
+	} else {
+		ERR_FAIL_V_MSG(Variant(), vformat("The script does not have a member '%s' with 'meta' values.", p_member));
+	}
+}
+
+TypedArray<StringName> Script::get_member_meta_list(const StringName &p_member) const {
+	TypedArray<StringName> result;
+	if (member_metadata.has(p_member)) {
+		for (const auto &[key, _] : member_metadata[p_member]) {
+			result.append(key);
+		}
+	}
+	return result;
+}
+
 void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("can_instantiate"), &Script::can_instantiate);
 	//ClassDB::bind_method(D_METHOD("instance_create","base_object"),&Script::instance_create);
@@ -184,6 +260,17 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_abstract"), &Script::is_abstract);
 
 	ClassDB::bind_method(D_METHOD("get_rpc_config"), &Script::_get_rpc_config_bind);
+
+	ClassDB::bind_method(D_METHOD("has_class_meta", "name"), &Script::has_class_meta);
+	ClassDB::bind_method(D_METHOD("set_class_meta", "name", "value"), &Script::set_class_meta);
+	ClassDB::bind_method(D_METHOD("remove_class_meta", "name"), &Script::remove_class_meta);
+	ClassDB::bind_method(D_METHOD("get_class_meta", "name", "default"), &Script::get_class_meta, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("get_class_meta_list"), &Script::get_class_meta_list);
+	ClassDB::bind_method(D_METHOD("has_member_meta", "name"), &Script::has_member_meta);
+	ClassDB::bind_method(D_METHOD("set_member_meta", "name", "value"), &Script::set_member_meta);
+	ClassDB::bind_method(D_METHOD("remove_member_meta", "name"), &Script::remove_member_meta);
+	ClassDB::bind_method(D_METHOD("get_member_meta", "name", "default"), &Script::get_member_meta, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("get_member_meta_list"), &Script::get_member_meta_list);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
 }

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -224,7 +224,8 @@ void Script::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
 
-	// TODO: Figure out why BIND_ENUM_CONSTANT doesn't work here.
+	// TODO: Why doesn't e.g. BIND_ENUM_CONSTANT(META_TARGET_CLASS) work here?
+	// error: incomplete type 'GetTypeInfo<Script::MetaTargetType, void>' used in nested name specifier
 	ClassDB::bind_integer_constant(get_class_static(), StringName("MetaTargetType"), "META_TARGET_CLASS", META_TARGET_CLASS);
 	ClassDB::bind_integer_constant(get_class_static(), StringName("MetaTargetType"), "META_TARGET_VARIABLE", META_TARGET_VARIABLE);
 	ClassDB::bind_integer_constant(get_class_static(), StringName("MetaTargetType"), "META_TARGET_CONSTANT", META_TARGET_CONSTANT);

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -112,6 +112,17 @@ public:
 
 class PlaceHolderScriptInstance;
 
+class ScriptMetadata {
+public:
+	StringName name;
+	StringName target_container;
+	StringName target_name;
+	int target_type; // Script::MetaTargetType
+	Variant value;
+
+	Dictionary to_dictionary() const;
+};
+
 class Script : public Resource {
 	GDCLASS(Script, Resource);
 	OBJ_SAVE_TYPE(Script);
@@ -140,11 +151,18 @@ protected:
 	}
 
 private:
-	HashMap<StringName, Variant> script_metadata;
-	HashMap<StringName, HashMap<StringName, Variant>> member_metadata;
+	HashMap<StringName, Vector<ScriptMetadata>> script_metadata;
 
 public:
 	static constexpr AncestralClass static_ancestral_class = AncestralClass::SCRIPT;
+
+	enum MetaTargetType {
+		META_TARGET_CLASS,
+		META_TARGET_VARIABLE,
+		META_TARGET_CONSTANT,
+		META_TARGET_SIGNAL,
+		META_TARGET_FUNCTION
+	};
 
 	virtual void reload_from_file() override;
 
@@ -164,18 +182,9 @@ public:
 	virtual void set_source_code(const String &p_code) = 0;
 	virtual Error reload(bool p_keep_state = false) = 0;
 
-	// TODO: Is there a better interface that works for both class- and member-level metadata?
-	bool has_class_meta(const StringName &p_name) const;
-	void set_class_meta(const StringName &p_name, const Variant &p_value);
-	void remove_class_meta(const StringName &p_name);
-	Variant get_class_meta(const StringName &p_name, const Variant &p_default = Variant()) const;
-	TypedArray<StringName> get_class_meta_list() const;
-
-	bool has_member_meta(const StringName &p_member, const StringName &p_name) const;
-	void set_member_meta(const StringName &p_member, const StringName &p_name, const Variant &p_value);
-	void remove_member_meta(const StringName &p_member, const StringName &p_name);
-	Variant get_member_meta(const StringName &p_member, const StringName &p_name, const Variant &p_default = Variant()) const;
-	TypedArray<StringName> get_member_meta_list(const StringName &p_member) const;
+	TypedArray<Dictionary> get_script_meta(const StringName &p_name) const;
+	PackedStringArray get_script_meta_list() const;
+	void copy_script_meta_from(const HashMap<StringName, Vector<ScriptMetadata>> &p_source);
 
 #ifdef TOOLS_ENABLED
 	virtual StringName get_doc_class_name() const = 0;

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -161,7 +161,7 @@ public:
 		META_TARGET_VARIABLE,
 		META_TARGET_CONSTANT,
 		META_TARGET_SIGNAL,
-		META_TARGET_FUNCTION
+		META_TARGET_FUNCTION,
 	};
 
 	virtual void reload_from_file() override;

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -139,6 +139,10 @@ protected:
 		return get_rpc_config().duplicate(true);
 	}
 
+private:
+	HashMap<StringName, Variant> script_metadata;
+	HashMap<StringName, HashMap<StringName, Variant>> member_metadata;
+
 public:
 	static constexpr AncestralClass static_ancestral_class = AncestralClass::SCRIPT;
 
@@ -159,6 +163,19 @@ public:
 	virtual String get_source_code() const = 0;
 	virtual void set_source_code(const String &p_code) = 0;
 	virtual Error reload(bool p_keep_state = false) = 0;
+
+	// TODO: Is there a better interface that works for both class- and member-level metadata?
+	bool has_class_meta(const StringName &p_name) const;
+	void set_class_meta(const StringName &p_name, const Variant &p_value);
+	void remove_class_meta(const StringName &p_name);
+	Variant get_class_meta(const StringName &p_name, const Variant &p_default = Variant()) const;
+	TypedArray<StringName> get_class_meta_list() const;
+
+	bool has_member_meta(const StringName &p_member, const StringName &p_name) const;
+	void set_member_meta(const StringName &p_member, const StringName &p_name, const Variant &p_value);
+	void remove_member_meta(const StringName &p_member, const StringName &p_name);
+	Variant get_member_meta(const StringName &p_member, const StringName &p_name, const Variant &p_default = Variant()) const;
+	TypedArray<StringName> get_member_meta_list(const StringName &p_member) const;
 
 #ifdef TOOLS_ENABLED
 	virtual StringName get_doc_class_name() const = 0;

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -71,7 +71,8 @@
 			</description>
 		</method>
 		<method name="get_script_meta">
-			<return type="Array[Dictionary]" />
+			<param index="0" name="name" type="StringName" />
+			<return type="Dictionary[]" />
 			<description>
 				Returns an [Array] of dictionaries describing each [annotation @GDScript.@meta] annotation target in this [Script] with first argument [param name]. Each [Dictionary] contains the following entries:
 				- [code]target_type[/code] is a [enum MetaTargetType] indicating the type of the annotation target.
@@ -81,7 +82,7 @@
 			</description>
 		</method>
 		<method name="get_script_meta_list">
-			<return type="Array[StringName]" />
+			<return type="StringName[]" />
 			<description>
 				Returns the list of all the distinct [StringName] values passed as [code]name[/code] arguments to [annotation @GDScript.@meta] annotations in this [Script].
 			</description>

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -71,8 +71,8 @@
 			</description>
 		</method>
 		<method name="get_script_meta">
-			<param index="0" name="name" type="StringName" />
 			<return type="Dictionary[]" />
+			<param index="0" name="name" type="StringName" />
 			<description>
 				Returns an [Array] of dictionaries describing each [annotation @GDScript.@meta] annotation target in this [Script] with first argument [param name]. Each [Dictionary] contains the following entries:
 				- [code]target_type[/code] is a [enum MetaTargetType] indicating the type of the annotation target.

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -73,17 +73,17 @@
 		<method name="get_script_meta">
 			<return type="Array[Dictionary]" />
 			<description>
-				Returns an [Array] of dictionaries describing each target in this [Script] that was annotated with a [annotation @GDScript.@meta] annotation having its first argument equal to [param name]. Each [Dictionary] contains the following entries:
+				Returns an [Array] of dictionaries describing each [annotation @GDScript.@meta] annotation target in this [Script] with first argument [param name]. Each [Dictionary] contains the following entries:
 				- [code]target_type[/code] is a [enum MetaTargetType] indicating the type of the annotation target.
 				- [code]target_name[/code] is the [StringName] identifier of the target, if any.
-				- [code]target_container[/code] is a [StringName] fully specifying the class containing this annotation target.
-				- [code]value[/code] is the [Variant] value that was passed as the second argument to the [code]@meta[/code] annotation.
+				- [code]target_container[/code] is a [StringName] fully specifying the class containing the annotation target. For example, if an inner class property is annotated the [code]target_container[/code] might be [code]"OuterClass.InnerClass"[/code].
+				- [code]value[/code] holds the [Variant] passed as the second argument to the [annotation @GDScript.@meta] annotation.
 			</description>
 		</method>
 		<method name="get_script_meta_list">
 			<return type="Array[StringName]" />
 			<description>
-				Returns the list of all the [StringNames] that were passed as the first argument to [annotation @GDScript.@meta] annotations in this [Script].
+				Returns the list of all the distinct [StringName] values passed as [code]name[/code] arguments to [annotation @GDScript.@meta] annotations in this [Script].
 			</description>
 		</method>
 		<method name="get_script_method_list">
@@ -155,19 +155,19 @@
 	</members>
 	<constants>
 		<constant name="META_TARGET_CLASS" value="0" enum="MetaTargetType">
-			Indicates that the target of a [code]@meta[/code] annotation is a class.
+			Indicates that the target of a [annotation @GDScript.@meta] annotation is a class.
 		</constant>
 		<constant name="META_TARGET_VARIABLE" value="1" enum="MetaTargetType">
-			Indicates that the target of a [code]@meta[/code] annotation is a variable.
+			Indicates that the target of a [annotation @GDScript.@meta] annotation is a variable.
 		</constant>
 		<constant name="META_TARGET_CONSTANT" value="2" enum="MetaTargetType">
-			Indicates that the target of a [code]@meta[/code] annotation is a constant.
+			Indicates that the target of a [annotation @GDScript.@meta] annotation is a constant.
 		</constant>
 		<constant name="META_TARGET_SIGNAL" value="3" enum="MetaTargetType">
-			Indicates that the target of a [code]@meta[/code] annotation is a signal.
+			Indicates that the target of a [annotation @GDScript.@meta] annotation is a signal.
 		</constant>
 		<constant name="META_TARGET_FUNCTION" value="3" enum="MetaTargetType">
-			Indicates that the target of a [code]@meta[/code] annotation is a function.
+			Indicates that the target of a [annotation @GDScript.@meta] annotation is a function.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -70,6 +70,22 @@
 				Returns a dictionary containing constant names and their values.
 			</description>
 		</method>
+		<method name="get_script_meta">
+			<return type="Array[Dictionary]" />
+			<description>
+				Returns an [Array] of dictionaries describing each target in this [Script] that was annotated with a [annotation @GDScript.@meta] annotation having its first argument equal to [param name]. Each [Dictionary] contains the following entries:
+				- [code]target_type[/code] is a [enum MetaTargetType] indicating the type of the annotation target.
+				- [code]target_name[/code] is the [StringName] identifier of the target, if any.
+				- [code]target_container[/code] is a [StringName] fully specifying the class containing this annotation target.
+				- [code]value[/code] is the [Variant] value that was passed as the second argument to the [code]@meta[/code] annotation.
+			</description>
+		</method>
+		<method name="get_script_meta_list">
+			<return type="Array[StringName]" />
+			<description>
+				Returns the list of all the [StringNames] that were passed as the first argument to [annotation @GDScript.@meta] annotations in this [Script].
+			</description>
+		</method>
 		<method name="get_script_method_list">
 			<return type="Dictionary[]" />
 			<description>
@@ -137,4 +153,21 @@
 			The script source code or an empty string if source code is not available. When set, does not reload the class implementation automatically.
 		</member>
 	</members>
+	<constants>
+		<constant name="META_TARGET_CLASS" value="0" enum="MetaTargetType">
+			Indicates that the target of a [code]@meta[/code] annotation is a class.
+		</constant>
+		<constant name="META_TARGET_VARIABLE" value="1" enum="MetaTargetType">
+			Indicates that the target of a [code]@meta[/code] annotation is a variable.
+		</constant>
+		<constant name="META_TARGET_CONSTANT" value="2" enum="MetaTargetType">
+			Indicates that the target of a [code]@meta[/code] annotation is a constant.
+		</constant>
+		<constant name="META_TARGET_SIGNAL" value="3" enum="MetaTargetType">
+			Indicates that the target of a [code]@meta[/code] annotation is a signal.
+		</constant>
+		<constant name="META_TARGET_FUNCTION" value="3" enum="MetaTargetType">
+			Indicates that the target of a [code]@meta[/code] annotation is a function.
+		</constant>
+	</constants>
 </class>

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -773,6 +773,26 @@
 				[b]Note:[/b] Unlike most other annotations, the argument of the [annotation @icon] annotation must be a string literal (constant expressions are not supported).
 			</description>
 		</annotation>
+		<annotation name="@meta">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="value" type="Variant" />
+			<description>
+				Attach a piece of named metadata to the given class or class member. The metadata can then be read back at runtime using [method Script.get_script_meta].
+				[codeblock]
+				class_name MyClass
+				extends RefCounted
+
+				@meta("my_tag", true)
+				var my_property: String
+
+				func _init():
+					var script = get_script()
+					for metadata in script.get_script_meta("my_tag"):
+						print("The member %s was annotated with @meta(\"my_tag\", %s)" % [metadata.target_name, metadata.value])
+				[/codeblock]
+			</description>
+		</annotation>
 		<annotation name="@onready">
 			<return type="void" />
 			<description>

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -776,7 +776,7 @@
 		<annotation name="@meta">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
-			<param index="1" name="value" type="Variant" />
+			<param index="1" name="value" type="Variant" default="true" />
 			<description>
 				Attach a piece of named metadata to the given class or class member. The metadata can then be read back at runtime using [method Script.get_script_meta].
 				[codeblock]

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -780,16 +780,14 @@
 			<description>
 				Attach a piece of named metadata to the given class or class member. The metadata can then be read back at runtime using [method Script.get_script_meta].
 				[codeblock]
-				class_name MyClass
-				extends RefCounted
-
-				@meta("my_tag", true)
+				@meta("my_tag", "my_data")
 				var my_property: String
 
 				func _init():
 					var script = get_script()
 					for metadata in script.get_script_meta("my_tag"):
-						print("The member %s was annotated with @meta(\"my_tag\", %s)" % [metadata.target_name, metadata.value])
+						# prints "my_property has my_data"
+						print("%s has %s" % [metadata.target_name, metadata.value])
 				[/codeblock]
 			</description>
 		</annotation>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -579,14 +579,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 						break; // Nothing.
 				}
 			}
-			for (const auto& [key, value] : parser.get_script_meta_annotations()) {
-				set_class_meta(key, value);
-			}
-			for (const auto& [member, member_meta] : parser.get_member_meta_annotations()) {
-				for (const auto& [key, value] : member_meta) {
-					set_member_meta(member, key, value);
-				}
-			}
+			copy_script_meta_from(parser.get_script_metadata());
 		} else {
 			placeholder_fallback_enabled = true;
 			return false;
@@ -861,14 +854,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 	can_run = ScriptServer::is_scripting_enabled() || parser.is_tool();
 
-	for (const auto& [key, value] : parser.get_script_meta_annotations()) {
-		set_class_meta(key, value);
-	}
-	for (const auto& [member, member_meta] : parser.get_member_meta_annotations()) {
-		for (const auto& [key, value] : member_meta) {
-			set_member_meta(member, key, value);
-		}
-	}
+	copy_script_meta_from(parser.get_script_metadata());
 
 	GDScriptCompiler compiler;
 	err = compiler.compile(&parser, this, p_keep_state);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -579,6 +579,14 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 						break; // Nothing.
 				}
 			}
+			for (const auto& [key, value] : parser.get_script_meta_annotations()) {
+				set_class_meta(key, value);
+			}
+			for (const auto& [member, member_meta] : parser.get_member_meta_annotations()) {
+				for (const auto& [key, value] : member_meta) {
+					set_member_meta(member, key, value);
+				}
+			}
 		} else {
 			placeholder_fallback_enabled = true;
 			return false;
@@ -852,6 +860,15 @@ Error GDScript::reload(bool p_keep_state) {
 	}
 
 	can_run = ScriptServer::is_scripting_enabled() || parser.is_tool();
+
+	for (const auto& [key, value] : parser.get_script_meta_annotations()) {
+		set_class_meta(key, value);
+	}
+	for (const auto& [member, member_meta] : parser.get_member_meta_annotations()) {
+		for (const auto& [key, value] : member_meta) {
+			set_member_meta(member, key, value);
+		}
+	}
 
 	GDScriptCompiler compiler;
 	err = compiler.compile(&parser, this, p_keep_state);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -128,6 +128,8 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@export_category", PropertyInfo(Variant::STRING, "name")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_CATEGORY>);
 		register_annotation(MethodInfo("@export_group", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::STRING, "prefix")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_GROUP>, varray(""));
 		register_annotation(MethodInfo("@export_subgroup", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::STRING, "prefix")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_SUBGROUP>, varray(""));
+		// Metadata annotation.
+		register_annotation(MethodInfo("@meta", PropertyInfo(Variant::NIL, "metadata", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)), AnnotationInfo::CLASS_LEVEL, &GDScriptParser::meta_annotation, varray(), true);
 		// Warning annotations.
 		register_annotation(MethodInfo("@warning_ignore", PropertyInfo(Variant::STRING, "warning")), AnnotationInfo::CLASS_LEVEL | AnnotationInfo::STATEMENT, &GDScriptParser::warning_ignore_annotation, varray(), true);
 		register_annotation(MethodInfo("@warning_ignore_start", PropertyInfo(Variant::STRING, "warning")), AnnotationInfo::STANDALONE, &GDScriptParser::warning_ignore_region_annotations, varray(), true);
@@ -5170,6 +5172,10 @@ bool GDScriptParser::rpc_annotation(AnnotationNode *p_annotation, Node *p_target
 		}
 	}
 	function->rpc_config = rpc_config;
+	return true;
+}
+
+bool GDScriptParser::meta_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
 	return true;
 }
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -5227,7 +5227,7 @@ bool GDScriptParser::meta_annotation(AnnotationNode *p_annotation, Node *p_targe
 	StringName name = p_annotation->resolved_arguments[0];
 	ScriptMetadata metadata;
 	metadata.name = name;
-	metadata.value = p_annotation->resolved_arguments[1]; // <- Only works for primitives??;
+	metadata.value = p_annotation->resolved_arguments[1];
 	metadata.target_name = target_name;
 	metadata.target_container = String(".").join(class_path);
 	metadata.target_type = target_type;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -129,8 +129,7 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@export_group", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::STRING, "prefix")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_GROUP>, varray(""));
 		register_annotation(MethodInfo("@export_subgroup", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::STRING, "prefix")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_SUBGROUP>, varray(""));
 		// Metadata annotation.
-		// TODO: Can we make it so that "value" is optional and defaults to "true", making it easy to do e.g. @meta("some_tag")?
-		register_annotation(MethodInfo("@meta", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)), AnnotationInfo::CLASS_LEVEL, &GDScriptParser::meta_annotation, varray(), false);
+		register_annotation(MethodInfo("@meta", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)), AnnotationInfo::CLASS_LEVEL, &GDScriptParser::meta_annotation, varray(true));
 		// Warning annotations.
 		register_annotation(MethodInfo("@warning_ignore", PropertyInfo(Variant::STRING, "warning")), AnnotationInfo::CLASS_LEVEL | AnnotationInfo::STATEMENT, &GDScriptParser::warning_ignore_annotation, varray(), true);
 		register_annotation(MethodInfo("@warning_ignore_start", PropertyInfo(Variant::STRING, "warning")), AnnotationInfo::STANDALONE, &GDScriptParser::warning_ignore_region_annotations, varray(), true);
@@ -5177,7 +5176,7 @@ bool GDScriptParser::rpc_annotation(AnnotationNode *p_annotation, Node *p_target
 }
 
 bool GDScriptParser::meta_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
-	ERR_FAIL_COND_V(p_annotation->resolved_arguments.size() < 2, false);
+	ERR_FAIL_COND_V(p_annotation->resolved_arguments.is_empty(), false);
 	ERR_FAIL_COND_V(!Variant::can_convert(p_annotation->resolved_arguments[0].get_type(), Variant::STRING_NAME), false);
 
 	Script::MetaTargetType target_type;
@@ -5225,9 +5224,10 @@ bool GDScriptParser::meta_annotation(AnnotationNode *p_annotation, Node *p_targe
 	}
 
 	StringName name = p_annotation->resolved_arguments[0];
+	Variant value = p_annotation->resolved_arguments.size() < 2 ? Variant(true) : p_annotation->resolved_arguments[1];
 	ScriptMetadata metadata;
 	metadata.name = name;
-	metadata.value = p_annotation->resolved_arguments[1];
+	metadata.value = value;
 	metadata.target_name = target_name;
 	metadata.target_container = String(".").join(class_path);
 	metadata.target_type = target_type;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1540,6 +1540,7 @@ private:
 	bool warning_ignore_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool warning_ignore_region_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool rpc_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool meta_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	// Statements.
 	Node *parse_statement();
 	VariableNode *parse_variable(bool p_is_static);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1400,9 +1400,7 @@ private:
 	static HashMap<StringName, AnnotationInfo> valid_annotations;
 	List<AnnotationNode *> annotation_stack;
 
-	// member name -> metadata name -> value
-	HashMap<StringName, HashMap<StringName, Variant>> member_meta_annotations;
-	HashMap<StringName, Variant> script_meta_annotations;
+	HashMap<StringName, Vector<ScriptMetadata>> script_metadata;
 
 	typedef ExpressionNode *(GDScriptParser::*ParseFunction)(ExpressionNode *p_previous_operand, bool p_can_assign);
 	// Higher value means higher precedence (i.e. is evaluated first).
@@ -1621,8 +1619,7 @@ public:
 		// TODO: Keep track of deps.
 		return List<String>();
 	}
-	const HashMap<StringName, Variant> get_script_meta_annotations() const { return script_meta_annotations; }
-	const HashMap<StringName, HashMap<StringName, Variant>> get_member_meta_annotations() const { return member_meta_annotations; }
+	const HashMap<StringName, Vector<ScriptMetadata>> get_script_metadata() const { return script_metadata; }
 
 #ifdef DEBUG_ENABLED
 	const List<GDScriptWarning> &get_warnings() const { return warnings; }

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1029,6 +1029,7 @@ public:
 			type = PATTERN;
 		}
 	};
+
 	struct PreloadNode : public ExpressionNode {
 		ExpressionNode *path = nullptr;
 		String resolved_path;
@@ -1399,6 +1400,10 @@ private:
 	static HashMap<StringName, AnnotationInfo> valid_annotations;
 	List<AnnotationNode *> annotation_stack;
 
+	// member name -> metadata name -> value
+	HashMap<StringName, HashMap<StringName, Variant>> member_meta_annotations;
+	HashMap<StringName, Variant> script_meta_annotations;
+
 	typedef ExpressionNode *(GDScriptParser::*ParseFunction)(ExpressionNode *p_previous_operand, bool p_can_assign);
 	// Higher value means higher precedence (i.e. is evaluated first).
 	enum Precedence {
@@ -1616,6 +1621,9 @@ public:
 		// TODO: Keep track of deps.
 		return List<String>();
 	}
+	const HashMap<StringName, Variant> get_script_meta_annotations() const { return script_meta_annotations; }
+	const HashMap<StringName, HashMap<StringName, Variant>> get_member_meta_annotations() const { return member_meta_annotations; }
+
 #ifdef DEBUG_ENABLED
 	const List<GDScriptWarning> &get_warnings() const { return warnings; }
 	const HashSet<int> &get_unsafe_lines() const { return unsafe_lines; }


### PR DESCRIPTION
This PR implements a new `@meta` annotation similar to the one described in https://github.com/godotengine/godot/pull/102516#issuecomment-2658985337.

The `@meta(name: StringName, value: Variant = true)` annotation allows script authors to tag classes and class members in their scripts with `StringName`-keyed arbitrary metadata. This metadata can then be inspected at runtime by calling one of the following new `Script` methods:
* `Array[StringName] Script.get_script_meta_list() const` - gets a list of all `@meta` names appearing in the script.
* `Array[Dictionary] Script.get_script_meta(name: StringName) const` - gets a list of dictionaries describing each appearance of `@meta` having the given `name` in the script.

## Usage example
**annotated_script.gd**
```gdscript
@meta("meta1", [0, 1, 2, 3])
class_name MyOuterClass
extends Node

@meta("meta1")
var outer_prop: String

@meta("meta2", { key = "value" })
class MyInnerClass:
    extends RefCounted

    class MyInnerInnerClass:
        extends RefCounted

        @meta("meta2", false)
        var inner_inner_prop: String
```

**introspector_script.gd**
```gdscript
func _init() -> void:
    var annotated_script: Script = load("res://annotated_script.gd")

    # Prints: ["meta1", "meta2"]
    print(annotated_script.get_script_meta_list())

    # Prints: [{ &"target_container": &"", &"target_name": &"MyOuterClass", &"target_type": 0, &"value": [0, 1, 2, 3] }, { &"target_container": &"MyOuterClass", &"target_name": &"outer_prop", &"target_type": 1, &"value": true }]
    print(annotated_script.get_script_meta("meta1"))

    # Prints: [{ &"target_container": &"MyOuterClass", &"target_name": &"MyInnerClass", &"target_type": 0, &"value": { &"key": "value" } }, { &"target_container": &"MyOuterClass.MyInnerClass.MyInnerInnerClass", &"target_name": &"inner_inner_prop", &"target_type": 1, &"value": false }]
    print(annotated_script.get_script_meta("meta2"))
```

## Specifications
* The `@meta` annotation can target classes, constants, signals, properties, and methods. This includes arbitrarily deep inner classes and their members.
* `@meta` can annotate a given target multiple times, even with the same `name`.
* The second argument to `@meta` must be a constant expression. If omitted, it defaults to `true`.
* `Script.get_script_meta(name)` returns a list of dictionaries, where each dictionary describes an instance of `@meta(name, ...)` in the script. The format of the dictionary is described in the docs added in bc46b3299308a50cdbaae2f78dca561f08caff91. It includes the target name, target type, container class name (if any), and metadata value.

## Notes
* `@meta` is a new builtin annotation and doesn't add support for custom user-defined annotations. However, I believe it should unblock most of the use cases in https://github.com/godotengine/godot-proposals/issues/1316.
* `@meta` is for constant key-value metadata. The goal was not to implement something like Python decorators in Godot.
* This PR only implements `@meta` for GDScript, but support for (e.g.) a companion C# `[Meta(...)]` attribute hooked up to the same getter interface on `Script` should be feasible.