### PR TITLE
Implement `FPSLOD` for `AnimationMixer`

### DIFF
--- a/doc/classes/AnimationMixer.xml
+++ b/doc/classes/AnimationMixer.xml
@@ -103,6 +103,12 @@
 				Returns the list of stored animation keys.
 			</description>
 		</method>
+		<method name="get_fpslod_current_index_level" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the index of the currently active [FPSLODLevel].
+			</description>
+		</method>
 		<method name="get_root_motion_position" qualifiers="const">
 			<return type="Vector3" />
 			<description>
@@ -313,11 +319,29 @@
 			[b]Note:[/b] In [AnimationTree], the blending with [AnimationNodeAdd2], [AnimationNodeAdd3], [AnimationNodeSub2] or the weight greater than [code]1.0[/code] may produce unexpected results.
 			For example, if [AnimationNodeAdd2] blends two nodes with the amount [code]1.0[/code], then total weight is [code]2.0[/code] but it will be normalized to make the total amount [code]1.0[/code] and the result will be equal to [AnimationNodeBlend2] with the amount [code]0.5[/code].
 		</member>
+		<member name="fps_lod_enable" type="bool" setter="set_fpslod" getter="is_fpslod" default="false">
+			Enables frame skipping using FPSLOD.
+			Animation frames are skipped based on the distance of the active camera and the [member fps_lod_target] node, as well as [FPSLODLevel] levels. This is effective for improving performance when you have multiple animated models overlapping each other.
+			This occurs if [member fps_lod_manual] is set to [code]false[/code], otherwise, frames are always skipped, regardless of the camera. This can be used for manual frame skipping or for specific artistic animation styles.
+		</member>
+		<member name="fps_lod_levels" type="FPSLODLevel[]" setter="set_fpslod_levels" getter="get_fpslod_levels" default="[]">
+			Specifies an array of [FPSLODLevel] used to calculate levels of detail in [b]FPSLOD[/b].
+		</member>
+		<member name="fps_lod_manual" type="bool" setter="set_fpslod_manual" getter="is_fpslod_manual" default="false">
+			Sets the manual frame skipping mode for [b]FPSLOD[/b].
+			See also [member fps_lod_skip_frames].
+		</member>
+		<member name="fps_lod_skip_frames" type="int" setter="set_fpslod_skip_frames" getter="get_fpslod_skip_frames" default="0">
+			Sets the strength of animation frame skipping when [member fps_lod_manual] is [code]true[/code].
+		</member>
+		<member name="fps_lod_target" type="NodePath" setter="set_fpslod_target" getter="get_fpslod_target" default="NodePath(&quot;&quot;)">
+			Specifies the target node to denote the origin of coordinates from which the calculation to the active camera begins when [b]FPSLOD[/b] is enabled.
+		</member>
 		<member name="reset_on_save" type="bool" setter="set_reset_on_save_enabled" getter="is_reset_on_save_enabled" default="true">
 			This is used by the editor. If set to [code]true[/code], the scene will be saved with the effects of the reset animation (the animation with the key [code]"RESET"[/code]) applied as if it had been seeked to time 0, with the editor keeping the values that the scene had before saving.
 			This makes it more convenient to preview and edit animations in the editor, as changes to the scene will not be saved as long as they are set in the reset animation.
 		</member>
-		<member name="root_motion_local" type="bool" setter="set_root_motion_local" getter="is_root_motion_local" default="false">
+		<member name="root_motion_local" type="bool" setter="set_root_motion_local" getter="is_root_motion_local">
 			If [code]true[/code], [method get_root_motion_position] value is extracted as a local translation value before blending. In other words, it is treated like the translation is done after the rotation.
 		</member>
 		<member name="root_motion_track" type="NodePath" setter="set_root_motion_track" getter="get_root_motion_track" default="NodePath(&quot;&quot;)">

--- a/doc/classes/FPSLODLevel.xml
+++ b/doc/classes/FPSLODLevel.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="FPSLODLevel" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A resource responsible for animation detail levels in [AnimationMixer] when using [b]FPSLOD[/b].
+	</brief_description>
+	<description>
+		A resource responsible for animation detail levels in [AnimationMixer] when using [b]FPSLOD[/b].
+		This resource is used to specify at which remote a particular [FPSLODLevel] should be enabled and how many animation frames should be skipped.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="distance" type="float" setter="set_distance" getter="get_distance" default="0.0">
+			The distance at which this level is activated.
+		</member>
+		<member name="skip_frames" type="int" setter="set_skip_frames" getter="get_skip_frames" default="0">
+			The number of frames to skip when activating this level.
+			[b]Skip frames[/b] should be interpreted as [code]N + 1[/code] frames.
+			For example, if set to 2, the animation will be updated every third frame (20 frames per second if the game is running at 60 frames per second).
+		</member>
+	</members>
+</class>

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -43,9 +43,11 @@
 
 #ifndef _3D_DISABLED
 #include "scene/3d/audio_stream_player_3d.h"
