### PR TITLE
GLTF: Write integer min/max for integer accessors

### DIFF
--- a/modules/gltf/structures/gltf_accessor.cpp
+++ b/modules/gltf/structures/gltf_accessor.cpp
@@ -1173,8 +1173,28 @@ Dictionary GLTFAccessor::to_dictionary() const {
 	}
 	dict["componentType"] = component_type;
 	dict["count"] = count;
-	dict["max"] = max;
-	dict["min"] = min;
+	switch (component_type) {
+		case COMPONENT_TYPE_NONE: {
+			ERR_PRINT("glTF export: Invalid component type 'NONE' for glTF accessor.");
+		} break;
+		case COMPONENT_TYPE_SIGNED_BYTE:
+		case COMPONENT_TYPE_UNSIGNED_BYTE:
+		case COMPONENT_TYPE_SIGNED_SHORT:
+		case COMPONENT_TYPE_UNSIGNED_SHORT:
+		case COMPONENT_TYPE_SIGNED_INT:
+		case COMPONENT_TYPE_UNSIGNED_INT:
+		case COMPONENT_TYPE_SIGNED_LONG:
+		case COMPONENT_TYPE_UNSIGNED_LONG: {
+			dict["max"] = PackedInt64Array(Variant(max));
+			dict["min"] = PackedInt64Array(Variant(min));
+		} break;
+		case COMPONENT_TYPE_SINGLE_FLOAT:
+		case COMPONENT_TYPE_DOUBLE_FLOAT:
+		case COMPONENT_TYPE_HALF_FLOAT: {
+			dict["max"] = max;
+			dict["min"] = min;
+		} break;
+	}
 	dict["normalized"] = normalized;
 	dict["type"] = _get_accessor_type_name();
 


### PR DESCRIPTION
Currently, when exporting a file from Godot with an integer accessor type, it looks like this:

```json
{ "bufferView": 3, "componentType": 5126, "count": 24, "max": [1.0, 1.0], "min": [0.0, 0.0], "normalized": false, "type": "VEC2" },
{ "bufferView": 4, "componentType": 5121, "count": 36, "max": [23.0], "min": [0.0], "normalized": false, "type": "SCALAR" },
{ "bufferView": 5, "componentType": 5126, "count": 11, "max": [5.0], "min": [0.0], "normalized": false, "type": "SCALAR" },
{ "bufferView": 6, "componentType": 5121, "count": 11, "max": [1.0], "min": [0.0], "normalized": false, "type": "SCALAR" }
```

5126 means single-precision float (32-bit float), and 5121 means unsigned byte (8-bit integer). The `"max": [23.0], "min": [0.0]` values are not technically wrong, since JSON just has "number", but they are misleading. This PR changes the serialization of accessors with integer data types to use integer min/max values, so it would look like this:

```json
{ "bufferView": 3, "componentType": 5126, "count": 24, "max": [1.0, 1.0], "min": [0.0, 0.0], "normalized": false, "type": "VEC2" },
{ "bufferView": 4, "componentType": 5121, "count": 36, "max": [23], "min": [0], "normalized": false, "type": "SCALAR" },
{ "bufferView": 5, "componentType": 5126, "count": 11, "max": [5.0], "min": [0.0], "normalized": false, "type": "SCALAR" },
{ "bufferView": 6, "componentType": 5121, "count": 11, "max": [1], "min": [0], "normalized": false, "type": "SCALAR" }
```

This helps with KHR_node_visibility, because it needs to encode accessors as unsigned byte (8-bit unsigned integers).