### PR TITLE
Add corner smoothing to StyleBoxFlat

### DIFF
--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -154,7 +154,7 @@
 			The top-right corner's radius. If [code]0[/code], the corner is not rounded.
 		</member>
 		<member name="corner_radius_smoothing" type="float" setter="set_corner_radius_smoothing" getter="get_corner_radius_smoothing" default="1.0">
-			Controls the shape of rounded corners. A value of [code]0.0[/code] results in sharp (unsmoothed) corners, [code]1.0[/code] produces standard rounded corners, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes corners gradually approach a perfect squre. With values above [code]10.0[/code], the corners are virtually indistinguishable from square. 
+			Controls the shape of rounded corners. A value of [code]0.0[/code] results in sharp (unsmoothed) corners, [code]1.0[/code] produces standard rounded corners, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes corners gradually approach a perfect square. With values above [code]10.0[/code], the corners are virtually indistinguishable from square. 
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			Toggles drawing of the inner part of the stylebox.

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -154,7 +154,7 @@
 			The top-right corner's radius. If [code]0[/code], the corner is not rounded.
 		</member>
 		<member name="corner_radius_smoothing" type="float" setter="set_corner_radius_smoothing" getter="get_corner_radius_smoothing" default="1.0">
-			This property controls the smoothing of rounded corners. A value of [code]0.0[/code] produces straight-line corners, [code]1.0[/code] produces ordinary rounded corners, and [code]2.0[/code] produces a squircle shape. Values greater than [code]10.0[/code] produce shapes indistinguishable from a square.
+			Controls the shape of rounded corners. A value of [code]0.0[/code] results in sharp (unsmoothed) corners, [code]1.0[/code] produces standard rounded corners, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes corners gradually approach a perfect squre. With values above [code]10.0[/code], the corners are virtually indistinguishable from square. 
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			Toggles drawing of the inner part of the stylebox.

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -40,12 +40,6 @@
 				Returns the given [param corner]'s radius.
 			</description>
 		</method>
-		<method name="get_corner_radius_smoothing" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the smoothing exponent.
-			</description>
-		</method>
 		<method name="get_expand_margin" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="margin" type="int" enum="Side" />
@@ -81,13 +75,6 @@
 			<param index="0" name="radius" type="int" />
 			<description>
 				Sets the corner radius to [param radius] pixels for all corners.
-			</description>
-		</method>
-		<method name="set_corner_radius_smoothing">
-			<return type="void" />
-			<param index="0" name="strength" type="float" />
-			<description>
-				Sets smoothing exponent to [param strength].
 			</description>
 		</method>
 		<method name="set_expand_margin">
@@ -147,14 +134,14 @@
 		<member name="corner_radius_bottom_right" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
 			The bottom-right corner's radius. If [code]0[/code], the corner is not rounded.
 		</member>
+		<member name="corner_radius_smoothing" type="float" setter="set_corner_radius_smoothing" getter="get_corner_radius_smoothing" default="1.0">
+			Controls the shape of rounded corners. A value of [code]0.0[/code] results in sharp (unsmoothed) corners, [code]1.0[/code] produces standard rounded corners, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes corners gradually approach a perfect square. With values above [code]10.0[/code], the corners are virtually indistinguishable from square.
+		</member>
 		<member name="corner_radius_top_left" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
 			The top-left corner's radius. If [code]0[/code], the corner is not rounded.
 		</member>
 		<member name="corner_radius_top_right" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
 			The top-right corner's radius. If [code]0[/code], the corner is not rounded.
-		</member>
-		<member name="corner_radius_smoothing" type="float" setter="set_corner_radius_smoothing" getter="get_corner_radius_smoothing" default="1.0">
-			Controls the shape of rounded corners. A value of [code]0.0[/code] results in sharp (unsmoothed) corners, [code]1.0[/code] produces standard rounded corners, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes corners gradually approach a perfect square. With values above [code]10.0[/code], the corners are virtually indistinguishable from square.
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			Toggles drawing of the inner part of the stylebox.

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -154,7 +154,7 @@
 			The top-right corner's radius. If [code]0[/code], the corner is not rounded.
 		</member>
 		<member name="corner_radius_smoothing" type="float" setter="set_corner_radius_smoothing" getter="get_corner_radius_smoothing" default="1.0">
-			Controls the shape of rounded corners. A value of [code]0.0[/code] results in sharp (unsmoothed) corners, [code]1.0[/code] produces standard rounded corners, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes corners gradually approach a perfect square. With values above [code]10.0[/code], the corners are virtually indistinguishable from square. 
+			Controls the shape of rounded corners. A value of [code]0.0[/code] results in sharp (unsmoothed) corners, [code]1.0[/code] produces standard rounded corners, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes corners gradually approach a perfect square. With values above [code]10.0[/code], the corners are virtually indistinguishable from square.
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			Toggles drawing of the inner part of the stylebox.

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -40,6 +40,12 @@
 				Returns the given [param corner]'s radius.
 			</description>
 		</method>
+		<method name="get_corner_radius_smoothing" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the smoothing exponent.
+			</description>
+		</method>
 		<method name="get_expand_margin" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="margin" type="int" enum="Side" />
@@ -75,6 +81,13 @@
 			<param index="0" name="radius" type="int" />
 			<description>
 				Sets the corner radius to [param radius] pixels for all corners.
+			</description>
+		</method>
+		<method name="set_corner_radius_smoothing">
+			<return type="void" />
+			<param index="0" name="strength" type="float" />
+			<description>
+				Sets smoothing exponent to [param strength].
 			</description>
 		</method>
 		<method name="set_expand_margin">
@@ -139,6 +152,9 @@
 		</member>
 		<member name="corner_radius_top_right" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
 			The top-right corner's radius. If [code]0[/code], the corner is not rounded.
+		</member>
+		<member name="corner_radius_smoothing" type="float" setter="set_corner_radius_smoothing" getter="get_corner_radius_smoothing" default="1.0">
+			This property controls the smoothing of rounded corners. A value of [code]0.0[/code] produces straight-line corners, [code]1.0[/code] produces ordinary rounded corners, and [code]2.0[/code] produces a squircle shape. Values greater than [code]10.0[/code] produce shapes indistinguishable from a square.
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			Toggles drawing of the inner part of the stylebox.

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -153,6 +153,12 @@
 		<member name="corner_radius_bottom_right" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
 			The bottom-right corner's radius. If [code]0[/code], the corner is not rounded.
 		</member>
+		<member name="corner_radius_top_left" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
+			The top-left corner's radius. If [code]0[/code], the corner is not rounded.
+		</member>
+		<member name="corner_radius_top_right" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
+			The top-right corner's radius. If [code]0[/code], the corner is not rounded.
+		</member>
 		<member name="corner_smoothing_bottom_left" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
 			The bottom-left corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
 		</member>
@@ -164,12 +170,6 @@
 		</member>
 		<member name="corner_smoothing_top_right" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
 			The top-right corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
-		</member>
-		<member name="corner_radius_top_left" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
-			The top-left corner's radius. If [code]0[/code], the corner is not rounded.
-		</member>
-		<member name="corner_radius_top_right" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
-			The top-right corner's radius. If [code]0[/code], the corner is not rounded.
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			Toggles drawing of the inner part of the stylebox.

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -40,6 +40,12 @@
 				Returns the given [param corner]'s radius.
 			</description>
 		</method>
+		<method name="get_corner_smoothing" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="corner" type="int" enum="Corner" />
+			<description>
+			</description>
+		</method>
 		<method name="get_expand_margin" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="margin" type="int" enum="Side" />
@@ -75,6 +81,19 @@
 			<param index="0" name="radius" type="int" />
 			<description>
 				Sets the corner radius to [param radius] pixels for all corners.
+			</description>
+		</method>
+		<method name="set_corner_smoothing">
+			<return type="void" />
+			<param index="0" name="corner" type="int" enum="Corner" />
+			<param index="1" name="smoothing" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="set_corner_smoothing_all">
+			<return type="void" />
+			<param index="0" name="smoothing" type="float" />
+			<description>
 			</description>
 		</method>
 		<method name="set_expand_margin">
@@ -134,17 +153,17 @@
 		<member name="corner_radius_bottom_right" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
 			The bottom-right corner's radius. If [code]0[/code], the corner is not rounded.
 		</member>
-		<member name="corner_smoothing_bottom_right" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
-			The bottom-right corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
-		</member>
 		<member name="corner_smoothing_bottom_left" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
 			The bottom-left corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
 		</member>
-		<member name="top_right" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
-			The top-right corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
+		<member name="corner_smoothing_bottom_right" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
+			The bottom-right corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
 		</member>
-		<member name="top_left" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
+		<member name="corner_smoothing_top_left" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
 			The top-left corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
+		</member>
+		<member name="corner_smoothing_top_right" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
+			The top-right corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
 		</member>
 		<member name="corner_radius_top_left" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
 			The top-left corner's radius. If [code]0[/code], the corner is not rounded.

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -134,8 +134,17 @@
 		<member name="corner_radius_bottom_right" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
 			The bottom-right corner's radius. If [code]0[/code], the corner is not rounded.
 		</member>
-		<member name="corner_radius_smoothing" type="float" setter="set_corner_radius_smoothing" getter="get_corner_radius_smoothing" default="1.0">
-			Controls the shape of rounded corners. A value of [code]0.0[/code] results in sharp (unsmoothed) corners, [code]1.0[/code] produces standard rounded corners, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes corners gradually approach a perfect square. With values above [code]10.0[/code], the corners are virtually indistinguishable from square.
+		<member name="corner_smoothing_bottom_right" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
+			The bottom-right corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
+		</member>
+		<member name="corner_smoothing_bottom_left" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
+			The bottom-left corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
+		</member>
+		<member name="top_right" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
+			The top-right corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
+		</member>
+		<member name="top_left" type="float" setter="set_corner_smoothing" getter="get_corner_smoothing" default="1.0">
+			The top-left corner's smoothing. A value of [code]0.0[/code] results in a sharp (unsmoothed) corner, [code]1.0[/code] produces a standard rounded corner, and [code]2.0[/code] creates a squircle-like shape. Increasing the value further makes a corner gradually approach a perfect square.
 		</member>
 		<member name="corner_radius_top_left" type="int" setter="set_corner_radius" getter="get_corner_radius" default="0">
 			The top-left corner's radius. If [code]0[/code], the corner is not rounded.

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -310,20 +310,20 @@ inline void set_corner_scale(const Rect2 &style_rect, const Rect2 &inner_rect, c
 	}
 }
 
