### PR TITLE
Rename `appleembedded.permission.{AUDIO_RECORD->RECORD_AUDIO}`

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -801,7 +801,7 @@
 				- [code]OS.request_permission("android.permission.READ_EXTERNAL_STORAGE")[/code]
 				- [code]OS.request_permission("android.permission.POST_NOTIFICATIONS")[/code]
 				- [code]OS.request_permission("macos.permission.RECORD_SCREEN")[/code]
-				- [code]OS.request_permission("appleembedded.permission.AUDIO_RECORD")[/code]
+				- [code]OS.request_permission("appleembedded.permission.RECORD_AUDIO")[/code]
 				[b]Note:[/b] On Android, permission must be checked during export.
 				[b]Note:[/b] This method is implemented on Android, macOS, and visionOS platforms.
 			</description>

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -736,7 +736,15 @@ Rect2 OS_AppleEmbedded::calculate_boot_screen_rect(const Size2 &p_window_size, c
 }
 
 bool OS_AppleEmbedded::request_permission(const String &p_name) {
-	if (p_name == "appleembedded.permission.AUDIO_RECORD") {
+	String permission_name = p_name;
+#ifndef DISABLE_DEPRECATED
+	if (permission_name == "appleembedded.permission.AUDIO_RECORD") {
+		WARN_PRINT(R"*(OS.request_permission("appleembedded.permission.AUDIO_RECORD") is deprecated. Please use "appleembedded.permission.RECORD_AUDIO" instead.)*");
+		permission_name = "appleembedded.permission.RECORD_AUDIO";
+	}
+#endif
+
+	if (permission_name == "appleembedded.permission.RECORD_AUDIO") {
 		if (@available(iOS 17.0, *)) {
 			AVAudioApplicationRecordPermission permission = [AVAudioApplication sharedInstance].recordPermission;
 			if (permission == AVAudioApplicationRecordPermissionGranted) {
@@ -761,7 +769,10 @@ Vector<String> OS_AppleEmbedded::get_granted_permissions() const {
 
 	if (@available(iOS 17.0, *)) {
 		if ([AVAudioApplication sharedInstance].recordPermission == AVAudioApplicationRecordPermissionGranted) {
+			ret.push_back("appleembedded.permission.RECORD_AUDIO");
+#ifndef DISABLE_DEPRECATED
 			ret.push_back("appleembedded.permission.AUDIO_RECORD");
+#endif
 		}
 	}
 	return ret;


### PR DESCRIPTION
The current (and newly added #107973) `appleembedded.permission.AUDIO_RECORD` don't follow the current permission name framework of "\<ACTION\>_\<SUBJECT\>".

This PR rectifies this issue. It warns the user when `AUDIO_RECORD` is used, but grants the request nonetheless. Though, to keep compatibility with 4.5 users, when requesting granted permissions, both `AUDIO_RECORD` and `RECORD_AUDIO` are given for the same permission. In a future version, we could remove the `AUDIO_RECORD` one.

<figure>

<img width="849" height="381" alt="Capture d’écran, le 2025-10-14 à 21 17 59" src="https://github.com/user-attachments/assets/0959dd6f-c98e-4957-9cd3-150e77b8e3b8" />

<figcaption markdown=1>

The `AUDIO_RECORD` mention in [the docs](https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-method-request-permission) stick out from the rest.

</figcaption>
</figure>