+#include "scene/3d/camera_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/3d/skeleton_3d.h"
+#include "scene/main/viewport.h"
 #endif // _3D_DISABLED
 
 #ifdef TOOLS_ENABLED
@@ -116,8 +118,29 @@ void AnimationMixer::_get_property_list(List<PropertyInfo> *p_list) const {
 
 void AnimationMixer::_validate_property(PropertyInfo &p_property) const {
 #ifdef TOOLS_ENABLED // `editing` is surrounded by TOOLS_ENABLED so this should also be.
-	if (Engine::get_singleton()->is_editor_hint() && editing && (p_property.name == "active" || p_property.name == "deterministic" || p_property.name == "root_motion_track")) {
-		p_property.usage |= PROPERTY_USAGE_READ_ONLY;
+	if (Engine::get_singleton()->is_editor_hint()) {
+		if (editing && (p_property.name == "active" || p_property.name == "deterministic" || p_property.name == "root_motion_track")) {
+			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
+		}
+		if (!fps_lod) {
+			if (p_property.name == "fps_lod_target" ||
+					p_property.name == "fps_lod_levels" ||
+					p_property.name == "fps_lod_manual" ||
+					p_property.name == "fps_lod_skip_frames") {
+				p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+			}
+		} else {
+			if (fps_lod_manual) {
+				if (p_property.name == "fps_lod_target" ||
+						p_property.name == "fps_lod_levels") {
+					p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+				}
+			} else {
+				if (p_property.name == "fps_lod_skip_frames") {
+					p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+				}
+			}
+		}
 	}
 #endif // TOOLS_ENABLED
 	if (root_motion_track.is_empty() && p_property.name == "root_motion_local") {
@@ -990,6 +1013,68 @@ void AnimationMixer::_process_animation(double p_delta, bool p_update_only) {
 		emit_signal(SNAME("mixer_applied"));
 	};
 	clear_animation_instances();
+}
+
+void AnimationMixer::_process_fpslod(double p_delta) {
+	if (!fps_lod_manual) {
+		Node *n = get_node_or_null(lod_target_path);
+		Node3D *target = Object::cast_to<Node3D>(n);
+		if (target != lod_target) {
+			lod_target = target;
+		}
+
+		if (lod_target && fpslod_levels.size() > 0) {
+			double dist = 0.0;
+			Camera3D *cam = get_viewport()->get_camera_3d();
+			dist = lod_target->get_global_position().distance_to(cam->get_global_position());
+			if (cam->get_projection() == Camera3D::PROJECTION_PERSPECTIVE) {
+				double base_fov = 75.0;
+				double current_fov = cam->get_fov();
+				double fov_factor = current_fov / base_fov;
+				dist *= fov_factor;
+			} else if (cam->get_projection() == Camera3D::PROJECTION_ORTHOGONAL) {
+				double base_size = 10.0;
+				double current_size = cam->get_size();
+				double ortho_factor = current_size / base_size;
+				dist *= ortho_factor;
+			}
+
+			int lod_index = _get_fpslod_for_distance(dist);
+			Ref<FPSLODLevel> first_lvl = fpslod_levels[0];
+			current_lod_index = 0;
+			if (!first_lvl.is_valid()) {
+				return;
+			}
+
+			double min_dist = first_lvl->get_distance();
+			if (dist < min_dist) {
+				skip_frames_fpslod = 0;
+			} else if (lod_index >= 0) {
+				Ref<FPSLODLevel> lvl = fpslod_levels[lod_index];
+				if (lvl.is_valid() && current_lod_index != lod_index) {
+					skip_frames_fpslod = lvl->get_skip_frames();
+					current_lod_index = lod_index;
+				}
+			}
+		}
+	}
+
+	frame_time_accum -= frame_time_history[frame_time_index];
+	frame_time_accum += p_delta;
+	frame_time_history[frame_time_index] = p_delta;
+	frame_time_index = (frame_time_index + 1) % FRAME_HISTORY_SIZE;
+	average_frame_time = frame_time_accum / FRAME_HISTORY_SIZE;
+
+	tick_fpslod += 1.0;
+
+	if (skip_frames_fpslod <= 0) {
+		_process_animation(p_delta);
+		tick_fpslod = 0.0;
+	} else if (tick_fpslod >= skip_frames_fpslod) {
+		double time_to_play = average_frame_time * (tick_fpslod);
+		_process_animation(time_to_play);
+		tick_fpslod = 0.0;
+	}
 }
 
 Variant AnimationMixer::_post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant &p_value, ObjectID p_object_id, int p_object_sub_idx) {
@@ -2059,6 +2144,81 @@ void AnimationMixer::clear_caches() {
 	_clear_caches();
 }
 
+void AnimationMixer::set_fpslod(bool p_enabled) {
+	fps_lod = p_enabled;
+	notify_property_list_changed();
+}
+
+bool AnimationMixer::is_fpslod() const {
+	return fps_lod;
+}
+
+void AnimationMixer::set_fpslod_manual(bool p_enabled) {
+	fps_lod_manual = p_enabled;
+	if (p_enabled) {
+		current_lod_index = -1;
+	}
+	notify_property_list_changed();
+}
+
+bool AnimationMixer::is_fpslod_manual() const {
+	return fps_lod_manual;
+}
+
+void AnimationMixer::set_fpslod_skip_frames(int frames) {
+	if (fps_lod_manual) {
+		skip_frames_fpslod = frames;
+	}
+}
+
+int AnimationMixer::get_fpslod_skip_frames() const {
+	return skip_frames_fpslod;
+}
+
+void AnimationMixer::set_fpslod_target(const NodePath &p_path) {
+	lod_target_path = p_path;
+	if (is_inside_tree()) {
+		Node *n = get_node_or_null(p_path);
+		lod_target = Object::cast_to<Node3D>(n);
+	}
+}
+
+NodePath AnimationMixer::get_fpslod_target() const {
+	return lod_target_path;
+}
+
+void AnimationMixer::set_fpslod_levels(const TypedArray<FPSLODLevel> &p_levels) {
+	fpslod_levels = p_levels;
+}
+
+TypedArray<FPSLODLevel> AnimationMixer::get_fpslod_levels() const {
+	return fpslod_levels;
+}
+
+int AnimationMixer::get_fpslod_current_index_level() const {
+	return current_lod_index;
+}
+
+int AnimationMixer::_get_fpslod_for_distance(double dist) const {
+	int best = -1;
+	for (int i = 0; i < fpslod_levels.size(); i++) {
+		Ref<FPSLODLevel> lvl = fpslod_levels[i];
+		if (!lvl.is_valid()) {
+			continue;
+		}
+
+		if (dist < lvl->get_distance()) {
+			best = i;
+			break;
+		}
+	}
+
+	if (best == -1 && fpslod_levels.size() > 0) {
+		best = fpslod_levels.size() - 1;
+	}
+	return best;
+}
+
 /* -------------------------------------------- */
 /* -- Root motion ----------------------------- */
 /* -------------------------------------------- */
@@ -2347,14 +2507,22 @@ void AnimationMixer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			if (active && callback_mode_process == ANIMATION_CALLBACK_MODE_PROCESS_IDLE) {
-				_process_animation(get_process_delta_time());
+			if (active) {
+				if (fps_lod) {
+					_process_fpslod(get_process_delta_time());
+				} else if (callback_mode_process == ANIMATION_CALLBACK_MODE_PROCESS_IDLE) {
+					_process_animation(get_process_delta_time());
+				}
 			}
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			if (active && callback_mode_process == ANIMATION_CALLBACK_MODE_PROCESS_PHYSICS) {
-				_process_animation(get_physics_process_delta_time());
+			if (active) {
+				if (fps_lod) {
+					_process_fpslod(get_physics_process_delta_time());
+				} else if (callback_mode_process == ANIMATION_CALLBACK_MODE_PROCESS_PHYSICS) {
+					_process_animation(get_physics_process_delta_time());
+				}
 			}
 		} break;
 
@@ -2418,6 +2586,22 @@ void AnimationMixer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_callback_mode_discrete", "mode"), &AnimationMixer::set_callback_mode_discrete);
 	ClassDB::bind_method(D_METHOD("get_callback_mode_discrete"), &AnimationMixer::get_callback_mode_discrete);
 
+	ClassDB::bind_method(D_METHOD("set_fpslod", "enable"), &AnimationMixer::set_fpslod);
+	ClassDB::bind_method(D_METHOD("is_fpslod"), &AnimationMixer::is_fpslod);
+
+	ClassDB::bind_method(D_METHOD("set_fpslod_manual", "enable"), &AnimationMixer::set_fpslod_manual);
+	ClassDB::bind_method(D_METHOD("is_fpslod_manual"), &AnimationMixer::is_fpslod_manual);
+
+	ClassDB::bind_method(D_METHOD("set_fpslod_target", "path"), &AnimationMixer::set_fpslod_target);
+	ClassDB::bind_method(D_METHOD("get_fpslod_target"), &AnimationMixer::get_fpslod_target);
+
+	ClassDB::bind_method(D_METHOD("set_fpslod_levels", "levels"), &AnimationMixer::set_fpslod_levels);
+	ClassDB::bind_method(D_METHOD("get_fpslod_levels"), &AnimationMixer::get_fpslod_levels);
+
+	ClassDB::bind_method(D_METHOD("get_fpslod_current_index_level"), &AnimationMixer::get_fpslod_current_index_level);
+	ClassDB::bind_method(D_METHOD("set_fpslod_skip_frames", "frames"), &AnimationMixer::set_fpslod_skip_frames);
+	ClassDB::bind_method(D_METHOD("get_fpslod_skip_frames"), &AnimationMixer::get_fpslod_skip_frames);
+
 	/* ---- Audio ---- */
 	ClassDB::bind_method(D_METHOD("set_audio_max_polyphony", "max_polyphony"), &AnimationMixer::set_audio_max_polyphony);
 	ClassDB::bind_method(D_METHOD("get_audio_max_polyphony"), &AnimationMixer::get_audio_max_polyphony);
@@ -2451,6 +2635,13 @@ void AnimationMixer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deterministic"), "set_deterministic", "is_deterministic");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reset_on_save", PROPERTY_HINT_NONE, ""), "set_reset_on_save_enabled", "is_reset_on_save_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "root_node"), "set_root_node", "get_root_node");
+
+	ADD_GROUP("FPS LOD", "fps_lod");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fps_lod_enable"), "set_fpslod", "is_fpslod");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fps_lod_manual"), "set_fpslod_manual", "is_fpslod_manual");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "fps_lod_skip_frames", PROPERTY_HINT_RANGE, "0,60,1"), "set_fpslod_skip_frames", "get_fpslod_skip_frames");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "fps_lod_target", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node3D"), "set_fpslod_target", "get_fpslod_target");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "fps_lod_levels", PROPERTY_HINT_ARRAY_TYPE, "FPSLODLevel", PROPERTY_USAGE_DEFAULT, "FPSLODLevel"), "set_fpslod_levels", "get_fpslod_levels");
 
 	ADD_GROUP("Root Motion", "root_motion_");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "root_motion_track"), "set_root_motion_track", "get_root_motion_track");

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -36,6 +36,7 @@
 #include "scene/resources/animation.h"
 #include "scene/resources/animation_library.h"
 #include "scene/resources/audio_stream_polyphonic.h"
