### PR TITLE
Simplify some `binder_common.h` implementations.

### DIFF
--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -258,8 +258,8 @@ struct PtrToArg<Ref<T>> {
 
 template <typename T>
 struct GetTypeInfo<Ref<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -59,28 +59,10 @@ struct VariantCaster {
 };
 
 template <typename T>
-struct VariantCaster<T &> {
-	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
-		using TStripped = std::remove_pointer_t<T>;
-		if constexpr (std::is_base_of_v<Object, TStripped>) {
-			return Object::cast_to<TStripped>(p_variant);
-		} else {
-			return p_variant;
-		}
-	}
-};
+struct VariantCaster<T &> : VariantCaster<T> {};
 
 template <typename T>
-struct VariantCaster<const T &> {
-	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
-		using TStripped = std::remove_pointer_t<T>;
-		if constexpr (std::is_base_of_v<Object, TStripped>) {
-			return Object::cast_to<TStripped>(p_variant);
-		} else {
-			return p_variant;
-		}
-	}
-};
+struct VariantCaster<const T &> : VariantCaster<T> {};
 
 #define VARIANT_ENUM_CAST(m_enum) MAKE_ENUM_TYPE_INFO(m_enum)
 #define VARIANT_BITFIELD_CAST(m_enum) MAKE_BITFIELD_TYPE_INFO(m_enum)
@@ -148,7 +130,7 @@ struct VariantObjectClassChecker {
 		using TStripped = std::remove_pointer_t<T>;
 		if constexpr (std::is_base_of_v<Object, TStripped>) {
 			Object *obj = p_variant;
-			return Object::cast_to<TStripped>(p_variant) || !obj;
+			return !obj || obj->derives_from<TStripped>();
 		} else {
 			return true;
 		}
@@ -162,8 +144,7 @@ template <typename T>
 struct VariantObjectClassChecker<const Ref<T> &> {
 	static _FORCE_INLINE_ bool check(const Variant &p_variant) {
 		Object *obj = p_variant;
-		const Ref<T> node = p_variant;
-		return node.ptr() || !obj;
+		return !obj || obj->derives_from<T>();
 	}
 };
 
@@ -185,34 +166,10 @@ struct VariantCasterAndValidate {
 };
 
 template <typename T>
-struct VariantCasterAndValidate<T &> {
-	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, Callable::CallError &r_error) {
-		Variant::Type argtype = GetTypeInfo<T>::VARIANT_TYPE;
-		if (!Variant::can_convert_strict(p_args[p_arg_idx]->get_type(), argtype) ||
-				!VariantObjectClassChecker<T>::check(*p_args[p_arg_idx])) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = p_arg_idx;
-			r_error.expected = argtype;
-		}
-
-		return VariantCaster<T>::cast(*p_args[p_arg_idx]);
-	}
-};
+struct VariantCasterAndValidate<T &> : VariantCasterAndValidate<T> {};
 
 template <typename T>
-struct VariantCasterAndValidate<const T &> {
-	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, Callable::CallError &r_error) {
-		Variant::Type argtype = GetTypeInfo<T>::VARIANT_TYPE;
-		if (!Variant::can_convert_strict(p_args[p_arg_idx]->get_type(), argtype) ||
-				!VariantObjectClassChecker<T>::check(*p_args[p_arg_idx])) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = p_arg_idx;
-			r_error.expected = argtype;
-		}
-
-		return VariantCaster<T>::cast(*p_args[p_arg_idx]);
-	}
-};
+struct VariantCasterAndValidate<const T &> : VariantCasterAndValidate<T> {};
 
 #endif // DEBUG_ENABLED
 
