### PR TITLE
FTI - Fix `SceneTreeFTI` depth limit behavior

### DIFF
--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -286,7 +286,7 @@ void SceneTreeFTI::_create_depth_lists() {
 
 			// This shouldn't happen, but wouldn't be terrible if it did.
 			DEV_ASSERT(depth >= 0);
-			depth = MIN(depth, (int32_t)data.scene_tree_depth_limit);
+			depth = MIN(depth, (int32_t)data.scene_tree_depth_limit - 1);
 
 			LocalVector<Node3D *> &dest_list = data.dirty_node_depth_lists[depth];
 #ifdef GODOT_SCENE_TREE_FTI_EXTRA_CHECKS

--- a/scene/main/scene_tree_fti.h
+++ b/scene/main/scene_tree_fti.h
@@ -77,7 +77,7 @@ class SceneTreeFTI {
 	};
 
 	struct Data {
-		static const uint32_t scene_tree_depth_limit = 32;
+		static const uint32_t scene_tree_depth_limit = 48;
 
 		// Prev / Curr lists of Node3Ds having local xforms pumped.
 		LocalVector<Node3D *> tick_xform_list[2];


### PR DESCRIPTION
Fixes off by one bug, and increases the limit slightly.

Forward port of #111443
Fixes crash mentioned in https://github.com/godotengine/godot/pull/106244#issuecomment-3384639133

## Notes
* My bad, simple off by one bug here, so it writes just off the end of the array. It didn't show up in testing because not only does the scene depth need to reach the limit, but one of the nodes past the limit needs to be moved (rather than via a parent).
* I've also increased the limit just a tad from 32 to 48. There's no particularly bad consequence from overrunning the limit (just slightly less efficiency in the interpolation calculations), but there isn't much cost to increasing this. I did consider 64 but  users should really not be using such scene depths anyway as it will be super inefficient.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
