### PR TITLE
Fix 2D builds (again)

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -34,6 +34,8 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/dir_access.h"
 #include "core/io/marshalls.h"
+#include "core/io/resource_loader.h"
+#include "core/io/resource_saver.h"
 #include "core/math/math_fieldwise.h"
 #include "core/object/script_language.h"
 #include "core/os/time.h"


### PR DESCRIPTION
Given the repeated broken builds on either debug or 2D disabled or both I think anyone doing major reworks of include hierarchy etc. should definitely do due diligence and compile 2D only templates to make sure this doesn't happen, again

Regression from:
* https://github.com/godotengine/godot/pull/111405

Other recent cases:
* https://github.com/godotengine/godot/pull/111242
* https://github.com/godotengine/godot/pull/111368
* https://github.com/godotengine/godot/pull/110892

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
