### PR TITLE
Reorder registration of types, to register supertypes before subtypes.

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -181,8 +181,8 @@ void register_core_types() {
 
 	GDREGISTER_CLASS(Shortcut);
 	GDREGISTER_ABSTRACT_CLASS(InputEvent);
-	GDREGISTER_ABSTRACT_CLASS(InputEventWithModifiers);
 	GDREGISTER_ABSTRACT_CLASS(InputEventFromWindow);
+	GDREGISTER_ABSTRACT_CLASS(InputEventWithModifiers);
 	GDREGISTER_CLASS(InputEventKey);
 	GDREGISTER_CLASS(InputEventShortcut);
 	GDREGISTER_ABSTRACT_CLASS(InputEventMouse);

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -382,7 +382,18 @@ static Variant get_documentation_default_value(const StringName &p_class_name, c
 	if (ClassDB::can_instantiate(p_class_name) && !ClassDB::is_virtual(p_class_name)) { // Keep this condition in sync with ClassDB::class_get_default_property_value.
 		default_value = ClassDB::class_get_default_property_value(p_class_name, p_property_name, &r_default_value_valid);
 	} else {
-		// Cannot get default value of classes that can't be instantiated
+		// Cannot get default value of classes that can't be instantiated.
+
+		// Let's see if the abstract class has an explicitly set default.
+		const HashMap<StringName, Variant> *default_properties = ClassDB::default_values.getptr(p_class_name);
+		if (default_properties) {
+			const Variant *property = default_properties->getptr(p_property_name);
+			if (property) {
+				r_default_value_valid = true;
+				return *property;
+			}
+		}
+
 		List<StringName> inheriting_classes;
 		ClassDB::get_direct_inheriters_from_class(p_class_name, &inheriting_classes);
 		for (const StringName &class_name : inheriting_classes) {

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1496,6 +1496,9 @@ void CanvasItem::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_parent_material"), "set_use_parent_material", "get_use_parent_material");
 	// ADD_PROPERTY(PropertyInfo(Variant::BOOL,"transform/notify"),"set_transform_notify","is_transform_notify_enabled");
 
+	// Supply property explicitly; workaround for GH-111431 docs issue.
+	ADD_PROPERTY_DEFAULT("physics_interpolation_mode", PhysicsInterpolationMode::PHYSICS_INTERPOLATION_MODE_INHERIT);
+
 	ADD_SIGNAL(MethodInfo("draw"));
 	ADD_SIGNAL(MethodInfo("visibility_changed"));
 	ADD_SIGNAL(MethodInfo("hidden"));

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -414,6 +414,14 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(MissingNode);
 	GDREGISTER_ABSTRACT_CLASS(InstancePlaceholder);
 
+	GDREGISTER_ABSTRACT_CLASS(CanvasItem);
+
+	GDREGISTER_VIRTUAL_CLASS(Texture);
+	GDREGISTER_VIRTUAL_CLASS(Texture2D);
+
+	GDREGISTER_VIRTUAL_CLASS(Material);
+	GDREGISTER_CLASS(PlaceholderMaterial);
+
 	GDREGISTER_ABSTRACT_CLASS(Viewport);
 	GDREGISTER_CLASS(SubViewport);
 	GDREGISTER_CLASS(ViewportTexture);
@@ -428,7 +436,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(HTTPRequest);
 	GDREGISTER_CLASS(Timer);
 	GDREGISTER_CLASS(CanvasLayer);
-	GDREGISTER_CLASS(CanvasModulate);
 	GDREGISTER_CLASS(ResourcePreloader);
 	GDREGISTER_CLASS(Window);
 
@@ -436,14 +443,13 @@ void register_scene_types() {
 
 	/* REGISTER GUI */
 
-	GDREGISTER_CLASS(ButtonGroup);
-	GDREGISTER_VIRTUAL_CLASS(BaseButton);
-
 	OS::get_singleton()->yield(); // may take time to init
 
 	GDREGISTER_CLASS(Control);
+	GDREGISTER_VIRTUAL_CLASS(BaseButton);
 	GDREGISTER_CLASS(Button);
 	GDREGISTER_CLASS(Label);
+	GDREGISTER_VIRTUAL_CLASS(Range);
 	GDREGISTER_ABSTRACT_CLASS(ScrollBar);
 	GDREGISTER_CLASS(HScrollBar);
 	GDREGISTER_CLASS(VScrollBar);
@@ -457,10 +463,11 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CheckButton);
 	GDREGISTER_CLASS(LinkButton);
 	GDREGISTER_CLASS(Panel);
-	GDREGISTER_VIRTUAL_CLASS(Range);
+	GDREGISTER_CLASS(ButtonGroup);
 
 	OS::get_singleton()->yield(); // may take time to init
 
+	GDREGISTER_CLASS(Container);
 	GDREGISTER_CLASS(TextureRect);
 	GDREGISTER_CLASS(ColorRect);
 	GDREGISTER_CLASS(NinePatchRect);
@@ -472,7 +479,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(HSeparator);
 	GDREGISTER_CLASS(VSeparator);
 	GDREGISTER_CLASS(TextureButton);
-	GDREGISTER_CLASS(Container);
 	GDREGISTER_CLASS(BoxContainer);
 	GDREGISTER_CLASS(HBoxContainer);
 	GDREGISTER_CLASS(VBoxContainer);
@@ -496,6 +502,9 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(VideoStream);
 
 #ifndef ADVANCED_GUI_DISABLED
+	GDREGISTER_CLASS(AcceptDialog);
+	GDREGISTER_CLASS(ConfirmationDialog);
+
 	GDREGISTER_CLASS(FileDialog);
 
 	GDREGISTER_CLASS(PopupMenu);
@@ -516,9 +525,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(RichTextLabel);
 	GDREGISTER_CLASS(RichTextEffect);
 	GDREGISTER_CLASS(CharFXTransform);
-
-	GDREGISTER_CLASS(AcceptDialog);
-	GDREGISTER_CLASS(ConfirmationDialog);
 
 	GDREGISTER_CLASS(SubViewportContainer);
 	GDREGISTER_CLASS(SplitContainer);
@@ -599,16 +605,6 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(GeometryInstance3D);
 	GDREGISTER_CLASS(Camera3D);
 	GDREGISTER_CLASS(AudioListener3D);
-#ifndef XR_DISABLED
-	GDREGISTER_CLASS(XRCamera3D);
-	GDREGISTER_CLASS(XRNode3D);
-	GDREGISTER_CLASS(XRController3D);
-	GDREGISTER_CLASS(XRAnchor3D);
-	GDREGISTER_CLASS(XROrigin3D);
-	GDREGISTER_CLASS(XRBodyModifier3D);
-	GDREGISTER_CLASS(XRHandModifier3D);
-	GDREGISTER_CLASS(XRFaceModifier3D);
-#endif // XR_DISABLED
 	GDREGISTER_CLASS(MeshInstance3D);
 	GDREGISTER_CLASS(OccluderInstance3D);
 	GDREGISTER_ABSTRACT_CLASS(Occluder3D);
@@ -645,9 +641,9 @@ void register_scene_types() {
 	GDREGISTER_CLASS(GPUParticlesAttractorVectorField3D);
 	GDREGISTER_CLASS(CPUParticles3D);
 	GDREGISTER_CLASS(Marker3D);
-	GDREGISTER_CLASS(ModifierBoneTarget3D);
 	GDREGISTER_CLASS(RootMotionView);
 	GDREGISTER_VIRTUAL_CLASS(SkeletonModifier3D);
+	GDREGISTER_CLASS(ModifierBoneTarget3D);
 	GDREGISTER_CLASS(RetargetModifier3D);
 	GDREGISTER_CLASS(SpringBoneSimulator3D);
 	GDREGISTER_VIRTUAL_CLASS(SpringBoneCollision3D);
@@ -658,6 +654,17 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CopyTransformModifier3D);
 	GDREGISTER_CLASS(ConvertTransformModifier3D);
 	GDREGISTER_CLASS(AimModifier3D);
+
+#ifndef XR_DISABLED
+	GDREGISTER_CLASS(XRCamera3D);
+	GDREGISTER_CLASS(XRNode3D);
+	GDREGISTER_CLASS(XRController3D);
+	GDREGISTER_CLASS(XRAnchor3D);
+	GDREGISTER_CLASS(XROrigin3D);
+	GDREGISTER_CLASS(XRBodyModifier3D);
+	GDREGISTER_CLASS(XRHandModifier3D);
+	GDREGISTER_CLASS(XRFaceModifier3D);
+#endif // XR_DISABLED
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -844,10 +851,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(VisualShaderNodeParticleAccelerator);
 	GDREGISTER_CLASS(VisualShaderNodeParticleEmit);
 
-	GDREGISTER_VIRTUAL_CLASS(Material);
-	GDREGISTER_CLASS(PlaceholderMaterial);
 	GDREGISTER_CLASS(ShaderMaterial);
-	GDREGISTER_ABSTRACT_CLASS(CanvasItem);
 	GDREGISTER_CLASS(CanvasTexture);
 	GDREGISTER_CLASS(CanvasItemMaterial);
 	SceneTree::add_idle_callback(CanvasItemMaterial::flush_changes);
@@ -891,6 +895,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(LightOccluder2D);
 	GDREGISTER_CLASS(OccluderPolygon2D);
 	GDREGISTER_CLASS(BackBufferCopy);
+	GDREGISTER_CLASS(CanvasModulate);
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -1005,8 +1010,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CameraAttributesPhysical);
 	GDREGISTER_CLASS(CameraAttributesPractical);
 	GDREGISTER_CLASS(World2D);
-	GDREGISTER_VIRTUAL_CLASS(Texture);
-	GDREGISTER_VIRTUAL_CLASS(Texture2D);
 	GDREGISTER_CLASS(Sky);
 	GDREGISTER_CLASS(CompressedTexture2D);
 	GDREGISTER_CLASS(PortableCompressedTexture2D);

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -273,7 +273,9 @@ void register_server_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(PhysicsServer2D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsServer2DExtension);
+	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState2D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectBodyState2DExtension);
+	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState2D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectSpaceState2DExtension);
 
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer2DExtensionRayResult, "Vector2 position;Vector2 normal;RID rid;ObjectID collider_id;Object *collider;int shape");
@@ -281,8 +283,6 @@ void register_server_types() {
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer2DExtensionShapeRestInfo, "Vector2 point;Vector2 normal;RID rid;ObjectID collider_id;int shape;Vector2 linear_velocity");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer2DExtensionMotionResult, "Vector2 travel;Vector2 remainder;Vector2 collision_point;Vector2 collision_normal;Vector2 collider_velocity;real_t collision_depth;real_t collision_safe_fraction;real_t collision_unsafe_fraction;int collision_local_shape;ObjectID collider_id;RID collider;int collider_shape");
 
