### PR TITLE
Add support for setting a joypad's LED light color

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -151,6 +151,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_accelerometer", "value"), &Input::set_accelerometer);
 	ClassDB::bind_method(D_METHOD("set_magnetometer", "value"), &Input::set_magnetometer);
 	ClassDB::bind_method(D_METHOD("set_gyroscope", "value"), &Input::set_gyroscope);
+	ClassDB::bind_method(D_METHOD("set_joy_light", "device", "color"), &Input::set_joy_light);
+	ClassDB::bind_method(D_METHOD("has_joy_light", "device"), &Input::has_joy_light);
 	ClassDB::bind_method(D_METHOD("get_last_mouse_velocity"), &Input::get_last_mouse_velocity);
 	ClassDB::bind_method(D_METHOD("get_last_mouse_screen_velocity"), &Input::get_last_mouse_screen_velocity);
 	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &Input::get_mouse_button_mask);
@@ -995,6 +997,19 @@ void Input::set_joy_features(int p_device, JoypadFeatures *p_features) {
 	_update_joypad_features(p_device);
 }
 
+bool Input::set_joy_light(int p_device, const Color &p_color) {
+	Joypad *joypad = joy_names.getptr(p_device);
+	if (!joypad || joypad->features == nullptr) {
+		return false;
+	}
+	return joypad->features->set_joy_light(p_color);
+}
+
+bool Input::has_joy_light(int p_device) const {
+	const Joypad *joypad = joy_names.getptr(p_device);
+	return joypad && joypad->has_light;
+}
+
 void Input::start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration) {
 	_THREAD_SAFE_METHOD_
 	if (p_weak_magnitude < 0.f || p_weak_magnitude > 1.f || p_strong_magnitude < 0.f || p_strong_magnitude > 1.f) {
@@ -1492,8 +1507,9 @@ void Input::_update_joypad_features(int p_device) {
 	if (!joypad || joypad->features == nullptr) {
 		return;
 	}
-	// Do something based on the features. For example, we can save the information about
-	// the joypad having motion sensors, LED light, etc.
+	if (joypad->features->has_joy_light()) {
+		joypad->has_light = true;
+	}
 }
 
 Input::JoyEvent Input::_get_mapped_button_event(const JoyDeviceMapping &mapping, JoyButton p_button) {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -83,9 +83,8 @@ public:
 	public:
 		virtual ~JoypadFeatures() {}
 
-		// None at the moment, but later we can add new features like:
-		// virtual bool has_joy_accelerometer() const { return false; }
-		// virtual bool set_joy_accelerometer_enabled(bool p_enable) { return false; }
+		virtual bool has_joy_light() const { return false; }
+		virtual bool set_joy_light(const Color &p_color) { return false; }
 	};
 
 	static constexpr int32_t JOYPADS_MAX = 16;
@@ -183,6 +182,7 @@ private:
 		int mapping = -1;
 		int hat_current = 0;
 		Dictionary info;
+		bool has_light = false;
 		Input::JoypadFeatures *features = nullptr;
 	};
 
@@ -358,6 +358,9 @@ public:
 	void set_joy_axis(int p_device, JoyAxis p_axis, float p_value);
 
 	void set_joy_features(int p_device, JoypadFeatures *p_features);
+
+	bool set_joy_light(int p_device, const Color &p_color);
+	bool has_joy_light(int p_device) const;
 
 	void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration = 0);
 	void stop_joy_vibration(int p_device);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -200,6 +200,14 @@
 				By default, the deadzone is automatically calculated from the average of the action deadzones. However, you can override the deadzone to be whatever you want (on the range of 0 to 1).
 			</description>
 		</method>
+		<method name="has_joy_light" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<description>
+				Returns [code]true[/code] if the joypad has an LED light that can change colors and/or brightness. See also [method set_joy_light].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+			</description>
+		</method>
 		<method name="is_action_just_pressed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="action" type="StringName" />
@@ -387,6 +395,16 @@
 			<description>
 				Sets the value of the rotation rate of the gyroscope sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
+			</description>
+		</method>
+		<method name="set_joy_light">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="color" type="Color" />
+			<description>
+				Sets the joypad's LED light, if available, to the specified color. Returns [code]true[/code] if the operation was successful. See also [method has_joy_light].
+				[b]Note:[/b] There is no way to get the color of the light from a joypad. If you need to know the assigned color, store it separately.
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
 			</description>
 		</method>
 		<method name="set_magnetometer">

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -301,6 +301,19 @@ void JoypadSDL::close_joypad(int p_pad_idx) {
 	}
 }
 
+bool JoypadSDL::Joypad::has_joy_light() const {
+	SDL_PropertiesID properties_id = SDL_GetJoystickProperties(get_sdl_joystick());
+	if (properties_id == 0) {
+		return false;
+	}
+	return SDL_GetBooleanProperty(properties_id, SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN, false) || SDL_GetBooleanProperty(properties_id, SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN, false);
+}
+
+bool JoypadSDL::Joypad::set_joy_light(const Color &p_color) {
+	Color linear = p_color.srgb_to_linear();
+	return SDL_SetJoystickLED(get_sdl_joystick(), linear.get_r8(), linear.get_g8(), linear.get_b8());
+}
+
 SDL_Joystick *JoypadSDL::Joypad::get_sdl_joystick() const {
 	return SDL_GetJoystickFromID(sdl_instance_idx);
 }

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -62,6 +62,9 @@ private:
 		bool supports_force_feedback = false;
 		uint64_t ff_effect_timestamp = 0;
 
+		virtual bool has_joy_light() const override;
+		virtual bool set_joy_light(const Color &p_color) override;
+
 		SDL_Joystick *get_sdl_joystick() const;
 		SDL_Gamepad *get_sdl_gamepad() const;
 	};


### PR DESCRIPTION
Based on https://github.com/godotengine/godot/pull/111707 (it can be closed if this PR can be merged)

I decided to split my big SDL3 joypad features PR ( https://github.com/godotengine/godot/pull/107967 ) into several smaller PRs, this PR is one of them.

This PR adds the ability to set the color/brightness of a joypad's LED light color, if it has one. An example of a controller with an LED light is DualShock 4.

This PR hasn't been tested yet 😅 but it should work correctly since I copied the code from my earlier PR that had this feature working correctly. ~~After the CI passes, I will test it and create a small test project.~~ (Not sure it's required, this PR is a pretty simple one, it only adds 2 more methods on top of the motion sensors PR)

TODO:
- [x] fix encapsulation, see: https://github.com/godotengine/godot/pull/111679#discussion_r2432523623