### PR TITLE
Fix custom icon in Android export

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -39,7 +39,6 @@
 #include "core/io/json.h"
 #include "core/io/marshalls.h"
 #include "core/version.h"
-#include "drivers/png/png_driver_common.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/export/export_template_manager.h"
@@ -240,39 +239,39 @@ static const char *LAUNCHER_ADAPTIVE_ICON_BACKGROUND_OPTION = PNAME("launcher_ic
 static const char *LAUNCHER_ADAPTIVE_ICON_MONOCHROME_OPTION = PNAME("launcher_icons/adaptive_monochrome_432x432");
 
 static const LauncherIcon LAUNCHER_ICONS[ICON_DENSITIES_COUNT] = {
-	{ "res/mipmap-xxxhdpi-v4/icon.png", 192 },
-	{ "res/mipmap-xxhdpi-v4/icon.png", 144 },
-	{ "res/mipmap-xhdpi-v4/icon.png", 96 },
-	{ "res/mipmap-hdpi-v4/icon.png", 72 },
-	{ "res/mipmap-mdpi-v4/icon.png", 48 },
-	{ "res/mipmap/icon.png", 192 }
+	{ "res/mipmap-xxxhdpi-v4/icon.webp", 192 },
+	{ "res/mipmap-xxhdpi-v4/icon.webp", 144 },
+	{ "res/mipmap-xhdpi-v4/icon.webp", 96 },
+	{ "res/mipmap-hdpi-v4/icon.webp", 72 },
+	{ "res/mipmap-mdpi-v4/icon.webp", 48 },
+	{ "res/mipmap/icon.webp", 192 }
 };
 
 static const LauncherIcon LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[ICON_DENSITIES_COUNT] = {
-	{ "res/mipmap-xxxhdpi-v4/icon_foreground.png", 432 },
-	{ "res/mipmap-xxhdpi-v4/icon_foreground.png", 324 },
-	{ "res/mipmap-xhdpi-v4/icon_foreground.png", 216 },
-	{ "res/mipmap-hdpi-v4/icon_foreground.png", 162 },
-	{ "res/mipmap-mdpi-v4/icon_foreground.png", 108 },
-	{ "res/mipmap/icon_foreground.png", 432 }
+	{ "res/mipmap-xxxhdpi-v4/icon_foreground.webp", 432 },
+	{ "res/mipmap-xxhdpi-v4/icon_foreground.webp", 324 },
+	{ "res/mipmap-xhdpi-v4/icon_foreground.webp", 216 },
+	{ "res/mipmap-hdpi-v4/icon_foreground.webp", 162 },
+	{ "res/mipmap-mdpi-v4/icon_foreground.webp", 108 },
+	{ "res/mipmap/icon_foreground.webp", 432 }
 };
 
 static const LauncherIcon LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[ICON_DENSITIES_COUNT] = {
-	{ "res/mipmap-xxxhdpi-v4/icon_background.png", 432 },
-	{ "res/mipmap-xxhdpi-v4/icon_background.png", 324 },
-	{ "res/mipmap-xhdpi-v4/icon_background.png", 216 },
-	{ "res/mipmap-hdpi-v4/icon_background.png", 162 },
-	{ "res/mipmap-mdpi-v4/icon_background.png", 108 },
-	{ "res/mipmap/icon_background.png", 432 }
+	{ "res/mipmap-xxxhdpi-v4/icon_background.webp", 432 },
+	{ "res/mipmap-xxhdpi-v4/icon_background.webp", 324 },
+	{ "res/mipmap-xhdpi-v4/icon_background.webp", 216 },
+	{ "res/mipmap-hdpi-v4/icon_background.webp", 162 },
+	{ "res/mipmap-mdpi-v4/icon_background.webp", 108 },
+	{ "res/mipmap/icon_background.webp", 432 }
 };
 
 static const LauncherIcon LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[ICON_DENSITIES_COUNT] = {
-	{ "res/mipmap-xxxhdpi-v4/icon_monochrome.png", 432 },
-	{ "res/mipmap-xxhdpi-v4/icon_monochrome.png", 324 },
-	{ "res/mipmap-xhdpi-v4/icon_monochrome.png", 216 },
-	{ "res/mipmap-hdpi-v4/icon_monochrome.png", 162 },
-	{ "res/mipmap-mdpi-v4/icon_monochrome.png", 108 },
-	{ "res/mipmap/icon_monochrome.png", 432 }
+	{ "res/mipmap-xxxhdpi-v4/icon_monochrome.webp", 432 },
+	{ "res/mipmap-xxhdpi-v4/icon_monochrome.webp", 324 },
+	{ "res/mipmap-xhdpi-v4/icon_monochrome.webp", 216 },
+	{ "res/mipmap-hdpi-v4/icon_monochrome.webp", 162 },
+	{ "res/mipmap-mdpi-v4/icon_monochrome.webp", 108 },
+	{ "res/mipmap/icon_monochrome.webp", 432 }
 };
 
 static const int EXPORT_FORMAT_APK = 0;
@@ -1852,18 +1851,6 @@ void EditorExportPlatformAndroid::_fix_resources(const Ref<EditorExportPreset> &
 	//printf("end\n");
 }
 
-void EditorExportPlatformAndroid::_load_image_data(const Ref<Image> &p_splash_image, Vector<uint8_t> &p_data) {
-	Vector<uint8_t> png_buffer;
-	Error err = PNGDriverCommon::image_to_png(p_splash_image, png_buffer);
-	if (err == OK) {
-		p_data.resize(png_buffer.size());
-		memcpy(p_data.ptrw(), png_buffer.ptr(), p_data.size());
-	} else {
-		String err_str = String("Failed to convert splash image to png.");
-		WARN_PRINT(err_str.utf8().get_data());
-	}
-}
-
 void EditorExportPlatformAndroid::_process_launcher_icons(const String &p_file_name, const Ref<Image> &p_source_image, int dimension, Vector<uint8_t> &p_data) {
 	Ref<Image> working_image = p_source_image;
 
@@ -1872,15 +1859,9 @@ void EditorExportPlatformAndroid::_process_launcher_icons(const String &p_file_n
 		working_image->resize(dimension, dimension, Image::Interpolation::INTERPOLATE_LANCZOS);
 	}
 
-	Vector<uint8_t> png_buffer;
-	Error err = PNGDriverCommon::image_to_png(working_image, png_buffer);
-	if (err == OK) {
-		p_data.resize(png_buffer.size());
-		memcpy(p_data.ptrw(), png_buffer.ptr(), p_data.size());
-	} else {
-		String err_str = String("Failed to convert resized icon (") + p_file_name + ") to png.";
-		WARN_PRINT(err_str.utf8().get_data());
-	}
+	Vector<uint8_t> buffer = working_image->save_webp_to_buffer();
+	p_data.resize(buffer.size());
+	memcpy(p_data.ptrw(), buffer.ptr(), p_data.size());
 }
 
 void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &p_preset, Ref<Image> &icon, Ref<Image> &foreground, Ref<Image> &background, Ref<Image> &monochrome) {
@@ -2168,10 +2149,10 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/show_in_app_library"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/show_as_launcher_app"), false));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, LAUNCHER_ICON_OPTION, PROPERTY_HINT_FILE, "*.png"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, LAUNCHER_ADAPTIVE_ICON_FOREGROUND_OPTION, PROPERTY_HINT_FILE, "*.png"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, LAUNCHER_ADAPTIVE_ICON_BACKGROUND_OPTION, PROPERTY_HINT_FILE, "*.png"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, LAUNCHER_ADAPTIVE_ICON_MONOCHROME_OPTION, PROPERTY_HINT_FILE, "*.png"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, LAUNCHER_ICON_OPTION, PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, LAUNCHER_ADAPTIVE_ICON_FOREGROUND_OPTION, PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, LAUNCHER_ADAPTIVE_ICON_BACKGROUND_OPTION, PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, LAUNCHER_ADAPTIVE_ICON_MONOCHROME_OPTION, PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "graphics/opengl_debug"), false));
 