-void StyleBoxFlat::set_corner_smoothing_strength(float p_corner_smoothing_strength) {
-	// Below corner_smoothing_strength 0.0 antialiasing and border_width break.
-	ERR_FAIL_COND_MSG(p_corner_smoothing_strength < 0.0 || p_corner_smoothing_strength > 10.0, "Corner smoothing strength must be between 0.0 and 10.0");
-	corner_smoothing_strength = CLAMP(p_corner_smoothing_strength, 0.0, 10.0);
+void StyleBoxFlat::set_corner_radius_smoothing(float p_corner_radius_smoothing) {
+	// Below corner_radius_smoothing 0.0 antialiasing and border_width break.
+	ERR_FAIL_COND_MSG(p_corner_radius_smoothing < 0.0 || p_corner_radius_smoothing > 10.0, "Corner smoothing strength must be between 0.0 and 10.0");
+	corner_radius_smoothing = CLAMP(p_corner_radius_smoothing, 0.0, 10.0);
 	emit_changed();
 }
 
-float StyleBoxFlat::get_corner_smoothing_strength() const {
-	return corner_smoothing_strength;
+float StyleBoxFlat::get_corner_radius_smoothing() const {
+	return corner_radius_smoothing;
 }
 
 inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color> &colors, const Rect2 &style_rect, const real_t corner_radius[4],
 		const Rect2 &ring_rect, const Rect2 &inner_rect, const Color &inner_color, const Color &outer_color, const int corner_detail, const Vector2 &skew,
-		bool is_filled = false, const real_t corner_smoothing_strength = 0.0) {
+		bool is_filled = false, const real_t corner_radius_smoothing = 0.0) {
 	int vert_offset = verts.size();
 	int adapted_corner_detail = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0) ? corner_detail : 1;
 
@@ -384,7 +384,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			const real_t angle_sine = Math::sin(pt_angle);
 
 			real_t x, y;
-			if (corner_smoothing_strength > 0.0f) {
+			if (corner_radius_smoothing > 0.0f) {
 				real_t cos_abs = Math::abs(angle_cosine);
 				real_t sin_abs = Math::abs(angle_sine);
 				real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
@@ -392,9 +392,9 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 				// Lamé curve for superellipse smoothing of corners.
 				// Corner smoothing strength of 0.0 produces a circular arc and looks like regular rounded corners.
 				// Higher smoothing strengths produce more rounded corner shapes.
-				// The corner_smoothing_strength is offset by +2.0f due to semantic reasons: to produce regular corner rounding when the strength is 0.0f.
-				x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
-				y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
+				// The corner_radius_smoothing is offset by +2.0f due to semantic reasons: to produce regular corner rounding when the strength is 0.0f.
+				x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_radius_smoothing + 2.0f)) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
+				y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_radius_smoothing + 2.0f)) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
 			} else {
 				x = inner_corner_radius[corner_idx] * angle_cosine * inner_scale[corner_idx].x + inner_points[corner_idx].x;
 				y = inner_corner_radius[corner_idx] * angle_sine * inner_scale[corner_idx].y + inner_points[corner_idx].y;
@@ -406,13 +406,13 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			colors_ptr[colors_size + idx_ofs] = inner_color;
 
 			if (draw_border) {
-				if (corner_smoothing_strength > 0.0f) {
+				if (corner_radius_smoothing > 0.0f) {
 					real_t cos_abs = Math::abs(angle_cosine);
 					real_t sin_abs = Math::abs(angle_sine);
 					real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
 					real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
-					x = ring_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * ring_scale[corner_idx].x + outer_points[corner_idx].x;
-					y = ring_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * ring_scale[corner_idx].y + outer_points[corner_idx].y;
+					x = ring_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_radius_smoothing + 2.0f)) * ring_scale[corner_idx].x + outer_points[corner_idx].x;
+					y = ring_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_radius_smoothing + 2.0f)) * ring_scale[corner_idx].y + outer_points[corner_idx].y;
 				} else {
 					x = ring_corner_radius[corner_idx] * angle_cosine * ring_scale[corner_idx].x + outer_points[corner_idx].x;
 					y = ring_corner_radius[corner_idx] * angle_sine * ring_scale[corner_idx].y + outer_points[corner_idx].y;
@@ -569,24 +569,24 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 		Color shadow_color_transparent = Color(shadow_color.r, shadow_color.g, shadow_color.b, 0);
 
 		draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner, shadow_rect,
-				shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew, false, corner_smoothing_strength);
+				shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew, false, corner_radius_smoothing);
 
 		if (draw_center) {
 			draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,
-					shadow_inner_rect, shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true, corner_smoothing_strength);
+					shadow_inner_rect, shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true, corner_radius_smoothing);
 		}
 	}
 
 	// Create border (no AA).
 	if (draw_border && !aa_on) {
 		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-				border_style_rect, infill_rect, border_color_inner, border_color, corner_detail, skew, false, corner_smoothing_strength);
+				border_style_rect, infill_rect, border_color_inner, border_color, corner_detail, skew, false, corner_radius_smoothing);
 	}
 
 	// Create infill (no AA).
 	if (draw_center && (!aa_on || blend_on)) {
 		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-				infill_rect, infill_rect, bg_color, bg_color, corner_detail, skew, true, corner_smoothing_strength);
+				infill_rect, infill_rect, bg_color, bg_color, corner_detail, skew, true, corner_radius_smoothing);
 	}
 
 	if (aa_on) {
@@ -628,13 +628,13 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 			if (!blend_on) {
 				// Create center fill, not antialiased yet
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						infill_rect_aa_colored, infill_rect_aa_colored, bg_color, bg_color, corner_detail, skew, true, corner_smoothing_strength);
+						infill_rect_aa_colored, infill_rect_aa_colored, bg_color, bg_color, corner_detail, skew, true, corner_radius_smoothing);
 			}
 			if (!blend_on || !draw_border) {
 				Color alpha_bg = Color(bg_color.r, bg_color.g, bg_color.b, 0);
 				// Add antialiasing on the center fill
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						infill_rect_aa_transparent, infill_rect_aa_colored, bg_color, alpha_bg, corner_detail, skew, false, corner_smoothing_strength);
+						infill_rect_aa_transparent, infill_rect_aa_colored, bg_color, alpha_bg, corner_detail, skew, false, corner_radius_smoothing);
 			}
 		}
 
@@ -654,15 +654,15 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 			// Create border ring, not antialiased yet
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-					outer_rect_aa_colored, ((blend_on) ? infill_rect : inner_rect_aa_colored), border_color_inner, border_color, corner_detail, skew, false, corner_smoothing_strength);
+					outer_rect_aa_colored, ((blend_on) ? infill_rect : inner_rect_aa_colored), border_color_inner, border_color, corner_detail, skew, false, corner_radius_smoothing);
 			if (!blend_on) {
 				// Add antialiasing on the ring inner border
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						inner_rect_aa_colored, inner_rect_aa_transparent, border_color_blend, border_color, corner_detail, skew, false, corner_smoothing_strength);
+						inner_rect_aa_colored, inner_rect_aa_transparent, border_color_blend, border_color, corner_detail, skew, false, corner_radius_smoothing);
 			}
 			// Add antialiasing on the ring outer border
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-					outer_rect_aa_transparent, outer_rect_aa_colored, border_color, border_color_alpha, corner_detail, skew, false, corner_smoothing_strength);
+					outer_rect_aa_transparent, outer_rect_aa_colored, border_color, border_color_alpha, corner_detail, skew, false, corner_radius_smoothing);
 		}
 	}
 
@@ -698,8 +698,8 @@ void StyleBoxFlat::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius_all", "radius"), &StyleBoxFlat::set_corner_radius_all);
 
-	ClassDB::bind_method(D_METHOD("set_corner_smoothing_strength", "corner_smoothing_strength"), &StyleBoxFlat::set_corner_smoothing_strength);
-	ClassDB::bind_method(D_METHOD("get_corner_smoothing_strength"), &StyleBoxFlat::get_corner_smoothing_strength);
+	ClassDB::bind_method(D_METHOD("set_corner_radius_smoothing", "corner_radius_smoothing"), &StyleBoxFlat::set_corner_radius_smoothing);
+	ClassDB::bind_method(D_METHOD("get_corner_radius_smoothing"), &StyleBoxFlat::get_corner_radius_smoothing);
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius", "corner", "radius"), &StyleBoxFlat::set_corner_radius);
 	ClassDB::bind_method(D_METHOD("get_corner_radius", "corner"), &StyleBoxFlat::get_corner_radius);
@@ -753,7 +753,7 @@ void StyleBoxFlat::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_top_right", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_TOP_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_right", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_left", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_LEFT);
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "corner_smoothing_strength", PROPERTY_HINT_RANGE, "0.0,10,0.1"), "set_corner_smoothing_strength", "get_corner_smoothing_strength");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing", PROPERTY_HINT_RANGE, "0.0,10,0.1"), "set_corner_radius_smoothing", "get_corner_radius_smoothing");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "corner_detail", PROPERTY_HINT_RANGE, "1,20,1"), "set_corner_detail", "get_corner_detail");
 

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -401,7 +401,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 				// Lamé curve for superellipse smoothing of corners.
 				// Corner smoothing strength of 0.0 produces a circular arc and results similar to corner_smoothing_enable == false.
 				// Higher smoothing strengths produce more rounded corner shapes.
-				// The corner_smoothing_strength is offset by -2.0f due to semantic reasons: to produce regular corner rounding when the strength is 0.0f.
+				// The corner_smoothing_strength is offset by +2.0f due to semantic reasons: to produce regular corner rounding when the strength is 0.0f.
                 x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
                 y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
 			}

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -384,17 +384,19 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			const real_t angle_sine = Math::sin(pt_angle);
 
 			real_t x, y;
