### PR TITLE
Set step before set value, to fix animation length issue

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -1836,8 +1836,8 @@ void AnimationTimelineEdit::update_values() {
 
 	editing = true;
 	if (use_fps && animation->get_step() > 0.0) {
-		length->set_value(animation->get_length() / animation->get_step());
 		length->set_step(FPS_DECIMAL);
+		length->set_value(animation->get_length() / animation->get_step());
 		length->set_tooltip_text(TTR("Animation length (frames)"));
 		time_icon->set_tooltip_text(TTR("Animation length (frames)"));
 		if (track_edit) {
@@ -1845,8 +1845,8 @@ void AnimationTimelineEdit::update_values() {
 			track_edit->editor->marker_edit->_update_key_edit();
 		}
 	} else {
-		length->set_value(animation->get_length());
 		length->set_step(SECOND_DECIMAL);
+		length->set_value(animation->get_length());
 		length->set_tooltip_text(TTR("Animation length (seconds)"));
 		time_icon->set_tooltip_text(TTR("Animation length (seconds)"));
 	}


### PR DESCRIPTION
* *fixes: https://github.com/godotengine/godot/issues/111122*

When switch unit from fps to seconds, we update step after update value. That causes we use FPS_DECIMAL to process seconds length, which rounded decimal to zero.

So update step before update value can solve this issue.

https://github.com/godotengine/godot/blob/d0ad6d6023053b85f6454bf00c9dc4ce84ecbb94/editor/animation/animation_track_editor.cpp#L67-L68
