### PR TITLE
Fix description of `Viewport::set_input_as_handled`

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -285,7 +285,7 @@
 		<method name="set_input_as_handled">
 			<return type="void" />
 			<description>
-				Stops the input from propagating further down the [SceneTree].
+				Stops the input from propagating further up the [SceneTree].
 				[b]Note:[/b] This does not affect the methods in [Input], only the way events are propagated.
 			</description>
 		</method>


### PR DESCRIPTION
The input is propagated bottom-up in the scene tree hierarchy. It's not obvious that it's the case, so let's prove that the nodes are indeed traversed post-order.

In method `SceneTree::_call_input_pause` the nodes to be traversed are ordered using `SceneTree::_update_group_order`, which orders the nodes from first to last in tree hierarchy. Then this ordered Vector is traversed in the reverese order.

Indeed, the old description was incorrect and it has been fixed. The `set_input_as_handled` method stops the `InputEvent` from propagating up, not down.

Fixes #111571.