-			if (corner_radius_smoothing > 0.0f) {
+			// Corner smoothing formula is adapted from CSS documentation: https://developer.mozilla.org/en-US/docs/Web/CSS/superellipse.
+			// Corner smoothing strength of 0.0 produces straight line corners.
+			// Corner smoothing strength of 1.0 produces ordinary corner rounding.
+			// Corner smoothing strength of 2.0 produces a squircle.
+			// Corner smoothing strength values > 10.0 produce shapes indistinguishable from a square.
+			real_t smoothing_exponent = 2.0f / Math::pow(2.0f, corner_radius_smoothing);
+			if (Math::is_equal_approx(corner_radius_smoothing, 1.0f)) {
 				real_t cos_abs = Math::abs(angle_cosine);
 				real_t sin_abs = Math::abs(angle_sine);
 				real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
 				real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
-				// Lamé curve for superellipse smoothing of corners.
-				// Corner smoothing strength of 0.0 produces a circular arc and looks like regular rounded corners.
-				// Higher smoothing strengths produce more rounded corner shapes.
-				// The corner_radius_smoothing is offset by +2.0f due to semantic reasons: to produce regular corner rounding when the strength is 0.0f.
-				x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_radius_smoothing + 2.0f)) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
-				y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_radius_smoothing + 2.0f)) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
+				x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, smoothing_exponent) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
+				y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, smoothing_exponent) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
 			} else {
 				x = inner_corner_radius[corner_idx] * angle_cosine * inner_scale[corner_idx].x + inner_points[corner_idx].x;
 				y = inner_corner_radius[corner_idx] * angle_sine * inner_scale[corner_idx].y + inner_points[corner_idx].y;
@@ -406,13 +408,13 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			colors_ptr[colors_size + idx_ofs] = inner_color;
 
 			if (draw_border) {
-				if (corner_radius_smoothing > 0.0f) {
+				if (Math::is_equal_approx(corner_radius_smoothing, 1.0f)) {
 					real_t cos_abs = Math::abs(angle_cosine);
 					real_t sin_abs = Math::abs(angle_sine);
 					real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
 					real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
-					x = ring_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_radius_smoothing + 2.0f)) * ring_scale[corner_idx].x + outer_points[corner_idx].x;
-					y = ring_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_radius_smoothing + 2.0f)) * ring_scale[corner_idx].y + outer_points[corner_idx].y;
+					x = ring_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, smoothing_exponent) * ring_scale[corner_idx].x + outer_points[corner_idx].x;
+					y = ring_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, smoothing_exponent) * ring_scale[corner_idx].y + outer_points[corner_idx].y;
 				} else {
 					x = ring_corner_radius[corner_idx] * angle_cosine * ring_scale[corner_idx].x + outer_points[corner_idx].x;
 					y = ring_corner_radius[corner_idx] * angle_sine * ring_scale[corner_idx].y + outer_points[corner_idx].y;

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -402,8 +402,8 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 				// Corner smoothing strength of 0.0 produces a circular arc and results similar to corner_smoothing_enable == false.
 				// Higher smoothing strengths produce more rounded corner shapes.
 				// The corner_smoothing_strength is offset by -2.0f due to semantic reasons: to produce regular corner rounding when the strength is 0.0f.
-                x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / corner_smoothing_strength + 2.0f) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
-                y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / corner_smoothing_strength + 2.0f) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
+                x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
+                y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
 			}
 			else {
 				x = inner_corner_radius[corner_idx] * angle_cosine * inner_scale[corner_idx].x + inner_points[corner_idx].x;
@@ -421,8 +421,8 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 					real_t sin_abs = Math::abs(angle_sine);
 					real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
 					real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
-					x = ring_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / corner_smoothing_strength + 2.0f) * ring_scale[corner_idx].x + outer_points[corner_idx].x;
-					y = ring_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / corner_smoothing_strength + 2.0f) * ring_scale[corner_idx].y + outer_points[corner_idx].y;
+					x = ring_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * ring_scale[corner_idx].x + outer_points[corner_idx].x;
+					y = ring_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * ring_scale[corner_idx].y + outer_points[corner_idx].y;
 				}
 				else {
 					x = ring_corner_radius[corner_idx] * angle_cosine * ring_scale[corner_idx].x + outer_points[corner_idx].x;
@@ -771,7 +771,7 @@ void StyleBoxFlat::_bind_methods() {
 	
 	ADD_GROUP("Corner Smoothing", "corner_smoothing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "corner_smoothing_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_use_corner_smoothing", "is_corner_smoothing_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "corner_smoothing_strength", PROPERTY_HINT_RANGE, "2.0,10,0.1"), "set_corner_smoothing_strength", "get_corner_smoothing_strength");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "corner_smoothing_strength", PROPERTY_HINT_RANGE, "0.0,10,0.1"), "set_corner_smoothing_strength", "get_corner_smoothing_strength");
 
 	ADD_GROUP("Expand Margins", "expand_margin_");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_left", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_expand_margin", "get_expand_margin", SIDE_LEFT);

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -330,8 +330,8 @@ float StyleBoxFlat::get_corner_smoothing_strength() const {
 	return corner_smoothing_strength;
 }
 
-inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color> &colors, const Rect2 &style_rect, const real_t corner_radius[4], 
-		const Rect2 &ring_rect, const Rect2 &inner_rect, const Color &inner_color, const Color &outer_color, const int corner_detail, const Vector2 &skew, 
+inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color> &colors, const Rect2 &style_rect, const real_t corner_radius[4],
+		const Rect2 &ring_rect, const Rect2 &inner_rect, const Color &inner_color, const Color &outer_color, const int corner_detail, const Vector2 &skew,
 		bool is_filled = false, const bool corner_smoothing_enabled = false, const real_t corner_smoothing_strength = 0.0) {
 	int vert_offset = verts.size();
 	int adapted_corner_detail = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0) ? corner_detail : 1;
@@ -395,17 +395,16 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			real_t x, y;
 			if (corner_smoothing_enabled && !Math::is_equal_approx(corner_smoothing_strength + 2.0f, 2.0f)) {
 				real_t cos_abs = Math::abs(angle_cosine);
-                real_t sin_abs = Math::abs(angle_sine);
-                real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
-                real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
+				real_t sin_abs = Math::abs(angle_sine);
+				real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
+				real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
 				// Lamé curve for superellipse smoothing of corners.
 				// Corner smoothing strength of 0.0 produces a circular arc and results similar to corner_smoothing_enable == false.
 				// Higher smoothing strengths produce more rounded corner shapes.
 				// The corner_smoothing_strength is offset by +2.0f due to semantic reasons: to produce regular corner rounding when the strength is 0.0f.
-                x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
-                y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
-			}
-			else {
+				x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
+				y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
+			} else {
 				x = inner_corner_radius[corner_idx] * angle_cosine * inner_scale[corner_idx].x + inner_points[corner_idx].x;
 				y = inner_corner_radius[corner_idx] * angle_sine * inner_scale[corner_idx].y + inner_points[corner_idx].y;
 			}
@@ -423,8 +422,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 					real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
 					x = ring_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * ring_scale[corner_idx].x + outer_points[corner_idx].x;
 					y = ring_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / (corner_smoothing_strength + 2.0f)) * ring_scale[corner_idx].y + outer_points[corner_idx].y;
-				}
-				else {
+				} else {
 					x = ring_corner_radius[corner_idx] * angle_cosine * ring_scale[corner_idx].x + outer_points[corner_idx].x;
 					y = ring_corner_radius[corner_idx] * angle_sine * ring_scale[corner_idx].y + outer_points[corner_idx].y;
 				}
@@ -579,7 +577,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 		Color shadow_color_transparent = Color(shadow_color.r, shadow_color.g, shadow_color.b, 0);
 
-		draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,shadow_rect, 
+		draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner, shadow_rect,
 				shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew, false, corner_smoothing_enabled, corner_smoothing_strength);
 
 		if (draw_center) {
@@ -708,7 +706,7 @@ void StyleBoxFlat::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_border_blend"), &StyleBoxFlat::get_border_blend);
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius_all", "radius"), &StyleBoxFlat::set_corner_radius_all);
-	
+
 	ClassDB::bind_method(D_METHOD("set_use_corner_smoothing", "use_corner_smoothing"), &StyleBoxFlat::set_use_corner_smoothing);
 	ClassDB::bind_method(D_METHOD("is_corner_smoothing_enabled"), &StyleBoxFlat::is_corner_smoothing_enabled);
 	ClassDB::bind_method(D_METHOD("set_corner_smoothing_strength", "corner_smoothing_strength"), &StyleBoxFlat::set_corner_smoothing_strength);
@@ -768,7 +766,7 @@ void StyleBoxFlat::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_left", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_LEFT);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "corner_detail", PROPERTY_HINT_RANGE, "1,20,1"), "set_corner_detail", "get_corner_detail");
-	
+
 	ADD_GROUP("Corner Smoothing", "corner_smoothing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "corner_smoothing_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_use_corner_smoothing", "is_corner_smoothing_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "corner_smoothing_strength", PROPERTY_HINT_RANGE, "0.0,10,0.1"), "set_corner_smoothing_strength", "get_corner_smoothing_strength");

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -409,8 +409,8 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 				y = inner_corner_radius[corner_idx] * angle_sine * inner_scale[corner_idx].y + inner_points[corner_idx].y;
 			}
 
-			const float x_skew = -skew.x * (y - style_rect_center.y);
-			const float y_skew = -skew.y * (x - style_rect_center.x);
+			float x_skew = -skew.x * (y - style_rect_center.y);
+			float y_skew = -skew.y * (x - style_rect_center.x);
 			verts_ptr[verts_size + idx_ofs] = Vector2(x + x_skew, y + y_skew);
 			colors_ptr[colors_size + idx_ofs] = inner_color;
 
@@ -426,8 +426,8 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 					x = ring_corner_radius[corner_idx] * angle_cosine * ring_scale[corner_idx].x + outer_points[corner_idx].x;
 					y = ring_corner_radius[corner_idx] * angle_sine * ring_scale[corner_idx].y + outer_points[corner_idx].y;
 				}
-				const float x_skew = -skew.x * (y - style_rect_center.y);
-				const float y_skew = -skew.y * (x - style_rect_center.x);
+				x_skew = -skew.x * (y - style_rect_center.y);
+				y_skew = -skew.y * (x - style_rect_center.x);
 				verts_ptr[verts_size + idx_ofs + 1] = Vector2(x + x_skew, y + y_skew);
 				colors_ptr[colors_size + idx_ofs + 1] = outer_color;
 			}

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -389,8 +389,8 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			// Corner smoothing strength of 1.0 produces ordinary corner rounding.
 			// Corner smoothing strength of 2.0 produces a squircle.
 			// Corner smoothing strength values > 10.0 produce shapes indistinguishable from a square.
