### PR TITLE
Fix memory leak when falling back to a different display server

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3118,7 +3118,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 		// rendering_driver now held in static global String in main and initialized in setup()
 		Error err;
 		display_server = DisplayServer::create(display_driver_idx, rendering_driver, window_mode, window_vsync_mode, window_flags, window_position, window_size, init_screen, context, init_embed_parent_window_id, err);
-		if (err != OK || display_server == nullptr) {
+		if (display_server == nullptr) {
 			String last_name = DisplayServer::get_create_function_name(display_driver_idx);
 
 			// We can't use this display server, try other ones as fallback.
@@ -3132,18 +3132,14 @@ Error Main::setup2(bool p_show_boot_logo) {
 				WARN_PRINT(vformat("Display driver %s failed, falling back to %s.", last_name, name));
 
 				display_server = DisplayServer::create(i, rendering_driver, window_mode, window_vsync_mode, window_flags, window_position, window_size, init_screen, context, init_embed_parent_window_id, err);
-				if (err == OK && display_server != nullptr) {
+				if (display_server != nullptr) {
 					break;
 				}
 			}
 		}
 
-		if (err != OK || display_server == nullptr) {
+		if (display_server == nullptr) {
 			ERR_PRINT("Unable to create DisplayServer, all display drivers failed.\nUse \"--headless\" command line argument to run the engine in headless mode if this is desired (e.g. for continuous integration).");
-
-			if (display_server) {
-				memdelete(display_server);
-			}
 
 			GDExtensionManager::get_singleton()->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
 			uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -662,6 +662,9 @@ DisplayServer *DisplayServerAndroid::create_func(const String &p_rendering_drive
 					"Your device seems not to support the required OpenGL ES 3.0 version.",
 					"Unable to initialize OpenGL video driver");
 		}
+
+		memdelete(ds);
+		return nullptr;
 	}
 	return ds;
 }

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -47,7 +47,12 @@ DisplayServerIOS::~DisplayServerIOS() {
 }
 
 DisplayServer *DisplayServerIOS::create_func(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
-	return memnew(DisplayServerIOS(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, p_parent_window, r_error));
+	DisplayServer *ds = memnew(DisplayServerIOS(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, p_parent_window, r_error));
+	if (r_error != OK) {
+		memdelete(ds);
+		return nullptr;
+	}
+	return ds;
 }
 
 void DisplayServerIOS::register_ios_driver() {

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1880,9 +1880,7 @@ Vector<String> DisplayServerWayland::get_rendering_drivers_func() {
 DisplayServer *DisplayServerWayland::create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Point2i *p_position, const Size2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
 	DisplayServer *ds = memnew(DisplayServerWayland(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_resolution, p_context, p_parent_window, r_error));
 	if (r_error != OK) {
-		ERR_PRINT("Can't create the Wayland display server.");
 		memdelete(ds);
-
 		return nullptr;
 	}
 	return ds;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -6323,6 +6323,10 @@ Vector<String> DisplayServerX11::get_rendering_drivers_func() {
 
 DisplayServer *DisplayServerX11::create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
 	DisplayServer *ds = memnew(DisplayServerX11(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, p_parent_window, r_error));
+	if (r_error != OK) {
+		memdelete(ds);
+		return nullptr;
+	}
 	return ds;
 }
 

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -241,7 +241,12 @@ DisplayServerEmbedded::~DisplayServerEmbedded() {
 }
 
 DisplayServer *DisplayServerEmbedded::create_func(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t /* p_parent_window */, Error &r_error) {
-	return memnew(DisplayServerEmbedded(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, r_error));
+	DisplayServer *ds = memnew(DisplayServerEmbedded(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, r_error));
+	if (r_error != OK) {
+		memdelete(ds);
+		return nullptr;
+	}
+	return ds;
 }
 
 Vector<String> DisplayServerEmbedded::get_rendering_drivers_func() {

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3552,6 +3552,9 @@ DisplayServer *DisplayServerMacOS::create_func(const String &p_rendering_driver,
 					"If possible, consider updating your macOS version.",
 					"Unable to initialize OpenGL video driver");
 		}
+
+		memdelete(ds);
+		return nullptr;
 	}
 	return ds;
 }

--- a/platform/visionos/display_server_visionos.mm
+++ b/platform/visionos/display_server_visionos.mm
@@ -42,7 +42,12 @@ DisplayServerVisionOS::~DisplayServerVisionOS() {
 }
 
 DisplayServer *DisplayServerVisionOS::create_func(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
-	return memnew(DisplayServerVisionOS(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, p_parent_window, r_error));
+	DisplayServer *ds = memnew(DisplayServerVisionOS(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, p_parent_window, r_error));
+	if (r_error != OK) {
+		memdelete(ds);
+		return nullptr;
+	}
+	return ds;
 }
 
 void DisplayServerVisionOS::register_visionos_driver() {

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -1104,7 +1104,12 @@ void DisplayServerWeb::_dispatch_input_event(const Ref<InputEvent> &p_event) {
 }
 
 DisplayServer *DisplayServerWeb::create_func(const String &p_rendering_driver, WindowMode p_window_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Point2i *p_position, const Size2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
-	return memnew(DisplayServerWeb(p_rendering_driver, p_window_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, p_parent_window, r_error));
+	DisplayServer *ds = memnew(DisplayServerWeb(p_rendering_driver, p_window_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, p_parent_window, r_error));
+	if (r_error != OK) {
+		memdelete(ds);
+		return nullptr;
+	}
+	return ds;
 }
 
 DisplayServerWeb::DisplayServerWeb(const String &p_rendering_driver, WindowMode p_window_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Point2i *p_position, const Size2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7437,6 +7437,9 @@ DisplayServer *DisplayServerWindows::create_func(const String &p_rendering_drive
 							String(" or ").join(drivers)),
 					"Unable to initialize video driver");
 		}
+
+		memdelete(ds);
+		return nullptr;
 	}
 	return ds;
 }


### PR DESCRIPTION
When initialization in a display server's constructor fails, the display server instance is created normally, and the error is reported via the `r_error` parameter.

In this case, the instance should be freed before falling back to creating a different display server.

_Update:_ This PR moves the resposibility of cleaning up on failure to the create functions defined by each display server.