### PR TITLE
Always apply tonemapping to solid color background in Compatibility

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -862,7 +862,7 @@ void RasterizerSceneGLES3::_draw_sky(RID p_env, const Projection &p_projection, 
 			material_data = static_cast<GLES3::SkyMaterialData *>(material_storage->material_get_data(sky_material, RSE::SHADER_SKY));
 		}
 	} else if (background == RSE::ENV_BG_CLEAR_COLOR || background == RSE::ENV_BG_COLOR) {
-		sky_material = sky_globals.fog_material;
+		sky_material = sky_globals.clear_color_material;
 		material_data = static_cast<GLES3::SkyMaterialData *>(material_storage->material_get_data(sky_material, RSE::SHADER_SKY));
 	}
 
@@ -953,7 +953,7 @@ void RasterizerSceneGLES3::_update_sky_radiance(RID p_env, const Projection &p_p
 			material_data = static_cast<GLES3::SkyMaterialData *>(material_storage->material_get_data(sky_material, RSE::SHADER_SKY));
 		}
 	} else if (background == RSE::ENV_BG_CLEAR_COLOR || background == RSE::ENV_BG_COLOR) {
-		sky_material = sky_globals.fog_material;
+		sky_material = sky_globals.clear_color_material;
 		material_data = static_cast<GLES3::SkyMaterialData *>(material_storage->material_get_data(sky_material, RSE::SHADER_SKY));
 	}
 
@@ -2568,7 +2568,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	render_list[RENDER_LIST_ALPHA].sort_by_reverse_depth_and_priority();
 
 	bool draw_sky = false;
-	bool draw_sky_fog_only = false;
+	bool draw_sky_cc_only = false;
 	bool keep_color = false;
 	bool draw_canvas = false;
 	bool draw_feed = false;
@@ -2596,15 +2596,23 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 					clear_color = environment_get_bg_color(render_data.environment);
 				}
 
-				if (!render_data.transparent_bg && environment_get_fog_enabled(render_data.environment)) {
-					draw_sky_fog_only = true;
-					GLES3::MaterialStorage::get_singleton()->material_set_param(sky_globals.fog_material, "clear_color", Variant(clear_color));
+				int32_t tonemapper = environment_get_tone_mapper(render_data.environment);
+				float white = environment_get_white(render_data.environment, false, 1.0f);
+				bool use_tonemap = !apply_environment_effects_in_post && tonemapper != RSE::ENV_TONE_MAPPER_LINEAR && !(tonemapper == RSE::ENV_TONE_MAPPER_REINHARD && white == 1.0);
+
+				if (!render_data.transparent_bg && (environment_get_fog_enabled(render_data.environment) || use_tonemap)) {
+					draw_sky_cc_only = true;
+					GLES3::MaterialStorage::get_singleton()->material_set_param(sky_globals.clear_color_material, "clear_color", Variant(clear_color));
+				} else if (use_tonemap) {
+					apply_environment_effects_in_post = true;
 				}
 
+				float exposure = environment_get_exposure(render_data.environment);
+
 				clear_color = clear_color.srgb_to_linear();
-				clear_color.r *= bg_energy_multiplier;
-				clear_color.g *= bg_energy_multiplier;
-				clear_color.b *= bg_energy_multiplier;
+				clear_color.r *= bg_energy_multiplier * exposure;
+				clear_color.g *= bg_energy_multiplier * exposure;
+				clear_color.b *= bg_energy_multiplier * exposure;
 				clear_color = clear_color.linear_to_srgb();
 			} break;
 			case RSE::ENV_BG_SKY: {
@@ -2632,7 +2640,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		sky_ambient |= ambient_source == RSE::ENV_AMBIENT_SOURCE_BG && bg_mode == RSE::ENV_BG_SKY;
 
 		// setup sky if used for ambient, reflections, or background
-		if (draw_sky || draw_sky_fog_only || sky_reflections || sky_ambient) {
+		if (draw_sky || draw_sky_cc_only || sky_reflections || sky_ambient) {
 			RENDER_TIMESTAMP("Setup Sky");
 			Projection projection = render_data.cam_projection;
 
@@ -2862,7 +2870,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	scene_state.enable_gl_depth_draw(false);
 	scene_state.enable_gl_stencil_test(false);
 
-	if (draw_sky || draw_sky_fog_only) {
+	if (draw_sky || draw_sky_cc_only) {
 		RENDER_TIMESTAMP("Render Sky");
 
 		scene_state.enable_gl_depth_test(true);
@@ -4694,10 +4702,10 @@ void sky() {
 		material_storage->material_set_shader(sky_globals.default_material, sky_globals.default_shader);
 	}
 	{
-		sky_globals.fog_shader = material_storage->shader_allocate();
-		material_storage->shader_initialize(sky_globals.fog_shader);
+		sky_globals.clear_color_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(sky_globals.clear_color_shader);
 
-		material_storage->shader_set_code(sky_globals.fog_shader, R"(
+		material_storage->shader_set_code(sky_globals.clear_color_shader, R"(
 // Default clear color sky shader.
 
 shader_type sky;
@@ -4708,10 +4716,10 @@ void sky() {
 	COLOR = clear_color.rgb;
 }
 )");
-		sky_globals.fog_material = material_storage->material_allocate();
-		material_storage->material_initialize(sky_globals.fog_material);
+		sky_globals.clear_color_material = material_storage->material_allocate();
+		material_storage->material_initialize(sky_globals.clear_color_material);
 
-		material_storage->material_set_shader(sky_globals.fog_material, sky_globals.fog_shader);
+		material_storage->material_set_shader(sky_globals.clear_color_material, sky_globals.clear_color_shader);
 	}
 
 	{
@@ -4784,8 +4792,8 @@ RasterizerSceneGLES3::~RasterizerSceneGLES3() {
 	GLES3::MaterialStorage::get_singleton()->shaders.sky_shader.version_free(sky_globals.shader_default_version);
 	RSG::material_storage->material_free(sky_globals.default_material);
 	RSG::material_storage->shader_free(sky_globals.default_shader);
-	RSG::material_storage->material_free(sky_globals.fog_material);
-	RSG::material_storage->shader_free(sky_globals.fog_shader);
+	RSG::material_storage->material_free(sky_globals.clear_color_material);
+	RSG::material_storage->shader_free(sky_globals.clear_color_shader);
 	GLES3::Utilities::get_singleton()->buffer_free_data(sky_globals.screen_triangle);
 	glDeleteVertexArrays(1, &sky_globals.screen_triangle_array);
 	GLES3::Utilities::get_singleton()->buffer_free_data(sky_globals.directional_light_buffer);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -805,8 +805,8 @@ protected:
 		RID shader_default_version;
 		RID default_material;
 		RID default_shader;
-		RID fog_material;
-		RID fog_shader;
+		RID clear_color_material;
+		RID clear_color_shader;
 		GLuint screen_triangle = 0;
 		GLuint screen_triangle_array = 0;
 		uint32_t max_directional_lights = 4;


### PR DESCRIPTION
The sky shader always needs to be drawn if we are tonemapping.

If we are using a transparent background, tonemapping needs to happen in post because we are not drawing a sky shader.

Fixes https://github.com/godotengine/godot/issues/102860