+#include "scene/resources/fpslod_level.h"
 
 class AnimatedValuesBackup;
 
@@ -137,6 +138,23 @@ protected:
 	bool active = true;
 
 	void _set_process(bool p_process, bool p_force = false);
+
+	// FPSLOD
+	bool fps_lod = false;
+	int tick_fpslod = 0;
+	int skip_frames_fpslod = 0;
+	bool fps_lod_manual = false;
+
+	NodePath lod_target_path;
+	Node3D *lod_target = nullptr;
+	TypedArray<FPSLODLevel> fpslod_levels;
+	int current_lod_index = -1;
+
+	static const int FRAME_HISTORY_SIZE = 16;
+	double frame_time_history[FRAME_HISTORY_SIZE] = {};
+	int frame_time_index = 0;
+	double frame_time_accum = 0.0;
+	double average_frame_time = 0.016;
 
 	/* ---- Caches for blending ---- */
 	bool cache_valid = false;
@@ -341,7 +359,7 @@ protected:
 	virtual uint32_t _get_libraries_property_usage() const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &p_property) const;
+	void _validate_property(PropertyInfo &p_property) const;
 
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
@@ -357,6 +375,7 @@ protected:
 
 	/* ---- Blending processor ---- */
 	virtual void _process_animation(double p_delta, bool p_update_only = false);
