### PR TITLE
Use HarfBuzz to fix variant hinting in `TextServerAdvanced`

### DIFF
--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -72,6 +72,12 @@ if env["builtin_freetype"]:
     if env["builtin_libpng"]:
         env_freetype.Prepend(CPPPATH=["#thirdparty/libpng"])
 
+    if "text_server_adv" in env.module_list:
+        # HarfBuzz is only available if TextServerAdvanced is enabled
+        env_freetype.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_HARFBUZZ"])
+        if env["builtin_harfbuzz"]:
+            env_freetype.Prepend(CPPPATH=["#thirdparty/harfbuzz/src/"])
+
     sfnt = thirdparty_dir + "src/sfnt/sfnt.c"
     # Must be done after all CPPDEFINES are being set so we can copy them.
     if env["platform"] == "web":


### PR DESCRIPTION
Fixes font hinting for custom enabled character variations in `TextServerAdvanced`.

Before (uppercase i is a character variant from Inter):
![before](https://github.com/user-attachments/assets/0f5b1ce1-9e47-43a3-b919-743e28281f91)

After:
![after](https://github.com/user-attachments/assets/cf40662a-a344-4915-aaf0-ffa012d7620b)

Does not affect character variations if enabled through the font file with font feature freeze, as they should be working properly by default. And doesn't matter in `TextServerFallback` as it doesn't support using font variations without font feature freeze anyway.

This is done by simply activating a define in FreeType and exposing HarfBuzz to it in the build scripts. FreeType's source code has the following comments regarding this:
> FreeType uses the HarfBuzz library to improve auto-hinting of OpenType fonts. If available, many glyphs not directly addressable by a font's character map will be hinted also.

> If FreeType gets compiled with `FT_CONFIG_OPTION_USE_HARFBUZZ` to make the HarfBuzz library access OpenType features for getting better glyph coverages, this property sets the (auto-fitter) script to be used for the default (OpenType) script data of a font's GSUB table.  Features for the default script are intended for all scripts not explicitly handled in GSUB; an example is a 'dlig' feature, containing the combination of the characters 'T', 'E', and 'L' to form a 'TEL' ligature.

If accepted, this would allow #111140 to enable more variants without having to resort to font feature freezes.

I found this by compiling the engine with `builtin_freetype=no` and noticing the hinting fixed, as Arch Linux's FreeType is linked with HarfBuzz.