### PR TITLE
Fix `IsStaticallyResolvable`

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
@@ -37,6 +37,18 @@ partial class ExportedProperties
         /// </summary>
         public new static readonly global::Godot.StringName @LamdaPropertyString = "LamdaPropertyString";
         /// <summary>
+        /// Cached name for the 'PrimaryCtorParameter' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName @PrimaryCtorParameter = "PrimaryCtorParameter";
+        /// <summary>
+        /// Cached name for the 'ConstantMath' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName @ConstantMath = "ConstantMath";
+        /// <summary>
+        /// Cached name for the 'StaticStringAddition' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName @StaticStringAddition = "StaticStringAddition";
+        /// <summary>
         /// Cached name for the 'PropertyBoolean' property.
         /// </summary>
         public new static readonly global::Godot.StringName @PropertyBoolean = "PropertyBoolean";
@@ -315,6 +327,18 @@ partial class ExportedProperties
         }
         if (name == PropertyName.@LamdaPropertyString) {
             this.@LamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        if (name == PropertyName.@PrimaryCtorParameter) {
+            this.@PrimaryCtorParameter = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        if (name == PropertyName.@ConstantMath) {
+            this.@ConstantMath = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            return true;
+        }
+        if (name == PropertyName.@StaticStringAddition) {
+            this.@StaticStringAddition = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
         if (name == PropertyName.@PropertyBoolean) {
@@ -599,6 +623,18 @@ partial class ExportedProperties
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@LamdaPropertyString);
             return true;
         }
+        if (name == PropertyName.@PrimaryCtorParameter) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@PrimaryCtorParameter);
+            return true;
+        }
+        if (name == PropertyName.@ConstantMath) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@ConstantMath);
+            return true;
+        }
+        if (name == PropertyName.@StaticStringAddition) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@StaticStringAddition);
+            return true;
+        }
         if (name == PropertyName.@PropertyBoolean) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@PropertyBoolean);
             return true;
@@ -870,6 +906,9 @@ partial class ExportedProperties
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@FullPropertyString_Complex, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@_lamdaPropertyString, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@LamdaPropertyString, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@PrimaryCtorParameter, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@ConstantMath, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@StaticStringAddition, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.@PropertyBoolean, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.@PropertyChar, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.@PropertySByte, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
@@ -11,7 +11,7 @@ partial class ExportedProperties
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal new static global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant> GetGodotPropertyDefaultValues()
     {
-        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(64);
+        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(67);
         string __NotGenerateComplexLamdaProperty_default_value = default;
         values.Add(PropertyName.@NotGenerateComplexLamdaProperty, global::Godot.Variant.From<string>(__NotGenerateComplexLamdaProperty_default_value));
         string __NotGenerateLamdaNoFieldProperty_default_value = default;
@@ -26,6 +26,12 @@ partial class ExportedProperties
         values.Add(PropertyName.@FullPropertyString_Complex, global::Godot.Variant.From<string>(__FullPropertyString_Complex_default_value));
         string __LamdaPropertyString_default_value = "LamdaPropertyString";
         values.Add(PropertyName.@LamdaPropertyString, global::Godot.Variant.From<string>(__LamdaPropertyString_default_value));
+        string __PrimaryCtorParameter_default_value = default;
+        values.Add(PropertyName.@PrimaryCtorParameter, global::Godot.Variant.From<string>(__PrimaryCtorParameter_default_value));
+        float __ConstantMath_default_value = 2  * global::Godot.Mathf.Pi;
+        values.Add(PropertyName.@ConstantMath, global::Godot.Variant.From<float>(__ConstantMath_default_value));
+        string __StaticStringAddition_default_value = string.Empty   + string.Empty;
+        values.Add(PropertyName.@StaticStringAddition, global::Godot.Variant.From<string>(__StaticStringAddition_default_value));
         bool __PropertyBoolean_default_value = true;
         values.Add(PropertyName.@PropertyBoolean, global::Godot.Variant.From<bool>(__PropertyBoolean_default_value));
         char __PropertyChar_default_value = 'f';

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-public partial class ExportedProperties : GodotObject
+public partial class ExportedProperties(string primaryCtorParameter) : GodotObject
 {
     // Do not generate default value
     private String _notGeneratePropertyString = new string("not generate");
@@ -90,6 +90,18 @@ public partial class ExportedProperties : GodotObject
         get => _lamdaPropertyString;
         set => _lamdaPropertyString = value;
     }
+
+    // Primary Constructor Parameter
+    [Export]
+    public String PrimaryCtorParameter { get; set; } = primaryCtorParameter;
+
+    // Constant Math Expression
+    [Export]
+    public Single ConstantMath { get; set; } = 2 * Mathf.Pi;
+
+    // Static Strings Addition
+    [Export]
+    public string StaticStringAddition { get; set; } = string.Empty + string.Empty;
 
     // Auto Property
     [Export] private Boolean PropertyBoolean { get; set; } = true;


### PR DESCRIPTION
Fixes #111370.

In #104135, the `IsStaticallyResolvable` method was added to avoid trying to statically reference primary constructor parameters in property default values.

This pull request does the following:
-  Adds the `IsStaticallyResolvable` call to fields as well.
- The `IsStaticallyResolvable` is changed to support more expression types (e.g. `2 * Mathf.Pi`) by, instead of checking lots of supported types of expressions, instead only checks sub-expressions for local variable or parameter references.