### PR TITLE
Fix arrays with resources not being updated correctly in game when edited in the inspector

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1457,6 +1457,42 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 		NodePath path = EditorNode::get_singleton()->get_edited_scene()->get_path_to(node);
 		int pathid = _get_node_path_cache(path);
 
+		if (p_value.is_array()) {
+			Array array = p_value;
+			bool has_resources = false;
+
+			for (int i = 0; i < array.size(); i++) {
+				Ref<Resource> item_res = array[i];
+				if (item_res.is_valid() && !item_res->get_path().is_empty()) {
+					has_resources = true;
+				}
+			}
+
+			if (has_resources) {
+				Array res_array;
+				Array res_indexes_array;
+				res_array.resize(array.size());
+				for (int i = 0; i < array.size(); i++) {
+					Ref<Resource> item_res = array[i];
+					if (item_res.is_valid() && !item_res->get_path().is_empty()) {
+						res_array[i] = item_res->get_path();
+						res_indexes_array.push_back(i);
+					} else {
+						res_array[i] = array[i];
+					}
+				}
+
+				String script_path;
+				Ref<Script> array_script = array.get_typed_script();
+				if (array_script.is_valid()) {
+					script_path = array_script->get_path();
+				}
+
+				Array msg = { pathid, p_property, res_array, array.get_typed_builtin(), array.get_typed_class_name(), script_path, res_indexes_array };
+				_put_msg("scene:live_node_prop_res_array", msg);
+				return;
+			}
+		}
 		if (p_value.is_ref_counted()) {
 			Ref<Resource> res = p_value;
 			if (res.is_valid() && !res->get_path().is_empty()) {
@@ -1477,6 +1513,42 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 		String respath = res->get_path();
 		int pathid = _get_res_path_cache(respath);
 
+		if (p_value.is_array()) {
+			Array array = p_value;
+			bool has_resources = false;
+
+			for (int i = 0; i < array.size(); i++) {
+				Ref<Resource> item_res = array[i];
+				if (item_res.is_valid() && !item_res->get_path().is_empty()) {
+					has_resources = true;
+				}
+			}
+
+			if (has_resources) {
+				Array res_array;
+				Array res_indexes_array;
+				res_array.resize(array.size());
+				for (int i = 0; i < array.size(); i++) {
+					Ref<Resource> item_res = array[i];
+					if (item_res.is_valid() && !item_res->get_path().is_empty()) {
+						res_array[i] = item_res->get_path();
+						res_indexes_array.push_back(i);
+					} else {
+						res_array[i] = array[i];
+					}
+				}
+
+				String script_path;
+				Ref<Script> array_script = array.get_typed_script();
+				if (array_script.is_valid()) {
+					script_path = array_script->get_path();
+				}
+
+				Array msg = { pathid, p_property, res_array, array.get_typed_builtin(), array.get_typed_class_name(), script_path, res_indexes_array };
+				_put_msg("scene:live_res_prop_res_array", msg);
+				return;
+			}
+		}
 		if (p_value.is_ref_counted()) {
 			Ref<Resource> res2 = p_value;
 			if (res2.is_valid() && !res2->get_path().is_empty()) {

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -292,6 +292,12 @@ Error SceneDebugger::_msg_live_node_prop_res(const Array &p_args) {
 	return OK;
 }
 
+Error SceneDebugger::_msg_live_node_prop_res_array(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.size() < 7, ERR_INVALID_DATA);
+	LiveEditor::get_singleton()->_node_set_res_array_func(p_args[0], p_args[1], p_args[2], p_args[3], p_args[4], p_args[5], p_args[6]);
+	return OK;
+}
+
 Error SceneDebugger::_msg_live_node_prop(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);
 	LiveEditor::get_singleton()->_node_set_func(p_args[0], p_args[1], p_args[2]);
@@ -301,6 +307,12 @@ Error SceneDebugger::_msg_live_node_prop(const Array &p_args) {
 Error SceneDebugger::_msg_live_res_prop_res(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);
 	LiveEditor::get_singleton()->_res_set_res_func(p_args[0], p_args[1], p_args[2]);
+	return OK;
+}
+
+Error SceneDebugger::_msg_live_res_prop_res_array(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.size() < 7, ERR_INVALID_DATA);
+	LiveEditor::get_singleton()->_res_set_res_array_func(p_args[0], p_args[1], p_args[2], p_args[3], p_args[4], p_args[5], p_args[6]);
 	return OK;
 }
 
@@ -549,8 +561,10 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["live_node_path"] = _msg_live_node_path;
 	message_handlers["live_res_path"] = _msg_live_res_path;
 	message_handlers["live_node_prop_res"] = _msg_live_node_prop_res;
+	message_handlers["live_node_prop_res_array"] = _msg_live_node_prop_res_array;
 	message_handlers["live_node_prop"] = _msg_live_node_prop;
 	message_handlers["live_res_prop_res"] = _msg_live_res_prop_res;
+	message_handlers["live_res_prop_res_array"] = _msg_live_res_prop_res_array;
 	message_handlers["live_res_prop"] = _msg_live_res_prop;
 	message_handlers["live_node_call"] = _msg_live_node_call;
 	message_handlers["live_res_call"] = _msg_live_res_call;
@@ -1098,6 +1112,32 @@ void LiveEditor::_node_set_res_func(int p_id, const StringName &p_prop, const St
 	_node_set_func(p_id, p_prop, r);
 }
 
+void LiveEditor::_node_set_res_array_func(int p_id, const StringName &p_prop, const Variant &p_value, const uint32_t &p_typed_builtin, const StringName &p_typed_class_name, const String &p_typed_script_path, const Array &p_res_indexes_array) {
+	Array array = p_value;
+
+	Array res_array;
+	Variant script;
+	if (!p_typed_script_path.is_empty()) {
+		script = ResourceLoader::load(p_typed_script_path);
+	}
+
+	res_array.set_typed(p_typed_builtin, p_typed_class_name, script);
+	res_array.resize(array.size());
+
+	for (int i = 0; i < array.size(); i++) {
+		if (array[i].get_type() != Variant::NIL && p_res_indexes_array.has(i)) {
+			Ref<Resource> res = ResourceLoader::load(array[i]);
+			if (res.is_valid()) {
+				res_array[i] = res;
+			}
+		} else {
+			res_array[i] = array[i];
+		}
+	}
+
+	_node_set_func(p_id, p_prop, res_array);
+}
+
 void LiveEditor::_node_call_func(int p_id, const StringName &p_method, const Variant **p_args, int p_argcount) {
 	SceneTree *scene_tree = SceneTree::get_singleton();
 	if (!scene_tree) {
@@ -1187,6 +1227,32 @@ void LiveEditor::_res_set_res_func(int p_id, const StringName &p_prop, const Str
 		return;
 	}
 	_res_set_func(p_id, p_prop, r);
+}
+
+void LiveEditor::_res_set_res_array_func(int p_id, const StringName &p_prop, const Variant &p_value, const uint32_t &p_typed_builtin, const StringName &p_typed_class_name, const String &p_typed_script_path, const Array &p_res_indexes_array) {
+	Array array = p_value;
+
+	Array res_array;
+	Variant script;
+	if (!p_typed_script_path.is_empty()) {
+		script = ResourceLoader::load(p_typed_script_path);
+	}
+
+	res_array.set_typed(p_typed_builtin, p_typed_class_name, script);
+	res_array.resize(array.size());
+
+	for (int i = 0; i < array.size(); i++) {
+		if (array[i].get_type() != Variant::NIL && p_res_indexes_array.has(i)) {
+			Ref<Resource> res = ResourceLoader::load(array[i]);
+			if (res.is_valid()) {
+				res_array[i] = res;
+			}
+		} else {
+			res_array[i] = array[i];
+		}
+	}
+
+	_res_set_func(p_id, p_prop, res_array);
 }
 
 void LiveEditor::_res_call_func(int p_id, const StringName &p_method, const Variant **p_args, int p_argcount) {

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -99,8 +99,10 @@ private:
 	static Error _msg_live_node_path(const Array &p_args);
 	static Error _msg_live_res_path(const Array &p_args);
 	static Error _msg_live_node_prop_res(const Array &p_args);
+	static Error _msg_live_node_prop_res_array(const Array &p_args);
 	static Error _msg_live_node_prop(const Array &p_args);
 	static Error _msg_live_res_prop_res(const Array &p_args);
+	static Error _msg_live_res_prop_res_array(const Array &p_args);
 	static Error _msg_live_res_prop(const Array &p_args);
 	static Error _msg_live_node_call(const Array &p_args);
 	static Error _msg_live_res_call(const Array &p_args);
@@ -208,9 +210,11 @@ private:
 
 	void _node_set_func(int p_id, const StringName &p_prop, const Variant &p_value);
 	void _node_set_res_func(int p_id, const StringName &p_prop, const String &p_value);
+	void _node_set_res_array_func(int p_id, const StringName &p_prop, const Variant &p_value, const uint32_t &p_typed_builtin, const StringName &p_typed_class_name, const String &p_typed_script_path, const Array &p_res_indexes_array);
 	void _node_call_func(int p_id, const StringName &p_method, const Variant **p_args, int p_argcount);
 	void _res_set_func(int p_id, const StringName &p_prop, const Variant &p_value);
 	void _res_set_res_func(int p_id, const StringName &p_prop, const String &p_value);
+	void _res_set_res_array_func(int p_id, const StringName &p_prop, const Variant &p_value, const uint32_t &p_typed_builtin, const StringName &p_typed_class_name, const String &p_typed_script_path, const Array &p_res_indexes_array);
 	void _res_call_func(int p_id, const StringName &p_method, const Variant **p_args, int p_argcount);
 	void _root_func(const NodePath &p_scene_path, const String &p_scene_from);
 


### PR DESCRIPTION
This pull-request fixes https://github.com/godotengine/godot/issues/101979

It transforms resources in arrays to resource paths before sending them through the debugger.
At the game instance the resources are then loaded again by using the resource path. 

This is how Godot currently handles updating single resources in the inspector.

the typed_builtin, typed_class_name and typed_script have to be sent or else exposed arrays of custom-GDScript-resource-sub-types will not update correctly.

res_indexes_array is there so that the solution also works with arrays of Variant/Object, since those can contain Resources too.
Arrays of Variant/Object also have the same bug with resources not being updated correctly.
