### PR TITLE
Re-implement gdvirtual functions using templates and types

### DIFF
--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -1,193 +1,89 @@
-script_call = """ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\\
-		if (_script_instance) {\\
-			Callable::CallError ce;\\
-			$CALLSIARGS\\
-			$CALLSIBEGIN_script_instance->callp(_gdvirtual_##$VARNAME##_sn, $CALLSIARGPASS, ce);\\
-			if (ce.error == Callable::CallError::CALL_OK) {\\
-				$CALLSIRET\\
-				return true;\\
-			}\\
-		}"""
-
-script_has_method = """ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\\
-		if (_script_instance && _script_instance->has_method(_gdvirtual_##$VARNAME##_sn)) {\\
-			return true;\\
-		}"""
-
 proto = """#define GDVIRTUAL$VER($ALIAS $RET m_name $ARG)\\
-	mutable void *_gdvirtual_##$VARNAME = nullptr;\\
-	_FORCE_INLINE_ bool _gdvirtual_##$VARNAME##_call($CALLARGS) $CONST {\\
-		static const StringName _gdvirtual_##$VARNAME##_sn = StringName(#m_name, true);\\
-		$SCRIPTCALL\\
-		if (_get_extension()) {\\
-			if (unlikely(!_gdvirtual_##$VARNAME)) {\\
-			    _gdvirtual_init_method_ptr(_gdvirtual_##$VARNAME##_get_method_info().get_compatibility_hash(), _gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_sn, $COMPAT);\\
-			}\\
-			if (_gdvirtual_##$VARNAME != reinterpret_cast<void*>(_INVALID_GDVIRTUAL_FUNC_ADDR)) {\\
-				$CALLPTRARGS\\
-				$CALLPTRRETDEF\\
-				if (_get_extension()->call_virtual_with_data) {\\
-					_get_extension()->call_virtual_with_data(_get_extension_instance(), &_gdvirtual_##$VARNAME##_sn, _gdvirtual_##$VARNAME, $CALLPTRARGPASS, $CALLPTRRETPASS);\\
-					$CALLPTRRET\\
-				} else {\\
-					((GDExtensionClassCallVirtual)_gdvirtual_##$VARNAME)(_get_extension_instance(), $CALLPTRARGPASS, $CALLPTRRETPASS);\\
-					$CALLPTRRET\\
-				}\\
-				return true;\\
-			}\\
+	class _GDVIRTUAL##$VARNAME: public GDVirtualMethodInfo<$TEMPLATE_ARGS> {\\
+	public:\\
+		MethodInfo get_method_info() const override {\\
+			MethodInfo method_info;\\
+			method_info.name = #m_name;\\
+			method_info.flags = $METHOD_FLAGS;\\
+			$FILL_METHOD_INFO\\
+			return method_info;\\
 		}\\
-		$REQCHECK\\
-		$RVOID\\
-		return false;\\
+		using GDVirtualMethodInfo::GDVirtualMethodInfo;\\
+	};\\
+	static const _GDVIRTUAL##$VARNAME &get_gdvirtual_##$VARNAME() {\\
+		static _GDVIRTUAL##$VARNAME instance($METHOD_INFO_INIT_ARGS);\\
+		return instance;\\
 	}\\
-	_FORCE_INLINE_ bool _gdvirtual_##$VARNAME##_overridden() const {\\
-		static const StringName _gdvirtual_##$VARNAME##_sn = StringName(#m_name, true);\\
-		$SCRIPTHASMETHOD\\
-		if (_get_extension()) {\\
-			if (unlikely(!_gdvirtual_##$VARNAME)) {\\
-			    _gdvirtual_init_method_ptr(_gdvirtual_##$VARNAME##_get_method_info().get_compatibility_hash(), _gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_sn, $COMPAT);\\
-			}\\
-			if (_gdvirtual_##$VARNAME != reinterpret_cast<void*>(_INVALID_GDVIRTUAL_FUNC_ADDR)) {\\
-				return true;\\
-			}\\
-		}\\
-		return false;\\
-	}\\
-	_FORCE_INLINE_ static MethodInfo _gdvirtual_##$VARNAME##_get_method_info() {\\
-		MethodInfo method_info;\\
-		method_info.name = #m_name;\\
-		method_info.flags = $METHOD_FLAGS;\\
-		$FILL_METHOD_INFO\\
-		return method_info;\\
-	}
+	mutable void *_gdvirtual_##$VARNAME##_ptr = nullptr;\\
 
 """
 
 
 def generate_version(argcount, const=False, returns=False, required=False, compat=False):
     s = proto
