### PR TITLE
Core: Consolidate typed container logic with `type_info.h`

### DIFF
--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -335,3 +335,25 @@ struct PtrToArg<Vector<Face3>> {
 		}
 	}
 };
+
+template <typename T>
+struct PtrToArg<TypedArray<T>> {
+	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
+		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
+	}
+	typedef Array EncodeT;
+	_FORCE_INLINE_ static void encode(TypedArray<T> p_val, void *p_ptr) {
+		*(Array *)p_ptr = p_val;
+	}
+};
+
+template <typename K, typename V>
+struct PtrToArg<TypedDictionary<K, V>> {
+	_FORCE_INLINE_ static TypedDictionary<K, V> convert(const void *p_ptr) {
+		return TypedDictionary<K, V>(*reinterpret_cast<const Dictionary *>(p_ptr));
+	}
+	typedef Dictionary EncodeT;
+	_FORCE_INLINE_ static void encode(TypedDictionary<K, V> p_val, void *p_ptr) {
+		*(Dictionary *)p_ptr = p_val;
+	}
+};

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -30,12 +30,7 @@
 
 #pragma once
 
-#include "core/object/object.h"
-#include "core/variant/array.h"
-#include "core/variant/binder_common.h"
-#include "core/variant/method_ptrcall.h"
 #include "core/variant/type_info.h"
-#include "core/variant/variant.h"
 
 template <typename T>
 class TypedArray : public Array {
@@ -44,189 +39,20 @@ public:
 		ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type.");
 		Array::operator=(p_array);
 	}
-	_FORCE_INLINE_ TypedArray(const Variant &p_variant) :
-			TypedArray(Array(p_variant)) {
-	}
+
 	_FORCE_INLINE_ TypedArray(const Array &p_array) {
-		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
+		set_typed(GodotTypeInfo::Internal::get_variant_type<T>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<T>(), Variant());
 		if (is_same_typed(p_array)) {
 			Array::operator=(p_array);
 		} else {
 			assign(p_array);
 		}
 	}
+
 	_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :
 			TypedArray(Array(p_init)) {}
+
 	_FORCE_INLINE_ TypedArray() {
-		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
+		set_typed(GodotTypeInfo::Internal::get_variant_type<T>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<T>(), Variant());
 	}
 };
