### PR TITLE
Revert "Handle NaN and Infinity in JSON stringify function"

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -76,17 +76,6 @@ void JSON::_stringify(String &r_result, const Variant &p_var, const String &p_in
 		case Variant::FLOAT: {
 			const double num = p_var;
 
-			// JSON does not support NaN or Infinity, so use extremely large numbers for infinity.
-			if (!Math::is_finite(num)) {
-				if (num == Math::INF) {
-					r_result += "1e99999";
-				} else if (num == -Math::INF) {
-					r_result += "-1e99999";
-				} else {
-					r_result += "\"NaN\"";
-				}
-				return;
-			}
 			// Only for exactly 0. If we have approximately 0 let the user decide how much
 			// precision they want.
 			if (num == double(0.0)) {

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -75,18 +75,7 @@ TEST_CASE("[JSON] Stringify arrays") {
 	full_precision_array.push_back(0.12345678901234568);
 	CHECK(JSON::stringify(full_precision_array, "", true, true) == "[0.12345678901234568]");
 
-	Array non_finite_array;
-	non_finite_array.push_back(Math::INF);
-	non_finite_array.push_back(-Math::INF);
-	non_finite_array.push_back(Math::NaN);
-	CHECK(JSON::stringify(non_finite_array) == "[1e99999,-1e99999,\"NaN\"]");
-
 	ERR_PRINT_OFF
-	Array non_finite_round_trip = JSON::parse_string(JSON::stringify(non_finite_array));
-	CHECK(non_finite_round_trip[0] == Variant(Math::INF));
-	CHECK(non_finite_round_trip[1] == Variant(-Math::INF));
-	CHECK(non_finite_round_trip[2].get_type() == Variant::STRING);
-
 	Array self_array;
 	self_array.push_back(self_array);
 	CHECK(JSON::stringify(self_array) == "[\"[...]\"]");
@@ -124,18 +113,7 @@ TEST_CASE("[JSON] Stringify dictionaries") {
 	full_precision_dictionary["key"] = 0.12345678901234568;
 	CHECK(JSON::stringify(full_precision_dictionary, "", true, true) == "{\"key\":0.12345678901234568}");
 
-	Dictionary non_finite_dictionary;
-	non_finite_dictionary["-inf"] = -Math::INF;
-	non_finite_dictionary["inf"] = Math::INF;
-	non_finite_dictionary["nan"] = Math::NaN;
-	CHECK(JSON::stringify(non_finite_dictionary) == "{\"-inf\":-1e99999,\"inf\":1e99999,\"nan\":\"NaN\"}");
-
 	ERR_PRINT_OFF
-	Dictionary non_finite_round_trip = JSON::parse_string(JSON::stringify(non_finite_dictionary));
-	CHECK(non_finite_round_trip["-inf"] == Variant(-Math::INF));
-	CHECK(non_finite_round_trip["inf"] == Variant(Math::INF));
-	CHECK(non_finite_round_trip["nan"].get_type() == Variant::STRING);
-
 	Dictionary self_dictionary;
 	self_dictionary["key"] = self_dictionary;
 	CHECK(JSON::stringify(self_dictionary) == "{\"key\":\"{...}\"}");


### PR DESCRIPTION
Reverts godotengine/godot#108837 which was merged in error. The core team discussed it on September 17 2025 and agreed that it should not be merged as is. Further any attempt at slightly improving the behaviour here will likely create just as many problems since we are working outside the boundaries of the JSON spec and there is no consensus on how NaN and INF should be treated by other programs. Any option is liable to break more JSON parsers than it appeases. 

Therefore we agreed to do the following:
1. Have a big and notable warning whenever a users tries to save an invalid JSON
2. Output something that can be parsed by a notable JSON parsing system (i.e. match how Python or C# handles these cases. 

We agreed not to try to handle this in a unique way that we think is slightly better than what everyone else has done and instead try to match the behaviour of another JSON parser.