### PR TITLE
Fix debug templates when physics 3d is disabled

### DIFF
--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -36,10 +36,13 @@
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
-#include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
 #include "scene/resources/3d/primitive_meshes.h"
 #include "servers/xr/xr_server.h"
+
+#ifndef PHYSICS_3D_DISABLED
+#include "scene/resources/3d/box_shape_3d.h"
+#endif // PHYSICS_3D_DISABLED
 
 ////////////////////////////////////////////////////////////////////////////
 // OpenXRSpatialCapabilityConfigurationPlaneTracking
@@ -285,7 +288,9 @@ void OpenXRPlaneTracker::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_mesh_offset"), &OpenXRPlaneTracker::get_mesh_offset);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &OpenXRPlaneTracker::get_mesh);
+#ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_shape", "thickness"), &OpenXRPlaneTracker::get_shape, DEFVAL(0.01));
+#endif // PHYSICS_3D_DISABLED
 
 	ADD_SIGNAL(MethodInfo("mesh_changed"));
 }
@@ -390,7 +395,9 @@ void OpenXRPlaneTracker::set_mesh_data(const Transform3D &p_origin, const Packed
 
 		if (has_changed) {
 			mesh.mesh.unref();
+#ifndef PHYSICS_3D_DISABLED
 			mesh.shape3d.unref();
+#endif // PHYSICS_3D_DISABLED
 
 			emit_signal(SNAME("mesh_changed"));
 		}
@@ -399,7 +406,9 @@ void OpenXRPlaneTracker::set_mesh_data(const Transform3D &p_origin, const Packed
 
 void OpenXRPlaneTracker::clear_mesh_data() {
 	mesh.mesh.unref();
+#ifndef PHYSICS_3D_DISABLED
 	mesh.shape3d.unref();
+#endif // PHYSICS_3D_DISABLED
 
 	if (mesh.has_mesh_data) {
 		mesh.has_mesh_data = false;
@@ -479,6 +488,7 @@ Ref<Mesh> OpenXRPlaneTracker::get_mesh() {
 	return mesh.mesh;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 Ref<Shape3D> OpenXRPlaneTracker::get_shape(real_t p_thickness) {
 	// We've already created this? Just return it!
 	if (mesh.shape3d.is_valid()) {
@@ -567,6 +577,7 @@ Ref<Shape3D> OpenXRPlaneTracker::get_shape(real_t p_thickness) {
 
 	return mesh.shape3d;
 }
+#endif // PHYSICS_3D_DISABLED
 
 ////////////////////////////////////////////////////////////////////////////
 // OpenXRSpatialPlaneTrackingCapability

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
@@ -34,7 +34,9 @@
 #include "../openxr_future_extension.h"
 #include "openxr_spatial_entities.h"
 
+#ifndef PHYSICS_3D_DISABLED
 #include "scene/resources/3d/shape_3d.h"
+#endif // PHYSICS_3D_DISABLED
 
 // Plane tracking capability configuration
 class OpenXRSpatialCapabilityConfigurationPlaneTracking : public OpenXRSpatialCapabilityConfigurationBaseHeader {
@@ -166,7 +168,9 @@ public:
 
 	Transform3D get_mesh_offset() const;
 	Ref<Mesh> get_mesh();
+#ifndef PHYSICS_3D_DISABLED
 	Ref<Shape3D> get_shape(real_t p_thickness = 0.01);
+#endif // PHYSICS_3D_DISABLED
 
 protected:
 	static void _bind_methods();
@@ -184,7 +188,9 @@ private:
 		PackedInt32Array indices;
 
 		Ref<Mesh> mesh;
+#ifndef PHYSICS_3D_DISABLED
 		Ref<Shape3D> shape3d;
+#endif // PHYSICS_3D_DISABLED
 	} mesh;
 
 	struct Edge {

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -40,16 +40,17 @@
 #include "scene/2d/tile_map.h"
 #include "scene/gui/control.h"
 #include "scene/main/scene_tree.h"
-#include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "scene/resources/material.h"
 #include "scene/resources/world_2d.h"
 #include "servers/rendering/rendering_server.h"
 
 #ifndef PHYSICS_2D_DISABLED
+#include "scene/resources/mesh.h"
 #include "servers/physics_2d/physics_server_2d.h"
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef NAVIGATION_2D_DISABLED
+#include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 Callable TileMapLayer::_navmesh_source_geometry_parsing_callback;
 RID TileMapLayer::_navmesh_source_geometry_parser;

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -83,6 +83,7 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 #endif // PHYSICS_3D_DISABLED
 		} else if (what == "preview") {
 			set_item_preview(idx, p_value);
+#ifndef NAVIGATION_3D_DISABLED
 		} else if (what == "navigation_mesh") {
 			set_item_navigation_mesh(idx, p_value);
 		} else if (what == "navigation_mesh_transform") {
@@ -95,6 +96,7 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 #endif // DISABLE_DEPRECATED
 		} else if (what == "navigation_layers") {
 			set_item_navigation_layers(idx, p_value);
+#endif // NAVIGATION_3D_DISABLED
 		} else {
 			return false;
 		}
@@ -123,6 +125,7 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (what == "shapes") {
 		r_ret = _get_item_shapes(idx);
 #endif // PHYSICS_3D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
 	} else if (what == "navigation_mesh") {
 		r_ret = get_item_navigation_mesh(idx);
 	} else if (what == "navigation_mesh_transform") {
@@ -135,6 +138,7 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 #endif // DISABLE_DEPRECATED
 	} else if (what == "navigation_layers") {
 		r_ret = get_item_navigation_layers(idx);
+#endif // NAVIGATION_3D_DISABLED
 	} else if (what == "preview") {
 		r_ret = get_item_preview(idx);
 	} else {
@@ -251,6 +255,7 @@ Vector<MeshLibrary::ShapeData> MeshLibrary::get_item_shapes(int p_item) const {
 }
 #endif // PHYSICS_3D_DISABLED
 
+#ifndef NAVIGATION_3D_DISABLED
 Ref<NavigationMesh> MeshLibrary::get_item_navigation_mesh(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<NavigationMesh>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].navigation_mesh;
@@ -265,6 +270,7 @@ uint32_t MeshLibrary::get_item_navigation_layers(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), 0, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].navigation_layers;
 }
+#endif // NAVIGATION_3D_DISABLED
 
 Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<Texture2D>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
@@ -282,10 +288,17 @@ void MeshLibrary::remove_item(int p_item) {
 	emit_changed();
 }
 
-void MeshLibrary::clear() {
-	item_map.clear();
-	notify_property_list_changed();
-	emit_changed();
+bool MeshLibrary::has_item(int p_item) const {
+	return item_map.has(p_item);
+}
+
+int MeshLibrary::find_item_by_name(const String &p_name) const {
+	for (const KeyValue<int, Item> &E : item_map) {
+		if (E.value.name == p_name) {
+			return E.key;
+		}
+	}
+	return -1;
 }
 
 Vector<int> MeshLibrary::get_item_list() const {
@@ -299,15 +312,6 @@ Vector<int> MeshLibrary::get_item_list() const {
 	return ret;
 }
 
-int MeshLibrary::find_item_by_name(const String &p_name) const {
-	for (const KeyValue<int, Item> &E : item_map) {
-		if (E.value.name == p_name) {
-			return E.key;
-		}
-	}
-	return -1;
-}
-
 int MeshLibrary::get_last_unused_item_id() const {
 	if (!item_map.size()) {
 		return 0;
@@ -315,6 +319,102 @@ int MeshLibrary::get_last_unused_item_id() const {
 		return item_map.back()->key() + 1;
 	}
 }
+
+void MeshLibrary::set_item_name(int p_item, const String &p_name) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].name = p_name;
+	emit_changed();
+}
+
+String MeshLibrary::get_item_name(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), "", "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].name;
+}
+
+void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].mesh = p_mesh;
+	emit_changed();
+}
+
+Ref<Mesh> MeshLibrary::get_item_mesh(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<Mesh>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].mesh;
+}
+
+void MeshLibrary::set_item_mesh_transform(int p_item, const Transform3D &p_transform) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].mesh_transform = p_transform;
+	emit_changed();
+}
+
+Transform3D MeshLibrary::get_item_mesh_transform(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Transform3D(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].mesh_transform;
+}
+
+void MeshLibrary::set_item_mesh_cast_shadow(int p_item, RS::ShadowCastingSetting p_shadow_casting_setting) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].mesh_cast_shadow = p_shadow_casting_setting;
+	emit_changed();
+}
+
+RS::ShadowCastingSetting MeshLibrary::get_item_mesh_cast_shadow(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].mesh_cast_shadow;
+}
+
+void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].preview = p_preview;
+	emit_changed();
+}
+
+Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<Texture2D>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].preview;
+}
+
+void MeshLibrary::clear() {
+	item_map.clear();
+	notify_property_list_changed();
+	emit_changed();
+}
+
+#ifndef NAVIGATION_3D_DISABLED
+void MeshLibrary::set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].navigation_mesh = p_navigation_mesh;
+	emit_changed();
+}
+
+Ref<NavigationMesh> MeshLibrary::get_item_navigation_mesh(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<NavigationMesh>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].navigation_mesh;
+}
+
+void MeshLibrary::set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].navigation_mesh_transform = p_transform;
+	emit_changed();
+}
+
+Transform3D MeshLibrary::get_item_navigation_mesh_transform(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Transform3D(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].navigation_mesh_transform;
+}
+
+void MeshLibrary::set_item_navigation_layers(int p_item, uint32_t p_navigation_layers) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].navigation_layers = p_navigation_layers;
+	emit_changed();
+}
+
+uint32_t MeshLibrary::get_item_navigation_layers(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), 0, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].navigation_layers;
+}
+#endif // NAVIGATION_3D_DISABLED
 
 #ifndef PHYSICS_3D_DISABLED
 void MeshLibrary::_set_item_shapes(int p_item, const Array &p_shapes) {
@@ -366,6 +466,18 @@ Array MeshLibrary::_get_item_shapes(int p_item) const {
 
 	return ret;
 }
+
+void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].shapes = p_shapes;
+	emit_changed();
+	notify_property_list_changed();
+}
+
+Vector<MeshLibrary::ShapeData> MeshLibrary::get_item_shapes(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Vector<ShapeData>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].shapes;
+}
 #endif // PHYSICS_3D_DISABLED
 
 void MeshLibrary::reset_state() {
@@ -373,35 +485,46 @@ void MeshLibrary::reset_state() {
 }
 void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_item", "id"), &MeshLibrary::create_item);
-	ClassDB::bind_method(D_METHOD("set_item_name", "id", "name"), &MeshLibrary::set_item_name);
-	ClassDB::bind_method(D_METHOD("set_item_mesh", "id", "mesh"), &MeshLibrary::set_item_mesh);
-	ClassDB::bind_method(D_METHOD("set_item_mesh_transform", "id", "mesh_transform"), &MeshLibrary::set_item_mesh_transform);
-	ClassDB::bind_method(D_METHOD("set_item_mesh_cast_shadow", "id", "shadow_casting_setting"), &MeshLibrary::set_item_mesh_cast_shadow);
-	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh);
-	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh_transform", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh_transform);
-	ClassDB::bind_method(D_METHOD("set_item_navigation_layers", "id", "navigation_layers"), &MeshLibrary::set_item_navigation_layers);
-#ifndef PHYSICS_3D_DISABLED
-	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
-#endif // PHYSICS_3D_DISABLED
-	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
-	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
-	ClassDB::bind_method(D_METHOD("get_item_mesh", "id"), &MeshLibrary::get_item_mesh);
-	ClassDB::bind_method(D_METHOD("get_item_mesh_transform", "id"), &MeshLibrary::get_item_mesh_transform);
-	ClassDB::bind_method(D_METHOD("get_item_mesh_cast_shadow", "id"), &MeshLibrary::get_item_mesh_cast_shadow);
-	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh", "id"), &MeshLibrary::get_item_navigation_mesh);
-	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh_transform", "id"), &MeshLibrary::get_item_navigation_mesh_transform);
-	ClassDB::bind_method(D_METHOD("get_item_navigation_layers", "id"), &MeshLibrary::get_item_navigation_layers);
-#ifndef PHYSICS_3D_DISABLED
-	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
-#endif // PHYSICS_3D_DISABLED
-	ClassDB::bind_method(D_METHOD("get_item_preview", "id"), &MeshLibrary::get_item_preview);
 	ClassDB::bind_method(D_METHOD("remove_item", "id"), &MeshLibrary::remove_item);
