### PR TITLE
Enable maximize button for Editor/Project settings dialogs.

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1445,6 +1445,7 @@ void ProjectExportDialog::_bind_methods() {
 
 ProjectExportDialog::ProjectExportDialog() {
 	set_title(TTR("Export"));
+	set_flag(FLAG_MAXIMIZE_DISABLED, false);
 	set_clamp_to_embedder(true);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -1062,6 +1062,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	export_profile->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
 	set_title(TTR("Manage Editor Feature Profiles"));
+	set_flag(FLAG_MAXIMIZE_DISABLED, false);
 	EDITOR_DEF("_default_feature_profile", "");
 
 	update_timer = memnew(Timer);

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -875,6 +875,7 @@ void EditorSettingsDialog::_bind_methods() {
 
 EditorSettingsDialog::EditorSettingsDialog() {
 	set_title(TTRC("Editor Settings"));
+	set_flag(FLAG_MAXIMIZE_DISABLED, false);
 	set_clamp_to_embedder(true);
 
 	tabs = memnew(TabContainer);

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -685,6 +685,7 @@ void ProjectSettingsEditor::_bind_methods() {
 ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	singleton = this;
 	set_title(TTRC("Project Settings (project.godot)"));
+	set_flag(FLAG_MAXIMIZE_DISABLED, false);
 	set_clamp_to_embedder(true);
 
 	ps = ProjectSettings::get_singleton();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/111415

Minimize and maximize buttons were disabled in the default `Dialog` and `Popup` config. But for some large dialogs, maximization might be useful.