### PR TITLE
Fix incorrect transform calculation in `Camera2D` when using a custom viewport

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -738,7 +738,8 @@ Size2 Camera2D::_get_camera_screen_size() const {
 	if (is_part_of_edited_scene()) {
 		return Size2(GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_width"), GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_height"));
 	}
-	return get_viewport_rect().size;
+	ERR_FAIL_NULL_V(viewport, Size2());
+	return viewport->get_visible_rect().size;
 }
 
 void Camera2D::set_drag_horizontal_enabled(bool p_enabled) {


### PR DESCRIPTION
Even if `Camera2D::custom_viewport` was set, `_get_camera_screen_size` would still return the size of the nearest ancestor viewport instead of the custom viewport. This means that if `anchor_mode` was set to `ANCHOR_MODE_DRAG_CENTER`, then the camera's position would be calculated based on the size of the ancestor viewport instead of the custom one, so the camera would not be properly centered on the custom viewport. This PR fixes this.