### PR TITLE
Add theme sound items and playback on common UI events

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -47,6 +47,7 @@
 #include "core/variant/typed_array.h"
 #include "core/variant/variant_parser.h"
 #include "core/version.h"
+#include "servers/audio/audio_server.h"
 
 #ifdef TOOLS_ENABLED
 #include "core/config/engine.h"
@@ -513,6 +514,23 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 			PropertyInfo pi = custom_prop_info[base.name];
 			pi.name = base.name;
 			pi.usage = base.flags;
+
+#ifdef TOOLS_ENABLED
+			// Display list of audio buses in the project settings, similar to the `bus` property in AudioStreamPlayer.
+			if (AudioServer::get_singleton() && Engine::get_singleton()->is_editor_hint() && pi.name == "audio/buses/gui_theme_bus") {
+				String options;
+				for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
+					if (i > 0) {
+						options += ",";
+					}
+					String name = AudioServer::get_singleton()->get_bus_name(i);
+					options += name;
+				}
+
+				pi.hint_string = options;
+			}
+#endif
+
 			p_list->push_back(pi);
 #ifdef TOOLS_ENABLED
 		} else if (base.name.begins_with(EDITOR_SETTING_OVERRIDE_PREFIX)) {
@@ -1764,6 +1782,7 @@ ProjectSettings::ProjectSettings() {
 #endif
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "audio/buses/default_bus_layout", PROPERTY_HINT_FILE, "*.tres"), "res://default_bus_layout.tres");
+	GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::STRING_NAME, "audio/buses/gui_theme_bus", PROPERTY_HINT_ENUM, ""), StringName("Master"));
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/default_playback_type", PROPERTY_HINT_ENUM, "Stream,Sample"), 0);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/default_playback_type.web", PROPERTY_HINT_ENUM, "Stream,Sample"), 1);
 	GLOBAL_DEF_RST("audio/general/text_to_speech", false);

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1769,6 +1769,7 @@ ProjectSettings::ProjectSettings() {
 #endif
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "audio/buses/default_bus_layout", PROPERTY_HINT_FILE, "*.tres"), "res://default_bus_layout.tres");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING_NAME, "audio/buses/gui_theme_bus", PROPERTY_HINT_AUDIO_BUS, ""), StringName("Master"));
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/default_playback_type", PROPERTY_HINT_ENUM, "Stream,Sample"), 0);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/default_playback_type.web", PROPERTY_HINT_ENUM, "Stream,Sample"), 1);
 	GLOBAL_DEF_RST("audio/general/text_to_speech", false);

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -133,5 +133,17 @@
 		<theme_item name="click_margin" data_type="constant" type="int" default="0">
 			Defines the margin around the button's area that still counts as a valid click. This is useful to make it easier to click small buttons.
 		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [BaseButton] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="hover_sound" data_type="sound" type="AudioStream">
+			Played when the button is hovered with the mouse.
+		</theme_item>
+		<theme_item name="pressed_disabled_sound" data_type="sound" type="AudioStream">
+			Played when the button is pressed with any input method, but has [member disabled] set to [code]true[/code].
+		</theme_item>
+		<theme_item name="pressed_sound" data_type="sound" type="AudioStream">
+			Played when the button is pressed with any input method.
+		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -140,5 +140,17 @@
 		<theme_item name="click_margin" data_type="constant" type="int" default="0">
 			Defines the margin around the button's area that still counts as a valid click. This is useful to make it easier to click small buttons.
 		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [BaseButton] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="hover_sound" data_type="sound" type="AudioStream">
+			Played when the button is hovered with the mouse.
+		</theme_item>
+		<theme_item name="pressed_disabled_sound" data_type="sound" type="AudioStream">
+			Played when the button is pressed with any input method, but has [member disabled] set to [code]true[/code].
+		</theme_item>
+		<theme_item name="pressed_sound" data_type="sound" type="AudioStream">
+			Played when the button is pressed with any input method.
+		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -339,6 +339,15 @@
 				See also [method get_theme_icon].
 			</description>
 		</method>
+		<method name="add_theme_sound_override">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="audio" type="AudioStream" />
+			<description>
+				Creates a local override for a theme audio with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_sound_override].
+				See also [method get_theme_sound].
+			</description>
+		</method>
 		<method name="add_theme_stylebox_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
@@ -635,6 +644,15 @@
 				See [method get_theme_color] for details.
 			</description>
 		</method>
+		<method name="get_theme_sound" qualifiers="const">
+			<return type="AudioStream" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Returns an audio from the first matching [Theme] in the tree if that [Theme] has an audio item with the specified [param name] and [param theme_type].
+				See [method get_theme_color] for details.
+			</description>
+		</method>
 		<method name="get_theme_stylebox" qualifiers="const">
 			<return type="StyleBox" />
 			<param index="0" name="name" type="StringName" />
@@ -773,6 +791,23 @@
 				See [method add_theme_icon_override].
 			</description>
 		</method>
+		<method name="has_theme_sound" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has an audio item with the specified [param name] and [param theme_type].
+				See [method get_theme_color] for details.
+			</description>
+		</method>
+		<method name="has_theme_sound_override" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if there is a local override for a theme audio with the specified [param name] in this [Control] node.
+				See [method add_theme_sound_override].
+			</description>
+		</method>
 		<method name="has_theme_stylebox" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
@@ -842,6 +877,13 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Removes a local override for a theme icon with the specified [param name] previously added by [method add_theme_icon_override] or via the Inspector dock.
+			</description>
+		</method>
+		<method name="remove_theme_sound_override">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Removes a local override for a theme audio with the specified [param name] previously added by [method add_theme_sound_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="remove_theme_stylebox_override">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -339,6 +339,15 @@
 				See also [method get_theme_icon].
 			</description>
 		</method>
+		<method name="add_theme_sound_override">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="audio" type="AudioStream" />
+			<description>
+				Creates a local override for a theme sound with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_sound_override].
+				See also [method get_theme_sound].
+			</description>
+		</method>
 		<method name="add_theme_stylebox_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
@@ -635,6 +644,15 @@
 				See [method get_theme_color] for details.
 			</description>
 		</method>
+		<method name="get_theme_sound" qualifiers="const">
+			<return type="AudioStream" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Returns a sound from the first matching [Theme] in the tree if that [Theme] has a sound item with the specified [param name] and [param theme_type].
+				See [method get_theme_color] for details.
+			</description>
+		</method>
 		<method name="get_theme_stylebox" qualifiers="const">
 			<return type="StyleBox" />
 			<param index="0" name="name" type="StringName" />
@@ -773,6 +791,23 @@
 				See [method add_theme_icon_override].
 			</description>
 		</method>
+		<method name="has_theme_sound" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a sound item with the specified [param name] and [param theme_type].
+				See [method get_theme_color] for details.
+			</description>
+		</method>
+		<method name="has_theme_sound_override" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if there is a local override for a theme sound with the specified [param name] in this [Control] node.
+				See [method add_theme_sound_override].
+			</description>
+		</method>
 		<method name="has_theme_stylebox" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
@@ -842,6 +877,13 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Removes a local override for a theme icon with the specified [param name] previously added by [method add_theme_icon_override] or via the Inspector dock.
+			</description>
+		</method>
+		<method name="remove_theme_sound_override">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Removes a local override for a theme sound with the specified [param name] previously added by [method add_theme_sound_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="remove_theme_stylebox_override">

--- a/doc/classes/FoldableContainer.xml
+++ b/doc/classes/FoldableContainer.xml
@@ -120,6 +120,16 @@
 		<theme_item name="folded_arrow_mirrored" data_type="icon" type="Texture2D">
 			The title's icon used when collapsed (for right-to-left layouts).
 		</theme_item>
+		<theme_item name="expanded_sound" data_type="sound" type="AudioStream">
+			Played when the container is expanded with any input method.
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [FoldableContainer] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="folded_sound" data_type="sound" type="AudioStream">
+			Played when the container is folded with any input method.
+			[b]Note:[/b] This does not play if the container is folded as a result of being part of a [FoldableGroup] and another container in the same group was expanded.
+		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
 			Background used when [FoldableContainer] has GUI focus. The [theme_item focus] [StyleBox] is displayed [i]over[/i] the base [StyleBox], so a partially transparent [StyleBox] should be used to ensure the base [StyleBox] remains visible. A [StyleBox] that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a [StyleBoxEmpty] resource. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
 		</theme_item>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -587,6 +587,18 @@
 		<theme_item name="scroll_hint" data_type="icon" type="Texture2D">
 			The indicator that will be shown when the content can still be scrolled. See [member scroll_hint_mode].
 		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [ItemList] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="item_hovered_sound" data_type="sound" type="AudioStream">
+			Played when an item is hovered. Disabled items do not play a hover sound.
+		</theme_item>
+		<theme_item name="item_selected_disabled_sound" data_type="sound" type="AudioStream">
+			Played when selecting a disabled item is attempted.
+		</theme_item>
+		<theme_item name="item_selected_sound" data_type="sound" type="AudioStream">
+			Played when an item is selected.
+		</theme_item>
 		<theme_item name="cursor" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [ItemList] is being focused.
 		</theme_item>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -602,6 +602,21 @@
 		<theme_item name="clear" data_type="icon" type="Texture2D">
 			Texture for the clear button. See [member clear_button_enabled].
 		</theme_item>
+		<theme_item name="caret_moved_sound" data_type="sound" type="AudioStream">
+			Played when the caret is moved using the arrow keys, Home, End, Page Up, Page Down, or mouse clicks.
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [LineEdit] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="text_change_rejected_sound" data_type="sound" type="AudioStream">
+			Played when a text change is rejected (for instance, when pressing Backspace while there is no text or when [member max_length] is exceeded).
+		</theme_item>
+		<theme_item name="text_changed_sound" data_type="sound" type="AudioStream">
+			Played when text is changed through keyboard input (physical or virtual).
+		</theme_item>
+		<theme_item name="text_submitted_sound" data_type="sound" type="AudioStream">
+			Played when text is submitted using the [code]ui_text_submit[/code] action.
+		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
 			Background used when [LineEdit] has GUI focus. The [theme_item focus] [StyleBox] is displayed [i]over[/i] the base [StyleBox], so a partially transparent [StyleBox] should be used to ensure the base [StyleBox] remains visible. A [StyleBox] that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a [StyleBoxEmpty] resource. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
 		</theme_item>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -603,6 +603,24 @@
 		<theme_item name="clear" data_type="icon" type="Texture2D">
 			Texture for the clear button. See [member clear_button_enabled].
 		</theme_item>
+		<theme_item name="caret_move_rejected_sound" data_type="sound" type="AudioStream">
+			Played when the caret is attempted to be moved using the arrow keys, [kbd]Home[/kbd], [kbd]End[/kbd], [kbd]Page Up[/kbd], or [kbd]Page Down[/kbd], but the caret doesn't actually move since it's already at the beginning/end of the text.
+		</theme_item>
+		<theme_item name="caret_moved_sound" data_type="sound" type="AudioStream">
+			Played when the caret is moved using the arrow keys, [kbd]Home[/kbd], [kbd]End[/kbd], [kbd]Page Up[/kbd], [kbd]Page Down[/kbd], or mouse clicks.
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [LineEdit] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="text_change_rejected_sound" data_type="sound" type="AudioStream">
+			Played when a text change is rejected (for instance, when pressing Backspace while there is no text or when [member max_length] is exceeded).
+		</theme_item>
+		<theme_item name="text_changed_sound" data_type="sound" type="AudioStream">
+			Played when text is successfully changed through keyboard input (physical or virtual).
+		</theme_item>
+		<theme_item name="text_submitted_sound" data_type="sound" type="AudioStream">
+			Played when text is submitted using the [code]ui_text_submit[/code] action.
+		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
 			Background used when [LineEdit] has GUI focus. The [theme_item focus] [StyleBox] is displayed [i]over[/i] the base [StyleBox], so a partially transparent [StyleBox] should be used to ensure the base [StyleBox] remains visible. A [StyleBox] that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a [StyleBoxEmpty] resource. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
 		</theme_item>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -881,6 +881,15 @@
 		<theme_item name="unchecked_disabled" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the unchecked checkbox items when they are disabled.
 		</theme_item>
+		<theme_item name="item_activated_disabled_sound" data_type="sound" type="AudioStream">
+			Played when activating a disabled item is attempted.
+		</theme_item>
+		<theme_item name="item_activated_sound" data_type="sound" type="AudioStream">
+			Played when an item is activated.
+		</theme_item>
+		<theme_item name="item_hovered_sound" data_type="sound" type="AudioStream">
+			Played when an item is hovered. Disabled items do not play a hover sound.
+		</theme_item>
 		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] displayed when the [PopupMenu] item is hovered.
 		</theme_item>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -442,6 +442,10 @@
 		<member name="audio/buses/default_bus_layout" type="String" setter="" getter="" default="&quot;res://default_bus_layout.tres&quot;">
 			Default [AudioBusLayout] resource file to use in the project, unless overridden by the scene.
 		</member>
+		<member name="audio/buses/gui_theme_bus" type="StringName" setter="" getter="" default="&amp;&quot;Master&quot;">
+			The name of the audio bus to play GUI theme audio in (case-sensitive). All sounds played using [Control] theme items will go through the bus specified in [member audio/buses/gui_theme_bus]. This can be used to put UI sounds in a dedicated audio bus, which allows for adjusting UI volume independently from other sounds in the project.
+			If the specified audio bus doesn't exist, audio will play on the [code]Master[/code] bus instead.
+		</member>
 		<member name="audio/driver/driver" type="String" setter="" getter="">
 			Specifies the audio driver to use. This setting is platform-dependent as each platform supports different audio drivers. If left empty, the default audio driver will be used.
 			The [code]Dummy[/code] audio driver disables all audio playback and recording, which is useful for non-game applications as it reduces CPU usage. It also prevents the engine from appearing as an application playing audio in the OS's audio mixer.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -447,6 +447,10 @@
 		<member name="audio/buses/default_bus_layout" type="String" setter="" getter="" default="&quot;res://default_bus_layout.tres&quot;">
 			Default [AudioBusLayout] resource file to use in the project, unless overridden by the scene.
 		</member>
+		<member name="audio/buses/gui_theme_bus" type="StringName" setter="" getter="" default="&amp;&quot;Master&quot;">
+			The name of the audio bus to play GUI theme audio in (case-sensitive). All sounds played using [Control] theme items will go through the bus specified in [member audio/buses/gui_theme_bus]. This can be used to put UI sounds in a dedicated audio bus, which allows for adjusting UI volume independently from other sounds in the project.
+			If the specified audio bus doesn't exist, audio will play on the [code]Master[/code] bus instead.
+		</member>
 		<member name="audio/driver/driver" type="String" setter="" getter="">
 			Specifies the audio driver to use. This setting is platform-dependent as each platform supports different audio drivers. If left empty, the default audio driver will be used.
 			The [code]Dummy[/code] audio driver disables all audio playback and recording, which is useful for non-game applications as it reduces CPU usage. It also prevents the engine from appearing as an application playing audio in the OS's audio mixer.

--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -41,6 +41,18 @@
 		<theme_item name="increment_pressed" data_type="icon" type="Texture2D">
 			Displayed when the increment button is being pressed.
 		</theme_item>
+		<theme_item name="drag_ended_sound" data_type="sound" type="AudioStream">
+			Played when mouse or touch drag ends.
+		</theme_item>
+		<theme_item name="drag_started_sound" data_type="sound" type="AudioStream">
+			Played when mouse or touch drag begins.
+		</theme_item>
+		<theme_item name="value_change_rejected_sound" data_type="sound" type="AudioStream">
+			Played when the value is attempted to be changed through keyboard or gamepad input, but the value is already at the minimum (or maximum).
+		</theme_item>
+		<theme_item name="value_changed_sound" data_type="sound" type="AudioStream">
+			Played when the value is changed through keyboard or gamepad input. If the value is already at the minimum (or maximum), [theme_item value_change_rejected_sound] is played instead.
+		</theme_item>
 		<theme_item name="grabber" data_type="style" type="StyleBox">
 			Used as texture for the grabber, the draggable element representing current scroll.
 		</theme_item>

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -76,6 +76,18 @@
 		<theme_item name="tick" data_type="icon" type="Texture2D">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
 		</theme_item>
+		<theme_item name="drag_ended_sound" data_type="sound" type="AudioStream">
+			Played when mouse or touch drag ends. This is also used by [SpinBox] when dragging over its arrows, or [ColorPicker] when dragging over its color wheel/rectangle.
+		</theme_item>
+		<theme_item name="drag_started_sound" data_type="sound" type="AudioStream">
+			Played when mouse or touch drag begins. This is also used by [SpinBox] when dragging over its arrows, or [ColorPicker] when dragging over its color wheel/rectangle.
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [Slider] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="value_changed_sound" data_type="sound" type="AudioStream">
+			Played when the value is changed through keyboard or gamepad input.
+		</theme_item>
 		<theme_item name="grabber_area" data_type="style" type="StyleBox">
 			The background of the area to the left or bottom of the grabber.
 		</theme_item>

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -82,6 +82,21 @@
 		<theme_item name="tick" data_type="icon" type="Texture2D">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
 		</theme_item>
+		<theme_item name="drag_ended_sound" data_type="sound" type="AudioStream">
+			Played when mouse or touch drag ends. This is also used by [SpinBox] when dragging over its arrows, or [ColorPicker] when dragging over its color wheel/rectangle.
+		</theme_item>
+		<theme_item name="drag_started_sound" data_type="sound" type="AudioStream">
+			Played when mouse or touch drag begins. This is also used by [SpinBox] when dragging over its arrows, or [ColorPicker] when dragging over its color wheel/rectangle.
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [Slider] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="value_change_rejected_sound" data_type="sound" type="AudioStream">
+			Played when the value is attempted to be changed through keyboard or gamepad input, but the value is already at the minimum (or maximum).
+		</theme_item>
+		<theme_item name="value_changed_sound" data_type="sound" type="AudioStream">
+			Played when the value is changed through keyboard or gamepad input. If the value is already at the minimum (or maximum), [theme_item value_change_rejected_sound] is played instead.
+		</theme_item>
 		<theme_item name="grabber_area" data_type="style" type="StyleBox">
 			The background of the area to the left or bottom of the grabber.
 		</theme_item>

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -25,7 +25,7 @@
 		[/codeblocks]
 		See [Range] class for more options over the [SpinBox].
 		[b]Note:[/b] With the [SpinBox]'s context menu disabled, you can right-click the bottom half of the spinbox to set the value to its minimum, while right-clicking the top half sets the value to its maximum.
-		[b]Note:[/b] [SpinBox] relies on an underlying [LineEdit] node. To theme a [SpinBox]'s background, add theme items for [LineEdit] and customize them. The [LineEdit] has the [code]SpinBoxInnerLineEdit[/code] theme variation, so that you can give it a distinct appearance from regular [LineEdit]s.
+		[b]Note:[/b] [SpinBox] relies on an underlying [LineEdit] node. To theme a [SpinBox]'s background and audio feedback on its text field, add theme items for [LineEdit] and customize them. The [LineEdit] has the [code]SpinBoxInnerLineEdit[/code] theme variation, so that you can give it a distinct appearance from regular [LineEdit]s.
 		[b]Note:[/b] If you want to implement drag and drop for the underlying [LineEdit], you can use [method Control.set_drag_forwarding] on the node returned by [method get_line_edit].
 	</description>
 	<tutorials>
@@ -138,6 +138,15 @@
 		</theme_item>
 		<theme_item name="updown" data_type="icon" type="Texture2D" deprecated="Use [theme_item up] and [theme_item down] instead.">
 			Single texture representing both the up and down buttons icons. It is displayed in the middle of the buttons and does not change upon interaction. If a valid icon is assigned, it will replace [theme_item up] and [theme_item down].
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [SpinBox] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="pressed_disabled_sound" data_type="sound" type="AudioStream">
+			Played when the up or down button is pressed while the [SpinBox] is disabled due to [member editable] being [code]false[/code].
+		</theme_item>
+		<theme_item name="pressed_sound" data_type="sound" type="AudioStream">
+			Played when the up or down button is pressed.
 		</theme_item>
 		<theme_item name="down_background" data_type="style" type="StyleBox">
 			Background style of the down button.

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -25,7 +25,7 @@
 		[/codeblocks]
 		See [Range] class for more options over the [SpinBox].
 		[b]Note:[/b] With the [SpinBox]'s context menu disabled, you can right-click the bottom half of the spinbox to set the value to its minimum, while right-clicking the top half sets the value to its maximum.
-		[b]Note:[/b] [SpinBox] relies on an underlying [LineEdit] node. To theme a [SpinBox]'s background, add theme items for [LineEdit] and customize them. The [LineEdit] has the [code]SpinBoxInnerLineEdit[/code] theme variation, so that you can give it a distinct appearance from regular [LineEdit]s.
+		[b]Note:[/b] [SpinBox] relies on an underlying [LineEdit] node. To theme a [SpinBox]'s background and audio feedback on its text field, add theme items for [LineEdit] and customize them. The [LineEdit] has the [code]SpinBoxInnerLineEdit[/code] theme variation, so that you can give it a distinct appearance from regular [LineEdit]s.
 		[b]Note:[/b] If you want to implement drag and drop for the underlying [LineEdit], you can use [method Control.set_drag_forwarding] on the node returned by [method get_line_edit].
 	</description>
 	<tutorials>
@@ -154,6 +154,15 @@
 		</theme_item>
 		<theme_item name="updown" data_type="icon" type="Texture2D" deprecated="Use [theme_item up] and [theme_item down] instead.">
 			Single texture representing both the up and down buttons icons. It is displayed in the middle of the buttons and does not change upon interaction. If a valid icon is assigned, it will replace [theme_item up] and [theme_item down].
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [SpinBox] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="pressed_disabled_sound" data_type="sound" type="AudioStream">
+			Played when the up or down button is pressed while the [SpinBox] is disabled due to [member editable] being [code]false[/code].
+		</theme_item>
+		<theme_item name="pressed_sound" data_type="sound" type="AudioStream">
+			Played when the up or down button is pressed.
 		</theme_item>
 		<theme_item name="down_background" data_type="style" type="StyleBox">
 			Background style of the down button.

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -477,6 +477,18 @@
 		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [TabBar] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="hover_sound" data_type="sound" type="AudioStream">
+			Played when a tab is hovered with the mouse.
+		</theme_item>
+		<theme_item name="pressed_disabled_sound" data_type="sound" type="AudioStream">
+			Played when the tab close button is pressed while the tab is disabled, or when pressing the previous/next tab navigation buttons when already at the beginning/end of the list.
+		</theme_item>
+		<theme_item name="pressed_sound" data_type="sound" type="AudioStream">
+			Played when the tab close or previous/next tab navigation buttons are pressed.
+		</theme_item>
 		<theme_item name="button_highlight" data_type="style" type="StyleBox">
 			Background of the tab and close buttons when they're being hovered with the cursor.
 		</theme_item>

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -477,6 +477,24 @@
 		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
+		<theme_item name="drag_ended_sound" data_type="sound" type="AudioStream">
+			Played when a tab is done being dragged to rearrange it. Can only be heard if [member drag_to_rearrange_enabled] is [code]true[/code].
+		</theme_item>
+		<theme_item name="drag_started_sound" data_type="sound" type="AudioStream">
+			Played when a tab is beginning to be dragged to rearrange it. Can only be heard if [member drag_to_rearrange_enabled] is [code]true[/code].
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [TabBar] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="hover_sound" data_type="sound" type="AudioStream">
+			Played when a tab is hovered with the mouse.
+		</theme_item>
+		<theme_item name="pressed_disabled_sound" data_type="sound" type="AudioStream">
+			Played when the tab close button is pressed while the tab is disabled, or when pressing the previous/next tab navigation buttons when already at the beginning/end of the list.
+		</theme_item>
+		<theme_item name="pressed_sound" data_type="sound" type="AudioStream">
+			Played when the tab close or previous/next tab navigation buttons are pressed.
+		</theme_item>
 		<theme_item name="button_highlight" data_type="style" type="StyleBox">
 			Background of the tab and close buttons when they're being hovered with the cursor.
 		</theme_item>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1702,6 +1702,18 @@
 		<theme_item name="tab" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for tab text characters.
 		</theme_item>
+		<theme_item name="caret_moved_sound" data_type="sound" type="AudioStream">
+			Played when a caret is moved using the arrow keys, Home, End, Page Up, Page Down, or mouse clicks.
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [TextEdit] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="text_change_rejected_sound" data_type="sound" type="AudioStream">
+			Played when a text change is rejected (for instance, when pressing Backspace while there is no text).
+		</theme_item>
+		<theme_item name="text_changed_sound" data_type="sound" type="AudioStream">
+			Played when text is changed through keyboard input (physical or virtual).
+		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
 			Sets the [StyleBox] when in focus. The [theme_item focus] [StyleBox] is displayed [i]over[/i] the base [StyleBox], so a partially transparent [StyleBox] should be used to ensure the base [StyleBox] remains visible. A [StyleBox] that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a [StyleBoxEmpty] resource. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
 		</theme_item>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1703,6 +1703,21 @@
 		<theme_item name="tab" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for tab text characters.
 		</theme_item>
+		<theme_item name="caret_move_rejected_sound" data_type="sound" type="AudioStream">
+			Played when a caret is attempted to be moved using the arrow keys, [kbd]Home[/kbd], [kbd]End[/kbd], [kbd]Page Up[/kbd], or [kbd]Page Down[/kbd], but none of the carets actually move since they're already at the beginning/end of the text.
+		</theme_item>
+		<theme_item name="caret_moved_sound" data_type="sound" type="AudioStream">
+			Played when a caret is moved using the arrow keys, [kbd]Home[/kbd], [kbd]End[/kbd], [kbd]Page Up[/kbd], [kbd]Page Down[/kbd], or mouse clicks.
+		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [TextEdit] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="text_change_rejected_sound" data_type="sound" type="AudioStream">
+			Played when a text change is rejected (for instance, when pressing Backspace while there is no text).
+		</theme_item>
+		<theme_item name="text_changed_sound" data_type="sound" type="AudioStream">
+			Played when text is successfully changed through keyboard input (physical or virtual).
+		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
 			Sets the [StyleBox] when in focus. The [theme_item focus] [StyleBox] is displayed [i]over[/i] the base [StyleBox], so a partially transparent [StyleBox] should be used to ensure the base [StyleBox] remains visible. A [StyleBox] that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a [StyleBoxEmpty] resource. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
 		</theme_item>

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -72,6 +72,15 @@
 				Fails if it doesn't exist. Use [method has_icon] to check for existence.
 			</description>
 		</method>
+		<method name="clear_sound">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" />
+			<description>
+				Removes the sound property defined by [param name] and [param theme_type], if it exists.
+				Fails if it doesn't exist. Use [method has_sound] to check for existence.
+			</description>
+		</method>
 		<method name="clear_stylebox">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
@@ -211,6 +220,28 @@
 				Returns a list of all unique theme type names for icon properties. Use [method get_type_list] to get a list of all unique theme types.
 			</description>
 		</method>
+		<method name="get_sound" qualifiers="const">
+			<return type="AudioStream" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" />
+			<description>
+				Returns the sound property defined by [param name] and [param theme_type], if it exists.
+				Returns the engine fallback sound value if the property doesn't exist (see [member ThemeDB.fallback_sound]). Use [method has_sound] to check for existence.
+			</description>
+		</method>
+		<method name="get_sound_list" qualifiers="const">
+			<return type="PackedStringArray" />
+			<param index="0" name="theme_type" type="String" />
+			<description>
+				Returns a list of names for sound properties defined with [param theme_type]. Use [method get_sound_type_list] to get a list of possible theme type names.
+			</description>
+		</method>
+		<method name="get_sound_type_list" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns a list of all unique theme type names for sound properties. Use [method get_type_list] to get a list of all unique theme types.
+			</description>
+		</method>
 		<method name="get_stylebox" qualifiers="const">
 			<return type="StyleBox" />
 			<param index="0" name="name" type="StringName" />
@@ -347,6 +378,15 @@
 				Returns [code]false[/code] if it doesn't exist. Use [method set_icon] to define it.
 			</description>
 		</method>
+		<method name="has_sound" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the sound property defined by [param name] and [param theme_type] exists.
+				Returns [code]false[/code] if it doesn't exist. Use [method set_sound] to define it.
+			</description>
+		</method>
 		<method name="has_stylebox" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
@@ -440,6 +480,16 @@
 				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_icon] to check for existence, and [method clear_icon] to remove the existing property.
 			</description>
 		</method>
+		<method name="rename_sound">
+			<return type="void" />
+			<param index="0" name="old_name" type="StringName" />
+			<param index="1" name="name" type="StringName" />
+			<param index="2" name="theme_type" type="StringName" />
+			<description>
+				Renames the sound property defined by [param old_name] and [param theme_type] to [param name], if it exists.
+				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_sound] to check for existence, and [method clear_sound] to remove the existing property.
+			</description>
+		</method>
 		<method name="rename_stylebox">
 			<return type="void" />
 			<param index="0" name="old_name" type="StringName" />
@@ -516,6 +566,15 @@
 				Creates or changes the value of the icon property defined by [param name] and [param theme_type]. Use [method clear_icon] to remove the property.
 			</description>
 		</method>
+		<method name="set_sound">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" />
+			<param index="2" name="sound" type="AudioStream" />
+			<description>
+				Creates or changes the value of the sound property defined by [param name] and [param theme_type]. Use [method clear_sound] to remove the property.
+			</description>
+		</method>
 		<method name="set_stylebox">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
@@ -582,7 +641,10 @@
 		<constant name="DATA_TYPE_STYLEBOX" value="5" enum="DataType">
 			Theme's [StyleBox] item type.
 		</constant>
-		<constant name="DATA_TYPE_MAX" value="6" enum="DataType">
+		<constant name="DATA_TYPE_SOUND" value="6" enum="DataType">
+			Theme's [AudioStream] item type.
+		</constant>
+		<constant name="DATA_TYPE_MAX" value="7" enum="DataType">
 			Maximum value for the DataType enum.
 		</constant>
 	</constants>

--- a/doc/classes/ThemeDB.xml
+++ b/doc/classes/ThemeDB.xml
@@ -40,6 +40,9 @@
 		<member name="fallback_icon" type="Texture2D" setter="set_fallback_icon" getter="get_fallback_icon">
 			The fallback icon of every [Control] node and [Theme] resource. Used when no other value is available to the control.
 		</member>
+		<member name="fallback_sound" type="AudioStream" setter="set_fallback_sound" getter="get_fallback_sound">
+			The fallback audio of every [Control] node and [Theme] resource. Used when no other value is available to the control.
+		</member>
 		<member name="fallback_stylebox" type="StyleBox" setter="set_fallback_stylebox" getter="get_fallback_stylebox">
 			The fallback stylebox of every [Control] node and [Theme] resource. Used when no other value is available to the control.
 		</member>

--- a/doc/classes/ThemeDB.xml
+++ b/doc/classes/ThemeDB.xml
@@ -40,6 +40,9 @@
 		<member name="fallback_icon" type="Texture2D" setter="set_fallback_icon" getter="get_fallback_icon">
 			The fallback icon of every [Control] node and [Theme] resource. Used when no other value is available to the control.
 		</member>
+		<member name="fallback_sound" type="AudioStream" setter="set_fallback_sound" getter="get_fallback_sound">
+			The fallback sound of every [Control] node and [Theme] resource. Used when no other value is available to the control.
+		</member>
 		<member name="fallback_stylebox" type="StyleBox" setter="set_fallback_stylebox" getter="get_fallback_stylebox">
 			The fallback stylebox of every [Control] node and [Theme] resource. Used when no other value is available to the control.
 		</member>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -729,6 +729,15 @@
 		<theme_item name="updown" data_type="icon" type="Texture2D">
 			The updown arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
 		</theme_item>
+		<theme_item name="focus_sound" data_type="sound" type="AudioStream">
+			Played when this [Tree] receives keyboard or gamepad-induced focus. Mouse or touch-induced focus does not play a focus sound.
+		</theme_item>
+		<theme_item name="item_hovered_sound" data_type="sound" type="AudioStream">
+			Played when an item is hovered.
+		</theme_item>
+		<theme_item name="item_selected_sound" data_type="sound" type="AudioStream">
+			Played when an item is selected.
+		</theme_item>
 		<theme_item name="button_hover" data_type="style" type="StyleBox">
 			[StyleBox] used when a button in the tree is hovered.
 		</theme_item>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -63,6 +63,15 @@
 				See also [method get_theme_icon].
 			</description>
 		</method>
+		<method name="add_theme_sound_override">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="audio" type="AudioStream" />
+			<description>
+				Creates a local override for a theme audio with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_sound_override].
+				See also [method get_theme_sound].
+			</description>
+		</method>
 		<method name="add_theme_stylebox_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
@@ -184,28 +193,28 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns a constant from the first matching [Theme] in the tree if that [Theme] has a constant item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for more details.
+				See [method Control.get_theme_constant] for more details.
 			</description>
 		</method>
 		<method name="get_theme_default_base_scale" qualifiers="const">
 			<return type="float" />
 			<description>
 				Returns the default base scale value from the first matching [Theme] in the tree if that [Theme] has a valid [member Theme.default_base_scale] value.
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_default_base_scale] for details.
 			</description>
 		</method>
 		<method name="get_theme_default_font" qualifiers="const">
 			<return type="Font" />
 			<description>
 				Returns the default font from the first matching [Theme] in the tree if that [Theme] has a valid [member Theme.default_font] value.
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_default_font] for details.
 			</description>
 		</method>
 		<method name="get_theme_default_font_size" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the default font size value from the first matching [Theme] in the tree if that [Theme] has a valid [member Theme.default_font_size] value.
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_default_font_size] for details.
 			</description>
 		</method>
 		<method name="get_theme_font" qualifiers="const">
@@ -214,7 +223,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns a [Font] from the first matching [Theme] in the tree if that [Theme] has a font item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_font] for details.
 			</description>
 		</method>
 		<method name="get_theme_font_size" qualifiers="const">
@@ -223,7 +232,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns a font size from the first matching [Theme] in the tree if that [Theme] has a font size item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_font_size] for details.
 			</description>
 		</method>
 		<method name="get_theme_icon" qualifiers="const">
@@ -232,7 +241,16 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns an icon from the first matching [Theme] in the tree if that [Theme] has an icon item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_icon] for details.
+			</description>
+		</method>
+		<method name="get_theme_sound" qualifiers="const">
+			<return type="AudioStream" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Returns a sound from the first matching [Theme] in the tree if that [Theme] has a sound item with the specified [param name] and [param theme_type].
+				See [method Control.get_theme_sound] for details.
 			</description>
 		</method>
 		<method name="get_theme_stylebox" qualifiers="const">
@@ -241,7 +259,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns a [StyleBox] from the first matching [Theme] in the tree if that [Theme] has a stylebox item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_stylebox] for details.
 			</description>
 		</method>
 		<method name="get_window_id" qualifiers="const">
