### PR TITLE
User defined default project directory for Project Manager

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -695,7 +695,10 @@
 			[b]Note:[/b] Setting this path to a folder with very large amounts of files/folders can slow down the project manager startup significantly. To keep the project manager quick to start up, it is recommended to set this value to a folder as "specific" as possible.
 		</member>
 		<member name="filesystem/directories/default_project_path" type="String" setter="" getter="">
-			The folder where new projects should be created by default when clicking the project manager's [b]New Project[/b] button. This can be set to the same value as [member filesystem/directories/autoscan_project_path] for convenience.
+			The default folder Godot automatically selects based on operating system. This can be set to the same value as [member filesystem/directories/autoscan_project_path] for convenience.
+		</member>
+		<member name="filesystem/directories/user_defined_project_path" type="String" setter="" getter="">
+			The folder where new projects should be created by default when clicking the project manager's [b]New Project[/b] button. The user can define this option in the Project Manager's Settings menu.
 		</member>
 		<member name="filesystem/external_programs/3d_model_editor" type="String" setter="" getter="">
 			The program that opens 3D model scene files when clicking "Open in External Program" option in Filesystem Dock. If not specified, the file will be opened in the system's default program.

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -390,7 +390,7 @@ void ProjectDialog::_install_path_changed() {
 void ProjectDialog::_browse_project_path() {
 	String path = project_path->get_text();
 	if (path.is_relative_path()) {
-		path = EDITOR_GET("filesystem/directories/default_project_path");
+		path = EDITOR_GET("filesystem/directories/user_defined_project_path");
 	}
 	if (mode == MODE_IMPORT && install_path->is_visible_in_tree()) {
 		// Select last ZIP file.
@@ -421,7 +421,7 @@ void ProjectDialog::_browse_install_path() {
 
 	String path = install_path->get_text();
 	if (path.is_relative_path() || !DirAccess::dir_exists_absolute(path)) {
-		path = EDITOR_GET("filesystem/directories/default_project_path");
+		path = EDITOR_GET("filesystem/directories/user_defined_project_path");
 	}
 	if (create_dir->is_pressed()) {
 		// Select parent directory of install path.
@@ -862,7 +862,7 @@ void ProjectDialog::show_dialog(bool p_reset_name) {
 			install_path->set_text(original_dir);
 			fdialog_project->set_current_dir(original_dir);
 		} else {
-			String fav_dir = EDITOR_GET("filesystem/directories/default_project_path");
+			String fav_dir = EDITOR_GET("filesystem/directories/user_defined_project_path");
 			fav_dir = fav_dir.simplify_path();
 			if (!fav_dir.is_empty()) {
 				project_path->set_text(fav_dir);

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1693,7 +1693,7 @@ ProjectManager::ProjectManager() {
 		scan_dir->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 		scan_dir->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
 		scan_dir->set_title(TTRC("Select a Folder to Scan")); // Must be after mode or it's overridden.
-		scan_dir->set_current_dir(EDITOR_GET("filesystem/directories/default_project_path"));
+		scan_dir->set_current_dir(EDITOR_GET("filesystem/directories/user_defined_project_path"));
 		add_child(scan_dir);
 		scan_dir->connect("dir_selected", callable_mp(project_list, &ProjectList::find_projects));
 
@@ -1862,7 +1862,7 @@ ProjectManager::ProjectManager() {
 
 		Ref<DirAccess> dir_access = DirAccess::create(DirAccess::AccessType::ACCESS_FILESYSTEM);
 
-		String default_project_path = EDITOR_GET("filesystem/directories/default_project_path");
+		String default_project_path = EDITOR_GET("filesystem/directories/user_defined_project_path");
 		if (!default_project_path.is_empty() && !dir_access->dir_exists(default_project_path)) {
 			Error error = dir_access->make_dir_recursive(default_project_path);
 			if (error != OK) {

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -37,6 +37,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 
@@ -149,6 +150,12 @@ void QuickSettingsDialog::_update_current_values() {
 		}
 	}
 
+	// Default directory option.
+	{
+		const String current_directory = EDITOR_GET("filesystem/directories/user_defined_project_path");
+		default_directory_input->set_text(current_directory);
+	}
+
 	// Project directory naming options.
 	{
 		const int current_directory_naming = EDITOR_GET("project_manager/directory_naming_convention");
@@ -207,6 +214,10 @@ void QuickSettingsDialog::_check_for_update_selected(int p_id) {
 
 void QuickSettingsDialog::_directory_naming_convention_selected(int p_id) {
 	_set_setting_value("project_manager/directory_naming_convention", p_id);
+}
+
+void QuickSettingsDialog::_directory_input_changed(const String &p_text) {
+	_set_setting_value("filesystem/directories/user_defined_project_path", p_text);
 }
 
 void QuickSettingsDialog::_set_setting_value(const String &p_setting, const Variant &p_value, bool p_restart_required) {
@@ -359,6 +370,19 @@ QuickSettingsDialog::QuickSettingsDialog() {
 			}
 
 			_add_setting_control(TTRC("Check for Updates"), check_for_update_button);
+		}
+
+		// Default directory input.
+		{
+			HBoxContainer *dir_container = memnew(HBoxContainer);
+
+			default_directory_input = memnew(LineEdit);
+			default_directory_input->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			default_directory_input->set_placeholder(EDITOR_GET("filesystem/directories/default_project_path"));
+			default_directory_input->connect("text_changed", callable_mp(this, &QuickSettingsDialog::_directory_input_changed));
+			dir_container->add_child(default_directory_input);
+
+			_add_setting_control(TTRC("Default Project Directory"), dir_container);
 		}
 
 		// Project directory naming options.

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -34,6 +34,7 @@
 
 class Button;
 class Label;
+class LineEdit;
 class MarginContainer;
 class OptionButton;
 class PanelContainer;
@@ -49,6 +50,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	Vector<String> editor_scales;
 	Vector<String> editor_network_modes;
 	Vector<String> editor_check_for_updates;
+	Vector<String> editor_default_directory;
 	Vector<String> editor_directory_naming_conventions;
 
 	void _fetch_setting_values();
@@ -68,6 +70,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	OptionButton *scale_option_button = nullptr;
 	OptionButton *network_mode_option_button = nullptr;
 	OptionButton *check_for_update_button = nullptr;
+	LineEdit *default_directory_input = nullptr;
 	OptionButton *directory_naming_convention_button = nullptr;
 
 	Label *custom_theme_label = nullptr;
@@ -79,6 +82,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	void _scale_selected(int p_id);
 	void _network_mode_selected(int p_id);
 	void _check_for_update_selected(int p_id);
+	void _directory_input_changed(const String &p_text);
 	void _directory_naming_convention_selected(int p_id);
 	void _set_setting_value(const String &p_setting, const Variant &p_value, bool p_restart_required = false);
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -641,7 +641,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/autoscan_project_path", "", "")
 	const String fs_dir_default_project_path = OS::get_singleton()->has_environment("HOME") ? OS::get_singleton()->get_environment("HOME") : OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/default_project_path", fs_dir_default_project_path, "")
-
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/user_defined_project_path", fs_dir_default_project_path, "")
 
 	// On save

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -642,6 +642,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	const String fs_dir_default_project_path = OS::get_singleton()->has_environment("HOME") ? OS::get_singleton()->get_environment("HOME") : OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/default_project_path", fs_dir_default_project_path, "")
 
+	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/user_defined_project_path", fs_dir_default_project_path, "")
+
 	// On save
 	_initial_set("filesystem/on_save/compress_binary_resources", true);
 	_initial_set("filesystem/on_save/safe_save_on_backup_then_rename", true);


### PR DESCRIPTION
This PR aims to allow the user to set the default location of where new projects are created. 

[Screencast_20251014_011447.webm](https://github.com/user-attachments/assets/677853df-7b85-4cb2-b598-a5159eb6c8cb)

I've marked it as draft as it needs testing, and I'm unsure if this is the right way of implementing it.

All references to `filesystem/directories/default_project_path` have been changed to `../user_defined_project_path`.
default_project_path is now _always_ the Godot default location, this is so the user can delete their custom directory and see a placeholder of where the original directory was.

`user_defined_project_path` is set to the same value as default_project_path on creation, but can be changed via the settings menu. 
In theory, this shouldn't cause any loss of functionality for users used to this, and should only serve to improve the experience.

I still need to add translations (or well, the support for such) and change the naming(?), perhaps calling the user_defined option the "default" in the settings menu is misleading? Even though it is true...
Or perhaps call user_defined -> default, and call default... something else I guess?

I'm also toying with the idea of adding a reset button that resets the path to the true default, but given no other option has this functionality I'm unsure if it'd fit. 