### PR TITLE
Remove `message_queue.h` include from `object.h`.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -38,6 +38,7 @@
 #include "core/io/file_access_pack.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_uid.h"
+#include "core/object/message_queue.h"
 #include "core/object/script_language.h"
 #include "core/templates/rb_set.h"
 #include "core/variant/typed_array.h"

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -264,25 +264,15 @@ public:
 	static bool get_timestamp_on_load() { return timestamp_on_load; }
 
 	// Loaders can safely use this regardless which thread they are running on.
-	static void notify_load_error(const String &p_err) {
-		if (err_notify) {
-			MessageQueue::get_main_singleton()->push_callable(callable_mp_static(err_notify).bind(p_err));
-		}
-	}
+	static void notify_load_error(const String &p_err);
+
 	static void set_error_notify_func(ResourceLoadErrorNotify p_err_notify) {
 		err_notify = p_err_notify;
 	}
 
 	// Loaders can safely use this regardless which thread they are running on.
-	static void notify_dependency_error(const String &p_path, const String &p_dependency, const String &p_type) {
-		if (dep_err_notify) {
-			if (Thread::get_caller_id() == Thread::get_main_id()) {
-				dep_err_notify(p_path, p_dependency, p_type);
-			} else {
-				MessageQueue::get_main_singleton()->push_callable(callable_mp_static(dep_err_notify).bind(p_path, p_dependency, p_type));
-			}
-		}
-	}
+	static void notify_dependency_error(const String &p_path, const String &p_dependency, const String &p_type);
+
 	static void set_dependency_error_notify_func(DependencyErrorNotify p_err_notify) {
 		dep_err_notify = p_err_notify;
 	}

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -130,15 +130,6 @@ public:
 	}
 
 	Error push_callp(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error = false);
-	template <typename... VarArgs>
-	Error push_call(Object *p_object, const StringName &p_method, VarArgs... p_args) {
-		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
-		const Variant *argptrs[sizeof...(p_args) + 1];
-		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
-			argptrs[i] = &args[i];
-		}
-		return push_callp(p_object, p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
-	}
 
 	Error push_notification(Object *p_object, int p_notification);
 	Error push_set(Object *p_object, const StringName &p_prop, const Variant &p_value);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2079,6 +2079,10 @@ void Object::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONNECT_APPEND_SOURCE_OBJECT);
 }
 
+void Object::call_deferredp(const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error) {
+	MessageQueue::get_singleton()->push_callp(this, p_method, p_args, p_argcount);
+}
+
 void Object::set_deferred(const StringName &p_property, const Variant &p_value) {
 	MessageQueue::get_singleton()->push_set(this, p_property, p_value);
 }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -32,9 +32,9 @@
 
 #include "core/extension/gdextension_interface.gen.h"
 #include "core/object/gdtype.h"
-#include "core/object/message_queue.h"
 #include "core/object/object_id.h"
 #include "core/os/spin_lock.h"
+#include "core/os/thread_safe.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
 #include "core/templates/list.h"
@@ -991,9 +991,15 @@ public:
 	DEBUG_VIRTUAL bool is_connected(const StringName &p_signal, const Callable &p_callable) const;
 	DEBUG_VIRTUAL bool has_connections(const StringName &p_signal) const;
 
+	void call_deferredp(const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error = false);
 	template <typename... VarArgs>
 	void call_deferred(const StringName &p_name, VarArgs... p_args) {
-		MessageQueue::get_singleton()->push_call(this, p_name, p_args...);
+		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
+		const Variant *argptrs[sizeof...(p_args) + 1];
+		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
+			argptrs[i] = &args[i];
+		}
+		return call_deferredp(p_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
 	void set_deferred(const StringName &p_property, const Variant &p_value);

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -30,6 +30,7 @@
 
 #include "worker_thread_pool.h"
 
+#include "core/object/message_queue.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "core/os/safe_binary_mutex.h"

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -30,6 +30,7 @@
 
 #include "callable.h"
 
+#include "core/object/message_queue.h"
 #include "core/object/object.h"
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/message_queue.h"
 #include "core/object/ref_counted.h"
 #include "core/os/main_loop.h"
 #include "core/os/thread_safe.h"

--- a/scene/resources/animated_texture.cpp
+++ b/scene/resources/animated_texture.cpp
@@ -30,6 +30,7 @@
 
 #include "animated_texture.h"
 
+#include "core/object/message_queue.h"
 #include "core/os/os.h"
 #include "servers/rendering/rendering_server.h"
 


### PR DESCRIPTION
- Helps address #111218 

I was able to resolve this include by moving the implementation of `push_call` from `MessageQueue` to `Object`. It should work the exact same as before.
In addition, I'm moving two function definitions of `ResourceLoader` to the `cpp` file to avoid needing to include `MessageQueue` there.

`MessageQueue` is a sort of heavy include, but I think `Object` includes all of its includees anyway, so I don't think this will help compile time that much practically. But it should help people who work on `MessageQueue` compile a lot faster.