-			real_t smoothing_exponent = 2.0f / Math::pow(2.0f, corner_radius_smoothing);
-			if (Math::is_equal_approx(corner_radius_smoothing, 1.0f)) {
+			real_t smoothing_exponent = (real_t)2.0f / Math::pow((real_t)2.0f, corner_radius_smoothing);
+			if (!Math::is_equal_approx(corner_radius_smoothing, (real_t)1.0f)) {
 				real_t cos_abs = Math::abs(angle_cosine);
 				real_t sin_abs = Math::abs(angle_sine);
 				real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
@@ -408,7 +408,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			colors_ptr[colors_size + idx_ofs] = inner_color;
 
 			if (draw_border) {
-				if (Math::is_equal_approx(corner_radius_smoothing, 1.0f)) {
+				if (!Math::is_equal_approx(corner_radius_smoothing, (real_t)1.0f)) {
 					real_t cos_abs = Math::abs(angle_cosine);
 					real_t sin_abs = Math::abs(angle_sine);
 					real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -310,8 +310,29 @@ inline void set_corner_scale(const Rect2 &style_rect, const Rect2 &inner_rect, c
 	}
 }
 
-inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color> &colors, const Rect2 &style_rect, const real_t corner_radius[4],
-		const Rect2 &ring_rect, const Rect2 &inner_rect, const Color &inner_color, const Color &outer_color, const int corner_detail, const Vector2 &skew, bool is_filled = false) {
+void StyleBoxFlat::set_use_corner_smoothing(bool p_use_corner_smoothing) {
+	corner_smoothing_enabled = p_use_corner_smoothing;
+	emit_changed();
+}
+
+bool StyleBoxFlat::is_corner_smoothing_enabled() const {
+	return corner_smoothing_enabled;
+}
+
+void StyleBoxFlat::set_corner_smoothing_strength(float p_corner_smoothing_strength) {
+	// Below corner_smoothing_strength 0.0 antialiasing and border_width break.
+	ERR_FAIL_COND_MSG(p_corner_smoothing_strength < 0.0 || p_corner_smoothing_strength > 10.0, "Corner smoothing strength must be between 0.0 and 10.0");
+	corner_smoothing_strength = CLAMP(p_corner_smoothing_strength, 0.0, 10.0);
+	emit_changed();
+}
+
+float StyleBoxFlat::get_corner_smoothing_strength() const {
+	return corner_smoothing_strength;
+}
+
+inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color> &colors, const Rect2 &style_rect, const real_t corner_radius[4], 
+		const Rect2 &ring_rect, const Rect2 &inner_rect, const Color &inner_color, const Color &outer_color, const int corner_detail, const Vector2 &skew, 
+		bool is_filled = false, const bool corner_smoothing_enabled = false, const real_t corner_smoothing_strength = 0.0) {
 	int vert_offset = verts.size();
 	int adapted_corner_detail = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0) ? corner_detail : 1;
 
@@ -371,18 +392,42 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			const real_t angle_cosine = Math::cos(pt_angle);
 			const real_t angle_sine = Math::sin(pt_angle);
 
-			{
-				const real_t x = inner_corner_radius[corner_idx] * angle_cosine * inner_scale[corner_idx].x + inner_points[corner_idx].x;
-				const real_t y = inner_corner_radius[corner_idx] * angle_sine * inner_scale[corner_idx].y + inner_points[corner_idx].y;
-				const float x_skew = -skew.x * (y - style_rect_center.y);
-				const float y_skew = -skew.y * (x - style_rect_center.x);
-				verts_ptr[verts_size + idx_ofs] = Vector2(x + x_skew, y + y_skew);
-				colors_ptr[colors_size + idx_ofs] = inner_color;
+			real_t x, y;
+			if (corner_smoothing_enabled && !Math::is_equal_approx(corner_smoothing_strength + 2.0f, 2.0f)) {
+				real_t cos_abs = Math::abs(angle_cosine);
+                real_t sin_abs = Math::abs(angle_sine);
+                real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
+                real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
+				// Lamé curve for superellipse smoothing of corners.
+				// Corner smoothing strength of 0.0 produces a circular arc and results similar to corner_smoothing_enable == false.
+				// Higher smoothing strengths produce more rounded corner shapes.
+				// The corner_smoothing_strength is offset by -2.0f due to semantic reasons: to produce regular corner rounding when the strength is 0.0f.
+                x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / corner_smoothing_strength + 2.0f) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
+                y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / corner_smoothing_strength + 2.0f) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
+			}
+			else {
+				x = inner_corner_radius[corner_idx] * angle_cosine * inner_scale[corner_idx].x + inner_points[corner_idx].x;
+				y = inner_corner_radius[corner_idx] * angle_sine * inner_scale[corner_idx].y + inner_points[corner_idx].y;
 			}
 
+			const float x_skew = -skew.x * (y - style_rect_center.y);
+			const float y_skew = -skew.y * (x - style_rect_center.x);
+			verts_ptr[verts_size + idx_ofs] = Vector2(x + x_skew, y + y_skew);
+			colors_ptr[colors_size + idx_ofs] = inner_color;
+
 			if (draw_border) {
-				const real_t x = ring_corner_radius[corner_idx] * angle_cosine * ring_scale[corner_idx].x + outer_points[corner_idx].x;
-				const real_t y = ring_corner_radius[corner_idx] * angle_sine * ring_scale[corner_idx].y + outer_points[corner_idx].y;
+				if (corner_smoothing_enabled && !Math::is_equal_approx(corner_smoothing_strength + 2.0f, 2.0f)) {
+					real_t cos_abs = Math::abs(angle_cosine);
+					real_t sin_abs = Math::abs(angle_sine);
+					real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
+					real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
+					x = ring_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, 2.0f / corner_smoothing_strength + 2.0f) * ring_scale[corner_idx].x + outer_points[corner_idx].x;
+					y = ring_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, 2.0f / corner_smoothing_strength + 2.0f) * ring_scale[corner_idx].y + outer_points[corner_idx].y;
+				}
+				else {
+					x = ring_corner_radius[corner_idx] * angle_cosine * ring_scale[corner_idx].x + outer_points[corner_idx].x;
+					y = ring_corner_radius[corner_idx] * angle_sine * ring_scale[corner_idx].y + outer_points[corner_idx].y;
+				}
 				const float x_skew = -skew.x * (y - style_rect_center.y);
 				const float y_skew = -skew.y * (x - style_rect_center.x);
 				verts_ptr[verts_size + idx_ofs + 1] = Vector2(x + x_skew, y + y_skew);
@@ -534,25 +579,25 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 		Color shadow_color_transparent = Color(shadow_color.r, shadow_color.g, shadow_color.b, 0);
 
-		draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,
-				shadow_rect, shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew);
+		draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,shadow_rect, 
+				shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew, false, corner_smoothing_enabled, corner_smoothing_strength);
 
 		if (draw_center) {
 			draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,
-					shadow_inner_rect, shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true);
+					shadow_inner_rect, shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true, corner_smoothing_enabled, corner_smoothing_strength);
 		}
 	}
 
 	// Create border (no AA).
 	if (draw_border && !aa_on) {
 		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-				border_style_rect, infill_rect, border_color_inner, border_color, corner_detail, skew);
+				border_style_rect, infill_rect, border_color_inner, border_color, corner_detail, skew, false, corner_smoothing_enabled, corner_smoothing_strength);
 	}
 
 	// Create infill (no AA).
 	if (draw_center && (!aa_on || blend_on)) {
 		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-				infill_rect, infill_rect, bg_color, bg_color, corner_detail, skew, true);
+				infill_rect, infill_rect, bg_color, bg_color, corner_detail, skew, true, corner_smoothing_enabled, corner_smoothing_strength);
 	}
 
 	if (aa_on) {
@@ -594,13 +639,13 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 			if (!blend_on) {
 				// Create center fill, not antialiased yet
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						infill_rect_aa_colored, infill_rect_aa_colored, bg_color, bg_color, corner_detail, skew, true);
+						infill_rect_aa_colored, infill_rect_aa_colored, bg_color, bg_color, corner_detail, skew, true, corner_smoothing_enabled, corner_smoothing_strength);
 			}
 			if (!blend_on || !draw_border) {
 				Color alpha_bg = Color(bg_color.r, bg_color.g, bg_color.b, 0);
 				// Add antialiasing on the center fill
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						infill_rect_aa_transparent, infill_rect_aa_colored, bg_color, alpha_bg, corner_detail, skew);
+						infill_rect_aa_transparent, infill_rect_aa_colored, bg_color, alpha_bg, corner_detail, skew, false, corner_smoothing_enabled, corner_smoothing_strength);
 			}
 		}
 
@@ -620,15 +665,15 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 			// Create border ring, not antialiased yet
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-					outer_rect_aa_colored, ((blend_on) ? infill_rect : inner_rect_aa_colored), border_color_inner, border_color, corner_detail, skew);
+					outer_rect_aa_colored, ((blend_on) ? infill_rect : inner_rect_aa_colored), border_color_inner, border_color, corner_detail, skew, false, corner_smoothing_enabled, corner_smoothing_strength);
 			if (!blend_on) {
 				// Add antialiasing on the ring inner border
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						inner_rect_aa_colored, inner_rect_aa_transparent, border_color_blend, border_color, corner_detail, skew);
+						inner_rect_aa_colored, inner_rect_aa_transparent, border_color_blend, border_color, corner_detail, skew, false, corner_smoothing_enabled, corner_smoothing_strength);
 			}
 			// Add antialiasing on the ring outer border
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-					outer_rect_aa_transparent, outer_rect_aa_colored, border_color, border_color_alpha, corner_detail, skew);
+					outer_rect_aa_transparent, outer_rect_aa_colored, border_color, border_color_alpha, corner_detail, skew, false, corner_smoothing_enabled, corner_smoothing_strength);
 		}
 	}
 
@@ -663,6 +708,11 @@ void StyleBoxFlat::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_border_blend"), &StyleBoxFlat::get_border_blend);
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius_all", "radius"), &StyleBoxFlat::set_corner_radius_all);
+	
+	ClassDB::bind_method(D_METHOD("set_use_corner_smoothing", "use_corner_smoothing"), &StyleBoxFlat::set_use_corner_smoothing);
+	ClassDB::bind_method(D_METHOD("is_corner_smoothing_enabled"), &StyleBoxFlat::is_corner_smoothing_enabled);
+	ClassDB::bind_method(D_METHOD("set_corner_smoothing_strength", "corner_smoothing_strength"), &StyleBoxFlat::set_corner_smoothing_strength);
+	ClassDB::bind_method(D_METHOD("get_corner_smoothing_strength"), &StyleBoxFlat::get_corner_smoothing_strength);
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius", "corner", "radius"), &StyleBoxFlat::set_corner_radius);
 	ClassDB::bind_method(D_METHOD("get_corner_radius", "corner"), &StyleBoxFlat::get_corner_radius);
