### PR TITLE
Add 2D MSAA to GLES3 backend

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -577,7 +577,7 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	GLES3::RenderTarget *render_target = texture_storage->get_render_target(p_to_render_target);
 
-	if (p_to_backbuffer && render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+	if (p_to_backbuffer && render_target->msaa_2d.mode != RSE::VIEWPORT_MSAA_DISABLED) {
 		WARN_PRINT_ONCE("MSAA is not supported by the Canvas backbuffer.");
 	}
 
@@ -2216,7 +2216,7 @@ void RasterizerCanvasGLES3::canvas_begin(RID p_to_render_target, bool p_to_backb
 		GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_WHITE));
 		glBindTexture(GL_TEXTURE_2D, tex->tex_id);
 	} else {
-		if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.fbo != 0) {
+		if (render_target->msaa_2d.mode != RSE::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.fbo != 0) {
 			glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.fbo);
 		} else {
 			glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -109,11 +109,23 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 	GLES3::MeshStorage *mesh_storage = GLES3::MeshStorage::get_singleton();
+	GLES3::RenderTarget *render_target = texture_storage->get_render_target(p_to_render_target);
 
 	Transform2D canvas_transform_inverse = p_canvas_transform.affine_inverse();
 
 	// Clear out any state that may have been left from the 3D pass.
 	reset_canvas();
+
+	// Blit FBO to MSAA 2D FBO
+	if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, render_target->fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, render_target->msaa_2d.fbo);
+
+		glBlitFramebuffer(0, 0, render_target->size.x, render_target->size.y,
+				0, 0, render_target->size.x, render_target->size.y,
+				GL_COLOR_BUFFER_BIT, GL_NEAREST);
+		glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.fbo);
+	}
 
 	if (state.canvas_instance_data_buffers[state.current_data_buffer_index].fence != GLsync()) {
 		GLint syncStatus;
@@ -522,7 +534,6 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 				update_skeletons = false;
 			}
 			//render anything pending, including clearing if no items
-
 			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, r_sdf_used, false, r_render_info, material_screen_texture_mipmaps_cached);
 			item_count = 0;
 
@@ -567,14 +578,31 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 
 	state.canvas_instance_data_buffers[state.current_data_buffer_index].fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 
+	// Blit MSAA 2D buffer to final buffer
+	if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.needs_resolve) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, render_target->msaa_2d.fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, render_target->fbo);
+
+		glBlitFramebuffer(0, 0, render_target->size.x, render_target->size.y,
+				0, 0, render_target->size.x, render_target->size.y,
+				GL_COLOR_BUFFER_BIT, GL_NEAREST);
+		glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);
+	}
+
 	// Clear out state used in 2D pass
 	reset_canvas();
 	state.current_data_buffer_index = (state.current_data_buffer_index + 1) % state.canvas_instance_data_buffers.size();
 	state.current_instance_buffer_index = 0;
+	if (!backbuffer_cleared) {
+		texture_storage->render_target_clear_back_buffer(p_to_render_target, Rect2i(), Color(0, 0, 0, 0));
+		backbuffer_cleared = true;
+	}
 }
 
 void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool &r_sdf_used, bool p_to_backbuffer, RenderingServerTypes::RenderInfo *r_render_info, bool p_backbuffer_has_mipmaps) {
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
+	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
+	GLES3::RenderTarget *render_target = texture_storage->get_render_target(p_to_render_target);
 
 	canvas_begin(p_to_render_target, p_to_backbuffer, p_backbuffer_has_mipmaps);
 
@@ -809,6 +837,18 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 	state.current_batch_index = 0;
 	state.canvas_instance_batches.clear();
 	state.last_item_index += index;
+
+	// Blit MSAA 2D Backbuffer to normal backbuffer
+	// to support sampling from backbuffer
+	if (p_to_backbuffer && render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.backbuffer_fbo != 0 && render_target->msaa_2d.needs_resolve) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, render_target->msaa_2d.backbuffer_fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, render_target->backbuffer_fbo);
+
+		glBlitFramebuffer(0, 0, render_target->size.x, render_target->size.y,
+				0, 0, render_target->size.x, render_target->size.y,
+				GL_COLOR_BUFFER_BIT, GL_NEAREST);
+		glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.backbuffer_fbo);
+	}
 }
 
 void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_render_target, const Transform2D &p_canvas_transform_inverse, Item *&current_clip, GLES3::CanvasShaderData::BlendMode p_blend_mode, Light *p_lights, uint32_t &r_index, bool &r_batch_broken, bool &r_sdf_used, const Point2 &p_repeat_offset) {
@@ -2206,12 +2246,20 @@ void RasterizerCanvasGLES3::canvas_begin(RID p_to_render_target, bool p_to_backb
 	GLES3::RenderTarget *render_target = texture_storage->get_render_target(p_to_render_target);
 
 	if (p_to_backbuffer) {
-		glBindFramebuffer(GL_FRAMEBUFFER, render_target->backbuffer_fbo);
+		if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.backbuffer_fbo != 0) {
+			glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.backbuffer_fbo);
+		} else {
+			glBindFramebuffer(GL_FRAMEBUFFER, render_target->backbuffer_fbo);
+		}
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
 		GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_WHITE));
 		glBindTexture(GL_TEXTURE_2D, tex->tex_id);
 	} else {
-		glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);
+		if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.fbo != 0) {
+			glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.fbo);
+		} else {
+			glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);
+		}
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
 		glBindTexture(GL_TEXTURE_2D, render_target->backbuffer);
 		if (render_target->backbuffer != 0) {

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -109,23 +109,11 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 	GLES3::MeshStorage *mesh_storage = GLES3::MeshStorage::get_singleton();
-	GLES3::RenderTarget *render_target = texture_storage->get_render_target(p_to_render_target);
 
 	Transform2D canvas_transform_inverse = p_canvas_transform.affine_inverse();
 
 	// Clear out any state that may have been left from the 3D pass.
 	reset_canvas();
-
-	// Blit FBO to MSAA 2D FBO
-	if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, render_target->fbo);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, render_target->msaa_2d.fbo);
-
-		glBlitFramebuffer(0, 0, render_target->size.x, render_target->size.y,
-				0, 0, render_target->size.x, render_target->size.y,
-				GL_COLOR_BUFFER_BIT, GL_NEAREST);
-		glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.fbo);
-	}
 
 	if (state.canvas_instance_data_buffers[state.current_data_buffer_index].fence != GLsync()) {
 		GLint syncStatus;
@@ -578,31 +566,20 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 
 	state.canvas_instance_data_buffers[state.current_data_buffer_index].fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 
-	// Blit MSAA 2D buffer to final buffer
-	if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.needs_resolve) {
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, render_target->msaa_2d.fbo);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, render_target->fbo);
-
-		glBlitFramebuffer(0, 0, render_target->size.x, render_target->size.y,
-				0, 0, render_target->size.x, render_target->size.y,
-				GL_COLOR_BUFFER_BIT, GL_NEAREST);
-		glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);
-	}
-
 	// Clear out state used in 2D pass
 	reset_canvas();
 	state.current_data_buffer_index = (state.current_data_buffer_index + 1) % state.canvas_instance_data_buffers.size();
 	state.current_instance_buffer_index = 0;
