### PR TITLE
Don't show exported script variables twice in the remote inspector

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -751,7 +751,7 @@ SceneDebuggerObject::SceneDebuggerObject(Object *p_obj) {
 	class_name = p_obj->get_class();
 
 	if (ScriptInstance *si = p_obj->get_script_instance()) {
-		// Read script instance constants and variables
+		// Read script instance constants and variables.
 		if (!si->get_script().is_null()) {
 			Script *s = si->get_script().ptr();
 			_parse_script_properties(s, si);
@@ -815,9 +815,23 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 		base = base->get_base_script();
 	}
 
+	HashSet<String> exported_members;
+
+	List<PropertyInfo> pinfo;
+	p_instance->get_property_list(&pinfo);
+	for (const PropertyInfo &E : pinfo) {
+		if (E.usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CATEGORY)) {
+			exported_members.insert(E.name);
+		}
+	}
+
 	// Members
 	for (KeyValue<const Script *, HashSet<StringName>> sm : members) {
 		for (const StringName &E : sm.value) {
+			if (exported_members.has(E)) {
+				continue; // Exported variables already show up in the inspector.
+			}
+
 			Variant m;
 			if (p_instance->get(E, m)) {
 				String script_path = sm.key == p_script ? "" : sm.key->get_path().get_file() + "/";


### PR DESCRIPTION
Fixes #39847.