### PR TITLE
Fix UI focus being shown when it shouldn't

### DIFF
--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -515,7 +515,7 @@ void GroupsEditor::_confirm_add() {
 	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
-	tree->grab_focus();
+	tree->grab_focus(true);
 }
 
 void GroupsEditor::_confirm_rename() {
@@ -566,7 +566,7 @@ void GroupsEditor::_confirm_rename() {
 
 	undo_redo->commit_action();
 
-	tree->grab_focus();
+	tree->grab_focus(true);
 }
 
 void GroupsEditor::_confirm_delete() {
@@ -606,7 +606,7 @@ void GroupsEditor::_confirm_delete() {
 	undo_redo->add_undo_method(this, "_update_tree");
 
 	undo_redo->commit_action();
-	tree->grab_focus();
+	tree->grab_focus(true);
 }
 
 void GroupsEditor::_show_add_group_dialog() {

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -277,6 +277,7 @@ void EditorSpinSlider::_value_input_gui_input(const Ref<InputEvent> &p_event) {
 			case Key::ESCAPE: {
 				value_input_closed_frame = Engine::get_singleton()->get_frames_drawn();
 				if (value_input_popup) {
+					value_input_focus_visible = value_input->has_focus(true);
 					value_input_popup->hide();
 				}
 			} break;
@@ -612,6 +613,7 @@ void EditorSpinSlider::_evaluate_input_text() {
 void EditorSpinSlider::_value_input_submitted(const String &p_text) {
 	value_input_closed_frame = Engine::get_singleton()->get_frames_drawn();
 	if (value_input_popup) {
+		value_input_focus_visible = value_input->has_focus(true);
 		value_input_popup->hide();
 	}
 }
@@ -646,9 +648,10 @@ void EditorSpinSlider::_value_focus_exited() {
 			value_input_popup->hide();
 		}
 	} else {
-		// Enter or Esc was pressed.
-		grab_focus();
+		// Enter or Esc was pressed. Keep showing the focus if already present.
+		grab_focus(!value_input_focus_visible);
 	}
+	value_input_focus_visible = false;
 
 	emit_signal("value_focus_exited");
 }

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -67,6 +67,7 @@ class EditorSpinSlider : public Range {
 	LineEdit *value_input = nullptr;
 	uint64_t value_input_closed_frame = 0;
 	bool value_input_dirty = false;
+	bool value_input_focus_visible = false;
 
 public:
 	enum ControlState {

--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -435,6 +435,13 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 		actions_cache = p_action_infos;
 	}
 
+	Pair<String, int> selected_item;
+	TreeItem *ti = action_tree->get_selected();
+	if (ti) {
+		selected_item.first = ti->get_text(0);
+		selected_item.second = action_tree->get_selected_column();
+	}
+
 	HashSet<String> collapsed_actions;
 	TreeItem *root = action_tree->get_root();
 	if (root) {
@@ -496,6 +503,10 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 		action_item->set_custom_bg_color(0, get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor)));
 		action_item->set_custom_bg_color(1, get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor)));
 
+		if (selected_item.first == action_info.name) {
+			action_item->select(selected_item.second);
+		}
+
 		for (int evnt_idx = 0; evnt_idx < events.size(); evnt_idx++) {
 			Ref<InputEvent> event = events[evnt_idx];
 			if (event.is_null()) {
@@ -544,6 +555,10 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 			event_item->add_button(2, get_editor_theme_icon(SNAME("Remove")), BUTTON_REMOVE_EVENT, false, TTRC("Remove Event"), TTRC("Remove Event"));
 			event_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 			event_item->set_button_color(2, 1, Color(1, 1, 1, 0.75));
+
+			if (selected_item.first == event_item->get_text(0)) {
+				event_item->select(selected_item.second);
+			}
 		}
 	}
 }

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -480,9 +480,7 @@ private:
 
 	int pressed_button = -1;
 	bool pressing_for_editor = false;
-	String pressing_for_editor_text;
 	Vector2 pressing_pos;
-	Rect2 pressing_item_rect;
 
 	Vector2 hovered_pos;
 	bool is_mouse_hovering = false;
@@ -562,7 +560,7 @@ private:
 	void select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_col, TreeItem *p_prev = nullptr, bool *r_in_range = nullptr, bool p_force_deselect = false);
 	int propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int x_limit, bool p_double_click, TreeItem *p_item, MouseButton p_button, const Ref<InputEventWithModifiers> &p_mod);
 	void _line_editor_submit(String p_text);
-	void _apply_multiline_edit();
+	void _apply_multiline_edit(bool p_hide_focus = false);
 	void _text_editor_popup_modal_close();
 	void _text_editor_gui_input(const Ref<InputEvent> &p_event);
 	void value_editor_changed(double p_value);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -552,7 +552,7 @@ bool Viewport::_can_hide_focus_state() {
 }
 
 void Viewport::_on_settings_changed() {
-	if (!gui.hide_focus && _can_hide_focus_state()) {
+	if (!gui.hide_focus || _can_hide_focus_state()) {
 		return;
 	}
 


### PR DESCRIPTION
This can be reproduced by toggling plugins in the settings dialog, as it will show the focus outline when doing so.