### PR TITLE
Update missing info from FreeType 2.14.1

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -302,7 +302,7 @@ License: OFL-1.1
 
 Files: thirdparty/freetype/*
 Comment: The FreeType Project
-Copyright: 1996-2023, David Turner, Robert Wilhelm, and Werner Lemberg.
+Copyright: 1996-2025, David Turner, Robert Wilhelm, and Werner Lemberg.
 License: FTL
 
 Files: thirdparty/glad/*
@@ -1537,9 +1537,9 @@ License: FTL
                     The FreeType Project LICENSE
                     ----------------------------
  .
-                            2000-Feb-08
+                            2006-Jan-27
  .
-                       Copyright 1996-2000 by
+                       Copyright 1996-2002, 2006 by
           David Turner, Robert Wilhelm, and Werner Lemberg
  .
  .
@@ -1577,6 +1577,19 @@ License: FTL
  software, with  or without modifications,  in commercial products.
  We  disclaim  all warranties  covering  The  FreeType Project  and
  assume no liability related to The FreeType Project.
+ .
+ .
+ Finally,  many  people  asked  us  for  a  preferred  form  for  a
+ credit/disclaimer to use in compliance with this license.  We thus
+ encourage you to use the following text:
+ .
+  """
+   Portions of this software are copyright © <year> The FreeType
+   Project (https://freetype.org).  All rights reserved.
+  """
+ .
+ Please replace <year> with the value from the FreeType version you
+ actually use.
  .
  .
  Legal Terms
@@ -1629,12 +1642,12 @@ License: FTL
  authorize others  to exercise  some or all  of the  rights granted
  herein, subject to the following conditions:
  .
-   o Redistribution  of source code  must retain this  license file
-     (`LICENSE.TXT') unaltered; any additions, deletions or changes
-     to   the  original   files  must   be  clearly   indicated  in
-     accompanying  documentation.   The  copyright notices  of  the
-     unaltered, original  files must be preserved in  all copies of
-     source files.
+   o Redistribution of  source code  must retain this  license file
+     (`FTL.TXT') unaltered; any  additions, deletions or changes to
+     the original  files must be clearly  indicated in accompanying
+     documentation.   The  copyright   notices  of  the  unaltered,
+     original  files must  be  preserved in  all  copies of  source
+     files.
  .
    o Redistribution in binary form must provide a  disclaimer  that
      states  that  the software is based in part of the work of the
@@ -1672,29 +1685,21 @@ License: FTL
  .
  There are two mailing lists related to FreeType:
  .
-   o freetype@freetype.org
+   o freetype@nongnu.org
  .
      Discusses general use and applications of FreeType, as well as
      future and  wanted additions to the  library and distribution.
      If  you are looking  for support,  start in  this list  if you
      haven't found anything to help you in the documentation.
  .
-   o devel@freetype.org
+   o freetype-devel@nongnu.org
  .
      Discusses bugs,  as well  as engine internals,  design issues,
      specific licenses, porting, etc.
  .
-   o http://www.freetype.org
+ Our home page can be found at
  .
-     Holds the current  FreeType web page, which will  allow you to
-     download  our  latest  development  version  and  read  online
-     documentation.
- .
- You can also contact us individually at:
- .
-   David Turner      <david.turner@freetype.org>
-   Robert Wilhelm    <robert.wilhelm@freetype.org>
-   Werner Lemberg    <werner.lemberg@freetype.org>
+   https://freetype.org
 
 License: HarfBuzz
  HarfBuzz is licensed under the so-called "Old MIT" license.  Details follow.

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -340,7 +340,7 @@ for UI.
 
 ## freetype
 
-- Upstream: https://www.freetype.org
+- Upstream: https://gitlab.freedesktop.org/freetype/freetype
 - Version: 2.14.1 (526ec5c47b9ebccc4754c85ac0c0cdf7c85a5e9b, 2025)
 - License: FreeType License (BSD-like)
 


### PR DESCRIPTION
~~Update FreeType from 2.13.3 to 2.14.1. No changes to SCsub files seemed necessary.~~

~~It seems to have improvements to diacritic auto-hinting at small sizes.~~

Repurposed PR. This one was missed by mistake, so I made it update missing info that should have changed in #112411.

This includes the FTL license in `COPYRIGHT.txt`, which apparently hasn't been updated in a **very** long time (this license was that in their repo was like, year 2000).