+
 	ClassDB::bind_method(D_METHOD("find_item_by_name", "name"), &MeshLibrary::find_item_by_name);
 
-	ClassDB::bind_method(D_METHOD("clear"), &MeshLibrary::clear);
+	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
+	ClassDB::bind_method(D_METHOD("get_item_preview", "id"), &MeshLibrary::get_item_preview);
+
 	ClassDB::bind_method(D_METHOD("get_item_list"), &MeshLibrary::get_item_list);
 	ClassDB::bind_method(D_METHOD("get_item_count"), &MeshLibrary::get_item_count);
 	ClassDB::bind_method(D_METHOD("get_last_unused_item_id"), &MeshLibrary::get_last_unused_item_id);
+
+	ClassDB::bind_method(D_METHOD("set_item_name", "id", "name"), &MeshLibrary::set_item_name);
+	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
+
+	ClassDB::bind_method(D_METHOD("set_item_mesh", "id", "mesh"), &MeshLibrary::set_item_mesh);
+	ClassDB::bind_method(D_METHOD("get_item_mesh", "id"), &MeshLibrary::get_item_mesh);
+
+	ClassDB::bind_method(D_METHOD("set_item_mesh_transform", "id", "mesh_transform"), &MeshLibrary::set_item_mesh_transform);
+	ClassDB::bind_method(D_METHOD("get_item_mesh_transform", "id"), &MeshLibrary::get_item_mesh_transform);
+
+	ClassDB::bind_method(D_METHOD("set_item_mesh_cast_shadow", "id", "shadow_casting_setting"), &MeshLibrary::set_item_mesh_cast_shadow);
+	ClassDB::bind_method(D_METHOD("get_item_mesh_cast_shadow", "id"), &MeshLibrary::get_item_mesh_cast_shadow);
+
+#ifndef NAVIGATION_3D_DISABLED
+	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh);
+	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh", "id"), &MeshLibrary::get_item_navigation_mesh);
+
+	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh_transform", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh_transform);
+	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh_transform", "id"), &MeshLibrary::get_item_navigation_mesh_transform);
+
+	ClassDB::bind_method(D_METHOD("set_item_navigation_layers", "id", "navigation_layers"), &MeshLibrary::set_item_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_item_navigation_layers", "id"), &MeshLibrary::get_item_navigation_layers);
+#endif // NAVIGATION_3D_DISABLED
+
+#ifndef PHYSICS_3D_DISABLED
+	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
+	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
+#endif // PHYSICS_3D_DISABLED
+
+	ClassDB::bind_method(D_METHOD("clear"), &MeshLibrary::clear);
 }
 
 MeshLibrary::MeshLibrary() {

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -86,9 +86,11 @@ public:
 	void set_item_mesh(int p_item, const Ref<Mesh> &p_mesh);
 	void set_item_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_mesh_cast_shadow(int p_item, RSE::ShadowCastingSetting p_shadow_casting_setting);
+#ifndef NAVIGATION_3D_DISABLED
 	void set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh);
 	void set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_navigation_layers(int p_item, uint32_t p_navigation_layers);
