### PR TITLE
Add support for DualSense Adaptive Triggers and custom joypad data packets

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -53,6 +53,16 @@ Comment: Godot Engine logo
 Copyright: 2017, Andrea Calabró
 License: CC-BY-4.0
 
+Files: core/input/input.cpp
+Comment: Factories for all DualSense trigger effects
+Copyright: 2021-2022 John "Nielk1" Klein
+License: Expat
+
+Files: core/input/input_dualsense.h
+Comment: Sony DualSense Output Reports
+Copyright: 2021-2022 John "Nielk1" Klein
+License: CC-BY-SA-3.0
+
 Files: core/math/convex_hull.cpp
  core/math/convex_hull.h
 Comment: Bullet Continuous Collision Detection and Physics Library
@@ -1371,6 +1381,367 @@ License: CC-BY-4.0
  as a limitation upon, or waiver of, any privileges and immunities
  that apply to the Licensor or You, including from the legal
  processes of any jurisdiction or authority.
+
+License: CC-BY-SA-3.0
+ Creative Commons Legal Code
+
+ Attribution-ShareAlike 3.0 Unported
+
+     CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+     LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN
+     ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+     INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+     REGARDING THE INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR
+     DAMAGES RESULTING FROM ITS USE.
+
+ License
+
+ THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
+ COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
+ COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+ AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+ BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE
+ TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY
+ BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS
+ CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+ CONDITIONS.
+
+ 1. Definitions
+
+  a. "Adaptation" means a work based upon the Work, or upon the Work and
+     other pre-existing works, such as a translation, adaptation,
+     derivative work, arrangement of music or other alterations of a
+     literary or artistic work, or phonogram or performance and includes
+     cinematographic adaptations or any other form in which the Work may be
+     recast, transformed, or adapted including in any form recognizably
+     derived from the original, except that a work that constitutes a
+     Collection will not be considered an Adaptation for the purpose of
+     this License. For the avoidance of doubt, where the Work is a musical
+     work, performance or phonogram, the synchronization of the Work in
+     timed-relation with a moving image ("synching") will be considered an
+     Adaptation for the purpose of this License.
+  b. "Collection" means a collection of literary or artistic works, such as
+     encyclopedias and anthologies, or performances, phonograms or
+     broadcasts, or other works or subject matter other than works listed
+     in Section 1(f) below, which, by reason of the selection and
+     arrangement of their contents, constitute intellectual creations, in
+     which the Work is included in its entirety in unmodified form along
+     with one or more other contributions, each constituting separate and
+     independent works in themselves, which together are assembled into a
+     collective whole. A work that constitutes a Collection will not be
+     considered an Adaptation (as defined below) for the purposes of this
+     License.
+  c. "Creative Commons Compatible License" means a license that is listed
+     at https://creativecommons.org/compatiblelicenses that has been
+     approved by Creative Commons as being essentially equivalent to this
+     License, including, at a minimum, because that license: (i) contains
+     terms that have the same purpose, meaning and effect as the License
+     Elements of this License; and, (ii) explicitly permits the relicensing
+     of adaptations of works made available under that license under this
+     License or a Creative Commons jurisdiction license with the same
+     License Elements as this License.
+  d. "Distribute" means to make available to the public the original and
+     copies of the Work or Adaptation, as appropriate, through sale or
+     other transfer of ownership.
+  e. "License Elements" means the following high-level license attributes
+     as selected by Licensor and indicated in the title of this License:
+     Attribution, ShareAlike.
+  f. "Licensor" means the individual, individuals, entity or entities that
+     offer(s) the Work under the terms of this License.
+  g. "Original Author" means, in the case of a literary or artistic work,
+     the individual, individuals, entity or entities who created the Work
+     or if no individual or entity can be identified, the publisher; and in
+     addition (i) in the case of a performance the actors, singers,
+     musicians, dancers, and other persons who act, sing, deliver, declaim,
+     play in, interpret or otherwise perform literary or artistic works or
+     expressions of folklore; (ii) in the case of a phonogram the producer
+     being the person or legal entity who first fixes the sounds of a
+     performance or other sounds; and, (iii) in the case of broadcasts, the
+     organization that transmits the broadcast.
+  h. "Work" means the literary and/or artistic work offered under the terms
+     of this License including without limitation any production in the
+     literary, scientific and artistic domain, whatever may be the mode or
+     form of its expression including digital form, such as a book,
+     pamphlet and other writing; a lecture, address, sermon or other work
+     of the same nature; a dramatic or dramatico-musical work; a
+     choreographic work or entertainment in dumb show; a musical
+     composition with or without words; a cinematographic work to which are
+     assimilated works expressed by a process analogous to cinematography;
+     a work of drawing, painting, architecture, sculpture, engraving or
+     lithography; a photographic work to which are assimilated works
+     expressed by a process analogous to photography; a work of applied
+     art; an illustration, map, plan, sketch or three-dimensional work
+     relative to geography, topography, architecture or science; a
+     performance; a broadcast; a phonogram; a compilation of data to the
+     extent it is protected as a copyrightable work; or a work performed by
+     a variety or circus performer to the extent it is not otherwise
+     considered a literary or artistic work.
+  i. "You" means an individual or entity exercising rights under this
+     License who has not previously violated the terms of this License with
+     respect to the Work, or who has received express permission from the
+     Licensor to exercise rights under this License despite a previous
+     violation.
+  j. "Publicly Perform" means to perform public recitations of the Work and
+     to communicate to the public those public recitations, by any means or
+     process, including by wire or wireless means or public digital
+     performances; to make available to the public Works in such a way that
+     members of the public may access these Works from a place and at a
+     place individually chosen by them; to perform the Work to the public
+     by any means or process and the communication to the public of the
+     performances of the Work, including by public digital performance; to
+     broadcast and rebroadcast the Work by any means including signs,
+     sounds or images.
+  k. "Reproduce" means to make copies of the Work by any means including
+     without limitation by sound or visual recordings and the right of
+     fixation and reproducing fixations of the Work, including storage of a
+     protected performance or phonogram in digital form or other electronic
+     medium.
+
+ 2. Fair Dealing Rights. Nothing in this License is intended to reduce,
+ limit, or restrict any uses free from copyright or rights arising from
+ limitations or exceptions that are provided for in connection with the
+ copyright protection under copyright law or other applicable laws.
+
+ 3. License Grant. Subject to the terms and conditions of this License,
+ Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+ perpetual (for the duration of the applicable copyright) license to
+ exercise the rights in the Work as stated below:
+
+  a. to Reproduce the Work, to incorporate the Work into one or more
+     Collections, and to Reproduce the Work as incorporated in the
+     Collections;
+  b. to create and Reproduce Adaptations provided that any such Adaptation,
+     including any translation in any medium, takes reasonable steps to
+     clearly label, demarcate or otherwise identify that changes were made
+     to the original Work. For example, a translation could be marked "The
+     original work was translated from English to Spanish," or a
+     modification could indicate "The original work has been modified.";
+  c. to Distribute and Publicly Perform the Work including as incorporated
+     in Collections; and,
+  d. to Distribute and Publicly Perform Adaptations.
+  e. For the avoidance of doubt:
+
+      i. Non-waivable Compulsory License Schemes. In those jurisdictions in
+         which the right to collect royalties through any statutory or
+         compulsory licensing scheme cannot be waived, the Licensor
+         reserves the exclusive right to collect such royalties for any
+         exercise by You of the rights granted under this License;
+     ii. Waivable Compulsory License Schemes. In those jurisdictions in
+         which the right to collect royalties through any statutory or
+         compulsory licensing scheme can be waived, the Licensor waives the
+         exclusive right to collect such royalties for any exercise by You
+         of the rights granted under this License; and,
+    iii. Voluntary License Schemes. The Licensor waives the right to
+         collect royalties, whether individually or, in the event that the
+         Licensor is a member of a collecting society that administers
+         voluntary licensing schemes, via that society, from any exercise
+         by You of the rights granted under this License.
+
+ The above rights may be exercised in all media and formats whether now
+ known or hereafter devised. The above rights include the right to make
+ such modifications as are technically necessary to exercise the rights in
+ other media and formats. Subject to Section 8(f), all rights not expressly
+ granted by Licensor are hereby reserved.
+
+ 4. Restrictions. The license granted in Section 3 above is expressly made
+ subject to and limited by the following restrictions:
+
+  a. You may Distribute or Publicly Perform the Work only under the terms
+     of this License. You must include a copy of, or the Uniform Resource
+     Identifier (URI) for, this License with every copy of the Work You
+     Distribute or Publicly Perform. You may not offer or impose any terms
+     on the Work that restrict the terms of this License or the ability of
+     the recipient of the Work to exercise the rights granted to that
+     recipient under the terms of the License. You may not sublicense the
+     Work. You must keep intact all notices that refer to this License and
+     to the disclaimer of warranties with every copy of the Work You
+     Distribute or Publicly Perform. When You Distribute or Publicly
+     Perform the Work, You may not impose any effective technological
+     measures on the Work that restrict the ability of a recipient of the
+     Work from You to exercise the rights granted to that recipient under
+     the terms of the License. This Section 4(a) applies to the Work as
+     incorporated in a Collection, but this does not require the Collection
+     apart from the Work itself to be made subject to the terms of this
+     License. If You create a Collection, upon notice from any Licensor You
+     must, to the extent practicable, remove from the Collection any credit
+     as required by Section 4(c), as requested. If You create an
+     Adaptation, upon notice from any Licensor You must, to the extent
+     practicable, remove from the Adaptation any credit as required by
+     Section 4(c), as requested.
+  b. You may Distribute or Publicly Perform an Adaptation only under the
+     terms of: (i) this License; (ii) a later version of this License with
+     the same License Elements as this License; (iii) a Creative Commons
+     jurisdiction license (either this or a later license version) that
+     contains the same License Elements as this License (e.g.,
+     Attribution-ShareAlike 3.0 US)); (iv) a Creative Commons Compatible
+     License. If you license the Adaptation under one of the licenses
+     mentioned in (iv), you must comply with the terms of that license. If
+     you license the Adaptation under the terms of any of the licenses
+     mentioned in (i), (ii) or (iii) (the "Applicable License"), you must
+     comply with the terms of the Applicable License generally and the
+     following provisions: (I) You must include a copy of, or the URI for,
+     the Applicable License with every copy of each Adaptation You
+     Distribute or Publicly Perform; (II) You may not offer or impose any
+     terms on the Adaptation that restrict the terms of the Applicable
+     License or the ability of the recipient of the Adaptation to exercise
+     the rights granted to that recipient under the terms of the Applicable
+     License; (III) You must keep intact all notices that refer to the
+     Applicable License and to the disclaimer of warranties with every copy
+     of the Work as included in the Adaptation You Distribute or Publicly
+     Perform; (IV) when You Distribute or Publicly Perform the Adaptation,
+     You may not impose any effective technological measures on the
+     Adaptation that restrict the ability of a recipient of the Adaptation
+     from You to exercise the rights granted to that recipient under the
+     terms of the Applicable License. This Section 4(b) applies to the
+     Adaptation as incorporated in a Collection, but this does not require
+     the Collection apart from the Adaptation itself to be made subject to
+     the terms of the Applicable License.
+  c. If You Distribute, or Publicly Perform the Work or any Adaptations or
+     Collections, You must, unless a request has been made pursuant to
+     Section 4(a), keep intact all copyright notices for the Work and
+     provide, reasonable to the medium or means You are utilizing: (i) the
+     name of the Original Author (or pseudonym, if applicable) if supplied,
+     and/or if the Original Author and/or Licensor designate another party
+     or parties (e.g., a sponsor institute, publishing entity, journal) for
+     attribution ("Attribution Parties") in Licensor's copyright notice,
+     terms of service or by other reasonable means, the name of such party
+     or parties; (ii) the title of the Work if supplied; (iii) to the
+     extent reasonably practicable, the URI, if any, that Licensor
+     specifies to be associated with the Work, unless such URI does not
+     refer to the copyright notice or licensing information for the Work;
+     and (iv) , consistent with Ssection 3(b), in the case of an
+     Adaptation, a credit identifying the use of the Work in the Adaptation
+     (e.g., "French translation of the Work by Original Author," or
+     "Screenplay based on original Work by Original Author"). The credit
+     required by this Section 4(c) may be implemented in any reasonable
+     manner; provided, however, that in the case of a Adaptation or
+     Collection, at a minimum such credit will appear, if a credit for all
+     contributing authors of the Adaptation or Collection appears, then as
+     part of these credits and in a manner at least as prominent as the
+     credits for the other contributing authors. For the avoidance of
+     doubt, You may only use the credit required by this Section for the
+     purpose of attribution in the manner set out above and, by exercising
+     Your rights under this License, You may not implicitly or explicitly
+     assert or imply any connection with, sponsorship or endorsement by the
+     Original Author, Licensor and/or Attribution Parties, as appropriate,
+     of You or Your use of the Work, without the separate, express prior
+     written permission of the Original Author, Licensor and/or Attribution
+     Parties.
+  d. Except as otherwise agreed in writing by the Licensor or as may be
+     otherwise permitted by applicable law, if You Reproduce, Distribute or
+     Publicly Perform the Work either by itself or as part of any
+     Adaptations or Collections, You must not distort, mutilate, modify or
+     take other derogatory action in relation to the Work which would be
+     prejudicial to the Original Author's honor or reputation. Licensor
+     agrees that in those jurisdictions (e.g. Japan), in which any exercise
+     of the right granted in Section 3(b) of this License (the right to
+     make Adaptations) would be deemed to be a distortion, mutilation,
+     modification or other derogatory action prejudicial to the Original
+     Author's honor and reputation, the Licensor will waive or not assert,
+     as appropriate, this Section, to the fullest extent permitted by the
+     applicable national law, to enable You to reasonably exercise Your
+     right under Section 3(b) of this License (right to make Adaptations)
+     but not otherwise.
+
+ 5. Representations, Warranties and Disclaimer
+
+ UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR
+ OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
+ KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
+ INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
+ FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
+ LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS,
+ WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION
+ OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+
+ 6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE
+ LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR
+ ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES
+ ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS
+ BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+ 7. Termination
+
+  a. This License and the rights granted hereunder will terminate
+     automatically upon any breach by You of the terms of this License.
+     Individuals or entities who have received Adaptations or Collections
+     from You under this License, however, will not have their licenses
+     terminated provided such individuals or entities remain in full
+     compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will
+     survive any termination of this License.
+  b. Subject to the above terms and conditions, the license granted here is
+     perpetual (for the duration of the applicable copyright in the Work).
+     Notwithstanding the above, Licensor reserves the right to release the
+     Work under different license terms or to stop distributing the Work at
+     any time; provided, however that any such election will not serve to
+     withdraw this License (or any other license that has been, or is
+     required to be, granted under the terms of this License), and this
+     License will continue in full force and effect unless terminated as
+     stated above.
+
+ 8. Miscellaneous
+
+  a. Each time You Distribute or Publicly Perform the Work or a Collection,
+     the Licensor offers to the recipient a license to the Work on the same
+     terms and conditions as the license granted to You under this License.
+  b. Each time You Distribute or Publicly Perform an Adaptation, Licensor
+     offers to the recipient a license to the original Work on the same
+     terms and conditions as the license granted to You under this License.
+  c. If any provision of this License is invalid or unenforceable under
+     applicable law, it shall not affect the validity or enforceability of
+     the remainder of the terms of this License, and without further action
+     by the parties to this agreement, such provision shall be reformed to
+     the minimum extent necessary to make such provision valid and
+     enforceable.
+  d. No term or provision of this License shall be deemed waived and no
+     breach consented to unless such waiver or consent shall be in writing
+     and signed by the party to be charged with such waiver or consent.
+  e. This License constitutes the entire agreement between the parties with
+     respect to the Work licensed here. There are no understandings,
+     agreements or representations with respect to the Work not specified
+     here. Licensor shall not be bound by any additional provisions that
+     may appear in any communication from You. This License may not be
+     modified without the mutual written agreement of the Licensor and You.
+  f. The rights granted under, and the subject matter referenced, in this
+     License were drafted utilizing the terminology of the Berne Convention
+     for the Protection of Literary and Artistic Works (as amended on
+     September 28, 1979), the Rome Convention of 1961, the WIPO Copyright
+     Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996
+     and the Universal Copyright Convention (as revised on July 24, 1971).
+     These rights and subject matter take effect in the relevant
+     jurisdiction in which the License terms are sought to be enforced
+     according to the corresponding provisions of the implementation of
+     those treaty provisions in the applicable national law. If the
+     standard suite of rights granted under applicable copyright law
+     includes additional rights not granted under this License, such
+     additional rights are deemed to be included in the License; this
+     License is not intended to restrict the license of any rights under
+     applicable law.
+
+
+ Creative Commons Notice
+
+     Creative Commons is not a party to this License, and makes no warranty
+     whatsoever in connection with the Work. Creative Commons will not be
+     liable to You or any party on any legal theory for any damages
+     whatsoever, including without limitation any general, special,
+     incidental or consequential damages arising in connection to this
+     license. Notwithstanding the foregoing two (2) sentences, if Creative
+     Commons has expressly identified itself as the Licensor hereunder, it
+     shall have all rights and obligations of Licensor.
+
+     Except for the limited purpose of indicating to the public that the
+     Work is licensed under the CCPL, Creative Commons does not authorize
+     the use by either party of the trademark "Creative Commons" or any
+     related trademark or logo of Creative Commons without the prior
+     written consent of Creative Commons. Any permitted use will be in
+     compliance with Creative Commons' then-current trademark usage
+     guidelines, as may be published on its website or otherwise made
+     available upon request from time to time. For the avoidance of doubt,
+     this trademark restriction does not form part of the License.
+
+     Creative Commons may be contacted at https://creativecommons.org/.
 
 License: Expat
  Permission is hereby granted, free of charge, to any person obtaining

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -85,6 +85,8 @@ public:
 
 		virtual bool has_joy_light() const { return false; }
 		virtual bool set_joy_light(const Color &p_color) { return false; }
