### PR TITLE
GLTF: Determine the component type when encoding object model properties

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3764,9 +3764,10 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> p_state) {
 				Dictionary sampler;
 				sampler["input"] = GLTFAccessor::encode_new_accessor_from_float64s(p_state, pointer_track.times);
 				sampler["interpolation"] = interpolation_to_string(pointer_track.interpolation);
+				GLTFAccessor::GLTFComponentType component_type = obj_model_prop->get_component_type(pointer_track.values);
 				// TODO: This can be made faster after this pull request is merged: https://github.com/godotengine/godot/pull/109003
 				Array values_arr = GLTFTemplateConvert::to_array(pointer_track.values);
-				sampler["output"] = GLTFAccessor::encode_new_accessor_from_variants(p_state, values_arr, obj_model_prop->get_variant_type(), obj_model_prop->get_accessor_type());
+				sampler["output"] = GLTFAccessor::encode_new_accessor_from_variants(p_state, values_arr, obj_model_prop->get_variant_type(), obj_model_prop->get_accessor_type(), component_type);
 				samplers.push_back(sampler);
 			}
 		}

--- a/modules/gltf/structures/gltf_object_model_property.cpp
+++ b/modules/gltf/structures/gltf_object_model_property.cpp
@@ -103,6 +103,25 @@ GLTFAccessor::GLTFAccessorType GLTFObjectModelProperty::get_accessor_type() cons
 	}
 }
 
+GLTFAccessor::GLTFComponentType GLTFObjectModelProperty::get_component_type(const Vector<Variant> &p_values) const {
+	switch (object_model_type) {
+		case GLTFObjectModelProperty::GLTF_OBJECT_MODEL_TYPE_BOOL: {
+			return GLTFAccessor::COMPONENT_TYPE_UNSIGNED_BYTE;
+		} break;
+		case GLTFObjectModelProperty::GLTF_OBJECT_MODEL_TYPE_INT: {
+			PackedInt64Array int_values;
+			for (int i = 0; i < p_values.size(); i++) {
+				int_values.append(p_values[i]);
+			}
+			return GLTFAccessor::get_minimal_integer_component_type_from_ints(int_values);
+		} break;
+		default: {
+			// The base glTF specification only supports 32-bit float accessors for floating point data.
+			return GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT;
+		} break;
+	}
+}
+
 Ref<Expression> GLTFObjectModelProperty::get_gltf_to_godot_expression() const {
 	return gltf_to_godot_expr;
 }

--- a/modules/gltf/structures/gltf_object_model_property.h
+++ b/modules/gltf/structures/gltf_object_model_property.h
@@ -71,6 +71,7 @@ public:
 	void append_path_to_property(const NodePath &p_node_path, const StringName &p_prop_name);
 
 	GLTFAccessor::GLTFAccessorType get_accessor_type() const;
+	GLTFAccessor::GLTFComponentType get_component_type(const Vector<Variant> &p_values) const;
 
 	Ref<Expression> get_gltf_to_godot_expression() const;
 	void set_gltf_to_godot_expression(const Ref<Expression> &p_gltf_to_godot_expr);


### PR DESCRIPTION
The [KHR_animation_pointer specification](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_animation_pointer) is very clear:

> If the Object Model Data Type is `int`, the output accessor component type **MUST** be one of the non-normalized integer types and its values are used as-is.
> 
> If the Object Model Data Type is `bool`, the output accessor component type **MUST** be unsigned byte; `0` is converted to `false`, any other value is converted to `true`.

Currently, Godot is always using single-precision floats when serializing Variant arrays, which means that Godot is generating invalid output when attempting to export an animation using ints or floats. This PR fixes this.