@@ -285,7 +303,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a constant item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_constant] for details.
 			</description>
 		</method>
 		<method name="has_theme_constant_override" qualifiers="const">
@@ -302,7 +320,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a font item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_font] for details.
 			</description>
 		</method>
 		<method name="has_theme_font_override" qualifiers="const">
@@ -319,7 +337,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a font size item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_font_size] for details.
 			</description>
 		</method>
 		<method name="has_theme_font_size_override" qualifiers="const">
@@ -336,7 +354,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns [code]true[/code] if there is a matching [Theme] in the tree that has an icon item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_icon] for details.
 			</description>
 		</method>
 		<method name="has_theme_icon_override" qualifiers="const">
@@ -347,13 +365,30 @@
 				See [method add_theme_icon_override].
 			</description>
 		</method>
+		<method name="has_theme_sound" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has an audio item with the specified [param name] and [param theme_type].
+				See [method Control.get_theme_sound] for details.
+			</description>
+		</method>
+		<method name="has_theme_sound_override" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if there is a local override for a theme audio with the specified [param name] in this [Control] node.
+				See [method add_theme_sound_override].
+			</description>
+		</method>
 		<method name="has_theme_stylebox" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a stylebox item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_stylebox] for details.
 			</description>
 		</method>
 		<method name="has_theme_stylebox_override" qualifiers="const">
@@ -527,6 +562,13 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Removes a local override for a theme icon with the specified [param name] previously added by [method add_theme_icon_override] or via the Inspector dock.
+			</description>
+		</method>
+		<method name="remove_theme_sound_override">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Removes a local override for a theme audio with the specified [param name] previously added by [method add_theme_sound_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="remove_theme_stylebox_override">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -63,6 +63,15 @@
 				See also [method get_theme_icon].
 			</description>
 		</method>
+		<method name="add_theme_sound_override">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="sound" type="AudioStream" />
+			<description>
+				Creates a local override for a theme sound with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_sound_override].
+				See also [method get_theme_sound].
+			</description>
+		</method>
 		<method name="add_theme_stylebox_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
@@ -175,7 +184,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns a [Color] from the first matching [Theme] in the tree if that [Theme] has a color item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for more details.
+				See [method Control.get_theme_color] for details.
 			</description>
 		</method>
 		<method name="get_theme_constant" qualifiers="const">
@@ -184,7 +193,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns a constant from the first matching [Theme] in the tree if that [Theme] has a constant item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for more details.
+				See [method Control.get_theme_color] for details.
 			</description>
 		</method>
 		<method name="get_theme_default_base_scale" qualifiers="const">
@@ -232,6 +241,15 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns an icon from the first matching [Theme] in the tree if that [Theme] has an icon item with the specified [param name] and [param theme_type].
+				See [method Control.get_theme_color] for details.
+			</description>
+		</method>
+		<method name="get_theme_sound" qualifiers="const">
+			<return type="AudioStream" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Returns a sound from the first matching [Theme] in the tree if that [Theme] has a sound item with the specified [param name] and [param theme_type].
 				See [method Control.get_theme_color] for details.
 			</description>
 		</method>
@@ -302,7 +320,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a font item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_font] for details.
 			</description>
 		</method>
 		<method name="has_theme_font_override" qualifiers="const">
@@ -319,7 +337,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a font size item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_font_size] for details.
 			</description>
 		</method>
 		<method name="has_theme_font_size_override" qualifiers="const">
@@ -336,7 +354,7 @@
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns [code]true[/code] if there is a matching [Theme] in the tree that has an icon item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_icon] for details.
 			</description>
 		</method>
 		<method name="has_theme_icon_override" qualifiers="const">
@@ -347,13 +365,30 @@
 				See [method add_theme_icon_override].
 			</description>
 		</method>
+		<method name="has_theme_sound" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a sound item with the specified [param name] and [param theme_type].
+				See [method Control.get_theme_sound] for details.
+			</description>
+		</method>
+		<method name="has_theme_sound_override" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if there is a local override for a theme sound with the specified [param name] in this [Control] node.
+				See [method add_theme_sound_override].
+			</description>
+		</method>
 		<method name="has_theme_stylebox" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a stylebox item with the specified [param name] and [param theme_type].
-				See [method Control.get_theme_color] for details.
+				See [method Control.get_theme_stylebox] for details.
 			</description>
 		</method>
 		<method name="has_theme_stylebox_override" qualifiers="const">
