### PR TITLE
Game View Plugin: Fix signal connected too early causing theme warning

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -1244,9 +1244,12 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	selection_hb->add_child(hide_selection);
 	hide_selection->set_toggle_mode(true);
 	hide_selection->set_theme_type_variation(SceneStringName(FlatButton));
-	hide_selection->connect(SceneStringName(toggled), callable_mp(this, &GameView::_hide_selection_toggled));
 	hide_selection->set_tooltip_text(TTRC("Toggle Selection Visibility"));
 	hide_selection->set_pressed(EditorSettings::get_singleton()->get_project_metadata("game_view", "hide_selection", false));
+	if (hide_selection->is_pressed()) {
+		debugger->set_selection_visible(false);
+	}
+	hide_selection->connect(SceneStringName(toggled), callable_mp(this, &GameView::_hide_selection_toggled));
 
 	selection_hb->add_child(memnew(VSeparator));
 


### PR DESCRIPTION
- *Fixed: https://github.com/godotengine/godot/issues/111751*

**Issue Description**

When we set `Toggle Selection Visibility` in `GameView`, there will save a project setting, named `hide_selection=true` in `user://.godot/editor/project/project_metadata.cfg`.

When we restart editor, it will load `hide_selection` from project config, using this config to update button.

https://github.com/godotengine/godot/blob/60710df3b6fffb5a9a9479f80a0e9d8f05069946/editor/run/game_view_plugin.cpp#L1208-L1210

As we can see, the button already bind an event listener `_hide_selection_toggled`, to response when button toggled. So the init operation will trigger `_hide_selection_toggled` in `L1210`.

Actually, we didn't want to trigger event at initiating time, the event will be triggered later on `NOTIFICATION_THEME_CHANGED`, so moved `connect` behind `set_press` can solve this issue.



