### PR TITLE
Add support for delta encoding to patch PCKs (using bsdiff)

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -53,6 +53,20 @@ Comment: Godot Engine logo
 Copyright: 2017, Andrea Calabró
 License: CC-BY-4.0
 
+Files: core/io/delta_patch_reader.cpp
+Comment: Android/ChromiumOS bsdiff fork
+Copyright: 2017, The Chromium OS Authors
+ 2014-present, Godot Engine contributors
+ 2007-2014, Juan Linietsky, Ariel Manzur
+License: BSD-3-clause
+
+Files: core/io/delta_patch_writer.cpp
+Comment: Android/ChromiumOS bsdiff fork
+Copyright: 2017, The Chromium OS Authors
+ 2014-present, Godot Engine contributors
+ 2007-2014, Juan Linietsky, Ariel Manzur
+License: BSD-3-clause
+
 Files: core/math/convex_hull.cpp
  core/math/convex_hull.h
 Comment: Bullet Continuous Collision Detection and Physics Library
@@ -222,6 +236,12 @@ Comment: Brotli
 Copyright: 2009, 2010, 2013-2016 by the Brotli Authors.
 License: Expat
 
+Files: thirdparty/bsdiff/*
+Comment: bsdiff
+Copyright: 2003-2005, Colin Percival.
+ 2015, The Chromium OS Authors.
+License: BSD-3-clause
+
 Files: thirdparty/certs/ca-certificates.crt
 Comment: CA certificates
 Copyright: Mozilla Contributors
@@ -352,6 +372,11 @@ Files: thirdparty/libbacktrace/*
 Comment: libbacktrace
 Copyright: 2012-2021, Free Software Foundation, Inc.
 License: BSD-3-clause
+
+Files: thirdparty/libdivsufsort/*
+Comment: libdivsufsort
+Copyright: 2003, Yuta Mori.
+License: Expat
 
 Files: thirdparty/libjpeg-turbo/*
 Comment: libjpeg-turbo

--- a/core/SCsub
+++ b/core/SCsub
@@ -159,6 +159,41 @@ if env["builtin_zstd"]:
 
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_zstd_sources)
 
+# libdivsufsort library, needed for bsdiff below
+thirdparty_divsufsort_dir = "#thirdparty/libdivsufsort/"
+thirdparty_divsufsort_sources = [
+    "lib/divsufsort.c",
+    "lib/sssort.c",
+    "lib/trsort.c",
+    "lib/utils.c",
+]
+thirdparty_divsufsort_sources = [thirdparty_divsufsort_dir + file for file in thirdparty_divsufsort_sources]
+env_thirdparty.Prepend(CPPPATH=[thirdparty_divsufsort_dir + "include"])
+env.Prepend(CPPPATH=[thirdparty_divsufsort_dir + "include"])
+env_divsufsort32 = env_thirdparty.Clone()
+env_divsufsort32["OBJSUFFIX"] = f"_32{env_divsufsort32['OBJSUFFIX']}"
+env_divsufsort32.Append(CPPDEFINES=["HAVE_CONFIG_H=1"])
+env_divsufsort32.add_source_files(thirdparty_obj, thirdparty_divsufsort_sources)
+env_divsufsort64 = env_thirdparty.Clone()
+env_divsufsort64["OBJSUFFIX"] = f"_64{env_divsufsort64['OBJSUFFIX']}"
+env_divsufsort64.Append(CPPDEFINES=["HAVE_CONFIG_H=1", "BUILD_DIVSUFSORT64"])
+env_divsufsort64.add_source_files(thirdparty_obj, thirdparty_divsufsort_sources)
+
+# bsdiff library
+thirdparty_bsdiff_dir = "#thirdparty/bsdiff/"
+thirdparty_bsdiff_sources = [
+    "bsdiff/bsdiff.cc",
+    "bsdiff/bspatch.cc",
+    "bsdiff/diff_encoder.cc",
+    "bsdiff/logging.cc",
+    "bsdiff/suffix_array_index.cc",
+]
+thirdparty_bsdiff_sources = [thirdparty_bsdiff_dir + file for file in thirdparty_bsdiff_sources]
+env_thirdparty.Prepend(CPPPATH=[thirdparty_bsdiff_dir, thirdparty_bsdiff_dir + "bsdiff/include"])
+env.Prepend(CPPPATH=[thirdparty_bsdiff_dir + "bsdiff/include"])
+env_thirdparty.Append(CPPDEFINES=["BSDIFF_EXPORT="])
+env.Append(CPPDEFINES=["BSDIFF_EXPORT="])
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_bsdiff_sources)
 
 env.core_sources += thirdparty_obj
 

--- a/core/io/delta_patch_file_interface.cpp
+++ b/core/io/delta_patch_file_interface.cpp
@@ -1,0 +1,65 @@
+/**************************************************************************/
+/*  delta_patch_file_interface.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "delta_patch_file_interface.h"
+
+bool DeltaPatchFileInterface::Read(void *p_data, size_t p_size, size_t *p_bytes_read) {
+	*p_bytes_read = file->get_buffer(static_cast<uint8_t *>(p_data), p_size);
+	return true;
+}
+
+bool DeltaPatchFileInterface::Write(const void *p_data, size_t p_count, size_t *p_bytes_written) {
+	if (!file->store_buffer(static_cast<const uint8_t *>(p_data), p_count)) {
+		*p_bytes_written = 0;
+		return false;
+	}
+
+	*p_bytes_written = p_count;
+	return true;
+}
+
+bool DeltaPatchFileInterface::Seek(int64_t p_pos) {
+	file->seek(p_pos);
+	return true;
+}
+
+bool DeltaPatchFileInterface::Close() {
+	file->close();
+	return true;
+}
+
+bool DeltaPatchFileInterface::GetSize(uint64_t *p_size) {
+	*p_size = file->get_length();
+	return true;
+}
+
+DeltaPatchFileInterface::DeltaPatchFileInterface(const Ref<FileAccess> &p_file) :
+		file(p_file) {
+}

--- a/core/io/delta_patch_file_interface.h
+++ b/core/io/delta_patch_file_interface.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  delta_patch_file_interface.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/file_access.h"
+
+#include <bsdiff/file_interface.h>
+
+class DeltaPatchFileInterface final : public bsdiff::FileInterface {
+	Ref<FileAccess> file;
+
+public:
+	virtual bool Read(void *p_data, size_t p_size, size_t *p_bytes_read) override;
+
+	virtual bool Write(const void *p_data, size_t p_count, size_t *p_bytes_written) override;
+
+	virtual bool Seek(int64_t p_pos) override;
+
+	virtual bool Close() override;
+
+	virtual bool GetSize(uint64_t *p_size) override;
+
+	DeltaPatchFileInterface(const Ref<FileAccess> &p_file);
+
+	virtual ~DeltaPatchFileInterface() = default;
+};

--- a/core/io/delta_patch_reader.cpp
+++ b/core/io/delta_patch_reader.cpp
@@ -1,0 +1,229 @@
+/**************************************************************************/
+/*  delta_patch_reader.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+/*
+Adapted to Godot from the Android fork (originally ChromiumOS fork) of the bsdiff project.
+*/
+
+/*
+Copyright 2017 The Chromium OS Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or
+	 other materials provided with the distribution.
+   * Neither the name of Google Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific
+	 prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "delta_patch_reader.h"
+
+#include "core/crypto/crypto_core.h"
+#include "core/io/delta_patch_writer.h"
+#include "core/io/file_access_memory.h"
+
+#include <string.h>
+#include <zstd.h>
+
+bool DeltaPatchReader::stream_decompress(ZSTD_DStream *p_stream, Span<uint8_t> p_input, size_t *p_input_pos, uint8_t *p_output, size_t p_output_size) {
+	ZSTD_inBuffer input_buf = {};
+	input_buf.src = p_input.ptr();
+	input_buf.size = p_input.size();
+	input_buf.pos = *p_input_pos;
+
+	ZSTD_outBuffer output_buf = {};
+	output_buf.dst = p_output;
+	output_buf.size = p_output_size;
+	output_buf.pos = 0;
+
+	while (output_buf.pos < output_buf.size && input_buf.pos < input_buf.size) {
+		size_t result = ZSTD_decompressStream(p_stream, &output_buf, &input_buf);
+		ERR_FAIL_COND_V(ZSTD_isError(result), false);
+
+		if (result == 0) {
+			break;
+		}
+	}
+
+	*p_input_pos = input_buf.pos;
+	return output_buf.pos == output_buf.size;
+}
+
+int64_t DeltaPatchReader::decode_int64(const uint8_t *p_src) {
+	int64_t value;
+	memcpy(&value, p_src, sizeof(int64_t));
+#ifdef BIG_ENDIAN_ENABLED
+	value = BSWAP64(value);
+#endif
+	return value;
+}
+
+bool DeltaPatchReader::matches_old_md5(Span<uint8_t> p_data) {
+	uint8_t data_md5[16];
+	Error err = CryptoCore::md5(p_data.ptr(), p_data.size(), data_md5);
+	ERR_FAIL_COND_V(err != OK, false);
+	return memcmp(data_md5, old_file_md5, 16) == 0;
+}
+
+bool DeltaPatchReader::matches_new_md5(Span<uint8_t> p_data) {
+	uint8_t data_md5[16];
+	Error err = CryptoCore::md5(p_data.ptr(), p_data.size(), data_md5);
+	ERR_FAIL_COND_V(err != OK, false);
+	return memcmp(data_md5, new_file_md5, 16) == 0;
+}
+
+int64_t DeltaPatchReader::read_new_file_size(Span<uint8_t> p_patch_data) {
+	int64_t signed_new_file_size = decode_int64(p_patch_data.ptr() + 17);
+	ERR_FAIL_COND_V_MSG(signed_new_file_size < 0, 0, "Patch is corrupt.");
+	return signed_new_file_size;
+}
+
+bool DeltaPatchReader::Init(const uint8_t *p_patch_data, size_t p_patch_size) {
+	ERR_FAIL_COND_V(ctrl_stream != nullptr, false);
+	ERR_FAIL_COND_V(diff_stream != nullptr, false);
+	ERR_FAIL_COND_V(extra_stream != nullptr, false);
+
+	ctrl_buffer.clear();
+	diff_buffer.clear();
+	extra_buffer.clear();
+
+	memset(old_file_md5, 0, 16);
+	memset(new_file_md5, 0, 16);
+
+	new_size = 0;
+
+	ctrl_stream_pos = 0;
+	diff_stream_pos = 0;
+	extra_stream_pos = 0;
+
+	ERR_FAIL_COND_V_MSG(p_patch_size < DELTA_PATCH_HEADER_SIZE, false, "Patch is corrupt.");
+
+	Ref<FileAccessMemory> patch_file;
+	patch_file.instantiate();
+	patch_file->open_custom(p_patch_data, p_patch_size);
+
+	uint8_t version_number = patch_file->get_8();
+	ERR_FAIL_COND_V_MSG(version_number != DELTA_PATCH_VERSION_NUMBER, false, vformat("Unexpected version number '%d', expected '%d'.", version_number, DELTA_PATCH_VERSION_NUMBER));
+
+	int64_t ctrl_buffer_size = patch_file->get_64();
+	ERR_FAIL_COND_V_MSG(ctrl_buffer_size < 0, false, "Patch is corrupt.");
+	ERR_FAIL_COND_V_MSG(static_cast<int64_t>(p_patch_size) - DELTA_PATCH_HEADER_SIZE < ctrl_buffer_size, false, "Patch is corrupt.");
+
+	int64_t diff_buffer_size = patch_file->get_64();
+	ERR_FAIL_COND_V_MSG(diff_buffer_size < 0, false, "Patch is corrupt.");
+	ERR_FAIL_COND_V_MSG(static_cast<int64_t>(p_patch_size) - DELTA_PATCH_HEADER_SIZE - ctrl_buffer_size < diff_buffer_size, false, "Patch is corrupt.");
+
+	int64_t signed_new_file_size = patch_file->get_64();
+	ERR_FAIL_COND_V_MSG(signed_new_file_size < 0, false, "Patch is corrupt.");
+	new_size = signed_new_file_size;
+
+	patch_file->get_buffer(old_file_md5, 16);
+	patch_file->get_buffer(new_file_md5, 16);
+
+	ctrl_buffer.resize(ctrl_buffer_size);
+	patch_file->get_buffer(ctrl_buffer.ptr(), ctrl_buffer.size());
+
+	diff_buffer.resize(diff_buffer_size);
+	patch_file->get_buffer(diff_buffer.ptr(), diff_buffer.size());
+
+	uint64_t extra_buffer_size = patch_file->get_length() - patch_file->get_position();
+	extra_buffer.resize(extra_buffer_size);
+	patch_file->get_buffer(extra_buffer.ptr(), extra_buffer.size());
+
+	ctrl_stream = ZSTD_createDStream();
+	ERR_FAIL_NULL_V(ctrl_stream, false);
+
+	diff_stream = ZSTD_createDStream();
+	ERR_FAIL_NULL_V(diff_stream, false);
+
+	extra_stream = ZSTD_createDStream();
+	ERR_FAIL_NULL_V(extra_stream, false);
+
+	size_t result = ZSTD_initDStream(ctrl_stream);
+	ERR_FAIL_COND_V(ZSTD_isError(result), false);
+
+	result = ZSTD_initDStream(diff_stream);
+	ERR_FAIL_COND_V(ZSTD_isError(result), false);
+
+	result = ZSTD_initDStream(extra_stream);
+	ERR_FAIL_COND_V(ZSTD_isError(result), false);
+
+	return true;
+}
+
+bool DeltaPatchReader::ParseControlEntry(ControlEntry *p_control_entry) {
+	uint8_t ctrl[24];
+	bool success = stream_decompress(ctrl_stream, ctrl_buffer, &ctrl_stream_pos, ctrl, sizeof(ctrl));
+	ERR_FAIL_COND_V(!success, false);
+
+	p_control_entry->diff_size = decode_int64(ctrl);
+	p_control_entry->extra_size = decode_int64(ctrl + 8);
+	p_control_entry->offset_increment = decode_int64(ctrl + 16);
+
+	return true;
+}
+
+bool DeltaPatchReader::ReadDiffStream(uint8_t *p_data, size_t p_size) {
+	return stream_decompress(diff_stream, diff_buffer, &diff_stream_pos, p_data, p_size);
+}
+
+bool DeltaPatchReader::ReadExtraStream(uint8_t *p_data, size_t p_size) {
+	return stream_decompress(extra_stream, extra_buffer, &extra_stream_pos, p_data, p_size);
+}
+
+bool DeltaPatchReader::Finish() {
+	if (ctrl_stream != nullptr) {
+		ZSTD_freeDStream(ctrl_stream);
+		ctrl_stream = nullptr;
+	}
+
+	if (diff_stream != nullptr) {
+		ZSTD_freeDStream(diff_stream);
+		diff_stream = nullptr;
+	}
+
+	if (extra_stream != nullptr) {
+		ZSTD_freeDStream(extra_stream);
+		extra_stream = nullptr;
+	}
+
+	return true;
+}
+
+DeltaPatchReader::~DeltaPatchReader() {
+	Finish();
+}

--- a/core/io/delta_patch_reader.h
+++ b/core/io/delta_patch_reader.h
@@ -1,0 +1,83 @@
+/**************************************************************************/
+/*  delta_patch_reader.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+#include "core/templates/local_vector.h"
+
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wshadow")
+#include <bsdiff/patch_reader_interface.h>
+#include <zstd.h>
+GODOT_GCC_WARNING_POP
+
+class DeltaPatchReader final : public bsdiff::PatchReaderInterface {
+public:
+	typedef LocalVector<uint8_t, uint64_t> ByteBuffer;
+
+private:
+	ByteBuffer ctrl_buffer;
+	ByteBuffer diff_buffer;
+	ByteBuffer extra_buffer;
+
+	uint8_t old_file_md5[16];
+	uint8_t new_file_md5[16];
+
+	ZSTD_DStream *ctrl_stream = nullptr;
+	ZSTD_DStream *diff_stream = nullptr;
+	ZSTD_DStream *extra_stream = nullptr;
+
+	uint64_t new_size = 0;
+
+	size_t ctrl_stream_pos = 0;
+	size_t diff_stream_pos = 0;
+	size_t extra_stream_pos = 0;
+
+	static bool stream_decompress(ZSTD_DStream *p_stream, Span<uint8_t> p_input, size_t *p_input_pos, uint8_t *p_output, size_t p_output_size);
+	static int64_t decode_int64(const uint8_t *p_src);
+
+public:
+	bool matches_old_md5(Span<uint8_t> p_data);
+	bool matches_new_md5(Span<uint8_t> p_data);
+
+	static int64_t read_new_file_size(Span<uint8_t> p_patch_data);
+
+	virtual bool Init(const uint8_t *p_patch_data, size_t p_patch_size) override;
+
+	virtual bool ParseControlEntry(ControlEntry *p_control_entry) override;
+	virtual bool ReadDiffStream(uint8_t *p_data, size_t p_size) override;
+	virtual bool ReadExtraStream(uint8_t *p_data, size_t p_size) override;
+
+	virtual uint64_t new_file_size() const override { return new_size; }
+
+	virtual bool Finish() override;
+
+	virtual ~DeltaPatchReader();
+};

--- a/core/io/delta_patch_writer.cpp
+++ b/core/io/delta_patch_writer.cpp
@@ -1,0 +1,200 @@
+/**************************************************************************/
+/*  delta_patch_writer.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+/*
+Adapted to Godot from the Android fork (originally ChromiumOS fork) of the bsdiff project.
+*/
+
+/*
+Copyright 2017 The Chromium OS Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or
+	 other materials provided with the distribution.
+   * Neither the name of Google Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific
+	 prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "delta_patch_writer.h"
+
+#include "core/io/compression.h"
+
+#include <string.h>
+#include <zstd.h>
+
+bool DeltaPatchWriter::stream_compress(ZSTD_CStream *p_stream, Span<uint8_t> p_input, ByteBuffer &p_output) {
+	ZSTD_inBuffer input_buf = {};
+	input_buf.src = p_input.ptr();
+	input_buf.size = p_input.size();
+	input_buf.pos = 0;
+
+	while (input_buf.pos < input_buf.size) {
+		ZSTD_outBuffer output_buffer = {};
+		output_buffer.dst = tmp_buffer.ptr();
+		output_buffer.size = tmp_buffer.size();
+		output_buffer.pos = 0;
+
+		size_t result = ZSTD_compressStream(p_stream, &output_buffer, &input_buf);
+		ERR_FAIL_COND_V(ZSTD_isError(result), false);
+
+		uint64_t old_size = p_output.size();
+		p_output.resize(old_size + output_buffer.pos);
+		memcpy(p_output.ptr() + old_size, tmp_buffer.ptr(), output_buffer.pos);
+	}
+
+	return true;
+}
+
+bool DeltaPatchWriter::stream_end(ZSTD_CStream *p_stream, ByteBuffer &p_output) {
+	ZSTD_outBuffer output_buffer = {};
+	output_buffer.dst = tmp_buffer.ptr();
+	output_buffer.size = tmp_buffer.size();
+	output_buffer.pos = 0;
+
+	size_t result = ZSTD_endStream(p_stream, &output_buffer);
+	ERR_FAIL_COND_V(ZSTD_isError(result), false);
+
+	uint64_t old_size = p_output.size();
+	p_output.resize(old_size + output_buffer.pos);
+	memcpy(p_output.ptr() + old_size, tmp_buffer.ptr(), output_buffer.pos);
+
+	return true;
+}
+
+void DeltaPatchWriter::encode_int64(int64_t p_value, void *p_dst) {
+#ifdef BIG_ENDIAN_ENABLED
+	p_value = BSWAP64(p_value);
+#endif
+	memcpy(p_dst, &p_value, sizeof(int64_t));
+}
+
+bool DeltaPatchWriter::Init(size_t /* p_new_size */) {
+	tmp_buffer.resize(ZSTD_CStreamOutSize());
+
+	ctrl_stream = ZSTD_createCStream();
+	ERR_FAIL_NULL_V(ctrl_stream, false);
+
+	diff_stream = ZSTD_createCStream();
+	ERR_FAIL_NULL_V(diff_stream, false);
+
+	extra_stream = ZSTD_createCStream();
+	ERR_FAIL_NULL_V(extra_stream, false);
+
+	size_t result = ZSTD_initCStream(ctrl_stream, zstd_level);
+	ERR_FAIL_COND_V(ZSTD_isError(result), false);
+
+	result = ZSTD_initCStream(diff_stream, zstd_level);
+	ERR_FAIL_COND_V(ZSTD_isError(result), false);
+
+	result = ZSTD_initCStream(extra_stream, zstd_level);
+	ERR_FAIL_COND_V(ZSTD_isError(result), false);
+
+	return true;
+}
+
+bool DeltaPatchWriter::WriteDiffStream(const uint8_t *p_data, size_t p_size) {
+	return stream_compress(diff_stream, Span(p_data, p_size), diff_buffer);
+}
+
+bool DeltaPatchWriter::WriteExtraStream(const uint8_t *p_data, size_t p_size) {
+	return stream_compress(extra_stream, Span(p_data, p_size), extra_buffer);
+}
+
+bool DeltaPatchWriter::AddControlEntry(const ControlEntry &p_entry) {
+	uint8_t ctrl[24];
+	encode_int64(p_entry.diff_size, ctrl);
+	encode_int64(p_entry.extra_size, ctrl + 8);
+	encode_int64(p_entry.offset_increment, ctrl + 16);
+
+	new_file_size += p_entry.diff_size + p_entry.extra_size;
+
+	return stream_compress(ctrl_stream, ctrl, ctrl_buffer);
+}
+
+bool DeltaPatchWriter::Close() {
+	if (!stream_end(ctrl_stream, ctrl_buffer)) {
+		return false;
+	}
+
+	if (!stream_end(diff_stream, diff_buffer)) {
+		return false;
+	}
+
+	if (!stream_end(extra_stream, extra_buffer)) {
+		return false;
+	}
+
+	patch_file->store_8(DELTA_PATCH_VERSION_NUMBER);
+	patch_file->store_64(ctrl_buffer.size());
+	patch_file->store_64(diff_buffer.size());
+	patch_file->store_64(new_file_size);
+	patch_file->store_buffer(old_file_md5, 16);
+	patch_file->store_buffer(new_file_md5, 16);
+
+	ERR_FAIL_COND_V(patch_file->get_position() != DELTA_PATCH_HEADER_SIZE, false);
+
+	patch_file->store_buffer(ctrl_buffer.ptr(), ctrl_buffer.size());
+	patch_file->store_buffer(diff_buffer.ptr(), diff_buffer.size());
+	patch_file->store_buffer(extra_buffer.ptr(), extra_buffer.size());
+
+	return true;
+}
+
+DeltaPatchWriter::DeltaPatchWriter(Ref<FileAccess> p_patch_file, uint8_t p_old_file_md5[16], uint8_t p_new_file_md5[16], int p_zstd_level) :
+		patch_file(p_patch_file),
+		zstd_level(p_zstd_level) {
+	memcpy(old_file_md5, p_old_file_md5, 16);
+	memcpy(new_file_md5, p_new_file_md5, 16);
+}
+
+DeltaPatchWriter::~DeltaPatchWriter() {
+	if (ctrl_stream != nullptr) {
+		ZSTD_freeCStream(ctrl_stream);
+		ctrl_stream = nullptr;
+	}
+
+	if (diff_stream != nullptr) {
+		ZSTD_freeCStream(diff_stream);
+		diff_stream = nullptr;
+	}
+
+	if (extra_stream != nullptr) {
+		ZSTD_freeCStream(extra_stream);
+		extra_stream = nullptr;
+	}
+}