@@ -718,6 +768,10 @@ void StyleBoxFlat::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_left", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_LEFT);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "corner_detail", PROPERTY_HINT_RANGE, "1,20,1"), "set_corner_detail", "get_corner_detail");
+	
+	ADD_GROUP("Corner Smoothing", "corner_smoothing_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "corner_smoothing_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_use_corner_smoothing", "is_corner_smoothing_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "corner_smoothing_strength", PROPERTY_HINT_RANGE, "2.0,10,0.1"), "set_corner_smoothing_strength", "get_corner_smoothing_strength");
 
 	ADD_GROUP("Expand Margins", "expand_margin_");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_left", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_expand_margin", "get_expand_margin", SIDE_LEFT);

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -310,14 +310,14 @@ inline void set_corner_scale(const Rect2 &style_rect, const Rect2 &inner_rect, c
 	}
 }
 
-void StyleBoxFlat::set_corner_radius_smoothing(float p_corner_radius_smoothing) {
+void StyleBoxFlat::set_corner_radius_smoothing(real_t p_corner_radius_smoothing) {
 	// Below corner_radius_smoothing 0.0 antialiasing and border_width break.
 	ERR_FAIL_COND_MSG(p_corner_radius_smoothing < 0.0 || p_corner_radius_smoothing > 10.0, "Corner smoothing strength must be between 0.0 and 10.0");
 	corner_radius_smoothing = CLAMP(p_corner_radius_smoothing, 0.0, 10.0);
 	emit_changed();
 }
 
-float StyleBoxFlat::get_corner_radius_smoothing() const {
+real_t StyleBoxFlat::get_corner_radius_smoothing() const {
 	return corner_radius_smoothing;
 }
 

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -455,8 +455,8 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 					}
 
 					// Modified superellipse formula to produce borders of consistent thickness.
-					x = Math::pow(Math::abs(angle_cosine), smoothing_exponent) * ring_corner_radius[corner_idx] * SIGN(angle_cosine) * ring_scale[corner_idx].x + outer_points[corner_idx].x - (xy_offset + offset_0) * SIGN(angle_cosine);
-					y = Math::pow(Math::abs(angle_sine), smoothing_exponent) * ring_corner_radius[corner_idx] * SIGN(angle_sine) * ring_scale[corner_idx].y + outer_points[corner_idx].y - (xy_offset + offset_0) * SIGN(angle_sine);
+					x = Math::pow(Math::abs(angle_cosine), smoothing_exponent) * ring_corner_radius[corner_idx] * SIGN(angle_cosine) * ring_scale[corner_idx].x + outer_points[corner_idx].x - xy_offset * SIGN(angle_cosine);
+					y = Math::pow(Math::abs(angle_sine), smoothing_exponent) * ring_corner_radius[corner_idx] * SIGN(angle_sine) * ring_scale[corner_idx].y + outer_points[corner_idx].y - xy_offset * SIGN(angle_sine);
 					// Prevents overflow artifacts.
 					x = CLAMP(x, ring_rect.position.x, ring_rect.position.x + ring_rect.size.x);
 					y = CLAMP(y, ring_rect.position.y, ring_rect.position.y + ring_rect.size.y);
@@ -710,7 +710,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 						border_color_blend, border_color, corner_detail, skew, false, corner_smoothing);
 			}
 			// Add antialiasing on the ring outer border
-			draw_rounded_rectangle(verts, indices, colors, border_style_rect.grow(corner_radius_center_offset), adapted_corner, outer_rect_aa_transparent, outer_rect_aa_colored,
+			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, outer_rect_aa_transparent, outer_rect_aa_colored,
 					border_color, border_color_alpha, corner_detail, skew, false, corner_smoothing);
 		}
 	}

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -406,7 +406,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 					real_t curve_h_offset = -0.75f;
 					real_t curve_v_offset = 0.9651982f;
 
-					exponent_adjustment = curve_height * Math::exp(-Math::pow(corner_smoothing[corner_idx] - curve_h_offset, 2.0f) / (2.0f * Math::pow(steepness, 2.0f))) + curve_v_offset;
+					exponent_adjustment = curve_height * Math::exp(-Math::pow(corner_smoothing[corner_idx] - curve_h_offset, (real_t)2.0f) / ((real_t)2.0f * Math::pow(steepness, (real_t)2.0f))) + curve_v_offset;
 				}
 
 				// Modified smoothing exponent to draw outer border points.
@@ -421,7 +421,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 					real_t curve_h_offset = -0.3645290f;
 					real_t curve_v_offset = 0.0374931f;
 
-					xy_ring_offset = curve_height / (1.0f + Math::exp(-steepness * (corner_smoothing[corner_idx] - curve_h_offset))) + curve_v_offset;
+					xy_ring_offset = curve_height / ((real_t)1.0f + Math::exp(-steepness * (corner_smoothing[corner_idx] - curve_h_offset))) + curve_v_offset;
 				}
 			}
 		}

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -310,20 +310,36 @@ inline void set_corner_scale(const Rect2 &style_rect, const Rect2 &inner_rect, c
 	}
 }
 
