### PR TITLE
Add source lines to file locations on POT generation

### DIFF
--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[EditorTranslationParserPlugin] is invoked when a file is being parsed to extract strings that require translation. To define the parsing and string extraction logic, override the [method _parse_file] method in script.
-		The return value should be an [Array] of [PackedStringArray]s, one for each extracted translatable string. Each entry should contain [code][msgid, msgctxt, msgid_plural, comment][/code], where all except [code]msgid[/code] are optional. Empty strings will be ignored.
+		The return value should be an [Array] of [PackedStringArray]s, one for each extracted translatable string. Each entry should contain [code][msgid, msgctxt, msgid_plural, comment, source_line][/code], where all except [code]msgid[/code] are optional. Empty strings will be ignored.
 		The extracted strings will be written into a POT file selected by user under "POT Generation" in "Localization" tab in "Project Settings" menu.
 		Below shows an example of a custom parser that extracts strings from a CSV file to write into a POT.
 		[codeblocks]
@@ -54,19 +54,19 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		To add a translatable string associated with a context, plural, or comment:
+		To add a translatable string associated with a context, plural, comment, or source line:
 		[codeblocks]
 		[gdscript]
-		# This will add a message with msgid "Test 1", msgctxt "context", msgid_plural "test 1 plurals", and comment "test 1 comment".
-		ret.append(PackedStringArray(["Test 1", "context", "test 1 plurals", "test 1 comment"]))
+		# This will add a message with msgid "Test 1", msgctxt "context", msgid_plural "test 1 plurals", comment "test 1 comment", and source line "7".
+		ret.append(PackedStringArray(["Test 1", "context", "test 1 plurals", "test 1 comment", "7"]))
 		# This will add a message with msgid "A test without context" and msgid_plural "plurals".
 		ret.append(PackedStringArray(["A test without context", "", "plurals"]))
 		# This will add a message with msgid "Only with context" and msgctxt "a friendly context".
 		ret.append(PackedStringArray(["Only with context", "a friendly context"]))
 		[/gdscript]
 		[csharp]
-		// This will add a message with msgid "Test 1", msgctxt "context", msgid_plural "test 1 plurals", and comment "test 1 comment".
-		ret.Add(["Test 1", "context", "test 1 plurals", "test 1 comment"]);
+		// This will add a message with msgid "Test 1", msgctxt "context", msgid_plural "test 1 plurals", comment "test 1 comment", and source line "7".
+		ret.Add(["Test 1", "context", "test 1 plurals", "test 1 comment", "7"]);
 		// This will add a message with msgid "A test without context" and msgid_plural "plurals".
 		ret.Add(["A test without context", "", "plurals"]);
 		// This will add a message with msgid "Only with context" and msgctxt "a friendly context".

--- a/editor/translations/pot_generator.cpp
+++ b/editor/translations/pot_generator.cpp
@@ -84,7 +84,12 @@ void POTGenerator::generate_pot(const String &p_file) {
 			const String &msgctxt = (translation.size() > 1) ? translation[1] : String();
 			const String &msgid_plural = (translation.size() > 2) ? translation[2] : String();
 			const String &comment = (translation.size() > 3) ? translation[3] : String();
-			_add_new_msgid(translation[0], msgctxt, msgid_plural, file_path, comment);
+			const int source_line = (translation.size() > 4) ? translation[4].to_int() : 0;
+			String location = file_path;
+			if (source_line > 0) {
+				location += vformat(":%d", source_line);
+			}
+			_add_new_msgid(translation[0], msgctxt, msgid_plural, location, comment);
 		}
 	}
 

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -126,7 +126,7 @@ void GDScriptEditorTranslationParserPlugin::_add_id(const String &p_id, int p_li
 		return;
 	}
 
-	translations->push_back({ p_id, String(), String(), comment });
+	translations->push_back({ p_id, String(), String(), comment, itos(p_line) });
 }
 
 void GDScriptEditorTranslationParserPlugin::_add_id_ctx_plural(const Vector<String> &p_id_ctx_plural, int p_line) {
@@ -136,7 +136,7 @@ void GDScriptEditorTranslationParserPlugin::_add_id_ctx_plural(const Vector<Stri
 		return;
 	}
 
-	translations->push_back({ p_id_ctx_plural[0], p_id_ctx_plural[1], p_id_ctx_plural[2], comment });
+	translations->push_back({ p_id_ctx_plural[0], p_id_ctx_plural[1], p_id_ctx_plural[2], comment, itos(p_line) });
 }
 
 void GDScriptEditorTranslationParserPlugin::_traverse_class(const GDScriptParser::ClassNode *p_class) {


### PR DESCRIPTION
[gettext](https://en.wikipedia.org/wiki/Gettext) allows not just adding the file path where a string comes from, but also the specific line number. This PR makes so that strings extracted from GDScripts also state the source line, as well as allowing plugins to do the same.