### PR TITLE
Add missing typedefs.h include in iterable.h

### DIFF
--- a/core/templates/iterable.h
+++ b/core/templates/iterable.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/typedefs.h"
+
 template <typename I>
 class Iterable {
 	I _begin;


### PR DESCRIPTION
Adds a missing `typedefs.h` include in `core/templates/iterable.h`

Detected by attempting to compile a `iterable.syntax.cpp` file including only `iterable.h` as header using `syntax_only=true` argument from #111694 