--- a/core/io/delta_patch_writer.h
+++ b/core/io/delta_patch_writer.h
@@ -1,0 +1,82 @@
+/**************************************************************************/
+/*  delta_patch_writer.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/file_access.h"
+
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wshadow")
+#include <bsdiff/patch_writer_interface.h>
+GODOT_GCC_WARNING_POP
+#include <zstd.h>
+
+#define DELTA_PATCH_VERSION_V1 1
+#define DELTA_PATCH_VERSION_NUMBER DELTA_PATCH_VERSION_V1
+
+#define DELTA_PATCH_HEADER_SIZE 57
+
+class DeltaPatchWriter final : public bsdiff::PatchWriterInterface {
+public:
+	typedef LocalVector<uint8_t, uint64_t> ByteBuffer;
+
+private:
+	ByteBuffer tmp_buffer;
+	ByteBuffer ctrl_buffer;
+	ByteBuffer diff_buffer;
+	ByteBuffer extra_buffer;
+
+	uint8_t old_file_md5[16];
+	uint8_t new_file_md5[16];
+
+	Ref<FileAccess> patch_file;
+
+	ZSTD_CStream *ctrl_stream = nullptr;
+	ZSTD_CStream *diff_stream = nullptr;
+	ZSTD_CStream *extra_stream = nullptr;
+
+	int zstd_level = 3;
+	uint64_t new_file_size = 0;
+
+	bool stream_compress(ZSTD_CStream *p_stream, Span<uint8_t> p_input, ByteBuffer &p_output);
+	bool stream_end(ZSTD_CStream *p_stream, ByteBuffer &p_output);
+
+	static void encode_int64(int64_t p_value, void *p_dst);
+
+public:
+	virtual bool Init(size_t p_new_size) override;
+	virtual bool WriteDiffStream(const uint8_t *p_data, size_t p_size) override;
+	virtual bool WriteExtraStream(const uint8_t *p_data, size_t p_size) override;
+	virtual bool AddControlEntry(const ControlEntry &p_entry) override;
+	virtual bool Close() override;
+
+	DeltaPatchWriter(Ref<FileAccess> p_patch_file, uint8_t p_old_file_md5[16], uint8_t p_new_file_md5[16], int p_zstd_level);
+
+	virtual ~DeltaPatchWriter();
+};

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -130,11 +130,6 @@ uint64_t FileAccessMemory::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 
 	uint64_t left = length - pos;
 	uint64_t read = MIN(p_length, left);
-
-	if (read < p_length) {
-		WARN_PRINT("Reading less data than requested");
-	}
-
 	memcpy(p_dst, &data[pos], read);
 	pos += read;
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -31,6 +31,7 @@
 #include "file_access_pack.h"
 
 #include "core/io/file_access_encrypted.h"
+#include "core/io/file_access_patched.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "core/version.h"
@@ -45,7 +46,7 @@ Error PackedData::add_pack(const String &p_path, bool p_replace_files, uint64_t 
 	return ERR_FILE_UNRECOGNIZED;
 }
 
-void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted, bool p_bundle) {
+void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted, bool p_bundle, bool p_delta) {
 	String simplified_path = p_path.simplify_path().trim_prefix("res://");
 	PathMD5 pmd5(simplified_path.md5_buffer());
 
@@ -54,6 +55,7 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 	PackedFile pf;
 	pf.encrypted = p_encrypted;
 	pf.bundle = p_bundle;
+	pf.delta = p_delta;
 	pf.pack = p_pkg_path;
 	pf.offset = p_ofs;
 	pf.size = p_size;
@@ -62,8 +64,11 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 	}
 	pf.src = p_src;
 
-	if (!exists || p_replace_files) {
+	if (p_delta) {
+		delta_patches[pmd5].push_back(pf);
+	} else if (!exists || p_replace_files) {
 		files[pmd5] = pf;
+		delta_patches[pmd5].clear();
 	}
 
 	if (!exists) {
@@ -137,6 +142,28 @@ uint8_t *PackedData::get_file_hash(const String &p_path) {
 	return E->value.md5;
 }
 
+Vector<PackedData::PackedFile> PackedData::get_delta_patches(const String &p_path) const {
+	String simplified_path = p_path.simplify_path().trim_prefix("res://");
+	PathMD5 pmd5(simplified_path.md5_buffer());
+	HashMap<PathMD5, Vector<PackedFile>, PathMD5>::ConstIterator E = delta_patches.find(pmd5);
+	if (!E) {
+		return Vector<PackedFile>();
+	}
+
+	return E->value;
+}
+
+bool PackedData::has_delta_patches(const String &p_path) const {
+	String simplified_path = p_path.simplify_path().trim_prefix("res://");
+	PathMD5 pmd5(simplified_path.md5_buffer());
+	HashMap<PathMD5, Vector<PackedFile>, PathMD5>::ConstIterator E = delta_patches.find(pmd5);
+	if (!E) {
+		return false;
+	}
+
+	return !E->value.is_empty();
+}
+
 HashSet<String> PackedData::get_file_paths() const {
 	HashSet<String> file_paths;
 	_get_file_paths(root, root->name, file_paths);
@@ -155,6 +182,7 @@ void PackedData::_get_file_paths(PackedDir *p_dir, const String &p_parent_dir, H
 
 void PackedData::clear() {
 	files.clear();
+	delta_patches.clear();
 	_free_packed_dirs(root);
 	root = memnew(PackedDir);
 }
@@ -322,7 +350,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		if (flags & PACK_FILE_REMOVAL) { // The file was removed.
 			PackedData::get_singleton()->remove_path(path);
 		} else {
-			PackedData::get_singleton()->add_path(p_path, path, file_base + ofs, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED), sparse_bundle);
+			PackedData::get_singleton()->add_path(p_path, path, file_base + ofs, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED), sparse_bundle, (flags & PACK_FILE_DELTA));
 		}
 	}
 
@@ -330,7 +358,17 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 }
 
 Ref<FileAccess> PackedSourcePCK::get_file(const String &p_path, PackedData::PackedFile *p_file) {
-	return memnew(FileAccessPack(p_path, *p_file));
+	Ref<FileAccess> file(memnew(FileAccessPack(p_path, *p_file)));
+
+	if (PackedData::get_singleton()->has_delta_patches(p_path)) {
+		Ref<FileAccessPatched> file_patched;
+		file_patched.instantiate();
+		Error err = file_patched->open_custom(file);
+		ERR_FAIL_COND_V(err != OK, Ref<FileAccess>());
+		file = file_patched;
+	}
+
+	return file;
 }
 
 //////////////////////////////////////////////////////////////////
@@ -362,7 +400,7 @@ void PackedSourceDirectory::add_directory(const String &p_path, bool p_replace_f
 	for (const String &file_name : da->get_files()) {
 		String file_path = p_path.path_join(file_name);
 		uint8_t md5[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-		PackedData::get_singleton()->add_path(p_path, file_path, 0, 0, md5, this, p_replace_files, false, false);
+		PackedData::get_singleton()->add_path(p_path, file_path, 0, 0, md5, this, p_replace_files, false, false, false);
 	}
 
 	for (const String &sub_dir_name : da->get_directories()) {
@@ -470,6 +508,7 @@ void FileAccessPack::close() {
 }
 
 FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFile &p_file) {
+	path = p_path;
 	pf = p_file;
 	if (pf.bundle) {
 		String simplified_path = p_path.simplify_path();

--- a/core/io/file_access_patched.cpp
+++ b/core/io/file_access_patched.cpp
@@ -1,0 +1,224 @@
+/**************************************************************************/
+/*  file_access_patched.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "file_access_patched.h"
+
+#include "file_access_pack.h"
+
+#include "core/io/delta_patch_file_interface.h"
+#include "core/io/delta_patch_reader.h"
+#include "core/os/os.h"
+
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wshadow")
+#include <bsdiff/bspatch.h>
+GODOT_GCC_WARNING_POP
+
+Error FileAccessPatched::try_apply_patch() const {
+	if (last_error != OK || patched_file.is_valid()) {
+		return last_error;
+	}
+
+	ERR_FAIL_COND_V(!is_open(), FAILED);
+
+	String path = old_file->get_path();
+	Vector<PackedData::PackedFile> delta_patches = PackedData::get_singleton()->get_delta_patches(path);
+	Vector<uint8_t> old_file_data = old_file->get_buffer(old_file->get_length());
+	DeltaPatchReader patch_reader;
+
+	for (int i = 0; i < delta_patches.size(); ++i) {
+		const PackedData::PackedFile &delta_patch = delta_patches[i];
+		Error err = OK;
+
+		uint64_t usec_start = OS::get_singleton()->get_ticks_usec();
+
+		Ref<FileAccessMemory> old_file_mem;
+		old_file_mem.instantiate();
+		err = old_file_mem->open_custom(old_file_data.ptr(), old_file_data.size());
+		ERR_FAIL_COND_V(err != OK, err);
+
+		Ref<FileAccess> patch_file;
+
+		if (delta_patch.bundle) {
+			patch_file = FileAccess::open(delta_patch.pack, FileAccess::READ | FileAccess::SKIP_PACK, &err);
+			ERR_FAIL_COND_V(err != OK, err);
+		} else {
+			patch_file = FileAccess::open(delta_patch.pack, FileAccess::READ, &err);
+			ERR_FAIL_COND_V(err != OK, err);
+
+			patch_file->seek(delta_patch.offset);
+			ERR_FAIL_COND_V(patch_file->get_error() != OK, patch_file->get_error());
+		}
+
+		Vector<uint8_t> patch_data = patch_file->get_buffer(patch_file->get_length());
+		ERR_FAIL_COND_V(patch_data.is_empty(), ERR_FILE_CANT_READ);
+
+		int64_t new_file_size = DeltaPatchReader::read_new_file_size(patch_data);
+		ERR_FAIL_COND_V_MSG(new_file_size <= 0, ERR_FILE_CORRUPT, vformat("Failed to apply delta patch (%d of %d) to '%s'.", i + 1, delta_patches.size(), path));
+		Vector<uint8_t> new_file_data;
+		new_file_data.resize(new_file_size);
+
+		Ref<FileAccessMemory> new_file_mem;
+		new_file_mem.instantiate();
+		err = new_file_mem->open_custom(new_file_data.ptr(), new_file_data.size());
+		ERR_FAIL_COND_V(err != OK, err);
+
+		std::unique_ptr<bsdiff::FileInterface> old_file_iface(new DeltaPatchFileInterface(old_file_mem));
+		std::unique_ptr<bsdiff::FileInterface> new_file_iface(new DeltaPatchFileInterface(new_file_mem));
+
+		int patch_error = bsdiff::bspatch(old_file_iface, new_file_iface, patch_data.ptr(), patch_data.size(), patch_reader);
+
+		ERR_FAIL_COND_V_MSG(patch_error != 0, FAILED, vformat("Failed to apply delta patch (%d of %d) to '%s'.", i + 1, delta_patches.size(), path));
+		ERR_FAIL_COND_V_MSG(!patch_reader.matches_old_md5(old_file_data), ERR_FILE_CORRUPT, vformat("Failed to apply delta patch (%d of %d) to '%s'. Old file did not match expected checksum.", i + 1, delta_patches.size(), path));
+		ERR_FAIL_COND_V_MSG(!patch_reader.matches_new_md5(new_file_data), ERR_FILE_CORRUPT, vformat("Failed to apply delta patch (%d of %d) to '%s'. New file did not match expected checksum.", i + 1, delta_patches.size(), path));
+
+		uint64_t usec_end = OS::get_singleton()->get_ticks_usec();
+
+		print_verbose(vformat("Applied delta patch (%d of %d) to '%s' in %d microseconds.", i + 1, delta_patches.size(), path, usec_end - usec_start));
+
+		old_file_data = new_file_data;
+	}
+
+	patched_file_data = old_file_data;
+	patched_file.instantiate();
+	return patched_file->open_custom(patched_file_data.ptr(), patched_file_data.size());
+}
+
+Error FileAccessPatched::open_custom(const Ref<FileAccess> &p_old_file) {
+	close();
+
+	if (!p_old_file->is_open()) {
+		last_error = ERR_FILE_CANT_OPEN;
+		return last_error;
+	}
+
+	old_file = p_old_file;
+
+	return OK;
+}
+
+bool FileAccessPatched::is_open() const {
+	return old_file.is_valid() && old_file->is_open();
+}
+
+void FileAccessPatched::seek(uint64_t p_position) {
+	last_error = try_apply_patch();
+	if (last_error != OK) {
+		return;
+	}
+
+	patched_file->seek(p_position);
+}
+
+void FileAccessPatched::seek_end(int64_t p_position) {
+	last_error = try_apply_patch();
+	if (last_error != OK) {
+		return;
+	}
+
+	patched_file->seek_end(p_position);
+}
+
+uint64_t FileAccessPatched::get_position() const {
+	last_error = try_apply_patch();
+	if (last_error != OK) {
+		return 0;
+	}
+
+	return patched_file->get_position();
+}
+
+uint64_t FileAccessPatched::get_length() const {
+	last_error = try_apply_patch();
+	if (last_error != OK) {
+		return 0;
+	}
+
+	return patched_file->get_length();
+}
+
+bool FileAccessPatched::eof_reached() const {
+	last_error = try_apply_patch();
+	if (last_error != OK) {
+		return true;
+	}
+
+	return patched_file->eof_reached();
+}
+
+Error FileAccessPatched::get_error() const {
+	if (last_error != OK) {
+		return last_error;
+	}
+
+	if (patched_file.is_valid()) {
+		last_error = patched_file->get_error();
+	}
+
+	return last_error;
+}
+
+bool FileAccessPatched::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	last_error = try_apply_patch();
+	if (last_error != OK) {
+		return false;
+	}
+
+	return patched_file->store_buffer(p_src, p_length);
+}
+
+uint64_t FileAccessPatched::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+	last_error = try_apply_patch();
+	if (last_error != OK) {
+		return 0;
+	}
+
+	return patched_file->get_buffer(p_dst, p_length);
+}
+
+void FileAccessPatched::flush() {
+	last_error = try_apply_patch();
+	if (last_error != OK) {
+		return;
+	}
+
+	patched_file->flush();
+}
+
+void FileAccessPatched::close() {
+	old_file = Ref<FileAccess>();
+	patched_file = Ref<FileAccessMemory>();
+	patched_file_data.clear();
+	last_error = OK;
+}
+
+bool FileAccessPatched::file_exists(const String &p_name) {
+	ERR_FAIL_COND_V(old_file.is_null(), false);
+	return old_file->file_exists(p_name);
+}

--- a/core/io/file_access_patched.h
+++ b/core/io/file_access_patched.h
@@ -1,0 +1,83 @@
+/**************************************************************************/
+/*  file_access_patched.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "file_access.h"
+#include "file_access_memory.h"
+
+class FileAccessPatched : public FileAccess {
+	GDSOFTCLASS(FileAccessPatched, FileAccess);
+
+	Ref<FileAccess> old_file;
+	mutable Vector<uint8_t> patched_file_data;
+	mutable Ref<FileAccessMemory> patched_file;
+	mutable Error last_error = OK;
+
+protected:
+	Error try_apply_patch() const;
+
+	virtual BitField<UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
+	virtual Error _set_unix_permissions(const String &p_file, BitField<UnixPermissionFlags> p_permissions) override { return FAILED; }
+
+	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
+	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
+
+	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
+	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
+
+	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
+	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
+	virtual int64_t _get_size(const String &p_file) override { return -1; }
+
+	virtual Error open_internal(const String &p_path, int p_mode_flags) override { return ERR_UNAVAILABLE; }
+
+public:
+	Error open_custom(const Ref<FileAccess> &p_old_file);
+
+	virtual bool is_open() const override;
+
+	virtual void seek(uint64_t p_position) override;
+	virtual void seek_end(int64_t p_position = 0) override;
+
+	virtual uint64_t get_position() const override;
+	virtual uint64_t get_length() const override;
+	virtual bool eof_reached() const override;
+	virtual Error get_error() const override;
+
+	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
+	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
+
+	virtual void flush() override;
+	virtual void close() override;
+
+	virtual bool file_exists(const String &p_name) override;
+};

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -84,7 +84,12 @@ void EditorExport::_save() {
 		config->set_value(section, "include_filter", preset->get_include_filter());
 		config->set_value(section, "exclude_filter", preset->get_exclude_filter());
 		config->set_value(section, "export_path", preset->get_export_path());
+
 		config->set_value(section, "patches", preset->get_patches());
+		config->set_value(section, "patch_delta_encoding", preset->is_delta_encoding_enabled());
+		config->set_value(section, "patch_delta_compression_level_zstd", preset->get_patch_delta_zstd_level());
+		config->set_value(section, "patch_delta_min_reduction", preset->get_patch_delta_min_reduction());
+		config->set_value(section, "patch_delta_exclude_filters", preset->get_patch_delta_exclude_filter());
 
 		config->set_value(section, "encryption_include_filters", preset->get_enc_in_filter());
 		config->set_value(section, "encryption_exclude_filters", preset->get_enc_ex_filter());
@@ -310,6 +315,19 @@ void EditorExport::load_config() {
 		preset->set_export_path(config->get_value(section, "export_path", ""));
 		preset->set_script_export_mode(config->get_value(section, "script_export_mode", EditorExportPreset::MODE_SCRIPT_BINARY_TOKENS_COMPRESSED));
 		preset->set_patches(config->get_value(section, "patches", Vector<String>()));
+
+		if (config->has_section_key(section, "patch_delta_encoding")) {
+			preset->set_patch_delta_encoding_enabled(config->get_value(section, "patch_delta_encoding"));
+		}
+		if (config->has_section_key(section, "patch_delta_compression_level_zstd")) {
+			preset->set_patch_delta_zstd_level(config->get_value(section, "patch_delta_compression_level_zstd"));
+		}
+		if (config->has_section_key(section, "patch_delta_min_reduction")) {
+			preset->set_patch_delta_min_reduction(config->get_value(section, "patch_delta_min_reduction"));
+		}
+		if (config->has_section_key(section, "patch_delta_exclude_filters")) {
+			preset->set_patch_delta_exclude_filter(config->get_value(section, "patch_delta_exclude_filters"));
+		}
 
 		if (config->has_section_key(section, "seed")) {
 			preset->set_seed(config->get_value(section, "seed"));

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -35,6 +35,7 @@
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/extension/gdextension.h"
+#include "core/io/delta_patch_writer.h"
 #include "core/io/file_access_encrypted.h"
 #include "core/io/file_access_pack.h" // PACK_HEADER_MAGIC, PACK_FORMAT_VERSION
 #include "core/io/image_loader.h"
@@ -54,6 +55,8 @@
 #include "scene/resources/image_texture.h"
 #include "scene/resources/packed_scene.h"
 
+#include <bsdiff/bsdiff.h>
+
 class EditorExportSaveProxy {
 	HashSet<String> saved_paths;
 	EditorExportPlatform::EditorExportSaveFunction save_func;
@@ -62,12 +65,12 @@ class EditorExportSaveProxy {
 public:
 	bool has_saved(const String &p_path) const { return saved_paths.has(p_path); }
 
-	Error save_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+	Error save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 		if (tracking_saves) {
 			saved_paths.insert(p_path.simplify_path().trim_prefix("res://"));
 		}
 
-		return save_func(p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed);
+		return save_func(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta);
 	}
 
 	EditorExportSaveProxy(EditorExportPlatform::EditorExportSaveFunction p_save_func, bool p_track_saves) :
@@ -214,26 +217,6 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err) 
 	return has_messages;
 }
 
-bool EditorExportPlatform::_check_hash(const uint8_t *p_hash, const Vector<uint8_t> &p_data) {
-	if (p_hash == nullptr) {
-		return false;
-	}
-
-	unsigned char hash[16];
-	Error err = CryptoCore::md5(p_data.ptr(), p_data.size(), hash);
-	if (err != OK) {
-		return false;
-	}
-
-	for (int i = 0; i < 16; i++) {
-		if (p_hash[i] != hash[i]) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 Error EditorExportPlatform::_load_patches(const Vector<String> &p_patches) {
 	Error err = OK;
 	if (!p_patches.is_empty()) {
@@ -306,7 +289,7 @@ Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const 
 	return OK;
 }
 
-Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	ERR_FAIL_COND_V_MSG(p_total < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
 
 	PackData *pd = (PackData *)p_userdata;
@@ -328,6 +311,7 @@ Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_pa
 	sd.path_utf8 = simplified_path.trim_prefix("res://").utf8();
 	sd.ofs = (pd->use_sparse_pck) ? 0 : pd->f->get_position();
 	sd.size = p_data.size();
+	sd.delta = p_delta;
 	Error err = _encrypt_and_store_data(ftmp, simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, sd.encrypted);
 	if (err != OK) {
 		return err;
@@ -363,15 +347,79 @@ Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_pa
 	return OK;
 }
 
-Error EditorExportPlatform::_save_pack_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
-	if (_check_hash(PackedData::get_singleton()->get_file_hash(p_path), p_data)) {
-		return OK;
+Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+	Vector<uint8_t> patch_data = p_data;
+	bool delta = false;
+
+	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_path);
+	if (old_file.is_valid()) {
+		// We cannot rely on the MD5 as stored in PCK, since delta patches might affect it.
+		Vector<uint8_t> old_data = old_file->get_buffer(old_file->get_length());
+
+		Error err = OK;
+
+		uint8_t old_md5[16];
+		err = CryptoCore::md5(old_data.ptr(), old_data.size(), old_md5);
+		if (err != OK) {
+			return err;
+		}
+
+		uint8_t new_md5[16];
+		err = CryptoCore::md5(p_data.ptr(), p_data.size(), new_md5);
+		if (err != OK) {
+			return err;
+		}
+
+		if (memcmp(old_md5, new_md5, 16) == 0) {
+			return OK;
+		}
+
+		if (p_preset->is_delta_encoding_enabled()) {
+			delta = true;
+
+			for (const String &filter : p_preset->get_patch_delta_exclude_filter().split(",")) {
+				String filter_stripped = filter.strip_edges();
+				if (p_path.matchn(filter_stripped) || p_path.trim_prefix("res://").matchn(filter_stripped)) {
+					delta = false;
+					print_verbose(vformat("Skipped delta encoding of '%s' due to exclude filter '%s'.", p_path, filter_stripped));
+					break;
+				}
+			}
+
+			if (delta) {
+				Ref<FileAccess> patch_file = FileAccess::create_temp(FileAccess::WRITE_READ, "export_delta", "tmp", false, &err);
+				if (err != OK) {
+					return err;
+				}
+
+				DeltaPatchWriter patch_writer(patch_file, old_md5, new_md5, p_preset->get_patch_delta_zstd_level());
+				int diff_error = bsdiff::bsdiff(old_data.ptr(), old_data.size(), p_data.ptr(), p_data.size(), &patch_writer, nullptr);
+				if (diff_error != 0) {
+					return FAILED;
+				}
+
+				patch_data.resize(patch_file->get_length());
+				patch_file->seek(0);
+				patch_file->get_buffer(patch_data.ptrw(), patch_data.size());
+
+				int64_t reduction_bytes = MAX(0, p_data.size() - patch_data.size());
+				double reduction_ratio = reduction_bytes / (double)p_data.size();
+
+				if (reduction_ratio >= p_preset->get_patch_delta_min_reduction()) {
+					print_verbose(vformat("Used delta encoding for '%s' (%d bytes) which reduced the size by %.2f%% (%d bytes) compared to the new file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+				} else {
+					print_verbose(vformat("Skipped delta encoding of '%s' (%d bytes) as it only reduced the size by %.2f%% (%d bytes) compared to the new file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+					patch_data = p_data;
+					delta = false;
+				}
+			}
+		}
 	}
 
-	return _save_pack_file(p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed);
+	return _save_pack_file(p_preset, p_userdata, p_path, patch_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, delta);
 }
 
-Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatform::_save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	ERR_FAIL_COND_V_MSG(p_total < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
 
 	String path = p_path.simplify_path();
@@ -409,12 +457,32 @@ Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_pat
 	return OK;
 }
 
-Error EditorExportPlatform::_save_zip_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
-	if (_check_hash(PackedData::get_singleton()->get_file_hash(p_path), p_data)) {
-		return OK;
+Error EditorExportPlatform::_save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_path);
+	if (old_file.is_valid()) {
+		// We cannot rely on the MD5 as stored in PCK, since delta patches might affect it.
+		Vector<uint8_t> old_data = old_file->get_buffer(old_file->get_length());
+
+		Error err = OK;
+
+		uint8_t old_md5[16];
+		err = CryptoCore::md5(old_data.ptr(), old_data.size(), old_md5);
+		if (err != OK) {
+			return err;
+		}
+
+		uint8_t new_md5[16];
+		err = CryptoCore::md5(p_data.ptr(), p_data.size(), new_md5);
+		if (err != OK) {
+			return err;
+		}
+
+		if (memcmp(old_md5, new_md5, 16) == 0) {
+			return OK;
+		}
 	}
 
-	return _save_zip_file(p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed);
+	return _save_zip_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta);
 }
 
 Ref<Texture2D> EditorExportPlatform::get_option_icon(int p_index) const {
@@ -1042,7 +1110,7 @@ Vector<String> EditorExportPlatform::get_forced_export_files(const Ref<EditorExp
 	return files;
 }
 
-Error EditorExportPlatform::_script_save_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatform::_script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	Callable cb = ((ScriptCallbackData *)p_userdata)->file_cb;
 	ERR_FAIL_COND_V(!cb.is_valid(), FAILED);
 
@@ -1070,7 +1138,7 @@ Error EditorExportPlatform::_script_save_file(void *p_userdata, const String &p_
 	return (Error)ret.operator int();
 }
 
-Error EditorExportPlatform::_script_add_shared_object(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatform::_script_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	Callable cb = ((ScriptCallbackData *)p_userdata)->so_cb;
 	if (!cb.is_valid()) {
 		return OK; // Optional.
@@ -1226,14 +1294,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		for (int i = 0; i < export_plugins.size(); i++) {
 			if (p_so_func) {
 				for (int j = 0; j < export_plugins[i]->shared_objects.size(); j++) {
-					err = p_so_func(p_udata, export_plugins[i]->shared_objects[j]);
+					err = p_so_func(p_preset, p_udata, export_plugins[i]->shared_objects[j]);
 					if (err != OK) {
 						return err;
 					}
 				}
 			}
 			for (int j = 0; j < export_plugins[i]->extra_files.size(); j++) {
-				err = save_proxy.save_file(p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, 0, paths.size(), enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, 0, paths.size(), enc_in_filters, enc_ex_filters, key, seed, false);
 				if (err != OK) {
 					return err;
 				}
@@ -1325,9 +1393,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	// for continue statements without accidentally skipping an increment.
 	int idx = total > 0 ? -1 : 0;
 
-	for (const String &E : paths) {
+	for (const String &path : paths) {
 		idx++;
-		String path = E;
 		String type = ResourceLoader::get_resource_type(path);
 
 		bool has_import_file = FileAccess::exists(path + ".import");
@@ -1359,7 +1426,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			}
 			if (p_so_func) {
 				for (int j = 0; j < export_plugins[i]->shared_objects.size(); j++) {
-					err = p_so_func(p_udata, export_plugins[i]->shared_objects[j]);
+					err = p_so_func(p_preset, p_udata, export_plugins[i]->shared_objects[j]);
 					if (err != OK) {
 						return err;
 					}
@@ -1377,7 +1444,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		for (int i = 0; i <= skipped_i; i++) {
 			if (!skip_all) {
 				for (const EditorExportPlugin::ExtraFile &extra_file : export_plugins[i]->extra_files) {
-					err = save_proxy.save_file(p_udata, extra_file.path, extra_file.data, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+					err = save_proxy.save_file(p_preset, p_udata, extra_file.path, extra_file.data, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 					if (err != OK) {
 						return err;
 					}
@@ -1401,7 +1468,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			if (importer_type == "keep") {
 				// Just keep file as-is.
 				Vector<uint8_t> array = FileAccess::get_file_as_bytes(path);
-				err = save_proxy.save_file(p_udata, path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 
 				if (err != OK) {
 					return err;
@@ -1443,13 +1510,13 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				sarr.resize(cs.size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
-				err = save_proxy.save_file(p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 				if (err != OK) {
 					return err;
 				}
 				// Now actual remapped file:
 				sarr = FileAccess::get_file_as_bytes(export_path);
-				err = save_proxy.save_file(p_udata, export_path, sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, export_path, sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 				if (err != OK) {
 					return err;
 				}
@@ -1477,14 +1544,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 					if (remap == "path") {
 						String remapped_path = config->get_value("remap", remap);
 						Vector<uint8_t> array = FileAccess::get_file_as_bytes(remapped_path);
-						err = save_proxy.save_file(p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+						err = save_proxy.save_file(p_preset, p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 					} else if (remap.begins_with("path.")) {
 						String feature = remap.get_slicec('.', 1);
 
 						if (remap_features.has(feature)) {
 							String remapped_path = config->get_value("remap", remap);
 							Vector<uint8_t> array = FileAccess::get_file_as_bytes(remapped_path);
-							err = save_proxy.save_file(p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+							err = save_proxy.save_file(p_preset, p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 						} else {
 							// Remove paths if feature not enabled.
 							config->erase_section_key("remap", remap);
@@ -1510,7 +1577,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				sarr.resize(cs.size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
-				err = save_proxy.save_file(p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 
 				if (err != OK) {
 					return err;
@@ -1531,7 +1598,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			}
 
 			Vector<uint8_t> array = FileAccess::get_file_as_bytes(export_path);
-			err = save_proxy.save_file(p_udata, export_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+			err = save_proxy.save_file(p_preset, p_udata, export_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 			if (err != OK) {
 				return err;
 			}
@@ -1600,7 +1667,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				new_file.write[j] = utf8[j];
 			}
 
-			err = save_proxy.save_file(p_udata, from + ".remap", new_file, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+			err = save_proxy.save_file(p_preset, p_udata, from + ".remap", new_file, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 			if (err != OK) {
 				return err;
 			}
@@ -1618,7 +1685,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		} else {
 			array = FileAccess::get_file_as_bytes(forced_export[i]);
 		}
-		err = save_proxy.save_file(p_udata, forced_export[i], array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+		err = save_proxy.save_file(p_preset, p_udata, forced_export[i], array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 		if (err != OK) {
 			return err;
 		}
@@ -1627,7 +1694,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	Dictionary int_export = get_internal_export_files(p_preset, p_debug);
 	for (const KeyValue<Variant, Variant> &int_export_kv : int_export) {
 		const PackedByteArray &array = int_export_kv.value;
-		err = save_proxy.save_file(p_udata, int_export_kv.key, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+		err = save_proxy.save_file(p_preset, p_udata, int_export_kv.key, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 		if (err != OK) {
 			return err;
 		}
@@ -1640,7 +1707,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	Vector<uint8_t> data = FileAccess::get_file_as_bytes(engine_cfb);
 	DirAccess::remove_file_or_error(engine_cfb);
 
-	err = save_proxy.save_file(p_udata, "res://" + config_file, data, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+	err = save_proxy.save_file(p_preset, p_udata, "res://" + config_file, data, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 	if (err != OK) {
 		return err;
 	}
@@ -1649,7 +1716,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		HashSet<String> currently_loaded_paths = PackedData::get_singleton()->get_file_paths();
 		for (const String &path : currently_loaded_paths) {
 			if (!save_proxy.has_saved(path)) {
-				err = p_remove_func(p_udata, path);
+				err = p_remove_func(p_preset, p_udata, path);
 				if (err != OK) {
 					return err;
 				}
@@ -1676,7 +1743,7 @@ Vector<uint8_t> EditorExportPlatform::_filter_extension_list_config_file(const S
 	return data;
 }
 
-Error EditorExportPlatform::_pack_add_shared_object(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatform::_pack_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	PackData *pack_data = (PackData *)p_userdata;
 	if (pack_data->so_files) {
 		pack_data->so_files->push_back(p_so);
@@ -1685,7 +1752,7 @@ Error EditorExportPlatform::_pack_add_shared_object(void *p_userdata, const Shar
 	return OK;
 }
 
-Error EditorExportPlatform::_remove_pack_file(void *p_userdata, const String &p_path) {
+Error EditorExportPlatform::_remove_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path) {
 	PackData *pd = (PackData *)p_userdata;
 
 	SavedData sd;
@@ -1707,7 +1774,7 @@ Error EditorExportPlatform::_remove_pack_file(void *p_userdata, const String &p_
 	return OK;
 }
 
-Error EditorExportPlatform::_zip_add_shared_object(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatform::_zip_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	ZipData *zip_data = (ZipData *)p_userdata;
 	if (zip_data->so_files) {
 		zip_data->so_files->push_back(p_so);
@@ -2011,6 +2078,9 @@ bool EditorExportPlatform::_encrypt_and_store_directory(Ref<FileAccess> p_fd, Pa
 		}
 		if (p_pack_data.file_ofs[i].removal) {
 			flags |= PACK_FILE_REMOVAL;
+		}
+		if (p_pack_data.file_ofs[i].delta) {
+			flags |= PACK_FILE_DELTA;
 		}
 		fhead->store_32(flags);
 	}

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -53,9 +53,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	typedef Error (*EditorExportRemoveFunction)(void *p_userdata, const String &p_path);
-	typedef Error (*EditorExportSaveSharedObject)(void *p_userdata, const SharedObject &p_so);
+	typedef Error (*EditorExportSaveFunction)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	typedef Error (*EditorExportRemoveFunction)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path);
+	typedef Error (*EditorExportSaveSharedObject)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	enum DebugFlags {
 		DEBUG_FLAG_DUMB_CLIENT = 1,
@@ -83,6 +83,7 @@ public:
 		uint64_t size = 0;
 		bool encrypted = false;
 		bool removal = false;
+		bool delta = false;
 		Vector<uint8_t> md5;
 		CharString path_utf8;
 
@@ -119,25 +120,23 @@ private:
 	void _export_find_customized_resources(const Ref<EditorExportPreset> &p_preset, EditorFileSystemDirectory *p_dir, EditorExportPreset::FileExportMode p_mode, HashSet<String> &p_paths);
 	void _export_find_dependencies(const String &p_path, HashSet<String> &p_paths);
 
-	static bool _check_hash(const uint8_t *p_hash, const Vector<uint8_t> &p_data);
+	static Error _save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _pack_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
-	static Error _save_pack_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _save_pack_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _pack_add_shared_object(void *p_userdata, const SharedObject &p_so);
+	static Error _remove_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path);
 
-	static Error _remove_pack_file(void *p_userdata, const String &p_path);
-
-	static Error _save_zip_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _save_zip_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _zip_add_shared_object(void *p_userdata, const SharedObject &p_so);
+	static Error _save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _zip_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	struct ScriptCallbackData {
 		Callable file_cb;
 		Callable so_cb;
 	};
 
-	static Error _script_save_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _script_add_shared_object(void *p_userdata, const SharedObject &p_so);
+	static Error _script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _script_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	void _edit_files_with_filter(Ref<DirAccess> &da, const Vector<String> &p_filters, HashSet<String> &r_list, bool exclude);
 	void _edit_filter_list(HashSet<String> &r_list, const String &p_filter, bool exclude);

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -31,6 +31,7 @@
 #include "editor_export.h"
 
 #include "core/config/project_settings.h"
+#include "editor_export_preset.h"
 
 bool EditorExportPreset::_set(const StringName &p_name, const Variant &p_value) {
 	values[p_name] = p_value;
@@ -445,6 +446,42 @@ void EditorExportPreset::set_patches(const Vector<String> &p_patches) {
 
 Vector<String> EditorExportPreset::get_patches() const {
 	return patches;
+}
+
+void EditorExportPreset::set_patch_delta_encoding_enabled(bool p_enable) {
+	patch_delta_encoding_enabled = p_enable;
+	EditorExport::singleton->save_presets();
+}
+
+bool EditorExportPreset::is_delta_encoding_enabled() const {
+	return patch_delta_encoding_enabled;
+}
+
+void EditorExportPreset::set_patch_delta_zstd_level(int p_level) {
+	patch_delta_zstd_level = p_level;
+	EditorExport::singleton->save_presets();
+}
+
+int EditorExportPreset::get_patch_delta_zstd_level() const {
+	return patch_delta_zstd_level;
+}
+
+void EditorExportPreset::set_patch_delta_min_reduction(double p_ratio) {
+	patch_delta_min_reduction = p_ratio;
+	EditorExport::singleton->save_presets();
+}
+
+double EditorExportPreset::get_patch_delta_min_reduction() const {
+	return patch_delta_min_reduction;
+}
+
+void EditorExportPreset::set_patch_delta_exclude_filter(const String &p_exclude) {
+	patch_delta_exclude_filter = p_exclude;
+	EditorExport::singleton->save_presets();
+}
+
+String EditorExportPreset::get_patch_delta_exclude_filter() const {
+	return patch_delta_exclude_filter;
 }
 
 void EditorExportPreset::set_custom_features(const String &p_custom_features) {

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -74,6 +74,10 @@ private:
 	bool dedicated_server = false;
 
 	Vector<String> patches;
+	bool patch_delta_encoding_enabled = false;
+	int patch_delta_zstd_level = 19;
+	double patch_delta_min_reduction = 0.1;
+	String patch_delta_exclude_filter;
 
 	friend class EditorExport;
 	friend class EditorExportPlatform;
@@ -150,10 +154,24 @@ public:
 
 	void add_patch(const String &p_path, int p_at_pos = -1);
 	void set_patch(int p_index, const String &p_path);
+
 	String get_patch(int p_index);
 	void remove_patch(int p_index);
+
 	void set_patches(const Vector<String> &p_patches);
 	Vector<String> get_patches() const;
+
+	void set_patch_delta_encoding_enabled(bool p_enable);
+	bool is_delta_encoding_enabled() const;
+
+	void set_patch_delta_zstd_level(int p_level);
+	int get_patch_delta_zstd_level() const;
+
+	void set_patch_delta_min_reduction(double p_ratio);
+	double get_patch_delta_min_reduction() const;
+
+	void set_patch_delta_exclude_filter(const String &p_exclude);
+	String get_patch_delta_exclude_filter() const;
 
 	void set_custom_features(const String &p_custom_features);
 	String get_custom_features() const;

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -46,6 +46,7 @@ class OptionButton;
 class PopupMenu;
 class ProjectExportDialog;
 class RichTextLabel;
+class SpinBox;
 class TabContainer;
 class Tree;
 class TreeItem;
@@ -107,6 +108,10 @@ class ProjectExportDialog : public ConfirmationDialog {
 
 	RBSet<String> feature_set;
 
+	CheckButton *delta_encoding = nullptr;
+	SpinBox *patch_delta_zstd_level = nullptr;
+	SpinBox *patch_delta_min_reduction = nullptr;
+	LineEdit *patch_delta_exclude_filter = nullptr;
 	Tree *patches = nullptr;
 	int patch_index = -1;
 	EditorFileDialog *patch_dialog = nullptr;
@@ -157,6 +162,11 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _tree_popup_edited(bool p_arrow_clicked);
 	void _set_file_export_mode(int p_id);
 
+	bool updating_delta_encoding_filter = false;
+	void _patch_delta_encoding_changed(bool p_pressed);
+	void _patch_delta_filter_changed(const String &p_filter);
+	void _patch_delta_zstd_level_changed(double p_value);
+	void _patch_delta_min_reduction_changed(double p_value);
 	void _patch_tree_button_clicked(Object *p_item, int p_column, int p_id, int p_mouse_button_index);
 	void _patch_tree_item_edited();
 	void _patch_file_selected(const String &p_path);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -764,7 +764,7 @@ Error EditorExportPlatformAndroid::store_in_apk(APKExportData *ed, const String 
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::save_apk_so(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatformAndroid::save_apk_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	if (!p_so.path.get_file().begins_with("lib")) {
 		String err = "Android .so file names must start with \"lib\", but got: " + p_so.path;
 		ERR_PRINT(err);
@@ -798,7 +798,7 @@ Error EditorExportPlatformAndroid::save_apk_so(void *p_userdata, const SharedObj
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::save_apk_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	APKExportData *ed = static_cast<APKExportData *>(p_userdata);
 
 	String simplified_path = p_path.simplify_path();
@@ -809,7 +809,7 @@ Error EditorExportPlatformAndroid::save_apk_file(void *p_userdata, const String 
 
 	Vector<uint8_t> enc_data;
 	EditorExportPlatform::SavedData sd;
-	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, enc_data, sd);
+	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd);
 	if (err != OK) {
 		return err;
 	}
@@ -823,11 +823,11 @@ Error EditorExportPlatformAndroid::save_apk_file(void *p_userdata, const String 
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::ignore_apk_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatformAndroid::ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::copy_gradle_so(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatformAndroid::copy_gradle_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	ERR_FAIL_COND_V_MSG(!p_so.path.get_file().begins_with("lib"), FAILED,
 			"Android .so file names must start with \"lib\", but got: " + p_so.path);
 	Vector<ABI> abis = get_abis();

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -148,13 +148,13 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	static Error store_in_apk(APKExportData *ed, const String &p_path, const Vector<uint8_t> &p_data, int compression_method = Z_DEFLATED);
 
-	static Error save_apk_so(void *p_userdata, const SharedObject &p_so);
+	static Error save_apk_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
-	static Error save_apk_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
+	static Error save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
 
-	static Error ignore_apk_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
+	static Error ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
 
-	static Error copy_gradle_so(void *p_userdata, const SharedObject &p_so);
+	static Error copy_gradle_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	bool _has_read_write_storage_permission(const Vector<String> &p_permissions);
 

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -169,7 +169,7 @@ Error store_string_at_path(const String &p_path, const String &p_data) {
 // It is used by the export_project_files method to save all the asset files into the gradle project.
 // It's functionality mirrors that of the method save_apk_file.
 // This method will be called ONLY when gradle build is enabled.
-Error rename_and_store_file_in_gradle_project(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	CustomExportData *export_data = static_cast<CustomExportData *>(p_userdata);
 
 	String simplified_path = p_path.simplify_path();
@@ -180,7 +180,7 @@ Error rename_and_store_file_in_gradle_project(void *p_userdata, const String &p_
 
 	Vector<uint8_t> enc_data;
 	EditorExportPlatform::SavedData sd;
-	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, enc_data, sd);
+	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd);
 	if (err != OK) {
 		return err;
 	}
@@ -364,7 +364,7 @@ String _get_application_tag(const Ref<EditorExportPlatform> &p_export_platform, 
 	return manifest_application_text;
 }
 
-Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd) {
+Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd) {
 	Error err = OK;
 	Ref<FileAccess> ftmp = FileAccess::create_temp(FileAccess::WRITE_READ, "export", "tmp", false, &err);
 	if (err != OK) {
@@ -373,6 +373,7 @@ Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p
 	r_sd.path_utf8 = p_simplified_path.trim_prefix("res://").utf8();
 	r_sd.ofs = 0;
 	r_sd.size = p_data.size();
+	r_sd.delta = p_delta;
 	err = EditorExportPlatform::_encrypt_and_store_data(ftmp, p_simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, r_sd.encrypted);
 	if (err != OK) {
 		return err;

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -84,7 +84,7 @@ int _get_app_category_value(int category_index);
 
 String _get_app_category_label(int category_index);
 
-Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd);
+Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd);
 
 // Utility method used to create a directory.
 Error create_directory(const String &p_dir);
@@ -102,7 +102,7 @@ Error store_string_at_path(const String &p_path, const String &p_data);
 // It is used by the export_project_files method to save all the asset files into the gradle project.
 // It's functionality mirrors that of the method save_apk_file.
 // This method will be called ONLY when gradle build is enabled.
-Error rename_and_store_file_in_gradle_project(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
+Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
 
 // Creates strings.xml files inside the gradle project for different locales.
 Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &p_project_name, const String &p_gradle_build_dir, const Dictionary &p_appnames);

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -105,6 +105,35 @@ Files extracted from upstream source:
 - `LICENSE`
 
 
+## bsdiff
+
+- Upstream: https://android.googlesource.com/platform/external/bsdiff
+- Version: git (22535836b12c5e7430dc9867261c2116d5a4947e, 2024)
+- License: BSD-3-Clause
+
+Files extracted from upstream source:
+
+- `include/bsdiff/bsdiff.h`
+- `include/bsdiff/bspatch.h`
+- `include/bsdiff/common.h`
+- `include/bsdiff/control_entry.h`
+- `include/bsdiff/file_interface.h`
+- `include/bsdiff/patch_writer_interface.h`
+- `include/bsdiff/suffix_array_index_interface.h`
+- `bsdiff.cc`
+- `bspatch.cc`
+- `diff_encoder.cc`
+- `diff_encoder.h`
+- `logging.cc`
+- `logging.h`
+- `suffix_array_index.cc`
+- `suffix_array_index.h`
+
+Patches:
+
+- `0001-shrink-and-fix-windows` (GH-??????)
+
+
 ## certs
 
 - Upstream: Mozilla, via https://github.com/bagder/ca-bundle
@@ -517,6 +546,22 @@ Files extracted from upstream source:
 Patches:
 
 - `0001-big-files-support.patch` (GH-100281)
+
+
+## libdivsufsort
+
+- Upstream: https://android.googlesource.com/platform/external/libdivsufsort
+- Version: git (ed23a07e3ed69d815aa9b8480fd9c2672c4b0c51, 2024)
+- License: MIT
+
+Files extracted from upstream source:
+
+- `include/*.h`
+- `lib/*.c`
+
+Patches:
+
+- `0001-build-fixes.patch` (GH-??????)
 
 
 ## libjpeg-turbo

--- a/thirdparty/bsdiff/LICENSE
+++ b/thirdparty/bsdiff/LICENSE
@@ -1,0 +1,58 @@
+This project governed by the following BSD-style licenses. Check each file
+header to known the licenses applying to it:
+
+--------------------------------------------------------------------------------
+
+Copyright 2003-2005 Colin Percival
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+Copyright 2015 The Chromium OS Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/thirdparty/bsdiff/bsdiff/bsdiff.cc
+++ b/thirdparty/bsdiff/bsdiff/bsdiff.cc
@@ -1,0 +1,175 @@
+/*-
+ * Copyright 2003-2005 Colin Percival
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted providing that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if 0
+__FBSDID("$FreeBSD: src/usr.bin/bsdiff/bsdiff/bsdiff.c,v 1.1 2005/08/06 01:59:05 cperciva Exp $");
+#endif
+
+#include "bsdiff/bsdiff.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include <algorithm>
+
+#include "bsdiff/diff_encoder.h"
+#include "bsdiff/suffix_array_index.h"
+
+namespace bsdiff {
+
+int bsdiff(const uint8_t* old_buf, size_t oldsize, const uint8_t* new_buf,
+           size_t newsize, PatchWriterInterface* patch,
+           SuffixArrayIndexInterface** sai_cache) {
+	return bsdiff(old_buf, oldsize, new_buf, newsize, 0, patch,
+	              sai_cache);
+}
+
+int bsdiff(const uint8_t* old_buf, size_t oldsize, const uint8_t* new_buf,
+           size_t newsize, size_t min_length, PatchWriterInterface* patch,
+           SuffixArrayIndexInterface** sai_cache) {
+	size_t scsc, scan;
+	uint64_t pos=0;
+	size_t len;
+	size_t lastscan,lastpos,lastoffset;
+	uint64_t oldscore;
+	int64_t s,Sf,lenf,Sb,lenb;
+	int64_t overlap,Ss,lens;
+	int64_t i;
+
+	std::unique_ptr<SuffixArrayIndexInterface> local_sai;
+	SuffixArrayIndexInterface* sai;
+
+	if (sai_cache && *sai_cache) {
+		sai = *sai_cache;
+	} else {
+		local_sai = CreateSuffixArrayIndex(old_buf, oldsize);
+		if (!local_sai)
+			return 1;
+		sai = local_sai.get();
+
+		// Transfer ownership to the caller.
+		if (sai_cache)
+			*sai_cache = local_sai.release();
+	}
+
+	/* Initialize the patch file encoder */
+	DiffEncoder diff_encoder(patch, old_buf, oldsize, new_buf, newsize);
+	if (!diff_encoder.Init())
+		return 1;
+
+	/* Compute the differences, writing ctrl as we go */
+	scan=0;len=0;
+	lastscan=0;lastpos=0;lastoffset=0;
+	while(scan<newsize) {
+		oldscore=0;
+
+		/* If we come across a large block of data that only differs
+		 * by less than 8 bytes, this loop will take a long time to
+		 * go past that block of data. We need to track the number of
+		 * times we're stuck in the block and break out of it. */
+		int num_less_than_eight = 0;
+		size_t prev_len;
+		uint64_t prev_pos, prev_oldscore;
+		for(scsc=scan+=len;scan<newsize;scan++) {
+			prev_len=len;
+			prev_oldscore=oldscore;
+			prev_pos=pos;
+
+			sai->SearchPrefix(new_buf + scan, newsize - scan, &len, &pos);
+
+			for(;scsc<scan+len && scsc+lastoffset<oldsize;scsc++)
+				if(old_buf[scsc+lastoffset] == new_buf[scsc])
+					oldscore++;
+
+			if(((len==oldscore) && (len!=0)) ||
+				(len>=oldscore+8 && len>=min_length)) break;
+
+			if((scan+lastoffset<oldsize) &&
+				(old_buf[scan+lastoffset] == new_buf[scan]))
+				oldscore--;
+
+			const size_t fuzz = 8;
+			if (prev_len-fuzz<=len && len<=prev_len &&
+			    prev_oldscore-fuzz<=oldscore &&
+			    oldscore<=prev_oldscore &&
+			    prev_pos<=pos && pos <=prev_pos+fuzz &&
+			    oldscore<=len && len<=oldscore+fuzz)
+				++num_less_than_eight;
+			else
+				num_less_than_eight=0;
+			if (num_less_than_eight > 100) break;
+		};
+
+		if((len!=oldscore) || (scan==newsize)) {
+			s=0;Sf=0;lenf=0;
+			for(i=0;(lastscan+i<scan)&&(lastpos+i<oldsize);) {
+				if(old_buf[lastpos+i]==new_buf[lastscan+i]) s++;
+				i++;
+				if(s*2-i>Sf*2-lenf) { Sf=s; lenf=i; };
+			};
+
+			lenb=0;
+			if(scan<newsize) {
+				s=0;Sb=0;
+				for(i=1;(scan>=lastscan+i)&&(pos>=static_cast<uint64_t>(i));i++) {
+					if(old_buf[pos-i]==new_buf[scan-i]) s++;
+					if(s*2-i>Sb*2-lenb) { Sb=s; lenb=i; };
+				};
+			};
+
+			if(lastscan+lenf>scan-lenb) {
+				overlap=(lastscan+lenf)-(scan-lenb);
+				s=0;Ss=0;lens=0;
+				for(i=0;i<overlap;i++) {
+					if(new_buf[lastscan+lenf-overlap+i]==
+					   old_buf[lastpos+lenf-overlap+i]) s++;
+					if(new_buf[scan-lenb+i]==
+					   old_buf[pos-lenb+i]) s--;
+					if(s>Ss) { Ss=s; lens=i+1; };
+				};
+
+				lenf+=lens-overlap;
+				lenb-=lens;
+			};
+
+			if (!diff_encoder.AddControlEntry(
+			        ControlEntry(lenf,
+			                     (scan - lenb) - (lastscan + lenf),
+			                     (pos - lenb) - (lastpos + lenf))))
+				return 1;
+
+			lastscan=scan-lenb;
+			lastpos=pos-lenb;
+			lastoffset=pos-scan;
+		};
+	};
+	if (!diff_encoder.Close())
+		return 1;
+
+	return 0;
+}
+
+}  // namespace bsdiff

