### PR TITLE
Avoid implicit copies in ternary operators used for returning data

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -372,7 +372,10 @@ String ResourceFormatImporter::get_import_group_file(const String &p_path) const
 	bool valid = true;
 	PathAndType pat;
 	_get_path_and_type(p_path, pat, false, &valid);
-	return valid ? pat.group_file : String();
+	if (valid) {
+		return pat.group_file;
+	}
+	return String();
 }
 
 bool ResourceFormatImporter::is_import_valid(const String &p_path) const {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -718,7 +718,10 @@ public:
 		}
 		Callable::CallError cerr;
 		const Variant ret = callp(p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args), cerr);
-		return (cerr.error == Callable::CallError::CALL_OK) ? ret : Variant();
+		if (cerr.error == Callable::CallError::CALL_OK) {
+			return ret;
+		}
+		return Variant();
 	}
 
 	// Depending on the boolean, we call either the virtual function _notification_backward or _notification_forward.

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -712,7 +712,10 @@ public:
 		}
 		Callable::CallError cerr;
 		const Variant ret = callp(p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args), cerr);
-		return (cerr.error == Callable::CallError::CALL_OK) ? ret : Variant();
+		if (cerr.error == Callable::CallError::CALL_OK) {
+			return ret;
+		}
+		return Variant();
 	}
 
 	// Depending on the boolean, we call either the virtual function _notification_backward or _notification_forward.

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -381,7 +381,10 @@ public:
 	};
 
 	_FORCE_INLINE_ Iterator begin() const _LIFETIME_BOUND_ {
-		return _size ? Iterator(_keys, _size, 0) : Iterator();
+		if (_size == 0) {
+			return Iterator();
+		}
+		return Iterator(_keys, _size, 0);
 	}
 	_FORCE_INLINE_ Iterator end() const _LIFETIME_BOUND_ {
 		return Iterator();

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1759,7 +1759,10 @@ bool Variant::has_enum(Variant::Type p_type, const StringName &p_enum_name) {
 StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringName &p_enumeration) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, StringName());
 	const GDType::EnumInfo *enum_info = _get_gdtype_for_type(p_type).get_integer_constant_enum(p_enumeration, false);
-	return enum_info ? enum_info->name : StringName();
+	if (enum_info == nullptr) {
+		return StringName();
+	}
+	return enum_info->name;
 }
 
 #ifdef DEBUG_ENABLED

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1763,7 +1763,10 @@ bool Variant::has_enum(Variant::Type p_type, const StringName &p_enum_name) {
 StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringName &p_enumeration) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, StringName());
 	const GDType::EnumInfo *enum_info = _get_gdtype_for_type(p_type).get_integer_constant_enum(p_enumeration, false);
