### PR TITLE
Remove `compositor.h` include from `world_3d.h`.

### DIFF
--- a/scene/resources/3d/world_3d.h
+++ b/scene/resources/3d/world_3d.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "scene/resources/compositor.h"
 #include "scene/resources/environment.h"
 
 #ifndef PHYSICS_3D_DISABLED
@@ -40,6 +39,7 @@
 
 class CameraAttributes;
 class Camera3D;
+class Compositor;
 class VisibleOnScreenNotifier3D;
 struct SpatialIndexer;
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -34,6 +34,7 @@
 #include "core/io/file_access.h"
 #include "core/io/missing_resource.h"
 #include "core/io/resource_loader.h"
+#include "core/object/script_language.h"
 #include "core/templates/local_vector.h"
 #include "scene/2d/node_2d.h"
 #include "scene/gui/control.h"


### PR DESCRIPTION
- Helps address #111218 

I've profiled a random compile unit (`audio_stream_editor_plugin.json`). As a `Node3D` inheritor (which is somewhat common), it includes an include path to `world_3d.h`. I initially tried to remove the `world_3d.h` include, but it turns out, most `Node3D` make active use of it. 

`world_3d.h`'s build cost is mostly caused by `compositor.h`, which can be more easily removed. It accounts for 10% of total build time in this compile unit, through `render_data.h` > `render_scene_data.h` > `script_language.h` > `doc_data.h`.

