### PR TITLE
Allow extracting translation strings without generating POT

### DIFF
--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		[EditorTranslationParserPlugin] is invoked when a file is being parsed to extract strings that require translation. To define the parsing and string extraction logic, override the [method _parse_file] method in script.
-		The return value should be an [Array] of [PackedStringArray]s, one for each extracted translatable string. Each entry should contain [code][msgid, msgctxt, msgid_plural, comment, source_line][/code], where all except [code]msgid[/code] are optional. Empty strings will be ignored.
 		The extracted strings will be written into a POT file selected by user under "POT Generation" in "Localization" tab in "Project Settings" menu.
 		Below shows an example of a custom parser that extracts strings from a CSV file to write into a POT.
 		[codeblocks]
@@ -114,6 +113,17 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Override this method to define a custom parsing logic to extract the translatable strings.
+				The return value should be an array of [PackedStringArray]s, one for each extracted translatable string. Each entry should contain [code][msgid, msgctxt, msgid_plural, comment, source_line][/code], where all except [code]msgid[/code] are optional. Empty strings will be ignored.
+			</description>
+		</method>
+		<method name="parse" qualifiers="static">
+			<return type="PackedStringArray[]" />
+			<param index="0" name="paths" type="PackedStringArray" />
+			<param index="1" name="add_builtin" type="bool" />
+			<description>
+				Returns strings parsed from files located in [param paths]. Built-in extractable strings are included if [param add_builtin] is [code]true[/code].
+				The returned value is an array of extracted string information. Each entry is an array of five strings: [code][msgid, msgctxt, msgid_plural, comment, source_line][/code].
+				[b]Note:[/b] This is a static method intended to be called externally. It must [b]not[/b] be called from [method _parse_file].
 			</description>
 		</method>
 	</methods>

--- a/editor/translations/editor_translation_parser.h
+++ b/editor/translations/editor_translation_parser.h
@@ -37,6 +37,8 @@
 class EditorTranslationParserPlugin : public RefCounted {
 	GDCLASS(EditorTranslationParserPlugin, RefCounted);
 
+	static TypedArray<PackedStringArray> parse(const PackedStringArray &p_paths, bool p_add_builtin);
+
 protected:
 	static void _bind_methods();
 
@@ -65,6 +67,8 @@ public:
 
 	Vector<Ref<EditorTranslationParserPlugin>> standard_parsers;
 	Vector<Ref<EditorTranslationParserPlugin>> custom_parsers;
+
+	Vector<Vector<String>> parse(const Vector<String> &p_paths, bool p_add_builtin) const;
 
 	void get_recognized_extensions(List<String> *r_extensions) const;
 	bool can_parse(const String &p_extension) const;

--- a/editor/translations/pot_generator.h
+++ b/editor/translations/pot_generator.h
@@ -39,22 +39,7 @@
 class POTGenerator {
 	static POTGenerator *singleton;
 
-	struct MsgidData {
-		String ctx;
-		String plural;
-		HashSet<String> locations;
-		HashSet<String> comments;
-	};
-	// Store msgid as key and the additional data around the msgid - if it's under a context, has plurals and its file locations.
-	HashMap<String, Vector<MsgidData>> all_translation_strings;
-
-	void _write_to_pot(const String &p_file);
 	void _write_msgid(Ref<FileAccess> r_file, const String &p_id, bool p_plural);
-	void _add_new_msgid(const String &p_msgid, const String &p_context, const String &p_plural, const String &p_location, const String &p_comment);
-
-#ifdef DEBUG_POT
-	void _print_all_translation_strings();
-#endif
 
 public:
 	static POTGenerator *get_singleton();


### PR DESCRIPTION
Alternate of #111074

Adds `EditorTranslationParserPlugin.parse()` to explicitly request translation string extraction. This method is basically `POTGenerator::generate_pot()` without the POT-related stuff.

Example of a translation CSV generator :)

```gdscript
@tool
extends EditorScript

func _run() -> void:
	var files = ProjectSettings.get_setting("internationalization/locale/translations_pot_files")
	var builtin = ProjectSettings.get_setting("internationalization/locale/translation_add_builtin_strings_to_pot")
	
	var messages: PackedStringArray
	for entry in EditorTranslationParserPlugin.parse(files, builtin):
		var msgctxt: String = entry[1]
		if not msgctxt.is_empty():
			printerr("CSV does not support message context")
			continue
		var msgid: String = entry[0]
		if msgid not in messages:
			messages.append(msgid)
	
	var csv := FileAccess.open("res://test.csv", FileAccess.WRITE)
	csv.store_csv_line(["key", "fr", "es", "ja", "zh"])
	for message in messages:
		csv.store_csv_line([message, "", "", "", ""])
```

To only extract built-in strings, call `parse([], true)`.

The method is added as a static method of `EditorTranslationParserPlugin` to avoid bloating `EditorPlugin`. Suggestions are welcome.