### PR TITLE
Make most container template copy constructors explicit

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1640,9 +1640,9 @@ void ProjectSettings::_bind_methods() {
 
 void ProjectSettings::_add_builtin_input_map() {
 	if (InputMap::get_singleton()) {
-		HashMap<String, List<Ref<InputEvent>>> builtins = InputMap::get_singleton()->get_builtins();
+		const HashMap<String, List<Ref<InputEvent>>> builtins = HashMap<String, List<Ref<InputEvent>>>(InputMap::get_singleton()->get_builtins());
 
-		for (KeyValue<String, List<Ref<InputEvent>>> &E : builtins) {
+		for (const KeyValue<String, List<Ref<InputEvent>>> &E : builtins) {
 			Array events;
 
 			// Convert list of input events into array

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -204,7 +204,7 @@ public:
 	const HashMap<StringName, PropertyInfo> &get_custom_property_info() const;
 	uint64_t get_last_saved_time() { return last_save_time; }
 
-	List<String> get_input_presets() const { return input_presets; }
+	List<String> get_input_presets() const { return List<String>(input_presets); }
 
 	Variant get_setting_with_override(const StringName &p_name) const;
 	Variant get_setting_with_override_and_custom_features(const StringName &p_name, const Vector<String> &p_features) const;

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -950,7 +950,7 @@ void GDExtension::prepare_reload() {
 				state.push_back(Pair<String, Variant>(P.name, value));
 			}
 			E.value.instance_state[obj_id] = {
-				state, // List<Pair<String, Variant>> properties;
+				List<Pair<String, Variant>>(state), // List<Pair<String, Variant>> properties;
 				obj->is_extension_placeholder(), // bool is_placeholder;
 			};
 		}

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -896,7 +896,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_featur
 }
 
 void InputMap::load_default() {
-	HashMap<String, List<Ref<InputEvent>>> builtins = get_builtins_with_feature_overrides_applied();
+	const HashMap<String, List<Ref<InputEvent>>> builtins = HashMap<String, List<Ref<InputEvent>>>(get_builtins_with_feature_overrides_applied());
 
 	for (const KeyValue<String, List<Ref<InputEvent>>> &E : builtins) {
 		String name = E.key;

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -167,7 +167,7 @@ bool PackedData::has_delta_patches(const String &p_path) const {
 HashSet<String> PackedData::get_file_paths() const {
 	HashSet<String> file_paths;
 	_get_file_paths(root, root->name, file_paths);
-	return file_paths;
+	return HashSet<String>(file_paths);
 }
 
 void PackedData::_get_file_paths(PackedDir *p_dir, const String &p_parent_dir, HashSet<String> &r_paths) const {

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -205,7 +205,7 @@ IPAddress IP::get_resolve_item_address(ResolverID p_id) const {
 		return IPAddress();
 	}
 
-	List<IPAddress> res = resolver->queue[p_id].response;
+	const List<IPAddress> res = List<IPAddress>(resolver->queue[p_id].response);
 
 	for (const IPAddress &E : res) {
 		if (E.is_valid()) {
@@ -224,7 +224,7 @@ Array IP::get_resolve_item_addresses(ResolverID p_id) const {
 		return Array();
 	}
 
-	List<IPAddress> res = resolver->queue[p_id].response;
+	const List<IPAddress> res = List<IPAddress>(resolver->queue[p_id].response);
 
 	Array result;
 	for (const IPAddress &E : res) {

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -158,7 +158,7 @@ void AStarGrid2D::update() {
 			solid_mask.push_back(false);
 		}
 		solid_mask.push_back(true);
-		points.push_back(line);
+		points.push_back(LocalVector<Point>(line));
 	}
 
 	for (int32_t x = region.position.x; x < end_x + 2; x++) {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1018,7 +1018,7 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 #endif // DEBUG_ENABLED
 
 		for (const KeyValue<StringName, LocalVector<MethodBind *, unsigned int, false, false>> &E : type->method_map_compatibility) {
-			LocalVector<MethodBind *> compat = E.value;
+			const LocalVector<MethodBind *> compat = LocalVector<MethodBind *>(E.value);
 			for (MethodBind *method : compat) {
 				MethodInfo minfo = info_from_bind(method);
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -654,7 +654,7 @@ bool OS::is_restart_on_exit_set() const {
 }
 
 List<String> OS::get_restart_on_exit_arguments() const {
-	return restart_commandline;
+	return List<String>(restart_commandline);
 }
 
 PackedStringArray OS::get_connected_midi_inputs() {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -218,8 +218,8 @@ public:
 	virtual String get_distribution_name() const = 0;
 	virtual String get_version() const = 0;
 	virtual String get_version_alias() const { return get_version(); }
-	virtual List<String> get_cmdline_args() const { return _cmdline; }
-	virtual List<String> get_cmdline_user_args() const { return _user_args; }
+	virtual List<String> get_cmdline_args() const { return List<String>(_cmdline); }
+	virtual List<String> get_cmdline_user_args() const { return List<String>(_user_args); }
 	virtual List<String> get_cmdline_platform_args() const { return List<String>(); }
 	virtual String get_model_name() const;
 

--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -286,7 +286,7 @@ void TranslationDomain::clear() {
 }
 
 const HashSet<Ref<Translation>> TranslationDomain::get_translations() const {
-	return translations;
+	return HashSet<Ref<Translation>>(translations);
 }
 
 HashSet<Ref<Translation>> TranslationDomain::find_translations(const String &p_locale, bool p_exact) const {
@@ -304,7 +304,7 @@ HashSet<Ref<Translation>> TranslationDomain::find_translations(const String &p_l
 			}
 		}
 	}
-	return res;
+	return HashSet<Ref<Translation>>(res);
 }
 
 bool TranslationDomain::has_translation(const Ref<Translation> &p_translation) const {

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -63,7 +63,7 @@ public:
 		}
 	}
 
-	constexpr FixedVector(const FixedVector &p_from) {
+	constexpr explicit FixedVector(const FixedVector &p_from) {
 		if constexpr (std::is_trivially_copyable_v<T>) {
 			// Copy size and all provided elements at once.
 			memcpy((void *)&_size, (void *)&p_from._size, sizeof(_size) + DATA_PADDING + p_from.size() * sizeof(T));

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -582,7 +582,7 @@ public:
 
 	/* Constructors */
 
-	HashMap(const HashMap &p_other) {
+	explicit HashMap(const HashMap &p_other) {
 		reserve(hash_table_size_primes[p_other._capacity_idx]);
 
 		if (p_other._size == 0) {

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -417,7 +417,7 @@ public:
 
 	/* Constructors */
 
-	HashSet(const HashSet &p_other) {
+	explicit HashSet(const HashSet &p_other) {
 		_init_from(p_other);
 	}
 

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -688,7 +688,7 @@ public:
 	/**
 	 * copy constructor for the list
 	 */
-	List(const List &p_list) {
+	explicit List(const List &p_list) {
 		const Element *it = p_list.front();
 		while (it) {
 			push_back(it->get());

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -349,7 +349,7 @@ public:
 			push_back(element);
 		}
 	}
-	_FORCE_INLINE_ LocalVector(const LocalVector &p_from) {
+	_FORCE_INLINE_ explicit LocalVector(const LocalVector &p_from) {
 		resize(p_from.size());
 		for (U i = 0; i < p_from.count; i++) {
 			data[i] = p_from.data[i];

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -760,7 +760,7 @@ public:
 		_copy_from(p_map);
 	}
 
-	RBMap(const RBMap &p_map) {
+	explicit RBMap(const RBMap &p_map) {
 		_copy_from(p_map);
 	}
 

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -697,7 +697,7 @@ public:
 		_copy_from(p_set);
 	}
 
-	RBSet(const RBSet &p_set) {
+	explicit RBSet(const RBSet &p_set) {
 		_copy_from(p_set);
 	}
 

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -619,7 +619,7 @@ bool ShaderGLES3::_load_from_cache(Version *p_version) {
 
 			variant.insert(specialization_key, specialization);
 		}
-		variants.push_back(variant);
+		variants.push_back(AHashMap<uint64_t, Version::Specialization>(variant));
 	}
 	p_version->variants = variants;
 
@@ -706,7 +706,7 @@ void ShaderGLES3::_initialize_version(Version *p_version) {
 	p_version->variants.reserve(variant_count);
 	for (int i = 0; i < variant_count; i++) {
 		AHashMap<uint64_t, Version::Specialization> variant;
-		p_version->variants.push_back(variant);
+		p_version->variants.push_back(AHashMap<uint64_t, Version::Specialization>(variant));
 		Version::Specialization spec;
 		_compile_specialization(spec, i, p_version, specialization_default_mask);
 		p_version->variants[i].insert(specialization_default_mask, spec);

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1223,7 +1223,7 @@ void TextureStorage::texture_remap_proxies(RID p_from_texture, RID p_to_texture)
 	}
 
 	// Make a local copy, we're about to change the content of the original.
-	thread_local LocalVector<RID> proxies = from_tex->proxies;
+	thread_local LocalVector<RID> proxies = LocalVector<RID>(from_tex->proxies);
 
 	// Now change them to our new texture.
 	for (RID &proxy : proxies) {

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1234,7 +1234,7 @@ HashSet<String> FileSystemDock::_get_valid_conversions_for_file_paths(const Vect
 		}
 	}
 
-	return all_valid_conversion_to_targets;
+	return HashSet<String>(all_valid_conversion_to_targets);
 }
 
 void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorites, bool p_navigate) {
@@ -1630,7 +1630,7 @@ void FileSystemDock::_update_dependencies_after_move(const HashMap<String, Strin
 
 void FileSystemDock::_update_project_settings_after_move(const HashMap<String, String> &p_renames, const HashMap<String, String> &p_folders_renames) {
 	// Find all project settings of type FILE and replace them if needed.
-	const HashMap<StringName, PropertyInfo> prop_info = ProjectSettings::get_singleton()->get_custom_property_info();
+	const HashMap<StringName, PropertyInfo> prop_info = HashMap<StringName, PropertyInfo>(ProjectSettings::get_singleton()->get_custom_property_info());
 	for (const KeyValue<StringName, PropertyInfo> &E : prop_info) {
 		if (E.value.hint == PROPERTY_HINT_FILE || E.value.hint == PROPERTY_HINT_FILE_PATH) {
 			String old_path = GLOBAL_GET(E.key);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -664,7 +664,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			List<Node *> selection = editor_selection->get_top_selected_node_list();
+			List<Node *> selection = List<Node *>(editor_selection->get_top_selected_node_list());
 			if (selection.is_empty()) {
 				break;
 			}
@@ -885,7 +885,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			List<Node *> selection = editor_selection->get_top_selected_node_list();
+			List<Node *> selection = List<Node *>(editor_selection->get_top_selected_node_list());
 			if (selection.is_empty()) {
 				break;
 			}
@@ -990,7 +990,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			List<Node *> nodes = editor_selection->get_top_selected_node_list();
+			const List<Node *> nodes = List<Node *>(editor_selection->get_top_selected_node_list());
 			HashSet<Node *> nodeset;
 			for (Node *E : nodes) {
 				nodeset.insert(E);
@@ -1003,7 +1003,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			List<Node *> nodes = editor_selection->get_top_selected_node_list();
+			const List<Node *> nodes = List<Node *>(editor_selection->get_top_selected_node_list());
 			ERR_FAIL_COND(nodes.size() != 1);
 
 			Node *node = nodes.front()->get();
@@ -1086,7 +1086,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			List<Node *> remove_list = editor_selection->get_top_selected_node_list();
+			const List<Node *> remove_list = List<Node *>(editor_selection->get_top_selected_node_list());
 
 			if (remove_list.is_empty()) {
 				return;
@@ -1097,7 +1097,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			bool allow_ask_delete_tracks = EDITOR_GET("docks/scene_tree/ask_before_deleting_related_animation_tracks").operator bool();
-			bool has_tracks_to_delete = allow_ask_delete_tracks && _has_tracks_to_delete(edited_scene, remove_list);
+			bool has_tracks_to_delete = allow_ask_delete_tracks && _has_tracks_to_delete(edited_scene, List<Node *>(remove_list));
 			if (p_confirm_override && !has_tracks_to_delete) {
 				_delete_confirm();
 			} else {
@@ -1915,7 +1915,7 @@ void SceneTreeDock::_fill_path_renames(Vector<StringName> base_path, Vector<Stri
 	}
 }
 
-bool SceneTreeDock::_has_tracks_to_delete(Node *p_node, List<Node *> &p_to_delete) const {
+bool SceneTreeDock::_has_tracks_to_delete(Node *p_node, const List<Node *> &p_to_delete) const {
 	// Skip if this node will be deleted.
 	for (const Node *F : p_to_delete) {
 		if (F == p_node || F->is_ancestor_of(p_node)) {
@@ -2771,7 +2771,7 @@ void SceneTreeDock::_toggle_editable_children(Node *p_node) {
 }
 
 void SceneTreeDock::_delete_confirm(bool p_cut) {
-	List<Node *> remove_list = editor_selection->get_top_selected_node_list();
+	List<Node *> remove_list = List<Node *>(editor_selection->get_top_selected_node_list());
 
 	if (remove_list.is_empty()) {
 		return;
@@ -4418,7 +4418,7 @@ List<Node *> SceneTreeDock::paste_nodes(bool p_paste_as_sibling) {
 }
 
 List<Node *> SceneTreeDock::get_node_clipboard() const {
-	return node_clipboard;
+	return List<Node *>(node_clipboard);
 }
 
 void SceneTreeDock::add_remote_tree_editor(Control *p_remote) {

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -258,7 +258,7 @@ class SceneTreeDock : public EditorDock {
 	void _queue_update_script_button();
 
 	void _fill_path_renames(Vector<StringName> base_path, Vector<StringName> new_base_path, Node *p_node, HashMap<Node *, NodePath> *p_renames);
-	bool _has_tracks_to_delete(Node *p_node, List<Node *> &p_to_delete) const;
+	bool _has_tracks_to_delete(Node *p_node, const List<Node *> &p_to_delete) const;
 
 	void _normalize_drop(Node *&to_node, int &to_pos, int p_type);
 	Array _get_selection_array();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -256,7 +256,7 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 
 	// For each index set with a size > 1, we need to disambiguate.
 	for (int i = 0; i < index_sets.size(); i++) {
-		RBSet<int> iset = index_sets[i];
+		RBSet<int> iset = RBSet<int>(index_sets[i]);
 		while (iset.size() > 1) {
 			// Append the parent folder to each scene name.
 			for (const int &E : iset) {
@@ -1906,7 +1906,10 @@ int EditorNode::get_resource_count(Ref<Resource> p_res) {
 
 List<Node *> EditorNode::get_resource_node_list(Ref<Resource> p_res) {
 	List<Node *> *L = resource_count.getptr(p_res);
-	return L == nullptr ? List<Node *>() : *L;
+	if (L == nullptr) {
+		return List<Node *>();
+	}
+	return List<Node *>(*L);
 }
 
 void EditorNode::update_node_reference(const Variant &p_value, Node *p_node, bool p_remove) {
@@ -4865,7 +4868,7 @@ HashMap<StringName, Variant> EditorNode::get_modified_properties_for_node(Node *
 		}
 	}
 
-	return modified_property_map;
+	return HashMap<StringName, Variant>(modified_property_map);
 }
 
 HashMap<StringName, Variant> EditorNode::get_modified_properties_reference_to_nodes(Node *p_node, List<Node *> &p_nodes_referenced_by) {
@@ -4886,7 +4889,7 @@ HashMap<StringName, Variant> EditorNode::get_modified_properties_reference_to_no
 		}
 	}
 
-	return modified_property_map;
+	return HashMap<StringName, Variant>(modified_property_map);
 }
 
 void EditorNode::update_node_from_node_modification_entry(Node *p_node, ModificationNodeEntry &p_node_modification) {
@@ -7891,7 +7894,7 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	HashMap<String, Variant> settings;
 	settings["physics/3d/physics_engine"] = "Jolt Physics";
 	settings["rendering/rendering_device/driver.windows"] = "d3d12";
-	return settings;
+	return HashMap<String, Variant>(settings);
 }
 
 EditorNode::EditorNode() {

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -439,7 +439,7 @@ void EditorExport::update_export_presets() {
 			export_presets_updated = true;
 
 			bool update_value_overrides = false;
-			List<EditorExportPlatform::ExportOption> options = platform_options[preset->get_platform()->get_name()];
+			const List<EditorExportPlatform::ExportOption> options = List<EditorExportPlatform::ExportOption>(platform_options[preset->get_platform()->get_name()]);
 
 			// Clear the preset properties prior to reloading, keep the values to preserve options from plugins that may be currently disabled.
 			preset->properties.clear();

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -655,7 +655,7 @@ HashSet<String> EditorExportPlatform::get_features(const Ref<EditorExportPreset>
 		}
 	}
 
-	return result;
+	return HashSet<String>(result);
 }
 
 EditorExportPlatform::ExportNotifier::ExportNotifier(EditorExportPlatform &p_platform, const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2539,7 +2539,7 @@ void EditorFileSystem::_notify_filesystem_changed() {
 }
 
 HashSet<String> EditorFileSystem::get_valid_extensions() const {
-	return valid_extensions;
+	return HashSet<String>(valid_extensions);
 }
 
 void EditorFileSystem::_register_global_class_script(const String &p_search_path, const String &p_target_path, const ScriptClassInfoUpdate &p_script_update) {
@@ -2785,7 +2785,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 
 	//try to obtain existing params
 
-	HashMap<StringName, Variant> params = p_custom_options;
+	HashMap<StringName, Variant> params = HashMap<StringName, Variant>(p_custom_options);
 	String importer_name; //empty by default though
 
 	if (!p_custom_importer.is_empty()) {

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1021,7 +1021,7 @@ void SceneImportSettingsDialog::_inspector_property_edited(const String &p_name)
 		if (!animation_map.has(selected_id)) {
 			return;
 		}
-		HashMap<StringName, Variant> settings = animation_map[selected_id].settings;
+		const HashMap<StringName, Variant> settings = HashMap<StringName, Variant>(animation_map[selected_id].settings);
 		if (settings.has(p_name)) {
 			animation_loop_mode = static_cast<Animation::LoopMode>((int)settings[p_name]);
 		} else {
@@ -1105,7 +1105,7 @@ void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name)
 		animation_pingpong = false;
 
 		if (animation_map.has(p_animation_name)) {
-			HashMap<StringName, Variant> settings = animation_map[p_animation_name].settings;
+			HashMap<StringName, Variant> settings = HashMap<StringName, Variant>(animation_map[p_animation_name].settings);
 			if (settings.has("settings/loop_mode")) {
 				animation_loop_mode = static_cast<Animation::LoopMode>((int)settings["settings/loop_mode"]);
 			}

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3833,7 +3833,7 @@ static EditorProperty *get_input_action_editor(const String &p_hint_text, bool i
 	ProjectSettings::get_singleton()->get_property_list(&pinfo);
 	Vector<String> hints = p_hint_text.remove_char(' ').split(",", false);
 
-	HashMap<String, List<Ref<InputEvent>>> builtins = InputMap::get_singleton()->get_builtins();
+	const HashMap<String, List<Ref<InputEvent>>> builtins = HashMap<String, List<Ref<InputEvent>>>(InputMap::get_singleton()->get_builtins());
 	bool show_builtin = hints.has("show_builtin");
 
 	for (const PropertyInfo &pi : pinfo) {

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -625,7 +625,7 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 		int idx = 0;
 
 		_ensure_allowed_types();
-		HashSet<StringName> allowed_types = allowed_types_without_convert;
+		HashSet<StringName> allowed_types = HashSet<StringName>(allowed_types_without_convert);
 		if (!allowed_types.is_empty()) {
 			edit_menu->add_separator(TTRC("New"));
 		}
@@ -865,7 +865,7 @@ bool EditorResourcePicker::_is_drop_valid(const Dictionary &p_drag_data) const {
 	}
 
 	_ensure_allowed_types();
-	HashSet<StringName> allowed_types = allowed_types_with_convert;
+	HashSet<StringName> allowed_types = HashSet<StringName>(allowed_types_with_convert);
 
 	if (res.is_valid()) {
 		String res_type = _get_resource_type(res);
@@ -954,7 +954,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 
 	if (dropped_resource.is_valid()) {
 		_ensure_allowed_types();
-		HashSet<StringName> allowed_types = allowed_types_without_convert;
+		HashSet<StringName> allowed_types = HashSet<StringName>(allowed_types_without_convert);
 
 		String res_type = _get_resource_type(dropped_resource);
 
@@ -1098,7 +1098,7 @@ void EditorResourcePicker::set_base_type(const String &p_base_type) {
 	// Keep the value, but warn the user that there is a potential mistake.
 	if (!base_type.is_empty() && edited_resource.is_valid()) {
 		_ensure_allowed_types();
-		HashSet<StringName> allowed_types = allowed_types_with_convert;
+		HashSet<StringName> allowed_types = HashSet<StringName>(allowed_types_with_convert);
 
 		StringName custom_class;
 		bool is_custom = false;
@@ -1120,7 +1120,7 @@ String EditorResourcePicker::get_base_type() const {
 
 Vector<String> EditorResourcePicker::get_allowed_types() const {
 	_ensure_allowed_types();
-	HashSet<StringName> allowed_types = allowed_types_without_convert;
+	HashSet<StringName> allowed_types = HashSet<StringName>(allowed_types_without_convert);
 
 	Vector<String> types;
 	types.resize(allowed_types.size());
@@ -1144,7 +1144,7 @@ void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
 
 	if (!base_type.is_empty()) {
 		_ensure_allowed_types();
-		HashSet<StringName> allowed_types = allowed_types_with_convert;
+		HashSet<StringName> allowed_types = HashSet<StringName>(allowed_types_with_convert);
 
 		StringName custom_class;
 		bool is_custom = false;

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -1093,7 +1093,7 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_line(Vector2
 			}
 		}
 	}
-	return output;
+	return HashMap<Vector2i, TileMapCell>(output);
 }
 
 HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_rect(Vector2i p_start_cell, Vector2i p_end_cell, bool p_erase) {
@@ -1148,7 +1148,7 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_rect(Vector2
 		}
 	}
 
-	return output;
+	return HashMap<Vector2i, TileMapCell>(output);
 }
 
 HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_bucket_fill(Vector2i p_coords, bool p_contiguous, bool p_erase) {
@@ -1253,7 +1253,7 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_bucket_fill(
 			}
 		}
 	}
-	return output;
+	return HashMap<Vector2i, TileMapCell>(output);
 }
 
 void TileMapLayerEditorTilesPlugin::_stop_dragging() {
@@ -2537,7 +2537,7 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTerrainsPlugin::_draw_terrain_p
 			}
 		}
 	}
-	return output;
+	return HashMap<Vector2i, TileMapCell>(output);
 }
 
 HashMap<Vector2i, TileMapCell> TileMapLayerEditorTerrainsPlugin::_draw_terrain_pattern(const Vector<Vector2i> &p_to_paint, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern) const {
@@ -2584,7 +2584,7 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTerrainsPlugin::_draw_terrain_p
 			}
 		}
 	}
-	return output;
+	return HashMap<Vector2i, TileMapCell>(output);
 }
 
 HashMap<Vector2i, TileMapCell> TileMapLayerEditorTerrainsPlugin::_draw_line(Vector2i p_start_cell, Vector2i p_end_cell, bool p_erase) {
@@ -2753,7 +2753,7 @@ RBSet<Vector2i> TileMapLayerEditorTerrainsPlugin::_get_cells_for_bucket_fill(Vec
 			}
 		}
 	}
-	return output;
+	return RBSet<Vector2i>(output);
 }
 
 HashMap<Vector2i, TileMapCell> TileMapLayerEditorTerrainsPlugin::_draw_bucket_fill(Vector2i p_coords, bool p_contiguous, bool p_erase) {

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -1602,7 +1602,7 @@ HashMap<Vector2i, List<const PropertyInfo *>> TileSetAtlasSourceEditor::_group_p
 			}
 		}
 	}
-	return per_tile;
+	return HashMap<Vector2i, List<const PropertyInfo *>>(per_tile);
 }
 
 void TileSetAtlasSourceEditor::_menu_option(int p_option) {

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
@@ -101,7 +101,7 @@ public:
 
 	public:
 		Ref<TileSetAtlasSource> get_edited_tile_set_atlas_source() const { return tile_set_atlas_source; }
-		RBSet<TileSelection> get_edited_tiles() const { return tiles; }
+		RBSet<TileSelection> get_edited_tiles() const { return RBSet<TileSelection>(tiles); }
 
 		// Update the proxied object.
 		void edit(Ref<TileSetAtlasSource> p_tile_set_atlas_source, const RBSet<TileSelection> &p_tiles = RBSet<TileSelection>());

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
@@ -275,7 +275,7 @@ Vector<Ref<Shape3D>> MeshInstance3DEditor::create_shape_from_mesh(Ref<Mesh> p_me
 
 void MeshInstance3DEditor::_shape_dialog_about_to_popup() {
 	EditorSelection *editor_selection = EditorNode::get_singleton()->get_editor_selection();
-	List<Node *> selection = editor_selection->get_top_selected_node_list();
+	List<Node *> selection = List<Node *>(editor_selection->get_top_selected_node_list());
 	if (selection.is_empty()) {
 		selection.push_back(node);
 	}
@@ -355,7 +355,7 @@ void MeshInstance3DEditor::_create_collision_shape() {
 			break;
 	}
 
-	List<Node *> selection = editor_selection->get_top_selected_node_list();
+	List<Node *> selection = List<Node *>(editor_selection->get_top_selected_node_list());
 
 	bool verbose = false;
 	if (selection.is_empty()) {

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -8622,7 +8622,7 @@ HashSet<T *> _get_child_nodes(Node *parent_node) {
 		}
 	}
 
-	return nodes;
+	return HashSet<T *>(nodes);
 }
 
 HashSet<RID> _get_physics_bodies_rid(Node *node) {
@@ -8636,7 +8636,7 @@ HashSet<RID> _get_physics_bodies_rid(Node *node) {
 		rids.insert(I->get_rid());
 	}
 
-	return rids;
+	return HashSet<RID>(rids);
 }
 
 void Node3DEditor::snap_selected_nodes_to_floor() {

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -330,13 +330,13 @@ void CanvasItemEditor::_snap_other_nodes(
 		const Point2 p_value,
 		const Transform2D p_transform_to_snap,
 		Point2 &r_current_snap, SnapTarget (&r_current_snap_target)[2],
-		const SnapTarget p_snap_target, List<const CanvasItem *> p_exceptions,
+		const SnapTarget p_snap_target, const List<const CanvasItem *> p_exceptions,
 		const Node *p_current) {
 	const CanvasItem *ci = Object::cast_to<CanvasItem>(p_current);
 
 	// Check if the element is in the exception
 	bool exception = false;
-	for (const CanvasItem *&E : p_exceptions) {
+	for (const CanvasItem *const &E : p_exceptions) {
 		if (E == p_current) {
 			exception = true;
 			break;
@@ -359,7 +359,7 @@ void CanvasItemEditor::_snap_other_nodes(
 		}
 	}
 	for (int i = 0; i < p_current->get_child_count(); i++) {
-		_snap_other_nodes(p_value, p_transform_to_snap, r_current_snap, r_current_snap_target, p_snap_target, p_exceptions, p_current->get_child(i));
+		_snap_other_nodes(p_value, p_transform_to_snap, r_current_snap, r_current_snap_target, p_snap_target, List<const CanvasItem *>(p_exceptions), p_current->get_child(i));
 	}
 }
 
@@ -446,7 +446,7 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 				p_target, to_snap_transform,
 				output, snap_target,
 				SNAP_TARGET_OTHER_NODE,
-				exceptions,
+				List<const CanvasItem *>(exceptions),
 				get_tree()->get_edited_scene_root());
 	}
 
@@ -4853,7 +4853,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			snap_dialog->popup_centered(Size2(320, 160) * EDSCALE);
 		} break;
 		case SKELETON_SHOW_BONES: {
-			List<Node *> selection = editor_selection->get_top_selected_node_list();
+			List<Node *> selection = List<Node *>(editor_selection->get_top_selected_node_list());
 			for (Node *E : selection) {
 				// Add children nodes so they are processed
 				for (int child = 0; child < E->get_child_count(); child++) {

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -523,7 +523,7 @@ private:
 			const Point2 p_value,
 			const Transform2D p_transform_to_snap,
 			Point2 &r_current_snap, SnapTarget (&r_current_snap_target)[2],
-			const SnapTarget p_snap_target, List<const CanvasItem *> p_exceptions,
+			const SnapTarget p_snap_target, const List<const CanvasItem *> p_exceptions,
 			const Node *p_current);
 
 	VBoxContainer *controls_vb = nullptr;

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -189,7 +189,7 @@ void GroupSettingsEditor::_group_name_text_changed(const String &p_name) {
 void GroupSettingsEditor::_modify_references(const StringName &p_name, const StringName &p_new_name, bool p_is_rename) {
 	HashSet<String> scenes;
 
-	HashMap<StringName, HashSet<StringName>> scene_groups_cache = ProjectSettings::get_singleton()->get_scene_groups_cache();
+	const HashMap<StringName, HashSet<StringName>> scene_groups_cache = HashMap<StringName, HashSet<StringName>>(ProjectSettings::get_singleton()->get_scene_groups_cache());
 	for (const KeyValue<StringName, HashSet<StringName>> &E : scene_groups_cache) {
 		if (E.value.has(p_name)) {
 			scenes.insert(E.key);

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -2511,7 +2511,7 @@ HashMap<StringName, bool> ThemeTypeEditor::_get_type_items(String p_type_name, T
 		ordered_items[E] = items[E];
 	}
 
-	return ordered_items;
+	return HashMap<StringName, bool>(ordered_items);
 }
 
 HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_type, String p_item_name, bool p_editable) {

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -119,7 +119,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 	} else if (p_id == BUTTON_VISIBILITY) {
 		undo_redo->create_action(TTR("Toggle Visible"));
 		_toggle_visible(n);
-		List<Node *> selection = editor_selection->get_top_selected_node_list();
+		const List<Node *> selection = List<Node *>(editor_selection->get_top_selected_node_list());
 		if (selection.size() > 1 && selection.find(n) != nullptr) {
 			for (Node *nv : selection) {
 				ERR_FAIL_NULL(nv);

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -540,7 +540,7 @@ HashSet<String> FindInFilesDialog::get_filter() const {
 			filters.insert(cb->get_text());
 		}
 	}
-	return filters;
+	return HashSet<String>(filters);
 }
 
 HashSet<String> FindInFilesDialog::get_includes() const {
@@ -548,14 +548,14 @@ HashSet<String> FindInFilesDialog::get_includes() const {
 	String text = _includes_line_edit->get_text();
 
 	if (text.is_empty()) {
-		return includes;
+		return HashSet<String>(includes);
 	}
 
 	PackedStringArray wildcards = text.split(",", false);
 	for (const String &wildcard : wildcards) {
 		includes.insert(validate_filter_wildcard(wildcard));
 	}
-	return includes;
+	return HashSet<String>(includes);
 }
 
 HashSet<String> FindInFilesDialog::get_excludes() const {
@@ -563,14 +563,14 @@ HashSet<String> FindInFilesDialog::get_excludes() const {
 	String text = _excludes_line_edit->get_text();
 
 	if (text.is_empty()) {
-		return excludes;
+		return HashSet<String>(excludes);
 	}
 
 	PackedStringArray wildcards = text.split(",", false);
 	for (const String &wildcard : wildcards) {
 		excludes.insert(validate_filter_wildcard(wildcard));
 	}
-	return excludes;
+	return HashSet<String>(excludes);
 }
 
 void FindInFilesDialog::_notification(int p_what) {

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -141,7 +141,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 	}
 
 	/* Autoloads. */
-	HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
+	const HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = HashMap<StringName, ProjectSettings::AutoloadInfo>(ProjectSettings::get_singleton()->get_autoload_list());
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
 		const ProjectSettings::AutoloadInfo &info = E.value;
 		if (info.is_singleton) {

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -456,17 +456,26 @@ EditorBuildProfile::BuildOptionCategory EditorBuildProfile::get_build_option_cat
 
 LocalVector<EditorBuildProfile::BuildOption> EditorBuildProfile::get_build_option_dependencies(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, LocalVector<EditorBuildProfile::BuildOption>());
-	return build_option_dependencies.has(p_build_option) ? build_option_dependencies[p_build_option] : LocalVector<EditorBuildProfile::BuildOption>();
+	if (build_option_dependencies.has(p_build_option)) {
+		return LocalVector<EditorBuildProfile::BuildOption>(build_option_dependencies[p_build_option]);
+	}
+	return LocalVector<EditorBuildProfile::BuildOption>();
 }
 
 HashMap<String, LocalVector<Variant>> EditorBuildProfile::get_build_option_settings(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, (HashMap<String, LocalVector<Variant>>()));
-	return build_option_settings.has(p_build_option) ? build_option_settings[p_build_option] : HashMap<String, LocalVector<Variant>>();
+	if (build_option_settings.has(p_build_option)) {
+		return HashMap<String, LocalVector<Variant>>(build_option_settings[p_build_option]);
+	}
+	return HashMap<String, LocalVector<Variant>>();
 }
 
 LocalVector<String> EditorBuildProfile::get_build_option_classes(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, LocalVector<String>());
-	return build_option_classes.has(p_build_option) ? build_option_classes[p_build_option] : LocalVector<String>();
+	if (build_option_classes.has(p_build_option)) {
+		return LocalVector<String>(build_option_classes[p_build_option]);
+	}
+	return LocalVector<String>();
 }
 
 String EditorBuildProfile::get_build_option_category_name(BuildOptionCategory p_build_option_category) {

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -203,7 +203,7 @@ bool EditorSettings::_get(const StringName &p_name, Variant &r_ret) const {
 				continue;
 			}
 
-			List<Ref<InputEvent>> events = action_override.value;
+			const List<Ref<InputEvent>> events = List<Ref<InputEvent>>(action_override.value);
 
 			Dictionary action_dict;
 			action_dict["name"] = action_override.key;
@@ -1635,7 +1635,7 @@ Vector<String> EditorSettings::get_favorites() const {
 }
 
 HashMap<String, PackedStringArray> EditorSettings::get_favorite_properties() const {
-	return favorite_properties;
+	return HashMap<String, PackedStringArray>(favorite_properties);
 }
 
 void EditorSettings::set_recent_dirs(const Vector<String> &p_recent_dirs, bool p_update_file_dialog) {
@@ -1779,7 +1779,7 @@ HashMap<StringName, Color> EditorSettings::get_godot2_text_editor_theme() {
 	colors["text_editor/theme/highlighting/comment_markers/critical_color"] = Color(0.77, 0.35, 0.35);
 	colors["text_editor/theme/highlighting/comment_markers/warning_color"] = Color(0.72, 0.61, 0.48);
 	colors["text_editor/theme/highlighting/comment_markers/notice_color"] = Color(0.56, 0.67, 0.51);
-	return colors;
+	return HashMap<StringName, Color>(colors);
 }
 
 bool EditorSettings::is_default_text_editor_theme(const String &p_theme_name) {
@@ -2196,7 +2196,7 @@ const Array EditorSettings::get_builtin_action_overrides(const String &p_name) c
 	if (AO) {
 		Array event_array;
 
-		List<Ref<InputEvent>> events_list = AO->value;
+		const List<Ref<InputEvent>> events_list = List<Ref<InputEvent>>(AO->value);
 		for (const Ref<InputEvent> &E : events_list) {
 			event_array.push_back(E);
 		}

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -345,7 +345,7 @@ bool EditorSettingsDialog::_is_in_project_manager() const {
 void EditorSettingsDialog::_update_builtin_action(const String &p_name, const Array &p_events) {
 	Array old_input_array = EditorSettings::get_singleton()->get_builtin_action_overrides(p_name);
 	if (old_input_array.is_empty()) {
-		List<Ref<InputEvent>> defaults = InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_edited_identifier];
+		const List<Ref<InputEvent>> defaults = List<Ref<InputEvent>>(InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_edited_identifier]);
 		old_input_array = _event_list_to_array_helper(defaults);
 	}
 
@@ -725,7 +725,7 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 		case EditorSettingsDialog::SHORTCUT_REVERT: {
 			// Only for "shortcut" types
 			if (is_editing_action) {
-				List<Ref<InputEvent>> defaults = InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_edited_identifier];
+				const List<Ref<InputEvent>> defaults = List<Ref<InputEvent>>(InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_edited_identifier]);
 				Array events = _event_list_to_array_helper(defaults);
 
 				_update_builtin_action(current_edited_identifier, events);

--- a/editor/shader/shader_create_dialog.cpp
+++ b/editor/shader/shader_create_dialog.cpp
@@ -265,7 +265,7 @@ void ShaderCreateDialog::_browse_path() {
 	file_browse->set_customization_flag_enabled(FileDialog::CUSTOMIZATION_OVERWRITE_WARNING, false);
 	file_browse->clear_filters();
 
-	List<String> extensions = type_data.get(type_menu->get_selected()).extensions;
+	const List<String> extensions = List<String>(type_data.get(type_menu->get_selected()).extensions);
 
 	for (const String &E : extensions) {
 		file_browse->add_filter("*." + E);

--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -105,7 +105,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 	Dictionary color_conversion_map = p_dark_theme ? color_conversion_map_dark : color_conversion_map_light;
 
 	// The names of the icons to exclude from the standard color conversion.
-	HashSet<StringName> conversion_exceptions = EditorColorMap::get_color_conversion_exceptions();
+	const HashSet<StringName> conversion_exceptions = HashSet<StringName>(EditorColorMap::get_color_conversion_exceptions());
 
 	// The names of the icons to exclude when adjusting for saturation.
 	HashSet<StringName> saturation_exceptions;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4361,7 +4361,7 @@ int Main::start() {
 			if (!game_path.is_empty() || !script.is_empty()) {
 				//autoload
 				OS::get_singleton()->benchmark_begin_measure("Startup", "Load Autoloads");
-				HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
+				const HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = HashMap<StringName, ProjectSettings::AutoloadInfo>(ProjectSettings::get_singleton()->get_autoload_list());
 
 				//first pass, add the constants so they exist before any script is loaded
 				for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -644,7 +644,7 @@ void GDScript::_update_exports_down(bool p_base_exports_changed) {
 		return;
 	}
 
-	HashSet<ObjectID> copy = inheriters_cache; //might get modified
+	HashSet<ObjectID> copy = HashSet<ObjectID>(inheriters_cache); //might get modified
 
 	for (const ObjectID &E : copy) {
 		Object *id = ObjectDB::get_instance(E);
@@ -1267,7 +1267,7 @@ RBSet<GDScript *> GDScript::get_dependencies() {
 	_collect_dependencies(dependencies, this);
 	dependencies.erase(this);
 
-	return dependencies;
+	return RBSet<GDScript *>(dependencies);
 }
 
 HashMap<GDScript *, RBSet<GDScript *>> GDScript::get_all_dependencies() {
@@ -1291,7 +1291,7 @@ HashMap<GDScript *, RBSet<GDScript *>> GDScript::get_all_dependencies() {
 		all_dependencies.insert(scr, scr->get_dependencies());
 	}
 
-	return all_dependencies;
+	return HashMap<GDScript *, RBSet<GDScript *>>(all_dependencies);
 }
 
 RBSet<GDScript *> GDScript::get_must_clear_dependencies() {
@@ -1321,7 +1321,7 @@ RBSet<GDScript *> GDScript::get_must_clear_dependencies() {
 	cant_clear.clear();
 	dependencies.clear();
 	all_dependencies.clear();
-	return must_clear_dependencies;
+	return RBSet<GDScript *>(must_clear_dependencies);
 }
 
 bool GDScript::has_script_signal(const StringName &p_signal) const {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -6377,7 +6377,7 @@ void GDScriptAnalyzer::resolve_pending_lambda_bodies() {
 	GDScriptParser::LambdaNode *previous_lambda = current_lambda;
 	bool previous_static_context = static_context;
 
-	List<GDScriptParser::LambdaNode *> lambdas = pending_body_resolution_lambdas;
+	List<GDScriptParser::LambdaNode *> lambdas = List<GDScriptParser::LambdaNode *>(pending_body_resolution_lambdas);
 	pending_body_resolution_lambdas.clear();
 
 	for (GDScriptParser::LambdaNode *lambda : lambdas) {

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -255,7 +255,7 @@ void GDScriptCache::remove_parser(const String &p_path) {
 	singleton->parser_map.erase(p_path);
 
 	// Have to copy while iterating, because parser_inverse_dependencies is modified.
-	HashSet<String> ideps = singleton->parser_inverse_dependencies[p_path];
+	HashSet<String> ideps = HashSet<String>(singleton->parser_inverse_dependencies[p_path]);
 	singleton->parser_inverse_dependencies.erase(p_path);
 	for (String idep_path : ideps) {
 		remove_parser(idep_path);
@@ -423,10 +423,10 @@ Error GDScriptCache::finish_compiling(const String &p_owner) {
 	singleton->full_gdscript_cache[p_owner] = script;
 	singleton->shallow_gdscript_cache.erase(p_owner);
 
-	HashSet<String> depends = singleton->dependencies[p_owner];
+	HashSet<String> depends_copy = HashSet<String>(singleton->dependencies[p_owner]);
 
 	Error err = OK;
-	for (const String &E : depends) {
+	for (const String &E : depends_copy) {
 		Error this_err = OK;
 		// No need to save the script. We assume it's already referenced in the owner.
 		get_full_script(E, this_err);

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -419,7 +419,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					if (GDScriptLanguage::get_singleton()->get_global_map().has(identifier)) {
 						// If it's an autoload singleton, we postpone to load it at runtime.
 						// This is so one autoload doesn't try to load another before it's compiled.
-						HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
+						const HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = HashMap<StringName, ProjectSettings::AutoloadInfo>(ProjectSettings::get_singleton()->get_autoload_list());
 						if (autoloads.has(identifier) && autoloads[identifier].is_singleton) {
 							GDScriptCodeGenerator::Address global = codegen.add_temporary(_gdtype_from_datatype(in->get_datatype(), codegen.script));
 							int idx = GDScriptLanguage::get_singleton()->get_global_map()[identifier];

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -129,8 +129,7 @@ class GDScriptCompiler {
 		}
 
 		void start_block() {
-			HashMap<StringName, GDScriptCodeGenerator::Address> old_locals = locals;
-			locals_stack.push_back(old_locals);
+			locals_stack.push_back(HashMap<StringName, GDScriptCodeGenerator::Address>(locals));
 			generator->start_block();
 		}
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1123,7 +1123,7 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 	}
 
 	// Autoload singletons
-	HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
+	const HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = HashMap<StringName, ProjectSettings::AutoloadInfo>(ProjectSettings::get_singleton()->get_autoload_list());
 
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
 		const ProjectSettings::AutoloadInfo &info = E.value;
@@ -1879,7 +1879,7 @@ static HashMap<String, Dictionary> make_structure_samples() {
 		res["Time::get_time_zone_from_system"] = d;
 	}
 
-	return res;
+	return HashMap<String, Dictionary>(res);
 }
 
 static const HashMap<String, Dictionary> structure_examples = make_structure_samples();

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -49,7 +49,7 @@
 namespace GDScriptTests {
 
 void init_autoloads() {
-	HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
+	const HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = HashMap<StringName, ProjectSettings::AutoloadInfo>(ProjectSettings::get_singleton()->get_autoload_list());
 
 	// First pass, add the constants so they exist before any script is loaded.
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6804,7 +6804,7 @@ HashSet<String> GLTFDocument::get_supported_gltf_extensions_hashset() {
 			supported_extensions.insert(ext_supported_extensions[i]);
 		}
 	}
-	return supported_extensions;
+	return HashSet<String>(supported_extensions);
 }
 
 PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err) {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -1114,7 +1114,7 @@ void GridMap::_queue_octants_dirty() {
 
 void GridMap::_recreate_octant_data() {
 	recreating_octants = true;
-	HashMap<IndexKey, Cell, IndexKey> cell_copy = cell_map;
+	HashMap<IndexKey, Cell, IndexKey> cell_copy = HashMap<IndexKey, Cell, IndexKey>(cell_map);
 	_clear_internal();
 	for (const KeyValue<IndexKey, Cell> &E : cell_copy) {
 		set_cell_item(Vector3i(E.key), E.value.item, E.value.rot);

--- a/modules/jolt_physics/shapes/jolt_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_shape_3d.cpp
@@ -75,7 +75,7 @@ void JoltShape3D::remove_owner(JoltShapedObject3D *p_owner) {
 void JoltShape3D::remove_self() {
 	// `remove_owner` will be called when we `remove_shape`, so we need to copy the map since the
 	// iterator would be invalidated from underneath us.
-	const HashMap<JoltShapedObject3D *, int> ref_counts_by_owner_copy = ref_counts_by_owner;
+	const HashMap<JoltShapedObject3D *, int> ref_counts_by_owner_copy = HashMap<JoltShapedObject3D *, int>(ref_counts_by_owner);
 
 	for (const KeyValue<JoltShapedObject3D *, int> &E : ref_counts_by_owner_copy) {
 		E.key->remove_shape(this);

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -123,7 +123,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 		case CompletionKind::NODE_PATHS: {
 			{
 				// Autoloads.
-				HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
+				HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = HashMap<StringName, ProjectSettings::AutoloadInfo>(ProjectSettings::get_singleton()->get_autoload_list());
 
 				for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
 					const ProjectSettings::AutoloadInfo &info = E.value;

--- a/modules/mono/utils/naming_utils.cpp
+++ b/modules/mono/utils/naming_utils.cpp
@@ -38,7 +38,7 @@ HashMap<String, String> _create_hashmap_from_vector(Vector<Pair<String, String>>
 	for (const Pair<String, String> &pair : vector) {
 		hashmap.insert(pair.first, pair.second);
 	}
-	return hashmap;
+	return HashMap<String, String>(hashmap);
 }
 
 // Hardcoded collection of PascalCase name conversions.

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -372,7 +372,7 @@ void MultiplayerSynchronizer::set_multiplayer_authority(int p_peer_id, bool p_re
 
 Error MultiplayerSynchronizer::_watch_changes(uint64_t p_usec) {
 	ERR_FAIL_COND_V(replication_config.is_null(), FAILED);
-	const List<NodePath> props = replication_config->get_watch_properties();
+	const List<NodePath> props = List<NodePath>(replication_config->get_watch_properties());
 	if (props.size() != watchers.size()) {
 		watchers.resize(props.size());
 	}
@@ -436,7 +436,7 @@ List<Variant> MultiplayerSynchronizer::get_delta_state(uint64_t p_cur_usec, uint
 List<NodePath> MultiplayerSynchronizer::get_delta_properties(uint64_t p_indexes) {
 	List<NodePath> out;
 	ERR_FAIL_COND_V(replication_config.is_null(), out);
-	const List<NodePath> watch_props = replication_config->get_watch_properties();
+	const List<NodePath> watch_props = List<NodePath>(replication_config->get_watch_properties());
 	int idx = 0;
 	for (const NodePath &prop : watch_props) {
 		if ((p_indexes & (1ULL << idx++)) == 0) {

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -182,7 +182,7 @@ public:
 	Error send_bytes(Vector<uint8_t> p_data, int p_to = MultiplayerPeer::TARGET_PEER_BROADCAST, MultiplayerPeer::TransferMode p_mode = MultiplayerPeer::TRANSFER_MODE_RELIABLE, int p_channel = 0);
 	String get_rpc_md5(const Object *p_obj);
 
-	const HashSet<int> get_connected_peers() const { return connected_peers; }
+	const HashSet<int> get_connected_peers() const { return HashSet<int>(connected_peers); }
 
 	void set_remote_sender_override(int p_id) { remote_sender_override = p_id; }
 	void set_refuse_new_connections(bool p_refuse);

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -142,7 +142,7 @@ void SceneReplicationInterface::on_network_process() {
 	// Process syncs.
 	uint64_t usec = OS::get_singleton()->get_ticks_usec();
 	for (KeyValue<int, PeerInfo> &E : peers_info) {
-		const HashSet<ObjectID> to_sync = E.value.sync_nodes;
+		const HashSet<ObjectID> to_sync = HashSet<ObjectID>(E.value.sync_nodes);
 		if (to_sync.is_empty()) {
 			continue; // Nothing to sync
 		}
@@ -249,7 +249,7 @@ Error SceneReplicationInterface::on_replication_start(Object *p_obj, Variant p_c
 		if (pending_buffer_size > 0) {
 			ERR_FAIL_COND_V(!node || !sync->get_replication_config_ptr(), ERR_UNCONFIGURED);
 			int consumed = 0;
-			const List<NodePath> props = sync->get_replication_config_ptr()->get_spawn_properties();
+			const List<NodePath> props = List<NodePath>(sync->get_replication_config_ptr()->get_spawn_properties());
 			Vector<Variant> vars;
 			vars.resize(props.size());
 			Error err = MultiplayerAPI::decode_and_decompress_variants(vars, pending_buffer, pending_buffer_size, consumed);
@@ -386,7 +386,7 @@ Error SceneReplicationInterface::_update_spawn_visibility(int p_peer, const Obje
 	ERR_FAIL_NULL_V(spawner, ERR_BUG);
 	ERR_FAIL_COND_V(!_has_authority(spawner), ERR_BUG);
 	ERR_FAIL_COND_V(!tracked_nodes.has(p_oid), ERR_BUG);
-	const HashSet<ObjectID> synchronizers = tracked_nodes[p_oid].synchronizers;
+	const HashSet<ObjectID> synchronizers = HashSet<ObjectID>(tracked_nodes[p_oid].synchronizers);
 	bool is_visible = true;
 	for (const ObjectID &sid : synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(sid);
@@ -490,7 +490,7 @@ Error SceneReplicationInterface::_make_spawn_packet(Node *p_node, MultiplayerSpa
 	// Prepare spawn state.
 	List<NodePath> state_props;
 	List<uint32_t> sync_ids;
-	const HashSet<ObjectID> synchronizers = tnode->synchronizers;
+	const HashSet<ObjectID> synchronizers = HashSet<ObjectID>(tnode->synchronizers);
 	for (const ObjectID &sid : synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(sid);
 		if (!_has_authority(sync)) {
@@ -823,7 +823,7 @@ void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> &
 		int size;
 		Vector<Variant> vars;
 		Vector<const Variant *> varp;
-		const List<NodePath> props = sync->get_replication_config_ptr()->get_sync_properties();
+		const List<NodePath> props = List<NodePath>(sync->get_replication_config_ptr()->get_sync_properties());
 		Error err = MultiplayerSynchronizer::get_state(props, node, vars, varp);
 		ERR_CONTINUE_MSG(err != OK, "Unable to retrieve sync state.");
 		err = MultiplayerAPI::encode_and_compress_variants(varp.ptrw(), varp.size(), nullptr, size);
@@ -882,7 +882,7 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 			ofs += size;
 			continue;
 		}
-		const List<NodePath> props = sync->get_replication_config_ptr()->get_sync_properties();
+		const List<NodePath> props = List<NodePath>(sync->get_replication_config_ptr()->get_sync_properties());
 		Vector<Variant> vars;
 		vars.resize(props.size());
 		int consumed;

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
@@ -82,7 +82,7 @@ void GodotNavigationServer2D::init() {
 	navmesh_generator_2d = memnew(NavMeshGenerator2D);
 	ERR_FAIL_NULL_MSG(navmesh_generator_2d, "Failed to init NavMeshGenerator2D.");
 	RWLockRead read_lock(geometry_parser_rwlock);
-	navmesh_generator_2d->set_generator_parsers(generator_parsers);
+	navmesh_generator_2d->set_generator_parsers(LocalVector<NavMeshGeometryParser2D *>(generator_parsers));
 #endif // CLIPPER2_ENABLED
 	// TODO
 }
@@ -251,7 +251,7 @@ TypedArray<RID> GodotNavigationServer2D::map_get_obstacles(RID p_map) const {
 	TypedArray<RID> obstacles_rids;
 	const NavMap2D *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_NULL_V(map, obstacles_rids);
-	const LocalVector<NavObstacle2D *> obstacles = map->get_obstacles();
+	const LocalVector<NavObstacle2D *> obstacles = LocalVector<NavObstacle2D *>(map->get_obstacles());
 	obstacles_rids.resize(obstacles.size());
 	for (uint32_t i = 0; i < obstacles.size(); i++) {
 		obstacles_rids[i] = obstacles[i]->get_self();
@@ -1198,7 +1198,7 @@ COMMAND_1(free_rid, RID, p_object) {
 
 		generator_parsers.erase(parser);
 #ifdef CLIPPER2_ENABLED
-		NavMeshGenerator2D::get_singleton()->set_generator_parsers(generator_parsers);
+		NavMeshGenerator2D::get_singleton()->set_generator_parsers(LocalVector<NavMeshGeometryParser2D *>(generator_parsers));
 #endif
 		geometry_parser_owner.free(parser->self);
 		return;
@@ -1384,7 +1384,7 @@ RID GodotNavigationServer2D::source_geometry_parser_create() {
 
 	generator_parsers.push_back(parser);
 #ifdef CLIPPER2_ENABLED
-	NavMeshGenerator2D::get_singleton()->set_generator_parsers(generator_parsers);
+	NavMeshGenerator2D::get_singleton()->set_generator_parsers(LocalVector<NavMeshGeometryParser2D *>(generator_parsers));
 #endif
 	return rid;
 }

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -333,7 +333,7 @@ TypedArray<RID> GodotNavigationServer3D::map_get_obstacles(RID p_map) const {
 	TypedArray<RID> obstacles_rids;
 	const NavMap3D *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_NULL_V(map, obstacles_rids);
-	const LocalVector<NavObstacle3D *> obstacles = map->get_obstacles();
+	const LocalVector<NavObstacle3D *> obstacles = LocalVector<NavObstacle3D *>(map->get_obstacles());
 	obstacles_rids.resize(obstacles.size());
 	for (uint32_t i = 0; i < obstacles.size(); i++) {
 		obstacles_rids[i] = obstacles[i]->get_self();
@@ -1296,7 +1296,7 @@ COMMAND_1(free_rid, RID, p_object) {
 		ERR_FAIL_NULL(parser);
 
 		generator_parsers.erase(parser);
-		NavMeshGenerator3D::get_singleton()->set_generator_parsers(generator_parsers);
+		NavMeshGenerator3D::get_singleton()->set_generator_parsers(LocalVector<NavMeshGeometryParser3D *>(generator_parsers));
 		geometry_parser_owner.free(parser->self);
 
 	} else {
@@ -1435,7 +1435,7 @@ void GodotNavigationServer3D::physics_process(double p_delta_time) {
 void GodotNavigationServer3D::init() {
 	navmesh_generator_3d = memnew(NavMeshGenerator3D);
 	RWLockRead read_lock(geometry_parser_rwlock);
-	navmesh_generator_3d->set_generator_parsers(generator_parsers);
+	navmesh_generator_3d->set_generator_parsers(LocalVector<NavMeshGeometryParser3D *>(generator_parsers));
 }
 
 void GodotNavigationServer3D::finish() {
@@ -1466,7 +1466,7 @@ RID GodotNavigationServer3D::source_geometry_parser_create() {
 	parser->self = rid;
 
 	generator_parsers.push_back(parser);
-	NavMeshGenerator3D::get_singleton()->set_generator_parsers(generator_parsers);
+	NavMeshGenerator3D::get_singleton()->set_generator_parsers(LocalVector<NavMeshGeometryParser3D *>(generator_parsers));
 	return rid;
 }
 

--- a/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.cpp
@@ -265,7 +265,7 @@ void NavigationRegion3DEditorPlugin::edit(Object *p_object) {
 		NavigationRegion3D *region = Object::cast_to<NavigationRegion3D>(p_object);
 		if (region) {
 			regions.push_back(region);
-			navigation_region_editor->edit(regions);
+			navigation_region_editor->edit(LocalVector<NavigationRegion3D *>(regions));
 			return;
 		}
 	}
@@ -281,7 +281,7 @@ void NavigationRegion3DEditorPlugin::edit(Object *p_object) {
 		}
 	}
 
-	navigation_region_editor->edit(regions);
+	navigation_region_editor->edit(LocalVector<NavigationRegion3D *>(regions));
 }
 
 bool NavigationRegion3DEditorPlugin::handles(Object *p_object) const {

--- a/modules/objectdb_profiler/editor/snapshot_data.cpp
+++ b/modules/objectdb_profiler/editor/snapshot_data.cpp
@@ -198,15 +198,15 @@ HashSet<ObjectID> SnapshotDataObject::_unique_references(const HashMap<String, O
 		obj_set.insert(pair.value);
 	}
 
-	return obj_set;
+	return HashSet<ObjectID>(obj_set);
 }
 
 HashSet<ObjectID> SnapshotDataObject::get_unique_outbound_refernces() {
-	return _unique_references(outbound_references);
+	return HashSet<ObjectID>(_unique_references(outbound_references));
 }
 
 HashSet<ObjectID> SnapshotDataObject::get_unique_inbound_references() {
-	return _unique_references(inbound_references);
+	return HashSet<ObjectID>(_unique_references(inbound_references));
 }
 
 void GameStateSnapshot::_get_outbound_references(Variant &p_var, HashMap<String, ObjectID> &r_ret_val, const String &p_current_path) {
@@ -271,11 +271,11 @@ void GameStateSnapshot::_get_rc_cycles(
 
 		SnapshotDataObject *next = objects[next_child.value];
 		if (next != nullptr && next->is_class(RefCounted::get_class_static()) && !next->is_class(WeakRef::get_class_static()) && !p_traversed_objs.has(next)) {
-			HashSet<SnapshotDataObject *> traversed_copy = p_traversed_objs;
+			HashSet<SnapshotDataObject *> traversed_copy = HashSet<SnapshotDataObject *>(p_traversed_objs);
 			if (p_obj != p_source_obj) {
 				traversed_copy.insert(p_obj);
 			}
-			_get_rc_cycles(next, p_source_obj, traversed_copy, r_ret_val, child_path);
+			_get_rc_cycles(next, p_source_obj, HashSet<SnapshotDataObject *>(traversed_copy), r_ret_val, child_path);
 		}
 	}
 }
@@ -309,7 +309,7 @@ void GameStateSnapshot::recompute_references() {
 		HashSet<SnapshotDataObject *> traversed_objs;
 		LocalVector<String> cycles;
 
-		_get_rc_cycles(obj.value, obj.value, traversed_objs, cycles, "");
+		_get_rc_cycles(obj.value, obj.value, HashSet<SnapshotDataObject *>(traversed_objs), cycles, "");
 		Array cycles_array;
 		for (const String &cycle : cycles) {
 			cycles_array.push_back(cycle);

--- a/modules/openxr/extensions/openxr_composition_layer_depth_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_depth_extension.cpp
@@ -49,7 +49,7 @@ HashMap<String, bool *> OpenXRCompositionLayerDepthExtension::get_requested_exte
 
 	request_extensions[XR_KHR_COMPOSITION_LAYER_DEPTH_EXTENSION_NAME] = &available;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRCompositionLayerDepthExtension::is_available() {

--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -66,7 +66,7 @@ HashMap<String, bool *> OpenXRCompositionLayerExtension::get_requested_extension
 	request_extensions[XR_KHR_ANDROID_SURFACE_SWAPCHAIN_EXTENSION_NAME] = &android_surface_ext_available;
 #endif
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRCompositionLayerExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_debug_utils_extension.cpp
+++ b/modules/openxr/extensions/openxr_debug_utils_extension.cpp
@@ -55,7 +55,7 @@ HashMap<String, bool *> OpenXRDebugUtilsExtension::get_requested_extensions(XrVe
 
 	request_extensions[XR_EXT_DEBUG_UTILS_EXTENSION_NAME] = &debug_utils_ext;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRDebugUtilsExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_dpad_binding_extension.cpp
+++ b/modules/openxr/extensions/openxr_dpad_binding_extension.cpp
@@ -59,7 +59,7 @@ HashMap<String, bool *> OpenXRDPadBindingExtension::get_requested_extensions(XrV
 	request_extensions[XR_KHR_BINDING_MODIFICATION_EXTENSION_NAME] = &binding_modifier_ext;
 	request_extensions[XR_EXT_DPAD_BINDING_EXTENSION_NAME] = &dpad_binding_ext;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRDPadBindingExtension::is_available() {

--- a/modules/openxr/extensions/openxr_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper.cpp
@@ -97,7 +97,7 @@ HashMap<String, bool *> OpenXRExtensionWrapper::get_requested_extensions(XrVersi
 			GDExtensionPtr<bool> value = VariantCaster<GDExtensionPtr<bool>>::cast(kv.value);
 			result.insert(kv.key, value);
 		}
-		return result;
+		return HashMap<String, bool *>(result);
 	}
 
 #ifndef DISABLE_DEPRECATED

--- a/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
+++ b/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
@@ -60,7 +60,7 @@ HashMap<String, bool *> OpenXREyeGazeInteractionExtension::get_requested_extensi
 		request_extensions[XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME] = &available;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void *OpenXREyeGazeInteractionExtension::set_system_properties_and_get_next_pointer(void *p_next_pointer) {

--- a/modules/openxr/extensions/openxr_fb_display_refresh_rate_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_display_refresh_rate_extension.cpp
@@ -50,7 +50,7 @@ HashMap<String, bool *> OpenXRDisplayRefreshRateExtension::get_requested_extensi
 
 	request_extensions[XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME] = &display_refresh_rate_ext;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRDisplayRefreshRateExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_fb_foveation_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_foveation_extension.cpp
@@ -96,7 +96,7 @@ HashMap<String, bool *> OpenXRFBFoveationExtension::get_requested_extensions(XrV
 	}
 #endif // XR_USE_GRAPHICS_API_VULKAN
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRFBFoveationExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_fb_update_swapchain_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_update_swapchain_extension.cpp
@@ -80,7 +80,7 @@ HashMap<String, bool *> OpenXRFBUpdateSwapchainExtension::get_requested_extensio
 	request_extensions[XR_FB_SWAPCHAIN_UPDATE_STATE_ANDROID_SURFACE_EXTENSION_NAME] = &fb_swapchain_update_state_android_ext;
 #endif
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRFBUpdateSwapchainExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_future_extension.cpp
+++ b/modules/openxr/extensions/openxr_future_extension.cpp
@@ -134,7 +134,7 @@ HashMap<String, bool *> OpenXRFutureExtension::get_requested_extensions(XrVersio
 
 	request_extensions[XR_EXT_FUTURE_EXTENSION_NAME] = &future_ext;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRFutureExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_hand_interaction_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_interaction_extension.cpp
@@ -60,7 +60,7 @@ HashMap<String, bool *> OpenXRHandInteractionExtension::get_requested_extensions
 		request_extensions[XR_META_HAND_TRACKING_MICROGESTURES_EXTENSION_NAME] = &available;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRHandInteractionExtension::is_available() {

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -67,7 +67,7 @@ HashMap<String, bool *> OpenXRHandTrackingExtension::get_requested_extensions(Xr
 		request_extensions[XR_EXT_HAND_TRACKING_DATA_SOURCE_EXTENSION_NAME] = &hand_tracking_source_ext;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRHandTrackingExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_htc_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_htc_controller_extension.cpp
@@ -44,7 +44,7 @@ HashMap<String, bool *> OpenXRHTCControllerExtension::get_requested_extensions(X
 
 	request_extensions[XR_HTC_HAND_INTERACTION_EXTENSION_NAME] = &available[HTC_HAND_INTERACTION];
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 PackedStringArray OpenXRHTCControllerExtension::get_suggested_tracker_names() {

--- a/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
+++ b/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
@@ -39,7 +39,7 @@ HashMap<String, bool *> OpenXRHTCViveTrackerExtension::get_requested_extensions(
 
 	request_extensions[XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME] = &available;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 PackedStringArray OpenXRHTCViveTrackerExtension::get_suggested_tracker_names() {

--- a/modules/openxr/extensions/openxr_huawei_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_huawei_controller_extension.cpp
@@ -38,7 +38,7 @@ HashMap<String, bool *> OpenXRHuaweiControllerExtension::get_requested_extension
 
 	request_extensions[XR_HUAWEI_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRHuaweiControllerExtension::is_available() {

--- a/modules/openxr/extensions/openxr_local_floor_extension.cpp
+++ b/modules/openxr/extensions/openxr_local_floor_extension.cpp
@@ -54,7 +54,7 @@ HashMap<String, bool *> OpenXRLocalFloorExtension::get_requested_extensions(XrVe
 		request_extensions[XR_EXT_LOCAL_FLOOR_EXTENSION_NAME] = &available;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRLocalFloorExtension::is_available() {

--- a/modules/openxr/extensions/openxr_meta_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_meta_controller_extension.cpp
@@ -56,7 +56,7 @@ HashMap<String, bool *> OpenXRMetaControllerExtension::get_requested_extensions(
 
 	request_extensions[XR_FB_TOUCH_CONTROLLER_PROXIMITY_EXTENSION_NAME] = &available[META_TOUCH_PROXIMITY];
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRMetaControllerExtension::is_available(MetaControllers p_type) {

--- a/modules/openxr/extensions/openxr_ml2_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_ml2_controller_extension.cpp
@@ -41,7 +41,7 @@ HashMap<String, bool *> OpenXRML2ControllerExtension::get_requested_extensions(X
 		request_extensions[XR_ML_ML2_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRML2ControllerExtension::is_available() {

--- a/modules/openxr/extensions/openxr_mxink_extension.cpp
+++ b/modules/openxr/extensions/openxr_mxink_extension.cpp
@@ -40,7 +40,7 @@ HashMap<String, bool *> OpenXRMxInkExtension::get_requested_extensions(XrVersion
 
 	request_extensions[XR_LOGITECH_MX_INK_STYLUS_INTERACTION_EXTENSION_NAME] = &available;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRMxInkExtension::is_available() {

--- a/modules/openxr/extensions/openxr_palm_pose_extension.cpp
+++ b/modules/openxr/extensions/openxr_palm_pose_extension.cpp
@@ -54,7 +54,7 @@ HashMap<String, bool *> OpenXRPalmPoseExtension::get_requested_extensions(XrVers
 		request_extensions[XR_EXT_PALM_POSE_EXTENSION_NAME] = &available;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRPalmPoseExtension::is_available() {

--- a/modules/openxr/extensions/openxr_performance_settings_extension.cpp
+++ b/modules/openxr/extensions/openxr_performance_settings_extension.cpp
@@ -51,7 +51,7 @@ HashMap<String, bool *> OpenXRPerformanceSettingsExtension::get_requested_extens
 
 	request_extensions[XR_EXT_PERFORMANCE_SETTINGS_EXTENSION_NAME] = &available;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRPerformanceSettingsExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_pico_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_pico_controller_extension.cpp
@@ -46,7 +46,7 @@ HashMap<String, bool *> OpenXRPicoControllerExtension::get_requested_extensions(
 		request_extensions[XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRPicoControllerExtension::is_available() {

--- a/modules/openxr/extensions/openxr_render_model_extension.cpp
+++ b/modules/openxr/extensions/openxr_render_model_extension.cpp
@@ -83,7 +83,7 @@ HashMap<String, bool *> OpenXRRenderModelExtension::get_requested_extensions(XrV
 		request_extensions[XR_EXT_INTERACTION_RENDER_MODEL_EXTENSION_NAME] = &interaction_render_model_ext;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRRenderModelExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_valve_analog_threshold_extension.cpp
+++ b/modules/openxr/extensions/openxr_valve_analog_threshold_extension.cpp
@@ -60,7 +60,7 @@ HashMap<String, bool *> OpenXRValveAnalogThresholdExtension::get_requested_exten
 	request_extensions[XR_KHR_BINDING_MODIFICATION_EXTENSION_NAME] = &binding_modifier_ext;
 	request_extensions[XR_VALVE_ANALOG_THRESHOLD_EXTENSION_NAME] = &threshold_ext;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRValveAnalogThresholdExtension::is_available() {

--- a/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
+++ b/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
@@ -74,7 +74,7 @@ HashMap<String, bool *> OpenXRVisibilityMaskExtension::get_requested_extensions(
 
 	request_extensions[XR_KHR_VISIBILITY_MASK_EXTENSION_NAME] = &available;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRVisibilityMaskExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/openxr_wmr_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_wmr_controller_extension.cpp
@@ -44,7 +44,7 @@ HashMap<String, bool *> OpenXRWMRControllerExtension::get_requested_extensions(X
 	}
 	request_extensions[XR_MSFT_HAND_INTERACTION_EXTENSION_NAME] = &available[WMR_HAND_INTERACTION];
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 bool OpenXRWMRControllerExtension::is_available(WMRControllers p_type) {

--- a/modules/openxr/extensions/platform/openxr_android_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_android_extension.cpp
@@ -63,7 +63,7 @@ HashMap<String, bool *> OpenXRAndroidExtension::get_requested_extensions(XrVersi
 	request_extensions[XR_KHR_LOADER_INIT_ANDROID_EXTENSION_NAME] = &loader_init_android_extension_available;
 	request_extensions[XR_KHR_ANDROID_CREATE_INSTANCE_EXTENSION_NAME] = &create_instance_extension_available;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRAndroidExtension::on_before_instance_created() {

--- a/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
@@ -42,7 +42,7 @@ HashMap<String, bool *> OpenXRD3D12Extension::get_requested_extensions(XrVersion
 
 	request_extensions[XR_KHR_D3D12_ENABLE_EXTENSION_NAME] = nullptr;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRD3D12Extension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/platform/openxr_metal_extension.mm
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.mm
@@ -40,7 +40,7 @@ HashMap<String, bool *> OpenXRMetalExtension::get_requested_extensions(XrVersion
 
 	request_extensions[XR_KHR_METAL_ENABLE_EXTENSION_NAME] = nullptr;
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRMetalExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -68,7 +68,7 @@ HashMap<String, bool *> OpenXROpenGLExtension::get_requested_extensions(XrVersio
 	request_extensions[XR_MNDX_EGL_ENABLE_EXTENSION_NAME] = &egl_extension_enabled;
 #endif
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXROpenGLExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
@@ -44,7 +44,7 @@ HashMap<String, bool *> OpenXRVulkanExtension::get_requested_extensions(XrVersio
 
 	request_extensions[XR_KHR_VULKAN_ENABLE2_EXTENSION_NAME] = nullptr; // must be available
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRVulkanExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
@@ -343,7 +343,7 @@ HashMap<String, bool *> OpenXRSpatialAnchorCapability::get_requested_extensions(
 		}
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRSpatialAnchorCapability::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
@@ -113,7 +113,7 @@ HashMap<String, bool *> OpenXRSpatialEntityExtension::get_requested_extensions(X
 		request_extensions[XR_EXT_SPATIAL_ENTITY_EXTENSION_NAME] = &spatial_entity_ext;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRSpatialEntityExtension::on_instance_created(const XrInstance p_instance) {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -451,7 +451,7 @@ HashMap<String, bool *> OpenXRSpatialMarkerTrackingCapability::get_requested_ext
 		request_extensions[XR_EXT_SPATIAL_MARKER_TRACKING_EXTENSION_NAME] = &spatial_marker_tracking_ext;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRSpatialMarkerTrackingCapability::on_session_created(const XrSession p_session) {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -590,7 +590,7 @@ HashMap<String, bool *> OpenXRSpatialPlaneTrackingCapability::get_requested_exte
 		request_extensions[XR_EXT_SPATIAL_PLANE_TRACKING_EXTENSION_NAME] = &spatial_plane_tracking_ext;
 	}
 
-	return request_extensions;
+	return HashMap<String, bool *>(request_extensions);
 }
 
 void OpenXRSpatialPlaneTrackingCapability::on_session_created(const XrSession p_session) {

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -130,7 +130,7 @@ HashMap<String, Variant> EditorExportPlatformIOS::get_custom_project_settings(co
 		}
 	}
 	settings["ios/launch_screen_image_mode"] = value;
-	return settings;
+	return HashMap<String, Variant>(settings);
 }
 
 Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExportPreset> &p_preset, const String &p_dest_dir) {

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -273,7 +273,7 @@ void OS_MacOS::set_cmdline_platform_args(const List<String> &p_args) {
 }
 
 List<String> OS_MacOS::get_cmdline_platform_args() const {
-	return launch_service_args;
+	return List<String>(launch_service_args);
 }
 
 void OS_MacOS::load_shell_environment() const {
@@ -868,7 +868,7 @@ Error OS_MacOS::create_instance(const List<String> &p_arguments, ProcessID *r_ch
 			// Project started from the editor, inject "path" argument to set instance working directory.
 			char cwd[PATH_MAX];
 			if (::getcwd(cwd, sizeof(cwd)) != nullptr) {
-				List<String> arguments = p_arguments;
+				List<String> arguments = List<String>(p_arguments);
 				arguments.push_back("--path");
 				arguments.push_back(String::utf8(cwd));
 				return create_process(path, arguments, r_child_id, false);

--- a/platform/windows/export/template_modifier.cpp
+++ b/platform/windows/export/template_modifier.cpp
@@ -615,7 +615,7 @@ HashMap<String, String> TemplateModifier::_get_strings(const Ref<EditorExportPre
 		strings["LegalTrademarks"] = trademarks;
 	}
 
-	return strings;
+	return HashMap<String, String>(strings);
 }
 
 Error TemplateModifier::_modify_template(const Ref<EditorExportPreset> &p_preset, const String &p_template_path, const String &p_icon_path) const {

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -125,7 +125,7 @@ void AudioStreamPlayer2D::_update_panning() {
 
 	Vector2 global_pos = get_global_position();
 
-	HashSet<Viewport *> viewports = world_2d->get_viewports();
+	const HashSet<Viewport *> viewports = HashSet<Viewport *>(world_2d->get_viewports());
 
 	volume_vector.resize(4);
 	volume_vector.write[0] = AudioFrame(0, 0);

--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -357,7 +357,7 @@ void Area2D::_clear_monitoring() {
 	ERR_FAIL_COND_MSG(locked, "This function can't be used during the in/out signal.");
 
 	{
-		HashMap<ObjectID, BodyState> bmcopy = body_map;
+		HashMap<ObjectID, BodyState> bmcopy = HashMap<ObjectID, BodyState>(body_map);
 		body_map.clear();
 		//disconnect all monitored stuff
 
@@ -385,7 +385,7 @@ void Area2D::_clear_monitoring() {
 	}
 
 	{
-		HashMap<ObjectID, AreaState> bmcopy = area_map;
+		HashMap<ObjectID, AreaState> bmcopy = HashMap<ObjectID, AreaState>(area_map);
 		area_map.clear();
 		//disconnect all monitored stuff
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -147,7 +147,7 @@ Vector<int> TileMap::_get_tile_map_data_using_compatibility_format(int p_layer) 
 	ERR_FAIL_INDEX_V(p_layer, (int)layers.size(), Vector<int>());
 
 	// Export tile data to raw format.
-	const HashMap<Vector2i, CellData> tile_map_layer_data = layers[p_layer]->get_tile_map_layer_data();
+	const HashMap<Vector2i, CellData> tile_map_layer_data = HashMap<Vector2i, CellData>(layers[p_layer]->get_tile_map_layer_data());
 	Vector<int> tile_data;
 	tile_data.resize(tile_map_layer_data.size() * 3);
 	int *w = tile_data.ptrw();

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1920,7 +1920,7 @@ RBSet<TerrainConstraint> TileMapLayer::_get_terrain_constraints_from_added_patte
 		}
 	}
 
-	return output;
+	return RBSet<TerrainConstraint>(output);
 }
 
 RBSet<TerrainConstraint> TileMapLayer::_get_terrain_constraints_from_painted_cells_list(const RBSet<Vector2i> &p_painted, int p_terrain_set, bool p_ignore_empty_terrains) const {
@@ -2007,7 +2007,7 @@ RBSet<TerrainConstraint> TileMapLayer::_get_terrain_constraints_from_painted_cel
 		}
 	}
 
-	return constraints;
+	return RBSet<TerrainConstraint>(constraints);
 }
 
 void TileMapLayer::_tile_set_changed() {
@@ -2382,7 +2382,7 @@ HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_constrain
 	}
 
 	// Copy the constraints set.
-	RBSet<TerrainConstraint> constraints = p_constraints;
+	RBSet<TerrainConstraint> constraints = RBSet<TerrainConstraint>(p_constraints);
 
 	// Output map.
 	HashMap<Vector2i, TileSet::TerrainsPattern> output;
@@ -2420,7 +2420,7 @@ HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_constrain
 
 		output[coords] = pattern;
 	}
-	return output;
+	return HashMap<Vector2i, TileSet::TerrainsPattern>(output);
 }
 
 HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_connect(const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains) const {
@@ -2546,7 +2546,7 @@ HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_path(cons
 				}
 			}
 		}
-		ERR_FAIL_COND_V_MSG(found_bit == TileSet::CELL_NEIGHBOR_MAX, output, vformat("Invalid terrain path, %s is not a neighboring tile of %s", p_coords_array[i + 1], p_coords_array[i]));
+		ERR_FAIL_COND_V_MSG(found_bit == TileSet::CELL_NEIGHBOR_MAX, (HashMap<Vector2i, TileSet::TerrainsPattern>(output)), vformat("Invalid terrain path, %s is not a neighboring tile of %s", p_coords_array[i + 1], p_coords_array[i]));
 		neighbor_list.push_back(found_bit);
 	}
 
@@ -3649,7 +3649,7 @@ HashMap<Vector2i, TileSet::CellNeighbor> TerrainConstraint::get_overlapping_coor
 				output[tile_set->get_neighbor_cell(base_cell_coords, TileSet::CELL_NEIGHBOR_BOTTOM_SIDE)] = TileSet::CELL_NEIGHBOR_TOP_SIDE;
 				break;
 			default:
-				ERR_FAIL_V(output);
+				ERR_FAIL_V((HashMap<Vector2i, TileSet::CellNeighbor>(output)));
 		}
 	} else if (shape == TileSet::TILE_SHAPE_ISOMETRIC) {
 		switch (bit) {
@@ -3668,7 +3668,7 @@ HashMap<Vector2i, TileSet::CellNeighbor> TerrainConstraint::get_overlapping_coor
 				output[tile_set->get_neighbor_cell(base_cell_coords, TileSet::CELL_NEIGHBOR_BOTTOM_LEFT_SIDE)] = TileSet::CELL_NEIGHBOR_TOP_RIGHT_SIDE;
 				break;
 			default:
-				ERR_FAIL_V(output);
+				ERR_FAIL_V((HashMap<Vector2i, TileSet::CellNeighbor>(output)));
 		}
 	} else {
 		// Half offset shapes.
@@ -3698,7 +3698,7 @@ HashMap<Vector2i, TileSet::CellNeighbor> TerrainConstraint::get_overlapping_coor
 					output[tile_set->get_neighbor_cell(base_cell_coords, TileSet::CELL_NEIGHBOR_BOTTOM_LEFT_SIDE)] = TileSet::CELL_NEIGHBOR_TOP_RIGHT_SIDE;
 					break;
 				default:
-					ERR_FAIL_V(output);
+					ERR_FAIL_V((HashMap<Vector2i, TileSet::CellNeighbor>(output)));
 			}
 		} else {
 			switch (bit) {
@@ -3725,11 +3725,11 @@ HashMap<Vector2i, TileSet::CellNeighbor> TerrainConstraint::get_overlapping_coor
 					output[tile_set->get_neighbor_cell(base_cell_coords, TileSet::CELL_NEIGHBOR_BOTTOM_LEFT_SIDE)] = TileSet::CELL_NEIGHBOR_TOP_RIGHT_SIDE;
 					break;
 				default:
-					ERR_FAIL_V(output);
+					ERR_FAIL_V((HashMap<Vector2i, TileSet::CellNeighbor>(output)));
 			}
 		}
 	}
-	return output;
+	return HashMap<Vector2i, TileSet::CellNeighbor>(output);
 }
 
 TerrainConstraint::TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, int p_terrain) {

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -378,7 +378,7 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 	Ref<World3D> world_3d = get_world_3d();
 	ERR_FAIL_COND_V(world_3d.is_null(), output_volume_vector);
 
-	HashSet<Camera3D *> cameras = world_3d->get_cameras();
+	HashSet<Camera3D *> cameras = HashSet<Camera3D *>(world_3d->get_cameras());
 	cameras.insert(get_viewport()->get_camera_3d());
 
 #ifndef PHYSICS_3D_DISABLED

--- a/scene/3d/physics/area_3d.cpp
+++ b/scene/3d/physics/area_3d.cpp
@@ -303,7 +303,7 @@ void Area3D::_clear_monitoring() {
 	ERR_FAIL_COND_MSG(locked, "This function can't be used during the in/out signal.");
 
 	{
-		HashMap<ObjectID, BodyState> bmcopy = body_map;
+		HashMap<ObjectID, BodyState> bmcopy = HashMap<ObjectID, BodyState>(body_map);
 		body_map.clear();
 		//disconnect all monitored stuff
 
@@ -332,7 +332,7 @@ void Area3D::_clear_monitoring() {
 	}
 
 	{
-		HashMap<ObjectID, AreaState> bmcopy = area_map;
+		HashMap<ObjectID, AreaState> bmcopy = HashMap<ObjectID, AreaState>(area_map);
 		area_map.clear();
 		//disconnect all monitored stuff
 

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -1222,7 +1222,7 @@ LocalVector<ObjectID> SpringBoneSimulator3D::get_valid_collision_instance_ids(in
 	if (collisions_dirty) {
 		_find_collisions();
 	}
-	return settings[p_index]->cached_collisions;
+	return LocalVector<ObjectID>(settings[p_index]->cached_collisions);
 }
 
 void SpringBoneSimulator3D::set_external_force(const Vector3 &p_force) {

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2225,7 +2225,7 @@ Ref<AnimatedValuesBackup> AnimationMixer::make_backup() {
 	make_animation_instance(SceneStringName(RESET), pi);
 	_build_backup_track_cache();
 
-	backup->set_data(track_cache);
+	backup->set_data(AHashMap<Animation::TypeHash, AnimationMixer::TrackCache *, HashHasher>(track_cache));
 	clear_animation_instances();
 
 	return backup;
@@ -2522,7 +2522,7 @@ AHashMap<Animation::TypeHash, AnimationMixer::TrackCache *, HashHasher> Animated
 
 		ret.insert(E.key, track);
 	}
-	return ret;
+	return AHashMap<Animation::TypeHash, AnimationMixer::TrackCache *, HashHasher>(ret);
 }
 
 void AnimatedValuesBackup::clear_data() {

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2598,7 +2598,7 @@ TypedArray<Dictionary> GraphEdit::_get_connections_intersecting_with_rect(const 
 TypedArray<Dictionary> GraphEdit::_get_connection_list_from_node(const StringName &p_node) const {
 	ERR_FAIL_COND_V(!connection_map.has(p_node), TypedArray<Dictionary>());
 
-	List<Ref<GraphEdit::Connection>> connections_from_node = connection_map.get(p_node);
+	const List<Ref<GraphEdit::Connection>> connections_from_node = List<Ref<GraphEdit::Connection>>(connection_map.get(p_node));
 	TypedArray<Dictionary> connections_from_node_dict;
 
 	for (const Ref<Connection> &conn : connections_from_node) {

--- a/scene/gui/graph_edit_arranger.cpp
+++ b/scene/gui/graph_edit_arranger.cpp
@@ -242,14 +242,14 @@ int GraphEditArranger::_set_operations(SET_OPERATIONS p_operation, HashSet<Strin
 HashMap<int, Vector<StringName>> GraphEditArranger::_layering(const HashSet<StringName> &r_selected_nodes, const HashMap<StringName, HashSet<StringName>> &r_upper_neighbours) {
 	HashMap<int, Vector<StringName>> l;
 
-	HashSet<StringName> p = r_selected_nodes, q = r_selected_nodes, u, z;
+	HashSet<StringName> p = HashSet<StringName>(r_selected_nodes), q = HashSet<StringName>(r_selected_nodes), u, z;
 	int current_layer = 0;
 	bool selected = false;
 
 	while (!_set_operations(GraphEditArranger::IS_EQUAL, q, u)) {
 		_set_operations(GraphEditArranger::DIFFERENCE, p, u);
 		for (const StringName &E : p) {
-			HashSet<StringName> n = r_upper_neighbours[E];
+			HashSet<StringName> n = HashSet<StringName>(r_upper_neighbours[E]);
 			if (_set_operations(GraphEditArranger::IS_SUBSET, n, z)) {
 				Vector<StringName> t;
 				t.push_back(E);
@@ -282,7 +282,7 @@ HashMap<int, Vector<StringName>> GraphEditArranger::_layering(const HashSet<Stri
 		selected = false;
 	}
 
-	return l;
+	return HashMap<int, Vector<StringName>>(l);
 }
 
 Vector<StringName> GraphEditArranger::_split(const Vector<StringName> &r_layer, const HashMap<StringName, Dictionary> &r_crossings) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3211,7 +3211,7 @@ void Node::replace_by(RequiredParam<Node> rp_node, bool p_keep_groups) {
 	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	ERR_FAIL_COND(p_node->data.parent);
 
-	List<Node *> owned = data.owned;
+	const List<Node *> owned = List<Node *>(data.owned);
 	List<Node *> owned_by_owner;
 	Node *owner = (data.owner == this) ? p_node : data.owner;
 
@@ -3499,7 +3499,7 @@ void Node::get_argument_options(const StringName &p_function, int p_idx, List<St
 	if (p_idx == 0 && (pf == "has_node" || pf == "get_node" || pf == "get_node_or_null")) {
 		_add_nodes_to_options(this, this, r_options);
 	} else if (p_idx == 0 && (pf == "add_to_group" || pf == "remove_from_group" || pf == "is_in_group")) {
-		HashMap<StringName, String> global_groups = ProjectSettings::get_singleton()->get_global_groups_list();
+		const HashMap<StringName, String> global_groups = HashMap<StringName, String>(ProjectSettings::get_singleton()->get_global_groups_list());
 		for (const KeyValue<StringName, String> &E : global_groups) {
 			r_options->push_back(E.key.operator String().quote());
 		}

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2008,7 +2008,7 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 		add_options = names.has(p_function);
 	}
 	if (add_options) {
-		HashMap<StringName, String> global_groups = ProjectSettings::get_singleton()->get_global_groups_list();
+		const HashMap<StringName, String> global_groups = HashMap<StringName, String>(ProjectSettings::get_singleton()->get_global_groups_list());
 		for (const KeyValue<StringName, String> &E : global_groups) {
 			r_options->push_back(E.key.operator String().quote());
 		}

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -403,7 +403,7 @@ public:
 	void child_controls_changed();
 
 	Window *get_exclusive_child() const { return exclusive_child; }
-	HashSet<Window *> get_transient_children() const { return transient_children; }
+	HashSet<Window *> get_transient_children() const { return HashSet<Window *>(transient_children); }
 	Window *get_parent_visible_window() const;
 	Window *get_non_popup_window() const;
 	Viewport *get_parent_viewport() const;

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -1393,13 +1393,13 @@ RBSet<TileSet::TerrainsPattern> TileSet::get_terrains_pattern_set(int p_terrain_
 	for (KeyValue<TileSet::TerrainsPattern, RBSet<TileMapCell>> kv : per_terrain_pattern_tiles[p_terrain_set]) {
 		output.insert(kv.key);
 	}
-	return output;
+	return RBSet<TileSet::TerrainsPattern>(output);
 }
 
 RBSet<TileMapCell> TileSet::get_tiles_for_terrains_pattern(int p_terrain_set, TerrainsPattern p_terrain_tile_pattern) {
 	ERR_FAIL_INDEX_V(p_terrain_set, terrain_sets.size(), RBSet<TileMapCell>());
 	_update_terrains_cache();
-	return per_terrain_pattern_tiles[p_terrain_set][p_terrain_tile_pattern];
+	return RBSet<TileMapCell>(per_terrain_pattern_tiles[p_terrain_set][p_terrain_tile_pattern]);
 }
 
 TileMapCell TileSet::get_random_tile_from_terrains_pattern(int p_terrain_set, TileSet::TerrainsPattern p_terrain_tile_pattern) {
@@ -1408,7 +1408,7 @@ TileMapCell TileSet::get_random_tile_from_terrains_pattern(int p_terrain_set, Ti
 
 	// Count the sum of probabilities.
 	double sum = 0.0;
-	RBSet<TileMapCell> set = per_terrain_pattern_tiles[p_terrain_set][p_terrain_tile_pattern];
+	const RBSet<TileMapCell> set = RBSet<TileMapCell>(per_terrain_pattern_tiles[p_terrain_set][p_terrain_tile_pattern]);
 	for (const TileMapCell &E : set) {
 		if (E.source_id >= 0) {
 			Ref<TileSetSource> source = sources[E.source_id];

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -478,7 +478,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 		const float max_mesh_error = 1.0f; // We only need LODs that can be selected by error threshold.
 		const unsigned min_target_indices = 12;
 
-		LocalVector<int> current_indices = merged_indices;
+		LocalVector<int> current_indices = LocalVector<int>(merged_indices);
 		float current_error = 0.0f;
 		bool allow_prune = true;
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -2386,7 +2386,7 @@ HashSet<StringName> SceneState::get_all_groups() {
 			ret.insert(names[group]);
 		}
 	}
-	return ret;
+	return HashSet<StringName>(ret);
 }
 
 Vector<String> SceneState::_get_node_groups(int p_idx) const {
@@ -2560,7 +2560,7 @@ HashSet<StringName> PackedScene::get_scene_groups(const String &p_path) {
 				i = k + 1;
 			}
 		}
-		return ret;
+		return HashSet<StringName>(ret);
 	} else {
 		Ref<PackedScene> packed_scene = ResourceLoader::load(p_path);
 		ERR_FAIL_COND_V(packed_scene.is_null(), HashSet<StringName>());

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -776,7 +776,7 @@ void SurfaceTool::deindex() {
 		return; //nothing to deindex
 	}
 
-	LocalVector<Vertex> old_vertex_array = vertex_array;
+	LocalVector<Vertex> old_vertex_array = LocalVector<Vertex>(vertex_array);
 	vertex_array.clear();
 	for (const int &index : index_array) {
 		ERR_FAIL_COND(uint32_t(index) >= old_vertex_array.size());
@@ -1289,7 +1289,7 @@ void SurfaceTool::optimize_indices_for_cache() {
 	ERR_FAIL_COND(primitive != Mesh::PRIMITIVE_TRIANGLES);
 	ERR_FAIL_COND(index_array.size() % 3 != 0);
 
-	LocalVector old_index_array = index_array;
+	LocalVector<int> old_index_array = LocalVector<int>(index_array);
 	memset(index_array.ptr(), 0, index_array.size() * sizeof(int));
 	optimize_vertex_cache_func((unsigned int *)index_array.ptr(), (unsigned int *)old_index_array.ptr(), old_index_array.size(), vertex_array.size());
 }

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -6676,7 +6676,7 @@ HashMap<StringName, String> VisualShaderNodeTextureParameter::get_editable_prope
 	names.insert("texture_filter", RTR("Filter"));
 	names.insert("texture_repeat", RTR("Repeat"));
 	names.insert("texture_source", RTR("Source"));
-	return names;
+	return HashMap<StringName, String>(names);
 }
 
 void VisualShaderNodeTextureParameter::_bind_methods() {

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -78,7 +78,7 @@ Vector<StringName> VisualShaderNodeParticleEmitter::get_editable_properties() co
 HashMap<StringName, String> VisualShaderNodeParticleEmitter::get_editable_properties_names() const {
 	HashMap<StringName, String> names;
 	names.insert("mode_2d", RTR("2D Mode"));
-	return names;
+	return HashMap<StringName, String>(names);
 }
 
 bool VisualShaderNodeParticleEmitter::is_show_prop_names() const {
@@ -708,7 +708,7 @@ HashMap<StringName, String> VisualShaderNodeParticleMeshEmitter::get_editable_pr
 		names.insert("surface_index", RTR("Surface Index"));
 	}
 
-	return names;
+	return HashMap<StringName, String>(names);
 }
 
 void VisualShaderNodeParticleMeshEmitter::_bind_methods() {

--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -267,7 +267,7 @@ static FfxErrorCode register_resource_rd(FfxFsr2Interface *p_backend_interface, 
 
 static FfxErrorCode unregister_resources_rd(FfxFsr2Interface *p_backend_interface) {
 	FSR2Context::Scratch &scratch = *reinterpret_cast<FSR2Context::Scratch *>(p_backend_interface->scratchBuffer);
-	LocalVector<uint32_t> dynamic_list_copy = scratch.resources.dynamic_list;
+	LocalVector<uint32_t> dynamic_list_copy = LocalVector<uint32_t>(scratch.resources.dynamic_list);
 	for (uint32_t i : dynamic_list_copy) {
 		scratch.resources.remove(i);
 	}

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -11611,7 +11611,7 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 				if (comp_ident) {
 					if (is_shader_inc) {
 						for (int i = 0; i < RenderingServer::SHADER_MAX; i++) {
-							const HashMap<StringName, ShaderLanguage::FunctionInfo> info = ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(i));
+							const HashMap<StringName, ShaderLanguage::FunctionInfo> info = HashMap<StringName, ShaderLanguage::FunctionInfo>(ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(i)));
 
 							if (info.has("global")) {
 								for (const KeyValue<StringName, BuiltInInfo> &E : info["global"].built_ins) {

--- a/tests/core/templates/test_a_hash_map.h
+++ b/tests/core/templates/test_a_hash_map.h
@@ -137,7 +137,7 @@ TEST_CASE("[AHashMap] Const iteration") {
 	map.insert(123485, 1238888);
 	map.insert(123, 111111);
 
-	const AHashMap<int, int> const_map = map;
+	const AHashMap<int, int> const_map = AHashMap<int, int>(map);
 
 	Vector<Pair<int, int>> expected;
 	expected.push_back(Pair<int, int>(42, 84));

--- a/tests/core/templates/test_hash_map.h
+++ b/tests/core/templates/test_hash_map.h
@@ -130,7 +130,7 @@ TEST_CASE("[HashMap] Const iteration") {
 	map.insert(123485, 1238888);
 	map.insert(123, 111111);
 
-	const HashMap<int, int> const_map = map;
+	const HashMap<int, int> const_map = HashMap<int, int>(map);
 
 	Vector<Pair<int, int>> expected;
 	expected.push_back(Pair<int, int>(42, 84));

--- a/tests/core/templates/test_hash_set.h
+++ b/tests/core/templates/test_hash_set.h
@@ -221,7 +221,7 @@ TEST_CASE("[HashSet] Copy") {
 	expected.push_back(0);
 	expected.push_back(123485);
 
-	HashSet<int> copy_assign = set;
+	HashSet<int> copy_assign = HashSet<int>(set);
 
 	int idx = 0;
 	for (const int &E : copy_assign) {


### PR DESCRIPTION
This PR makes most container copy constructors explicit. Specifically `CowData`, `FixedVector`, `HashMap`, `HashSet`, `List`, `LocalVector`, `RBMap`, and `RBSet`. These already had many places in the code where copies were implicitly happening, but now the copies are explicit.

This is most of the template containers, except for `Vector`, since changing that type would be a really big change and should probably get its own PR. This PR also doesn't change `Array` and `Dictionary`, which are also big changes.