### PR TITLE
Update Godot.SourceGenerators packages

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpAnalyzerVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpAnalyzerVerifier.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Godot.SourceGenerators.Tests;
@@ -17,7 +16,7 @@ public static class CSharpAnalyzerVerifier<TAnalyzer>
 {
     public const LanguageVersion LangVersion = LanguageVersion.CSharp11;
 
-    public class Test : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
+    public class Test : CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
     {
         public Test()
         {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpCodeFixVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpCodeFixVerifier.cs
@@ -1,10 +1,10 @@
-using System.IO;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace Godot.SourceGenerators.Tests;
 
@@ -12,7 +12,7 @@ public static class CSharpCodeFixVerifier<TCodeFix, TAnalyzer>
     where TCodeFix : CodeFixProvider, new()
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
-    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
     {
         public Test()
         {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Godot.SourceGenerators.Tests;
@@ -14,7 +13,7 @@ namespace Godot.SourceGenerators.Tests;
 public static class CSharpSourceGeneratorVerifier<TSourceGenerator>
 where TSourceGenerator : ISourceGenerator, new()
 {
-    public class Test : CSharpSourceGeneratorTest<TSourceGenerator, XUnitVerifier>
+    public class Test : CSharpSourceGeneratorTest<TSourceGenerator, DefaultVerifier>
     {
         public Test()
         {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ClassPartialModifierAnalyzerTest.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ClassPartialModifierAnalyzerTest.cs
@@ -13,7 +13,7 @@ public class ClassPartialModifierTest
     }
 
     [Fact]
-    public async void OuterClassPartialModifierAnalyzerTest()
+    public async Task OuterClassPartialModifierAnalyzerTest()
     {
         await CSharpAnalyzerVerifier<ClassPartialModifierAnalyzer>.Verify("OuterClassPartialModifierAnalyzer.GD0002.cs");
     }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ExportDiagnosticsTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ExportDiagnosticsTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,7 +6,7 @@ namespace Godot.SourceGenerators.Tests;
 public class ExportDiagnosticsTests
 {
     [Fact]
-    public async void StaticMembers()
+    public async Task StaticMembers()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             "ExportDiagnostics_GD0101.cs",
@@ -14,7 +15,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void TypeIsNotSupported()
+    public async Task TypeIsNotSupported()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             "ExportDiagnostics_GD0102.cs",
@@ -23,7 +24,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void ReadOnly()
+    public async Task ReadOnly()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             "ExportDiagnostics_GD0103.cs",
@@ -32,7 +33,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void WriteOnly()
+    public async Task WriteOnly()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             "ExportDiagnostics_GD0104.cs",
@@ -41,7 +42,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void Indexer()
+    public async Task Indexer()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             "ExportDiagnostics_GD0105.cs",
@@ -50,7 +51,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void ExplicitInterfaceImplementation()
+    public async Task ExplicitInterfaceImplementation()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             new string[] { "ExportDiagnostics_GD0106.cs" },
@@ -63,7 +64,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void NodeExports()
+    public async Task NodeExports()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             new string[] { "ExportDiagnostics_GD0107.cs" },
@@ -76,7 +77,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void ExportToolButtonInNonToolClass()
+    public async Task ExportToolButtonInNonToolClass()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             new string[] { "ExportDiagnostics_GD0108.cs" },
@@ -85,7 +86,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void ExportAndExportToolButtonOnSameMember()
+    public async Task ExportAndExportToolButtonOnSameMember()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             new string[] { "ExportDiagnostics_GD0109.cs" },
@@ -94,7 +95,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void ExportToolButtonOnNonCallable()
+    public async Task ExportToolButtonOnNonCallable()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             new string[] { "ExportDiagnostics_GD0110.cs" },
@@ -103,7 +104,7 @@ public class ExportDiagnosticsTests
     }
 
     [Fact]
-    public async void ExportToolButtonStoringCallable()
+    public async Task ExportToolButtonStoringCallable()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             new string[] { "ExportDiagnostics_GD0111.cs" },

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/GlobalClassAnalyzerTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/GlobalClassAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,14 +6,14 @@ namespace Godot.SourceGenerators.Tests;
 public class GlobalClassAnalyzerTests
 {
     [Fact]
-    public async void GlobalClassMustDeriveFromGodotObjectTest()
+    public async Task GlobalClassMustDeriveFromGodotObjectTest()
     {
         const string GlobalClassGD0401 = "GlobalClass.GD0401.cs";
         await CSharpAnalyzerVerifier<GlobalClassAnalyzer>.Verify(GlobalClassGD0401);
     }
 
     [Fact]
-    public async void GlobalClassMustNotBeGenericTest()
+    public async Task GlobalClassMustNotBeGenericTest()
     {
         const string GlobalClassGD0402 = "GlobalClass.GD0402.cs";
         await CSharpAnalyzerVerifier<GlobalClassAnalyzer>.Verify(GlobalClassGD0402);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
@@ -14,22 +14,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+
+    <!-- Must support oldest .NET 8.0 version (see https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md#versioning) -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+
+    <!-- Explicit reference needed to fix vulnerability: https://github.com/dotnet/roslyn-sdk/issues/1191 -->
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/KeywordClassNameAndNamespaceTest.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/KeywordClassNameAndNamespaceTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,7 +6,7 @@ namespace Godot.SourceGenerators.Tests;
 public class KeywordClassAndNamespaceTest
 {
     [Fact]
-    public async void GenerateScriptMethodsTest()
+    public async Task GenerateScriptMethodsTest()
     {
         await CSharpSourceGeneratorVerifier<ScriptMethodsGenerator>.Verify(
             "KeywordClassNameAndNamespace.cs",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/MustBeVariantAnalyzerTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/MustBeVariantAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,14 +6,14 @@ namespace Godot.SourceGenerators.Tests;
 public class MustBeVariantAnalyzerTests
 {
     [Fact]
-    public async void GenericTypeArgumentMustBeVariantTest()
+    public async Task GenericTypeArgumentMustBeVariantTest()
     {
         const string MustBeVariantGD0301 = "MustBeVariant.GD0301.cs";
         await CSharpAnalyzerVerifier<MustBeVariantAnalyzer>.Verify(MustBeVariantGD0301);
     }
 
     [Fact]
-    public async void GenericTypeParameterMustBeVariantAnnotatedTest()
+    public async Task GenericTypeParameterMustBeVariantAnnotatedTest()
     {
         const string MustBeVariantGD0302 = "MustBeVariant.GD0302.cs";
         await CSharpAnalyzerVerifier<MustBeVariantAnalyzer>.Verify(MustBeVariantGD0302);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/NestedInGenericTest.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/NestedInGenericTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,7 +6,7 @@ namespace Godot.SourceGenerators.Tests;
 public class NestedInGenericTest
 {
     [Fact]
-    public async void GenerateScriptMethodsTest()
+    public async Task GenerateScriptMethodsTest()
     {
         await CSharpSourceGeneratorVerifier<ScriptMethodsGenerator>.Verify(
             "NestedInGeneric.cs",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptMethodsGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptMethodsGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,7 +6,7 @@ namespace Godot.SourceGenerators.Tests;
 public class ScriptMethodsGeneratorTests
 {
     [Fact]
-    public async void Methods()
+    public async Task Methods()
     {
         await CSharpSourceGeneratorVerifier<ScriptMethodsGenerator>.Verify(
             "Methods.cs",
@@ -14,7 +15,7 @@ public class ScriptMethodsGeneratorTests
     }
 
     [Fact]
-    public async void ScriptBoilerplate()
+    public async Task ScriptBoilerplate()
     {
         await CSharpSourceGeneratorVerifier<ScriptMethodsGenerator>.Verify(
             "ScriptBoilerplate.cs",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPathAttributeGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPathAttributeGeneratorTests.cs
@@ -1,9 +1,10 @@
+using Microsoft.CodeAnalysis.Text;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Microsoft.CodeAnalysis.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -22,7 +23,7 @@ public class ScriptPathAttributeGeneratorTests
     }
 
     [Fact]
-    public async void ScriptBoilerplate()
+    public async Task ScriptBoilerplate()
     {
         var verifier = CSharpSourceGeneratorVerifier<ScriptPathAttributeGenerator>.MakeVerifier(
             new string[] { "ScriptBoilerplate.cs" },
@@ -33,7 +34,7 @@ public class ScriptPathAttributeGeneratorTests
     }
 
     [Fact]
-    public async void FooBar()
+    public async Task FooBar()
     {
         var verifier = CSharpSourceGeneratorVerifier<ScriptPathAttributeGenerator>.MakeVerifier(
             new string[] { "Foo.cs", "Bar.cs" },
@@ -44,7 +45,7 @@ public class ScriptPathAttributeGeneratorTests
     }
 
     [Fact]
-    public async void Generic()
+    public async Task Generic()
     {
         var verifier = CSharpSourceGeneratorVerifier<ScriptPathAttributeGenerator>.MakeVerifier(
             new string[] { "Generic.cs" },
@@ -55,7 +56,7 @@ public class ScriptPathAttributeGeneratorTests
     }
 
     [Fact]
-    public async void GenericMultipleClassesSameName()
+    public async Task GenericMultipleClassesSameName()
     {
         var verifier = CSharpSourceGeneratorVerifier<ScriptPathAttributeGenerator>.MakeVerifier(
             Array.Empty<string>(),
@@ -67,7 +68,7 @@ public class ScriptPathAttributeGeneratorTests
     }
 
     [Fact]
-    public async void NamespaceMultipleClassesSameName()
+    public async Task NamespaceMultipleClassesSameName()
     {
         var verifier = CSharpSourceGeneratorVerifier<ScriptPathAttributeGenerator>.MakeVerifier(
             Array.Empty<string>(),

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertiesGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertiesGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,7 +6,7 @@ namespace Godot.SourceGenerators.Tests;
 public class ScriptPropertiesGeneratorTests
 {
     [Fact]
-    public async void ExportedFields()
+    public async Task ExportedFields()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             new string[] { "ExportedFields.cs", "MoreExportedFields.cs" },
@@ -14,7 +15,7 @@ public class ScriptPropertiesGeneratorTests
     }
 
     [Fact]
-    public async void ExportedProperties()
+    public async Task ExportedProperties()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             "ExportedProperties.cs",
@@ -23,7 +24,7 @@ public class ScriptPropertiesGeneratorTests
     }
 
     [Fact]
-    public async void OneWayPropertiesAllReadOnly()
+    public async Task OneWayPropertiesAllReadOnly()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             "AllReadOnly.cs",
@@ -32,7 +33,7 @@ public class ScriptPropertiesGeneratorTests
     }
 
     [Fact]
-    public async void OneWayPropertiesAllWriteOnly()
+    public async Task OneWayPropertiesAllWriteOnly()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             "AllWriteOnly.cs",
@@ -41,7 +42,7 @@ public class ScriptPropertiesGeneratorTests
     }
 
     [Fact]
-    public async void OneWayPropertiesMixedReadOnlyWriteOnly()
+    public async Task OneWayPropertiesMixedReadOnlyWriteOnly()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             "MixedReadOnlyWriteOnly.cs",
@@ -50,7 +51,7 @@ public class ScriptPropertiesGeneratorTests
     }
 
     [Fact]
-    public async void ScriptBoilerplate()
+    public async Task ScriptBoilerplate()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             "ScriptBoilerplate.cs",
@@ -59,7 +60,7 @@ public class ScriptPropertiesGeneratorTests
     }
 
     [Fact]
-    public async void AbstractGenericNode()
+    public async Task AbstractGenericNode()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             "AbstractGenericNode.cs",
@@ -68,7 +69,7 @@ public class ScriptPropertiesGeneratorTests
     }
 
     [Fact]
-    public async void ExportedButtons()
+    public async Task ExportedButtons()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
             "ExportedToolButtons.cs",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertyDefValGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertyDefValGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,7 +6,7 @@ namespace Godot.SourceGenerators.Tests;
 public class ScriptPropertyDefValGeneratorTests
 {
     [Fact]
-    public async void ExportedFields()
+    public async Task ExportedFields()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             new string[] { "ExportedFields.cs", "MoreExportedFields.cs" },
@@ -14,7 +15,7 @@ public class ScriptPropertyDefValGeneratorTests
     }
 
     [Fact]
-    public async void ExportedProperties()
+    public async Task ExportedProperties()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             "ExportedProperties.cs",
@@ -23,14 +24,14 @@ public class ScriptPropertyDefValGeneratorTests
     }
 
     [Fact]
-    public async void ExportedProperties2()
+    public async Task ExportedProperties2()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             "ExportedProperties2.cs", "ExportedProperties2_ScriptPropertyDefVal.generated.cs");
     }
 
     [Fact]
-    public async void ExportedComplexStrings()
+    public async Task ExportedComplexStrings()
     {
         await CSharpSourceGeneratorVerifier<ScriptPropertyDefValGenerator>.Verify(
             "ExportedComplexStrings.cs",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptSerializationGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptSerializationGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,7 +6,7 @@ namespace Godot.SourceGenerators.Tests;
 public class ScriptSerializationGeneratorTests
 {
     [Fact]
-    public async void ScriptBoilerplate()
+    public async Task ScriptBoilerplate()
     {
         await CSharpSourceGeneratorVerifier<ScriptSerializationGenerator>.VerifyNoCompilerDiagnostics(
             "ScriptBoilerplate.cs",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptSignalsGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptSignalsGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Godot.SourceGenerators.Tests;
@@ -5,7 +6,7 @@ namespace Godot.SourceGenerators.Tests;
 public class ScriptSignalsGeneratorTests
 {
     [Fact]
-    public async void EventSignals()
+    public async Task EventSignals()
     {
         await CSharpSourceGeneratorVerifier<ScriptSignalsGenerator>.Verify(
             "EventSignals.cs",


### PR DESCRIPTION
Updates the packages used in Godot.SourceGenerators including the test packages.

Without these updates, the tests don't run in Visual Studio 2022.

Also fixes a high-severity security vulnerability (https://github.com/dotnet/roslyn-sdk/issues/1191).