### PR TITLE
Core: rm class_db.h include from variant_call.cpp

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -30,11 +30,12 @@
 
 #include "variant.h"
 
+STATIC_ASSERT_INCOMPLETE_TYPE(class, ClassDB);
+
 #include "core/crypto/crypto_core.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
 #include "core/io/marshalls.h"
-#include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/templates/a_hash_map.h"
 #include "core/templates/local_vector.h"


### PR DESCRIPTION
* Part of #111218

Removed the unnecessary `class_db.h` include from `variant_call.cpp` and replaced with incomplete assertion to guard against regressions. 
