### PR TITLE
Convert LibGodot over to instance IDs, for safety and ease of use in GDExtension libraries.

### DIFF
--- a/core/extension/libgodot.h
+++ b/core/extension/libgodot.h
@@ -53,9 +53,9 @@ extern "C" {
  * @param p_argv The C-style array of command line arguments.
  * @param p_init_func GDExtension initialization function of the host application.
  *
- * @return A pointer to created \ref GodotInstance GDExtension object or nullptr if there was an error.
+ * @return An instance ID of created \ref GodotInstance object or 0 if there was an error.
  */
-LIBGODOT_API GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func);
+LIBGODOT_API GDObjectInstanceID libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func);
 
 /**
  * @name libgodot_destroy_godot_instance
@@ -63,10 +63,10 @@ LIBGODOT_API GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, cha
  *
  * Destroys an existing Godot instance.
  *
- * @param p_godot_instance The reference to the GodotInstance object to destroy.
+ * @param p_godot_instance_id The instance ID of the \ref GodotInstance object to destroy.
  *
  */
-LIBGODOT_API void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance);
+LIBGODOT_API void libgodot_destroy_godot_instance(GDObjectInstanceID p_godot_instance_id);
 
 #ifdef __cplusplus
 }

--- a/platform/linuxbsd/libgodot_linuxbsd.cpp
+++ b/platform/linuxbsd/libgodot_linuxbsd.cpp
@@ -39,14 +39,14 @@ static OS_LinuxBSD *os = nullptr;
 
 static GodotInstance *instance = nullptr;
 
-GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
-	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
+GDObjectInstanceID libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	ERR_FAIL_COND_V_MSG(instance != nullptr, 0, "Only one Godot Instance may be created.");
 
 	os = new OS_LinuxBSD();
 
 	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false);
 	if (err != OK) {
-		return nullptr;
+		return 0;
 	}
 
 	instance = memnew(GodotInstance);
@@ -54,14 +54,14 @@ GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], 
 		memdelete(instance);
 		// Note: When Godot Engine supports reinitialization, clear the instance pointer here.
 		//instance = nullptr;
-		return nullptr;
+		return 0;
 	}
 
-	return (GDExtensionObjectPtr)instance;
+	return instance->get_instance_id();
 }
 
-void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
-	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+void libgodot_destroy_godot_instance(GDObjectInstanceID p_godot_instance_id) {
+	GodotInstance *godot_instance = ObjectDB::get_instance<GodotInstance>(ObjectID(p_godot_instance_id));
 	if (instance == godot_instance) {
 		godot_instance->stop();
 		memdelete(godot_instance);

--- a/platform/macos/libgodot_macos.mm
+++ b/platform/macos/libgodot_macos.mm
@@ -39,8 +39,8 @@ static OS_MacOS *os = nullptr;
 
 static GodotInstance *instance = nullptr;
 
-GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
-	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
+GDObjectInstanceID libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	ERR_FAIL_COND_V_MSG(instance != nullptr, 0, "Only one Godot Instance may be created.");
 
 	uint32_t remaining_args = p_argc - 1;
 	os = new OS_MacOS_NSApp(p_argv[0], remaining_args, remaining_args > 0 ? &p_argv[1] : nullptr);
@@ -48,22 +48,22 @@ GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], 
 	@autoreleasepool {
 		Error err = Main::setup(p_argv[0], remaining_args, remaining_args > 0 ? &p_argv[1] : nullptr, false);
 		if (err != OK) {
-			return nullptr;
+			return 0;
 		}
 
 		instance = memnew(GodotInstance);
 		if (!instance->initialize(p_init_func)) {
 			memdelete(instance);
 			instance = nullptr;
-			return nullptr;
+			return 0;
 		}
 
-		return (GDExtensionObjectPtr)instance;
+		return instance->get_instance_id();
 	}
 }
 
-void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
-	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+void libgodot_destroy_godot_instance(GDObjectInstanceID p_godot_instance_id) {
+	GodotInstance *godot_instance = ObjectDB::get_instance<GodotInstance>(ObjectID(p_godot_instance_id));
 	if (instance == godot_instance) {
 		godot_instance->stop();
 		memdelete(godot_instance);

--- a/platform/windows/libgodot_windows.cpp
+++ b/platform/windows/libgodot_windows.cpp
@@ -39,28 +39,28 @@ static OS_Windows *os = nullptr;
 
 static GodotInstance *instance = nullptr;
 
-GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
-	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created at a time.");
+GDObjectInstanceID libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	ERR_FAIL_COND_V_MSG(instance != nullptr, 0, "Only one Godot Instance may be created at a time.");
 
 	os = new OS_Windows(GetModuleHandle(nullptr));
 
 	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false);
 	if (err != OK) {
-		return nullptr;
+		return 0;
 	}
 
 	instance = memnew(GodotInstance);
 	if (!instance->initialize(p_init_func)) {
 		memdelete(instance);
 		instance = nullptr;
-		return nullptr;
+		return 0;
 	}
 
-	return (GDExtensionObjectPtr)instance;
+	return instance->get_instance_id();
 }
 
-void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
-	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+void libgodot_destroy_godot_instance(GDObjectInstanceID p_godot_instance_id) {
+	GodotInstance *godot_instance = ObjectDB::get_instance<GodotInstance>(ObjectID(p_godot_instance_id));
 	if (instance == godot_instance) {
 		godot_instance->stop();
 		memdelete(godot_instance);


### PR DESCRIPTION
While working on the C# LibGodot functionality, @raulsntos pointed out that this API would be cleaner if we used instance IDs instead of raw pointers. This turns out to be completely correct; [here's the resulting changes in my test harness](https://github.com/zorbathut/libgodot_example/commit/ff3305a39a29313981a75737962e48102ee0889f), which you'll note avoids using two separate internal-only function calls in favor of a GDExtension-provided API.

The LibGodot API has not yet been released and so we can "break" it at will, but it's important that this go in before 4.6 to avoid locking us in to the old design.