### PR TITLE
GDScript: Fix indentation level check when using multi-line lambdas within nested brackets

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1319,6 +1319,10 @@ void GDScriptTokenizerText::check_indent() {
 				indent_stack.pop_back();
 				pending_indents--;
 			}
+			// If we are in a lambda, the next indentation doesn't need to match the lambda body's indentation.
+			if (indent_stack_stack.size() > 0) {
+				return;
+			}
 			if ((indent_level() > 0 && indent_stack.back()->get() != indent_count) || (indent_level() == 0 && indent_count != 0)) {
 				// Mismatched indentation alignment.
 				Token error = make_error("Unindent doesn't match the previous indentation level.");

--- a/modules/gdscript/tests/scripts/parser/features/lambda_indentation.gd
+++ b/modules/gdscript/tests/scripts/parser/features/lambda_indentation.gd
@@ -1,0 +1,55 @@
+# https://github.com/godotengine/godot/issues/71109
+# https://github.com/godotengine/godot/issues/97204
+# https://github.com/godotengine/godot/issues/106692
+# https://github.com/godotengine/godot/issues/109319
+
+
+func test():
+	(
+		(
+			func():
+				print("lambda")
+		)
+	).call()
+
+	(
+		(
+			func():
+				(
+					(
+						func():
+							print("nested")
+					)
+				).call()
+		)
+	).call()
+
+	var lambda_array = [
+		func():
+			print("array0")
+		,
+		func():
+			print("array1")
+		,
+		func():
+			print("array2")
+		,
+	]
+
+	for lambda in lambda_array:
+		@warning_ignore("unsafe_method_access")
+		lambda.call()
+
+	var lambda_dictionary = {
+		0: func():
+			print("dict0")
+		,
+		1: func():
+			print("dict1")
+		,
+	}
+
+	@warning_ignore("unsafe_method_access")
+	lambda_dictionary[0].call()
+	@warning_ignore("unsafe_method_access")
+	lambda_dictionary[1].call()

--- a/modules/gdscript/tests/scripts/parser/features/lambda_indentation.out
+++ b/modules/gdscript/tests/scripts/parser/features/lambda_indentation.out
@@ -1,0 +1,8 @@
+GDTEST_OK
+lambda
+nested
+array0
+array1
+array2
+dict0
+dict1


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

- Fixes #71109
- Fixes #97204
- Fixes #106692
- Fixes #109319

## Summary

Previously, using a multi-line lambda within nested brackets would require the following token outside the lambda body to either have less indentation as the outermost bracket indentation or have the same or more indentation as the lambda's body.

GDScript seems to ignore indentation levels when in brackets anyway, so this change extends that flexibility for multi-line lambdas as well. All the lines in the lambda body still needs to be at the same indentation to be considered part of the lambda, though.

## Examples

The following code snippet errors on `master`:

```gdscript
func test():
	(
		(
			func():
				pass  # Parse Error: Unindent doesn't match the previous indentation level.
		) # <-- this bracket has bad indentation for some reason
	).call()

	(
		(
			func():
				pass  # Parse Error: Unindent doesn't match the previous indentation level.
			) # <-- this bracket also has bad indentation
	).call()
```
This PR removes the above errors.

For completeness, the following snippet doesn't error on `master`:

```gdscript
func test():
	(
		(
			func():
				pass
) # <-- this bracket is okay
	).call()

	(
		(
			func():
				pass
	) # <-- this bracket is also okay
	).call()

	(
		(
			func():
				pass
				) # <-- this bracket is okay too
	).call()

	(
		(
			func():
				pass
					) # <-- so is this one
	).call()
```

Also see the test cases added in `modules/gdscript/tests/scripts/parser/features/lambda_indentation.gd`, which all fail to be parsed by the `master` branch.