### PR TITLE
Only include `hash_set.h` and `safe_refcount.h` in `object.h` when used.

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/object.h"
+#include "core/templates/hash_set.h"
 #include "core/templates/rb_map.h"
 
 template <typename T>

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -36,11 +36,17 @@
 #include "core/object/object_id.h"
 #include "core/os/spin_lock.h"
 #include "core/templates/hash_map.h"
-#include "core/templates/hash_set.h"
 #include "core/templates/list.h"
-#include "core/templates/safe_refcount.h"
 #include "core/variant/callable_bind.h"
 #include "core/variant/variant.h"
+
+#ifdef TOOLS_ENABLED
+#include "core/templates/hash_set.h"
+#endif
+
+#ifdef DEBUG_ENABLED
+#include "core/templates/safe_refcount.h"
+#endif
 
 template <typename T>
 class TypedArray;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Addresses https://github.com/godotengine/godot/issues/111218

`hash_set.h` and `safe_refcount.h` are only used in editor builds and debug builds respectively. This PR makes it so their headers aren't unnecessarily included and should improve compilation times for release builds.