### PR TITLE
WIP: form validation

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -252,6 +252,7 @@ void GDExtension::_register_extension_class(GDExtensionClassLibraryPtr p_library
 		nullptr, // GDExtensionClassFreePropertyList2 free_property_list_func;
 		p_extension_funcs->property_can_revert_func, // GDExtensionClassPropertyCanRevert property_can_revert_func;
 		p_extension_funcs->property_get_revert_func, // GDExtensionClassPropertyGetRevert property_get_revert_func;
+		nullptr, // GDExtensionClassIsValidPropertyValue is_valid_property_value_func;
 		nullptr, // GDExtensionClassValidateProperty validate_property_func;
 		nullptr, // GDExtensionClassNotification2 notification_func;
 		p_extension_funcs->to_string_func, // GDExtensionClassToString to_string_func;
@@ -291,6 +292,7 @@ void GDExtension::_register_extension_class2(GDExtensionClassLibraryPtr p_librar
 		nullptr, // GDExtensionClassFreePropertyList2 free_property_list_func;
 		p_extension_funcs->property_can_revert_func, // GDExtensionClassPropertyCanRevert property_can_revert_func;
 		p_extension_funcs->property_get_revert_func, // GDExtensionClassPropertyGetRevert property_get_revert_func;
+		nullptr, // GDExtensionClassIsValidPropertyValue is_valid_property_value_func;
 		p_extension_funcs->validate_property_func, // GDExtensionClassValidateProperty validate_property_func;
 		p_extension_funcs->notification_func, // GDExtensionClassNotification2 notification_func;
 		p_extension_funcs->to_string_func, // GDExtensionClassToString to_string_func;
@@ -330,6 +332,7 @@ void GDExtension::_register_extension_class3(GDExtensionClassLibraryPtr p_librar
 		p_extension_funcs->free_property_list_func, // GDExtensionClassFreePropertyList free_property_list_func;
 		p_extension_funcs->property_can_revert_func, // GDExtensionClassPropertyCanRevert property_can_revert_func;
 		p_extension_funcs->property_get_revert_func, // GDExtensionClassPropertyGetRevert property_get_revert_func;
+		nullptr, // GDExtensionClassIsValidPropertyValue is_valid_property_value_func;
 		p_extension_funcs->validate_property_func, // GDExtensionClassValidateProperty validate_property_func;
 		p_extension_funcs->notification_func, // GDExtensionClassNotification2 notification_func;
 		p_extension_funcs->to_string_func, // GDExtensionClassToString to_string_func;
@@ -454,6 +457,7 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 	extension->gdextension.free_property_list2 = p_extension_funcs->free_property_list_func;
 	extension->gdextension.property_can_revert = p_extension_funcs->property_can_revert_func;
 	extension->gdextension.property_get_revert = p_extension_funcs->property_get_revert_func;
+	extension->gdextension.is_valid_property_value = p_extension_funcs->is_valid_property_value_func;
 	extension->gdextension.validate_property = p_extension_funcs->validate_property_func;
 #ifndef DISABLE_DEPRECATED
 	if (p_deprecated_funcs) {

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -261,6 +261,7 @@ typedef void (*GDExtensionClassFreePropertyList)(GDExtensionClassInstancePtr p_i
 typedef void (*GDExtensionClassFreePropertyList2)(GDExtensionClassInstancePtr p_instance, const GDExtensionPropertyInfo *p_list, uint32_t p_count);
 typedef GDExtensionBool (*GDExtensionClassPropertyCanRevert)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name);
 typedef GDExtensionBool (*GDExtensionClassPropertyGetRevert)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret);
+typedef GDExtensionBool (*GDExtensionClassIsValidPropertyValue)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_path, GDExtensionConstVariantPtr p_value, GDExtensionVariantPtr r_ret);
 typedef GDExtensionBool (*GDExtensionClassValidateProperty)(GDExtensionClassInstancePtr p_instance, GDExtensionPropertyInfo *p_property);
 typedef void (*GDExtensionClassNotification)(GDExtensionClassInstancePtr p_instance, int32_t p_what); // Deprecated. Use GDExtensionClassNotification2 instead.
 typedef void (*GDExtensionClassNotification2)(GDExtensionClassInstancePtr p_instance, int32_t p_what, GDExtensionBool p_reversed);
@@ -377,6 +378,7 @@ typedef struct {
 	GDExtensionClassFreePropertyList2 free_property_list_func;
 	GDExtensionClassPropertyCanRevert property_can_revert_func;
 	GDExtensionClassPropertyGetRevert property_get_revert_func;
+	GDExtensionClassIsValidPropertyValue is_valid_property_value_func;
 	GDExtensionClassValidateProperty validate_property_func;
 	GDExtensionClassNotification2 notification_func;
 	GDExtensionClassToString to_string_func;
@@ -571,6 +573,7 @@ typedef GDExtensionBool (*GDExtensionScriptInstanceValidateProperty)(GDExtension
 
 typedef GDExtensionBool (*GDExtensionScriptInstancePropertyCanRevert)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name);
 typedef GDExtensionBool (*GDExtensionScriptInstancePropertyGetRevert)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret);
+typedef GDExtensionBool (*GDExtensionScriptInstanceIsValidPropertyValue)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value, GDExtensionVariantPtr r_ret);
 
 typedef GDExtensionObjectPtr (*GDExtensionScriptInstanceGetOwner)(GDExtensionScriptInstanceDataPtr p_instance);
 typedef void (*GDExtensionScriptInstancePropertyStateAdd)(GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value, void *p_userdata);
@@ -692,6 +695,7 @@ typedef struct {
 
 	GDExtensionScriptInstancePropertyCanRevert property_can_revert_func;
 	GDExtensionScriptInstancePropertyGetRevert property_get_revert_func;
+	GDExtensionScriptInstanceIsValidPropertyValue is_valid_property_value_func;
 
 	GDExtensionScriptInstanceGetOwner get_owner_func;
 	GDExtensionScriptInstanceGetPropertyState get_property_state_func;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -157,6 +157,10 @@ public:
 		return false;
 	}
 
+	static GDExtensionBool placeholder_instance_is_valid_property_value(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_path, GDExtensionVariantPtr p_value, GDExtensionBool *r_is_valid, GDExtensionVariantPtr r_ret) {
+		return false;
+	}
+
 	static GDExtensionBool placeholder_instance_validate_property(GDExtensionClassInstancePtr p_instance, GDExtensionPropertyInfo *p_property) {
 		return false;
 	}

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2104,6 +2104,30 @@ bool Object::is_edited() const {
 uint32_t Object::get_edited_version() const {
 	return _edited_version;
 }
+
+bool Object::is_valid_property_value(const StringName &p_path, const Variant &p_value, String &p_error_message) const {
+	Variant ret;
+	if (get_script_instance()) {
+		bool is_script_valid = get_script_instance()->is_valid_property_value(p_path, p_value, ret);
+		if (is_script_valid) {
+			p_error_message = ret;
+			return ret == String();
+		}
+	}
+	if (_get_extension() && _get_extension()->is_valid_property_value) {
+		GDExtensionBool is_valid = _get_extension()->is_valid_property_value(_get_extension_instance(),
+				(GDExtensionConstStringNamePtr)&p_path, p_value, (GDExtensionVariantPtr)&ret);
+		if (is_valid) {
+			p_error_message = ret;
+			return ret == String();
+		}
+	}
+	return _is_valid_property_value(p_path, p_value, p_error_message);
+}
+
+bool Object::_is_valid_property_value(const StringName &p_path, const Variant &p_value, String &p_error_message) const {
+	return true;
+}
 #endif
 
 const GDType &Object::get_gdtype() const {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -337,6 +337,7 @@ struct ObjectGDExtension {
 	GDExtensionClassFreePropertyList2 free_property_list2;
 	GDExtensionClassPropertyCanRevert property_can_revert;
 	GDExtensionClassPropertyGetRevert property_get_revert;
+	GDExtensionClassIsValidPropertyValue is_valid_property_value;
 	GDExtensionClassValidateProperty validate_property;
 #ifndef DISABLE_DEPRECATED
 	GDExtensionClassNotification notification;
@@ -667,6 +668,7 @@ private:
 	bool _edited : 1;
 	uint32_t _edited_version = 0;
 	HashSet<String> editor_section_folding;
+	virtual bool _is_valid_property_value(const StringName &p_path, const Variant &p_value, String &p_error_message) const;
 #endif
 	ScriptInstance *script_instance = nullptr;
 	HashMap<StringName, Variant> metadata;
@@ -950,6 +952,7 @@ public:
 	bool is_edited() const;
 	// This function is used to check when something changed beyond a point, it's used mainly for generating previews.
 	uint32_t get_edited_version() const;
+	virtual bool is_valid_property_value(const StringName &p_path, const Variant &p_value, String &p_error_message) const;
 #endif
 
 	void set_script_instance(ScriptInstance *p_instance);

--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -45,6 +45,7 @@ public:
 
 	virtual bool property_can_revert(const StringName &p_name) const = 0;
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const = 0;
+	virtual bool is_valid_property_value(const StringName &p_path, const Variant &p_value, Variant &r_ret) const = 0;
 
 	virtual Object *get_owner() { return nullptr; }
 	virtual void get_property_state(List<Pair<StringName, Variant>> &state);

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -469,6 +469,7 @@ public:
 
 	virtual bool property_can_revert(const StringName &p_name) const override { return false; }
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const override { return false; }
+	virtual bool is_valid_property_value(const StringName &p_path, const Variant &p_value, Variant &r_ret) const override { return true; }
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const override;
 	virtual bool has_method(const StringName &p_method) const override;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -792,6 +792,12 @@ public:
 		}
 		return false;
 	}
+	virtual bool is_valid_property_value(const StringName &p_name, const Variant &p_value, Variant &r_error_message) const override {
+		if (native_info->is_valid_property_value_func) {
+			return native_info->is_valid_property_value_func(instance, (GDExtensionConstStringNamePtr)&p_name, (GDExtensionConstVariantPtr)&p_value, (GDExtensionVariantPtr)&r_error_message);
+		}
+		return false;
+	}
 
 	virtual Object *get_owner() override {
 		if (native_info->get_owner_func) {

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5117,6 +5117,25 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 }
 
 void EditorInspector::_property_changed(const String &p_path, const Variant &p_value, const String &p_name, bool p_changing, bool p_update_all) {
+#ifdef TOOLS_ENABLED
+	if (editor_property_map.has(p_path)) {
+		// validate before edit value
+		String p_error_message;
+		bool is_valid = object->is_valid_property_value(p_path, p_value, p_error_message);
+		for (EditorProperty *E : editor_property_map[p_path]) {
+			// show or hide warning color
+			E->set_draw_warning(!is_valid);
+			if (is_valid) {
+				E->clean_unsaved();
+			}
+		}
+		if (!is_valid) {
+			WARN_PRINT(p_error_message);
+			return;
+		}
+	}
+#endif
+
 	// The "changing" variable must be true for properties that trigger events as typing occurs,
 	// like "text_changed" signal. E.g. text property of Label, Button, RichTextLabel, etc.
 	if (p_changing) {

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -162,6 +162,7 @@ private:
 protected:
 	bool has_borders = false;
 	bool can_override = false;
+	bool has_unsaved_value = false;
 
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -178,6 +179,10 @@ protected:
 
 	void _accessibility_action_menu(const Variant &p_data);
 	void _accessibility_action_click(const Variant &p_data);
+
+	bool is_unsaved() { return has_unsaved_value; }
+	void mark_unsaved() { has_unsaved_value = true; }
+	void clean_unsaved() { has_unsaved_value = false; }
 
 public:
 	void emit_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field = StringName(), bool p_changing = false);

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -183,6 +183,10 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 		text->set_tooltip_text(get_tooltip_string(text->get_text()));
 	}
 
+#ifdef TOOLS_ENABLED
+	mark_unsaved();
+#endif
+
 	if (string_name) {
 		emit_changed(get_edited_property(), StringName(p_string));
 	} else {
@@ -191,6 +195,11 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 }
 
 void EditorPropertyText::update_property() {
+#ifdef TOOLS_ENABLED
+	if (is_unsaved()) {
+		return;
+	}
+#endif
 	String s = get_edited_property_value();
 	updating = true;
 	if (text->get_text() != s) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1998,6 +1998,29 @@ bool GDScriptInstance::property_get_revert(const StringName &p_name, Variant &r_
 	return false;
 }
 
+bool GDScriptInstance::is_valid_property_value(const StringName &p_path, const Variant &p_value, Variant &r_ret) const {
+	Variant path = p_path;
+	const Variant *args[2] = { &path, &p_value };
+
+	const GDScript *sptr = script.ptr();
+	while (sptr) {
+		if (likely(sptr->valid)) {
+			HashMap<StringName, GDScriptFunction *>::ConstIterator E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._is_valid_property_value);
+			if (E) {
+				Callable::CallError err;
+				Variant ret = E->value->call(const_cast<GDScriptInstance *>(this), args, 1, err);
+				if (err.error == Callable::CallError::CALL_OK && ret.get_type() != Variant::NIL) {
+					r_ret = ret;
+					return true;
+				}
+			}
+		}
+		sptr = sptr->_base;
+	}
+
+	return false;
+}
+
 void GDScriptInstance::get_method_list(List<MethodInfo> *p_list) const {
 	const GDScript *sptr = script.ptr();
 	while (sptr) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -390,6 +390,7 @@ public:
 
 	virtual bool property_can_revert(const StringName &p_name) const;
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const;
+	virtual bool is_valid_property_value(const StringName &p_path, const Variant &p_value, Variant &_ret) const;
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const;
 	virtual bool has_method(const StringName &p_method) const;
@@ -573,6 +574,7 @@ public:
 		StringName _validate_property;
 		StringName _property_can_revert;
 		StringName _property_get_revert;
+		StringName _is_valid_property_value;
 		StringName _script_source;
 
 	} strings;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1611,6 +1611,24 @@ bool CSharpInstance::property_can_revert(const StringName &p_name) const {
 	return (bool)ret;
 }
 
+bool CSharpInstance::is_valid_property_value(const StringName &p_name, const Variant &p_value, Variant &p_error_message) const {
+	ERR_FAIL_COND_V(script.is_null(), false);
+
+	Variant name_arg = p_name;
+	const Variant *args[3] = { &name_arg, &p_value, &p_error_message };
+
+	Variant ret;
+	Callable::CallError call_error;
+	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
+			gchandle.get_intptr(), &SNAME("_is_valid_property_value"), args, 3, &call_error, &ret);
+
+	if (call_error.error != Callable::CallError::CALL_OK) {
+		return false;
+	}
+
+	return (bool)ret;
+}
+
 void CSharpInstance::validate_property(PropertyInfo &p_property) const {
 	ERR_FAIL_COND(script.is_null());
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -350,6 +350,7 @@ public:
 
 	bool property_can_revert(const StringName &p_name) const override;
 	bool property_get_revert(const StringName &p_name, Variant &r_ret) const override;
+	bool is_valid_property_value(const StringName &p_name, const Variant &p_value, Variant &p_error_message) const override;
 
 	void get_method_list(List<MethodInfo> *p_list) const override;
 	bool has_method(const StringName &p_method) const override;

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -498,6 +498,7 @@ public:
 	void move_custom_data_layer(int p_from_index, int p_to_pos);
 	void remove_custom_data_layer(int p_index);
 	int get_custom_data_layer_by_name(String p_value) const;
+	bool validate_custom_data_layer_name(int p_layer_id, String p_value, String &p_error_message) const;
 	void set_custom_data_layer_name(int p_layer_id, String p_value);
 	bool has_custom_data_layer_by_name(const String &p_value) const;
 	String get_custom_data_layer_name(int p_layer_id) const;
@@ -560,6 +561,10 @@ public:
 
 	// Resource management
 	virtual void reset_state() override;
+
+#ifdef TOOLS_ENABLED
+	bool _is_valid_property_value(const StringName &p_path, const Variant &p_value, String &p_error_message) const override;
+#endif
 
 	// Helpers.
 	static Vector2i transform_coords_layout(const Vector2i &p_coords, TileSet::TileOffsetAxis p_offset_axis, TileSet::TileLayout p_from_layout, TileSet::TileLayout p_to_layout);

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -98,6 +98,9 @@ public:
 	bool property_get_revert(const StringName &p_name, Variant &r_ret) const override {
 		return false;
 	}
+	bool is_valid_property_value(const StringName &p_name, const Variant &p_value, Variant &r_ret) const override {
+		return true;
+	}
 	void get_method_list(List<MethodInfo> *p_list) const override {
 	}
 	bool has_method(const StringName &p_method) const override {


### PR DESCRIPTION
* *Closes: https://github.com/godotengine/godot-proposals/issues/13349*
* *Fixes: https://github.com/godotengine/godot/issues/110879*

I am working on adding form validation feature in Editor Inspector.

With this feature, we can get a warning color when updating property value is invalid.

And this feature allow us editing unsaved invalid value, without revert invalid value to previous every key pressed.

It is graceful for any suggestion. Thank you very much.

Without validation, we cannot get 'foo'.

[without-valid.webm](https://github.com/user-attachments/assets/3ca01a96-1bf5-4cde-a62b-5e6246fdcb61)

With validation, we can modify property value to an invalid value and keep editing it.

[form-validation.webm](https://github.com/user-attachments/assets/ca87f195-60f4-426d-80ab-8230ef4cbf90)

**MRP**

[mrp-validation.zip](https://github.com/user-attachments/files/22791880/mrp-validation.zip)


