### PR TITLE
Inline uid to .gd/.shader/.shaderinc/.cs.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1209,6 +1209,21 @@
 		<member name="filesystem/import/fbx2gltf/enabled.web" type="bool" setter="" getter="" default="false">
 			Override for [member filesystem/import/fbx2gltf/enabled] on the Web where FBX2glTF can't easily be accessed from Godot.
 		</member>
+		<member name="filesystem/inline_text_resource_uids/c_sharp_script" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], inline text resource UIDs will be used for [code].cs[/code] files.
+		</member>
+		<member name="filesystem/inline_text_resource_uids/compatibility/no_inline_text_resource_uids_in_addons" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], disables the use of inline text resource UIDs in addons. This is useful for compatibility with old addons that concerning about file's md5.
+		</member>
+		<member name="filesystem/inline_text_resource_uids/gdscript" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], inline text resource UIDs will be used for [code].gd[/code] files.
+		</member>
+		<member name="filesystem/inline_text_resource_uids/shader" type="bool" setter="" getter="" default="true">
+			if [code]true[/code], inline text resource UIDs will be used for [code].shader[/code] files.
+		</member>
+		<member name="filesystem/inline_text_resource_uids/shader_include" type="bool" setter="" getter="" default="true">
+			if [code]true[/code], inline text resource UIDs will be used for [code].shaderinc[/code] files.
+		</member>
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.
 		</member>

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -164,6 +164,7 @@ void ScriptTextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 	ERR_FAIL_COND(p_res.is_null());
 
 	script = p_res;
+	script->connect_changed(callable_mp(this, &ScriptTextEditor::reload_text));
 
 	code_editor->get_text_editor()->set_text(script->get_source_code());
 	code_editor->get_text_editor()->clear_undo_history();

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -152,6 +152,7 @@ void ShaderTextEditor::_shader_changed() {
 		return;
 	}
 	dependencies_version++;
+	reload_text();
 	_validate_script();
 }
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2963,6 +2963,8 @@ GDScriptLanguage::GDScriptLanguage() {
 	track_call_stack = GLOBAL_DEF_RST("debug/settings/gdscript/always_track_call_stacks", false);
 	track_locals = GLOBAL_DEF_RST("debug/settings/gdscript/always_track_local_variables", false);
 
+	GLOBAL_DEF("filesystem/inline_text_resource_uids/gdscript", true);
+
 #ifdef DEBUG_ENABLED
 	track_call_stack = true;
 	track_locals = track_locals || EngineDebugger::is_active();
@@ -3148,6 +3150,99 @@ void ResourceFormatLoaderGDScript::get_classes_used(const String &p_path, HashSe
 	}
 }
 