-    if compat:
-        s = s.replace("$SCRIPTCALL", "")
-        s = s.replace("$SCRIPTHASMETHOD", "")
-    else:
-        s = s.replace("$SCRIPTCALL", script_call)
-        s = s.replace("$SCRIPTHASMETHOD", script_has_method)
+
+    def to_c_bool(b: bool) -> str:
+        return "true" if b else "false"
+
+    s = s.replace("$METHOD_INFO_INIT_ARGS", f"#m_name, {to_c_bool(required)}, {to_c_bool(compat)}")
 
     sproto = str(argcount)
     method_info = ""
     method_flags = "METHOD_FLAG_VIRTUAL"
+    template_args = f"{to_c_bool(const)}, "
+
     if returns:
         sproto += "R"
         s = s.replace("$RET", "m_ret,")
-        s = s.replace("$RVOID", "(void)r_ret;")  # If required, may lead to uninitialized errors
-        s = s.replace("$CALLPTRRETDEF", "PtrToArg<m_ret>::EncodeT ret;")
         method_info += "method_info.return_val = GetTypeInfo<m_ret>::get_class_info();\\\n"
-        method_info += "\t\tmethod_info.return_val_metadata = GetTypeInfo<m_ret>::METADATA;"
+        method_info += "\t\t\tmethod_info.return_val_metadata = GetTypeInfo<m_ret>::METADATA;"
+        template_args += "m_ret"
     else:
         s = s.replace("$RET ", "")
-        s = s.replace("\t\t$RVOID\\\n", "")
-        s = s.replace("\t\t\t$CALLPTRRETDEF\\\n", "")
+        template_args += "void"
 
     if const:
         sproto += "C"
         method_flags += " | METHOD_FLAG_CONST"
-        s = s.replace("$CONST", "const")
-    else:
-        s = s.replace("$CONST ", "")
 
     if required:
         sproto += "_REQUIRED"
         method_flags += " | METHOD_FLAG_VIRTUAL_REQUIRED"
-        s = s.replace(
-            "$REQCHECK",
-            'ERR_PRINT_ONCE("Required virtual method " + get_class() + "::" + #m_name + " must be overridden before calling.");',
-        )
-    else:
-        s = s.replace("\t\t$REQCHECK\\\n", "")
 
     if compat:
         sproto += "_COMPAT"
-        s = s.replace("$COMPAT", "true")
         s = s.replace("$ALIAS", "m_alias,")
         s = s.replace("$VARNAME", "m_alias")
     else:
-        s = s.replace("$COMPAT", "false")
         s = s.replace("$ALIAS ", "")
         s = s.replace("$VARNAME", "m_name")
 
     s = s.replace("$METHOD_FLAGS", method_flags)
     s = s.replace("$VER", sproto)
     argtext = ""
-    callargtext = ""
-    callsiargs = ""
-    callsiargptrs = ""
-    callptrargsptr = ""
     if argcount > 0:
         argtext += ", "
-        callsiargs = f"Variant vargs[{argcount}] = {{ "
-        callsiargptrs = f"\t\t\tconst Variant *vargptrs[{argcount}] = {{ "
-        callptrargsptr = f"\t\t\tGDExtensionConstTypePtr argptrs[{argcount}] = {{ "
 
         if method_info:
-            method_info += "\\\n\t\t"
+            method_info += "\\\n\t\t\t"
         method_info += (
             "_gdvirtual_set_method_info_args<"
             + ", ".join(f"m_type{i + 1}" for i in range(argcount))
             + ">(method_info);"
         )
 
