### PR TITLE
[macOS] Fix microphone issue

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -394,6 +394,11 @@ Error AudioDriverCoreAudio::init_input_device() {
 	UInt32 flag = 1;
 	result = AudioUnitSetProperty(input_unit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, kInputBus, &flag, sizeof(flag));
 	ERR_FAIL_COND_V(result != noErr, FAILED);
+#ifdef MACOS_ENABLED
+	flag = 0;
+	result = AudioUnitSetProperty(input_unit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, kOutputBus, &flag, sizeof(flag));
+	ERR_FAIL_COND_V(result != noErr, FAILED);
+#endif
 
 	UInt32 size;
 #ifdef MACOS_ENABLED


### PR DESCRIPTION
Fixes #110624
Supersedes (in some ways) #111662 (as it doesn't require checking for permissions)

>[!NOTE]
>A variation of #111662 will be needed, as macOS seems to ask for permission each time the binary needs microphone access. I'm investigating.