### PR TITLE
Add autocomplete support to AnimationPlayer's `play_section` methods

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -52,6 +52,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/settings/editor_settings.h"
+#include "scene/animation/animation_player.h"
 #endif
 
 Vector<String> GDScriptLanguage::get_comment_delimiters() const {
@@ -3193,6 +3194,44 @@ static void _list_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						r_result.insert(option.display, option);
 					}
 				}
+
+				if ((p_argidx == 1 || p_argidx == 2) && p_call && ClassDB::is_parent_class(class_name, SNAME("AnimationPlayer")) && (method == SNAME("play_section_with_markers") || method == SNAME("play_section_with_markers_backwards"))) {
+					if (p_call->arguments.size() > 0 && p_call->arguments[0]->reduced && p_call->arguments[0]->reduced_value.is_string()) {
+						StringName animation_name = p_call->arguments[0]->reduced_value;
+						AnimationPlayer *animation_player = Object::cast_to<AnimationPlayer>(base);
+						if (animation_player->has_animation(animation_name)) {
+							PackedStringArray marker_names = animation_player->get_animation(animation_name)->get_marker_names();
+							int64_t from = 0;
+							int64_t to = marker_names.size();
+							if (p_call->arguments.size() > 1 && p_call->arguments[1]->reduced && p_call->arguments[1]->reduced_value.is_string() && p_call->arguments[1]->reduced_value.booleanize()) {
+								if (p_argidx == 1) {
+									// For the start marker, only suggest markers that come before the end marker.
+									// Note that this code path can only happen if the start and end markers are both filled, and then the user tries to rewrite the start marker argument,
+									// so the end marker argument would move forward from slot 2 to slot 1 here.
+									int64_t idx = marker_names.rfind(p_call->arguments[1]->reduced_value);
+									if (idx >= 0) {
+										to = idx;
+									}
+								} else {
+									// For the end marker, only suggest markers that come after the start marker.
+									int64_t idx = marker_names.find(p_call->arguments[1]->reduced_value);
+									if (idx >= 0) {
+										from = idx + 1;
+									}
+								}
+							}
+
+							for (int64_t i = from; i < to; i++) {
+								ScriptLanguage::CodeCompletionOption option(marker_names[i].quote(), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
+								r_result.insert(option.display, option);
+							}
+						}
+					}
+					// Empty marker is always valid.
+					ScriptLanguage::CodeCompletionOption option("\"\"", ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
+					r_result.insert(option.display, option);
+				}
+
 				if (EDITOR_GET("text_editor/completion/complete_file_paths")) {
 					if (p_argidx == 0 && method == SNAME("change_scene_to_file") && ClassDB::is_parent_class(class_name, SNAME("SceneTree"))) {
 						HashMap<String, ScriptLanguage::CodeCompletionOption> list;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -871,7 +871,7 @@ Tween::EaseType AnimationPlayer::get_auto_capture_ease_type() const {
 #ifdef TOOLS_ENABLED
 void AnimationPlayer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
-	if (p_idx == 0 && (pf == "play" || pf == "play_backwards" || pf == "has_animation" || pf == "queue")) {
+	if (p_idx == 0 && (pf == "play" || pf == "play_backwards" || pf == "play_section" || pf == "play_section_backwards" || pf == "play_section_with_markers" || pf == "play_section_with_markers_backwards" || pf == "has_animation" || pf == "queue")) {
 		List<StringName> al;
 		get_animation_list(&al);
 		for (const StringName &name : al) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Follow-up PR to https://github.com/godotengine/godot/pull/91765, in which I forgot to add autocomplete support to the new section playback methods. You may have noticed that the animation name autocomplete dropdown doesn't show up at all for `play_section` and `play_section_with_markers()`, etc.

In addition to providing autocomplete for the animation name argument, autocomplete support for marker names is also added. ~~This requires modifying `Object::get_argument_options()`'s signature and passing a list of resolved arguments, but as this virtual method isn't exposed to ClassDB to begin with, compatibility is not affected.~~

<img width="905" height="144" alt="image" src="https://github.com/user-attachments/assets/1bbd1d89-47f1-4d5c-8efc-80caa940c874" />

<img width="896" height="152" alt="image" src="https://github.com/user-attachments/assets/2702a119-00a1-4af4-8773-30e111db4927" />

https://github.com/user-attachments/assets/c9d53fa5-0e7b-422c-95a2-38f2bda92fa6

