### PR TITLE
Add support for syntax-only to Scons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ misc/hooks/pre-commit-custom-*
 # Buildsystem
 bin
 *.gen.*
+*.syntax.cpp
 compile_commands.json
 platform/windows/godot_res.res
 

--- a/SConstruct
+++ b/SConstruct
@@ -211,6 +211,9 @@ opts.Add(
 )
 opts.Add(BoolVariable("tests", "Build the unit tests", False))
 opts.Add(BoolVariable("fast_unsafe", "Enable unsafe options for faster incremental builds", False))
+opts.Add(
+    BoolVariable("syntax_only", "Only check syntax without generating object files (faster compilation check)", False)
+)
 opts.Add(BoolVariable("ninja", "Use the ninja backend for faster rebuilds", False))
 opts.Add(BoolVariable("ninja_auto_run", "Run ninja automatically after generating the ninja file", True))
 opts.Add("ninja_file", "Path to the generated ninja file", "build.ninja")
@@ -768,6 +771,27 @@ elif methods.using_clang(env) or methods.using_emcc(env):
     env.AppendUnique(CCFLAGS=["-fcolor-diagnostics" if is_stderr_color() else "-fno-color-diagnostics"])
     if sys.platform == "win32":
         env.AppendUnique(CCFLAGS=["-fansi-escape-codes"])
+
+# Syntax-only compilation (no object file generation)
+if env["syntax_only"]:
+    # Register robust cleanup on exit/interruption.
+    try:
+        methods._register_syntax_cleanup()
+    except Exception:
+        pass
+    if env.msvc:
+        # MSVC: /Zs performs syntax checking only
+        env.AppendUnique(CCFLAGS=["/Zs"])
+    elif methods.using_gcc(env) or methods.using_clang(env) or methods.using_emcc(env):
+        # GCC/Clang: -fsyntax-only checks syntax without generating code
+        env.AppendUnique(CCFLAGS=["-fsyntax-only"])
+    else:
+        print_warning("Syntax-only compilation requested but not supported for current compiler.")
+
+    # In syntax_only mode, platform-specific code may fail to compile, which is expected.
+    # Recommend using -k flag to continue building despite errors.
+    if not GetOption("keep_going"):
+        print_info("Syntax-only mode: Use the -k flag to continue building despite compilation errors.")
 
 # Set optimize and debug_symbols flags.
 # "custom" means do nothing and let users set their own optimization flags.


### PR DESCRIPTION
This PR adds support for the `syntax_only` boolean argument to Scons. This argument enables header inclusion checking for each compile unit separately, as discussed here. 

This check both `.cpp` and `.h` files. To support `.h` file checking, for every `.h` file, an associated dummy `.syntax.cpp` file is generated when scons is run with `syntax_only=true` and compiled as if it were a normal `.cpp` file. 
* Any generated file is automatically cleaned up when scons exits, either through an error or normal end.
  * If scons is killed by killing the runner (Windows ex: closing powershell, killing in task manager), the files will not be deleted.
* Additionally, these files are added to the `.gitignore` to prevent PR pollution in the event that they do not get deleted as they should be. 

This throws an error code 2 (standard compilation error) if the file being compiled does not include all of its necessary headers. This is done to enable checking of edge cases like the one found and fixed in #111561, whereby the include could be missing but wouldn't cause a compilation error due to compile order. 
* It is recommended to always run this with `-k` argument, which enables `keep_going` on errors
  * Warning: attempting to kill scons with `keep_going` enabled with Ctrl+C will not work.
* This can throw out errors for forward declared classes, which may not be an actual problem. 
  * `ref_counted.h` for example supports using a forward declared class in a template, but the compiler will still return an error
* This may throw out errors for modules related to another platform than the one it is being run on, as it will not find these includes. 
  * These could potentially be prevented by adding `#ifdef {platform}` guards which scons will respect.
* This will not check any file in the thirdparty/ folder, as that code is not our responsibility, and WILL throw out errors (especially JoltPhysics)

~ 

List of issues/PRs detected by this change:
* #111696 (squashed version of the 4 listed)
* #111697 
* #111698 
* #111699 
* Note: I cannot detect issues on non-windows platforms since I am running Windows on my machine and don't have environments set up for other platforms. 