### PR TITLE
Assert that `dictionary.h` does not include `String`, and that neither of the fundamental containers include `Object`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -30,8 +30,9 @@
 
 #include "ustring.h"
 
-STATIC_ASSERT_INCOMPLETE_TYPE(class, Dictionary);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Array);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Dictionary);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Object);
 
 #include "core/crypto/crypto_core.h"
 #include "core/math/color.h"

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -31,6 +31,7 @@
 #include "array.h"
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Dictionary);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Object);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, String);
 
 #include "container_type_validate.h"

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -31,6 +31,8 @@
 #include "dictionary.h"
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Array);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Object);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, String);
 
 #include "core/templates/hash_map.h"
 #include "core/templates/safe_refcount.h"


### PR DESCRIPTION
- Follow-up of #107587 
- Follow-up of #106434

Now that hashfuncs includes have been simplified, we can add some more assertions to prevent regressions.