### PR TITLE
Fix the LODs array returned by `mesh_get_surface`

### DIFF
--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2034,7 +2034,7 @@ Dictionary RenderingServer::_mesh_get_surface(RID p_mesh, int p_idx) {
 			Dictionary ld;
 			ld["edge_length"] = sd.lods[i].edge_length;
 			ld["index_data"] = sd.lods[i].index_data;
-			lods.push_back(lods);
+			lods.push_back(ld);
 		}
 		d["lods"] = lods;
 	}


### PR DESCRIPTION
We were pushing the wrong array into the "lods" field of the dictionary returned by `RenderingServer.mesh_get_surface`

This would cause some weird issues when trying to read lods from the mesh. Printing the dictionary returned would also result in a maximum array recursion error.

Thanks to blackshift from the godot discord for finding this one

_bugsquad edit: Fixes https://github.com/godotengine/godot/issues/111750_