### PR TITLE
LSP: Fix goto native declaration

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -496,8 +496,8 @@ Array GDScriptTextDocument::find_symbols(const LSP::TextDocumentPositionParams &
 			if (file_checker->file_exists(path)) {
 				arr.push_back(location.to_json());
 			}
-			r_list.push_back(symbol);
 		}
+		r_list.push_back(symbol);
 	} else if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
 		List<const LSP::DocumentSymbol *> list;
 		GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_related_symbols(p_location, list);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/111400

Regression from https://github.com/godotengine/godot/pull/104401

When adding an additional `uri.is_empty` check I accidentally pulled this line into it. Even though it would run for invalid uri's before. This PR restores the original behaviour. Which down the line fixes some checks during the native declaration lookup.

