### PR TITLE
Fix missing ustring.h and bit_field.h include in rendering_shader_library.h

### DIFF
--- a/servers/rendering/rendering_shader_library.h
+++ b/servers/rendering/rendering_shader_library.h
@@ -30,6 +30,9 @@
 
 #pragma once
 
+#include "core/string/ustring.h"
+#include "core/templates/bit_field.h"
+
 class RenderingShaderLibrary {
 public:
 	enum FeatureBits {


### PR DESCRIPTION
Adds missing `core/string/ustring.h` and `core/templates/bit_field.h` includes in `servers/rendering/rendering_shader_library.h`

Detected by attempting to compile a `rendering_shader_library.syntax.cpp` file including only `rendering_shader_library.h` as header using `syntax_only=true` argument from #111694 