@@ -527,6 +562,13 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Removes a local override for a theme icon with the specified [param name] previously added by [method add_theme_icon_override] or via the Inspector dock.
+			</description>
+		</method>
+		<method name="remove_theme_sound_override">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Removes a local override for a theme sound with the specified [param name] previously added by [method add_theme_sound_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="remove_theme_stylebox_override">

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -779,6 +779,10 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 							tid.type = "StyleBox";
 							tid.data_type = "style";
 							break;
+						case Theme::DATA_TYPE_SOUND:
+							tid.type = "AudioStream";
+							tid.data_type = "sound";
+							break;
 						case Theme::DATA_TYPE_MAX:
 							break; // Can't happen, but silences warning.
 					}

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -1445,6 +1445,7 @@ void EditorHelp::_update_doc() {
 		data_type_names["font_size"] = TTR("Font Sizes");
 		data_type_names["icon"] = TTR("Icons");
 		data_type_names["style"] = TTR("Styles");
+		data_type_names["sound"] = TTR("Sounds");
 
 		for (const DocData::ThemeItemDoc &theme_item : cd.theme_properties) {
 			if (theme_data_type != theme_item.data_type) {

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -1444,6 +1444,7 @@ void EditorHelp::_update_doc() {
 		data_type_names["font_size"] = TTR("Font Sizes");
 		data_type_names["icon"] = TTR("Icons");
 		data_type_names["style"] = TTR("Styles");
+		data_type_names["sound"] = TTR("Sounds");
 
 		for (const DocData::ThemeItemDoc &theme_item : cd.theme_properties) {
 			if (theme_data_type != theme_item.data_type) {

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -107,6 +107,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	int font_size_amount = 0;
 	int icon_amount = 0;
 	int stylebox_amount = 0;
+	int sound_amount = 0;
 
 	tree_color_items.clear();
 	tree_constant_items.clear();
@@ -114,6 +115,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	tree_font_size_items.clear();
 	tree_icon_items.clear();
 	tree_stylebox_items.clear();
+	tree_sound_items.clear();
 
 	for (const StringName &E : types) {
 		String type_name = (String)E;
@@ -228,6 +230,14 @@ void ThemeItemImportTree::_update_items_tree() {
 
 					item_list = &tree_stylebox_items;
 					stylebox_amount += filtered_names.size();
+					break;
+
+				case Theme::DATA_TYPE_SOUND:
+					data_type_node->set_icon(0, get_editor_theme_icon(SNAME("AudioStream")));
+					data_type_node->set_text(0, TTR("Sounds"));
+
+					item_list = &tree_sound_items;
+					sound_amount += filtered_names.size();
 					break;
 
 				case Theme::DATA_TYPE_MAX:
@@ -346,6 +356,19 @@ void ThemeItemImportTree::_update_items_tree() {
 		select_full_styleboxes_button->set_visible(false);
 		deselect_all_styleboxes_button->set_visible(false);
 	}
+
+	if (sound_amount > 0) {
+		Array arr = { sound_amount };
+		select_sounds_label->set_text(TTRN("1 sound", "{num} sounds", sound_amount).format(arr, "{num}"));
+		select_all_sounds_button->set_visible(true);
+		select_full_sounds_button->set_visible(true);
+		deselect_all_sounds_button->set_visible(true);
+	} else {
+		select_sounds_label->set_text(TTR("No sounds found."));
+		select_all_sounds_button->set_visible(false);
+		select_full_sounds_button->set_visible(false);
+		deselect_all_sounds_button->set_visible(false);
+	}
 }
 
 void ThemeItemImportTree::_toggle_type_items(bool p_collapse) {
@@ -461,6 +484,10 @@ void ThemeItemImportTree::_update_total_selected(Theme::DataType p_data_type) {
 
 		case Theme::DATA_TYPE_STYLEBOX:
 			total_selected_items_label = total_selected_styleboxes_label;
+			break;
+
+		case Theme::DATA_TYPE_SOUND:
+			total_selected_items_label = total_selected_sounds_label;
 			break;
 
 		case Theme::DATA_TYPE_MAX:
@@ -627,6 +654,10 @@ void ThemeItemImportTree::_select_all_data_type_pressed(int p_data_type) {
 			item_list = &tree_stylebox_items;
 			break;
 
+		case Theme::DATA_TYPE_SOUND:
+			item_list = &tree_sound_items;
+			break;
+
 		case Theme::DATA_TYPE_MAX:
 			return; // Can't happen, but silences warning.
 	}
@@ -680,6 +711,10 @@ void ThemeItemImportTree::_select_full_data_type_pressed(int p_data_type) {
 
 		case Theme::DATA_TYPE_STYLEBOX:
 			item_list = &tree_stylebox_items;
+			break;
+
+		case Theme::DATA_TYPE_SOUND:
+			item_list = &tree_sound_items;
 			break;
 
 		case Theme::DATA_TYPE_MAX:
@@ -737,6 +772,10 @@ void ThemeItemImportTree::_deselect_all_data_type_pressed(int p_data_type) {
 
 		case Theme::DATA_TYPE_STYLEBOX:
 			item_list = &tree_stylebox_items;
+			break;
+
+		case Theme::DATA_TYPE_SOUND:
+			item_list = &tree_sound_items;
 			break;
 
 		case Theme::DATA_TYPE_MAX:
@@ -815,6 +854,10 @@ void ThemeItemImportTree::_import_selected() {
 						item_value = Ref<StyleBox>();
 						break;
 
+					case Theme::DATA_TYPE_SOUND:
+						item_value = Ref<AudioStream>();
+						break;
+
 					case Theme::DATA_TYPE_MAX:
 						break; // Can't happen, but silences warning.
 				}
@@ -866,6 +909,7 @@ void ThemeItemImportTree::reset_item_tree() {
 	total_selected_font_sizes_label->hide();
 	total_selected_icons_label->hide();
 	total_selected_styleboxes_label->hide();
+	total_selected_sounds_label->hide();
 
 	_update_items_tree();
 }
@@ -920,6 +964,11 @@ void ThemeItemImportTree::_notification(int p_what) {
 			deselect_all_styleboxes_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeDeselectAll")));
 			select_all_styleboxes_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeSelectAll")));
 			select_full_styleboxes_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeSelectFull")));
+
+			select_sounds_icon->set_texture(get_editor_theme_icon(SNAME("AudioStream")));
+			deselect_all_sounds_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeDeselectAll")));
+			select_all_sounds_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeSelectAll")));
+			select_full_sounds_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeSelectFull")));
 		} break;
 	}
 }
@@ -1016,6 +1065,13 @@ ThemeItemImportTree::ThemeItemImportTree() {
 	select_all_styleboxes_button = memnew(Button);
 	select_full_styleboxes_button = memnew(Button);
 	total_selected_styleboxes_label = memnew(Label);
+
+	select_sounds_icon = memnew(TextureRect);
+	select_sounds_label = memnew(Label);
+	deselect_all_sounds_button = memnew(Button);
+	select_all_sounds_button = memnew(Button);
+	select_full_sounds_button = memnew(Button);
+	total_selected_sounds_label = memnew(Label);
 
 	for (int i = 0; i < Theme::DATA_TYPE_MAX; i++) {
 		Theme::DataType dt = (Theme::DataType)i;
@@ -1115,6 +1171,20 @@ ThemeItemImportTree::ThemeItemImportTree() {
 				select_all_items_tooltip = TTR("Select all visible stylebox items.");
 				select_full_items_tooltip = TTR("Select all visible stylebox items and their data.");
 				deselect_all_items_tooltip = TTR("Deselect all visible stylebox items.");
+				break;
+
+			case Theme::DATA_TYPE_SOUND:
+				select_items_icon = select_sounds_icon;
+				select_items_label = select_sounds_label;
+				deselect_all_items_button = deselect_all_sounds_button;
+				select_all_items_button = select_all_sounds_button;
+				select_full_items_button = select_full_sounds_button;
+				total_selected_items_label = total_selected_sounds_label;
+
+				items_title = TTRC("Sounds");
+				select_all_items_tooltip = TTRC("Select all visible sound items.");
+				select_full_items_tooltip = TTRC("Select all visible sound items and their data.");
+				deselect_all_items_tooltip = TTRC("Deselect all visible sound items.");
 				break;
 
 			case Theme::DATA_TYPE_MAX:
@@ -1303,6 +1373,7 @@ void ThemeItemEditorDialog::_update_edit_types() {
 		edit_items_add_font_size->set_disabled(false);
 		edit_items_add_icon->set_disabled(false);
 		edit_items_add_stylebox->set_disabled(false);
+		edit_items_add_sound->set_disabled(false);
 
 		edit_items_remove_class->set_disabled(false);
 		edit_items_remove_custom->set_disabled(false);
@@ -1317,6 +1388,7 @@ void ThemeItemEditorDialog::_update_edit_types() {
 		edit_items_add_font_size->set_disabled(true);
 		edit_items_add_icon->set_disabled(true);
 		edit_items_add_stylebox->set_disabled(true);
+		edit_items_add_sound->set_disabled(true);
 
 		edit_items_remove_class->set_disabled(true);
 		edit_items_remove_custom->set_disabled(true);
@@ -1536,6 +1608,29 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 		}
 	}
 
+	{ // Sounds.
+		names.clear();
+		edited_theme->get_sound_list(p_item_type, &names);
+
+		if (names.size() > 0) {
+			TreeItem *sound_root = edit_items_tree->create_item(root);
+			sound_root->set_metadata(0, Theme::DATA_TYPE_SOUND);
+			sound_root->set_icon(0, get_editor_theme_icon(SNAME("AudioStream")));
+			sound_root->set_text(0, TTRC("Sounds"));
+			sound_root->add_button(0, get_editor_theme_icon(SNAME("Clear")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTRC("Remove All Audio Items"));
+
+			names.sort_custom<StringName::AlphCompare>();
+			for (const StringName &E : names) {
+				TreeItem *item = edit_items_tree->create_item(sound_root);
+				item->set_text(0, E);
+				item->add_button(0, get_editor_theme_icon(SNAME("Edit")), ITEMS_TREE_RENAME_ITEM, false, TTRC("Rename Item"));
+				item->add_button(0, get_editor_theme_icon(SNAME("Remove")), ITEMS_TREE_REMOVE_ITEM, false, TTRC("Remove Item"));
+			}
+
+			has_any_items = true;
+		}
+	}
+
 	// If some type is selected, but it doesn't seem to have any items, show a guiding message.
 	TreeItem *selected_item = edit_type_list->get_selected();
 	if (selected_item) {
@@ -1633,6 +1728,10 @@ void ThemeItemEditorDialog::_add_theme_item(Theme::DataType p_data_type, const S
 		case Theme::DATA_TYPE_CONSTANT:
 			ur->add_do_method(*edited_theme, "set_constant", p_item_name, p_item_type, 0);
 			ur->add_undo_method(*edited_theme, "clear_constant", p_item_name, p_item_type);
+			break;
+		case Theme::DATA_TYPE_SOUND:
+			ur->add_do_method(*edited_theme, "set_sound", p_item_name, p_item_type, Ref<AudioStream>());
+			ur->add_undo_method(*edited_theme, "clear_sound", p_item_name, p_item_type);
 			break;
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
@@ -1820,6 +1919,9 @@ void ThemeItemEditorDialog::_open_add_theme_item_dialog(int p_data_type) {
 		case Theme::DATA_TYPE_STYLEBOX:
 			edit_theme_item_dialog->set_title(TTR("Add Stylebox Item"));
 			break;
+		case Theme::DATA_TYPE_SOUND:
+			edit_theme_item_dialog->set_title(TTRC("Add Sound Item"));
+			break;
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1855,6 +1957,9 @@ void ThemeItemEditorDialog::_open_rename_theme_item_dialog(Theme::DataType p_dat
 			break;
 		case Theme::DATA_TYPE_STYLEBOX:
 			edit_theme_item_dialog->set_title(TTR("Rename Stylebox Item"));
+			break;
+		case Theme::DATA_TYPE_SOUND:
+			edit_theme_item_dialog->set_title(TTRC("Rename Sound Item"));
 			break;
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
@@ -1942,6 +2047,7 @@ void ThemeItemEditorDialog::_notification(int p_what) {
 			edit_items_add_font_size->set_button_icon(get_editor_theme_icon(SNAME("FontSize")));
 			edit_items_add_icon->set_button_icon(get_editor_theme_icon(SNAME("ImageTexture")));
 			edit_items_add_stylebox->set_button_icon(get_editor_theme_icon(SNAME("StyleBoxFlat")));
+			edit_items_add_sound->set_button_icon(get_editor_theme_icon(SNAME("AudioStream")));
 
 			edit_items_remove_class->set_button_icon(get_editor_theme_icon(SNAME("Control")));
 			edit_items_remove_custom->set_button_icon(get_editor_theme_icon(SNAME("ThemeRemoveCustomItems")));
@@ -2065,6 +2171,13 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	edit_items_add_stylebox->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_add_stylebox);
 	edit_items_add_stylebox->connect(SceneStringName(pressed), callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog).bind(Theme::DATA_TYPE_STYLEBOX));
+
+	edit_items_add_sound = memnew(Button);
+	edit_items_add_sound->set_tooltip_text(TTRC("Add Sound Item"));
+	edit_items_add_sound->set_flat(true);
+	edit_items_add_sound->set_disabled(true);
+	edit_items_toolbar->add_child(edit_items_add_sound);
+	edit_items_add_sound->connect(SceneStringName(pressed), callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog).bind(Theme::DATA_TYPE_SOUND));
 
 	edit_items_toolbar->add_child(memnew(VSeparator));
 
@@ -2856,6 +2969,44 @@ void ThemeTypeEditor::_update_type_items() {
 		}
 	}
 
+	// Sounds.
+	{
+		for (int i = sound_items_list->get_child_count() - 1; i >= 0; i--) {
+			Node *node = sound_items_list->get_child(i);
+			node->queue_free();
+			sound_items_list->remove_child(node);
+		}
+
+		HashMap<StringName, bool> sound_items = _get_type_items(edited_type, Theme::DATA_TYPE_SOUND, show_default);
+		for (const KeyValue<StringName, bool> &E : sound_items) {
+			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_SOUND, E.key, E.value);
+			EditorResourcePicker *item_editor = memnew(EditorResourcePicker);
+			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
+			item_editor->set_base_type("AudioStream");
+			item_control->add_child(item_editor);
+
+			if (E.value) {
+				if (edited_theme->has_sound(E.key, edited_type)) {
+					item_editor->set_edited_resource(edited_theme->get_sound(E.key, edited_type));
+				} else {
+					item_editor->set_edited_resource(Ref<Resource>());
+				}
+				item_editor->connect("resource_selected", callable_mp(this, &ThemeTypeEditor::_edit_resource_item));
+				item_editor->connect("resource_changed", callable_mp(this, &ThemeTypeEditor::_sound_item_changed).bind(E.key));
+			} else {
+				if (ThemeDB::get_singleton()->get_default_theme()->has_sound(E.key, edited_type)) {
+					item_editor->set_edited_resource(ThemeDB::get_singleton()->get_default_theme()->get_sound(E.key, edited_type));
+				} else {
+					item_editor->set_edited_resource(Ref<Resource>());
+				}
+				item_editor->set_editable(false);
+			}
+
+			_add_focusable(item_editor);
+			sound_items_list->add_child(item_control);
+		}
+	}
+
 	// Various type settings.
 	if (edited_type.is_empty() || ClassDB::class_exists(edited_type)) {
 		type_variation_edit->set_editable(false);
@@ -2994,6 +3145,15 @@ void ThemeTypeEditor::_add_default_type_items() {
 			}
 		}
 	}
+	{
+		names.clear();
+		ThemeDB::get_singleton()->get_default_theme()->get_sound_list(default_type, &names);
+		for (const StringName &E : names) {
+			if (!new_snapshot->has_sound(E, edited_type)) {
+				new_snapshot->set_sound(E, edited_type, ThemeDB::get_singleton()->get_default_theme()->get_sound(E, edited_type));
+			}
+		}
+	}
 
 	updating = false;
 
@@ -3056,6 +3216,10 @@ void ThemeTypeEditor::_item_add_cbk(int p_data_type, Control *p_control) {
 				ur->add_undo_method(this, "_unpin_leading_stylebox");
 			}
 		} break;
+		case Theme::DATA_TYPE_SOUND: {
+			ur->add_do_method(*edited_theme, "set_sound", item_name, edited_type, Ref<AudioStream>());
+			ur->add_undo_method(*edited_theme, "clear_sound", item_name, edited_type);
+		} break;
 	}
 
 	ur->commit_action();
@@ -3106,6 +3270,10 @@ void ThemeTypeEditor::_item_override_cbk(int p_data_type, String p_item_name) {
 			if (is_stylebox_pinned(sb)) {
 				ur->add_undo_method(this, "_unpin_leading_stylebox");
 			}
+		} break;
+		case Theme::DATA_TYPE_SOUND: {
+			ur->add_do_method(*edited_theme, "set_sound", p_item_name, edited_type, Ref<AudioStream>());
+			ur->add_undo_method(*edited_theme, "clear_sound", p_item_name, edited_type);
 		} break;
 	}
 
@@ -3162,6 +3330,14 @@ void ThemeTypeEditor::_item_remove_cbk(int p_data_type, String p_item_name) {
 			if (is_stylebox_pinned(sb)) {
 				ur->add_do_method(this, "_unpin_leading_stylebox");
 				ur->add_undo_method(this, "_pin_leading_stylebox", p_item_name, sb);
+			}
+		} break;
+		case Theme::DATA_TYPE_SOUND: {
+			ur->add_do_method(*edited_theme, "clear_sound", p_item_name, edited_type);
+			if (edited_theme->has_sound(p_item_name, edited_type)) {
+				ur->add_undo_method(*edited_theme, "set_sound", p_item_name, edited_type, edited_theme->get_sound(p_item_name, edited_type));
+			} else {
+				ur->add_undo_method(*edited_theme, "set_sound", p_item_name, edited_type, Ref<AudioStream>());
 			}
 		} break;
 	}
@@ -3227,6 +3403,10 @@ void ThemeTypeEditor::_item_rename_confirmed(int p_data_type, String p_item_name
 			if (leading_stylebox.pinned && leading_stylebox.item_name == p_item_name) {
 				leading_stylebox.item_name = new_name;
 			}
+		} break;
+		case Theme::DATA_TYPE_SOUND: {
+			ur->add_do_method(*edited_theme, "rename_sound", p_item_name, new_name, edited_type);
+			ur->add_undo_method(*edited_theme, "rename_sound", new_name, p_item_name, edited_type);
 		} break;
 	}
 
@@ -3329,6 +3509,23 @@ void ThemeTypeEditor::_stylebox_item_changed(Ref<StyleBox> p_value, String p_ite
 
 	ur->add_do_method(this, CoreStringName(call_deferred), "_update_type_items");
 	ur->add_undo_method(this, CoreStringName(call_deferred), "_update_type_items");
+
+	ur->commit_action();
+}
+
+void ThemeTypeEditor::_sound_item_changed(Ref<AudioStream> p_value, String p_item_name) {
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	ur->create_action(TTR("Set Sound Item in Theme"));
+
+	ur->add_do_method(*edited_theme, "set_sound", p_item_name, edited_type, p_value.is_valid() ? p_value : Ref<AudioStream>());
+	if (edited_theme->has_sound(p_item_name, edited_type)) {
+		ur->add_undo_method(*edited_theme, "set_sound", p_item_name, edited_type, edited_theme->get_sound(p_item_name, edited_type));
+	} else {
+		ur->add_undo_method(*edited_theme, "set_sound", p_item_name, edited_type, Ref<AudioStream>());
+	}
+
+	ur->add_do_method(this, "call_deferred", "_update_type_items");
+	ur->add_undo_method(this, "call_deferred", "_update_type_items");
 
 	ur->commit_action();
 }
@@ -3510,7 +3707,8 @@ void ThemeTypeEditor::_notification(int p_what) {
 			data_type_tabs->set_tab_icon(3, get_editor_theme_icon(SNAME("FontSize")));
 			data_type_tabs->set_tab_icon(4, get_editor_theme_icon(SNAME("ImageTexture")));
 			data_type_tabs->set_tab_icon(5, get_editor_theme_icon(SNAME("StyleBoxFlat")));
-			data_type_tabs->set_tab_icon(6, get_editor_theme_icon(SNAME("Tools")));
+			data_type_tabs->set_tab_icon(6, get_editor_theme_icon(SNAME("AudioStream")));
+			data_type_tabs->set_tab_icon(7, get_editor_theme_icon(SNAME("Tools")));
 
 			type_variation_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		} break;
@@ -3561,6 +3759,7 @@ void ThemeTypeEditor::select_type(String p_type_name) {
 		edited_theme->add_font_size_type(edited_type);
 		edited_theme->add_color_type(edited_type);
 		edited_theme->add_constant_type(edited_type);
+		edited_theme->add_sound_type(edited_type);
 
 		_update_type_list();
 	}
@@ -3656,6 +3855,8 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("Icons"));
 	stylebox_items_list = _create_item_list(Theme::DATA_TYPE_STYLEBOX);
 	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("StyleBoxes"));
+	sound_items_list = _create_item_list(Theme::DATA_TYPE_SOUND);
+	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("Sounds"));
 
 	VBoxContainer *type_settings_tab = memnew(VBoxContainer);
 	type_settings_tab->set_custom_minimum_size(Size2(0, 160) * EDSCALE);

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -107,6 +107,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	int font_size_amount = 0;
 	int icon_amount = 0;
 	int stylebox_amount = 0;
+	int sound_amount = 0;
 
 	tree_color_items.clear();
 	tree_constant_items.clear();
@@ -114,6 +115,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	tree_font_size_items.clear();
 	tree_icon_items.clear();
 	tree_stylebox_items.clear();
+	tree_sound_items.clear();
 
 	for (const StringName &E : types) {
 		String type_name = (String)E;
@@ -228,6 +230,14 @@ void ThemeItemImportTree::_update_items_tree() {
 
 					item_list = &tree_stylebox_items;
 					stylebox_amount += filtered_names.size();
+					break;
+
+				case Theme::DATA_TYPE_SOUND:
+					data_type_node->set_icon(0, get_editor_theme_icon(SNAME("AudioStream")));
+					data_type_node->set_text(0, TTRC("Sounds"));
+
+					item_list = &tree_sound_items;
+					sound_amount += filtered_names.size();
 					break;
 
 				case Theme::DATA_TYPE_MAX:
@@ -346,6 +356,19 @@ void ThemeItemImportTree::_update_items_tree() {
 		select_full_styleboxes_button->set_visible(false);
 		deselect_all_styleboxes_button->set_visible(false);
 	}
+
+	if (sound_amount > 0) {
+		Array arr = { sound_amount };
+		select_sounds_label->set_text(TTRN("1 sound", "{num} sounds", sound_amount).format(arr, "{num}"));
+		select_all_sounds_button->set_visible(true);
+		select_full_sounds_button->set_visible(true);
+		deselect_all_sounds_button->set_visible(true);
+	} else {
+		select_sounds_label->set_text(TTR("No sounds found."));
+		select_all_sounds_button->set_visible(false);
+		select_full_sounds_button->set_visible(false);
+		deselect_all_sounds_button->set_visible(false);
+	}
 }
 
 void ThemeItemImportTree::_toggle_type_items(bool p_collapse) {
@@ -461,6 +484,10 @@ void ThemeItemImportTree::_update_total_selected(Theme::DataType p_data_type) {
 
 		case Theme::DATA_TYPE_STYLEBOX:
 			total_selected_items_label = total_selected_styleboxes_label;
+			break;
+
+		case Theme::DATA_TYPE_SOUND:
+			total_selected_items_label = total_selected_sounds_label;
 			break;
 
 		case Theme::DATA_TYPE_MAX:
@@ -627,6 +654,10 @@ void ThemeItemImportTree::_select_all_data_type_pressed(int p_data_type) {
 			item_list = &tree_stylebox_items;
 			break;
 
+		case Theme::DATA_TYPE_SOUND:
+			item_list = &tree_sound_items;
+			break;
+
 		case Theme::DATA_TYPE_MAX:
 			return; // Can't happen, but silences warning.
 	}
@@ -680,6 +711,10 @@ void ThemeItemImportTree::_select_full_data_type_pressed(int p_data_type) {
 
 		case Theme::DATA_TYPE_STYLEBOX:
 			item_list = &tree_stylebox_items;
+			break;
+
+		case Theme::DATA_TYPE_SOUND:
+			item_list = &tree_sound_items;
 			break;
 
 		case Theme::DATA_TYPE_MAX:
@@ -737,6 +772,10 @@ void ThemeItemImportTree::_deselect_all_data_type_pressed(int p_data_type) {
 
 		case Theme::DATA_TYPE_STYLEBOX:
 			item_list = &tree_stylebox_items;
+			break;
+
+		case Theme::DATA_TYPE_SOUND:
+			item_list = &tree_sound_items;
 			break;
 
 		case Theme::DATA_TYPE_MAX:
@@ -815,6 +854,10 @@ void ThemeItemImportTree::_import_selected() {
 						item_value = Ref<StyleBox>();
 						break;
 
+					case Theme::DATA_TYPE_SOUND:
+						item_value = Ref<AudioStream>();
+						break;
+
 					case Theme::DATA_TYPE_MAX:
 						break; // Can't happen, but silences warning.
 				}
@@ -866,6 +909,7 @@ void ThemeItemImportTree::reset_item_tree() {
 	total_selected_font_sizes_label->hide();
 	total_selected_icons_label->hide();
 	total_selected_styleboxes_label->hide();
+	total_selected_sounds_label->hide();
 
 	_update_items_tree();
 }
@@ -920,6 +964,11 @@ void ThemeItemImportTree::_notification(int p_what) {
 			deselect_all_styleboxes_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeDeselectAll")));
 			select_all_styleboxes_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeSelectAll")));
 			select_full_styleboxes_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeSelectFull")));
+
+			select_sounds_icon->set_texture(get_editor_theme_icon(SNAME("AudioStream")));
+			deselect_all_sounds_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeDeselectAll")));
+			select_all_sounds_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeSelectAll")));
+			select_full_sounds_button->set_button_icon(get_editor_theme_icon(SNAME("ThemeSelectFull")));
 		} break;
 	}
 }
@@ -1016,6 +1065,13 @@ ThemeItemImportTree::ThemeItemImportTree() {
 	select_all_styleboxes_button = memnew(Button);
 	select_full_styleboxes_button = memnew(Button);
 	total_selected_styleboxes_label = memnew(Label);
+
+	select_sounds_icon = memnew(TextureRect);
+	select_sounds_label = memnew(Label);
+	deselect_all_sounds_button = memnew(Button);
+	select_all_sounds_button = memnew(Button);
+	select_full_sounds_button = memnew(Button);
+	total_selected_sounds_label = memnew(Label);
 
 	for (int i = 0; i < Theme::DATA_TYPE_MAX; i++) {
 		Theme::DataType dt = (Theme::DataType)i;
@@ -1115,6 +1171,20 @@ ThemeItemImportTree::ThemeItemImportTree() {
 				select_all_items_tooltip = TTRC("Select all visible stylebox items.");
 				select_full_items_tooltip = TTRC("Select all visible stylebox items and their data.");
 				deselect_all_items_tooltip = TTRC("Deselect all visible stylebox items.");
+				break;
+
+			case Theme::DATA_TYPE_SOUND:
+				select_items_icon = select_sounds_icon;
+				select_items_label = select_sounds_label;
+				deselect_all_items_button = deselect_all_sounds_button;
+				select_all_items_button = select_all_sounds_button;
+				select_full_items_button = select_full_sounds_button;
+				total_selected_items_label = total_selected_sounds_label;
+
+				items_title = TTRC("Sounds");
+				select_all_items_tooltip = TTRC("Select all visible sound items.");
+				select_full_items_tooltip = TTRC("Select all visible sound items and their data.");
+				deselect_all_items_tooltip = TTRC("Deselect all visible sound items.");
 				break;
 
 			case Theme::DATA_TYPE_MAX:
@@ -1303,6 +1373,7 @@ void ThemeItemEditorDialog::_update_edit_types() {
 		edit_items_add_font_size->set_disabled(false);
 		edit_items_add_icon->set_disabled(false);
 		edit_items_add_stylebox->set_disabled(false);
+		edit_items_add_sound->set_disabled(false);
 
 		edit_items_remove_class->set_disabled(false);
 		edit_items_remove_custom->set_disabled(false);
@@ -1317,6 +1388,7 @@ void ThemeItemEditorDialog::_update_edit_types() {
 		edit_items_add_font_size->set_disabled(true);
 		edit_items_add_icon->set_disabled(true);
 		edit_items_add_stylebox->set_disabled(true);
+		edit_items_add_sound->set_disabled(true);
 
 		edit_items_remove_class->set_disabled(true);
 		edit_items_remove_custom->set_disabled(true);
@@ -1536,6 +1608,29 @@ void ThemeItemEditorDialog::_update_edit_item_tree(String p_item_type) {
 		}
 	}
 
+	{ // Sounds.
+		names.clear();
+		edited_theme->get_sound_list(p_item_type, &names);
+
+		if (names.size() > 0) {
+			TreeItem *sound_root = edit_items_tree->create_item(root);
+			sound_root->set_metadata(0, Theme::DATA_TYPE_SOUND);
+			sound_root->set_icon(0, get_editor_theme_icon(SNAME("AudioStream")));
+			sound_root->set_text(0, TTRC("Sounds"));
+			sound_root->add_button(0, get_editor_theme_icon(SNAME("Clear")), ITEMS_TREE_REMOVE_DATA_TYPE, false, TTRC("Remove All Sound Items"));
+
+			names.sort_custom<StringName::AlphCompare>();
+			for (const StringName &E : names) {
+				TreeItem *item = edit_items_tree->create_item(sound_root);
+				item->set_text(0, E);
+				item->add_button(0, get_editor_theme_icon(SNAME("Edit")), ITEMS_TREE_RENAME_ITEM, false, TTRC("Rename Item"));
+				item->add_button(0, get_editor_theme_icon(SNAME("Remove")), ITEMS_TREE_REMOVE_ITEM, false, TTRC("Remove Item"));
+			}
+
+			has_any_items = true;
+		}
+	}
+
 	// If some type is selected, but it doesn't seem to have any items, show a guiding message.
 	TreeItem *selected_item = edit_type_list->get_selected();
 	if (selected_item) {
@@ -1633,6 +1728,10 @@ void ThemeItemEditorDialog::_add_theme_item(Theme::DataType p_data_type, const S
 		case Theme::DATA_TYPE_CONSTANT:
 			ur->add_do_method(*edited_theme, "set_constant", p_item_name, p_item_type, 0);
 			ur->add_undo_method(*edited_theme, "clear_constant", p_item_name, p_item_type);
+			break;
+		case Theme::DATA_TYPE_SOUND:
+			ur->add_do_method(*edited_theme, "set_sound", p_item_name, p_item_type, Ref<AudioStream>());
+			ur->add_undo_method(*edited_theme, "clear_sound", p_item_name, p_item_type);
 			break;
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
@@ -1820,6 +1919,9 @@ void ThemeItemEditorDialog::_open_add_theme_item_dialog(int p_data_type) {
 		case Theme::DATA_TYPE_STYLEBOX:
 			edit_theme_item_dialog->set_title(TTRC("Add Stylebox Item"));
 			break;
+		case Theme::DATA_TYPE_SOUND:
+			edit_theme_item_dialog->set_title(TTRC("Add Sound Item"));
+			break;
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1855,6 +1957,9 @@ void ThemeItemEditorDialog::_open_rename_theme_item_dialog(Theme::DataType p_dat
 			break;
 		case Theme::DATA_TYPE_STYLEBOX:
 			edit_theme_item_dialog->set_title(TTRC("Rename Stylebox Item"));
+			break;
+		case Theme::DATA_TYPE_SOUND:
+			edit_theme_item_dialog->set_title(TTRC("Rename Sound Item"));
 			break;
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
@@ -1942,6 +2047,7 @@ void ThemeItemEditorDialog::_notification(int p_what) {
 			edit_items_add_font_size->set_button_icon(get_editor_theme_icon(SNAME("FontSize")));
 			edit_items_add_icon->set_button_icon(get_editor_theme_icon(SNAME("ImageTexture")));
 			edit_items_add_stylebox->set_button_icon(get_editor_theme_icon(SNAME("StyleBoxFlat")));
+			edit_items_add_sound->set_button_icon(get_editor_theme_icon(SNAME("AudioStream")));
 
 			edit_items_remove_class->set_button_icon(get_editor_theme_icon(SNAME("Control")));
 			edit_items_remove_custom->set_button_icon(get_editor_theme_icon(SNAME("ThemeRemoveCustomItems")));
@@ -2065,6 +2171,13 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	edit_items_add_stylebox->set_disabled(true);
 	edit_items_toolbar->add_child(edit_items_add_stylebox);
 	edit_items_add_stylebox->connect(SceneStringName(pressed), callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog).bind(Theme::DATA_TYPE_STYLEBOX));
+
+	edit_items_add_sound = memnew(Button);
+	edit_items_add_sound->set_tooltip_text(TTRC("Add Sound Item"));
+	edit_items_add_sound->set_flat(true);
+	edit_items_add_sound->set_disabled(true);
+	edit_items_toolbar->add_child(edit_items_add_sound);
+	edit_items_add_sound->connect(SceneStringName(pressed), callable_mp(this, &ThemeItemEditorDialog::_open_add_theme_item_dialog).bind(Theme::DATA_TYPE_SOUND));
 
 	edit_items_toolbar->add_child(memnew(VSeparator));
 
@@ -2856,6 +2969,44 @@ void ThemeTypeEditor::_update_type_items() {
 		}
 	}
 
+	// Sounds.
+	{
+		for (int i = sound_items_list->get_child_count() - 1; i >= 0; i--) {
+			Node *node = sound_items_list->get_child(i);
+			node->queue_free();
+			sound_items_list->remove_child(node);
+		}
+
+		HashMap<StringName, bool> sound_items = _get_type_items(edited_type, Theme::DATA_TYPE_SOUND, show_default);
+		for (const KeyValue<StringName, bool> &E : sound_items) {
+			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_SOUND, E.key, E.value);
+			EditorResourcePicker *item_editor = memnew(EditorResourcePicker);
+			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
+			item_editor->set_base_type("AudioStream");
+			item_control->add_child(item_editor);
+
+			if (E.value) {
+				if (edited_theme->has_sound(E.key, edited_type)) {
+					item_editor->set_edited_resource(edited_theme->get_sound(E.key, edited_type));
+				} else {
+					item_editor->set_edited_resource(Ref<Resource>());
+				}
+				item_editor->connect("resource_selected", callable_mp(this, &ThemeTypeEditor::_edit_resource_item));
+				item_editor->connect("resource_changed", callable_mp(this, &ThemeTypeEditor::_sound_item_changed).bind(E.key));
+			} else {
+				if (ThemeDB::get_singleton()->get_default_theme()->has_sound(E.key, edited_type)) {
+					item_editor->set_edited_resource(ThemeDB::get_singleton()->get_default_theme()->get_sound(E.key, edited_type));
+				} else {
+					item_editor->set_edited_resource(Ref<Resource>());
+				}
+				item_editor->set_editable(false);
+			}
+
+			_add_focusable(item_editor);
+			sound_items_list->add_child(item_control);
+		}
+	}
+
 	// Various type settings.
 	if (edited_type.is_empty() || ClassDB::class_exists(edited_type)) {
 		type_variation_edit->set_editable(false);
@@ -2994,6 +3145,15 @@ void ThemeTypeEditor::_add_default_type_items() {
 			}
 		}
 	}
+	{
+		names.clear();
+		ThemeDB::get_singleton()->get_default_theme()->get_sound_list(default_type, &names);
+		for (const StringName &E : names) {
+			if (!new_snapshot->has_sound(E, edited_type)) {
+				new_snapshot->set_sound(E, edited_type, ThemeDB::get_singleton()->get_default_theme()->get_sound(E, edited_type));
+			}
+		}
+	}
 
 	updating = false;
 
@@ -3056,6 +3216,10 @@ void ThemeTypeEditor::_item_add_cbk(int p_data_type, Control *p_control) {
 				ur->add_undo_method(this, "_unpin_leading_stylebox");
 			}
 		} break;
+		case Theme::DATA_TYPE_SOUND: {
+			ur->add_do_method(*edited_theme, "set_sound", item_name, edited_type, Ref<AudioStream>());
+			ur->add_undo_method(*edited_theme, "clear_sound", item_name, edited_type);
+		} break;
 	}
 
 	ur->commit_action();
@@ -3106,6 +3270,10 @@ void ThemeTypeEditor::_item_override_cbk(int p_data_type, String p_item_name) {
 			if (is_stylebox_pinned(sb)) {
 				ur->add_undo_method(this, "_unpin_leading_stylebox");
 			}
+		} break;
+		case Theme::DATA_TYPE_SOUND: {
+			ur->add_do_method(*edited_theme, "set_sound", p_item_name, edited_type, Ref<AudioStream>());
+			ur->add_undo_method(*edited_theme, "clear_sound", p_item_name, edited_type);
 		} break;
 	}
 
@@ -3162,6 +3330,14 @@ void ThemeTypeEditor::_item_remove_cbk(int p_data_type, String p_item_name) {
 			if (is_stylebox_pinned(sb)) {
 				ur->add_do_method(this, "_unpin_leading_stylebox");
 				ur->add_undo_method(this, "_pin_leading_stylebox", p_item_name, sb);
+			}
+		} break;
+		case Theme::DATA_TYPE_SOUND: {
+			ur->add_do_method(*edited_theme, "clear_sound", p_item_name, edited_type);
+			if (edited_theme->has_sound(p_item_name, edited_type)) {
+				ur->add_undo_method(*edited_theme, "set_sound", p_item_name, edited_type, edited_theme->get_sound(p_item_name, edited_type));
+			} else {
+				ur->add_undo_method(*edited_theme, "set_sound", p_item_name, edited_type, Ref<AudioStream>());
 			}
 		} break;
 	}
@@ -3227,6 +3403,10 @@ void ThemeTypeEditor::_item_rename_confirmed(int p_data_type, String p_item_name
 			if (leading_stylebox.pinned && leading_stylebox.item_name == p_item_name) {
 				leading_stylebox.item_name = new_name;
 			}
+		} break;
+		case Theme::DATA_TYPE_SOUND: {
+			ur->add_do_method(*edited_theme, "rename_sound", p_item_name, new_name, edited_type);
+			ur->add_undo_method(*edited_theme, "rename_sound", new_name, p_item_name, edited_type);
 		} break;
 	}
 
@@ -3326,6 +3506,23 @@ void ThemeTypeEditor::_stylebox_item_changed(Ref<StyleBox> p_value, String p_ite
 
 	ur->add_do_method(this, "_change_pinned_stylebox");
 	ur->add_undo_method(this, "_change_pinned_stylebox");
+
+	ur->add_do_method(this, CoreStringName(call_deferred), "_update_type_items");
+	ur->add_undo_method(this, CoreStringName(call_deferred), "_update_type_items");
+
+	ur->commit_action();
+}
+
+void ThemeTypeEditor::_sound_item_changed(Ref<AudioStream> p_value, String p_item_name) {
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	ur->create_action(TTR("Set Sound Item in Theme"));
+
+	ur->add_do_method(*edited_theme, "set_sound", p_item_name, edited_type, p_value.is_valid() ? p_value : Ref<AudioStream>());
+	if (edited_theme->has_sound(p_item_name, edited_type)) {
+		ur->add_undo_method(*edited_theme, "set_sound", p_item_name, edited_type, edited_theme->get_sound(p_item_name, edited_type));
+	} else {
+		ur->add_undo_method(*edited_theme, "set_sound", p_item_name, edited_type, Ref<AudioStream>());
+	}
 
 	ur->add_do_method(this, CoreStringName(call_deferred), "_update_type_items");
 	ur->add_undo_method(this, CoreStringName(call_deferred), "_update_type_items");
@@ -3510,7 +3707,8 @@ void ThemeTypeEditor::_notification(int p_what) {
 			data_type_tabs->set_tab_icon(3, get_editor_theme_icon(SNAME("FontSize")));
 			data_type_tabs->set_tab_icon(4, get_editor_theme_icon(SNAME("ImageTexture")));
 			data_type_tabs->set_tab_icon(5, get_editor_theme_icon(SNAME("StyleBoxFlat")));
-			data_type_tabs->set_tab_icon(6, get_editor_theme_icon(SNAME("Tools")));
+			data_type_tabs->set_tab_icon(6, get_editor_theme_icon(SNAME("AudioStream")));
+			data_type_tabs->set_tab_icon(7, get_editor_theme_icon(SNAME("Tools")));
 
 			type_variation_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		} break;
@@ -3561,6 +3759,7 @@ void ThemeTypeEditor::select_type(String p_type_name) {
 		edited_theme->add_font_size_type(edited_type);
 		edited_theme->add_color_type(edited_type);
 		edited_theme->add_constant_type(edited_type);
+		edited_theme->add_sound_type(edited_type);
 
 		_update_type_list();
 	}
@@ -3656,6 +3855,8 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("Icons"));
 	stylebox_items_list = _create_item_list(Theme::DATA_TYPE_STYLEBOX);
 	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("StyleBoxes"));
+	sound_items_list = _create_item_list(Theme::DATA_TYPE_SOUND);
+	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("Sounds"));
 
 	VBoxContainer *type_settings_tab = memnew(VBoxContainer);
 	type_settings_tab->set_custom_minimum_size(Size2(0, 160) * EDSCALE);

--- a/editor/scene/gui/theme_editor_plugin.h
+++ b/editor/scene/gui/theme_editor_plugin.h
@@ -92,6 +92,7 @@ class ThemeItemImportTree : public VBoxContainer {
 	List<TreeItem *> tree_font_size_items;
 	List<TreeItem *> tree_icon_items;
 	List<TreeItem *> tree_stylebox_items;
+	List<TreeItem *> tree_sound_items;
 
 	bool updating_tree = false;
 
@@ -141,6 +142,13 @@ class ThemeItemImportTree : public VBoxContainer {
 	Button *select_full_styleboxes_button = nullptr;
 	Button *deselect_all_styleboxes_button = nullptr;
 	Label *total_selected_styleboxes_label = nullptr;
+
+	TextureRect *select_sounds_icon = nullptr;
+	Label *select_sounds_label = nullptr;
+	Button *select_all_sounds_button = nullptr;
+	Button *select_full_sounds_button = nullptr;
+	Button *deselect_all_sounds_button = nullptr;
+	Label *total_selected_sounds_label = nullptr;
 
 	HBoxContainer *select_icons_warning_hb = nullptr;
 	TextureRect *select_icons_warning_icon = nullptr;
@@ -215,6 +223,7 @@ class ThemeItemEditorDialog : public AcceptDialog {
 	Button *edit_items_add_font_size = nullptr;
 	Button *edit_items_add_icon = nullptr;
 	Button *edit_items_add_stylebox = nullptr;
+	Button *edit_items_add_sound = nullptr;
 	Button *edit_items_remove_class = nullptr;
 	Button *edit_items_remove_custom = nullptr;
 	Button *edit_items_remove_all = nullptr;
@@ -363,6 +372,7 @@ class ThemeTypeEditor : public MarginContainer {
 	VBoxContainer *font_size_items_list = nullptr;
 	VBoxContainer *icon_items_list = nullptr;
 	VBoxContainer *stylebox_items_list = nullptr;
+	VBoxContainer *sound_items_list = nullptr;
 
 	LineEdit *type_variation_edit = nullptr;
 	Button *type_variation_button = nullptr;
@@ -411,6 +421,7 @@ class ThemeTypeEditor : public MarginContainer {
 	void _font_item_changed(Ref<Font> p_value, String p_item_name);
 	void _icon_item_changed(Ref<Texture2D> p_value, String p_item_name);
 	void _stylebox_item_changed(Ref<StyleBox> p_value, String p_item_name);
+	void _sound_item_changed(Ref<AudioStream> p_value, String p_item_name);
 	void _change_pinned_stylebox();
 	void _on_pin_leader_button_pressed(Control *p_editor, String p_item_name);
 	void _pin_leading_stylebox(String p_item_name, Ref<StyleBox> p_stylebox);

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -99,7 +99,7 @@ void AudioStreamPlayerInternal::ensure_playback_limit() {
 void AudioStreamPlayerInternal::notification(int p_what) {
 	switch (p_what) {
 		case Node::NOTIFICATION_ENTER_TREE: {
-			if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
+			if (autoplay && !node->is_part_of_edited_scene()) {
 				play_callable.call(0.0);
 			}
 			set_stream_paused(!node->can_process());

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -60,10 +60,6 @@ void BaseButton::_unpress_group() {
 void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (status.disabled) { // no interaction with disabled button
-		return;
-	}
-
 	if (p_event->get_device() == InputEvent::DEVICE_ID_EMULATION) {
 		return;
 	}
@@ -170,6 +166,9 @@ void BaseButton::_notification(int p_what) {
 
 		case NOTIFICATION_MOUSE_ENTER: {
 			status.hovering = true;
+			if (!status.disabled) {
+				play_theme_sound(theme_cache.hover_sound);
+			}
 			queue_accessibility_update();
 			queue_redraw();
 		} break;
@@ -225,12 +224,23 @@ void BaseButton::_notification(int p_what) {
 }
 
 void BaseButton::_pressed() {
+	if (status.disabled) {
+		play_theme_sound(theme_cache.pressed_disabled_sound);
+		return;
+	}
+
+	play_theme_sound(theme_cache.pressed_sound);
+
 	GDVIRTUAL_CALL(_pressed);
 	pressed();
 	emit_signal(SceneStringName(pressed));
 }
 
 void BaseButton::_toggled(bool p_pressed) {
+	if (status.disabled) {
+		return;
+	}
+
 	GDVIRTUAL_CALL(_toggled, p_pressed);
 	toggled(p_pressed);
 	emit_signal(SceneStringName(toggled), p_pressed);
@@ -260,10 +270,12 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 					status.pressing_inside = false;
 					status.touch_index = -1; // Action completed, release matching touch so later taps aren't dropped if a modal consumes the release.
 				}
-				status.pressed = !status.pressed;
-				_unpress_group();
-				if (button_group.is_valid()) {
-					button_group->emit_signal(SceneStringName(pressed), this);
+				if (!status.disabled) {
+					status.pressed = !status.pressed;
+					_unpress_group();
+					if (button_group.is_valid()) {
+						button_group->emit_signal(SceneStringName(pressed), this);
+					}
 				}
 				_toggled(status.pressed);
 				_pressed();
@@ -484,7 +496,7 @@ void BaseButton::_shortcut_feedback_timeout() {
 void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!is_disabled() && p_event->is_pressed() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
+	if (p_event->is_pressed() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
 		if (toggle_mode) {
 			status.pressed = !status.pressed;
 
@@ -647,6 +659,11 @@ void BaseButton::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_PRESS);
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_RELEASE);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, BaseButton, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, BaseButton, hover_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, BaseButton, pressed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, BaseButton, pressed_disabled_sound);
 
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/timers/button_shortcut_feedback_highlight_time", PROPERTY_HINT_RANGE, "0.01,10,0.01,suffix:s"), 0.2);
 }

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -60,10 +60,6 @@ void BaseButton::_unpress_group() {
 void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (status.disabled) { // no interaction with disabled button
-		return;
-	}
-
 	if (p_event->get_device() == InputEvent::DEVICE_ID_EMULATION) {
 		return;
 	}
@@ -154,6 +150,9 @@ void BaseButton::_notification(int p_what) {
 
 		case NOTIFICATION_MOUSE_ENTER: {
 			status.hovering = true;
+			if (!status.disabled) {
+				play_theme_sound(theme_cache.hover_sound);
+			}
 			queue_accessibility_update();
 			queue_redraw();
 		} break;
@@ -209,12 +208,23 @@ void BaseButton::_notification(int p_what) {
 }
 
 void BaseButton::_pressed() {
+	if (status.disabled) {
+		play_theme_sound(theme_cache.pressed_disabled_sound);
+		return;
+	}
+
+	play_theme_sound(theme_cache.pressed_sound);
+
 	GDVIRTUAL_CALL(_pressed);
 	pressed();
 	emit_signal(SceneStringName(pressed));
 }
 
 void BaseButton::_toggled(bool p_pressed) {
+	if (status.disabled) {
+		return;
+	}
+
 	GDVIRTUAL_CALL(_toggled, p_pressed);
 	toggled(p_pressed);
 	emit_signal(SceneStringName(toggled), p_pressed);
@@ -232,7 +242,9 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		status.pressing_inside = true;
 		if (!status.pressed_down_with_focus) {
 			status.pressed_down_with_focus = true;
-			emit_signal(SNAME("button_down"));
+			if (!status.disabled) {
+				emit_signal(SNAME("button_down"));
+			}
 		}
 	}
 
@@ -245,11 +257,13 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 					status.touch_index = -1; // Action completed, release matching touch so later taps aren't dropped if a modal consumes the release.
 				}
 
-				status.pressed = !status.pressed;
+				if (!status.disabled) {
+					status.pressed = !status.pressed;
 
-				_unpress_group();
-				if (button_group.is_valid()) {
-					button_group->emit_signal(SceneStringName(pressed), this);
+					_unpress_group();
+					if (button_group.is_valid()) {
+						button_group->emit_signal(SceneStringName(pressed), this);
+					}
 				}
 
 				_toggled(status.pressed);
@@ -267,7 +281,9 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		status.pressing_inside = false;
 		if (status.pressed_down_with_focus) {
 			status.pressed_down_with_focus = false;
-			emit_signal(SNAME("button_up"));
+			if (!status.disabled) {
+				emit_signal(SNAME("button_up"));
+			}
 		}
 	}
 
@@ -494,7 +510,14 @@ void BaseButton::_shortcut_feedback_timeout() {
 void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!is_disabled() && p_event->is_pressed() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
+	if (p_event->is_pressed() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
+		if (is_disabled()) {
+			// Play the disabled sound here, as `press()` early returns if the button is disabled
+			// (which causes the `play_theme_sound()` call in `_pressed()` to not be called).
+			// This is not needed for the non-disabled press sound.
+			play_theme_sound(theme_cache.pressed_disabled_sound);
+		}
+
 		press();
 		accept_event();
 
@@ -653,6 +676,11 @@ void BaseButton::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_PRESS);
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_RELEASE);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, BaseButton, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, BaseButton, hover_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, BaseButton, pressed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, BaseButton, pressed_disabled_sound);
 
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/timers/button_shortcut_feedback_highlight_time", PROPERTY_HINT_RANGE, "0.01,10,0.01,suffix:s"), 0.2);
 }

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -48,6 +48,11 @@ public:
 private:
 	struct ThemeCache {
 		int click_margin = 0;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> hover_sound;
+		Ref<AudioStream> pressed_sound;
+		Ref<AudioStream> pressed_disabled_sound;
 	} theme_cache;
 
 	BitField<MouseButtonMask> button_mask = MouseButtonMask::LEFT;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1365,6 +1365,9 @@ void ColorPicker::_sample_input(const Ref<InputEvent> &p_event) {
 		const Rect2 rect_old = Rect2(Point2(), Size2(sample->get_size().width * 0.5, sample->get_size().height * 0.95));
 		if (rect_old.has_point(mb->get_position())) {
 			// Revert to the old color when left-clicking the old color sample.
+			if (!old_color.is_equal_approx(color)) {
+				play_theme_sound(theme_cache.pressed_sound);
+			}
 			set_pick_color(old_color);
 
 			sample->set_focus_mode(FOCUS_NONE);
@@ -1373,6 +1376,9 @@ void ColorPicker::_sample_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (p_event->is_action_pressed(SNAME("ui_accept"), false, true)) {
+		if (!old_color.is_equal_approx(color)) {
+			play_theme_sound(theme_cache.pressed_sound);
+		}
 		set_pick_color(old_color);
 		emit_signal(SNAME("color_changed"), color);
 	}
@@ -2084,6 +2090,10 @@ void ColorPicker::_bind_methods() {
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_pressed, "tab_selected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover, "tab_selected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover_pressed, "tab_selected", "TabContainer");
+
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, ColorPicker, pressed_sound, "pressed_sound", "BaseButton");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, ColorPicker, drag_started_sound, "drag_started_sound", "Slider");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, ColorPicker, drag_ended_sound, "drag_ended_sound", "Slider");
 
 	ADD_CLASS_DEPENDENCY("LineEdit");
 	ADD_CLASS_DEPENDENCY("MenuButton");

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1365,6 +1365,9 @@ void ColorPicker::_sample_input(const Ref<InputEvent> &p_event) {
 		const Rect2 rect_old = Rect2(Point2(), Size2(sample->get_size().width * 0.5, sample->get_size().height * 0.95));
 		if (rect_old.has_point(mb->get_position())) {
 			// Revert to the old color when left-clicking the old color sample.
+			if (!old_color.is_equal_approx(color)) {
+				play_theme_sound(theme_cache.pressed_sound);
+			}
 			set_pick_color(old_color);
 
 			sample->set_focus_mode(FOCUS_NONE);
@@ -1373,6 +1376,9 @@ void ColorPicker::_sample_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (p_event->is_action_pressed(SNAME("ui_accept"), false, true)) {
+		if (!old_color.is_equal_approx(color)) {
+			play_theme_sound(theme_cache.pressed_sound);
+		}
 		set_pick_color(old_color);
 		emit_signal(SNAME("color_changed"), color);
 	}
@@ -1498,6 +1504,7 @@ void ColorPicker::_preset_input(const Ref<InputEvent> &p_event, const Color &p_c
 			emit_signal(SNAME("color_changed"), p_color);
 		} else if (bev->is_pressed() && bev->get_button_index() == MouseButton::RIGHT && can_add_swatches) {
 			erase_preset(p_color);
+			play_theme_sound(theme_cache.pressed_sound);
 			emit_signal(SNAME("preset_removed"), p_color);
 		}
 	}
@@ -2084,6 +2091,10 @@ void ColorPicker::_bind_methods() {
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_pressed, "tab_selected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover, "tab_selected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover_pressed, "tab_selected", "TabContainer");
+
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, ColorPicker, pressed_sound, "pressed_sound", "BaseButton");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, ColorPicker, drag_started_sound, "drag_started_sound", "Slider");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, ColorPicker, drag_ended_sound, "drag_ended_sound", "Slider");
 
 	ADD_CLASS_DEPENDENCY("LineEdit");
 	ADD_CLASS_DEPENDENCY("MenuButton");

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -348,6 +348,10 @@ private:
 		Ref<StyleBox> mode_button_pressed;
 		Ref<StyleBox> mode_button_hover;
 		Ref<StyleBox> mode_button_hover_pressed;
+
+		Ref<AudioStream> pressed_sound;
+		Ref<AudioStream> drag_started_sound;
+		Ref<AudioStream> drag_ended_sound;
 	} theme_cache;
 
 	void _copy_normalized_to_hsv_okhsl();

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -165,12 +165,14 @@ bool ColorPickerShape::can_handle(const Ref<InputEvent> &p_event, Vector2 &r_pos
 		}
 
 		if (mb->is_pressed()) {
+			color_picker->play_theme_sound(color_picker->theme_cache.drag_started_sound);
 			is_dragging = true;
 			r_position = mb->get_position();
 			return true;
 		} else {
 			_emit_color_changed();
 			color_picker->add_recent_preset(color_picker->color);
+			color_picker->play_theme_sound(color_picker->theme_cache.drag_ended_sound);
 			is_dragging = false;
 			return false;
 		}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -259,6 +259,8 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 			type = Theme::DATA_TYPE_ICON;
 		} else if (pf == "add_theme_stylebox_override" || pf == "has_theme_stylebox" || pf == "has_theme_stylebox_override" || pf == "get_theme_stylebox" || pf == "remove_theme_stylebox_override") {
 			type = Theme::DATA_TYPE_STYLEBOX;
+		} else if (pf == "add_theme_sound_override" || pf == "has_theme_sound" || pf == "has_theme_sound_override" || pf == "get_theme_sound" || pf == "remove_theme_sound_override") {
+			type = Theme::DATA_TYPE_SOUND;
 		}
 
 		if (type != Theme::DATA_TYPE_MAX) {
@@ -389,6 +391,13 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 			String dname = name.get_slicec('/', 1);
 			data.theme_constant_override.erase(dname);
 			_notify_theme_override_changed();
+		} else if (name.begins_with("theme_override_sounds/")) {
+			String dname = name.get_slicec('/', 1);
+			if (data.theme_sound_override.has(dname)) {
+				data.theme_sound_override[dname]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
+			}
+			data.theme_sound_override.erase(dname);
+			_notify_theme_override_changed();
 		} else {
 			return false;
 		}
@@ -411,6 +420,9 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (name.begins_with("theme_override_constants/")) {
 			String dname = name.get_slicec('/', 1);
 			add_theme_constant_override(dname, p_value);
+		} else if (name.begins_with("theme_override_sounds/")) {
+			String dname = name.get_slicec('/', 1);
+			add_theme_sound_override(dname, p_value);
 		} else {
 			return false;
 		}
@@ -445,6 +457,9 @@ bool Control::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (sname.begins_with("theme_override_constants/")) {
 		String name = sname.get_slicec('/', 1);
 		r_ret = data.theme_constant_override.has(name) ? Variant(data.theme_constant_override[name]) : Variant();
+	} else if (sname.begins_with("theme_override_sounds/")) {
+		String name = sname.get_slicec('/', 1);
+		r_ret = data.theme_sound_override.has(name) ? Variant(data.theme_sound_override[name]) : Variant();
 	} else {
 		return false;
 	}
@@ -507,6 +522,13 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 				}
 				p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_styles") + String("/") + E.item_name, PROPERTY_HINT_RESOURCE_TYPE, StyleBox::get_class_static(), usage));
+			} break;
+
+			case Theme::DATA_TYPE_SOUND: {
+				if (data.theme_sound_override.has(E.item_name)) {
+					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+				}
+				p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_sounds") + String("/") + E.item_name, PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static(), usage));
 			} break;
 
 			default: {
@@ -3082,6 +3104,15 @@ void Control::release_focus() {
 	get_viewport()->gui_release_focus();
 }
 
+void Control::play_theme_sound(const Ref<AudioStream> &p_stream) {
+	ERR_MAIN_THREAD_GUARD;
+	if (p_stream.is_null() || !get_tree()) {
+		return;
+	}
+
+	get_tree()->play_theme_sound(p_stream);
+}
+
 static Control *_next_control(Control *p_from) {
 	if (p_from->is_set_as_top_level()) {
 		return nullptr; // Can't go above.
@@ -3642,6 +3673,7 @@ void Control::_invalidate_theme_cache() {
 	data.theme_font_size_cache.clear();
 	data.theme_color_cache.clear();
 	data.theme_constant_cache.clear();
+	data.theme_audio_cache.clear();
 }
 
 void Control::_update_theme_item_cache() {
@@ -3867,6 +3899,30 @@ int Control::get_theme_constant(const StringName &p_name, const StringName &p_th
 	return constant;
 }
 
+Ref<AudioStream> Control::get_theme_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	ERR_READ_THREAD_GUARD_V(Ref<AudioStream>());
+	if (!data.initialized) {
+		WARN_PRINT_ONCE(vformat("Attempting to access theme items too early in %s; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED", get_description()));
+	}
+
+	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+		const Ref<AudioStream> *audio = data.theme_sound_override.getptr(p_name);
+		if (audio) {
+			return *audio;
+		}
+	}
+
+	if (data.theme_audio_cache.has(p_theme_type) && data.theme_audio_cache[p_theme_type].has(p_name)) {
+		return data.theme_audio_cache[p_theme_type][p_name];
+	}
+
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<AudioStream> audio = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_SOUND, p_name, theme_types);
+	data.theme_audio_cache[p_theme_type][p_name] = audio;
+	return audio;
+}
+
 Variant Control::get_theme_item(Theme::DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
 	switch (p_data_type) {
 		case Theme::DATA_TYPE_COLOR:
@@ -3881,6 +3937,8 @@ Variant Control::get_theme_item(Theme::DataType p_data_type, const StringName &p
 			return get_theme_icon(p_name, p_theme_type);
 		case Theme::DATA_TYPE_STYLEBOX:
 			return get_theme_stylebox(p_name, p_theme_type);
+		case Theme::DATA_TYPE_SOUND:
+			return get_theme_sound(p_name, p_theme_type);
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -3918,6 +3976,11 @@ Variant Control::get_used_theme_item(const String &p_full_name, const StringName
 		String name = p_full_name.substr(strlen("theme_override_constants/"));
 		if (has_theme_constant(name)) {
 			return get_theme_constant(name);
+		}
+	} else if (p_full_name.begins_with("theme_override_sounds/")) {
+		String name = p_full_name.substr(strlen("theme_override_sounds/"));
+		if (has_theme_sound(name)) {
+			return get_theme_sound(name);
 		}
 	} else {
 		ERR_FAIL_V_MSG(Variant(), vformat("The property %s is not a theme item.", p_full_name));
@@ -4034,6 +4097,23 @@ bool Control::has_theme_constant(const StringName &p_name, const StringName &p_t
 	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 }
 
+bool Control::has_theme_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	if (!data.initialized) {
+		WARN_PRINT_ONCE(vformat("Attempting to access theme items too early in %s; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED", get_description()));
+	}
+
+	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+		if (has_theme_sound_override(p_name)) {
+			return true;
+		}
+	}
+
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_SOUND, p_name, theme_types);
+}
+
 /// Local property overrides.
 
 void Control::add_theme_icon_override(const StringName &p_name, RequiredParam<Texture2D> rp_icon) {
@@ -4093,6 +4173,19 @@ void Control::add_theme_constant_override(const StringName &p_name, int p_consta
 	_notify_theme_override_changed();
 }
 
+void Control::add_theme_sound_override(const StringName &p_name, const Ref<AudioStream> &p_audio) {
+	ERR_MAIN_THREAD_GUARD;
+	ERR_FAIL_COND(!p_audio.is_valid());
+
+	if (data.theme_sound_override.has(p_name)) {
+		data.theme_sound_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
+	}
+
+	data.theme_sound_override[p_name] = p_audio;
+	data.theme_sound_override[p_name]->connect_changed(callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
+	_notify_theme_override_changed();
+}
+
 void Control::remove_theme_icon_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (data.theme_icon_override.has(p_name)) {
@@ -4141,6 +4234,12 @@ void Control::remove_theme_constant_override(const StringName &p_name) {
 	_notify_theme_override_changed();
 }
 
+void Control::remove_theme_sound_override(const StringName &p_name) {
+	ERR_MAIN_THREAD_GUARD;
+	data.theme_sound_override.erase(p_name);
+	_notify_theme_override_changed();
+}
+
 bool Control::has_theme_icon_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	const Ref<Texture2D> *tex = data.theme_icon_override.getptr(p_name);
@@ -4175,6 +4274,12 @@ bool Control::has_theme_constant_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	const int *constant = data.theme_constant_override.getptr(p_name);
 	return constant != nullptr;
+}
+
+bool Control::has_theme_sound_override(const StringName &p_name) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	const Ref<AudioStream> *audio = data.theme_sound_override.getptr(p_name);
+	return audio != nullptr;
 }
 
 /// Default theme properties.
@@ -4829,6 +4934,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_theme_font_size_override", "name", "font_size"), &Control::add_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("add_theme_color_override", "name", "color"), &Control::add_theme_color_override);
 	ClassDB::bind_method(D_METHOD("add_theme_constant_override", "name", "constant"), &Control::add_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("add_theme_sound_override", "name", "audio"), &Control::add_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("remove_theme_icon_override", "name"), &Control::remove_theme_icon_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_stylebox_override", "name"), &Control::remove_theme_style_override);
@@ -4836,6 +4942,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_theme_font_size_override", "name"), &Control::remove_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_color_override", "name"), &Control::remove_theme_color_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_constant_override", "name"), &Control::remove_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("remove_theme_sound_override", "name"), &Control::remove_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("get_theme_icon", "name", "theme_type"), &Control::get_theme_icon, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_stylebox", "name", "theme_type"), &Control::get_theme_stylebox, DEFVAL(StringName()));
@@ -4843,6 +4950,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_theme_font_size", "name", "theme_type"), &Control::get_theme_font_size, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_color", "name", "theme_type"), &Control::get_theme_color, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_constant", "name", "theme_type"), &Control::get_theme_constant, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("get_theme_sound", "name", "theme_type"), &Control::get_theme_sound, DEFVAL(StringName()));
 
 	ClassDB::bind_method(D_METHOD("has_theme_icon_override", "name"), &Control::has_theme_icon_override);
 	ClassDB::bind_method(D_METHOD("has_theme_stylebox_override", "name"), &Control::has_theme_stylebox_override);
@@ -4850,6 +4958,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size_override", "name"), &Control::has_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("has_theme_color_override", "name"), &Control::has_theme_color_override);
 	ClassDB::bind_method(D_METHOD("has_theme_constant_override", "name"), &Control::has_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("has_theme_sound_override", "name"), &Control::has_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("has_theme_icon", "name", "theme_type"), &Control::has_theme_icon, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_stylebox", "name", "theme_type"), &Control::has_theme_stylebox, DEFVAL(StringName()));
@@ -4857,6 +4966,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size", "name", "theme_type"), &Control::has_theme_font_size, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_color", "name", "theme_type"), &Control::has_theme_color, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_constant", "name", "theme_type"), &Control::has_theme_constant, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("has_theme_sound", "name", "theme_type"), &Control::has_theme_sound, DEFVAL(StringName()));
 
 	ClassDB::bind_method(D_METHOD("get_theme_default_base_scale"), &Control::get_theme_default_base_scale);
 	ClassDB::bind_method(D_METHOD("get_theme_default_font"), &Control::get_theme_default_font);
@@ -5235,6 +5345,9 @@ Control::~Control() {
 	for (KeyValue<StringName, Ref<Font>> &E : data.theme_font_override) {
 		E.value->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
+	for (KeyValue<StringName, Ref<AudioStream>> &E : data.theme_sound_override) {
+		E.value->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
+	}
 
 	// Then override maps can be simply cleared.
 	data.theme_icon_override.clear();
@@ -5243,4 +5356,5 @@ Control::~Control() {
 	data.theme_font_size_override.clear();
 	data.theme_color_override.clear();
 	data.theme_constant_override.clear();
+	data.theme_sound_override.clear();
 }

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -260,6 +260,8 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 			type = Theme::DATA_TYPE_ICON;
 		} else if (pf == "add_theme_stylebox_override" || pf == "has_theme_stylebox" || pf == "has_theme_stylebox_override" || pf == "get_theme_stylebox" || pf == "remove_theme_stylebox_override") {
 			type = Theme::DATA_TYPE_STYLEBOX;
+		} else if (pf == "add_theme_sound_override" || pf == "has_theme_sound" || pf == "has_theme_sound_override" || pf == "get_theme_sound" || pf == "remove_theme_sound_override") {
+			type = Theme::DATA_TYPE_SOUND;
 		}
 
 		if (type != Theme::DATA_TYPE_MAX) {
@@ -390,6 +392,13 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 			String dname = name.get_slicec('/', 1);
 			data.theme_constant_override.erase(dname);
 			_notify_theme_override_changed();
+		} else if (name.begins_with("theme_override_sounds/")) {
+			String dname = name.get_slicec('/', 1);
+			if (data.theme_sound_override.has(dname)) {
+				data.theme_sound_override[dname]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
+			}
+			data.theme_sound_override.erase(dname);
+			_notify_theme_override_changed();
 		} else {
 			return false;
 		}
@@ -412,6 +421,9 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (name.begins_with("theme_override_constants/")) {
 			String dname = name.get_slicec('/', 1);
 			add_theme_constant_override(dname, p_value);
+		} else if (name.begins_with("theme_override_sounds/")) {
+			String dname = name.get_slicec('/', 1);
+			add_theme_sound_override(dname, p_value);
 		} else {
 			return false;
 		}
@@ -446,6 +458,9 @@ bool Control::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (sname.begins_with("theme_override_constants/")) {
 		String name = sname.get_slicec('/', 1);
 		r_ret = data.theme_constant_override.has(name) ? Variant(data.theme_constant_override[name]) : Variant();
+	} else if (sname.begins_with("theme_override_sounds/")) {
+		String name = sname.get_slicec('/', 1);
+		r_ret = data.theme_sound_override.has(name) ? Variant(data.theme_sound_override[name]) : Variant();
 	} else {
 		return false;
 	}
@@ -508,6 +523,13 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 				}
 				p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_styles") + String("/") + E.item_name, PROPERTY_HINT_RESOURCE_TYPE, StyleBox::get_class_static(), usage));
+			} break;
+
+			case Theme::DATA_TYPE_SOUND: {
+				if (data.theme_sound_override.has(E.item_name)) {
+					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+				}
+				p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_sounds") + String("/") + E.item_name, PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static(), usage));
 			} break;
 
 			default: {
@@ -3089,6 +3111,15 @@ void Control::release_focus() {
 	get_viewport()->gui_release_focus();
 }
 
+void Control::play_theme_sound(const Ref<AudioStream> &p_stream) {
+	ERR_MAIN_THREAD_GUARD;
+	if (p_stream.is_null() || !get_tree()) {
+		return;
+	}
+
+	get_tree()->play_theme_sound(p_stream);
+}
+
 static Control *_next_control(Control *p_from) {
 	if (p_from->is_set_as_top_level()) {
 		return nullptr; // Can't go above.
@@ -3740,6 +3771,7 @@ void Control::_invalidate_theme_cache() {
 	data.theme_font_size_cache.clear();
 	data.theme_color_cache.clear();
 	data.theme_constant_cache.clear();
+	data.theme_audio_cache.clear();
 }
 
 void Control::_update_theme_item_cache() {
@@ -3965,6 +3997,30 @@ int Control::get_theme_constant(const StringName &p_name, const StringName &p_th
 	return constant;
 }
 
+Ref<AudioStream> Control::get_theme_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	ERR_READ_THREAD_GUARD_V(Ref<AudioStream>());
+	if (!data.initialized) {
+		WARN_PRINT_ONCE(vformat("Attempting to access theme items too early in %s; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED", get_description()));
+	}
+
+	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+		const Ref<AudioStream> *audio = data.theme_sound_override.getptr(p_name);
+		if (audio) {
+			return *audio;
+		}
+	}
+
+	if (data.theme_audio_cache.has(p_theme_type) && data.theme_audio_cache[p_theme_type].has(p_name)) {
+		return data.theme_audio_cache[p_theme_type][p_name];
+	}
+
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<AudioStream> audio = data.theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_SOUND, p_name, theme_types);
+	data.theme_audio_cache[p_theme_type][p_name] = audio;
+	return audio;
+}
+
 Variant Control::get_theme_item(Theme::DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
 	switch (p_data_type) {
 		case Theme::DATA_TYPE_COLOR:
@@ -3979,6 +4035,8 @@ Variant Control::get_theme_item(Theme::DataType p_data_type, const StringName &p
 			return get_theme_icon(p_name, p_theme_type);
 		case Theme::DATA_TYPE_STYLEBOX:
 			return get_theme_stylebox(p_name, p_theme_type);
+		case Theme::DATA_TYPE_SOUND:
+			return get_theme_sound(p_name, p_theme_type);
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -4016,6 +4074,11 @@ Variant Control::get_used_theme_item(const String &p_full_name, const StringName
 		String name = p_full_name.substr(strlen("theme_override_constants/"));
 		if (has_theme_constant(name)) {
 			return get_theme_constant(name);
+		}
+	} else if (p_full_name.begins_with("theme_override_sounds/")) {
+		String name = p_full_name.substr(strlen("theme_override_sounds/"));
+		if (has_theme_sound(name)) {
+			return get_theme_sound(name);
 		}
 	} else {
 		ERR_FAIL_V_MSG(Variant(), vformat("The property %s is not a theme item.", p_full_name));
@@ -4132,6 +4195,23 @@ bool Control::has_theme_constant(const StringName &p_name, const StringName &p_t
 	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 }
 
+bool Control::has_theme_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	if (!data.initialized) {
+		WARN_PRINT_ONCE(vformat("Attempting to access theme items too early in %s; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED", get_description()));
+	}
+
+	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+		if (has_theme_sound_override(p_name)) {
+			return true;
+		}
+	}
+
+	Vector<StringName> theme_types;
+	data.theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return data.theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_SOUND, p_name, theme_types);
+}
+
 /// Local property overrides.
 
 void Control::add_theme_icon_override(const StringName &p_name, RequiredParam<Texture2D> p_icon) {
@@ -4191,6 +4271,19 @@ void Control::add_theme_constant_override(const StringName &p_name, int p_consta
 	_notify_theme_override_changed();
 }
 
+void Control::add_theme_sound_override(const StringName &p_name, const Ref<AudioStream> &p_sound) {
+	ERR_MAIN_THREAD_GUARD;
+	ERR_FAIL_COND(!p_sound.is_valid());
+
+	if (data.theme_sound_override.has(p_name)) {
+		data.theme_sound_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
+	}
+
+	data.theme_sound_override[p_name] = p_sound;
+	data.theme_sound_override[p_name]->connect_changed(callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
+	_notify_theme_override_changed();
+}
+
 void Control::remove_theme_icon_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (data.theme_icon_override.has(p_name)) {
@@ -4239,6 +4332,12 @@ void Control::remove_theme_constant_override(const StringName &p_name) {
 	_notify_theme_override_changed();
 }
 
+void Control::remove_theme_sound_override(const StringName &p_name) {
+	ERR_MAIN_THREAD_GUARD;
+	data.theme_sound_override.erase(p_name);
+	_notify_theme_override_changed();
+}
+
 bool Control::has_theme_icon_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	const Ref<Texture2D> *tex = data.theme_icon_override.getptr(p_name);
@@ -4273,6 +4372,12 @@ bool Control::has_theme_constant_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	const int *constant = data.theme_constant_override.getptr(p_name);
 	return constant != nullptr;
+}
+
+bool Control::has_theme_sound_override(const StringName &p_name) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	const Ref<AudioStream> *audio = data.theme_sound_override.getptr(p_name);
+	return audio != nullptr;
 }
 
 /// Default theme properties.
@@ -4927,6 +5032,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_theme_font_size_override", "name", "font_size"), &Control::add_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("add_theme_color_override", "name", "color"), &Control::add_theme_color_override);
 	ClassDB::bind_method(D_METHOD("add_theme_constant_override", "name", "constant"), &Control::add_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("add_theme_sound_override", "name", "audio"), &Control::add_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("remove_theme_icon_override", "name"), &Control::remove_theme_icon_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_stylebox_override", "name"), &Control::remove_theme_style_override);
@@ -4934,6 +5040,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_theme_font_size_override", "name"), &Control::remove_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_color_override", "name"), &Control::remove_theme_color_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_constant_override", "name"), &Control::remove_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("remove_theme_sound_override", "name"), &Control::remove_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("get_theme_icon", "name", "theme_type"), &Control::get_theme_icon, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_stylebox", "name", "theme_type"), &Control::get_theme_stylebox, DEFVAL(StringName()));
@@ -4941,6 +5048,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_theme_font_size", "name", "theme_type"), &Control::get_theme_font_size, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_color", "name", "theme_type"), &Control::get_theme_color, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_constant", "name", "theme_type"), &Control::get_theme_constant, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("get_theme_sound", "name", "theme_type"), &Control::get_theme_sound, DEFVAL(StringName()));
 
 	ClassDB::bind_method(D_METHOD("has_theme_icon_override", "name"), &Control::has_theme_icon_override);
 	ClassDB::bind_method(D_METHOD("has_theme_stylebox_override", "name"), &Control::has_theme_stylebox_override);
@@ -4948,6 +5056,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size_override", "name"), &Control::has_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("has_theme_color_override", "name"), &Control::has_theme_color_override);
 	ClassDB::bind_method(D_METHOD("has_theme_constant_override", "name"), &Control::has_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("has_theme_sound_override", "name"), &Control::has_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("has_theme_icon", "name", "theme_type"), &Control::has_theme_icon, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_stylebox", "name", "theme_type"), &Control::has_theme_stylebox, DEFVAL(StringName()));
@@ -4955,6 +5064,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size", "name", "theme_type"), &Control::has_theme_font_size, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_color", "name", "theme_type"), &Control::has_theme_color, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_constant", "name", "theme_type"), &Control::has_theme_constant, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("has_theme_sound", "name", "theme_type"), &Control::has_theme_sound, DEFVAL(StringName()));
 
 	ClassDB::bind_method(D_METHOD("get_theme_default_base_scale"), &Control::get_theme_default_base_scale);
 	ClassDB::bind_method(D_METHOD("get_theme_default_font"), &Control::get_theme_default_font);
@@ -5334,6 +5444,9 @@ Control::~Control() {
 	for (KeyValue<StringName, Ref<Font>> &E : data.theme_font_override) {
 		E.value->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
+	for (KeyValue<StringName, Ref<AudioStream>> &E : data.theme_sound_override) {
+		E.value->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
+	}
 
 	// Then override maps can be simply cleared.
 	data.theme_icon_override.clear();
@@ -5342,4 +5455,5 @@ Control::~Control() {
 	data.theme_font_size_override.clear();
 	data.theme_color_override.clear();
 	data.theme_constant_override.clear();
+	data.theme_sound_override.clear();
 }

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -322,6 +322,7 @@ private:
 		Theme::ThemeFontSizeMap theme_font_size_override;
 		Theme::ThemeColorMap theme_color_override;
 		Theme::ThemeConstantMap theme_constant_override;
+		Theme::ThemeSoundMap theme_sound_override;
 
 		mutable HashMap<StringName, Theme::ThemeIconMap> theme_icon_cache;
 		mutable HashMap<StringName, Theme::ThemeStyleMap> theme_style_cache;
@@ -329,6 +330,7 @@ private:
 		mutable HashMap<StringName, Theme::ThemeFontSizeMap> theme_font_size_cache;
 		mutable HashMap<StringName, Theme::ThemeColorMap> theme_color_cache;
 		mutable HashMap<StringName, Theme::ThemeConstantMap> theme_constant_cache;
+		mutable HashMap<StringName, Theme::ThemeSoundMap> theme_audio_cache;
 
 		// Internationalization.
 
@@ -738,6 +740,10 @@ public:
 	void set_focus_previous(const NodePath &p_prev);
 	NodePath get_focus_previous() const;
 
+	// Theme audio playback.
+
+	void play_theme_sound(const Ref<AudioStream> &p_stream);
+
 	// Accessibility.
 
 	virtual String get_accessibility_container_name(const Node *p_node) const;
@@ -802,6 +808,7 @@ public:
 	void add_theme_font_size_override(const StringName &p_name, int p_font_size);
 	void add_theme_color_override(const StringName &p_name, const Color &p_color);
 	void add_theme_constant_override(const StringName &p_name, int p_constant);
+	void add_theme_sound_override(const StringName &p_name, const Ref<AudioStream> &p_audio);
 
 	void remove_theme_icon_override(const StringName &p_name);
 	void remove_theme_style_override(const StringName &p_name);
@@ -809,6 +816,7 @@ public:
 	void remove_theme_font_size_override(const StringName &p_name);
 	void remove_theme_color_override(const StringName &p_name);
 	void remove_theme_constant_override(const StringName &p_name);
+	void remove_theme_sound_override(const StringName &p_name);
 
 	Ref<Texture2D> get_theme_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Ref<StyleBox> get_theme_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
@@ -816,6 +824,7 @@ public:
 	int get_theme_font_size(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Color get_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	int get_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	Ref<AudioStream> get_theme_sound(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Variant get_theme_item(Theme::DataType p_data_type, const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Variant get_used_theme_item(const String &p_full_name, const StringName &p_theme_type = StringName()) const;
 #ifdef TOOLS_ENABLED
@@ -828,6 +837,7 @@ public:
 	bool has_theme_font_size_override(const StringName &p_name) const;
 	bool has_theme_color_override(const StringName &p_name) const;
 	bool has_theme_constant_override(const StringName &p_name) const;
+	bool has_theme_sound_override(const StringName &p_name) const;
 
 	bool has_theme_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
@@ -835,6 +845,7 @@ public:
 	bool has_theme_font_size(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	bool has_theme_sound(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 
 	float get_theme_default_base_scale() const;
 	Ref<Font> get_theme_default_font() const;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -328,6 +328,7 @@ private:
 		Theme::ThemeFontSizeMap theme_font_size_override;
 		Theme::ThemeColorMap theme_color_override;
 		Theme::ThemeConstantMap theme_constant_override;
+		Theme::ThemeSoundMap theme_sound_override;
 
 		mutable HashMap<StringName, Theme::ThemeIconMap> theme_icon_cache;
 		mutable HashMap<StringName, Theme::ThemeStyleMap> theme_style_cache;
@@ -335,6 +336,7 @@ private:
 		mutable HashMap<StringName, Theme::ThemeFontSizeMap> theme_font_size_cache;
 		mutable HashMap<StringName, Theme::ThemeColorMap> theme_color_cache;
 		mutable HashMap<StringName, Theme::ThemeConstantMap> theme_constant_cache;
+		mutable HashMap<StringName, Theme::ThemeSoundMap> theme_audio_cache;
 
 		// Internationalization.
 
@@ -749,6 +751,10 @@ public:
 	void set_focus_previous(const NodePath &p_prev);
 	NodePath get_focus_previous() const;
 
+	// Theme sound playback.
+
+	void play_theme_sound(const Ref<AudioStream> &p_stream);
+
 	// Accessibility.
 
 	virtual String get_accessibility_container_name(const Node *p_node) const;
@@ -813,6 +819,7 @@ public:
 	void add_theme_font_size_override(const StringName &p_name, int p_font_size);
 	void add_theme_color_override(const StringName &p_name, const Color &p_color);
 	void add_theme_constant_override(const StringName &p_name, int p_constant);
+	void add_theme_sound_override(const StringName &p_name, const Ref<AudioStream> &p_sound);
 
 	void remove_theme_icon_override(const StringName &p_name);
 	void remove_theme_style_override(const StringName &p_name);
@@ -820,6 +827,7 @@ public:
 	void remove_theme_font_size_override(const StringName &p_name);
 	void remove_theme_color_override(const StringName &p_name);
 	void remove_theme_constant_override(const StringName &p_name);
+	void remove_theme_sound_override(const StringName &p_name);
 
 	Ref<Texture2D> get_theme_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Ref<StyleBox> get_theme_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
@@ -827,6 +835,7 @@ public:
 	int get_theme_font_size(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Color get_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	int get_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	Ref<AudioStream> get_theme_sound(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Variant get_theme_item(Theme::DataType p_data_type, const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Variant get_used_theme_item(const String &p_full_name, const StringName &p_theme_type = StringName()) const;
 #ifdef TOOLS_ENABLED
@@ -839,6 +848,7 @@ public:
 	bool has_theme_font_size_override(const StringName &p_name) const;
 	bool has_theme_color_override(const StringName &p_name) const;
 	bool has_theme_constant_override(const StringName &p_name) const;
+	bool has_theme_sound_override(const StringName &p_name) const;
 
 	bool has_theme_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
@@ -846,6 +856,7 @@ public:
 	bool has_theme_font_size(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	bool has_theme_sound(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 
 	float get_theme_default_base_scale() const;
 	Ref<Font> get_theme_default_font() const;

--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -264,6 +264,7 @@ void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (p_event->is_action_pressed(SNAME("ui_accept"), false, true)) {
 		set_folded(!folded);
+		play_theme_sound(folded ? theme_cache.folded_sound : theme_cache.expanded_sound);
 		emit_signal(SNAME("folding_changed"), folded);
 		accept_event();
 		return;
@@ -273,6 +274,7 @@ void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 	if (b.is_valid()) {
 		if (b->get_button_index() == MouseButton::LEFT && b->is_pressed() && _get_title_rect().has_point(b->get_position())) {
 			set_folded(!folded);
+			play_theme_sound(folded ? theme_cache.folded_sound : theme_cache.expanded_sound);
 			emit_signal(SNAME("folding_changed"), folded);
 			accept_event();
 		}
@@ -622,6 +624,10 @@ void FoldableContainer::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, FoldableContainer, folded_arrow_mirrored);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, FoldableContainer, h_separation);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, FoldableContainer, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, FoldableContainer, expanded_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, FoldableContainer, folded_sound);
 }
 
 FoldableContainer::FoldableContainer(const String &p_text) {

--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -255,7 +255,11 @@ void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (p_event->is_action_pressed(SNAME("ui_accept"), false, true)) {
+		const bool previously_folded = folded;
 		set_folded(!folded);
+		if (previously_folded != folded) {
+			play_theme_sound(folded ? theme_cache.folded_sound : theme_cache.expanded_sound);
+		}
 		emit_signal(SNAME("folding_changed"), folded);
 		accept_event();
 		return;
@@ -264,7 +268,11 @@ void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> b = p_event;
 	if (b.is_valid()) {
 		if (b->get_button_index() == MouseButton::LEFT && b->is_pressed() && _get_title_rect().has_point(b->get_position())) {
+			const bool previously_folded = folded;
 			set_folded(!folded);
+			if (previously_folded != folded) {
+				play_theme_sound(folded ? theme_cache.folded_sound : theme_cache.expanded_sound);
+			}
 			emit_signal(SNAME("folding_changed"), folded);
 			accept_event();
 		}
@@ -614,6 +622,10 @@ void FoldableContainer::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, FoldableContainer, folded_arrow_mirrored);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, FoldableContainer, h_separation);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, FoldableContainer, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, FoldableContainer, expanded_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, FoldableContainer, folded_sound);
 }
 
 FoldableContainer::FoldableContainer(const String &p_text) {

--- a/scene/gui/foldable_container.h
+++ b/scene/gui/foldable_container.h
@@ -85,6 +85,10 @@ private:
 		Ref<Texture2D> folded_arrow_mirrored;
 
 		int h_separation = 0;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> expanded_sound;
+		Ref<AudioStream> folded_sound;
 	} theme_cache;
 
 	Ref<StyleBox> _get_title_style() const;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -771,6 +771,9 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		if (closest != hovered) {
 			prev_hovered = hovered;
 			hovered = closest;
+			if (hovered != -1 && !items[hovered].disabled) {
+				play_theme_sound(theme_cache.item_hovered_sound);
+			}
 			queue_accessibility_update();
 			queue_redraw();
 		}
@@ -781,42 +784,48 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 		int closest = get_item_at_position(mb->get_position(), true);
 
-		if (closest != -1 && (mb->get_button_index() == MouseButton::LEFT || (allow_rmb_select && mb->get_button_index() == MouseButton::RIGHT))) {
+		const bool input_can_select = mb->get_button_index() == MouseButton::LEFT || (allow_rmb_select && mb->get_button_index() == MouseButton::RIGHT);
+
+		if (closest != -1 && input_can_select) {
 			int i = closest;
 
-			if (items[i].disabled) {
-				// Don't emit any signal or do any action with clicked item when disabled.
-				return;
-			}
+			// Don't emit any signal or do any action with clicked item when disabled (other than playing the "disabled" audio feedback).
+			const bool audio_only = items[i].disabled;
 
-			if (select_mode == SELECT_MULTI && items[i].selected && mb->is_command_or_control_pressed()) {
+			if (!audio_only && select_mode == SELECT_MULTI && items[i].selected && mb->is_command_or_control_pressed()) {
 				deselect(i);
 				emit_signal(SNAME("multi_selected"), i, false);
 				emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
 
 			} else if (select_mode == SELECT_MULTI && mb->is_shift_pressed() && current >= 0 && current < items.size() && current != i) {
-				// Range selection.
+				if (!audio_only) {
+					// Range selection.
 
-				int from = current;
-				int to = i;
-				if (i < current) {
-					SWAP(from, to);
-				}
-				for (int j = from; j <= to; j++) {
-					if (!CAN_SELECT(j)) {
-						// Item is not selectable during a range selection, so skip it.
-						continue;
+					int from = current;
+					int to = i;
+					if (i < current) {
+						SWAP(from, to);
 					}
-					bool selected = !items[j].selected;
-					select(j, false);
-					if (selected) {
-						emit_signal(SNAME("multi_selected"), j, true);
+					for (int j = from; j <= to; j++) {
+						if (!CAN_SELECT(j)) {
+							// Item is not selectable during a range selection, so skip it.
+							continue;
+						}
+						bool selected = !items[j].selected;
+						select(j, false);
+						if (selected) {
+							emit_signal(SNAME("multi_selected"), j, true);
+						}
 					}
+
+					emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
 				}
-				emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
+				if (input_can_select) {
+					play_theme_sound(items[i].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
+				}
 
 			} else {
-				if (!mb->is_double_click() &&
+				if (!audio_only && !mb->is_double_click() &&
 						!mb->is_command_or_control_pressed() &&
 						select_mode == SELECT_MULTI &&
 						items[i].selectable &&
@@ -828,35 +837,55 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 				if (select_mode == SELECT_TOGGLE) {
 					if (items[i].selectable) {
-						if (items[i].selected) {
-							deselect(i);
-							current = i;
-							emit_signal(SNAME("multi_selected"), i, false);
-						} else {
-							select(i, false);
-							current = i;
-							emit_signal(SNAME("multi_selected"), i, true);
+						if (!audio_only) {
+							if (items[i].selected) {
+								deselect(i);
+								current = i;
+								emit_signal(SNAME("multi_selected"), i, false);
+							} else {
+								select(i, false);
+								current = i;
+								emit_signal(SNAME("multi_selected"), i, true);
+							}
+						}
+
+						if (input_can_select) {
+							play_theme_sound(items[i].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
 						}
 					}
 				} else if (items[i].selectable && (!items[i].selected || allow_reselect)) {
-					select(i, select_mode == SELECT_SINGLE || !mb->is_command_or_control_pressed());
+					if (!audio_only) {
+						select(i, select_mode == SELECT_SINGLE || !mb->is_command_or_control_pressed());
+					}
 
-					if (select_mode == SELECT_SINGLE) {
-						emit_signal(SceneStringName(item_selected), i);
-					} else {
-						emit_signal(SNAME("multi_selected"), i, true);
+					if (input_can_select) {
+						play_theme_sound(items[i].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
+					}
+
+					if (!audio_only) {
+						if (select_mode == SELECT_SINGLE) {
+							emit_signal(SceneStringName(item_selected), i);
+						} else {
+							emit_signal(SNAME("multi_selected"), i, true);
+						}
 					}
 				}
 
-				emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
+				if (!audio_only) {
+					emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
 
-				if (mb->get_button_index() == MouseButton::LEFT && mb->is_double_click()) {
-					emit_signal(SNAME("item_activated"), i);
+					if (mb->get_button_index() == MouseButton::LEFT && mb->is_double_click()) {
+						emit_signal(SNAME("item_activated"), i);
+					}
 				}
 			}
 
 			return;
 		} else if (closest != -1) {
+			if (input_can_select) {
+				play_theme_sound(items[closest].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
+			}
+
 			if (!items[closest].disabled) {
 				emit_signal(SNAME("item_clicked"), closest, get_local_mouse_position(), mb->get_button_index());
 			}
@@ -965,6 +994,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					accept_event();
 					return;
 				}
+				play_theme_sound(theme_cache.focus_sound);
 				set_current(next);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
@@ -1011,6 +1041,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					accept_event();
 					return;
 				}
+				play_theme_sound(theme_cache.focus_sound);
 				set_current(next);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
@@ -1071,6 +1102,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					accept_event();
 					return;
 				}
+				play_theme_sound(theme_cache.focus_sound);
 				set_current(next);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
@@ -1100,6 +1132,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					accept_event();
 					return;
 				}
+				play_theme_sound(theme_cache.focus_sound);
 				set_current(next);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
@@ -1113,9 +1146,11 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 			if (current >= 0 && current < items.size()) {
 				if (CAN_SELECT(current) && !items[current].selected) {
 					select(current, false);
+					play_theme_sound(items[current].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
 					emit_signal(SNAME("multi_selected"), current, true);
 				} else if (items[current].selected) {
 					deselect(current);
+					play_theme_sound(items[current].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
 					emit_signal(SNAME("multi_selected"), current, false);
 				}
 			}
@@ -1123,6 +1158,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 			search_string = ""; //any mousepress cancels
 
 			if (current >= 0 && current < items.size() && !items[current].disabled) {
+				play_theme_sound(items[current].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
 				emit_signal(SNAME("item_activated"), current);
 			}
 		} else {
@@ -1156,6 +1192,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					}
 
 					if (items[i].text.findn(search_string) == 0) {
+						play_theme_sound(theme_cache.focus_sound);
 						set_current(i);
 						ensure_current_is_visible();
 						if (select_mode == SELECT_SINGLE) {
@@ -1984,6 +2021,7 @@ void ItemList::_shift_range_select(int p_from, int p_to) {
 		if (i >= MIN(shift_anchor, p_to) && i <= MAX(shift_anchor, p_to)) {
 			if (!is_selected(i)) {
 				select(i, false);
+				play_theme_sound(theme_cache.focus_sound);
 				emit_signal(SNAME("multi_selected"), i, true);
 			}
 		} else if (is_selected(i)) {
@@ -2517,6 +2555,11 @@ void ItemList::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ItemList, disabled_style, "disabled");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ItemList, disabled_hovered_style, "disabled_hovered");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, ItemList, guide_color);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ItemList, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ItemList, item_hovered_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ItemList, item_selected_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ItemList, item_selected_disabled_sound);
 
 	Item defaults(true);
 

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -771,6 +771,9 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		if (closest != hovered) {
 			prev_hovered = hovered;
 			hovered = closest;
+			if (hovered != -1 && !items[hovered].disabled) {
+				play_theme_sound(theme_cache.item_hovered_sound);
+			}
 			queue_accessibility_update();
 			queue_redraw();
 		}
@@ -781,42 +784,48 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 		int closest = get_item_at_position(mb->get_position(), true);
 
-		if (closest != -1 && (mb->get_button_index() == MouseButton::LEFT || (allow_rmb_select && mb->get_button_index() == MouseButton::RIGHT))) {
+		const bool input_can_select = mb->get_button_index() == MouseButton::LEFT || (allow_rmb_select && mb->get_button_index() == MouseButton::RIGHT);
+
+		if (closest != -1 && input_can_select) {
 			int i = closest;
 
-			if (items[i].disabled) {
-				// Don't emit any signal or do any action with clicked item when disabled.
-				return;
-			}
+			// Don't emit any signal or do any action with clicked item when disabled (other than playing the "disabled" audio feedback).
+			const bool audio_only = items[i].disabled;
 
-			if (select_mode == SELECT_MULTI && items[i].selected && mb->is_command_or_control_pressed()) {
+			if (!audio_only && select_mode == SELECT_MULTI && items[i].selected && mb->is_command_or_control_pressed()) {
 				deselect(i);
 				emit_signal(SNAME("multi_selected"), i, false);
 				emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
 
 			} else if (select_mode == SELECT_MULTI && mb->is_shift_pressed() && current >= 0 && current < items.size() && current != i) {
-				// Range selection.
+				if (!audio_only) {
+					// Range selection.
 
-				int from = current;
-				int to = i;
-				if (i < current) {
-					SWAP(from, to);
-				}
-				for (int j = from; j <= to; j++) {
-					if (!CAN_SELECT(j)) {
-						// Item is not selectable during a range selection, so skip it.
-						continue;
+					int from = current;
+					int to = i;
+					if (i < current) {
+						SWAP(from, to);
 					}
-					bool selected = !items[j].selected;
-					select(j, false);
-					if (selected) {
-						emit_signal(SNAME("multi_selected"), j, true);
+					for (int j = from; j <= to; j++) {
+						if (!CAN_SELECT(j)) {
+							// Item is not selectable during a range selection, so skip it.
+							continue;
+						}
+						bool selected = !items[j].selected;
+						select(j, false);
+						if (selected) {
+							emit_signal(SNAME("multi_selected"), j, true);
+						}
 					}
+
+					emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
 				}
-				emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
+				if (input_can_select) {
+					play_theme_sound(items[i].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
+				}
 
 			} else {
-				if (!mb->is_double_click() &&
+				if (!audio_only && !mb->is_double_click() &&
 						!mb->is_command_or_control_pressed() &&
 						select_mode == SELECT_MULTI &&
 						items[i].selectable &&
@@ -828,30 +837,46 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 				if (select_mode == SELECT_TOGGLE) {
 					if (items[i].selectable) {
-						if (items[i].selected) {
-							deselect(i);
-							current = i;
-							emit_signal(SNAME("multi_selected"), i, false);
-						} else {
-							select(i, false);
-							current = i;
-							emit_signal(SNAME("multi_selected"), i, true);
+						if (!audio_only) {
+							if (items[i].selected) {
+								deselect(i);
+								current = i;
+								emit_signal(SNAME("multi_selected"), i, false);
+							} else {
+								select(i, false);
+								current = i;
+								emit_signal(SNAME("multi_selected"), i, true);
+							}
+						}
+
+						if (input_can_select) {
+							play_theme_sound(items[i].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
 						}
 					}
 				} else if (items[i].selectable && (!items[i].selected || allow_reselect)) {
-					select(i, select_mode == SELECT_SINGLE || !mb->is_command_or_control_pressed());
+					if (!audio_only) {
+						select(i, select_mode == SELECT_SINGLE || !mb->is_command_or_control_pressed());
+					}
 
-					if (select_mode == SELECT_SINGLE) {
-						emit_signal(SceneStringName(item_selected), i);
-					} else {
-						emit_signal(SNAME("multi_selected"), i, true);
+					if (input_can_select) {
+						play_theme_sound(items[i].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
+					}
+
+					if (!audio_only) {
+						if (select_mode == SELECT_SINGLE) {
+							emit_signal(SceneStringName(item_selected), i);
+						} else {
+							emit_signal(SNAME("multi_selected"), i, true);
+						}
 					}
 				}
 
-				emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
+				if (!audio_only) {
+					emit_signal(SNAME("item_clicked"), i, get_local_mouse_position(), mb->get_button_index());
 
-				if (mb->get_button_index() == MouseButton::LEFT && mb->is_double_click()) {
-					emit_signal(SNAME("item_activated"), i);
+					if (mb->get_button_index() == MouseButton::LEFT && mb->is_double_click()) {
+						emit_signal(SNAME("item_activated"), i);
+					}
 				}
 			}
 
@@ -965,6 +990,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					accept_event();
 					return;
 				}
+				play_theme_sound(theme_cache.focus_sound);
 				set_current(next);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
@@ -1011,6 +1037,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					accept_event();
 					return;
 				}
+				play_theme_sound(theme_cache.focus_sound);
 				set_current(next);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
@@ -1071,6 +1098,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					accept_event();
 					return;
 				}
+				play_theme_sound(theme_cache.focus_sound);
 				set_current(next);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
@@ -1100,6 +1128,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					accept_event();
 					return;
 				}
+				play_theme_sound(theme_cache.focus_sound);
 				set_current(next);
 				ensure_current_is_visible();
 				if (select_mode == SELECT_SINGLE) {
@@ -1113,9 +1142,11 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 			if (current >= 0 && current < items.size()) {
 				if (CAN_SELECT(current) && !items[current].selected) {
 					select(current, false);
+					play_theme_sound(items[current].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
 					emit_signal(SNAME("multi_selected"), current, true);
 				} else if (items[current].selected) {
 					deselect(current);
+					play_theme_sound(items[current].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
 					emit_signal(SNAME("multi_selected"), current, false);
 				}
 			}
@@ -1123,6 +1154,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 			search_string = ""; //any mousepress cancels
 
 			if (current >= 0 && current < items.size() && !items[current].disabled) {
+				play_theme_sound(items[current].disabled ? theme_cache.item_selected_disabled_sound : theme_cache.item_selected_sound);
 				emit_signal(SNAME("item_activated"), current);
 			}
 		} else {
@@ -1156,6 +1188,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					}
 
 					if (items[i].text.findn(search_string) == 0) {
+						play_theme_sound(theme_cache.focus_sound);
 						set_current(i);
 						ensure_current_is_visible();
 						if (select_mode == SELECT_SINGLE) {
@@ -1985,6 +2018,7 @@ void ItemList::_shift_range_select(int p_from, int p_to) {
 		if (i >= MIN(shift_anchor, p_to) && i <= MAX(shift_anchor, p_to)) {
 			if (!is_selected(i)) {
 				select(i, false);
+				play_theme_sound(theme_cache.focus_sound);
 				emit_signal(SNAME("multi_selected"), i, true);
 			}
 		} else if (is_selected(i)) {
@@ -2518,6 +2552,11 @@ void ItemList::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ItemList, disabled_style, "disabled");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ItemList, disabled_hovered_style, "disabled_hovered");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, ItemList, guide_color);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ItemList, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ItemList, item_hovered_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ItemList, item_selected_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ItemList, item_selected_disabled_sound);
 
 	Item defaults(true);
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -194,6 +194,11 @@ protected:
 
 		Ref<Texture2D> scroll_hint;
 		Color scroll_hint_color;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> item_hovered_sound;
+		Ref<AudioStream> item_selected_sound;
+		Ref<AudioStream> item_selected_disabled_sound;
 	} theme_cache;
 
 	void _notification(int p_what);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -228,6 +228,7 @@ void LineEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
 
 	shift_selection_check_post(p_select);
 	_reset_caret_blink_timer();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void LineEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
@@ -266,18 +267,21 @@ void LineEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
 
 	shift_selection_check_post(p_select);
 	_reset_caret_blink_timer();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void LineEdit::_move_caret_start(bool p_select) {
 	shift_selection_check_pre(p_select);
 	set_caret_column(0);
 	shift_selection_check_post(p_select);
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void LineEdit::_move_caret_end(bool p_select) {
 	shift_selection_check_pre(p_select);
 	set_caret_column(text.length());
 	shift_selection_check_post(p_select);
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
@@ -291,6 +295,7 @@ void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
 	}
 
 	if (caret_column == 0) {
+		play_theme_sound(theme_cache.text_change_rejected_sound);
 		return; // Nothing to do.
 	}
 
@@ -516,6 +521,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			set_caret_at_pixel_pos(b->get_position().x);
+			play_theme_sound(theme_cache.caret_moved_sound);
 
 			if (b->is_shift_pressed()) {
 				selection_fill_at_caret();
@@ -927,6 +933,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (editing && !keep_editing_on_text_submit) {
 			unedit();
+			play_theme_sound(theme_cache.text_submitted_sound);
 			emit_signal(SNAME("editing_toggled"), false);
 			if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
 				DisplayServer::get_singleton()->virtual_keyboard_hide();
@@ -2425,6 +2432,7 @@ void LineEdit::insert_text_at_caret(String p_text) {
 		// Truncate text to append to fit in max_length, if needed.
 		int available_chars = max_length - text.length();
 		if (p_text.length() > available_chars) {
+			play_theme_sound(theme_cache.text_change_rejected_sound);
 			emit_signal(SNAME("text_change_rejected"), p_text.substr(available_chars));
 			p_text = p_text.substr(0, available_chars);
 		}
@@ -3081,6 +3089,8 @@ void LineEdit::_text_changed() {
 
 void LineEdit::_emit_text_change() {
 	emit_signal(SceneStringName(text_changed), text);
+	play_theme_sound(theme_cache.text_changed_sound);
+
 	text_changed_dirty = false;
 }
 
@@ -3562,6 +3572,12 @@ void LineEdit::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, LineEdit, clear_icon, "clear");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, LineEdit, clear_button_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, LineEdit, clear_button_color_pressed);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, caret_moved_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, text_submitted_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, text_changed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, text_change_rejected_sound);
 
 	ADD_CLASS_DEPENDENCY("PopupMenu");
 }

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -199,6 +199,8 @@ void LineEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
 		return;
 	}
 
+	const int previous_caret_column = caret_column;
+
 	shift_selection_check_pre(p_select);
 
 	if (p_move_by_word) {
@@ -228,6 +230,7 @@ void LineEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
 
 	shift_selection_check_post(p_select);
 	_reset_caret_blink_timer();
+	play_theme_sound(caret_column == previous_caret_column ? theme_cache.caret_move_rejected_sound : theme_cache.caret_moved_sound);
 }
 
 void LineEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
@@ -236,6 +239,8 @@ void LineEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
 		deselect();
 		return;
 	}
+
+	const int previous_caret_column = caret_column;
 
 	shift_selection_check_pre(p_select);
 
@@ -266,18 +271,23 @@ void LineEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
 
 	shift_selection_check_post(p_select);
 	_reset_caret_blink_timer();
+	play_theme_sound(caret_column == previous_caret_column ? theme_cache.caret_move_rejected_sound : theme_cache.caret_moved_sound);
 }
 
 void LineEdit::_move_caret_start(bool p_select) {
+	const int previous_caret_column = caret_column;
 	shift_selection_check_pre(p_select);
 	set_caret_column(0);
 	shift_selection_check_post(p_select);
+	play_theme_sound(caret_column == previous_caret_column ? theme_cache.caret_move_rejected_sound : theme_cache.caret_moved_sound);
 }
 
 void LineEdit::_move_caret_end(bool p_select) {
+	const int previous_caret_column = caret_column;
 	shift_selection_check_pre(p_select);
 	set_caret_column(text.length());
 	shift_selection_check_post(p_select);
+	play_theme_sound(caret_column == previous_caret_column ? theme_cache.caret_move_rejected_sound : theme_cache.caret_moved_sound);
 }
 
 void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
@@ -291,6 +301,7 @@ void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
 	}
 
 	if (caret_column == 0) {
+		play_theme_sound(theme_cache.text_change_rejected_sound);
 		return; // Nothing to do.
 	}
 
@@ -337,6 +348,7 @@ void LineEdit::_delete(bool p_word, bool p_all_to_right) {
 	}
 
 	if (caret_column == text.length()) {
+		play_theme_sound(theme_cache.text_change_rejected_sound);
 		return; // Nothing to do.
 	}
 
@@ -516,6 +528,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			set_caret_at_pixel_pos(b->get_position().x);
+			play_theme_sound(theme_cache.caret_moved_sound);
 
 			if (b->is_shift_pressed()) {
 				selection_fill_at_caret();
@@ -927,6 +940,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (editing && !keep_editing_on_text_submit) {
 			unedit();
+			play_theme_sound(theme_cache.text_submitted_sound);
 			emit_signal(SNAME("editing_toggled"), false);
 			if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
 				DisplayServer::get_singleton()->virtual_keyboard_hide();
@@ -2431,6 +2445,7 @@ void LineEdit::insert_text_at_caret(String p_text) {
 		// Truncate text to append to fit in max_length, if needed.
 		int available_chars = max_length - text.length();
 		if (p_text.length() > available_chars) {
+			play_theme_sound(theme_cache.text_change_rejected_sound);
 			emit_signal(SNAME("text_change_rejected"), p_text.substr(available_chars));
 			p_text = p_text.substr(0, available_chars);
 		}
@@ -3087,6 +3102,8 @@ void LineEdit::_text_changed() {
 
 void LineEdit::_emit_text_change() {
 	emit_signal(SceneStringName(text_changed), text);
+	play_theme_sound(theme_cache.text_changed_sound);
+
 	text_changed_dirty = false;
 }
 
@@ -3568,6 +3585,13 @@ void LineEdit::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, LineEdit, clear_icon, "clear");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, LineEdit, clear_button_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, LineEdit, clear_button_color_pressed);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, caret_moved_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, caret_move_rejected_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, text_submitted_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, text_changed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, LineEdit, text_change_rejected_sound);
 
 	ADD_CLASS_DEPENDENCY("PopupMenu");
 }

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -226,6 +226,12 @@ private:
 		Color clear_button_color;
 		Color clear_button_color_pressed;
 
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> caret_moved_sound;
+		Ref<AudioStream> text_submitted_sound;
+		Ref<AudioStream> text_changed_sound;
+		Ref<AudioStream> text_change_rejected_sound;
+
 		float base_scale = 1.0;
 	} theme_cache;
 

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -226,6 +226,13 @@ private:
 		Color clear_button_color;
 		Color clear_button_color_pressed;
 
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> caret_moved_sound;
+		Ref<AudioStream> caret_move_rejected_sound;
+		Ref<AudioStream> text_submitted_sound;
+		Ref<AudioStream> text_changed_sound;
+		Ref<AudioStream> text_change_rejected_sound;
+
 		float base_scale = 1.0;
 	} theme_cache;
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -541,6 +541,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 					prev_mouse_over = mouse_over;
 					mouse_over = i;
 					control->grab_focus();
+					play_theme_sound(theme_cache.focus_sound);
 					emit_signal(SNAME("id_focused"), items[i].id);
 					scroll_to_item(i);
 					queue_accessibility_update();
@@ -558,6 +559,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 						prev_mouse_over = mouse_over;
 						mouse_over = i;
 						control->grab_focus();
+						play_theme_sound(theme_cache.focus_sound);
 						emit_signal(SNAME("id_focused"), items[i].id);
 						scroll_to_item(i);
 						queue_accessibility_update();
@@ -586,6 +588,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 					prev_mouse_over = mouse_over;
 					mouse_over = i;
 					control->grab_focus();
+					play_theme_sound(theme_cache.focus_sound);
 					emit_signal(SNAME("id_focused"), items[i].id);
 					scroll_to_item(i);
 					queue_accessibility_update();
@@ -603,6 +606,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 						prev_mouse_over = mouse_over;
 						mouse_over = i;
 						control->grab_focus();
+						play_theme_sound(theme_cache.focus_sound);
 						emit_signal(SNAME("id_focused"), items[i].id);
 						scroll_to_item(i);
 						queue_accessibility_update();
@@ -640,8 +644,10 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 		} else if (p_event->is_action("ui_accept", true) && p_event->is_pressed()) {
 			if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator) {
 				if (items[mouse_over].submenu && submenu_over != mouse_over) {
+					play_theme_sound(items[mouse_over].disabled ? theme_cache.item_activated_disabled_sound : theme_cache.item_activated_sound);
 					_activate_submenu(mouse_over, true);
 				} else {
+					play_theme_sound(items[mouse_over].disabled ? theme_cache.item_activated_disabled_sound : theme_cache.item_activated_sound);
 					activate_item(mouse_over);
 				}
 				set_input_as_handled();
@@ -729,7 +735,13 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 					return;
 				}
 
-				if (items[over].separator || items[over].disabled) {
+				if (items[over].separator) {
+					return;
+				}
+
+				play_theme_sound(items[over].disabled ? theme_cache.item_activated_disabled_sound : theme_cache.item_activated_sound);
+
+				if (items[over].disabled) {
 					return;
 				}
 
@@ -819,6 +831,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 			if (items[i].text.findn(search_string) == 0) {
 				prev_mouse_over = mouse_over;
 				mouse_over = i;
+				play_theme_sound(theme_cache.focus_sound);
 				emit_signal(SNAME("id_focused"), items[i].id);
 				scroll_to_item(i);
 				queue_accessibility_update();
@@ -874,6 +887,9 @@ void PopupMenu::_mouse_over_update(const Point2 &p_over) {
 
 	if (over_index != mouse_over) {
 		mouse_over = over_index;
+		if (!items[over_index].disabled) {
+			play_theme_sound(theme_cache.item_hovered_sound);
+		}
 		queue_accessibility_update();
 		control->queue_redraw();
 	}
@@ -1595,6 +1611,7 @@ void PopupMenu::_notification(int p_what) {
 						for (int i = search_from; i < items.size(); i++) {
 							if (!items[i].separator && !items[i].disabled && items[i].visible) {
 								mouse_over = i;
+								play_theme_sound(theme_cache.focus_sound);
 								emit_signal(SNAME("id_focused"), items[i].id);
 								scroll_to_item(i);
 								control->queue_redraw();
@@ -1608,6 +1625,7 @@ void PopupMenu::_notification(int p_what) {
 							for (int i = 0; i < search_from; i++) {
 								if (!items[i].separator && !items[i].disabled && items[i].visible) {
 									mouse_over = i;
+									play_theme_sound(theme_cache.focus_sound);
 									emit_signal(SNAME("id_focused"), items[i].id);
 									scroll_to_item(i);
 									control->queue_redraw();
@@ -1628,6 +1646,7 @@ void PopupMenu::_notification(int p_what) {
 						for (int i = search_from; i >= 0; i--) {
 							if (!items[i].separator && !items[i].disabled && items[i].visible) {
 								mouse_over = i;
+								play_theme_sound(theme_cache.focus_sound);
 								emit_signal(SNAME("id_focused"), items[i].id);
 								scroll_to_item(i);
 								control->queue_redraw();
@@ -1641,6 +1660,7 @@ void PopupMenu::_notification(int p_what) {
 							for (int i = items.size() - 1; i >= search_from; i--) {
 								if (!items[i].separator && !items[i].disabled && items[i].visible) {
 									mouse_over = i;
+									play_theme_sound(theme_cache.focus_sound);
 									emit_signal(SNAME("id_focused"), items[i].id);
 									scroll_to_item(i);
 									control->queue_redraw();
@@ -3627,6 +3647,11 @@ void PopupMenu::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, PopupMenu, font_separator_color);
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_CONSTANT, PopupMenu, font_separator_outline_size, "separator_outline_size");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, PopupMenu, font_separator_outline_color);
+
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, PopupMenu, focus_sound, "focus", "Control");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, PopupMenu, item_hovered_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, PopupMenu, item_activated_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, PopupMenu, item_activated_disabled_sound);
 
 	Item defaults(true);
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -590,6 +590,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 				}
 			} else if (p_event->is_action("ui_right", true)) {
 				if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator && items[mouse_over].submenu && submenu_over != mouse_over) {
+					play_theme_sound(items[mouse_over].disabled ? theme_cache.item_activated_disabled_sound : theme_cache.item_activated_sound);
 					_activate_submenu(mouse_over, true);
 					set_input_as_handled();
 				} else {
@@ -602,11 +603,14 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 				}
 			} else if (p_event->is_action("ui_accept", true)) {
 				if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator) {
+					play_theme_sound(items[mouse_over].disabled ? theme_cache.item_activated_disabled_sound : theme_cache.item_activated_sound);
+
 					if (items[mouse_over].submenu && submenu_over != mouse_over) {
 						_activate_submenu(mouse_over, true);
 					} else {
 						activate_item(mouse_over);
 					}
+
 					set_input_as_handled();
 				}
 			}
@@ -697,7 +701,13 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 					return;
 				}
 
-				if (items[over].separator || items[over].disabled) {
+				if (items[over].separator) {
+					return;
+				}
+
+				play_theme_sound(items[over].disabled ? theme_cache.item_activated_disabled_sound : theme_cache.item_activated_sound);
+
+				if (items[over].disabled) {
 					return;
 				}
 
@@ -787,6 +797,7 @@ void PopupMenu::_input_from_window_internal(const Ref<InputEvent> &p_event) {
 			if (items[i].text.findn(search_string) == 0) {
 				prev_mouse_over = mouse_over;
 				mouse_over = i;
+				play_theme_sound(theme_cache.focus_sound);
 				emit_signal(SNAME("id_focused"), items[i].id);
 				scroll_to_item(i);
 				queue_accessibility_update();
@@ -842,6 +853,9 @@ void PopupMenu::_mouse_over_update(const Point2 &p_over) {
 
 	if (over_index != mouse_over) {
 		mouse_over = over_index;
+		if (!items[over_index].disabled) {
+			play_theme_sound(theme_cache.item_hovered_sound);
+		}
 		queue_accessibility_update();
 		control->queue_redraw();
 	}
@@ -1090,6 +1104,7 @@ bool PopupMenu::_highlight_first_available_item(int p_from, int p_to, bool p_rev
 		if (!items[i].separator && !items[i].disabled && items[i].visible) {
 			prev_mouse_over = mouse_over;
 			mouse_over = i;
+			play_theme_sound(theme_cache.focus_sound);
 			emit_signal(SNAME("id_focused"), items[i].id);
 			scroll_to_item(i);
 			queue_accessibility_update();
@@ -1566,6 +1581,7 @@ void PopupMenu::_notification(int p_what) {
 						for (int i = search_from; i < items.size(); i++) {
 							if (!items[i].separator && !items[i].disabled && items[i].visible) {
 								mouse_over = i;
+								play_theme_sound(theme_cache.focus_sound);
 								emit_signal(SNAME("id_focused"), items[i].id);
 								scroll_to_item(i);
 								control->queue_redraw();
@@ -1579,6 +1595,7 @@ void PopupMenu::_notification(int p_what) {
 							for (int i = 0; i < search_from; i++) {
 								if (!items[i].separator && !items[i].disabled && items[i].visible) {
 									mouse_over = i;
+									play_theme_sound(theme_cache.focus_sound);
 									emit_signal(SNAME("id_focused"), items[i].id);
 									scroll_to_item(i);
 									control->queue_redraw();
@@ -1599,6 +1616,7 @@ void PopupMenu::_notification(int p_what) {
 						for (int i = search_from; i >= 0; i--) {
 							if (!items[i].separator && !items[i].disabled && items[i].visible) {
 								mouse_over = i;
+								play_theme_sound(theme_cache.focus_sound);
 								emit_signal(SNAME("id_focused"), items[i].id);
 								scroll_to_item(i);
 								control->queue_redraw();
@@ -1612,6 +1630,7 @@ void PopupMenu::_notification(int p_what) {
 							for (int i = items.size() - 1; i >= search_from; i--) {
 								if (!items[i].separator && !items[i].disabled && items[i].visible) {
 									mouse_over = i;
+									play_theme_sound(theme_cache.focus_sound);
 									emit_signal(SNAME("id_focused"), items[i].id);
 									scroll_to_item(i);
 									control->queue_redraw();
@@ -3598,6 +3617,11 @@ void PopupMenu::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, PopupMenu, font_separator_color);
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_CONSTANT, PopupMenu, font_separator_outline_size, "separator_outline_size");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, PopupMenu, font_separator_outline_color);
+
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, PopupMenu, focus_sound, "focus", "Control");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, PopupMenu, item_hovered_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, PopupMenu, item_activated_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, PopupMenu, item_activated_disabled_sound);
 
 	Item defaults(true);
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -245,6 +245,11 @@ class PopupMenu : public Popup {
 		Color font_separator_color;
 		int font_separator_outline_size = 0;
 		Color font_separator_outline_color;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> item_hovered_sound;
+		Ref<AudioStream> item_activated_sound;
+		Ref<AudioStream> item_activated_disabled_sound;
 	} theme_cache;
 
 	void _draw_items();

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -86,13 +86,21 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (b->get_button_index() == MouseButton::WHEEL_DOWN && b->is_pressed()) {
 			double change = ((get_page() != 0.0) ? get_page() / PAGE_DIVISOR : (get_max() - get_min()) / 16.0) * b->get_factor();
+			const double previous_value = get_value();
 			scroll(MAX(change, get_step()));
+			// If the value didn't change as a result of the scroll operation,
+			// assume we were at the end of the scrollbar already.
+			play_theme_sound(Math::is_equal_approx(get_value(), previous_value) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			accept_event();
 		}
 
 		if (b->get_button_index() == MouseButton::WHEEL_UP && b->is_pressed()) {
 			double change = ((get_page() != 0.0) ? get_page() / PAGE_DIVISOR : (get_max() - get_min()) / 16.0) * b->get_factor();
+			const double previous_value = get_value();
 			scroll(-MAX(change, get_step()));
+			// If the value didn't change as a result of the scroll operation,
+			// assume we were at the beginning of the scrollbar already.
+			play_theme_sound(Math::is_equal_approx(get_value(), previous_value) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			accept_event();
 		}
 
@@ -113,6 +121,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 
 			if (ofs < decr_size) {
 				decr_active = true;
+				play_theme_sound(Math::is_equal_approx(get_value(), get_min()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 				scroll(-(custom_step >= 0 ? custom_step : get_step()));
 				queue_redraw();
 				return;
@@ -120,6 +129,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 
 			if (ofs > total - incr_size) {
 				incr_active = true;
+				play_theme_sound(Math::is_equal_approx(get_value(), get_max()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 				scroll(custom_step >= 0 ? custom_step : get_step());
 				queue_redraw();
 				return;
@@ -135,6 +145,8 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 					target_scroll = CLAMP(get_value() - change, get_min(), get_max() - get_page());
 				}
 
+				play_theme_sound(theme_cache.value_changed_sound);
+
 				if (smooth_scroll_enabled) {
 					scrolling = true;
 					set_process_internal(true);
@@ -147,6 +159,9 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 			ofs -= grabber_ofs;
 
 			if (ofs < grabber_size) {
+				if (!drag.active) {
+					play_theme_sound(theme_cache.drag_started_sound);
+				}
 				drag.active = true;
 				drag.pos_at_click = grabber_ofs + ofs;
 				drag.value_at_click = get_as_ratio();
@@ -159,6 +174,8 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 					target_scroll = CLAMP(get_value() + change, get_min(), get_max() - get_page());
 				}
 
+				play_theme_sound(theme_cache.value_changed_sound);
+
 				if (smooth_scroll_enabled) {
 					scrolling = true;
 					set_process_internal(true);
@@ -170,6 +187,10 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 		} else {
 			incr_active = false;
 			decr_active = false;
+
+			if (drag.active) {
+				play_theme_sound(theme_cache.drag_ended_sound);
+			}
 			drag.active = false;
 			queue_redraw();
 		}
@@ -227,12 +248,14 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 			if (orientation != HORIZONTAL) {
 				return;
 			}
+			play_theme_sound(Math::is_equal_approx(get_value(), get_min()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			scroll(-(custom_step >= 0 ? custom_step : get_step()));
 
 		} else if (p_event->is_action("ui_right", true)) {
 			if (orientation != HORIZONTAL) {
 				return;
 			}
+			play_theme_sound(Math::is_equal_approx(get_value(), get_max()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			scroll(custom_step >= 0 ? custom_step : get_step());
 
 		} else if (p_event->is_action("ui_up", true)) {
@@ -240,18 +263,22 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 				return;
 			}
 
+			play_theme_sound(Math::is_equal_approx(get_value(), get_min()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			scroll(-(custom_step >= 0 ? custom_step : get_step()));
 
 		} else if (p_event->is_action("ui_down", true)) {
 			if (orientation != VERTICAL) {
 				return;
 			}
+			play_theme_sound(Math::is_equal_approx(get_value(), get_max()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			scroll(custom_step >= 0 ? custom_step : get_step());
 
 		} else if (p_event->is_action("ui_home", true)) {
+			play_theme_sound(Math::is_equal_approx(get_value(), get_min()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			scroll_to(get_min());
 
 		} else if (p_event->is_action("ui_end", true)) {
+			play_theme_sound(Math::is_equal_approx(get_value(), get_max()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			scroll_to(get_max());
 		}
 	}
@@ -699,6 +726,11 @@ void ScrollBar::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, ScrollBar, decrement_icon, "decrement");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, ScrollBar, decrement_hl_icon, "decrement_highlight");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, ScrollBar, decrement_pressed_icon, "decrement_pressed");
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ScrollBar, drag_started_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ScrollBar, drag_ended_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ScrollBar, value_changed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, ScrollBar, value_change_rejected_sound);
 }
 
 ScrollBar::ScrollBar(Orientation p_orientation) {

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -107,6 +107,11 @@ protected:
 		int padding_top = 0;
 		int padding_right = 0;
 		int padding_bottom = 0;
+
+		Ref<AudioStream> drag_started_sound;
+		Ref<AudioStream> drag_ended_sound;
+		Ref<AudioStream> value_changed_sound;
+		Ref<AudioStream> value_change_rejected_sound;
 	} theme_cache;
 
 	void _notification(int p_what);

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -68,6 +68,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 
 				grab.pos = orientation == VERTICAL ? mb->get_position().y : mb->get_position().x;
 				grab.value_before_dragging = get_as_ratio();
+				play_theme_sound(theme_cache.drag_started_sound);
 				emit_signal(SNAME("drag_started"));
 
 				double grab_width = theme_cache.center_grabber ? 0.0 : (double)grabber->get_width();
@@ -89,6 +90,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				grab.active = false;
 
 				const bool value_changed = !Math::is_equal_approx((double)grab.value_before_dragging, get_as_ratio());
+				play_theme_sound(theme_cache.drag_ended_sound);
 				emit_signal(SNAME("drag_ended"), value_changed);
 			}
 		} else if (scrollable) {
@@ -96,11 +98,13 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				if (_is_focusable()) {
 					grab_focus();
 				}
+				play_theme_sound(theme_cache.value_changed_sound);
 				set_value(get_value() + get_step());
 			} else if (mb->is_pressed() && mb->get_button_index() == MouseButton::WHEEL_DOWN) {
 				if (_is_focusable()) {
 					grab_focus();
 				}
+				play_theme_sound(theme_cache.value_changed_sound);
 				set_value(get_value() - get_step());
 			}
 		}
@@ -150,6 +154,8 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 			} else {
 				set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			}
+
+			play_theme_sound(theme_cache.value_changed_sound);
 			accept_event();
 		} else if (p_event->is_action_pressed("ui_right", true)) {
 			if (orientation != HORIZONTAL) {
@@ -166,6 +172,8 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 			} else {
 				set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			}
+
+			play_theme_sound(theme_cache.value_changed_sound);
 			accept_event();
 		} else if (p_event->is_action_pressed("ui_up", true)) {
 			if (orientation != VERTICAL) {
@@ -177,6 +185,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
+			play_theme_sound(theme_cache.value_changed_sound);
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
 		} else if (p_event->is_action_pressed("ui_down", true)) {
@@ -189,12 +198,15 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
+			play_theme_sound(theme_cache.value_changed_sound);
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
 		} else if (p_event->is_action("ui_home", true) && p_event->is_pressed()) {
+			play_theme_sound(theme_cache.value_changed_sound);
 			set_value(get_min());
 			accept_event();
 		} else if (p_event->is_action("ui_end", true) && p_event->is_pressed()) {
+			play_theme_sound(theme_cache.value_changed_sound);
 			set_value(get_max());
 			accept_event();
 		}
@@ -489,6 +501,11 @@ void Slider::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Slider, center_grabber);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Slider, grabber_offset);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Slider, tick_offset);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Slider, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Slider, drag_started_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Slider, drag_ended_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Slider, value_changed_sound);
 }
 
 Slider::Slider(Orientation p_orientation) {

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -68,6 +68,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 
 				grab.pos = orientation == VERTICAL ? mb->get_position().y : mb->get_position().x;
 				grab.value_before_dragging = get_as_ratio();
+				play_theme_sound(theme_cache.drag_started_sound);
 				emit_signal(SNAME("drag_started"));
 
 				double grab_width = theme_cache.center_grabber ? 0.0 : (double)grabber->get_width();
@@ -89,6 +90,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				grab.active = false;
 
 				const bool value_changed = !Math::is_equal_approx((double)grab.value_before_dragging, get_as_ratio());
+				play_theme_sound(theme_cache.drag_ended_sound);
 				emit_signal(SNAME("drag_ended"), value_changed);
 			}
 		} else if (scrollable) {
@@ -96,11 +98,13 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				if (_is_focusable()) {
 					grab_focus();
 				}
+				play_theme_sound(Math::is_equal_approx(get_value(), get_max()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 				set_value(get_value() + get_step());
 			} else if (mb->is_pressed() && mb->get_button_index() == MouseButton::WHEEL_DOWN) {
 				if (_is_focusable()) {
 					grab_focus();
 				}
+				play_theme_sound(Math::is_equal_approx(get_value(), get_min()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 				set_value(get_value() - get_step());
 			}
 		}
@@ -145,11 +149,14 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
+
+			play_theme_sound(Math::is_equal_approx(get_value(), get_min()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			if (is_layout_rtl()) {
 				set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			} else {
 				set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			}
+
 			accept_event();
 		} else if (p_event->is_action_pressed("ui_right", true)) {
 			if (orientation != HORIZONTAL) {
@@ -161,11 +168,14 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
+
+			play_theme_sound(Math::is_equal_approx(get_value(), get_max()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			if (is_layout_rtl()) {
 				set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			} else {
 				set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			}
+
 			accept_event();
 		} else if (p_event->is_action_pressed("ui_up", true)) {
 			if (orientation != VERTICAL) {
@@ -177,6 +187,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
+			play_theme_sound(Math::is_equal_approx(get_value(), get_min()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
 		} else if (p_event->is_action_pressed("ui_down", true)) {
@@ -189,12 +200,15 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
+			play_theme_sound(Math::is_equal_approx(get_value(), get_max()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
 		} else if (p_event->is_action("ui_home", true) && p_event->is_pressed()) {
+			play_theme_sound(Math::is_equal_approx(get_value(), get_min()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			set_value(get_min());
 			accept_event();
 		} else if (p_event->is_action("ui_end", true) && p_event->is_pressed()) {
+			play_theme_sound(Math::is_equal_approx(get_value(), get_max()) ? theme_cache.value_change_rejected_sound : theme_cache.value_changed_sound);
 			set_value(get_max());
 			accept_event();
 		}
@@ -511,6 +525,12 @@ void Slider::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Slider, grabber_max_size);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Slider, tick_offset);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Slider, tick_max_size);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Slider, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Slider, drag_started_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Slider, drag_ended_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Slider, value_changed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Slider, value_change_rejected_sound);
 }
 
 Slider::Slider(Orientation p_orientation) {

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -77,6 +77,11 @@ private:
 		bool center_grabber = false;
 		int grabber_offset = 0;
 		int tick_offset = 0;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> drag_started_sound;
+		Ref<AudioStream> drag_ended_sound;
+		Ref<AudioStream> value_changed_sound;
 	} theme_cache;
 
 protected:

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -79,6 +79,12 @@ private:
 		int grabber_max_size = 0;
 		int tick_offset = 0;
 		int tick_max_size = 0;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> drag_started_sound;
+		Ref<AudioStream> drag_ended_sound;
+		Ref<AudioStream> value_changed_sound;
+		Ref<AudioStream> value_change_rejected_sound;
 	} theme_cache;
 
 protected:

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -232,11 +232,18 @@ void SpinBox::_release_mouse_from_drag_mode() {
 		Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_HIDDEN);
 		warp_mouse(drag.capture_pos);
 		Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
+		play_theme_sound(theme_cache.drag_ended_sound);
 	}
 }
 
 void SpinBox::_arrow_clicked(bool p_up) {
 	double arrow_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
+
+	// Play the sound before setting the value, so that the "disabled" sound
+	// does not play when the value was changed one last time before reaching the limit.
+	const bool disabled = !is_editable() || (p_up && state_cache.up_button_disabled) || (!p_up && state_cache.down_button_disabled);
+	play_theme_sound(disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
+
 	if (custom_arrow_round) {
 		// Arrow button is being pressed, snap the value to next `arrow_step`.
 		// `arrow_step` should be a multiple of `step`, otherwise it may not be able to increase/decrease the value.
@@ -307,17 +314,21 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 			case MouseButton::RIGHT: {
 				line_edit->grab_focus(true);
 				if (mouse_on_up_button || mouse_on_down_button) {
+					const bool disabled = mouse_on_up_button ? state_cache.up_button_disabled : state_cache.down_button_disabled;
+					play_theme_sound(disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
 					set_value(mouse_on_up_button ? get_max() : get_min());
 				}
 			} break;
 			case MouseButton::WHEEL_UP: {
 				if (line_edit->is_editing()) {
+					play_theme_sound(state_cache.up_button_disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
 					set_value(get_value() + step * mb->get_factor());
 					accept_event();
 				}
 			} break;
 			case MouseButton::WHEEL_DOWN: {
 				if (line_edit->is_editing()) {
+					play_theme_sound(state_cache.down_button_disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
 					set_value(get_value() - step * mb->get_factor());
 					accept_event();
 				}
@@ -363,6 +374,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 			drag.enabled = true;
 			drag.base_val = get_value();
 			drag.diff_y = 0;
+			play_theme_sound(theme_cache.drag_started_sound);
 		}
 	}
 }
@@ -728,6 +740,12 @@ void SpinBox::_bind_methods() {
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, SpinBox, field_and_buttons_separator, "field_and_buttons_separator");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, SpinBox, up_down_buttons_separator, "up_down_buttons_separator");
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, SpinBox, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, SpinBox, pressed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, SpinBox, pressed_disabled_sound);
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, SpinBox, drag_started_sound, "drag_started_sound", "Slider");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, SpinBox, drag_ended_sound, "drag_ended_sound", "Slider");
 
 	ADD_CLASS_DEPENDENCY("LineEdit");
 }

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -268,11 +268,18 @@ void SpinBox::_release_mouse_from_drag_mode() {
 		Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_HIDDEN);
 		warp_mouse(drag.capture_pos);
 		Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
+		play_theme_sound(theme_cache.drag_ended_sound);
 	}
 }
 
 void SpinBox::_arrow_clicked(bool p_up) {
 	double arrow_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
+
+	// Play the sound before setting the value, so that the "disabled" sound
+	// does not play when the value was changed one last time before reaching the limit.
+	const bool disabled = !is_editable() || (p_up && state_cache.up_button_disabled) || (!p_up && state_cache.down_button_disabled);
+	play_theme_sound(disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
+
 	if (custom_arrow_round) {
 		// Arrow button is being pressed, snap the value to next `arrow_step`.
 		// `arrow_step` should be a multiple of `step`, otherwise it may not be able to increase/decrease the value.
@@ -343,17 +350,21 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 			case MouseButton::RIGHT: {
 				line_edit->grab_focus(true);
 				if (mouse_on_up_button || mouse_on_down_button) {
+					const bool disabled = mouse_on_up_button ? state_cache.up_button_disabled : state_cache.down_button_disabled;
+					play_theme_sound(disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
 					set_value(mouse_on_up_button ? get_max() : get_min());
 				}
 			} break;
 			case MouseButton::WHEEL_UP: {
 				if (line_edit->is_editing()) {
+					play_theme_sound(state_cache.up_button_disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
 					set_value(get_value() + step * mb->get_factor());
 					accept_event();
 				}
 			} break;
 			case MouseButton::WHEEL_DOWN: {
 				if (line_edit->is_editing()) {
+					play_theme_sound(state_cache.down_button_disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
 					set_value(get_value() - step * mb->get_factor());
 					accept_event();
 				}
@@ -399,6 +410,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 			drag.enabled = true;
 			drag.base_val = get_value();
 			drag.diff_y = 0;
+			play_theme_sound(theme_cache.drag_started_sound);
 		}
 	}
 }
@@ -874,6 +886,12 @@ void SpinBox::_bind_methods() {
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, SpinBox, field_and_buttons_separator, "field_and_buttons_separator");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, SpinBox, up_down_buttons_separator, "up_down_buttons_separator");
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, SpinBox, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, SpinBox, pressed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, SpinBox, pressed_disabled_sound);
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, SpinBox, drag_started_sound, "drag_started_sound", "Slider");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_SOUND, SpinBox, drag_ended_sound, "drag_ended_sound", "Slider");
 
 	ADD_CLASS_DEPENDENCY("LineEdit");
 }

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -139,6 +139,13 @@ class SpinBox : public Range {
 		int buttons_vertical_separation = 0;
 		int field_and_buttons_separation = 0;
 		int buttons_width = 0;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> pressed_sound;
+		Ref<AudioStream> pressed_disabled_sound;
+		Ref<AudioStream> drag_started_sound;
+		Ref<AudioStream> drag_ended_sound;
+
 #ifndef DISABLE_DEPRECATED
 		Ref<Texture2D> updown_icon;
 		bool is_updown_assigned = false;

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -149,6 +149,13 @@ class SpinBox : public Range {
 		int field_and_buttons_separation = 0;
 		int buttons_width = 0;
 		int icon_max_width = 0;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> pressed_sound;
+		Ref<AudioStream> pressed_disabled_sound;
+		Ref<AudioStream> drag_started_sound;
+		Ref<AudioStream> drag_ended_sound;
+
 #ifndef DISABLE_DEPRECATED
 		Ref<Texture2D> updown_icon;
 		bool is_updown_assigned = false;

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -222,6 +222,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (rb_pressing && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 			if (rb_hover != -1) {
+				play_theme_sound(theme_cache.pressed_sound);
 				emit_signal(SNAME("tab_button_pressed"), rb_hover);
 			}
 
@@ -231,6 +232,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (cb_pressing && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 			if (cb_hover != -1) {
+				play_theme_sound(theme_cache.pressed_sound);
 				emit_signal(SNAME("tab_close_pressed"), cb_hover);
 			}
 
@@ -253,15 +255,21 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 					if (pos.x < theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
+							play_theme_sound(theme_cache.pressed_sound);
 							_update_cache();
 							queue_redraw();
+						} else {
+							play_theme_sound(theme_cache.pressed_disabled_sound);
 						}
 						return;
 					} else if (pos.x < theme_cache.increment_icon->get_width() + theme_cache.decrement_icon->get_width()) {
 						if (offset > 0) {
 							offset--;
+							play_theme_sound(theme_cache.pressed_sound);
 							_update_cache();
 							queue_redraw();
+						} else {
+							play_theme_sound(theme_cache.pressed_disabled_sound);
 						}
 						return;
 					}
@@ -270,15 +278,21 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 					if (pos.x > limit + theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
+							play_theme_sound(theme_cache.pressed_sound);
 							_update_cache();
 							queue_redraw();
+						} else {
+							play_theme_sound(theme_cache.pressed_disabled_sound);
 						}
 						return;
 					} else if (pos.x > limit) {
 						if (offset > 0) {
 							offset--;
+							play_theme_sound(theme_cache.pressed_sound);
 							_update_cache();
 							queue_redraw();
+						} else {
+							play_theme_sound(theme_cache.pressed_disabled_sound);
 						}
 						return;
 					}
@@ -298,6 +312,10 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 						rb_pressing = true;
 						_update_hover();
 						queue_redraw();
+
+						if (current != found) {
+							play_theme_sound(theme_cache.pressed_sound);
+						}
 					}
 					return;
 				}
@@ -308,19 +326,30 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 						cb_pressing = true;
 						_update_hover();
 						queue_redraw();
+
+						if (current != found) {
+							play_theme_sound(theme_cache.pressed_sound);
+						}
 					}
 					return;
 				}
 
 				// Selecting a tab.
-				if (selecting && !tabs[found].disabled) {
-					if (deselect_enabled && get_current_tab() == found) {
-						set_current_tab(-1);
-					} else {
-						set_current_tab(found);
+				if (selecting) {
+					// Handle audio feedback separately, so that we can play the "disabled" sound when needed.
+					if (current != found) {
+						play_theme_sound(tabs[found].disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
 					}
 
-					emit_signal(SNAME("tab_clicked"), found);
+					if (!tabs[found].disabled) {
+						if (deselect_enabled && get_current_tab() == found) {
+							set_current_tab(-1);
+						} else {
+							set_current_tab(found);
+						}
+
+						emit_signal(SNAME("tab_clicked"), found);
+					}
 				}
 
 				// Right mouse button clicked on a tab.
@@ -343,7 +372,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
-			if (is_layout_rtl() ? select_previous_available() : select_next_available()) {
+			if (is_layout_rtl() ? _select_previous_available(true) : _select_next_available(true)) {
 				accept_event();
 			}
 		} else if (p_event->is_action("ui_left", true)) {
@@ -353,7 +382,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
-			if (is_layout_rtl() ? select_next_available() : select_previous_available()) {
+			if (is_layout_rtl() ? _select_next_available(true) : _select_previous_available(true)) {
 				accept_event();
 			}
 		}
@@ -438,11 +467,11 @@ void TabBar::_notification(int p_what) {
 			if (gamepad_event_delay_ms <= 0) {
 				gamepad_event_delay_ms = GAMEPAD_EVENT_REPEAT_RATE_MS + gamepad_event_delay_ms;
 				if (input->is_action_pressed("ui_right")) {
-					is_layout_rtl() ? select_previous_available() : select_next_available();
+					is_layout_rtl() ? _select_previous_available(true) : _select_next_available(true);
 				}
 
 				if (input->is_action_pressed("ui_left")) {
-					is_layout_rtl() ? select_next_available() : select_previous_available();
+					is_layout_rtl() ? _select_next_available(true) : _select_previous_available(true);
 				}
 			}
 		} break;
@@ -899,18 +928,33 @@ int TabBar::get_next_available(int p_idx) const {
 }
 
 bool TabBar::select_previous_available() {
+	return _select_previous_available(false);
+}
+
+bool TabBar::_select_previous_available(bool p_play_sound) {
 	const int previous_available = get_previous_available();
 	if (previous_available != -1) {
 		set_current_tab(previous_available);
+		if (p_play_sound) {
+			play_theme_sound(theme_cache.pressed_sound);
+		}
 	}
 	return previous_available != -1;
 }
 
 bool TabBar::select_next_available() {
+	return _select_next_available(false);
+}
+
+bool TabBar::_select_next_available(bool p_play_sound) {
 	const int next_available = get_next_available();
 	if (next_available != -1) {
 		set_current_tab(next_available);
+		if (p_play_sound) {
+			play_theme_sound(theme_cache.pressed_sound);
+		}
 	}
+
 	return next_available != -1;
 }
 
@@ -1213,6 +1257,9 @@ void TabBar::_update_hover() {
 		hover = hover_now;
 
 		if (hover != -1) {
+			if (hover != current && !is_tab_disabled(hover)) {
+				play_theme_sound(theme_cache.hover_sound);
+			}
 			emit_signal(SNAME("tab_hovered"), hover);
 		}
 
@@ -2408,6 +2455,11 @@ void TabBar::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, TabBar, close_icon, "close");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, TabBar, button_pressed_style, "button_pressed");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, TabBar, button_hl_style, "button_highlight");
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, hover_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, pressed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, pressed_disabled_sound);
 
 	Tab defaults(true);
 

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -186,6 +186,10 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (get_viewport()->gui_is_dragging() && can_drop_data(pos, get_viewport()->gui_get_drag_data())) {
+			if (!dragging_valid_tab) {
+				// Play the sound only once when the drag operation begins.
+				play_theme_sound(theme_cache.drag_started_sound);
+			}
 			dragging_valid_tab = true;
 			queue_redraw();
 		}
@@ -226,6 +230,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (rb_pressing && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 			if (rb_hover != -1) {
+				play_theme_sound(theme_cache.pressed_sound);
 				emit_signal(SNAME("tab_button_pressed"), rb_hover);
 			}
 
@@ -235,6 +240,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (cb_pressing && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 			if (cb_hover != -1) {
+				play_theme_sound(theme_cache.pressed_sound);
 				emit_signal(SNAME("tab_close_pressed"), cb_hover);
 			}
 
@@ -257,15 +263,21 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 					if (pos.x < theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
+							play_theme_sound(theme_cache.pressed_sound);
 							_update_cache();
 							queue_redraw();
+						} else {
+							play_theme_sound(theme_cache.pressed_disabled_sound);
 						}
 						return;
 					} else if (pos.x < theme_cache.increment_icon->get_width() + theme_cache.decrement_icon->get_width()) {
 						if (offset > 0) {
 							offset--;
+							play_theme_sound(theme_cache.pressed_sound);
 							_update_cache();
 							queue_redraw();
+						} else {
+							play_theme_sound(theme_cache.pressed_disabled_sound);
 						}
 						return;
 					}
@@ -274,15 +286,21 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 					if (pos.x > limit + theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
+							play_theme_sound(theme_cache.pressed_sound);
 							_update_cache();
 							queue_redraw();
+						} else {
+							play_theme_sound(theme_cache.pressed_disabled_sound);
 						}
 						return;
 					} else if (pos.x > limit) {
 						if (offset > 0) {
 							offset--;
+							play_theme_sound(theme_cache.pressed_sound);
 							_update_cache();
 							queue_redraw();
+						} else {
+							play_theme_sound(theme_cache.pressed_disabled_sound);
 						}
 						return;
 					}
@@ -302,6 +320,10 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 						rb_pressing = true;
 						_update_hover();
 						queue_redraw();
+
+						if (current != found) {
+							play_theme_sound(theme_cache.pressed_sound);
+						}
 					}
 					return;
 				}
@@ -312,19 +334,30 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 						cb_pressing = true;
 						_update_hover();
 						queue_redraw();
+
+						if (current != found) {
+							play_theme_sound(theme_cache.pressed_sound);
+						}
 					}
 					return;
 				}
 
 				// Selecting a tab.
-				if (selecting && !tabs[found].disabled) {
-					if (deselect_enabled && get_current_tab() == found) {
-						set_current_tab(-1);
-					} else {
-						set_current_tab(found);
+				if (selecting) {
+					// Handle audio feedback separately, so that we can play the "disabled" sound when needed.
+					if (current != found) {
+						play_theme_sound(tabs[found].disabled ? theme_cache.pressed_disabled_sound : theme_cache.pressed_sound);
 					}
 
-					emit_signal(SNAME("tab_clicked"), found);
+					if (!tabs[found].disabled) {
+						if (deselect_enabled && get_current_tab() == found) {
+							set_current_tab(-1);
+						} else {
+							set_current_tab(found);
+						}
+
+						emit_signal(SNAME("tab_clicked"), found);
+					}
 				}
 
 				// Right mouse button clicked on a tab.
@@ -348,7 +381,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
-			if (is_layout_rtl() ? select_previous_available() : select_next_available()) {
+			if (is_layout_rtl() ? _select_previous_available(true) : _select_next_available(true)) {
 				accept_event();
 			}
 		} else if (p_event->is_action("ui_left", true)) {
@@ -359,7 +392,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				set_process_internal(true);
 			}
-			if (is_layout_rtl() ? select_next_available() : select_previous_available()) {
+			if (is_layout_rtl() ? _select_next_available(true) : _select_previous_available(true)) {
 				accept_event();
 			}
 		}
@@ -444,11 +477,11 @@ void TabBar::_notification(int p_what) {
 			if (gamepad_event_delay_ms <= 0) {
 				gamepad_event_delay_ms = GAMEPAD_EVENT_REPEAT_RATE_MS + gamepad_event_delay_ms;
 				if (input->is_action_pressed("ui_right")) {
-					is_layout_rtl() ? select_previous_available() : select_next_available();
+					is_layout_rtl() ? _select_previous_available(true) : _select_next_available(true);
 				}
 
 				if (input->is_action_pressed("ui_left")) {
-					is_layout_rtl() ? select_next_available() : select_previous_available();
+					is_layout_rtl() ? _select_next_available(true) : _select_previous_available(true);
 				}
 			}
 		} break;
@@ -535,6 +568,7 @@ void TabBar::_notification(int p_what) {
 		case NOTIFICATION_DRAG_END: {
 			if (dragging_valid_tab) {
 				dragging_valid_tab = false;
+				play_theme_sound(theme_cache.drag_ended_sound);
 				queue_redraw();
 			}
 			[[fallthrough]];
@@ -905,18 +939,33 @@ int TabBar::get_next_available(int p_idx) const {
 }
 
 bool TabBar::select_previous_available() {
+	return _select_previous_available(false);
+}
+
+bool TabBar::_select_previous_available(bool p_play_sound) {
 	const int previous_available = get_previous_available();
 	if (previous_available != -1) {
 		set_current_tab(previous_available);
+		if (p_play_sound) {
+			play_theme_sound(theme_cache.pressed_sound);
+		}
 	}
 	return previous_available != -1;
 }
 
 bool TabBar::select_next_available() {
+	return _select_next_available(false);
+}
+
+bool TabBar::_select_next_available(bool p_play_sound) {
 	const int next_available = get_next_available();
 	if (next_available != -1) {
 		set_current_tab(next_available);
+		if (p_play_sound) {
+			play_theme_sound(theme_cache.pressed_sound);
+		}
 	}
+
 	return next_available != -1;
 }
 
@@ -1219,6 +1268,9 @@ void TabBar::_update_hover() {
 		hover = hover_now;
 
 		if (hover != -1) {
+			if (hover != current && !is_tab_disabled(hover)) {
+				play_theme_sound(theme_cache.hover_sound);
+			}
 			emit_signal(SNAME("tab_hovered"), hover);
 		}
 
@@ -2425,6 +2477,13 @@ void TabBar::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, TabBar, close_icon, "close");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, TabBar, button_pressed_style, "button_pressed");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, TabBar, button_hl_style, "button_highlight");
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, hover_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, pressed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, pressed_disabled_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, drag_started_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TabBar, drag_ended_sound);
 
 	Tab defaults(true);
 

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -189,6 +189,11 @@ private:
 		Ref<Texture2D> close_icon;
 		Ref<StyleBox> button_pressed_style;
 		Ref<StyleBox> button_hl_style;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> hover_sound;
+		Ref<AudioStream> pressed_sound;
+		Ref<AudioStream> pressed_disabled_sound;
 	} theme_cache;
 
 	Timer *hover_switch_delay = nullptr;
@@ -209,6 +214,9 @@ private:
 
 	void _accessibility_action_scroll_into_view(const Variant &p_data, int p_index);
 	void _accessibility_action_focus(const Variant &p_data, int p_index);
+
+	bool _select_previous_available(bool p_play_sound);
+	bool _select_next_available(bool p_play_sound);
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -189,6 +189,13 @@ private:
 		Ref<Texture2D> close_icon;
 		Ref<StyleBox> button_pressed_style;
 		Ref<StyleBox> button_hl_style;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> hover_sound;
+		Ref<AudioStream> pressed_sound;
+		Ref<AudioStream> pressed_disabled_sound;
+		Ref<AudioStream> drag_started_sound;
+		Ref<AudioStream> drag_ended_sound;
 	} theme_cache;
 
 	Timer *hover_switch_delay = nullptr;
@@ -209,6 +216,9 @@ private:
 
 	void _accessibility_action_scroll_into_view(const Variant &p_data, int p_index);
 	void _accessibility_action_focus(const Variant &p_data, int p_index);
+
+	bool _select_previous_available(bool p_play_sound);
+	bool _select_next_available(bool p_play_sound);
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2604,6 +2604,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					_push_current_op();
 					set_caret_line(line, false, true, -1, caret);
 					set_caret_column(col, false, caret);
+					play_theme_sound(theme_cache.caret_moved_sound);
 					selection_drag_attempt = false;
 					bool caret_moved = get_caret_column(caret) != prev_col || get_caret_line(caret) != prev_line;
 
@@ -3450,6 +3451,7 @@ void TextEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void TextEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
@@ -3500,6 +3502,7 @@ void TextEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void TextEdit::_move_caret_up(bool p_select) {
@@ -3526,6 +3529,7 @@ void TextEdit::_move_caret_up(bool p_select) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void TextEdit::_move_caret_down(bool p_select) {
@@ -3548,6 +3552,7 @@ void TextEdit::_move_caret_down(bool p_select) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void TextEdit::_move_caret_to_line_start(bool p_select) {
@@ -3579,6 +3584,7 @@ void TextEdit::_move_caret_to_line_start(bool p_select) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void TextEdit::_move_caret_to_line_end(bool p_select) {
@@ -3604,6 +3610,7 @@ void TextEdit::_move_caret_to_line_end(bool p_select) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void TextEdit::_move_caret_page_up(bool p_select) {
@@ -3620,6 +3627,7 @@ void TextEdit::_move_caret_page_up(bool p_select) {
 		set_caret_line(n_line, i == 0, false, next_line.y, i);
 	}
 	merge_overlapping_carets();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void TextEdit::_move_caret_page_down(bool p_select) {
@@ -3636,6 +3644,7 @@ void TextEdit::_move_caret_page_down(bool p_select) {
 		set_caret_line(n_line, i == 0, false, next_line.y, i);
 	}
 	merge_overlapping_carets();
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
@@ -3655,6 +3664,7 @@ void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
 		}
 
 		if (get_caret_column(caret_index) == 0 && get_caret_line(caret_index) == 0 && !has_selection(caret_index)) {
+			play_theme_sound(theme_cache.text_change_rejected_sound);
 			continue;
 		}
 
@@ -3796,6 +3806,7 @@ void TextEdit::_move_caret_document_start(bool p_select) {
 
 	set_caret_line(0, false, true, -1);
 	set_caret_column(0);
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 void TextEdit::_move_caret_document_end(bool p_select) {
@@ -3808,6 +3819,7 @@ void TextEdit::_move_caret_document_end(bool p_select) {
 
 	set_caret_line(get_last_unhidden_line(), true, false, -1);
 	set_caret_column(text[get_caret_line()].length());
+	play_theme_sound(theme_cache.caret_moved_sound);
 }
 
 bool TextEdit::_clear_carets_and_selection() {
@@ -8403,6 +8415,11 @@ void TextEdit::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, TextEdit, current_line_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, TextEdit, word_highlighted_color);
 
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TextEdit, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TextEdit, caret_moved_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TextEdit, text_changed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TextEdit, text_change_rejected_sound);
+
 	/* Settings. */
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/timers/text_edit_idle_detect_sec", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), 3);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/common/text_edit_undo_stack_max_size", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"), 1024);
@@ -9875,6 +9892,8 @@ void TextEdit::_text_changed() {
 }
 
 void TextEdit::_emit_text_changed() {
+	play_theme_sound(theme_cache.text_changed_sound);
+
 	emit_signal(SceneStringName(text_changed));
 	text_changed_dirty = false;
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2616,6 +2616,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					_push_current_op();
 					set_caret_line(line, false, true, -1, caret);
 					set_caret_column(col, false, caret);
+					play_theme_sound(theme_cache.caret_moved_sound);
 					selection_drag_attempt = false;
 					bool caret_moved = get_caret_column(caret) != prev_col || get_caret_line(caret) != prev_line;
 
@@ -3406,7 +3407,11 @@ void TextEdit::_new_line(bool p_split_current_line, bool p_above) {
 
 void TextEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
 	_push_current_op();
+
+	PackedVector2Array previous_caret_positions;
 	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+
 		// Handle selection.
 		if (p_select) {
 			_pre_shift_selection(i);
@@ -3451,12 +3456,18 @@ void TextEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
 			}
 		}
 	}
+
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
 	merge_overlapping_carets();
 }
 
 void TextEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
 	_push_current_op();
+
+	PackedVector2Array previous_caret_positions;
 	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+
 		// Handle selection.
 		if (p_select) {
 			_pre_shift_selection(i);
@@ -3501,12 +3512,17 @@ void TextEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
 			}
 		}
 	}
+
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
 	merge_overlapping_carets();
 }
 
 void TextEdit::_move_caret_up(bool p_select) {
 	_push_current_op();
+	PackedVector2Array previous_caret_positions;
 	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+
 		if (p_select) {
 			_pre_shift_selection(i);
 		} else {
@@ -3528,11 +3544,16 @@ void TextEdit::_move_caret_up(bool p_select) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
 }
 
 void TextEdit::_move_caret_down(bool p_select) {
 	_push_current_op();
+
+	PackedVector2Array previous_caret_positions;
 	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+
 		if (p_select) {
 			_pre_shift_selection(i);
 		} else {
@@ -3550,11 +3571,16 @@ void TextEdit::_move_caret_down(bool p_select) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
 }
 
 void TextEdit::_move_caret_to_line_start(bool p_select) {
 	_push_current_op();
+
+	PackedVector2Array previous_caret_positions;
 	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+
 		if (p_select) {
 			_pre_shift_selection(i);
 		} else {
@@ -3581,11 +3607,15 @@ void TextEdit::_move_caret_to_line_start(bool p_select) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
 }
 
 void TextEdit::_move_caret_to_line_end(bool p_select) {
 	_push_current_op();
+	PackedVector2Array previous_caret_positions;
 	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+
 		if (p_select) {
 			_pre_shift_selection(i);
 		} else {
@@ -3606,11 +3636,16 @@ void TextEdit::_move_caret_to_line_end(bool p_select) {
 		}
 	}
 	merge_overlapping_carets();
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
 }
 
 void TextEdit::_move_caret_page_up(bool p_select) {
 	_push_current_op();
+
+	PackedVector2Array previous_caret_positions;
 	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+
 		if (p_select) {
 			_pre_shift_selection(i);
 		} else {
@@ -3622,11 +3657,16 @@ void TextEdit::_move_caret_page_up(bool p_select) {
 		set_caret_line(n_line, i == 0, false, next_line.y, i);
 	}
 	merge_overlapping_carets();
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
 }
 
 void TextEdit::_move_caret_page_down(bool p_select) {
 	_push_current_op();
+
+	PackedVector2Array previous_caret_positions;
 	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+
 		if (p_select) {
 			_pre_shift_selection(i);
 		} else {
@@ -3638,6 +3678,7 @@ void TextEdit::_move_caret_page_down(bool p_select) {
 		set_caret_line(n_line, i == 0, false, next_line.y, i);
 	}
 	merge_overlapping_carets();
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
 }
 
 void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
@@ -3657,6 +3698,7 @@ void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
 		}
 
 		if (get_caret_column(caret_index) == 0 && get_caret_line(caret_index) == 0 && !has_selection(caret_index)) {
+			play_theme_sound(theme_cache.text_change_rejected_sound);
 			continue;
 		}
 
@@ -3735,6 +3777,7 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 
 		int curline_len = text[get_caret_line(caret_index)].length();
 		if (get_caret_line(caret_index) == text.size() - 1 && get_caret_column(caret_index) == curline_len) {
+			play_theme_sound(theme_cache.text_change_rejected_sound);
 			continue; // Last line, last column: Nothing to do.
 		}
 
@@ -3789,7 +3832,13 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 }
 
 void TextEdit::_move_caret_document_start(bool p_select) {
+	PackedVector2Array previous_caret_positions;
+	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+	}
+
 	remove_secondary_carets();
+
 	if (p_select) {
 		_pre_shift_selection(0);
 	} else {
@@ -3798,9 +3847,15 @@ void TextEdit::_move_caret_document_start(bool p_select) {
 
 	set_caret_line(0, false, true, -1);
 	set_caret_column(0);
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
 }
 
 void TextEdit::_move_caret_document_end(bool p_select) {
+	PackedVector2Array previous_caret_positions;
+	for (int i = 0; i < get_caret_count(); i++) {
+		previous_caret_positions.push_back(Vector2(get_caret_line(i), get_caret_column(i)));
+	}
+
 	remove_secondary_carets();
 	if (p_select) {
 		_pre_shift_selection(0);
@@ -3810,6 +3865,22 @@ void TextEdit::_move_caret_document_end(bool p_select) {
 
 	set_caret_line(get_last_unhidden_line(), true, false, -1);
 	set_caret_column(text[get_caret_line()].length());
+	play_theme_sound(_has_any_caret_moved(previous_caret_positions) ? theme_cache.caret_moved_sound : theme_cache.caret_move_rejected_sound);
+}
+
+bool TextEdit::_has_any_caret_moved(const PackedVector2Array &p_previous_caret_positions) const {
+	if (get_caret_count() != p_previous_caret_positions.size()) {
+		// A caret merge has occurred, which means at least one caret has moved.
+		return true;
+	}
+
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (!p_previous_caret_positions[i].is_equal_approx(Vector2(get_caret_line(i), get_caret_column(i)))) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 bool TextEdit::_clear_carets_and_selection() {
@@ -8311,6 +8382,12 @@ void TextEdit::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, TextEdit, current_line_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, TextEdit, word_highlighted_color);
 
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TextEdit, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TextEdit, caret_moved_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TextEdit, caret_move_rejected_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TextEdit, text_changed_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, TextEdit, text_change_rejected_sound);
+
 	/* Settings. */
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/timers/text_edit_idle_detect_sec", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), 3);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/common/text_edit_undo_stack_max_size", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"), 1024);
@@ -9798,6 +9875,8 @@ void TextEdit::_text_changed() {
 }
 
 void TextEdit::_emit_text_changed() {
+	play_theme_sound(theme_cache.text_changed_sound);
+
 	emit_signal(SceneStringName(text_changed));
 	text_changed_dirty = false;
 }

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -695,6 +695,11 @@ private:
 #ifndef DISABLE_DEPRECATED
 		Color background_color = Color(1, 1, 1);
 #endif // DISABLE_DEPRECATED
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> caret_moved_sound;
+		Ref<AudioStream> text_changed_sound;
+		Ref<AudioStream> text_change_rejected_sound;
 	} theme_cache;
 
 	bool window_has_focus = true;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -697,6 +697,12 @@ private:
 #ifndef DISABLE_DEPRECATED
 		Color background_color = Color(1, 1, 1);
 #endif // DISABLE_DEPRECATED
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> caret_moved_sound;
+		Ref<AudioStream> caret_move_rejected_sound;
+		Ref<AudioStream> text_changed_sound;
+		Ref<AudioStream> text_change_rejected_sound;
 	} theme_cache;
 
 	bool window_has_focus = true;
@@ -741,6 +747,7 @@ private:
 	void _delete(bool p_word = false, bool p_all_to_right = false);
 	void _move_caret_document_start(bool p_select);
 	void _move_caret_document_end(bool p_select);
+	bool _has_any_caret_moved(const PackedVector2Array &p_previous_caret_positions) const;
 	bool _clear_carets_and_selection();
 
 protected:

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3282,9 +3282,11 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 				if (select_mode == SELECT_MULTI && p_mod->is_command_or_control_pressed()) {
 					if (c.selected && p_button == MouseButton::LEFT) {
 						p_item->deselect(col);
+						play_theme_sound(theme_cache.item_selected_sound);
 						emit_signal(SNAME("multi_selected"), p_item, col, false);
 					} else {
 						p_item->select(col);
+						play_theme_sound(theme_cache.item_selected_sound);
 						emit_signal(SNAME("multi_selected"), p_item, col, true);
 						emit_signal(SNAME("item_mouse_selected"), get_local_mouse_position(), p_button);
 					}
@@ -3292,6 +3294,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 					if (select_mode == SELECT_MULTI && p_mod->is_shift_pressed() && selected_item && selected_item != p_item) {
 						bool inrange = false;
 
+						play_theme_sound(theme_cache.item_selected_sound);
 						select_single_item(p_item, root, col, selected_item, &inrange);
 						emit_signal(SNAME("item_mouse_selected"), get_local_mouse_position(), p_button);
 					} else {
@@ -3314,6 +3317,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 								}
 							}
 
+							play_theme_sound(theme_cache.item_selected_sound);
 							emit_signal(SNAME("item_mouse_selected"), get_local_mouse_position(), p_button);
 						}
 					}
@@ -3680,8 +3684,10 @@ void Tree::_go_left() {
 		selected_button = -1;
 		if (select_mode == SELECT_MULTI) {
 			selected_col--;
+			play_theme_sound(theme_cache.focus_sound);
 			emit_signal(SNAME("cell_selected"));
 		} else {
+			play_theme_sound(theme_cache.focus_sound);
 			selected_item->select(selected_col - 1);
 		}
 	}
@@ -3707,8 +3713,10 @@ void Tree::_go_right() {
 		selected_button = -1;
 		if (select_mode == SELECT_MULTI) {
 			selected_col++;
+			play_theme_sound(theme_cache.focus_sound);
 			emit_signal(SNAME("cell_selected"));
 		} else {
+			play_theme_sound(theme_cache.focus_sound);
 			selected_item->select(selected_col + 1);
 		}
 	}
@@ -3736,6 +3744,7 @@ void Tree::_go_up() {
 		}
 
 		selected_item = prev;
+		play_theme_sound(theme_cache.focus_sound);
 		emit_signal(SNAME("cell_selected"));
 		queue_redraw();
 	} else {
@@ -3745,6 +3754,7 @@ void Tree::_go_up() {
 		if (!prev) {
 			return; // Do nothing.
 		}
+		play_theme_sound(theme_cache.focus_sound);
 		prev->select(col);
 	}
 
@@ -3777,10 +3787,12 @@ void Tree::_shift_select_range(TreeItem *new_item) {
 			if (in_range || at_range_edge) {
 				if (!item->is_selected(selected_col) && item->is_selectable(selected_col)) {
 					item->select(selected_col);
+					play_theme_sound(theme_cache.focus_sound);
 					emit_signal(SNAME("multi_selected"), item, selected_col, true);
 				}
 			} else if (item->is_selected(selected_col)) {
 				item->deselect(selected_col);
+				play_theme_sound(theme_cache.focus_sound);
 				emit_signal(SNAME("multi_selected"), item, selected_col, false);
 			}
 		}
@@ -3812,6 +3824,7 @@ void Tree::_go_down() {
 		}
 
 		selected_item = next;
+		play_theme_sound(theme_cache.focus_sound);
 		emit_signal(SNAME("cell_selected"));
 		queue_redraw();
 	} else {
@@ -3821,6 +3834,7 @@ void Tree::_go_down() {
 		if (!next) {
 			return; // Do nothing.
 		}
+		play_theme_sound(theme_cache.focus_sound);
 		next->select(col);
 	}
 
@@ -4128,8 +4142,10 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			// Bring up editor if possible.
 			if (selected_item && selected_col != -1 && selected_button != -1) {
 				const TreeItem::Cell &c = selected_item->cells[selected_col];
+				play_theme_sound(theme_cache.item_selected_sound);
 				emit_signal("button_clicked", selected_item, selected_col, c.buttons[selected_button].id, MouseButton::LEFT);
 			} else if (!edit_selected()) {
+				play_theme_sound(theme_cache.item_selected_sound);
 				emit_signal(SNAME("item_activated"));
 				incr_search.clear();
 			}
@@ -4579,6 +4595,11 @@ void Tree::_determine_hovered_item() {
 	bool header_hover_needs_redraw = cache.hover_header_row && cache.hover_header_column != old_header_column;
 	// Mouse has moved between header and "main" areas.
 	bool whole_needs_redraw = cache.hover_header_row != old_header_row;
+
+	if (cache.hover_item != nullptr && (header_hover_needs_redraw || item_hover_needs_redraw)) {
+		// Play sound if the hover state has changed, but don't play it when unhovering.
+		play_theme_sound(theme_cache.item_hovered_sound);
+	}
 
 	if (whole_needs_redraw || header_hover_needs_redraw || item_hover_needs_redraw) {
 		queue_redraw();
@@ -7637,6 +7658,10 @@ void Tree::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, title_button_pressed);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, title_button_hover);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, title_button_color);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Tree, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Tree, item_hovered_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Tree, item_selected_sound);
 
 	ADD_CLASS_DEPENDENCY("HScrollBar");
 	ADD_CLASS_DEPENDENCY("HSlider");

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3272,9 +3272,11 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 				if (select_mode == SELECT_MULTI && p_mod->is_command_or_control_pressed()) {
 					if (c.selected && p_button == MouseButton::LEFT) {
 						p_item->deselect(col);
+						play_theme_sound(theme_cache.item_selected_sound);
 						emit_signal(SNAME("multi_selected"), p_item, col, false);
 					} else {
 						p_item->select(col);
+						play_theme_sound(theme_cache.item_selected_sound);
 						emit_signal(SNAME("multi_selected"), p_item, col, true);
 						emit_signal(SNAME("item_mouse_selected"), get_local_mouse_position(), p_button);
 					}
@@ -3282,6 +3284,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 					if (select_mode == SELECT_MULTI && p_mod->is_shift_pressed() && selected_item && selected_item != p_item) {
 						bool inrange = false;
 
+						play_theme_sound(theme_cache.item_selected_sound);
 						select_single_item(p_item, root, col, selected_item, &inrange);
 						emit_signal(SNAME("item_mouse_selected"), get_local_mouse_position(), p_button);
 					} else {
@@ -3304,6 +3307,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 								}
 							}
 
+							play_theme_sound(theme_cache.item_selected_sound);
 							emit_signal(SNAME("item_mouse_selected"), get_local_mouse_position(), p_button);
 						}
 					}
@@ -3692,8 +3696,10 @@ void Tree::_go_left() {
 		selected_button = -1;
 		if (select_mode == SELECT_MULTI) {
 			selected_col--;
+			play_theme_sound(theme_cache.focus_sound);
 			emit_signal(SNAME("cell_selected"));
 		} else {
+			play_theme_sound(theme_cache.focus_sound);
 			selected_item->select(selected_col - 1);
 		}
 	}
@@ -3719,8 +3725,10 @@ void Tree::_go_right() {
 		selected_button = -1;
 		if (select_mode == SELECT_MULTI) {
 			selected_col++;
+			play_theme_sound(theme_cache.focus_sound);
 			emit_signal(SNAME("cell_selected"));
 		} else {
+			play_theme_sound(theme_cache.focus_sound);
 			selected_item->select(selected_col + 1);
 		}
 	}
@@ -3748,6 +3756,7 @@ void Tree::_go_up() {
 		}
 
 		selected_item = prev;
+		play_theme_sound(theme_cache.focus_sound);
 		emit_signal(SNAME("cell_selected"));
 		queue_redraw();
 	} else {
@@ -3757,6 +3766,7 @@ void Tree::_go_up() {
 		if (!prev) {
 			return; // Do nothing.
 		}
+		play_theme_sound(theme_cache.focus_sound);
 		prev->select(col);
 	}
 
@@ -3789,10 +3799,12 @@ void Tree::_shift_select_range(TreeItem *new_item) {
 			if (in_range || at_range_edge) {
 				if (!item->is_selected(selected_col) && item->is_selectable(selected_col)) {
 					item->select(selected_col);
+					play_theme_sound(theme_cache.focus_sound);
 					emit_signal(SNAME("multi_selected"), item, selected_col, true);
 				}
 			} else if (item->is_selected(selected_col)) {
 				item->deselect(selected_col);
+				play_theme_sound(theme_cache.focus_sound);
 				emit_signal(SNAME("multi_selected"), item, selected_col, false);
 			}
 		}
@@ -3824,6 +3836,7 @@ void Tree::_go_down() {
 		}
 
 		selected_item = next;
+		play_theme_sound(theme_cache.focus_sound);
 		emit_signal(SNAME("cell_selected"));
 		queue_redraw();
 	} else {
@@ -3833,6 +3846,7 @@ void Tree::_go_down() {
 		if (!next) {
 			return; // Do nothing.
 		}
+		play_theme_sound(theme_cache.focus_sound);
 		next->select(col);
 	}
 
@@ -4140,8 +4154,10 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			// Bring up editor if possible.
 			if (selected_item && selected_col != -1 && selected_button != -1) {
 				const TreeItem::Cell &c = selected_item->cells[selected_col];
+				play_theme_sound(theme_cache.item_selected_sound);
 				emit_signal("button_clicked", selected_item, selected_col, c.buttons[selected_button].id, MouseButton::LEFT);
 			} else if (!edit_selected()) {
+				play_theme_sound(theme_cache.item_selected_sound);
 				emit_signal(SNAME("item_activated"));
 				incr_search.clear();
 			}
@@ -4591,6 +4607,11 @@ void Tree::_determine_hovered_item() {
 	bool header_hover_needs_redraw = cache.hover_header_row && cache.hover_header_column != old_header_column;
 	// Mouse has moved between header and "main" areas.
 	bool whole_needs_redraw = cache.hover_header_row != old_header_row;
+
+	if (cache.hover_item != nullptr && (header_hover_needs_redraw || item_hover_needs_redraw)) {
+		// Play sound if the hover state has changed, but don't play it when unhovering.
+		play_theme_sound(theme_cache.item_hovered_sound);
+	}
 
 	if (whole_needs_redraw || header_hover_needs_redraw || item_hover_needs_redraw) {
 		queue_redraw();
@@ -7653,6 +7674,10 @@ void Tree::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, title_button_pressed);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, title_button_hover);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, title_button_color);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Tree, focus_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Tree, item_hovered_sound);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_SOUND, Tree, item_selected_sound);
 
 	ADD_CLASS_DEPENDENCY("HScrollBar");
 	ADD_CLASS_DEPENDENCY("HSlider");

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -713,6 +713,10 @@ private:
 		int scrollbar_margin_left = -1;
 		int scrollbar_h_separation = 0;
 		int scrollbar_v_separation = 0;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> item_hovered_sound;
+		Ref<AudioStream> item_selected_sound;
 	} theme_cache;
 
 	struct Cache {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -716,6 +716,10 @@ private:
 		int scrollbar_margin_left = -1;
 		int scrollbar_h_separation = 0;
 		int scrollbar_v_separation = 0;
+
+		Ref<AudioStream> focus_sound;
+		Ref<AudioStream> item_hovered_sound;
+		Ref<AudioStream> item_selected_sound;
 	} theme_cache;
 
 	struct Cache {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -43,6 +43,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "scene/animation/tween.h"
+#include "scene/audio/audio_stream_player.h"
 #include "scene/debugger/scene_debugger.h"
 #include "scene/gui/control.h"
 #include "scene/main/multiplayer_api.h"
@@ -1805,6 +1806,16 @@ TypedArray<Tween> SceneTree::get_processed_tweens() {
 	return ret;
 }
 
+void SceneTree::play_theme_sound(const Ref<AudioStream> &p_stream) {
+	AudioStreamPlayer *audio_stream_player = memnew(AudioStreamPlayer);
+	audio_stream_player->set_name(SNAME("_theme_sound"));
+	audio_stream_player->set_bus(gui_theme_bus);
+	audio_stream_player->set_stream(p_stream);
+	audio_stream_player->set_autoplay(true);
+	audio_stream_player->connect(SceneStringName(finished), callable_mp((Node *)audio_stream_player, &Node::queue_free));
+	root->add_child(audio_stream_player);
+}
+
 RequiredResult<MultiplayerAPI> SceneTree::get_multiplayer(const NodePath &p_for_path) const {
 	ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<MultiplayerAPI>(), "Multiplayer can only be manipulated from the main thread.");
 	if (p_for_path.is_empty()) {
@@ -2053,6 +2064,7 @@ SceneTree::SceneTree() {
 	debug_paths_width = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "debug/shapes/paths/geometry_width", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), 2.0);
 	collision_debug_contacts = GLOBAL_DEF(PropertyInfo(Variant::INT, "debug/shapes/collision/max_contacts_displayed", PROPERTY_HINT_RANGE, "0,20000,1"), 10000);
 	accessibility_upd_per_sec = GLOBAL_GET(SNAME("accessibility/general/updates_per_second"));
+	gui_theme_bus = GLOBAL_GET("audio/buses/gui_theme_bus");
 
 	GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -43,6 +43,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "scene/animation/tween.h"
+#include "scene/audio/audio_stream_player.h"
 #include "scene/debugger/scene_debugger.h"
 #include "scene/gui/control.h"
 #include "scene/main/multiplayer_api.h"
@@ -1526,6 +1527,10 @@ void SceneTree::_call_input_pause(const StringName &p_group, CallInputType p_cal
 	}
 }
 
+void SceneTree::_project_settings_changed() {
+	gui_theme_bus = GLOBAL_GET("audio/buses/gui_theme_bus");
+}
+
 void SceneTree::_call_group_flags(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	r_error.error = Callable::CallError::CALL_OK;
 
@@ -1811,6 +1816,17 @@ TypedArray<Tween> SceneTree::get_processed_tweens() {
 	return ret;
 }
 
+void SceneTree::play_theme_sound(const Ref<AudioStream> &p_stream) {
+	AudioStreamPlayer *audio_stream_player = memnew(AudioStreamPlayer);
+	audio_stream_player->set_name(SNAME("_theme_sound"));
+	audio_stream_player->set_bus(gui_theme_bus);
+	audio_stream_player->set_stream(p_stream);
+	audio_stream_player->set_autoplay(true);
+	audio_stream_player->set_process_mode(Node::PROCESS_MODE_ALWAYS);
+	audio_stream_player->connect(SceneStringName(finished), callable_mp((Node *)audio_stream_player, &Node::queue_free));
+	root->add_child(audio_stream_player);
+}
+
 RequiredResult<MultiplayerAPI> SceneTree::get_multiplayer(const NodePath &p_for_path) const {
 	ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<MultiplayerAPI>(), "Multiplayer can only be manipulated from the main thread.");
 	if (p_for_path.is_empty()) {
@@ -2059,6 +2075,7 @@ SceneTree::SceneTree() {
 	debug_paths_width = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "debug/shapes/paths/geometry_width", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), 2.0);
 	collision_debug_contacts = GLOBAL_DEF(PropertyInfo(Variant::INT, "debug/shapes/collision/max_contacts_displayed", PROPERTY_HINT_RANGE, "0,20000,1"), 10000);
 	accessibility_upd_per_sec = GLOBAL_GET(SNAME("accessibility/general/updates_per_second"));
+	gui_theme_bus = GLOBAL_GET("audio/buses/gui_theme_bus");
 
 	GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
 
@@ -2222,6 +2239,8 @@ SceneTree::SceneTree() {
 	root->connect("close_requested", callable_mp(this, &SceneTree::_main_window_close));
 	root->connect("go_back_requested", callable_mp(this, &SceneTree::_main_window_go_back));
 	root->connect(SceneStringName(focus_entered), callable_mp(this, &SceneTree::_main_window_focus_in));
+
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &SceneTree::_project_settings_changed));
 
 #ifdef TOOLS_ENABLED
 	edited_scene_root = nullptr;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -41,6 +41,9 @@
 #include <cstdlib>
 
 class ArrayMesh;
+class AudioStream;
+class AudioStreamPlayback;
+class AudioStreamPlayer;
 class InputEvent;
 class Material;
 class MultiplayerAPI;
@@ -191,6 +194,7 @@ private:
 	bool accessibility_force_update = true;
 	HashSet<ObjectID> accessibility_change_queue;
 	uint64_t accessibility_last_update = 0;
+	StringName gui_theme_bus;
 
 	HashMap<UGCall, Vector<Variant>, UGCall> unique_group_calls;
 	bool ugc_locked = false;
@@ -434,6 +438,8 @@ public:
 	RequiredResult<Tween> create_tween();
 	void remove_tween(const Ref<Tween> &p_tween);
 	TypedArray<Tween> get_processed_tweens();
+
+	void play_theme_sound(const Ref<AudioStream> &p_stream);
 
 	//used by Main::start, don't use otherwise
 	void add_current_scene(Node *p_current);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -41,6 +41,9 @@
 #include <cstdlib>
 
 class ArrayMesh;
+class AudioStream;
+class AudioStreamPlayback;
+class AudioStreamPlayer;
 class InputEvent;
 class Material;
 class MultiplayerAPI;
@@ -191,6 +194,7 @@ private:
 	bool accessibility_force_update = true;
 	HashSet<ObjectID> accessibility_change_queue;
 	uint64_t accessibility_last_update = 0;
+	StringName gui_theme_bus;
 
 	HashMap<UGCall, Vector<Variant>, UGCall> unique_group_calls;
 	bool ugc_locked = false;
@@ -282,6 +286,8 @@ private:
 
 	//used by viewport
 	void _call_input_pause(const StringName &p_group, CallInputType p_call_type, const Ref<InputEvent> &p_input, Viewport *p_viewport);
+
+	void _project_settings_changed();
 
 protected:
 	void _notification(int p_notification);
@@ -434,6 +440,8 @@ public:
 	RequiredResult<Tween> create_tween();
 	void remove_tween(const Ref<Tween> &p_tween);
 	TypedArray<Tween> get_processed_tweens();
+
+	void play_theme_sound(const Ref<AudioStream> &p_stream);
 
 	//used by Main::start, don't use otherwise
 	void add_current_scene(Node *p_current);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -41,6 +41,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/object/class_db.h"
 #include "core/templates/pair.h"
 #include "core/templates/sort_array.h"
+#include "scene/audio/audio_stream_player.h"
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/popup.h"
@@ -1991,7 +1992,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 							// Grabbing unhovered focus can cause issues when mouse is dragged
 							// with another button held down.
 							if (gui.mouse_over_hierarchy.has(control->get_instance_id())) {
-								// Hide the focus when it comes from a click.
+								// Don't play a sound when the focus comes from a click.
+								// Also, hide the focus when it comes from a click.
 								control->grab_focus(true);
 							}
 							break;
@@ -2430,6 +2432,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 
 			if (next) {
+				play_theme_sound(next->get_theme_sound(SNAME("focus_sound")));
 				next->grab_focus();
 				set_input_as_handled();
 			} else if (show_focus && gui.hide_focus && gui.key_focus) {
@@ -2594,6 +2597,15 @@ void Viewport::_gui_remove_control(Control *p_control) {
 	if (gui.tooltip_control == p_control) {
 		gui.tooltip_control = nullptr;
 	}
+}
+
+void Viewport::play_theme_sound(const Ref<AudioStream> &p_stream) {
+	ERR_MAIN_THREAD_GUARD;
+	if (p_stream.is_null() || !get_tree()) {
+		return;
+	}
+
+	get_tree()->play_theme_sound(p_stream);
 }
 
 void Viewport::canvas_item_top_level_changed() {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -41,6 +41,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/object/class_db.h"
 #include "core/templates/pair.h"
 #include "core/templates/sort_array.h"
+#include "scene/audio/audio_stream_player.h"
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/popup.h"
@@ -1997,7 +1998,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 							// Grabbing unhovered focus can cause issues when mouse is dragged
 							// with another button held down.
 							if (gui.mouse_over_hierarchy.has(control->get_instance_id())) {
-								// Hide the focus when it comes from a click.
+								// Don't play a sound when the focus comes from a click.
+								// Also, hide the focus when it comes from a click.
 								control->grab_focus(true);
 							}
 							break;
@@ -2436,6 +2438,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 
 			if (next) {
+				play_theme_sound(next->get_theme_sound(SNAME("focus_sound")));
 				next->grab_focus();
 				set_input_as_handled();
 			} else if (show_focus && gui.hide_focus && gui.key_focus) {
@@ -2600,6 +2603,15 @@ void Viewport::_gui_remove_control(Control *p_control) {
 	if (gui.tooltip_control == p_control) {
 		gui.tooltip_control = nullptr;
 	}
+}
+
+void Viewport::play_theme_sound(const Ref<AudioStream> &p_stream) {
+	ERR_MAIN_THREAD_GUARD;
+	if (p_stream.is_null() || !get_tree()) {
+		return;
+	}
+
+	get_tree()->play_theme_sound(p_stream);
 }
 
 void Viewport::canvas_item_top_level_changed() {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -36,6 +36,8 @@
 #include "servers/rendering/rendering_server_enums.h"
 
 class AudioListener2D;
+class AudioStream;
+class AudioStreamPlayer;
 class Camera2D;
 class CanvasItem;
 class CanvasLayer;
@@ -699,6 +701,8 @@ public:
 	void gui_perform_drop_at(const Point2 &p_pos, Control *p_control = nullptr);
 
 	Control *gui_find_control(const Point2 &p_global);
+
+	void play_theme_sound(const Ref<AudioStream> &p_stream);
 
 	void set_sdf_oversize(SDFOversize p_sdf_oversize);
 	SDFOversize get_sdf_oversize() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -102,6 +102,13 @@ bool Window::_set(const StringName &p_name, const Variant &p_value) {
 			String dname = name.get_slicec('/', 1);
 			theme_constant_override.erase(dname);
 			_notify_theme_override_changed();
+		} else if (name.begins_with("theme_override_sounds/")) {
+			String dname = name.get_slicec('/', 1);
+			if (theme_sound_override.has(dname)) {
+				theme_sound_override[dname]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
+			}
+			theme_sound_override.erase(dname);
+			_notify_theme_override_changed();
 		} else {
 			return false;
 		}
@@ -124,6 +131,9 @@ bool Window::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (name.begins_with("theme_override_constants/")) {
 			String dname = name.get_slicec('/', 1);
 			add_theme_constant_override(dname, p_value);
+		} else if (name.begins_with("theme_override_sounds/")) {
+			String dname = name.get_slicec('/', 1);
+			add_theme_sound_override(dname, p_value);
 		} else {
 			return false;
 		}
@@ -157,6 +167,9 @@ bool Window::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (sname.begins_with("theme_override_constants/")) {
 		String name = sname.get_slicec('/', 1);
 		r_ret = theme_constant_override.has(name) ? Variant(theme_constant_override[name]) : Variant();
+	} else if (sname.begins_with("theme_override_sounds/")) {
+		String name = sname.get_slicec('/', 1);
+		r_ret = theme_sound_override.has(name) ? Variant(theme_sound_override[name]) : Variant();
 	} else {
 		return false;
 	}
@@ -241,6 +254,18 @@ void Window::_get_property_list(List<PropertyInfo> *p_list) const {
 			}
 
 			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_styles") + String("/") + E, PROPERTY_HINT_RESOURCE_TYPE, StyleBox::get_class_static(), usage));
+		}
+	}
+	{
+		List<StringName> names;
+		default_theme->get_stylebox_list(get_class_name(), &names);
+		for (const StringName &E : names) {
+			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
+			if (theme_style_override.has(E)) {
+				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+			}
+
+			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_sounds") + String("/") + E, PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static(), usage));
 		}
 	}
 }
@@ -2603,6 +2628,7 @@ void Window::_invalidate_theme_cache() {
 	theme_font_size_cache.clear();
 	theme_color_cache.clear();
 	theme_constant_cache.clear();
+	theme_audio_cache.clear();
 }
 
 void Window::_update_theme_item_cache() {
@@ -2789,6 +2815,30 @@ int Window::get_theme_constant(const StringName &p_name, const StringName &p_the
 	return constant;
 }
 
+Ref<AudioStream> Window::get_theme_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	ERR_READ_THREAD_GUARD_V(Ref<AudioStream>());
+	if (!initialized) {
+		WARN_PRINT_ONCE(vformat("Attempting to access theme items too early in %s; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED", get_description()));
+	}
+
+	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == theme_type_variation) {
+		const Ref<AudioStream> *audio = theme_sound_override.getptr(p_name);
+		if (audio) {
+			return *audio;
+		}
+	}
+
+	if (theme_audio_cache.has(p_theme_type) && theme_audio_cache[p_theme_type].has(p_name)) {
+		return theme_audio_cache[p_theme_type][p_name];
+	}
+
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<AudioStream> audio = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_SOUND, p_name, theme_types);
+	theme_audio_cache[p_theme_type][p_name] = audio;
+	return audio;
+}
+
 Variant Window::get_theme_item(Theme::DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
 	switch (p_data_type) {
 		case Theme::DATA_TYPE_COLOR:
@@ -2803,6 +2853,8 @@ Variant Window::get_theme_item(Theme::DataType p_data_type, const StringName &p_
 			return get_theme_icon(p_name, p_theme_type);
 		case Theme::DATA_TYPE_STYLEBOX:
 			return get_theme_stylebox(p_name, p_theme_type);
+		case Theme::DATA_TYPE_SOUND:
+			return get_theme_sound(p_name, p_theme_type);
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -2918,6 +2970,23 @@ bool Window::has_theme_constant(const StringName &p_name, const StringName &p_th
 	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 }
 
+bool Window::has_theme_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	if (!initialized) {
+		WARN_PRINT_ONCE(vformat("Attempting to access theme items too early in %s; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED", get_description()));
+	}
+
+	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == theme_type_variation) {
+		if (has_theme_sound_override(p_name)) {
+			return true;
+		}
+	}
+
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_SOUND, p_name, theme_types);
+}
+
 /// Local property overrides.
 
 void Window::add_theme_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon) {
@@ -2977,6 +3046,12 @@ void Window::add_theme_constant_override(const StringName &p_name, int p_constan
 	_notify_theme_override_changed();
 }
 
+void Window::add_theme_sound_override(const StringName &p_name, const Ref<AudioStream> &p_audio) {
+	ERR_MAIN_THREAD_GUARD;
+	theme_sound_override[p_name] = p_audio;
+	_notify_theme_override_changed();
+}
+
 void Window::remove_theme_icon_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (theme_icon_override.has(p_name)) {
@@ -3025,6 +3100,12 @@ void Window::remove_theme_constant_override(const StringName &p_name) {
 	_notify_theme_override_changed();
 }
 
+void Window::remove_theme_sound_override(const StringName &p_name) {
+	ERR_MAIN_THREAD_GUARD;
+	theme_sound_override.erase(p_name);
+	_notify_theme_override_changed();
+}
+
 bool Window::has_theme_icon_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	const Ref<Texture2D> *tex = theme_icon_override.getptr(p_name);
@@ -3059,6 +3140,12 @@ bool Window::has_theme_constant_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	const int *constant = theme_constant_override.getptr(p_name);
 	return constant != nullptr;
+}
+
+bool Window::has_theme_sound_override(const StringName &p_name) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	const Ref<AudioStream> *audio = theme_sound_override.getptr(p_name);
+	return audio != nullptr;
 }
 
 /// Default theme properties.
@@ -3505,6 +3592,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_theme_font_size_override", "name", "font_size"), &Window::add_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("add_theme_color_override", "name", "color"), &Window::add_theme_color_override);
 	ClassDB::bind_method(D_METHOD("add_theme_constant_override", "name", "constant"), &Window::add_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("add_theme_sound_override", "name", "audio"), &Window::add_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("remove_theme_icon_override", "name"), &Window::remove_theme_icon_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_stylebox_override", "name"), &Window::remove_theme_style_override);
@@ -3512,6 +3600,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_theme_font_size_override", "name"), &Window::remove_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_color_override", "name"), &Window::remove_theme_color_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_constant_override", "name"), &Window::remove_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("remove_theme_sound_override", "name"), &Window::remove_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("get_theme_icon", "name", "theme_type"), &Window::get_theme_icon, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_stylebox", "name", "theme_type"), &Window::get_theme_stylebox, DEFVAL(StringName()));
@@ -3519,6 +3608,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_theme_font_size", "name", "theme_type"), &Window::get_theme_font_size, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_color", "name", "theme_type"), &Window::get_theme_color, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_constant", "name", "theme_type"), &Window::get_theme_constant, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("get_theme_sound", "name", "theme_type"), &Window::get_theme_sound, DEFVAL(StringName()));
 
 	ClassDB::bind_method(D_METHOD("has_theme_icon_override", "name"), &Window::has_theme_icon_override);
 	ClassDB::bind_method(D_METHOD("has_theme_stylebox_override", "name"), &Window::has_theme_stylebox_override);
@@ -3526,6 +3616,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size_override", "name"), &Window::has_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("has_theme_color_override", "name"), &Window::has_theme_color_override);
 	ClassDB::bind_method(D_METHOD("has_theme_constant_override", "name"), &Window::has_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("has_theme_sound_override", "name"), &Window::has_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("has_theme_icon", "name", "theme_type"), &Window::has_theme_icon, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_stylebox", "name", "theme_type"), &Window::has_theme_stylebox, DEFVAL(StringName()));
@@ -3533,6 +3624,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size", "name", "theme_type"), &Window::has_theme_font_size, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_color", "name", "theme_type"), &Window::has_theme_color, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_constant", "name", "theme_type"), &Window::has_theme_constant, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("has_theme_sound", "name", "theme_type"), &Window::has_theme_sound, DEFVAL(StringName()));
 
 	ClassDB::bind_method(D_METHOD("get_theme_default_base_scale"), &Window::get_theme_default_base_scale);
 	ClassDB::bind_method(D_METHOD("get_theme_default_font"), &Window::get_theme_default_font);
@@ -3760,4 +3852,5 @@ Window::~Window() {
 	theme_font_size_override.clear();
 	theme_color_override.clear();
 	theme_constant_override.clear();
+	theme_sound_override.clear();
 }

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -102,6 +102,13 @@ bool Window::_set(const StringName &p_name, const Variant &p_value) {
 			String dname = name.get_slicec('/', 1);
 			theme_constant_override.erase(dname);
 			_notify_theme_override_changed();
+		} else if (name.begins_with("theme_override_sounds/")) {
+			String dname = name.get_slicec('/', 1);
+			if (theme_sound_override.has(dname)) {
+				theme_sound_override[dname]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
+			}
+			theme_sound_override.erase(dname);
+			_notify_theme_override_changed();
 		} else {
 			return false;
 		}
@@ -124,6 +131,9 @@ bool Window::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (name.begins_with("theme_override_constants/")) {
 			String dname = name.get_slicec('/', 1);
 			add_theme_constant_override(dname, p_value);
+		} else if (name.begins_with("theme_override_sounds/")) {
+			String dname = name.get_slicec('/', 1);
+			add_theme_sound_override(dname, p_value);
 		} else {
 			return false;
 		}
@@ -157,6 +167,9 @@ bool Window::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (sname.begins_with("theme_override_constants/")) {
 		String name = sname.get_slicec('/', 1);
 		r_ret = theme_constant_override.has(name) ? Variant(theme_constant_override[name]) : Variant();
+	} else if (sname.begins_with("theme_override_sounds/")) {
+		String name = sname.get_slicec('/', 1);
+		r_ret = theme_sound_override.has(name) ? Variant(theme_sound_override[name]) : Variant();
 	} else {
 		return false;
 	}
@@ -241,6 +254,18 @@ void Window::_get_property_list(List<PropertyInfo> *p_list) const {
 			}
 
 			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_styles") + String("/") + E, PROPERTY_HINT_RESOURCE_TYPE, StyleBox::get_class_static(), usage));
+		}
+	}
+	{
+		List<StringName> names;
+		default_theme->get_sound_list(get_class_name(), &names);
+		for (const StringName &E : names) {
+			uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
+			if (theme_sound_override.has(E)) {
+				usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+			}
+
+			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("theme_override_sounds") + String("/") + E, PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static(), usage));
 		}
 	}
 }
@@ -2603,6 +2628,7 @@ void Window::_invalidate_theme_cache() {
 	theme_font_size_cache.clear();
 	theme_color_cache.clear();
 	theme_constant_cache.clear();
+	theme_audio_cache.clear();
 }
 
 void Window::_update_theme_item_cache() {
@@ -2789,6 +2815,30 @@ int Window::get_theme_constant(const StringName &p_name, const StringName &p_the
 	return constant;
 }
 
+Ref<AudioStream> Window::get_theme_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	ERR_READ_THREAD_GUARD_V(Ref<AudioStream>());
+	if (!initialized) {
+		WARN_PRINT_ONCE(vformat("Attempting to access theme items too early in %s; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED", get_description()));
+	}
+
+	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == theme_type_variation) {
+		const Ref<AudioStream> *audio = theme_sound_override.getptr(p_name);
+		if (audio) {
+			return *audio;
+		}
+	}
+
+	if (theme_audio_cache.has(p_theme_type) && theme_audio_cache[p_theme_type].has(p_name)) {
+		return theme_audio_cache[p_theme_type][p_name];
+	}
+
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
+	Ref<AudioStream> audio = theme_owner->get_theme_item_in_types(Theme::DATA_TYPE_SOUND, p_name, theme_types);
+	theme_audio_cache[p_theme_type][p_name] = audio;
+	return audio;
+}
+
 Variant Window::get_theme_item(Theme::DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const {
 	switch (p_data_type) {
 		case Theme::DATA_TYPE_COLOR:
@@ -2803,6 +2853,8 @@ Variant Window::get_theme_item(Theme::DataType p_data_type, const StringName &p_
 			return get_theme_icon(p_name, p_theme_type);
 		case Theme::DATA_TYPE_STYLEBOX:
 			return get_theme_stylebox(p_name, p_theme_type);
+		case Theme::DATA_TYPE_SOUND:
+			return get_theme_sound(p_name, p_theme_type);
 		case Theme::DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -2918,6 +2970,23 @@ bool Window::has_theme_constant(const StringName &p_name, const StringName &p_th
 	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
 }
 
+bool Window::has_theme_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	if (!initialized) {
+		WARN_PRINT_ONCE(vformat("Attempting to access theme items too early in %s; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED", get_description()));
+	}
+
+	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == theme_type_variation) {
+		if (has_theme_sound_override(p_name)) {
+			return true;
+		}
+	}
+
+	Vector<StringName> theme_types;
+	theme_owner->get_theme_type_dependencies(this, p_theme_type, theme_types);
+	return theme_owner->has_theme_item_in_types(Theme::DATA_TYPE_SOUND, p_name, theme_types);
+}
+
 /// Local property overrides.
 
 void Window::add_theme_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon) {
@@ -2977,6 +3046,12 @@ void Window::add_theme_constant_override(const StringName &p_name, int p_constan
 	_notify_theme_override_changed();
 }
 
+void Window::add_theme_sound_override(const StringName &p_name, const Ref<AudioStream> &p_sound) {
+	ERR_MAIN_THREAD_GUARD;
+	theme_sound_override[p_name] = p_sound;
+	_notify_theme_override_changed();
+}
+
 void Window::remove_theme_icon_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (theme_icon_override.has(p_name)) {
@@ -3025,6 +3100,12 @@ void Window::remove_theme_constant_override(const StringName &p_name) {
 	_notify_theme_override_changed();
 }
 
+void Window::remove_theme_sound_override(const StringName &p_name) {
+	ERR_MAIN_THREAD_GUARD;
+	theme_sound_override.erase(p_name);
+	_notify_theme_override_changed();
+}
+
 bool Window::has_theme_icon_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	const Ref<Texture2D> *tex = theme_icon_override.getptr(p_name);
@@ -3059,6 +3140,12 @@ bool Window::has_theme_constant_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	const int *constant = theme_constant_override.getptr(p_name);
 	return constant != nullptr;
+}
+
+bool Window::has_theme_sound_override(const StringName &p_name) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	const Ref<AudioStream> *audio = theme_sound_override.getptr(p_name);
+	return audio != nullptr;
 }
 
 /// Default theme properties.
@@ -3505,6 +3592,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_theme_font_size_override", "name", "font_size"), &Window::add_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("add_theme_color_override", "name", "color"), &Window::add_theme_color_override);
 	ClassDB::bind_method(D_METHOD("add_theme_constant_override", "name", "constant"), &Window::add_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("add_theme_sound_override", "name", "sound"), &Window::add_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("remove_theme_icon_override", "name"), &Window::remove_theme_icon_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_stylebox_override", "name"), &Window::remove_theme_style_override);
@@ -3512,6 +3600,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_theme_font_size_override", "name"), &Window::remove_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_color_override", "name"), &Window::remove_theme_color_override);
 	ClassDB::bind_method(D_METHOD("remove_theme_constant_override", "name"), &Window::remove_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("remove_theme_sound_override", "name"), &Window::remove_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("get_theme_icon", "name", "theme_type"), &Window::get_theme_icon, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_stylebox", "name", "theme_type"), &Window::get_theme_stylebox, DEFVAL(StringName()));
@@ -3519,6 +3608,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_theme_font_size", "name", "theme_type"), &Window::get_theme_font_size, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_color", "name", "theme_type"), &Window::get_theme_color, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_theme_constant", "name", "theme_type"), &Window::get_theme_constant, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("get_theme_sound", "name", "theme_type"), &Window::get_theme_sound, DEFVAL(StringName()));
 
 	ClassDB::bind_method(D_METHOD("has_theme_icon_override", "name"), &Window::has_theme_icon_override);
 	ClassDB::bind_method(D_METHOD("has_theme_stylebox_override", "name"), &Window::has_theme_stylebox_override);
@@ -3526,6 +3616,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size_override", "name"), &Window::has_theme_font_size_override);
 	ClassDB::bind_method(D_METHOD("has_theme_color_override", "name"), &Window::has_theme_color_override);
 	ClassDB::bind_method(D_METHOD("has_theme_constant_override", "name"), &Window::has_theme_constant_override);
+	ClassDB::bind_method(D_METHOD("has_theme_sound_override", "name"), &Window::has_theme_sound_override);
 
 	ClassDB::bind_method(D_METHOD("has_theme_icon", "name", "theme_type"), &Window::has_theme_icon, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_stylebox", "name", "theme_type"), &Window::has_theme_stylebox, DEFVAL(StringName()));
@@ -3533,6 +3624,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_theme_font_size", "name", "theme_type"), &Window::has_theme_font_size, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_color", "name", "theme_type"), &Window::has_theme_color, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("has_theme_constant", "name", "theme_type"), &Window::has_theme_constant, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("has_theme_sound", "name", "theme_type"), &Window::has_theme_sound, DEFVAL(StringName()));
 
 	ClassDB::bind_method(D_METHOD("get_theme_default_base_scale"), &Window::get_theme_default_base_scale);
 	ClassDB::bind_method(D_METHOD("get_theme_default_font"), &Window::get_theme_default_font);
@@ -3760,4 +3852,5 @@ Window::~Window() {
 	theme_font_size_override.clear();
 	theme_color_override.clear();
 	theme_constant_override.clear();
+	theme_sound_override.clear();
 }

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -212,6 +212,7 @@ private:
 	Theme::ThemeFontSizeMap theme_font_size_override;
 	Theme::ThemeColorMap theme_color_override;
 	Theme::ThemeConstantMap theme_constant_override;
+	Theme::ThemeSoundMap theme_sound_override;
 
 	mutable HashMap<StringName, Theme::ThemeIconMap> theme_icon_cache;
 	mutable HashMap<StringName, Theme::ThemeStyleMap> theme_style_cache;
@@ -219,6 +220,7 @@ private:
 	mutable HashMap<StringName, Theme::ThemeFontSizeMap> theme_font_size_cache;
 	mutable HashMap<StringName, Theme::ThemeColorMap> theme_color_cache;
 	mutable HashMap<StringName, Theme::ThemeConstantMap> theme_constant_cache;
+	mutable HashMap<StringName, Theme::ThemeSoundMap> theme_audio_cache;
 
 	void _theme_changed();
 	void _notify_theme_override_changed();
@@ -501,6 +503,7 @@ public:
 	void add_theme_font_size_override(const StringName &p_name, int p_font_size);
 	void add_theme_color_override(const StringName &p_name, const Color &p_color);
 	void add_theme_constant_override(const StringName &p_name, int p_constant);
+	void add_theme_sound_override(const StringName &p_name, const Ref<AudioStream> &p_audio);
 
 	void remove_theme_icon_override(const StringName &p_name);
 	void remove_theme_style_override(const StringName &p_name);
@@ -508,6 +511,7 @@ public:
 	void remove_theme_font_size_override(const StringName &p_name);
 	void remove_theme_color_override(const StringName &p_name);
 	void remove_theme_constant_override(const StringName &p_name);
+	void remove_theme_sound_override(const StringName &p_name);
 
 	Ref<Texture2D> get_theme_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Ref<StyleBox> get_theme_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
@@ -515,6 +519,7 @@ public:
 	int get_theme_font_size(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Color get_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	int get_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	Ref<AudioStream> get_theme_sound(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Variant get_theme_item(Theme::DataType p_data_type, const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 #ifdef TOOLS_ENABLED
 	Ref<Texture2D> get_editor_theme_icon(const StringName &p_name) const;
@@ -526,6 +531,7 @@ public:
 	bool has_theme_font_size_override(const StringName &p_name) const;
 	bool has_theme_color_override(const StringName &p_name) const;
 	bool has_theme_constant_override(const StringName &p_name) const;
+	bool has_theme_sound_override(const StringName &p_name) const;
 
 	bool has_theme_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
@@ -533,6 +539,7 @@ public:
 	bool has_theme_font_size(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	bool has_theme_sound(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 
 	float get_theme_default_base_scale() const;
 	Ref<Font> get_theme_default_font() const;

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -212,6 +212,7 @@ private:
 	Theme::ThemeFontSizeMap theme_font_size_override;
 	Theme::ThemeColorMap theme_color_override;
 	Theme::ThemeConstantMap theme_constant_override;
+	Theme::ThemeSoundMap theme_sound_override;
 
 	mutable HashMap<StringName, Theme::ThemeIconMap> theme_icon_cache;
 	mutable HashMap<StringName, Theme::ThemeStyleMap> theme_style_cache;
@@ -219,6 +220,7 @@ private:
 	mutable HashMap<StringName, Theme::ThemeFontSizeMap> theme_font_size_cache;
 	mutable HashMap<StringName, Theme::ThemeColorMap> theme_color_cache;
 	mutable HashMap<StringName, Theme::ThemeConstantMap> theme_constant_cache;
+	mutable HashMap<StringName, Theme::ThemeSoundMap> theme_audio_cache;
 
 	void _theme_changed();
 	void _notify_theme_override_changed();
@@ -501,6 +503,7 @@ public:
 	void add_theme_font_size_override(const StringName &p_name, int p_font_size);
 	void add_theme_color_override(const StringName &p_name, const Color &p_color);
 	void add_theme_constant_override(const StringName &p_name, int p_constant);
+	void add_theme_sound_override(const StringName &p_name, const Ref<AudioStream> &p_sound);
 
 	void remove_theme_icon_override(const StringName &p_name);
 	void remove_theme_style_override(const StringName &p_name);
@@ -508,6 +511,7 @@ public:
 	void remove_theme_font_size_override(const StringName &p_name);
 	void remove_theme_color_override(const StringName &p_name);
 	void remove_theme_constant_override(const StringName &p_name);
+	void remove_theme_sound_override(const StringName &p_name);
 
 	Ref<Texture2D> get_theme_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Ref<StyleBox> get_theme_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
@@ -515,6 +519,7 @@ public:
 	int get_theme_font_size(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Color get_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	int get_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	Ref<AudioStream> get_theme_sound(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Variant get_theme_item(Theme::DataType p_data_type, const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 #ifdef TOOLS_ENABLED
 	Ref<Texture2D> get_editor_theme_icon(const StringName &p_name) const;
@@ -526,6 +531,7 @@ public:
 	bool has_theme_font_size_override(const StringName &p_name) const;
 	bool has_theme_color_override(const StringName &p_name) const;
 	bool has_theme_constant_override(const StringName &p_name) const;
+	bool has_theme_sound_override(const StringName &p_name) const;
 
 	bool has_theme_icon(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_stylebox(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
@@ -533,6 +539,7 @@ public:
 	bool has_theme_font_size(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	bool has_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	bool has_theme_sound(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 
 	float get_theme_default_base_scale() const;
 	Ref<Font> get_theme_default_font() const;

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -55,6 +55,8 @@ bool Theme::_set(const StringName &p_name, const Variant &p_value) {
 			set_color(prop_name, theme_type, p_value);
 		} else if (type == "constants") {
 			set_constant(prop_name, theme_type, p_value);
+		} else if (type == "sounds") {
+			set_sound(prop_name, theme_type, p_value);
 		} else if (type == "base_type") {
 			set_type_variation(theme_type, p_value);
 		} else {
@@ -99,6 +101,12 @@ bool Theme::_get(const StringName &p_name, Variant &r_ret) const {
 			r_ret = get_color(prop_name, theme_type);
 		} else if (type == "constants") {
 			r_ret = get_constant(prop_name, theme_type);
+		} else if (type == "sounds") {
+			if (!has_sound(prop_name, theme_type)) {
+				r_ret = Ref<AudioStream>();
+			} else {
+				r_ret = get_sound(prop_name, theme_type);
+			}
 		} else if (type == "base_type") {
 			r_ret = get_type_variation_base(theme_type);
 		} else {
@@ -158,6 +166,13 @@ void Theme::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const KeyValue<StringName, ThemeConstantMap> &E : constant_map) {
 		for (const KeyValue<StringName, int> &F : E.value) {
 			list.push_back(PropertyInfo(Variant::INT, String() + E.key + "/constants/" + F.key));
+		}
+	}
+
+	// Sounds.
+	for (const KeyValue<StringName, ThemeSoundMap> &E : sound_map) {
+		for (const KeyValue<StringName, Ref<AudioStream>> &F : E.value) {
+			list.push_back(PropertyInfo(Variant::OBJECT, String() + E.key + "/sounds/" + F.key, PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
 		}
 	}
 
@@ -943,6 +958,126 @@ void Theme::get_constant_type_list(List<StringName> *p_list) const {
 	}
 }
 
+void Theme::set_sound(const StringName &p_name, const StringName &p_theme_type, const Ref<AudioStream> &p_sound) {
+	ERR_FAIL_COND_MSG(!is_valid_item_name(p_name), vformat("Invalid item name: '%s'", p_name));
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+
+	bool existing = false;
+	if (sound_map[p_theme_type][p_name].is_valid()) {
+		existing = true;
+		sound_map[p_theme_type][p_name]->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
+	}
+
+	sound_map[p_theme_type][p_name] = p_sound;
+
+	if (p_sound.is_valid()) {
+		sound_map[p_theme_type][p_name]->connect_changed(callable_mp(this, &Theme::_emit_theme_changed).bind(false), CONNECT_REFERENCE_COUNTED);
+	}
+
+	_emit_theme_changed(!existing);
+}
+
+Ref<AudioStream> Theme::get_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	if (sound_map.has(p_theme_type) && sound_map[p_theme_type].has(p_name) && sound_map[p_theme_type][p_name].is_valid()) {
+		return sound_map[p_theme_type][p_name];
+	} else {
+		return ThemeDB::get_singleton()->get_fallback_sound();
+	}
+}
+
+bool Theme::has_sound(const StringName &p_name, const StringName &p_theme_type) const {
+	return (sound_map.has(p_theme_type) && sound_map[p_theme_type].has(p_name) && sound_map[p_theme_type][p_name].is_valid());
+}
+
+bool Theme::has_sound_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
+	return (sound_map.has(p_theme_type) && sound_map[p_theme_type].has(p_name));
+}
+
+void Theme::rename_sound(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!is_valid_item_name(p_name), vformat("Invalid item name: '%s'", p_name));
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+	ERR_FAIL_COND_MSG(!sound_map.has(p_theme_type), "Cannot rename the sound '" + String(p_old_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(sound_map[p_theme_type].has(p_name), "Cannot rename the sound '" + String(p_old_name) + "' because the new name '" + String(p_name) + "' already exists.");
+	ERR_FAIL_COND_MSG(!sound_map[p_theme_type].has(p_old_name), "Cannot rename the sound '" + String(p_old_name) + "' because it does not exist.");
+
+	sound_map[p_theme_type][p_name] = sound_map[p_theme_type][p_old_name];
+	sound_map[p_theme_type].erase(p_old_name);
+
+	_emit_theme_changed(true);
+}
+
+void Theme::clear_sound(const StringName &p_name, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!sound_map.has(p_theme_type), "Cannot clear the sound '" + String(p_name) + "' because the node type '" + String(p_theme_type) + "' does not exist.");
+	ERR_FAIL_COND_MSG(!sound_map[p_theme_type].has(p_name), "Cannot clear the sound '" + String(p_name) + "' because it does not exist.");
+
+	if (sound_map[p_theme_type][p_name].is_valid()) {
+		sound_map[p_theme_type][p_name]->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
+	}
+
+	sound_map[p_theme_type].erase(p_name);
+
+	_emit_theme_changed(true);
+}
+
+void Theme::get_sound_list(StringName p_theme_type, List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	if (!sound_map.has(p_theme_type)) {
+		return;
+	}
+
+	for (const KeyValue<StringName, Ref<AudioStream>> &E : sound_map[p_theme_type]) {
+		p_list->push_back(E.key);
+	}
+}
+
+void Theme::add_sound_type(const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+
+	if (sound_map.has(p_theme_type)) {
+		return;
+	}
+	sound_map[p_theme_type] = ThemeSoundMap();
+}
+
+void Theme::remove_sound_type(const StringName &p_theme_type) {
+	if (!sound_map.has(p_theme_type)) {
+		return;
+	}
+
+	_freeze_change_propagation();
+
+	for (const KeyValue<StringName, Ref<AudioStream>> &E : sound_map[p_theme_type]) {
+		Ref<AudioStream> sound = E.value;
+		if (sound.is_valid()) {
+			sound->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
+		}
+	}
+
+	sound_map.erase(p_theme_type);
+
+	_unfreeze_and_propagate_changes();
+}
+
+void Theme::rename_sound_type(const StringName &p_old_theme_type, const StringName &p_theme_type) {
+	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
+
+	if (!sound_map.has(p_old_theme_type) || sound_map.has(p_theme_type)) {
+		return;
+	}
+
+	sound_map[p_theme_type] = sound_map[p_old_theme_type];
+	sound_map.erase(p_old_theme_type);
+}
+
+void Theme::get_sound_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	for (const KeyValue<StringName, ThemeSoundMap> &E : sound_map) {
+		p_list->push_back(E.key);
+	}
+}
+
 // Generic methods for managing theme items.
 void Theme::set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type, const Variant &p_value) {
 	switch (p_data_type) {
@@ -982,6 +1117,12 @@ void Theme::set_theme_item(DataType p_data_type, const StringName &p_name, const
 			Ref<StyleBox> stylebox_value = Object::cast_to<StyleBox>(p_value.get_validated_object());
 			set_stylebox(p_name, p_theme_type, stylebox_value);
 		} break;
+		case DATA_TYPE_SOUND: {
+			ERR_FAIL_COND_MSG(p_value.get_type() != Variant::OBJECT, "Theme item's data type (Object) does not match Variant's type (" + Variant::get_type_name(p_value.get_type()) + ").");
+
+			Ref<AudioStream> sound_value = Object::cast_to<AudioStream>(p_value.get_validated_object());
+			set_sound(p_name, p_theme_type, sound_value);
+		} break;
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1001,6 +1142,8 @@ Variant Theme::get_theme_item(DataType p_data_type, const StringName &p_name, co
 			return get_icon(p_name, p_theme_type);
 		case DATA_TYPE_STYLEBOX:
 			return get_stylebox(p_name, p_theme_type);
+		case DATA_TYPE_SOUND:
+			return get_sound(p_name, p_theme_type);
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1030,6 +1173,8 @@ bool Theme::has_theme_item(DataType p_data_type, const StringName &p_name, const
 			return has_icon(p_name, p_theme_type);
 		case DATA_TYPE_STYLEBOX:
 			return has_stylebox(p_name, p_theme_type);
+		case DATA_TYPE_SOUND:
+			return has_sound(p_name, p_theme_type);
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1051,6 +1196,8 @@ bool Theme::has_theme_item_nocheck(DataType p_data_type, const StringName &p_nam
 			return has_icon_nocheck(p_name, p_theme_type);
 		case DATA_TYPE_STYLEBOX:
 			return has_stylebox_nocheck(p_name, p_theme_type);
+		case DATA_TYPE_SOUND:
+			return has_sound_nocheck(p_name, p_theme_type);
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1078,6 +1225,9 @@ void Theme::rename_theme_item(DataType p_data_type, const StringName &p_old_name
 		case DATA_TYPE_STYLEBOX:
 			rename_stylebox(p_old_name, p_name, p_theme_type);
 			break;
+		case DATA_TYPE_SOUND:
+			rename_sound(p_old_name, p_name, p_theme_type);
+			break;
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1102,6 +1252,9 @@ void Theme::clear_theme_item(DataType p_data_type, const StringName &p_name, con
 			break;
 		case DATA_TYPE_STYLEBOX:
 			clear_stylebox(p_name, p_theme_type);
+			break;
+		case DATA_TYPE_SOUND:
+			clear_sound(p_name, p_theme_type);
 			break;
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
@@ -1128,6 +1281,9 @@ void Theme::get_theme_item_list(DataType p_data_type, const StringName &p_theme_
 		case DATA_TYPE_STYLEBOX:
 			get_stylebox_list(p_theme_type, p_list);
 			break;
+		case DATA_TYPE_SOUND:
+			get_sound_list(p_theme_type, p_list);
+			break;
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1152,6 +1308,9 @@ void Theme::add_theme_item_type(DataType p_data_type, const StringName &p_theme_
 			break;
 		case DATA_TYPE_STYLEBOX:
 			add_stylebox_type(p_theme_type);
+			break;
+		case DATA_TYPE_SOUND:
+			add_sound_type(p_theme_type);
 			break;
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
@@ -1178,6 +1337,9 @@ void Theme::remove_theme_item_type(DataType p_data_type, const StringName &p_the
 		case DATA_TYPE_STYLEBOX:
 			remove_stylebox_type(p_theme_type);
 			break;
+		case DATA_TYPE_SOUND:
+			remove_sound_type(p_theme_type);
+			break;
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1203,6 +1365,9 @@ void Theme::rename_theme_item_type(DataType p_data_type, const StringName &p_old
 		case DATA_TYPE_STYLEBOX:
 			rename_stylebox_type(p_old_theme_type, p_theme_type);
 			break;
+		case DATA_TYPE_SOUND:
+			rename_sound_type(p_old_theme_type, p_theme_type);
+			break;
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1227,6 +1392,9 @@ void Theme::get_theme_item_type_list(DataType p_data_type, List<StringName> *p_l
 			break;
 		case DATA_TYPE_STYLEBOX:
 			get_stylebox_type_list(p_list);
+			break;
+		case DATA_TYPE_SOUND:
+			get_sound_type_list(p_list);
 			break;
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
@@ -1390,6 +1558,11 @@ void Theme::get_type_list(List<StringName> *p_list) const {
 
 	// Constants.
 	for (const KeyValue<StringName, ThemeConstantMap> &E : constant_map) {
+		types.insert(E.key);
+	}
+
+	// Sounds.
+	for (const KeyValue<StringName, ThemeSoundMap> &E : sound_map) {
 		types.insert(E.key);
 	}
 
@@ -1603,6 +1776,36 @@ Vector<String> Theme::_get_constant_type_list() const {
 	return ilret;
 }
 
+Vector<String> Theme::_get_sound_list(const String &p_theme_type) const {
+	Vector<String> ilret;
+	List<StringName> il;
+
+	get_sound_list(p_theme_type, &il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	String *w = ilret.ptrw();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+Vector<String> Theme::_get_sound_type_list() const {
+	Vector<String> ilret;
+	List<StringName> il;
+
+	get_sound_type_list(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	String *w = ilret.ptrw();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
 Vector<String> Theme::_get_theme_item_list(DataType p_data_type, const String &p_theme_type) const {
 	switch (p_data_type) {
 		case DATA_TYPE_COLOR:
@@ -1617,6 +1820,8 @@ Vector<String> Theme::_get_theme_item_list(DataType p_data_type, const String &p
 			return _get_icon_list(p_theme_type);
 		case DATA_TYPE_STYLEBOX:
 			return _get_stylebox_list(p_theme_type);
+		case DATA_TYPE_SOUND:
+			return _get_sound_list(p_theme_type);
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1638,6 +1843,8 @@ Vector<String> Theme::_get_theme_item_type_list(DataType p_data_type) const {
 			return _get_icon_type_list();
 		case DATA_TYPE_STYLEBOX:
 			return _get_stylebox_type_list();
+		case DATA_TYPE_SOUND:
+			return _get_sound_type_list();
 		case DATA_TYPE_MAX:
 			break; // Can't happen, but silences warning.
 	}
@@ -1757,6 +1964,15 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 		}
 	}
 
+	// Sounds.
+	{
+		for (const KeyValue<StringName, ThemeSoundMap> &E : p_other->sound_map) {
+			for (const KeyValue<StringName, Ref<AudioStream>> &F : E.value) {
+				set_sound(F.key, E.key, F.value);
+			}
+		}
+	}
+
 	// Type variations.
 	{
 		for (const KeyValue<StringName, StringName> &E : p_other->variation_map) {
@@ -1813,12 +2029,24 @@ void Theme::clear() {
 		}
 	}
 
+	{
+		for (const KeyValue<StringName, ThemeSoundMap> &E : sound_map) {
+			for (const KeyValue<StringName, Ref<AudioStream>> &F : E.value) {
+				if (F.value.is_valid()) {
+					Ref<AudioStream> sound = F.value;
+					sound->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
+				}
+			}
+		}
+	}
+
 	icon_map.clear();
 	style_map.clear();
 	font_map.clear();
 	font_size_map.clear();
 	color_map.clear();
 	constant_map.clear();
+	sound_map.clear();
 
 	variation_map.clear();
 	variation_base_map.clear();
@@ -1879,6 +2107,14 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_constant_list", "theme_type"), &Theme::_get_constant_list);
 	ClassDB::bind_method(D_METHOD("get_constant_type_list"), &Theme::_get_constant_type_list);
 
+	ClassDB::bind_method(D_METHOD("set_sound", "name", "theme_type", "sound"), &Theme::set_sound);
+	ClassDB::bind_method(D_METHOD("get_sound", "name", "theme_type"), &Theme::get_sound);
+	ClassDB::bind_method(D_METHOD("has_sound", "name", "theme_type"), &Theme::has_sound);
+	ClassDB::bind_method(D_METHOD("rename_sound", "old_name", "name", "theme_type"), &Theme::rename_sound);
+	ClassDB::bind_method(D_METHOD("clear_sound", "name", "theme_type"), &Theme::clear_sound);
+	ClassDB::bind_method(D_METHOD("get_sound_list", "theme_type"), &Theme::_get_sound_list);
+	ClassDB::bind_method(D_METHOD("get_sound_type_list"), &Theme::_get_sound_type_list);
+
 	ClassDB::bind_method(D_METHOD("set_default_base_scale", "base_scale"), &Theme::set_default_base_scale);
 	ClassDB::bind_method(D_METHOD("get_default_base_scale"), &Theme::get_default_base_scale);
 	ClassDB::bind_method(D_METHOD("has_default_base_scale"), &Theme::has_default_base_scale);
@@ -1923,6 +2159,7 @@ void Theme::_bind_methods() {
 	BIND_ENUM_CONSTANT(DATA_TYPE_FONT_SIZE);
 	BIND_ENUM_CONSTANT(DATA_TYPE_ICON);
 	BIND_ENUM_CONSTANT(DATA_TYPE_STYLEBOX);
+	BIND_ENUM_CONSTANT(DATA_TYPE_SOUND);
 	BIND_ENUM_CONSTANT(DATA_TYPE_MAX);
 }
 

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
+#include "scene/resources/audio/audio_stream.h"
 #include "scene/resources/font.h"
 #include "scene/resources/style_box.h"
 #include "scene/resources/texture.h"
@@ -52,6 +53,7 @@ public:
 	using ThemeFontSizeMap = HashMap<StringName, int>;
 	using ThemeColorMap = HashMap<StringName, Color>;
 	using ThemeConstantMap = HashMap<StringName, int>;
+	using ThemeSoundMap = HashMap<StringName, Ref<AudioStream>>;
 
 	enum DataType {
 		DATA_TYPE_COLOR,
@@ -60,6 +62,7 @@ public:
 		DATA_TYPE_FONT_SIZE,
 		DATA_TYPE_ICON,
 		DATA_TYPE_STYLEBOX,
+		DATA_TYPE_SOUND,
 		DATA_TYPE_MAX
 	};
 
@@ -80,6 +83,8 @@ private:
 	Vector<String> _get_color_type_list() const;
 	Vector<String> _get_constant_list(const String &p_theme_type) const;
 	Vector<String> _get_constant_type_list() const;
+	Vector<String> _get_sound_list(const String &p_theme_type) const;
+	Vector<String> _get_sound_type_list() const;
 
 	Vector<String> _get_theme_item_list(DataType p_data_type, const String &p_theme_type) const;
 	Vector<String> _get_theme_item_type_list(DataType p_data_type) const;
@@ -103,6 +108,7 @@ protected:
 	HashMap<StringName, ThemeFontSizeMap> font_size_map;
 	HashMap<StringName, ThemeColorMap> color_map;
 	HashMap<StringName, ThemeConstantMap> constant_map;
+	HashMap<StringName, ThemeSoundMap> sound_map;
 	HashMap<StringName, StringName> variation_map;
 	HashMap<StringName, List<StringName>> variation_base_map;
 
@@ -203,6 +209,18 @@ public:
 	void remove_constant_type(const StringName &p_theme_type);
 	void rename_constant_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_constant_type_list(List<StringName> *p_list) const;
+
+	void set_sound(const StringName &p_name, const StringName &p_theme_type, const Ref<AudioStream> &p_sound);
+	Ref<AudioStream> get_sound(const StringName &p_name, const StringName &p_theme_type) const;
+	bool has_sound(const StringName &p_name, const StringName &p_theme_type) const;
+	bool has_sound_nocheck(const StringName &p_name, const StringName &p_theme_type) const;
+	void rename_sound(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type);
+	void clear_sound(const StringName &p_name, const StringName &p_theme_type);
+	void get_sound_list(StringName p_theme_type, List<StringName> *p_list) const;
+	void add_sound_type(const StringName &p_theme_type);
+	void remove_sound_type(const StringName &p_theme_type);
+	void rename_sound_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
+	void get_sound_type_list(List<StringName> *p_list) const;
 
 	void set_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type, const Variant &p_value);
 	Variant get_theme_item(DataType p_data_type, const StringName &p_name, const StringName &p_theme_type) const;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -131,7 +131,15 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	}
 
 	// Panel
+
 	theme->set_stylebox(SceneStringName(panel), "Panel", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
+
+	// BaseButton
+
+	theme->set_sound("hover_sound", "BaseButton", Ref<AudioStream>());
+	theme->set_sound("focus_sound", "BaseButton", Ref<AudioStream>());
+	theme->set_sound("pressed_sound", "BaseButton", Ref<AudioStream>());
+	theme->set_sound("pressed_disabled_sound", "BaseButton", Ref<AudioStream>());
 
 	// Button
 
@@ -435,6 +443,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_icon("clear", "LineEdit", icons["line_edit_clear"]);
 
+	theme->set_sound("focus_sound", "LineEdit", Ref<AudioStream>());
+	theme->set_sound("caret_moved_sound", "LineEdit", Ref<AudioStream>());
+	theme->set_sound("text_changed_sound", "LineEdit", Ref<AudioStream>());
+	theme->set_sound("text_submitted_sound", "LineEdit", Ref<AudioStream>());
+	theme->set_sound("text_change_rejected_sound", "LineEdit", Ref<AudioStream>());
+
 	// ProgressBar
 
 	theme->set_stylebox("background", "ProgressBar", make_flat_stylebox(style_disabled_color, 2, 2, 2, 2, 6));
@@ -480,6 +494,11 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("outline_size", "TextEdit", 0);
 	theme->set_constant("caret_width", "TextEdit", 1);
 	theme->set_constant("wrap_offset", "TextEdit", 10);
+
+	theme->set_sound("focus_sound", "TextEdit", Ref<AudioStream>());
+	theme->set_sound("caret_moved_sound", "TextEdit", Ref<AudioStream>());
+	theme->set_sound("text_changed_sound", "TextEdit", Ref<AudioStream>());
+	theme->set_sound("text_change_rejected_sound", "TextEdit", Ref<AudioStream>());
 
 	// CodeEdit
 
@@ -580,6 +599,13 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	const Ref<StyleBoxFlat> style_slider_grabber = make_flat_stylebox(style_progress_color, 4, 4, 4, 4, 4);
 	const Ref<StyleBoxFlat> style_slider_grabber_highlight = make_flat_stylebox(style_focus_color, 4, 4, 4, 4, 4);
 
+	// Slider
+
+	theme->set_sound("focus_sound", "Slider", Ref<AudioStream>());
+	theme->set_sound("drag_started_sound", "Slider", Ref<AudioStream>());
+	theme->set_sound("drag_ended_sound", "Slider", Ref<AudioStream>());
+	theme->set_sound("value_changed_sound", "Slider", Ref<AudioStream>());
+
 	// HSlider
 
 	theme->set_stylebox("slider", "HSlider", style_slider);
@@ -649,6 +675,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 #ifndef DISABLE_DEPRECATED
 	theme->set_constant("set_min_buttons_width_from_icons", "SpinBox", 1);
 #endif
+
+	theme->set_sound("focus_sound", "SpinBox", Ref<AudioStream>());
+	theme->set_sound("pressed_sound", "SpinBox", Ref<AudioStream>());
+	theme->set_sound("pressed_disabled_sound", "SpinBox", Ref<AudioStream>());
 
 	// ScrollContainer
 
@@ -806,6 +836,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("icon_max_width", "PopupMenu", 0);
 	theme->set_constant("gutter_compact", "PopupMenu", 1);
 
+	theme->set_sound("item_hovered_sound", "PopupMenu", Ref<AudioStream>());
+	theme->set_sound("item_activated_sound", "PopupMenu", Ref<AudioStream>());
+	theme->set_sound("item_activated_disabled_sound", "PopupMenu", Ref<AudioStream>());
+
 	// GraphNode
 
 	Ref<StyleBoxFlat> graphnode_normal = make_flat_stylebox(style_normal_color, 18, 12, 18, 12);
@@ -962,6 +996,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("scrollbar_h_separation", "Tree", Math::round(4 * scale));
 	theme->set_constant("scrollbar_v_separation", "Tree", Math::round(4 * scale));
 
+	theme->set_sound("focus_sound", "Tree", Ref<AudioStream>());
+	theme->set_sound("item_hovered_sound", "Tree", Ref<AudioStream>());
+	theme->set_sound("item_selected_sound", "Tree", Ref<AudioStream>());
+
 	// ItemList
 
 	theme->set_stylebox(SceneStringName(panel), "ItemList", make_flat_stylebox(style_normal_color));
@@ -996,6 +1034,11 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("scroll_hint", "ItemList", icons["scroll_hint_vertical"]);
 
 	theme->set_constant("outline_size", "ItemList", 0);
+
+	theme->set_sound("focus_sound", "ItemList", Ref<AudioStream>());
+	theme->set_sound("item_hovered_sound", "ItemList", Ref<AudioStream>());
+	theme->set_sound("item_selected_sound", "ItemList", Ref<AudioStream>());
+	theme->set_sound("item_selected_disabled_sound", "ItemList", Ref<AudioStream>());
 
 	// TabContainer
 
@@ -1085,6 +1128,11 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("icon_max_width", "TabBar", 0);
 	theme->set_constant("outline_size", "TabBar", 0);
 	theme->set_constant("hover_switch_wait_msec", "TabBar", 500);
+
+	theme->set_sound("hover_sound", "TabBar", Ref<AudioStream>());
+	theme->set_sound("focus_sound", "TabBar", Ref<AudioStream>());
+	theme->set_sound("pressed_sound", "TabBar", Ref<AudioStream>());
+	theme->set_sound("pressed_disabled_sound", "TabBar", Ref<AudioStream>());
 
 	// Separators
 
@@ -1362,6 +1410,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_constant("outline_size", "FoldableContainer", 0);
 	theme->set_constant("h_separation", "FoldableContainer", Math::round(2 * scale));
+
+	theme->set_sound("focus_sound", "FoldableContainer", Ref<AudioStream>());
+	theme->set_sound("expanded_sound", "FoldableContainer", Ref<AudioStream>());
+	theme->set_sound("folded_sound", "FoldableContainer", Ref<AudioStream>());
 
 	// Visual Node Ports
 

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -200,6 +200,19 @@ Ref<StyleBox> ThemeDB::get_fallback_stylebox() {
 	return fallback_stylebox;
 }
 
+void ThemeDB::set_fallback_sound(const Ref<AudioStream> &p_audio) {
+	if (fallback_sound == p_audio) {
+		return;
+	}
+
+	fallback_sound = p_audio;
+	emit_signal(SNAME("fallback_changed"));
+}
+
+Ref<AudioStream> ThemeDB::get_fallback_sound() {
+	return fallback_sound;
+}
+
 void ThemeDB::get_native_type_dependencies(const StringName &p_base_type, Vector<StringName> &r_result) {
 	if (p_base_type == StringName()) {
 		return;
@@ -430,6 +443,8 @@ void ThemeDB::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_fallback_icon"), &ThemeDB::get_fallback_icon);
 	ClassDB::bind_method(D_METHOD("set_fallback_stylebox", "stylebox"), &ThemeDB::set_fallback_stylebox);
 	ClassDB::bind_method(D_METHOD("get_fallback_stylebox"), &ThemeDB::get_fallback_stylebox);
+	ClassDB::bind_method(D_METHOD("set_fallback_sound", "audio"), &ThemeDB::set_fallback_sound);
+	ClassDB::bind_method(D_METHOD("get_fallback_sound"), &ThemeDB::get_fallback_sound);
 
 	ADD_GROUP("Fallback values", "fallback_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fallback_base_scale", PROPERTY_HINT_RANGE, "0.0,2.0,0.01,or_greater"), "set_fallback_base_scale", "get_fallback_base_scale");
@@ -437,6 +452,7 @@ void ThemeDB::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fallback_font_size", PROPERTY_HINT_RANGE, "0,256,1,or_greater,suffix:px"), "set_fallback_font_size", "get_fallback_font_size");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_NONE), "set_fallback_icon", "get_fallback_icon");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_stylebox", PROPERTY_HINT_RESOURCE_TYPE, StyleBox::get_class_static(), PROPERTY_USAGE_NONE), "set_fallback_stylebox", "get_fallback_stylebox");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_sound", PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static(), PROPERTY_USAGE_NONE), "set_fallback_sound", "get_fallback_sound");
 
 	ADD_SIGNAL(MethodInfo("fallback_changed"));
 }
@@ -469,6 +485,7 @@ ThemeDB::~ThemeDB() {
 	fallback_font.unref();
 	fallback_icon.unref();
 	fallback_stylebox.unref();
+	fallback_sound.unref();
 
 	singleton = nullptr;
 }

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -200,6 +200,19 @@ Ref<StyleBox> ThemeDB::get_fallback_stylebox() {
 	return fallback_stylebox;
 }
 
+void ThemeDB::set_fallback_sound(const Ref<AudioStream> &p_sound) {
+	if (fallback_sound == p_sound) {
+		return;
+	}
+
+	fallback_sound = p_sound;
+	emit_signal(SNAME("fallback_changed"));
+}
+
+Ref<AudioStream> ThemeDB::get_fallback_sound() {
+	return fallback_sound;
+}
+
 void ThemeDB::get_native_type_dependencies(const StringName &p_base_type, Vector<StringName> &r_result) {
 	if (p_base_type == StringName()) {
 		return;
@@ -430,6 +443,8 @@ void ThemeDB::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_fallback_icon"), &ThemeDB::get_fallback_icon);
 	ClassDB::bind_method(D_METHOD("set_fallback_stylebox", "stylebox"), &ThemeDB::set_fallback_stylebox);
 	ClassDB::bind_method(D_METHOD("get_fallback_stylebox"), &ThemeDB::get_fallback_stylebox);
+	ClassDB::bind_method(D_METHOD("set_fallback_sound", "audio"), &ThemeDB::set_fallback_sound);
+	ClassDB::bind_method(D_METHOD("get_fallback_sound"), &ThemeDB::get_fallback_sound);
 
 	ADD_GROUP("Fallback values", "fallback_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fallback_base_scale", PROPERTY_HINT_RANGE, "0.0,2.0,0.01,or_greater"), "set_fallback_base_scale", "get_fallback_base_scale");
@@ -437,6 +452,7 @@ void ThemeDB::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fallback_font_size", PROPERTY_HINT_RANGE, "0,256,1,or_greater,suffix:px"), "set_fallback_font_size", "get_fallback_font_size");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_NONE), "set_fallback_icon", "get_fallback_icon");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_stylebox", PROPERTY_HINT_RESOURCE_TYPE, StyleBox::get_class_static(), PROPERTY_USAGE_NONE), "set_fallback_stylebox", "get_fallback_stylebox");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_sound", PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static(), PROPERTY_USAGE_NONE), "set_fallback_sound", "get_fallback_sound");
 
 	ADD_SIGNAL(MethodInfo("fallback_changed"));
 }
@@ -469,6 +485,7 @@ ThemeDB::~ThemeDB() {
 	fallback_font.unref();
 	fallback_icon.unref();
 	fallback_stylebox.unref();
+	fallback_sound.unref();
 
 	singleton = nullptr;
 }

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -37,6 +37,7 @@
 
 class Font;
 class Node;
+class AudioStream;
 class StyleBox;
 class Texture2D;
 class ThemeContext;
@@ -85,6 +86,7 @@ class ThemeDB : public Object {
 	int fallback_font_size = 16;
 	Ref<Texture2D> fallback_icon;
 	Ref<StyleBox> fallback_stylebox;
+	Ref<AudioStream> fallback_sound;
 
 	// Global theme contexts used to scope global Theme resources.
 
@@ -154,6 +156,9 @@ public:
 
 	void set_fallback_stylebox(const Ref<StyleBox> &p_stylebox);
 	Ref<StyleBox> get_fallback_stylebox();
+
+	void set_fallback_sound(const Ref<AudioStream> &p_audio);
+	Ref<AudioStream> get_fallback_sound();
 
 	void get_native_type_dependencies(const StringName &p_base_type, Vector<StringName> &r_result);
 

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -37,6 +37,7 @@
 
 class Font;
 class Node;
+class AudioStream;
 class StyleBox;
 class Texture2D;
 class ThemeContext;
@@ -85,6 +86,7 @@ class ThemeDB : public Object {
 	int fallback_font_size = 16;
 	Ref<Texture2D> fallback_icon;
 	Ref<StyleBox> fallback_stylebox;
+	Ref<AudioStream> fallback_sound;
 
 	// Global theme contexts used to scope global Theme resources.
 
@@ -154,6 +156,9 @@ public:
 
 	void set_fallback_stylebox(const Ref<StyleBox> &p_stylebox);
 	Ref<StyleBox> get_fallback_stylebox();
+
+	void set_fallback_sound(const Ref<AudioStream> &p_sound);
+	Ref<AudioStream> get_fallback_sound();
 
 	void get_native_type_dependencies(const StringName &p_base_type, Vector<StringName> &r_result);
 

--- a/tests/scene/test_theme.cpp
+++ b/tests/scene/test_theme.cpp
@@ -51,6 +51,7 @@ public:
 		{ Theme::DATA_TYPE_FONT_SIZE, 42 },
 		{ Theme::DATA_TYPE_ICON, Ref<Texture>(memnew(ImageTexture)) },
 		{ Theme::DATA_TYPE_STYLEBOX, Ref<StyleBox>(memnew(StyleBoxFlat)) },
+		{ Theme::DATA_TYPE_SOUND, Ref<AudioStream>(memnew(AudioStream)) },
 	};
 
 	const StringName valid_item_name = "valid_item_name";


### PR DESCRIPTION
This allows themes to play sounds when hovering/pressing buttons, typing text and using sliders.

A new "audio" theme item type is added to allow custom controls to define their own audio streams, as well as benefit from the theme override system.

Playback is handled by adding internal nodes at the top of the SceneTree, and is not affected by pause or scene changes. Nodes are automatically freed once playback is done. Polyphony is implicitly supported by creating a node for each audio playback event.

~~`get_tree().create_audio_stream_player(stream: AudioStream, bus: StringName, volume_db: float)` can now be used to play a sound non-positionally, without having to worry about a parent node being freed and having the sound be cut off early. This is useful to play one-off sounds such as announcer audio.~~
**Edit:** Removed from this PR (it's now `Control::play_theme_sound()` and is not exposed to scripting).

- This closes https://github.com/godotengine/godot-proposals/issues/1472.
- See also https://github.com/godotengine/godot-proposals/issues/12266.

**Testing project:** [control_gallery.zip](https://github.com/user-attachments/files/31981657/control_gallery.zip)

## Preview

Watch with sound on :slightly_smiling_face: Both mouse and keyboard input is showcased.

https://github.com/user-attachments/assets/cc4c3705-be7e-46e7-aabc-a218aa79b24f

*Audio samples from https://github.com/redeclipse/sounds (CC BY-SA 4.0).*

## TODO

- [x] Review the list of exposed UI sounds. While I've covered the essentials, feel free to suggest extra actions that could benefit from sounds (or more granularity where needed, with examples).
  - [x] Add sound events for ColorPicker drag begin/end (similar to Slider), and reverting to the old color by clicking the revert icon.
    - Done using `BIND_THEME_ITEM_EXT()` (automatically reuses sounds from BaseButton and Slider, no configuration needed).
- [x] Rename "audios" in the API (or at least the UI) to something else, as the word "audio" doesn't have a plural form. I've done this in the theme item editor where I called it "audio samples" instead.
  - Renamed to "sounds".
- [x] Return early in `Control::play_theme_sound()` if using a bare AudioStream resource (useful to mute specific sounds with theme overrides without spamming errors).
  - ~~How to check that an object inherits from AudioStream, but is not any derived class like AudioStreamRandomizer or AudioStreamWAV?~~
    - Fixed with https://github.com/godotengine/godot/pull/111455#discussion_r3991294998, thanks @kitbdev :slightly_smiling_face: 