--- a/thirdparty/bsdiff/bsdiff/bspatch.cc
+++ b/thirdparty/bsdiff/bsdiff/bspatch.cc
@@ -1,0 +1,240 @@
+/*-
+ * Copyright 2003-2005 Colin Percival
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted providing that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if 0
+__FBSDID("$FreeBSD: src/usr.bin/bsdiff/bspatch/bspatch.c,v 1.1 2005/08/06 01:59:06 cperciva Exp $");
+#endif
+
+#include "bsdiff/bspatch.h"
+
+#include <stdlib.h>
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+
+#include "bsdiff/control_entry.h"
+#include "bsdiff/logging.h"
+
+namespace {
+// Read the data in |stream| and write |size| decompressed data to |file|;
+// using the buffer in |buf| with size |buf_size|.
+// Returns 0 on success, 1 on I/O error and 2 on data error.
+int ReadStreamAndWriteAll(
+    const std::unique_ptr<bsdiff::FileInterface>& file,
+    size_t size,
+    uint8_t* buf,
+    size_t buf_size,
+    const std::function<bool(uint8_t*, size_t)>& read_func) {
+  while (size > 0) {
+    size_t bytes_to_output = std::min(size, buf_size);
+    if (!read_func(buf, bytes_to_output)) {
+      LOG(ERROR) << "Failed to read stream.";
+      return 2;
+    }
+
+    if (!WriteAll(file, buf, bytes_to_output)) {
+      PLOG(ERROR) << "WriteAll() failed.";
+      return 1;
+    }
+    size -= bytes_to_output;
+  }
+  return 0;
+}
+
+}  // namespace
+
+namespace bsdiff {
+
+bool ReadAll(const std::unique_ptr<FileInterface>& file,
+             uint8_t* data,
+             size_t size) {
+  size_t offset = 0, read;
+  while (offset < size) {
+    if (!file->Read(data + offset, size - offset, &read) || read == 0)
+      return false;
+    offset += read;
+  }
+  return true;
+}
+
+bool WriteAll(const std::unique_ptr<FileInterface>& file,
+              const uint8_t* data,
+              size_t size) {
+  size_t offset = 0, written;
+  while (offset < size) {
+    if (!file->Write(data + offset, size - offset, &written) || written == 0)
+      return false;
+    offset += written;
+  }
+  return true;
+}
+
+// Patch |old_file| with |patch_data| and save it to |new_file|.
+// Returns 0 on success, 1 on I/O error and 2 on data error.
+int bspatch(const std::unique_ptr<FileInterface>& old_file,
+            const std::unique_ptr<FileInterface>& new_file,
+            const uint8_t* patch_data,
+            size_t patch_size,
+			PatchReaderInterface& patch_reader) {
+  if (!patch_reader.Init(patch_data, patch_size)) {
+    LOG(ERROR) << "Failed to initialize patch reader.";
+    return 2;
+  }
+
+  uint64_t old_file_size;
+  if (!old_file->GetSize(&old_file_size)) {
+    LOG(ERROR) << "Cannot obtain the size of old file.";
+    return 1;
+  }
+
+  // The oldpos can be negative, but the new pos is only incremented linearly.
+  int64_t oldpos = 0;
+  uint64_t newpos = 0;
+  std::vector<uint8_t> old_buf(1024 * 1024);
+  std::vector<uint8_t> new_buf(1024 * 1024);
+  uint64_t old_file_pos = 0;
+  while (newpos < patch_reader.new_file_size()) {
+    ControlEntry control_entry(0, 0, 0);
+    if (!patch_reader.ParseControlEntry(&control_entry)) {
+      LOG(ERROR) << "Failed to read control stream.";
+      return 2;
+    }
+
+    // Sanity-check.
+    if (newpos + control_entry.diff_size > patch_reader.new_file_size()) {
+      LOG(ERROR) << "Corrupt patch.";
+      return 2;
+    }
+
+    int ret = 0;
+    // Add old data to diff string. It is enough to fseek once, at
+    // the beginning of the sequence, to avoid unnecessary overhead.
+    int64_t seek_offset = oldpos;
+    if (seek_offset < 0) {
+      // Write diff block directly to new file without adding old data,
+      // because we will skip part where |oldpos| < 0.
+      ret = ReadStreamAndWriteAll(
+          new_file, oldpos - old_file_size, new_buf.data(), new_buf.size(),
+          std::bind(&PatchReaderInterface::ReadDiffStream, &patch_reader,
+                    std::placeholders::_1, std::placeholders::_2));
+      if (ret)
+        return ret;
+      seek_offset = 0;
+    }
+
+    // We just checked that |seek_offset| is not negative.
+    if (static_cast<uint64_t>(seek_offset) != old_file_pos &&
+        !old_file->Seek(seek_offset)) {
+      PLOG(ERROR) << "Error seeking input file to offset: " << seek_offset;
+      return 1;
+    }
+
+    old_file_pos =
+        std::min<uint64_t>(oldpos + control_entry.diff_size, old_file_size);
+    size_t chunk_size = old_file_pos - seek_offset;
+    while (chunk_size > 0) {
+      size_t read_bytes;
+      size_t bytes_to_read = std::min(chunk_size, old_buf.size());
+      if (!old_file->Read(old_buf.data(), bytes_to_read, &read_bytes)) {
+        PLOG(ERROR) << "Error reading from input file.";
+        return 1;
+      }
+      if (!read_bytes) {
+        LOG(ERROR) << "EOF reached while reading from input file.";
+        return 2;
+      }
+      // Read same amount of bytes from diff block
+      if (!patch_reader.ReadDiffStream(new_buf.data(), read_bytes)) {
+        LOG(ERROR) << "Failed to read diff stream.";
+        return 2;
+      }
+      // new_buf already has data from diff block, adds old data to it.
+      for (size_t k = 0; k < read_bytes; k++)
+        new_buf[k] += old_buf[k];
+      if (!WriteAll(new_file, new_buf.data(), read_bytes)) {
+        PLOG(ERROR) << "Error writing to new file.";
+        return 1;
+      }
+      chunk_size -= read_bytes;
+    }
+
+    // Adjust pointers.
+    newpos += control_entry.diff_size;
+    if (oldpos > INT64_MAX - static_cast<int64_t>(control_entry.diff_size))
+      return 2;
+    oldpos += control_entry.diff_size;
+
+    if (oldpos > static_cast<int64_t>(old_file_size)) {
+      // Write diff block directly to new file without adding old data,
+      // because we skipped part where |oldpos| > old_file_size.
+      ret = ReadStreamAndWriteAll(
+          new_file, oldpos - old_file_size, new_buf.data(), new_buf.size(),
+          std::bind(&PatchReaderInterface::ReadDiffStream, &patch_reader,
+                    std::placeholders::_1, std::placeholders::_2));
+      if (ret)
+        return ret;
+    }
+
+    // Sanity-check.
+    if (newpos + control_entry.extra_size > patch_reader.new_file_size()) {
+      LOG(ERROR) << "Corrupt patch.";
+      return 2;
+    }
+
+    // Read extra block.
+    ret = ReadStreamAndWriteAll(
+        new_file, control_entry.extra_size, new_buf.data(), new_buf.size(),
+        std::bind(&PatchReaderInterface::ReadExtraStream, &patch_reader,
+                  std::placeholders::_1, std::placeholders::_2));
+    if (ret)
+      return ret;
+
+    // Adjust pointers.
+    newpos += control_entry.extra_size;
+    if (control_entry.offset_increment > 0 &&
+        oldpos > INT64_MAX - control_entry.offset_increment)
+      return 2;
+    oldpos += control_entry.offset_increment;
+  }
+
+  // Close input file.
+  old_file->Close();
+
+  if (!patch_reader.Finish()) {
+    LOG(ERROR) << "Failed to finish the patch reader.";
+    return 2;
+  }
+
+  if (!new_file->Close()) {
+    PLOG(ERROR) << "Error closing new file.";
+    return 1;
+  }
+
+  return 0;
+}
+
+}  // namespace bsdiff

--- a/thirdparty/bsdiff/bsdiff/diff_encoder.cc
+++ b/thirdparty/bsdiff/bsdiff/diff_encoder.cc
@@ -1,0 +1,88 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "bsdiff/diff_encoder.h"
+
+#include <vector>
+
+#include "bsdiff/logging.h"
+
+namespace {
+
+// The maximum positive number that we should encode. A number larger than this
+// for unsigned fields will be interpreted as a negative value and thus a
+// corrupt patch.
+const uint64_t kMaxEncodedUint64Value = (1ULL << 63) - 1;
+
+}  // namespace
+
+namespace bsdiff {
+
+bool DiffEncoder::Init() {
+  return patch_->Init(new_size_);
+}
+
+bool DiffEncoder::AddControlEntry(const ControlEntry& entry) {
+  if (entry.diff_size > kMaxEncodedUint64Value) {
+    LOG(ERROR) << "Encoding value out of range " << entry.diff_size;
+    return false;
+  }
+
+  if (entry.extra_size > kMaxEncodedUint64Value) {
+    LOG(ERROR) << "Encoding value out of range " << entry.extra_size;
+    return false;
+  }
+
+  // entry.diff_size + entry.extra_size don't overflow in uint64_t since we
+  // checked the kMaxEncodedUint64Value limit before.
+  if (entry.diff_size + entry.extra_size > new_size_ - written_output_) {
+    LOG(ERROR) << "Wrote more output than the declared new_size";
+    return false;
+  }
+
+  if (entry.diff_size > 0 &&
+      (old_pos_ < 0 ||
+       static_cast<uint64_t>(old_pos_) + entry.diff_size > old_size_)) {
+    LOG(ERROR) << "The pointer in the old stream [" << old_pos_ << ", "
+               << (static_cast<uint64_t>(old_pos_) + entry.diff_size)
+               << ") is out of bounds [0, " << old_size_ << ")";
+    return false;
+  }
+
+  // Pass down the control entry.
+  if (!patch_->AddControlEntry(entry))
+    return false;
+
+  // Generate the diff stream.
+  std::vector<uint8_t> diff(entry.diff_size);
+  for (uint64_t i = 0; i < entry.diff_size; ++i) {
+    diff[i] = new_buf_[written_output_ + i] - old_buf_[old_pos_ + i];
+  }
+  if (!patch_->WriteDiffStream(diff.data(), diff.size())) {
+    LOG(ERROR) << "Writing " << diff.size() << " bytes to the diff stream";
+    return false;
+  }
+
+  if (!patch_->WriteExtraStream(new_buf_ + written_output_ + entry.diff_size,
+                                entry.extra_size)) {
+    LOG(ERROR) << "Writing " << entry.extra_size
+               << " bytes to the extra stream";
+    return false;
+  }
+
+  old_pos_ += entry.diff_size + entry.offset_increment;
+  written_output_ += entry.diff_size + entry.extra_size;
+
+  return true;
+}
+
+bool DiffEncoder::Close() {
+  if (written_output_ != new_size_) {
+    LOG(ERROR) << "Close() called but not all the output was written";
+    return false;
+  }
+  return patch_->Close();
+}
+
+}  // namespace bsdiff

--- a/thirdparty/bsdiff/bsdiff/diff_encoder.h
+++ b/thirdparty/bsdiff/bsdiff/diff_encoder.h
@@ -1,0 +1,66 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_DIFF_ENCODER_H_
+#define _BSDIFF_DIFF_ENCODER_H_
+
+#include <stdint.h>
+
+#include "bsdiff/patch_writer_interface.h"
+
+namespace bsdiff {
+
+// Helper class to encapsulate the diff and extra stream generation logic
+// derived from the old and new file buffers. Using this class is impossible to
+// produce an invalid or incomplete bsdiff patch, since it has checks in place
+// verifying its correct usage.
+
+class DiffEncoder {
+ public:
+  // Initialize the DiffEncoder with the old and new file buffers, as well as
+  // the path writer used. The |patch| will be initialized when calling Init().
+  DiffEncoder(PatchWriterInterface* patch,
+              const uint8_t* old_buf,
+              uint64_t old_size,
+              const uint8_t* new_buf,
+              uint64_t new_size)
+      : patch_(patch),
+        old_buf_(old_buf),
+        old_size_(old_size),
+        new_buf_(new_buf),
+        new_size_(new_size) {}
+
+  // Initialize the diff encoder and the underlying patch.
+  bool Init();
+
+  // Add a new control triplet entry to the patch. The |entry.diff_size| bytes
+  // for the diff stream and the |entry.extra_size| bytes for the extra stream
+  // will be computed and added to the corresponding streams in the patch.
+  // Returns whether the operation succeeded. The operation can fail if either
+  // the old or new files are referenced out of bounds.
+  bool AddControlEntry(const ControlEntry& entry);
+
+  // Finalize the patch writing process and close the underlying patch writer.
+  bool Close();
+
+ private:
+  // Pointer to the patch we are writing to.
+  PatchWriterInterface* patch_;
+
+  // Old and new file buffers.
+  const uint8_t* old_buf_;
+  uint64_t old_size_;
+  const uint8_t* new_buf_;
+  uint64_t new_size_;
+
+  // Bytes of the new_buf_ already written.
+  uint64_t written_output_{0};
+
+  // The current position in the old buf.
+  int64_t old_pos_{0};
+};
+
+}  // namespace bsdiff
+
+#endif  // _BSDIFF_DIFF_ENCODER_H_

--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/bsdiff.h
+++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/bsdiff.h
@@ -1,0 +1,44 @@
+// Copyright 2015 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_BSDIFF_H_
+#define _BSDIFF_BSDIFF_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "bsdiff/common.h"
+#include "bsdiff/patch_writer_interface.h"
+#include "bsdiff/suffix_array_index_interface.h"
+
+namespace bsdiff {
+
+BSDIFF_EXPORT
+int bsdiff(const uint8_t* old_buf,
+           size_t oldsize,
+           const uint8_t* new_buf,
+           size_t newsize,
+           PatchWriterInterface* patch,
+           SuffixArrayIndexInterface** sai_cache);
+
+// The |min_length| parameter determines the required minimum length of a match
+// to be considered instead of emitting mismatches. The minimum value is 9,
+// since smaller matches are always ignored. If a smaller value is passed, the
+// minimum value of 9 will be used instead. A very large value (past 30) will
+// give increasingly bad results as you increase the minimum length since legit
+// matches between the old and new data will be ignored. The exact best value
+// depends on the data, but the sweet spot should be between 9 and 20 for the
+// examples tested.
+BSDIFF_EXPORT
+int bsdiff(const uint8_t* old_buf,
+           size_t oldsize,
+           const uint8_t* new_buf,
+           size_t newsize,
+           size_t min_length,
+           PatchWriterInterface* patch,
+           SuffixArrayIndexInterface** sai_cache);
+
+}  // namespace bsdiff
+
+#endif  // _BSDIFF_BSDIFF_H_

--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/bspatch.h
+++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/bspatch.h
@@ -1,0 +1,32 @@
+// Copyright 2015 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_BSPATCH_H_
+#define _BSDIFF_BSPATCH_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+
+#include "bsdiff/common.h"
+#include "bsdiff/file_interface.h"
+#include "bsdiff/patch_reader_interface.h"
+
+namespace bsdiff {
+
+BSDIFF_EXPORT
+int bspatch(const std::unique_ptr<FileInterface>& old_file,
+            const std::unique_ptr<FileInterface>& new_file,
+            const uint8_t* patch_data,
+            size_t patch_size,
+			PatchReaderInterface& patch_reader);
+
+bool WriteAll(const std::unique_ptr<FileInterface>& file,
+              const uint8_t* data,
+              size_t size);
+
+}  // namespace bsdiff
+
+#endif  // _BSDIFF_BSPATCH_H_

--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/common.h
+++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/common.h
@@ -1,0 +1,14 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_COMMON_H_
+#define _BSDIFF_COMMON_H_
+
+// We defined this export macro to avoid depending on brillo (BRILLO_EXPORT in
+// "brillo/brillo_export.h")
+#ifndef BSDIFF_EXPORT
+#define BSDIFF_EXPORT __attribute__((__visibility__("default")))
+#endif
+
+#endif  // _BSDIFF_COMMON_H_

--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/control_entry.h
+++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/control_entry.h
@@ -1,0 +1,34 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_CONTROL_ENTRY_H_
+#define _BSDIFF_CONTROL_ENTRY_H_
+
+#include <stdint.h>
+
+struct ControlEntry {
+  constexpr ControlEntry(uint64_t diff_size,
+                         uint64_t extra_size,
+                         int64_t offset_increment)
+      : diff_size(diff_size),
+        extra_size(extra_size),
+        offset_increment(offset_increment) {}
+  constexpr ControlEntry() = default;
+
+  // The number of bytes to copy from the source and diff stream.
+  uint64_t diff_size{0};
+
+  // The number of bytes to copy from the extra stream.
+  uint64_t extra_size{0};
+
+  // The value to add to the source pointer after patching from the diff stream.
+  int64_t offset_increment{0};
+
+  [[nodiscard]] bool operator==(const ControlEntry& o) const {
+    return diff_size == o.diff_size && extra_size == o.extra_size &&
+           offset_increment == o.offset_increment;
+  }
+};
+
+#endif  // _BSDIFF_CONTROL_ENTRY_H_

--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/file_interface.h
+++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/file_interface.h
@@ -1,0 +1,51 @@
+// Copyright 2015 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_FILE_INTERFACE_H_
+#define _BSDIFF_FILE_INTERFACE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "bsdiff/common.h"
+
+namespace bsdiff {
+
+class BSDIFF_EXPORT FileInterface {
+ public:
+  virtual ~FileInterface() = default;
+
+  // Reads synchronously from the current file position up to |count| bytes into
+  // the passed |buf| buffer. On success, stores in |bytes_read| how many bytes
+  // were actually read from the file. In case of error returns false. This
+  // method may read less than |count| bytes even if there's no error. If the
+  // end of file is reached, 0 bytes will be read and this methods returns true.
+  virtual bool Read(void* buf, size_t count, size_t* bytes_read) = 0;
+
+  // Writes synchronously up to |count| bytes from to passed |buf| buffer to
+  // the file. On success, stores in |bytes_written| how many bytes
+  // were actually written to the file. This method may write less than |count|
+  // bytes and return successfully, or even write 0 bytes if there's no more
+  // space left on the device. Returns whether the write succeeded.
+  virtual bool Write(const void* buf, size_t count, size_t* bytes_written) = 0;
+
+  // Change the current file position to |pos| bytes from the beginning of the
+  // file. Return whether the seek succeeded.
+  virtual bool Seek(int64_t pos) = 0;
+
+  // Closes the file and flushes any cached data. Returns whether the close
+  // succeeded.
+  virtual bool Close() = 0;
+
+  // Compute the size of the file and store it in |size|. Returns whether it
+  // computed the size successfully.
+  virtual bool GetSize(uint64_t* size) = 0;
+
+ protected:
+  FileInterface() = default;
+};
+
+}  // namespace bsdiff
+
+#endif  // _BSDIFF_FILE_INTERFACE_H_

--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/patch_reader_interface.h
+++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/patch_reader_interface.h
@@ -1,0 +1,43 @@
+#ifndef _BSDIFF_PATCH_READER_INTERFACE_H_
+#define _BSDIFF_PATCH_READER_INTERFACE_H_
+
+#include <stddef.h>
+
+#include "bsdiff/control_entry.h"
+
+namespace bsdiff {
+
+class PatchReaderInterface {
+ public:
+  virtual ~PatchReaderInterface() = default;
+
+  // Initialize the control stream, diff stream and extra stream from the
+  // corresponding offset of |patch_data|.
+  virtual bool Init(const uint8_t* patch_data, size_t patch_size) = 0;
+
+  // Read the control stream and parse the metadata of |diff_size_|,
+  // |extra_size_| and |offset_incremental_|.
+  virtual bool ParseControlEntry(ControlEntry* control_entry) = 0;
+
+  // Read the data in |diff_stream_| and write |size| decompressed data to
+  // |buf|.
+  virtual bool ReadDiffStream(uint8_t* buf, size_t size) = 0;
+
+  // Read the data in |extra_stream_| and write |size| decompressed data to
+  // |buf|.
+  virtual bool ReadExtraStream(uint8_t* buf, size_t size) = 0;
+
+  // Returns the new file size as read from the header.
+  virtual uint64_t new_file_size() const = 0;
+
+  // Close the control/diff/extra stream. Return false if errors occur when
+  // closing any of these streams.
+  virtual bool Finish() = 0;
+
+ protected:
+  PatchReaderInterface() = default;
+};
+
+}  // namespace bsdiff
+
+#endif  // _BSDIFF_PATCH_WRITER_INTERFACE_H_

--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/patch_writer_interface.h
+++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/patch_writer_interface.h
@@ -1,0 +1,51 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_PATCH_WRITER_INTERFACE_H_
+#define _BSDIFF_PATCH_WRITER_INTERFACE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "bsdiff/control_entry.h"
+
+namespace bsdiff {
+
+enum class BsdiffFormat {
+  kLegacy,
+  kBsdf2,
+  kEndsley,
+};
+
+class PatchWriterInterface {
+ public:
+  virtual ~PatchWriterInterface() = default;
+
+  // Initialize the patch writer for a patch where the new file will have
+  // |new_size| bytes.
+  virtual bool Init(size_t new_size) = 0;
+
+  // Write the passed |data| buffer of length |size| to the Diff or Extra
+  // streams respectively. Each method can be called independently from each
+  // other and calls don't need to be a correlation with the AddControlEntry()
+  // until Close() is called.
+  virtual bool WriteDiffStream(const uint8_t* data, size_t size) = 0;
+  virtual bool WriteExtraStream(const uint8_t* data, size_t size) = 0;
+
+  // Add a new control triplet entry to the patch. These triplets may be added
+  // at any point before calling Close(), regardless of whether the
+  // corresponding WriteDiffStream() and WriteExtraStream() have been called
+  // yet.
+  virtual bool AddControlEntry(const ControlEntry& entry) = 0;
+
+  // Finalize the patch writing process and close the file.
+  virtual bool Close() = 0;
+
+ protected:
+  PatchWriterInterface() = default;
+};
+
+}  // namespace bsdiff
+
+#endif  // _BSDIFF_PATCH_WRITER_INTERFACE_H_

--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/suffix_array_index_interface.h
+++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/suffix_array_index_interface.h
@@ -1,0 +1,37 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_SUFFIX_ARRAY_INDEX_INTERFACE_H_
+#define _BSDIFF_SUFFIX_ARRAY_INDEX_INTERFACE_H_
+
+// The SuffixArrayIndexInterface encapsulates a search index based on a
+// suffix-array with a common string search interface. The implementations of
+// this index can vary on technical details, such as the size of the internal
+// suffix array elements, which are not visible in this interface.
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace bsdiff {
+
+class SuffixArrayIndexInterface {
+ public:
+  virtual ~SuffixArrayIndexInterface() = default;
+
+  // Search in the index the longest prefix of the string |target| of length
+  // |length|. The length of the longest prefix found, which could be 0, is
+  // stored in |out_length| and a position in the source text where this prefix
+  // was found is store in |out_pos|.
+  virtual void SearchPrefix(const uint8_t* target,
+                            size_t length,
+                            size_t* out_length,
+                            uint64_t* out_pos) const = 0;
+
+ protected:
+  SuffixArrayIndexInterface() = default;
+};
+
+}  // namespace bsdiff
+
+#endif  // _BSDIFF_SUFFIX_ARRAY_INDEX_INTERFACE_H_

--- a/thirdparty/bsdiff/bsdiff/logging.cc
+++ b/thirdparty/bsdiff/bsdiff/logging.cc
@@ -1,0 +1,32 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "bsdiff/logging.h"
+
+#include <ctime>
+
+LogMessage::LogMessage(const char* file,
+                       unsigned int line,
+                       const char* severity)
+    : LogMessage(file, line, severity, -1) {}
+
+
+LogMessage::LogMessage(const char* file,
+                       unsigned int line,
+                       const char* severity,
+                       int error)
+    : error_(error) {
+  std::time_t t = std::time(nullptr);
+  char timestamp[32];
+  strftime(timestamp, sizeof(timestamp), "%m-%d %H:%M:%S", std::localtime(&t));
+
+  stream_ << severity << " " << timestamp << " " << file << ":" << line << ": ";
+}
+
+LogMessage::~LogMessage() {
+  if (error_ != -1) {
+    stream_ << ": " << strerror(error_);
+  }
+  std::cerr << stream_.str() << std::endl;
+}

--- a/thirdparty/bsdiff/bsdiff/logging.h
+++ b/thirdparty/bsdiff/bsdiff/logging.h
@@ -1,0 +1,40 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_LOGGING_H_
+#define _BSDIFF_LOGGING_H_
+
+#include <string.h>
+
+#include <iostream>
+#include <sstream>
+
+// Simple error logging macro to avoid dependencies in other base libraries.
+#define LOG(severity) LogMessage(__FILE__, __LINE__, #severity).stream()
+
+// A variant of LOG that also logs the current errno value.
+#define PLOG(severity) LogMessage(__FILE__, __LINE__, #severity, errno).stream()
+
+// A temporarily scoped object used by LOG & PLOG.
+class LogMessage {
+ public:
+  LogMessage(const char* file, unsigned int line, const char* severity);
+
+  LogMessage(const char* file,
+             unsigned int line,
+             const char* severity,
+             int error);
+
+  ~LogMessage();
+
+  // Returns the stream associated with the message, the LogMessage performs
+  // output when it goes out of scope.
+  std::ostream& stream() { return stream_; }
+
+ private:
+  std::ostringstream stream_;
+  int error_;  // The saved errno value.
+};
+
+#endif  // _BSDIFF_LOGGING_H_

--- a/thirdparty/bsdiff/bsdiff/suffix_array_index.cc
+++ b/thirdparty/bsdiff/bsdiff/suffix_array_index.cc
@@ -1,0 +1,173 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "bsdiff/suffix_array_index.h"
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include <divsufsort.h>
+#include <divsufsort64.h>
+
+#include "bsdiff/logging.h"
+
+namespace {
+
+// libdivsufsort C++ overloaded functions used to allow calling the right
+// implementation based on the pointer size.
+int CallDivSufSort(const uint8_t* text, saidx_t* sa, size_t n) {
+  return divsufsort(text, sa, n);
+}
+int CallDivSufSort(const uint8_t* text, saidx64_t* sa, size_t n) {
+  return divsufsort64(text, sa, n);
+}
+
+saidx_t CallSaSearch(const uint8_t* text,
+                     size_t text_size,
+                     const uint8_t* pattern,
+                     size_t pattern_size,
+                     const saidx_t* sa,
+                     size_t sa_size,
+                     saidx_t* left) {
+  return sa_search(text, text_size, pattern, pattern_size, sa, sa_size, left);
+}
+saidx64_t CallSaSearch(const uint8_t* text,
+                       size_t text_size,
+                       const uint8_t* pattern,
+                       size_t pattern_size,
+                       const saidx64_t* sa,
+                       size_t sa_size,
+                       saidx64_t* left) {
+  return sa_search64(text, text_size, pattern, pattern_size, sa, sa_size, left);
+}
+
+}  // namespace
+
+namespace bsdiff {
+
+// The SAIDX template type must be either saidx_t or saidx64_t, which will
+// depend on the maximum size of the input text needed.
+template <typename SAIDX>
+class SuffixArrayIndex : public SuffixArrayIndexInterface {
+ public:
+  SuffixArrayIndex() = default;
+
+  // Initialize and construct the suffix array of the |text| string of length
+  // |n|. The memory pointed by |text| must be kept alive. Returns whether the
+  // construction succeeded.
+  bool Init(const uint8_t* text, size_t n);
+
+  // SuffixArrayIndexInterface overrides.
+  void SearchPrefix(const uint8_t* target,
+                    size_t length,
+                    size_t* out_length,
+                    uint64_t* out_pos) const override;
+
+ private:
+  const uint8_t* text_{nullptr};  // Owned by the caller.
+  size_t n_{0};
+
+  std::vector<SAIDX> sa_;
+};
+
+template <typename SAIDX>
+bool SuffixArrayIndex<SAIDX>::Init(const uint8_t* text, size_t n) {
+  if (!sa_.empty()) {
+    // Already initialized.
+    LOG(ERROR) << "SuffixArray already initialized";
+    return false;
+  }
+  if (static_cast<uint64_t>(n) >
+      static_cast<uint64_t>(std::numeric_limits<SAIDX>::max())) {
+    LOG(ERROR) << "Input too big (" << n << ") for this implementation";
+    return false;
+  }
+  text_ = text;
+  n_ = n;
+  sa_.resize(n + 1);
+
+  if (n > 0 && CallDivSufSort(text_, sa_.data(), n) != 0) {
+    LOG(ERROR) << "divsufsrot() failed";
+    return false;
+  }
+
+  return true;
+}
+
+template <typename SAIDX>
+void SuffixArrayIndex<SAIDX>::SearchPrefix(const uint8_t* target,
+                                           size_t length,
+                                           size_t* out_length,
+                                           uint64_t* out_pos) const {
+  SAIDX suf_left;
+  SAIDX count =
+      CallSaSearch(text_, n_, target, length, sa_.data(), n_, &suf_left);
+  if (count > 0) {
+    // This is the simple case where we found the whole |target| string was
+    // found.
+    *out_pos = sa_[suf_left];
+    *out_length = length;
+    return;
+  }
+  // In this case, |suf_left| points to the first suffix array position such
+  // that the suffix at that position is lexicographically larger than |target|.
+  // We only need to check whether the previous entry or the current entry is a
+  // longer match.
+  size_t prev_suffix_len = 0;
+  if (suf_left > 0) {
+    const size_t prev_max_len =
+        std::min(n_ - static_cast<size_t>(sa_[suf_left - 1]), length);
+    const uint8_t* prev_suffix = text_ + sa_[suf_left - 1];
+    prev_suffix_len =
+        std::mismatch(target, target + prev_max_len, prev_suffix).first -
+        target;
+  }
+
+  size_t next_suffix_len = 0;
+  if (static_cast<size_t>(suf_left) < n_) {
+    const uint8_t* next_suffix = text_ + sa_[suf_left];
+    const size_t next_max_len =
+        std::min(n_ - static_cast<size_t>(sa_[suf_left]), length);
+    next_suffix_len =
+        std::mismatch(target, target + next_max_len, next_suffix).first -
+        target;
+  }
+
+  *out_length = std::max(next_suffix_len, prev_suffix_len);
+  if (!*out_length) {
+    *out_pos = 0;
+  } else if (next_suffix_len >= prev_suffix_len) {
+    *out_pos = sa_[suf_left];
+  } else {
+    *out_pos = sa_[suf_left - 1];
+  }
+}
+
+std::unique_ptr<SuffixArrayIndexInterface> CreateSuffixArrayIndex(
+    const uint8_t* text,
+    size_t n) {
+  // The maximum supported size when using the suffix array based on the 32-bit
+  // saidx_t type. We limit this to something a bit smaller (16 bytes smaller)
+  // than the maximum representable number so references like "n + 1" are don't
+  // overflow.
+  const size_t kMaxSaidxSize = std::numeric_limits<saidx_t>::max() - 16;
+  std::unique_ptr<SuffixArrayIndexInterface> ret;
+
+  if (n > kMaxSaidxSize) {
+    SuffixArrayIndex<saidx64_t>* sa_ptr = new SuffixArrayIndex<saidx64_t>();
+    ret.reset(sa_ptr);
+    if (!sa_ptr->Init(text, n))
+      return nullptr;
+  } else {
+    SuffixArrayIndex<saidx_t>* sa_ptr = new SuffixArrayIndex<saidx_t>();
+    ret.reset(sa_ptr);
+    if (!sa_ptr->Init(text, n))
+      return nullptr;
+  }
+  return ret;
+}
+
+
+}  // namespace bsdiff

--- a/thirdparty/bsdiff/bsdiff/suffix_array_index.h
+++ b/thirdparty/bsdiff/bsdiff/suffix_array_index.h
@@ -1,0 +1,22 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef _BSDIFF_SUFFIX_ARRAY_INDEX_H_
+#define _BSDIFF_SUFFIX_ARRAY_INDEX_H_
+
+#include <stdint.h>
+
+#include <memory>
+
+#include "bsdiff/suffix_array_index_interface.h"
+
+namespace bsdiff {
+
+std::unique_ptr<SuffixArrayIndexInterface> CreateSuffixArrayIndex(
+    const uint8_t* text,
+    size_t n);
+
+}  // namespace bsdiff
+
+#endif  // _BSDIFF_SUFFIX_ARRAY_INDEX_H_

--- a/thirdparty/bsdiff/patches/0001-shrink-and-fix-windows.patch
+++ b/thirdparty/bsdiff/patches/0001-shrink-and-fix-windows.patch
@@ -1,0 +1,451 @@
+diff --git a/thirdparty/bsdiff/bsdiff/bsdiff.cc b/thirdparty/bsdiff/bsdiff/bsdiff.cc
+index a1112d503f..9ee4aa01c4 100644
+--- a/thirdparty/bsdiff/bsdiff/bsdiff.cc
++++ b/thirdparty/bsdiff/bsdiff/bsdiff.cc
+@@ -30,30 +30,16 @@ __FBSDID("$FreeBSD: src/usr.bin/bsdiff/bsdiff/bsdiff.c,v 1.1 2005/08/06 01:59:05
+ 
+ #include "bsdiff/bsdiff.h"
+ 
+-#include <sys/types.h>
+-
+-#include <err.h>
++#include <stdint.h>
+ #include <string.h>
+ 
+ #include <algorithm>
+ 
+ #include "bsdiff/diff_encoder.h"
+-#include "bsdiff/patch_writer.h"
+ #include "bsdiff/suffix_array_index.h"
+ 
+ namespace bsdiff {
+ 
+-// TODO(deymo): Deprecate this version of the interface and move all callers
+-// to the underlying version using PatchWriterInterface instead. This allows
+-// more flexible options including different encodings.
+-int bsdiff(const uint8_t* old_buf, size_t oldsize, const uint8_t* new_buf,
+-           size_t newsize, const char* patch_filename,
+-           SuffixArrayIndexInterface** sai_cache) {
+-	BsdiffPatchWriter patch(patch_filename);
+-	return bsdiff(old_buf, oldsize, new_buf, newsize, 0, &patch,
+-	              sai_cache);
+-}
+-
+ int bsdiff(const uint8_t* old_buf, size_t oldsize, const uint8_t* new_buf,
+            size_t newsize, PatchWriterInterface* patch,
+            SuffixArrayIndexInterface** sai_cache) {
+@@ -69,9 +55,9 @@ int bsdiff(const uint8_t* old_buf, size_t oldsize, const uint8_t* new_buf,
+ 	size_t len;
+ 	size_t lastscan,lastpos,lastoffset;
+ 	uint64_t oldscore;
+-	ssize_t s,Sf,lenf,Sb,lenb;
+-	ssize_t overlap,Ss,lens;
+-	ssize_t i;
++	int64_t s,Sf,lenf,Sb,lenb;
++	int64_t overlap,Ss,lens;
++	int64_t i;
+ 
+ 	std::unique_ptr<SuffixArrayIndexInterface> local_sai;
+ 	SuffixArrayIndexInterface* sai;
+@@ -173,7 +159,7 @@ int bsdiff(const uint8_t* old_buf, size_t oldsize, const uint8_t* new_buf,
+ 			        ControlEntry(lenf,
+ 			                     (scan - lenb) - (lastscan + lenf),
+ 			                     (pos - lenb) - (lastpos + lenf))))
+-				errx(1, "Writing a control entry");
++				return 1;
+ 
+ 			lastscan=scan-lenb;
+ 			lastpos=pos-lenb;
+@@ -181,7 +167,7 @@ int bsdiff(const uint8_t* old_buf, size_t oldsize, const uint8_t* new_buf,
+ 		};
+ 	};
+ 	if (!diff_encoder.Close())
+-		errx(1, "Closing the patch file");
++		return 1;
+ 
+ 	return 0;
+ }
+diff --git a/thirdparty/bsdiff/bsdiff/bspatch.cc b/thirdparty/bsdiff/bsdiff/bspatch.cc
+index e95b9a2862..fabd3989c8 100644
+--- a/thirdparty/bsdiff/bsdiff/bspatch.cc
++++ b/thirdparty/bsdiff/bsdiff/bspatch.cc
+@@ -30,32 +30,14 @@ __FBSDID("$FreeBSD: src/usr.bin/bsdiff/bspatch/bspatch.c,v 1.1 2005/08/06 01:59:
+ 
+ #include "bsdiff/bspatch.h"
+ 
+-#include <errno.h>
+-#include <fcntl.h>
+-#include <inttypes.h>
+-#include <stdint.h>
+-#include <stdio.h>
+ #include <stdlib.h>
+-#include <string.h>
+-#include <sys/stat.h>
+-#include <sys/types.h>
+-#include <unistd.h>
+ 
+ #include <algorithm>
++#include <functional>
+ #include <memory>
+-#include <vector>
+ 
+-#include "bsdiff/buffer_file.h"
+ #include "bsdiff/control_entry.h"
+-#include "bsdiff/extents.h"
+-#include "bsdiff/extents_file.h"
+-#include "bsdiff/file.h"
+-#include "bsdiff/file_interface.h"
+ #include "bsdiff/logging.h"
+-#include "bsdiff/memory_file.h"
+-#include "bsdiff/patch_reader.h"
+-#include "bsdiff/sink_file.h"
+-#include "bsdiff/utils.h"
+ 
+ namespace {
+ // Read the data in |stream| and write |size| decompressed data to |file|;
+@@ -111,141 +93,13 @@ bool WriteAll(const std::unique_ptr<FileInterface>& file,
+   return true;
+ }
+ 
+-bool IsOverlapping(const char* old_filename,
+-                   const char* new_filename,
+-                   const std::vector<ex_t>& old_extents,
+-                   const std::vector<ex_t>& new_extents) {
+-  struct stat old_stat, new_stat;
+-  if (stat(new_filename, &new_stat) == -1) {
+-    if (errno == ENOENT)
+-      return false;
+-    PLOG(ERROR) << "Error stat the new file: " << new_filename;
+-    return true;
+-  }
+-  if (stat(old_filename, &old_stat) == -1) {
+-    PLOG(ERROR) << "Error stat the old file: " << old_filename;
+-    return true;
+-  }
+-
+-  if (old_stat.st_dev != new_stat.st_dev || old_stat.st_ino != new_stat.st_ino)
+-    return false;
+-
+-  if (old_extents.empty() && new_extents.empty())
+-    return true;
+-
+-  for (ex_t old_ex : old_extents)
+-    for (ex_t new_ex : new_extents)
+-      if (static_cast<uint64_t>(old_ex.off) < new_ex.off + new_ex.len &&
+-          static_cast<uint64_t>(new_ex.off) < old_ex.off + old_ex.len)
+-        return true;
+-
+-  return false;
+-}
+-
+-// Patch |old_filename| with |patch_filename| and save it to |new_filename|.
+-// |old_extents| and |new_extents| are comma-separated lists of "offset:length"
+-// extents of |old_filename| and |new_filename|.
+-// Returns 0 on success, 1 on I/O error and 2 on data error.
+-int bspatch(const char* old_filename,
+-            const char* new_filename,
+-            const char* patch_filename,
+-            const char* old_extents,
+-            const char* new_extents) {
+-  std::unique_ptr<FileInterface> patch_file =
+-      File::FOpen(patch_filename, O_RDONLY);
+-  if (!patch_file) {
+-    PLOG(ERROR) << "Error opening the patch file: " << patch_filename;
+-    return 1;
+-  }
+-  uint64_t patch_size;
+-  patch_file->GetSize(&patch_size);
+-  std::vector<uint8_t> patch(patch_size);
+-  if (!ReadAll(patch_file, patch.data(), patch_size)) {
+-    PLOG(ERROR) << "Error reading the patch file: " << patch_filename;
+-    return 1;
+-  }
+-  patch_file.reset();
+-
+-  return bspatch(old_filename, new_filename, patch.data(), patch_size,
+-                 old_extents, new_extents);
+-}
+-
+-// Patch |old_filename| with |patch_data| and save it to |new_filename|.
+-// |old_extents| and |new_extents| are comma-separated lists of "offset:length"
+-// extents of |old_filename| and |new_filename|.
+-// Returns 0 on success, 1 on I/O error and 2 on data error.
+-int bspatch(const char* old_filename,
+-            const char* new_filename,
+-            const uint8_t* patch_data,
+-            size_t patch_size,
+-            const char* old_extents,
+-            const char* new_extents) {
+-  int using_extents = (old_extents != NULL || new_extents != NULL);
+-
+-  // Open input file for reading.
+-  std::unique_ptr<FileInterface> old_file = File::FOpen(old_filename, O_RDONLY);
+-  if (!old_file) {
+-    PLOG(ERROR) << "Error opening the old file: " << old_filename;
+-    return 1;
+-  }
+-
+-  std::vector<ex_t> parsed_old_extents;
+-  if (using_extents) {
+-    if (!ParseExtentStr(old_extents, &parsed_old_extents)) {
+-      LOG(ERROR) << "Error parsing the old extents.";
+-      return 2;
+-    }
+-    old_file.reset(new ExtentsFile(std::move(old_file), parsed_old_extents));
+-  }
+-
+-  // Open output file for writing.
+-  std::unique_ptr<FileInterface> new_file =
+-      File::FOpen(new_filename, O_CREAT | O_WRONLY);
+-  if (!new_file) {
+-    PLOG(ERROR) << "Error opening the new file: " << new_filename;
+-    return 1;
+-  }
+-
+-  std::vector<ex_t> parsed_new_extents;
+-  if (using_extents) {
+-    if (!ParseExtentStr(new_extents, &parsed_new_extents)) {
+-      LOG(ERROR) << "Error parsing the new extents.";
+-      return 2;
+-    }
+-    new_file.reset(new ExtentsFile(std::move(new_file), parsed_new_extents));
+-  }
+-
+-  if (IsOverlapping(old_filename, new_filename, parsed_old_extents,
+-                    parsed_new_extents)) {
+-    // New and old file is overlapping, we can not stream output to new file,
+-    // cache it in a buffer and write to the file at the end.
+-    uint64_t newsize = ParseInt64(patch_data + 24);
+-    new_file.reset(new BufferFile(std::move(new_file), newsize));
+-  }
+-
+-  return bspatch(old_file, new_file, patch_data, patch_size);
+-}
+-
+-// Patch |old_data| with |patch_data| and save it by calling sink function.
+-// Returns 0 on success, 1 on I/O error and 2 on data error.
+-int bspatch(const uint8_t* old_data,
+-            size_t old_size,
+-            const uint8_t* patch_data,
+-            size_t patch_size,
+-            const sink_func& sink) {
+-  std::unique_ptr<FileInterface> old_file(new MemoryFile(old_data, old_size));
+-  std::unique_ptr<FileInterface> new_file(new SinkFile(sink));
+-
+-  return bspatch(old_file, new_file, patch_data, patch_size);
+-}
+-
+ // Patch |old_file| with |patch_data| and save it to |new_file|.
+ // Returns 0 on success, 1 on I/O error and 2 on data error.
+ int bspatch(const std::unique_ptr<FileInterface>& old_file,
+             const std::unique_ptr<FileInterface>& new_file,
+             const uint8_t* patch_data,
+-            size_t patch_size) {
+-  BsdiffPatchReader patch_reader;
++            size_t patch_size,
++			PatchReaderInterface& patch_reader) {
+   if (!patch_reader.Init(patch_data, patch_size)) {
+     LOG(ERROR) << "Failed to initialize patch reader.";
+     return 2;
+@@ -285,7 +139,7 @@ int bspatch(const std::unique_ptr<FileInterface>& old_file,
+       // because we will skip part where |oldpos| < 0.
+       ret = ReadStreamAndWriteAll(
+           new_file, oldpos - old_file_size, new_buf.data(), new_buf.size(),
+-          std::bind(&BsdiffPatchReader::ReadDiffStream, &patch_reader,
++          std::bind(&PatchReaderInterface::ReadDiffStream, &patch_reader,
+                     std::placeholders::_1, std::placeholders::_2));
+       if (ret)
+         return ret;
+@@ -339,7 +193,7 @@ int bspatch(const std::unique_ptr<FileInterface>& old_file,
+       // because we skipped part where |oldpos| > old_file_size.
+       ret = ReadStreamAndWriteAll(
+           new_file, oldpos - old_file_size, new_buf.data(), new_buf.size(),
+-          std::bind(&BsdiffPatchReader::ReadDiffStream, &patch_reader,
++          std::bind(&PatchReaderInterface::ReadDiffStream, &patch_reader,
+                     std::placeholders::_1, std::placeholders::_2));
+       if (ret)
+         return ret;
+@@ -354,7 +208,7 @@ int bspatch(const std::unique_ptr<FileInterface>& old_file,
+     // Read extra block.
+     ret = ReadStreamAndWriteAll(
+         new_file, control_entry.extra_size, new_buf.data(), new_buf.size(),
+-        std::bind(&BsdiffPatchReader::ReadExtraStream, &patch_reader,
++        std::bind(&PatchReaderInterface::ReadExtraStream, &patch_reader,
+                   std::placeholders::_1, std::placeholders::_2));
+     if (ret)
+       return ret;
+diff --git a/thirdparty/bsdiff/bsdiff/diff_encoder.h b/thirdparty/bsdiff/bsdiff/diff_encoder.h
+index 3d992df8d2..6fa0854dba 100644
+--- a/thirdparty/bsdiff/bsdiff/diff_encoder.h
++++ b/thirdparty/bsdiff/bsdiff/diff_encoder.h
+@@ -7,7 +7,6 @@
+ 
+ #include <stdint.h>
+ 
+-#include "bsdiff/bz2_compressor.h"
+ #include "bsdiff/patch_writer_interface.h"
+ 
+ namespace bsdiff {
+diff --git a/thirdparty/bsdiff/bsdiff/include/bsdiff/bsdiff.h b/thirdparty/bsdiff/bsdiff/include/bsdiff/bsdiff.h
+index b6475f4b30..d418879270 100644
+--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/bsdiff.h
++++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/bsdiff.h
+@@ -14,18 +14,6 @@
+ 
+ namespace bsdiff {
+ 
+-// Generate bsdiff patch from |old_buf| to |new_buf|, save the patch file to
+-// |patch_filename|. Returns 0 on success.
+-// |sai_cache| can be used to cache the suffix array if the same |old_buf| is
+-//  used repeatedly, pass nullptr if not needed.
+-BSDIFF_EXPORT
+-int bsdiff(const uint8_t* old_buf,
+-           size_t oldsize,
+-           const uint8_t* new_buf,
+-           size_t newsize,
+-           const char* patch_filename,
+-           SuffixArrayIndexInterface** sai_cache);
+-
+ BSDIFF_EXPORT
+ int bsdiff(const uint8_t* old_buf,
+            size_t oldsize,
+diff --git a/thirdparty/bsdiff/bsdiff/include/bsdiff/bspatch.h b/thirdparty/bsdiff/bsdiff/include/bsdiff/bspatch.h
+index 0e67ede344..9a0733e777 100644
+--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/bspatch.h
++++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/bspatch.h
+@@ -8,51 +8,25 @@
+ #include <stddef.h>
+ #include <stdint.h>
+ 
+-#include <functional>
+ #include <memory>
+-#include <vector>
+ 
+-#include "bsdiff/extents_file.h"
++#include "bsdiff/common.h"
++#include "bsdiff/file_interface.h"
++#include "bsdiff/patch_reader_interface.h"
+ 
+ namespace bsdiff {
+ 
+-BSDIFF_EXPORT
+-int bspatch(const char* old_filename,
+-            const char* new_filename,
+-            const char* patch_filename,
+-            const char* old_extents,
+-            const char* new_extents);
+-
+-BSDIFF_EXPORT
+-int bspatch(const char* old_filename,
+-            const char* new_filename,
+-            const uint8_t* patch_data,
+-            size_t patch_size,
+-            const char* old_extents,
+-            const char* new_extents);
+-
+-BSDIFF_EXPORT
+-int bspatch(const uint8_t* old_data,
+-            size_t old_size,
+-            const uint8_t* patch_data,
+-            size_t patch_size,
+-            const std::function<size_t(const uint8_t*, size_t)>& sink);
+-
+ BSDIFF_EXPORT
+ int bspatch(const std::unique_ptr<FileInterface>& old_file,
+             const std::unique_ptr<FileInterface>& new_file,
+             const uint8_t* patch_data,
+-            size_t patch_size);
++            size_t patch_size,
++			PatchReaderInterface& patch_reader);
+ 
+ bool WriteAll(const std::unique_ptr<FileInterface>& file,
+               const uint8_t* data,
+               size_t size);
+ 
+-bool IsOverlapping(const char* old_filename,
+-                   const char* new_filename,
+-                   const std::vector<ex_t>& old_extents,
+-                   const std::vector<ex_t>& new_extents);
+-
+ }  // namespace bsdiff
+ 
+ #endif  // _BSDIFF_BSPATCH_H_
+diff --git a/thirdparty/bsdiff/bsdiff/include/bsdiff/file_interface.h b/thirdparty/bsdiff/bsdiff/include/bsdiff/file_interface.h
+index fe10e9806e..e1c60d9675 100644
+--- a/thirdparty/bsdiff/bsdiff/include/bsdiff/file_interface.h
++++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/file_interface.h
+@@ -5,16 +5,11 @@
+ #ifndef _BSDIFF_FILE_INTERFACE_H_
+ #define _BSDIFF_FILE_INTERFACE_H_
+ 
+-#include <sys/types.h>
+-
+ #include <stddef.h>
+ #include <stdint.h>
+ 
+ #include "bsdiff/common.h"
+ 
+-static_assert(sizeof(off_t) == sizeof(int64_t),
+-              "off_t must be a 64-bit number, use -D_FILE_OFFSET_BITS=64");
+-
+ namespace bsdiff {
+ 
+ class BSDIFF_EXPORT FileInterface {
+@@ -37,7 +32,7 @@ class BSDIFF_EXPORT FileInterface {
+ 
+   // Change the current file position to |pos| bytes from the beginning of the
+   // file. Return whether the seek succeeded.
+-  virtual bool Seek(off_t pos) = 0;
++  virtual bool Seek(int64_t pos) = 0;
+ 
+   // Closes the file and flushes any cached data. Returns whether the close
+   // succeeded.
+diff --git a/thirdparty/bsdiff/bsdiff/include/bsdiff/patch_reader_interface.h b/thirdparty/bsdiff/bsdiff/include/bsdiff/patch_reader_interface.h
+new file mode 100644
+index 0000000000..48416d6fd7
+--- /dev/null
++++ b/thirdparty/bsdiff/bsdiff/include/bsdiff/patch_reader_interface.h
+@@ -0,0 +1,43 @@
++#ifndef _BSDIFF_PATCH_READER_INTERFACE_H_
++#define _BSDIFF_PATCH_READER_INTERFACE_H_
++
++#include <stddef.h>
++
++#include "bsdiff/control_entry.h"
++
++namespace bsdiff {
++
++class PatchReaderInterface {
++ public:
++  virtual ~PatchReaderInterface() = default;
++
++  // Initialize the control stream, diff stream and extra stream from the
++  // corresponding offset of |patch_data|.
++  virtual bool Init(const uint8_t* patch_data, size_t patch_size) = 0;
++
++  // Read the control stream and parse the metadata of |diff_size_|,
++  // |extra_size_| and |offset_incremental_|.
++  virtual bool ParseControlEntry(ControlEntry* control_entry) = 0;
++
++  // Read the data in |diff_stream_| and write |size| decompressed data to
++  // |buf|.
++  virtual bool ReadDiffStream(uint8_t* buf, size_t size) = 0;
++
++  // Read the data in |extra_stream_| and write |size| decompressed data to
++  // |buf|.
++  virtual bool ReadExtraStream(uint8_t* buf, size_t size) = 0;
++
++  // Returns the new file size as read from the header.
++  virtual uint64_t new_file_size() const = 0;
++
++  // Close the control/diff/extra stream. Return false if errors occur when
++  // closing any of these streams.
++  virtual bool Finish() = 0;
++
++ protected:
++  PatchReaderInterface() = default;
++};
++
++}  // namespace bsdiff
++
++#endif  // _BSDIFF_PATCH_WRITER_INTERFACE_H_

--- a/thirdparty/libdivsufsort/LICENSE
+++ b/thirdparty/libdivsufsort/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2003 Yuta Mori All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/thirdparty/libdivsufsort/include/config.h
+++ b/thirdparty/libdivsufsort/include/config.h
@@ -1,0 +1,81 @@
+/*
+ * config.h for libdivsufsort
+ * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _CONFIG_H
+#define _CONFIG_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** Define to the version of this package. **/
+#define PROJECT_VERSION_FULL "2.0.1-13-gb7f3d18"
+
+/** Define to 1 if you have the header files. **/
+#define HAVE_INTTYPES_H 1
+#define HAVE_STDDEF_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRING_H 1
+#define HAVE_STRINGS_H 0
+#define HAVE_MEMORY_H 1
+#define HAVE_SYS_TYPES_H 1
+
+/** for WinIO **/
+/* #undef HAVE_IO_H */
+/* #undef HAVE_FCNTL_H */
+/* #undef HAVE__SETMODE */
+/* #undef HAVE_SETMODE */
+/* #undef HAVE__FILENO */
+/* #undef HAVE_FOPEN_S */
+/* #undef HAVE__O_BINARY */
+#ifndef HAVE__SETMODE
+# if HAVE_SETMODE
+#  define _setmode setmode
+#  define HAVE__SETMODE 1
+# endif
+# if HAVE__SETMODE && !HAVE__O_BINARY
+#  define _O_BINARY 0
+#  define HAVE__O_BINARY 1
+# endif
+#endif
+
+/** for inline **/
+#ifndef INLINE
+# define INLINE inline
+#endif
+
+/** for VC++ warning **/
+#ifdef _MSC_VER
+#pragma warning(disable: 4127)
+#endif
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* _CONFIG_H */

