### PR TITLE
X11: Fix fullscreen exit behavior

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4452,17 +4452,6 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 		return;
 	}
 
-	// Readjusting the window position if the window is being reparented by the window manager for decoration
-	Window root, parent, *children;
-	unsigned int nchildren;
-	if (XQueryTree(x11_display, wd.x11_window, &root, &parent, &children, &nchildren) && wd.parent != parent) {
-		wd.parent = parent;
-		if (!wd.embed_parent) {
-			window_set_position(wd.position, window_id);
-		}
-	}
-	XFree(children);
-
 	{
 		//the position in xconfigure is not useful here, obtain it manually
 		int x = 0, y = 0;
@@ -6446,8 +6435,6 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 
 	{
 		wd.x11_window = XCreateWindow(x11_display, RootWindow(x11_display, visualInfo.screen), win_rect.position.x, win_rect.position.y, win_rect.size.width > 0 ? win_rect.size.width : 1, win_rect.size.height > 0 ? win_rect.size.height : 1, 0, visualInfo.depth, InputOutput, visualInfo.visual, valuemask, &windowAttributes);
-
-		wd.parent = RootWindow(x11_display, visualInfo.screen);
 
 		DEBUG_LOG_X11("CreateWindow window=%lu, parent: %lu \n", wd.x11_window, wd.parent);
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -200,7 +200,6 @@ class DisplayServerX11 : public DisplayServer {
 		bool resize_disabled = false;
 		bool no_min_btn = false;
 		bool no_max_btn = false;
-		Vector2i last_position_before_fs;
 		bool focused = true;
 		bool minimized = false;
 		bool maximized = false;

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -164,7 +164,6 @@ class DisplayServerX11 : public DisplayServer {
 	struct WindowData {
 		Window x11_window;
 		Window x11_xim_window;
-		Window parent;
 		::XIC xic;
 		bool ime_active = false;
 		bool ime_in_progress = false;


### PR DESCRIPTION
Follow-up to #110990
Fixes #104071

Current problems:

- If a fullscreen window is minimized via code, unminimizing the window by clicking the window button on task bar brings the window to windowed mode instead of fullscreen.
- Making a maximized window fullscreen via code might show contents behind the window for a brief moment. This is more obvious if your window manager show animations for this kind of transitions.
- Each time you switch a fullscreen window back to windowed, the window is shifted by a fixed amount relative to the original position.

The first two problems have the same cause. It's because that we always exit fullscreen mode first when updating a window's mode, regardless of the target window mode. This PR changes it the exit only when necessary.

The last problem is more or less messed up, like the min/max issue last time.

In Godot, a window's position is the top-left corner of the client area (i.e., not including frame decorations like the title bar). In X11, the frame is not part of the window, the window manager adds the frame by reparenting the window to a dedicated frame window. 

When the frame is added, the window (client area) is shifted towards bottom-right by default. So subtracting by frame extents when setting the window's position lands at the desired position eventually :exploding_head: 

https://github.com/godotengine/godot/blob/4219ce91f2d1fae65f289d27284a1ab35e9b7b5f/platform/linuxbsd/x11/display_server_x11.cpp#L2553-L2587

This makes sense in 3.x as the use case is very simple (getter + setter). However the window's position is cached in `WindowData` since 4.0. As one of the hardest problems in computer science, cache invalidation strikes, resulting in issues like https://github.com/godotengine/godot/issues/75292.

This PR reverts #76040 as it did not fix the core issue. The window still shifts when exiting fullscreen. (The direct cause is that X11 being client-server. We can only request exiting fullscreen, whether and when the exit happens is window manager dependent. In this case, restoring the saved window position gets a zero frame extent in `window_set_position()` since fullscreen is not yet removed at that point in time.)

Instead of fighting the system to make the cache up-to-date, it turns out that we can simply set the window's gravity in `WM_NORMAL_HINTS` to `Static` so that the window keeps its position when the frame is added. The code is a lot simpler :stuck_out_tongue:

This PR also removed `last_position_before_fs`. We don't need to save the window's original position before entering fullscreen and restore it after exiting. A EWMH-compliant window manager tracks and restores the geometry info for fullscreen windows anyway.