### PR TITLE
Fix Steam time tracker build.

### DIFF
--- a/main/steam_tracker.cpp
+++ b/main/steam_tracker.cpp
@@ -32,6 +32,8 @@
 
 #include "steam_tracker.h"
 
+#include "core/io/file_access.h"
+
 // https://partner.steamgames.com/doc/sdk/api#initialization_and_shutdown
 
 SteamTracker::SteamTracker() {


### PR DESCRIPTION
Fixes build with `steamapi=yes`, which was broken by recent include cleanups.