### PR TITLE
Fix crash in Jolt when doing incremental builds

### DIFF
--- a/thirdparty/jolt_physics/Jolt/RegisterTypes.cpp
+++ b/thirdparty/jolt_physics/Jolt/RegisterTypes.cpp
@@ -74,6 +74,10 @@ void RegisterTypesInternal(uint64 inVersionID)
 	{
 		Trace("Version mismatch, make sure you compile the client code with the same Jolt version and compiler definitions!");
 		uint64 mismatch = JPH_VERSION_ID ^ inVersionID;
+		if (mismatch & 0xffffff)
+			Trace("Client reported version %d.%d.%d, library version is %d.%d.%d.",
+				(inVersionID >> 16) & 0xff, (inVersionID >> 8) & 0xff, inVersionID & 0xff,
+				JPH_VERSION_MAJOR, JPH_VERSION_MINOR, JPH_VERSION_PATCH);
 		auto check_bit = [mismatch](int inBit, const char *inLabel) { if (mismatch & (uint64(1) << (inBit + 23))) Trace("Mismatching define %s.", inLabel); };
 		check_bit(1, "JPH_DOUBLE_PRECISION");
 		check_bit(2, "JPH_CROSS_PLATFORM_DETERMINISTIC");


### PR DESCRIPTION
We've had at least one report of someone crashing here after doing an incremental build after #110965 was merged:

https://github.com/godotengine/godot/blob/d61cd9149aaee6195b83bc65ca5539a27d76d61f/thirdparty/jolt_physics/Jolt/RegisterTypes.cpp#L72-L90

The reason for this isn't confirmed, but is (as discussed in #110965) potentially as follows:

1. [#104893](https://github.com/godotengine/godot/pull/104893) broke the SCons dependencies between the source and header files in `thirdparty/jolt_physics` (and possibly other third-party vendorings as well).
2. This was then reverted in [#111331](https://github.com/godotengine/godot/pull/111331), but since the revert relies on changing `CPPPATH`, it likely clashes with us relying on `fast_unsafe=yes` by default when `dev_build=yes`, which enables the `implicit_cache` SCons option, which in [its documentation](https://scons.org/doc/production/HTML/scons-user/ch06s03.html) states that it causes SCons to "ignore any changes that may have been made to search paths (like $CPPPATH or $LIBPATH)".
3. [#110965](https://github.com/godotengine/godot/pull/110965) was then merged, and while `Jolt/RegisterTypes.cpp` didn't have any changes to it, it **should** still have been recompiled, since its header dependencies did change, but these dependencies were likely not restored because of `fast_unsafe=yes`.
4. Jolt then (rightfully) `std::abort` in its version check because the compilation environment of that particular file doesn't line up with the caller's compilation environment, leading to this crash.

While the fix here is as simple as doing a clean rebuild, this will likely keep happening to people in the future as they go to bisect with `dev_build=yes`, since incremental builds from any commit between 1f56d96cf2c768c3844c68ccb504dfeee841ae15 and 9052d31c68b852f9b38f4e60f1956a97386d0153 will be subject to this.

As such, this PR cherrypicks jrouwe/JoltPhysics@9e48d59beea6a10ee8dfed45216c2dec7e9a8918 in order to have some kind of change to `Jolt/RegisterTypes.cpp`, which should at least prevent the crash from happening going forward.

Note that the crash is arguably a red herring here, the real problem is ending up with incomplete incremental builds because of what is likely to be `fast_unsafe=yes`, potentially across several third-party vendorings.