### PR TITLE
[3.x] Make `Span` -> `LocalVector` conversion function explicit.

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -295,7 +295,7 @@ public:
 		}
 	}
 
-	LocalVector(const Span<T> &p_from) {
+	explicit LocalVector(const Span<T> &p_from) {
 		resize(p_from.size());
 		for (U i = 0; i < count; i++) {
 			data[i] = p_from[i];


### PR DESCRIPTION
- Follow-up from #111424

Turns out I forgot to check the added constructor is `explicit`. It's vital that it is, otherwise we'll risk very expensive implicit data copying.