### PR TITLE
[C#] Fix source generation of statically imported members

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
@@ -61,6 +61,10 @@ partial class ExportedFields
         /// </summary>
         public new static readonly global::Godot.StringName @_fieldString = "_fieldString";
         /// <summary>
+        /// Cached name for the '_fieldStaticImport' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName @_fieldStaticImport = "_fieldStaticImport";
+        /// <summary>
         /// Cached name for the '_fieldVector2' field.
         /// </summary>
         public new static readonly global::Godot.StringName @_fieldVector2 = "_fieldVector2";
@@ -303,6 +307,10 @@ partial class ExportedFields
         }
         if (name == PropertyName.@_fieldString) {
             this.@_fieldString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        if (name == PropertyName.@_fieldStaticImport) {
+            this.@_fieldStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
             return true;
         }
         if (name == PropertyName.@_fieldVector2) {
@@ -551,6 +559,10 @@ partial class ExportedFields
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_fieldString);
             return true;
         }
+        if (name == PropertyName.@_fieldStaticImport) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_fieldStaticImport);
+            return true;
+        }
         if (name == PropertyName.@_fieldVector2) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(this.@_fieldVector2);
             return true;
@@ -763,6 +775,7 @@ partial class ExportedFields
         properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@_fieldSingle, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@_fieldDouble, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@_fieldString, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@_fieldStaticImport, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)5, name: PropertyName.@_fieldVector2, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)6, name: PropertyName.@_fieldVector2I, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)7, name: PropertyName.@_fieldRect2, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptPropertyDefVal.generated.cs
@@ -11,7 +11,7 @@ partial class ExportedFields
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal new static global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant> GetGodotPropertyDefaultValues()
     {
-        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(60);
+        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(61);
         bool ___fieldBoolean_default_value = true;
         values.Add(PropertyName.@_fieldBoolean, global::Godot.Variant.From<bool>(___fieldBoolean_default_value));
         char ___fieldChar_default_value = 'f';
@@ -38,6 +38,8 @@ partial class ExportedFields
         values.Add(PropertyName.@_fieldDouble, global::Godot.Variant.From<double>(___fieldDouble_default_value));
         string ___fieldString_default_value = "foo";
         values.Add(PropertyName.@_fieldString, global::Godot.Variant.From<string>(___fieldString_default_value));
+        float ___fieldStaticImport_default_value = global::Godot.Mathf.RadToDeg(2  * global::Godot.Mathf.Pi);
+        values.Add(PropertyName.@_fieldStaticImport, global::Godot.Variant.From<float>(___fieldStaticImport_default_value));
         global::Godot.Vector2 ___fieldVector2_default_value = new(10f, 10f);
         values.Add(PropertyName.@_fieldVector2, global::Godot.Variant.From<global::Godot.Vector2>(___fieldVector2_default_value));
         global::Godot.Vector2I ___fieldVector2I_default_value = global::Godot.Vector2I.Up;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
@@ -33,9 +33,17 @@ partial class ExportedProperties
         /// </summary>
         public new static readonly global::Godot.StringName @FullPropertyString_Complex = "FullPropertyString_Complex";
         /// <summary>
+        /// Cached name for the 'FullPropertyStaticImport' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName @FullPropertyStaticImport = "FullPropertyStaticImport";
+        /// <summary>
         /// Cached name for the 'LamdaPropertyString' property.
         /// </summary>
         public new static readonly global::Godot.StringName @LamdaPropertyString = "LamdaPropertyString";
+        /// <summary>
+        /// Cached name for the 'LambdaPropertyStaticImport' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName @LambdaPropertyStaticImport = "LambdaPropertyStaticImport";
         /// <summary>
         /// Cached name for the 'PrimaryCtorParameter' property.
         /// </summary>
@@ -44,6 +52,10 @@ partial class ExportedProperties
         /// Cached name for the 'ConstantMath' property.
         /// </summary>
         public new static readonly global::Godot.StringName @ConstantMath = "ConstantMath";
+        /// <summary>
+        /// Cached name for the 'ConstantMathStaticImport' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName @ConstantMathStaticImport = "ConstantMathStaticImport";
         /// <summary>
         /// Cached name for the 'StaticStringAddition' property.
         /// </summary>
@@ -293,9 +305,17 @@ partial class ExportedProperties
         /// </summary>
         public new static readonly global::Godot.StringName @_fullPropertyStringComplex = "_fullPropertyStringComplex";
         /// <summary>
+        /// Cached name for the '_fullPropertyStaticImport' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName @_fullPropertyStaticImport = "_fullPropertyStaticImport";
+        /// <summary>
         /// Cached name for the '_lamdaPropertyString' field.
         /// </summary>
         public new static readonly global::Godot.StringName @_lamdaPropertyString = "_lamdaPropertyString";
+        /// <summary>
+        /// Cached name for the '_lambdaPropertyStaticImport' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName @_lambdaPropertyStaticImport = "_lambdaPropertyStaticImport";
     }
     /// <inheritdoc/>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -325,8 +345,16 @@ partial class ExportedProperties
             this.@FullPropertyString_Complex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
