### PR TITLE
Fix `Control` nodes cull rect not taking into account draw commands

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -4611,8 +4611,11 @@ void Control::_notification(int p_notification) {
 
 		case NOTIFICATION_DRAW: {
 			_update_canvas_item_transform();
-			RenderingServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), !data.disable_visibility_clip, Rect2(Point2(), get_size()));
-			RenderingServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), data.clip_contents);
+
+			RID ci = get_canvas_item();
+			RenderingServer::get_singleton()->canvas_item_set_custom_rect(ci, !data.disable_visibility_clip, Rect2(Point2(), get_size()));
+			RenderingServer::get_singleton()->canvas_item_set_merge_custom_rect(ci, !data.disable_visibility_clip);
+			RenderingServer::get_singleton()->canvas_item_set_clip(ci, data.clip_contents);
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -684,6 +684,14 @@ void RendererCanvasCull::canvas_item_set_custom_rect(RID p_item, bool p_custom_r
 
 	canvas_item->custom_rect = p_custom_rect;
 	canvas_item->rect = p_rect;
+	canvas_item->custom_rect_value = p_rect;
+}
+
+void RendererCanvasCull::canvas_item_set_merge_custom_rect(RID p_item, bool p_merge_custom_rect) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	canvas_item->merge_custom_rect = p_merge_custom_rect;
 }
 
 void RendererCanvasCull::canvas_item_set_modulate(RID p_item, const Color &p_color) {

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -249,6 +249,7 @@ public:
 	void canvas_item_set_clip(RID p_item, bool p_clip);
 	void canvas_item_set_distance_field_mode(RID p_item, bool p_enable);
 	void canvas_item_set_custom_rect(RID p_item, bool p_custom_rect, const Rect2 &p_rect = Rect2());
+	void canvas_item_set_merge_custom_rect(RID p_item, bool p_merge_custom_rect);
 	void canvas_item_set_modulate(RID p_item, const Color &p_color);
 	void canvas_item_set_self_modulate(RID p_item, const Color &p_color);
 

--- a/servers/rendering/renderer_canvas_render.cpp
+++ b/servers/rendering/renderer_canvas_render.cpp
@@ -35,14 +35,25 @@
 RendererCanvasRender *RendererCanvasRender::singleton = nullptr;
 
 const Rect2 &RendererCanvasRender::Item::get_rect() const {
-	if (custom_rect || (!rect_dirty && !update_when_visible && skeleton == RID())) {
+	bool should_merge_custom = merge_custom_rect && !clip;
+
+	if (custom_rect && !should_merge_custom) {
+		return custom_rect_value;
+	}
+
+	if (!rect_dirty && !update_when_visible && skeleton == RID()) {
 		return rect;
 	}
 
-	//must update rect
+	// Must update rect.
 
 	if (commands == nullptr) {
-		rect = Rect2();
+		if (custom_rect && should_merge_custom) {
+			rect = custom_rect_value;
+		} else {
+			rect = Rect2();
+		}
+
 		rect_dirty = false;
 		return rect;
 	}
@@ -126,6 +137,10 @@ const Rect2 &RendererCanvasRender::Item::get_rect() const {
 			rect = rect.merge(r);
 		}
 		c = c->next;
+	}
+
+	if (custom_rect && should_merge_custom) {
+		rect = rect.merge(custom_rect_value);
 	}
 
 	rect_dirty = false;

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -340,6 +340,8 @@ public:
 		int z_final;
 
 		mutable bool custom_rect;
+		mutable Rect2 custom_rect_value;
+		mutable bool merge_custom_rect;
 		mutable bool rect_dirty;
 		mutable Rect2 rect;
 		RID material;

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -811,6 +811,7 @@ public:
 	virtual void canvas_item_set_clip(RID p_item, bool p_clip) = 0;
 	virtual void canvas_item_set_distance_field_mode(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_custom_rect(RID p_item, bool p_custom_rect, const Rect2 &p_rect = Rect2()) = 0;
+	virtual void canvas_item_set_merge_custom_rect(RID p_item, bool p_merge_custom_rect) = 0;
 	virtual void canvas_item_set_modulate(RID p_item, const Color &p_color) = 0;
 	virtual void canvas_item_set_self_modulate(RID p_item, const Color &p_color) = 0;
 	virtual void canvas_item_set_visibility_layer(RID p_item, uint32_t p_visibility_layer) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1018,6 +1018,7 @@ public:
 	FUNC2(canvas_item_set_clip, RID, bool)
 	FUNC2(canvas_item_set_distance_field_mode, RID, bool)
 	FUNC3(canvas_item_set_custom_rect, RID, bool, const Rect2 &)
+	FUNC2(canvas_item_set_merge_custom_rect, RID, bool)
 	FUNC2(canvas_item_set_modulate, RID, const Color &)
 	FUNC2(canvas_item_set_self_modulate, RID, const Color &)
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/100567
Fixes https://github.com/godotengine/godot/issues/112757
Fixes https://github.com/godotengine/godot/issues/112758

At the root of this issue is that any `Control` sets a custom rect in `NOTIFICATION_DRAW` for the renderer that was only ever as big as its own bounds (Position at (0, 0) and size of the control) causing it to ignore all draw commands due to this guard:

https://github.com/godotengine/godot/blob/20430236e749306e1968656ffdc7f78e502a0ccc/servers/rendering/renderer_canvas_render.cpp#L37-L39

Now the control node merges its own size rect with the draw command rect if applicable.