-    callptrargs = ""
     for i in range(argcount):
         if i > 0:
             argtext += ", "
-            callargtext += ", "
-            callsiargs += ", "
-            callsiargptrs += ", "
-            callptrargs += "\t\t\t"
-            callptrargsptr += ", "
         argtext += f"m_type{i + 1}"
-        callargtext += f"m_type{i + 1} arg{i + 1}"
-        callsiargs += f"arg{i + 1}"
-        callsiargptrs += f"&vargs[{i}]"
-        callptrargs += (
-            f"PtrToArg<m_type{i + 1}>::EncodeT argval{i + 1} = (PtrToArg<m_type{i + 1}>::EncodeT)arg{i + 1};\\\n"
-        )
-        callptrargsptr += f"&argval{i + 1}"
-
-    if argcount:
-        callsiargs += " };\\\n"
-        callsiargptrs += " };"
-        s = s.replace("$CALLSIARGS", callsiargs + callsiargptrs)
-        s = s.replace("$CALLSIARGPASS", f"(const Variant **)vargptrs, {argcount}")
-        callptrargsptr += " };"
-        s = s.replace("$CALLPTRARGS", callptrargs + callptrargsptr)
-        s = s.replace("$CALLPTRARGPASS", "reinterpret_cast<GDExtensionConstTypePtr *>(argptrs)")
-    else:
-        s = s.replace("\t\t\t$CALLSIARGS\\\n", "")
-        s = s.replace("$CALLSIARGPASS", "nullptr, 0")
-        s = s.replace("\t\t\t$CALLPTRARGS\\\n", "")
-        s = s.replace("$CALLPTRARGPASS", "nullptr")
-
-    if returns:
-        if argcount > 0:
-            callargtext += ", "
-        callargtext += "m_ret &r_ret"
-        s = s.replace("$CALLSIBEGIN", "Variant ret = ")
-        s = s.replace("$CALLSIRET", "r_ret = VariantCaster<m_ret>::cast(ret);")
-        s = s.replace("$CALLPTRRETPASS", "&ret")
-        s = s.replace("$CALLPTRRET", "r_ret = (m_ret)ret;")
-    else:
-        s = s.replace("$CALLSIBEGIN", "")
-        s = s.replace("\t\t\t\t$CALLSIRET\\\n", "")
-        s = s.replace("$CALLPTRRETPASS", "nullptr")
-        s = s.replace("\t\t\t\t$CALLPTRRET\\\n", "")
 
     s = s.replace(" $ARG", argtext)
-    s = s.replace("$CALLARGS", callargtext)
     if method_info:
         s = s.replace("$FILL_METHOD_INFO", method_info)
     else:
-        s = s.replace("\t\t$FILL_METHOD_INFO\\\n", method_info)
+        s = s.replace("\t\t\t$FILL_METHOD_INFO\\\n", method_info)
+
+    s = s.replace("$TEMPLATE_ARGS", template_args + argtext)
 
     return s
 
@@ -199,8 +95,6 @@ def run(target, source, env):
 #pragma once
 
 #include "core/object/script_instance.h"
-
-inline constexpr uintptr_t _INVALID_GDVIRTUAL_FUNC_ADDR = static_cast<uintptr_t>(-1);
 
 template <typename... Args>
 void _gdvirtual_set_method_info_args(MethodInfo &p_method_info) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -39,6 +39,7 @@
 #include "core/templates/hash_set.h"
 #include "core/templates/list.h"
 #include "core/templates/safe_refcount.h"
+#include "core/templates/simple_type.h"
 #include "core/variant/variant.h"
 
 template <typename T>
@@ -381,17 +382,17 @@ struct ObjectGDExtension {
 #endif
 };
 
