### PR TITLE
Editor: Fix incorrect selection for collapsed log output

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -417,7 +417,8 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 
 	if (p_replace_previous) {
 		// Force sync last line update (skip if number of unprocessed log messages is too large to avoid editor lag).
-		if (log->get_pending_paragraphs() < 100) {
+		// Using is_finished() to trigger refresh cache
+		if (!log->is_finished() && log->get_pending_paragraphs() < 100) {
 			log->wait_until_finished();
 		}
 	}


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/111664*

It looks like `log->remove_paragraph(log->get_paragraph_count() - 2);` break something in `RickTextLabel`.

Go on `remove_paragraph(-1)` will remove all of previous paragraphs.

Go on `add_newline()` let both output and selection properly.

As the comment, "RickTextLabel is indeed weird".

---

Edit: 2025-10-15

Previous solution used `add_newline()` trigger refreshing cache.

After investigation, we can use `is_finished()` to trigger refreshing. This is better.
