### PR TITLE
Enable script templates by default

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -124,7 +124,7 @@ void ScriptCreateDialog::_notification(int p_what) {
 			} else {
 				language_menu->select(default_language);
 			}
-			is_using_templates = EDITOR_DEF("_script_setup_use_script_templates", false);
+			is_using_templates = EDITOR_GET("_script_setup_use_script_templates");
 			use_templates->set_pressed(is_using_templates);
 		} break;
 
@@ -849,6 +849,7 @@ void ScriptCreateDialog::_bind_methods() {
 ScriptCreateDialog::ScriptCreateDialog() {
 	if (EditorSettings::get_singleton()) {
 		EDITOR_DEF("_script_setup_templates_dictionary", Dictionary());
+		EDITOR_DEF("_script_setup_use_script_templates", true);
 	}
 
 	/* Main Controls */


### PR DESCRIPTION
Fixes #111350
Note that it only affects fresh Godot installations. If someone already created a script at least once, they will still need to enable the templates.