### PR TITLE
Handle NaN and Infinity in JSON stringify function

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -76,6 +76,18 @@ void JSON::_stringify(String &r_result, const Variant &p_var, const String &p_in
 		case Variant::FLOAT: {
 			const double num = p_var;
 
+			// JSON does not support NaN or Infinity, so use extremely large numbers for infinity.
+			if (!Math::is_finite(num)) {
+				if (num == Math::INF) {
+					r_result += "1e99999";
+				} else if (num == -Math::INF) {
+					r_result += "-1e99999";
+				} else {
+					WARN_PRINT_ONCE("`NaN` (\"Not a Number\") found in argument passed to JSON.stringify(). `NaN` cannot be represented in JSON, so the value has been replaced with `null`. This warning will not be printed for any later NaN occurrences.");
+					r_result += "null";
+				}
+				return;
+			}
 			// Only for exactly 0. If we have approximately 0 let the user decide how much
 			// precision they want.
 			if (num == double(0.0)) {

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -98,6 +98,7 @@
 				[b]Note:[/b] The JSON specification does not define integer or float types, but only a [i]number[/i] type. Therefore, converting a Variant to JSON text will convert all numerical values to [float] types.
 				[b]Note:[/b] If [param full_precision] is [code]true[/code], when stringifying floats, the unreliable digits are stringified in addition to the reliable digits to guarantee exact decoding.
 				The [param indent] parameter controls if and how something is indented; its contents will be used where there should be an indent in the output. Even spaces like [code]"   "[/code] will work. [code]\t[/code] and [code]\n[/code] can also be used for a tab indent, or to make a newline for each indent respectively.
+				[b]Warning:[/b] Non-finite numbers are not supported in JSON. Any occurrences of [constant @GDScript.INF] will be replaced with [code]1e99999[/code], and negative [constant @GDScript.INF] will be replaced with [code]-1e99999[/code], but they will be interpreted correctly as infinity by most JSON parsers. [constant @GDScript.NAN] will be replaced with [code]null[/code], and it will not be interpreted as NaN in JSON parsers. If you expect non-finite numbers, consider passing your data through [method from_native] first.
 				[b]Example output:[/b]
 				[codeblock]
 				## JSON.stringify(my_dictionary)

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -75,7 +75,18 @@ TEST_CASE("[JSON] Stringify arrays") {
 	full_precision_array.push_back(0.12345678901234568);
 	CHECK(JSON::stringify(full_precision_array, "", true, true) == "[0.12345678901234568]");
 
+	Array non_finite_array;
+	non_finite_array.push_back(Math::INF);
+	non_finite_array.push_back(-Math::INF);
+	non_finite_array.push_back(Math::NaN);
 	ERR_PRINT_OFF
+	CHECK(JSON::stringify(non_finite_array) == "[1e99999,-1e99999,null]");
+
+	Array non_finite_round_trip = JSON::parse_string(JSON::stringify(non_finite_array));
+	CHECK(non_finite_round_trip[0] == Variant(Math::INF));
+	CHECK(non_finite_round_trip[1] == Variant(-Math::INF));
+	CHECK(non_finite_round_trip[2].get_type() == Variant::NIL);
+
 	Array self_array;
 	self_array.push_back(self_array);
 	CHECK(JSON::stringify(self_array) == "[\"[...]\"]");
@@ -113,7 +124,18 @@ TEST_CASE("[JSON] Stringify dictionaries") {
 	full_precision_dictionary["key"] = 0.12345678901234568;
 	CHECK(JSON::stringify(full_precision_dictionary, "", true, true) == "{\"key\":0.12345678901234568}");
 
+	Dictionary non_finite_dictionary;
+	non_finite_dictionary["-inf"] = -Math::INF;
+	non_finite_dictionary["inf"] = Math::INF;
+	non_finite_dictionary["nan"] = Math::NaN;
 	ERR_PRINT_OFF
+	CHECK(JSON::stringify(non_finite_dictionary) == "{\"-inf\":-1e99999,\"inf\":1e99999,\"nan\":null}");
+
+	Dictionary non_finite_round_trip = JSON::parse_string(JSON::stringify(non_finite_dictionary));
+	CHECK(non_finite_round_trip["-inf"] == Variant(-Math::INF));
+	CHECK(non_finite_round_trip["inf"] == Variant(Math::INF));
+	CHECK(non_finite_round_trip["nan"].get_type() == Variant::NIL);
+
 	Dictionary self_dictionary;
 	self_dictionary["key"] = self_dictionary;
 	CHECK(JSON::stringify(self_dictionary) == "{\"key\":\"{...}\"}");


### PR DESCRIPTION
Fixes #89777, restores PR #108837, reverts the revert PR #111496. Depends on #111522 which should be merged first.

Regardless of what the user desires, we should pick something sane as the default behavior to ensure that the JSON is valid. The old behavior is bad.

The revert PR #111496 argues:

> create just as many problems since we are working outside the boundaries of the JSON spec

No, `1e99999` is a valid numeric literal according to the JSON spec.

> and there is no consensus on how NaN and INF should be treated by other programs.

This is a common approach used by other programs.

Even if there is no consensus, that just means any behavior is acceptable, except the behavior in master which produces invalid JSON, which is the only behavior that is unacceptable.

> Any option is liable to break more JSON parsers than it appeases.

Very very very false, the old behavior produces invalid JSON, so it breaks ***100%*** of JSON parsers. It is literally impossible to break more than 100% of JSON parsers, this is a nonsense argument.

---

Imagine if you edit an image in an image editor and you have transparency in the image.

Then you try to save the image to JPEG, a format which doesn't support transparency.

It would be completely unacceptable to write an invalid JPEG file that can't be opened by anything!

---

The JSON specification does not support NaN or Infinity values. However, it does support scientific notation. https://www.json.org/json-en.html

Without this PR, trying to export JSON containing NaN or Infinity will result in invalid JSON, which cannot be parsed back by Godot, nor can it be parsed by web browsers.

With this PR, trying to export JSON containing NaN and Infinity will result in valid JSON, with Infinity being replaced with extremely large `1e99999` numbers, and NaN being replaced with `null`. These large `1e99999` values are read in as Infinity both by Godot and by web browsers, and this seems to be a common trick in the JSON ecosystem. See https://github.com/graphite-project/graphite-web/issues/813

The unit tests added in this PR include examples of round-trip parsing, and the same tests fail without the other changes.

Why `1e99999`: This is greater than the maximum value of an IEEE-standard 256-bit octuple-precision float, which is a bit over `1e78913`, pretty much guaranteeing an overflow to infinity since it will happen for all IEEE-standard floating point sizes. Also, just as a general note, this number is big enough that human readers should be able to tell that this is not intended to be a finite float value.