### PR TITLE
Implement a reflection probe preview gizmo

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1362,6 +1362,10 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 					RID atlas = light_storage->reflection_probe_instance_get_atlas(probe_instance);
 					RID probe = light_storage->reflection_probe_instance_get_probe(probe_instance);
 					uint32_t reflection_mask = light_storage->reflection_probe_get_reflection_mask(probe);
+					if (Engine::get_singleton()->is_editor_hint()) {
+						// Add bit 26 to allow rendering preview gizmos.
+						reflection_mask |= (1 << 26);
+					}
 					if (atlas.is_valid() && (inst->layer_mask & reflection_mask)) {
 						Transform3D local_matrix = p_render_data->inv_cam_transform * light_storage->reflection_probe_instance_get_transform(probe_instance);
 						inst->reflection_probes_local_transform_cache.push_back(local_matrix.affine_inverse());

--- a/editor/scene/3d/gizmos/reflection_probe_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/reflection_probe_gizmo_plugin.cpp
@@ -37,6 +37,7 @@
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/3d/reflection_probe.h"
+#include "scene/resources/3d/primitive_meshes.h"
 
 ReflectionProbeGizmoPlugin::ReflectionProbeGizmoPlugin() {
 	helper.instantiate();
@@ -46,6 +47,15 @@ ReflectionProbeGizmoPlugin::ReflectionProbeGizmoPlugin() {
 
 	gizmo_color.a = 0.5;
 	create_material("reflection_internal_material", gizmo_color);
+
+	preview_sphere.instantiate();
+	preview_sphere->set_radius(0.5f);
+
+	Ref<StandardMaterial3D> mat = memnew(StandardMaterial3D);
+	mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	mat->set_roughness(0.0f);
+	mat->set_metallic(1.0f);
+	add_material("reflection_probe_sphere_material", mat);
 
 	create_icon_material("reflection_probe_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoReflectionProbe"), EditorStringName(EditorIcons)));
 	create_handle_material("handles");
@@ -205,6 +215,11 @@ void ReflectionProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(internal_lines, material_internal);
 
 		p_gizmo->add_handles(handles, get_material("handles"));
+
+		Transform3D preview_transform;
+		preview_transform.set_origin(probe->get_origin_offset());
+
+		p_gizmo->add_mesh(preview_sphere, get_material("reflection_probe_sphere_material", p_gizmo), preview_transform);
 	}
 
 	Ref<Material> icon = get_material("reflection_probe_icon", p_gizmo);

--- a/editor/scene/3d/gizmos/reflection_probe_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/reflection_probe_gizmo_plugin.h
@@ -33,11 +33,13 @@
 #include "editor/scene/3d/node_3d_editor_gizmos.h"
 
 class Gizmo3DHelper;
+class SphereMesh;
 
 class ReflectionProbeGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(ReflectionProbeGizmoPlugin, EditorNode3DGizmoPlugin);
 
 	Ref<Gizmo3DHelper> helper;
+	Ref<SphereMesh> preview_sphere;
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1767,7 +1767,13 @@ void LightStorage::update_reflection_probe_buffer(RenderDataRD *p_render_data, c
 
 		Vector3 extents = probe->size / 2;
 
-		rpi->cull_mask = probe->reflection_mask;
+		uint32_t reflection_mask = probe->reflection_mask;
+		if (Engine::get_singleton()->is_editor_hint()) {
+			// Add bit 26 to allow rendering preview gizmos.
+			reflection_mask |= (1 << 26);
+		}
+
+		rpi->cull_mask = reflection_mask;
 
 		reflection_ubo.box_extents[0] = extents.x;
 		reflection_ubo.box_extents[1] = extents.y;
@@ -1779,7 +1785,7 @@ void LightStorage::update_reflection_probe_buffer(RenderDataRD *p_render_data, c
 		reflection_ubo.box_offset[0] = origin_offset.x;
 		reflection_ubo.box_offset[1] = origin_offset.y;
 		reflection_ubo.box_offset[2] = origin_offset.z;
-		reflection_ubo.mask = probe->reflection_mask;
+		reflection_ubo.mask = reflection_mask;
 
 		reflection_ubo.intensity = probe->intensity;
 		reflection_ubo.blend_distance = probe->blend_distance;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13262

Implements passivestar's proposed reflection probe previewer. The reflection probes will create a fully smooth and metallic preview sphere mesh when selected:

![preview](https://github.com/user-attachments/assets/c3d1becf-64fd-45ca-94f2-066f1d948073)

This required modifying the rendering system's reflection probe mask to also apply the reflections to editor gizmos.