### PR TITLE
GDExtension: Allow forward-declaring `GDVIRTUAL`

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -37,6 +37,11 @@
 #include "core/variant/container_type_validate.h"
 #include "scene/main/node.h" //only so casting works
 
+IMPLEMENT_GDVIRTUAL0(Resource, _setup_local_to_scene);
+IMPLEMENT_GDVIRTUAL0RC(Resource, RID, _get_rid);
+IMPLEMENT_GDVIRTUAL1C(Resource, _set_path_cache, String);
+IMPLEMENT_GDVIRTUAL0(Resource, _reset_state);
+
 void Resource::emit_changed() {
 	if (emit_changed_state != EMIT_CHANGED_UNBLOCKED) {
 		emit_changed_state = EMIT_CHANGED_BLOCKED_PENDING_EMIT;

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -114,12 +114,12 @@ protected:
 	void _take_over_path(const String &p_path);
 
 	virtual void reset_local_to_scene();
-	GDVIRTUAL0(_setup_local_to_scene);
+	DECLARE_GDVIRTUAL0(_setup_local_to_scene);
 
-	GDVIRTUAL0RC(RID, _get_rid);
+	DECLARE_GDVIRTUAL0RC(RID, _get_rid);
 
-	GDVIRTUAL1C(_set_path_cache, String);
-	GDVIRTUAL0(_reset_state);
+	DECLARE_GDVIRTUAL1C(_set_path_cache, String);
+	DECLARE_GDVIRTUAL0(_reset_state);
 
 	virtual Ref<Resource> _duplicate(const DuplicateParams &p_params) const;
 


### PR DESCRIPTION
- Fixes #101002
- Helps address #111218

Originally, I attempted to solve the enum issue by resolving Enum data earlier. While that idea can eventually be integrated, it *wouldn't* work for a similar but related issue: forward-declared types. Because these macros cause the functions to be defined immediately, this necessitates files with virtual methods to include headers for *all arguments*, which runs completely counter to current attempts to strip down header chains

This PR addresses this roadblock in a more explicit manner: separate macros to declare & implement virtual functions! While this does end up increasing the size of `gdvirtual.gen.inc` (480KiB → 730KiB), there's no change in the logic of an expanded `GDVIRTUAL*` macro. Instead, the size comes from accomodating the two new macros: `DECLARE_GDVIRTUAL*` and `IMPLEMENT_GDVIRTUAL*`, for forward-declares and implementation respectively

Integrated arbitrarily on `Resource` to showcase functionality