### PR TITLE
Deprecate per-Object disabling of `tr()` functionality

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1737,22 +1737,30 @@ void Object::set_translation_domain(const StringName &p_domain) {
 }
 
 String Object::tr(const StringName &p_message, const StringName &p_context) const {
+#ifndef DISABLE_DEPRECATED
 	if (!_can_translate || !TranslationServer::get_singleton()) {
 		return p_message;
 	}
+#else
+	if (!TranslationServer::get_singleton()) {
+		return p_message;
+	}
+#endif // DISABLE_DEPRECATED
 
 	const Ref<TranslationDomain> domain = TranslationServer::get_singleton()->get_or_add_domain(get_translation_domain());
 	return domain->translate(p_message, p_context);
 }
 
 String Object::tr_n(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+#ifndef DISABLE_DEPRECATED
 	if (!_can_translate || !TranslationServer::get_singleton()) {
-		// Return message based on English plural rule if translation is not possible.
-		if (p_n == 1) {
-			return p_message;
-		}
-		return p_message_plural;
+		return p_n == 1 ? p_message : p_message_plural; // Fallback to English plural rule.
 	}
+#else
+	if (!TranslationServer::get_singleton()) {
+		return p_n == 1 ? p_message : p_message_plural; // Fallback to English plural rule.
+	}
+#endif // DISABLE_DEPRECATED
 
 	const Ref<TranslationDomain> domain = TranslationServer::get_singleton()->get_or_add_domain(get_translation_domain());
 	return domain->translate_plural(p_message, p_message_plural, p_n, p_context);
@@ -1917,8 +1925,11 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_blocking_signals"), &Object::is_blocking_signals);
 	ClassDB::bind_method(D_METHOD("notify_property_list_changed"), &Object::notify_property_list_changed);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_message_translation", "enable"), &Object::set_message_translation);
 	ClassDB::bind_method(D_METHOD("can_translate_messages"), &Object::can_translate_messages);
+#endif // DISABLE_DEPRECATED
+
 	ClassDB::bind_method(D_METHOD("tr", "message", "context"), &Object::tr, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("tr_n", "message", "plural_message", "n", "context"), &Object::tr_n, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_translation_domain"), &Object::get_translation_domain);
@@ -2299,7 +2310,11 @@ void Object::reset_internal_extension(ObjectGDExtension *p_extension) {
 
 void Object::_construct_object(bool p_reference) {
 	_block_signals = false;
+
+#ifndef DISABLE_DEPRECATED
 	_can_translate = true;
+#endif // DISABLE_DEPRECATED
+
 	_emitting = false;
 	_is_queued_for_deletion = false;
 	_predelete_ok = false;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -655,7 +655,9 @@ private:
 	uint32_t _ancestry : 15;
 
 	bool _block_signals : 1;
+#ifndef DISABLE_DEPRECATED
 	bool _can_translate : 1;
+#endif // DISABLE_DEPRECATED
 	bool _emitting : 1;
 	bool _predelete_ok : 1;
 
@@ -999,8 +1001,10 @@ public:
 
 	bool is_queued_for_deletion() const;
 
+#ifndef DISABLE_DEPRECATED
 	_FORCE_INLINE_ void set_message_translation(bool p_enable) { _can_translate = p_enable; }
 	_FORCE_INLINE_ bool can_translate_messages() const { return _can_translate; }
+#endif // DISABLE_DEPRECATED
 
 	virtual StringName get_translation_domain() const;
 	virtual void set_translation_domain(const StringName &p_domain);

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -207,8 +207,8 @@
 			<param index="1" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
 				Translates a [param message], using the translation catalogs configured in the Project Settings. Further [param context] can be specified to help with the translation. Note that most [Control] nodes automatically translate their strings, so this method is mostly useful for formatted strings or custom drawn text.
-				This method works the same as [method Object.tr], with the addition of respecting the [member auto_translate_mode] state.
-				If [method Object.can_translate_messages] is [code]false[/code], or no translation is available, this method returns the [param message] without changes. See [method Object.set_message_translation].
+				This method uses [method Object.tr] under the hood, with the addition of respecting the [member auto_translate_mode] state.
+				If no translation is available, this method returns the [param message] without changes.
 				For detailed examples, see [url=$DOCS_URL/tutorials/i18n/internationalizing_games.html]Internationalizing games[/url].
 			</description>
 		</method>
@@ -220,8 +220,8 @@
 			<param index="3" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
 				Translates a [param message] or [param plural_message], using the translation catalogs configured in the Project Settings. Further [param context] can be specified to help with the translation.
-				This method works the same as [method Object.tr_n], with the addition of respecting the [member auto_translate_mode] state.
-				If [method Object.can_translate_messages] is [code]false[/code], or no translation is available, this method returns [param message] or [param plural_message], without changes. See [method Object.set_message_translation].
+				This method uses [method Object.tr_n] under the hood, with the addition of respecting the [member auto_translate_mode] state.
+				If no translation is available, this method returns [param message] or [param plural_message], without changes.
 				The [param n] is the number, or amount, of the message's subject. It is used by the translation system to fetch the correct plural form for the current language.
 				For detailed examples, see [url=$DOCS_URL/tutorials/i18n/localization_using_gettext.html]Localization using gettext[/url].
 				[b]Note:[/b] Negative and [float] numbers may not properly apply to some countable subjects. It's recommended to handle these cases with [method atr].

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -503,7 +503,7 @@
 				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods. Prefer using the names exposed in the [code]MethodName[/code] class to avoid allocating a new [StringName] on each call.
 			</description>
 		</method>
-		<method name="can_translate_messages" qualifiers="const">
+		<method name="can_translate_messages" qualifiers="const" deprecated="See [method set_message_translation].">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the object is allowed to translate messages with [method tr] and [method tr_n]. See also [method set_message_translation].
@@ -941,11 +941,12 @@
 				[b]Note:[/b] In C#, [param property_path] must be in snake_case when referring to built-in Godot properties. Prefer using the names exposed in the [code]PropertyName[/code] class to avoid allocating a new [StringName] on each call.
 			</description>
 		</method>
-		<method name="set_message_translation">
+		<method name="set_message_translation" deprecated="">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
 				If set to [code]true[/code], allows the object to translate messages with [method tr] and [method tr_n]. Enabled by default. See also [method can_translate_messages].
+				[b]Note:[/b] This method is deprecated. For [Node]s, use [method Node.atr] and [member Node.auto_translate_mode] instead. For other objects, it's recommended to manually skip [method tr]. Alternatively, set the object's translation domain to a custom domain with [member TranslationDomain.enabled] set to [code]false[/code].
 			</description>
 		</method>
 		<method name="set_meta">
@@ -986,9 +987,9 @@
 			<param index="1" name="context" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Translates a [param message], using the translation catalogs configured in the Project Settings. Further [param context] can be specified to help with the translation. Note that most [Control] nodes automatically translate their strings, so this method is mostly useful for formatted strings or custom drawn text.
-				If [method can_translate_messages] is [code]false[/code], or no translation is available, this method returns the [param message] without changes. See [method set_message_translation].
+				If no translation is available, this method returns the [param message] without changes.
 				For detailed examples, see [url=$DOCS_URL/tutorials/i18n/internationalizing_games.html]Internationalizing games[/url].
-				[b]Note:[/b] This method can't be used without an [Object] instance, as it requires the [method can_translate_messages] method. To translate strings in a static context, use [method TranslationServer.translate].
+				[b]Note:[/b] This method can't be used without an [Object] instance. To translate strings in a static context, use [method TranslationServer.translate].
 			</description>
 		</method>
 		<method name="tr_n" qualifiers="const">
@@ -999,11 +1000,11 @@
 			<param index="3" name="context" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Translates a [param message] or [param plural_message], using the translation catalogs configured in the Project Settings. Further [param context] can be specified to help with the translation.
-				If [method can_translate_messages] is [code]false[/code], or no translation is available, this method returns [param message] or [param plural_message], without changes. See [method set_message_translation].
+				If no translation is available, this method returns [param message] or [param plural_message], without changes.
 				The [param n] is the number, or amount, of the message's subject. It is used by the translation system to fetch the correct plural form for the current language.
 				For detailed examples, see [url=$DOCS_URL/tutorials/i18n/localization_using_gettext.html]Localization using gettext[/url].
 				[b]Note:[/b] Negative and [float] numbers may not properly apply to some countable subjects. It's recommended to handle these cases with [method tr].
-				[b]Note:[/b] This method can't be used without an [Object] instance, as it requires the [method can_translate_messages] method. To translate strings in a static context, use [method TranslationServer.translate_plural].
+				[b]Note:[/b] This method can't be used without an [Object] instance. To translate strings in a static context, use [method TranslationServer.translate_plural].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TextMesh.xml
+++ b/doc/classes/TextMesh.xml
@@ -12,6 +12,9 @@
 		<link title="3D text">$DOCS_URL/tutorials/3d/3d_text.html</link>
 	</tutorials>
 	<members>
+		<member name="auto_translate" type="bool" setter="set_auto_translate" getter="is_auto_translating" default="true">
+			If [code]true[/code], the displayed text is auto translated according to the current locale.
+		</member>
 		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="0">
 			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text.
 		</member>
@@ -53,7 +56,7 @@
 		</member>
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
 			The text to generate mesh from.
-			[b]Note:[/b] Due to being a [Resource], it doesn't follow the rules of [member Node.auto_translate_mode]. If disabling translation is desired, it should be done manually with [method Object.set_message_translation].
+			[b]Note:[/b] Due to being a [Resource], it doesn't follow the rules of [member Node.auto_translate_mode]. See [member auto_translate].
 		</member>
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="TextServer.Direction" default="0">
 			Base text writing direction.

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -3659,6 +3659,9 @@ void TextMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_uppercase", "enable"), &TextMesh::set_uppercase);
 	ClassDB::bind_method(D_METHOD("is_uppercase"), &TextMesh::is_uppercase);
 
+	ClassDB::bind_method(D_METHOD("set_auto_translate", "enable"), &TextMesh::set_auto_translate);
+	ClassDB::bind_method(D_METHOD("is_auto_translating"), &TextMesh::is_auto_translating);
+
 	ADD_GROUP("Text", "");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT, ""), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "font", PROPERTY_HINT_RESOURCE_TYPE, "Font"), "set_font", "get_font");
@@ -3669,6 +3672,7 @@ void TextMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "line_spacing", PROPERTY_HINT_NONE, "suffix:px"), "set_line_spacing", "get_line_spacing");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "autowrap_mode", PROPERTY_HINT_ENUM, "Off,Arbitrary,Word,Word (Smart)"), "set_autowrap_mode", "get_autowrap_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "justification_flags", PROPERTY_HINT_FLAGS, "Kashida Justification:1,Word Justification:2,Justify Only After Last Tab:8,Skip Last Line:32,Skip Last Line With Visible Characters:64,Do Not Skip Single Line:128"), "set_justification_flags", "get_justification_flags");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate"), "set_auto_translate", "is_auto_translating");
 
 	ADD_GROUP("Mesh", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pixel_size", PROPERTY_HINT_RANGE, "0.0001,128,0.0001,suffix:m"), "set_pixel_size", "get_pixel_size");
@@ -3688,7 +3692,7 @@ void TextMesh::_notification(int p_what) {
 	switch (p_what) {
 		case MainLoop::NOTIFICATION_TRANSLATION_CHANGED: {
 			// Language update might change the appearance of some characters.
-			xl_text = tr(text);
+			xl_text = auto_translate ? tr(text) : text;
 			dirty_text = true;
 			request_update();
 		} break;
@@ -3739,7 +3743,7 @@ VerticalAlignment TextMesh::get_vertical_alignment() const {
 void TextMesh::set_text(const String &p_string) {
 	if (text != p_string) {
 		text = p_string;
-		xl_text = tr(text);
+		xl_text = auto_translate ? tr(text) : text;
 		dirty_text = true;
 		request_update();
 	}
@@ -3973,4 +3977,17 @@ void TextMesh::set_uppercase(bool p_uppercase) {
 
 bool TextMesh::is_uppercase() const {
 	return uppercase;
+}
+
+void TextMesh::set_auto_translate(bool p_enable) {
+	if (auto_translate != p_enable) {
+		auto_translate = p_enable;
+		xl_text = auto_translate ? tr(text) : text;
+		dirty_text = true;
+		request_update();
+	}
+}
+
+bool TextMesh::is_auto_translating() const {
+	return auto_translate;
 }

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -590,6 +590,7 @@ private:
 	HorizontalAlignment horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER;
 	VerticalAlignment vertical_alignment = VERTICAL_ALIGNMENT_CENTER;
 	bool uppercase = false;
+	bool auto_translate = true;
 	String language;
 	TextServer::Direction text_direction = TextServer::DIRECTION_AUTO;
 	TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
@@ -658,6 +659,9 @@ public:
 
 	void set_uppercase(bool p_uppercase);
 	bool is_uppercase() const;
+
+	void set_auto_translate(bool p_enable);
+	bool is_auto_translating() const;
 
 	void set_width(real_t p_width);
 	real_t get_width() const;


### PR DESCRIPTION
`set_message_translation(enabled)` can be used to disable the functionality of `tr()`. It occupies one bit in every `Object`, and was introduced at the very beginning of Godot. Currently, nearly all of its functions have been replaced by other mechanisms.

The editor used this feature to disable translations for the edited scenes. This has now been reimplemented through translation domains.

For nodes, auto translate mode and `atr()` is now the preferred way to disable translation.

Disabling `tr()` is much less common for non-node objects. The only use case in the Godot codebase is the `TextMesh` resource. This PR adds a property that skips calling `tr()` instead of relying on `set_message_translation()` to disable `tr()`. User code that needs to can also do this.