### PR TITLE
Remove edit version tracking from `Object`

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -611,8 +611,8 @@ RID Resource::get_rid() const {
 
 #ifdef TOOLS_ENABLED
 
-uint32_t Resource::hash_edited_version_for_preview() const {
-	uint32_t hash = hash_murmur3_one_32(get_edited_version());
+uint32_t Resource::hash_modified_version_for_preview() const {
+	uint32_t hash = hash_murmur3_one_64(last_modified_time);
 
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
@@ -621,7 +621,7 @@ uint32_t Resource::hash_edited_version_for_preview() const {
 		if (E.usage & PROPERTY_USAGE_STORAGE && E.type == Variant::OBJECT && E.hint == PROPERTY_HINT_RESOURCE_TYPE) {
 			Ref<Resource> res = get(E.name);
 			if (res.is_valid()) {
-				hash = hash_murmur3_one_32(res->hash_edited_version_for_preview(), hash);
+				hash = hash_murmur3_one_32(res->hash_modified_version_for_preview(), hash);
 			}
 		}
 	}

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -165,7 +165,7 @@ public:
 
 #ifdef TOOLS_ENABLED
 
-	virtual uint32_t hash_edited_version_for_preview() const;
+	virtual uint32_t hash_modified_version_for_preview() const;
 
 	virtual void set_last_modified_time(uint64_t p_time) { last_modified_time = p_time; }
 	uint64_t get_last_modified_time() const { return last_modified_time; }

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2073,15 +2073,10 @@ bool Object::is_queued_for_deletion() const {
 #ifdef TOOLS_ENABLED
 void Object::set_edited(bool p_edited) {
 	_edited = p_edited;
-	_edited_version++;
 }
 
 bool Object::is_edited() const {
 	return _edited;
-}
-
-uint32_t Object::get_edited_version() const {
-	return _edited_version;
 }
 #endif
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -664,7 +664,6 @@ private:
 	bool _emitting : 1;
 #ifdef TOOLS_ENABLED
 	bool _edited : 1;
-	uint32_t _edited_version = 0;
 	HashSet<String> editor_section_folding;
 #endif
 	ScriptInstance *script_instance = nullptr;
@@ -944,8 +943,6 @@ public:
 #ifdef TOOLS_ENABLED
 	void set_edited(bool p_edited);
 	bool is_edited() const;
-	// This function is used to check when something changed beyond a point, it's used mainly for generating previews.
-	uint32_t get_edited_version() const;
 #endif
 
 	void set_script_instance(ScriptInstance *p_instance);

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -299,7 +299,7 @@ void EditorResourcePreview::_iterate() {
 	if (item.resource.is_valid()) {
 		Dictionary preview_metadata;
 		_generate_preview(texture, small_texture, item, String(), preview_metadata);
-		_preview_ready(item.path, item.resource->hash_edited_version_for_preview(), texture, small_texture, item.callback, preview_metadata);
+		_preview_ready(item.path, item.resource->hash_modified_version_for_preview(), texture, small_texture, item.callback, preview_metadata);
 		return;
 	}
 
@@ -471,7 +471,7 @@ void EditorResourcePreview::queue_edited_resource_preview(const Ref<Resource> &p
 		String path_id = "ID:" + itos(p_res->get_instance_id());
 		HashMap<String, EditorResourcePreview::Item>::Iterator I = cache.find(path_id);
 
-		if (I && I->value.last_hash == p_res->hash_edited_version_for_preview()) {
+		if (I && I->value.last_hash == p_res->hash_modified_version_for_preview()) {
 			p_callback.call(path_id, I->value.preview, I->value.small_preview);
 			return;
 		}

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -305,7 +305,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 #ifdef TOOLS_ENABLED
-	virtual uint32_t hash_edited_version_for_preview() const override { return 0; } // Not using preview, so disable it for performance.
+	virtual uint32_t hash_modified_version_for_preview() const override { return 0; } // Not using preview, so disable it for performance.
 #endif
 
 private:


### PR DESCRIPTION
`_edit_version` in `Object` has only one usage, which is a hash that is used in the resource thumbnail generation.

`_edit_version` was only increased when directly calling `set_edited`.
The cases when this happens can be categorized as:

- when resources are saved or loaded (I suspect this is the main usecase for thumbnails, because the hash changes on save)
- when the folding state of inspector sections changed -> this has no influence on thumbnails anyway
- on `AudioServer` which is not a resource -> not relevant for thumbnail generation
- in some editor plugins this is called on specific resource subtypes. Namely a lot of OpenXR resources and Tileset. Both of them are irrelevant for thumbnails based on my understanding. (the bump when saving resources would be enough to generate new thumbnails, and thumbnails seem to only be generated for persisted changes anyway)

There already is a "versioning" on `Resource` which is update when resources are saved: `last_modified_time`.

This PR changes the hashing used for thumbnails to be based on `last_modified_time` and removes `_edit_version` from object.

On it's own this does not make object smaller in memory due to padding, however it opens up a nice 4byte spot for `_lock_index`, which in combination with https://github.com/godotengine/godot/pull/111339 can remove 8byte from object, for `DEBUG` enabled builds.