-	return enum_info ? enum_info->name : StringName();
+	if (enum_info == nullptr) {
+		return StringName();
+	}
+	return enum_info->name;
 }
 
 #ifdef DEBUG_ENABLED

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1107,7 +1107,10 @@ String EditorData::script_class_get_icon_path(const String &p_class, bool *r_val
 }
 
 StringName EditorData::script_class_get_name(const String &p_path) const {
-	return _script_class_file_to_path.has(p_path) ? _script_class_file_to_path[p_path] : StringName();
+	if (_script_class_file_to_path.has(p_path)) {
+		return _script_class_file_to_path[p_path];
+	}
+	return StringName();
 }
 
 void EditorData::script_class_set_name(const String &p_path, const StringName &p_class) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4653,7 +4653,10 @@ void EditorNode::set_edited_scene_root(Node *p_scene, bool p_auto_add) {
 
 String EditorNode::get_preview_locale() const {
 	const Ref<TranslationDomain> &main_domain = TranslationServer::get_singleton()->get_main_domain();
-	return main_domain->is_enabled() ? main_domain->get_locale_override() : String();
+	if (main_domain->is_enabled()) {
+		return main_domain->get_locale_override();
+	}
+	return String();
 }
 
 bool EditorNode::is_pseudolocalization_enabled() const {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4701,7 +4701,10 @@ void EditorNode::set_edited_scene_root(Node *p_scene, bool p_auto_add) {
 
 String EditorNode::get_preview_locale() const {
 	const Ref<TranslationDomain> &main_domain = TranslationServer::get_singleton()->get_main_domain();
-	return main_domain->is_enabled() ? main_domain->get_locale_override() : String();
+	if (main_domain->is_enabled()) {
+		return main_domain->get_locale_override();
+	}
+	return String();
 }
 
 bool EditorNode::is_pseudolocalization_enabled() const {

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -1119,8 +1119,11 @@ QuickOpenDisplayMode QuickOpenResultContainer::get_adaptive_display_mode(const V
 }
 
 String _get_uid_string(const String &p_filepath) {
-	ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_filepath);
-	return id == ResourceUID::INVALID_ID ? p_filepath : ResourceUID::get_singleton()->id_to_text(id);
+	const ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_filepath);
+	if (id == ResourceUID::INVALID_ID) {
+		return p_filepath;
+	}
+	return ResourceUID::get_singleton()->id_to_text(id);
 }
 
 bool QuickOpenResultContainer::is_instant_preview_enabled() const {

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -490,17 +490,26 @@ EditorBuildProfile::BuildOptionCategory EditorBuildProfile::get_build_option_cat
 
 LocalVector<EditorBuildProfile::BuildOption> EditorBuildProfile::get_build_option_dependencies(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, LocalVector<EditorBuildProfile::BuildOption>());
-	return build_option_dependencies.has(p_build_option) ? LocalVector<EditorBuildProfile::BuildOption>(build_option_dependencies[p_build_option]) : LocalVector<EditorBuildProfile::BuildOption>();
+	if (build_option_dependencies.has(p_build_option)) {
+		return LocalVector<EditorBuildProfile::BuildOption>(build_option_dependencies[p_build_option]);
+	}
+	return LocalVector<EditorBuildProfile::BuildOption>();
 }
 
 HashMap<String, LocalVector<Variant>> EditorBuildProfile::get_build_option_settings(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, (HashMap<String, LocalVector<Variant>>()));
-	return build_option_settings.has(p_build_option) ? HashMap<String, LocalVector<Variant>>(build_option_settings[p_build_option]) : HashMap<String, LocalVector<Variant>>();
+	if (build_option_settings.has(p_build_option)) {
+		return HashMap<String, LocalVector<Variant>>(build_option_settings[p_build_option]);
+	}
+	return HashMap<String, LocalVector<Variant>>();
 }
 
 LocalVector<String> EditorBuildProfile::get_build_option_classes(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, LocalVector<String>());
-	return build_option_classes.has(p_build_option) ? LocalVector<String>(build_option_classes[p_build_option]) : LocalVector<String>();
+	if (build_option_classes.has(p_build_option)) {
+		return LocalVector<String>(build_option_classes[p_build_option]);
+	}
+	return LocalVector<String>();
 }
 
 String EditorBuildProfile::get_build_option_category_name(BuildOptionCategory p_build_option_category) {

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -505,17 +505,26 @@ EditorBuildProfile::BuildOptionCategory EditorBuildProfile::get_build_option_cat
 
 LocalVector<EditorBuildProfile::BuildOption> EditorBuildProfile::get_build_option_dependencies(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, LocalVector<EditorBuildProfile::BuildOption>());
-	return build_option_dependencies.has(p_build_option) ? LocalVector<EditorBuildProfile::BuildOption>(build_option_dependencies[p_build_option]) : LocalVector<EditorBuildProfile::BuildOption>();
+	if (build_option_dependencies.has(p_build_option)) {
+		return LocalVector<EditorBuildProfile::BuildOption>(build_option_dependencies[p_build_option]);
+	}
+	return LocalVector<EditorBuildProfile::BuildOption>();
 }
 
 HashMap<String, LocalVector<Variant>> EditorBuildProfile::get_build_option_settings(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, (HashMap<String, LocalVector<Variant>>()));
-	return build_option_settings.has(p_build_option) ? HashMap<String, LocalVector<Variant>>(build_option_settings[p_build_option]) : HashMap<String, LocalVector<Variant>>();
+	if (build_option_settings.has(p_build_option)) {
+		return HashMap<String, LocalVector<Variant>>(build_option_settings[p_build_option]);
+	}
+	return HashMap<String, LocalVector<Variant>>();
 }
 
 LocalVector<String> EditorBuildProfile::get_build_option_classes(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, LocalVector<String>());
