### PR TITLE
Improvements to ProjectManager's `_update_theme()`

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -198,7 +198,7 @@ void ProjectManager::_update_size_limits() {
 void ProjectManager::_update_theme(bool p_skip_creation) {
 	if (!p_skip_creation) {
 		theme = EditorThemeManager::generate_theme(theme);
-		DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), EditorStringName(Editor)));
+		DisplayServer::set_early_window_clear_color_override(true, theme->get_color("background", EditorStringName(Editor)));
 	}
 
 	Vector<Ref<Theme>> editor_themes;
@@ -224,74 +224,75 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 
 	// Update styles.
 	{
-		const int top_bar_separation = get_theme_constant(SNAME("top_bar_separation"), EditorStringName(Editor));
+		const int top_bar_separation = get_theme_constant("top_bar_separation", EditorStringName(Editor));
 		root_container->add_theme_constant_override("margin_left", top_bar_separation);
 		root_container->add_theme_constant_override("margin_top", top_bar_separation);
 		root_container->add_theme_constant_override("margin_bottom", top_bar_separation);
 		root_container->add_theme_constant_override("margin_right", top_bar_separation);
 		main_vbox->add_theme_constant_override("separation", top_bar_separation);
 
-		background_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("Background"), EditorStringName(EditorStyles)));
-		main_view_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("TabContainer")));
+		background_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox("Background", EditorStringName(EditorStyles)));
+		main_view_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), "TabContainer"));
 
-		title_bar_logo->set_button_icon(get_editor_theme_icon(SNAME("TitleBarLogo")));
+		title_bar_logo->set_button_icon(get_editor_theme_icon("TitleBarLogo"));
 
-		_set_main_view_icon(MAIN_VIEW_PROJECTS, get_editor_theme_icon(SNAME("ProjectList")));
-		_set_main_view_icon(MAIN_VIEW_ASSETLIB, get_editor_theme_icon(SNAME("AssetLib")));
+		_set_main_view_icon(MAIN_VIEW_PROJECTS, get_editor_theme_icon("ProjectList"));
+		_set_main_view_icon(MAIN_VIEW_ASSETLIB, get_editor_theme_icon("AssetLib"));
 
 		// Project list.
 		{
-			loading_label->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
-			project_list_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("project_list"), SNAME("ProjectManager")));
+			loading_label->add_theme_font_override(SceneStringName(font), get_theme_font("bold", EditorStringName(EditorFonts)));
+			project_list_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox("project_list", "ProjectManager"));
 
-			empty_list_create_project->set_button_icon(get_editor_theme_icon(SNAME("Add")));
-			empty_list_import_project->set_button_icon(get_editor_theme_icon(SNAME("Load")));
-			empty_list_open_assetlib->set_button_icon(get_editor_theme_icon(SNAME("AssetLib")));
+			empty_list_create_project->set_button_icon(get_editor_theme_icon("Add"));
+			empty_list_import_project->set_button_icon(get_editor_theme_icon("Load"));
+			empty_list_open_assetlib->set_button_icon(get_editor_theme_icon("AssetLib"));
 
-			empty_list_online_warning->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("italic"), EditorStringName(EditorFonts)));
-			empty_list_online_warning->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("font_placeholder_color"), EditorStringName(Editor)));
+			empty_list_online_warning->add_theme_font_override(SceneStringName(font), get_theme_font("italic", EditorStringName(EditorFonts)));
+			empty_list_online_warning->add_theme_color_override(SceneStringName(font_color), get_theme_color("font_placeholder_color", EditorStringName(Editor)));
 
 			// Top bar.
-			search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
-			quick_settings_button->set_button_icon(get_editor_theme_icon(SNAME("Tools")));
+			search_box->set_right_icon(get_editor_theme_icon("Search"));
+			quick_settings_button->set_button_icon(get_editor_theme_icon("Tools"));
 
 			// Sidebar.
