### PR TITLE
Add missing initialization for bitpacked object members

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2284,6 +2284,8 @@ void Object::_construct_object(bool p_reference) {
 	_block_signals = false;
 	_can_translate = true;
 	_emitting = false;
+	_is_queued_for_deletion = false;
+	_predelete_ok = false;
 
 	// ObjectDB::add_instance relies on AncestralClass::REF_COUNTED
 	// being already set in the case of references.


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot/pull/111339
~Probably~ fixes https://github.com/godotengine/godot/issues/111598

When doing the original PR I did try inline initialization which is only available for C++20. And then I somehow completely forgot about the initializers. And obviously this compiles fine anyway and passes the tests ._.