+#define UID_COMMENT_PREFIX "# uid://"
+#define UID_COMMENT_SUFFIX "This line is generated, don't modify or remove it."
+static ResourceUID::ID extract_uid_from_line(const String &p_line) {
+	Vector<String> splits = p_line.strip_edges().substr(2).split(" ", false, 1);
+	if (splits.is_empty()) {
+		return ResourceUID::INVALID_ID;
+	}
+	return ResourceUID::get_singleton()->text_to_id(splits[0]);
+}
+
+ResourceUID::ID ResourceFormatLoaderGDScript::get_resource_uid(const String &p_path) const {
+	int64_t uid = ResourceUID::INVALID_ID;
+
+	if (FileAccess::exists(p_path + ".uid")) {
+		Ref<FileAccess> file = FileAccess::open(p_path + ".uid", FileAccess::READ);
+		if (file.is_valid()) {
+			uid = ResourceUID::get_singleton()->text_to_id(file->get_line());
+		}
+	} else {
+		const String extension = p_path.get_extension().to_lower();
+		if (extension == "gd") {
+			Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ);
+			if (file.is_valid()) {
+				while (!file->eof_reached()) {
+					String line = file->get_line().strip_edges();
+					if (!line.is_empty()) {
+						if (line.begins_with(UID_COMMENT_PREFIX)) {
+							uid = extract_uid_from_line(line);
+						}
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	return uid;
+}
+
+bool ResourceFormatLoaderGDScript::has_custom_uid_support() const {
+	return GLOBAL_GET("filesystem/inline_text_resource_uids/gdscript");
+}
+
+bool ResourceFormatSaverGDScript::add_uid_to_source(String &p_r_source, const String &p_path, ResourceUID::ID p_uid) const {
+	bool need_update = false;
+	Vector<String> lines = p_r_source.split("\n");
+	bool uid_comment_valid = false;
+	for (Vector<String>::Size i = 0; i < lines.size(); i++) {
+		const String &line = lines[i].strip_edges();
+		if (line.begins_with(UID_COMMENT_PREFIX)) {
+			ResourceUID::ID uid = extract_uid_from_line(line);
+			if (uid == ResourceUID::INVALID_ID || p_uid != uid) {
+				if (p_uid == ResourceUID::INVALID_ID) {
+					p_uid = ResourceSaver::get_resource_id_for_path(p_path, true);
+				}
+
+				if (uid != p_uid) {
+					lines.set(i, vformat("# %s %s", ResourceUID::get_singleton()->id_to_text(uid), UID_COMMENT_SUFFIX));
+					if (ResourceUID::get_singleton()->has_id(uid)) {
+						ResourceUID::get_singleton()->set_id(uid, p_path);
+					} else {
+						ResourceUID::get_singleton()->add_id(uid, p_path);
+					}
+					need_update = true;
+				}
+			}
+
+			uid_comment_valid = true;
+			break;
+		} else if (!line.strip_edges().is_empty()) {
+			break;
+		}
+	}
+
+	if (!uid_comment_valid) {
+		ResourceUID::ID uid = p_uid == ResourceUID::INVALID_ID ? ResourceSaver::get_resource_id_for_path(p_path, true) : p_uid;
+		lines.insert(0, vformat("# %s %s", ResourceUID::get_singleton()->id_to_text(uid), UID_COMMENT_SUFFIX));
+		if (ResourceUID::get_singleton()->has_id(uid)) {
+			ResourceUID::get_singleton()->set_id(uid, p_path);
+		} else {
+			ResourceUID::get_singleton()->add_id(uid, p_path);
+		}
+		need_update = true;
+	}
+
+	if (need_update) {
+		p_r_source = String("\n").join(lines);
+		return true;
+	} else {
+		return false;
+	}
+}
+
 Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<GDScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
@@ -3160,9 +3255,31 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 
 		ERR_FAIL_COND_V_MSG(err, err, "Cannot save GDScript file '" + p_path + "'.");
 
+		bool source_changed = false;
+		if (!FileAccess::exists(p_path + ".uid")) {
+			if (p_path.begins_with("res://addons/") && GLOBAL_GET("filesystem/inline_text_resource_uids/compatibility/no_inline_text_resource_uids_in_addons")) {
+				Ref<FileAccess> f = FileAccess::open(p_path + ".uid", FileAccess::WRITE);
+				if (f.is_valid()) {
+					ResourceUID::ID uid = ResourceUID::get_singleton()->create_id_for_path(p_path);
+					f->store_line(ResourceUID::get_singleton()->id_to_text(uid));
+					f->close();
+				}
+			} else {
+				source_changed = add_uid_to_source(source, p_path);
+			}
+		}
+
 		file->store_string(source);
 		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
 			return ERR_CANT_CREATE;
+		}
+
+		file->close();
+
+		if (source_changed) {
+			sqscr->set_source_code(source);
+			sqscr->reload(true);
+			sqscr->emit_changed();
 		}
 	}
 
@@ -3181,4 +3298,47 @@ void ResourceFormatSaverGDScript::get_recognized_extensions(const Ref<Resource> 
 
 bool ResourceFormatSaverGDScript::recognize(const Ref<Resource> &p_resource) const {
 	return Object::cast_to<GDScript>(*p_resource) != nullptr;
+}
+
+Error ResourceFormatSaverGDScript::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+	if (FileAccess::exists(p_path + ".uid") || (p_path.begins_with("res://addons/") && GLOBAL_GET("filesystem/inline_text_resource_uids/compatibility/no_inline_text_resource_uids_in_addons"))) {
+		Ref<FileAccess> f = FileAccess::open(p_path + ".uid", FileAccess::WRITE);
+		if (f.is_valid()) {
+			f->store_line(ResourceUID::get_singleton()->id_to_text(p_uid));
+			return OK;
+		} else {
+			return FileAccess::get_open_error();
+		}
+	} else if (p_path.get_extension().to_lower() == "gd") {
+		Error err = OK;
+		String source = FileAccess::get_file_as_string(p_path, &err);
+		if (err != OK) {
+			return err;
+		}
+
+		const bool source_changed = add_uid_to_source(source, p_path, p_uid);
+		if (source_changed) {
+			Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
+			if (f.is_valid()) {
+				f->store_string(source);
+				f->close();
+
+				// Update source code if it's loaded.
+				Ref<GDScript> loaded_gdscript = ResourceCache::get_ref(p_path);
+				if (loaded_gdscript.is_valid()) {
+					loaded_gdscript->set_source_code(source);
+					loaded_gdscript->reload(true);
+					loaded_gdscript->emit_changed();
+				}
+
+				err = OK;
+			} else {
+				err = FileAccess::get_open_error();
+			}
+		}
+
+		return err;
+	}
+
+	return ERR_FILE_UNRECOGNIZED;
 }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -680,13 +680,21 @@ public:
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
+
+	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
+	virtual bool has_custom_uid_support() const override;
 };
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {
 	GDSOFTCLASS(ResourceFormatSaverGDScript, ResourceFormatSaver);
 
+private:
+	bool add_uid_to_source(String &p_r_source, const String &p_path, ResourceUID::ID p_uid = ResourceUID::INVALID_ID) const;
+
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
+
+	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 };

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -599,13 +599,21 @@ public:
 	void get_recognized_extensions(List<String> *p_extensions) const override;
 	bool handles_type(const String &p_type) const override;
 	String get_resource_type(const String &p_path) const override;
+
+	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
+	virtual bool has_custom_uid_support() const override;
 };
 
 class ResourceFormatSaverCSharpScript : public ResourceFormatSaver {
 	GDSOFTCLASS(ResourceFormatSaverCSharpScript, ResourceFormatSaver);
 
+private:
+	bool add_uid_to_source(String &p_r_source, const String &p_path, ResourceUID::ID p_uid = ResourceUID::INVALID_ID) const;
+
 public:
 	Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	bool recognize(const Ref<Resource> &p_resource) const override;
+
+	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 };

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -414,6 +414,8 @@ void register_scene_types() {
 
 		resource_loader_shader.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_shader, true);