-
-template <typename T>
-struct VariantInternalAccessor<TypedArray<T>> {
-	static _FORCE_INLINE_ TypedArray<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
-	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
-};
-template <typename T>
-struct VariantInternalAccessor<const TypedArray<T> &> {
-	static _FORCE_INLINE_ TypedArray<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
-	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
-};
-
-//specialization for the rest of variant types
-
-#define MAKE_TYPED_ARRAY(m_type, m_variant_type)                                                                 \
-	template <>                                                                                                  \
-	class TypedArray<m_type> : public Array {                                                                    \
-	public:                                                                                                      \
-		_FORCE_INLINE_ void operator=(const Array &p_array) {                                                    \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type."); \
-			Array::operator=(p_array);                                                                           \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :                                       \
-				Array(Array(p_init), m_variant_type, StringName(), Variant()) {                                  \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Variant &p_variant) :                                                    \
-				TypedArray(Array(p_variant)) {                                                                   \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Array &p_array) {                                                        \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
-			if (is_same_typed(p_array)) {                                                                        \
-				Array::operator=(p_array);                                                                       \
-			} else {                                                                                             \
-				assign(p_array);                                                                                 \
-			}                                                                                                    \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray() {                                                                            \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
-		}                                                                                                        \
-	};
-
-// All Variant::OBJECT types are intentionally omitted from this list because they are handled by
-// the unspecialized TypedArray definition.
-MAKE_TYPED_ARRAY(bool, Variant::BOOL)
-MAKE_TYPED_ARRAY(uint8_t, Variant::INT)
-MAKE_TYPED_ARRAY(int8_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint16_t, Variant::INT)
-MAKE_TYPED_ARRAY(int16_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint32_t, Variant::INT)
-MAKE_TYPED_ARRAY(int32_t, Variant::INT)
-MAKE_TYPED_ARRAY(uint64_t, Variant::INT)
-MAKE_TYPED_ARRAY(int64_t, Variant::INT)
-MAKE_TYPED_ARRAY(float, Variant::FLOAT)
-MAKE_TYPED_ARRAY(double, Variant::FLOAT)
-MAKE_TYPED_ARRAY(String, Variant::STRING)
-MAKE_TYPED_ARRAY(Vector2, Variant::VECTOR2)
-MAKE_TYPED_ARRAY(Vector2i, Variant::VECTOR2I)
-MAKE_TYPED_ARRAY(Rect2, Variant::RECT2)
-MAKE_TYPED_ARRAY(Rect2i, Variant::RECT2I)
-MAKE_TYPED_ARRAY(Vector3, Variant::VECTOR3)
-MAKE_TYPED_ARRAY(Vector3i, Variant::VECTOR3I)
-MAKE_TYPED_ARRAY(Transform2D, Variant::TRANSFORM2D)
-MAKE_TYPED_ARRAY(Vector4, Variant::VECTOR4)
-MAKE_TYPED_ARRAY(Vector4i, Variant::VECTOR4I)
-MAKE_TYPED_ARRAY(Plane, Variant::PLANE)
-MAKE_TYPED_ARRAY(Quaternion, Variant::QUATERNION)
-MAKE_TYPED_ARRAY(AABB, Variant::AABB)
-MAKE_TYPED_ARRAY(Basis, Variant::BASIS)
-MAKE_TYPED_ARRAY(Transform3D, Variant::TRANSFORM3D)
-MAKE_TYPED_ARRAY(Projection, Variant::PROJECTION)
-MAKE_TYPED_ARRAY(Color, Variant::COLOR)
-MAKE_TYPED_ARRAY(StringName, Variant::STRING_NAME)
-MAKE_TYPED_ARRAY(NodePath, Variant::NODE_PATH)
-MAKE_TYPED_ARRAY(RID, Variant::RID)
-MAKE_TYPED_ARRAY(Callable, Variant::CALLABLE)
-MAKE_TYPED_ARRAY(Signal, Variant::SIGNAL)
-MAKE_TYPED_ARRAY(Dictionary, Variant::DICTIONARY)
-MAKE_TYPED_ARRAY(Array, Variant::ARRAY)
-MAKE_TYPED_ARRAY(PackedByteArray, Variant::PACKED_BYTE_ARRAY)
-MAKE_TYPED_ARRAY(PackedInt32Array, Variant::PACKED_INT32_ARRAY)
-MAKE_TYPED_ARRAY(PackedInt64Array, Variant::PACKED_INT64_ARRAY)
-MAKE_TYPED_ARRAY(PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY)
-MAKE_TYPED_ARRAY(PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY)
-MAKE_TYPED_ARRAY(PackedStringArray, Variant::PACKED_STRING_ARRAY)
-MAKE_TYPED_ARRAY(PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY)
-MAKE_TYPED_ARRAY(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
-MAKE_TYPED_ARRAY(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
-MAKE_TYPED_ARRAY(PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY)
-MAKE_TYPED_ARRAY(IPAddress, Variant::STRING)
-
-template <typename T>
-struct PtrToArg<TypedArray<T>> {
-	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
-		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
-	}
-	typedef Array EncodeT;
-	_FORCE_INLINE_ static void encode(TypedArray<T> p_val, void *p_ptr) {
-		*(Array *)p_ptr = p_val;
-	}
-};
-
-template <typename T>
-struct GetTypeInfo<TypedArray<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
-	}
-};
-
-#define MAKE_TYPED_ARRAY_INFO(m_type, m_variant_type)                                                                        \
-	template <>                                                                                                              \
-	struct GetTypeInfo<TypedArray<m_type>> {                                                                                 \
-		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
-		static inline PropertyInfo get_class_info() {                                                                        \
-			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
-		}                                                                                                                    \
-	};
-
-MAKE_TYPED_ARRAY_INFO(bool, Variant::BOOL)
-MAKE_TYPED_ARRAY_INFO(uint8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(float, Variant::FLOAT)
-MAKE_TYPED_ARRAY_INFO(double, Variant::FLOAT)
-MAKE_TYPED_ARRAY_INFO(String, Variant::STRING)
-MAKE_TYPED_ARRAY_INFO(Vector2, Variant::VECTOR2)
-MAKE_TYPED_ARRAY_INFO(Vector2i, Variant::VECTOR2I)
-MAKE_TYPED_ARRAY_INFO(Rect2, Variant::RECT2)
-MAKE_TYPED_ARRAY_INFO(Rect2i, Variant::RECT2I)
-MAKE_TYPED_ARRAY_INFO(Vector3, Variant::VECTOR3)
-MAKE_TYPED_ARRAY_INFO(Vector3i, Variant::VECTOR3I)
-MAKE_TYPED_ARRAY_INFO(Transform2D, Variant::TRANSFORM2D)
-MAKE_TYPED_ARRAY_INFO(Vector4, Variant::VECTOR4)
-MAKE_TYPED_ARRAY_INFO(Vector4i, Variant::VECTOR4I)
-MAKE_TYPED_ARRAY_INFO(Plane, Variant::PLANE)
-MAKE_TYPED_ARRAY_INFO(Quaternion, Variant::QUATERNION)
-MAKE_TYPED_ARRAY_INFO(AABB, Variant::AABB)
-MAKE_TYPED_ARRAY_INFO(Basis, Variant::BASIS)
-MAKE_TYPED_ARRAY_INFO(Transform3D, Variant::TRANSFORM3D)
-MAKE_TYPED_ARRAY_INFO(Projection, Variant::PROJECTION)
-MAKE_TYPED_ARRAY_INFO(Color, Variant::COLOR)
-MAKE_TYPED_ARRAY_INFO(StringName, Variant::STRING_NAME)
-MAKE_TYPED_ARRAY_INFO(NodePath, Variant::NODE_PATH)
-MAKE_TYPED_ARRAY_INFO(RID, Variant::RID)
-MAKE_TYPED_ARRAY_INFO(Callable, Variant::CALLABLE)
-MAKE_TYPED_ARRAY_INFO(Signal, Variant::SIGNAL)
-MAKE_TYPED_ARRAY_INFO(Dictionary, Variant::DICTIONARY)
-MAKE_TYPED_ARRAY_INFO(Array, Variant::ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedByteArray, Variant::PACKED_BYTE_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedInt32Array, Variant::PACKED_INT32_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedInt64Array, Variant::PACKED_INT64_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedStringArray, Variant::PACKED_STRING_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY)
-MAKE_TYPED_ARRAY_INFO(IPAddress, Variant::STRING)
-
-#undef MAKE_TYPED_ARRAY
-#undef MAKE_TYPED_ARRAY_INFO

--- a/core/variant/typed_dictionary.h
+++ b/core/variant/typed_dictionary.h
@@ -30,293 +30,31 @@
 
 #pragma once
 
-#include "core/object/object.h"
-#include "core/variant/binder_common.h"
-#include "core/variant/dictionary.h"
-#include "core/variant/method_ptrcall.h"
 #include "core/variant/type_info.h"
-#include "core/variant/variant.h"
 
 template <typename K, typename V>
 class TypedDictionary : public Dictionary {
 public:
 	_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {
-		ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign a dictionary with a different element type.");
+		ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign a dictionary with different element types.");
 		Dictionary::operator=(p_dictionary);
 	}
-	_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :
-			TypedDictionary(Dictionary(p_variant)) {
-	}
+
 	_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {
-		set_typed(Variant::OBJECT, K::get_class_static(), Variant(), Variant::OBJECT, V::get_class_static(), Variant());
+		set_typed(GodotTypeInfo::Internal::get_variant_type<K>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<K>(), Variant(),
+				GodotTypeInfo::Internal::get_variant_type<V>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<V>(), Variant());
 		if (is_same_typed(p_dictionary)) {
 			Dictionary::operator=(p_dictionary);
 		} else {
 			assign(p_dictionary);
 		}
 	}
+
+	_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<Variant, Variant>> p_init) :
+			TypedDictionary(Dictionary(p_init)) {}
+
 	_FORCE_INLINE_ TypedDictionary() {
-		set_typed(Variant::OBJECT, K::get_class_static(), Variant(), Variant::OBJECT, V::get_class_static(), Variant());
-	}
-
-	_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<K, V>> p_init) :
-			Dictionary() {
-		set_typed(Variant::OBJECT, K::get_class_static(), Variant(), Variant::OBJECT, V::get_class_static(), Variant());
-		for (const KeyValue<K, V> &E : p_init) {
-			operator[](E.key) = E.value;
-		}
+		set_typed(GodotTypeInfo::Internal::get_variant_type<K>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<K>(), Variant(),
+				GodotTypeInfo::Internal::get_variant_type<V>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<V>(), Variant());
 	}
 };
