### PR TITLE
Add "Show in File Manager" button to sidebar of Project Manager

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -265,6 +265,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			rename_btn->set_button_icon(get_editor_theme_icon(SNAME("Rename")));
 			duplicate_btn->set_button_icon(get_editor_theme_icon(SNAME("Duplicate")));
 			manage_tags_btn->set_button_icon(get_editor_theme_icon("Script"));
+			show_in_fm_btn->set_button_icon(get_editor_theme_icon("Load"));
 			erase_btn->set_button_icon(get_editor_theme_icon(SNAME("Remove")));
 			erase_missing_btn->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 			create_tag_btn->set_button_icon(get_editor_theme_icon("Add"));
@@ -280,6 +281,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			rename_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
 			duplicate_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
 			manage_tags_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
+			show_in_fm_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
 			erase_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
 			erase_missing_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
 
@@ -738,6 +740,17 @@ void ProjectManager::_duplicate_project_with_action(PostDuplicateAction p_post_a
 	project_dialog->show_dialog(false);
 }
 
+void ProjectManager::_show_project_in_file_manager() {
+	const Vector<ProjectList::Item> &selected_list = project_list->get_selected_projects();
+	if (selected_list.is_empty()) {
+		return;
+	}
+
+	for (const ProjectList::Item &E : selected_list) {
+		OS::get_singleton()->shell_show_in_file_manager(E.path, true);
+	}
+}
+
 void ProjectManager::_erase_project() {
 	const HashSet<String> &selected_list = project_list->get_selected_project_keys();
 
@@ -792,6 +805,7 @@ void ProjectManager::_update_project_buttons() {
 	rename_btn->set_disabled(empty_selection || is_missing_project_selected);
 	duplicate_btn->set_disabled(empty_selection || is_missing_project_selected);
 	manage_tags_btn->set_disabled(empty_selection || is_missing_project_selected || selected_projects.size() > 1);
+	show_in_fm_btn->set_disabled(empty_selection || is_missing_project_selected);
 	run_btn->set_disabled(empty_selection || is_missing_project_selected);
 
 	erase_missing_btn->set_disabled(!project_list->is_any_project_missing());
@@ -1631,6 +1645,11 @@ ProjectManager::ProjectManager() {
 			manage_tags_btn->set_text(TTRC("Manage Tags"));
 			manage_tags_btn->set_shortcut(ED_SHORTCUT("project_manager/project_tags", TTRC("Manage Tags"), KeyModifierMask::CMD_OR_CTRL | Key::T));
 			project_list_sidebar->add_child(manage_tags_btn);
+
+			show_in_fm_btn = memnew(Button);
+			show_in_fm_btn->set_text(TTRC("Show in File Manager"));
+			show_in_fm_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_show_project_in_file_manager));
+			project_list_sidebar->add_child(show_in_fm_btn);
 
 			erase_btn = memnew(Button);
 			erase_btn->set_text(TTRC("Remove"));

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -160,6 +160,7 @@ class ProjectManager : public Control {
 	Button *rename_btn = nullptr;
 	Button *duplicate_btn = nullptr;
 	Button *manage_tags_btn = nullptr;
+	Button *show_in_fm_btn = nullptr;
 	Button *erase_btn = nullptr;
 	Button *erase_missing_btn = nullptr;
 
@@ -194,6 +195,7 @@ class ProjectManager : public Control {
 	void _rename_project();
 	void _duplicate_project();
 	void _duplicate_project_with_action(PostDuplicateAction p_action);
+	void _show_project_in_file_manager();
 	void _erase_project();
 	void _erase_missing_projects();
 	void _erase_project_confirm();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8875 (?)[^1]

This PR adds a "Show in File Manager" button to the right-hand sidebar in the Project Manager:

<img width="1556" height="1050" alt="CleanShot 2025-10-13 at 18 26 23@2x" src="https://github.com/user-attachments/assets/8b3f756e-2618-442a-a548-eaf4c8d5cd0a" />

Since most project actions are listed in this sidebar, I think it makes sense to include a button for opening in the file manager as well. As discussed in the linked proposal, the current icon button blends into its background and is likely to be perceived as a mere icon; including it as a titled button in the sidebar makes it much easier to find.

Note that this PR does not currently touch the existing icon button's functionality or presence. If desired, I can remove it from the row items so that there is a single location for performing the action.

[^1]: The contributions of this PR (adding a single button to the sidebar) are technically different from the linked proposal (making the folder icon on each project item row stand out more). However, the PR accomplishes the same underlying goal in my opinion (making it easier for users to open a project folder).