### PR TITLE
SCons: Add `optimize=none` to `dev_mode`

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -637,12 +637,6 @@ def configure_mingw(env: "SConsEnvironment"):
         print("Detected GCC to be a wrapper for Clang.")
         env["use_llvm"] = True
 
-    if env.dev_build:
-        # Allow big objects. It's supposed not to have drawbacks but seems to break
-        # GCC LTO, so enabling for debug builds only (which are not built with LTO
-        # and are the only ones with too big objects).
-        env.Append(CCFLAGS=["-Wa,-mbig-obj"])
-
     if env["windows_subsystem"] == "gui":
         env.Append(LINKFLAGS=["-Wl,--subsystem,windows"])
     else:
@@ -697,6 +691,11 @@ def configure_mingw(env: "SConsEnvironment"):
 
     if env["lto"] == "auto":  # Enable LTO for production with MinGW.
         env["lto"] = "thin" if env["use_llvm"] else "full"
+
+    if env["lto"] == "none" and not env["use_llvm"]:
+        # FIXME: Allow big objects. It's supposed to have no drawbacks, but seems to break LTO on
+        # GCC specifically.
+        env.Append(CCFLAGS=["-Wa,-mbig-obj"])
 
     if env["lto"] != "none":
         if env["lto"] == "thin":


### PR DESCRIPTION
- Inspired by this [RC](https://chat.godotengine.org/channel/buildsystem?msg=HwSq3dWLzpaFq5xCJ) post

Integrates a new option into the `dev_mode` alias: `optimize=none`. This will result in our CI builds skipping any optimization, which hopefully means an increase in compile speed.

A few other buildsystem tweaks were made to account for this (and fix oversights). First was sorting the `dev_mode`/`production` conditionals earlier in `SConstruct`, as the `optimize` conditional occurs uncharacteristically early. Second was changing the `-wa,-mbig-obj` trigger for windows mingw builds to only exclude them in gcc lto-enabled contexts, as otherwise the output size would be too large.