### PR TITLE
Fix gpu particles never emit finish signal

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -88,6 +88,10 @@ void GPUParticles2D::set_one_shot(bool p_enable) {
 		set_process_internal(true);
 		if (!one_shot) {
 			RenderingServer::get_singleton()->particles_restart(particles);
+			signal_canceled = true;
+		} else if (!active) {
+			active = true;
+			signal_canceled = false;
 		}
 	}
 

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -96,6 +96,10 @@ void GPUParticles3D::set_one_shot(bool p_one_shot) {
 	if (is_emitting()) {
 		if (!one_shot) {
 			RenderingServer::get_singleton()->particles_restart(particles);
+			signal_canceled = true;
+		} else if (!active) {
+			active = true;
+			signal_canceled = false;
 		}
 	}
 }


### PR DESCRIPTION
- *Fixed: https://github.com/godotengine/godot/issues/85802*

The issue caused by first set `one_shot=false`, then set `emitting=true` in the constructor.

That makes `active` never be `true`, so it is never a `finished` signal.

https://github.com/godotengine/godot/blob/60710df3b6fffb5a9a9479f80a0e9d8f05069946/scene/2d/gpu_particles_2d.cpp#L990-L991

https://github.com/godotengine/godot/blob/60710df3b6fffb5a9a9479f80a0e9d8f05069946/scene/2d/gpu_particles_2d.cpp#L47-L50

When `one_shot=false` and `p_emtting=true`, it will update `emitting` to true, so `active` never be `true`.

But Why `emitting=true` in constructor, still need discuss. I guess maybe we need it to emitting particles auto-load?