### PR TITLE
Add `max()` to `Span`, replacing `<algorithm>` include from `rendering_device_commons.h`

### DIFF
--- a/core/templates/span.h
+++ b/core/templates/span.h
@@ -108,6 +108,9 @@ public:
 	/// Note: Assumes that elements in the span are sorted. Otherwise, use find() instead.
 	template <typename Comparator = Comparator<T>>
 	constexpr uint64_t bisect(const T &p_value, bool p_before, Comparator compare = Comparator()) const;
+
+	/// The caller is responsible to ensure size() > 0.
+	constexpr T max() const;
 };
 
 template <typename T>
@@ -202,6 +205,18 @@ constexpr uint64_t Span<T>::bisect(const T &p_value, bool p_before, Comparator c
 		}
 	}
 	return lo;
+}
+
+template <typename T>
+constexpr T Span<T>::max() const {
+	DEV_ASSERT(size() > 0);
+	T max_val = _ptr[0];
+	for (size_t i = 1; i < _len; ++i) {
+		if (_ptr[i] > max_val) {
+			max_val = _ptr[i];
+		}
+	}
+	return max_val;
 }
 
 // Zero-constructing Span initializes _ptr and _len to 0 (and thus empty).

--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -56,6 +56,7 @@
 #import "rendering_shader_container_metal.h"
 
 #import <os/signpost.h>
+#import <algorithm>
 
 // We have to undefine these macros because they are defined in NSObjCRuntime.h.
 #undef MIN

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -33,8 +33,6 @@
 #include "core/object/object.h"
 #include "core/variant/type_info.h"
 
-#include <algorithm>
-
 #define STEPIFY(m_number, m_alignment) ((((m_number) + ((m_alignment) - 1)) / (m_alignment)) * (m_alignment))
 
 // This may one day be used in Godot for interoperability between C arrays, Vector and LocalVector.

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -70,7 +70,7 @@ class RenderingShaderContainerFormat;
 template <typename... RESOURCE_TYPES>
 struct VersatileResourceTemplate {
 	static constexpr size_t RESOURCE_SIZES[] = { sizeof(RESOURCE_TYPES)... };
-	static constexpr size_t MAX_RESOURCE_SIZE = std::max_element(RESOURCE_SIZES, RESOURCE_SIZES + sizeof...(RESOURCE_TYPES))[0];
+	static constexpr size_t MAX_RESOURCE_SIZE = Span(RESOURCE_SIZES).max();
 	uint8_t data[MAX_RESOURCE_SIZE];
 
 	template <typename T>


### PR DESCRIPTION
- Helps address #111218 

So it turns out `<algorithm>` is another unexpectedly expensive include. It causes ca. 400mb of parsing churn to a fresh compile, landing it in the top 6 spot.

I managed to avoid it by adding `max()` to `Span`. Although this is the only user for now, I think it's a common and useful enough function to warrant living in `Span`. I chose not to add `min()` because it's not needed yet.

Edit: I should have named this branch `span-and-max` 