### PR TITLE
Core: Enforce strict JSON for non-finite numbers, document native workaround

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1056,7 +1056,15 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 			if (s.begins_with("i:")) {
 				return s.substr(2).to_int();
 			} else if (s.begins_with("f:")) {
-				return s.substr(2).to_float();
+				const String sub = s.substr(2);
+				if (sub == "inf") {
+					return Math::INF;
+				} else if (sub == "-inf") {
+					return -Math::INF;
+				} else if (sub == "nan") {
+					return Math::NaN;
+				}
+				return sub.to_float();
 			} else if (s.begins_with("s:")) {
 				return s.substr(2);
 			} else if (s.begins_with("sn:")) {

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -98,6 +98,7 @@
 				[b]Note:[/b] The JSON specification does not define integer or float types, but only a [i]number[/i] type. Therefore, converting a Variant to JSON text will convert all numerical values to [float] types.
 				[b]Note:[/b] If [param full_precision] is [code]true[/code], when stringifying floats, the unreliable digits are stringified in addition to the reliable digits to guarantee exact decoding.
 				The [param indent] parameter controls if and how something is indented; its contents will be used where there should be an indent in the output. Even spaces like [code]"   "[/code] will work. [code]\t[/code] and [code]\n[/code] can also be used for a tab indent, or to make a newline for each indent respectively.
+				[b]Warning:[/b] The JSON specification only permits finite numbers. Any instances of [constant @GDScript.INF], -[constant @GDScript.INF], or [constant @GDScript.NAN] will be converted to [code]null[/code]. If you rely on these constants, you must pass your data through [method from_native] first.
 				[b]Example output:[/b]
 				[codeblock]
 				## JSON.stringify(my_dictionary)

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -401,4 +401,38 @@ TEST_CASE("[JSON] Serialization") {
 		}
 	}
 }
+
+TEST_CASE("[JSON] Passing from/to native") {
+	JSON json;
+
+	struct Native {
+		Variant native;
+		Variant parsed;
+	};
+
+	static const Native tests_native[] = {
+		{ Variant(), Variant() },
+		{ true, true },
+		{ false, false },
+		{ 123456, "i:123456" },
+		{ 0.123456, "f:0.123456" },
+		{ "Hello", "s:Hello" },
+		{ Math::INF, "f:inf" },
+		{ -Math::INF, "f:-inf" },
+		{ Math::NaN, "f:nan" },
+	};
+
+	for (const Native &test : tests_native) {
+		const Variant from_native = json.from_native(test.native);
+		CHECK_MESSAGE(
+				from_native == test.parsed,
+				vformat("Converting `%s` from native should result in `%s`, got `%s` instead.", test.native, test.parsed, from_native));
+
+		const Variant to_native = json.to_native(from_native);
+		CHECK_MESSAGE(
+				to_native == test.native,
+				vformat("Converting `%s` to native should result in `%s`, got `%s` instead.", test.parsed, test.native, to_native));
+	}
+}
+
 } // namespace TestJSON


### PR DESCRIPTION
- Fixes #89777
- Supersedes #111498
- Depends on #111522

Consider this my penance for kicking the hornet's nest with that premptive merge.

In trying to come up with a solution that would line up with the core team's specifications, I was looking into how various other implementations of JSON handle non-finite numbers. The one I ended up settling on is Javascript's, which turns the values into `null`. This is obviously not ideal, but JSON isn't an ideal standard so that checks out. Plus, it's more ideal than what we have now, as it follows what is arguably the most prevalent standard.

However, because it's important to support transfering `INF`/`NAN` unambiguously through JSON by *some* means, this PR is dependent on the fix in #111522. This would allow these types to be converted to and from their native selves and JSON-safe string wrapper. This allows us to sidestep the rabbit hole of finding a "correct" way of representing these invalid types.

Tests and documentation have been expanded to account for this new behavior and the aforementioned workaround. This is also *technically* compatibility-breaking for the non-zero chance anyone was simultaneously relying on our invalid output **and** made a dedicated parser for the invalid output that we never supported, so it shouldn't be cherry-picked.