-#define GDVIRTUAL_CALL(m_name, ...) _gdvirtual_##m_name##_call(__VA_ARGS__)
-#define GDVIRTUAL_CALL_PTR(m_obj, m_name, ...) m_obj->_gdvirtual_##m_name##_call(__VA_ARGS__)
+#define GDVIRTUAL_CALL(m_name, ...) gdvirtual_call(get_gdvirtual_##m_name(), _gdvirtual_##m_name##_ptr, ##__VA_ARGS__)
+#define GDVIRTUAL_CALL_PTR(m_obj, m_name, ...) m_obj->gdvirtual_call(std::remove_pointer_t<RemoveRefT<GetSimpleTypeT<decltype(m_obj)>>>::get_gdvirtual_##m_name(), m_obj->_gdvirtual_##m_name##_ptr, ##__VA_ARGS__)
 
 #ifdef DEBUG_ENABLED
-#define GDVIRTUAL_BIND(m_name, ...) ::ClassDB::add_virtual_method(get_class_static(), _gdvirtual_##m_name##_get_method_info(), true, sarray(__VA_ARGS__));
+#define GDVIRTUAL_BIND(m_name, ...) ::ClassDB::add_virtual_method(get_class_static(), get_gdvirtual_##m_name().get_method_info(), true, sarray(__VA_ARGS__));
 #else
 #define GDVIRTUAL_BIND(m_name, ...)
 #endif // DEBUG_ENABLED
