### PR TITLE
Remove `typed_dictionary.h` include where it's unused or can be forward-declared

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -33,6 +33,7 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_loader.h"
+#include "core/variant/typed_dictionary.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
@@ -111,6 +112,11 @@ Variant EditorDebuggerRemoteObjects::get_variant(const StringName &p_name) {
 	Variant var;
 	_get(p_name, var);
 	return var;
+}
+
+void EditorDebuggerRemoteObjects::clear() {
+	prop_list.clear();
+	prop_values.clear();
 }
 
 void EditorDebuggerRemoteObjects::_bind_methods() {

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -30,10 +30,12 @@
 
 #pragma once
 
-#include "core/variant/typed_dictionary.h"
 #include "editor/inspector/editor_inspector.h"
 
 class SceneDebuggerObject;
+
+template <typename K, typename V>
+class TypedDictionary;
 
 class EditorDebuggerRemoteObjects : public Object {
 	GDCLASS(EditorDebuggerRemoteObjects, Object);
@@ -60,10 +62,7 @@ public:
 	String get_title();
 	Variant get_variant(const StringName &p_name);
 
-	void clear() {
-		prop_list.clear();
-		prop_values.clear();
-	}
+	void clear();
 
 	void update() { notify_property_list_changed(); }
 };

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -34,6 +34,7 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/remote_debugger.h"
 #include "core/string/ustring.h"
+#include "core/variant/typed_dictionary.h"
 #include "core/version.h"
 #include "editor/debugger/editor_debugger_plugin.h"
 #include "editor/debugger/editor_expression_evaluator.h"

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/variant/typed_dictionary.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/graph_frame.h"
 #include "scene/gui/graph_node.h"


### PR DESCRIPTION
Related to #111218 

`typed_dictionary.h` is a very heavy header (a single `MAKE_TYPED_DICTIONARY` expansion results in about 1,800 LOC, and the full expansion goes over 70,000 lines). I noticed this because every time I open it, it causes clangd to freeze, and making any changes to it makes the freeze even longer. `TypedDictionary` is only used in a few places, but through `graph_edit.h` and `editor_debugger_inspector.h` it ends up affecting many more files, causing intellisense to lag even in unrelated files.