+#endif // NAVIGATION_3D_DISABLED
 #ifndef PHYSICS_3D_DISABLED
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 #endif // PHYSICS_3D_DISABLED
@@ -97,24 +99,57 @@ public:
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Transform3D get_item_mesh_transform(int p_item) const;
 	RSE::ShadowCastingSetting get_item_mesh_cast_shadow(int p_item) const;
+#ifndef NAVIGATION_3D_DISABLED
 	Ref<NavigationMesh> get_item_navigation_mesh(int p_item) const;
 	Transform3D get_item_navigation_mesh_transform(int p_item) const;
 	uint32_t get_item_navigation_layers(int p_item) const;
+#endif // NAVIGATION_3D_DISABLED
 #ifndef PHYSICS_3D_DISABLED
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 #endif // PHYSICS_3D_DISABLED
 	Ref<Texture2D> get_item_preview(int p_item) const;
 
 	void remove_item(int p_item);
+
 	bool has_item(int p_item) const;
-
-	void clear();
-
 	int find_item_by_name(const String &p_name) const;
 
 	Vector<int> get_item_list() const;
 	int get_item_count() const { return item_map.size(); }
 	int get_last_unused_item_id() const;
+
+	void set_item_name(int p_item, const String &p_name);
+	String get_item_name(int p_item) const;
+
+	void set_item_mesh(int p_item, const Ref<Mesh> &p_mesh);
+	Ref<Mesh> get_item_mesh(int p_item) const;
+
+	void set_item_mesh_transform(int p_item, const Transform3D &p_transform);
+	Transform3D get_item_mesh_transform(int p_item) const;
+
+	void set_item_mesh_cast_shadow(int p_item, RS::ShadowCastingSetting p_shadow_casting_setting);
+	RS::ShadowCastingSetting get_item_mesh_cast_shadow(int p_item) const;
+
+	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
+	Ref<Texture2D> get_item_preview(int p_item) const;
+
+#ifndef NAVIGATION_3D_DISABLED
+	void set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh);
+	Ref<NavigationMesh> get_item_navigation_mesh(int p_item) const;
+
+	void set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform);
+	Transform3D get_item_navigation_mesh_transform(int p_item) const;
+
+	void set_item_navigation_layers(int p_item, uint32_t p_navigation_layers);
+	uint32_t get_item_navigation_layers(int p_item) const;
+#endif // NAVIGATION_3D_DISABLED
+
+#ifndef PHYSICS_3D_DISABLED
+	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
+	Vector<ShapeData> get_item_shapes(int p_item) const;
+#endif // PHYSICS_3D_DISABLED
+
+	void clear();
 
 	MeshLibrary();
 	~MeshLibrary();


### PR DESCRIPTION
* Fix building with `disable_physics_3d=yes`, regession from: https://github.com/godotengine/godot/pull/107391
* Fix unit tests when `Navigation3D` is disabled.

Build fails here: https://github.com/godotengine/godot/actions/runs/18333920913

Tested all the debug templates here after this PR: https://github.com/godotengine/godot/actions/runs/18337500431