### PR TITLE
Remove `Object::script`

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1019,18 +1019,8 @@ String Object::to_string() {
 	return "<" + get_class() + "#" + itos(get_instance_id()) + ">";
 }
 
-void Object::set_script_and_instance(const Variant &p_script, ScriptInstance *p_instance) {
-	//this function is not meant to be used in any of these ways
-	ERR_FAIL_COND(p_script.is_null());
-	ERR_FAIL_NULL(p_instance);
-	ERR_FAIL_COND(script_instance != nullptr || !script.is_null());
-
-	script = p_script;
-	script_instance = p_instance;
-}
-
 void Object::set_script(const Variant &p_script) {
-	if (script == p_script) {
+	if (get_script() == p_script) {
 		return;
 	}
 
@@ -1039,8 +1029,6 @@ void Object::set_script(const Variant &p_script) {
 		ERR_FAIL_COND_MSG(s.is_null(), "Cannot set object script. Parameter should be null or a reference to a valid script.");
 		ERR_FAIL_COND_MSG(s->is_abstract(), vformat("Cannot set object script. Script '%s' should not be abstract.", s->get_path()));
 	}
-
-	script = p_script;
 
 	if (script_instance) {
 		memdelete(script_instance);
@@ -1071,16 +1059,10 @@ void Object::set_script_instance(ScriptInstance *p_instance) {
 	}
 
 	script_instance = p_instance;
-
-	if (p_instance) {
-		script = p_instance->get_script();
-	} else {
-		script = Variant();
-	}
 }
 
 Variant Object::get_script() const {
-	return script;
+	return script_instance ? Variant(script_instance->get_script()) : Variant();
 }
 
 bool Object::has_meta(const StringName &p_name) const {
@@ -1263,7 +1245,7 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 #ifdef DEBUG_ENABLED
 			bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_name);
 			//check in script
-			ERR_FAIL_COND_V_MSG(!signal_is_valid && !script.is_null() && !Ref<Script>(script)->has_script_signal(p_name), ERR_UNAVAILABLE, vformat("Can't emit non-existing signal \"%s\".", p_name));
+			ERR_FAIL_COND_V_MSG(!signal_is_valid && script_instance && !script_instance->get_script()->has_script_signal(p_name), ERR_UNAVAILABLE, vformat("Can't emit non-existing signal \"%s\".", p_name));
 #endif
 			//not connected? just return
 			return ERR_UNAVAILABLE;
@@ -1333,7 +1315,7 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 
 			if (ce.error != Callable::CallError::CALL_OK) {
 #ifdef DEBUG_ENABLED
-				if (flags & CONNECT_PERSIST && Engine::get_singleton()->is_editor_hint() && (script.is_null() || !Ref<Script>(script)->is_tool())) {
+				if (flags & CONNECT_PERSIST && Engine::get_singleton()->is_editor_hint() && (!script_instance || !script_instance->get_script()->is_tool())) {
 					continue;
 				}
 #endif
@@ -1437,11 +1419,8 @@ TypedArray<Dictionary> Object::_get_incoming_connections() const {
 }
 
 bool Object::has_signal(const StringName &p_name) const {
-	if (!script.is_null()) {
-		Ref<Script> scr = script;
-		if (scr.is_valid() && scr->has_script_signal(p_name)) {
-			return true;
-		}
+	if (script_instance && script_instance->get_script()->has_script_signal(p_name)) {
+		return true;
 	}
 
 	if (ClassDB::has_signal(get_class_name(), p_name)) {
@@ -1458,11 +1437,8 @@ bool Object::has_signal(const StringName &p_name) const {
 void Object::get_signal_list(List<MethodInfo> *p_signals) const {
 	OBJ_SIGNAL_LOCK
 
-	if (!script.is_null()) {
-		Ref<Script> scr = script;
-		if (scr.is_valid()) {
-			scr->get_script_signal_list(p_signals);
-		}
+	if (script_instance) {
+		script_instance->get_script()->get_script_signal_list(p_signals);
 	}
 
 	ClassDB::get_signal_list(get_class_name(), p_signals);
@@ -1543,14 +1519,14 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 	if (!s) {
 		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_signal);
 		//check in script
-		if (!signal_is_valid && !script.is_null()) {
-			if (Ref<Script>(script)->has_script_signal(p_signal)) {
+		if (!signal_is_valid && script_instance) {
+			if (script_instance->get_script()->has_script_signal(p_signal)) {
 				signal_is_valid = true;
 			}
 #ifdef TOOLS_ENABLED
 			else {
 				//allow connecting signals anyway if script is invalid, see issue #17070
-				if (!Ref<Script>(script)->is_valid()) {
+				if (!script_instance->get_script()->is_valid()) {
 					signal_is_valid = true;
 				}
 			}
@@ -1606,7 +1582,7 @@ bool Object::is_connected(const StringName &p_signal, const Callable &p_callable
 			return false;
 		}
 
-		if (!script.is_null() && Ref<Script>(script)->has_script_signal(p_signal)) {
+		if (script_instance && script_instance->get_script()->has_script_signal(p_signal)) {
 			return false;
 		}
 
@@ -1626,7 +1602,7 @@ bool Object::has_connections(const StringName &p_signal) const {
 			return false;
 		}
 
-		if (!script.is_null() && Ref<Script>(script)->has_script_signal(p_signal)) {
+		if (script_instance && script_instance->get_script()->has_script_signal(p_signal)) {
 			return false;
 		}
 
@@ -1647,7 +1623,7 @@ bool Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 	SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
 		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_signal) ||
-				(!script.is_null() && Ref<Script>(script)->has_script_signal(p_signal));
+				(script_instance && script_instance->get_script()->has_script_signal(p_signal));
 		ERR_FAIL_COND_V_MSG(signal_is_valid, false, vformat("Attempt to disconnect a nonexistent connection from '%s'. Signal: '%s', callable: '%s'.", to_string(), p_signal, p_callable));
 	}
 	ERR_FAIL_NULL_V_MSG(s, false, vformat("Disconnecting nonexistent signal '%s' in '%s'.", p_signal, to_string()));

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -668,7 +668,6 @@ private:
 	HashSet<String> editor_section_folding;
 #endif
 	ScriptInstance *script_instance = nullptr;
-	Variant script; // Reference does not exist yet, store it in a Variant.
 	HashMap<StringName, Variant> metadata;
 	HashMap<StringName, Variant *> metadata_properties;
 	mutable const StringName *_class_name_ptr = nullptr;
@@ -950,9 +949,6 @@ public:
 
 	void set_script_instance(ScriptInstance *p_instance);
 	_FORCE_INLINE_ ScriptInstance *get_script_instance() const { return script_instance; }
-
-	// Some script languages can't control instance creation, so this function eases the process.
-	void set_script_and_instance(const Variant &p_script, ScriptInstance *p_instance);
 
 	void add_user_signal(const MethodInfo &p_signal);
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1432,7 +1432,7 @@ void CSharpLanguage::tie_user_managed_to_unmanaged(GCHandleIntPtr p_gchandle_int
 
 	CSharpInstance *csharp_instance = CSharpInstance::create_for_managed_type(p_unmanaged, script.ptr(), gchandle);
 
-	p_unmanaged->set_script_and_instance(script, csharp_instance);
+	p_unmanaged->set_script_instance(csharp_instance);
 
 	csharp_instance->connect_event_signals();
 }

--- a/modules/objectdb_profiler/editor/snapshot_data.cpp
+++ b/modules/objectdb_profiler/editor/snapshot_data.cpp
@@ -78,7 +78,7 @@ SnapshotDataObject::SnapshotDataObject(SceneDebuggerObject &p_obj, GameStateSnap
 					if (scr.is_valid()) {
 						ScriptInstance *scr_instance = scr->placeholder_instance_create(this);
 						if (scr_instance) {
-							set_script_and_instance(pvalue, scr_instance);
+							set_script_instance(scr_instance);
 						}
 					}
 				}


### PR DESCRIPTION
Removes 24 bytes from `Object` since the script was stored as `Variant`. Instead obtains the script from the `ScriptInstance`.

As far as I can see `Object::get_script` is not used in any obvious hot paths, so the additional overhead should not matter that much.

In addition to making object smaller, this is also makes inconsistent states impossible.