+	void _process_fpslod(double p_delta);
 
 	// For post process with retrieved key value during blending.
 	virtual Variant _post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant &p_value, ObjectID p_object_id, int p_object_sub_idx = -1);
@@ -433,6 +452,19 @@ public:
 
 	void set_callback_mode_discrete(AnimationCallbackModeDiscrete p_mode);
 	AnimationCallbackModeDiscrete get_callback_mode_discrete() const;
+
+	void set_fpslod(bool p_enabled);
+	bool is_fpslod() const;
+	void set_fpslod_manual(bool p_enabled);
+	bool is_fpslod_manual() const;
+	void set_fpslod_skip_frames(int frames);
+	int get_fpslod_skip_frames() const;
+	void set_fpslod_target(const NodePath &p_path);
+	NodePath get_fpslod_target() const;
+	void set_fpslod_levels(const TypedArray<FPSLODLevel> &p_levels);
+	TypedArray<FPSLODLevel> get_fpslod_levels() const;
+	int get_fpslod_current_index_level() const;
+	int _get_fpslod_for_distance(double dist) const;
 
 	/* ---- Audio ---- */
 	void set_audio_max_polyphony(int p_audio_max_polyphony);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -141,7 +141,7 @@ private:
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
-	virtual void _validate_property(PropertyInfo &p_property) const override;
+	virtual void _validate_property(PropertyInfo &p_property) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -314,7 +314,7 @@ private:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	virtual uint32_t _get_libraries_property_usage() const override;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
-	virtual void _validate_property(PropertyInfo &p_property) const override;
+	virtual void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 
 	static void _bind_methods();

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -122,6 +122,7 @@
 #include "scene/resources/environment.h"
 #include "scene/resources/external_texture.h"
 #include "scene/resources/font.h"
