### PR TITLE
Add all PowerVR devices to the transform feedback shader cache ban list

### DIFF
--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -236,7 +236,7 @@ Config::Config() {
 			//https://github.com/godotengine/godot/issues/92662#issuecomment-2161199477
 			//disable_particles_workaround = false;
 		}
-	} else if (rendering_device_name == "PowerVR Rogue GE8320") {
+	} else if (rendering_device_name.contains("PowerVR")) {
 		disable_transform_feedback_shader_cache = true;
 	}
 


### PR DESCRIPTION
Based on the feedback from @kisg and the comments in https://github.com/godotengine/godot/issues/94915 it seems safest to just disable the shader cache for transform feedback shaders for all PowerVR devices. From what we have learned the latest devices may no longer have the bug that causes this crash. But for users it is much better for us to put a stop to this crash once and for all, and then later evaluate opting in to drivers above a certain version threshold. 

We should merge this PR soon for 4.6 and then prioritize it for 4.5.2 so that we can quickly help reduce crash rates for released games