### PR TITLE
Remove duplicated `path` from `GDScriptExtendParser`

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1367,12 +1367,14 @@ public:
 		CompletionCall call;
 	};
 
+protected:
+	String script_path;
+
 private:
 	friend class GDScriptAnalyzer;
 	friend class GDScriptParserRef;
 
 	bool _is_tool = false;
-	String script_path;
 	bool for_completion = false;
 	bool parse_body = true;
 	bool panic_mode = false;

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -131,7 +131,7 @@ void ExtendGDScriptParser::update_document_links(const String &p_code) {
 			if (const_val.get_type() == Variant::STRING) {
 				String scr_path = const_val;
 				if (scr_path.is_relative_path()) {
-					scr_path = get_path().get_base_dir().path_join(scr_path).simplify_path();
+					scr_path = script_path.get_base_dir().path_join(scr_path).simplify_path();
 				}
 				bool exists = fs->file_exists(scr_path);
 
@@ -157,11 +157,11 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 	const String uri = get_uri();
 
 	r_symbol.uri = uri;
-	r_symbol.script_path = path;
+	r_symbol.script_path = script_path;
 	r_symbol.children.clear();
 	r_symbol.name = p_class->identifier != nullptr ? String(p_class->identifier->name) : String();
 	if (r_symbol.name.is_empty()) {
-		r_symbol.name = path.get_file();
+		r_symbol.name = script_path.get_file();
 	}
 	r_symbol.kind = LSP::SymbolKind::Class;
 	r_symbol.deprecated = false;
@@ -217,7 +217,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 
 				symbol.documentation = m.variable->doc_data.description;
 				symbol.uri = uri;
-				symbol.script_path = path;
+				symbol.script_path = script_path;
 
 				if (m.variable->initializer && m.variable->initializer->type == GDScriptParser::Node::LAMBDA) {
 					GDScriptParser::LambdaNode *lambda_node = (GDScriptParser::LambdaNode *)m.variable->initializer;
@@ -252,7 +252,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				symbol.selectionRange = range_of_node(m.constant->identifier);
 				symbol.documentation = m.constant->doc_data.description;
 				symbol.uri = uri;
-				symbol.script_path = path;
+				symbol.script_path = script_path;
 
 				symbol.detail = "const " + symbol.name;
 				if (m.constant->type_constraint.is_hard_type()) {
@@ -292,7 +292,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				symbol.selectionRange = range_of_node(m.signal->identifier);
 				symbol.documentation = m.signal->doc_data.description;
 				symbol.uri = uri;
-				symbol.script_path = path;
+				symbol.script_path = script_path;
 				symbol.detail = "signal " + String(m.signal->identifier->name) + "(";
 				for (int j = 0; j < m.signal->parameters.size(); j++) {
 					if (j > 0) {
@@ -311,7 +311,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 					param_symbol.range = range_of_node(param);
 					param_symbol.selectionRange = range_of_node(param->identifier);
 					param_symbol.uri = uri;
-					param_symbol.script_path = path;
+					param_symbol.script_path = script_path;
 					param_symbol.detail = "var " + param_symbol.name;
 					if (param->type_constraint.is_hard_type()) {
 						param_symbol.detail += ": " + param->type_constraint.to_string();
@@ -331,7 +331,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				symbol.selectionRange = range_of_node(m.enum_value.identifier);
 				symbol.documentation = m.enum_value.doc_data.description;
 				symbol.uri = uri;
-				symbol.script_path = path;
+				symbol.script_path = script_path;
 
 				symbol.detail = symbol.name + " = " + itos(m.enum_value.value);
 
@@ -345,7 +345,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				symbol.selectionRange = range_of_node(m.m_enum->identifier);
 				symbol.documentation = m.m_enum->doc_data.description;
 				symbol.uri = uri;
-				symbol.script_path = path;
+				symbol.script_path = script_path;
 
 				symbol.detail = "enum " + String(m.m_enum->identifier->name) + "{";
 				for (int j = 0; j < m.m_enum->values.size(); j++) {
@@ -367,7 +367,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 					child.selectionRange = range_of_node(value.identifier);
 					child.documentation = value.doc_data.description;
 					child.uri = uri;
-					child.script_path = path;
+					child.script_path = script_path;
 
 					child.detail = child.name + " = " + itos(value.value);
 
@@ -415,7 +415,7 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 	}
 	r_symbol.documentation = p_func->doc_data.description;
 	r_symbol.uri = uri;
-	r_symbol.script_path = path;
+	r_symbol.script_path = script_path;
 
 	String parameters;
 	for (int i = 0; i < p_func->parameters.size(); i++) {
@@ -544,7 +544,7 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 			}
 			symbol.local = true;
 			symbol.uri = uri;
-			symbol.script_path = path;
+			symbol.script_path = script_path;
 			symbol.detail = local.type == SuiteNode::Local::CONSTANT ? "const " : "var ";
 			symbol.detail += symbol.name;
 			if (local.get_datatype().is_hard_type()) {
@@ -717,7 +717,7 @@ String ExtendGDScriptParser::get_symbol_name_under_position(const LSP::Position 
 }
 
 String ExtendGDScriptParser::get_uri() const {
-	return GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_uri(path);
+	return GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_uri(script_path);
 }
 
 const LSP::DocumentSymbol *ExtendGDScriptParser::search_symbol_defined_at_line(int p_line, const LSP::DocumentSymbol &p_parent, const String &p_symbol_name) const {
@@ -839,7 +839,7 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 	Dictionary class_api;
 
 	class_api["name"] = p_class->identifier != nullptr ? String(p_class->identifier->name) : String();
-	class_api["path"] = path;
+	class_api["path"] = script_path;
 	Array extends_class;
 	for (int i = 0; i < p_class->extends.size(); i++) {
 		extends_class.append(String(p_class->extends[i]->name));
@@ -965,7 +965,6 @@ Dictionary ExtendGDScriptParser::generate_api() const {
 }
 
 void ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
-	path = p_path;
 	lines = p_code.split("\n");
 
 	parse_result = GDScriptParser::parse(p_code, p_path, false);

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -103,7 +103,6 @@ struct GodotRange {
 };
 
 class ExtendGDScriptParser : public GDScriptParser {
-	String path;
 	Vector<String> lines;
 
 	LSP::DocumentSymbol class_symbol;
@@ -127,7 +126,6 @@ class ExtendGDScriptParser : public GDScriptParser {
 	const LSP::DocumentSymbol *search_symbol_defined_at_line(int p_line, const LSP::DocumentSymbol &p_parent, const String &p_symbol_name = "") const;
 
 public:
-	_FORCE_INLINE_ const String &get_path() const { return path; }
 	_FORCE_INLINE_ const Vector<String> &get_lines() const { return lines; }
 	_FORCE_INLINE_ const LSP::DocumentSymbol &get_symbols() const { return class_symbol; }
 	_FORCE_INLINE_ const Vector<LSP::Diagnostic> &get_diagnostics() const { return diagnostics; }


### PR DESCRIPTION
The GDScript language server has its own subclassed parser that inherits from the standard GDScript parser. I'm currently looking into why that's necessary. 

While doing so I noticed that the subclass tracks it's path, but the standard GDScript parser does that as well. This PR removes the additional path member from `GDScriptExtendParser`, mainly to slim down responsibilities inside of the LSP implementation.