### PR TITLE
Fix use of outdated macros in ObjectDBProfiler

### DIFF
--- a/modules/objectdb_profiler/snapshot_collector.cpp
+++ b/modules/objectdb_profiler/snapshot_collector.cpp
@@ -168,9 +168,9 @@ Error SnapshotCollector::parse_message(void *p_user, const String &p_msg, const 
 }
 
 String SnapshotCollector::get_godot_version_string() {
-	String hash = String(VERSION_HASH);
+	String hash = String(GODOT_VERSION_HASH);
 	if (hash.length() != 0) {
 		hash = " " + vformat("[%s]", hash.left(9));
 	}
-	return "v" VERSION_FULL_BUILD + hash;
+	return "v" GODOT_VERSION_FULL_BUILD + hash;
 }


### PR DESCRIPTION
These were renamed but were missed in this PR and fails with disable deprecated.

* Fixes: https://github.com/godotengine/godot/issues/111599

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
