### PR TITLE
Improve readability of negated ternary expressions

### DIFF
--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -679,7 +679,7 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 		}
 
 	} else {
-		int to_read = !read_until_eof ? MIN(body_left, read_chunk_size) : read_chunk_size;
+		int to_read = read_until_eof ? read_chunk_size : MIN(body_left, read_chunk_size);
 		ret.resize(to_read);
 		int _offset = 0;
 		while (to_read > 0) {

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1238,7 +1238,7 @@ Ref<Resource> ResourceFormatLoaderBinary::load(const String &p_path, const Strin
 	}
 	loader.use_sub_threads = p_use_sub_threads;
 	loader.progress = r_progress;
-	String path = !p_original_path.is_empty() ? p_original_path : p_path;
+	String path = p_original_path.is_empty() ? p_path : p_original_path;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(path);
 	loader.res_path = loader.local_path;
 	loader.open(f);

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -69,7 +69,7 @@ bool ResourceFormatLoader::recognize_path(const String &p_path, const String &p_
 	}
 
 	for (const String &E : extensions) {
-		const String ext = !E.begins_with(".") ? "." + E : E;
+		const String ext = E.begins_with(".") ? E : ("." + E);
 		if (p_path.right(ext.length()).nocasecmp_to(ext) == 0) {
 			return true;
 		}
@@ -348,14 +348,14 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 		if (r_error) {
 			*r_error = ERR_FILE_NOT_FOUND;
 		}
-		ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Resource file not found: %s (expected type: %s)", p_path, !p_type_hint.is_empty() ? p_type_hint : "unknown"));
+		ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Resource file not found: %s (expected type: %s)", p_path, p_type_hint.is_empty() ? "unknown" : p_type_hint));
 	}
 #endif
 
 	if (r_error) {
 		*r_error = ERR_FILE_UNRECOGNIZED;
 	}
-	ERR_FAIL_V_MSG(Ref<Resource>(), vformat("No loader found for resource: %s (expected type: %s)", p_path, !p_type_hint.is_empty() ? p_type_hint : "unknown"));
+	ERR_FAIL_V_MSG(Ref<Resource>(), vformat("No loader found for resource: %s (expected type: %s)", p_path, p_type_hint.is_empty() ? "unknown" : p_type_hint));
 }
 
 // This implementation must allow re-entrancy for a task that started awaiting in a deeper stack frame.

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -1441,7 +1441,7 @@ void ConvexHullInternal::merge(IntermediateHull &p_h0, IntermediateHull &p_h1) {
 			c1->edges = e;
 			return;
 		} else {
-			int32_t cmp = !min0 ? 1 : (!min1 ? -1 : min_cot0.compare(min_cot1));
+			int32_t cmp = min0 ? (min1 ? min_cot0.compare(min_cot1) : -1) : 1;
 #ifdef DEBUG_CONVEX_HULL
 			printf("    -> Result %d\n", cmp);
 #endif

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1603,7 +1603,7 @@ RDD::TextureID RenderingDeviceDriverD3D12::texture_create_from_extension(uint64_
 	tex_info->owner_info.allocation = nullptr; // Not allocated by us.
 	tex_info->owner_info.states.subresource_states.resize(resource_desc.MipLevels * p_array_layers);
 	for (uint32_t i = 0; i < tex_info->owner_info.states.subresource_states.size(); i++) {
-		tex_info->owner_info.states.subresource_states[i] = !p_depth_stencil ? D3D12_RESOURCE_STATE_RENDER_TARGET : D3D12_RESOURCE_STATE_DEPTH_WRITE;
+		tex_info->owner_info.states.subresource_states[i] = p_depth_stencil ? D3D12_RESOURCE_STATE_DEPTH_WRITE : D3D12_RESOURCE_STATE_RENDER_TARGET;
 	}
 	tex_info->states_ptr = &tex_info->owner_info.states;
 	tex_info->format = p_format;

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2417,7 +2417,7 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 				texture->layers = 1;
 			}
 			texture->gl_format_cache = rt->color_format;
-			texture->gl_type_cache = !rt->hdr ? GL_UNSIGNED_BYTE : GL_FLOAT; // to set HDR format size to 8 and keep 4 for LDR format
+			texture->gl_type_cache = rt->hdr ? GL_FLOAT : GL_UNSIGNED_BYTE; // To set HDR format size to 8 and keep 4 for LDR format.
 			texture->gl_internal_format_cache = rt->color_internal_format;
 			texture->tex_id = rt->color;
 			texture->width = rt->size.x;

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -92,7 +92,7 @@ String AnimationNodeStateMachineEditor::_get_root_playback_path(String &r_node_d
 	if (edited_path.size()) {
 		while (!is_playable_anodesm_found) {
 			base_path = String("/").join(edited_path);
-			Ref<AnimationNodeStateMachine> anodesm = !edited_path.size() ? Ref<AnimationNode>(tree->get_root_animation_node().ptr()) : tree->get_root_animation_node()->find_node_by_path(base_path);
+			Ref<AnimationNodeStateMachine> anodesm = edited_path.is_empty() ? Ref<AnimationNode>(tree->get_root_animation_node().ptr()) : tree->get_root_animation_node()->find_node_by_path(base_path);
 			if (anodesm.is_null()) {
 				break;
 			} else {
@@ -114,7 +114,7 @@ String AnimationNodeStateMachineEditor::_get_root_playback_path(String &r_node_d
 		if (node_directory_path.size()) {
 			r_node_directory += "/";
 		}
-		base_path = !edited_path.size() ? Animation::PARAMETERS_BASE_PATH + "playback" : Animation::PARAMETERS_BASE_PATH + base_path + "/playback";
+		base_path = Animation::PARAMETERS_BASE_PATH + (edited_path.is_empty() ? "" : (base_path + "/")) + "playback";
 	} else {
 		// Hmmm, we have to return Grouped state machine playback...
 		// It will give the user the error that Root/Nested state machine should be retrieved, that would be kind :-)

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -1685,7 +1685,7 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 		_write_string(f, 1, "<tutorials>");
 		for (int i = 0; i < c.tutorials.size(); i++) {
 			DocData::TutorialDoc tutorial = c.tutorials.get(i);
-			String title_attribute = (!tutorial.title.is_empty()) ? " title=\"" + _translate_doc_string(tutorial.title).xml_escape(true) + "\"" : "";
+			String title_attribute = tutorial.title.is_empty() ? "" : (" title=\"" + _translate_doc_string(tutorial.title).xml_escape(true) + "\"");
 			_write_string(f, 2, "<link" + title_attribute + ">" + tutorial.link.xml_escape() + "</link>");
 		}
 		_write_string(f, 1, "</tutorials>");

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3727,7 +3727,7 @@ void EditorFileSystem::_update_extensions() {
 	extensionsl.clear();
 	ResourceFormatImporter::get_singleton()->get_recognized_extensions(&extensionsl);
 	for (const String &E : extensionsl) {
-		import_extensions.insert(!E.begins_with(".") ? "." + E : E);
+		import_extensions.insert(E.begins_with(".") ? E : ("." + E));
 	}
 }
 

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -304,9 +304,9 @@ void EditorSpinSlider::_update_value_input_stylebox() {
 	// higher margin to match the location where the text begins.
 	// The margin values below were determined by empirical testing.
 	if (is_layout_rtl()) {
-		stylebox->set_content_margin(SIDE_RIGHT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
+		stylebox->set_content_margin(SIDE_RIGHT, (get_label().is_empty() ? 16 : 23) * EDSCALE);
 	} else {
-		stylebox->set_content_margin(SIDE_LEFT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
+		stylebox->set_content_margin(SIDE_LEFT, (get_label().is_empty() ? 16 : 23) * EDSCALE);
 	}
 
 	value_input->add_theme_style_override(CoreStringName(normal), stylebox);

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -167,7 +167,7 @@ void EditorToaster::_error_handler_impl(const String &p_file, int p_line, const 
 	int show_all_setting = EDITOR_GET("interface/editor/show_internal_errors_in_toast_notifications");
 
 	if (p_editor_notify || (show_all_setting == 0 && in_dev) || show_all_setting == 1) {
-		String err_str = !p_errorexp.is_empty() ? p_errorexp : p_error;
+		String err_str = p_errorexp.is_empty() ? p_error : p_errorexp;
 		String tooltip_str = p_file + ":" + itos(p_line);
 
 		if (!p_editor_notify) {

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -1929,10 +1929,10 @@ void Collada::_parse_library(XMLParser &p_parser) {
 				while (p_parser.read() == OK) {
 					if (p_parser.get_node_type() == XMLParser::NODE_ELEMENT) {
 						if (p_parser.get_node_name() == "mesh") {
-							state.mesh_name_map[id] = (!name2.is_empty()) ? name2 : id;
+							state.mesh_name_map[id] = name2.is_empty() ? id : name2;
 							_parse_mesh_geometry(p_parser, id, name2);
 						} else if (p_parser.get_node_name() == "spline") {
-							state.mesh_name_map[id] = (!name2.is_empty()) ? name2 : id;
+							state.mesh_name_map[id] = name2.is_empty() ? id : name2;
 							_parse_curve_geometry(p_parser, id, name2);
 						} else if (!p_parser.is_empty()) {
 							p_parser.skip_section();

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1035,7 +1035,7 @@ void ProjectList::_create_project_item_control(int p_index) {
 	ProjectListItemControl *hb = memnew(ProjectListItemControl);
 	hb->add_theme_constant_override("separation", 10 * EDSCALE);
 
-	hb->set_project_title(!item.missing ? item.project_name : TTR("Missing Project"));
+	hb->set_project_title(item.missing ? TTR("Missing Project") : item.project_name);
 	hb->set_project_path(item.path);
 	hb->set_tooltip_text(item.description);
 	hb->set_tags(item.tags, this);

--- a/editor/scene/3d/gizmos/physics/collision_object_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_object_3d_gizmo_plugin.cpp
@@ -67,7 +67,7 @@ void CollisionObject3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Object *owner = co->shape_owner_get_owner(owner_id);
 		// Exclude CollisionShape3D and CollisionPolygon3D as they have their gizmo.
 		if (!Object::cast_to<CollisionShape3D>(owner) && !Object::cast_to<CollisionPolygon3D>(owner)) {
-			Ref<Material> material = get_material(!co->is_shape_owner_disabled(owner_id) ? "shape_material" : "shape_material_disabled", p_gizmo);
+			Ref<Material> material = get_material(co->is_shape_owner_disabled(owner_id) ? "shape_material_disabled" : "shape_material", p_gizmo);
 			for (int shape_id = 0; shape_id < co->shape_owner_get_shape_count(owner_id); shape_id++) {
 				Ref<Shape3D> s = co->shape_owner_get_shape(owner_id, shape_id);
 				if (s.is_null()) {

--- a/editor/scene/3d/gizmos/physics/collision_polygon_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_polygon_3d_gizmo_plugin.cpp
@@ -88,9 +88,9 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	p_gizmo->clear();
 
 	const Ref<StandardMaterial3D> material =
-			get_material(!polygon->is_disabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
+			get_material(polygon->is_disabled() ? "shape_material_disabled" : "shape_material", p_gizmo);
 	const Ref<StandardMaterial3D> material_arraymesh =
-			get_material(!polygon->is_disabled() ? "shape_material_arraymesh" : "shape_material_arraymesh_disabled", p_gizmo);
+			get_material(polygon->is_disabled() ? "shape_material_arraymesh_disabled" : "shape_material_arraymesh", p_gizmo);
 
 	const Color collision_color = polygon->is_disabled() ? Color(1.0, 1.0, 1.0, 0.75) : polygon->get_debug_color();
 

--- a/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
@@ -308,9 +308,9 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	const Ref<StandardMaterial3D> material =
-			get_material(!cs->is_disabled() ? "shape_material" : "shape_material_disabled", p_gizmo);
+			get_material(cs->is_disabled() ? "shape_material_disabled" : "shape_material", p_gizmo);
 	const Ref<StandardMaterial3D> material_arraymesh =
-			get_material(!cs->is_disabled() ? "shape_material_arraymesh" : "shape_material_arraymesh_disabled", p_gizmo);
+			get_material(cs->is_disabled() ? "shape_material_arraymesh_disabled" : "shape_material_arraymesh", p_gizmo);
 	const Ref<Material> handles_material = get_material("handles");
 
 	const Color collision_color = cs->is_disabled() ? Color(1.0, 1.0, 1.0, 0.75) : cs->get_debug_color();

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -434,7 +434,7 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 	profile_actions[PROFILE_EXPORT]->set_disabled(selected_profile.is_empty());
 	profile_actions[PROFILE_SET]->set_disabled(selected_profile.is_empty());
 
-	current_profile_name->set_text(!current_profile.is_empty() ? current_profile : TTR("(none)"));
+	current_profile_name->set_text(current_profile.is_empty() ? TTR("(none)") : current_profile);
 
 	_update_selected_profile();
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2242,7 +2242,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// and even if file logging is disabled in the Project Settings.
 	// `--log-file` can be used with any path (including absolute paths outside the project folder),
 	// so check for filesystem access if it's used.
-	if (FileAccess::get_create_func(!log_file.is_empty() ? FileAccess::ACCESS_FILESYSTEM : FileAccess::ACCESS_USERDATA) &&
+	if (FileAccess::get_create_func(log_file.is_empty() ? FileAccess::ACCESS_USERDATA : FileAccess::ACCESS_FILESYSTEM) &&
 			(!log_file.is_empty() || (!project_manager && !editor && GLOBAL_GET("debug/file_logging/enable_file_logging")))) {
 		// Don't create logs for the project manager as they would be written to
 		// the current working directory, which is inconvenient.

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -450,7 +450,7 @@ void JoltBody3D::_exit_all_areas() {
 }
 
 void JoltBody3D::_update_group_filter() {
-	JPH::GroupFilter *group_filter = !exceptions.is_empty() ? JoltGroupFilter::instance : nullptr;
+	JPH::GroupFilter *group_filter = exceptions.is_empty() ? nullptr : JoltGroupFilter::instance;
 
 	if (!in_space()) {
 		jolt_settings->mCollisionGroup.SetGroupFilter(group_filter);

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -253,7 +253,7 @@ void JoltSoftBody3D::_update_simulation_precision() {
 }
 
 void JoltSoftBody3D::_update_group_filter() {
-	JPH::GroupFilter *group_filter = !exceptions.is_empty() ? JoltGroupFilter::instance : nullptr;
+	JPH::GroupFilter *group_filter = exceptions.is_empty() ? nullptr : JoltGroupFilter::instance;
 
 	if (!in_space()) {
 		jolt_settings->mCollisionGroup.SetGroupFilter(group_filter);

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -958,7 +958,7 @@ void BindingsGenerator::_append_text_signal(StringBuilder &p_output, const TypeI
 }
 
 void BindingsGenerator::_append_text_enum(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
-	const StringName search_cname = !p_target_itype ? p_target_cname : StringName(p_target_itype->name + "." + (String)p_target_cname);
+	const StringName search_cname = p_target_itype ? StringName(p_target_itype->name + "." + (String)p_target_cname) : p_target_cname;
 
 	HashMap<StringName, TypeInterface>::ConstIterator enum_match = enum_types.find(search_cname);
 
@@ -1251,7 +1251,7 @@ void BindingsGenerator::_append_xml_signal(StringBuilder &p_xml_output, const Ty
 }
 
 void BindingsGenerator::_append_xml_enum(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts, const TypeInterface *p_source_itype) {
-	const StringName search_cname = !p_target_itype ? p_target_cname : StringName(p_target_itype->name + "." + (String)p_target_cname);
+	const StringName search_cname = p_target_itype ? StringName(p_target_itype->name + "." + (String)p_target_cname) : p_target_cname;
 
 	HashMap<StringName, TypeInterface>::ConstIterator enum_match = enum_types.find(search_cname);
 
@@ -1695,7 +1695,7 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 			p_output << "\npublic partial struct " << enum_class_name << "\n" OPEN_BLOCK;
 		}
 
-		const String maybe_indent = !enum_in_static_class ? "" : INDENT1;
+		const String maybe_indent = enum_in_static_class ? INDENT1 : "";
 
 		if (ienum.is_flags) {
 			p_output << "\n"
@@ -3553,7 +3553,7 @@ Error BindingsGenerator::_generate_cs_native_calls(const InternalCall &p_icall, 
 			r_output << base_indent << C_CLASS_NATIVE_FUNCS ".godotsharp_method_bind_ptrcall("
 					 << CS_PARAM_METHODBIND ", " << (p_icall.is_static ? "IntPtr.Zero" : CS_PARAM_INSTANCE)
 					 << ", " << (p_icall.get_arguments_count() ? C_LOCAL_PTRCALL_ARGS : "null")
-					 << ", " << (!ret_void ? "&" C_LOCAL_RET ");\n" : "null);\n");
+					 << ", " << (ret_void ? "null);\n" : "&" C_LOCAL_RET ");\n");
 		}
 
 		// Return statement

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -127,7 +127,7 @@ GCHandleIntPtr godotsharp_internal_object_get_associated_gchandle(Object *p_ptr)
 		CSharpScriptBinding &script_binding = ((RBMap<Object *, CSharpScriptBinding>::Element *)data)->get();
 		if (script_binding.inited) {
 			MonoGCHandleData &gchandle = script_binding.gchandle;
-			return !gchandle.is_released() ? gchandle.get_intptr() : GCHandleIntPtr{ nullptr };
+			return gchandle.is_released() ? GCHandleIntPtr{ nullptr } : gchandle.get_intptr();
 		}
 	}
 

--- a/modules/objectdb_profiler/editor/data_viewers/class_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/class_view.cpp
@@ -211,7 +211,7 @@ void SnapshotClassView::_add_objects_to_class_map(HashMap<String, ClassData> &p_
 			p_class_map[parent_class_name].child_classes.insert(class_name);
 
 			class_name = parent_class_name;
-			parent_class_name = !class_name.is_empty() ? ClassDB::get_parent_class(class_name) : "";
+			parent_class_name = class_name.is_empty() ? "" : ClassDB::get_parent_class(class_name);
 		}
 	}
 }

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1326,7 +1326,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							rot = post_process_key_value(a, rot_track, rot, t->object_id, t->bone_idx);
 
 							root_motion_cache.loc += rot.xform_inv(loc[1] - loc[0]) * blend;
-							prev_time = !backward ? start : end;
+							prev_time = backward ? end : start;
 						} else {
 							Vector3 loc[2];
 							if (!backward) {
@@ -1362,7 +1362,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							a->try_position_track_interpolate(i, time, &loc[1]);
 							loc[1] = post_process_key_value(a, i, loc[1], t->object_id, t->bone_idx);
 							root_motion_cache.loc += (loc[1] - loc[0]) * blend;
-							prev_time = !backward ? start : end;
+							prev_time = backward ? end : start;
 						}
 					}
 					{
@@ -1539,7 +1539,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						a->try_scale_track_interpolate(i, time, &scale[1]);
 						scale[1] = post_process_key_value(a, i, scale[1], t->object_id, t->bone_idx);
 						root_motion_cache.scale += (scale[1] - scale[0]) * blend;
-						prev_time = !backward ? start : end;
+						prev_time = backward ? end : start;
 					}
 					{
 						Vector3 scale;

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1190,7 +1190,7 @@ Ref<AnimationNodeStateMachine> AnimationNodeStateMachinePlayback::_get_parent_st
 	Ref<AnimationNode> root = p_tree->get_root_animation_node();
 	ERR_FAIL_COND_V_MSG(root.is_null(), Ref<AnimationNodeStateMachine>(), "There is no root AnimationNode in AnimationTree: " + String(p_tree->get_name()));
 	String anodesm_path = String("/").join(split);
-	Ref<AnimationNodeStateMachine> anodesm = !anodesm_path.size() ? root : root->find_node_by_path(anodesm_path);
+	Ref<AnimationNodeStateMachine> anodesm = anodesm_path.is_empty() ? root : root->find_node_by_path(anodesm_path);
 	ERR_FAIL_COND_V_MSG(anodesm.is_null(), Ref<AnimationNodeStateMachine>(), "Can't get state machine with path: " + anodesm_path);
 	return anodesm;
 }

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -331,7 +331,7 @@ void ScrollContainer::ensure_control_visible(Control *p_control) {
 	float side_margin = v_scroll->is_visible() ? v_scroll->get_size().x : 0.0f;
 	float bottom_margin = h_scroll->is_visible() ? h_scroll->get_size().y : 0.0f;
 
-	Vector2 diff = Vector2(MAX(MIN(other_rect.position.x - (is_layout_rtl() ? side_margin : 0.0f), 0.0f), other_rect.position.x + other_rect.size.x - size.x + (!is_layout_rtl() ? side_margin : 0.0f)),
+	Vector2 diff = Vector2(MAX(MIN(other_rect.position.x - (is_layout_rtl() ? side_margin : 0.0f), 0.0f), other_rect.position.x + other_rect.size.x - size.x + (is_layout_rtl() ? 0.0f : side_margin)),
 			MAX(MIN(other_rect.position.y, 0.0f), other_rect.position.y + other_rect.size.y - size.y + bottom_margin));
 
 	set_h_scroll(get_h_scroll() + diff.x);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -293,8 +293,8 @@ void TextEdit::Text::invalidate_cache(int p_line, bool p_text_changed) {
 	text_line.data_buf->set_custom_punctuation(get_enabled_word_separators());
 	text_line.indent_ofs = -1.0;
 
-	const String &text_with_ime = (!text_line.ime_data.is_empty()) ? text_line.ime_data : text_line.data;
-	const Array &bidi_override_with_ime = (!text_line.ime_data.is_empty()) ? text_line.ime_bidi_override : text_line.bidi_override;
+	const String &text_with_ime = text_line.ime_data.is_empty() ? text_line.data : text_line.ime_data;
+	const Array &bidi_override_with_ime = text_line.ime_data.is_empty() ? text_line.bidi_override : text_line.ime_bidi_override;
 
 	if (p_text_changed) {
 		int from = 0;
@@ -1346,7 +1346,7 @@ void TextEdit::_notification(int p_what) {
 				const Vector<Pair<int64_t, Color>> color_map = _get_line_syntax_highlighting(line);
 
 				// Ensure we at least use the font color.
-				Color current_color = !editable ? theme_cache.font_readonly_color : theme_cache.font_color;
+				Color current_color = editable ? theme_cache.font_color : theme_cache.font_readonly_color;
 				if (draw_placeholder) {
 					current_color = theme_cache.font_placeholder_color;
 				}
@@ -1597,7 +1597,7 @@ void TextEdit::_notification(int p_what) {
 
 					if (!clipped && lookup_symbol_word.length() != 0) { // Highlight word
 						if (is_unicode_identifier_start(lookup_symbol_word[0]) || lookup_symbol_word[0] == '.') {
-							Color highlight_underline_color = !editable ? theme_cache.font_readonly_color : theme_cache.font_color;
+							Color highlight_underline_color = editable ? theme_cache.font_color : theme_cache.font_readonly_color;
 							int lookup_symbol_word_col = _get_column_pos_of_word(lookup_symbol_word, str, SEARCH_MATCH_CASE | SEARCH_WHOLE_WORDS, 0);
 							int lookup_symbol_word_len = lookup_symbol_word.length();
 							while (lookup_symbol_word_col != -1) {
@@ -5336,7 +5336,7 @@ void TextEdit::add_caret_at_carets(bool p_below) {
 		const int selection_origin_line = get_selection_origin_line(i);
 		const int selection_origin_column = get_selection_origin_column(i);
 		const int caret_wrap_index = get_caret_wrap_index(i);
-		const int selection_origin_wrap_index = !is_selected ? -1 : get_line_wrap_index_at_column(selection_origin_line, selection_origin_column);
+		const int selection_origin_wrap_index = is_selected ? get_line_wrap_index_at_column(selection_origin_line, selection_origin_column) : -1;
 
 		if (caret_line == 0 && !p_below && (caret_wrap_index == 0 || selection_origin_wrap_index == 0)) {
 			// Can't add above the first line.
@@ -5596,7 +5596,7 @@ void TextEdit::merge_overlapping_carets() {
 			if (has_selection(caret_to_remove) && has_selection(caret_to_save)) {
 				caret_dir_to_copy = caret_to_remove == get_caret_count() - 1 ? caret_to_remove : caret_to_save;
 			} else {
-				caret_dir_to_copy = !has_selection(caret_to_remove) ? caret_to_save : caret_to_remove;
+				caret_dir_to_copy = has_selection(caret_to_remove) ? caret_to_remove : caret_to_save;
 			}
 
 			if (is_caret_after_selection_origin(caret_dir_to_copy)) {
@@ -8341,7 +8341,7 @@ void TextEdit::_offset_carets_after(int p_old_line, int p_old_column, int p_new_
 		if (!selected) {
 			continue;
 		}
-		bool include_selection_origin_at = !caret_at_end ? p_include_selection_end : p_include_selection_begin;
+		bool include_selection_origin_at = caret_at_end ? p_include_selection_begin : p_include_selection_end;
 
 		int selection_origin_line = get_selection_origin_line(i);
 		int selection_origin_column = get_selection_origin_column(i);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -287,7 +287,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 						int32_t id = ids[i];
 						if (id != Node::UNIQUE_SCENE_ID_UNASSIGNED) {
 							if (!deep_search_warned) {
-								WARN_PRINT(vformat("%sA node in the scene this one inherits from has been removed or moved, so a recovery process needs to take place. Please re-save this scene to avoid the cost of this process next time.", !get_path().is_empty() ? get_path() + ": " : ""));
+								WARN_PRINT(vformat("%sA node in the scene this one inherits from has been removed or moved, so a recovery process needs to take place. Please re-save this scene to avoid the cost of this process next time.", get_path().is_empty() ? "" : (get_path() + ": ")));
 								deep_search_warned = true;
 							}
 							Node *base = parent;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1429,7 +1429,7 @@ Ref<Resource> ResourceFormatLoaderText::load(const String &p_path, const String 
 	ERR_FAIL_COND_V_MSG(err != OK, Ref<Resource>(), "Cannot open file '" + p_path + "'.");
 
 	ResourceLoaderText loader;
-	String path = !p_original_path.is_empty() ? p_original_path : p_path;
+	String path = p_original_path.is_empty() ? p_path : p_original_path;
 	switch (p_cache_mode) {
 		case CACHE_MODE_IGNORE:
 		case CACHE_MODE_REUSE:

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -264,7 +264,7 @@ void RendererCanvasCull::_attach_canvas_item_for_draw(RendererCanvasCull::Item *
 		}
 
 		if (ci->commands != nullptr || ci->copy_back_buffer) {
-			ci->final_transform = !ci->use_identity_transform ? p_transform : _current_camera_transform;
+			ci->final_transform = ci->use_identity_transform ? _current_camera_transform : p_transform;
 			ci->final_modulate = p_modulate * ci->self_modulate;
 			ci->global_rect_cache = p_global_rect;
 			ci->global_rect_cache.position -= p_clip_rect.position;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2307,7 +2307,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		{
 			//just mix specular back
 			RENDER_TIMESTAMP("Merge Specular");
-			copy_effects->merge_specular(color_only_framebuffer, rb_data->get_specular(), !use_msaa ? RID() : rb->get_internal_texture(), RID(), p_render_data->scene_data->view_count);
+			copy_effects->merge_specular(color_only_framebuffer, rb_data->get_specular(), use_msaa ? rb->get_internal_texture() : RID(), RID(), p_render_data->scene_data->view_count);
 		}
 	}
 

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -1334,10 +1334,10 @@ void RenderingDeviceGraph::_group_barriers_for_render_commands(RDD::CommandBuffe
 		return;
 	}
 
-	const VectorView<RDD::MemoryAccessBarrier> memory_barriers = !is_memory_barrier_empty ? barrier_group.memory_barrier : VectorView<RDD::MemoryAccessBarrier>();
+	const VectorView<RDD::MemoryAccessBarrier> memory_barriers = is_memory_barrier_empty ? VectorView<RDD::MemoryAccessBarrier>() : barrier_group.memory_barrier;
 	const VectorView<RDD::TextureBarrier> texture_barriers = barrier_group.normalization_barriers.is_empty() ? barrier_group.transition_barriers : barrier_group.normalization_barriers;
 #if USE_BUFFER_BARRIERS
-	const VectorView<RDD::BufferBarrier> buffer_barriers = !are_buffer_barriers_empty ? barrier_group.buffer_barriers : VectorView<RDD::BufferBarrier>();
+	const VectorView<RDD::BufferBarrier> buffer_barriers = are_buffer_barriers_empty ? VectorView<RDD::BufferBarrier>() : barrier_group.buffer_barriers;
 #else
 	const VectorView<RDD::BufferBarrier> buffer_barriers = VectorView<RDD::BufferBarrier>();
 #endif

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8877,7 +8877,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			if (tk.type == TK_SEMICOLON) {
 				//all is good
 				if (b->parent_function->return_type != TYPE_VOID) {
-					_set_error(vformat(RTR("Expected '%s' with an expression of type '%s'."), "return", (!return_struct_name.is_empty() ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string));
+					_set_error(vformat(RTR("Expected '%s' with an expression of type '%s'."), "return", (return_struct_name.is_empty() ? get_datatype_name(b->parent_function->return_type) : return_struct_name) + array_size_string));
 					return ERR_PARSE_ERROR;
 				}
 			} else {
@@ -8900,7 +8900,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				}
 
 				if (b->parent_function->return_type != expr->get_datatype() || b->parent_function->return_array_size != expr->get_array_size() || return_struct_name != expr->get_datatype_name()) {
-					_set_error(vformat(RTR("Expected return with an expression of type '%s'."), (!return_struct_name.is_empty() ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string));
+					_set_error(vformat(RTR("Expected return with an expression of type '%s'."), (return_struct_name.is_empty() ? get_datatype_name(b->parent_function->return_type) : return_struct_name) + array_size_string));
 					return ERR_PARSE_ERROR;
 				}
 


### PR DESCRIPTION
Avoiding negation of the condition, and adding a few parentheses where relevant.

There are still a few in `cowdata.h` but left that alone for now because the recompilation is brutal

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
