### PR TITLE
Add "with" stop word to the editor property name processor

### DIFF
--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -328,8 +328,8 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["yz"] = "YZ";
 
 	// Articles, conjunctions, prepositions.
-	// The following initialization is parsed in `editor/translations/scripts/common.py` with a regex.
-	// The word definition format should be kept synced with the regex.
+	// The following initialization is parsed in https://github.com/godotengine/godot-editor-l10n/blob/main/scripts/common.py
+	// with a regex. The word definition format should be kept synced with the regex.
 	stop_words = LocalVector<String>({
 			"a",
 			"an",
@@ -348,6 +348,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 			"the",
 			"then",
 			"to",
+			"with",
 	});
 
 	// Translation context associated with a name.
@@ -356,8 +357,8 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	// - `Class::full/property/path`
 	// In case a class name is needed to distinguish between usages, all usages should use the second format.
 	//
-	// The following initialization is parsed in `editor/translations/scripts/common.py` with a regex.
-	// The map name and value definition format should be kept synced with the regex.
+	// The following initialization is parsed in https://github.com/godotengine/godot-editor-l10n/blob/main/scripts/common.py
+	// with a regex. The map name and value definition format should be kept synced with the regex.
 	translation_contexts["force"]["constant_force"] = "Physics";
 	translation_contexts["force"]["force/8_bit"] = "Enforce";
 	translation_contexts["force"]["force/mono"] = "Enforce";


### PR DESCRIPTION
This makes properties such as "Convert Colors with Editor Theme" have better-looking capitalization in the inspector and import options.

I noticed this while working on https://github.com/godotengine/godot-docs/pull/11381.

PS: This is stated above the list:

```cpp
// The following initialization is parsed in `editor/translations/scripts/common.py` with a regex.
// The word definition format should be kept synced with the regex.
```

However, I can't find this file in the current `master` branch. Is the comment still up-to-date? cc @akien-mga 

## Preview

### Before

<img width="358" height="94" alt="Screenshot_20251016_222113" src="https://github.com/user-attachments/assets/7dcad1b3-62cc-413b-b08a-bb1772414262" />

### After

<img width="341" height="99" alt="Screenshot_20251016_222347" src="https://github.com/user-attachments/assets/941269c8-d217-42b3-8b01-e0f3a6ab754d" />
