### PR TITLE
Fix missing includes in headers

### DIFF
--- a/core/templates/iterable.h
+++ b/core/templates/iterable.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 template <typename I>
 class Iterable {
 	I _begin;

--- a/modules/godot_physics_3d/godot_constraint_3d.h
+++ b/modules/godot_physics_3d/godot_constraint_3d.h
@@ -30,6 +30,9 @@
 
 #pragma once
 
+#include "core/templates/rid.h"
+#include "core/typedefs.h"
+
 class GodotBody3D;
 class GodotSoftBody3D;
 

--- a/platform/windows/lang_table.h
+++ b/platform/windows/lang_table.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <winnt.h>
+
 struct _WinLocale {
 	const char *locale;
 	int main_lang;

--- a/servers/rendering/rendering_shader_library.h
+++ b/servers/rendering/rendering_shader_library.h
@@ -30,6 +30,10 @@
 
 #pragma once
 
+class String;
+template <typename T>
+class BitField;
+
 class RenderingShaderLibrary {
 public:
 	enum FeatureBits {


### PR DESCRIPTION
Adds missing `<winnt.h>` include in `windows/lang_table.h`
Adds missing `typedefs.h` and `rid.h` includes in `godot_constraint_3d.h`
Adds missing `<type_traits>` include in `iterable.h`
Adds missing forward class declarations in `rendering_shader_library.h`

All of these were detected using the `syntax_only=true` argument in scons added by #111694 