-void StyleBoxFlat::set_corner_radius_smoothing(real_t p_corner_radius_smoothing) {
-	// Below corner_radius_smoothing 0.0 antialiasing and border_width break.
-	ERR_FAIL_COND_MSG(p_corner_radius_smoothing < 0.0 || p_corner_radius_smoothing > 10.0, "Corner smoothing strength must be between 0.0 and 10.0");
-	corner_radius_smoothing = CLAMP(p_corner_radius_smoothing, 0.0, 10.0);
+void StyleBoxFlat::set_corner_radius_smoothing_all(real_t smoothing) {
+	for (int i = 0; i < 4; i++) {
+		corner_radius_smoothing[i] = smoothing;
+	}
+
 	emit_changed();
 }
 
-real_t StyleBoxFlat::get_corner_radius_smoothing() const {
-	return corner_radius_smoothing;
+void StyleBoxFlat::set_corner_radius_smoothing_individual(const real_t smoothing_top_left, const real_t smoothing_top_right, const real_t smoothing_bottom_right, const real_t smoothing_bottom_left) {
+	corner_radius_smoothing[0] = smoothing_top_left;
+	corner_radius_smoothing[1] = smoothing_top_right;
+	corner_radius_smoothing[2] = smoothing_bottom_right;
+	corner_radius_smoothing[3] = smoothing_bottom_left;
+
+	emit_changed();
+}
+
+void StyleBoxFlat::set_corner_radius_smoothing(const Corner p_corner, real_t p_corner_radius_smoothing) {
+	corner_radius_smoothing[p_corner] = p_corner_radius_smoothing;
+	emit_changed();
+}
+
+real_t StyleBoxFlat::get_corner_radius_smoothing(const Corner p_corner) const {
+	ERR_FAIL_INDEX_V((int)p_corner, 4, 0);
+	return corner_radius_smoothing[p_corner];
 }
 
 inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color> &colors, const Rect2 &style_rect, const real_t corner_radius[4],
 		const Rect2 &ring_rect, const Rect2 &inner_rect, const Color &inner_color, const Color &outer_color, const int corner_detail, const Vector2 &skew,
-		bool is_filled = false, const real_t corner_radius_smoothing = 0.0) {
+		bool is_filled = false, const real_t corner_radius_smoothing[4] = {}) {
 	int vert_offset = verts.size();
 	int adapted_corner_detail = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0) ? corner_detail : 1;
 
@@ -373,6 +389,15 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 	Vector2 *verts_ptr = verts.ptrw();
 
 	for (int corner_idx = 0; corner_idx < 4; corner_idx++) {
+		// Corner smoothing formula is adapted from CSS documentation: https://developer.mozilla.org/en-US/docs/Web/CSS/superellipse.
+		// Corner smoothing strength of 0.0 produces straight line corners.
+		// Corner smoothing strength of 1.0 produces ordinary corner rounding.
+		// Corner smoothing strength of 2.0 produces a squircle.
+		// Corner smoothing strength values > 10.0 produce shapes similar to a square.
+
+		const bool use_smoothing = (!Math::is_equal_approx(corner_radius_smoothing[corner_idx], (real_t)1.0f) && corner_radius[corner_idx] > (real_t)0.0f);
+		real_t smoothing_exponent = use_smoothing ? (real_t)2.0f / Math::pow((real_t)2.0f, corner_radius_smoothing[corner_idx]) : (real_t)1.0f;
+
 		for (int detail = 0; detail <= adapted_corner_detail; detail++) {
 			int idx_ofs = (adapted_corner_detail + 1) * corner_idx + detail;
 			if (draw_border) {
@@ -384,19 +409,12 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			const real_t angle_sine = Math::sin(pt_angle);
 
 			real_t x, y;
-			// Corner smoothing formula is adapted from CSS documentation: https://developer.mozilla.org/en-US/docs/Web/CSS/superellipse.
-			// Corner smoothing strength of 0.0 produces straight line corners.
-			// Corner smoothing strength of 1.0 produces ordinary corner rounding.
-			// Corner smoothing strength of 2.0 produces a squircle.
-			// Corner smoothing strength values > 10.0 produce shapes indistinguishable from a square.
-			real_t smoothing_exponent = (real_t)2.0f / Math::pow((real_t)2.0f, corner_radius_smoothing);
-			if (!Math::is_equal_approx(corner_radius_smoothing, (real_t)1.0f)) {
-				real_t cos_abs = Math::abs(angle_cosine);
-				real_t sin_abs = Math::abs(angle_sine);
-				real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
-				real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
-				x = inner_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, smoothing_exponent) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
-				y = inner_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, smoothing_exponent) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
+			if (use_smoothing) {
+				x = Math::pow(Math::abs(angle_cosine), smoothing_exponent) * inner_corner_radius[corner_idx] * SIGN(angle_cosine) * inner_scale[corner_idx].x + inner_points[corner_idx].x;
+				y = Math::pow(Math::abs(angle_sine), smoothing_exponent) * inner_corner_radius[corner_idx] * SIGN(angle_sine) * inner_scale[corner_idx].y + inner_points[corner_idx].y;
+				// Prevents overflow artifacts.
+				x = CLAMP(x, inner_rect.position.x, inner_rect.position.x + inner_rect.size.x);
+				y = CLAMP(y, inner_rect.position.y, inner_rect.position.y + inner_rect.size.y);
 			} else {
 				x = inner_corner_radius[corner_idx] * angle_cosine * inner_scale[corner_idx].x + inner_points[corner_idx].x;
 				y = inner_corner_radius[corner_idx] * angle_sine * inner_scale[corner_idx].y + inner_points[corner_idx].y;
@@ -408,13 +426,41 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			colors_ptr[colors_size + idx_ofs] = inner_color;
 
 			if (draw_border) {
-				if (!Math::is_equal_approx(corner_radius_smoothing, (real_t)1.0f)) {
-					real_t cos_abs = Math::abs(angle_cosine);
-					real_t sin_abs = Math::abs(angle_sine);
-					real_t cos_sign = angle_cosine >= 0 ? 1.0f : -1.0f;
-					real_t sin_sign = angle_sine >= 0 ? 1.0f : -1.0f;
-					x = ring_corner_radius[corner_idx] * cos_sign * Math::pow(cos_abs, smoothing_exponent) * ring_scale[corner_idx].x + outer_points[corner_idx].x;
-					y = ring_corner_radius[corner_idx] * sin_sign * Math::pow(sin_abs, smoothing_exponent) * ring_scale[corner_idx].y + outer_points[corner_idx].y;
+				if (use_smoothing) {
+					// Adjusts outer border curvature.
+					real_t exponent_adjustment = 1.0f;
+					if (corner_radius_smoothing[corner_idx] < 1.0f) {
+						// The values below are fitted to a Gaussian bump.
+						real_t curve_height = 0.1889992f;
+						real_t steepness = 0.9610043f;
+						real_t curve_h_offset = -0.75f;
+						real_t curve_v_offset = 0.9651982f;
+
+						exponent_adjustment = curve_height * Math::exp(-Math::pow(corner_radius_smoothing[corner_idx] - curve_h_offset, 2.0f) / (2.0f * Math::pow(steepness, 2.0f))) + curve_v_offset;
+					}
+
+					// Modified smoothing exponent to draw outer border points.
+					real_t smoothing_exponent = (real_t)2.0f / Math::pow((real_t)2.0f, corner_radius_smoothing[corner_idx] * exponent_adjustment);
+
+					// Moves points towards the nearest corner and makes corner border appear thicker or thinner.
+					real_t xy_offset = 0.0f;
+					if (corner_radius_smoothing[corner_idx] < 1.0f) {
+						// The values below are fitted to a Sigmoid.
+						real_t curve_height = -3.0821111f;
+						real_t steepness = -3.3522981f;
+						real_t curve_h_offset = -0.3645290f;
+						real_t curve_v_offset = 0.0374931f;
+
+						xy_offset = curve_height / (1.0f + Math::exp(-steepness * (corner_radius_smoothing[corner_idx] - curve_h_offset))) + curve_v_offset;
+					}
+
+					// Modified superellipse formula to produce borders of consistent thickness.
+					x = Math::pow(Math::abs(angle_cosine), smoothing_exponent) * ring_corner_radius[corner_idx] * SIGN(angle_cosine) * ring_scale[corner_idx].x + outer_points[corner_idx].x - (xy_offset + offset_0) * SIGN(angle_cosine);
+					y = Math::pow(Math::abs(angle_sine), smoothing_exponent) * ring_corner_radius[corner_idx] * SIGN(angle_sine) * ring_scale[corner_idx].y + outer_points[corner_idx].y - (xy_offset + offset_0) * SIGN(angle_sine);
+					// Prevents overflow artifacts.
+					x = CLAMP(x, ring_rect.position.x, ring_rect.position.x + ring_rect.size.x);
+					y = CLAMP(y, ring_rect.position.y, ring_rect.position.y + ring_rect.size.y);
+
 				} else {
 					x = ring_corner_radius[corner_idx] * angle_cosine * ring_scale[corner_idx].x + outer_points[corner_idx].x;
 					y = ring_corner_radius[corner_idx] * angle_sine * ring_scale[corner_idx].y + outer_points[corner_idx].y;
@@ -502,6 +548,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	}
 
 	const bool rounded_corners = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0);
+	const bool use_smoothing = rounded_corners && (!Math::is_equal_approx(corner_radius_smoothing[0], (real_t)1.0f) || !Math::is_equal_approx(corner_radius_smoothing[1], (real_t)1.0f) || !Math::is_equal_approx(corner_radius_smoothing[2], (real_t)1.0f) || !Math::is_equal_approx(corner_radius_smoothing[3], (real_t)1.0f));
 	// Only enable antialiasing if it is actually needed. This improves performance
 	// and maximizes sharpness for non-skewed StyleBoxes with sharp corners.
 	const bool aa_on = (rounded_corners || !skew.is_zero_approx()) && anti_aliased;
@@ -574,21 +621,21 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 				shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew, false, corner_radius_smoothing);
 
 		if (draw_center) {
-			draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,
-					shadow_inner_rect, shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true, corner_radius_smoothing);
+			draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner, shadow_inner_rect,
+					shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true, corner_radius_smoothing);
 		}
 	}
 
 	// Create border (no AA).
 	if (draw_border && !aa_on) {
-		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-				border_style_rect, infill_rect, border_color_inner, border_color, corner_detail, skew, false, corner_radius_smoothing);
+		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, border_style_rect, infill_rect,
+				border_color_inner, border_color, corner_detail, skew, false, corner_radius_smoothing);
 	}
 
 	// Create infill (no AA).
 	if (draw_center && (!aa_on || blend_on)) {
-		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-				infill_rect, infill_rect, bg_color, bg_color, corner_detail, skew, true, corner_radius_smoothing);
+		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, border_style_rect, infill_rect,
+				bg_color, bg_color, corner_detail, skew, true, corner_radius_smoothing);
 	}
 
 	if (aa_on) {
@@ -629,14 +676,14 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 					-aa_fill_width[SIDE_RIGHT], -aa_fill_width[SIDE_BOTTOM]);
 			if (!blend_on) {
 				// Create center fill, not antialiased yet
-				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						infill_rect_aa_colored, infill_rect_aa_colored, bg_color, bg_color, corner_detail, skew, true, corner_radius_smoothing);
+				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, infill_rect_aa_colored, infill_rect_aa_colored,
+						bg_color, bg_color, corner_detail, skew, true, corner_radius_smoothing);
 			}
 			if (!blend_on || !draw_border) {
 				Color alpha_bg = Color(bg_color.r, bg_color.g, bg_color.b, 0);
 				// Add antialiasing on the center fill
-				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						infill_rect_aa_transparent, infill_rect_aa_colored, bg_color, alpha_bg, corner_detail, skew, false, corner_radius_smoothing);
+				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, infill_rect_aa_transparent, infill_rect_aa_colored,
+						bg_color, alpha_bg, corner_detail, skew, false, corner_radius_smoothing);
 			}
 		}
 
@@ -655,16 +702,16 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 					aa_border_width_half[SIDE_RIGHT], aa_border_width_half[SIDE_BOTTOM]);
 
 			// Create border ring, not antialiased yet
-			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-					outer_rect_aa_colored, ((blend_on) ? infill_rect : inner_rect_aa_colored), border_color_inner, border_color, corner_detail, skew, false, corner_radius_smoothing);
+			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, outer_rect_aa_colored, blend_on ? infill_rect : inner_rect_aa_colored,
+					border_color_inner, border_color, corner_detail, skew, false, corner_radius_smoothing);
 			if (!blend_on) {
 				// Add antialiasing on the ring inner border
-				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						inner_rect_aa_colored, inner_rect_aa_transparent, border_color_blend, border_color, corner_detail, skew, false, corner_radius_smoothing);
+				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, inner_rect_aa_colored, inner_rect_aa_transparent,
+						border_color_blend, border_color, corner_detail, skew, false, corner_radius_smoothing);
 			}
 			// Add antialiasing on the ring outer border
-			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-					outer_rect_aa_transparent, outer_rect_aa_colored, border_color, border_color_alpha, corner_detail, skew, false, corner_radius_smoothing);
+			draw_rounded_rectangle(verts, indices, colors, border_style_rect.grow(corner_radius_center_offset), adapted_corner, outer_rect_aa_transparent, outer_rect_aa_colored,
+					border_color, border_color_alpha, corner_detail, skew, false, corner_radius_smoothing);
 		}
 	}
 
@@ -700,8 +747,9 @@ void StyleBoxFlat::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius_all", "radius"), &StyleBoxFlat::set_corner_radius_all);
 
-	ClassDB::bind_method(D_METHOD("set_corner_radius_smoothing", "corner_radius_smoothing"), &StyleBoxFlat::set_corner_radius_smoothing);
-	ClassDB::bind_method(D_METHOD("get_corner_radius_smoothing"), &StyleBoxFlat::get_corner_radius_smoothing);
+	ClassDB::bind_method(D_METHOD("set_corner_radius_smoothing_all", "smoothing"), &StyleBoxFlat::set_corner_radius_smoothing_all);
+	ClassDB::bind_method(D_METHOD("set_corner_radius_smoothing", "corner", "smoothing"), &StyleBoxFlat::set_corner_radius_smoothing);
+	ClassDB::bind_method(D_METHOD("get_corner_radius_smoothing", "corner"), &StyleBoxFlat::get_corner_radius_smoothing);
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius", "corner", "radius"), &StyleBoxFlat::set_corner_radius);
 	ClassDB::bind_method(D_METHOD("get_corner_radius", "corner"), &StyleBoxFlat::get_corner_radius);
@@ -750,12 +798,18 @@ void StyleBoxFlat::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "border_blend"), "set_border_blend", "get_border_blend");
 
