### PR TITLE
Remove undocumented script only enter_world callbacks

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -245,10 +245,6 @@ void Node3D::_notification(int p_what) {
 
 			ERR_FAIL_NULL(data.viewport);
 
-			if (get_script_instance()) {
-				get_script_instance()->call(SNAME("_enter_world"));
-			}
-
 #ifdef TOOLS_ENABLED
 			if (is_part_of_edited_scene() && !data.gizmos_requested) {
 				data.gizmos_requested = true;
@@ -263,10 +259,6 @@ void Node3D::_notification(int p_what) {
 #ifdef TOOLS_ENABLED
 			clear_gizmos();
 #endif
-
-			if (get_script_instance()) {
-				get_script_instance()->call(SNAME("_exit_world"));
-			}
 
 			data.viewport = nullptr;
 			data.inside_world = false;


### PR DESCRIPTION
Those callbacks are there since Godot was open sourced. They don't work with the extension system and are entirely undocumented.

Removing them might be considered compat breaking, so this PR is more meant like a heads up, that the current state isn't optimal. There are two options:
- either we consider them part of the stable api -> then they should be documented (and potentially deprecated)
- or we don't consider them part of the stable api -> then we can just remove them like in this PR
