### PR TITLE
Remove unnecessary class_db.h includes

### DIFF
--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -31,7 +31,6 @@
 #include "core_constants.h"
 
 #include "core/input/input_event.h"
-#include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "core/variant/variant.h"
 

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -31,7 +31,6 @@
 #include "message_queue.h"
 
 #include "core/config/project_settings.h"
-#include "core/object/class_db.h"
 #include "core/object/script_language.h"
 
 #include <cstdio>

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -39,7 +39,6 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, String);
 #include "core/variant/container_type_validate.h"
 #include "core/variant/variant.h"
 // required in this order by VariantInternal, do not remove this comment.
-#include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/variant/type_info.h"
 #include "core/variant/variant_internal.h"

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -34,7 +34,6 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
 #include "core/io/marshalls.h"
-#include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/templates/a_hash_map.h"
 #include "core/templates/local_vector.h"


### PR DESCRIPTION
rm class_db.h include from variant_call.cpp
rm class_db.h include from message_queue.cpp
rm class_db.h include from dictionary.cpp
rm class_db.h include from core_constants.cpp

* Part of #111218 

Went through the `*.cpp` files that included `class_db.h` and found 4 low hanging fruits. 
All others need ClassDB unfortunately. There are also no low hanging fruits in `.h` files which include `class_db.h`.

`.cpp`: 24 -> 20 files, 16.7% reduction
`.cpp` + `.h` : 61 -> 65 files, 6.1% reduction