### PR TITLE
Core: Add support for loading engine shaders from disk

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -80,6 +80,7 @@ private:
 	bool extra_gpu_memory_tracking = false;
 #if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
 	bool accurate_breadcrumbs = false;
+	String _godot_source_root;
 #endif
 	int32_t gpu_idx = -1;
 
@@ -214,6 +215,9 @@ public:
 	bool is_extra_gpu_memory_tracking_enabled() const;
 #if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
 	bool is_accurate_breadcrumbs_enabled() const;
+	const String &godot_source_root() const {
+		return _godot_source_root;
+	}
 #endif
 	int32_t get_gpu_index() const;
 

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -126,6 +126,13 @@ public:
         file.write(f"""\
 		setup(_vertex_code, _fragment_code, _compute_code, "{class_name}");
 	}}
+""")
+        file.write(f"""\
+
+protected:
+#ifdef DEV_ENABLED
+	const char *rel_shader_path() const override {{ return "{os.path.relpath(shader)}"; }}
+#endif
 }};
 """)
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -637,6 +637,7 @@ void Main::print_help(const char *p_binary) {
 #if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
 	print_help_option("--extra-gpu-memory-tracking", "Enables additional memory tracking (see class reference for `RenderingDevice.get_driver_and_device_memory_report()` and linked methods). Currently only implemented for Vulkan. Enabling this feature may cause crashes on some systems due to buggy drivers or bugs in the Vulkan Loader. See https://github.com/godotengine/godot/issues/95967\n");
 	print_help_option("--accurate-breadcrumbs", "Force barriers between breadcrumbs. Useful for narrowing down a command causing GPU resets. Currently only implemented for Vulkan.\n");
+	print_help_option("--source-root", "Specify the path to Godot's source for enabling shader dynamic loading of core shaders.");
 #endif
 	print_help_option("--remote-debug <uri>", "Remote debug (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007).\n");
 	print_help_option("--single-threaded-scene", "Force scene tree to run in single-threaded mode. Sub-thread groups are disabled and run on the main thread.\n");
@@ -1272,6 +1273,20 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			Engine::singleton->extra_gpu_memory_tracking = true;
 		} else if (arg == "--accurate-breadcrumbs") {
 			Engine::singleton->accurate_breadcrumbs = true;
+		} else if (arg == "--source-root") {
+			if (N) {
+				Engine::singleton->_godot_source_root = N->get();
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing path for source-root argument, aborting.\n");
+				goto error;
+			}
+			// Test the existence of a well-known file, to verify the path is valid.
+			String shader_path = Engine::singleton->_godot_source_root.path_join("SConstruct");
+			if (!FileAccess::exists(shader_path)) {
+				OS::get_singleton()->print("Invalid Godot source root path.");
+				goto error;
+			}
 #endif
 		} else if (arg == "--tablet-driver") {
 			if (N) {

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -168,6 +168,9 @@ private:
 protected:
 	ShaderRD();
 	void setup(const char *p_vertex_code, const char *p_fragment_code, const char *p_compute_code, const char *p_name);
+#ifdef DEV_ENABLED
+	virtual char const *rel_shader_path() const { return ""; }
+#endif
 
 public:
 	RID version_create(bool p_embedded = true);

--- a/tests/python_build/fixtures/rd_glsl/compute.out
+++ b/tests/python_build/fixtures/rd_glsl/compute.out
@@ -22,4 +22,9 @@ void main() {
 		};
 		setup(_vertex_code, _fragment_code, _compute_code, "ComputeShaderRD");
 	}
+
+protected:
+#ifdef DEV_ENABLED
+	const char *rel_shader_path() const override { return "tests/python_build/fixtures/rd_glsl/compute.glsl"; }
+#endif
 };

--- a/tests/python_build/fixtures/rd_glsl/vertex_fragment.out
+++ b/tests/python_build/fixtures/rd_glsl/vertex_fragment.out
@@ -35,4 +35,9 @@ void main() {
 		static const char *_compute_code = nullptr;
 		setup(_vertex_code, _fragment_code, _compute_code, "VertexFragmentShaderRD");
 	}
+
+protected:
+#ifdef DEV_ENABLED
+	const char *rel_shader_path() const override { return "tests/python_build/fixtures/rd_glsl/vertex_fragment.glsl"; }
+#endif
 };


### PR DESCRIPTION
# Summary

When `DEV_ENABLED` is defined, core `.glsl` shaders can be changed without recompiling Godot.

> [!IMPORTANT]
>
> This feature is intended for **engine developers**.

# How to use

Specify `--source-root <godot source root>` and then in Project Settings you'll be able to configure individual shaders to load from disk by enabling a property under `rendering/shaders/load_from_file/*`:

<img width="2271" height="1483" alt="CleanShot 2025-10-09 at 07 14 04@2x" src="https://github.com/user-attachments/assets/2b30b2f6-c2ab-4b84-8289-0ab11f2dcd38" />

> [!IMPORTANT]
>
> When the `--source-root` argument is absent, the project settings do _not_ include this section.

https://github.com/user-attachments/assets/e805e0c3-ba81-4c91-a239-2851b4bdb007