-	ADD_GROUP("Corner Radius", "corner_radius_");
+	ADD_GROUP("Corners", "corner_");
+	ADD_SUBGROUP("Radius", "corner_radius_");
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_top_left", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_TOP_LEFT);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_top_right", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_TOP_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_right", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_left", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_LEFT);
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing", PROPERTY_HINT_RANGE, "0.0,10,0.1"), "set_corner_radius_smoothing", "get_corner_radius_smoothing");
+
+	ADD_SUBGROUP("Smoothing", "corner_radius_smoothing");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing_top_left", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_radius_smoothing", "get_corner_radius_smoothing", CORNER_TOP_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing_top_right", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_radius_smoothing", "get_corner_radius_smoothing", CORNER_TOP_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing_bottom_right", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_radius_smoothing", "get_corner_radius_smoothing", CORNER_BOTTOM_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing_bottom_left", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_radius_smoothing", "get_corner_radius_smoothing", CORNER_BOTTOM_LEFT);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "corner_detail", PROPERTY_HINT_RANGE, "1,20,1"), "set_corner_detail", "get_corner_detail");
 

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -390,8 +390,9 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 
 	for (int corner_idx = 0; corner_idx < 4; corner_idx++) {
 		const bool use_smoothing = (!Math::is_equal_approx(corner_smoothing[corner_idx], (real_t)1.0f) && corner_radius[corner_idx] > (real_t)0.0f);
-		real_t smoothing_exponent_inner, smoothing_exponent_outer;
-		real_t xy_ring_offset;
+		real_t smoothing_exponent_inner = 1.0f;
+		real_t smoothing_exponent_outer = 1.0f;
+		real_t xy_ring_offset = 0.0f;
 
 		if (use_smoothing) {
 			smoothing_exponent_inner = (real_t)2.0f / Math::pow((real_t)2.0f, corner_smoothing[corner_idx]);

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -310,36 +310,36 @@ inline void set_corner_scale(const Rect2 &style_rect, const Rect2 &inner_rect, c
 	}
 }
 
-void StyleBoxFlat::set_corner_radius_smoothing_all(real_t smoothing) {
+void StyleBoxFlat::set_corner_smoothing_all(real_t smoothing) {
 	for (int i = 0; i < 4; i++) {
-		corner_radius_smoothing[i] = smoothing;
+		corner_smoothing[i] = smoothing;
 	}
 
 	emit_changed();
 }
 
-void StyleBoxFlat::set_corner_radius_smoothing_individual(const real_t smoothing_top_left, const real_t smoothing_top_right, const real_t smoothing_bottom_right, const real_t smoothing_bottom_left) {
-	corner_radius_smoothing[0] = smoothing_top_left;
-	corner_radius_smoothing[1] = smoothing_top_right;
-	corner_radius_smoothing[2] = smoothing_bottom_right;
-	corner_radius_smoothing[3] = smoothing_bottom_left;
+void StyleBoxFlat::set_corner_smoothing_individual(const real_t smoothing_top_left, const real_t smoothing_top_right, const real_t smoothing_bottom_right, const real_t smoothing_bottom_left) {
+	corner_smoothing[0] = smoothing_top_left;
+	corner_smoothing[1] = smoothing_top_right;
+	corner_smoothing[2] = smoothing_bottom_right;
+	corner_smoothing[3] = smoothing_bottom_left;
 
 	emit_changed();
 }
 
-void StyleBoxFlat::set_corner_radius_smoothing(const Corner p_corner, real_t p_corner_radius_smoothing) {
-	corner_radius_smoothing[p_corner] = p_corner_radius_smoothing;
+void StyleBoxFlat::set_corner_smoothing(const Corner p_corner, real_t p_corner_smoothing) {
+	corner_smoothing[p_corner] = p_corner_smoothing;
 	emit_changed();
 }
 
-real_t StyleBoxFlat::get_corner_radius_smoothing(const Corner p_corner) const {
+real_t StyleBoxFlat::get_corner_smoothing(const Corner p_corner) const {
 	ERR_FAIL_INDEX_V((int)p_corner, 4, 0);
-	return corner_radius_smoothing[p_corner];
+	return corner_smoothing[p_corner];
 }
 
 inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color> &colors, const Rect2 &style_rect, const real_t corner_radius[4],
 		const Rect2 &ring_rect, const Rect2 &inner_rect, const Color &inner_color, const Color &outer_color, const int corner_detail, const Vector2 &skew,
-		bool is_filled = false, const real_t corner_radius_smoothing[4] = {}) {
+		bool is_filled = false, const real_t corner_smoothing[4] = {}) {
 	int vert_offset = verts.size();
 	int adapted_corner_detail = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0) ? corner_detail : 1;
 
@@ -395,8 +395,8 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 		// Corner smoothing strength of 2.0 produces a squircle.
 		// Corner smoothing strength values > 10.0 produce shapes similar to a square.
 
-		const bool use_smoothing = (!Math::is_equal_approx(corner_radius_smoothing[corner_idx], (real_t)1.0f) && corner_radius[corner_idx] > (real_t)0.0f);
-		real_t smoothing_exponent = use_smoothing ? (real_t)2.0f / Math::pow((real_t)2.0f, corner_radius_smoothing[corner_idx]) : (real_t)1.0f;
+		const bool use_smoothing = (!Math::is_equal_approx(corner_smoothing[corner_idx], (real_t)1.0f) && corner_radius[corner_idx] > (real_t)0.0f);
+		real_t smoothing_exponent = use_smoothing ? (real_t)2.0f / Math::pow((real_t)2.0f, corner_smoothing[corner_idx]) : (real_t)1.0f;
 
 		for (int detail = 0; detail <= adapted_corner_detail; detail++) {
 			int idx_ofs = (adapted_corner_detail + 1) * corner_idx + detail;
@@ -429,29 +429,29 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 				if (use_smoothing) {
 					// Adjusts outer border curvature.
 					real_t exponent_adjustment = 1.0f;
-					if (corner_radius_smoothing[corner_idx] < 1.0f) {
+					if (corner_smoothing[corner_idx] < 1.0f) {
 						// The values below are fitted to a Gaussian bump.
 						real_t curve_height = 0.1889992f;
 						real_t steepness = 0.9610043f;
 						real_t curve_h_offset = -0.75f;
 						real_t curve_v_offset = 0.9651982f;
 
-						exponent_adjustment = curve_height * Math::exp(-Math::pow(corner_radius_smoothing[corner_idx] - curve_h_offset, 2.0f) / (2.0f * Math::pow(steepness, 2.0f))) + curve_v_offset;
+						exponent_adjustment = curve_height * Math::exp(-Math::pow(corner_smoothing[corner_idx] - curve_h_offset, 2.0f) / (2.0f * Math::pow(steepness, 2.0f))) + curve_v_offset;
 					}
 
 					// Modified smoothing exponent to draw outer border points.
-					real_t smoothing_exponent = (real_t)2.0f / Math::pow((real_t)2.0f, corner_radius_smoothing[corner_idx] * exponent_adjustment);
+					real_t smoothing_exponent = (real_t)2.0f / Math::pow((real_t)2.0f, corner_smoothing[corner_idx] * exponent_adjustment);
 
 					// Moves points towards the nearest corner and makes corner border appear thicker or thinner.
 					real_t xy_offset = 0.0f;
-					if (corner_radius_smoothing[corner_idx] < 1.0f) {
+					if (corner_smoothing[corner_idx] < 1.0f) {
 						// The values below are fitted to a Sigmoid.
 						real_t curve_height = -3.0821111f;
 						real_t steepness = -3.3522981f;
 						real_t curve_h_offset = -0.3645290f;
 						real_t curve_v_offset = 0.0374931f;
 
-						xy_offset = curve_height / (1.0f + Math::exp(-steepness * (corner_radius_smoothing[corner_idx] - curve_h_offset))) + curve_v_offset;
+						xy_offset = curve_height / (1.0f + Math::exp(-steepness * (corner_smoothing[corner_idx] - curve_h_offset))) + curve_v_offset;
 					}
 
 					// Modified superellipse formula to produce borders of consistent thickness.
@@ -548,7 +548,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	}
 
 	const bool rounded_corners = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0);
-	const bool use_smoothing = rounded_corners && (!Math::is_equal_approx(corner_radius_smoothing[0], (real_t)1.0f) || !Math::is_equal_approx(corner_radius_smoothing[1], (real_t)1.0f) || !Math::is_equal_approx(corner_radius_smoothing[2], (real_t)1.0f) || !Math::is_equal_approx(corner_radius_smoothing[3], (real_t)1.0f));
+	const bool use_smoothing = rounded_corners && (!Math::is_equal_approx(corner_smoothing[0], (real_t)1.0f) || !Math::is_equal_approx(corner_smoothing[1], (real_t)1.0f) || !Math::is_equal_approx(corner_smoothing[2], (real_t)1.0f) || !Math::is_equal_approx(corner_smoothing[3], (real_t)1.0f));
 	// Only enable antialiasing if it is actually needed. This improves performance
 	// and maximizes sharpness for non-skewed StyleBoxes with sharp corners.
 	const bool aa_on = (rounded_corners || !skew.is_zero_approx()) && anti_aliased;
@@ -618,24 +618,24 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 		Color shadow_color_transparent = Color(shadow_color.r, shadow_color.g, shadow_color.b, 0);
 
 		draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner, shadow_rect,
-				shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew, false, corner_radius_smoothing);
+				shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew, false, corner_smoothing);
 
 		if (draw_center) {
 			draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner, shadow_inner_rect,
-					shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true, corner_radius_smoothing);
+					shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true, corner_smoothing);
 		}
 	}
 
 	// Create border (no AA).
 	if (draw_border && !aa_on) {
 		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, border_style_rect, infill_rect,
-				border_color_inner, border_color, corner_detail, skew, false, corner_radius_smoothing);
+				border_color_inner, border_color, corner_detail, skew, false, corner_smoothing);
 	}
 
 	// Create infill (no AA).
 	if (draw_center && (!aa_on || blend_on)) {
 		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, border_style_rect, infill_rect,
-				bg_color, bg_color, corner_detail, skew, true, corner_radius_smoothing);
+				bg_color, bg_color, corner_detail, skew, true, corner_smoothing);
 	}
 
 	if (aa_on) {
@@ -677,13 +677,13 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 			if (!blend_on) {
 				// Create center fill, not antialiased yet
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, infill_rect_aa_colored, infill_rect_aa_colored,
-						bg_color, bg_color, corner_detail, skew, true, corner_radius_smoothing);
+						bg_color, bg_color, corner_detail, skew, true, corner_smoothing);
 			}
 			if (!blend_on || !draw_border) {
 				Color alpha_bg = Color(bg_color.r, bg_color.g, bg_color.b, 0);
 				// Add antialiasing on the center fill
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, infill_rect_aa_transparent, infill_rect_aa_colored,
-						bg_color, alpha_bg, corner_detail, skew, false, corner_radius_smoothing);
+						bg_color, alpha_bg, corner_detail, skew, false, corner_smoothing);
 			}
 		}
 
@@ -703,15 +703,15 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 			// Create border ring, not antialiased yet
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, outer_rect_aa_colored, blend_on ? infill_rect : inner_rect_aa_colored,
-					border_color_inner, border_color, corner_detail, skew, false, corner_radius_smoothing);
+					border_color_inner, border_color, corner_detail, skew, false, corner_smoothing);
 			if (!blend_on) {
 				// Add antialiasing on the ring inner border
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner, inner_rect_aa_colored, inner_rect_aa_transparent,
-						border_color_blend, border_color, corner_detail, skew, false, corner_radius_smoothing);
+						border_color_blend, border_color, corner_detail, skew, false, corner_smoothing);
 			}
 			// Add antialiasing on the ring outer border
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect.grow(corner_radius_center_offset), adapted_corner, outer_rect_aa_transparent, outer_rect_aa_colored,
-					border_color, border_color_alpha, corner_detail, skew, false, corner_radius_smoothing);
+					border_color, border_color_alpha, corner_detail, skew, false, corner_smoothing);
 		}
 	}
 
@@ -747,9 +747,9 @@ void StyleBoxFlat::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius_all", "radius"), &StyleBoxFlat::set_corner_radius_all);
 
