### PR TITLE
Fix crash when rearranging filtered animation tracks

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3921,8 +3921,13 @@ void AnimationTrackEditor::remove_track_edit_plugin(const Ref<AnimationTrackEdit
 }
 
 void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_read_only) {
-	if (animation != p_anim && _get_track_selected() >= 0) {
-		track_edits[_get_track_selected()]->release_focus();
+	if (animation != p_anim) {
+		for (int i = 0; i < track_edits.size(); i++) {
+			if (track_edits[i]->has_focus()) {
+				track_edits[i]->release_focus();
+				break;
+			}
+		}
 	}
 	if (animation.is_valid()) {
 		animation->disconnect_changed(callable_mp(this, &AnimationTrackEditor::_animation_changed));
@@ -4191,7 +4196,11 @@ void AnimationTrackEditor::_animation_track_remove_request(int p_track, Ref<Anim
 void AnimationTrackEditor::_track_grab_focus(int p_track) {
 	// Don't steal focus if not working with the track editor.
 	if (Object::cast_to<AnimationTrackEdit>(get_viewport()->gui_get_focus_owner())) {
-		track_edits[p_track]->grab_focus();
+		for (int i = 0; i < track_edits.size(); i++) {
+			if (track_edits[i]->get_track() == p_track) {
+				track_edits[i]->grab_focus();
+			}
+		}
 	}
 }
 
@@ -5704,7 +5713,7 @@ void AnimationTrackEditor::_timeline_value_changed(double) {
 int AnimationTrackEditor::_get_track_selected() {
 	for (int i = 0; i < track_edits.size(); i++) {
 		if (track_edits[i]->has_focus()) {
-			return i;
+			return track_edits[i]->get_track();
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes https://github.com/godotengine/godot/issues/99713.

The root cause was using the real track index (unaffected by filtering) to index into a list of track edit controls (potentially smaller when filtered). Curiously, other than the crash when dropping a track at the bottom the correct control still somehow received focus. This is because there was another opposite index mixup cancelling it out: `_update_tracks()` fetched the index of the selected edit control but treated it as a real track index.

I found at least one other edge case bug fixed by this PR, that I found no open issue for: Pasting a key via the Edit menu with a track selected and node filtering enabled would paste the key into the wrong track.

For convenience, pre-packaged MRP (original issue provided it as a .tscn code block): 
[animation-player-crash_2025-10-08_21-27-00.zip](https://github.com/user-attachments/files/22784760/animation-player-crash_2025-10-08_21-27-00.zip)
