### PR TITLE
Add relative option to LookAt/AimModifier3D

### DIFF
--- a/doc/classes/AimModifier3D.xml
+++ b/doc/classes/AimModifier3D.xml
@@ -24,6 +24,13 @@
 				Returns the axis of the first rotation. It is enabled only if [method is_using_euler] is [code]true[/code].
 			</description>
 		</method>
+		<method name="is_relative" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns [code]true[/code] if the relative option is enabled in the setting at [param index].
+			</description>
+		</method>
 		<method name="is_using_euler" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
@@ -52,6 +59,16 @@
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
 			<description>
 				Sets the axis of the first rotation. It is enabled only if [method is_using_euler] is [code]true[/code].
+			</description>
+		</method>
+		<method name="set_relative">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Sets relative option in the setting at [param index] to [param enabled].
+				If sets [param enabled] to [code]true[/code], the rotation is applied relative to the pose.
+				If sets [param enabled] to [code]false[/code], the rotation is applied relative to the rest. It means to replace the current pose with the [AimModifier3D]'s result.
 			</description>
 		</method>
 		<method name="set_use_euler">

--- a/doc/classes/LookAtModifier3D.xml
+++ b/doc/classes/LookAtModifier3D.xml
@@ -91,6 +91,9 @@
 		<member name="primary_rotation_axis" type="int" setter="set_primary_rotation_axis" getter="get_primary_rotation_axis" enum="Vector3.Axis" default="1">
 			The axis of the first rotation. This [SkeletonModifier3D] works by compositing the rotation by Euler angles to prevent to rotate the [member forward_axis].
 		</member>
+		<member name="relative" type="bool" setter="set_relative" getter="is_relative" default="true">
+			The relative option. If [code]true[/code], the rotation is applied relative to the pose. If [code]false[/code], the rotation is applied relative to the rest. It means to replace the current pose with the [LookAtModifier3D]'s result.
+		</member>
 		<member name="secondary_damp_threshold" type="float" setter="set_secondary_damp_threshold" getter="get_secondary_damp_threshold">
 			The threshold to start damping for [member secondary_limit_angle].
 		</member>

--- a/scene/3d/aim_modifier_3d.h
+++ b/scene/3d/aim_modifier_3d.h
@@ -41,6 +41,7 @@ public:
 		bool use_euler = false;
 		Vector3::Axis primary_rotation_axis = Vector3::AXIS_X;
 		bool use_secondary_rotation = true;
+		bool relative = true;
 	};
 
 protected:
@@ -65,6 +66,8 @@ public:
 	Vector3::Axis get_primary_rotation_axis(int p_index) const;
 	void set_use_secondary_rotation(int p_index, bool p_enabled);
 	bool is_using_secondary_rotation(int p_index) const;
+	void set_relative(int p_index, bool p_enabled);
+	bool is_relative(int p_index) const;
 
 	~AimModifier3D();
 };

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -143,6 +143,14 @@ bool LookAtModifier3D::is_using_secondary_rotation() const {
 	return use_secondary_rotation;
 }
 