+		virtual bool has_joy_adaptive_triggers() const { return false; }
+		virtual bool send_joy_packet(const void *p_data, int p_size) { return false; }
 	};
 
 	static constexpr int32_t JOYPADS_MAX = 16;
@@ -366,6 +368,17 @@ public:
 	void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration = 0);
 	void stop_joy_vibration(int p_device);
 	void vibrate_handheld(int p_duration_ms = 500, float p_amplitude = -1.0);
+
+	bool has_joy_adaptive_triggers(int p_device) const;
+	bool joy_adaptive_triggers_off(int p_device, JoyAxis p_axis);
+	bool joy_adaptive_triggers_feedback(int p_device, JoyAxis p_axis, int p_position, int p_strength);
+	bool joy_adaptive_triggers_weapon(int p_device, JoyAxis p_axis, int p_start_position, int p_end_position, int p_strength);
+	bool joy_adaptive_triggers_vibration(int p_device, JoyAxis p_axis, int p_position, int p_frequency, int p_amplitude);
+	bool joy_adaptive_triggers_multi_feedback(int p_device, JoyAxis p_axis, const PackedInt32Array &p_strengths);
+	bool joy_adaptive_triggers_slope_feedback(int p_device, JoyAxis p_axis, int p_start_position, int p_end_position, int p_start_strength, int p_end_strength);
+	bool joy_adaptive_triggers_multi_vibration(int p_device, JoyAxis p_axis, int p_frequency, const PackedInt32Array &p_amplitudes);
+
+	bool send_joy_packet(int p_device, const PackedByteArray &p_packet);
 
 	void set_mouse_position(const Point2 &p_posf);
 

