### PR TITLE
Remove circular unneeded `debug_adapter_protocol.h` include from `debug_adapter_parser.h`

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -30,7 +30,7 @@
 
 #include "debug_adapter_parser.h"
 
-#include "editor/debugger/debug_adapter/debug_adapter_types.h"
+#include "editor/debugger/debug_adapter/debug_adapter_protocol.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/export/editor_export_platform.h"

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -32,8 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/debugger/remote_debugger.h"
-#include "debug_adapter_protocol.h"
-#include "debug_adapter_types.h"
+#include "editor/debugger/debug_adapter/debug_adapter_types.h"
 
 struct DAPeer;
 class DebugAdapterProtocol;

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -34,6 +34,7 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/io/json.h"
 #include "core/io/marshalls.h"
+#include "editor/debugger/debug_adapter/debug_adapter_parser.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -31,11 +31,10 @@
 #pragma once
 
 #include "core/debugger/debugger_marshalls.h"
+#include "core/debugger/remote_debugger.h"
 #include "core/io/stream_peer_tcp.h"
 #include "core/io/tcp_server.h"
-
-#include "debug_adapter_parser.h"
-#include "debug_adapter_types.h"
+#include "editor/debugger/debug_adapter/debug_adapter_types.h"
 #include "scene/debugger/scene_debugger.h"
 
 #define DAP_MAX_BUFFER_SIZE 4194304 // 4MB

--- a/editor/debugger/debug_adapter/debug_adapter_server.h
+++ b/editor/debugger/debug_adapter/debug_adapter_server.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "debug_adapter_protocol.h"
+#include "editor/debugger/debug_adapter/debug_adapter_protocol.h"
 #include "editor/plugins/editor_plugin.h"
 
 class DebugAdapterServer : public EditorPlugin {


### PR DESCRIPTION
Currently, `debug_adapter_protocol.h` includes `debug_adapter_parser.h`, and `debug_adapter_parser.h` includes `debug_adapter_protocol.h`. This can break builds in case `debug_adapter_parser.h ` is included first, because the following would happen:

- `debug_adapter_parser.h` starts to parse
- include to `debug_adapter_protocol.h` found
- `debug_adapter_protocol.h` starts to parse
- include to `debug_adapter_parser.h` found, but ignored
- `RemoteDebugger` fails to resolve (usually included through `debug_adapter_parser.h`)

Turns out neither of these actually needs to include the other, so I simplified the includes.