--- a/thirdparty/libdivsufsort/include/divsufsort.h
+++ b/thirdparty/libdivsufsort/include/divsufsort.h
@@ -1,0 +1,180 @@
+/*
+ * divsufsort.h for libdivsufsort
+ * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _DIVSUFSORT_H
+#define _DIVSUFSORT_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <inttypes.h>
+
+#ifndef DIVSUFSORT_API
+# ifdef DIVSUFSORT_BUILD_DLL
+#  define DIVSUFSORT_API 
+# else
+#  define DIVSUFSORT_API 
+# endif
+#endif
+
+/*- Datatypes -*/
+#ifndef SAUCHAR_T
+#define SAUCHAR_T
+typedef uint8_t sauchar_t;
+#endif /* SAUCHAR_T */
+#ifndef SAINT_T
+#define SAINT_T
+typedef int32_t saint_t;
+#endif /* SAINT_T */
+#ifndef SAIDX_T
+#define SAIDX_T
+typedef int32_t saidx_t;
+#endif /* SAIDX_T */
+#ifndef PRIdSAINT_T
+#define PRIdSAINT_T PRId32
+#endif /* PRIdSAINT_T */
+#ifndef PRIdSAIDX_T
+#define PRIdSAIDX_T PRId32
+#endif /* PRIdSAIDX_T */
+
+
+/*- Prototypes -*/
+
+/**
+ * Constructs the suffix array of a given string.
+ * @param T[0..n-1] The input string.
+ * @param SA[0..n-1] The output array of suffixes.
+ * @param n The length of the given string.
+ * @return 0 if no error occurred, -1 or -2 otherwise.
+ */
+DIVSUFSORT_API
+saint_t
+divsufsort(const sauchar_t *T, saidx_t *SA, saidx_t n);
+
+/**
+ * Constructs the burrows-wheeler transformed string of a given string.
+ * @param T[0..n-1] The input string.
+ * @param U[0..n-1] The output string. (can be T)
+ * @param A[0..n-1] The temporary array. (can be NULL)
+ * @param n The length of the given string.
+ * @return The primary index if no error occurred, -1 or -2 otherwise.
+ */
+DIVSUFSORT_API
+saidx_t
+divbwt(const sauchar_t *T, sauchar_t *U, saidx_t *A, saidx_t n);
+
+/**
+ * Returns the version of the divsufsort library.
+ * @return The version number string.
+ */
+DIVSUFSORT_API
+const char *
+divsufsort_version(void);
+
+
+/**
+ * Constructs the burrows-wheeler transformed string of a given string and suffix array.
+ * @param T[0..n-1] The input string.
+ * @param U[0..n-1] The output string. (can be T)
+ * @param SA[0..n-1] The suffix array. (can be NULL)
+ * @param n The length of the given string.
+ * @param idx The output primary index.
+ * @return 0 if no error occurred, -1 or -2 otherwise.
+ */
+DIVSUFSORT_API
+saint_t
+bw_transform(const sauchar_t *T, sauchar_t *U,
+             saidx_t *SA /* can NULL */,
+             saidx_t n, saidx_t *idx);
+
+/**
+ * Inverse BW-transforms a given BWTed string.
+ * @param T[0..n-1] The input string.
+ * @param U[0..n-1] The output string. (can be T)
+ * @param A[0..n-1] The temporary array. (can be NULL)
+ * @param n The length of the given string.
+ * @param idx The primary index.
+ * @return 0 if no error occurred, -1 or -2 otherwise.
+ */
+DIVSUFSORT_API
+saint_t
+inverse_bw_transform(const sauchar_t *T, sauchar_t *U,
+                     saidx_t *A /* can NULL */,
+                     saidx_t n, saidx_t idx);
+
+/**
+ * Checks the correctness of a given suffix array.
+ * @param T[0..n-1] The input string.
+ * @param SA[0..n-1] The input suffix array.
+ * @param n The length of the given string.
+ * @param verbose The verbose mode.
+ * @return 0 if no error occurred.
+ */
+DIVSUFSORT_API
+saint_t
+sufcheck(const sauchar_t *T, const saidx_t *SA, saidx_t n, saint_t verbose);
+
+/**
+ * Search for the pattern P in the string T.
+ * @param T[0..Tsize-1] The input string.
+ * @param Tsize The length of the given string.
+ * @param P[0..Psize-1] The input pattern string.
+ * @param Psize The length of the given pattern string.
+ * @param SA[0..SAsize-1] The input suffix array.
+ * @param SAsize The length of the given suffix array.
+ * @param idx The output index.
+ * @return The count of matches if no error occurred, -1 otherwise.
+ */
+DIVSUFSORT_API
+saidx_t
+sa_search(const sauchar_t *T, saidx_t Tsize,
+          const sauchar_t *P, saidx_t Psize,
+          const saidx_t *SA, saidx_t SAsize,
+          saidx_t *left);
+
+/**
+ * Search for the character c in the string T.
+ * @param T[0..Tsize-1] The input string.
+ * @param Tsize The length of the given string.
+ * @param SA[0..SAsize-1] The input suffix array.
+ * @param SAsize The length of the given suffix array.
+ * @param c The input character.
+ * @param idx The output index.
+ * @return The count of matches if no error occurred, -1 otherwise.
+ */
+DIVSUFSORT_API
+saidx_t
+sa_simplesearch(const sauchar_t *T, saidx_t Tsize,
+                const saidx_t *SA, saidx_t SAsize,
+                saint_t c, saidx_t *left);
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* _DIVSUFSORT_H */

