### PR TITLE
Fix incorrect selection drawing when transform changes during frame processing but is the same at the end of the frame

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -4155,6 +4155,16 @@ void CanvasItemEditor::_draw_viewport() {
 	_draw_focus();
 	_draw_hover();
 	_draw_message();
+
+	// Update any CanvasItem that could affect drawing
+	const List<CanvasItem *> selection = _get_edited_canvas_items(true, false);
+	for (CanvasItem *selected_ci : selection) {
+		CanvasItemEditorSelectedItem *se = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(selected_ci);
+
+		se->prev_rect = selected_ci->_edit_use_rect() ? selected_ci->_edit_get_rect() : Rect2();
+		se->prev_xform = selected_ci->get_global_transform();
+		se->prev_drawn = true;
+	}
 }
 
 void CanvasItemEditor::update_viewport() {
@@ -4256,10 +4266,8 @@ void CanvasItemEditor::_notification(int p_what) {
 				}
 				Transform2D xform = ci->get_global_transform();
 
-				if (rect != se->prev_rect || xform != se->prev_xform) {
+				if (!se->prev_drawn || rect != se->prev_rect || xform != se->prev_xform) {
 					viewport->queue_redraw();
-					se->prev_rect = rect;
-					se->prev_xform = xform;
 				}
 
 				Control *control = Object::cast_to<Control>(ci);

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -55,6 +55,7 @@ class CanvasItemEditorSelectedItem : public Object {
 	GDCLASS(CanvasItemEditorSelectedItem, Object);
 
 public:
+	bool prev_drawn = false;
 	Transform2D prev_xform;
 	Rect2 prev_rect;
 	Vector2 prev_pivot;


### PR DESCRIPTION
Fixes #105564

Issue was that nested `Container`s may take an arbitrary amount of deferred sort calls to adjust positions and put its descendants in many intermediate positions before the final positions are set. If the editor viewport is redrawn between any of the Container sort calls, various parts (selection highlight in the original issue, but things like relative snapping rulers would also be affected) will be drawn using some incorrect intermediate position, but not be corrected by the transform and rect checks since there wasn't a change between values at the end of the frame.

The fix changes the redraw trigger for transform and rect changes to be comparing against the values at last draw rather than at last frame. This should fix any kind of mistimed drawing since it'll eventually get corrected by the process notification. 

`prev_drawn` was also added since the transform and rect values being are meaningless until a draw has occurred. Tangentially, it fixed a similar issue of not causing a redraw when selecting a control that was at (0,0) with size (0,0) that I realized while fixing.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