@@ -3988,7 +3969,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			}
 		}
 
-		if (file.ends_with(".png") && file.contains("mipmap")) {
+		if ((file.ends_with(".webp") || file.ends_with(".png")) && file.contains("mipmap")) {
 			for (int i = 0; i < ICON_DENSITIES_COUNT; ++i) {
 				if (main_image.is_valid() && !main_image->is_empty()) {
 					if (file == LAUNCHER_ICONS[i].export_path) {

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -176,8 +176,6 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	void _fix_resources(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &r_manifest);
 
-	void _load_image_data(const Ref<Image> &p_splash_image, Vector<uint8_t> &p_data);
-
 	void _process_launcher_icons(const String &p_file_name, const Ref<Image> &p_source_image, int dimension, Vector<uint8_t> &p_data);
 
 	void load_icon_refs(const Ref<EditorExportPreset> &p_preset, Ref<Image> &icon, Ref<Image> &foreground, Ref<Image> &background, Ref<Image> &monochrome);


### PR DESCRIPTION
Fixes #111132

Follow-up to #110566 
_(We converted a lot of PNG to WebP there, which caused a regression; custom icons could no longer be exported.)_

-----------

Test project: [test.zip](https://github.com/user-attachments/files/22934482/test.zip). (MRP with more svg icons)

This PR contains additionally:
-  small optimizations, allows to specify `WebP` and `SVG` formats 
_(before only PNG was accepted, although there was no reason, I think)_
- cleanup: remove `_load_image_data()` and `PNGDriverCommon`

The graphics are now converted to WebP `save_webp_to_buffer` in the export [docs](https://docs.godotengine.org/en/stable/classes/class_image.html#class-image-method-save-webp-to-buffer) 


Test on Samsung Tab S7, Android 13:
<img width="190" height="107" alt="Bildschirmfoto 2025-10-15 um 21 19 16" src="https://github.com/user-attachments/assets/c190ca02-09c0-4070-b870-c5e860268694" />



<img width="992" height="551" alt="Bildschirmfoto 2025-10-15 um 20 50 07" src="https://github.com/user-attachments/assets/6e8db55a-eab2-44bd-95b9-60a070d631bd" />