+        if (name == PropertyName.@FullPropertyStaticImport) {
+            this.@FullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            return true;
+        }
         if (name == PropertyName.@LamdaPropertyString) {
             this.@LamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        if (name == PropertyName.@LambdaPropertyStaticImport) {
+            this.@LambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
             return true;
         }
         if (name == PropertyName.@PrimaryCtorParameter) {
@@ -335,6 +363,10 @@ partial class ExportedProperties
         }
         if (name == PropertyName.@ConstantMath) {
             this.@ConstantMath = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            return true;
+        }
+        if (name == PropertyName.@ConstantMathStaticImport) {
+            this.@ConstantMathStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
             return true;
         }
         if (name == PropertyName.@StaticStringAddition) {
@@ -585,8 +617,16 @@ partial class ExportedProperties
             this.@_fullPropertyStringComplex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
+        if (name == PropertyName.@_fullPropertyStaticImport) {
+            this.@_fullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            return true;
+        }
         if (name == PropertyName.@_lamdaPropertyString) {
             this.@_lamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        if (name == PropertyName.@_lambdaPropertyStaticImport) {
+            this.@_lambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
             return true;
         }
         return base.SetGodotClassPropertyValue(name, value);
@@ -619,8 +659,16 @@ partial class ExportedProperties
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@FullPropertyString_Complex);
             return true;
         }
+        if (name == PropertyName.@FullPropertyStaticImport) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@FullPropertyStaticImport);
+            return true;
+        }
         if (name == PropertyName.@LamdaPropertyString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@LamdaPropertyString);
+            return true;
+        }
+        if (name == PropertyName.@LambdaPropertyStaticImport) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@LambdaPropertyStaticImport);
             return true;
         }
         if (name == PropertyName.@PrimaryCtorParameter) {
@@ -629,6 +677,10 @@ partial class ExportedProperties
         }
         if (name == PropertyName.@ConstantMath) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@ConstantMath);
+            return true;
+        }
+        if (name == PropertyName.@ConstantMathStaticImport) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@ConstantMathStaticImport);
             return true;
         }
         if (name == PropertyName.@StaticStringAddition) {
@@ -879,8 +931,16 @@ partial class ExportedProperties
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_fullPropertyStringComplex);
             return true;
         }
+        if (name == PropertyName.@_fullPropertyStaticImport) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_fullPropertyStaticImport);
+            return true;
+        }
         if (name == PropertyName.@_lamdaPropertyString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_lamdaPropertyString);
+            return true;
+        }
+        if (name == PropertyName.@_lambdaPropertyStaticImport) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_lambdaPropertyStaticImport);
             return true;
         }
         return base.GetGodotClassPropertyValue(name, out value);
