### PR TITLE
Make StateMachinePlayback set `Start` state as default in constructor

### DIFF
--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -263,7 +263,7 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	String base_path;
 
 	AnimationNode::NodeTimeInfo current_nti;
-	StringName current;
+	StringName current = SceneStringName(Start);
 	Ref<Curve> current_curve;
 
 	Ref<AnimationNodeStateMachineTransition> group_start_transition;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/111315

This is more of a StateMachine issue than a NodeOneShot issue.

StateMachinePlayback does not have any states when it is generated.

When StateMachine is not having state, a reset (seeking to the beginning) causes it to transition to the Start state. In other words, it does not transition to Start unless a reset occurs.

While this could be resolved by having all Playbacks transition to Start beforehand, I believe setting the constructor Start as the default is fine.

Since this involves a slight change in behavior, I'll add a break compat label. However, the only cases affected are those where the StateMachine is intentionally stopped, which is likely very niche; If such a case exists, the migration path would probably involve setting the Start transition property to something other than Auto or setting an advance expression.