+void LookAtModifier3D::set_relative(bool p_enabled) {
+	relative = p_enabled;
+}
+
+bool LookAtModifier3D::is_relative() const {
+	return relative;
+}
+
 void LookAtModifier3D::set_target_node(const NodePath &p_target_node) {
 	if (target_node != p_target_node) {
 		init_transition();
@@ -394,9 +402,11 @@ void LookAtModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_primary_rotation_axis"), &LookAtModifier3D::get_primary_rotation_axis);
 	ClassDB::bind_method(D_METHOD("set_use_secondary_rotation", "enabled"), &LookAtModifier3D::set_use_secondary_rotation);
 	ClassDB::bind_method(D_METHOD("is_using_secondary_rotation"), &LookAtModifier3D::is_using_secondary_rotation);
+	ClassDB::bind_method(D_METHOD("set_relative", "enabled"), &LookAtModifier3D::set_relative);
+	ClassDB::bind_method(D_METHOD("is_relative"), &LookAtModifier3D::is_relative);
+
 	ClassDB::bind_method(D_METHOD("set_origin_safe_margin", "margin"), &LookAtModifier3D::set_origin_safe_margin);
 	ClassDB::bind_method(D_METHOD("get_origin_safe_margin"), &LookAtModifier3D::get_origin_safe_margin);
-
 	ClassDB::bind_method(D_METHOD("set_origin_from", "origin_from"), &LookAtModifier3D::set_origin_from);
 	ClassDB::bind_method(D_METHOD("get_origin_from"), &LookAtModifier3D::get_origin_from);
 	ClassDB::bind_method(D_METHOD("set_origin_bone_name", "bone_name"), &LookAtModifier3D::set_origin_bone_name);
@@ -460,6 +470,7 @@ void LookAtModifier3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "forward_axis", PROPERTY_HINT_ENUM, SkeletonModifier3D::get_hint_bone_axis()), "set_forward_axis", "get_forward_axis");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "primary_rotation_axis", PROPERTY_HINT_ENUM, "X,Y,Z"), "set_primary_rotation_axis", "get_primary_rotation_axis");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_secondary_rotation"), "set_use_secondary_rotation", "is_using_secondary_rotation");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "relative"), "set_relative", "is_relative");
 
 	ADD_GROUP("Origin Settings", "origin_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "origin_from", PROPERTY_HINT_ENUM, "Self,SpecificBone,ExternalNode"), "set_origin_from", "get_origin_from");
@@ -506,14 +517,15 @@ void LookAtModifier3D::_process_modification(double p_delta) {
 	}
 
 	// Calculate bone rest space in the world.
+	Transform3D bone_rest = relative ? skeleton->get_bone_pose(bone) : skeleton->get_bone_rest(bone);
 	Transform3D bone_rest_space;
 	int parent_bone = skeleton->get_bone_parent(bone);
 	if (parent_bone < 0) {
 		bone_rest_space = skeleton->get_global_transform_interpolated();
-		bone_rest_space.translate_local(skeleton->get_bone_rest(bone).origin);
+		bone_rest_space.translate_local(bone_rest.origin);
 	} else {
 		bone_rest_space = skeleton->get_global_transform_interpolated() * skeleton->get_bone_global_pose(parent_bone);
-		bone_rest_space.translate_local(skeleton->get_bone_rest(bone).origin);
+		bone_rest_space.translate_local(bone_rest.origin);
 	}
 
 	// Calculate forward_vector and destination.
@@ -543,7 +555,7 @@ void LookAtModifier3D::_process_modification(double p_delta) {
 			destination = skeleton->get_bone_pose_rotation(bone);
 			forward_vector = Vector3(0, 0, 0); // The zero-vector to be used for checking in the line immediately below to avoid animation glitch.
 		} else {
-			destination = look_at_with_axes(skeleton->get_bone_rest(bone)).basis.get_rotation_quaternion();
+			destination = look_at_with_axes(bone_rest).basis.get_rotation_quaternion();
 		}
 	}
 

--- a/scene/3d/look_at_modifier_3d.h
+++ b/scene/3d/look_at_modifier_3d.h
@@ -53,6 +53,7 @@ private:
 	Vector3::Axis primary_rotation_axis = Vector3::AXIS_Y;
 	Vector3::Axis secondary_rotation_axis = Vector3::AXIS_X;
 	bool use_secondary_rotation = true;
+	bool relative = true;
 
 	OriginFrom origin_from = ORIGIN_FROM_SELF;
 	String origin_bone_name;
@@ -123,6 +124,8 @@ public:
 	Vector3::Axis get_primary_rotation_axis() const;
 	void set_use_secondary_rotation(bool p_enabled);
 	bool is_using_secondary_rotation() const;
+	void set_relative(bool p_enabled);
+	bool is_relative() const;
 
 	void set_origin_from(OriginFrom p_origin_from);
 	OriginFrom get_origin_from() const;


### PR DESCRIPTION
- Prerequisite https://github.com/godotengine/godot/pull/110336

Add a relative option to make Aim/LookAt rotate after other Modifier rotations. This is useful when you want to handle only Twist after some modifiers processed.

https://github.com/user-attachments/assets/97712846-b715-44e6-a095-c80728457b76

The default is set to false for compatibility, but since it's likely true in most cases, it might be acceptable to set the default to true.