-	if (!backbuffer_cleared) {
-		texture_storage->render_target_clear_back_buffer(p_to_render_target, Rect2i(), Color(0, 0, 0, 0));
-		backbuffer_cleared = true;
-	}
 }
 
 void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool &r_sdf_used, bool p_to_backbuffer, RenderingServerTypes::RenderInfo *r_render_info, bool p_backbuffer_has_mipmaps) {
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	GLES3::RenderTarget *render_target = texture_storage->get_render_target(p_to_render_target);
+
+	if (p_to_backbuffer && render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+		WARN_PRINT_ONCE("MSAA is not supported by the Canvas backbuffer.");
+	}
 
 	canvas_begin(p_to_render_target, p_to_backbuffer, p_backbuffer_has_mipmaps);
 
@@ -837,18 +814,6 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 	state.current_batch_index = 0;
 	state.canvas_instance_batches.clear();
 	state.last_item_index += index;
-
-	// Blit MSAA 2D Backbuffer to normal backbuffer
-	// to support sampling from backbuffer
-	if (p_to_backbuffer && render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.backbuffer_fbo != 0 && render_target->msaa_2d.needs_resolve) {
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, render_target->msaa_2d.backbuffer_fbo);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, render_target->backbuffer_fbo);
-
-		glBlitFramebuffer(0, 0, render_target->size.x, render_target->size.y,
-				0, 0, render_target->size.x, render_target->size.y,
-				GL_COLOR_BUFFER_BIT, GL_NEAREST);
-		glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.backbuffer_fbo);
-	}
 }
 
 void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_render_target, const Transform2D &p_canvas_transform_inverse, Item *&current_clip, GLES3::CanvasShaderData::BlendMode p_blend_mode, Light *p_lights, uint32_t &r_index, bool &r_batch_broken, bool &r_sdf_used, const Point2 &p_repeat_offset) {
@@ -2246,11 +2211,7 @@ void RasterizerCanvasGLES3::canvas_begin(RID p_to_render_target, bool p_to_backb
 	GLES3::RenderTarget *render_target = texture_storage->get_render_target(p_to_render_target);
 
 	if (p_to_backbuffer) {
-		if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.backbuffer_fbo != 0) {
-			glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.backbuffer_fbo);
-		} else {
-			glBindFramebuffer(GL_FRAMEBUFFER, render_target->backbuffer_fbo);
-		}
+		glBindFramebuffer(GL_FRAMEBUFFER, render_target->backbuffer_fbo);
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
 		GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_WHITE));
 		glBindTexture(GL_TEXTURE_2D, tex->tex_id);

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2702,10 +2702,78 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 			texture->alloc_height = rt->size.y;
 			texture->active = true;
 		}
+		glClearColor(0, 0, 0, 0);
+		glClear(GL_COLOR_BUFFER_BIT);
 	}
 
-	glClearColor(0, 0, 0, 0);
-	glClear(GL_COLOR_BUFFER_BIT);
+	if (rt->view_count == 1 && rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && (config->msaa_supported || config->rt_msaa_supported)) {
+		/* MSAA 2D FBO */
+		GLsizei samples[] = { 1, 2, 4, 8 };
+		rt->msaa_2d.samples = samples[rt->msaa_2d.mode];
+
+		glGenFramebuffers(1, &rt->msaa_2d.fbo);
+		glBindFramebuffer(GL_FRAMEBUFFER, rt->msaa_2d.fbo);
+
+#ifdef ANDROID_ENABLED // Only supported on OpenGLES!
+		if (config->rt_msaa_supported) {
+			// If this extension is supported we use this,
+			// MSAA will remain in tile memory and we write out directly into our final buffers
+			rt->msaa_2d.needs_resolve = false;
+
+			glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->color, 0, rt->msaa_2d.samples);
+		} else {
+#else
+		{
+#endif
+			// We create separate MSAA buffers and require a resolve when we're done
+			rt->msaa_2d.needs_resolve = true;
+
+			// Create our color buffer
+			glGenRenderbuffers(1, &rt->msaa_2d.color);
+			glBindRenderbuffer(GL_RENDERBUFFER, rt->msaa_2d.color);
+
+			glRenderbufferStorageMultisample(GL_RENDERBUFFER, rt->msaa_2d.samples, rt->color_internal_format, rt->size.x, rt->size.y);
+			GLES3::Utilities::get_singleton()->render_buffer_allocated_data(rt->msaa_2d.color, rt->size.x * rt->size.y * 4 * rt->msaa_2d.samples, "MSAA 2D color render buffer");
+
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rt->msaa_2d.color);
+		}
+
+		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+		if (status != GL_FRAMEBUFFER_COMPLETE) {
+			// If we couldn't create our framebuffer just fail and disable MSAA.
+			WARN_PRINT("Could not create 2D MSAA render target, status: " + get_framebuffer_error(status));
+
+			glDeleteFramebuffers(1, &rt->msaa_2d.fbo);
+			rt->msaa_2d.fbo = 0;
+
+			if (rt->msaa_2d.color != 0) {
+				GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.color);
+				rt->msaa_2d.color = 0;
+			}
+
+			rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
+			rt->msaa_2d.samples = 1;
+			rt->msaa_2d.needs_resolve = false;
+		} else {
+			glClearColor(0, 0, 0, 0);
+			glClear(GL_COLOR_BUFFER_BIT);
+		}
+
+	} else {
+		if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+			if (rt->view_count > 1) {
+				// We don't support 2D MSAA in multiview
+				WARN_PRINT_ONCE("MSAA 2D not supported in multiview");
+			} else if (!config->msaa_supported && !config->rt_msaa_supported) {
+				WARN_PRINT_ONCE("MSAA 2D not supported on this device");
+			}
+			rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
+		}
+
+		rt->msaa_2d.samples = 1;
+		rt->msaa_2d.needs_resolve = false;
+	}
+
 	glBindFramebuffer(GL_FRAMEBUFFER, system_fbo);
 }
 
