### PR TITLE
Implement mouse thumb button support for FileSystem dock

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -3850,7 +3850,32 @@ void FileSystemDock::_reselect_items_selected_on_drag_begin(bool reset) {
 	}
 }
 
+bool FileSystemDock::_handle_mouse_button_input(Ref<InputEvent> p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->is_pressed()) {
+		// Forward/Mouse5
+		if (mb->get_button_index() == MouseButton::MB_XBUTTON2) {
+			_fw_history();
+			return true;
+		}
+		// Back/Mouse4
+		if (mb->get_button_index() == MouseButton::MB_XBUTTON1) {
+			_bw_history();
+			return true;
+		}
+	}
+	return false;
+}
+
 void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid()) {
+		if (_handle_mouse_button_input(p_event)) {
+			accept_event();
+			return;
+		}
+	}
+
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
 		TreeItem *item = tree->get_item_at_position(mm->get_position());
@@ -3914,6 +3939,14 @@ void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
 }
 
 void FileSystemDock::_file_list_gui_input(Ref<InputEvent> p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid()) {
+		if (_handle_mouse_button_input(p_event)) {
+			accept_event();
+			return;
+		}
+	}
+
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid() && holding_branch) {
 		const int item_idx = files->get_item_at_position(mm->get_position(), true);

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -297,6 +297,7 @@ private:
 	void _file_list_activate_file(int p_idx);
 	void _file_multi_selected(int p_index, bool p_selected);
 	void _tree_multi_selected(Object *p_item, int p_column, bool p_selected);
+	bool _handle_mouse_button_input(Ref<InputEvent> p_event);
 
 	bool _get_imported_files(const String &p_path, String &r_extension, Vector<String> &r_files) const;
 	void _update_import_dock();


### PR DESCRIPTION
I'm a huge fan of the bottom docked FileSystem with the big icon layout, but something I noticed was that thumb button navigation wasn't implemented. 
This PR resolves that by allowing the user to navigate through the FileSystem via thumb buttons, much like some file explorers and web browsers. 
The Forward button (Mouse5) moves you forward in history, this is identical to pressing the forward button at the top left.
The Back button (Mouse4) moves you backwards, this too, is identical to the behaviour caused by the backwards button. 

[Screencast_20251013_230324.webm](https://github.com/user-attachments/assets/9fef3581-939e-44fb-9cec-80e966c8b01f)

A neat unintended side-effect is that since you no longer need to navigate by clicking, this lets you drag items through folders while pressing these buttons.

_
Do note that this doesn't include support for file dialogs, I'm unsure if that is within the scope of the PR as the file dialog does things a bit differently, such as having a shortcut for back/forward within alt+left and alt+right.
It would need to be up for discussion on whether or not these shortcuts should also apply to the FileSystem dock.
In my opinion, ideally M5/M4 are default shortcut keys alongside alt+left/alt+right, which would give the user the ability to disable it if they wish. The issue is that the shortcut system doesn't seem setup to support mouse inputs, which is probably for the better given the mouse literally only has 2 real bindable buttons. 

Edit:
It seems #65790 would actually allow for the shortcut method to be an option, seems to be stuck though. 