### PR TITLE
Remove unused `Window::debugger_stop_shortcut`

### DIFF
--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -254,8 +254,6 @@ private:
 
 	void _update_displayed_title();
 
-	Ref<Shortcut> debugger_stop_shortcut;
-
 	static int root_layout_direction;
 
 protected:


### PR DESCRIPTION
Corresponding code was removed in https://github.com/godotengine/godot/pull/98891