### PR TITLE
Fix selection highlight not updating when selecting a hidden canvasitems

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -4492,6 +4492,32 @@ void CanvasItemEditor::_selection_changed() {
 		temp_pivot = Vector2(Math::INF, Math::INF);
 		viewport->queue_redraw();
 	}
+
+	// Check to redraw to clear anything drawn from visible selections if no selections are visible.
+	bool has_visible = false;
+	for (const KeyValue<ObjectID, Object *> &E : editor_selection->get_selection()) {
+		CanvasItem *ci = ObjectDB::get_instance<CanvasItem>(E.key);
+		if (!ci || !ci->is_visible_in_tree()) {
+			continue;
+		}
+
+		Viewport *vp = ci->get_viewport();
+		if (vp && !vp->is_visible_subviewport()) {
+			continue;
+		}
+
+		CanvasItemEditorSelectedItem *se = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(ci);
+		if (se) {
+			has_visible = true;
+			break;
+		}
+	}
+	if (had_visible_selection != has_visible) {
+		if (!has_visible) {
+			viewport->queue_redraw();
+		}
+		had_visible_selection = has_visible;
+	}
 }
 
 void CanvasItemEditor::edit(CanvasItem *p_canvas_item) {

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -234,6 +234,7 @@ private:
 	real_t resample_delay = 0.3;
 
 	bool selected_from_canvas = false;
+	bool had_visible_selection = false;
 
 	// Defaults are defined in clear().
 	Point2 grid_offset;


### PR DESCRIPTION
Fixes #111686

Adds a check to redraw to clear drawings for a previous visible selection if the current selection is not visible.

From what I could tell, all the calls to redraw the viewport that I could find do not trigger on `CanvasItem`s with visibility off. This normally makes sense since nothing is drawn when visibility is off, but this issue is that it's not clearing a previous drawing.

Order in tree mattered in the issue because it affects the order of add/remove.
If the new selection is below, remove of the old selection is done first, so selection thinks it's a single selection the whole time.
If the new selection is above, add of the new selection is done first, so the selection momentarily is treated like a multi-select until the remove, which triggered redraws associated with multi-select.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
