### PR TITLE
Fix error when editing multifield values inside arrays and dictionaries

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -96,7 +96,13 @@ void EditorDebuggerRemoteObjects::_get_property_list(List<PropertyInfo> *p_list)
 }
 
 void EditorDebuggerRemoteObjects::set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field) {
-	_set_impl(p_property, p_value, p_field);
+	// Ignore the field with arrays and dictionaries, as they are passed whole when edited.
+	Variant::Type type = p_value.get_type();
+	if (type == Variant::ARRAY || type == Variant::DICTIONARY) {
+		_set_impl(p_property, p_value, "");
+	} else {
+		_set_impl(p_property, p_value, p_field);
+	}
 }
 
 String EditorDebuggerRemoteObjects::get_title() {

--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -310,7 +310,13 @@ StringName MultiNodeEdit::get_edited_class_name() const {
 }
 
 void MultiNodeEdit::set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field) {
-	_set_impl(p_property, p_value, p_field);
+	// Ignore the field with arrays and dictionaries, as they are passed whole when edited.
+	Variant::Type type = p_value.get_type();
+	if (type == Variant::ARRAY || type == Variant::DICTIONARY) {
+		_set_impl(p_property, p_value, "");
+	} else {
+		_set_impl(p_property, p_value, p_field);
+	}
 }
 
 void MultiNodeEdit::_bind_methods() {


### PR DESCRIPTION
This affects both remote objects and `MultiNodeEdit`. When editing a value that contains multiple fields (such as `Vector`, `Rect`, etc), Godot tries to just change the field that was edited. However, this doesn't work when done from inside arrays and dictionaries, as their full values are passed. This PR makes so that the field is ignored for those two types.

Fixes #44903.