@@ -904,10 +964,15 @@ partial class ExportedProperties
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@FullPropertyString, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@_fullPropertyStringComplex, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@FullPropertyString_Complex, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@_fullPropertyStaticImport, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@FullPropertyStaticImport, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@_lamdaPropertyString, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@LamdaPropertyString, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@_lambdaPropertyStaticImport, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@LambdaPropertyStaticImport, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@PrimaryCtorParameter, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@ConstantMath, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)3, name: PropertyName.@ConstantMathStaticImport, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@StaticStringAddition, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.@PropertyBoolean, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.@PropertyChar, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
@@ -11,7 +11,7 @@ partial class ExportedProperties
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal new static global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant> GetGodotPropertyDefaultValues()
     {
-        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(67);
+        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(70);
         string __NotGenerateComplexLamdaProperty_default_value = default;
         values.Add(PropertyName.@NotGenerateComplexLamdaProperty, global::Godot.Variant.From<string>(__NotGenerateComplexLamdaProperty_default_value));
         string __NotGenerateLamdaNoFieldProperty_default_value = default;
@@ -24,12 +24,18 @@ partial class ExportedProperties
         values.Add(PropertyName.@FullPropertyString, global::Godot.Variant.From<string>(__FullPropertyString_default_value));
         string __FullPropertyString_Complex_default_value = new string("FullPropertyString_Complex")   + global::System.Convert.ToInt32("1");
         values.Add(PropertyName.@FullPropertyString_Complex, global::Godot.Variant.From<string>(__FullPropertyString_Complex_default_value));
+        float __FullPropertyStaticImport_default_value = global::Godot.Mathf.Pi;
+        values.Add(PropertyName.@FullPropertyStaticImport, global::Godot.Variant.From<float>(__FullPropertyStaticImport_default_value));
         string __LamdaPropertyString_default_value = "LamdaPropertyString";
         values.Add(PropertyName.@LamdaPropertyString, global::Godot.Variant.From<string>(__LamdaPropertyString_default_value));
+        float __LambdaPropertyStaticImport_default_value = global::Godot.Mathf.Tau;
+        values.Add(PropertyName.@LambdaPropertyStaticImport, global::Godot.Variant.From<float>(__LambdaPropertyStaticImport_default_value));
         string __PrimaryCtorParameter_default_value = default;
         values.Add(PropertyName.@PrimaryCtorParameter, global::Godot.Variant.From<string>(__PrimaryCtorParameter_default_value));
         float __ConstantMath_default_value = 2  * global::Godot.Mathf.Pi;
         values.Add(PropertyName.@ConstantMath, global::Godot.Variant.From<float>(__ConstantMath_default_value));
+        float __ConstantMathStaticImport_default_value = global::Godot.Mathf.RadToDeg(2  * global::Godot.Mathf.Pi);
+        values.Add(PropertyName.@ConstantMathStaticImport, global::Godot.Variant.From<float>(__ConstantMathStaticImport_default_value));
         string __StaticStringAddition_default_value = string.Empty   + string.Empty;
         values.Add(PropertyName.@StaticStringAddition, global::Godot.Variant.From<string>(__StaticStringAddition_default_value));
         bool __PropertyBoolean_default_value = true;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedFields.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedFields.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 using System.Collections.Generic;
+using static Godot.Mathf;
 
 public partial class ExportedFields : GodotObject
 {
@@ -17,6 +18,9 @@ public partial class ExportedFields : GodotObject
     [Export] private Single _fieldSingle = 10;
     [Export] private Double _fieldDouble = 10;
     [Export] private String _fieldString = "foo";
+
+    // Static import
+    [Export] private Single _fieldStaticImport = RadToDeg(2 * Pi);
 
     // Godot structs
     [Export] private Vector2 _fieldVector2 = new(10f, 10f);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using static Godot.Mathf;
 
 public partial class ExportedProperties(string primaryCtorParameter) : GodotObject
 {
@@ -82,6 +83,20 @@ public partial class ExportedProperties(string primaryCtorParameter) : GodotObje
         }
     }
 
+    private Single _fullPropertyStaticImport = Pi;
+    [Export]
+    public Single FullPropertyStaticImport
+    {
+        get
+        {
+            return _fullPropertyStaticImport;
+        }
+        set
+        {
+            _fullPropertyStaticImport = value;
+        }
+    }
+
     // Lambda Property
     private String _lamdaPropertyString = "LamdaPropertyString";
     [Export]
@@ -91,6 +106,14 @@ public partial class ExportedProperties(string primaryCtorParameter) : GodotObje
         set => _lamdaPropertyString = value;
     }
 
+    private Single _lambdaPropertyStaticImport = Tau;
+    [Export]
+    public Single LambdaPropertyStaticImport
+    {
+        get => _lambdaPropertyStaticImport;
+        set => _lambdaPropertyStaticImport = value;
+    }
+
     // Primary Constructor Parameter
     [Export]
     public String PrimaryCtorParameter { get; set; } = primaryCtorParameter;
@@ -98,6 +121,10 @@ public partial class ExportedProperties(string primaryCtorParameter) : GodotObje
     // Constant Math Expression
     [Export]
     public Single ConstantMath { get; set; } = 2 * Mathf.Pi;
+
+    //Constant Math Expression With Static Import
+    [Export]
+    public Single ConstantMathStaticImport { get; set; } = RadToDeg(2 * Pi);
 
     // Static Strings Addition
     [Export]

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -183,11 +183,13 @@ namespace Godot.SourceGenerators
 
         private static SymbolDisplayFormat FullyQualifiedFormatOmitGlobal { get; } =
             SymbolDisplayFormat.FullyQualifiedFormat
-                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
+                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)
+                .WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType);
 
         private static SymbolDisplayFormat FullyQualifiedFormatIncludeGlobal { get; } =
             SymbolDisplayFormat.FullyQualifiedFormat
-                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Included);
+                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Included)
+                .WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType);
 
         public static string FullQualifiedNameOmitGlobal(this ITypeSymbol symbol)
             => symbol.ToDisplayString(NullableFlowState.NotNull, FullyQualifiedFormatOmitGlobal);
@@ -210,7 +212,7 @@ namespace Godot.SourceGenerators
 
         private static void FullQualifiedSyntax(SyntaxNode node, SemanticModel sm, StringBuilder sb, bool isFirstNode)
         {
-            if (node is NameSyntax ns && isFirstNode)
+            if (node is NameSyntax ns && (isFirstNode || node.Parent is not MemberAccessExpressionSyntax))
             {
                 SymbolInfo nameInfo = sm.GetSymbolInfo(ns);
                 sb.Append(nameInfo.Symbol?.ToDisplayString(FullyQualifiedFormatIncludeGlobal) ?? ns.ToString());


### PR DESCRIPTION
Fixes #93666
Possibly also fixes #85844

Adds `using static` declarations to the beginning of generated C# scripts for default values. Enables the use of static imports when initializing properties and fields.