### PR TITLE
Fix indented line wrap with no spaces

### DIFF
--- a/servers/text/text_server.cpp
+++ b/servers/text/text_server.cpp
@@ -969,7 +969,7 @@ PackedInt32Array TextServer::shaped_text_get_line_breaks_adv(const RID &p_shaped
 							last_safe_break = i;
 							word_count++;
 						}
-					} else {
+					} else if (i >= indent_end) {
 						last_safe_break = i;
 						word_count++;
 					}
@@ -1153,7 +1153,7 @@ PackedInt32Array TextServer::shaped_text_get_line_breaks(const RID &p_shaped, do
 							last_safe_break = i;
 							word_count++;
 						}
-					} else {
+					} else if (i >= indent_end) {
 						last_safe_break = i;
 						word_count++;
 					}


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/76268

When indented line wrapping (`BREAK_TRIM_INDENT`) is set, the first line indentation should not be considered a safe break.
This was causing an unnecessary line wrap.

before:

<img width="635" height="118" alt="image" src="https://github.com/user-attachments/assets/06f992de-4f5d-4196-b154-b52aa06829da" />

after:

<img width="576" height="86" alt="image" src="https://github.com/user-attachments/assets/e0c57152-63ec-4ae6-95bd-360352ae89b4" />
