### PR TITLE
Fix `call_group()` not calling nodes that have just been reparented inside `_process()`

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -146,6 +146,9 @@ void SceneTree::tree_changed() {
 
 void SceneTree::node_added(Node *p_node) {
 	emit_signal(node_added_name, p_node);
+	if (nodes_removed_on_group_call_lock) {
+		nodes_removed_on_group_call.erase(p_node);
+	}
 }
 
 void SceneTree::node_removed(Node *p_node) {


### PR DESCRIPTION
Fixes #111348