### PR TITLE
Bitpack more `Object` booleans

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -252,7 +252,7 @@ Object::Connection::Connection(const Variant &p_variant) {
 }
 
 bool Object::_predelete() {
-	_predelete_ok = 1;
+	_predelete_ok = true;
 	notification(NOTIFICATION_PREDELETE, true);
 	if (!_predelete_ok) {
 		return false;
@@ -2349,7 +2349,7 @@ Object::~Object() {
 		ObjectDB::remove_instance(this);
 		_instance_id = ObjectID();
 	}
-	_predelete_ok = 2;
+	_predelete_ok = true;
 
 	if (_instance_bindings != nullptr) {
 		for (uint32_t i = 0; i < _instance_binding_count; i++) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -651,7 +651,6 @@ private:
 #ifdef DEBUG_ENABLED
 	SafeRefCount _lock_index;
 #endif // DEBUG_ENABLED
-	int _predelete_ok = 0;
 	ObjectID _instance_id;
 	bool _predelete();
 	void _initialize();
@@ -662,6 +661,12 @@ private:
 	bool _block_signals : 1;
 	bool _can_translate : 1;
 	bool _emitting : 1;
+	bool _predelete_ok : 1;
+
+public:
+	bool _is_queued_for_deletion : 1; // Set to true by SceneTree::queue_delete().
+
+private:
 #ifdef TOOLS_ENABLED
 	bool _edited : 1;
 	uint32_t _edited_version = 0;
@@ -996,7 +1001,6 @@ public:
 	String tr(const StringName &p_message, const StringName &p_context = "") const;
 	String tr_n(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
 
-	bool _is_queued_for_deletion = false; // Set to true by SceneTree::queue_delete().
 	bool is_queued_for_deletion() const;
 
 	_FORCE_INLINE_ void set_message_translation(bool p_enable) { _can_translate = p_enable; }


### PR DESCRIPTION
- `_predelete_ok` was not a bool before, but the only read access uses it like a bool. The assignment of `2` at some point is pretty old, and currently there is nothing actually using it.

Object size on my system:

| Definitions   | Before | After |     |
|---------------|--------|-------|-----|
| DEBUG + TOOLS | 344    | 336   | -8  |
| TOOLS         | 344    | 328   | -16 |
| DEBUG         | 296    | 288   | -8  |
| -             | 296    | 280   | -16 |