### PR TITLE
Fix segfault in `GLTFDocument::export_object_model_property`

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -7066,7 +7066,8 @@ Ref<GLTFObjectModelProperty> GLTFDocument::export_object_model_property(Ref<GLTF
 	const Vector<StringName> subpath = p_node_path.get_subnames();
 	ERR_FAIL_COND_V_MSG(subpath.is_empty(), ret, "glTF: Cannot export empty property. No property was specified in the NodePath: " + String(p_node_path));
 	int target_prop_depth = 0;
-	for (StringName subname : subpath) {
+	for (int64_t i = 0; i < subpath.size() - 1; i++) {
+		const StringName &subname = subpath[i];
 		Variant target_property = target_object->get(subname);
 		if (target_property.get_type() == Variant::OBJECT) {
 			target_object = target_property;


### PR DESCRIPTION
In GLTFDocument::export_object_model_property, if the last subname happened to be an object, it would increment the `target_prop_depth` index to size + 1 and cause a segfault (e.g. `Path/To/Node:surface_material_override/0`). We prevent this by not checking the last subname (which would be the ultimate property being set)