### PR TITLE
Use StringBuffer instead of String operations in `sprintf`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -41,6 +41,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, Object);
 #include "core/os/memory.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
+#include "core/string/string_buffer.h"
 #include "core/string/string_name.h"
 #include "core/string/translation_server.h"
 #include "core/string/ucaps.h"
@@ -5372,12 +5373,12 @@ String String::lpad(int min_length, const String &character) const {
 //   "fish %s %d pie" % ["frog", 12]
 // In case of an error, the string returned is the error description and "error" is true.
 String String::sprintf(const Span<Variant> &values, bool *error) const {
-	static const String ZERO("0");
-	static const String SPACE(" ");
-	static const String MINUS("-");
-	static const String PLUS("+");
+	constexpr char32_t ZERO = '0';
+	constexpr char32_t SPACE = ' ';
+	constexpr char32_t MINUS = '-';
+	constexpr char32_t PLUS = '+';
 
-	String formatted;
+	StringBuffer formatted;
 	char32_t *self = (char32_t *)get_data();
 	bool in_format = false;
 	uint64_t value_index = 0;
@@ -5431,7 +5432,9 @@ String String::sprintf(const Span<Variant> &values, bool *error) const {
 							capitalize = true;
 							break;
 					}
-					// Get basic number.
+
+					bool negative = value < 0 && !as_unsigned;
+
 					String str;
 					if (!as_unsigned) {
 						str = String::num_int64(Math::abs(value), base, capitalize);
@@ -5443,30 +5446,38 @@ String String::sprintf(const Span<Variant> &values, bool *error) const {
 						}
 						str = String::num_uint64(uvalue, base, capitalize);
 					}
-					int number_len = str.length();
 
-					bool negative = value < 0 && !as_unsigned;
+					int pad_chars_count = ((negative || show_sign) ? min_chars - 1 : min_chars) - str.length();
+					const char32_t pad_char = pad_with_zeros ? ZERO : SPACE;
 
-					// Padding.
-					int pad_chars_count = (negative || show_sign) ? min_chars - 1 : min_chars;
-					const String &pad_char = pad_with_zeros ? ZERO : SPACE;
-					if (left_justified) {
-						str = str.rpad(pad_chars_count, pad_char);
-					} else {
-						str = str.lpad(pad_chars_count, pad_char);
+					// Left pad with spaces.
+					if (!pad_with_zeros && !left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += pad_char;
+						}
 					}
 
 					// Sign.
 					if (show_sign || negative) {
-						const String &sign_char = negative ? MINUS : PLUS;
-						if (left_justified) {
-							str = str.insert(0, sign_char);
-						} else {
-							str = str.insert(pad_with_zeros ? 0 : str.length() - number_len, sign_char);
+						formatted += negative ? MINUS : PLUS;
+					}
+
+					// Left pad with zeroes.
+					if (pad_with_zeros && !left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += pad_char;
 						}
 					}
 
 					formatted += str;
+
+					// Right pad.
+					if (left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += pad_char;
+						}
+					}
+
 					++value_index;
 					in_format = false;
 
@@ -5483,36 +5494,45 @@ String String::sprintf(const Span<Variant> &values, bool *error) const {
 
 					double value = values[value_index];
 					bool is_negative = std::signbit(value);
-					String str = String::num(Math::abs(value), min_decimals);
 					const bool is_finite = Math::is_finite(value);
 
+					String str = String::num(Math::abs(value), min_decimals);
 					// Pad decimals out.
 					if (is_finite) {
 						str = str.pad_decimals(min_decimals);
 					}
 
-					int initial_len = str.length();
+					int pad_chars_count = ((is_negative || show_sign) ? min_chars - 1 : min_chars) - str.length();
+					const char32_t pad_char = (pad_with_zeros && is_finite) ? ZERO : SPACE; // Never pad NaN or inf with zeros
 
-					// Padding. Leave room for sign later if required.
-					int pad_chars_count = (is_negative || show_sign) ? min_chars - 1 : min_chars;
-					const String &pad_char = (pad_with_zeros && is_finite) ? ZERO : SPACE; // Never pad NaN or inf with zeros
-					if (left_justified) {
-						str = str.rpad(pad_chars_count, pad_char);
-					} else {
-						str = str.lpad(pad_chars_count, pad_char);
+					// Left pad with spaces.
+					if (!pad_with_zeros && !left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += pad_char;
+						}
 					}
 
 					// Add sign if needed.
 					if (show_sign || is_negative) {
-						const String &sign_char = is_negative ? MINUS : PLUS;
-						if (left_justified) {
-							str = str.insert(0, sign_char);
-						} else {
-							str = str.insert(pad_with_zeros ? 0 : str.length() - initial_len, sign_char);
+						formatted += is_negative ? MINUS : PLUS;
+					}
+
+					// Left pad with zeroes.
+					if (pad_with_zeros && !left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += pad_char;
 						}
 					}
 
 					formatted += str;
+
+					// Right pad.
+					if (left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += pad_char;
+						}
+					}
+
 					++value_index;
 					in_format = false;
 					break;
@@ -5542,47 +5562,55 @@ String String::sprintf(const Span<Variant> &values, bool *error) const {
 					}
 
 					Vector4 vec = values[value_index];
-					String str = "(";
+					formatted += '(';
 					for (int i = 0; i < count; i++) {
 						double val = vec[i];
-						String number_str = String::num(Math::abs(val), min_decimals);
 						const bool is_finite = Math::is_finite(val);
+						String str = String::num(Math::abs(val), min_decimals);
 
 						// Pad decimals out.
 						if (is_finite) {
-							number_str = number_str.pad_decimals(min_decimals);
+							str = str.pad_decimals(min_decimals);
 						}
 
-						int initial_len = number_str.length();
+						int pad_chars_count = (val < 0 ? min_chars - 1 : min_chars) - str.length();
+						const char32_t pad_char = (pad_with_zeros && is_finite) ? ZERO : SPACE; // Never pad NaN or inf with zeros
 
-						// Padding. Leave room for sign later if required.
-						int pad_chars_count = val < 0 ? min_chars - 1 : min_chars;
-						const String &pad_char = (pad_with_zeros && is_finite) ? ZERO : SPACE; // Never pad NaN or inf with zeros
-						if (left_justified) {
-							number_str = number_str.rpad(pad_chars_count, pad_char);
-						} else {
-							number_str = number_str.lpad(pad_chars_count, pad_char);
+						// Left pad with spaces.
+						if (!pad_with_zeros && !left_justified) {
+							for (int j = 0; j < pad_chars_count; j++) {
+								formatted += pad_char;
+							}
 						}
 
 						// Add sign if needed.
 						if (val < 0) {
-							if (left_justified) {
-								number_str = number_str.insert(0, MINUS);
-							} else {
-								number_str = number_str.insert(pad_with_zeros ? 0 : number_str.length() - initial_len, MINUS);
+							formatted += MINUS;
+						}
+
+						// Left pad with zeroes.
+						if (pad_with_zeros && !left_justified) {
+							for (int j = 0; j < pad_chars_count; j++) {
+								formatted += pad_char;
 							}
 						}
 
 						// Add number to combined string
-						str += number_str;
+						formatted += str;
+
+						// Right pad.
+						if (left_justified) {
+							for (int j = 0; j < pad_chars_count; j++) {
+								formatted += pad_char;
+							}
+						}
 
 						if (i < count - 1) {
-							str += ", ";
+							formatted += ", ";
 						}
 					}
-					str += ")";
+					formatted += ')';
 
-					formatted += str;
 					++value_index;
 					in_format = false;
 					break;
@@ -5593,14 +5621,25 @@ String String::sprintf(const Span<Variant> &values, bool *error) const {
 					}
 
 					String str = values[value_index];
-					// Padding.
-					if (left_justified) {
-						str = str.rpad(min_chars);
-					} else {
-						str = str.lpad(min_chars);
+
+					int pad_chars_count = min_chars - str.length();
+
+					// Left pad.
+					if (!left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += ' ';
+						}
 					}
 
 					formatted += str;
+
+					// Right pad.
+					if (left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += ' ';
+						}
+					}
+
 					++value_index;
 					in_format = false;
 					break;
@@ -5631,14 +5670,24 @@ String String::sprintf(const Span<Variant> &values, bool *error) const {
 						return "%c requires number or single-character string";
 					}
 
-					// Padding.
-					if (left_justified) {
-						str = str.rpad(min_chars);
-					} else {
-						str = str.lpad(min_chars);
+					int pad_chars_count = min_chars - str.length();
+
+					// Left pad.
+					if (!left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += ' ';
+						}
 					}
 
 					formatted += str;
+
+					// Right pad.
+					if (left_justified) {
+						for (int i = 0; i < pad_chars_count; i++) {
+							formatted += ' ';
+						}
+					}
+
 					++value_index;
 					in_format = false;
 					break;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

EDIT: This PR now uses StringBuffer instead. See https://github.com/godotengine/godot/pull/111604#issuecomment-3401486477.

---

This PR uses StringBuilder to minimize intermediate Strings generated by String functions such as `String::lpad()` inside `sprintf`. Note that `sprintf` is used by `vformat`, which can be found all over the engine and is also indirectly used by users for print-debugging.

There's still room for improvement (like combining `String::num` and `String::pad_decimals` so the latter doesn't cause an additional allocation, and of course the number-to-string methods themselves) but I think those can be for a future PR for those interested.

Benchmark script:
```gdscript
func _ready():
	var start := Time.get_ticks_msec()
	var format := "fish %05d frog %07f fish %v"
	var args := [ -5, 3.251, Vector3(0.5, 1.0, 1.5) ]
	for i in range(300000):
		var _output = format % args
	var end := Time.get_ticks_msec()
	print("%dms" % [end - start])
```

Here are the results:

- Relevant system information: 11th Gen Intel(R) Core(TM) i5-11400H @ 2.70GHz (12 threads) - 15.78 GiB memory
- Build arguments: `scons platform=windows production=yes`

|  | Before | After |
| ----- | -- | - |
| Time (msec) | 1205 | 1027 |

I suspect that longer format strings will benefit more from this optimization, but even with short format strings the improvement is still noticeable.

Unit tests for StringBuilder are also added in `test_string_builder.h` since I've made changes to it in this PR.