### PR TITLE
[Core] Use `getptr` in more places

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -330,8 +330,8 @@ void Engine::add_singleton(const Singleton &p_singleton) {
 }
 
 Object *Engine::get_singleton_object(const StringName &p_name) const {
-	HashMap<StringName, Object *>::ConstIterator E = singleton_ptrs.find(p_name);
-	ERR_FAIL_COND_V_MSG(!E, nullptr, vformat("Failed to retrieve non-existent singleton '%s'.", p_name));
+	Object *const *E = singleton_ptrs.getptr(p_name);
+	ERR_FAIL_NULL_V_MSG(E, nullptr, vformat("Failed to retrieve non-existent singleton '%s'.", p_name));
 
 #ifdef TOOLS_ENABLED
 	if (!is_editor_hint() && is_singleton_editor_only(p_name)) {
@@ -339,7 +339,7 @@ Object *Engine::get_singleton_object(const StringName &p_name) const {
 	}
 #endif
 
-	return E->value;
+	return *E;
 }
 
 bool Engine::is_singleton_user_created(const StringName &p_name) const {

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -367,12 +367,12 @@ Variant ProjectSettings::get_setting_with_override_and_custom_features(const Str
 	_THREAD_SAFE_METHOD_
 
 	StringName name = p_name;
-	if (feature_overrides.has(name)) {
-		const LocalVector<Pair<StringName, StringName>> &overrides = feature_overrides[name];
-		for (uint32_t i = 0; i < overrides.size(); i++) {
-			if (p_features.has(String(overrides[i].first).to_lower())) {
-				if (props.has(overrides[i].second)) {
-					name = overrides[i].second;
+	const LocalVector<Pair<StringName, StringName>> *overrides = feature_overrides.getptr(name);
+	if (overrides) {
+		for (const Pair<StringName, StringName> &override : *overrides) {
+			if (p_features.has(String(override.first).to_lower())) {
+				if (props.has(override.second)) {
+					name = override.second;
 					break;
 				}
 			}
@@ -504,8 +504,9 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 			p_list->push_back(PropertyInfo(base.type, base.name, PROPERTY_HINT_NONE, "", base.flags));
 		}
 
-		if (setting_overrides.has(base.name)) {
-			for (const _VCSort &over : setting_overrides.get(base.name)) {
+		LocalVector<_VCSort> *setting_override = setting_overrides.getptr(base.name);
+		if (setting_override) {
+			for (const _VCSort &over : *setting_override) {
 				if (custom_prop_info.has(over.name)) {
 					PropertyInfo pi = custom_prop_info[over.name];
 					pi.name = over.name;
@@ -1415,8 +1416,9 @@ bool ProjectSettings::has_autoload(const StringName &p_autoload) const {
 }
 
 ProjectSettings::AutoloadInfo ProjectSettings::get_autoload(const StringName &p_name) const {
-	ERR_FAIL_COND_V_MSG(!autoloads.has(p_name), AutoloadInfo(), "Trying to get non-existent autoload.");
-	return autoloads[p_name];
+	const AutoloadInfo *autoload = autoloads.getptr(p_name);
+	ERR_FAIL_NULL_V_MSG(autoload, AutoloadInfo(), "Trying to get non-existent autoload.");
+	return *autoload;
 }
 
 const HashMap<StringName, String> &ProjectSettings::get_global_groups_list() const {

--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -848,8 +848,9 @@ bool CoreConstants::is_global_constant(const StringName &p_name) {
 }
 
 int CoreConstants::get_global_constant_index(const StringName &p_name) {
-	ERR_FAIL_COND_V_MSG(!_global_constants_map.has(p_name), -1, "Trying to get index of non-existing constant.");
-	return _global_constants_map[p_name];
+	const int *ret = _global_constants_map.getptr(p_name);
+	ERR_FAIL_NULL_V_MSG(ret, -1, "Trying to get index of non-existing constant.");
+	return *ret;
 }
 
 bool CoreConstants::is_global_enum(const StringName &p_enum) {
@@ -858,8 +859,9 @@ bool CoreConstants::is_global_enum(const StringName &p_enum) {
 
 void CoreConstants::get_enum_values(const StringName &p_enum, HashMap<StringName, int64_t> *p_values) {
 	ERR_FAIL_NULL_MSG(p_values, "Trying to get enum values with null map.");
-	ERR_FAIL_COND_MSG(!_global_enums.has(p_enum), "Trying to get values of non-existing enum.");
-	for (const _CoreConstant &constant : _global_enums[p_enum]) {
+	const Vector<_CoreConstant> *global_enum = _global_enums.getptr(p_enum);
+	ERR_FAIL_NULL_MSG(global_enum, "Trying to get values of non-existing enum.");
+	for (const _CoreConstant &constant : *global_enum) {
 		(*p_values)[constant.name] = constant.value;
 	}
 }

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -44,11 +44,11 @@ void EngineDebugger::register_profiler(const StringName &p_name, const Profiler 
 }
 
 void EngineDebugger::unregister_profiler(const StringName &p_name) {
-	ERR_FAIL_COND_MSG(!profilers.has(p_name), vformat("Profiler not registered: '%s'.", p_name));
-	Profiler &p = profilers[p_name];
-	if (p.active && p.toggle) {
-		p.toggle(p.data, false, Array());
-		p.active = false;
+	Profiler *p = profilers.getptr(p_name);
+	ERR_FAIL_NULL_MSG(p, vformat("Profiler not registered: '%s'.", p_name));
+	if (p->active && p->toggle) {
+		p->toggle(p->data, false, Array());
+		p->active = false;
 	}
 	profilers.erase(p_name);
 }
@@ -69,24 +69,25 @@ void EngineDebugger::register_uri_handler(const String &p_protocol, CreatePeerFu
 }
 
 void EngineDebugger::profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts) {
-	ERR_FAIL_COND_MSG(!profilers.has(p_name), vformat("Can't change profiler state, no profiler: '%s'.", p_name));
-	Profiler &p = profilers[p_name];
-	if (p.toggle) {
-		p.toggle(p.data, p_enabled, p_opts);
+	Profiler *p = profilers.getptr(p_name);
+	ERR_FAIL_NULL_MSG(p, vformat("Can't change profiler state, no profiler: '%s'.", p_name));
+	if (p->toggle) {
+		p->toggle(p->data, p_enabled, p_opts);
 	}
-	p.active = p_enabled;
+	p->active = p_enabled;
 }
 
 void EngineDebugger::profiler_add_frame_data(const StringName &p_name, const Array &p_data) {
-	ERR_FAIL_COND_MSG(!profilers.has(p_name), vformat("Can't add frame data, no profiler: '%s'.", p_name));
-	Profiler &p = profilers[p_name];
-	if (p.add) {
-		p.add(p.data, p_data);
+	Profiler *p = profilers.getptr(p_name);
+	ERR_FAIL_NULL_MSG(p, vformat("Can't add frame data, no profiler: '%s'.", p_name));
+	if (p->add) {
+		p->add(p->data, p_data);
 	}
 }
 
 bool EngineDebugger::is_profiling(const StringName &p_name) {
-	return profilers.has(p_name) && profilers[p_name].active;
+	const Profiler *p = profilers.getptr(p_name);
+	return p && p->active;
 }
 
 bool EngineDebugger::has_profiler(const StringName &p_name) {
@@ -99,9 +100,9 @@ bool EngineDebugger::has_capture(const StringName &p_name) {
 
 Error EngineDebugger::capture_parse(const StringName &p_name, const String &p_msg, const Array &p_args, bool &r_captured) {
 	r_captured = false;
-	ERR_FAIL_COND_V_MSG(!captures.has(p_name), ERR_UNCONFIGURED, vformat("Capture not registered: '%s'.", p_name));
-	const Capture &cap = captures[p_name];
-	return cap.capture(cap.data, p_msg, p_args, r_captured);
+	const Capture *cap = captures.getptr(p_name);
+	ERR_FAIL_NULL_V_MSG(cap, ERR_UNCONFIGURED, vformat("Capture not registered: '%s'.", p_name));
+	return cap->capture(cap->data, p_msg, p_args, r_captured);
 }
 
 void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, double p_physics_frame_time) {

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -179,13 +179,14 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				} else {
 					String key = key_value.left(value_pos);
 
-					if (!options.has(key)) {
+					String *option = options.getptr(key);
+					if (!option) {
 						print_line("Error: Unknown option " + key);
 					} else {
 						// Allow explicit tab character
 						String value = key_value.substr(value_pos + 1).replace("\\t", "\t");
 
-						options[key] = value;
+						*option = value;
 					}
 				}
 			}

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -355,14 +355,15 @@ void RemoteDebugger::_poll_messages() {
 
 		Thread::ID thread = cmd[1];
 
-		if (!messages.has(thread)) {
+		List<Message> *message_ptr = messages.getptr(thread);
+		if (!message_ptr) {
 			continue; // This thread is not around to receive the messages
 		}
 
 		Message msg;
 		msg.message = cmd[0];
 		msg.data = cmd[2];
-		messages[thread].push_back(msg);
+		message_ptr->push_back(msg);
 	}
 }
 

--- a/core/debugger/script_debugger.h
+++ b/core/debugger/script_debugger.h
@@ -69,10 +69,11 @@ public:
 	void insert_breakpoint(int p_line, const StringName &p_source);
 	void remove_breakpoint(int p_line, const StringName &p_source);
 	_ALWAYS_INLINE_ bool is_breakpoint(int p_line, const StringName &p_source) const {
-		if (likely(!breakpoints.has(p_line))) {
+		const HashSet<StringName> *bkp = breakpoints.getptr(p_line);
+		if (likely(!bkp)) {
 			return false;
 		}
-		return breakpoints[p_line].has(p_source);
+		return bkp->has(p_source);
 	}
 	void clear_breakpoints();
 	const HashMap<int, HashSet<StringName>> &get_breakpoints() const { return breakpoints; }

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -506,10 +506,10 @@ void GDExtension::_register_extension_class_method(GDExtensionClassLibraryPtr p_
 
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
 	StringName method_name = *reinterpret_cast<const StringName *>(p_method_info->name);
-	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), vformat("Attempt to register extension method '%s' for unexisting class '%s'.", String(method_name), class_name));
+	Extension *extension = self->extension_classes.getptr(class_name);
+	ERR_FAIL_NULL_MSG(extension, vformat("Attempted to register extension method '%s' for unexisting class '%s'.", String(method_name), class_name));
 
 #ifdef TOOLS_ENABLED
-	Extension *extension = &self->extension_classes[class_name];
 	GDExtensionMethodBind *method = nullptr;
 
 	// If the extension is still marked as reloading, that means it failed to register again.
@@ -556,11 +556,11 @@ void GDExtension::_register_extension_class_integer_constant(GDExtensionClassLib
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
 	StringName enum_name = *reinterpret_cast<const StringName *>(p_enum_name);
 	StringName constant_name = *reinterpret_cast<const StringName *>(p_constant_name);
-	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), vformat("Attempt to register extension constant '%s' for unexisting class '%s'.", constant_name, class_name));
+	Extension *extension = self->extension_classes.getptr(class_name);
+	ERR_FAIL_NULL_MSG(extension, vformat("Attempted to register extension constant '%s' for unexisting class '%s'.", constant_name, class_name));
 
 #ifdef TOOLS_ENABLED
 	// If the extension is still marked as reloading, that means it failed to register again.
-	Extension *extension = &self->extension_classes[class_name];
 	if (extension->is_reloading) {
 		return;
 	}
@@ -580,11 +580,11 @@ void GDExtension::_register_extension_class_property_indexed(GDExtensionClassLib
 	StringName setter = *reinterpret_cast<const StringName *>(p_setter);
 	StringName getter = *reinterpret_cast<const StringName *>(p_getter);
 	String property_name = *reinterpret_cast<const StringName *>(p_info->name);
-	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), vformat("Attempt to register extension class property '%s' for unexisting class '%s'.", property_name, class_name));
+	Extension *extension = self->extension_classes.getptr(class_name);
+	ERR_FAIL_NULL_MSG(extension, vformat("Attempted to register extension class property '%s' for unexisting class '%s'.", property_name, class_name));
 
 #ifdef TOOLS_ENABLED
 	// If the extension is still marked as reloading, that means it failed to register again.
-	Extension *extension = &self->extension_classes[class_name];
 	if (extension->is_reloading) {
 		return;
 	}
@@ -601,11 +601,11 @@ void GDExtension::_register_extension_class_property_group(GDExtensionClassLibra
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
 	String group_name = *reinterpret_cast<const String *>(p_group_name);
 	String prefix = *reinterpret_cast<const String *>(p_prefix);
-	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), vformat("Attempt to register extension class property group '%s' for unexisting class '%s'.", group_name, class_name));
+	Extension *extension = self->extension_classes.getptr(class_name);
+	ERR_FAIL_NULL_MSG(extension, vformat("Attempted to register extension class property group '%s' for unexisting class '%s'.", group_name, class_name));
 
 #ifdef TOOLS_ENABLED
 	// If the extension is still marked as reloading, that means it failed to register again.
-	Extension *extension = &self->extension_classes[class_name];
 	if (extension->is_reloading) {
 		return;
 	}
@@ -620,11 +620,11 @@ void GDExtension::_register_extension_class_property_subgroup(GDExtensionClassLi
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
 	String subgroup_name = *reinterpret_cast<const String *>(p_subgroup_name);
 	String prefix = *reinterpret_cast<const String *>(p_prefix);
-	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), vformat("Attempt to register extension class property subgroup '%s' for unexisting class '%s'.", subgroup_name, class_name));
+	Extension *extension = self->extension_classes.getptr(class_name);
+	ERR_FAIL_NULL_MSG(extension, vformat("Attempted to register extension class property subgroup '%s' for unexisting class '%s'.", subgroup_name, class_name));
 
 #ifdef TOOLS_ENABLED
 	// If the extension is still marked as reloading, that means it failed to register again.
-	Extension *extension = &self->extension_classes[class_name];
 	if (extension->is_reloading) {
 		return;
 	}
@@ -638,11 +638,11 @@ void GDExtension::_register_extension_class_signal(GDExtensionClassLibraryPtr p_
 
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
 	StringName signal_name = *reinterpret_cast<const StringName *>(p_signal_name);
-	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), vformat("Attempt to register extension class signal '%s' for unexisting class '%s'.", signal_name, class_name));
+	Extension *extension = self->extension_classes.getptr(class_name);
+	ERR_FAIL_NULL_MSG(extension, vformat("Attempted to register extension class signal '%s' for unexisting class '%s'.", signal_name, class_name));
 
 #ifdef TOOLS_ENABLED
 	// If the extension is still marked as reloading, that means it failed to register again.
-	Extension *extension = &self->extension_classes[class_name];
 	if (extension->is_reloading) {
 		return;
 	}
@@ -661,9 +661,9 @@ void GDExtension::_unregister_extension_class(GDExtensionClassLibraryPtr p_libra
 	GDExtension *self = reinterpret_cast<GDExtension *>(p_library);
 
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
-	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), vformat("Attempt to unregister unexisting extension class '%s'.", class_name));
+	Extension *ext = self->extension_classes.getptr(class_name);
+	ERR_FAIL_NULL_MSG(ext, vformat("Attempted to unregister unexisting extension class '%s'.", class_name));
 
-	Extension *ext = &self->extension_classes[class_name];
 #ifdef TOOLS_ENABLED
 	if (ext->is_reloading) {
 		self->_clear_extension(ext);

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -379,12 +379,12 @@ bool Input::is_action_pressed(const StringName &p_action, bool p_exact) const {
 		return false;
 	}
 
-	HashMap<StringName, ActionState>::ConstIterator E = action_states.find(p_action);
+	const ActionState *E = action_states.getptr(p_action);
 	if (!E) {
 		return false;
 	}
 
-	return E->value.cache.pressed && (p_exact ? E->value.exact : true);
+	return E->cache.pressed && (p_exact ? E->exact : true);
 }
 
 bool Input::is_action_just_pressed(const StringName &p_action, bool p_exact) const {
@@ -394,22 +394,22 @@ bool Input::is_action_just_pressed(const StringName &p_action, bool p_exact) con
 		return false;
 	}
 
-	HashMap<StringName, ActionState>::ConstIterator E = action_states.find(p_action);
+	const ActionState *E = action_states.getptr(p_action);
 	if (!E) {
 		return false;
 	}
 
-	if (p_exact && E->value.exact == false) {
+	if (p_exact && !E->exact) {
 		return false;
 	}
 
 	// Backward compatibility for legacy behavior, only return true if currently pressed.
-	bool pressed_requirement = legacy_just_pressed_behavior ? E->value.cache.pressed : true;
+	bool pressed_requirement = legacy_just_pressed_behavior ? E->cache.pressed : true;
 
 	if (Engine::get_singleton()->is_in_physics_frame()) {
-		return pressed_requirement && E->value.pressed_physics_frame == Engine::get_singleton()->get_physics_frames();
+		return pressed_requirement && E->pressed_physics_frame == Engine::get_singleton()->get_physics_frames();
 	} else {
-		return pressed_requirement && E->value.pressed_process_frame == Engine::get_singleton()->get_process_frames();
+		return pressed_requirement && E->pressed_process_frame == Engine::get_singleton()->get_process_frames();
 	}
 }
 
@@ -421,26 +421,26 @@ bool Input::is_action_just_pressed_by_event(const StringName &p_action, const Re
 		return false;
 	}
 
-	HashMap<StringName, ActionState>::ConstIterator E = action_states.find(p_action);
+	const ActionState *E = action_states.getptr(p_action);
 	if (!E) {
 		return false;
 	}
 
-	if (p_exact && E->value.exact == false) {
+	if (p_exact && !E->exact) {
 		return false;
 	}
 
-	if (E->value.pressed_event_id != p_event->get_instance_id()) {
+	if (E->pressed_event_id != p_event->get_instance_id()) {
 		return false;
 	}
 
 	// Backward compatibility for legacy behavior, only return true if currently pressed.
-	bool pressed_requirement = legacy_just_pressed_behavior ? E->value.cache.pressed : true;
+	bool pressed_requirement = legacy_just_pressed_behavior ? E->cache.pressed : true;
 
 	if (Engine::get_singleton()->is_in_physics_frame()) {
-		return pressed_requirement && E->value.pressed_physics_frame == Engine::get_singleton()->get_physics_frames();
+		return pressed_requirement && E->pressed_physics_frame == Engine::get_singleton()->get_physics_frames();
 	} else {
-		return pressed_requirement && E->value.pressed_process_frame == Engine::get_singleton()->get_process_frames();
+		return pressed_requirement && E->pressed_process_frame == Engine::get_singleton()->get_process_frames();
 	}
 }
 
@@ -451,22 +451,22 @@ bool Input::is_action_just_released(const StringName &p_action, bool p_exact) co
 		return false;
 	}
 
-	HashMap<StringName, ActionState>::ConstIterator E = action_states.find(p_action);
+	const ActionState *E = action_states.getptr(p_action);
 	if (!E) {
 		return false;
 	}
 
-	if (p_exact && E->value.exact == false) {
+	if (p_exact && !E->exact) {
 		return false;
 	}
 
 	// Backward compatibility for legacy behavior, only return true if currently released.
-	bool released_requirement = legacy_just_pressed_behavior ? !E->value.cache.pressed : true;
+	bool released_requirement = legacy_just_pressed_behavior ? !E->cache.pressed : true;
 
 	if (Engine::get_singleton()->is_in_physics_frame()) {
-		return released_requirement && E->value.released_physics_frame == Engine::get_singleton()->get_physics_frames();
+		return released_requirement && E->released_physics_frame == Engine::get_singleton()->get_physics_frames();
 	} else {
-		return released_requirement && E->value.released_process_frame == Engine::get_singleton()->get_process_frames();
+		return released_requirement && E->released_process_frame == Engine::get_singleton()->get_process_frames();
 	}
 }
 
@@ -478,26 +478,26 @@ bool Input::is_action_just_released_by_event(const StringName &p_action, const R
 		return false;
 	}
 
-	HashMap<StringName, ActionState>::ConstIterator E = action_states.find(p_action);
+	const ActionState *E = action_states.getptr(p_action);
 	if (!E) {
 		return false;
 	}
 
-	if (p_exact && E->value.exact == false) {
+	if (p_exact && !E->exact) {
 		return false;
 	}
 
-	if (E->value.released_event_id != p_event->get_instance_id()) {
+	if (E->released_event_id != p_event->get_instance_id()) {
 		return false;
 	}
 
 	// Backward compatibility for legacy behavior, only return true if currently released.
-	bool released_requirement = legacy_just_pressed_behavior ? !E->value.cache.pressed : true;
+	bool released_requirement = legacy_just_pressed_behavior ? !E->cache.pressed : true;
 
 	if (Engine::get_singleton()->is_in_physics_frame()) {
-		return released_requirement && E->value.released_physics_frame == Engine::get_singleton()->get_physics_frames();
+		return released_requirement && E->released_physics_frame == Engine::get_singleton()->get_physics_frames();
 	} else {
-		return released_requirement && E->value.released_process_frame == Engine::get_singleton()->get_process_frames();
+		return released_requirement && E->released_process_frame == Engine::get_singleton()->get_process_frames();
 	}
 }
 
@@ -508,16 +508,16 @@ float Input::get_action_strength(const StringName &p_action, bool p_exact) const
 		return 0.0f;
 	}
 
-	HashMap<StringName, ActionState>::ConstIterator E = action_states.find(p_action);
+	const ActionState *E = action_states.getptr(p_action);
 	if (!E) {
 		return 0.0f;
 	}
 
-	if (p_exact && E->value.exact == false) {
+	if (p_exact && !E->exact) {
 		return 0.0f;
 	}
 
-	return E->value.cache.strength;
+	return E->cache.strength;
 }
 
 float Input::get_action_raw_strength(const StringName &p_action, bool p_exact) const {
@@ -527,16 +527,16 @@ float Input::get_action_raw_strength(const StringName &p_action, bool p_exact) c
 		return 0.0f;
 	}
 
-	HashMap<StringName, ActionState>::ConstIterator E = action_states.find(p_action);
+	const ActionState *E = action_states.getptr(p_action);
 	if (!E) {
 		return 0.0f;
 	}
 
-	if (p_exact && E->value.exact == false) {
+	if (p_exact && !E->exact) {
 		return 0.0f;
 	}
 
-	return E->value.cache.raw_strength;
+	return E->cache.raw_strength;
 }
 
 float Input::get_axis(const StringName &p_negative_action, const StringName &p_positive_action) const {
@@ -590,27 +590,30 @@ String Input::get_joy_name(int p_idx) {
 }
 
 Vector2 Input::get_joy_vibration_strength(int p_device) {
-	if (joy_vibration.has(p_device)) {
-		return Vector2(joy_vibration[p_device].weak_magnitude, joy_vibration[p_device].strong_magnitude);
-	} else {
-		return Vector2(0, 0);
+	const VibrationInfo *vibration = joy_vibration.getptr(p_device);
+	if (!vibration) {
+		return Vector2();
 	}
+
+	return Vector2(vibration->weak_magnitude, vibration->strong_magnitude);
 }
 
 uint64_t Input::get_joy_vibration_timestamp(int p_device) {
-	if (joy_vibration.has(p_device)) {
-		return joy_vibration[p_device].timestamp;
-	} else {
+	const VibrationInfo *vibration = joy_vibration.getptr(p_device);
+	if (!vibration) {
 		return 0;
 	}
+
+	return vibration->timestamp;
 }
 
 float Input::get_joy_vibration_duration(int p_device) {
-	if (joy_vibration.has(p_device)) {
-		return joy_vibration[p_device].duration;
-	} else {
-		return 0.f;
+	const VibrationInfo *vibration = joy_vibration.getptr(p_device);
+	if (!vibration) {
+		return 0.0f;
 	}
+
+	return vibration->duration;
 }
 
 static String _hex_str(uint8_t p_byte) {
@@ -1859,8 +1862,9 @@ void Input::set_fallback_mapping(const String &p_guid) {
 
 //platforms that use the remapping system can override and call to these ones
 bool Input::is_joy_known(int p_device) {
-	if (joy_names.has(p_device)) {
-		int mapping = joy_names[p_device].mapping;
+	const Joypad *joypad = joy_names.getptr(p_device);
+	if (joypad) {
+		int mapping = joypad->mapping;
 		if (mapping != -1 && mapping != fallback_mapping) {
 			return true;
 		}
@@ -1869,13 +1873,15 @@ bool Input::is_joy_known(int p_device) {
 }
 
 String Input::get_joy_guid(int p_device) const {
-	ERR_FAIL_COND_V(!joy_names.has(p_device), "");
-	return joy_names[p_device].uid;
+	const Joypad *joypad = joy_names.getptr(p_device);
+	ERR_FAIL_NULL_V_MSG(joypad, String(), vformat("Invalid joypad %s.", p_device));
+	return joypad->uid;
 }
 
 Dictionary Input::get_joy_info(int p_device) const {
-	ERR_FAIL_COND_V(!joy_names.has(p_device), Dictionary());
-	return joy_names[p_device].info;
+	const Joypad *joypad = joy_names.getptr(p_device);
+	ERR_FAIL_NULL_V_MSG(joypad, Dictionary(), vformat("Invalid joypad %s.", p_device));
+	return joypad->info;
 }
 
 bool Input::should_ignore_device(int p_vendor_id, int p_product_id) const {

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -69,10 +69,8 @@ bool ConfigFile::has_section(const String &p_section) const {
 }
 
 bool ConfigFile::has_section_key(const String &p_section, const String &p_key) const {
-	if (!values.has(p_section)) {
-		return false;
-	}
-	return values[p_section].has(p_key);
+	const HashMap<String, Variant> *ret = values.getptr(p_section);
+	return ret && ret->has(p_key);
 }
 
 Vector<String> ConfigFile::get_sections() const {
@@ -90,14 +88,14 @@ Vector<String> ConfigFile::get_sections() const {
 
 Vector<String> ConfigFile::get_section_keys(const String &p_section) const {
 	Vector<String> keys;
-	ERR_FAIL_COND_V_MSG(!values.has(p_section), keys, vformat("Cannot get keys from nonexistent section \"%s\".", p_section));
+	const HashMap<String, Variant> *keys_map = values.getptr(p_section);
+	ERR_FAIL_NULL_V_MSG(keys_map, keys, vformat("Cannot get keys from nonexistent section \"%s\".", p_section));
 
-	const HashMap<String, Variant> &keys_map = values[p_section];
-	keys.resize(keys_map.size());
+	keys.resize(keys_map->size());
 
 	int i = 0;
 	String *keys_write = keys.ptrw();
-	for (const KeyValue<String, Variant> &E : keys_map) {
+	for (const KeyValue<String, Variant> &E : *keys_map) {
 		keys_write[i++] = E.key;
 	}
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -129,12 +129,12 @@ void PackedData::add_pack_source(PackSource *p_source) {
 uint8_t *PackedData::get_file_hash(const String &p_path) {
 	String simplified_path = p_path.simplify_path().trim_prefix("res://");
 	PathMD5 pmd5(simplified_path.md5_buffer());
-	HashMap<PathMD5, PackedFile, PathMD5>::Iterator E = files.find(pmd5);
+	PackedFile *E = files.getptr(pmd5);
 	if (!E) {
 		return nullptr;
 	}
 
-	return E->value.md5;
+	return E->md5;
 }
 
 HashSet<String> PackedData::get_file_paths() const {

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -213,25 +213,25 @@ public:
 int64_t PackedData::get_size(const String &p_path) {
 	String simplified_path = p_path.simplify_path();
 	PathMD5 pmd5(simplified_path.md5_buffer());
-	HashMap<PathMD5, PackedFile, PathMD5>::Iterator E = files.find(pmd5);
+	PackedFile *E = files.getptr(pmd5);
 	if (!E) {
 		return -1; // File not found.
 	}
-	if (E->value.offset == 0) {
+	if (E->offset == 0) {
 		return -1; // File was erased.
 	}
-	return E->value.size;
+	return E->size;
 }
 
 Ref<FileAccess> PackedData::try_open_path(const String &p_path) {
 	String simplified_path = p_path.simplify_path().trim_prefix("res://");
 	PathMD5 pmd5(simplified_path.md5_buffer());
-	HashMap<PathMD5, PackedFile, PathMD5>::Iterator E = files.find(pmd5);
+	PackedFile *E = files.getptr(pmd5);
 	if (!E) {
 		return nullptr; // Not found.
 	}
 
-	return E->value.src->get_file(p_path, &E->value);
+	return E->src->get_file(p_path, E);
 }
 
 bool PackedData::has_path(const String &p_path) {

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -133,8 +133,9 @@ PackedStringArray IP::resolve_hostname_addresses(const String &p_hostname, Type 
 
 	{
 		MutexLock lock(resolver->mutex);
-		if (resolver->cache.has(key)) {
-			res = resolver->cache[key];
+		List<IPAddress> *cache = resolver->cache.getptr(key);
+		if (cache) {
+			res = *cache;
 		} else {
 			// This should be run unlocked so the resolver thread can keep resolving
 			// other requests.
@@ -168,8 +169,9 @@ IP::ResolverID IP::resolve_hostname_queue_item(const String &p_hostname, IP::Typ
 	String key = _IP_ResolverPrivate::get_cache_key(p_hostname, p_type);
 	resolver->queue[id].hostname = p_hostname;
 	resolver->queue[id].type = p_type;
-	if (resolver->cache.has(key)) {
-		resolver->queue[id].response = resolver->cache[key];
+	List<IPAddress> *cache = resolver->cache.getptr(key);
+	if (cache) {
+		resolver->queue[id].response = *cache;
 		resolver->queue[id].status.set(IP::RESOLVER_STATUS_DONE);
 	} else {
 		resolver->queue[id].response = List<IPAddress>();

--- a/core/io/missing_resource.cpp
+++ b/core/io/missing_resource.cpp
@@ -35,20 +35,22 @@ bool MissingResource::_set(const StringName &p_name, const Variant &p_value) {
 		properties.insert(p_name, p_value);
 		return true; //always valid to set (add)
 	} else {
-		if (!properties.has(p_name)) {
+		Variant *property = properties.getptr(p_name);
+		if (!property) {
 			return false;
 		}
 
-		properties[p_name] = p_value;
+		*property = p_value;
 		return true;
 	}
 }
 
 bool MissingResource::_get(const StringName &p_name, Variant &r_ret) const {
-	if (!properties.has(p_name)) {
+	const Variant *property = properties.getptr(p_name);
+	if (!property) {
 		return false;
 	}
-	r_ret = properties[p_name];
+	r_ret = *property;
 	return true;
 }
 

--- a/core/io/packed_data_container.cpp
+++ b/core/io/packed_data_container.cpp
@@ -213,8 +213,9 @@ uint32_t PackedDataContainer::_pack(const Variant &p_data, Vector<uint8_t> &tmpd
 	switch (p_data.get_type()) {
 		case Variant::STRING: {
 			String s = p_data;
-			if (string_cache.has(s)) {
-				return string_cache[s];
+			uint32_t *string_id = string_cache.getptr(s);
+			if (string_id) {
+				return *string_id;
 			}
 
 			string_cache[s] = tmpdata.size();

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -423,9 +423,9 @@ int Color::find_named_color(const String &p_name) {
 		}
 	}
 
-	const HashMap<String, int>::ConstIterator E = named_colors_hashmap.find(name);
+	const int *E = named_colors_hashmap.getptr(name);
 	if (E) {
-		return E->value;
+		return *E;
 	}
 
 	return -1;

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -402,13 +402,13 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 							}
 							Edge e2(idx, idxn);
 
-							HashMap<Edge, RetFaceConnect, Edge>::Iterator F2 = ret_edges.find(e2);
+							RetFaceConnect *F2 = ret_edges.getptr(e2);
 							ERR_CONTINUE(!F2);
 							//change faceconnect, point to this face instead
-							if (F2->value.left == O) {
-								F2->value.left = E;
-							} else if (F2->value.right == O) {
-								F2->value.right = E;
+							if (F2->left == O) {
+								F2->left = E;
+							} else if (F2->right == O) {
+								F2->right = E;
 							}
 						}
 

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -134,9 +134,9 @@ void TriangleMesh::create(const Vector<Vector3> &p_faces, const Vector<int32_t> 
 			for (int j = 0; j < 3; j++) {
 				int vidx = -1;
 				Vector3 vs = v[j].snappedf(0.0001);
-				HashMap<Vector3, int>::Iterator E = db.find(vs);
+				int *E = db.getptr(vs);
 				if (E) {
-					vidx = E->value;
+					vidx = *E;
 				} else {
 					vidx = db.size();
 					db[vs] = vidx;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1112,12 +1112,12 @@ void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 		return;
 	}
 
-	HashMap<StringName, Variant>::Iterator E = metadata.find(p_name);
-	if (E) {
-		E->value = p_value;
+	Variant *V = metadata.getptr(p_name);
+	if (V) {
+		*V = p_value;
 	} else {
 		ERR_FAIL_COND_MSG(!p_name.operator String().is_valid_ascii_identifier(), vformat("Invalid metadata identifier: '%s'.", p_name));
-		Variant *V = &metadata.insert(p_name, p_value)->value;
+		V = &metadata.insert(p_name, p_value)->value;
 
 		const String &sname = p_name;
 		metadata_properties["metadata/" + sname] = V;
@@ -1128,14 +1128,15 @@ void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 }
 
 Variant Object::get_meta(const StringName &p_name, const Variant &p_default) const {
-	if (!metadata.has(p_name)) {
+	const Variant *meta = metadata.getptr(p_name);
+	if (!meta) {
 		if (p_default != Variant()) {
 			return p_default;
 		} else {
 			ERR_FAIL_V_MSG(Variant(), vformat("The object does not have any 'meta' values with the key '%s'.", p_name));
 		}
 	}
-	return metadata[p_name];
+	return *meta;
 }
 
 void Object::remove_meta(const StringName &p_name) {
@@ -1201,10 +1202,11 @@ void Object::add_user_signal(const MethodInfo &p_signal) {
 bool Object::_has_user_signal(const StringName &p_name) const {
 	OBJ_SIGNAL_LOCK
 
-	if (!signal_map.has(p_name)) {
+	const SignalData *signal = signal_map.getptr(p_name);
+	if (!signal) {
 		return false;
 	}
-	return signal_map[p_name].user.name.length() > 0;
+	return signal->user.name.length() > 0;
 }
 
 void Object::_remove_user_signal(const StringName &p_name) {
@@ -1405,8 +1407,9 @@ void Object::_add_user_signal(const String &p_name, const Array &p_args) {
 
 	add_user_signal(mi);
 
-	if (signal_map.has(p_name)) {
-		signal_map.getptr(p_name)->removable = true;
+	SignalData *signal = signal_map.getptr(p_name);
+	if (signal) {
+		signal->removable = true;
 	}
 }
 

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -179,13 +179,15 @@ TranslationServer::Locale::Locale(const TranslationServer &p_server, const Strin
 	}
 
 	// Handles known non-ISO language names used e.g. on Windows.
-	if (p_server.locale_rename_map.has(language)) {
-		language = p_server.locale_rename_map[language];
+	const String *locale_rename = p_server.locale_rename_map.getptr(language);
+	if (locale_rename) {
+		language = *locale_rename;
 	}
 
 	// Handle country renames.
-	if (p_server.country_rename_map.has(country)) {
-		country = p_server.country_rename_map[country];
+	const String *country_rename = p_server.country_rename_map.getptr(country);
+	if (country_rename) {
+		country = *country_rename;
 	}
 
 	// Remove unsupported script codes.
@@ -340,11 +342,8 @@ Vector<String> TranslationServer::get_all_languages() const {
 }
 
 String TranslationServer::get_language_name(const String &p_language) const {
-	if (language_map.has(p_language)) {
-		return language_map[p_language];
-	} else {
-		return p_language;
-	}
+	const String *ret = language_map.getptr(p_language);
+	return ret ? *ret : p_language;
 }
 
 Vector<String> TranslationServer::get_all_scripts() const {
@@ -358,11 +357,8 @@ Vector<String> TranslationServer::get_all_scripts() const {
 }
 
 String TranslationServer::get_script_name(const String &p_script) const {
-	if (script_map.has(p_script)) {
-		return script_map[p_script];
-	} else {
-		return p_script;
-	}
+	const String *ret = script_map.getptr(p_script);
+	return ret ? *ret : p_script;
 }
 
 Vector<String> TranslationServer::get_all_countries() const {
@@ -376,11 +372,8 @@ Vector<String> TranslationServer::get_all_countries() const {
 }
 
 String TranslationServer::get_country_name(const String &p_country) const {
-	if (country_name_map.has(p_country)) {
-		return country_name_map[p_country];
-	} else {
-		return p_country;
-	}
+	const String *ret = country_name_map.getptr(p_country);
+	return ret ? *ret : p_country;
 }
 
 void TranslationServer::set_locale(const String &p_locale) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1639,14 +1639,14 @@ Variant Variant::get_constant_value(Variant::Type p_type, const StringName &p_va
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, 0);
 	_VariantCall::ConstantData &cd = _VariantCall::constant_data[p_type];
 
-	HashMap<StringName, int64_t>::Iterator E = cd.value.find(p_value);
+	int64_t *E = cd.value.getptr(p_value);
 	if (!E) {
-		HashMap<StringName, Variant>::Iterator F = cd.variant_value.find(p_value);
+		Variant *F = cd.variant_value.getptr(p_value);
 		if (F) {
 			if (r_valid) {
 				*r_valid = true;
 			}
-			return F->value;
+			return *F;
 		} else {
 			return -1;
 		}
@@ -1655,7 +1655,7 @@ Variant Variant::get_constant_value(Variant::Type p_type, const StringName &p_va
 		*r_valid = true;
 	}
 
-	return E->value;
+	return *E;
 }
 
 void Variant::get_enums_for_type(Variant::Type p_type, List<StringName> *p_enums) {
@@ -1689,12 +1689,12 @@ int Variant::get_enum_value(Variant::Type p_type, const StringName &p_enum_name,
 
 	_VariantCall::EnumData &enum_data = _VariantCall::enum_data[p_type];
 
-	HashMap<StringName, HashMap<StringName, int>>::Iterator E = enum_data.value.find(p_enum_name);
+	HashMap<StringName, int> *E = enum_data.value.getptr(p_enum_name);
 	if (!E) {
 		return -1;
 	}
 
-	HashMap<StringName, int>::Iterator V = E->value.find(p_enumeration);
+	int *V = E->getptr(p_enumeration);
 	if (!V) {
 		return -1;
 	}
@@ -1703,7 +1703,7 @@ int Variant::get_enum_value(Variant::Type p_type, const StringName &p_enum_name,
 		*r_valid = true;
 	}
 
-	return V->value;
+	return *V;
 }
 
 bool Variant::has_enum(Variant::Type p_type, const StringName &p_enum_name) {

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1211,8 +1211,9 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			StringName key_class_name;
 			Variant key_script;
 			bool got_comma_token = false;
-			if (builtin_types.has(token.value)) {
-				key_type = builtin_types.get(token.value);
+			const Variant::Type *builtin_type = builtin_types.getptr(token.value);
+			if (builtin_type) {
+				key_type = *builtin_type;
 			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
@@ -1257,8 +1258,9 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			StringName value_class_name;
 			Variant value_script;
 			bool got_bracket_token = false;
-			if (builtin_types.has(token.value)) {
-				value_type = builtin_types.get(token.value);
+			builtin_type = builtin_types.getptr(token.value);
+			if (builtin_type) {
+				value_type = *builtin_type;
 			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
@@ -1348,8 +1350,9 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 			Array array = Array();
 			bool got_bracket_token = false;
-			if (builtin_types.has(token.value)) {
-				array.set_typed(builtin_types.get(token.value), StringName(), Variant());
+			const Variant::Type *builtin_type = builtin_types.getptr(token.value);
+			if (builtin_type) {
+				array.set_typed(*builtin_type, StringName(), Variant());
 			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);


### PR DESCRIPTION
* To avoid repeated lookup
* Instead of `find` when appropriate

Not sure if it will improve performance in any of these places specifically but avoiding double lookup is beneficial in general.

If any of these cases result in poor readability we can rework them or drop them, some of these cases could benefit from being declared in the if-statement if it has better readability but avoided such for now

The change from `find` to `getptr` is in cases where the iterator isn't really necessary and it's redundant to have a full iterator, or access through `E->value` etc.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
