### PR TITLE
Apply luminance multiplier in `copy_cubemap_to_panorama`

### DIFF
--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -401,6 +401,8 @@ void CopyEffects::copy_cubemap_to_panorama(RID p_source_cube, RID p_dest_panoram
 	copy.push_constant.target[1] = 0;
 	copy.push_constant.camera_z_far = p_lod;
 
+	copy.push_constant.luminance_multiplier = prefer_raster_effects ? 2.0 : 1.0;
+
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -138,7 +138,7 @@ private:
 		int32_t section[4];
 		int32_t target[2];
 		uint32_t flags;
-		uint32_t pad;
+		float luminance_multiplier;
 		// Glow.
 		float glow_strength;
 		float glow_bloom;

--- a/servers/rendering/renderer_rd/shaders/effects/copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy.glsl
@@ -20,7 +20,7 @@ layout(push_constant, std430) uniform Params {
 	ivec4 section;
 	ivec2 target;
 	uint flags;
-	uint pad;
+	float luminance_multiplier;
 	// Glow.
 	float glow_strength;
 	float glow_bloom;
@@ -276,7 +276,7 @@ void main() {
 #else
 	vec4 color = textureLod(source_color, vec4(normal, params.camera_z_far), 0.0); //the biggest the lod the least the acne
 #endif
-	imageStore(dest_buffer, pos + params.target, color);
+	imageStore(dest_buffer, pos + params.target, color * params.luminance_multiplier);
 #endif // defined(MODE_CUBEMAP_TO_PANORAMA) || defined(MODE_CUBEMAP_ARRAY_TO_PANORAMA)
 
 #ifdef MODE_SET_COLOR


### PR DESCRIPTION
As predicted in the linked issue, it seems that the luminance multiplier needs to be factored in.

The luminance multiplier only affects the panorama copy mode in the shader currently, but I can make it usable for all the modes if need be.

Fixes https://github.com/godotengine/godot/issues/94401