### PR TITLE
Add `popup_hide` signal to dialogs

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -85,6 +85,10 @@
 		<member name="wrap_controls" type="bool" setter="set_wrap_controls" getter="is_wrapping_controls" overrides="Window" default="true" />
 	</members>
 	<signals>
+		<signal name="popup_hide">
+			<description>
+				Emitted when the dialog is hidden.
+			</description>
 		<signal name="canceled">
 			<description>
 				Emitted when the dialog is closed or the button created with [method add_cancel_button] is pressed.

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -67,6 +67,8 @@ void AcceptDialog::_notification(int p_what) {
 				if (get_ok_button()->is_inside_tree()) {
 					get_ok_button()->grab_focus();
 				}
+				emit_signal(SNAME("popup_hide"));
+				popped_up = false;
 				_update_child_rects();
 
 				parent_visible = get_parent_visible_window();
@@ -427,6 +429,7 @@ void AcceptDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ok_button_text", "text"), &AcceptDialog::set_ok_button_text);
 	ClassDB::bind_method(D_METHOD("get_ok_button_text"), &AcceptDialog::get_ok_button_text);
 
+	ADD_SIGNAL(MethodInfo("popup_hide"));
 	ADD_SIGNAL(MethodInfo("confirmed"));
 	ADD_SIGNAL(MethodInfo("canceled"));
 	ADD_SIGNAL(MethodInfo("custom_action", PropertyInfo(Variant::STRING_NAME, "action")));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/13366 and https://github.com/godotengine/godot-proposals/issues/7084

First contribution!
This implements the simple solution from https://github.com/godotengine/godot-proposals/issues/13366 and addresses https://github.com/godotengine/godot-proposals/issues/7084 by adding popup_hide to the dialogs class(es).

Very simple, adds a new signal to dialogs called `popup_hide`, it's fired after a visibility change where we are also not already visible, in the same way as on `Popup`, and sets `popped_up` to false. I believe Godot 3.X already had this but Godot 4 does not.