### PR TITLE
Fix Camera2D limit checks for inverted boundaries

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -164,7 +164,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 		if (limit_enabled && limit_smoothing_enabled) {
 			// Apply horizontal limiting.
-			if (screen_rect.size.x > limit[SIDE_RIGHT] - limit[SIDE_LEFT]) {
+			if (limit[SIDE_LEFT] > limit[SIDE_RIGHT] - screen_rect.size.x) {
 				// Split the limit difference horizontally.
 				camera_pos.x -= screen_rect.position.x + (screen_rect.size.x - limit[SIDE_RIGHT] - limit[SIDE_LEFT]) / 2;
 			} else if (screen_rect.position.x < limit[SIDE_LEFT]) {
@@ -176,7 +176,7 @@ Transform2D Camera2D::get_camera_transform() {
 			}
 
 			// Apply vertical limiting.
-			if (screen_rect.size.y > limit[SIDE_BOTTOM] - limit[SIDE_TOP]) {
+			if (limit[SIDE_TOP] > limit[SIDE_BOTTOM] - screen_rect.size.y) {
 				// Split the limit difference vertically.
 				camera_pos.y -= screen_rect.position.y + (screen_rect.size.y - limit[SIDE_BOTTOM] - limit[SIDE_TOP]) / 2;
 			} else if (screen_rect.position.y < limit[SIDE_TOP]) {
@@ -226,7 +226,7 @@ Transform2D Camera2D::get_camera_transform() {
 	if (limit_enabled && (!position_smoothing_enabled || !limit_smoothing_enabled)) {
 		Point2 bottom_right_corner = Point2(screen_rect.position + 2.0 * (ret_camera_pos - screen_rect.position));
 		// Apply horizontal limiting.
-		if (bottom_right_corner.x - screen_rect.position.x > limit[SIDE_RIGHT] - limit[SIDE_LEFT]) {
+		if (limit[SIDE_LEFT] > limit[SIDE_RIGHT] - (bottom_right_corner.x - screen_rect.position.x)) {
 			// Split the difference horizontally (center it).
 			screen_rect.position.x = (limit[SIDE_LEFT] + limit[SIDE_RIGHT] - (bottom_right_corner.x - screen_rect.position.x)) / 2;
 		} else if (screen_rect.position.x < limit[SIDE_LEFT]) {
@@ -238,7 +238,7 @@ Transform2D Camera2D::get_camera_transform() {
 		}
 
 		// Apply vertical limiting.
-		if (bottom_right_corner.y - screen_rect.position.y > limit[SIDE_BOTTOM] - limit[SIDE_TOP]) {
+		if (limit[SIDE_TOP] > limit[SIDE_BOTTOM] - (bottom_right_corner.y - screen_rect.position.y)) {
 			// Split the limit difference vertically.
 			screen_rect.position.y = (limit[SIDE_TOP] + limit[SIDE_BOTTOM] - (bottom_right_corner.y - screen_rect.position.y)) / 2;
 		} else if (screen_rect.position.y < limit[SIDE_TOP]) {


### PR DESCRIPTION
Update limit boundary conditions to properly detect when limits are inverted (left > right or top > bottom).

Resolves #111587

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