+#include "scene/resources/fpslod_level.h"
 #include "scene/resources/gradient.h"
 #include "scene/resources/gradient_texture.h"
 #include "scene/resources/image_texture.h"
@@ -586,6 +587,8 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AnimationNodeTimeScale);
 	GDREGISTER_CLASS(AnimationNodeTimeSeek);
 	GDREGISTER_CLASS(AnimationNodeTransition);
+
+	GDREGISTER_CLASS(FPSLODLevel);
 
 	GDREGISTER_CLASS(ShaderGlobalsOverride); // can be used in any shader
 

--- a/scene/resources/fpslod_level.h
+++ b/scene/resources/fpslod_level.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  fpslod_level.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource.h"
+
+class FPSLODLevel : public Resource {
+	GDCLASS(FPSLODLevel, Resource);
+
+	double distance = 0.0;
+	int skip_frames = 0;
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("set_distance", "value"), &FPSLODLevel::set_distance);
+		ClassDB::bind_method(D_METHOD("get_distance"), &FPSLODLevel::get_distance);
+		ClassDB::bind_method(D_METHOD("set_skip_frames", "value"), &FPSLODLevel::set_skip_frames);
+		ClassDB::bind_method(D_METHOD("get_skip_frames"), &FPSLODLevel::get_skip_frames);
+
+		ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "distance", PROPERTY_HINT_RANGE, "0,10000,0.1"), "set_distance", "get_distance");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "skip_frames", PROPERTY_HINT_RANGE, "0,60,1"), "set_skip_frames", "get_skip_frames");
+	}
+
+public:
+	void set_distance(double p_value) { distance = p_value; }
+	double get_distance() const { return distance; }
+
+	void set_skip_frames(int p_value) { skip_frames = p_value; }
+	int get_skip_frames() const { return skip_frames; }
+};


### PR DESCRIPTION
Partially covers: [Implement animation update slicing for animations and bones](https://github.com/godotengine/godot-proposals/issues/12142)
Possibly solves for: #90943 , #88954 , #99194

This adds FPSLOD to optimize animations, this is especially useful for crowd animation, tests have shown a big performance boost, even when implemented with GDScript.
I also added a manual FPSLOD processing mode for specific tasks.

<img width="475" height="556" alt="1" src="https://github.com/user-attachments/assets/2b23a78f-a435-404c-87af-64db7d97053a" />


This also adds the ability to dynamically use frame-by-frame animation in 3D, without complex solutions, such as those described by Blender Studio [here](https://godotengine.org/article/godot-showcase-dogwalk/#were-there-any-quirks-with-the-way-the-material-rendering-and-animations-were-converted-from-blender-to-godot).

**How it works:**
When FPSLOD is enabled, we add new `FPSLODLevel` parameters, which store the distance to activate a given LOD level, as well as the number of frames to skip for animations.
For example, we have the following levels:
```
Level 0: Distance=10, Skip Frames: 4
Level 1: Distance=20, Skip Frames: 6
Level 2: Distance=25, Skip Frames: 15
```
Consequently, if the active camera is at a distance of 25.0, `AnimationMixer` will skip 15 animation frames, which will reduce CPU load by reducing the number of animation update calls.

https://github.com/user-attachments/assets/74d76587-e6e1-4d0a-98e5-cd7f4aaa224d


**Test Project:**
[test-fpslod.zip](https://github.com/user-attachments/files/22984737/test-fpslod.zip)