### PR TITLE
[Windows] Fix MinGW build

### DIFF
--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -31,6 +31,7 @@
 #include "crash_handler_windows.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/file_access.h"
 #include "core/object/script_language.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"


### PR DESCRIPTION
`file_access.h` was removed from the include hierarchy and wasn't caught by CI as it only occurs with MinGW builds

Unsure if this affects any other area not caught by CI, but this was the one I ran across myself and could confirm

Regression from:
* https://github.com/godotengine/godot/pull/111274

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
