### PR TITLE
Core: rm class_db.h include from dictionary.cpp

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -33,13 +33,13 @@
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Array);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Object);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, String);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, ClassDB);
 
 #include "core/templates/hash_map.h"
 #include "core/templates/safe_refcount.h"
 #include "core/variant/container_type_validate.h"
 #include "core/variant/variant.h"
 // required in this order by VariantInternal, do not remove this comment.
-#include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/variant/type_info.h"
 #include "core/variant/variant_internal.h"


### PR DESCRIPTION
* Part of #111218

Removed the unnecessary `class_db.h` include from `dictionary.cpp` and replaced with incomplete assertion to guard against regressions. 