### PR TITLE
LSP: Use safe methods to get data from dictionaries

### DIFF
--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -687,9 +687,9 @@ struct TextDocumentItem {
 
 	void load(const Dictionary &p_dict) {
 		uri = p_dict["uri"];
-		languageId = p_dict["languageId"];
-		version = p_dict["version"];
-		text = p_dict["text"];
+		languageId = p_dict.get("languageId", "");
+		version = p_dict.get("version", 0);
+		text = p_dict.get("text", "");
 	}
 
 	Dictionary to_json() const {
@@ -703,20 +703,9 @@ struct TextDocumentItem {
 };
 
 /**
- * An event describing a change to a text document. If range and rangeLength are omitted
- * the new text is considered to be the full content of the document.
+ * An event describing a change to a text document.
  */
 struct TextDocumentContentChangeEvent {
-	/**
-	 * The range of the document that changed.
-	 */
-	Range range;
-
-	/**
-	 * The length of the range that got replaced.
-	 */
-	int rangeLength = 0;
-
 	/**
 	 * The new text of the range/document.
 	 */
@@ -724,8 +713,6 @@ struct TextDocumentContentChangeEvent {
 
 	void load(const Dictionary &p_params) {
 		text = p_params["text"];
-		rangeLength = p_params["rangeLength"];
-		range.load(p_params["range"]);
 	}
 };
 
@@ -1457,7 +1444,7 @@ struct CompletionContext {
 
 	void load(const Dictionary &p_params) {
 		triggerKind = int(p_params["triggerKind"]);
-		triggerCharacter = p_params["triggerCharacter"];
+		triggerCharacter = p_params.get("triggerCharacter", "");
 	}
 };
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

This fixes a few cases where dict[] operator was being used when the key (or value?) didn't exist. See relevant PR that started to error print these cases: https://github.com/godotengine/godot/pull/106636

I don't have a MRP at the moment, but can confirm that this fixes issues with my project getting lots of the `Bug: Dictionary::operator[] used when there was no value for the given key, please report.` spam when editing the project with VSCode while connected to Godot LSP.

Thanks @Ivorforce for the small nudge to figure this out myself.