+
+		GLOBAL_DEF("filesystem/inline_text_resource_uids/shader", true);
 	}
 
 	if constexpr (GD_IS_CLASS_ENABLED(ShaderInclude)) {
@@ -422,7 +424,11 @@ void register_scene_types() {
 
 		resource_loader_shader_include.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_shader_include, true);
+
+		GLOBAL_DEF("filesystem/inline_text_resource_uids/shader_include", true);
 	}
+
+	GLOBAL_DEF("filesystem/inline_text_resource_uids/compatibility/no_inline_text_resource_uids_in_addons", false);
 
 	OS::get_singleton()->yield(); // may take time to init
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -31,6 +31,7 @@
 #include "shader.h"
 #include "shader.compat.inc"
 
+#include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "scene/main/scene_tree.h"
 #include "servers/rendering/rendering_server.h"
@@ -344,6 +345,99 @@ String ResourceFormatLoaderShader::get_resource_type(const String &p_path) const
 	return "";
 }
 
+#define UID_COMMENT_PREFIX "// uid://"
+#define UID_COMMENT_SUFFIX "This line is generated, don't modify or remove it."
+static ResourceUID::ID extract_shader_uid_from_line(const String &p_line) {
+	Vector<String> splits = p_line.strip_edges().substr(3).split(" ", false, 1);
+	if (splits.is_empty()) {
+		return ResourceUID::INVALID_ID;
+	}
+	return ResourceUID::get_singleton()->text_to_id(splits[0]);
+}
+
+ResourceUID::ID ResourceFormatLoaderShader::get_resource_uid(const String &p_path) const {
+	int64_t uid = ResourceUID::INVALID_ID;
+
+	if (FileAccess::exists(p_path + ".uid")) {
+		Ref<FileAccess> file = FileAccess::open(p_path + ".uid", FileAccess::READ);
+		if (file.is_valid()) {
+			uid = ResourceUID::get_singleton()->text_to_id(file->get_line());
+		}
+	} else {
+		const String extension = p_path.get_extension().to_lower();
+		if (extension == "gdshader") {
+			Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ);
+			if (file.is_valid()) {
+				while (!file->eof_reached()) {
+					String line = file->get_line().strip_edges();
+					if (!line.is_empty()) {
+						if (line.begins_with(UID_COMMENT_PREFIX)) {
+							uid = extract_shader_uid_from_line(line);
+						}
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	return uid;
+}
+
+bool ResourceFormatLoaderShader::has_custom_uid_support() const {
+	return GLOBAL_GET("filesystem/inline_text_resource_uids/shader");
+}
+
+bool ResourceFormatSaverShader::add_uid_to_source(String &p_r_source, const String &p_path, ResourceUID::ID p_uid) const {
+	bool need_update = false;
+	Vector<String> lines = p_r_source.split("\n");
+	bool uid_comment_valid = false;
+	for (Vector<String>::Size i = 0; i < lines.size(); i++) {
+		const String &line = lines[i].strip_edges();
+		if (line.begins_with(UID_COMMENT_PREFIX)) {
+			ResourceUID::ID uid = extract_shader_uid_from_line(line);
+			if (uid == ResourceUID::INVALID_ID || p_uid != uid) {
+				if (p_uid == ResourceUID::INVALID_ID) {
+					p_uid = ResourceSaver::get_resource_id_for_path(p_path, true);
+				}
+
+				if (uid != p_uid) {
+					lines.set(i, vformat("// %s %s", ResourceUID::get_singleton()->id_to_text(uid), UID_COMMENT_SUFFIX));
+					if (ResourceUID::get_singleton()->has_id(uid)) {
+						ResourceUID::get_singleton()->set_id(uid, p_path);
+					} else {
+						ResourceUID::get_singleton()->add_id(uid, p_path);
+					}
+					need_update = true;
+				}
+			}
+
+			uid_comment_valid = true;
+			break;
+		} else if (!line.strip_edges().is_empty()) {
+			break;
+		}
+	}
+
+	if (!uid_comment_valid) {
+		ResourceUID::ID uid = p_uid == ResourceUID::INVALID_ID ? ResourceSaver::get_resource_id_for_path(p_path, true) : p_uid;
+		lines.insert(0, vformat("// %s %s", ResourceUID::get_singleton()->id_to_text(uid), UID_COMMENT_SUFFIX));
+		if (ResourceUID::get_singleton()->has_id(uid)) {
+			ResourceUID::get_singleton()->set_id(uid, p_path);
+		} else {
+			ResourceUID::get_singleton()->add_id(uid, p_path);
+		}
+		need_update = true;
+	}
+
+	if (need_update) {
+		p_r_source = String("\n").join(lines);
+		return true;
+	} else {
+		return false;
+	}
+}
+
 Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<Shader> shader = p_resource;
 	ERR_FAIL_COND_V(shader.is_null(), ERR_INVALID_PARAMETER);
@@ -354,6 +448,21 @@ Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const Str
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader '" + p_path + "'.");
+
+	if (!FileAccess::exists(p_path + ".uid")) {
+		if (p_path.begins_with("res://addons/") && GLOBAL_GET("filesystem/inline_text_resource_uids/compatibility/no_inline_text_resource_uids_in_addons")) {
+			Ref<FileAccess> f = FileAccess::open(p_path + ".uid", FileAccess::WRITE);
+			if (f.is_valid()) {
+				ResourceUID::ID uid = ResourceUID::get_singleton()->create_id_for_path(p_path);
+				f->store_line(ResourceUID::get_singleton()->id_to_text(uid));
+				f->close();
+			}
+		} else {
+			if (add_uid_to_source(source, p_path)) {
+				shader->set_code(source);
+			}
+		}
+	}
 
 	file->store_string(source);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
@@ -373,4 +482,46 @@ void ResourceFormatSaverShader::get_recognized_extensions(const Ref<Resource> &p
 
 bool ResourceFormatSaverShader::recognize(const Ref<Resource> &p_resource) const {
 	return p_resource->get_class_name() == "Shader"; //only shader, not inherited
+}
+
+Error ResourceFormatSaverShader::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+	if (FileAccess::exists(p_path + ".uid") || (p_path.begins_with("res://addons/") && GLOBAL_GET("filesystem/inline_text_resource_uids/compatibility/no_inline_text_resource_uids_in_addons"))) {
+		Ref<FileAccess> f = FileAccess::open(p_path + ".uid", FileAccess::WRITE);
+		if (f.is_valid()) {
+			f->store_line(ResourceUID::get_singleton()->id_to_text(p_uid));
+
+			return OK;
+		} else {
+			return FileAccess::get_open_error();
+		}
+	} else if (p_path.get_extension().to_lower() == "gdshader") {
+		Error err = OK;
+		String source = FileAccess::get_file_as_string(p_path, &err);
+		if (err != OK) {
+			return err;
+		}
+
+		const bool source_code_changed = add_uid_to_source(source, p_path, p_uid);
+		if (source_code_changed) {
+			Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
+			if (f.is_valid()) {
+				f->store_string(source);
+				f->close();
+
+				// Update source code if it's loaded.
+				Ref<Shader> loaded_shader = ResourceCache::get_ref(p_path);
+				if (loaded_shader.is_valid()) {
+					loaded_shader->set_code(source);
+				}
+
+				err = OK;
+			} else {
+				err = FileAccess::get_open_error();
+			}
+		}
+
+		return err;
+	}
+
+	return ERR_FILE_UNRECOGNIZED;
 }

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -114,13 +114,21 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
+
+	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
+	virtual bool has_custom_uid_support() const override;
 };
 
 class ResourceFormatSaverShader : public ResourceFormatSaver {
 	GDSOFTCLASS(ResourceFormatSaverShader, ResourceFormatSaver);
 
+private:
+	bool add_uid_to_source(String &p_r_source, const String &p_path, ResourceUID::ID p_uid = ResourceUID::INVALID_ID) const;
+
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
+
+	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 };

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_include.h"
 
+#include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "servers/rendering/shader_preprocessor.h"
 
@@ -127,7 +128,99 @@ String ResourceFormatLoaderShaderInclude::get_resource_type(const String &p_path
 	return "";
 }
 
+#define UID_COMMENT_PREFIX "// uid://"
+#define UID_COMMENT_SUFFIX "This line is generated, don't modify or remove it."
+static ResourceUID::ID extract_shader_inc_uid_from_line(const String &p_line) {
+	Vector<String> splits = p_line.strip_edges().substr(3).split(" ", false, 1);
+	if (splits.is_empty()) {
+		return ResourceUID::INVALID_ID;
+	}
+	return ResourceUID::get_singleton()->text_to_id(splits[0]);
+}
+
+ResourceUID::ID ResourceFormatLoaderShaderInclude::get_resource_uid(const String &p_path) const {
+	int64_t uid = ResourceUID::INVALID_ID;
+
+	if (FileAccess::exists(p_path + ".uid")) {
+		Ref<FileAccess> file = FileAccess::open(p_path + ".uid", FileAccess::READ);
+		if (file.is_valid()) {
+			uid = ResourceUID::get_singleton()->text_to_id(file->get_line());
+		}
+	} else {
+		const String extension = p_path.get_extension().to_lower();
+		if (extension == "gdshaderinc") {
+			Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ);
+			if (file.is_valid()) {
+				while (!file->eof_reached()) {
+					String line = file->get_line().strip_edges();
+					if (!line.is_empty()) {
+						if (line.begins_with(UID_COMMENT_PREFIX)) {
+							uid = extract_shader_inc_uid_from_line(line);
+						}
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	return uid;
+}
+
+bool ResourceFormatLoaderShaderInclude::has_custom_uid_support() const {
+	return GLOBAL_GET("filesystem/inline_text_resource_uids/shader_include");
+}
+
 // ResourceFormatSaverShaderInclude
+bool ResourceFormatSaverShaderInclude::add_uid_to_source(String &p_r_source, const String &p_path, ResourceUID::ID p_uid) const {
+	bool need_update = false;
+	Vector<String> lines = p_r_source.split("\n");
+	bool uid_comment_valid = false;
+	for (Vector<String>::Size i = 0; i < lines.size(); i++) {
+		const String &line = lines[i].strip_edges();
+		if (line.begins_with(UID_COMMENT_PREFIX)) {
+			ResourceUID::ID uid = extract_shader_inc_uid_from_line(line);
+			if (uid == ResourceUID::INVALID_ID || p_uid != uid) {
+				if (p_uid == ResourceUID::INVALID_ID) {
+					p_uid = ResourceSaver::get_resource_id_for_path(p_path, true);
+				}
+
+				if (uid != p_uid) {
+					lines.set(i, vformat("// %s %s", ResourceUID::get_singleton()->id_to_text(uid), UID_COMMENT_SUFFIX));
+					if (ResourceUID::get_singleton()->has_id(uid)) {
+						ResourceUID::get_singleton()->set_id(uid, p_path);
+					} else {
+						ResourceUID::get_singleton()->add_id(uid, p_path);
+					}
+					need_update = true;
+				}
+			}
+
+			uid_comment_valid = true;
+			break;
+		} else if (!line.strip_edges().is_empty()) {
+			break;
+		}
+	}
+
+	if (!uid_comment_valid) {
+		ResourceUID::ID uid = p_uid == ResourceUID::INVALID_ID ? ResourceSaver::get_resource_id_for_path(p_path, true) : p_uid;
+		lines.insert(0, vformat("// %s %s", ResourceUID::get_singleton()->id_to_text(uid), UID_COMMENT_SUFFIX));
+		if (ResourceUID::get_singleton()->has_id(uid)) {
+			ResourceUID::get_singleton()->set_id(uid, p_path);
+		} else {
+			ResourceUID::get_singleton()->add_id(uid, p_path);
+		}
+		need_update = true;
+	}
+
+	if (need_update) {
+		p_r_source = String("\n").join(lines);
+		return true;
+	} else {
+		return false;
+	}
+}
 
 Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<ShaderInclude> shader_inc = p_resource;
@@ -139,6 +232,21 @@ Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, co
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &error);
 
 	ERR_FAIL_COND_V_MSG(error, error, "Cannot save shader include '" + p_path + "'.");
+
+	if (!FileAccess::exists(p_path + ".uid")) {
+		if (p_path.begins_with("res://addons/") && GLOBAL_GET("filesystem/inline_text_resource_uids/compatibility/no_inline_text_resource_uids_in_addons")) {
+			Ref<FileAccess> f = FileAccess::open(p_path + ".uid", FileAccess::WRITE);
+			if (f.is_valid()) {
+				ResourceUID::ID uid = ResourceUID::get_singleton()->create_id_for_path(p_path);
+				f->store_line(ResourceUID::get_singleton()->id_to_text(uid));
+				f->close();
+			}
+		} else {
+			if (add_uid_to_source(source, p_path)) {
+				shader_inc->set_code(source);
+			}
+		}
+	}
 
 	file->store_string(source);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
@@ -157,4 +265,45 @@ void ResourceFormatSaverShaderInclude::get_recognized_extensions(const Ref<Resou
 
 bool ResourceFormatSaverShaderInclude::recognize(const Ref<Resource> &p_resource) const {
 	return p_resource->get_class_name() == "ShaderInclude"; //only shader, not inherited
+}
+
+Error ResourceFormatSaverShaderInclude::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+	if (FileAccess::exists(p_path + ".uid") || (p_path.begins_with("res://addons/") && GLOBAL_GET("filesystem/inline_text_resource_uids/compatibility/no_inline_text_resource_uids_in_addons"))) {
+		Ref<FileAccess> f = FileAccess::open(p_path + ".uid", FileAccess::WRITE);
+		if (f.is_valid()) {
+			f->store_line(ResourceUID::get_singleton()->id_to_text(p_uid));
+			return OK;
+		} else {
+			return FileAccess::get_open_error();
+		}
+	} else if (p_path.get_extension().to_lower() == "gdshaderinc") {
+		Error err = OK;
+		String source = FileAccess::get_file_as_string(p_path, &err);
+		if (err != OK) {
+			return err;
+		}
+
+		const bool source_code_changed = add_uid_to_source(source, p_path, p_uid);
+		if (source_code_changed) {
+			Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
+			if (f.is_valid()) {
+				f->store_string(source);
+				f->close();
+
+				// Update source code if it's loaded.
+				Ref<ShaderInclude> loaded_shader_inc = ResourceCache::get_ref(p_path);
+				if (loaded_shader_inc.is_valid()) {
+					loaded_shader_inc->set_code(source);
+				}
+
+				err = OK;
+			} else {
+				err = FileAccess::get_open_error();
+			}
+		}
+
+		return err;
+	}
+
+	return ERR_FILE_UNRECOGNIZED;
 }

--- a/scene/resources/shader_include.h
+++ b/scene/resources/shader_include.h
@@ -63,13 +63,21 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
+
+	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
+	virtual bool has_custom_uid_support() const override;
 };
 
 class ResourceFormatSaverShaderInclude : public ResourceFormatSaver {
 	GDSOFTCLASS(ResourceFormatSaverShaderInclude, ResourceFormatSaver);
 
+private:
+	bool add_uid_to_source(String &p_r_source, const String &p_path, ResourceUID::ID p_uid = ResourceUID::INVALID_ID) const;
+
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
+
+	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 };


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
The main idea can be referred to [this thread](https://github.com/godotengine/godot-proposals/discussions/11574#discussioncomment-11849834),

- Get UID from ".uid" file first (for compatibility).
- Add a comment line to store UID in GDScript/Shader/ShaderInclude if ".uid" file is invalid.
- Scripts in “res://addons/” still using ".uid" files, avoid changing content of plugin's scripts.
- Add settings to enable this feature:
    - "filesystem/inline_text_resource_uids/gdscript"
    - "filesystem/inline_text_resource_uids/shader"
    - "filesystem/inline_text_resource_uids/shader_include"
    - "filesystem/inline_text_resource_uids/c_sharp_script"
- Add setting "filesystem/inline_text_resource_uids/compatibility/no_inline_text_resource_uids_in_addons" to disable this feature in "res://addons".

-------------
Edit: support this feature for ".cs" now.