### PR TITLE
Fix editor embedded windows partially resizing.

### DIFF
--- a/platform/macos/display_server_embedded.h
+++ b/platform/macos/display_server_embedded.h
@@ -114,6 +114,8 @@ public:
 	static DisplayServer *create_func(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error);
 	static Vector<String> get_rendering_drivers_func();
 
+	void _window_set_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID);
+
 	// MARK: - Events
 
 	virtual void process_events() override;

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -620,6 +620,10 @@ Size2i DisplayServerEmbedded::window_get_min_size(WindowID p_window) const {
 }
 
 void DisplayServerEmbedded::window_set_size(const Size2i p_size, WindowID p_window) {
+	print_line("Embedded window can't be resized.");
+}
+
+void DisplayServerEmbedded::_window_set_size(const Size2i p_size, WindowID p_window) {
 	[CATransaction begin];
 	[CATransaction setDisableActions:YES];
 

--- a/platform/macos/embedded_debugger.mm
+++ b/platform/macos/embedded_debugger.mm
@@ -81,7 +81,7 @@ void EmbeddedDebugger::_init_parse_message_handlers() {
 Error EmbeddedDebugger::_msg_window_size(const Array &p_args) {
 	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'window_size' message.");
 	Size2i size = p_args[0];
-	ds->window_set_size(size);
+	ds->_window_set_size(size);
 	return OK;
 }
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1180,6 +1180,8 @@ void Window::_update_window_size() {
 			DisplayServer::get_singleton()->window_set_max_size(max_size_used, window_id);
 			DisplayServer::get_singleton()->window_set_min_size(size_limit, window_id);
 			DisplayServer::get_singleton()->window_set_size(size, window_id);
+		} else if (Engine::get_singleton()->is_embedded_in_editor()) {
+			size = DisplayServer::get_singleton()->window_get_size(window_id); // Reset size.
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/111295

Embedded windows should not be resizable, but not every path was blocked.