### PR TITLE
Implement automatic instancing for the mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -389,6 +389,7 @@ private:
 	};
 
 	struct RenderElementInfo {
+		enum { MAX_REPEATS = (1 << 20) - 1 };
 		union {
 			struct {
 				uint32_t lod_index : 8;
@@ -397,6 +398,7 @@ private:
 			};
 			uint32_t value;
 		};
+		uint32_t repeat;
 	};
 
 	static_assert(std::is_trivially_destructible_v<RenderElementInfo>);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Closes https://github.com/godotengine/godot-proposals/issues/13364

When addressing https://github.com/godotengine/godot-proposals/issues/9947, I had thought that automatic instancing was supported by the mobile renderer as well, but recently I was asked about automatic instancing by a community member and realized that this isn't the case. This is also mentioned in the [documentation](https://docs.godotengine.org/en/4.5/tutorials/performance/optimizing_3d_performance.html#use-automatic-instancing).

Luckily, adding the support is largely trivial (the implementation here is almost a 1-to-1 copy of the implementation in the Forward+ renderer) and adds very little overhead.

Draw calls with minimal project:

https://github.com/user-attachments/assets/d1da4188-77b8-4924-8af8-ce5539b86185

Draw calls with demo project: https://github.com/godotengine/godot-demo-projects/tree/master/3d/variable_rate_shading

https://github.com/user-attachments/assets/607ed5a2-c0eb-490e-85a2-adf7cb62d6a9