### PR TITLE
Improve performance of SpinBox creation

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -123,6 +123,7 @@ GotoLinePopup::GotoLinePopup() {
 	vbc->add_child(l);
 
 	line_input = memnew(LineEdit);
+	line_input->set_emoji_menu_enabled(false);
 	line_input->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 	line_input->set_select_all_on_focus(true);
 	line_input->connect(SceneStringName(text_changed), callable_mp(this, &GotoLinePopup::_goto_line).unbind(1));

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2738,7 +2738,6 @@ void LineEdit::show_emoji_and_symbol_picker() {
 void LineEdit::set_emoji_menu_enabled(bool p_enabled) {
 	if (emoji_menu_enabled != p_enabled) {
 		emoji_menu_enabled = p_enabled;
-		_update_context_menu();
 	}
 }
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3881,7 +3881,6 @@ void TextEdit::show_emoji_and_symbol_picker() {
 void TextEdit::set_emoji_menu_enabled(bool p_enabled) {
 	if (emoji_menu_enabled != p_enabled) {
 		emoji_menu_enabled = p_enabled;
-		_update_context_menu();
 	}
 }
 


### PR DESCRIPTION
This affects all LineEdits (and TextEdits) where `set_emoji_menu_enabled()` is called, notably SpinBoxes and things that use SpinBoxes like ColorPicker and across the Editor.
The `set_emoji_menu_enabled()` method generated the context menu when it doesn't need to. `_update_context_menu()` is already called before the menu is opened.

The menu is still generated when the menu is opened. I have not noticed any performance issues when opening the menu. (It is the same case as when `set_emoji_menu_enabled()` is not called).

I could have checked if the menu exists instead of removing the update, but I doubt this setting ever needs to be called while the menu is already visible, and other settings that affect the menu like `editable` don't update it immediately either.

Also disabled the emoji menu from the ScriptEditor's GotoLinePopup LineEdit (it's for numbers and `:` only).

Tested by making 5000 Spinboxes (in a debug build):
```gdscript
func _test():
	print("starting test...")
	var startms := Time.get_ticks_msec()
	for i in 5000:
		var sb := SpinBox.new()
		add_child(sb)
	var endms := Time.get_ticks_msec()
	print("finished in %sms" % (endms - startms))
```

before - finished in 32787ms / 29885ms / 29500ms
after - finished in 3962ms / 4035ms / 4085ms
Which is ~7.6x faster.