--- a/core/input/input_dualsense.h
+++ b/core/input/input_dualsense.h
@@ -1,0 +1,157 @@
+/**************************************************************************/
+/*  input_dualsense.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+
+// https://controllers.fandom.com/wiki/Sony_DualSense#Output_Reports
+struct DS5SetStateData { // 47
+	/*    */ // Report Set Flags
+	/*    */ // These flags are used to indicate what contents from this report should be processed
+	/* 0.0*/ uint8_t EnableRumbleEmulation : 1; // Suggest halving rumble strength
+	/* 0.1*/ uint8_t UseRumbleNotHaptics : 1; //
+	/*    */
+	/* 0.2*/ uint8_t AllowRightTriggerFFB : 1; // Enable setting RightTriggerFFB
+	/* 0.3*/ uint8_t AllowLeftTriggerFFB : 1; // Enable setting LeftTriggerFFB
+	/*    */
+	/* 0.4*/ uint8_t AllowHeadphoneVolume : 1; // Enable setting VolumeHeadphones
+	/* 0.5*/ uint8_t AllowSpeakerVolume : 1; // Enable setting VolumeSpeaker
+	/* 0.6*/ uint8_t AllowMicVolume : 1; // Enable setting VolumeMic
+	/*    */
+	/* 0.7*/ uint8_t AllowAudioControl : 1; // Enable setting AudioControl section
+	/* 1.0*/ uint8_t AllowMuteLight : 1; // Enable setting MuteLightMode
+	/* 1.1*/ uint8_t AllowAudioMute : 1; // Enable setting MuteControl section
+	/*    */
+	/* 1.2*/ uint8_t AllowLedColor : 1; // Enable RGB LED section
+	/*    */
+	/* 1.3*/ uint8_t ResetLights : 1; // Release the LEDs from Wireless firmware control
+	/*    */ // When in wireless mode this must be signaled to control LEDs
+	/*    */ // This cannot be applied during the BT pair animation.
+	/*    */ // SDL2 waits until the SensorTimestamp value is >= 10200000
+	/*    */ // before pulsing this bit once.
+	/*    */
+	/* 1.4*/ uint8_t AllowPlayerIndicators : 1; // Enable setting PlayerIndicators section
+	/* 1.5*/ uint8_t AllowHapticLowPassFilter : 1; // Enable HapticLowPassFilter
+	/* 1.6*/ uint8_t AllowMotorPowerLevel : 1; // MotorPowerLevel reductions for trigger/haptic
+	/* 1.7*/ uint8_t AllowAudioControl2 : 1; // Enable setting AudioControl2 section
+	/*    */
+	/* 2  */ uint8_t RumbleEmulationRight; // emulates the light weight
+	/* 3  */ uint8_t RumbleEmulationLeft; // emulated the heavy weight
+	/*    */
+	/* 4  */ uint8_t VolumeHeadphones; // max 0x7f
+	/* 5  */ uint8_t VolumeSpeaker; // PS5 appears to only use the range 0x3d-0x64
+	/* 6  */ uint8_t VolumeMic; // not linear, seems to max at 64, 0 is fully muted only in chat mode
+	/*    */
+	/*    */ // AudioControl
+	/* 7.0*/ uint8_t MicSelect : 2; // 0 Auto
+	/*    */ // 1 Internal Only
+	/*    */ // 2 External Only
+	/*    */ // 3 Unclear, sets external mic flag but might use internal mic, do test
+	/* 7.2*/ uint8_t EchoCancelEnable : 1;
+	/* 7.3*/ uint8_t NoiseCancelEnable : 1;
+	/* 7.4*/ uint8_t OutputPathSelect : 2; // 0 L_R_X
+	/*    */ // 1 L_L_X
+	/*    */ // 2 L_L_R
+	/*    */ // 3 X_X_R
+	/* 7.6*/ uint8_t InputPathSelect : 2; // 0 CHAT_ASR
+	/*    */ // 1 CHAT_CHAT
+	/*    */ // 2 ASR_ASR
+	/*    */ // 3 Does Nothing, invalid
+	/*    */
+	/* 8  */ uint8_t MuteLightMode;
+	/*    */
+	/*    */ // MuteControl
+	/* 9.0*/ uint8_t TouchPowerSave : 1;
+	/* 9.1*/ uint8_t MotionPowerSave : 1;
+	/* 9.2*/ uint8_t HapticPowerSave : 1; // AKA BulletPowerSave
+	/* 9.3*/ uint8_t AudioPowerSave : 1;
+	/* 9.4*/ uint8_t MicMute : 1;
+	/* 9.5*/ uint8_t SpeakerMute : 1;
+	/* 9.6*/ uint8_t HeadphoneMute : 1;
+	/* 9.7*/ uint8_t HapticMute : 1; // AKA BulletMute
+	/*    */
+	/*10  */ uint8_t RightTriggerFFB[11];
+	/*21  */ uint8_t LeftTriggerFFB[11];
+	/*32  */ uint32_t HostTimestamp; // mirrored into report read
+	/*    */
+	/*    */ // MotorPowerLevel
+	/*36.0*/ uint8_t TriggerMotorPowerReduction : 4; // 0x0-0x7 (no 0x8?) Applied in 12.5% reductions
+	/*36.4*/ uint8_t RumbleMotorPowerReduction : 4; // 0x0-0x7 (no 0x8?) Applied in 12.5% reductions
+	/*    */
+	/*    */ // AudioControl2
+	/*37.0*/ uint8_t SpeakerCompPreGain : 3; // additional speaker volume boost
+	/*37.3*/ uint8_t BeamformingEnable : 1; // Probably for MIC given there's 2, might be more bits, can't find what it does
+	/*37.4*/ uint8_t UnkAudioControl2 : 4; // some of these bits might apply to the above
+	/*    */
+	/*38.0*/ uint8_t AllowLightBrightnessChange : 1; // LED_BRIHTNESS_CONTROL
+	/*38.1*/ uint8_t AllowColorLightFadeAnimation : 1; // LIGHTBAR_SETUP_CONTROL
+	/*38.2*/ uint8_t EnableImprovedRumbleEmulation : 1; // Use instead of EnableRumbleEmulation
+														// requires FW >= 0x0224
+														// No need to halve rumble strength
+	/*38.3*/ uint8_t UNKBITC : 5; // unused
+	/*    */
+	/*39.0*/ uint8_t HapticLowPassFilter : 1;
+	/*39.1*/ uint8_t UNKBIT : 7;
+	/*    */
+	/*40  */ uint8_t UNKBYTE; // previous notes suggested this was HLPF, was probably off by 1
+	/*    */
+	/*41  */ uint8_t LightFadeAnimation;
+	/*42  */ uint8_t LightBrightness;
+	/*    */
+	/*    */ // PlayerIndicators
+	/*    */ // These bits control the white LEDs under the touch pad.
+	/*    */ // Note the reduction in functionality for later revisions.
+	/*    */ // Generation 0x03 - Full Functionality
+	/*    */ // Generation 0x04 - Mirrored Only
+	/*    */ // Suggested detection: (HardwareInfo & 0x00FFFF00) == 0X00000400
+	/*    */ //
+	/*    */ // Layout used by PS5:
+	/*    */ // 0x04 - -x- -  Player 1
+	/*    */ // 0x06 - x-x -  Player 2
+	/*    */ // 0x15 x -x- x  Player 3
+	/*    */ // 0x1B x x-x x  Player 4
+	/*    */ // 0x1F x xxx x  Player 5* (Unconfirmed)
+	/*    */ //
+	/*    */ //                        // HW 0x03 // HW 0x04
+	/*43.0*/ uint8_t PlayerLight1 : 1; // x --- - // x --- x
+	/*43.1*/ uint8_t PlayerLight2 : 1; // - x-- - // - x-x -
+	/*43.2*/ uint8_t PlayerLight3 : 1; // - -x- - // - -x- -
+	/*43.3*/ uint8_t PlayerLight4 : 1; // - --x - // - x-x -
+	/*43.4*/ uint8_t PlayerLight5 : 1; // - --- x // x --- x
+	/*43.5*/ uint8_t PlayerLightFade : 1; // if low player lights fade in, if high player lights instantly change
+	/*43.6*/ uint8_t PlayerLightUNK : 2;
+	/*    */
+	/*    */ // RGB LED
+	/*44  */ uint8_t LedRed;
+	/*45  */ uint8_t LedGreen;
+	/*46  */ uint8_t LedBlue;
+	// Structure ends here though on BT there is padding and a CRC, see ReportOut31
+};

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -200,6 +200,14 @@
 				By default, the deadzone is automatically calculated from the average of the action deadzones. However, you can override the deadzone to be whatever you want (on the range of 0 to 1).
 			</description>
 		</method>