-	return build_option_classes.has(p_build_option) ? LocalVector<String>(build_option_classes[p_build_option]) : LocalVector<String>();
+	if (build_option_classes.has(p_build_option)) {
+		return LocalVector<String>(build_option_classes[p_build_option]);
+	}
+	return LocalVector<String>();
 }
 
 String EditorBuildProfile::get_build_option_category_name(BuildOptionCategory p_build_option_category) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2830,7 +2830,10 @@ String GDScriptLanguage::_get_global_class_name(const String &p_path, String *r_
 	if (r_is_tool) {
 		*r_is_tool = parser.is_tool();
 	}
-	return c->identifier != nullptr ? String(c->identifier->name) : String();
+	if (c->identifier != nullptr) {
+		return String(c->identifier->name);
+	}
+	return String();
 }
 
 thread_local GDScriptLanguage::CallLevel *GDScriptLanguage::_call_stack = nullptr;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2809,7 +2809,10 @@ String GDScriptLanguage::_get_global_class_name(const String &p_path, String *r_
 	if (r_is_tool) {
 		*r_is_tool = parser.is_tool();
 	}
-	return c->identifier != nullptr ? String(c->identifier->name) : String();
+	if (c->identifier != nullptr) {
+		return String(c->identifier->name);
+	}
+	return String();
 }
 
 thread_local GDScriptLanguage::CallLevel *GDScriptLanguage::_call_stack = nullptr;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4645,7 +4645,10 @@ static StringName _find_narrowest_native_or_global_class(const GDScriptParser::D
 			}
 
 			if (p_type.is_meta_type) {
-				return script.is_valid() ? script->get_class_name() : Script::get_class_static();
+				if (script.is_valid()) {
+					return script->get_class_name();
+				}
+				return Script::get_class_static();
 			}
 			if (script.is_null()) {
 				return p_type.native_type;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4609,7 +4609,10 @@ static StringName _find_narrowest_native_or_global_class(const GDScriptParser::D
 			}
 
 			if (p_type.is_meta_type) {
-				return script.is_valid() ? script->get_class_name() : Script::get_class_static();
+				if (script.is_valid()) {
+					return script->get_class_name();
+				}
+				return Script::get_class_static();
 			}
 			if (script.is_null()) {
 				return p_type.native_type;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -786,7 +786,10 @@ public:
 		bool resolved_body = false;
 
 		StringName get_global_name() const {
-			return (outer == nullptr && identifier != nullptr) ? identifier->name : StringName();
+			if (outer == nullptr && identifier != nullptr) {
+				return identifier->name;
+			}
+			return StringName();
 		}
 
 		Member get_member(const StringName &p_name) const {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -783,7 +783,10 @@ public:
 		bool resolved_body = false;
 
 		StringName get_global_name() const {
-			return (outer == nullptr && identifier != nullptr) ? identifier->name : StringName();
+			if (outer == nullptr && identifier != nullptr) {
+				return identifier->name;
+			}
+			return StringName();
 		}
 
 		Member get_member(const StringName &p_name) const {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2719,7 +2719,10 @@ Ref<Script> CSharpScript::get_base_script() const {
 }
 
 StringName CSharpScript::get_global_name() const {
-	return type_info.is_global_class ? StringName(type_info.class_name) : StringName();
+	if (type_info.is_global_class) {
+		return StringName(type_info.class_name);
+	}
+	return StringName();
 }
 
 void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2715,7 +2715,10 @@ Ref<Script> CSharpScript::get_base_script() const {
 }
 
 StringName CSharpScript::get_global_name() const {
-	return type_info.is_global_class ? StringName(type_info.class_name) : StringName();
+	if (type_info.is_global_class) {
+		return StringName(type_info.class_name);
+	}
+	return StringName();
 }
 
 void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -293,7 +293,10 @@ int MultiplayerSpawner::find_spawnable_scene_index_from_object(const ObjectID &p
 
 const Variant MultiplayerSpawner::get_spawn_argument(const ObjectID &p_id) const {
 	const SpawnInfo *info = tracked_nodes.getptr(p_id);
-	return info ? info->args : Variant();
+	if (info) {
+		return info->args;
+	}
+	return Variant();
 }
 
 Node *MultiplayerSpawner::instantiate_scene(int p_id) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -838,7 +838,10 @@ public:
 		if (can_auto_translate()) {
 			return tr_n(p_message, p_message_plural, p_n, _get_translation_context_with_override(p_context));
 		}
-		return p_n == 1 ? p_message : String(p_message_plural);
+		if (p_n == 1) {
+			return p_message;
+		}
+		return String(p_message_plural);
 	}
 
 	/* THREADING */

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -841,7 +841,10 @@ public:
 		if (can_auto_translate()) {
 			return tr_n(p_message, p_message_plural, p_n, _get_translation_context_with_override(p_context));
 		}
-		return p_n == 1 ? p_message : String(p_message_plural);
+		if (p_n == 1) {
+			return p_message;
+		}
+		return String(p_message_plural);
 	}
 
 	/* THREADING */

--- a/servers/rendering/shader_include_db.cpp
+++ b/servers/rendering/shader_include_db.cpp
@@ -60,8 +60,10 @@ bool ShaderIncludeDB::has_built_in_include_file(const String &p_filename) {
 
 String ShaderIncludeDB::get_built_in_include_file(const String &p_filename) {
 	const String *ptr = built_in_includes.getptr(p_filename);
-
-	return ptr ? *ptr : String();
+	if (ptr) {
+		return *ptr;
+	}
+	return String();
 }
 
 String ShaderIncludeDB::parse_include_files(const String &p_code) {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -476,8 +476,18 @@ public:
 		int array_size = 0;
 		bool is_local = false;
 
-		virtual DataType get_datatype() const override { return call_expression ? call_expression->get_datatype() : datatype_cache; }
-		virtual String get_datatype_name() const override { return call_expression ? call_expression->get_datatype_name() : String(struct_name); }
+		virtual DataType get_datatype() const override {
+			if (call_expression) {
+				return call_expression->get_datatype();
+			}
+			return datatype_cache;
+		}
+		virtual String get_datatype_name() const override {
+			if (call_expression) {
+				return call_expression->get_datatype_name();
+			}
+			return String(struct_name);
+		}
 		virtual int get_array_size() const override { return (index_expression || call_expression) ? 0 : array_size; }
 		virtual bool is_indexed() const override { return index_expression != nullptr; }
 
@@ -583,8 +593,18 @@ public:
 		Node *call_expression = nullptr;
 		bool has_swizzling_duplicates = false;
 
-		virtual DataType get_datatype() const override { return call_expression ? call_expression->get_datatype() : datatype; }
-		virtual String get_datatype_name() const override { return call_expression ? call_expression->get_datatype_name() : String(struct_name); }
+		virtual DataType get_datatype() const override {
+			if (call_expression) {
+				return call_expression->get_datatype();
+			}
+			return datatype;
+		}
+		virtual String get_datatype_name() const override {
+			if (call_expression) {
+				return call_expression->get_datatype_name();
+			}
+			return String(struct_name);
+		}
 		virtual int get_array_size() const override { return (index_expression || call_expression) ? 0 : array_size; }
 		virtual bool is_indexed() const override { return index_expression != nullptr || call_expression != nullptr; }
 

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -483,8 +483,18 @@ public:
 		int array_size = 0;
 		bool is_local = false;
 
-		virtual DataType get_datatype() const override { return call_expression ? call_expression->get_datatype() : datatype_cache; }
-		virtual String get_datatype_name() const override { return call_expression ? call_expression->get_datatype_name() : String(struct_name); }
+		virtual DataType get_datatype() const override {
+			if (call_expression) {
+				return call_expression->get_datatype();
+			}
+			return datatype_cache;
+		}
+		virtual String get_datatype_name() const override {
+			if (call_expression) {
+				return call_expression->get_datatype_name();
+			}
+			return String(struct_name);
+		}
 		virtual int get_array_size() const override { return (index_expression || call_expression) ? 0 : array_size; }
 		virtual bool is_indexed() const override { return index_expression != nullptr; }
 
@@ -590,8 +600,18 @@ public:
 		Node *call_expression = nullptr;
 		bool has_swizzling_duplicates = false;
 
-		virtual DataType get_datatype() const override { return call_expression ? call_expression->get_datatype() : datatype; }
-		virtual String get_datatype_name() const override { return call_expression ? call_expression->get_datatype_name() : String(struct_name); }
+		virtual DataType get_datatype() const override {
+			if (call_expression) {
+				return call_expression->get_datatype();
+			}
+			return datatype;
+		}
+		virtual String get_datatype_name() const override {
+			if (call_expression) {
+				return call_expression->get_datatype_name();
+			}
+			return String(struct_name);
+		}
 		virtual int get_array_size() const override { return (index_expression || call_expression) ? 0 : array_size; }
 		virtual bool is_indexed() const override { return index_expression != nullptr || call_expression != nullptr; }
 


### PR DESCRIPTION
Pop quiz: What's the difference between these 2 pieces of C++ code?
```cpp
return build_option_settings.has(p_build_option) ? HashMap<String, LocalVector<Variant>>(build_option_settings[p_build_option]) : HashMap<String, LocalVector<Variant>>();
```
vs
```cpp
if (build_option_settings.has(p_build_option)) {
    return HashMap<String, LocalVector<Variant>>(build_option_settings[p_build_option]);
}
return HashMap<String, LocalVector<Variant>>();
```
Answer (and the rest of the PR description):
<details>

The first piece of code performs an implicit copy, even though one case of the ternary is already a copy and the other is an empty object, C++ still tries to convert to the target type even though they are already of that type! So the second piece of code avoids an extra implicit copy constructor during compilation. Both have a branch (`?` and `if`), they are the same in that regard.

Apparently in C++ the ternary operator "inhibits return value optimization (RVO) and elision".

C++ compilers are smart enough to completely optimize out this extra copy. However, regardless of performance, this change is necessary if we ever want to change these copy constructors to explicit instead of implicit, and therefore I am opening a PR for this.

In the case of `HashSet::begin`, the `HashSet::last` function already looks like this, so it's more consistent.

There are likely more implicit-ternary-copy places that could be optimized, but these are what I was able to find with a quickly thrown together regular expression, and other places are more questionable of whether they are an improvement: like if the left side is complex, do we really want to have that repeated inside of `if`/`else` blocks? However, the `return` cases seem like an easy win, it's arguably more readable, but that aspect is subjective.
</details>