@@ -320,18 +277,38 @@ void call_with_validated_variant_args_static_method_helper(void (*p_method)(P...
 	p_method((VariantInternalAccessor<GetSimpleTypeT<P>>::get(p_args[Is]))...);
 }
 
+inline bool _call_helper_check_argcount(int p_argcount, int p_min, int p_max, Callable::CallError &r_error) {
+	if (p_argcount > p_max) {
+		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
+		r_error.expected = p_max;
+		return true;
+	}
+
+	if (p_argcount < p_min) {
+		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.expected = p_max;
+		return true;
+	}
+	return false;
+}
+
+inline void _call_helper_fill_args(const Variant **r_args, int32_t p_paramcount, int32_t p_argcount, const Variant **p_args, Span<Variant> p_default_values) {
+	const int32_t missing = p_paramcount - p_argcount;
+	const int32_t dvs = p_default_values.size();
+
+	int32_t i = 0;
+	for (; i < p_argcount; i++) {
+		r_args[i] = p_args[i];
+	}
+	for (; i < p_paramcount; i++) {
+		r_args[i] = &p_default_values[i - p_argcount + (dvs - missing)];
+	}
+}
+
 template <typename T, typename... P>
 void call_with_variant_args(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-
-	if ((size_t)p_argcount < sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
@@ -341,32 +318,13 @@ void call_with_variant_args(T *p_instance, void (T::*p_method)(P...), const Vari
 template <typename T, typename... P>
 void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-#endif // DEBUG_ENABLED
-
-	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
-
-	int32_t dvs = default_values.size();
-#ifdef DEBUG_ENABLED
-	if (missing > dvs) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P) - default_values.size(), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
-	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
-		if (i < p_argcount) {
-			args[i] = p_args[i];
-		} else {
-			args[i] = &default_values[i - p_argcount + (dvs - missing)];
-		}
-	}
+	_call_helper_fill_args(args, sizeof...(P), p_argcount, p_args, default_values);
 
 	call_with_variant_args_helper(p_instance, p_method, args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
@@ -374,15 +332,7 @@ void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const V
 template <typename T, typename... P>
 void call_with_variant_argsc(T *p_instance, void (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-
-	if ((size_t)p_argcount < sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
@@ -392,32 +342,13 @@ void call_with_variant_argsc(T *p_instance, void (T::*p_method)(P...) const, con
 template <typename T, typename... P>
 void call_with_variant_argsc_dv(T *p_instance, void (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-#endif // DEBUG_ENABLED
-
-	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
-
-	int32_t dvs = default_values.size();
-#ifdef DEBUG_ENABLED
-	if (missing > dvs) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P) - default_values.size(), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
-	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
-		if (i < p_argcount) {
-			args[i] = p_args[i];
-		} else {
-			args[i] = &default_values[i - p_argcount + (dvs - missing)];
-		}
-	}
+	_call_helper_fill_args(args, sizeof...(P), p_argcount, p_args, default_values);
 
 	call_with_variant_argsc_helper(p_instance, p_method, args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
@@ -425,32 +356,13 @@ void call_with_variant_argsc_dv(T *p_instance, void (T::*p_method)(P...) const, 
 template <typename T, typename R, typename... P>
 void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-#endif // DEBUG_ENABLED
-
-	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
-
-	int32_t dvs = default_values.size();
-#ifdef DEBUG_ENABLED
-	if (missing > dvs) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P) - default_values.size(), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
-	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
-		if (i < p_argcount) {
-			args[i] = p_args[i];
-		} else {
-			args[i] = &default_values[i - p_argcount + (dvs - missing)];
-		}
-	}
+	_call_helper_fill_args(args, sizeof...(P), p_argcount, p_args, default_values);
 
 	call_with_variant_args_ret_helper(p_instance, p_method, args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
@@ -458,32 +370,13 @@ void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const 
 template <typename T, typename R, typename... P>
 void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-#endif // DEBUG_ENABLED
-
-	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
-
-	int32_t dvs = default_values.size();
-#ifdef DEBUG_ENABLED
-	if (missing > dvs) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P) - default_values.size(), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
-	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
-		if (i < p_argcount) {
-			args[i] = p_args[i];
-		} else {
-			args[i] = &default_values[i - p_argcount + (dvs - missing)];
-		}
-	}
+	_call_helper_fill_args(args, sizeof...(P), p_argcount, p_args, default_values);
 
 	call_with_variant_args_retc_helper(p_instance, p_method, args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
@@ -601,64 +494,30 @@ void call_with_validated_object_instance_args_static_retc(T *base, R (*p_method)
 // it's not clever enough to treat other P values as making this branch valid.
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wunused-but-set-parameter")
 
-template <typename Q>
-void call_get_argument_type_helper(int p_arg, int &index, Variant::Type &type) {
-	if (p_arg == index) {
-		type = GetTypeInfo<Q>::VARIANT_TYPE;
-	}
-	index++;
-}
-
 template <typename... P>
 Variant::Type call_get_argument_type(int p_arg) {
-	Variant::Type type = Variant::NIL;
-	int index = 0;
-	// I think rocket science is simpler than modern C++.
-	using expand_type = int[];
-	expand_type a{ 0, (call_get_argument_type_helper<P>(p_arg, index, type), 0)... };
-	(void)a; // Suppress (valid, but unavoidable) -Wunused-variable warning.
-	(void)index; // Suppress GCC warning.
-	return type;
+	constexpr Variant::Type types[sizeof...(P) ? sizeof...(P) : 1] = { GetTypeInfo<P>::VARIANT_TYPE... };
+	return (p_arg < 0 || p_arg >= (int)sizeof...(P)) ? Variant::NIL : types[p_arg];
 }
 
 template <typename Q>
-void call_get_argument_type_info_helper(int p_arg, int &index, PropertyInfo &info) {
-	if (p_arg == index) {
-		info = GetTypeInfo<Q>::get_class_info();
+void call_get_argument_type_info_helper(int &r_idx, PropertyInfo &r_info) {
+	if (r_idx == 0) {
+		r_info = GetTypeInfo<Q>::get_class_info();
 	}
-	index++;
+	r_idx--;
 }
 
 template <typename... P>
 void call_get_argument_type_info(int p_arg, PropertyInfo &info) {
-	int index = 0;
-	// I think rocket science is simpler than modern C++.
-	using expand_type = int[];
-	expand_type a{ 0, (call_get_argument_type_info_helper<P>(p_arg, index, info), 0)... };
-	(void)a; // Suppress (valid, but unavoidable) -Wunused-variable warning.
-	(void)index; // Suppress GCC warning.
+	((call_get_argument_type_info_helper<P>(p_arg, info)), ...);
 }
 
 #ifdef DEBUG_ENABLED
-template <typename Q>
-void call_get_argument_metadata_helper(int p_arg, int &index, GodotTypeInfo::Metadata &md) {
-	if (p_arg == index) {
-		md = GetTypeInfo<Q>::METADATA;
-	}
-	index++;
-}
-
 template <typename... P>
 GodotTypeInfo::Metadata call_get_argument_metadata(int p_arg) {
-	GodotTypeInfo::Metadata md = GodotTypeInfo::METADATA_NONE;
-
-	int index = 0;
-	// I think rocket science is simpler than modern C++.
-	using expand_type = int[];
-	expand_type a{ 0, (call_get_argument_metadata_helper<P>(p_arg, index, md), 0)... };
-	(void)a; // Suppress (valid, but unavoidable) -Wunused-variable warning.
-	(void)index;
-	return md;
+	constexpr GodotTypeInfo::Metadata metadatas[sizeof...(P) ? sizeof...(P) : 1] = { GetTypeInfo<P>::METADATA... };
+	return (p_arg < 0 || p_arg >= (int)sizeof...(P)) ? GodotTypeInfo::METADATA_NONE : metadatas[p_arg];
 }
 
 #endif // DEBUG_ENABLED
@@ -701,17 +560,10 @@ void call_with_variant_args_static(void (*p_method)(P...), const Variant **p_arg
 template <typename T, typename R, typename... P>
 void call_with_variant_args_ret(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P), sizeof...(P), r_error)) {
 		return;
 	}
 
-	if ((size_t)p_argcount < sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
 #endif // DEBUG_ENABLED
 	call_with_variant_args_ret_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
@@ -731,15 +583,7 @@ void call_with_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) co
 template <typename R, typename... P>
 void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-
-	if ((size_t)p_argcount < sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
@@ -749,15 +593,7 @@ void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_ar
 template <typename... P>
 void call_with_variant_args_static(void (*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-
-	if ((size_t)p_argcount < sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
@@ -767,15 +603,7 @@ void call_with_variant_args_static(void (*p_method)(P...), const Variant **p_arg
 template <typename T, typename R, typename... P>
 void call_with_variant_args_retc(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-
-	if ((size_t)p_argcount < sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
@@ -798,32 +626,13 @@ void call_with_variant_args_retc_static_helper(T *p_instance, R (*p_method)(T *,
 template <typename T, typename R, typename... P>
 void call_with_variant_args_retc_static_helper_dv(T *p_instance, R (*p_method)(T *, P...), const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &default_values, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-#endif // DEBUG_ENABLED
-
-	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
-
-	int32_t dvs = default_values.size();
-#ifdef DEBUG_ENABLED
-	if (missing > dvs) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P) - default_values.size(), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
-	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
-		if (i < p_argcount) {
-			args[i] = p_args[i];
-		} else {
-			args[i] = &default_values[i - p_argcount + (dvs - missing)];
-		}
-	}
+	_call_helper_fill_args(args, sizeof...(P), p_argcount, p_args, default_values);
 
 	call_with_variant_args_retc_static_helper(p_instance, p_method, args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
@@ -844,32 +653,13 @@ void call_with_variant_args_static_helper(T *p_instance, void (*p_method)(T *, P
 template <typename T, typename... P>
 void call_with_variant_args_static_helper_dv(T *p_instance, void (*p_method)(T *, P...), const Variant **p_args, int p_argcount, const Vector<Variant> &default_values, Callable::CallError &r_error) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-#endif // DEBUG_ENABLED
-
-	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
-
-	int32_t dvs = default_values.size();
-#ifdef DEBUG_ENABLED
-	if (missing > dvs) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P) - default_values.size(), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
-	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
-		if (i < p_argcount) {
-			args[i] = p_args[i];
-		} else {
-			args[i] = &default_values[i - p_argcount + (dvs - missing)];
-		}
-	}
+	_call_helper_fill_args(args, sizeof...(P), p_argcount, p_args, default_values);
 
 	call_with_variant_args_static_helper(p_instance, p_method, args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
@@ -877,32 +667,13 @@ void call_with_variant_args_static_helper_dv(T *p_instance, void (*p_method)(T *
 template <typename R, typename... P>
 void call_with_variant_args_static_ret_dv(R (*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-#endif // DEBUG_ENABLED
-
-	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
-
-	int32_t dvs = default_values.size();
-#ifdef DEBUG_ENABLED
-	if (missing > dvs) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P) - default_values.size(), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
-	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
-		if (i < p_argcount) {
-			args[i] = p_args[i];
-		} else {
-			args[i] = &default_values[i - p_argcount + (dvs - missing)];
-		}
-	}
+	_call_helper_fill_args(args, sizeof...(P), p_argcount, p_args, default_values);
 
 	call_with_variant_args_static_ret(p_method, args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
@@ -910,32 +681,13 @@ void call_with_variant_args_static_ret_dv(R (*p_method)(P...), const Variant **p
 template <typename... P>
 void call_with_variant_args_static_dv(void (*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error, const Vector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
-	if ((size_t)p_argcount > sizeof...(P)) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
-		r_error.expected = sizeof...(P);
-		return;
-	}
-#endif // DEBUG_ENABLED
-
-	int32_t missing = (int32_t)sizeof...(P) - (int32_t)p_argcount;
-
-	int32_t dvs = default_values.size();
-#ifdef DEBUG_ENABLED
-	if (missing > dvs) {
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = sizeof...(P);
+	if (_call_helper_check_argcount(p_argcount, sizeof...(P) - default_values.size(), sizeof...(P), r_error)) {
 		return;
 	}
 #endif // DEBUG_ENABLED
 
 	const Variant *args[sizeof...(P) == 0 ? 1 : sizeof...(P)]; //avoid zero sized array
-	for (int32_t i = 0; i < (int32_t)sizeof...(P); i++) {
-		if (i < p_argcount) {
-			args[i] = p_args[i];
-		} else {
-			args[i] = &default_values[i - p_argcount + (dvs - missing)];
-		}
-	}
+	_call_helper_fill_args(args, sizeof...(P), p_argcount, p_args, default_values);
 
 	call_with_variant_args_static(p_method, args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -121,8 +121,8 @@ struct GDExtensionPtr {
 
 template <typename T>
 struct GetTypeInfo<GDExtensionConstPtr<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::INT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::INT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_POINTER, GDExtensionConstPtr<T>::get_name());
 	}
@@ -130,8 +130,8 @@ struct GetTypeInfo<GDExtensionConstPtr<T>> {
 
 template <typename T>
 struct GetTypeInfo<GDExtensionPtr<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::INT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::INT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_POINTER, GDExtensionPtr<T>::get_name());
 	}

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -67,24 +67,24 @@ struct GetTypeInfo;
 template <typename T>
 struct GetTypeInfo<T, std::enable_if_t<!std::is_same_v<T, GetSimpleTypeT<T>>>> : GetTypeInfo<GetSimpleTypeT<T>> {};
 
-#define MAKE_TYPE_INFO(m_type, m_var_type)                                            \
-	template <>                                                                       \
-	struct GetTypeInfo<m_type> {                                                      \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
+#define MAKE_TYPE_INFO(m_type, m_var_type)                                                \
+	template <>                                                                           \
+	struct GetTypeInfo<m_type> {                                                          \
+		static constexpr Variant::Type VARIANT_TYPE = m_var_type;                         \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() {                                     \
+			return PropertyInfo(VARIANT_TYPE, String());                                  \
+		}                                                                                 \
 	};
 
-#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata)    \
-	template <>                                                     \
-	struct GetTypeInfo<m_type> {                                    \
-		static const Variant::Type VARIANT_TYPE = m_var_type;       \
-		static const GodotTypeInfo::Metadata METADATA = m_metadata; \
-		static inline PropertyInfo get_class_info() {               \
-			return PropertyInfo(VARIANT_TYPE, String());            \
-		}                                                           \
+#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata)        \
+	template <>                                                         \
+	struct GetTypeInfo<m_type> {                                        \
+		static constexpr Variant::Type VARIANT_TYPE = m_var_type;       \
+		static constexpr GodotTypeInfo::Metadata METADATA = m_metadata; \
+		static inline PropertyInfo get_class_info() {                   \
+			return PropertyInfo(VARIANT_TYPE, String());                \
+		}                                                               \
 	};
 
 MAKE_TYPE_INFO(bool, Variant::BOOL)
@@ -141,8 +141,8 @@ MAKE_TYPE_INFO(IPAddress, Variant::STRING)
 //objectID
 template <>
 struct GetTypeInfo<ObjectID> {
-	static const Variant::Type VARIANT_TYPE = Variant::INT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_INT_IS_UINT64;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::INT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_INT_IS_UINT64;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_OBJECTID);
 	}
@@ -151,21 +151,21 @@ struct GetTypeInfo<ObjectID> {
 //for variant
 template <>
 struct GetTypeInfo<Variant> {
-	static const Variant::Type VARIANT_TYPE = Variant::NIL;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::NIL;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 	}
 };
 
-#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)                       \
-	template <>                                                                       \
-	struct GetTypeInfo<m_template<m_type>> {                                          \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
+#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)                           \
+	template <>                                                                           \
+	struct GetTypeInfo<m_template<m_type>> {                                              \
+		static constexpr Variant::Type VARIANT_TYPE = m_var_type;                         \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() {                                     \
+			return PropertyInfo(VARIANT_TYPE, String());                                  \
+		}                                                                                 \
 	};
 
 MAKE_TEMPLATE_TYPE_INFO(Vector, Variant, Variant::ARRAY)
@@ -176,8 +176,8 @@ MAKE_TEMPLATE_TYPE_INFO(Vector, StringName, Variant::PACKED_STRING_ARRAY)
 
 template <typename T>
 struct GetTypeInfo<T *, std::enable_if_t<std::is_base_of_v<Object, T>>> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
 	}
@@ -191,8 +191,8 @@ class RequiredResult;
 
 template <typename T>
 struct GetTypeInfo<RequiredParam<T>, std::enable_if_t<std::is_base_of_v<Object, T>>> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_OBJECT_IS_REQUIRED;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_OBJECT_IS_REQUIRED;
 
 	template <typename U = T, std::enable_if_t<std::is_base_of_v<RefCounted, U>, int> = 0>
 	static inline PropertyInfo get_class_info() {
@@ -237,8 +237,8 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 #define MAKE_ENUM_TYPE_INFO(m_enum)                                                                                                          \
 	template <>                                                                                                                              \
 	struct GetTypeInfo<m_enum> {                                                                                                             \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
+		static constexpr Variant::Type VARIANT_TYPE = Variant::INT;                                                                          \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                    \
 		static inline PropertyInfo get_class_info() {                                                                                        \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, \
 					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                       \
@@ -253,8 +253,8 @@ inline StringName __constant_get_enum_name(T param) {
 #define MAKE_BITFIELD_TYPE_INFO(m_enum)                                                                                                          \
 	template <>                                                                                                                                  \
 	struct GetTypeInfo<m_enum> {                                                                                                                 \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                  \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
+		static constexpr Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
 		static inline PropertyInfo get_class_info() {                                                                                            \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
 					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                           \
@@ -262,8 +262,8 @@ inline StringName __constant_get_enum_name(T param) {
 	};                                                                                                                                           \
 	template <>                                                                                                                                  \
 	struct GetTypeInfo<BitField<m_enum>> {                                                                                                       \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                  \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
+		static constexpr Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
 		static inline PropertyInfo get_class_info() {                                                                                            \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
 					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                           \
@@ -323,8 +323,8 @@ const String get_variant_type_identifier() {
 
 template <typename T>
 struct GetTypeInfo<TypedArray<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr auto VARIANT_TYPE = Variant::ARRAY;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, GodotTypeInfo::Internal::get_variant_type_identifier<T>());
 	}
@@ -332,8 +332,8 @@ struct GetTypeInfo<TypedArray<T>> {
 
 template <typename K, typename V>
 struct GetTypeInfo<TypedDictionary<K, V>> {
-	static const Variant::Type VARIANT_TYPE = Variant::DICTIONARY;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::DICTIONARY;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,
 				vformat("%s;%s", GodotTypeInfo::Internal::get_variant_type_identifier<K>(), GodotTypeInfo::Internal::get_variant_type_identifier<V>()));


### PR DESCRIPTION
Simplification of `binder_common.h` logic. 

I expect this PR to perform the same, or very slightly better, than `master`. I expect these changes to very slightly improve the binary size and compile time.

## Motivation

- Less code as part of templated functions gives the compiler more choice about what to inline.
    - Especially, not inlining code can be _better_ in some cases because of the code cache and binary size.
- Less code as part of templated functions improves compile time and binary size.
- Simpler code is easier to read and maintain.


## List of changes

- `VariantObjectClassChecker` now uses `derives_from`, which does the same as the previous implementation but should be faster to compile.
- `VariantCasterAndValidate` ref overloads are deduplicated (they were copy-pasted verbatim).
- `_call_helper_check_argcount` is introduced to deduplicate args checking.
- `_call_helper_fill_args` is introduced to deduplicate args filling, and optimized remove the unnecessary `if` in the loop.
- `call_get_argument_type`, `call_get_argument_type_info`  and `call_get_argument_metadata` are simplified.
    - This requires making `GetTypeInfo` static variables `constexpr`.