+		<method name="has_joy_adaptive_triggers" qualifiers="const" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<description>
+				Returns [code]true[/code] if the specified joypad supports adaptive triggers. See also [method joy_adaptive_triggers_off], [method joy_adaptive_triggers_weapon], etc.
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+			</description>
+		</method>
 		<method name="has_joy_light" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="device" type="int" />
@@ -320,6 +328,119 @@
 				[b]Note:[/b] Due to keyboard ghosting, [method is_physical_key_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
 			</description>
 		</method>
+		<method name="joy_adaptive_triggers_feedback" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="axis" type="int" enum="JoyAxis" />
+			<param index="2" name="position" type="int" />
+			<param index="3" name="strength" type="int" />
+			<description>
+				Starts the "Feedback" adaptive trigger effect on the specified joypad. This method will fail if the joypad does not support adaptive triggers.
+				The trigger specified by [param axis] will resist with [param strength] when pressed as least as far as [param position]; when pressed less, the trigger will not resist.
+				[param axis] should be [constant JOY_AXIS_TRIGGER_LEFT] for the left trigger, [constant JOY_AXIS_TRIGGER_RIGHT] for the right trigger, or [code]JOY_AXIS_TRIGGER_LEFT + JOY_AXIS_TRIGGER_RIGHT[/code] for both triggers at once.
+				[param position] should be in the range from [code]0[/code] to [code]9[/code] (inclusive), with [code]0[/code] representing the trigger being 0% pressed and [code]9[/code] being 90% pressed.
+				[param strength] should be in the range from [code]0[/code] to [code]8[/code] (inclusive), with [code]0[/code] representing no resistance and [code]8[/code] representing maximum resistance.
+				This method returns [code]true[/code] if the effect request was sent successfully. If it was unsuccessful (including if the joypad does not support adaptive triggers), this method returns [code]false[/code].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+			</description>
+		</method>
+		<method name="joy_adaptive_triggers_multi_feedback" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="axis" type="int" enum="JoyAxis" />
+			<param index="2" name="strengths" type="PackedInt32Array" />
+			<description>
+				Starts the "Multi Feedback" adaptive trigger effect on the specified joypad. This method will fail if the joypad does not support adaptive triggers.
+				The trigger specified by [param axis] will resist with the value in [param strengths] corresponding to the position closest to the trigger. Unlike [method joy_adaptive_triggers_feedback], this method allows multiple resistances to be felt when the trigger is pressed to different positions.
+				[param axis] should be [constant JOY_AXIS_TRIGGER_LEFT] for the left trigger, [constant JOY_AXIS_TRIGGER_RIGHT] for the right trigger, or [code]JOY_AXIS_TRIGGER_LEFT + JOY_AXIS_TRIGGER_RIGHT[/code] for both triggers at once.
+				[param strengths] should be an array with exactly 10 elements, and each in the range from [code]0[/code] to [code]8[/code] (inclusive).
+				This method returns [code]true[/code] if the effect request was sent successfully. If it was unsuccessful (including if the joypad does not support adaptive triggers), this method returns [code]false[/code].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+			</description>
+		</method>
+		<method name="joy_adaptive_triggers_multi_vibration" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="axis" type="int" enum="JoyAxis" />
+			<param index="2" name="frequency" type="int" />
+			<param index="3" name="amplitudes" type="PackedInt32Array" />
+			<description>
+				Starts the "Multi Vibration" adaptive trigger effect on the specified joypad. This method will fail if the joypad does not support adaptive triggers.
+				The trigger specified by [param axis] will vibrate with [param frequency] and the amplitude given by the value in [param amplitudes] corresponding to the position closest to the trigger. Unlike [method joy_adaptive_triggers_vibration], this method allows multiple amplitudes to be felt when the trigger is pressed to different positions.
+				[param axis] should be [constant JOY_AXIS_TRIGGER_LEFT] for the left trigger, [constant JOY_AXIS_TRIGGER_RIGHT] for the right trigger, or [code]JOY_AXIS_TRIGGER_LEFT + JOY_AXIS_TRIGGER_RIGHT[/code] for both triggers at once.
+				[param frequency] should be in the range from [code]0[/code] to [code]255[/code] (inclusive).
+				[param amplitudes] should be an array with exactly 10 elements, and each in the range from [code]0[/code] to [code]8[/code] (inclusive).
+				This method returns [code]true[/code] if the effect request was sent successfully. If it was unsuccessful (including if the joypad does not support adaptive triggers), this method returns [code]false[/code].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+			</description>
+		</method>
+		<method name="joy_adaptive_triggers_off" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="axis" type="int" enum="JoyAxis" />
+			<description>
+				Stops adaptive triggers effect on the specified joypad. This method will fail if the joypad does not support adaptive triggers.
+				[param axis] should be [constant JOY_AXIS_TRIGGER_LEFT] for the left trigger, [constant JOY_AXIS_TRIGGER_RIGHT] for the right trigger, or [code]JOY_AXIS_TRIGGER_LEFT + JOY_AXIS_TRIGGER_RIGHT[/code] for both triggers at once.
+				This method returns [code]true[/code] if the effect request was sent successfully. If it was unsuccessful (including if the joypad does not support adaptive triggers), this method returns [code]false[/code].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+			</description>
+		</method>
+		<method name="joy_adaptive_triggers_slope_feedback" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="axis" type="int" enum="JoyAxis" />
+			<param index="2" name="start_position" type="int" />
+			<param index="3" name="end_position" type="int" />
+			<param index="4" name="start_strength" type="int" />
+			<param index="5" name="end_strength" type="int" />
+			<description>
+				Starts the "Slope Feedback" adaptive trigger effect on the specified joypad. This method will fail if the joypad does not support adaptive triggers.
+				The trigger specified by [param axis] will start providing the resistance [param start_strength] when pressed in to [param start_position]. The resistance will increase as the trigger is pressed further; it will reach [param end_strength] once the trigger is pressed to [param end_position], and will maintain that resistance past that point.
+				[param axis] should be [constant JOY_AXIS_TRIGGER_LEFT] for the left trigger, [constant JOY_AXIS_TRIGGER_RIGHT] for the right trigger, or [code]JOY_AXIS_TRIGGER_LEFT + JOY_AXIS_TRIGGER_RIGHT[/code] for both triggers at once.
+				[param start_position] should be in the range from [code]0[/code] to [param end_position] (inclusive).
+				[param end_position] should be in the range from [code]start_position + 1[/code] to [code]9[/code] (inclusive).
+				[param start_strength] should be in the range from [code]1[/code] to [code]8[/code] (inclusive).
+				[param end_strength] should be in the range from [code]1[/code] to [code]8[/code] (inclusive).
+				This method returns [code]true[/code] if the effect request was sent successfully. If it was unsuccessful (including if the joypad does not support adaptive triggers), this method returns [code]false[/code].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+			</description>
+		</method>
+		<method name="joy_adaptive_triggers_vibration" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="axis" type="int" enum="JoyAxis" />
+			<param index="2" name="position" type="int" />
+			<param index="3" name="frequency" type="int" />
+			<param index="4" name="amplitude" type="int" />
+			<description>
+				Starts the "Vibration" adaptive trigger effect on the specified joypad. This method will fail if the joypad does not support adaptive triggers.
+				The trigger specified by [param axis] will vibrate with [param frequency] and [param amplitude] when pressed at least as far as [param position]; when pressed less, the trigger will not vibrate.
+				[param axis] should be [constant JOY_AXIS_TRIGGER_LEFT] for the left trigger, [constant JOY_AXIS_TRIGGER_RIGHT] for the right trigger, or [code]JOY_AXIS_TRIGGER_LEFT + JOY_AXIS_TRIGGER_RIGHT[/code] for both triggers at once.
+				[param position] should be in the range from [code]0[/code] to [code]9[/code] (inclusive).
+				[param amplitude] should be in the range from [code]0[/code] to [code]8[/code] (inclusive).
+				[param frequency] should be in the range from [code]0[/code] to [code]255[/code] (inclusive).
+				This method returns [code]true[/code] if the effect request was sent successfully. If it was unsuccessful (including if the joypad does not support adaptive triggers), this method returns [code]false[/code].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+			</description>
+		</method>
+		<method name="joy_adaptive_triggers_weapon" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="axis" type="int" enum="JoyAxis" />
+			<param index="2" name="start_position" type="int" />
+			<param index="3" name="end_position" type="int" />
+			<param index="4" name="strength" type="int" />
+			<description>
+				Starts the "Weapon" adaptive trigger effect on the specified joypad. This method will fail if the joypad does not support adaptive triggers.
+				The trigger specified by [param axis] will resist with [param strength] while pressed to within [param start_position] and [param end_position]; outside of this range, it will not resist.
+				[param axis] should be [constant JOY_AXIS_TRIGGER_LEFT] for the left trigger, [constant JOY_AXIS_TRIGGER_RIGHT] for the right trigger, or [code]JOY_AXIS_TRIGGER_LEFT + JOY_AXIS_TRIGGER_RIGHT[/code] for both triggers at once.
+				[param start_position] should be in the range from [code]2[/code] to [code]7[/code] (inclusive).
+				[param end_position] should be in the range from [code]start_position + 1[/code] to [code]8[/code] (inclusive).
+				[param strength] should be in the range from [code]0[/code] to [code]8[/code] (inclusive).
+				This method returns [code]true[/code] if the effect request was sent successfully. If it was unsuccessful (including if the joypad does not support adaptive triggers), this method returns [code]false[/code].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+			</description>
+		</method>
 		<method name="parse_input_event">
 			<return type="void" />
 			<param index="0" name="event" type="InputEvent" />
@@ -348,6 +469,15 @@
 			<description>
 				Removes all mappings from the internal database that match the given GUID. All currently connected joypads that use this GUID will become unmapped.
 				On Android, Godot will map to an internal fallback mapping.
+			</description>
+		</method>
+		<method name="send_joy_packet" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="packet" type="PackedByteArray" />
+			<description>
+				Sends a custom controller-specific data packet to the specified joypad, if supported. Returns [code]true[/code] on success and [code]false[/code] on failure.
+				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
 			</description>
 		</method>
 		<method name="set_accelerometer">

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -315,6 +315,14 @@ bool JoypadSDL::Joypad::set_joy_light(const Color &p_color) {
 	return SDL_SetJoystickLED(get_sdl_joystick(), linear.get_r8(), linear.get_g8(), linear.get_b8());
 }
 
+bool JoypadSDL::Joypad::has_joy_adaptive_triggers() const {
+	return SDL_GetGamepadTypeForID(sdl_instance_idx) == SDL_GAMEPAD_TYPE_PS5;
+}
+
+bool JoypadSDL::Joypad::send_joy_packet(const void *p_data, int p_size) {
+	return SDL_SendJoystickEffect(get_sdl_joystick(), p_data, p_size);
+}
+
 SDL_Joystick *JoypadSDL::Joypad::get_sdl_joystick() const {
 	return SDL_GetJoystickFromID(sdl_instance_idx);
 }

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -65,6 +65,9 @@ private:
 		virtual bool has_joy_light() const override;
 		virtual bool set_joy_light(const Color &p_color) override;
 
+		virtual bool has_joy_adaptive_triggers() const override;
+		virtual bool send_joy_packet(const void *p_data, int p_size) override;
+
 		SDL_Joystick *get_sdl_joystick() const;
 		SDL_Gamepad *get_sdl_gamepad() const;
 	};


