### PR TITLE
Fix Windows native FileDialog filters not showing descriptions

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -555,7 +555,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 			if (!exts.is_empty()) {
 				String str = String(";").join(exts);
 				filter_exts.push_back(str.utf16());
-				if (tokens.size() == 2) {
+				if (tokens.size() >= 2) {
 					filter_names.push_back(tokens[1].strip_edges().utf16());
 				} else {
 					filter_names.push_back(str.utf16());

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1162,13 +1162,13 @@ void FileDialog::update_filters() {
 		}
 
 		String native_all_name;
+		native_all_name += all_filters;
 		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE_MIME)) {
-			native_all_name += all_filters;
+			if (!native_all_name.is_empty()) {
+				native_all_name += ", ";
+			}
+			native_all_name += all_mime;
 		}
-		if (!native_all_name.is_empty()) {
-			native_all_name += ", ";
-		}
-		native_all_name += all_mime;
 
 		if (max_filters < filters.size()) {
 			all_filters += ", ...";
@@ -1183,13 +1183,14 @@ void FileDialog::update_filters() {
 		String desc = filters[i].get_slicec(';', 1).strip_edges();
 		String mime = filters[i].get_slicec(';', 2).strip_edges();
 		String native_name;
+
+		native_name += flt;
 		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE_MIME)) {
-			native_name += flt;
+			if (!native_name.is_empty() && !mime.is_empty()) {
+				native_name += ", ";
+			}
+			native_name += mime;
 		}
-		if (!native_name.is_empty() && !mime.is_empty()) {
-			native_name += ", ";
-		}
-		native_name += mime;
 		if (!desc.is_empty()) {
 			filter->add_item(atr(desc) + " (" + flt + ")");
 			processed_filters.push_back(flt + ";" + atr(desc) + " (" + native_name + ");" + mime);


### PR DESCRIPTION
Native file dialogs on Windows have been ignoring the descriptions set on filters because windows display server never has the DisplayServer::FEATURE_NATIVE_DIALOG_FILE_MIME flag.

This PR properly fixes that and the "All Regognized" not showing previously as well.

<img width="373" height="172" alt="image" src="https://github.com/user-attachments/assets/f3a2c3e3-836c-48cc-a82a-b7fc6856defb" />
