### PR TITLE
Fix incorrect margins in `ScrollContainer` with focus border enabled

### DIFF
--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -85,6 +85,8 @@ private:
 	bool _is_h_scroll_visible() const;
 	bool _is_v_scroll_visible() const;
 
+	Rect2 _get_margins() const;
+
 	bool draw_focus_border = false;
 	bool focus_border_is_drawn = false;
 	bool child_has_focus();


### PR DESCRIPTION
The new way to draw the focus border introduced by #104317 didn't cover all corner cases, resulting in some combinations of margins making the scrollbar clip into the contents, and some other sizing issues.

Here's a example with the panel margins being `(15, 5, 2, 2)`, and the focus margins being `(10, 10, 10, 10)`:
|`master`|This PR|
|-|-|
|<img width="453" height="383" alt="Screenshot_20251007_204330" src="https://github.com/user-attachments/assets/e4b91615-e72c-46cc-a796-d50611460640" />|<img width="453" height="383" alt="Screenshot_20251007_204306" src="https://github.com/user-attachments/assets/be2887e2-c96e-4735-8955-b12fabbf14ab" />|