### PR TITLE
Core: replace `class_db.h` include with `object.h` include in `ref_counted.h`

### DIFF
--- a/core/crypto/aes_context.cpp
+++ b/core/crypto/aes_context.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "core/crypto/aes_context.h"
+#include "core/object/class_db.h"
 
 Error AESContext::start(Mode p_mode, const PackedByteArray &p_key, const PackedByteArray &p_iv) {
 	ERR_FAIL_COND_V_MSG(mode != MODE_MAX, ERR_ALREADY_IN_USE, "AESContext already started. Call 'finish' before starting a new one.");

--- a/core/crypto/aes_context.h
+++ b/core/crypto/aes_context.h
@@ -32,6 +32,7 @@
 
 #include "core/crypto/crypto_core.h"
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class AESContext : public RefCounted {
 	GDCLASS(AESContext, RefCounted);

--- a/core/crypto/hashing_context.cpp
+++ b/core/crypto/hashing_context.cpp
@@ -31,6 +31,7 @@
 #include "hashing_context.h"
 
 #include "core/crypto/crypto_core.h"
+#include "core/object/class_db.h"
 
 Error HashingContext::start(HashType p_type) {
 	ERR_FAIL_COND_V(ctx != nullptr, ERR_ALREADY_IN_USE);

--- a/core/crypto/hashing_context.h
+++ b/core/crypto/hashing_context.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class HashingContext : public RefCounted {
 	GDCLASS(HashingContext, RefCounted);

--- a/core/debugger/engine_profiler.cpp
+++ b/core/debugger/engine_profiler.cpp
@@ -31,6 +31,7 @@
 #include "engine_profiler.h"
 
 #include "core/debugger/engine_debugger.h"
+#include "core/object/class_db.h"
 
 void EngineProfiler::_bind_methods() {
 	GDVIRTUAL_BIND(_toggle, "enable", "options");

--- a/core/io/file_access.compat.inc
+++ b/core/io/file_access.compat.inc
@@ -30,6 +30,8 @@
 
 #ifndef DISABLE_DEPRECATED
 
+#include "core/object/class_db.h"
+
 Ref<FileAccess> FileAccess::_open_encrypted_bind_compat_98918(const String &p_path, ModeFlags p_mode_flags, const Vector<uint8_t> &p_key) {
 	return open_encrypted(p_path, p_mode_flags, p_key, Vector<uint8_t>());
 }

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -36,6 +36,7 @@
 #include "core/os/memory.h"
 #include "core/string/ustring.h"
 #include "core/typedefs.h"
+#include "core/variant/binder_common.h"
 
 /**
  * Multi-Platform abstraction for accessing to files.

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -30,6 +30,7 @@
 
 #include "ip.h"
 
+#include "core/object/class_db.h"
 #include "core/os/semaphore.h"
 #include "core/os/thread.h"
 #include "core/templates/hash_map.h"

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -32,6 +32,7 @@
 
 #include "core/io/ip_address.h"
 #include "core/os/os.h"
+#include "core/variant/binder_common.h"
 
 template <typename T>
 class TypedArray;

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -34,6 +34,7 @@
 #include "core/io/file_access.h"
 #include "core/io/file_access_encrypted.h"
 #include "core/io/file_access_pack.h" // PACK_HEADER_MAGIC, PACK_FORMAT_VERSION
+#include "core/object/class_db.h"
 #include "core/version.h"
 
 static int _get_pad(int p_alignment, int p_n) {

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/class_db.h"
 #include "core/object/ref_counted.h"
 
 #include "core/extension/ext_wrappers.gen.inc"

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -31,6 +31,7 @@
 #include "xml_parser.h"
 
 #include "core/io/file_access.h"
+#include "core/object/class_db.h"
 
 //#define DEBUG_XML
 

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -33,6 +33,7 @@
 #include "core/object/ref_counted.h"
 #include "core/string/ustring.h"
 #include "core/templates/vector.h"
+#include "core/variant/binder_common.h"
 
 /*
   Based on irrXML (see their zlib license). Added mainly for compatibility with their Collada loader.

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -30,9 +30,11 @@
 
 #pragma once
 
+#include "core/object/class_db.h"
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/ref_counted.h"
 #include "core/templates/a_hash_map.h"
+#include "core/variant/binder_common.h"
 
 /**
 	A* pathfinding algorithm.

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -30,9 +30,11 @@
 
 #pragma once
 
+#include "core/object/class_db.h"
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/ref_counted.h"
 #include "core/templates/local_vector.h"
+#include "core/variant/binder_common.h"
 
 class AStarGrid2D : public RefCounted {
 	GDCLASS(AStarGrid2D, RefCounted);

--- a/core/math/random_number_generator.cpp
+++ b/core/math/random_number_generator.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "random_number_generator.h"
+#include "core/object/class_db.h"
 
 void RandomNumberGenerator::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_seed", "seed"), &RandomNumberGenerator::set_seed);

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -30,6 +30,7 @@
 
 #include "triangle_mesh.h"
 
+#include "core/object/class_db.h"
 #include "core/templates/sort_array.h"
 
 int TriangleMesh::_create_bvh(BVH *p_bvh, BVH **p_bb, int p_from, int p_size, int p_depth, int &r_max_depth, int &r_max_alloc) {

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -30,8 +30,10 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
 #include "core/templates/safe_refcount.h"
+#include "core/variant/method_ptrcall.h"
+#include "core/variant/variant_internal.h"
 
 class RefCounted : public Object {
 	GDCLASS(RefCounted, Object);

--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "main_loop.h"
+#include "core/object/class_db.h"
 
 void MainLoop::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_OS_MEMORY_WARNING);

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -32,6 +32,7 @@
 
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/object.h"
+#include "core/variant/binder_common.h"
 
 class MainLoop : public Object {
 	GDCLASS(MainLoop, Object);

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -33,6 +33,7 @@
 class EditorExportPlatform;
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class EditorExportPreset : public RefCounted {
 	GDCLASS(EditorExportPreset, RefCounted);

--- a/editor/inspector/editor_context_menu_plugin.h
+++ b/editor/inspector/editor_context_menu_plugin.h
@@ -32,6 +32,7 @@
 
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class InputEvent;
 class PopupMenu;

--- a/modules/navigation_2d/nav_utils_2d.h
+++ b/modules/navigation_2d/nav_utils_2d.h
@@ -32,6 +32,7 @@
 
 #include "core/math/vector3.h"
 #include "core/object/ref_counted.h"
+#include "core/os/rw_lock.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/local_vector.h"

--- a/modules/navigation_3d/nav_utils_3d.h
+++ b/modules/navigation_3d/nav_utils_3d.h
@@ -32,6 +32,7 @@
 
 #include "core/math/vector3.h"
 #include "core/object/ref_counted.h"
+#include "core/os/rw_lock.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/local_vector.h"

--- a/modules/openxr/openxr_structure.cpp
+++ b/modules/openxr/openxr_structure.cpp
@@ -30,6 +30,8 @@
 
 #include "openxr_structure.h"
 
+#include "core/object/class_db.h"
+
 void OpenXRStructureBase::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_structure_type"), &OpenXRStructureBase::_get_structure_type);
 

--- a/modules/openxr/openxr_structure.h
+++ b/modules/openxr/openxr_structure.h
@@ -32,6 +32,7 @@
 
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 #include "openxr_util.h"
 #include "util.h"
 

--- a/modules/regex/regex.compat.inc
+++ b/modules/regex/regex.compat.inc
@@ -30,6 +30,8 @@
 
 #ifndef DISABLE_DEPRECATED
 
+#include "core/object/class_db.h"
+
 Ref<RegEx> RegEx::_create_from_string_bind_compat_95212(const String &p_pattern) {
 	return create_from_string(p_pattern, true);
 }

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -31,6 +31,7 @@
 #include "regex.h"
 #include "regex.compat.inc"
 
+#include "core/object/class_db.h"
 #include "core/os/memory.h"
 
 extern "C" {

--- a/modules/upnp/upnp_device.h
+++ b/modules/upnp/upnp_device.h
@@ -30,7 +30,9 @@
 
 #pragma once
 
+#include "core/object/class_db.h"
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class UPNPDevice : public RefCounted {
 	GDCLASS(UPNPDevice, RefCounted);

--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -31,6 +31,7 @@
 #include "zip_packer.h"
 
 #include "core/io/zip_io.h"
+#include "core/object/class_db.h"
 #include "core/os/os.h"
 
 Error ZIPPacker::open(const String &p_path, ZipAppend p_append) {

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/io/zip_io.h"
+#include "core/object/class_db.h"
 
 Error ZIPReader::open(const String &p_path) {
 	if (fa.is_valid()) {

--- a/platform/android/api/api.cpp
+++ b/platform/android/api/api.cpp
@@ -34,6 +34,7 @@
 #include "jni_singleton.h"
 
 #include "core/config/engine.h"
+#include "core/object/class_db.h"
 
 #if !defined(ANDROID_ENABLED)
 static JavaClassWrapper *java_class_wrapper = nullptr;

--- a/platform/android/api/jni_singleton.h
+++ b/platform/android/api/jni_singleton.h
@@ -33,6 +33,7 @@
 #include "java_class_wrapper.h"
 
 #include "core/config/engine.h"
+#include "core/object/class_db.h"
 #include "core/templates/rb_map.h"
 #include "core/variant/variant.h"
 

--- a/scene/3d/velocity_tracker_3d.cpp
+++ b/scene/3d/velocity_tracker_3d.cpp
@@ -31,6 +31,7 @@
 #include "velocity_tracker_3d.h"
 
 #include "core/config/engine.h"
+#include "core/object/class_db.h"
 
 void VelocityTracker3D::set_track_physics_step(bool p_track_physics_step) {
 	physics_step = p_track_physics_step;

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class Tween;
 class Node;

--- a/servers/navigation_2d/navigation_path_query_parameters_2d.cpp
+++ b/servers/navigation_2d/navigation_path_query_parameters_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_path_query_parameters_2d.h"
 
+#include "core/object/class_db.h"
 #include "core/variant/typed_array.h"
 
 void NavigationPathQueryParameters2D::set_pathfinding_algorithm(const NavigationPathQueryParameters2D::PathfindingAlgorithm p_pathfinding_algorithm) {

--- a/servers/navigation_2d/navigation_path_query_parameters_2d.h
+++ b/servers/navigation_2d/navigation_path_query_parameters_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 #include "servers/navigation_2d/navigation_constants_2d.h"
 
 class NavigationPathQueryParameters2D : public RefCounted {

--- a/servers/navigation_2d/navigation_path_query_result_2d.cpp
+++ b/servers/navigation_2d/navigation_path_query_result_2d.cpp
@@ -30,6 +30,8 @@
 
 #include "navigation_path_query_result_2d.h"
 
+#include "core/object/class_db.h"
+
 void NavigationPathQueryResult2D::set_path(const Vector<Vector2> &p_path) {
 	path = p_path;
 }

--- a/servers/navigation_3d/navigation_path_query_parameters_3d.cpp
+++ b/servers/navigation_3d/navigation_path_query_parameters_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_path_query_parameters_3d.h"
 
+#include "core/object/class_db.h"
 #include "core/variant/typed_array.h"
 
 void NavigationPathQueryParameters3D::set_pathfinding_algorithm(const NavigationPathQueryParameters3D::PathfindingAlgorithm p_pathfinding_algorithm) {

--- a/servers/navigation_3d/navigation_path_query_parameters_3d.h
+++ b/servers/navigation_3d/navigation_path_query_parameters_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 #include "servers/navigation_3d/navigation_constants_3d.h"
 
 class NavigationPathQueryParameters3D : public RefCounted {

--- a/servers/navigation_3d/navigation_path_query_result_3d.cpp
+++ b/servers/navigation_3d/navigation_path_query_result_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "navigation_path_query_result_3d.h"
 
+#include "core/object/class_db.h"
+
 void NavigationPathQueryResult3D::set_path(const Vector<Vector3> &p_path) {
 	path = p_path;
 }

--- a/servers/xr/xr_pose.h
+++ b/servers/xr/xr_pose.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class XRPose : public RefCounted {
 	GDCLASS(XRPose, RefCounted);


### PR DESCRIPTION
* Part of #111218 

Replaces the `class_db.h` include in `ref_counted.h` with an `object.h` include. 
This reduces the total number of includes in `ref_counted.h` from 81 to 70.

All other changes are cascading and necessary for the project to compile. 

Some stats:
* 42 cascading files changed
* 104 total files include `ref_counted.h` directly, realizing a changed rate of 40.4%
  * caveat: not all files changed include `ref_counted.h`, in some cases the change was either applied to the cpp file only (if not needed in header file) or applied to a file upstream that provides it to several files downstream that needed the same change. This was only done with files primarily (or exclusively) included in files which needed the change. 
* 2940 total files include it directly or transitively, realizing a changed rater of 1.4%
* 2804 files now include `class_db.h`, down from 2986, a reduction of 6.16%
* The engine now has a total of 395,957 transitive includes, down from 396,921, a reduction of 0.245%

Disclaimer: the numbers above may seem fairly small, which I assume is in no unsignificant part due to `resource.h` still including `class_db.h`, and most paths that include `ref_counted.h` also include `resource.h`. I decided on doing `ref_counted.h` first since it is upstream of `resource.h`, so the most significant difference will be in my follow up PR which will fix that issue. 

Disclaimer 2: This PR does not attempt to reduce the number of `ref_counted.h` includes, even though some may not be obsolete as they might have been purely transitive to get to `ref_counted.h`'s includes. This is done in order to keep the changes exclusively related to the direct cascading effects. 