@@ -2816,6 +2884,58 @@ void TextureStorage::_create_render_target_backbuffer(RenderTarget *rt) {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+	// Generate MSAA 2D backbuffer
+	if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+		glGenFramebuffers(1, &rt->msaa_2d.backbuffer_fbo);
+		glBindFramebuffer(GL_FRAMEBUFFER, rt->msaa_2d.backbuffer_fbo);
+
+#ifdef ANDROID_ENABLED // Only supported on OpenGLES!
+		Config *config = Config::get_singleton();
+		if (config->rt_msaa_supported) {
+			// Needs resolve is already false at this point
+			glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->backbuffer, 0, rt->msaa_2d.samples);
+		} else {
+#else
+		{
+#endif
+			// Create our color buffer
+			glGenRenderbuffers(1, &rt->msaa_2d.backbuffer);
+			glBindRenderbuffer(GL_RENDERBUFFER, rt->msaa_2d.backbuffer);
+
+			glRenderbufferStorageMultisample(GL_RENDERBUFFER, rt->msaa_2d.samples, rt->color_internal_format, rt->size.x, rt->size.y);
+			GLES3::Utilities::get_singleton()->render_buffer_allocated_data(rt->msaa_2d.backbuffer, rt->size.x * rt->size.y * 4 * rt->msaa_2d.samples, "MSAA 2D backbuffer color render buffer");
+
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rt->msaa_2d.backbuffer);
+		}
+
+		status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+		if (status != GL_FRAMEBUFFER_COMPLETE) {
+			// If we couldn't create our framebuffer just fail and disable MSAA.
+			WARN_PRINT("Could not create 2D MSAA backbuffer, status: " + get_framebuffer_error(status));
+
+			glDeleteFramebuffers(1, &rt->msaa_2d.fbo);
+			glDeleteFramebuffers(1, &rt->msaa_2d.backbuffer_fbo);
+			rt->msaa_2d.fbo = 0;
+			rt->msaa_2d.backbuffer_fbo = 0;
+
+			if (rt->msaa_2d.color != 0) {
+				GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.color);
+				rt->msaa_2d.color = 0;
+			}
+			if (rt->msaa_2d.backbuffer != 0) {
+				GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.backbuffer);
+				rt->msaa_2d.backbuffer = 0;
+			}
+
+			rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
+			rt->msaa_2d.samples = 1;
+			rt->msaa_2d.needs_resolve = false;
+		} else {
+			glClearColor(0, 0, 0, 0);
+			glClear(GL_COLOR_BUFFER_BIT);
+		}
+	}
 }
 
 void TextureStorage::_clear_render_target(RenderTarget *rt) {
@@ -2843,6 +2963,15 @@ void TextureStorage::_clear_render_target(RenderTarget *rt) {
 	if (rt->fbo) {
 		glDeleteFramebuffers(1, &rt->fbo);
 		rt->fbo = 0;
+	}
+
+	if (rt->msaa_2d.fbo != 0) {
+		glDeleteFramebuffers(1, &rt->msaa_2d.fbo);
+		rt->msaa_2d.fbo = 0;
+	}
+	if (rt->msaa_2d.color != 0) {
+		GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.color);
+		rt->msaa_2d.color = 0;
 	}
 
 	if (rt->overridden.color.is_null()) {
@@ -2896,6 +3025,16 @@ void TextureStorage::_clear_render_target(RenderTarget *rt) {
 		GLES3::Utilities::get_singleton()->texture_free_data(rt->backbuffer_depth);
 		rt->backbuffer_depth = 0;
 	}
+
+	if (rt->msaa_2d.backbuffer_fbo != 0) {
+		glDeleteFramebuffers(1, &rt->msaa_2d.backbuffer_fbo);
+		rt->msaa_2d.backbuffer_fbo = 0;
+	}
+	if (rt->msaa_2d.backbuffer != 0) {
+		GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.backbuffer);
+		rt->msaa_2d.backbuffer = 0;
+	}
+
 	_render_target_clear_sdf(rt);
 }
 
