### PR TITLE
GDScript: Return correctly typed arrays for dict's keys() and values() methods

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -407,7 +407,8 @@
 		<method name="is_typed" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the dictionary is typed. Typed dictionaries can only store keys/values of their associated type and provide type safety for the [code][][/code] operator. Methods of typed dictionary still return [Variant].
+				Returns [code]true[/code] if the dictionary is typed. Typed dictionaries can only store keys/values of their associated type and provide type safety for the [code][][/code] operator.
+				[b]Note:[/b] Regardless of typing, some methods of a dictionary are always expected to require or return [Variant].
 			</description>
 		</method>
 		<method name="is_typed_key" qualifiers="const">
@@ -425,7 +426,7 @@
 		<method name="keys" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns the list of keys in the dictionary.
+				Returns the list of keys in the dictionary. The returned array is typed to match this dictionary (see [method is_typed_key]).
 			</description>
 		</method>
 		<method name="make_read_only">
@@ -534,7 +535,7 @@
 		<method name="values" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns the list of values in this dictionary.
+				Returns the list of values in the dictionary. The returned array is typed to match this dictionary (see [method is_typed_value]).
 			</description>
 		</method>
 	</methods>

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -137,6 +137,7 @@ class GDScriptAnalyzer {
 	void update_const_expression_builtin_type(GDScriptParser::ExpressionNode *p_expression, const GDScriptParser::DataType &p_type, const char *p_usage, bool p_is_cast = false);
 	void update_array_literal_element_type(GDScriptParser::ArrayNode *p_array, const GDScriptParser::DataType &p_element_type);
 	void update_dictionary_literal_element_type(GDScriptParser::DictionaryNode *p_dictionary, const GDScriptParser::DataType &p_key_element_type, const GDScriptParser::DataType &p_value_element_type);
+	void update_dict_array_return_type(GDScriptParser::DataType p_base_type, const StringName &p_function_name, GDScriptParser::DataType &r_return_type);
 	bool is_type_compatible(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source, bool p_allow_implicit_conversion = false, const GDScriptParser::Node *p_source_node = nullptr);
 	void push_error(const String &p_message, const GDScriptParser::Node *p_origin = nullptr);
 	void mark_node_unsafe(const GDScriptParser::Node *p_node);

--- a/modules/gdscript/tests/scripts/parser/features/typed_dictionaries.gd
+++ b/modules/gdscript/tests/scripts/parser/features/typed_dictionaries.gd
@@ -1,5 +1,9 @@
 func test():
 	var my_dictionary: Dictionary[int, String] = { 1: "one", 2: "two", 3: "three" }
 	var inferred_dictionary := { 1: "one", 2: "two", 3: "three" } # This is Dictionary[int, String].
+	var keys := my_dictionary.keys()  # Array[Int]
+	var values := my_dictionary.values()  # Array[String]
 	print(my_dictionary)
 	print(inferred_dictionary)
+	print(keys[0])
+	print(values[2].length())

--- a/modules/gdscript/tests/scripts/parser/features/typed_dictionaries.out
+++ b/modules/gdscript/tests/scripts/parser/features/typed_dictionaries.out
@@ -1,3 +1,5 @@
 GDTEST_OK
 { 1: "one", 2: "two", 3: "three" }
 { 1: "one", 2: "two", 3: "three" }
+1
+5


### PR DESCRIPTION
This change modifies `gdscript_analyzer.cpp` to update the return type of dictionaries `keys()` and `values()` methods so that they return correctly typed arrays.

Regarding the approach to solve the problem, I collaborated with @StarryWorm in chat and seems like whilst this is a bit hacky, it could be ok since this solves a gdscript-only issue. Solving it in a smarter way would require a bigger refactor in core like many have pointed out in the linked issues.

P.s. This is my first contribution, feel free to nitpick and suggest changes, here to learn. 

Related issues: 
* https://github.com/godotengine/godot/issues/59721
* https://github.com/godotengine/godot/issues/111107
* https://github.com/godotengine/godot-proposals/issues/10804

Note: this PR previously tried to fix element returning methods returning Variant as well, which wasn't correct as dalexeev explained below. This PR is now only focused on returning correctly typed arrays for the aforementioned dictionary methods. 