### PR TITLE
Core: Remove class_db.h include from core_constants.cpp

### DIFF
--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -30,8 +30,9 @@
 
 #include "core_constants.h"
 
+STATIC_ASSERT_INCOMPLETE_TYPE(class, ClassDB)
+
 #include "core/input/input_event.h"
-#include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "core/variant/variant.h"
 


### PR DESCRIPTION
* Part of #111218

Removed the unnecessary `class_db.h` include from `core_constants.cpp` and replaced with incomplete assertion to guard against regressions. 