-			create_btn->set_button_icon(get_editor_theme_icon(SNAME("Add")));
-			import_btn->set_button_icon(get_editor_theme_icon(SNAME("Load")));
-			scan_btn->set_button_icon(get_editor_theme_icon(SNAME("Search")));
-			open_btn->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
-			open_options_btn->set_button_icon(get_editor_theme_icon(SNAME("Collapse")));
-			run_btn->set_button_icon(get_editor_theme_icon(SNAME("Play")));
-			rename_btn->set_button_icon(get_editor_theme_icon(SNAME("Rename")));
-			duplicate_btn->set_button_icon(get_editor_theme_icon(SNAME("Duplicate")));
+			create_btn->set_button_icon(get_editor_theme_icon("Add"));
+			import_btn->set_button_icon(get_editor_theme_icon("Load"));
+			scan_btn->set_button_icon(get_editor_theme_icon("Search"));
+			open_btn->set_button_icon(get_editor_theme_icon("Edit"));
+			open_options_btn->set_button_icon(get_editor_theme_icon("Collapse"));
+			run_btn->set_button_icon(get_editor_theme_icon("Play"));
+			rename_btn->set_button_icon(get_editor_theme_icon("Rename"));
+			duplicate_btn->set_button_icon(get_editor_theme_icon("Duplicate"));
 			manage_tags_btn->set_button_icon(get_editor_theme_icon("Script"));
 			show_in_fm_btn->set_button_icon(get_editor_theme_icon("Load"));
-			erase_btn->set_button_icon(get_editor_theme_icon(SNAME("Remove")));
-			erase_missing_btn->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
+			erase_btn->set_button_icon(get_editor_theme_icon("Remove"));
+			erase_missing_btn->set_button_icon(get_editor_theme_icon("Clear"));
 			create_tag_btn->set_button_icon(get_editor_theme_icon("Add"));
 
 			tag_error->add_theme_color_override(SceneStringName(font_color), get_theme_color("error_color", EditorStringName(Editor)));
 			tag_edit_error->add_theme_color_override(SceneStringName(font_color), get_theme_color("error_color", EditorStringName(Editor)));
 
-			create_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			import_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			scan_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			open_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			run_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			rename_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			duplicate_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			manage_tags_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			show_in_fm_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			erase_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
-			erase_missing_btn->add_theme_constant_override("h_separation", get_theme_constant(SNAME("sidebar_button_icon_separation"), SNAME("ProjectManager")));
+			const int h_separation = get_theme_constant("sidebar_button_icon_separation", "ProjectManager");
+			create_btn->add_theme_constant_override("h_separation", h_separation);
+			import_btn->add_theme_constant_override("h_separation", h_separation);
+			scan_btn->add_theme_constant_override("h_separation", h_separation);
+			open_btn->add_theme_constant_override("h_separation", h_separation);
+			run_btn->add_theme_constant_override("h_separation", h_separation);
+			rename_btn->add_theme_constant_override("h_separation", h_separation);
+			duplicate_btn->add_theme_constant_override("h_separation", h_separation);
+			manage_tags_btn->add_theme_constant_override("h_separation", h_separation);
+			show_in_fm_btn->add_theme_constant_override("h_separation", h_separation);
+			erase_btn->add_theme_constant_override("h_separation", h_separation);
+			erase_missing_btn->add_theme_constant_override("h_separation", h_separation);
 
 			open_btn_container->add_theme_constant_override("separation", 0);
-			open_options_popup->set_item_icon(0, get_editor_theme_icon(SNAME("Notification")));
-			open_options_popup->set_item_icon(1, get_editor_theme_icon(SNAME("NodeWarning")));
+			open_options_popup->set_item_icon(0, get_editor_theme_icon("Notification"));
+			open_options_popup->set_item_icon(1, get_editor_theme_icon("NodeWarning"));
 		}
 
 		// Dialogs
-		migration_guide_button->set_button_icon(get_editor_theme_icon(SNAME("ExternalLink")));
+		migration_guide_button->set_button_icon(get_editor_theme_icon("ExternalLink"));
 
 		// Asset library popup.
 		if (asset_library) {
@@ -300,7 +301,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 		}
 	}
 #ifdef ANDROID_ENABLED
-	DisplayServer::get_singleton()->window_set_color(theme->get_color(SNAME("background"), EditorStringName(Editor)));
+	DisplayServer::get_singleton()->window_set_color(theme->get_color("background", EditorStringName(Editor)));
 #endif
 }
 


### PR DESCRIPTION
- Get `h_separation` constant only once
- Remove SNAMEs
  - They are unnecessary here and weren't even consistent