### PR TITLE
CodeEdit: Use flag to recalculate characteristics

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -617,13 +617,13 @@ TypedArray<int> ScriptLanguage::CodeCompletionOption::get_option_characteristics
 	// Return characteristics of the match found by order of importance.
 	// Matches will be ranked by a lexicographical order on the vector returned by this function.
 	// The lower values indicate better matches and that they should go before in the order of appearance.
-	if (last_matches == matches) {
+	if (!matches_dirty) {
 		return charac;
 	}
 	charac.clear();
 	// Ensure base is not empty and at the same time that matches is not empty too.
 	if (p_base.length() == 0) {
-		last_matches = matches;
+		matches_dirty = false;
 		charac.push_back(location);
 		return charac;
 	}
@@ -642,7 +642,7 @@ TypedArray<int> ScriptLanguage::CodeCompletionOption::get_option_characteristics
 	charac.push_back(bad_case);
 	charac.push_back(location);
 	charac.push_back(matches[0].first);
-	last_matches = matches;
+	matches_dirty = false;
 	return charac;
 }
 
@@ -652,7 +652,7 @@ void ScriptLanguage::CodeCompletionOption::clear_characteristics() {
 
 TypedArray<int> ScriptLanguage::CodeCompletionOption::get_option_cached_characteristics() const {
 	// Only returns the cached value and warns if it was not updated since the last change of matches.
-	if (last_matches != matches) {
+	if (matches_dirty) {
 		WARN_PRINT("Characteristics are not up to date.");
 	}
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -315,7 +315,7 @@ public:
 		Ref<Resource> icon;
 		Variant default_value;
 		Vector<Pair<int, int>> matches;
-		Vector<Pair<int, int>> last_matches = { { -1, -1 } }; // This value correspond to an impossible match
+		bool matches_dirty = true; // Must be set when mutating `matches`, so that sorting characteristics are recalculated.
 		int location = LOCATION_OTHER;
 		String theme_color_name;
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -427,6 +427,7 @@ public:
 						option.matches.push_back(Pair<int, int>(matches[j], matches[j + 1]));
 					}
 				}
+				option.matches_dirty = true;
 				r_options->push_back(option);
 			}
 		}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3637,6 +3637,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 
 	for (ScriptLanguage::CodeCompletionOption &option : code_completion_option_sources) {
 		option.matches.clear();
+		option.matches_dirty = true;
 		if (single_quote && option.display.is_quoted()) {
 			option.display = option.display.unquote().quote("'");
 		}
@@ -3722,6 +3723,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 		// go through all possible matches to get the best one as defined by CodeCompletionOptionCompare
 		if (all_possible_subsequence_matches.size() > 0) {
 			option.matches = all_possible_subsequence_matches[0];
+			option.matches_dirty = true;
 			option.get_option_characteristics(string_to_complete);
 			all_possible_subsequence_matches = all_possible_subsequence_matches.slice(1);
 			if (all_possible_subsequence_matches.size() > 0) {
@@ -3730,6 +3732,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 				compared_option.clear_characteristics();
 				for (Vector<Pair<int, int>> &matches : all_possible_subsequence_matches) {
 					compared_option.matches = matches;
+					compared_option.matches_dirty = true;
 					compared_option.get_option_characteristics(string_to_complete);
 					if (compare(compared_option, option)) {
 						option = compared_option;


### PR DESCRIPTION
Completion options would store old matching information, just to check it against the current match information. If they don't match sorting characteristics need to be recalculated (since options which don't fit in at the current cursor position rank lower).

This PR replaces the stored old matches with a dirty flag, that is set to true when matches are changed. This removes some overhead from moving around and comparing the vectors.

Without this PR, characteristics would not be recalculated, when matches were updated but stayed identical. With this PR they always will be.
However, in reality it's highly unlikely for the match list to stay identical, since an update only happens for the following:
- a "user" update (`request_code_completion`) -> all options get replaced by entirely new computed options -> matches change in any case
- a cursor movement -> the cursor position influences the matches, since only characters before the cursor have to match
- adding or deleting characters -> changes the string (source code) which is matched against

So just flagging on any change seems fine to me.

### Benchmark

Actually benchmarking this is quite hard, since finding a realistic workload isn't easy. My attempt at a benchmark uses 3000 options, which have prefixes, that control whether the option matches or not (20% matches, 80% does not). And just appends and uses random numbers for some arguments.

<details>
<summary>Benchmark script</summary>

```gdscript
var edit := CodeEdit.new()
var random = RandomNumberGenerator.new()

func _ready() -> void:
	add_child(edit)
	
	edit.text = "o"
	random.seed = hash("elpsykongroo")
	edit.add_caret(0, 1)
	
	benchmark(100)

func trigger():
	for i in range(3000):
		if random.randf() < 0.2:
			# create a match
			edit.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, "option_" + str(i) + str(random.randi()), "option_" + str(i), Color.ALICE_BLUE, null, null, random.randi())
		else:
			# create a nonmatch
			edit.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, "abc_" + str(i) + str(random.randi()), "abc_" + str(i), Color.ALICE_BLUE, null, null, random.randi())
	edit.update_code_completion_options(true)


func benchmark(n: int):
	var t1 = Time.get_ticks_usec()
	for i in range(n):
		trigger()
	var t2 = Time.get_ticks_usec()
	var delta = t2 - t1
	
	print("RL: %s usec (%s msec)" % [delta, delta / 1000])
```

</details>

Using this benchmark I see around a 4% speedup for "user" updates (`request_code_completion`).

If anyone has ideas for a better benchmark I'd love to hear it!

---

#### Why am I using "user" updates as the metric

My longterm goal would be, to let the script language recalculate completion options on every keystroke. Or speaking differently: I want to replace all internal CodeEdit sorting updates, with full user updates that pull in the current options from the script language.

So optimizing updates without a full replacement of the options isn't really worth it to me.