### PR TITLE
Core: Fix missing includes in `type_info.h`

### DIFF
--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -30,8 +30,10 @@
 
 #pragma once
 
+#include "core/object/object.h"
 #include "core/templates/simple_type.h"
 #include "core/typedefs.h"
+#include "core/variant/variant.h"
 
 #include <type_traits>
 


### PR DESCRIPTION
Added includes for `variant.h` and `object.h` to `type_info.h`. 

These were missing but due to `type_info.h` always being included after `class_db.h` wherever it was included, the `Variant` and `Object` classes would be defined and would let it compile. 
This made removing `class_db.h` in many places impossible as it would break `type_info.h`.

<details>
<summary> Old version of the PR </summary>
Reworks the include chains in core/variant. 

* Part of #111218 

Changes:
* Added includes for `variant.h` and `object.h` to `type_info.h`. These were missing but due to `type_info.h` always being included after `class_db.h` wherever it was included, the `Variant` and `Object` classes would be defined and would let it compile. This made removing `class_db.h` in many places impossible as it would break `type_info.h`
  * This will likely come at a performance cost, since the total # of includes by `type_info.h` goes from 4 to 70
  * See [rocket chat discussion](https://chat.godotengine.org/channel/core/thread/2oLCSgT6dqwKNEzxi)
* Following up on that, `class_db.h` was removed from `variant_construct.h`, `variant_destruct.h`, `variant_op.h`, `variant_setget.h`, and `dictionary.h`.
  * This results in the `core/variant` being theoretically completely decoupled from `class_db.h`
* Migrated some includes from `*.h` to `*.cpp` as they are only needed there in those cases.
* `variant_construct.h` was very bloated in terms of includes, this has been fixed
* Various removals and purely-transitive-to-direct replacements. Also added some explicit includes in some places which accessed it only transitively. 

My machine is too slow and unpredictable to measure compile-time difference between this and master, so I can't provide those stats. 
</details>