@@ -3170,6 +3309,7 @@ void TextureStorage::render_target_set_direct_to_screen(RID p_render_target, boo
 	_clear_render_target(rt);
 	rt->direct_to_screen = p_direct_to_screen;
 	if (rt->direct_to_screen) {
+		rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
 		rt->overridden.color = RID();
 		rt->overridden.depth = RID();
 		rt->overridden.velocity = RID();
@@ -3203,24 +3343,27 @@ void TextureStorage::render_target_set_msaa(RID p_render_target, RSE::ViewportMS
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL(rt);
 	ERR_FAIL_COND(rt->direct_to_screen);
-	if (p_msaa == rt->msaa) {
+	if (p_msaa == rt->msaa_2d.mode) {
 		return;
 	}
 
-	WARN_PRINT("2D MSAA is not yet supported for GLES3.");
+	// WARN_PRINT("2D MSAA is not yet supported for GLES3.");
 
-	if (rt->overridden.color.is_null()) {
-		_clear_render_target(rt);
-		rt->msaa = p_msaa;
-		_update_render_target_color(rt);
-	}
+	// if (rt->overridden.color.is_null()) {
+	// 	_clear_render_target(rt);
+	// 	rt->msaa = p_msaa;
+	// 	_update_render_target_color(rt);
+	// }
+	_clear_render_target(rt);
+	rt->msaa_2d.mode = p_msaa;
+	_update_render_target_color(rt);
 }
 
 RSE::ViewportMSAA TextureStorage::render_target_get_msaa(RID p_render_target) const {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RSE::VIEWPORT_MSAA_DISABLED);
 
-	return rt->msaa;
+	return rt->msaa_2d.mode;
 }
 
 void TextureStorage::render_target_set_use_hdr(RID p_render_target, bool p_use_hdr_2d) {
@@ -3673,6 +3816,15 @@ void TextureStorage::render_target_copy_to_back_buffer(RID p_render_target, cons
 		}
 	}
 
+	// MSAA 2D: Resolve (part of the) FBO for backbuffer
+	if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && rt->msaa_2d.needs_resolve) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, rt->msaa_2d.fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, rt->fbo);
+		glBlitFramebuffer(region.position.x, region.position.y, region.position.x + region.size.x, region.position.y + region.size.y,
+				region.position.x, region.position.y, region.position.x + region.size.x, region.position.y + region.size.y,
+				GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	}
+
 	glDisable(GL_BLEND);
 	// Single texture copy for backbuffer.
 	glBindFramebuffer(GL_FRAMEBUFFER, rt->backbuffer_fbo);
@@ -3689,6 +3841,15 @@ void TextureStorage::render_target_copy_to_back_buffer(RID p_render_target, cons
 	}
 
 	glEnable(GL_BLEND); // 2D starts with blend enabled.
+
+	// MSAA 2D: Blit backbuffer back to msaa backbuffer
+	if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && rt->msaa_2d.needs_resolve) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, rt->backbuffer_fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, rt->msaa_2d.backbuffer_fbo);
+		glBlitFramebuffer(region.position.x, region.position.y, region.position.x + region.size.x, region.position.y + region.size.y,
+				region.position.x, region.position.y, region.position.x + region.size.x, region.position.y + region.size.y,
+				GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	}
 }
 
 void TextureStorage::render_target_clear_back_buffer(RID p_render_target, const Rect2i &p_region, const Color &p_color) {
@@ -3699,6 +3860,28 @@ void TextureStorage::render_target_clear_back_buffer(RID p_render_target, const 
 	if (rt->backbuffer_fbo == 0) {
 		_create_render_target_backbuffer(rt);
 	}
+
+	// Clear MSAA 2D backbuffer
+
+	if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && rt->msaa_2d.backbuffer_fbo != 0) {
+		Rect2i region;
+		if (p_region != Rect2i()) {
+			// not fullscreen
+			region = Rect2i(Size2i(), rt->size).intersection(p_region);
+			if (region.size == Size2i()) {
+				return; // nothing to do
+			}
+			glEnable(GL_SCISSOR_TEST);
+			glScissor(region.position.x, region.position.y, region.size.x, region.size.y);
+		}
+		glBindFramebuffer(GL_FRAMEBUFFER, rt->msaa_2d.backbuffer_fbo);
+		glClearColor(p_color.r, p_color.g, p_color.b, p_color.a);
+		glClear(GL_COLOR_BUFFER_BIT);
+
+		glDisable(GL_SCISSOR_TEST);
+	}
+
+	// Clear normal backbuffer
 
 	Rect2i region;
 	if (p_region == Rect2i()) {

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2763,9 +2763,9 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 		if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
 			if (rt->view_count > 1) {
 				// We don't support 2D MSAA in multiview
-				WARN_PRINT_ONCE("MSAA 2D not supported in multiview");
+				WARN_PRINT_ONCE("MSAA 2D not supported in multiview.");
 			} else if (!config->msaa_supported && !config->rt_msaa_supported) {
-				WARN_PRINT_ONCE("MSAA 2D not supported on this device");
+				WARN_PRINT_ONCE("MSAA 2D not supported on this device.");
 			}
 			rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
 		}
@@ -2884,58 +2884,6 @@ void TextureStorage::_create_render_target_backbuffer(RenderTarget *rt) {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-	// Generate MSAA 2D backbuffer
-	if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
-		glGenFramebuffers(1, &rt->msaa_2d.backbuffer_fbo);
-		glBindFramebuffer(GL_FRAMEBUFFER, rt->msaa_2d.backbuffer_fbo);
-
-#ifdef ANDROID_ENABLED // Only supported on OpenGLES!
-		Config *config = Config::get_singleton();
-		if (config->rt_msaa_supported) {
-			// Needs resolve is already false at this point
-			glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->backbuffer, 0, rt->msaa_2d.samples);
-		} else {
-#else
-		{
-#endif
-			// Create our color buffer
-			glGenRenderbuffers(1, &rt->msaa_2d.backbuffer);
-			glBindRenderbuffer(GL_RENDERBUFFER, rt->msaa_2d.backbuffer);
-
-			glRenderbufferStorageMultisample(GL_RENDERBUFFER, rt->msaa_2d.samples, rt->color_internal_format, rt->size.x, rt->size.y);
-			GLES3::Utilities::get_singleton()->render_buffer_allocated_data(rt->msaa_2d.backbuffer, rt->size.x * rt->size.y * 4 * rt->msaa_2d.samples, "MSAA 2D backbuffer color render buffer");
-
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rt->msaa_2d.backbuffer);
-		}
-
-		status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-		if (status != GL_FRAMEBUFFER_COMPLETE) {
-			// If we couldn't create our framebuffer just fail and disable MSAA.
-			WARN_PRINT("Could not create 2D MSAA backbuffer, status: " + get_framebuffer_error(status));
-
-			glDeleteFramebuffers(1, &rt->msaa_2d.fbo);
-			glDeleteFramebuffers(1, &rt->msaa_2d.backbuffer_fbo);
-			rt->msaa_2d.fbo = 0;
-			rt->msaa_2d.backbuffer_fbo = 0;
-
-			if (rt->msaa_2d.color != 0) {
-				GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.color);
-				rt->msaa_2d.color = 0;
-			}
-			if (rt->msaa_2d.backbuffer != 0) {
-				GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.backbuffer);
-				rt->msaa_2d.backbuffer = 0;
-			}
-
-			rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
-			rt->msaa_2d.samples = 1;
-			rt->msaa_2d.needs_resolve = false;
-		} else {
-			glClearColor(0, 0, 0, 0);
-			glClear(GL_COLOR_BUFFER_BIT);
-		}
-	}
 }
 
 void TextureStorage::_clear_render_target(RenderTarget *rt) {
@@ -3025,16 +2973,6 @@ void TextureStorage::_clear_render_target(RenderTarget *rt) {
 		GLES3::Utilities::get_singleton()->texture_free_data(rt->backbuffer_depth);
 		rt->backbuffer_depth = 0;
 	}
-
-	if (rt->msaa_2d.backbuffer_fbo != 0) {
-		glDeleteFramebuffers(1, &rt->msaa_2d.backbuffer_fbo);
-		rt->msaa_2d.backbuffer_fbo = 0;
-	}
-	if (rt->msaa_2d.backbuffer != 0) {
-		GLES3::Utilities::get_singleton()->render_buffer_free_data(rt->msaa_2d.backbuffer);
-		rt->msaa_2d.backbuffer = 0;
-	}
-
 	_render_target_clear_sdf(rt);
 }
 