-
-template <typename K, typename V>
-struct VariantInternalAccessor<TypedDictionary<K, V>> {
-	static _FORCE_INLINE_ TypedDictionary<K, V> get(const Variant *v) { return *VariantInternal::get_dictionary(v); }
-	static _FORCE_INLINE_ void set(Variant *v, const TypedDictionary<K, V> &p_dictionary) { *VariantInternal::get_dictionary(v) = p_dictionary; }
-};
-
-template <typename K, typename V>
-struct VariantInternalAccessor<const TypedDictionary<K, V> &> {
-	static _FORCE_INLINE_ TypedDictionary<K, V> get(const Variant *v) { return *VariantInternal::get_dictionary(v); }
-	static _FORCE_INLINE_ void set(Variant *v, const TypedDictionary<K, V> &p_dictionary) { *VariantInternal::get_dictionary(v) = p_dictionary; }
-};
-
-template <typename K, typename V>
-struct PtrToArg<TypedDictionary<K, V>> {
-	_FORCE_INLINE_ static TypedDictionary<K, V> convert(const void *p_ptr) {
-		return TypedDictionary<K, V>(*reinterpret_cast<const Dictionary *>(p_ptr));
-	}
-	typedef Dictionary EncodeT;
-	_FORCE_INLINE_ static void encode(TypedDictionary<K, V> p_val, void *p_ptr) {
-		*(Dictionary *)p_ptr = p_val;
-	}
-};
-
-template <typename K, typename V>
-struct GetTypeInfo<TypedDictionary<K, V>> {
-	static const Variant::Type VARIANT_TYPE = Variant::DICTIONARY;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE, vformat("%s;%s", K::get_class_static(), V::get_class_static()));
-	}
-};
-
-// Specialization for the rest of the Variant types.
-
-#define MAKE_TYPED_DICTIONARY_WITH_OBJECT(m_type, m_variant_type)                                                                                  \
-	template <typename T>                                                                                                                          \
-	class TypedDictionary<T, m_type> : public Dictionary {                                                                                         \
-	public:                                                                                                                                        \
-		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                                            \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");                         \
-			Dictionary::operator=(p_dictionary);                                                                                                   \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                                 \
-				TypedDictionary(Dictionary(p_variant)) {                                                                                           \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                                           \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                                 \
-			if (is_same_typed(p_dictionary)) {                                                                                                     \
-				Dictionary::operator=(p_dictionary);                                                                                               \
-			} else {                                                                                                                               \
-				assign(p_dictionary);                                                                                                              \
-			}                                                                                                                                      \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary() {                                                                                                         \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                                 \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<T, m_type>> p_init) :                                                        \
-				Dictionary() {                                                                                                                     \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                                 \
-			for (const KeyValue<T, m_type> &E : p_init) {                                                                                          \
-				operator[](E.key) = E.value;                                                                                                       \
-			}                                                                                                                                      \
-		}                                                                                                                                          \
-	};                                                                                                                                             \
-	template <typename T>                                                                                                                          \
-	struct GetTypeInfo<TypedDictionary<T, m_type>> {                                                                                               \
-		static const Variant::Type VARIANT_TYPE = Variant::DICTIONARY;                                                                             \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                              \
-		static inline PropertyInfo get_class_info() {                                                                                              \
-			return PropertyInfo(Variant::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,                                                      \
-					vformat("%s;%s", T::get_class_static(), m_variant_type == Variant::NIL ? "Variant" : Variant::get_type_name(m_variant_type))); \
-		}                                                                                                                                          \
-	};                                                                                                                                             \
-	template <typename T>                                                                                                                          \
-	class TypedDictionary<m_type, T> : public Dictionary {                                                                                         \
-	public:                                                                                                                                        \
-		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                                            \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");                         \
-			Dictionary::operator=(p_dictionary);                                                                                                   \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                                 \
-				TypedDictionary(Dictionary(p_variant)) {                                                                                           \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                                           \
-			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());                                 \
-			if (is_same_typed(p_dictionary)) {                                                                                                     \
-				Dictionary::operator=(p_dictionary);                                                                                               \
-			} else {                                                                                                                               \
-				assign(p_dictionary);                                                                                                              \
-			}                                                                                                                                      \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary() {                                                                                                         \
-			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());                                 \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type, T>> p_init) :                                                        \
-				Dictionary() {                                                                                                                     \
-			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, std::remove_pointer<T>::type::get_class_static(), Variant());      \
-			for (const KeyValue<m_type, T> &E : p_init) {                                                                                          \
-				operator[](E.key) = E.value;                                                                                                       \
-			}                                                                                                                                      \
-		}                                                                                                                                          \
-	};                                                                                                                                             \
-	template <typename T>                                                                                                                          \
-	struct GetTypeInfo<TypedDictionary<m_type, T>> {                                                                                               \
-		static const Variant::Type VARIANT_TYPE = Variant::DICTIONARY;                                                                             \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                              \
-		static inline PropertyInfo get_class_info() {                                                                                              \
-			return PropertyInfo(Variant::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,                                                      \
-					vformat("%s;%s", m_variant_type == Variant::NIL ? "Variant" : Variant::get_type_name(m_variant_type), T::get_class_static())); \
-		}                                                                                                                                          \
-	};
-
-#define MAKE_TYPED_DICTIONARY_EXPANDED(m_type_key, m_variant_type_key, m_type_value, m_variant_type_value)                        \
-	template <>                                                                                                                   \
-	class TypedDictionary<m_type_key, m_type_value> : public Dictionary {                                                         \
-	public:                                                                                                                       \
-		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                           \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");        \
-			Dictionary::operator=(p_dictionary);                                                                                  \
-		}                                                                                                                         \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                \
-				TypedDictionary(Dictionary(p_variant)) {                                                                          \
-		}                                                                                                                         \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                          \
-			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());                \
-			if (is_same_typed(p_dictionary)) {                                                                                    \
-				Dictionary::operator=(p_dictionary);                                                                              \
-			} else {                                                                                                              \
-				assign(p_dictionary);                                                                                             \
-			}                                                                                                                     \
-		}                                                                                                                         \
-		_FORCE_INLINE_ TypedDictionary() {                                                                                        \
-			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());                \
-		}                                                                                                                         \
-		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type_key, m_type_value>> p_init) :                        \
-				Dictionary() {                                                                                                    \
-			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());                \
-			for (const KeyValue<m_type_key, m_type_value> &E : p_init) {                                                          \
-				operator[](E.key) = E.value;                                                                                      \
-			}                                                                                                                     \
-		}                                                                                                                         \
-	};                                                                                                                            \
-	template <>                                                                                                                   \
-	struct GetTypeInfo<TypedDictionary<m_type_key, m_type_value>> {                                                               \
-		static const Variant::Type VARIANT_TYPE = Variant::DICTIONARY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                             \
-		static inline PropertyInfo get_class_info() {                                                                             \
-			return PropertyInfo(Variant::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,                                     \
-					vformat("%s;%s", m_variant_type_key == Variant::NIL ? "Variant" : Variant::get_type_name(m_variant_type_key), \
-							m_variant_type_value == Variant::NIL ? "Variant" : Variant::get_type_name(m_variant_type_value)));    \
-		}                                                                                                                         \
-	};
-
-#define MAKE_TYPED_DICTIONARY_NIL(m_type, m_variant_type)                                                     \
-	MAKE_TYPED_DICTIONARY_WITH_OBJECT(m_type, m_variant_type)                                                 \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, bool, Variant::BOOL)                               \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint8_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int8_t, Variant::INT)                              \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint16_t, Variant::INT)                            \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int16_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint32_t, Variant::INT)                            \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int32_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, uint64_t, Variant::INT)                            \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, int64_t, Variant::INT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, float, Variant::FLOAT)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, double, Variant::FLOAT)                            \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, String, Variant::STRING)                           \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector2, Variant::VECTOR2)                         \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector2i, Variant::VECTOR2I)                       \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Rect2, Variant::RECT2)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Rect2i, Variant::RECT2I)                           \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector3, Variant::VECTOR3)                         \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Vector3i, Variant::VECTOR3I)                       \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Transform2D, Variant::TRANSFORM2D)                 \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Plane, Variant::PLANE)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Quaternion, Variant::QUATERNION)                   \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, AABB, Variant::AABB)                               \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Basis, Variant::BASIS)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Transform3D, Variant::TRANSFORM3D)                 \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Color, Variant::COLOR)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, StringName, Variant::STRING_NAME)                  \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, NodePath, Variant::NODE_PATH)                      \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, RID, Variant::RID)                                 \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Callable, Variant::CALLABLE)                       \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Signal, Variant::SIGNAL)                           \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Dictionary, Variant::DICTIONARY)                   \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Array, Variant::ARRAY)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedByteArray, Variant::PACKED_BYTE_ARRAY)       \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedInt32Array, Variant::PACKED_INT32_ARRAY)     \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedInt64Array, Variant::PACKED_INT64_ARRAY)     \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY) \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY) \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedStringArray, Variant::PACKED_STRING_ARRAY)   \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY) \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY) \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedColorArray, Variant::PACKED_COLOR_ARRAY)     \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY) \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, IPAddress, Variant::STRING)
-
-#define MAKE_TYPED_DICTIONARY(m_type, m_variant_type)                             \
-	MAKE_TYPED_DICTIONARY_EXPANDED(m_type, m_variant_type, Variant, Variant::NIL) \
-	MAKE_TYPED_DICTIONARY_NIL(m_type, m_variant_type)
-
-MAKE_TYPED_DICTIONARY_NIL(Variant, Variant::NIL)
-MAKE_TYPED_DICTIONARY(bool, Variant::BOOL)
-MAKE_TYPED_DICTIONARY(uint8_t, Variant::INT)
-MAKE_TYPED_DICTIONARY(int8_t, Variant::INT)
-MAKE_TYPED_DICTIONARY(uint16_t, Variant::INT)
-MAKE_TYPED_DICTIONARY(int16_t, Variant::INT)
-MAKE_TYPED_DICTIONARY(uint32_t, Variant::INT)
-MAKE_TYPED_DICTIONARY(int32_t, Variant::INT)
-MAKE_TYPED_DICTIONARY(uint64_t, Variant::INT)
-MAKE_TYPED_DICTIONARY(int64_t, Variant::INT)
-MAKE_TYPED_DICTIONARY(float, Variant::FLOAT)
-MAKE_TYPED_DICTIONARY(double, Variant::FLOAT)
-MAKE_TYPED_DICTIONARY(String, Variant::STRING)
-MAKE_TYPED_DICTIONARY(Vector2, Variant::VECTOR2)
-MAKE_TYPED_DICTIONARY(Vector2i, Variant::VECTOR2I)
-MAKE_TYPED_DICTIONARY(Rect2, Variant::RECT2)
-MAKE_TYPED_DICTIONARY(Rect2i, Variant::RECT2I)
-MAKE_TYPED_DICTIONARY(Vector3, Variant::VECTOR3)
-MAKE_TYPED_DICTIONARY(Vector3i, Variant::VECTOR3I)
-MAKE_TYPED_DICTIONARY(Transform2D, Variant::TRANSFORM2D)
-MAKE_TYPED_DICTIONARY(Plane, Variant::PLANE)
-MAKE_TYPED_DICTIONARY(Quaternion, Variant::QUATERNION)
-MAKE_TYPED_DICTIONARY(AABB, Variant::AABB)
-MAKE_TYPED_DICTIONARY(Basis, Variant::BASIS)
-MAKE_TYPED_DICTIONARY(Transform3D, Variant::TRANSFORM3D)
-MAKE_TYPED_DICTIONARY(Color, Variant::COLOR)
-MAKE_TYPED_DICTIONARY(StringName, Variant::STRING_NAME)
-MAKE_TYPED_DICTIONARY(NodePath, Variant::NODE_PATH)
-MAKE_TYPED_DICTIONARY(RID, Variant::RID)
-MAKE_TYPED_DICTIONARY(Callable, Variant::CALLABLE)
-MAKE_TYPED_DICTIONARY(Signal, Variant::SIGNAL)
-MAKE_TYPED_DICTIONARY(Dictionary, Variant::DICTIONARY)
-MAKE_TYPED_DICTIONARY(Array, Variant::ARRAY)
-MAKE_TYPED_DICTIONARY(PackedByteArray, Variant::PACKED_BYTE_ARRAY)
-MAKE_TYPED_DICTIONARY(PackedInt32Array, Variant::PACKED_INT32_ARRAY)
-MAKE_TYPED_DICTIONARY(PackedInt64Array, Variant::PACKED_INT64_ARRAY)
-MAKE_TYPED_DICTIONARY(PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY)
-MAKE_TYPED_DICTIONARY(PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY)
-MAKE_TYPED_DICTIONARY(PackedStringArray, Variant::PACKED_STRING_ARRAY)
-MAKE_TYPED_DICTIONARY(PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY)
-MAKE_TYPED_DICTIONARY(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
-MAKE_TYPED_DICTIONARY(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
-MAKE_TYPED_DICTIONARY(PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY)
-MAKE_TYPED_DICTIONARY(IPAddress, Variant::STRING)
-
-#undef MAKE_TYPED_DICTIONARY
-#undef MAKE_TYPED_DICTIONARY_NIL
-#undef MAKE_TYPED_DICTIONARY_EXPANDED
-#undef MAKE_TYPED_DICTIONARY_WITH_OBJECT

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -70,6 +70,10 @@ template <typename T>
 class Ref;
 template <typename T>
 class BitField;
+template <typename T>
+class TypedArray;
+template <typename K, typename V>
+class TypedDictionary;
 
 struct PropertyInfo;
 struct MethodInfo;
@@ -495,6 +499,10 @@ public:
 	_FORCE_INLINE_ operator T() const { return static_cast<T>(operator int64_t()); }
 	template <typename T>
 	_FORCE_INLINE_ operator BitField<T>() const { return static_cast<T>(operator uint64_t()); }
+	template <typename T>
+	_FORCE_INLINE_ operator TypedArray<T>() const { return operator Array(); }
+	template <typename K, typename V>
+	_FORCE_INLINE_ operator TypedDictionary<K, V>() const { return operator Dictionary(); }
 
 	Object *get_validated_object() const;
 	Object *get_validated_object_with_check(bool &r_previously_freed) const;
@@ -565,6 +573,12 @@ public:
 	template <typename T>
 	_FORCE_INLINE_ Variant(BitField<T> p_bitfield) :
 			Variant(static_cast<uint64_t>(p_bitfield)) {}
+	template <typename T>
+	_FORCE_INLINE_ Variant(const TypedArray<T> &p_typed_array) :
+			Variant(static_cast<const Array &>(p_typed_array)) {}
+	template <typename K, typename V>
+	_FORCE_INLINE_ Variant(const TypedDictionary<K, V> &p_typed_dictionary) :
+			Variant(static_cast<const Dictionary &>(p_typed_dictionary)) {}
 
 	// If this changes the table in variant_op must be updated
 	enum Operator {

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -590,6 +590,18 @@ struct VariantInternalAccessor<IPAddress> {
 	static _FORCE_INLINE_ void set(Variant *v, IPAddress p_value) { *VariantInternal::get_string(v) = String(p_value); }
 };
 
+template <typename T>
+struct VariantInternalAccessor<TypedArray<T>> {
+	static _FORCE_INLINE_ TypedArray<T> get(const Variant *v) { return TypedArray<T>(*VariantInternal::get_array(v)); }
+	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = Array(p_array); }
+};
+
+template <typename K, typename V>
+struct VariantInternalAccessor<TypedDictionary<K, V>> {
+	static _FORCE_INLINE_ TypedDictionary<K, V> get(const Variant *v) { return TypedDictionary<K, V>(*VariantInternal::get_dictionary(v)); }
+	static _FORCE_INLINE_ void set(Variant *v, const TypedDictionary<K, V> &p_dictionary) { *VariantInternal::get_dictionary(v) = Dictionary(p_dictionary); }
+};
+
 template <>
 struct VariantInternalAccessor<Object *> {
 	static _FORCE_INLINE_ Object *get(const Variant *v) { return const_cast<Object *>(*VariantInternal::get_object(v)); }


### PR DESCRIPTION
- Helps address #111218
- Supersedes #100953
- Supersedes #96741
- Supersedes #88567

The recent merge of #111561 enabled me to revisit this idea of simplifying typed container include logic, as that turned out to be the missing link in making everything else work! Instead of having to jump through hoops of dependency chains, `type_info.h` already has all the information it needs to declare relevant typing metadata for `TypedArray` and `TypedDictionary`.

The primary difference in this implementation compared to before is how the implementation is all handled in `type_info.h` now, instead of `variant.h`. This makes more sense logistically, as the typing metadata already exists in that context & could be safely reused. Because the information can be safely parsed ahead of time, the need for dedicated macros is completely gone: all typed containers can rely on a **single implementation** that covers all use-cases!

This entirely purges any attempted "bonus" codestyle changes/fixes from the original PR attempt: this attempts as atomic of a conversion as possible. As such, instead of removing the typed container headers entirely, they're now simple stub files. Miraculously, there was exactly one file where an additional include was required; everything else happens to utilize `type_info.h` transitively, which is a silver-lining of our current `#include` issues. A future PR focused entirely on stylistic changes can remove those headers outright & any references to them.