### PR TITLE
TextureRegionEditor should set up according to AtlasTexture's separation, step, snap_mode, and offset

### DIFF
--- a/editor/scene/texture/texture_region_editor_plugin.cpp
+++ b/editor/scene/texture/texture_region_editor_plugin.cpp
@@ -859,6 +859,12 @@ void TextureRegionEditor::_notification(int p_what) {
 				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_step", snap_step);
 				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_separation", snap_separation);
 				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_mode", snap_mode);
+
+				if (res_atlas_texture.is_valid()) {
+					res_atlas_texture->set_snap_mode(snap_mode);
+					res_atlas_texture->set_offset(snap_offset);
+					res_atlas_texture->set_separation(snap_separation);
+				}
 			}
 		} break;
 
@@ -918,6 +924,16 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		if (Object::cast_to<AtlasTexture>(p_obj)) {
 			res_atlas_texture = Ref<AtlasTexture>(p_obj);
 			is_resource = true;
+
+			snap_mode = (SnapMode)res_atlas_texture->get_snap_mode();
+			if (snap_mode == SnapMode::SNAP_GRID) {
+				snap_step = res_atlas_texture->get_region().get_size();
+				snap_separation = res_atlas_texture->get_separation();
+				snap_offset = res_atlas_texture->get_offset();
+			}
+
+			snap_mode_button->select(snap_mode);
+			_set_snap_mode(snap_mode);
 		}
 
 		if (is_resource) {

--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -113,6 +113,45 @@ Rect2 AtlasTexture::get_margin() const {
 	return margin;
 }
 
+void AtlasTexture::set_snap_mode(const int p_mode) {
+	if (snap_mode == p_mode) {
+		return;
+	}
+
+	snap_mode = p_mode;
+	emit_changed();
+}
+
+int AtlasTexture::get_snap_mode() const {
+	return snap_mode;
+}
+
+void AtlasTexture::set_separation(const Vector2i p_sep) {
+	if (separation == p_sep) {
+		return;
+	}
+
+	separation = p_sep;
+	emit_changed();
+}
+
+Vector2i AtlasTexture::get_separation() const {
+	return separation;
+}
+
+void AtlasTexture::set_offset(const Vector2i p_offset) {
+	if (offset == p_offset) {
+		return;
+	}
+
+	offset = p_offset;
+	emit_changed();
+}
+
+Vector2i AtlasTexture::get_offset() const {
+	return offset;
+}
+
 void AtlasTexture::set_filter_clip(const bool p_enable) {
 	filter_clip = p_enable;
 	emit_changed();
@@ -145,12 +184,24 @@ void AtlasTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &AtlasTexture::set_margin);
 	ClassDB::bind_method(D_METHOD("get_margin"), &AtlasTexture::get_margin);
 
+	ClassDB::bind_method(D_METHOD("_set_snap_mode", "snap_mode"), &AtlasTexture::set_snap_mode);
+	ClassDB::bind_method(D_METHOD("_get_snap_mode"), &AtlasTexture::get_snap_mode);
+
+	ClassDB::bind_method(D_METHOD("_set_separation", "separation"), &AtlasTexture::set_separation);
+	ClassDB::bind_method(D_METHOD("_get_separation"), &AtlasTexture::get_separation);
+
+	ClassDB::bind_method(D_METHOD("_set_offset", "offset"), &AtlasTexture::set_offset);
+	ClassDB::bind_method(D_METHOD("_get_offset"), &AtlasTexture::get_offset);
+
 	ClassDB::bind_method(D_METHOD("set_filter_clip", "enable"), &AtlasTexture::set_filter_clip);
 	ClassDB::bind_method(D_METHOD("has_filter_clip"), &AtlasTexture::has_filter_clip);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "atlas", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_atlas", "get_atlas");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "region", PROPERTY_HINT_NONE, "suffix:px"), "set_region", "get_region");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "margin", PROPERTY_HINT_NONE, "suffix:px"), "set_margin", "get_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "snap_mode", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL), "_set_snap_mode", "_get_snap_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "separation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL), "_set_separation", "_get_separation");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL), "_set_offset", "_get_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_clip"), "set_filter_clip", "has_filter_clip");
 }
 

--- a/scene/resources/atlas_texture.h
+++ b/scene/resources/atlas_texture.h
@@ -42,6 +42,9 @@ protected:
 	Ref<Texture2D> atlas;
 	Rect2 region;
 	Rect2 margin;
+	int snap_mode;
+	Vector2i separation;
+	Vector2i offset;
 	bool filter_clip = false;
 
 	static void _bind_methods();
@@ -61,6 +64,15 @@ public:
 
 	void set_margin(const Rect2 &p_margin);
 	Rect2 get_margin() const;
+
+	void set_snap_mode(const int p_mode);
+	int get_snap_mode() const;
+
+	void set_separation(const Vector2i p_sep);
+	Vector2i get_separation() const;
+
+	void set_offset(const Vector2i p_offset);
+	Vector2i get_offset() const;
 
 	void set_filter_clip(const bool p_enable);
 	bool has_filter_clip() const;


### PR DESCRIPTION
**Issue Description**
As of 4.5-stable, TextureRegionEditor will not use the current edited AtlasTexture's `separation`, `step`, `snap_mode` and `offset` but instead uses the previous asset's configuration cached in project metadata. This creates inconvenience when managing spritesheets of different dimensions.

**Solution Implemented**
This solution implement 3 internal variables: `separation`, `snap_mode` and `offset` to store the configurations. `step` is available in `region.w` and `region.h`. These variables are then used to setup the TextureRegionEditor when it is editing AtlasTexture. This implementation does not replace the existing caching in project metadata method, it will overwrite the values when its AtlasTexture.

This is my very first pull pull request, feel free to let me know if there is anything should be corrected.