@@ -3347,16 +3285,11 @@ void TextureStorage::render_target_set_msaa(RID p_render_target, RSE::ViewportMS
 		return;
 	}
 
-	// WARN_PRINT("2D MSAA is not yet supported for GLES3.");
-
-	// if (rt->overridden.color.is_null()) {
-	// 	_clear_render_target(rt);
-	// 	rt->msaa = p_msaa;
-	// 	_update_render_target_color(rt);
-	// }
-	_clear_render_target(rt);
-	rt->msaa_2d.mode = p_msaa;
-	_update_render_target_color(rt);
+	if (rt->overridden.color.is_null()) {
+		_clear_render_target(rt);
+		rt->msaa_2d.mode = p_msaa;
+		_update_render_target_color(rt);
+	}
 }
 
 RSE::ViewportMSAA TextureStorage::render_target_get_msaa(RID p_render_target) const {
@@ -3364,6 +3297,22 @@ RSE::ViewportMSAA TextureStorage::render_target_get_msaa(RID p_render_target) co
 	ERR_FAIL_NULL_V(rt, RSE::VIEWPORT_MSAA_DISABLED);
 
 	return rt->msaa_2d.mode;
+}
+
+void TextureStorage::render_target_do_msaa_resolve(RID p_render_target) {
+	RenderTarget *render_target = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL(render_target);
+
+	// Blit MSAA 2D buffer to final buffer
+	if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.needs_resolve) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, render_target->msaa_2d.fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, render_target->fbo);
+
+		glBlitFramebuffer(0, 0, render_target->size.x, render_target->size.y,
+				0, 0, render_target->size.x, render_target->size.y,
+				GL_COLOR_BUFFER_BIT, GL_NEAREST);
+		glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);
+	}
 }
 
 void TextureStorage::render_target_set_use_hdr(RID p_render_target, bool p_use_hdr_2d) {
@@ -3451,6 +3400,22 @@ void TextureStorage::render_target_do_clear_request(RID p_render_target) {
 	glClearBufferfv(GL_COLOR, 0, rt->clear_color.components);
 	rt->clear_requested = false;
 	glBindFramebuffer(GL_FRAMEBUFFER, system_fbo);
+}
+
+void TextureStorage::render_target_prepare_canvas_msaa(RID p_render_target) {
+	RenderTarget *render_target = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL(render_target);
+
+	if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+		glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.fbo);
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, render_target->color);
+		GLES3::CopyEffects::get_singleton()->copy_to_rect(Rect2(Vector2(0, 0), Vector2(1, 1)), false);
+	}
+}
+
+void TextureStorage::render_target_finalize_canvas_msaa(RID p_render_target) {
+	render_target_do_msaa_resolve(p_render_target);
 }
 
 GLuint TextureStorage::render_target_get_fbo(RID p_render_target) const {
@@ -3841,15 +3806,6 @@ void TextureStorage::render_target_copy_to_back_buffer(RID p_render_target, cons
 	}
 
 	glEnable(GL_BLEND); // 2D starts with blend enabled.
-
-	// MSAA 2D: Blit backbuffer back to msaa backbuffer
-	if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && rt->msaa_2d.needs_resolve) {
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, rt->backbuffer_fbo);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, rt->msaa_2d.backbuffer_fbo);
-		glBlitFramebuffer(region.position.x, region.position.y, region.position.x + region.size.x, region.position.y + region.size.y,
-				region.position.x, region.position.y, region.position.x + region.size.x, region.position.y + region.size.y,
-				GL_COLOR_BUFFER_BIT, GL_NEAREST);
-	}
 }
 
 void TextureStorage::render_target_clear_back_buffer(RID p_render_target, const Rect2i &p_region, const Color &p_color) {
@@ -3860,28 +3816,6 @@ void TextureStorage::render_target_clear_back_buffer(RID p_render_target, const 
 	if (rt->backbuffer_fbo == 0) {
 		_create_render_target_backbuffer(rt);
 	}
-
-	// Clear MSAA 2D backbuffer
-
-	if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && rt->msaa_2d.backbuffer_fbo != 0) {
-		Rect2i region;
-		if (p_region != Rect2i()) {
-			// not fullscreen
-			region = Rect2i(Size2i(), rt->size).intersection(p_region);
-			if (region.size == Size2i()) {
-				return; // nothing to do
-			}
-			glEnable(GL_SCISSOR_TEST);
-			glScissor(region.position.x, region.position.y, region.size.x, region.size.y);
-		}
-		glBindFramebuffer(GL_FRAMEBUFFER, rt->msaa_2d.backbuffer_fbo);
-		glClearColor(p_color.r, p_color.g, p_color.b, p_color.a);
-		glClear(GL_COLOR_BUFFER_BIT);
-
-		glDisable(GL_SCISSOR_TEST);
-	}
-
-	// Clear normal backbuffer
 
 	Rect2i region;
 	if (p_region == Rect2i()) {

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2706,7 +2706,7 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 		glClear(GL_COLOR_BUFFER_BIT);
 	}
 
-	if (rt->view_count == 1 && rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && (config->msaa_supported || config->rt_msaa_supported)) {
+	if (rt->view_count == 1 && rt->msaa_2d.mode != RSE::VIEWPORT_MSAA_DISABLED && (config->msaa_supported || config->rt_msaa_supported)) {
 		/* MSAA 2D FBO */
 		GLsizei samples[] = { 1, 2, 4, 8 };
 		rt->msaa_2d.samples = samples[rt->msaa_2d.mode];
@@ -2751,7 +2751,7 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 				rt->msaa_2d.color = 0;
 			}
 
-			rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
+			rt->msaa_2d.mode = RSE::VIEWPORT_MSAA_DISABLED;
 			rt->msaa_2d.samples = 1;
 			rt->msaa_2d.needs_resolve = false;
 		} else {
@@ -2760,14 +2760,14 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 		}
 
 	} else {
-		if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+		if (rt->msaa_2d.mode != RSE::VIEWPORT_MSAA_DISABLED) {
 			if (rt->view_count > 1) {
 				// We don't support 2D MSAA in multiview
 				WARN_PRINT_ONCE("MSAA 2D not supported in multiview.");
 			} else if (!config->msaa_supported && !config->rt_msaa_supported) {
 				WARN_PRINT_ONCE("MSAA 2D not supported on this device.");
 			}
-			rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
+			rt->msaa_2d.mode = RSE::VIEWPORT_MSAA_DISABLED;
 		}
 
 		rt->msaa_2d.samples = 1;
@@ -3247,7 +3247,7 @@ void TextureStorage::render_target_set_direct_to_screen(RID p_render_target, boo
 	_clear_render_target(rt);
 	rt->direct_to_screen = p_direct_to_screen;
 	if (rt->direct_to_screen) {
-		rt->msaa_2d.mode = RS::VIEWPORT_MSAA_DISABLED;
+		rt->msaa_2d.mode = RSE::VIEWPORT_MSAA_DISABLED;
 		rt->overridden.color = RID();
 		rt->overridden.depth = RID();
 		rt->overridden.velocity = RID();
@@ -3304,7 +3304,7 @@ void TextureStorage::render_target_do_msaa_resolve(RID p_render_target) {
 	ERR_FAIL_NULL(render_target);
 
 	// Blit MSAA 2D buffer to final buffer
-	if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.needs_resolve) {
+	if (render_target->msaa_2d.mode != RSE::VIEWPORT_MSAA_DISABLED && render_target->msaa_2d.needs_resolve) {
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, render_target->msaa_2d.fbo);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, render_target->fbo);
 
@@ -3406,7 +3406,7 @@ void TextureStorage::render_target_prepare_canvas_msaa(RID p_render_target) {
 	RenderTarget *render_target = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL(render_target);
 
-	if (render_target->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED) {
+	if (render_target->msaa_2d.mode != RSE::VIEWPORT_MSAA_DISABLED) {
 		glBindFramebuffer(GL_FRAMEBUFFER, render_target->msaa_2d.fbo);
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, render_target->color);
@@ -3782,7 +3782,7 @@ void TextureStorage::render_target_copy_to_back_buffer(RID p_render_target, cons
 	}
 
 	// MSAA 2D: Resolve (part of the) FBO for backbuffer
-	if (rt->msaa_2d.mode != RS::VIEWPORT_MSAA_DISABLED && rt->msaa_2d.needs_resolve) {
+	if (rt->msaa_2d.mode != RSE::VIEWPORT_MSAA_DISABLED && rt->msaa_2d.needs_resolve) {
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, rt->msaa_2d.fbo);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, rt->fbo);
 		glBlitFramebuffer(region.position.x, region.position.y, region.position.x + region.size.x, region.position.y + region.size.y,

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -388,7 +388,7 @@ struct RenderTarget {
 	Rect2i render_region;
 
 	struct RTmsaa2d {
-		RS::ViewportMSAA mode = RS::VIEWPORT_MSAA_DISABLED;
+		RSE::ViewportMSAA mode = RSE::VIEWPORT_MSAA_DISABLED;
 		bool needs_resolve = false;
 		GLsizei samples = 1;
 		GLuint fbo = 0;

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -387,6 +387,16 @@ struct RenderTarget {
 
 	Rect2i render_region;
 
+	struct RTmsaa2d {
+		RS::ViewportMSAA mode = RS::VIEWPORT_MSAA_DISABLED;
+		bool needs_resolve = false;
+		GLsizei samples = 1;
+		GLuint fbo = 0;
+		GLuint color = 0;
+		GLuint backbuffer_fbo = 0;
+		GLuint backbuffer = 0;
+	} msaa_2d;
+
 	struct RTOverridden {
 		bool is_overridden = false;
 		bool depth_has_stencil = false;

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -393,8 +393,6 @@ struct RenderTarget {
 		GLsizei samples = 1;
 		GLuint fbo = 0;
 		GLuint color = 0;
-		GLuint backbuffer_fbo = 0;
-		GLuint backbuffer = 0;
 	} msaa_2d;
 
 	struct RTOverridden {
@@ -697,11 +695,14 @@ public:
 	virtual RSE::ViewportMSAA render_target_get_msaa(RID p_render_target) const override;
 	virtual void render_target_set_msaa_needs_resolve(RID p_render_target, bool p_needs_resolve) override {}
 	virtual bool render_target_get_msaa_needs_resolve(RID p_render_target) const override { return false; }
-	virtual void render_target_do_msaa_resolve(RID p_render_target) override {}
+	virtual void render_target_do_msaa_resolve(RID p_render_target) override;
 	virtual void render_target_set_use_hdr(RID p_render_target, bool p_use_hdr_2d) override;
 	virtual bool render_target_is_using_hdr(RID p_render_target) const override;
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_use_debanding) override {}
 	virtual bool render_target_is_using_debanding(RID p_render_target) const override { return false; }
+
+	virtual void render_target_prepare_canvas_msaa(RID p_render_target) override;
+	virtual void render_target_finalize_canvas_msaa(RID p_render_target) override;
 
 	// new
 	void render_target_set_as_unused(RID p_render_target) override {

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -194,6 +194,9 @@ public:
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_use_debanding) override {}
 	virtual bool render_target_is_using_debanding(RID p_render_target) const override { return false; }
 
+	virtual void render_target_prepare_canvas_msaa(RID p_render_target) override {}
+	virtual void render_target_finalize_canvas_msaa(RID p_render_target) override {}
+
 	virtual void render_target_request_clear(RID p_render_target, const Color &p_clear_color) override {}
 	virtual bool render_target_is_clear_requested(RID p_render_target) override { return false; }
 	virtual Color render_target_get_clear_request_color(RID p_render_target) override { return Color(); }

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -870,6 +870,9 @@ public:
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_use_debanding) override;
 	virtual bool render_target_is_using_debanding(RID p_render_target) const override;
 
+	virtual void render_target_prepare_canvas_msaa(RID p_render_target) override {}
+	virtual void render_target_finalize_canvas_msaa(RID p_render_target) override {}
+
 	void render_target_copy_to_back_buffer(RID p_render_target, const Rect2i &p_region, bool p_gen_mipmaps);
 	void render_target_clear_back_buffer(RID p_render_target, const Rect2i &p_region, const Color &p_color);
 	void render_target_gen_back_buffer_mipmaps(RID p_render_target, const Rect2i &p_region);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -687,7 +687,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		if (!scenario_draw_canvas_bg && can_draw_3d) {
 			RSG::texture_storage->render_target_prepare_canvas_msaa(p_viewport->render_target);
 		}
-		
+
 		int canvas_idx = 0;
 		for (const KeyValue<Viewport::CanvasKey, Viewport::CanvasData *> &E : canvas_map) {
 			RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value->canvas);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -682,6 +682,12 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			scenario_draw_canvas_bg = false;
 		}
 
+		// 2D Render begin (Copy already drawn elements onto 2D MSAA fbo)
+		// Needs only to be done when we already have a 3D scene rendered which needs to be copied
+		if (!scenario_draw_canvas_bg && can_draw_3d) {
+			RSG::texture_storage->render_target_prepare_canvas_msaa(p_viewport->render_target);
+		}
+		
 		int canvas_idx = 0;
 		for (const KeyValue<Viewport::CanvasKey, Viewport::CanvasData *> &E : canvas_map) {
 			RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value->canvas);
@@ -720,6 +726,9 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			}
 
 			if (scenario_draw_canvas_bg && E.key.get_layer() >= scenario_canvas_max_layer) {
+				// We need to resolve already drawn 2D elements to be able to use it in the 3D render
+				// Doesn't matter if this is called before or after clear request since the clear request is only run if no 2D elements were drawn.
+				RSG::texture_storage->render_target_finalize_canvas_msaa(p_viewport->render_target);
 				// There may be an outstanding clear request if a clear was requested, but no 2D elements were drawn.
 				// Clear now otherwise we copy over garbage from the render target.
 				RSG::texture_storage->render_target_do_clear_request(p_viewport->render_target);
@@ -729,11 +738,15 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 					_draw_3d(p_viewport);
 				}
 
+				// After drawing the 3D scene we need to copy/draw it onto the 2D MSAA buffer again.
+				RSG::texture_storage->render_target_prepare_canvas_msaa(p_viewport->render_target);
 				scenario_draw_canvas_bg = false;
 			}
 
 			canvas_idx++;
 		}
+
+		RSG::texture_storage->render_target_finalize_canvas_msaa(p_viewport->render_target);
 
 		if (scenario_draw_canvas_bg) {
 			// There may be an outstanding clear request if a clear was requested, but no 2D elements were drawn.

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -172,6 +172,9 @@ public:
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_use_debanding) = 0;
 	virtual bool render_target_is_using_debanding(RID p_render_target) const = 0;
 
+	virtual void render_target_prepare_canvas_msaa(RID p_render_target) = 0;
+	virtual void render_target_finalize_canvas_msaa(RID p_render_target) = 0;
+
 	virtual void render_target_request_clear(RID p_render_target, const Color &p_clear_color) = 0;
 	virtual bool render_target_is_clear_requested(RID p_render_target) = 0;
 	virtual Color render_target_get_clear_request_color(RID p_render_target) = 0;


### PR DESCRIPTION
This PR implements the 2D MSAA in the OpenGL3 backend. It is based on the discussions in #83976 and the already existing code from #84688

Current base commit: 6d6e822 (4.7 Beta 1)

# New version (v2)

I overhauled the previous implementation to address the amount of blitting used in my first approach. You can find the implementation details of the older version below. Images are provided after.
I will squash the commits if this approach is approved. For now I'd keep both to have the comparison to the first version available.

### Technical details

We create a multisampled framebuffer when turning 2D MSAA on and delete it again when turned off again.

I introduced two new functions in the TextureStorage class:
- `render_target_prepare_canvas_msaa` in which we copy the scene that is rendered up to this point onto the MSAA framebuffer using the CopyEffects class.
- `render_target_finalize_canvas_msaa` in which we simply call `render_target_do_msaa_resolve` which in itself blits the final 2D render onto the normal framebuffer.

These functions are only implemented in the OpenGL backend since these operations are already implied in the other backends.

`render_target_prepare_canvas_msaa` is called after a potential 3D scene is rendered, before we render the 2D scene. `render_target_finalize_canvas_msaa` is called after the 2D scene is done rendering. Since Godot supports the rendering of the 3D scene in between the 2D scene which in turn relies on the non-multisampled framebuffer, we need to resolve our MSAA framebuffer before rendering the 3D scene. This means that in this case we need two full resolves in one render cycle.

Furthermore, if the backbuffer is used we might need to copy parts of the frontbuffer onto the backbuffer. For this I introduced a partial resolve in `TextureStorage::render_target_copy_to_back_buffer`.

For Mobile devices we can still use the `GL_EXT_multisampled_render_to_texture` extension so we don't need the resolve steps.

### Discussion
For this approach I decided to not support MSAA on the backbuffer, apart from the mentioned partial resolve when copying from the frontbuffer to the backbuffer.
1. Because the other backends don't support it as well
2. Because otherwise we would have way too many blitting and copying operations which is counterproductive, especially for the compatibility backend.

I also decided that the partial resolve is a tradeoff worth making, since otherwise we would need to turn off MSAA completely when encountering a copy from the frontbuffer to the backbuffer.


# Old version (v1)

### Technical details

~~We create a multisampled framebuffer when turning 2D MSAA on, as well as a multisampled backbuffer if it is needed.~~

~~When rendering without the backbuffer we simply have to blit the already rendered 3D scene (if available) to the multisampled framebuffer, render the complete scene and finally resolve the MSAA buffer into the normal framebuffer. I put the final resolve now into the end of `RasterizerCanvasGLES3::canvas_render_items`, since everything should be already rendererd at this point (but please correct if I am wrong).~~

~~When using the backbuffer we have to consider the following things:~~
- ~~We need to resolve the backbuffer everytime we render onto it, since we sample from it later on~~
- ~~When copying parts of or the complete render_target we first need to resolve the frontbuffer, so we can sample from it, and after copying we need to blit the backbuffer back to the multisampled backbuffer~~
- ~~When clearing the backbuffer we need to clear the normal backbuffer as well as the multisampled backbuffer~~

~~For Mobile devices we want to use the `GL_EXT_multisampled_render_to_texture` extension so we don't need the resolve step.~~

### Discussion

~~While this approach works, we introduce quite a lot of blitting operations when using the backbuffer. If this is not wanted, another approach could be to copy or adjust the relevant shaders (like the copy shader or the default_clip_children_shader) to support multisampled textures.~~
~~While making the images below, I noticed that the vulkan backend does not include MSAA on the backbuffer. That would of course also be an option for the OpenGL backend.~~

### Images

<figure>
<img width="1150" height="646" alt="OpenGL_2D_NoMSAA" src="https://github.com/user-attachments/assets/9b7b916a-9edd-4a28-bf7b-cefbf238891a" />
<figcaption>No Antialiasing; Scene with lines, meshes, Sprites, screenreading shader, canvasgroup and groups with a clipped child</figcaption>
</figure>

<figure>
<img width="1149" height="647" alt="OpenGL_2D_8xMSAA" src="https://github.com/user-attachments/assets/c210b3c3-9ceb-43e8-b7c7-62909cf20cd5" />
<figcaption>MSAA 8x in OpenGL</figcaption>
</figure>

<figure>
<img width="1152" height="647" alt="VK_2D_8xMSAA" src="https://github.com/user-attachments/assets/9e11cda6-fc51-4765-9761-a041fe5bbe9f" />
<figcaption>MSAA 8x in Vulkan</figcaption>
</figure>

<figure>
<img width="1152" height="648" alt="OpenGL_2D_NoMSAA_over_3D_8xMSAA" src="https://github.com/user-attachments/assets/64b88a53-4d58-4d7e-95fa-c5e5cd0f0108" />
<figcaption>MSAA 8x 3D scene with not antialised 2D scene on top in OpenGL</figcaption>
</figure>

<figure>
<img width="1150" height="647" alt="OpenGL_2D_8xMSAA_over_3D_8xMSAA" src="https://github.com/user-attachments/assets/aa007dd0-cb09-464f-9000-faeafd43d8da" />
<figcaption>MSAA 8x 3D scene with MSAA 8x 2D scene on top in OpenGL</figcaption>
</figure>

<figure>
<img width="1151" height="646" alt="OpenGL_3D_8xMSAA_inBetween_2D_8xMSAA" src="https://github.com/user-attachments/assets/c4b3a0f2-21fe-415d-9d84-34abb9e31350" />
<figcaption>MSAA 8x 3D scene in between MSAA 8x 2D scene in OpenGL</figcaption>
</figure>

closes #69462 and #84688
