### PR TITLE
AnimationTree State Machine node UX improvements

### DIFF
--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -360,11 +360,8 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		box_selecting_from = box_selecting_to = state_machine_draw->get_local_mouse_position();
 		box_selecting_rect = Rect2(box_selecting_from.min(box_selecting_to), (box_selecting_from - box_selecting_to).abs());
 
-		if (mb->is_command_or_control_pressed() || mb->is_shift_pressed()) {
+		if (mb->is_shift_pressed() || mb->is_command_or_control_pressed()) {
 			previous_selected = selected_nodes;
-		} else {
-			selected_nodes.clear();
-			previous_selected.clear();
 		}
 	}
 
@@ -372,6 +369,10 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed() && box_selecting) {
 		box_selecting = false;
 		state_machine_draw->queue_redraw();
+		if (!any_inside_selection) { // During box selection, we add/remove to this variable, if nothing occurred, we can assume we can clear.
+			selected_nodes.clear();
+		}
+		any_inside_selection = false;
 		_update_mode();
 	}
 
@@ -388,15 +389,21 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			if (selected_nodes.has(clicked_node) && mb->is_shift_pressed()) {
 				selected_nodes.erase(clicked_node);
 			} else {
-				if (!mb->is_shift_pressed()) {
+				if (!mb->is_command_or_control_pressed()) {
 					selected_nodes.clear();
 				}
 				selected_nodes.insert(clicked_node);
 			}
 			selected_node = clicked_node;
+			box_selecting = false;
 		} else {
 			// Clicked on empty space.
-			selected_nodes.clear();
+			// If the user is starting a shift/ctrl drag, don't clear the past selection.
+			if (!mb->is_shift_pressed() && !mb->is_command_or_control_pressed()) {
+				previous_selected.clear();
+			} else {
+				previous_selected = selected_nodes;
+			}
 			selected_node = StringName();
 		}
 
@@ -484,16 +491,28 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 		box_selecting_rect = Rect2(box_selecting_from.min(box_selecting_to), (box_selecting_from - box_selecting_to).abs());
 
+		if (!selected_node.is_empty()) {
+			box_selecting = false;
+		}
+
 		for (int i = 0; i < node_rects.size(); i++) {
 			bool in_box = node_rects[i].node.intersects(box_selecting_rect);
-
+			// If ctrl/cmd is pressed, only add to our current selection
+			// If shift is pressed, only remove from our current selection
+			bool shift_pressed =
+					Input::get_singleton()->is_key_pressed(Key::SHIFT);
+			bool ctrl_or_cmd_pressed =
+					Input::get_singleton()->is_key_pressed(Key::CTRL) ||
+					Input::get_singleton()->is_key_pressed(Key::META);
 			if (in_box) {
-				if (previous_selected.has(node_rects[i].node_name)) {
+				any_inside_selection = true;
+				if (previous_selected.has(node_rects[i].node_name) && !ctrl_or_cmd_pressed) {
 					selected_nodes.erase(node_rects[i].node_name);
-				} else {
+				} else if (!shift_pressed) {
 					selected_nodes.insert(node_rects[i].node_name);
 				}
 			} else {
+				any_inside_selection = true;
 				if (previous_selected.has(node_rects[i].node_name)) {
 					selected_nodes.insert(node_rects[i].node_name);
 				} else {
@@ -517,10 +536,15 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 				if (node_rects[i].node.has_point(mm->get_position())) {
 					new_hovered_node_name = node_rects[i].node_name;
-					if (node_rects[i].play.has_point(mm->get_position())) {
-						new_hovered_node_area = HOVER_NODE_PLAY;
-					} else if (node_rects[i].edit.has_point(mm->get_position())) {
-						new_hovered_node_area = HOVER_NODE_EDIT;
+					bool ctrl_or_cmd_pressed =
+							Input::get_singleton()->is_key_pressed(Key::CTRL) ||
+							Input::get_singleton()->is_key_pressed(Key::META);
+					if (!ctrl_or_cmd_pressed) {
+						if (node_rects[i].play.has_point(mm->get_position())) {
+							new_hovered_node_area = HOVER_NODE_PLAY;
+						} else if (node_rects[i].edit.has_point(mm->get_position())) {
+							new_hovered_node_area = HOVER_NODE_EDIT;
+						}
 					}
 					break;
 				}
@@ -574,11 +598,14 @@ Control::CursorShape AnimationNodeStateMachineEditor::get_cursor_shape(const Poi
 		// Put ibeam (text cursor) over names to make it clearer that they are editable.
 		Transform2D xform = panel->get_transform() * state_machine_draw->get_transform();
 		Point2 pos = xform.xform_inv(p_pos);
+		bool ctrl_or_cmd_pressed =
+				Input::get_singleton()->is_key_pressed(Key::CTRL) ||
+				Input::get_singleton()->is_key_pressed(Key::META);
 
 		for (int i = node_rects.size() - 1; i >= 0; i--) { // Inverse to draw order.
 			if (node_rects[i].node.has_point(pos)) {
 				if (node_rects[i].name.has_point(pos)) {
-					if (state_machine->can_edit_node(node_rects[i].node_name)) {
+					if (state_machine->can_edit_node(node_rects[i].node_name) && !ctrl_or_cmd_pressed) {
 						cursor_shape = Control::CURSOR_IBEAM;
 					}
 				}

--- a/editor/animation/animation_state_machine_editor.h
+++ b/editor/animation/animation_state_machine_editor.h
@@ -150,6 +150,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	Vector2 add_node_pos;
 
 	bool box_selecting = false;
+	bool any_inside_selection = false;
 	Point2 box_selecting_from;
 	Point2 box_selecting_to;
 	Rect2 box_selecting_rect;


### PR DESCRIPTION
This PR includes various UX improvements to how nodes in the AnimationTree's State Machine GUI functions. 

### Control Dragging
Node dragging via control/command is now *properly* supported. This feature allows you to click anywhere on a node and begin dragging it, this is primarily useful due to state machine nodes being 90% text.
Prior to this PR, this functionality existed, but the UX on it was lacking. 

(note: in both videos I am holding the control key)
Before:

[Screencast_20251013_113955.webm](https://github.com/user-attachments/assets/e768cfe1-b3bf-420a-b40a-0dfd85382a45)

After:

[Screencast_20251013_114038.webm](https://github.com/user-attachments/assets/16f5a0aa-9911-4e09-a5fe-aa768b2b9a4d)

When holding the control key,  the cursor IBeam shape and button highlights no longer show, as they aren't functional when control dragging. 
You can now re-pick up a node by simply dragging it again, before you had to go through a mandatory deselect
Fixes the selection box appearing despite dragging a node.

### Selection Box

Selection box behaviour prior to this PR was weird and inconsistent with how the main blend tree behaved, this PR fixes those issues, and it's behaviour is now consistent with other Node Graph GUIs.

Before:

[Screencast_20251013_114233.webm](https://github.com/user-attachments/assets/6ec74fec-249f-4f16-b85d-1f6b22770c5d)

After:

[Screencast_20251013_114302.webm](https://github.com/user-attachments/assets/4e2e958b-475e-4ed6-93e0-46fe9c6b0d12)

Shift selection now only *removes* nodes from the selection.
Control/Command selection now only *adds* nodes to the selection.

**Note**: This does *remove* the ability to invert selection, I don't know if anyone was using this functionality, but given this doesn't exist in the blend tree I found this to be unexpected behaviour. 

Additionally, the small flicker that occurs when re-selection happens has been fixed, it's now as smooth as ever. 