### PR TITLE
Remove raw base pointer from `GDScript`

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -93,7 +93,6 @@ class GDScript : public Script {
 
 	Ref<GDScriptNativeClass> native;
 	Ref<GDScript> base;
-	GDScript *_base = nullptr; //fast pointer access
 	GDScript *_owner = nullptr; //for subclasses
 
 	// Members are just indices to the instantiated script.

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -59,7 +59,7 @@ bool GDScriptCompiler::_is_class_member_property(GDScript *owner, const StringNa
 		if (scr->native.is_valid()) {
 			nc = scr->native.ptr();
 		}
-		scr = scr->_base;
+		scr = scr->base.ptr();
 	}
 
 	ERR_FAIL_NULL_V(nc, false);
@@ -343,7 +343,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							if (scr->native.is_valid()) {
 								nc = scr->native.ptr();
 							}
-							scr = scr->_base;
+							scr = scr->base.ptr();
 						}
 
 						if (nc && (identifier == CoreStringName(free_) || ClassDB::has_signal(nc->get_name(), identifier) || ClassDB::has_method(nc->get_name(), identifier))) {
@@ -371,7 +371,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							if (scr->native.is_valid()) {
 								nc = scr->native.ptr();
 							}
-							scr = scr->_base;
+							scr = scr->base.ptr();
 						}
 
 						// Class C++ integer constant.
@@ -407,7 +407,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								return temp;
 							}
 						}
-						scr = scr->_base;
+						scr = scr->base.ptr();
 					}
 				} break;
 
@@ -1051,7 +1051,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 												static_var_data_type = minfo.data_type;
 												break;
 											}
-											scr = scr->_base;
+											scr = scr->base.ptr();
 										}
 									}
 								}
@@ -1320,7 +1320,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								static_var_data_type = minfo.data_type;
 								break;
 							}
-							scr = scr->_base;
+							scr = scr->base.ptr();
 						}
 					}
 				}
@@ -2707,7 +2707,6 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 	p_script->native = Ref<GDScriptNativeClass>();
 	p_script->base = Ref<GDScript>();
-	p_script->_base = nullptr;
 	p_script->members.clear();
 
 	// This makes possible to clear script constants and member_functions without heap-use-after-free errors.
@@ -2818,7 +2817,6 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 			}
 
 			p_script->base = base;
-			p_script->_base = base.ptr();
 			p_script->member_indices = base->member_indices;
 		} break;
 		default: {


### PR DESCRIPTION
Currently GDScript stores its base once as `Ref<GDScript>` (`base`) and once as raw `GDScript*` (`_base`). They are always set/unset together, the raw pointer is just assigned `base->ptr()`. So the value of those should always be the same.

The comment on `_base` reads as if the raw pointer was cached for performance. However `Ref::ptr` is at the moment force inlined and just returns the raw pointer that the ref uses. So based on my knowledge it should be equally as fast. Both members are present since 0b806ee so maybe ref did have some overhead at some point.

Main advantage is preventing invalid states and to remove noise from the code.