--- a/thirdparty/libdivsufsort/include/divsufsort64.h
+++ b/thirdparty/libdivsufsort/include/divsufsort64.h
@@ -1,0 +1,180 @@
+/*
+ * divsufsort64.h for libdivsufsort64
+ * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _DIVSUFSORT64_H
+#define _DIVSUFSORT64_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <inttypes.h>
+
+#ifndef DIVSUFSORT_API
+# ifdef DIVSUFSORT_BUILD_DLL
+#  define DIVSUFSORT_API 
+# else
+#  define DIVSUFSORT_API 
+# endif
+#endif
+
+/*- Datatypes -*/
+#ifndef SAUCHAR_T
+#define SAUCHAR_T
+typedef uint8_t sauchar_t;
+#endif /* SAUCHAR_T */
+#ifndef SAINT_T
+#define SAINT_T
+typedef int32_t saint_t;
+#endif /* SAINT_T */
+#ifndef SAIDX64_T
+#define SAIDX64_T
+typedef int64_t saidx64_t;
+#endif /* SAIDX64_T */
+#ifndef PRIdSAINT_T
+#define PRIdSAINT_T PRId32
+#endif /* PRIdSAINT_T */
+#ifndef PRIdSAIDX64_T
+#define PRIdSAIDX64_T PRId64
+#endif /* PRIdSAIDX64_T */
+
+
+/*- Prototypes -*/
+
+/**
+ * Constructs the suffix array of a given string.
+ * @param T[0..n-1] The input string.
+ * @param SA[0..n-1] The output array of suffixes.
+ * @param n The length of the given string.
+ * @return 0 if no error occurred, -1 or -2 otherwise.
+ */
+DIVSUFSORT_API
+saint_t
+divsufsort64(const sauchar_t *T, saidx64_t *SA, saidx64_t n);
+
+/**
+ * Constructs the burrows-wheeler transformed string of a given string.
+ * @param T[0..n-1] The input string.
+ * @param U[0..n-1] The output string. (can be T)
+ * @param A[0..n-1] The temporary array. (can be NULL)
+ * @param n The length of the given string.
+ * @return The primary index if no error occurred, -1 or -2 otherwise.
+ */
+DIVSUFSORT_API
+saidx64_t
+divbwt64(const sauchar_t *T, sauchar_t *U, saidx64_t *A, saidx64_t n);
+
+/**
+ * Returns the version of the divsufsort library.
+ * @return The version number string.
+ */
+DIVSUFSORT_API
+const char *
+divsufsort64_version(void);
+
+
+/**
+ * Constructs the burrows-wheeler transformed string of a given string and suffix array.
+ * @param T[0..n-1] The input string.
+ * @param U[0..n-1] The output string. (can be T)
+ * @param SA[0..n-1] The suffix array. (can be NULL)
+ * @param n The length of the given string.
+ * @param idx The output primary index.
+ * @return 0 if no error occurred, -1 or -2 otherwise.
+ */
+DIVSUFSORT_API
+saint_t
+bw_transform64(const sauchar_t *T, sauchar_t *U,
+             saidx64_t *SA /* can NULL */,
+             saidx64_t n, saidx64_t *idx);
+
+/**
+ * Inverse BW-transforms a given BWTed string.
+ * @param T[0..n-1] The input string.
+ * @param U[0..n-1] The output string. (can be T)
+ * @param A[0..n-1] The temporary array. (can be NULL)
+ * @param n The length of the given string.
+ * @param idx The primary index.
+ * @return 0 if no error occurred, -1 or -2 otherwise.
+ */
+DIVSUFSORT_API
+saint_t
+inverse_bw_transform64(const sauchar_t *T, sauchar_t *U,
+                     saidx64_t *A /* can NULL */,
+                     saidx64_t n, saidx64_t idx);
+
+/**
+ * Checks the correctness of a given suffix array.
+ * @param T[0..n-1] The input string.
+ * @param SA[0..n-1] The input suffix array.
+ * @param n The length of the given string.
+ * @param verbose The verbose mode.
+ * @return 0 if no error occurred.
+ */
+DIVSUFSORT_API
+saint_t
+sufcheck64(const sauchar_t *T, const saidx64_t *SA, saidx64_t n, saint_t verbose);
+
+/**
+ * Search for the pattern P in the string T.
+ * @param T[0..Tsize-1] The input string.
+ * @param Tsize The length of the given string.
+ * @param P[0..Psize-1] The input pattern string.
+ * @param Psize The length of the given pattern string.
+ * @param SA[0..SAsize-1] The input suffix array.
+ * @param SAsize The length of the given suffix array.
+ * @param idx The output index.
+ * @return The count of matches if no error occurred, -1 otherwise.
+ */
+DIVSUFSORT_API
+saidx64_t
+sa_search64(const sauchar_t *T, saidx64_t Tsize,
+          const sauchar_t *P, saidx64_t Psize,
+          const saidx64_t *SA, saidx64_t SAsize,
+          saidx64_t *left);
+
+/**
+ * Search for the character c in the string T.
+ * @param T[0..Tsize-1] The input string.
+ * @param Tsize The length of the given string.
+ * @param SA[0..SAsize-1] The input suffix array.
+ * @param SAsize The length of the given suffix array.
+ * @param c The input character.
+ * @param idx The output index.
+ * @return The count of matches if no error occurred, -1 otherwise.
+ */
+DIVSUFSORT_API
+saidx64_t
+sa_simplesearch64(const sauchar_t *T, saidx64_t Tsize,
+                const saidx64_t *SA, saidx64_t SAsize,
+                saint_t c, saidx64_t *left);
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* _DIVSUFSORT64_H */

--- a/thirdparty/libdivsufsort/include/divsufsort_private.h
+++ b/thirdparty/libdivsufsort/include/divsufsort_private.h
@@ -1,0 +1,207 @@
+/*
+ * divsufsort_private.h for libdivsufsort
+ * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _DIVSUFSORT_PRIVATE_H
+#define _DIVSUFSORT_PRIVATE_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+#include <assert.h>
+#include <stdio.h>
+#if HAVE_STRING_H
+# include <string.h>
+#endif
+#if HAVE_STDLIB_H
+# include <stdlib.h>
+#endif
+#if HAVE_MEMORY_H
+# include <memory.h>
+#endif
+#if HAVE_STDDEF_H
+# include <stddef.h>
+#endif
+#if HAVE_STRINGS_H
+# include <strings.h>
+#endif
+#if HAVE_INTTYPES_H
+# include <inttypes.h>
+#else
+# if HAVE_STDINT_H
+#  include <stdint.h>
+# endif
+#endif
+#if defined(BUILD_DIVSUFSORT64)
+# include "divsufsort64.h"
+# ifndef SAIDX_T
+#  define SAIDX_T
+#  define saidx_t saidx64_t
+# endif /* SAIDX_T */
+# ifndef PRIdSAIDX_T
+#  define PRIdSAIDX_T PRIdSAIDX64_T
+# endif /* PRIdSAIDX_T */
+# define divsufsort divsufsort64
+# define divbwt divbwt64
+# define divsufsort_version divsufsort64_version
+# define bw_transform bw_transform64
+# define inverse_bw_transform inverse_bw_transform64
+# define sufcheck sufcheck64
+# define sa_search sa_search64
+# define sa_simplesearch sa_simplesearch64
+# define sssort sssort64
+# define trsort trsort64
+#else
+# include "divsufsort.h"
+#endif
+
+
+/*- Constants -*/
+#if !defined(UINT8_MAX)
+# define UINT8_MAX (255)
+#endif /* UINT8_MAX */
+#if defined(ALPHABET_SIZE) && (ALPHABET_SIZE < 1)
+# undef ALPHABET_SIZE
+#endif
+#if !defined(ALPHABET_SIZE)
+# define ALPHABET_SIZE (UINT8_MAX + 1)
+#endif
+/* for divsufsort.c */
+#define BUCKET_A_SIZE (ALPHABET_SIZE)
+#define BUCKET_B_SIZE (ALPHABET_SIZE * ALPHABET_SIZE)
+/* for sssort.c */
+#if defined(SS_INSERTIONSORT_THRESHOLD)
+# if SS_INSERTIONSORT_THRESHOLD < 1
+#  undef SS_INSERTIONSORT_THRESHOLD
+#  define SS_INSERTIONSORT_THRESHOLD (1)
+# endif
+#else
+# define SS_INSERTIONSORT_THRESHOLD (8)
+#endif
+#if defined(SS_BLOCKSIZE)
+# if SS_BLOCKSIZE < 0
+#  undef SS_BLOCKSIZE
+#  define SS_BLOCKSIZE (0)
+# elif 32768 <= SS_BLOCKSIZE
+#  undef SS_BLOCKSIZE
+#  define SS_BLOCKSIZE (32767)
+# endif
+#else
+# define SS_BLOCKSIZE (1024)
+#endif
+/* minstacksize = log(SS_BLOCKSIZE) / log(3) * 2 */
+#if SS_BLOCKSIZE == 0
+# if defined(BUILD_DIVSUFSORT64)
+#  define SS_MISORT_STACKSIZE (96)
+# else
+#  define SS_MISORT_STACKSIZE (64)
+# endif
+#elif SS_BLOCKSIZE <= 4096
+# define SS_MISORT_STACKSIZE (16)
+#else
+# define SS_MISORT_STACKSIZE (24)
+#endif
+#if defined(BUILD_DIVSUFSORT64)
+# define SS_SMERGE_STACKSIZE (64)
+#else
+# define SS_SMERGE_STACKSIZE (32)
+#endif
+/* for trsort.c */
+#define TR_INSERTIONSORT_THRESHOLD (8)
+#if defined(BUILD_DIVSUFSORT64)
+# define TR_STACKSIZE (96)
+#else
+# define TR_STACKSIZE (64)
+#endif
+
+
+/*- Macros -*/
+#ifndef SWAP
+# define SWAP(_a, _b) do { t = (_a); (_a) = (_b); (_b) = t; } while(0)
+#endif /* SWAP */
+#ifndef MIN
+# define MIN(_a, _b) (((_a) < (_b)) ? (_a) : (_b))
+#endif /* MIN */
+#ifndef MAX
+# define MAX(_a, _b) (((_a) > (_b)) ? (_a) : (_b))
+#endif /* MAX */
+#define STACK_PUSH(_a, _b, _c, _d)\
+  do {\
+    assert(ssize < STACK_SIZE);\
+    stack[ssize].a = (_a), stack[ssize].b = (_b),\
+    stack[ssize].c = (_c), stack[ssize++].d = (_d);\
+  } while(0)
+#define STACK_PUSH5(_a, _b, _c, _d, _e)\
+  do {\
+    assert(ssize < STACK_SIZE);\
+    stack[ssize].a = (_a), stack[ssize].b = (_b),\
+    stack[ssize].c = (_c), stack[ssize].d = (_d), stack[ssize++].e = (_e);\
+  } while(0)
+#define STACK_POP(_a, _b, _c, _d)\
+  do {\
+    assert(0 <= ssize);\
+    if(ssize == 0) { return; }\
+    (_a) = stack[--ssize].a, (_b) = stack[ssize].b,\
+    (_c) = stack[ssize].c, (_d) = stack[ssize].d;\
+  } while(0)
+#define STACK_POP5(_a, _b, _c, _d, _e)\
+  do {\
+    assert(0 <= ssize);\
+    if(ssize == 0) { return; }\
+    (_a) = stack[--ssize].a, (_b) = stack[ssize].b,\
+    (_c) = stack[ssize].c, (_d) = stack[ssize].d, (_e) = stack[ssize].e;\
+  } while(0)
+/* for divsufsort.c */
+#define BUCKET_A(_c0) bucket_A[(_c0)]
+#if ALPHABET_SIZE == 256
+#define BUCKET_B(_c0, _c1) (bucket_B[((_c1) << 8) | (_c0)])
+#define BUCKET_BSTAR(_c0, _c1) (bucket_B[((_c0) << 8) | (_c1)])
+#else
+#define BUCKET_B(_c0, _c1) (bucket_B[(_c1) * ALPHABET_SIZE + (_c0)])
+#define BUCKET_BSTAR(_c0, _c1) (bucket_B[(_c0) * ALPHABET_SIZE + (_c1)])
+#endif
+
+
+/*- Private Prototypes -*/
+/* sssort.c */
+void
+sssort(const sauchar_t *Td, const saidx_t *PA,
+       saidx_t *first, saidx_t *last,
+       saidx_t *buf, saidx_t bufsize,
+       saidx_t depth, saidx_t n, saint_t lastsuffix);
+/* trsort.c */
+void
+trsort(saidx_t *ISA, saidx_t *SA, saidx_t n, saidx_t depth);
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* _DIVSUFSORT_PRIVATE_H */

