### PR TITLE
Core: rm class_db.h include from message_queue.cpp

### DIFF
--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -30,8 +30,9 @@
 
 #include "message_queue.h"
 
+STATIC_ASSERT_INCOMPLETE_TYPE(class, ClassDB);
+
 #include "core/config/project_settings.h"
-#include "core/object/class_db.h"
 #include "core/object/script_language.h"
 
 #include <cstdio>


### PR DESCRIPTION
* Part of #111218

Removed the unnecessary `class_db.h` include from `message_queue.cpp` and replaced with incomplete assertion to guard against regressions. 
