### PR TITLE
Fix false positive warning with `FixedVector` array bounds in gcc.

### DIFF
--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -32,6 +32,8 @@
 
 #include "core/templates/span.h"
 
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Warray-bounds")
+
 /**
  * A high performance Vector of fixed capacity.
  * Especially useful if you need to create an array on the stack, to
@@ -201,3 +203,5 @@ public:
 	_FORCE_INLINE_ constexpr const T *begin() const { return ptr(); }
 	_FORCE_INLINE_ constexpr const T *end() const { return ptr() + _size; }
 };
+
+GODOT_GCC_WARNING_POP

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -151,6 +151,7 @@ Error MultiplayerPeerExtension::get_packet(const uint8_t **r_buffer, int &r_buff
 }
 
 Error MultiplayerPeerExtension::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
+	ERR_FAIL_COND_V(p_buffer_size < 0, ERR_INVALID_PARAMETER);
 	Error err;
 	if (GDVIRTUAL_CALL(_put_packet, p_buffer, p_buffer_size, err)) {
 		return err;


### PR DESCRIPTION
I've seen this error pop up two times lately: https://github.com/godotengine/godot/actions/runs/18588726196/job/52998616474?pr=111753

I'm 99% sure it's a false positive warning. `resize_initialized` _does_ start at index 3, but will stop before starting because `_size == 0` (and at maximum, 3) here.

The `multiplayer_peer.cpp` fix is unrelated, but was necessary because after the `resize_initialized` change, CI [started complaining](https://github.com/godotengine/godot/actions/runs/18590037107/job/53002910947?pr=111761) there. And right fully too, the function should be guarded.