### PR TITLE
Improve compile time with `libc++` by defining `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` in `typedefs.h`.

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -30,6 +30,10 @@
 
 #pragma once
 
+// For platforms using libc++, this definition improves compile time.
+// For more information, see https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html
+#define _LIBCPP_REMOVE_TRANSITIVE_INCLUDES
+
 /**
  * Basic definitions and simple functions to be used everywhere.
  */
@@ -51,6 +55,7 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <type_traits>
 #include <utility>
 
 // IWYU pragma: end_exports


### PR DESCRIPTION
- Helps address #111218 

In a quick test, this improved compile time on macOS from `5m6s` to `4m43s` (~8%).
It does this by reducing the impact of many of the `<libcpp>/` entries in the include tracker (#111218). For example, `<libcpp>/string` is reduced from 425s to 86s.

## Explanation

`libc++` had been created with many transitive includes, which means that including one file often led to implicit inclusion of other files. In recent versions (C++23 and later) they have been working to reduce this. However, they also offer a macro that allows users to disable transitive includes earlier than this (`_LIBCPP_REMOVE_TRANSITIVE_INCLUDES`).
For more information, see https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html

This change affects platforms using libc++, which most prominently includes Apple platforms and Android.
