### PR TITLE
Seek to beginning of section if current playback position is after its end

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -505,10 +505,10 @@ void AnimationPlayer::play_section(const StringName &p_name, double p_start_time
 		c.assigned = name;
 		emit_signal(SNAME("current_animation_changed"), c.assigned);
 	} else {
-		if (p_from_end && Math::is_equal_approx(c.current.pos, start)) {
+		if (p_from_end && Animation::is_less_or_equal_approx(c.current.pos, start)) {
 			// Animation reset but played backwards, set position to the end.
 			seek_internal(end, true, true, true);
-		} else if (!p_from_end && Math::is_equal_approx(c.current.pos, end)) {
+		} else if (!p_from_end && Animation::is_greater_or_equal_approx(c.current.pos, end)) {
 			// Animation resumed but already ended, set position to the beginning.
 			seek_internal(start, true, true, true);
 		} else if (playing) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes https://github.com/godotengine/godot/issues/111514

MRP: [mrp-111514.zip](https://github.com/user-attachments/files/22865380/mrp-111514.zip)

What the test animation looks like in editor:

https://github.com/user-attachments/assets/17a61db8-2d56-45bb-8b47-53101a4a81c9

Press "up" to play the first half of the animation, and "down" to play the second half of the animation.

---

Before (bugged): When the playback position is beyond the first section, playing the first section will cause AnimationPlayer to not reset playback position, causing the playback of the section to end immediately. (Clamping playback position to the `midpoint` marker) Playing the first section again in this state will cause `Math::is_approx_equal()` to return true and properly reset playback position.

https://github.com/user-attachments/assets/ed6c01b4-a060-4cbf-86d2-53184099fd12

---

After (fixed):

https://github.com/user-attachments/assets/89f86baa-e408-4057-90f8-b80ae43165e8