### PR TITLE
Fix D3D12 rendering device driver returning pointers to internal types for `get_resource_native_handle` instead of proper D3D12 primitives

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1163,6 +1163,7 @@
 		<constant name="DRIVER_RESOURCE_COMMAND_QUEUE" value="3" enum="DriverResource">
 			The main graphics-compute command queue ([code]rid[/code] parameter is ignored).
 			- Vulkan: [code]VkQueue[/code].
+			- D3D12: [code]ID3D12CommandQueue[/code].
 			- Metal: [code]MTLCommandQueue[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_QUEUE_FAMILY" value="4" enum="DriverResource">
@@ -1171,6 +1172,7 @@
 		</constant>
 		<constant name="DRIVER_RESOURCE_TEXTURE" value="5" enum="DriverResource">
 			- Vulkan: [code]VkImage[/code].
+			- D3D12: [code]ID3D12Resource[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_TEXTURE_VIEW" value="6" enum="DriverResource">
 			The view of an owned or shared texture.

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5679,14 +5679,18 @@ uint64_t RenderingDeviceDriverD3D12::get_resource_native_handle(DriverResource p
 			return 0;
 		}
 		case DRIVER_RESOURCE_COMMAND_QUEUE: {
-			return (uint64_t)p_driver_id.id;
+			const CommandQueueInfo *cmd_queue_info = (const CommandQueueInfo *)p_driver_id.id;
+			return (uint64_t)cmd_queue_info->d3d_queue.Get();
 		}
 		case DRIVER_RESOURCE_QUEUE_FAMILY: {
 			return 0;
 		}
 		case DRIVER_RESOURCE_TEXTURE: {
 			const TextureInfo *tex_info = (const TextureInfo *)p_driver_id.id;
-			return (uint64_t)tex_info->main_texture;
+			if (tex_info->main_texture) {
+				tex_info = tex_info->main_texture;
+			}
+			return (uint64_t)tex_info->resource;
 		} break;
 		case DRIVER_RESOURCE_TEXTURE_VIEW: {
 			const TextureInfo *tex_info = (const TextureInfo *)p_driver_id.id;


### PR DESCRIPTION
I am working on a project to display texture resources in Godot that are shared from another process. To do this I require interop with the underlying rendering primitives (e.g. ID3D12Device/VkLogicalDevice, ID3D12CommandQueue/VkQueue, ID3D12Resource/VkImage). I found with D3D12 that the wrong memory addresses were being returned by RenderingDevice::get_driver_resource in two cases:

* When querying for `DRIVER_RESOURCE_COMMAND_QUEUE`, a pointer to an internal structure (`CommandQueueInfo *`) rather than the `ID3D12CommandQueue *` pointer was being returned.
* When querying for `DRIVER_RESOURCE_TEXTURE`, a pointer to an internal structure was being returned (`(uint64_t)tex_info->main_texture` is a `TextureInfo *`). Instead, this should be returning the `ID3D12Resource *` pointer. In fact, looking back in the history, I can see that this is what was done before a big refactor to avoid code duplication between D3D12 and VK (See the old definition of `texture_get_native_handle` in rendering_device_d3d12.cpp - #83452).