-	ClassDB::bind_method(D_METHOD("set_corner_radius_smoothing_all", "smoothing"), &StyleBoxFlat::set_corner_radius_smoothing_all);
-	ClassDB::bind_method(D_METHOD("set_corner_radius_smoothing", "corner", "smoothing"), &StyleBoxFlat::set_corner_radius_smoothing);
-	ClassDB::bind_method(D_METHOD("get_corner_radius_smoothing", "corner"), &StyleBoxFlat::get_corner_radius_smoothing);
+	ClassDB::bind_method(D_METHOD("set_corner_smoothing_all", "smoothing"), &StyleBoxFlat::set_corner_smoothing_all);
+	ClassDB::bind_method(D_METHOD("set_corner_smoothing", "corner", "smoothing"), &StyleBoxFlat::set_corner_smoothing);
+	ClassDB::bind_method(D_METHOD("get_corner_smoothing", "corner"), &StyleBoxFlat::get_corner_smoothing);
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius", "corner", "radius"), &StyleBoxFlat::set_corner_radius);
 	ClassDB::bind_method(D_METHOD("get_corner_radius", "corner"), &StyleBoxFlat::get_corner_radius);
@@ -805,11 +805,11 @@ void StyleBoxFlat::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_right", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_left", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_LEFT);
 
-	ADD_SUBGROUP("Smoothing", "corner_radius_smoothing");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing_top_left", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_radius_smoothing", "get_corner_radius_smoothing", CORNER_TOP_LEFT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing_top_right", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_radius_smoothing", "get_corner_radius_smoothing", CORNER_TOP_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing_bottom_right", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_radius_smoothing", "get_corner_radius_smoothing", CORNER_BOTTOM_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_radius_smoothing_bottom_left", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_radius_smoothing", "get_corner_radius_smoothing", CORNER_BOTTOM_LEFT);
+	ADD_SUBGROUP("Smoothing", "corner_smoothing");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_smoothing_top_left", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_smoothing", "get_corner_smoothing", CORNER_TOP_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_smoothing_top_right", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_smoothing", "get_corner_smoothing", CORNER_TOP_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_smoothing_bottom_right", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_smoothing", "get_corner_smoothing", CORNER_BOTTOM_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "corner_smoothing_bottom_left", PROPERTY_HINT_RANGE, "-4.0,10,0.1,or_less,or_greater"), "set_corner_smoothing", "get_corner_smoothing", CORNER_BOTTOM_LEFT);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "corner_detail", PROPERTY_HINT_RANGE, "1,20,1"), "set_corner_detail", "get_corner_detail");
 

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -440,7 +440,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 					}
 
 					// Modified smoothing exponent to draw outer border points.
-					real_t smoothing_exponent = (real_t)2.0f / Math::pow((real_t)2.0f, corner_smoothing[corner_idx] * exponent_adjustment);
+					smoothing_exponent = (real_t)2.0f / Math::pow((real_t)2.0f, corner_smoothing[corner_idx] * exponent_adjustment);
 
 					// Moves points towards the nearest corner and makes corner border appear thicker or thinner.
 					real_t xy_offset = 0.0f;
@@ -548,7 +548,6 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	}
 
 	const bool rounded_corners = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0);
-	const bool use_smoothing = rounded_corners && (!Math::is_equal_approx(corner_smoothing[0], (real_t)1.0f) || !Math::is_equal_approx(corner_smoothing[1], (real_t)1.0f) || !Math::is_equal_approx(corner_smoothing[2], (real_t)1.0f) || !Math::is_equal_approx(corner_smoothing[3], (real_t)1.0f));
 	// Only enable antialiasing if it is actually needed. This improves performance
 	// and maximizes sharpness for non-skewed StyleBoxes with sharp corners.
 	const bool aa_on = (rounded_corners || !skew.is_zero_approx()) && anti_aliased;

--- a/scene/resources/style_box_flat.h
+++ b/scene/resources/style_box_flat.h
@@ -43,6 +43,9 @@ class StyleBoxFlat : public StyleBox {
 	real_t expand_margin[4] = {};
 	real_t corner_radius[4] = {};
 
+	bool corner_smoothing_enabled = false;
+	real_t corner_smoothing_strength = 0.0;
+
 	bool draw_center = true;
 	bool blend_border = false;
 	Vector2 skew;
@@ -78,6 +81,12 @@ public:
 	void set_corner_radius_individual(const int radius_top_left, const int radius_top_right, const int radius_bottom_right, const int radius_bottom_left);
 	void set_corner_radius(Corner p_corner, const int radius);
 	int get_corner_radius(Corner p_corner) const;
+
+	void set_use_corner_smoothing(bool p_corner_smoothing_enabled);
+	bool is_corner_smoothing_enabled() const;
+
+	void set_corner_smoothing_strength(real_t p_corner_smoothing_strength);
+	real_t get_corner_smoothing_strength() const;
 
 	void set_corner_detail(const int &p_corner_detail);
 	int get_corner_detail() const;

--- a/scene/resources/style_box_flat.h
+++ b/scene/resources/style_box_flat.h
@@ -42,9 +42,7 @@ class StyleBoxFlat : public StyleBox {
 	real_t border_width[4] = {};
 	real_t expand_margin[4] = {};
 	real_t corner_radius[4] = {};
-
-	bool corner_smoothing_enabled = false;
-	real_t corner_smoothing_strength = 0.0;
+	real_t corner_radius_smoothing = 0.0;
 
 	bool draw_center = true;
 	bool blend_border = false;
@@ -81,9 +79,6 @@ public:
 	void set_corner_radius_individual(const int radius_top_left, const int radius_top_right, const int radius_bottom_right, const int radius_bottom_left);
 	void set_corner_radius(Corner p_corner, const int radius);
 	int get_corner_radius(Corner p_corner) const;
-
-	void set_use_corner_smoothing(bool p_corner_smoothing_enabled);
-	bool is_corner_smoothing_enabled() const;
 
 	void set_corner_smoothing_strength(real_t p_corner_smoothing_strength);
 	real_t get_corner_smoothing_strength() const;

--- a/scene/resources/style_box_flat.h
+++ b/scene/resources/style_box_flat.h
@@ -42,7 +42,7 @@ class StyleBoxFlat : public StyleBox {
 	real_t border_width[4] = {};
 	real_t expand_margin[4] = {};
 	real_t corner_radius[4] = {};
-	real_t corner_radius_smoothing = 0.0;
+	real_t corner_radius_smoothing = 1.0;
 
 	bool draw_center = true;
 	bool blend_border = false;

--- a/scene/resources/style_box_flat.h
+++ b/scene/resources/style_box_flat.h
@@ -80,8 +80,8 @@ public:
 	void set_corner_radius(Corner p_corner, const int radius);
 	int get_corner_radius(Corner p_corner) const;
 
-	void set_corner_smoothing_strength(real_t p_corner_smoothing_strength);
-	real_t get_corner_smoothing_strength() const;
+	void set_corner_radius_smoothing(real_t p_corner_radius_smoothing);
+	real_t get_corner_radius_smoothing() const;
 
 	void set_corner_detail(const int &p_corner_detail);
 	int get_corner_detail() const;

--- a/scene/resources/style_box_flat.h
+++ b/scene/resources/style_box_flat.h
@@ -42,7 +42,7 @@ class StyleBoxFlat : public StyleBox {
 	real_t border_width[4] = {};
 	real_t expand_margin[4] = {};
 	real_t corner_radius[4] = {};
-	real_t corner_radius_smoothing = 1.0;
+	real_t corner_radius_smoothing[4] = { (real_t)1.0f, (real_t)1.0f, (real_t)1.0f, (real_t)1.0f };
 
 	bool draw_center = true;
 	bool blend_border = false;
@@ -80,8 +80,10 @@ public:
 	void set_corner_radius(Corner p_corner, const int radius);
 	int get_corner_radius(Corner p_corner) const;
 
-	void set_corner_radius_smoothing(real_t p_corner_radius_smoothing);
-	real_t get_corner_radius_smoothing() const;
+	void set_corner_radius_smoothing_all(real_t smoothing);
+	void set_corner_radius_smoothing_individual(const real_t smoothing_top_left, const real_t smoothing_top_right, const real_t smoothing_bottom_right, const real_t smoothing_bottom_left);
+	void set_corner_radius_smoothing(Corner p_corner, const real_t p_corner_radius_smoothing);
+	real_t get_corner_radius_smoothing(Corner p_corner) const;
 
 	void set_corner_detail(const int &p_corner_detail);
 	int get_corner_detail() const;

--- a/scene/resources/style_box_flat.h
+++ b/scene/resources/style_box_flat.h
@@ -42,7 +42,7 @@ class StyleBoxFlat : public StyleBox {
 	real_t border_width[4] = {};
 	real_t expand_margin[4] = {};
 	real_t corner_radius[4] = {};
-	real_t corner_radius_smoothing[4] = { (real_t)1.0f, (real_t)1.0f, (real_t)1.0f, (real_t)1.0f };
+	real_t corner_smoothing[4] = { (real_t)1.0f, (real_t)1.0f, (real_t)1.0f, (real_t)1.0f };
 
 	bool draw_center = true;
 	bool blend_border = false;
@@ -80,10 +80,10 @@ public:
 	void set_corner_radius(Corner p_corner, const int radius);
 	int get_corner_radius(Corner p_corner) const;
 
-	void set_corner_radius_smoothing_all(real_t smoothing);
-	void set_corner_radius_smoothing_individual(const real_t smoothing_top_left, const real_t smoothing_top_right, const real_t smoothing_bottom_right, const real_t smoothing_bottom_left);
-	void set_corner_radius_smoothing(Corner p_corner, const real_t p_corner_radius_smoothing);
-	real_t get_corner_radius_smoothing(Corner p_corner) const;
+	void set_corner_smoothing_all(real_t smoothing);
+	void set_corner_smoothing_individual(const real_t smoothing_top_left, const real_t smoothing_top_right, const real_t smoothing_bottom_right, const real_t smoothing_bottom_left);
+	void set_corner_smoothing(Corner p_corner, const real_t p_corner_smoothing);
+	real_t get_corner_smoothing(Corner p_corner) const;
 
 	void set_corner_detail(const int &p_corner_detail);
 	int get_corner_detail() const;


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/13353.

This PR adds squircle/superellipse rounding with two parameters: `corner_smoothing_enabled` and `corner_smoothing_strength`. I'm not sure if it's better to omit `corner_smoothing_enabled` and just do corner smoothing when `corner_smoothing_strength` > 0.