### PR TITLE
Fix `text_editor/script_list/show_members_overview` editor setting docs/tooltip

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1462,7 +1462,7 @@
 			How many script names can be highlighted at most, if [member text_editor/script_list/script_temperature_enabled] is [code]true[/code]. Scripts older than this value use the default font color.
 		</member>
 		<member name="text_editor/script_list/show_members_overview" type="bool" setter="" getter="">
-			If [code]true[/code], displays an overview of the current script's member variables and functions at the left of the script editor. See also [member text_editor/script_list/sort_members_outline_alphabetically].
+			If [code]true[/code], displays an overview of the current script's member functions at the left of the script editor. See also [member text_editor/script_list/sort_members_outline_alphabetically].
 		</member>
 		<member name="text_editor/script_list/sort_members_outline_alphabetically" type="bool" setter="" getter="">
 			If [code]true[/code], sorts the members outline (located at the left of the script editor) using alphabetical order. If [code]false[/code], sorts the members outline depending on the order in which members are found in the script.


### PR DESCRIPTION
Docs/tooltip for `text_editor/script_list/show_members_overview` says it allows displaying both member variables and functions. This is wrong, only the functions are actually checked/added in the code.

Confused user: https://www.reddit.com/r/godot/comments/1o486k4/members_list_only_has_methods_can_you_display/

https://github.com/godotengine/godot/blob/cb7cd815eeeb11aaa1f68453a515c76bec5ba73d/editor/script/script_editor_plugin.cpp#L2110-L2153