--- a/thirdparty/libdivsufsort/lib/divsufsort.c
+++ b/thirdparty/libdivsufsort/lib/divsufsort.c
@@ -1,0 +1,398 @@
+/*
+ * divsufsort.c for libdivsufsort
+ * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "divsufsort_private.h"
+#ifdef _OPENMP
+# include <omp.h>
+#endif
+
+
+/*- Private Functions -*/
+
+/* Sorts suffixes of type B*. */
+static
+saidx_t
+sort_typeBstar(const sauchar_t *T, saidx_t *SA,
+               saidx_t *bucket_A, saidx_t *bucket_B,
+               saidx_t n) {
+  saidx_t *PAb, *ISAb, *buf;
+#ifdef _OPENMP
+  saidx_t *curbuf;
+  saidx_t l;
+#endif
+  saidx_t i, j, k, t, m, bufsize;
+  saint_t c0, c1;
+#ifdef _OPENMP
+  saint_t d0, d1;
+  int tmp;
+#endif
+
+  /* Initialize bucket arrays. */
+  for(i = 0; i < BUCKET_A_SIZE; ++i) { bucket_A[i] = 0; }
+  for(i = 0; i < BUCKET_B_SIZE; ++i) { bucket_B[i] = 0; }
+
+  /* Count the number of occurrences of the first one or two characters of each
+     type A, B and B* suffix. Moreover, store the beginning position of all
+     type B* suffixes into the array SA. */
+  for(i = n - 1, m = n, c0 = T[n - 1]; 0 <= i;) {
+    /* type A suffix. */
+    do { ++BUCKET_A(c1 = c0); } while((0 <= --i) && ((c0 = T[i]) >= c1));
+    if(0 <= i) {
+      /* type B* suffix. */
+      ++BUCKET_BSTAR(c0, c1);
+      SA[--m] = i;
+      /* type B suffix. */
+      for(--i, c1 = c0; (0 <= i) && ((c0 = T[i]) <= c1); --i, c1 = c0) {
+        ++BUCKET_B(c0, c1);
+      }
+    }
+  }
+  m = n - m;
+/*
+note:
+  A type B* suffix is lexicographically smaller than a type B suffix that
+  begins with the same first two characters.
+*/
+
+  /* Calculate the index of start/end point of each bucket. */
+  for(c0 = 0, i = 0, j = 0; c0 < ALPHABET_SIZE; ++c0) {
+    t = i + BUCKET_A(c0);
+    BUCKET_A(c0) = i + j; /* start point */
+    i = t + BUCKET_B(c0, c0);
+    for(c1 = c0 + 1; c1 < ALPHABET_SIZE; ++c1) {
+      j += BUCKET_BSTAR(c0, c1);
+      BUCKET_BSTAR(c0, c1) = j; /* end point */
+      i += BUCKET_B(c0, c1);
+    }
+  }
+
+  if(0 < m) {
+    /* Sort the type B* suffixes by their first two characters. */
+    PAb = SA + n - m; ISAb = SA + m;
+    for(i = m - 2; 0 <= i; --i) {
+      t = PAb[i], c0 = T[t], c1 = T[t + 1];
+      SA[--BUCKET_BSTAR(c0, c1)] = i;
+    }
+    t = PAb[m - 1], c0 = T[t], c1 = T[t + 1];
+    SA[--BUCKET_BSTAR(c0, c1)] = m - 1;
+
+    /* Sort the type B* substrings using sssort. */
+#ifdef _OPENMP
+    tmp = omp_get_max_threads();
+    buf = SA + m, bufsize = (n - (2 * m)) / tmp;
+    c0 = ALPHABET_SIZE - 2, c1 = ALPHABET_SIZE - 1, j = m;
+#pragma omp parallel default(shared) private(curbuf, k, l, d0, d1, tmp)
+    {
+      tmp = omp_get_thread_num();
+      curbuf = buf + tmp * bufsize;
+      k = 0;
+      for(;;) {
+        #pragma omp critical(sssort_lock)
+        {
+          if(0 < (l = j)) {
+            d0 = c0, d1 = c1;
+            do {
+              k = BUCKET_BSTAR(d0, d1);
+              if(--d1 <= d0) {
+                d1 = ALPHABET_SIZE - 1;
+                if(--d0 < 0) { break; }
+              }
+            } while(((l - k) <= 1) && (0 < (l = k)));
+            c0 = d0, c1 = d1, j = k;
+          }
+        }
+        if(l == 0) { break; }
+        sssort(T, PAb, SA + k, SA + l,
+               curbuf, bufsize, 2, n, *(SA + k) == (m - 1));
+      }
+    }
+#else
+    buf = SA + m, bufsize = n - (2 * m);
+    for(c0 = ALPHABET_SIZE - 2, j = m; 0 < j; --c0) {
+      for(c1 = ALPHABET_SIZE - 1; c0 < c1; j = i, --c1) {
+        i = BUCKET_BSTAR(c0, c1);
+        if(1 < (j - i)) {
+          sssort(T, PAb, SA + i, SA + j,
+                 buf, bufsize, 2, n, *(SA + i) == (m - 1));
+        }
+      }
+    }
+#endif
+
+    /* Compute ranks of type B* substrings. */
+    for(i = m - 1; 0 <= i; --i) {
+      if(0 <= SA[i]) {
+        j = i;
+        do { ISAb[SA[i]] = i; } while((0 <= --i) && (0 <= SA[i]));
+        SA[i + 1] = i - j;
+        if(i <= 0) { break; }
+      }
+      j = i;
+      do { ISAb[SA[i] = ~SA[i]] = j; } while(SA[--i] < 0);
+      ISAb[SA[i]] = j;
+    }
+
+    /* Construct the inverse suffix array of type B* suffixes using trsort. */
+    trsort(ISAb, SA, m, 1);
+
+    /* Set the sorted order of tyoe B* suffixes. */
+    for(i = n - 1, j = m, c0 = T[n - 1]; 0 <= i;) {
+      for(--i, c1 = c0; (0 <= i) && ((c0 = T[i]) >= c1); --i, c1 = c0) { }
+      if(0 <= i) {
+        t = i;
+        for(--i, c1 = c0; (0 <= i) && ((c0 = T[i]) <= c1); --i, c1 = c0) { }
+        SA[ISAb[--j]] = ((t == 0) || (1 < (t - i))) ? t : ~t;
+      }
+    }
+
+    /* Calculate the index of start/end point of each bucket. */
+    BUCKET_B(ALPHABET_SIZE - 1, ALPHABET_SIZE - 1) = n; /* end point */
+    for(c0 = ALPHABET_SIZE - 2, k = m - 1; 0 <= c0; --c0) {
+      i = BUCKET_A(c0 + 1) - 1;
+      for(c1 = ALPHABET_SIZE - 1; c0 < c1; --c1) {
+        t = i - BUCKET_B(c0, c1);
+        BUCKET_B(c0, c1) = i; /* end point */
+
+        /* Move all type B* suffixes to the correct position. */
+        for(i = t, j = BUCKET_BSTAR(c0, c1);
+            j <= k;
+            --i, --k) { SA[i] = SA[k]; }
+      }
+      BUCKET_BSTAR(c0, c0 + 1) = i - BUCKET_B(c0, c0) + 1; /* start point */
+      BUCKET_B(c0, c0) = i; /* end point */
+    }
+  }
+
+  return m;
+}
+
+/* Constructs the suffix array by using the sorted order of type B* suffixes. */
+static
+void
+construct_SA(const sauchar_t *T, saidx_t *SA,
+             saidx_t *bucket_A, saidx_t *bucket_B,
+             saidx_t n, saidx_t m) {
+  saidx_t *i, *j, *k;
+  saidx_t s;
+  saint_t c0, c1, c2;
+
+  if(0 < m) {
+    /* Construct the sorted order of type B suffixes by using
+       the sorted order of type B* suffixes. */
+    for(c1 = ALPHABET_SIZE - 2; 0 <= c1; --c1) {
+      /* Scan the suffix array from right to left. */
+      for(i = SA + BUCKET_BSTAR(c1, c1 + 1),
+          j = SA + BUCKET_A(c1 + 1) - 1, k = NULL, c2 = -1;
+          i <= j;
+          --j) {
+        if(0 < (s = *j)) {
+          assert(T[s] == c1);
+          assert(((s + 1) < n) && (T[s] <= T[s + 1]));
+          assert(T[s - 1] <= T[s]);
+          *j = ~s;
+          c0 = T[--s];
+          if((0 < s) && (T[s - 1] > c0)) { s = ~s; }
+          if(c0 != c2) {
+            if(0 <= c2) { BUCKET_B(c2, c1) = k - SA; }
+            k = SA + BUCKET_B(c2 = c0, c1);
+          }
+          assert(k < j);
+          *k-- = s;
+        } else {
+          assert(((s == 0) && (T[s] == c1)) || (s < 0));
+          *j = ~s;
+        }
+      }
+    }
+  }
+
+  /* Construct the suffix array by using
+     the sorted order of type B suffixes. */
+  k = SA + BUCKET_A(c2 = T[n - 1]);
+  *k++ = (T[n - 2] < c2) ? ~(n - 1) : (n - 1);
+  /* Scan the suffix array from left to right. */
+  for(i = SA, j = SA + n; i < j; ++i) {
+    if(0 < (s = *i)) {
+      assert(T[s - 1] >= T[s]);
+      c0 = T[--s];
+      if((s == 0) || (T[s - 1] < c0)) { s = ~s; }
+      if(c0 != c2) {
+        BUCKET_A(c2) = k - SA;
+        k = SA + BUCKET_A(c2 = c0);
+      }
+      assert(i < k);
+      *k++ = s;
+    } else {
+      assert(s < 0);
+      *i = ~s;
+    }
+  }
+}
+
+/* Constructs the burrows-wheeler transformed string directly
+   by using the sorted order of type B* suffixes. */
+static
+saidx_t
+construct_BWT(const sauchar_t *T, saidx_t *SA,
+              saidx_t *bucket_A, saidx_t *bucket_B,
+              saidx_t n, saidx_t m) {
+  saidx_t *i, *j, *k, *orig;
+  saidx_t s;
+  saint_t c0, c1, c2;
+
+  if(0 < m) {
+    /* Construct the sorted order of type B suffixes by using
+       the sorted order of type B* suffixes. */
+    for(c1 = ALPHABET_SIZE - 2; 0 <= c1; --c1) {
+      /* Scan the suffix array from right to left. */
+      for(i = SA + BUCKET_BSTAR(c1, c1 + 1),
+          j = SA + BUCKET_A(c1 + 1) - 1, k = NULL, c2 = -1;
+          i <= j;
+          --j) {
+        if(0 < (s = *j)) {
+          assert(T[s] == c1);
+          assert(((s + 1) < n) && (T[s] <= T[s + 1]));
+          assert(T[s - 1] <= T[s]);
+          c0 = T[--s];
+          *j = ~((saidx_t)c0);
+          if((0 < s) && (T[s - 1] > c0)) { s = ~s; }
+          if(c0 != c2) {
+            if(0 <= c2) { BUCKET_B(c2, c1) = k - SA; }
+            k = SA + BUCKET_B(c2 = c0, c1);
+          }
+          assert(k < j);
+          *k-- = s;
+        } else if(s != 0) {
+          *j = ~s;
+#ifndef NDEBUG
+        } else {
+          assert(T[s] == c1);
+#endif
+        }
+      }
+    }
+  }
+
+  /* Construct the BWTed string by using
+     the sorted order of type B suffixes. */
+  k = SA + BUCKET_A(c2 = T[n - 1]);
+  *k++ = (T[n - 2] < c2) ? ~((saidx_t)T[n - 2]) : (n - 1);
+  /* Scan the suffix array from left to right. */
+  for(i = SA, j = SA + n, orig = SA; i < j; ++i) {
+    if(0 < (s = *i)) {
+      assert(T[s - 1] >= T[s]);
+      c0 = T[--s];
+      *i = c0;
+      if((0 < s) && (T[s - 1] < c0)) { s = ~((saidx_t)T[s - 1]); }
+      if(c0 != c2) {
+        BUCKET_A(c2) = k - SA;
+        k = SA + BUCKET_A(c2 = c0);
+      }
+      assert(i < k);
+      *k++ = s;
+    } else if(s != 0) {
+      *i = ~s;
+    } else {
+      orig = i;
+    }
+  }
+
+  return orig - SA;
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+/*- Function -*/
+
+saint_t
+divsufsort(const sauchar_t *T, saidx_t *SA, saidx_t n) {
+  saidx_t *bucket_A, *bucket_B;
+  saidx_t m;
+  saint_t err = 0;
+
+  /* Check arguments. */
+  if((T == NULL) || (SA == NULL) || (n < 0)) { return -1; }
+  else if(n == 0) { return 0; }
+  else if(n == 1) { SA[0] = 0; return 0; }
+  else if(n == 2) { m = (T[0] < T[1]); SA[m ^ 1] = 0, SA[m] = 1; return 0; }
+
+  bucket_A = (saidx_t *)malloc(BUCKET_A_SIZE * sizeof(saidx_t));
+  bucket_B = (saidx_t *)malloc(BUCKET_B_SIZE * sizeof(saidx_t));
+
+  /* Suffixsort. */
+  if((bucket_A != NULL) && (bucket_B != NULL)) {
+    m = sort_typeBstar(T, SA, bucket_A, bucket_B, n);
+    construct_SA(T, SA, bucket_A, bucket_B, n, m);
+  } else {
+    err = -2;
+  }
+
+  free(bucket_B);
+  free(bucket_A);
+
+  return err;
+}
+
+saidx_t
+divbwt(const sauchar_t *T, sauchar_t *U, saidx_t *A, saidx_t n) {
+  saidx_t *B;
+  saidx_t *bucket_A, *bucket_B;
+  saidx_t m, pidx, i;
+
+  /* Check arguments. */
+  if((T == NULL) || (U == NULL) || (n < 0)) { return -1; }
+  else if(n <= 1) { if(n == 1) { U[0] = T[0]; } return n; }
+
+  if((B = A) == NULL) { B = (saidx_t *)malloc((size_t)(n + 1) * sizeof(saidx_t)); }
+  bucket_A = (saidx_t *)malloc(BUCKET_A_SIZE * sizeof(saidx_t));
+  bucket_B = (saidx_t *)malloc(BUCKET_B_SIZE * sizeof(saidx_t));
+
+  /* Burrows-Wheeler Transform. */
+  if((B != NULL) && (bucket_A != NULL) && (bucket_B != NULL)) {
+    m = sort_typeBstar(T, B, bucket_A, bucket_B, n);
+    pidx = construct_BWT(T, B, bucket_A, bucket_B, n, m);
+
+    /* Copy to output string. */
+    U[0] = T[n - 1];
+    for(i = 0; i < pidx; ++i) { U[i + 1] = (sauchar_t)B[i]; }
+    for(i += 1; i < n; ++i) { U[i] = (sauchar_t)B[i]; }
+    pidx += 1;
+  } else {
+    pidx = -2;
+  }
+
+  free(bucket_B);
+  free(bucket_A);
+  if(A == NULL) { free(B); }
+
+  return pidx;
+}
+
+const char *
+divsufsort_version(void) {
+  return PROJECT_VERSION_FULL;
+}

--- a/thirdparty/libdivsufsort/lib/sssort.c
+++ b/thirdparty/libdivsufsort/lib/sssort.c
@@ -1,0 +1,815 @@
+/*
+ * sssort.c for libdivsufsort
+ * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "divsufsort_private.h"
+
+
+/*- Private Functions -*/
+
+static const saint_t lg_table[256]= {
+ -1,0,1,1,2,2,2,2,3,3,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+  5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7
+};
+
+#if (SS_BLOCKSIZE == 0) || (SS_INSERTIONSORT_THRESHOLD < SS_BLOCKSIZE)
+
+static INLINE
+saint_t
+ss_ilg(saidx_t n) {
+#if SS_BLOCKSIZE == 0
+# if defined(BUILD_DIVSUFSORT64)
+  return (n >> 32) ?
+          ((n >> 48) ?
+            ((n >> 56) ?
+              56 + lg_table[(n >> 56) & 0xff] :
+              48 + lg_table[(n >> 48) & 0xff]) :
+            ((n >> 40) ?
+              40 + lg_table[(n >> 40) & 0xff] :
+              32 + lg_table[(n >> 32) & 0xff])) :
+          ((n & 0xffff0000) ?
+            ((n & 0xff000000) ?
+              24 + lg_table[(n >> 24) & 0xff] :
+              16 + lg_table[(n >> 16) & 0xff]) :
+            ((n & 0x0000ff00) ?
+               8 + lg_table[(n >>  8) & 0xff] :
+               0 + lg_table[(n >>  0) & 0xff]));
+# else
+  return (n & 0xffff0000) ?
+          ((n & 0xff000000) ?
+            24 + lg_table[(n >> 24) & 0xff] :
+            16 + lg_table[(n >> 16) & 0xff]) :
+          ((n & 0x0000ff00) ?
+             8 + lg_table[(n >>  8) & 0xff] :
+             0 + lg_table[(n >>  0) & 0xff]);
+# endif
+#elif SS_BLOCKSIZE < 256
+  return lg_table[n];
+#else
+  return (n & 0xff00) ?
+          8 + lg_table[(n >> 8) & 0xff] :
+          0 + lg_table[(n >> 0) & 0xff];
+#endif
+}
+
+#endif /* (SS_BLOCKSIZE == 0) || (SS_INSERTIONSORT_THRESHOLD < SS_BLOCKSIZE) */
+
+#if SS_BLOCKSIZE != 0
+
+static const saint_t sqq_table[256] = {
+  0,  16,  22,  27,  32,  35,  39,  42,  45,  48,  50,  53,  55,  57,  59,  61,
+ 64,  65,  67,  69,  71,  73,  75,  76,  78,  80,  81,  83,  84,  86,  87,  89,
+ 90,  91,  93,  94,  96,  97,  98,  99, 101, 102, 103, 104, 106, 107, 108, 109,
+110, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126,
+128, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142,
+143, 144, 144, 145, 146, 147, 148, 149, 150, 150, 151, 152, 153, 154, 155, 155,
+156, 157, 158, 159, 160, 160, 161, 162, 163, 163, 164, 165, 166, 167, 167, 168,
+169, 170, 170, 171, 172, 173, 173, 174, 175, 176, 176, 177, 178, 178, 179, 180,
+181, 181, 182, 183, 183, 184, 185, 185, 186, 187, 187, 188, 189, 189, 190, 191,
+192, 192, 193, 193, 194, 195, 195, 196, 197, 197, 198, 199, 199, 200, 201, 201,
+202, 203, 203, 204, 204, 205, 206, 206, 207, 208, 208, 209, 209, 210, 211, 211,
+212, 212, 213, 214, 214, 215, 215, 216, 217, 217, 218, 218, 219, 219, 220, 221,
+221, 222, 222, 223, 224, 224, 225, 225, 226, 226, 227, 227, 228, 229, 229, 230,
+230, 231, 231, 232, 232, 233, 234, 234, 235, 235, 236, 236, 237, 237, 238, 238,
+239, 240, 240, 241, 241, 242, 242, 243, 243, 244, 244, 245, 245, 246, 246, 247,
+247, 248, 248, 249, 249, 250, 250, 251, 251, 252, 252, 253, 253, 254, 254, 255
+};
+
+static INLINE
+saidx_t
+ss_isqrt(saidx_t x) {
+  saidx_t y, e;
+
+  if(x >= (SS_BLOCKSIZE * SS_BLOCKSIZE)) { return SS_BLOCKSIZE; }
+  e = (x & 0xffff0000) ?
+        ((x & 0xff000000) ?
+          24 + lg_table[(x >> 24) & 0xff] :
+          16 + lg_table[(x >> 16) & 0xff]) :
+        ((x & 0x0000ff00) ?
+           8 + lg_table[(x >>  8) & 0xff] :
+           0 + lg_table[(x >>  0) & 0xff]);
+
+  if(e >= 16) {
+    y = sqq_table[x >> ((e - 6) - (e & 1))] << ((e >> 1) - 7);
+    if(e >= 24) { y = (y + 1 + x / y) >> 1; }
+    y = (y + 1 + x / y) >> 1;
+  } else if(e >= 8) {
+    y = (sqq_table[x >> ((e - 6) - (e & 1))] >> (7 - (e >> 1))) + 1;
+  } else {
+    return sqq_table[x] >> 4;
+  }
+
+  return (x < (y * y)) ? y - 1 : y;
+}
+
+#endif /* SS_BLOCKSIZE != 0 */
+
+
+/*---------------------------------------------------------------------------*/
+
+/* Compares two suffixes. */
+static INLINE
+saint_t
+ss_compare(const sauchar_t *T,
+           const saidx_t *p1, const saidx_t *p2,
+           saidx_t depth) {
+  const sauchar_t *U1, *U2, *U1n, *U2n;
+
+  for(U1 = T + depth + *p1,
+      U2 = T + depth + *p2,
+      U1n = T + *(p1 + 1) + 2,
+      U2n = T + *(p2 + 1) + 2;
+      (U1 < U1n) && (U2 < U2n) && (*U1 == *U2);
+      ++U1, ++U2) {
+  }
+
+  return U1 < U1n ?
+        (U2 < U2n ? *U1 - *U2 : 1) :
+        (U2 < U2n ? -1 : 0);
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+#if (SS_BLOCKSIZE != 1) && (SS_INSERTIONSORT_THRESHOLD != 1)
+
+/* Insertionsort for small size groups */
+static
+void
+ss_insertionsort(const sauchar_t *T, const saidx_t *PA,
+                 saidx_t *first, saidx_t *last, saidx_t depth) {
+  saidx_t *i, *j;
+  saidx_t t;
+  saint_t r;
+
+  for(i = last - 2; first <= i; --i) {
+    for(t = *i, j = i + 1; 0 < (r = ss_compare(T, PA + t, PA + *j, depth));) {
+      do { *(j - 1) = *j; } while((++j < last) && (*j < 0));
+      if(last <= j) { break; }
+    }
+    if(r == 0) { *j = ~*j; }
+    *(j - 1) = t;
+  }
+}
+
+#endif /* (SS_BLOCKSIZE != 1) && (SS_INSERTIONSORT_THRESHOLD != 1) */
+
+
+/*---------------------------------------------------------------------------*/
+
+#if (SS_BLOCKSIZE == 0) || (SS_INSERTIONSORT_THRESHOLD < SS_BLOCKSIZE)
+
+static INLINE
+void
+ss_fixdown(const sauchar_t *Td, const saidx_t *PA,
+           saidx_t *SA, saidx_t i, saidx_t size) {
+  saidx_t j, k;
+  saidx_t v;
+  saint_t c, d, e;
+
+  for(v = SA[i], c = Td[PA[v]]; (j = 2 * i + 1) < size; SA[i] = SA[k], i = k) {
+    d = Td[PA[SA[k = j++]]];
+    if(d < (e = Td[PA[SA[j]]])) { k = j; d = e; }
+    if(d <= c) { break; }
+  }
+  SA[i] = v;
+}
+
+/* Simple top-down heapsort. */
+static
+void
+ss_heapsort(const sauchar_t *Td, const saidx_t *PA, saidx_t *SA, saidx_t size) {
+  saidx_t i, m;
+  saidx_t t;
+
+  m = size;
+  if((size % 2) == 0) {
+    m--;
+    if(Td[PA[SA[m / 2]]] < Td[PA[SA[m]]]) { SWAP(SA[m], SA[m / 2]); }
+  }
+
+  for(i = m / 2 - 1; 0 <= i; --i) { ss_fixdown(Td, PA, SA, i, m); }
+  if((size % 2) == 0) { SWAP(SA[0], SA[m]); ss_fixdown(Td, PA, SA, 0, m); }
+  for(i = m - 1; 0 < i; --i) {
+    t = SA[0], SA[0] = SA[i];
+    ss_fixdown(Td, PA, SA, 0, i);
+    SA[i] = t;
+  }
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+/* Returns the median of three elements. */
+static INLINE
+saidx_t *
+ss_median3(const sauchar_t *Td, const saidx_t *PA,
+           saidx_t *v1, saidx_t *v2, saidx_t *v3) {
+  saidx_t *t;
+  if(Td[PA[*v1]] > Td[PA[*v2]]) { SWAP(v1, v2); }
+  if(Td[PA[*v2]] > Td[PA[*v3]]) {
+    if(Td[PA[*v1]] > Td[PA[*v3]]) { return v1; }
+    else { return v3; }
+  }
+  return v2;
+}
+
+/* Returns the median of five elements. */
+static INLINE
+saidx_t *
+ss_median5(const sauchar_t *Td, const saidx_t *PA,
+           saidx_t *v1, saidx_t *v2, saidx_t *v3, saidx_t *v4, saidx_t *v5) {
+  saidx_t *t;
+  if(Td[PA[*v2]] > Td[PA[*v3]]) { SWAP(v2, v3); }
+  if(Td[PA[*v4]] > Td[PA[*v5]]) { SWAP(v4, v5); }
+  if(Td[PA[*v2]] > Td[PA[*v4]]) { SWAP(v2, v4); SWAP(v3, v5); }
+  if(Td[PA[*v1]] > Td[PA[*v3]]) { SWAP(v1, v3); }
+  if(Td[PA[*v1]] > Td[PA[*v4]]) { SWAP(v1, v4); SWAP(v3, v5); }
+  if(Td[PA[*v3]] > Td[PA[*v4]]) { return v4; }
+  return v3;
+}
+
+/* Returns the pivot element. */
+static INLINE
+saidx_t *
+ss_pivot(const sauchar_t *Td, const saidx_t *PA, saidx_t *first, saidx_t *last) {
+  saidx_t *middle;
+  saidx_t t;
+
+  t = last - first;
+  middle = first + t / 2;
+
+  if(t <= 512) {
+    if(t <= 32) {
+      return ss_median3(Td, PA, first, middle, last - 1);
+    } else {
+      t >>= 2;
+      return ss_median5(Td, PA, first, first + t, middle, last - 1 - t, last - 1);
+    }
+  }
+  t >>= 3;
+  first  = ss_median3(Td, PA, first, first + t, first + (t << 1));
+  middle = ss_median3(Td, PA, middle - t, middle, middle + t);
+  last   = ss_median3(Td, PA, last - 1 - (t << 1), last - 1 - t, last - 1);
+  return ss_median3(Td, PA, first, middle, last);
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+/* Binary partition for substrings. */
+static INLINE
+saidx_t *
+ss_partition(const saidx_t *PA,
+                    saidx_t *first, saidx_t *last, saidx_t depth) {
+  saidx_t *a, *b;
+  saidx_t t;
+  for(a = first - 1, b = last;;) {
+    for(; (++a < b) && ((PA[*a] + depth) >= (PA[*a + 1] + 1));) { *a = ~*a; }
+    for(; (a < --b) && ((PA[*b] + depth) <  (PA[*b + 1] + 1));) { }
+    if(b <= a) { break; }
+    t = ~*b;
+    *b = *a;
+    *a = t;
+  }
+  if(first < a) { *first = ~*first; }
+  return a;
+}
+
+/* Multikey introsort for medium size groups. */
+static
+void
+ss_mintrosort(const sauchar_t *T, const saidx_t *PA,
+              saidx_t *first, saidx_t *last,
+              saidx_t depth) {
+#define STACK_SIZE SS_MISORT_STACKSIZE
+  struct { saidx_t *a, *b, c; saint_t d; } stack[STACK_SIZE];
+  const sauchar_t *Td;
+  saidx_t *a, *b, *c, *d, *e, *f;
+  saidx_t s, t;
+  saint_t ssize;
+  saint_t limit;
+  saint_t v, x = 0;
+
+  for(ssize = 0, limit = ss_ilg(last - first);;) {
+
+    if((last - first) <= SS_INSERTIONSORT_THRESHOLD) {
+#if 1 < SS_INSERTIONSORT_THRESHOLD
+      if(1 < (last - first)) { ss_insertionsort(T, PA, first, last, depth); }
+#endif
+      STACK_POP(first, last, depth, limit);
+      continue;
+    }
+
+    Td = T + depth;
+    if(limit-- == 0) { ss_heapsort(Td, PA, first, last - first); }
+    if(limit < 0) {
+      for(a = first + 1, v = Td[PA[*first]]; a < last; ++a) {
+        if((x = Td[PA[*a]]) != v) {
+          if(1 < (a - first)) { break; }
+          v = x;
+          first = a;
+        }
+      }
+      if(Td[PA[*first] - 1] < v) {
+        first = ss_partition(PA, first, a, depth);
+      }
+      if((a - first) <= (last - a)) {
+        if(1 < (a - first)) {
+          STACK_PUSH(a, last, depth, -1);
+          last = a, depth += 1, limit = ss_ilg(a - first);
+        } else {
+          first = a, limit = -1;
+        }
+      } else {
+        if(1 < (last - a)) {
+          STACK_PUSH(first, a, depth + 1, ss_ilg(a - first));
+          first = a, limit = -1;
+        } else {
+          last = a, depth += 1, limit = ss_ilg(a - first);
+        }
+      }
+      continue;
+    }
+
+    /* choose pivot */
+    a = ss_pivot(Td, PA, first, last);
+    v = Td[PA[*a]];
+    SWAP(*first, *a);
+
+    /* partition */
+    for(b = first; (++b < last) && ((x = Td[PA[*b]]) == v);) { }
+    if(((a = b) < last) && (x < v)) {
+      for(; (++b < last) && ((x = Td[PA[*b]]) <= v);) {
+        if(x == v) { SWAP(*b, *a); ++a; }
+      }
+    }
+    for(c = last; (b < --c) && ((x = Td[PA[*c]]) == v);) { }
+    if((b < (d = c)) && (x > v)) {
+      for(; (b < --c) && ((x = Td[PA[*c]]) >= v);) {
+        if(x == v) { SWAP(*c, *d); --d; }
+      }
+    }
+    for(; b < c;) {
+      SWAP(*b, *c);
+      for(; (++b < c) && ((x = Td[PA[*b]]) <= v);) {
+        if(x == v) { SWAP(*b, *a); ++a; }
+      }
+      for(; (b < --c) && ((x = Td[PA[*c]]) >= v);) {
+        if(x == v) { SWAP(*c, *d); --d; }
+      }
+    }
+
+    if(a <= d) {
+      c = b - 1;
+
+      if((s = a - first) > (t = b - a)) { s = t; }
+      for(e = first, f = b - s; 0 < s; --s, ++e, ++f) { SWAP(*e, *f); }
+      if((s = d - c) > (t = last - d - 1)) { s = t; }
+      for(e = b, f = last - s; 0 < s; --s, ++e, ++f) { SWAP(*e, *f); }
+
+      a = first + (b - a), c = last - (d - c);
+      b = (v <= Td[PA[*a] - 1]) ? a : ss_partition(PA, a, c, depth);
+
+      if((a - first) <= (last - c)) {
+        if((last - c) <= (c - b)) {
+          STACK_PUSH(b, c, depth + 1, ss_ilg(c - b));
+          STACK_PUSH(c, last, depth, limit);
+          last = a;
+        } else if((a - first) <= (c - b)) {
+          STACK_PUSH(c, last, depth, limit);
+          STACK_PUSH(b, c, depth + 1, ss_ilg(c - b));
+          last = a;
+        } else {
+          STACK_PUSH(c, last, depth, limit);
+          STACK_PUSH(first, a, depth, limit);
+          first = b, last = c, depth += 1, limit = ss_ilg(c - b);
+        }
+      } else {
+        if((a - first) <= (c - b)) {
+          STACK_PUSH(b, c, depth + 1, ss_ilg(c - b));
+          STACK_PUSH(first, a, depth, limit);
+          first = c;
+        } else if((last - c) <= (c - b)) {
+          STACK_PUSH(first, a, depth, limit);
+          STACK_PUSH(b, c, depth + 1, ss_ilg(c - b));
+          first = c;
+        } else {
+          STACK_PUSH(first, a, depth, limit);
+          STACK_PUSH(c, last, depth, limit);
+          first = b, last = c, depth += 1, limit = ss_ilg(c - b);
+        }
+      }
+    } else {
+      limit += 1;
+      if(Td[PA[*first] - 1] < v) {
+        first = ss_partition(PA, first, last, depth);
+        limit = ss_ilg(last - first);
+      }
+      depth += 1;
+    }
+  }
+#undef STACK_SIZE
+}
+
+#endif /* (SS_BLOCKSIZE == 0) || (SS_INSERTIONSORT_THRESHOLD < SS_BLOCKSIZE) */
+
+
+/*---------------------------------------------------------------------------*/
+
+#if SS_BLOCKSIZE != 0
+
+static INLINE
+void
+ss_blockswap(saidx_t *a, saidx_t *b, saidx_t n) {
+  saidx_t t;
+  for(; 0 < n; --n, ++a, ++b) {
+    t = *a, *a = *b, *b = t;
+  }
+}
+
+static INLINE
+void
+ss_rotate(saidx_t *first, saidx_t *middle, saidx_t *last) {
+  saidx_t *a, *b, t;
+  saidx_t l, r;
+  l = middle - first, r = last - middle;
+  for(; (0 < l) && (0 < r);) {
+    if(l == r) { ss_blockswap(first, middle, l); break; }
+    if(l < r) {
+      a = last - 1, b = middle - 1;
+      t = *a;
+      do {
+        *a-- = *b, *b-- = *a;
+        if(b < first) {
+          *a = t;
+          last = a;
+          if((r -= l + 1) <= l) { break; }
+          a -= 1, b = middle - 1;
+          t = *a;
+        }
+      } while(1);
+    } else {
+      a = first, b = middle;
+      t = *a;
+      do {
+        *a++ = *b, *b++ = *a;
+        if(last <= b) {
+          *a = t;
+          first = a + 1;
+          if((l -= r + 1) <= r) { break; }
+          a += 1, b = middle;
+          t = *a;
+        }
+      } while(1);
+    }
+  }
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+static
+void
+ss_inplacemerge(const sauchar_t *T, const saidx_t *PA,
+                saidx_t *first, saidx_t *middle, saidx_t *last,
+                saidx_t depth) {
+  const saidx_t *p;
+  saidx_t *a, *b;
+  saidx_t len, half;
+  saint_t q, r;
+  saint_t x;
+
+  for(;;) {
+    if(*(last - 1) < 0) { x = 1; p = PA + ~*(last - 1); }
+    else                { x = 0; p = PA +  *(last - 1); }
+    for(a = first, len = middle - first, half = len >> 1, r = -1;
+        0 < len;
+        len = half, half >>= 1) {
+      b = a + half;
+      q = ss_compare(T, PA + ((0 <= *b) ? *b : ~*b), p, depth);
+      if(q < 0) {
+        a = b + 1;
+        half -= (len & 1) ^ 1;
+      } else {
+        r = q;
+      }
+    }
+    if(a < middle) {
+      if(r == 0) { *a = ~*a; }
+      ss_rotate(a, middle, last);
+      last -= middle - a;
+      middle = a;
+      if(first == middle) { break; }
+    }
+    --last;
+    if(x != 0) { while(*--last < 0) { } }
+    if(middle == last) { break; }
+  }
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+/* Merge-forward with internal buffer. */
+static
+void
+ss_mergeforward(const sauchar_t *T, const saidx_t *PA,
+                saidx_t *first, saidx_t *middle, saidx_t *last,
+                saidx_t *buf, saidx_t depth) {
+  saidx_t *a, *b, *c, *bufend;
+  saidx_t t;
+  saint_t r;
+
+  bufend = buf + (middle - first) - 1;
+  ss_blockswap(buf, first, middle - first);
+
+  for(t = *(a = first), b = buf, c = middle;;) {
+    r = ss_compare(T, PA + *b, PA + *c, depth);
+    if(r < 0) {
+      do {
+        *a++ = *b;
+        if(bufend <= b) { *bufend = t; return; }
+        *b++ = *a;
+      } while(*b < 0);
+    } else if(r > 0) {
+      do {
+        *a++ = *c, *c++ = *a;
+        if(last <= c) {
+          while(b < bufend) { *a++ = *b, *b++ = *a; }
+          *a = *b, *b = t;
+          return;
+        }
+      } while(*c < 0);
+    } else {
+      *c = ~*c;
+      do {
+        *a++ = *b;
+        if(bufend <= b) { *bufend = t; return; }
+        *b++ = *a;
+      } while(*b < 0);
+
+      do {
+        *a++ = *c, *c++ = *a;
+        if(last <= c) {
+          while(b < bufend) { *a++ = *b, *b++ = *a; }
+          *a = *b, *b = t;
+          return;
+        }
+      } while(*c < 0);
+    }
+  }
+}
+
+/* Merge-backward with internal buffer. */
+static
+void
+ss_mergebackward(const sauchar_t *T, const saidx_t *PA,
+                 saidx_t *first, saidx_t *middle, saidx_t *last,
+                 saidx_t *buf, saidx_t depth) {
+  const saidx_t *p1, *p2;
+  saidx_t *a, *b, *c, *bufend;
+  saidx_t t;
+  saint_t r;
+  saint_t x;
+
+  bufend = buf + (last - middle) - 1;
+  ss_blockswap(buf, middle, last - middle);
+
+  x = 0;
+  if(*bufend < 0)       { p1 = PA + ~*bufend; x |= 1; }
+  else                  { p1 = PA +  *bufend; }
+  if(*(middle - 1) < 0) { p2 = PA + ~*(middle - 1); x |= 2; }
+  else                  { p2 = PA +  *(middle - 1); }
+  for(t = *(a = last - 1), b = bufend, c = middle - 1;;) {
+    r = ss_compare(T, p1, p2, depth);
+    if(0 < r) {
+      if(x & 1) { do { *a-- = *b, *b-- = *a; } while(*b < 0); x ^= 1; }
+      *a-- = *b;
+      if(b <= buf) { *buf = t; break; }
+      *b-- = *a;
+      if(*b < 0) { p1 = PA + ~*b; x |= 1; }
+      else       { p1 = PA +  *b; }
+    } else if(r < 0) {
+      if(x & 2) { do { *a-- = *c, *c-- = *a; } while(*c < 0); x ^= 2; }
+      *a-- = *c, *c-- = *a;
+      if(c < first) {
+        while(buf < b) { *a-- = *b, *b-- = *a; }
+        *a = *b, *b = t;
+        break;
+      }
+      if(*c < 0) { p2 = PA + ~*c; x |= 2; }
+      else       { p2 = PA +  *c; }
+    } else {
+      if(x & 1) { do { *a-- = *b, *b-- = *a; } while(*b < 0); x ^= 1; }
+      *a-- = ~*b;
+      if(b <= buf) { *buf = t; break; }
+      *b-- = *a;
+      if(x & 2) { do { *a-- = *c, *c-- = *a; } while(*c < 0); x ^= 2; }
+      *a-- = *c, *c-- = *a;
+      if(c < first) {
+        while(buf < b) { *a-- = *b, *b-- = *a; }
+        *a = *b, *b = t;
+        break;
+      }
+      if(*b < 0) { p1 = PA + ~*b; x |= 1; }
+      else       { p1 = PA +  *b; }
+      if(*c < 0) { p2 = PA + ~*c; x |= 2; }
+      else       { p2 = PA +  *c; }
+    }
+  }
+}
+
+/* D&C based merge. */
+static
+void
+ss_swapmerge(const sauchar_t *T, const saidx_t *PA,
+             saidx_t *first, saidx_t *middle, saidx_t *last,
+             saidx_t *buf, saidx_t bufsize, saidx_t depth) {
+#define STACK_SIZE SS_SMERGE_STACKSIZE
+#define GETIDX(a) ((0 <= (a)) ? (a) : (~(a)))
+#define MERGE_CHECK(a, b, c)\
+  do {\
+    if(((c) & 1) ||\
+       (((c) & 2) && (ss_compare(T, PA + GETIDX(*((a) - 1)), PA + *(a), depth) == 0))) {\
+      *(a) = ~*(a);\
+    }\
+    if(((c) & 4) && ((ss_compare(T, PA + GETIDX(*((b) - 1)), PA + *(b), depth) == 0))) {\
+      *(b) = ~*(b);\
+    }\
+  } while(0)
+  struct { saidx_t *a, *b, *c; saint_t d; } stack[STACK_SIZE];
+  saidx_t *l, *r, *lm, *rm;
+  saidx_t m, len, half;
+  saint_t ssize;
+  saint_t check, next;
+
+  for(check = 0, ssize = 0;;) {
+    if((last - middle) <= bufsize) {
+      if((first < middle) && (middle < last)) {
+        ss_mergebackward(T, PA, first, middle, last, buf, depth);
+      }
+      MERGE_CHECK(first, last, check);
+      STACK_POP(first, middle, last, check);
+      continue;
+    }
+
+    if((middle - first) <= bufsize) {
+      if(first < middle) {
+        ss_mergeforward(T, PA, first, middle, last, buf, depth);
+      }
+      MERGE_CHECK(first, last, check);
+      STACK_POP(first, middle, last, check);
+      continue;
+    }
+
+    for(m = 0, len = MIN(middle - first, last - middle), half = len >> 1;
+        0 < len;
+        len = half, half >>= 1) {
+      if(ss_compare(T, PA + GETIDX(*(middle + m + half)),
+                       PA + GETIDX(*(middle - m - half - 1)), depth) < 0) {
+        m += half + 1;
+        half -= (len & 1) ^ 1;
+      }
+    }
+
+    if(0 < m) {
+      lm = middle - m, rm = middle + m;
+      ss_blockswap(lm, middle, m);
+      l = r = middle, next = 0;
+      if(rm < last) {
+        if(*rm < 0) {
+          *rm = ~*rm;
+          if(first < lm) { for(; *--l < 0;) { } next |= 4; }
+          next |= 1;
+        } else if(first < lm) {
+          for(; *r < 0; ++r) { }
+          next |= 2;
+        }
+      }
+
+      if((l - first) <= (last - r)) {
+        STACK_PUSH(r, rm, last, (next & 3) | (check & 4));
+        middle = lm, last = l, check = (check & 3) | (next & 4);
+      } else {
+        if((next & 2) && (r == middle)) { next ^= 6; }
+        STACK_PUSH(first, lm, l, (check & 3) | (next & 4));
+        first = r, middle = rm, check = (next & 3) | (check & 4);
+      }
+    } else {
+      if(ss_compare(T, PA + GETIDX(*(middle - 1)), PA + *middle, depth) == 0) {
+        *middle = ~*middle;
+      }
+      MERGE_CHECK(first, last, check);
+      STACK_POP(first, middle, last, check);
+    }
+  }
+#undef STACK_SIZE
+}
+
+#endif /* SS_BLOCKSIZE != 0 */
+
+
+/*---------------------------------------------------------------------------*/
+
+/*- Function -*/
+
+/* Substring sort */
+void
+sssort(const sauchar_t *T, const saidx_t *PA,
+       saidx_t *first, saidx_t *last,
+       saidx_t *buf, saidx_t bufsize,
+       saidx_t depth, saidx_t n, saint_t lastsuffix) {
+  saidx_t *a;
+#if SS_BLOCKSIZE != 0
+  saidx_t *b, *middle, *curbuf;
+  saidx_t j, k, curbufsize, limit;
+#endif
+  saidx_t i;
+
+  if(lastsuffix != 0) { ++first; }
+
+#if SS_BLOCKSIZE == 0
+  ss_mintrosort(T, PA, first, last, depth);
+#else
+  if((bufsize < SS_BLOCKSIZE) &&
+      (bufsize < (last - first)) &&
+      (bufsize < (limit = ss_isqrt(last - first)))) {
+    if(SS_BLOCKSIZE < limit) { limit = SS_BLOCKSIZE; }
+    buf = middle = last - limit, bufsize = limit;
+  } else {
+    middle = last, limit = 0;
+  }
+  for(a = first, i = 0; SS_BLOCKSIZE < (middle - a); a += SS_BLOCKSIZE, ++i) {
+#if SS_INSERTIONSORT_THRESHOLD < SS_BLOCKSIZE
+    ss_mintrosort(T, PA, a, a + SS_BLOCKSIZE, depth);
+#elif 1 < SS_BLOCKSIZE
+    ss_insertionsort(T, PA, a, a + SS_BLOCKSIZE, depth);
+#endif
+    curbufsize = last - (a + SS_BLOCKSIZE);
+    curbuf = a + SS_BLOCKSIZE;
+    if(curbufsize <= bufsize) { curbufsize = bufsize, curbuf = buf; }
+    for(b = a, k = SS_BLOCKSIZE, j = i; j & 1; b -= k, k <<= 1, j >>= 1) {
+      ss_swapmerge(T, PA, b - k, b, b + k, curbuf, curbufsize, depth);
+    }
+  }
+#if SS_INSERTIONSORT_THRESHOLD < SS_BLOCKSIZE
+  ss_mintrosort(T, PA, a, middle, depth);
+#elif 1 < SS_BLOCKSIZE
+  ss_insertionsort(T, PA, a, middle, depth);
+#endif
+  for(k = SS_BLOCKSIZE; i != 0; k <<= 1, i >>= 1) {
+    if(i & 1) {
+      ss_swapmerge(T, PA, a - k, a, middle, buf, bufsize, depth);
+      a -= k;
+    }
+  }
+  if(limit != 0) {
+#if SS_INSERTIONSORT_THRESHOLD < SS_BLOCKSIZE
+    ss_mintrosort(T, PA, middle, last, depth);
+#elif 1 < SS_BLOCKSIZE
+    ss_insertionsort(T, PA, middle, last, depth);
+#endif
+    ss_inplacemerge(T, PA, first, middle, last, depth);
+  }
+#endif
+
+  if(lastsuffix != 0) {
+    /* Insert last type B* suffix. */
+    saidx_t PAi[2]; PAi[0] = PA[*(first - 1)], PAi[1] = n - 2;
+    for(a = first, i = *(first - 1);
+        (a < last) && ((*a < 0) || (0 < ss_compare(T, &(PAi[0]), PA + *a, depth)));
+        ++a) {
+      *(a - 1) = *a;
+    }
+    *(a - 1) = i;
+  }
+}

--- a/thirdparty/libdivsufsort/lib/trsort.c
+++ b/thirdparty/libdivsufsort/lib/trsort.c
@@ -1,0 +1,586 @@
+/*
+ * trsort.c for libdivsufsort
+ * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "divsufsort_private.h"
+
+
+/*- Private Functions -*/
+
+static const saint_t lg_table[256]= {
+ -1,0,1,1,2,2,2,2,3,3,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+  5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7
+};
+
+static INLINE
+saint_t
+tr_ilg(saidx_t n) {
+#if defined(BUILD_DIVSUFSORT64)
+  return (n >> 32) ?
+          ((n >> 48) ?
+            ((n >> 56) ?
+              56 + lg_table[(n >> 56) & 0xff] :
+              48 + lg_table[(n >> 48) & 0xff]) :
+            ((n >> 40) ?
+              40 + lg_table[(n >> 40) & 0xff] :
+              32 + lg_table[(n >> 32) & 0xff])) :
+          ((n & 0xffff0000) ?
+            ((n & 0xff000000) ?
+              24 + lg_table[(n >> 24) & 0xff] :
+              16 + lg_table[(n >> 16) & 0xff]) :
+            ((n & 0x0000ff00) ?
+               8 + lg_table[(n >>  8) & 0xff] :
+               0 + lg_table[(n >>  0) & 0xff]));
+#else
+  return (n & 0xffff0000) ?
+          ((n & 0xff000000) ?
+            24 + lg_table[(n >> 24) & 0xff] :
+            16 + lg_table[(n >> 16) & 0xff]) :
+          ((n & 0x0000ff00) ?
+             8 + lg_table[(n >>  8) & 0xff] :
+             0 + lg_table[(n >>  0) & 0xff]);
+#endif
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+/* Simple insertionsort for small size groups. */
+static
+void
+tr_insertionsort(const saidx_t *ISAd, saidx_t *first, saidx_t *last) {
+  saidx_t *a, *b;
+  saidx_t t, r;
+
+  for(a = first + 1; a < last; ++a) {
+    for(t = *a, b = a - 1; 0 > (r = ISAd[t] - ISAd[*b]);) {
+      do { *(b + 1) = *b; } while((first <= --b) && (*b < 0));
+      if(b < first) { break; }
+    }
+    if(r == 0) { *b = ~*b; }
+    *(b + 1) = t;
+  }
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+static INLINE
+void
+tr_fixdown(const saidx_t *ISAd, saidx_t *SA, saidx_t i, saidx_t size) {
+  saidx_t j, k;
+  saidx_t v;
+  saidx_t c, d, e;
+
+  for(v = SA[i], c = ISAd[v]; (j = 2 * i + 1) < size; SA[i] = SA[k], i = k) {
+    d = ISAd[SA[k = j++]];
+    if(d < (e = ISAd[SA[j]])) { k = j; d = e; }
+    if(d <= c) { break; }
+  }
+  SA[i] = v;
+}
+
+/* Simple top-down heapsort. */
+static
+void
+tr_heapsort(const saidx_t *ISAd, saidx_t *SA, saidx_t size) {
+  saidx_t i, m;
+  saidx_t t;
+
+  m = size;
+  if((size % 2) == 0) {
+    m--;
+    if(ISAd[SA[m / 2]] < ISAd[SA[m]]) { SWAP(SA[m], SA[m / 2]); }
+  }
+
+  for(i = m / 2 - 1; 0 <= i; --i) { tr_fixdown(ISAd, SA, i, m); }
+  if((size % 2) == 0) { SWAP(SA[0], SA[m]); tr_fixdown(ISAd, SA, 0, m); }
+  for(i = m - 1; 0 < i; --i) {
+    t = SA[0], SA[0] = SA[i];
+    tr_fixdown(ISAd, SA, 0, i);
+    SA[i] = t;
+  }
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+/* Returns the median of three elements. */
+static INLINE
+saidx_t *
+tr_median3(const saidx_t *ISAd, saidx_t *v1, saidx_t *v2, saidx_t *v3) {
+  saidx_t *t;
+  if(ISAd[*v1] > ISAd[*v2]) { SWAP(v1, v2); }
+  if(ISAd[*v2] > ISAd[*v3]) {
+    if(ISAd[*v1] > ISAd[*v3]) { return v1; }
+    else { return v3; }
+  }
+  return v2;
+}
+
+/* Returns the median of five elements. */
+static INLINE
+saidx_t *
+tr_median5(const saidx_t *ISAd,
+           saidx_t *v1, saidx_t *v2, saidx_t *v3, saidx_t *v4, saidx_t *v5) {
+  saidx_t *t;
+  if(ISAd[*v2] > ISAd[*v3]) { SWAP(v2, v3); }
+  if(ISAd[*v4] > ISAd[*v5]) { SWAP(v4, v5); }
+  if(ISAd[*v2] > ISAd[*v4]) { SWAP(v2, v4); SWAP(v3, v5); }
+  if(ISAd[*v1] > ISAd[*v3]) { SWAP(v1, v3); }
+  if(ISAd[*v1] > ISAd[*v4]) { SWAP(v1, v4); SWAP(v3, v5); }
+  if(ISAd[*v3] > ISAd[*v4]) { return v4; }
+  return v3;
+}
+
+/* Returns the pivot element. */
+static INLINE
+saidx_t *
+tr_pivot(const saidx_t *ISAd, saidx_t *first, saidx_t *last) {
+  saidx_t *middle;
+  saidx_t t;
+
+  t = last - first;
+  middle = first + t / 2;
+
+  if(t <= 512) {
+    if(t <= 32) {
+      return tr_median3(ISAd, first, middle, last - 1);
+    } else {
+      t >>= 2;
+      return tr_median5(ISAd, first, first + t, middle, last - 1 - t, last - 1);
+    }
+  }
+  t >>= 3;
+  first  = tr_median3(ISAd, first, first + t, first + (t << 1));
+  middle = tr_median3(ISAd, middle - t, middle, middle + t);
+  last   = tr_median3(ISAd, last - 1 - (t << 1), last - 1 - t, last - 1);
+  return tr_median3(ISAd, first, middle, last);
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+typedef struct _trbudget_t trbudget_t;
+struct _trbudget_t {
+  saidx_t chance;
+  saidx_t remain;
+  saidx_t incval;
+  saidx_t count;
+};
+
+static INLINE
+void
+trbudget_init(trbudget_t *budget, saidx_t chance, saidx_t incval) {
+  budget->chance = chance;
+  budget->remain = budget->incval = incval;
+}
+
+static INLINE
+saint_t
+trbudget_check(trbudget_t *budget, saidx_t size) {
+  if(size <= budget->remain) { budget->remain -= size; return 1; }
+  if(budget->chance == 0) { budget->count += size; return 0; }
+  budget->remain += budget->incval - size;
+  budget->chance -= 1;
+  return 1;
+}
+
+
+/*---------------------------------------------------------------------------*/
+
+static INLINE
+void
+tr_partition(const saidx_t *ISAd,
+             saidx_t *first, saidx_t *middle, saidx_t *last,
+             saidx_t **pa, saidx_t **pb, saidx_t v) {
+  saidx_t *a, *b, *c, *d, *e, *f;
+  saidx_t t, s;
+  saidx_t x = 0;
+
+  for(b = middle - 1; (++b < last) && ((x = ISAd[*b]) == v);) { }
+  if(((a = b) < last) && (x < v)) {
+    for(; (++b < last) && ((x = ISAd[*b]) <= v);) {
+      if(x == v) { SWAP(*b, *a); ++a; }
+    }
+  }
+  for(c = last; (b < --c) && ((x = ISAd[*c]) == v);) { }
+  if((b < (d = c)) && (x > v)) {
+    for(; (b < --c) && ((x = ISAd[*c]) >= v);) {
+      if(x == v) { SWAP(*c, *d); --d; }
+    }
+  }
+  for(; b < c;) {
+    SWAP(*b, *c);
+    for(; (++b < c) && ((x = ISAd[*b]) <= v);) {
+      if(x == v) { SWAP(*b, *a); ++a; }
+    }
+    for(; (b < --c) && ((x = ISAd[*c]) >= v);) {
+      if(x == v) { SWAP(*c, *d); --d; }
+    }
+  }
+
+  if(a <= d) {
+    c = b - 1;
+    if((s = a - first) > (t = b - a)) { s = t; }
+    for(e = first, f = b - s; 0 < s; --s, ++e, ++f) { SWAP(*e, *f); }
+    if((s = d - c) > (t = last - d - 1)) { s = t; }
+    for(e = b, f = last - s; 0 < s; --s, ++e, ++f) { SWAP(*e, *f); }
+    first += (b - a), last -= (d - c);
+  }
+  *pa = first, *pb = last;
+}
+
+static
+void
+tr_copy(saidx_t *ISA, const saidx_t *SA,
+        saidx_t *first, saidx_t *a, saidx_t *b, saidx_t *last,
+        saidx_t depth) {
+  /* sort suffixes of middle partition
+     by using sorted order of suffixes of left and right partition. */
+  saidx_t *c, *d, *e;
+  saidx_t s, v;
+
+  v = b - SA - 1;
+  for(c = first, d = a - 1; c <= d; ++c) {
+    if((0 <= (s = *c - depth)) && (ISA[s] == v)) {
+      *++d = s;
+      ISA[s] = d - SA;
+    }
+  }
+  for(c = last - 1, e = d + 1, d = b; e < d; --c) {
+    if((0 <= (s = *c - depth)) && (ISA[s] == v)) {
+      *--d = s;
+      ISA[s] = d - SA;
+    }
+  }
+}
+
+static
+void
+tr_partialcopy(saidx_t *ISA, const saidx_t *SA,
+               saidx_t *first, saidx_t *a, saidx_t *b, saidx_t *last,
+               saidx_t depth) {
+  saidx_t *c, *d, *e;
+  saidx_t s, v;
+  saidx_t rank, lastrank, newrank = -1;
+
+  v = b - SA - 1;
+  lastrank = -1;
+  for(c = first, d = a - 1; c <= d; ++c) {
+    if((0 <= (s = *c - depth)) && (ISA[s] == v)) {
+      *++d = s;
+      rank = ISA[s + depth];
+      if(lastrank != rank) { lastrank = rank; newrank = d - SA; }
+      ISA[s] = newrank;
+    }
+  }
+
+  lastrank = -1;
+  for(e = d; first <= e; --e) {
+    rank = ISA[*e];
+    if(lastrank != rank) { lastrank = rank; newrank = e - SA; }
+    if(newrank != rank) { ISA[*e] = newrank; }
+  }
+
+  lastrank = -1;
+  for(c = last - 1, e = d + 1, d = b; e < d; --c) {
+    if((0 <= (s = *c - depth)) && (ISA[s] == v)) {
+      *--d = s;
+      rank = ISA[s + depth];
+      if(lastrank != rank) { lastrank = rank; newrank = d - SA; }
+      ISA[s] = newrank;
+    }
+  }
+}
+
+static
+void
+tr_introsort(saidx_t *ISA, const saidx_t *ISAd,
+             saidx_t *SA, saidx_t *first, saidx_t *last,
+             trbudget_t *budget) {
+#define STACK_SIZE TR_STACKSIZE
+  struct { const saidx_t *a; saidx_t *b, *c; saint_t d, e; }stack[STACK_SIZE];
+  saidx_t *a, *b, *c;
+  saidx_t t;
+  saidx_t v, x = 0;
+  saidx_t incr = ISAd - ISA;
+  saint_t limit, next;
+  saint_t ssize, trlink = -1;
+
+  for(ssize = 0, limit = tr_ilg(last - first);;) {
+
+    if(limit < 0) {
+      if(limit == -1) {
+        /* tandem repeat partition */
+        tr_partition(ISAd - incr, first, first, last, &a, &b, last - SA - 1);
+
+        /* update ranks */
+        if(a < last) {
+          for(c = first, v = a - SA - 1; c < a; ++c) { ISA[*c] = v; }
+        }
+        if(b < last) {
+          for(c = a, v = b - SA - 1; c < b; ++c) { ISA[*c] = v; }
+        }
+
+        /* push */
+        if(1 < (b - a)) {
+          STACK_PUSH5(NULL, a, b, 0, 0);
+          STACK_PUSH5(ISAd - incr, first, last, -2, trlink);
+          trlink = ssize - 2;
+        }
+        if((a - first) <= (last - b)) {
+          if(1 < (a - first)) {
+            STACK_PUSH5(ISAd, b, last, tr_ilg(last - b), trlink);
+            last = a, limit = tr_ilg(a - first);
+          } else if(1 < (last - b)) {
+            first = b, limit = tr_ilg(last - b);
+          } else {
+            STACK_POP5(ISAd, first, last, limit, trlink);
+          }
+        } else {
+          if(1 < (last - b)) {
+            STACK_PUSH5(ISAd, first, a, tr_ilg(a - first), trlink);
+            first = b, limit = tr_ilg(last - b);
+          } else if(1 < (a - first)) {
+            last = a, limit = tr_ilg(a - first);
+          } else {
+            STACK_POP5(ISAd, first, last, limit, trlink);
+          }
+        }
+      } else if(limit == -2) {
+        /* tandem repeat copy */
+        a = stack[--ssize].b, b = stack[ssize].c;
+        if(stack[ssize].d == 0) {
+          tr_copy(ISA, SA, first, a, b, last, ISAd - ISA);
+        } else {
+          if(0 <= trlink) { stack[trlink].d = -1; }
+          tr_partialcopy(ISA, SA, first, a, b, last, ISAd - ISA);
+        }
+        STACK_POP5(ISAd, first, last, limit, trlink);
+      } else {
+        /* sorted partition */
+        if(0 <= *first) {
+          a = first;
+          do { ISA[*a] = a - SA; } while((++a < last) && (0 <= *a));
+          first = a;
+        }
+        if(first < last) {
+          a = first; do { *a = ~*a; } while(*++a < 0);
+          next = (ISA[*a] != ISAd[*a]) ? tr_ilg(a - first + 1) : -1;
+          if(++a < last) { for(b = first, v = a - SA - 1; b < a; ++b) { ISA[*b] = v; } }
+
+          /* push */
+          if(trbudget_check(budget, a - first)) {
+            if((a - first) <= (last - a)) {
+              STACK_PUSH5(ISAd, a, last, -3, trlink);
+              ISAd += incr, last = a, limit = next;
+            } else {
+              if(1 < (last - a)) {
+                STACK_PUSH5(ISAd + incr, first, a, next, trlink);
+                first = a, limit = -3;
+              } else {
+                ISAd += incr, last = a, limit = next;
+              }
+            }
+          } else {
+            if(0 <= trlink) { stack[trlink].d = -1; }
+            if(1 < (last - a)) {
+              first = a, limit = -3;
+            } else {
+              STACK_POP5(ISAd, first, last, limit, trlink);
+            }
+          }
+        } else {
+          STACK_POP5(ISAd, first, last, limit, trlink);
+        }
+      }
+      continue;
+    }
+
+    if((last - first) <= TR_INSERTIONSORT_THRESHOLD) {
+      tr_insertionsort(ISAd, first, last);
+      limit = -3;
+      continue;
+    }
+
+    if(limit-- == 0) {
+      tr_heapsort(ISAd, first, last - first);
+      for(a = last - 1; first < a; a = b) {
+        for(x = ISAd[*a], b = a - 1; (first <= b) && (ISAd[*b] == x); --b) { *b = ~*b; }
+      }
+      limit = -3;
+      continue;
+    }
+
+    /* choose pivot */
+    a = tr_pivot(ISAd, first, last);
+    SWAP(*first, *a);
+    v = ISAd[*first];
+
+    /* partition */
+    tr_partition(ISAd, first, first + 1, last, &a, &b, v);
+    if((last - first) != (b - a)) {
+      next = (ISA[*a] != v) ? tr_ilg(b - a) : -1;
+
+      /* update ranks */
+      for(c = first, v = a - SA - 1; c < a; ++c) { ISA[*c] = v; }
+      if(b < last) { for(c = a, v = b - SA - 1; c < b; ++c) { ISA[*c] = v; } }
+
+      /* push */
+      if((1 < (b - a)) && (trbudget_check(budget, b - a))) {
+        if((a - first) <= (last - b)) {
+          if((last - b) <= (b - a)) {
+            if(1 < (a - first)) {
+              STACK_PUSH5(ISAd + incr, a, b, next, trlink);
+              STACK_PUSH5(ISAd, b, last, limit, trlink);
+              last = a;
+            } else if(1 < (last - b)) {
+              STACK_PUSH5(ISAd + incr, a, b, next, trlink);
+              first = b;
+            } else {
+              ISAd += incr, first = a, last = b, limit = next;
+            }
+          } else if((a - first) <= (b - a)) {
+            if(1 < (a - first)) {
+              STACK_PUSH5(ISAd, b, last, limit, trlink);
+              STACK_PUSH5(ISAd + incr, a, b, next, trlink);
+              last = a;
+            } else {
+              STACK_PUSH5(ISAd, b, last, limit, trlink);
+              ISAd += incr, first = a, last = b, limit = next;
+            }
+          } else {
+            STACK_PUSH5(ISAd, b, last, limit, trlink);
+            STACK_PUSH5(ISAd, first, a, limit, trlink);
+            ISAd += incr, first = a, last = b, limit = next;
+          }
+        } else {
+          if((a - first) <= (b - a)) {
+            if(1 < (last - b)) {
+              STACK_PUSH5(ISAd + incr, a, b, next, trlink);
+              STACK_PUSH5(ISAd, first, a, limit, trlink);
+              first = b;
+            } else if(1 < (a - first)) {
+              STACK_PUSH5(ISAd + incr, a, b, next, trlink);
+              last = a;
+            } else {
+              ISAd += incr, first = a, last = b, limit = next;
+            }
+          } else if((last - b) <= (b - a)) {
+            if(1 < (last - b)) {
+              STACK_PUSH5(ISAd, first, a, limit, trlink);
+              STACK_PUSH5(ISAd + incr, a, b, next, trlink);
+              first = b;
+            } else {
+              STACK_PUSH5(ISAd, first, a, limit, trlink);
+              ISAd += incr, first = a, last = b, limit = next;
+            }
+          } else {
+            STACK_PUSH5(ISAd, first, a, limit, trlink);
+            STACK_PUSH5(ISAd, b, last, limit, trlink);
+            ISAd += incr, first = a, last = b, limit = next;
+          }
+        }
+      } else {
+        if((1 < (b - a)) && (0 <= trlink)) { stack[trlink].d = -1; }
+        if((a - first) <= (last - b)) {
+          if(1 < (a - first)) {
+            STACK_PUSH5(ISAd, b, last, limit, trlink);
+            last = a;
+          } else if(1 < (last - b)) {
+            first = b;
+          } else {
+            STACK_POP5(ISAd, first, last, limit, trlink);
+          }
+        } else {
+          if(1 < (last - b)) {
+            STACK_PUSH5(ISAd, first, a, limit, trlink);
+            first = b;
+          } else if(1 < (a - first)) {
+            last = a;
+          } else {
+            STACK_POP5(ISAd, first, last, limit, trlink);
+          }
+        }
+      }
+    } else {
+      if(trbudget_check(budget, last - first)) {
+        limit = tr_ilg(last - first), ISAd += incr;
+      } else {
+        if(0 <= trlink) { stack[trlink].d = -1; }
+        STACK_POP5(ISAd, first, last, limit, trlink);
+      }
+    }
+  }
+#undef STACK_SIZE
+}
+
+
+
+/*---------------------------------------------------------------------------*/
+
+/*- Function -*/
+
+/* Tandem repeat sort */
+void
+trsort(saidx_t *ISA, saidx_t *SA, saidx_t n, saidx_t depth) {
+  saidx_t *ISAd;
+  saidx_t *first, *last;
+  trbudget_t budget;
+  saidx_t t, skip, unsorted;
+
+  trbudget_init(&budget, tr_ilg(n) * 2 / 3, n);
+/*  trbudget_init(&budget, tr_ilg(n) * 3 / 4, n); */
+  for(ISAd = ISA + depth; -n < *SA; ISAd += ISAd - ISA) {
+    first = SA;
+    skip = 0;
+    unsorted = 0;
+    do {
+      if((t = *first) < 0) { first -= t; skip += t; }
+      else {
+        if(skip != 0) { *(first + skip) = skip; skip = 0; }
+        last = SA + ISA[t] + 1;
+        if(1 < (last - first)) {
+          budget.count = 0;
+          tr_introsort(ISA, ISAd, SA, first, last, &budget);
+          if(budget.count != 0) { unsorted += budget.count; }
+          else { skip = first - last; }
+        } else if((last - first) == 1) {
+          skip = -1;
+        }
+        first = last;
+      }
+    } while(first < (SA + n));
+    if(skip != 0) { *(first + skip) = skip; }
+    if(unsorted == 0) { break; }
+  }
+}

--- a/thirdparty/libdivsufsort/lib/utils.c
+++ b/thirdparty/libdivsufsort/lib/utils.c
@@ -1,0 +1,381 @@
+/*
+ * utils.c for libdivsufsort
+ * Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "divsufsort_private.h"
+
+
+/*- Private Function -*/
+
+/* Binary search for inverse bwt. */
+static
+saidx_t
+binarysearch_lower(const saidx_t *A, saidx_t size, saidx_t value) {
+  saidx_t half, i;
+  for(i = 0, half = size >> 1;
+      0 < size;
+      size = half, half >>= 1) {
+    if(A[i + half] < value) {
+      i += half + 1;
+      half -= (size & 1) ^ 1;
+    }
+  }
+  return i;
+}
+
+
+/*- Functions -*/
+
+/* Burrows-Wheeler transform. */
+saint_t
+bw_transform(const sauchar_t *T, sauchar_t *U, saidx_t *SA,
+             saidx_t n, saidx_t *idx) {
+  saidx_t *A, i, j, p, t;
+  saint_t c;
+
+  /* Check arguments. */
+  if((T == NULL) || (U == NULL) || (n < 0) || (idx == NULL)) { return -1; }
+  if(n <= 1) {
+    if(n == 1) { U[0] = T[0]; }
+    *idx = n;
+    return 0;
+  }
+
+  if((A = SA) == NULL) {
+    i = divbwt(T, U, NULL, n);
+    if(0 <= i) { *idx = i; i = 0; }
+    return (saint_t)i;
+  }
+
+  /* BW transform. */
+  if(T == U) {
+    t = n;
+    for(i = 0, j = 0; i < n; ++i) {
+      p = t - 1;
+      t = A[i];
+      if(0 <= p) {
+        c = T[j];
+        U[j] = (j <= p) ? T[p] : (sauchar_t)A[p];
+        A[j] = c;
+        j++;
+      } else {
+        *idx = i;
+      }
+    }
+    p = t - 1;
+    if(0 <= p) {
+      c = T[j];
+      U[j] = (j <= p) ? T[p] : (sauchar_t)A[p];
+      A[j] = c;
+    } else {
+      *idx = i;
+    }
+  } else {
+    U[0] = T[n - 1];
+    for(i = 0; A[i] != 0; ++i) { U[i + 1] = T[A[i] - 1]; }
+    *idx = i + 1;
+    for(++i; i < n; ++i) { U[i] = T[A[i] - 1]; }
+  }
+
+  if(SA == NULL) {
+    /* Deallocate memory. */
+    free(A);
+  }
+
+  return 0;
+}
+
+/* Inverse Burrows-Wheeler transform. */
+saint_t
+inverse_bw_transform(const sauchar_t *T, sauchar_t *U, saidx_t *A,
+                     saidx_t n, saidx_t idx) {
+  saidx_t C[ALPHABET_SIZE];
+  sauchar_t D[ALPHABET_SIZE];
+  saidx_t *B;
+  saidx_t i, p;
+  saint_t c, d;
+
+  /* Check arguments. */
+  if((T == NULL) || (U == NULL) || (n < 0) || (idx < 0) ||
+     (n < idx) || ((0 < n) && (idx == 0))) {
+    return -1;
+  }
+  if(n <= 1) { return 0; }
+
+  if((B = A) == NULL) {
+    /* Allocate n*sizeof(saidx_t) bytes of memory. */
+    if((B = (saidx_t *)malloc((size_t)n * sizeof(saidx_t))) == NULL) { return -2; }
+  }
+
+  /* Inverse BW transform. */
+  for(c = 0; c < ALPHABET_SIZE; ++c) { C[c] = 0; }
+  for(i = 0; i < n; ++i) { ++C[T[i]]; }
+  for(c = 0, d = 0, i = 0; c < ALPHABET_SIZE; ++c) {
+    p = C[c];
+    if(0 < p) {
+      C[c] = i;
+      D[d++] = (sauchar_t)c;
+      i += p;
+    }
+  }
+  for(i = 0; i < idx; ++i) { B[C[T[i]]++] = i; }
+  for( ; i < n; ++i)       { B[C[T[i]]++] = i + 1; }
+  for(c = 0; c < d; ++c) { C[c] = C[D[c]]; }
+  for(i = 0, p = idx; i < n; ++i) {
+    U[i] = D[binarysearch_lower(C, d, p)];
+    p = B[p - 1];
+  }
+
+  if(A == NULL) {
+    /* Deallocate memory. */
+    free(B);
+  }
+
+  return 0;
+}
+
+/* Checks the suffix array SA of the string T. */
+saint_t
+sufcheck(const sauchar_t *T, const saidx_t *SA,
+         saidx_t n, saint_t verbose) {
+  saidx_t C[ALPHABET_SIZE];
+  saidx_t i, p, q, t;
+  saint_t c;
+
+  if(verbose) { fprintf(stderr, "sufcheck: "); }
+
+  /* Check arguments. */
+  if((T == NULL) || (SA == NULL) || (n < 0)) {
+    if(verbose) { fprintf(stderr, "Invalid arguments.\n"); }
+    return -1;
+  }
+  if(n == 0) {
+    if(verbose) { fprintf(stderr, "Done.\n"); }
+    return 0;
+  }
+
+  /* check range: [0..n-1] */
+  for(i = 0; i < n; ++i) {
+    if((SA[i] < 0) || (n <= SA[i])) {
+      if(verbose) {
+        fprintf(stderr, "Out of the range [0,%" PRIdSAIDX_T "].\n"
+                        "  SA[%" PRIdSAIDX_T "]=%" PRIdSAIDX_T "\n",
+                        n - 1, i, SA[i]);
+      }
+      return -2;
+    }
+  }
+
+  /* check first characters. */
+  for(i = 1; i < n; ++i) {
+    if(T[SA[i - 1]] > T[SA[i]]) {
+      if(verbose) {
+        fprintf(stderr, "Suffixes in wrong order.\n"
+                        "  T[SA[%" PRIdSAIDX_T "]=%" PRIdSAIDX_T "]=%d"
+                        " > T[SA[%" PRIdSAIDX_T "]=%" PRIdSAIDX_T "]=%d\n",
+                        i - 1, SA[i - 1], T[SA[i - 1]], i, SA[i], T[SA[i]]);
+      }
+      return -3;
+    }
+  }
+
+  /* check suffixes. */
+  for(i = 0; i < ALPHABET_SIZE; ++i) { C[i] = 0; }
+  for(i = 0; i < n; ++i) { ++C[T[i]]; }
+  for(i = 0, p = 0; i < ALPHABET_SIZE; ++i) {
+    t = C[i];
+    C[i] = p;
+    p += t;
+  }
+
+  q = C[T[n - 1]];
+  C[T[n - 1]] += 1;
+  for(i = 0; i < n; ++i) {
+    p = SA[i];
+    if(0 < p) {
+      c = T[--p];
+      t = C[c];
+    } else {
+      c = T[p = n - 1];
+      t = q;
+    }
+    if((t < 0) || (p != SA[t])) {
+      if(verbose) {
+        fprintf(stderr, "Suffix in wrong position.\n"
+                        "  SA[%" PRIdSAIDX_T "]=%" PRIdSAIDX_T " or\n"
+                        "  SA[%" PRIdSAIDX_T "]=%" PRIdSAIDX_T "\n",
+                        t, (0 <= t) ? SA[t] : -1, i, SA[i]);
+      }
+      return -4;
+    }
+    if(t != q) {
+      ++C[c];
+      if((n <= C[c]) || (T[SA[C[c]]] != c)) { C[c] = -1; }
+    }
+  }
+
+  if(1 <= verbose) { fprintf(stderr, "Done.\n"); }
+  return 0;
+}
+
+
+static
+int
+_compare(const sauchar_t *T, saidx_t Tsize,
+         const sauchar_t *P, saidx_t Psize,
+         saidx_t suf, saidx_t *match) {
+  saidx_t i, j;
+  saint_t r;
+  for(i = suf + *match, j = *match, r = 0;
+      (i < Tsize) && (j < Psize) && ((r = T[i] - P[j]) == 0); ++i, ++j) { }
+  *match = j;
+  return (r == 0) ? -(j != Psize) : r;
+}
+
+/* Search for the pattern P in the string T. */
+saidx_t
+sa_search(const sauchar_t *T, saidx_t Tsize,
+          const sauchar_t *P, saidx_t Psize,
+          const saidx_t *SA, saidx_t SAsize,
+          saidx_t *idx) {
+  saidx_t size, lsize, rsize, half;
+  saidx_t match, lmatch, rmatch;
+  saidx_t llmatch, lrmatch, rlmatch, rrmatch;
+  saidx_t i, j, k;
+  saint_t r;
+
+  if(idx != NULL) { *idx = -1; }
+  if((T == NULL) || (P == NULL) || (SA == NULL) ||
+     (Tsize < 0) || (Psize < 0) || (SAsize < 0)) { return -1; }
+  if((Tsize == 0) || (SAsize == 0)) { return 0; }
+  if(Psize == 0) { if(idx != NULL) { *idx = 0; } return SAsize; }
+
+  for(i = j = k = 0, lmatch = rmatch = 0, size = SAsize, half = size >> 1;
+      0 < size;
+      size = half, half >>= 1) {
+    match = MIN(lmatch, rmatch);
+    r = _compare(T, Tsize, P, Psize, SA[i + half], &match);
+    if(r < 0) {
+      i += half + 1;
+      half -= (size & 1) ^ 1;
+      lmatch = match;
+    } else if(r > 0) {
+      rmatch = match;
+    } else {
+      lsize = half, j = i, rsize = size - half - 1, k = i + half + 1;
+
+      /* left part */
+      for(llmatch = lmatch, lrmatch = match, half = lsize >> 1;
+          0 < lsize;
+          lsize = half, half >>= 1) {
+        lmatch = MIN(llmatch, lrmatch);
+        r = _compare(T, Tsize, P, Psize, SA[j + half], &lmatch);
+        if(r < 0) {
+          j += half + 1;
+          half -= (lsize & 1) ^ 1;
+          llmatch = lmatch;
+        } else {
+          lrmatch = lmatch;
+        }
+      }
+
+      /* right part */
+      for(rlmatch = match, rrmatch = rmatch, half = rsize >> 1;
+          0 < rsize;
+          rsize = half, half >>= 1) {
+        rmatch = MIN(rlmatch, rrmatch);
+        r = _compare(T, Tsize, P, Psize, SA[k + half], &rmatch);
+        if(r <= 0) {
+          k += half + 1;
+          half -= (rsize & 1) ^ 1;
+          rlmatch = rmatch;
+        } else {
+          rrmatch = rmatch;
+        }
+      }
+
+      break;
+    }
+  }
+
+  if(idx != NULL) { *idx = (0 < (k - j)) ? j : i; }
+  return k - j;
+}
+
+/* Search for the character c in the string T. */
+saidx_t
+sa_simplesearch(const sauchar_t *T, saidx_t Tsize,
+                const saidx_t *SA, saidx_t SAsize,
+                saint_t c, saidx_t *idx) {
+  saidx_t size, lsize, rsize, half;
+  saidx_t i, j, k, p;
+  saint_t r;
+
+  if(idx != NULL) { *idx = -1; }
+  if((T == NULL) || (SA == NULL) || (Tsize < 0) || (SAsize < 0)) { return -1; }
+  if((Tsize == 0) || (SAsize == 0)) { return 0; }
+
+  for(i = j = k = 0, size = SAsize, half = size >> 1;
+      0 < size;
+      size = half, half >>= 1) {
+    p = SA[i + half];
+    r = (p < Tsize) ? T[p] - c : -1;
+    if(r < 0) {
+      i += half + 1;
+      half -= (size & 1) ^ 1;
+    } else if(r == 0) {
+      lsize = half, j = i, rsize = size - half - 1, k = i + half + 1;
+
+      /* left part */
+      for(half = lsize >> 1;
+          0 < lsize;
+          lsize = half, half >>= 1) {
+        p = SA[j + half];
+        r = (p < Tsize) ? T[p] - c : -1;
+        if(r < 0) {
+          j += half + 1;
+          half -= (lsize & 1) ^ 1;
+        }
+      }
+
+      /* right part */
+      for(half = rsize >> 1;
+          0 < rsize;
+          rsize = half, half >>= 1) {
+        p = SA[k + half];
+        r = (p < Tsize) ? T[p] - c : -1;
+        if(r <= 0) {
+          k += half + 1;
+          half -= (rsize & 1) ^ 1;
+        }
+      }
+
+      break;
+    }
+  }
+
+  if(idx != NULL) { *idx = (0 < (k - j)) ? j : i; }
+  return k - j;
+}

--- a/thirdparty/libdivsufsort/patches/0001-build-fixes.patch
+++ b/thirdparty/libdivsufsort/patches/0001-build-fixes.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/libdivsufsort/include/config.h b/thirdparty/libdivsufsort/include/config.h
+index 6e43b26a0e..acdf517547 100644
+--- a/thirdparty/libdivsufsort/include/config.h
++++ b/thirdparty/libdivsufsort/include/config.h
+@@ -40,7 +40,7 @@ extern "C" {
+ #define HAVE_STDINT_H 1
+ #define HAVE_STDLIB_H 1
+ #define HAVE_STRING_H 1
+-#define HAVE_STRINGS_H 1
++#define HAVE_STRINGS_H 0
+ #define HAVE_MEMORY_H 1
+ #define HAVE_SYS_TYPES_H 1
+ 


### PR DESCRIPTION
Resolves godotengine/godot-proposals#13404.

## Overview

This pull request adds the ability to use delta encoding (sometimes referred to as "binary patching") when exporting patch PCKs, as first introduced in #97118.

This means that only the parts of the files that have actually changed (or some close approximation of that) will end up being exported, often resulting in much smaller patch exports, which can benefit games that distribute patches by their own means, reducing bandwidth cost and storage usage for all parties involved.

This is especially true when dealing with changes to things like `*.translation` files, `uid_cache.bin` or `global_script_class_cache.cfg`, which often end up being included in patch exports and which together can easily make your patch several megabytes large despite very little having actually changed.

<img width="739" height="635" alt="Screenshot_20251015_162359" src="https://github.com/user-attachments/assets/2cfb0601-efbc-46fe-9eb1-e08b6dd7402e" />

## Implementation

This is achieved by utilizing the bsdiff algorithm, which has been used in quite a few prominent projects since its introduction in 2003. It is (or at least has been, in part) used to generate/apply the patches for Firefox, Chromium, ChromiumOS, Android, macOS, FreeBSD and probably a few other notable ones.

With the help of bsdiff we generate a delta between the old file (as found in the "Base Packs" entries) and the new file, which then gets exported instead of the actual file, along with a new `PACK_FILE_DELTA` PCK flag.

During the generation of this patch file we also compress it, using the Zstandard/zstd compression algorithm, as used in several other places in Godot. This is more or less a requirement when using bsdiff, as its raw output will otherwise (as I understand it) be larger than either of the two files, but will contain long strings of zeroes and such that heavily favor compression. The original implementation used bzip2, but with us already vendoring zstd I opted for that instead, which I believe should offer much better decompression speed while also compressing well.

As a result of using compression, exporting a patch PCK with this feature enabled takes considerably longer, especially when leaving the compression level set to its default of 19. This can however mostly be resolved by just lowering the compression level, at the cost of export size. Decompression speed should largely remain the same for zstd, regardless of compression level.

We also allow the user to tweak the "minimum size reduction", which is a threshold for how much smaller the patch would need to be compared to the new file in order to be exported as a delta, the reason being that applying these patches comes at a slight runtime cost during resource loading, so needs to be justified with some amount of space saving.

Once exported, patch PCKs (much like before) look and behave just like any other PCK, where you load them through `ProjectSettings.load_resource_pack`, ideally through some bootstrap script where nothing else has had a chance to be loaded yet.

We then store any delta patches alongside the regular files in `PackedData`, and whenever a file is loaded from `PackedData` we wrap the resulting `FileAccessPack` inside of the newly introduced `FileAccessPatched`, which will lazily apply all the patches as needed, meaning it's completely transparent and should hopefully just work with any existing file/resource loading.

> [!IMPORTANT]
>  Note that this means you pay the cost of applying these patches every time you load a patched resource that isn't already cached by `ResourceLoader`. The patches are not applied to the original PCKs in any way, nor are the patched resources cached anywhere on disk.

## Dependencies

This turned out to be surprisingly messy, but basically boils down to there being no ideal upstream version of bsdiff to vendor, depending on your requirements.

To start with, [the original](https://www.daemonology.net/bsdiff/) bsdiff/bspatch were released as programs, not as a library. This was later changed by the original author, as seen [here](https://github.com/cperciva/bsdiff), but for whatever reason most projects I've seen seem to base their forks on the older bsdiff 4.2/4.3. Either way, the code still assumes that you're dealing with actual files on a Unix system, which is not the case here.

There are a few forks on GitHub that have turned the older bsdiff into a more platform-agnostic library, with [mendsley/bsdiff](https://github.com/mendsley/bsdiff) being the more popular one. However, pretty much all of them seem to be either abandoned or have not seen enough traction to make me comfortable vendoring them.

There have also been some notable changes across the various forks. The bigger one probably being that Google replaced `qsufsort` (for creating the [suffix arrays](https://en.wikipedia.org/wiki/Suffix_array)) with [libdivsufsort](https://github.com/y-256/libdivsufsort), which cuts down on the memory usage (which is significant) and time spent when generating patches.

After a lot of back-and-forth I decided to vendor [Android's fork](https://android.googlesource.com/platform/external/bsdiff) of bsdiff, which seems to have originated from ChromiumOS. This not only had the benefits of it being battle-tested and actively used, but also had an interface that was agnostic to both I/O and compression. The same could not be said for the patch application side of things though, so I had to make some changes there, which I've included a patch for. I also stripped away a bunch of stuff that we didn't need/want, like Brotli and such.

## Performance

Export size will mostly depend on whether the original file is compressed or not. So things like textures or even GDScript files, when using its default export mode of "Compressed binary tokens", will diff poorly and often fall below the size reduction threshold. The same goes for compressed localization files.

> [!IMPORTANT]
> Disabling compression on anything you intend to patch is key to getting good results, as compression scrambles data in a way where the old and the new file will look almost nothing alike. 

In the real-world projects I've tested with you usually see an average reduction of around 60-90%, depending on the ratio of compressed resources, and a runtime overhead of about 200 microseconds per individual patch being applied.

### DOGWALK

In the interest of showing a real-world example from an actual game, I've generated patches for the two updates of [DOGWALK](https://store.steampowered.com/app/3775050/DOGWALK/) that have been published since its initial release. You can find the Godot project available through its [Supporter Pack](https://store.steampowered.com/app/3833380/DOGWALK__Supporter_Pack/), with earlier versions being downloadable with the help of the Steam console and [SteamDB](https://steamdb.info/depot/3833380/manifests/).

#### v1.0.1 to v1.0.2

<details><summary>[Click to expand/collapse]</summary>
<p>

The first update to the game contained modifications to the following file types:

- 8x texture files
- 5x `*.tscn` files
- 2x glTF files
- 2x `*.tres` files
- 2x `.json` files
- 1x `*.gd` file
- 1x `global_script_class_cache.cfg`
- 1x `uid_cache.bin`
- 1x `project.godot`

Out of those changes, 7 files (6 textures and 1 glTF file) fell below the reduction threshold and were not exported as a delta.

Without delta encoding the patch PCK ended up being 8.57 MiB, and with delta encoding the patch PCK ended up being 2.13 MiB, which is a reduction in size of roughly 75%.

For a breakdown of the individual files, see the output from the `--verbose` export:

```
Used delta encoding for 'res://.godot/exported/133200997/export-3e4d038c0f64156f4998ce2a1f4d929f-LOOP-pinda-pulling.res' (591 bytes) which reduced the size by 99.72% (210228 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-f82fa0b46b1af8649747bf0310b43d2c-snow_piles.res' (188 bytes) which reduced the size by 92.21% (2224 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-75cc15c6f96624c92a89cd4ea423aab0-SE-clearing.scn' (868 bytes) which reduced the size by 78.62% (3191 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/SL-clearing_terrain.gltf-6c7bfff97231b94de231cd87b0a043cc.scn' (313892 bytes) which reduced the size by 18.22% (69922 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/SL-fence-paths.gltf-5301a3dc110611ca08d2d765b45cc210.scn' (102233 bytes) as it only reduced the size by 0.24% (247 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/c1_0.png-633c826446b972eb64aa7ce688537a89.s3tc.ctex' (19169 bytes) which reduced the size by 99.36% (2985443 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/c1_1.png-f4d5442a5958d63be4969f9c43b55385.s3tc.ctex' (10513 bytes) which reduced the size by 99.65% (2994099 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/c1_2.png-9836fb6c6208e9abc7dd976d1dfb2114.ctex' (12454 bytes) as it only reduced the size by 3.16% (406 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/c1_3.png-242aee2106e53d55e5258038d675c5d2.ctex' (11243 bytes) as it only reduced the size by 3.11% (361 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/c1_4.png-a2aaa3eae0a8fc20dc1fb8b773a2a2fc.ctex' (20981 bytes) as it only reduced the size by 1.05% (223 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/c1_5.png-13279df50fab7cb69d9d4b5c4cf35607.ctex' (12258 bytes) as it only reduced the size by 2.00% (250 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/c1_6.png-58b98eacb8e3e715db9592bbc6721513.ctex' (19662 bytes) as it only reduced the size by 1.18% (234 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/c1_7.png-cbe2618dd59d397fdcd297bc57e2a89a.ctex' (19580 bytes) as it only reduced the size by 0.65% (128 bytes) compared to the new file.
Used delta encoding for 'res://source/entities/player_entities/pinda.gdc' (24489 bytes) which reduced the size by 86.99% (163715 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-4810a76f52cab761a40b217606f3b3f7-world.scn' (2272 bytes) which reduced the size by 96.89% (70797 bytes) compared to the new file.
Used delta encoding for 'res://source/sequences/credits/credits.json' (263 bytes) which reduced the size by 94.75% (4745 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-1ba630fc40b6c6f9f6410e00a7d23a6e-credits.scn' (609 bytes) which reduced the size by 93.17% (8307 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-f7d1d2a6eca5754467a7d6172d8ffd11-credit_slide.scn' (165 bytes) which reduced the size by 92.79% (2124 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-06339610f1a89a2edfbfa400f9fe80ce-menu_ui.scn' (663 bytes) which reduced the size by 78.13% (2369 bytes) compared to the new file.
Used delta encoding for 'res://material_index.json' (203 bytes) which reduced the size by 99.22% (25803 bytes) compared to the new file.
Used delta encoding for 'res://.godot/global_script_class_cache.cfg' (236 bytes) which reduced the size by 96.59% (6684 bytes) compared to the new file.
Used delta encoding for 'res://.godot/uid_cache.bin' (358 bytes) which reduced the size by 99.80% (175104 bytes) compared to the new file.
Used delta encoding for 'res://project.binary' (117 bytes) which reduced the size by 99.56% (26764 bytes) compared to the new file.
```

</p>
</details> 

#### v1.0.2 to v1.0.4

<details><summary>[Click to expand/collapse]</summary>
<p>

The second update to the game contained modifications to the following file types:

- 63x glTF files
- 3x texture files
- 7x `*.gd` files
- 4x `*.tres` files
- 4x `*.tscn` files
- 1x `*.json` file
- 1x `uid_cache.bin`
- 1x `project.godot`

Out of those changes, 19 files (18 glTF files and 1 texture) fell below the reduction threshold and were not exported as a delta.

Without delta encoding the patch PCK ended up being 14.56 MiB, and with delta encoding the patch PCK ended up being 5.17 MiB, which is a reduction in size of roughly 64%.

For a breakdown of the individual files, see the output from the `--verbose` export:

```
Used delta encoding for 'res://.godot/imported/LI-bush_001.gltf-40b8180f1a8db565195bb533fe5b3b60.scn' (1319 bytes) which reduced the size by 96.81% (40074 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_002.gltf-046eef6042349a872843bd2bad57871d.scn' (196 bytes) which reduced the size by 99.48% (37632 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_003.gltf-d8b6330d3fbe3be54b19ef784d826f6f.scn' (369 bytes) which reduced the size by 99.14% (42389 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_004.gltf-44dfe26583b38b9bacbc865c65056616.scn' (360 bytes) which reduced the size by 99.17% (42967 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_small_001.gltf-fd7ac3b286c919a158b306ecbdb65c35.scn' (319 bytes) which reduced the size by 98.95% (29967 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_small_002.gltf-4c9d050b1c074ff3d5423d3e5923b648.scn' (179 bytes) which reduced the size by 99.41% (30145 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_small_003.gltf-c5f1b275891f4c31b9784b8fc30cad59.scn' (175 bytes) which reduced the size by 99.43% (30672 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage-snowy_001.gltf-556d234ef38f9ddf45c29e8e2fbd3bda.scn' (338 bytes) which reduced the size by 89.07% (2753 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage-snowy_002.gltf-fcb65cf55f75e73cf40e47ccc7e74694.scn' (481 bytes) which reduced the size by 81.93% (2181 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-bush_foliage-snowy_003.gltf-ff44781b0785aff6e0f0fba2504a5904.scn' (2299 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-bush_foliage-snowy_004.gltf-0b9ac5457a4160af4672287ac31606df.scn' (2752 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage-snowy_005.gltf-bf1c764613b8fbc17f3c09534ddc67e4.scn' (260 bytes) which reduced the size by 91.34% (2742 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage-snowy_006.gltf-fe91dd6bc077731e9831797c06039603.scn' (1904 bytes) which reduced the size by 22.13% (541 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-bush_foliage-snowy_small_001.gltf-189c3413a03374f594c5fd1da5f290fe.scn' (2080 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage-snowy_small_002.gltf-36a183595198521e77f51fb267bbe794.scn' (407 bytes) which reduced the size by 86.99% (2721 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage-snowy_small_003.gltf-df154c9af2225b4e10e2a899bc5d401c.scn' (218 bytes) which reduced the size by 92.43% (2661 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_001.gltf-27d68679ea3dfb3c0bcb765feb133896.scn' (272 bytes) which reduced the size by 90.33% (2540 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-bush_foliage_002.gltf-fa162cd4cdb0eeea6328f050e8d6ef75.scn' (2615 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_003.gltf-47ffef07e418a23b9f05bed81fafafe4.scn' (300 bytes) which reduced the size by 88.84% (2389 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_004.gltf-ba2cb17ac74eb94060ddd32ab8207ff7.scn' (528 bytes) which reduced the size by 78.14% (1887 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_005.gltf-0f77c124e37bed036c3a7d999dceb178.scn' (602 bytes) which reduced the size by 81.79% (2704 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_006.gltf-316c5c718168f980bb653f8cd4644a67.scn' (285 bytes) which reduced the size by 88.48% (2189 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-bush_foliage_007.gltf-ab10a69cdb3259654a86117e6b1f268a.scn' (2861 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-bush_foliage_008.gltf-5c1b2b549e76a49e9329055a815afd41.scn' (2390 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_009.gltf-86062acae855ef8da4f0192b18566a14.scn' (1998 bytes) which reduced the size by 16.89% (406 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_010.gltf-e7890f91e8ee4789ab125803c3cabf69.scn' (554 bytes) which reduced the size by 82.51% (2613 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_011.gltf-8a6eed4426edd1f2d08e02acda003b1e.scn' (1801 bytes) which reduced the size by 19.27% (430 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_012.gltf-8f12950bd8b25dc07d659e0c22f604e0.scn' (223 bytes) which reduced the size by 91.85% (2514 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_small_001.gltf-884d1bc365df4345b1f0a67137c33d94.scn' (793 bytes) which reduced the size by 80.74% (3325 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_small_002.gltf-83f8fb5bbfe90f84f7601ee69c0ab163.scn' (2129 bytes) which reduced the size by 17.61% (455 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_small_003.gltf-33bc06b77915fc3a7da9d3145a566af4.scn' (368 bytes) which reduced the size by 86.67% (2393 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_small_004.gltf-b6c8e7c7acafc669df48bb8769618cb1.scn' (2009 bytes) which reduced the size by 19.25% (479 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_top_001.gltf-ed2c90ebad7fca378f6c6c5ad107b353.scn' (123 bytes) which reduced the size by 99.34% (18424 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_top_002.gltf-67d330a74fc8f5d641e040adec30e1c8.scn' (1121 bytes) which reduced the size by 72.14% (2903 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_top_003.gltf-9ef1a3dc5dc9965df4429232a5984d9a.scn' (1477 bytes) which reduced the size by 65.39% (2790 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-bush_foliage_top_004.gltf-7b5bd6068a817dd027a42f82d80e22ea.scn' (1278 bytes) which reduced the size by 67.75% (2685 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-e17e8915be33ba3caa7e4c702c918edc-bush.res' (124 bytes) which reduced the size by 95.04% (2377 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-fence_plank_01.gltf-e13215b4301c7b31a0949889125e2a89.scn' (7145 bytes) as it only reduced the size by 1.98% (144 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-fence_plank_02.gltf-6c1a23e046402ba81b318a02d735da28.scn' (7730 bytes) as it only reduced the size by 1.19% (93 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-fence_plank_03.gltf-0db9a0a5e23e0cdb2a27b16f295d7913.scn' (7450 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-fence_plank_04.gltf-2ac84343d96045227a99e36057e94150.scn' (8366 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-fence_plank_05.gltf-48c19d68954b8336cc05a17fefda8146.scn' (7185 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-fence_plank_06.gltf-7402b271f99e4981e1d342f5000e25b6.scn' (7639 bytes) as it only reduced the size by 0.00% (0 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-stone_plateau_001.gltf-81ce09b4a5ed8da31a696426534976cf.scn' (46165 bytes) as it only reduced the size by 6.19% (3046 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-stone_plateau_002.gltf-574959712e3c543d31ad36128a2b6dc0.scn' (38738 bytes) as it only reduced the size by 2.34% (927 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/LI-stone_plateau_003.gltf-37026e870d8fb0a798544f0dccc7b496.scn' (36294 bytes) as it only reduced the size by 5.62% (2160 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-293680cc51e9cd0486e497a8eb604d9d-stone_wall_snowy.res' (161 bytes) which reduced the size by 93.55% (2334 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_001.gltf-6c68ad4d827d2b7e25c8ec1694a9da78.scn' (21984 bytes) which reduced the size by 23.59% (6788 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_002.gltf-3999d05482c9e000e4436ec5e6510ca9.scn' (16547 bytes) which reduced the size by 35.93% (9279 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_003.gltf-8f877b58d5015175bf038b80b67f27c7.scn' (15392 bytes) which reduced the size by 31.18% (6973 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_004.gltf-dfd11977b987307e51beb8311c1ce28c.scn' (25147 bytes) which reduced the size by 23.28% (7631 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_005.gltf-b3c147109498a6276fff778d55741fda.scn' (34288 bytes) which reduced the size by 14.79% (5953 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_006.gltf-d1dd2bfefcf060652e63c3d0e5781138.scn' (17132 bytes) which reduced the size by 41.01% (11912 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_007.gltf-a3603ba590e9d8f97ea68bbb95e0a776.scn' (5244 bytes) which reduced the size by 68.12% (11206 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_008.gltf-624b84d84206001949001db0306e0295.scn' (8988 bytes) which reduced the size by 62.64% (15073 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_009.gltf-1e8816b13883295f833fb7319071709f.scn' (6529 bytes) which reduced the size by 74.48% (19058 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_010.gltf-2362d3699279fcc9458103e49cc790e8.scn' (1575 bytes) which reduced the size by 91.70% (17403 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_0011.gltf-ae3bd59c7d1d082cdb0fdb86508668ed.scn' (3280 bytes) which reduced the size by 83.56% (16668 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_012.gltf-e8446df129f613e4df46c3cdf8589041.scn' (9535 bytes) which reduced the size by 62.90% (16168 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/LI-stone_wall_013.gltf-7e139cd3a8ca569ca6b10c933d1c3b81.scn' (10694 bytes) which reduced the size by 43.68% (8294 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-8751d5cceb104760e2f281683e020794-stone_wall.res' (132 bytes) which reduced the size by 94.72% (2366 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/stone_plateau_albedo.png-090b3b252fbd6390538b00add7a29c3b.ctex' (2324021 bytes) as it only reduced the size by 3.38% (81397 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/stone_plateau_albedo.png-4e0e64b2e65449c1344dc953e684fdd1.s3tc.ctex' (1079718 bytes) which reduced the size by 80.69% (4512766 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/PR-traffic_cone.gltf-fe0a84d532dd8a51f807efa767a4fb5e.scn' (8155 bytes) as it only reduced the size by 6.30% (548 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-3943d6ae2e8b37b6d9da82a68c5f8ec7-traffic_cone.res' (137 bytes) which reduced the size by 94.13% (2197 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/bush_foliage_atlas_albedo_01.png-08ce4663401c96283ce790aed759bd1b.s3tc.ctex' (1424217 bytes) which reduced the size by 74.53% (4168267 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/SL-clearing-bushes.gltf-47565441b9825109bba0dbc787560a44.scn' (20539 bytes) as it only reduced the size by 6.14% (1343 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/SL-clearing_shrubs.gltf-d979ffa9eda7d4d041d54adcf325b78a.scn' (4832 bytes) which reduced the size by 61.28% (7647 bytes) compared to the new file.
Used delta encoding for 'res://.godot/imported/SL-fence-boulders.gltf-8f9ed2988aaf279616f03b0bd45b9280.scn' (541 bytes) which reduced the size by 85.88% (3290 bytes) compared to the new file.
Skipped delta encoding of 'res://.godot/imported/SL-fence-vegetation.gltf-2b0c3486f9d852252ed746c8c54f60c9.scn' (43826 bytes) as it only reduced the size by 7.84% (3727 bytes) compared to the new file.
Used delta encoding for 'res://source/audio/sfx/pinda/pinda_sfx.gdc' (1551 bytes) which reduced the size by 93.29% (21553 bytes) compared to the new file.
Used delta encoding for 'res://source/entities/player_entities/camera.gdc' (3424 bytes) which reduced the size by 84.15% (18180 bytes) compared to the new file.
Used delta encoding for 'res://source/entities/player_entities/chocomel.gdc' (9410 bytes) which reduced the size by 87.97% (68790 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-6d7bc4d39f8b5352d8abad820bf44d70-chocomel.scn' (631 bytes) which reduced the size by 96.46% (17197 bytes) compared to the new file.
Used delta encoding for 'res://source/entities/player_entities/leash.gdc' (293 bytes) which reduced the size by 99.27% (39583 bytes) compared to the new file.
Used delta encoding for 'res://source/entities/player_entities/pinda.gdc' (11272 bytes) which reduced the size by 94.04% (177956 bytes) compared to the new file.
Used delta encoding for 'res://source/entities/camera_magnet_zone.gdc' (117 bytes) which reduced the size by 97.12% (3951 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-4810a76f52cab761a40b217606f3b3f7-world.scn' (2598 bytes) which reduced the size by 96.49% (71333 bytes) compared to the new file.
Used delta encoding for 'res://source/sequences/credits/credits.json' (179 bytes) which reduced the size by 96.44% (4846 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-1ba630fc40b6c6f9f6410e00a7d23a6e-credits.scn' (394 bytes) which reduced the size by 95.58% (8512 bytes) compared to the new file.
Used delta encoding for 'res://source/user_interface/menus/settings_menu.gdc' (428 bytes) which reduced the size by 98.49% (27868 bytes) compared to the new file.
Used delta encoding for 'res://.godot/exported/133200997/export-3b7d2a6a20074e4b07b060ce359c7ebe-settings_menu.scn' (640 bytes) which reduced the size by 95.04% (12268 bytes) compared to the new file.
Used delta encoding for 'res://.godot/uid_cache.bin' (154 bytes) which reduced the size by 99.91% (175384 bytes) compared to the new file.
Used delta encoding for 'res://project.binary' (117 bytes) which reduced the size by 99.56% (26764 bytes) compared to the new file.
```

</p>
</details> 

#### Runtime overhead

<details><summary>[Click to expand/collapse]</summary>
<p>

On my machine (AMD 9950X3D) the overhead from applying the above mentioned patches averages around 300 µs, with a median of 191 µs and worst-case of 2267 µs. In total the two patch PCKs added 16022 µs (16 ms) of overhead to resource loading across 49 resources when starting a new game.

I've seen similar results with other projects on my OnePlus 8T (Snapdragon 865) from 2020, with the average hovering around 200-300 µs per patch.

I have not done any in-depth profiling to see where exactly the overhead is coming from. I assume it's a mix of I/O, `bspatch` and zstd, but there may very well be some low-hanging fruit (or mistakes) that's worth addressing.

For a breakdown of the individual files, see the output from a `--verbose` startup of the game:

```
Applied delta patch (1 of 1) to 'res://.godot/global_script_class_cache.cfg' in 174 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/uid_cache.bin' in 98 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/global_script_class_cache.cfg' in 84 microseconds.
Applied delta patch (1 of 2) to 'res://.godot/uid_cache.bin' in 50 microseconds.
Applied delta patch (2 of 2) to 'res://.godot/uid_cache.bin' in 37 microseconds.
Applied delta patch (1 of 1) to 'res://source/entities/player_entities/camera.gdc' in 636 microseconds.
Applied delta patch (1 of 1) to 'res://source/entities/player_entities/chocomel.gdc' in 77 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/c1_0.png-633c826446b972eb64aa7ce688537a89.s3tc.ctex' in 911 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/c1_1.png-f4d5442a5958d63be4969f9c43b55385.s3tc.ctex' in 512 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-06339610f1a89a2edfbfa400f9fe80ce-menu_ui.scn' in 33 microseconds.
Applied delta patch (1 of 1) to 'res://source/entities/player_entities/camera.gdc' in 53 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-3b7d2a6a20074e4b07b060ce359c7ebe-settings_menu.scn' in 29 microseconds.
Applied delta patch (1 of 1) to 'res://source/user_interface/menus/settings_menu.gdc' in 27 microseconds.
Applied delta patch (1 of 1) to 'res://source/user_interface/menus/settings_menu.gdc' in 25 microseconds.
Applied delta patch (1 of 2) to 'res://source/entities/player_entities/pinda.gdc' in 131 microseconds.
Applied delta patch (2 of 2) to 'res://source/entities/player_entities/pinda.gdc' in 88 microseconds.
Applied delta patch (1 of 2) to 'res://.godot/exported/133200997/export-4810a76f52cab761a40b217606f3b3f7-world.scn' in 50 microseconds.
Applied delta patch (2 of 2) to 'res://.godot/exported/133200997/export-4810a76f52cab761a40b217606f3b3f7-world.scn' in 38 microseconds.
Applied delta patch (1 of 2) to 'res://source/entities/player_entities/pinda.gdc' in 141 microseconds.
Applied delta patch (2 of 2) to 'res://source/entities/player_entities/pinda.gdc' in 85 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/SL-fence-boulders.gltf-8f9ed2988aaf279616f03b0bd45b9280.scn' in 218 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-293680cc51e9cd0486e497a8eb604d9d-stone_wall_snowy.res' in 1713 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/stone_plateau_albedo.png-4e0e64b2e65449c1344dc953e684fdd1.s3tc.ctex' in 2267 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-bush_001.gltf-40b8180f1a8db565195bb533fe5b3b60.scn' in 750 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-e17e8915be33ba3caa7e4c702c918edc-bush.res' in 297 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-bush_small_002.gltf-4c9d050b1c074ff3d5423d3e5923b648.scn' in 312 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-bush_002.gltf-046eef6042349a872843bd2bad57871d.scn' in 273 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-bush_003.gltf-d8b6330d3fbe3be54b19ef784d826f6f.scn' in 246 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-bush_small_003.gltf-c5f1b275891f4c31b9784b8fc30cad59.scn' in 196 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-bush_004.gltf-44dfe26583b38b9bacbc865c65056616.scn' in 199 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-bush_small_001.gltf-fd7ac3b286c919a158b306ecbdb65c35.scn' in 197 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-bush_foliage_top_004.gltf-7b5bd6068a817dd027a42f82d80e22ea.scn' in 194 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-stone_wall_008.gltf-624b84d84206001949001db0306e0295.scn' in 186 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-8751d5cceb104760e2f281683e020794-stone_wall.res' in 182 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-stone_wall_007.gltf-a3603ba590e9d8f97ea68bbb95e0a776.scn' in 185 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-stone_wall_006.gltf-d1dd2bfefcf060652e63c3d0e5781138.scn' in 191 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-stone_wall_005.gltf-b3c147109498a6276fff778d55741fda.scn' in 206 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-stone_wall_004.gltf-dfd11977b987307e51beb8311c1ce28c.scn' in 197 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-stone_wall_0011.gltf-ae3bd59c7d1d082cdb0fdb86508668ed.scn' in 456 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-stone_wall_010.gltf-2362d3699279fcc9458103e49cc790e8.scn' in 321 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-stone_wall_009.gltf-1e8816b13883295f833fb7319071709f.scn' in 302 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-75cc15c6f96624c92a89cd4ea423aab0-SE-clearing.scn' in 797 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/LI-stone_wall_012.gltf-e8446df129f613e4df46c3cdf8589041.scn' in 422 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/SL-clearing_terrain.gltf-6c7bfff97231b94de231cd87b0a043cc.scn' in 285 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-f82fa0b46b1af8649747bf0310b43d2c-snow_piles.res' in 271 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/imported/SL-clearing_shrubs.gltf-d979ffa9eda7d4d041d54adcf325b78a.scn' in 39 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-6d7bc4d39f8b5352d8abad820bf44d70-chocomel.scn' in 39 microseconds.
Applied delta patch (1 of 1) to 'res://source/entities/player_entities/chocomel.gdc' in 143 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-3e4d038c0f64156f4998ce2a1f4d929f-LOOP-pinda-pulling.res' in 1003 microseconds.
Applied delta patch (1 of 1) to 'res://source/entities/camera_magnet_zone.gdc' in 38 microseconds.
Applied delta patch (1 of 1) to 'res://.godot/exported/133200997/export-3943d6ae2e8b37b6d9da82a68c5f8ec7-traffic_cone.res' in 457 microseconds.
Applied delta patch (1 of 1) to 'res://source/entities/player_entities/camera.gdc' in 75 microseconds.
Applied delta patch (1 of 1) to 'res://source/entities/player_entities/chocomel.gdc' in 86 microseconds.
```

</p>
</details> 

## Potential improvements

- Allow people to compile `core` without this perhaps? Maybe it's better suited somewhere else?
- Have the exclusion filtering be based on the actual resource paths rather than the export paths.
- Provide some other way than `--verbose` for logging delta encoding details during export.
- Add profiling monitors for time spent applying patches.
- Do more in-depth profiling of the patch application to see what can be optimized.
- Experiment with the other compression algorithms we have available, maybe even picking the more effective one dynamically, like Android does.
- Maybe emit warnings during export if compression is enabled on applicable resource types.