### PR DESCRIPTION
- Partially addresses https://github.com/godotengine/godot-proposals/issues/12087
- Partially supersedes https://github.com/godotengine/godot/pull/88590

I decided to split my big SDL3 joypad features PR ( https://github.com/godotengine/godot/pull/107967 ) into several smaller PRs, this PR is one of them.

This PR adds the ability to use DualSense's Adaptive Triggers functionality. This code has been tested in my older PR, see: https://github.com/godotengine/godot/pull/107967#issuecomment-3322911200, https://github.com/godotengine/godot/pull/107967#issuecomment-3331035542

This code was based on this SDL2 Adaptive Triggers example: https://github.com/libsdl-org/SDL/blob/f201b64ffe1380713b181a3421c7fd910c95aada/test/testgamecontroller.c#L304-L352
Here's how the joypad packets are constructed: https://gist.github.com/Nielk1/6d54cc2c00d2201ccb8c2720ad7538db

(I hope I'm not spamming the PRs or anything 😅 )

TODO:
- [x] Return false if the controller is not DualSense
Get trigger status (see https://controllers.fandom.com/wiki/Sony_DualSense#Input_Reports and https://github.com/andrei-drexler/ironwail/pull/309 ) (I think it can be done in a separate PR if needed)
- [x] replace `[code skip-lint]...[/code]` with `[parameter ...]`
- [x] More documentation using the gist's comments and Apple documentation
- [x] An option to modify both triggers in one call
- [x] `Input.has_joy_adaptive_triggers()`
- [x] Mark as experimental
- [ ] Don't expose `Input.send_joy_packet()` (will be superseded by exposing HIDAPI)
- [ ] Change return type to `void` for most method
- [ ] Allow method calls to be ignored if joypad input is disabled on unfocused application