### PR TITLE
[TextEdit] Make `wrap_right_offset` adjustable theme constant.

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1676,6 +1676,9 @@
 			The size of the text outline.
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.
 		</theme_item>
+		<theme_item name="wrap_offset" data_type="constant" type="int" default="10">
+			Sets an additional margin for line wrapping width.
+		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">
 			Sets the default [Font].
 		</theme_item>

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7642,6 +7642,7 @@ void TextEdit::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_COLOR, TextEdit, outline_color, "font_outline_color");
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, TextEdit, line_spacing);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, TextEdit, wrap_offset);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, TextEdit, background_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, TextEdit, current_line_color);
@@ -8526,7 +8527,7 @@ void TextEdit::_update_wrap_at_column(bool p_force) {
 		new_wrap_at -= v_scroll->get_combined_minimum_size().width;
 	}
 	/* Give it a little more space. */
-	new_wrap_at -= wrap_right_offset;
+	new_wrap_at -= theme_cache.wrap_offset;
 
 	if ((wrap_at_column != new_wrap_at) || p_force) {
 		wrap_at_column = new_wrap_at;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -527,7 +527,6 @@ private:
 	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_WORD_SMART;
 
 	int wrap_at_column = 0;
-	int wrap_right_offset = 10;
 
 	void _update_wrap_at_column(bool p_force = false);
 
@@ -641,6 +640,7 @@ private:
 		Color outline_color = Color(1, 1, 1);
 
 		int line_spacing = 1;
+		int wrap_offset = 10;
 
 		Color background_color = Color(1, 1, 1);
 		Color current_line_color = Color(1, 1, 1);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -477,6 +477,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("line_spacing", "TextEdit", Math::round(4 * scale));
 	theme->set_constant("outline_size", "TextEdit", 0);
 	theme->set_constant("caret_width", "TextEdit", 1);
+	theme->set_constant("wrap_offset", "TextEdit", 10);
 
 	// CodeEdit
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/111739
