### PR TITLE
Scene importer: Fix skeleton path when physics body type is dynamic

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1699,6 +1699,11 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								base = col;
 							} break;
 							case MESH_PHYSICS_RIGID_BODY_AND_MESH: {
+								NodePath skeleton_path = mi->get_skeleton_path();
+								Skeleton3D *skeleton = nullptr;
+								if (!skeleton_path.is_empty()) {
+									skeleton = Object::cast_to<Skeleton3D>(mi->get_node_or_null(skeleton_path));
+								}
 								RigidBody3D *rigid_body = memnew(RigidBody3D);
 								rigid_body->set_name(p_node->get_name());
 								_copy_meta(p_node, rigid_body);
@@ -1714,6 +1719,10 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 									rigid_body->set_physics_material_override(pmo);
 								}
 								base = rigid_body;
+								if (skeleton) {
+									skeleton_path = mi->get_path_to(skeleton);
+									mi->set_skeleton_path(skeleton_path);
+								}
 							} break;
 							case MESH_PHYSICS_STATIC_COLLIDER_ONLY: {
 								StaticBody3D *col = memnew(StaticBody3D);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
When a mesh instance is set to have physics nodes generated with the body type of "Dynamic", the scene importer will generate a RigidBody3D and reparent the mesh instance to it. However, when it does so, it does not update the skeleton path on the mesh instance (which is likely ".."), so it will just point to the RigidBody3D as the skeleton:

<img width="880" height="646" alt="image" src="https://github.com/user-attachments/assets/5fb48808-3acd-44b0-bbf2-1531f232f05a" />


I have updated it such that it gets the skeleton node if it exists, and updates the path after the reparenting.

I should note that this particular section of code hasn't been appreciably updated in 5 years so it affects all Godot versions to 4.0