### PR TITLE
Fix `Input.is_joy_known` response for SDL joypads

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -656,10 +656,16 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, const String &p_
 		int mapping = fallback_mapping;
 		// Bypass the mapping system if the joypad's mapping is already handled by its driver
 		// (for example, the SDL joypad driver).
-		if (!p_joypad_info.get("mapping_handled", false)) {
+		if (p_joypad_info.get("mapping_handled", false)) {
+			js.is_known = true;
+		} else {
 			for (int i = 0; i < map_db.size(); i++) {
 				if (js.uid == map_db[i].uid) {
 					mapping = i;
+					if (mapping != fallback_mapping) {
+						js.is_known = true;
+					}
+					break;
 				}
 			}
 		}
@@ -1859,13 +1865,7 @@ void Input::set_fallback_mapping(const String &p_guid) {
 
 //platforms that use the remapping system can override and call to these ones
 bool Input::is_joy_known(int p_device) {
-	if (joy_names.has(p_device)) {
-		int mapping = joy_names[p_device].mapping;
-		if (mapping != -1 && mapping != fallback_mapping) {
-			return true;
-		}
-	}
-	return false;
+	return joy_names.has(p_device) && joy_names[p_device].is_known;
 }
 
 String Input::get_joy_guid(int p_device) const {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -168,6 +168,7 @@ private:
 		StringName name;
 		StringName uid;
 		bool connected = false;
+		bool is_known = false;
 		bool last_buttons[(size_t)JoyButton::MAX] = { false };
 		float last_axis[(size_t)JoyAxis::MAX] = { 0.0f };
 		HatMask last_hat = HatMask::CENTER;

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -186,7 +186,8 @@ void JoypadSDL::process_events() {
 				sdl_instance_id_to_joypad_id.insert(sdl_event.jdevice.which, joy_id);
 
 				Dictionary joypad_info;
-				joypad_info["mapping_handled"] = true; // Skip Godot's mapping system because SDL already handles the joypad's mapping.
+				// Skip Godot's mapping system if SDL already handles the joypad's mapping.
+				joypad_info["mapping_handled"] = SDL_IsGamepad(sdl_event.jdevice.which);
 				joypad_info["raw_name"] = String(SDL_GetJoystickName(joy));
 				joypad_info["vendor_id"] = itos(SDL_GetJoystickVendor(joy));
 				joypad_info["product_id"] = itos(SDL_GetJoystickProduct(joy));


### PR DESCRIPTION
Fix: #111176

~~I added a wrapped `SDL_IsGamepad` call in JoypadSDL `is_known` method as suggested by @Nintorch.
Later I call this method in `Input.is_joy_known` when SDL is enabled.~~

EDIT: I exposed new boolean on Joypad class called `is_known` that is checked in `Input.is_joy_known` method.
This variable is set during handling of `Input.joy_connection_changed` based on the joy_info `mapping_handled` param. This param value is set to `true` if SDL is recognizing gamepad during connection event

I hope I did it right. Let me know if there are any things I should change.

Not my first contribution, but I'm still a beginner.

