### PR TITLE
Fix transform won't update when first_time_kinematic=false

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -148,6 +148,15 @@
 				Returns [code]true[/code] if the body collided, otherwise, returns [code]false[/code].
 			</description>
 		</method>
+		<method name="teleport">
+			<return type="void" />
+			<param index="0" name="pos" type="Vector2" />
+			<description>
+				Let CharacterBody2D teleport to [param pos] directly.
+				If we update position directly, it will solve as moving original position to new position, and it makes one frame delay on collision detecting at least.
+				We can use teleport to prevent collision detecting delay.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="floor_block_on_wall" type="bool" setter="set_floor_block_on_wall_enabled" getter="is_floor_block_on_wall_enabled" default="true">

--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -130,6 +130,10 @@ void GodotBody2D::reset_mass_properties() {
 	_mass_properties_changed();
 }
 
+void GodotBody2D::body_teleport() {
+	first_time_kinematic = true;
+}
+
 void GodotBody2D::set_active(bool p_active) {
 	if (active == p_active) {
 		return;
@@ -411,6 +415,14 @@ void GodotBody2D::set_space(GodotSpace2D *p_space) {
 
 		if (active && !active_list.in_list()) {
 			get_space()->body_add_to_active_list(&active_list);
+		}
+	} else {
+		// when the player is a Global singleton and reused in many scenes,
+		// when it exits tree from a scene and re-add to another scene,
+		// we need reset first_time_kinematic to true, otherwise it will ignore BODY_STATE_TRANSFORM,
+		// which leads incorrect physics collisions.
+		if (mode == PhysicsServer2D::BODY_MODE_KINEMATIC) {
+			first_time_kinematic = true;
 		}
 	}
 }

--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -307,6 +307,7 @@ public:
 
 	void update_mass_properties();
 	void reset_mass_properties();
+	void body_teleport();
 
 	_FORCE_INLINE_ const Vector2 &get_center_of_mass() const { return center_of_mass; }
 	_FORCE_INLINE_ const Vector2 &get_center_of_mass_local() const { return center_of_mass_local; }

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -766,6 +766,13 @@ void GodotPhysicsServer2D::body_reset_mass_properties(RID p_body) {
 	return body->reset_mass_properties();
 }
 
+void GodotPhysicsServer2D::body_teleport(RID p_body) {
+	GodotBody2D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	return body->body_teleport();
+}
+
 void GodotPhysicsServer2D::body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -209,6 +209,7 @@ public:
 	virtual Variant body_get_param(RID p_body, BodyParameter p_param) const override;
 
 	virtual void body_reset_mass_properties(RID p_body) override;
+	virtual void body_teleport(RID p_body) override;
 
 	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) override;
 	virtual Variant body_get_state(RID p_body, BodyState p_state) const override;

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -334,6 +334,15 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 		first_slide = false;
 	}
 }
+
+void CharacterBody2D::teleport(const Vector2 &p_pos) {
+	PhysicsServer2D::get_singleton()->body_teleport(get_rid());
+
+	Transform2D gt = get_global_transform();
+	gt.columns[2] = p_pos;
+	set_global_transform(gt);
+}
+
 void CharacterBody2D::apply_floor_snap() {
 	_apply_floor_snap();
 }
@@ -684,6 +693,7 @@ void CharacterBody2D::_validate_property(PropertyInfo &p_property) const {
 
 void CharacterBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("move_and_slide"), &CharacterBody2D::move_and_slide);
+	ClassDB::bind_method(D_METHOD("teleport", "pos"), &CharacterBody2D::teleport);
 	ClassDB::bind_method(D_METHOD("apply_floor_snap"), &CharacterBody2D::apply_floor_snap);
 
 	ClassDB::bind_method(D_METHOD("set_velocity", "velocity"), &CharacterBody2D::set_velocity);

--- a/scene/2d/physics/character_body_2d.h
+++ b/scene/2d/physics/character_body_2d.h
@@ -47,6 +47,7 @@ public:
 		PLATFORM_ON_LEAVE_DO_NOTHING,
 	};
 	bool move_and_slide();
+	void teleport(const Vector2 &p_pos);
 	void apply_floor_snap();
 
 	const Vector2 &get_velocity() const;

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -437,6 +437,7 @@ public:
 	virtual Variant body_get_param(RID p_body, BodyParameter p_param) const = 0;
 
 	virtual void body_reset_mass_properties(RID p_body) = 0;
+	virtual void body_teleport(RID p_body) = 0;
 
 	//state
 	enum BodyState {

--- a/servers/physics_2d/physics_server_2d_dummy.h
+++ b/servers/physics_2d/physics_server_2d_dummy.h
@@ -254,6 +254,7 @@ public:
 	virtual Variant body_get_param(RID p_body, BodyParameter p_param) const override { return Variant(); }
 
 	virtual void body_reset_mass_properties(RID p_body) override {}
+	virtual void body_teleport(RID p_body) override {}
 
 	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) override {}
 	virtual Variant body_get_state(RID p_body, BodyState p_state) const override { return Variant(); }

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -336,6 +336,7 @@ public:
 	EXBIND2RC(Variant, body_get_param, RID, BodyParameter)
 
 	EXBIND1(body_reset_mass_properties, RID)
+	EXBIND1(body_teleport, RID);
 
 	EXBIND3(body_set_state, RID, BodyState, const Variant &)
 	EXBIND2RC(Variant, body_get_state, RID, BodyState)

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -218,6 +218,7 @@ public:
 	FUNC2RC(Variant, body_get_param, RID, BodyParameter);
 
 	FUNC1(body_reset_mass_properties, RID);
+	FUNC1(body_teleport, RID);
 
 	FUNC3(body_set_state, RID, BodyState, const Variant &);
 	FUNC2RC(Variant, body_get_state, RID, BodyState);


### PR DESCRIPTION
* *Fixes: https://github.com/godotengine/godot/issues/61584*

**Issue Description**

When scene changed, the transform of CharacterBody2D in physics cannot update immediately.

https://github.com/godotengine/godot/blob/cb7cd815eeeb11aaa1f68453a515c76bec5ba73d/modules/godot_physics_2d/godot_body_2d.cpp#L303-L312

In my opnion, when changing scene, we re-add CharacterBody2D to the new scene, there is a `NOTIFICATION_ENTER_TREE`. In this notification, we want to sync the latest position to physics, so we invoke `PhysicsServer2D::get_singleton()->body_set_state(rid, PhysicsServer2D::BODY_STATE_TRANSFORM, gl_transform);`.

But the `godot_body_2d.cpp` don't let we update transform when `first_time_kinematic=false`, and I didn't find anywhere we can init `first_time_kinematic` to `true`.

So I think we can think about `NOTIFICATION_EXIT_TREE` event. When CharacterBody2D leaves previous scene, it will invoke `PhysicsServer2D::get_singleton()->body_set_space(rid, RID());`, we can change `first_time_kinematic` to true, when `p_space` is empty in `body_set_space`.
