### PR TITLE
Fix editor auto display scale on Windows

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1823,6 +1823,9 @@ float EditorSettings::get_auto_display_scale() {
 		return 1.0;
 	}
 
+#if defined(WINDOWS_ENABLED)
+	return DisplayServer::get_singleton()->screen_get_dpi(screen) / 96.0;
+#else
 	// Use the smallest dimension to use a correct display scale on portrait displays.
 	const int smallest_dimension = MIN(DisplayServer::get_singleton()->screen_get_size(screen).x, DisplayServer::get_singleton()->screen_get_size(screen).y);
 	if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && smallest_dimension >= 1400) {
@@ -1838,7 +1841,9 @@ float EditorSettings::get_auto_display_scale() {
 		return 0.75;
 	}
 	return 1.0;
-#endif
+#endif // defined(WINDOWS_ENABLED)
+
+#endif // defined(MACOS_ENABLED) || defined(ANDROID_ENABLED)
 }
 
 // Shortcuts


### PR DESCRIPTION
The problem: I have my system display scale factor set to 175%. But the Godot editor fails to detect it, the UI is very small and the editor setting says `Auto (100%)`.

The editor is currently using a strange way to determine the default scale:

https://github.com/godotengine/godot/blob/d413181b8a6c427a56d6c37378d4dec8e658b630/editor/settings/editor_settings.cpp#L1832-L1846

My screen resolution is 2560x1600 and the DPI reported is 168. So the scale is indeed 100% according to this algorithm.

According to MSDN, the DPI reported by `GetDpiForMonitor(type=MDT_DEFAULT)` shows the correct factor for scaling UI elements (with 96 as 100%). I believe the default scale can be as easy as dividing `screen_get_dpi()` with 96.

In this PR, I also:
- optimized `screen_get_dpi()` to avoid enumerating the monitors twice
- changed the error return value of `screen_get_dpi()` from 72 to 96 as it means 100% scale on Windows
- removed an unnecessary optional parameter