### PR TITLE
Remove `display_server.h` transitive include from `node.h`.

### DIFF
--- a/editor/inspector/editor_preview_plugins.h
+++ b/editor/inspector/editor_preview_plugins.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/io/image.h"
 #include "editor/inspector/editor_resource_preview.h"
 
 class ScriptLanguage;

--- a/modules/multiplayer/multiplayer_debugger.cpp
+++ b/modules/multiplayer/multiplayer_debugger.cpp
@@ -34,6 +34,7 @@
 #include "scene_replication_config.h"
 
 #include "core/debugger/engine_debugger.h"
+#include "core/os/os.h"
 #include "scene/main/node.h"
 
 List<Ref<EngineProfiler>> multiplayer_profilers;

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -32,10 +32,7 @@
 
 #include "core/debugger/engine_debugger.h"
 #include "core/io/marshalls.h"
-
-#ifdef DEBUG_ENABLED
 #include "core/os/os.h"
-#endif
 
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneMultiplayer::_profile_bandwidth(const String &p_what, int p_value) {

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -34,6 +34,7 @@
 
 #include "core/debugger/engine_debugger.h"
 #include "core/io/marshalls.h"
+#include "core/os/os.h"
 #include "scene/main/node.h"
 
 #define MAKE_ROOM(m_amount)             \

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -34,6 +34,7 @@
 #include "multiplayer_synchronizer.h"
 
 #include "core/object/ref_counted.h"
+#include "core/templates/rb_set.h"
 
 class SceneMultiplayer;
 class SceneCacheInterface;

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -33,6 +33,7 @@
 
 #include "scene/audio/audio_stream_player_internal.h"
 #include "servers/audio/audio_stream.h"
+#include "servers/display/display_server.h"
 
 void AudioStreamPlayer::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ACCESSIBILITY_UPDATE) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -33,7 +33,10 @@
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Mesh);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, DisplayServer);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Shader);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, OS);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Engine);
 
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/input/input_event.h"
+#include "core/io/resource.h"
 #include "core/string/node_path.h"
 #include "core/templates/iterable.h"
 #include "core/variant/typed_array.h"

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -35,12 +35,12 @@
 #include "core/templates/paged_allocator.h"
 #include "core/templates/self_list.h"
 #include "scene/main/scene_tree_fti.h"
-#include "servers/display/display_server.h"
 
 #undef Window
 
 class ArrayMesh;
 class PackedScene;
+class InputEvent;
 class Node;
 #ifndef _3D_DISABLED
 class Node3D;
@@ -337,7 +337,7 @@ public:
 	void _accessibility_force_update();
 	void _accessibility_notify_change(const Node *p_node, bool p_remove = false);
 	void _flush_accessibility_changes();
-	void _process_accessibility_changes(DisplayServer::WindowID p_window_id);
+	void _process_accessibility_changes(int p_window_id); // Effectively DisplayServer::WindowID
 
 	virtual void initialize() override;
 

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -30,6 +30,8 @@
 
 #include "timer.h"
 
+#include "core/config/engine.h"
+
 void Timer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -32,6 +32,7 @@
 
 #include "scene/main/node.h"
 #include "scene/resources/texture.h"
+#include "servers/display/display_server.h"
 
 #ifndef _3D_DISABLED
 class Camera3D;

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -33,6 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/templates/rb_map.h"
 #include "core/variant/variant_parser.h"
 #include "scene/resources/packed_scene.h"
 


### PR DESCRIPTION
- Helps address #111218 

Another include that was embedded a lot more deeply into our codebase than necessary.

While arguably we should be introducing an enum-only header for `DisplayServer`, `RenderingServer`, etc., this is a lot of work and not necessary for this PR.
Instead, I'm simply replacing the `DisplayServer::WindowID` mention with its value (`int`). While arguably weird, its correctness is enforced by the `cpp` file continuing to use `WindowID`. If the type of `WindowID` changes, the code won't compile.

Tested with both `dev_mode=yes dev_enabled=yes` and `disable_3d=yes target=template_debug`