### PR TITLE
Rename glsl variables in glow effect.

### DIFF
--- a/drivers/gles3/shaders/effect_blur.glsl
+++ b/drivers/gles3/shaders/effect_blur.glsl
@@ -282,8 +282,8 @@ void main() {
 
 #ifdef GLOW_FIRST_PASS
 
-	float luminance = max(frag_color.r, max(frag_color.g, frag_color.b));
-	float feedback = max(smoothstep(glow_hdr_threshold, glow_hdr_threshold + glow_hdr_scale, luminance), glow_bloom);
+	float max_value = max(frag_color.r, max(frag_color.g, frag_color.b));
+	float feedback = max(smoothstep(glow_hdr_threshold, glow_hdr_threshold + glow_hdr_scale, max_value), glow_bloom);
 
 	frag_color = min(frag_color * feedback, vec4(luminance_cap));
 

--- a/drivers/gles3/shaders/effects/glow.glsl
+++ b/drivers/gles3/shaders/effects/glow.glsl
@@ -78,8 +78,8 @@ void main() {
 #endif // USE_MULTIVIEW
 	color /= luminance_multiplier * 8.0;
 
-	float feedback_factor = max(color.r, max(color.g, color.b));
-	float feedback = max(smoothstep(glow_hdr_threshold, glow_hdr_threshold + glow_hdr_scale, feedback_factor), glow_bloom);
+	float max_value = max(color.r, max(color.g, color.b));
+	float feedback = max(smoothstep(glow_hdr_threshold, glow_hdr_threshold + glow_hdr_scale, max_value), glow_bloom);
 
 	color = min(color * feedback, vec3(glow_luminance_cap));
 

--- a/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
@@ -202,8 +202,8 @@ void main() {
 	frag_color *= blur.luminance_multiplier;
 	frag_color *= blur.glow_exposure;
 
-	float luminance = max(frag_color.r, max(frag_color.g, frag_color.b));
-	float feedback = max(smoothstep(blur.glow_hdr_threshold, blur.glow_hdr_threshold + blur.glow_hdr_scale, luminance), blur.glow_bloom);
+	float max_value = max(frag_color.r, max(frag_color.g, frag_color.b));
+	float feedback = max(smoothstep(blur.glow_hdr_threshold, blur.glow_hdr_threshold + blur.glow_hdr_scale, max_value), blur.glow_bloom);
 
 	frag_color = min(frag_color * feedback, vec4(blur.glow_luminance_cap)) / blur.luminance_multiplier;
 #endif // MODE_GLOW_GATHER_WIDE

--- a/servers/rendering/renderer_rd/shaders/effects/copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy.glsl
@@ -191,8 +191,8 @@ void main() {
 #endif
 		color *= params.glow_exposure;
 
-		float luminance = max(color.r, max(color.g, color.b));
-		float feedback = max(smoothstep(params.glow_hdr_threshold, params.glow_hdr_threshold + params.glow_hdr_scale, luminance), params.glow_bloom);
+		float max_value = max(color.r, max(color.g, color.b));
+		float feedback = max(smoothstep(params.glow_hdr_threshold, params.glow_hdr_threshold + params.glow_hdr_scale, max_value), params.glow_bloom);
 
 		color = min(color * feedback, vec4(params.glow_luminance_cap));
 	}


### PR DESCRIPTION
This PR helps reduce confusion among developers about what the `smoothstep` value of the glow effect is:

This smoothstep value is not the luminance, it is simply the max value. By using the max value, glow is made to be an effect that helps circumvent the limitations of display technology rather than being related to luminance. Glow could be re-written to be based on luminance, but until then this new variable name is more appropriate.

- Related to #99337