-#define GDVIRTUAL_BIND_COMPAT(m_alias, ...) ::ClassDB::add_virtual_compatibility_method(get_class_static(), _gdvirtual_##m_alias##_get_method_info(), true, sarray(__VA_ARGS__));
-#define GDVIRTUAL_IS_OVERRIDDEN(m_name) _gdvirtual_##m_name##_overridden()
-#define GDVIRTUAL_IS_OVERRIDDEN_PTR(m_obj, m_name) m_obj->_gdvirtual_##m_name##_overridden()
+#define GDVIRTUAL_BIND_COMPAT(m_alias, ...) ::ClassDB::add_virtual_compatibility_method(get_class_static(), get_gdvirtual_##m_alias().get_method_info(), true, sarray(__VA_ARGS__));
+#define GDVIRTUAL_IS_OVERRIDDEN(m_name) is_gdvirtual_overridden(get_gdvirtual_##m_name(), _gdvirtual_##m_name##_ptr)
+#define GDVIRTUAL_IS_OVERRIDDEN_PTR(m_obj, m_name) m_obj->is_gdvirtual_overridden(std::remove_pointer_t<RemoveRefT<GetSimpleTypeT<decltype(m_obj)>>>::get_gdvirtual_##m_name(), m_obj->_gdvirtual_##m_name##_ptr)
 
 /*
  * The following is an incomprehensible blob of hacks and workarounds to
@@ -565,8 +566,39 @@ public:                                              \
                                                      \
 private:
 
+inline constexpr uintptr_t _INVALID_GDVIRTUAL_FUNC_ADDR = static_cast<uintptr_t>(-1);
+
 class ClassDB;
 class ScriptInstance;
+
+template <typename T>
+struct VariantCaster;
+
+template <typename T, typename = void>
+struct PtrToArg;
+
+class GDVirtualMethodInfoBase {
+public:
+	StringName fn_name;
+	bool required;
+	bool compat;
+
+	GDVirtualMethodInfoBase(StringName p_fn_name, bool p_required, bool p_compat) :
+			fn_name(p_fn_name), required(p_required), compat(p_compat) {}
+
+	virtual ~GDVirtualMethodInfoBase() {}
+	virtual MethodInfo get_method_info() const = 0;
+};
+
+template <bool t_const, typename Ret, typename... Args>
+class GDVirtualMethodInfo : public GDVirtualMethodInfoBase {
+	using GDVirtualMethodInfoBase::GDVirtualMethodInfoBase;
+};
+
+template <typename T>
+struct type_identity {
+	typedef T type;
+};
 
 class Object {
 public:
@@ -721,7 +753,7 @@ protected:
 	}
 
 	// Used in gdvirtual.gen.inc
-	void _gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr, const StringName &p_fn_name, bool p_compat) const;
+	void _gdvirtual_init_method_ptr(const GDVirtualMethodInfoBase &p_method_info, void *&r_fn_ptr) const;
 
 	friend class GDExtensionMethodBind;
 	_ALWAYS_INLINE_ const ObjectGDExtension *_get_extension() const { return _extension; }
@@ -903,6 +935,110 @@ public:
 		Callable::CallError cerr;
 		const Variant ret = callp(p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args), cerr);
 		return (cerr.error == Callable::CallError::CALL_OK) ? ret : Variant();
+	}
+
+	bool is_gdvirtual_overridden(const GDVirtualMethodInfoBase &p_method_info, void *&ptr) const;
+
+	template <typename Ret, typename... Args>
+	bool gdvirtual_call(const GDVirtualMethodInfo<false, Ret, Args...> &p_method_info, void *&ptr, typename type_identity<Args>::type... args, typename type_identity<Ret>::type &r_ret) {
+		constexpr size_t size_safe = sizeof...(args) ? sizeof...(args) : 1;
+
+		if (script_instance && !p_method_info.compat) {
+			Callable::CallError ce;
+			Variant vargs[size_safe] = { args... };
+			const Variant *argptrs[size_safe];
+			for (uint32_t i = 0; i < sizeof...(args); i++) {
+				argptrs[i] = &vargs[i];
+			}
+			// TODO use simpler callp which just forwards to ScriptInstance
+			Variant ret = callp(p_method_info.fn_name, (const Variant **)argptrs, sizeof...(args), ce);
+			if (ce.error == Callable::CallError::CALL_OK) {
+				r_ret = VariantCaster<Ret>::cast(ret);
+				return true;
+			}
+		}
+		if (_get_extension()) {
+			if (unlikely(!ptr)) {
+				_gdvirtual_init_method_ptr(p_method_info, ptr);
+			}
+			if (ptr != reinterpret_cast<void *>(_INVALID_GDVIRTUAL_FUNC_ADDR)) {
+				std::tuple<typename PtrToArg<Args>::EncodeT...> argval = { (typename PtrToArg<Args>::EncodeT)args... };
+				GDExtensionConstTypePtr argptrs[size_safe];
+				std::apply([&](auto &...elems) {
+					size_t i = 0;
+					((argptrs[i++] = static_cast<void *>(&elems)), ...);
+				},
+						argval);
+				typename PtrToArg<Ret>::EncodeT ret;
+				if (_get_extension()->call_virtual_with_data) {
+					_get_extension()->call_virtual_with_data(_get_extension_instance(), &p_method_info.fn_name, ptr, reinterpret_cast<GDExtensionConstTypePtr *>(argptrs), &ret);
+					r_ret = (Ret)ret;
+				} else {
+					((GDExtensionClassCallVirtual)ptr)(_get_extension_instance(), reinterpret_cast<GDExtensionConstTypePtr *>(argptrs), &ret);
+					r_ret = (Ret)ret;
+				}
+				return true;
+			}
+		}
+		if (p_method_info.required) {
+			ERR_PRINT_ONCE("Required virtual method " + get_class() + "::" + p_method_info.fn_name + " must be overridden before calling.");
+		}
+		return false;
+	}
+
+	template <typename... Args>
+	bool gdvirtual_call(const GDVirtualMethodInfo<false, void, Args...> &p_method_info, void *&ptr, typename type_identity<Args>::type... args) {
+		constexpr size_t size_safe = sizeof...(args) ? sizeof...(args) : 1;
+
+		if (script_instance && !p_method_info.compat) {
+			Callable::CallError ce;
+			Variant vargs[size_safe] = { args... };
+			const Variant *argptrs[size_safe];
+			for (uint32_t i = 0; i < sizeof...(args); i++) {
+				argptrs[i] = &vargs[i];
+			}
+			// TODO use simpler callp which just forwards to ScriptInstance
+			callp(p_method_info.fn_name, (const Variant **)argptrs, sizeof...(args), ce);
+			if (ce.error == Callable::CallError::CALL_OK) {
+				return true;
+			}
+		}
+		if (_get_extension()) {
+			if (unlikely(!ptr)) {
+				_gdvirtual_init_method_ptr(p_method_info, ptr);
+			}
+			if (ptr != reinterpret_cast<void *>(_INVALID_GDVIRTUAL_FUNC_ADDR)) {
+				std::tuple<typename PtrToArg<Args>::EncodeT...> argval = { (typename PtrToArg<Args>::EncodeT)args... };
+				GDExtensionConstTypePtr argptrs[size_safe];
+				std::apply([&](auto &...elems) {
+					size_t i = 0;
+					((argptrs[i++] = static_cast<void *>(&elems)), ...);
+				},
+						argval);
+				if (_get_extension()->call_virtual_with_data) {
+					_get_extension()->call_virtual_with_data(_get_extension_instance(), &p_method_info.fn_name, ptr, reinterpret_cast<GDExtensionConstTypePtr *>(argptrs), nullptr);
+				} else {
+					((GDExtensionClassCallVirtual)ptr)(_get_extension_instance(), reinterpret_cast<GDExtensionConstTypePtr *>(argptrs), nullptr);
+				}
+				return true;
+			}
+		}
+		if (p_method_info.required) {
+			ERR_PRINT_ONCE("Required virtual method " + get_class() + "::" + p_method_info.fn_name + " must be overridden before calling.");
+		}
+		return false;
+	}
+
+	template <typename Ret, typename... Args>
+	_FORCE_INLINE_ bool gdvirtual_call(const GDVirtualMethodInfo<true, Ret, Args...> &p_method_info, void *&ptr, typename type_identity<Args>::type... args, typename type_identity<Ret>::type &r_ret) const {
+		// Implementation is the same, just use the non-const version.
+		return gdvirtual_call((GDVirtualMethodInfo<true, Ret, Args...> &)p_method_info, ptr, args..., r_ret);
+	}
+
+	template <typename... Args>
+	_FORCE_INLINE_ bool gdvirtual_call(const GDVirtualMethodInfo<true, void, Args...> &p_method_info, void *&ptr, typename type_identity<Args>::type... args) const {
+		// Implementation is the same, just use the non-const version.
+		return gdvirtual_call((GDVirtualMethodInfo<true, void, Args...> &)p_method_info, ptr, args...);
 	}
 
 	// Depending on the boolean, we call either the virtual function _notification_backward or _notification_forward.

--- a/core/templates/simple_type.h
+++ b/core/templates/simple_type.h
@@ -33,4 +33,20 @@
 #include <type_traits>
 
 template <typename T>
-using GetSimpleTypeT = typename std::remove_cv_t<std::remove_reference_t<T>>;
+class Ref;
+
+template <typename T>
+struct RemoveRef {
+	using type = T;
+};
+
+template <typename T>
+struct RemoveRef<Ref<T>> {
+	using type = T;
+};
+
+template <typename T>
+using RemoveRefT = typename RemoveRef<T>::type;
+
+template <typename T>
+using GetSimpleTypeT = std::remove_cv_t<std::remove_reference_t<T>>;

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -137,9 +137,6 @@ struct PtrToArgStringConvertByReference {
 
 } //namespace Internal
 
-template <typename T, typename = void>
-struct PtrToArg;
-
 template <typename T>
 struct PtrToArg<T, std::enable_if_t<!std::is_same_v<T, GetSimpleTypeT<T>>>> : PtrToArg<GetSimpleTypeT<T>> {};
 

--- a/modules/webrtc/webrtc_peer_connection_extension.h
+++ b/modules/webrtc/webrtc_peer_connection_extension.h
@@ -46,7 +46,35 @@ public:
 	EXBIND0RC(ConnectionState, get_connection_state);
 	EXBIND0RC(GatheringState, get_gathering_state);
 	EXBIND0RC(SignalingState, get_signaling_state);
-	EXBIND1R(Error, initialize, const Dictionary &);
+
+	class _GDVIRTUAL_initialize : public GDVirtualMethodInfo<false, Error, const Dictionary &> {
+	public:
+		MethodInfo get_method_info() const override {
+			MethodInfo method_info;
+			method_info.name = "_initialize";
+			method_info.flags = METHOD_FLAG_VIRTUAL | METHOD_FLAG_VIRTUAL_REQUIRED;
+			method_info.return_val = GetTypeInfo<Error>::get_class_info();
+			method_info.return_val_metadata = GetTypeInfo<Error>::METADATA;
+			_gdvirtual_set_method_info_args<const Dictionary &>(method_info);
+			return method_info;
+		}
+
+		using GDVirtualMethodInfo::GDVirtualMethodInfo;
+	};
+
+	static const _GDVIRTUAL_initialize &get_gdvirtual__initialize() {
+		static _GDVIRTUAL_initialize instance("_initialize", true, false);
+		return instance;
+	}
+
+	mutable void *_gdvirtual__initialize_ptr = nullptr;
+
+	virtual Error initialize(const Dictionary &arg1) override {
+		Error ret;
+		ZeroInitializer<Error>::initialize(ret);
+		gdvirtual_call(get_gdvirtual__initialize(), _gdvirtual__initialize_ptr, arg1, ret);
+		return ret;
+	}
 	EXBIND2R(Ref<WebRTCDataChannel>, create_data_channel, const String &, const Dictionary &);
 	EXBIND0R(Error, create_offer);
 	EXBIND2R(Error, set_remote_description, const String &, const String &);

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1751,7 +1751,7 @@ void TileMapLayer::_build_runtime_update_tile_data_for_cell(CellData &r_cell_dat
 
 				if (p_use_tilemap_for_runtime) {
 					// Compatibility with TileMap.
-					if (tile_map_node->GDVIRTUAL_CALL(_use_tile_data_runtime_update, layer_index_in_tile_map_node, r_cell_data.coords, ret) && ret) {
+					if (GDVIRTUAL_CALL_PTR(tile_map_node, _use_tile_data_runtime_update, layer_index_in_tile_map_node, r_cell_data.coords, ret) && ret) {
 						TileData *tile_data = atlas_source->get_tile_data(c.get_atlas_coords(), c.alternative_tile);
 
 						// Create the runtime TileData.
@@ -1759,7 +1759,7 @@ void TileMapLayer::_build_runtime_update_tile_data_for_cell(CellData &r_cell_dat
 						tile_data_runtime_use->set_allow_transform(true);
 						r_cell_data.runtime_tile_data_cache = tile_data_runtime_use;
 
-						tile_map_node->GDVIRTUAL_CALL(_tile_data_runtime_update, layer_index_in_tile_map_node, r_cell_data.coords, tile_data_runtime_use);
+						GDVIRTUAL_CALL_PTR(tile_map_node, _tile_data_runtime_update, layer_index_in_tile_map_node, r_cell_data.coords, tile_data_runtime_use);
 
 						if (p_auto_add_to_dirty_list && !r_cell_data.dirty_list_element.in_list()) {
 							dirty.cell_list.add(&r_cell_data.dirty_list_element);


### PR DESCRIPTION
An experimental re-implementation of gdvirtual functions.

My main motivation was to try to avoid duplication, both in code and in the binary, and to better understand the code in preparation for trying to change gdvirtual to use function pointers.

I think this implementation was half successful. For a fresh rebuild, I measured a 5% decrease in compile time (although it might be partially up to chance / throttling), from 7m26s to 7m4s. I also measured a ~0.8mb reduction in binary size in DEBUG (0.5%). This might also be partially chance though. The size of `gdvirtual.gen.inc` is reduced from 500kb to 135kb (70% reduction).

The main thing I'm unhappy with in this implementation is that it's, in some respects, more complicated than the current one. The eventual pointer based implementation should mostly be simpler than both, and will work quite differently. So I'm not sure we should be taking this "side adventure" with an implementation that will likely be replaced soon anyway.
The implementation is also using a feature that's MSVC incompatible (`##__VA_ARGS__`). C++20 will add a feature that is compatible with all compilers (`__VA_OPT__`).
