### PR TITLE
D3D12: Greatly reduce shader conversion time & fix spec constant bitmasking.

### DIFF
--- a/drivers/d3d12/rendering_shader_container_d3d12.cpp
+++ b/drivers/d3d12/rendering_shader_container_d3d12.cpp
@@ -313,10 +313,6 @@ bool RenderingShaderContainerD3D12::_convert_spirv_to_nir(Span<ReflectShaderStag
 
 		ERR_FAIL_NULL_V_MSG(shader, false, "Shader translation (step 1) at stage " + String(RenderingDeviceCommons::SHADER_STAGE_NAMES[stage]) + " failed.");
 
-#ifdef DEV_ENABLED
-		nir_validate_shader(shader, "Validate before feeding NIR to the DXIL compiler");
-#endif
-
 		if (stage == RenderingDeviceCommons::SHADER_STAGE_VERTEX) {
 			dxil_runtime_conf.yz_flip.y_mask = 0xffff;
 			dxil_runtime_conf.yz_flip.mode = DXIL_SPIRV_Y_FLIP_UNCONDITIONAL;

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -32,7 +32,7 @@ else:
 
 # Mesa NIR
 # Check for latest version: https://github.com/godotengine/godot-nir-static/releases/latest
-mesa_version = "23.1.9-1"
+mesa_version = "23.1.9-2"
 # WinPixEventRuntime
 # Check for latest version: https://www.nuget.org/api/v2/package/WinPixEventRuntime (check downloaded filename)
 pix_version = "1.0.240308001"


### PR DESCRIPTION
Follow-up PR to https://github.com/godotengine/godot/pull/111356.

## Shader Conversion Time Reduction

Partner PR: https://github.com/godotengine/godot-nir-static/pull/23

Reduces shader conversion time up to 2x - 2.5x depending on the project. In TPS Demo, the loading screen goes from 82 seconds to 33 seconds on my system. For reference, Vulkan is 15 seconds.

NOTE: If you want to make a comparison yourself, you need to clear both Godot and driver shader caches before each launch to have a fair comparison:
- Editor shader cache: `project/.godot/shader_cache`
- Game shader cache: `%APPDATA%/Godot/app_userdata/project/shader_cache`
- NVIDIA shader cache: `%LOCALAPPDATA%/NVIDIA`
- AMD shader cache: `%LOCALAPPDATA%/AMD`

## Specialization Constants Bitmasking Fix

Partner PR: https://github.com/godotengine/godot-nir-static/pull/22

Old behavior used to set the second MSB to 1, then mask that out inside the DXIL shader. We shouldn't do that anymore now that we allow all of the specialization constant bits. 

This was causing less shadow map samples to be used, notably with the "Soft High (Slow)" mode for "Soft Shadow Filter Quality" parameter:

|Upstream|This PR|
|-|-|
|<img width="1356" height="836" alt="Upstream" src="https://github.com/user-attachments/assets/331390e5-e5d3-4abe-b6d4-f068c734f6a8" />|<img width="1356" height="836" alt="PR" src="https://github.com/user-attachments/assets/e2388417-406d-4876-8fe0-50aba3c31dcf" />|