### PR TITLE
GDScript: Use named globals for extensions that can be unloaded

### DIFF
--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -12,6 +12,8 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="value" type="Variant" />
 			<description>
+				Used by the engine to add a global constant which will be available for the entire program lifetime.
+				Since those constants can't be removed it might be possible to optimize the access.
 			</description>
 		</method>
 		<method name="_add_named_global_constant" qualifiers="virtual required">
@@ -19,6 +21,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="value" type="Variant" />
 			<description>
+				Used by the engine to add a global constant which can be removed at any point.
 			</description>
 		</method>
 		<method name="_auto_indent_code" qualifiers="virtual required const">

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2206,25 +2206,9 @@ void GDScriptLanguage::_add_global(const StringName &p_name, const Variant &p_va
 		return;
 	}
 
-	if (global_array_empty_indexes.size()) {
-		int index = global_array_empty_indexes[global_array_empty_indexes.size() - 1];
-		globals[p_name] = index;
-		global_array.write[index] = p_value;
-		global_array_empty_indexes.resize(global_array_empty_indexes.size() - 1);
-	} else {
-		globals[p_name] = global_array.size();
-		global_array.push_back(p_value);
-		_global_array = global_array.ptrw();
-	}
-}
-
-void GDScriptLanguage::_remove_global(const StringName &p_name) {
-	if (!globals.has(p_name)) {
-		return;
-	}
-	global_array_empty_indexes.push_back(globals[p_name]);
-	global_array.write[globals[p_name]] = Variant::NIL;
-	globals.erase(p_name);
+	globals[p_name] = global_array.size();
+	global_array.push_back(p_value);
+	_global_array = global_array.ptrw();
 }
 
 void GDScriptLanguage::add_global_constant(const StringName &p_variable, const Variant &p_value) {
@@ -2303,7 +2287,7 @@ void GDScriptLanguage::_extension_loaded(const Ref<GDExtension> &p_extension) {
 			continue;
 		}
 		Ref<GDScriptNativeClass> nc = memnew(GDScriptNativeClass(n));
-		_add_global(n, nc);
+		add_named_global_constant(n, nc);
 	}
 }
 
@@ -2311,7 +2295,7 @@ void GDScriptLanguage::_extension_unloading(const Ref<GDExtension> &p_extension)
 	List<StringName> class_list;
 	ClassDB::get_extension_class_list(p_extension, &class_list);
 	for (const StringName &n : class_list) {
-		_remove_global(n);
+		remove_named_global_constant(n);
 	}
 }
 #endif

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -424,11 +424,12 @@ class GDScriptLanguage : public ScriptLanguage {
 
 	bool finishing = false;
 
+	// Globals that can't be removed. Access path might be optimized using just the stable index.
 	Variant *_global_array = nullptr;
 	Vector<Variant> global_array;
 	HashMap<StringName, int> globals;
+	// Globals which can be removed. Used primarily in editor for autoloads and extensions.
 	HashMap<StringName, Variant> named_globals;
-	Vector<int> global_array_empty_indexes;
 
 	struct CallLevel {
 		Variant *stack = nullptr;
@@ -453,7 +454,6 @@ class GDScriptLanguage : public ScriptLanguage {
 	static CallLevel *_get_stack_level(uint32_t p_level);
 
 	void _add_global(const StringName &p_name, const Variant &p_value);
-	void _remove_global(const StringName &p_name);
 
 	friend class GDScriptInstance;
 


### PR DESCRIPTION
The script language system has two kinds of globals:
- globals registered using `add_named_global`. Those can be removed
- globals registered using `add_global`. Those can't be removed.

GDScript optimizes the access to the later by converting the name to an index that is embedded in the bytecode.

https://github.com/godotengine/godot/pull/93972 added extension unloading in the editor. For that it added code to remove globals added using `add_global`. However the way it was implemented meant that the index of those globals was not stable anymore. It also did not add any invalidation for scripts that embed the index in the bytecode. This could lead to issues were the index points to something else after reloading an extension.

This PR moves the editor editor extension loading to use `add_named_global`. This means the name is embedded in the bytecode, so reloading should be save.

I also added some comments and docs to explain the difference between `add_named_global` and `add_global`.