### PR TITLE
Fix error when compute shaders contain Unicode comment

### DIFF
--- a/modules/glslang/register_types.cpp
+++ b/modules/glslang/register_types.cpp
@@ -58,7 +58,7 @@ Vector<uint8_t> compile_glslang_shader(RenderingDeviceCommons::ShaderStage p_sta
 	glslang::EShTargetLanguageVersion TargetVersion = (glslang::EShTargetLanguageVersion)p_spirv_version;
 
 	glslang::TShader shader(stages[p_stage]);
-	CharString cs = p_source_code.ascii();
+	CharString cs = p_source_code.utf8();
 	const char *cs_strings = cs.get_data();
 	std::string preamble = "";
 


### PR DESCRIPTION
The `.glsl` file provided by the user might contain comments with non-ASCII characters.