-	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState2D);
-	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState2D);
 	GDREGISTER_CLASS(PhysicsRayQueryParameters2D);
 	GDREGISTER_CLASS(PhysicsPointQueryParameters2D);
 	GDREGISTER_CLASS(PhysicsShapeQueryParameters2D);
@@ -307,7 +307,9 @@ void register_server_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(PhysicsServer3D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsServer3DExtension);
+	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState3D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectBodyState3DExtension);
+	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState3D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectSpaceState3DExtension)
 	GDREGISTER_VIRTUAL_CLASS(PhysicsServer3DRenderingServerHandler)
 
@@ -317,8 +319,6 @@ void register_server_types() {
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionCollision, "Vector3 position;Vector3 normal;Vector3 collider_velocity;Vector3 collider_angular_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionResult, "Vector3 travel;Vector3 remainder;real_t collision_depth;real_t collision_safe_fraction;real_t collision_unsafe_fraction;PhysicsServer3DExtensionMotionCollision collisions[32];int collision_count");
 
-	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState3D);
-	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState3D);
 	GDREGISTER_CLASS(PhysicsRayQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsPointQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsShapeQueryParameters3D);
@@ -332,16 +332,16 @@ void register_server_types() {
 
 #ifndef XR_DISABLED
 	GDREGISTER_ABSTRACT_CLASS(XRInterface);
+	GDREGISTER_ABSTRACT_CLASS(XRTracker);
 	GDREGISTER_CLASS(XRVRS);
+	GDREGISTER_CLASS(XRPositionalTracker);
 	GDREGISTER_CLASS(XRBodyTracker);
 	GDREGISTER_CLASS(XRControllerTracker);
 	GDREGISTER_CLASS(XRFaceTracker);
 	GDREGISTER_CLASS(XRHandTracker);
 	GDREGISTER_CLASS(XRInterfaceExtension); // can't register this as virtual because we need a creation function for our extensions.
 	GDREGISTER_CLASS(XRPose);
-	GDREGISTER_CLASS(XRPositionalTracker);
 	GDREGISTER_CLASS(XRServer);
-	GDREGISTER_ABSTRACT_CLASS(XRTracker);
 #endif // XR_DISABLED
 
 	if constexpr (GD_IS_CLASS_ENABLED(MovieWriterPNGWAV)) {


### PR DESCRIPTION
- Prepares for and motivated by #106873 

This PR addresses various inconsistencies around registration order, where subtypes are registered before their respective supertypes.

My strategy:
- "Fundamental" types (like `Texture`) that are referenced in many of the blocks are registered at the top.
- Other supertypes are placed above the respective subtypes, if it fits the respective block. Most move only a few lines.
- The exception is `CanvasItem` which is moved from the 2D nodes to the Control nodes (since they're registered above 2D, and also inherit from `CanvasItem`).
- The optional "XR" block is not depended on and moves to the bottom of the `#ifdef`.

I think that covers everything. I worked entirely with cut-paste; no registrations were modified, added or removed.

## About the docs change

The docs instantiate classes automatically to infer default values of properties. Abstract classes cannot be instantiated. To infer default values in abstract classes, the docs will try to instantiate a subclass.
This PR triggered a re-order, which made `CanvasItem`'s 'designated subclass' be `Control` instead of `Node2D`. This caused `physics_interpolation_mode` to be changed, since `Node2D` has a different default from `Control` and `CanvasItem`.

I fixed the problem by supplying a default directly in `CanvasItem` explicitly. This required adding an explicit path for 'non-instantiatable objects that supply their own defaults', which was previously not supported.

Another solution would have been to check the superclass has the same property, and use the same default. However, this may not catch if the subtype changes the default. But, this could be added in a future PR. Even so, to respect `ADD_PROPERTY_DEFAULT` would be a prerequisite, because otherwise incorrect values may appear. So I think adding support for `ADD_PROPERTY_DEFAULT` in abstract classes is the best way to fix this, for now.