### PR TITLE
Remove transitive rendering includes from `node.h`

### DIFF
--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/gui/box_container.h"
+#include "scene/resources/material.h"
 
 class Button;
 class ConfirmationDialog;

--- a/editor/scene/2d/path_2d_editor_plugin.cpp
+++ b/editor/scene/2d/path_2d_editor_plugin.cpp
@@ -38,6 +38,7 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/menu_button.h"
+#include "scene/resources/mesh.h"
 
 void Path2DEditor::_notification(int p_what) {
 	switch (p_what) {

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -46,6 +46,7 @@
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/view_panner.h"
+#include "scene/resources/mesh.h"
 #include "thirdparty/clipper2/include/clipper2/clipper.h"
 
 #define PRECISION 1

--- a/editor/scene/3d/node_3d_editor_gizmos.h
+++ b/editor/scene/3d/node_3d_editor_gizmos.h
@@ -35,6 +35,7 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/3d/skeleton_3d.h"
+#include "scene/resources/mesh.h"
 
 class Timer;
 class EditorNode3DGizmoPlugin;

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -30,6 +30,7 @@
 
 #include "multiplayer_spawner.h"
 
+#include "core/io/resource_loader.h"
 #include "scene/main/multiplayer_api.h"
 
 #ifdef TOOLS_ENABLED

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/math/geometry_2d.h"
 #include "scene/main/timer.h"
+#include "scene/resources/mesh.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/themes/editor_scale.h"

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -37,6 +37,7 @@
 #include "scene/main/viewport.h"
 #include "scene/resources/curve_texture.h"
 #include "scene/resources/gradient_texture.h"
+#include "scene/resources/mesh.h"
 #include "scene/resources/particle_process_material.h"
 
 AABB CPUParticles3D::get_aabb() const {

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -34,6 +34,7 @@
 #include "scene/3d/cpu_particles_3d.h"
 #include "scene/resources/curve_texture.h"
 #include "scene/resources/gradient_texture.h"
+#include "scene/resources/mesh.h"
 #include "scene/resources/particle_process_material.h"
 
 AABB GPUParticles3D::get_aabb() const {

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -31,6 +31,7 @@
 #include "label_3d.h"
 
 #include "scene/main/window.h"
+#include "scene/resources/mesh.h"
 #include "scene/resources/theme.h"
 #include "scene/theme/theme_db.h"
 

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -32,6 +32,7 @@
 
 #include "core/templates/local_vector.h"
 #include "scene/3d/visual_instance_3d.h"
+#include "scene/resources/mesh.h"
 
 #ifndef NAVIGATION_3D_DISABLED
 class NavigationMesh;

--- a/scene/3d/navigation/navigation_agent_3d.h
+++ b/scene/3d/navigation/navigation_agent_3d.h
@@ -36,6 +36,7 @@
 #include "servers/navigation_3d/navigation_path_query_result_3d.h"
 
 class Node3D;
+class StandardMaterial3D;
 
 class NavigationAgent3D : public Node {
 	GDCLASS(NavigationAgent3D, Node);

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "path_3d.h"
 
+#include "scene/resources/mesh.h"
+
 Path3D::Path3D() {
 	SceneTree *st = SceneTree::get_singleton();
 	if (st && st->is_debugging_paths_hint()) {

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -31,6 +31,7 @@
 #include "collision_object_3d.h"
 
 #include "scene/resources/3d/shape_3d.h"
+#include "scene/resources/mesh.h"
 
 void CollisionObject3D::_notification(int p_what) {
 	switch (p_what) {

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -32,6 +32,7 @@
 
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/node_3d.h"
+#include "scene/resources/3d/shape_3d.h"
 
 class CollisionObject3D : public Node3D {
 	GDCLASS(CollisionObject3D, Node3D);

--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -31,6 +31,7 @@
 #include "ray_cast_3d.h"
 
 #include "scene/3d/physics/collision_object_3d.h"
+#include "scene/resources/mesh.h"
 
 void RayCast3D::set_target_position(const Vector3 &p_point) {
 	target_position = p_point;

--- a/scene/3d/physics/shape_cast_3d.cpp
+++ b/scene/3d/physics/shape_cast_3d.cpp
@@ -32,6 +32,7 @@
 
 #include "scene/3d/physics/collision_object_3d.h"
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
+#include "scene/resources/mesh.h"
 
 void ShapeCast3D::_notification(int p_what) {
 	switch (p_what) {

--- a/scene/3d/physics/spring_arm_3d.h
+++ b/scene/3d/physics/spring_arm_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/3d/node_3d.h"
+#include "scene/resources/3d/shape_3d.h"
 
 class SpringArm3D : public Node3D {
 	GDCLASS(SpringArm3D, Node3D);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -31,6 +31,7 @@
 #include "sprite_3d.h"
 
 #include "scene/resources/atlas_texture.h"
+#include "scene/resources/mesh.h"
 
 Color SpriteBase3D::_get_color_accum() {
 	if (!color_dirty) {

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -32,6 +32,8 @@
 
 #include "scene/3d/node_3d.h"
 
+class TriangleMesh;
+
 class VisualInstance3D : public Node3D {
 	GDCLASS(VisualInstance3D, Node3D);
 

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/animation/animation_tree.h"
+#include "scene/resources/curve.h"
 
 class AnimationNodeAnimation : public AnimationRootNode {
 	GDCLASS(AnimationNodeAnimation, AnimationRootNode);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -32,6 +32,7 @@
 
 #include "core/math/expression.h"
 #include "scene/animation/animation_tree.h"
+#include "scene/resources/curve.h"
 
 class AnimationNodeStateMachineTransition : public Resource {
 	GDCLASS(AnimationNodeStateMachineTransition, Resource);

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -33,6 +33,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/popup.h"
+#include "scene/resources/shader.h"
 
 class AspectRatioContainer;
 class ColorMode;

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -31,6 +31,7 @@
 #include "color_picker_shape.h"
 
 #include "scene/gui/margin_container.h"
+#include "scene/resources/material.h"
 
 void ColorPickerShape::_emit_color_changed() {
 	color_picker->emit_signal(SNAME("color_changed"), color_picker->color);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -44,6 +44,7 @@
 #include "scene/gui/scroll_bar.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/view_panner.h"
+#include "scene/resources/material.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/theme/theme_db.h"
 

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -34,6 +34,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/graph_frame.h"
 #include "scene/gui/graph_node.h"
+#include "scene/resources/shader.h"
 
 class Button;
 class GraphEdit;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -32,6 +32,7 @@
 #include "rich_text_label.compat.inc"
 
 #include "core/input/input_map.h"
+#include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -31,6 +31,10 @@
 #include "node.h"
 #include "node.compat.inc"
 
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Mesh);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Shader);
+
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/object/message_queue.h"

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -35,10 +35,11 @@
 #include "core/templates/paged_allocator.h"
 #include "core/templates/self_list.h"
 #include "scene/main/scene_tree_fti.h"
-#include "scene/resources/mesh.h"
+#include "servers/display/display_server.h"
 
 #undef Window
 
+class ArrayMesh;
 class PackedScene;
 class Node;
 #ifndef _3D_DISABLED

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -31,6 +31,7 @@
 #include "shader_globals_override.h"
 
 #include "scene/main/node.h"
+#include "servers/rendering/rendering_server.h"
 
 StringName *ShaderGlobalsOverride::_remap(const StringName &p_name) const {
 	StringName *r = param_remaps.getptr(p_name);

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -31,6 +31,7 @@
 #include "property_utils.h"
 
 #include "core/config/engine.h"
+#include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
 #include "core/templates/local_vector.h"
 #include "scene/resources/packed_scene.h"

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -31,6 +31,7 @@
 #include "visual_shader_particle_nodes.h"
 
 #include "scene/resources/image_texture.h"
+#include "scene/resources/mesh.h"
 
 // VisualShaderNodeParticleEmitter
 


### PR DESCRIPTION
- Helps address #111218 

This PR reduces total compile time by 3% (going by a single test). Further, it will benefit rendering contributors  because changes to rendering files will no longer cause a recompilation of almost all compile units.

## Explanation

`node.h` is a giant include hub. Most of our compile units include it in some way.
It currently has an include path to rendering (`mesh.h`, `shader.h`, `rendering_server.h`). However, most `Node` users don't interact with rendering at all.

This PR removes this include path (by removing the `mesh.h` include `scene_tree.h`), simply by forward-declaring `ArrayMesh`.

The cascading changes are individually simple and logical:
- Explicit includes in headers to previously transitively included headers.
- Explicit includes to `mesh.h` in cpp files that have meshes of their own.
- Forward declarations of other mesh types in headers that only use them internally.

Further, I'm making use of `STATIC_ASSERT_INCOMPLETE_TYPE` to prevent regression of this PR.