### PR TITLE
Core: Support `INF`/`NAN` in JSON from/to native

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1056,7 +1056,15 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 			if (s.begins_with("i:")) {
 				return s.substr(2).to_int();
 			} else if (s.begins_with("f:")) {
-				return s.substr(2).to_float();
+				const String sub = s.substr(2);
+				if (sub == "inf") {
+					return Math::INF;
+				} else if (sub == "-inf") {
+					return -Math::INF;
+				} else if (sub == "nan") {
+					return Math::NaN;
+				}
+				return sub.to_float();
 			} else if (s.begins_with("s:")) {
 				return s.substr(2);
 			} else if (s.begins_with("sn:")) {

--- a/tests/core/io/test_json_native.h
+++ b/tests/core/io/test_json_native.h
@@ -60,6 +60,9 @@ TEST_CASE("[JSON][Native] Conversion between native and JSON formats") {
 	// Numbers and strings (represented as JSON strings).
 	test(1, R"("i:1")");
 	test(1.0, R"("f:1.0")");
+	test(Math::INF, R"("f:inf")");
+	test(-Math::INF, R"("f:-inf")");
+	test(Math::NaN, R"("f:nan")");
 	test(String("abc"), R"("s:abc")");
 	test(StringName("abc"), R"("sn:abc")");
 	test(NodePath("abc"), R"("np:abc")");


### PR DESCRIPTION
- Fixes #111505

In the interest of minimality, this integrates a fix as a hardcoded override for the `to_native()` function. An alternative implementation would be expanding `built_in_strtod` to recognize `INF`/`NAN`, which would be MUCH faster but risks subtle bugs basically everywhere