### PR TITLE
SCons: Remove transitive includes in `libc++`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -267,6 +267,11 @@ opts.Add(
 )
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
 opts.Add(BoolVariable("strict_checks", "Enforce stricter checks (debug option)", False))
+opts.Add(
+    BoolVariable(
+        "limit_transitive_includes", "Attempt to limit the amount of transitive includes in system headers", True
+    )
+)
 opts.Add(BoolVariable("scu_build", "Use single compilation unit build", False))
 opts.Add("scu_limit", "Max includes per SCU file when using scu_build (determines RAM use)", "0")
 opts.Add(BoolVariable("engine_update_check", "Enable engine update checks in the Project Manager", True))
@@ -777,6 +782,13 @@ elif methods.using_clang(env) or methods.using_emcc(env):
     env.AppendUnique(CCFLAGS=["-fcolor-diagnostics" if is_stderr_color() else "-fno-color-diagnostics"])
     if sys.platform == "win32":
         env.AppendUnique(CCFLAGS=["-fansi-escape-codes"])
+
+# Attempt to reduce transitive includes.
+if env["limit_transitive_includes"]:
+    if not env.msvc:
+        # FIXME: This define only affects `libcpp`, but lack of guaranteed, granular detection means
+        #  we're better off applying it universally.
+        env.AppendUnique(CPPDEFINES=["_LIBCPP_REMOVE_TRANSITIVE_INCLUDES"])
 
 # Set optimize and debug_symbols flags.
 # "custom" means do nothing and let users set their own optimization flags.

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -51,6 +51,7 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <type_traits>
 #include <utility>
 
 // IWYU pragma: end_exports

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -65,6 +65,7 @@
 #import <simd/simd.h>
 #import <zlib.h>
 #import <initializer_list>
+#import <memory>
 #import <optional>
 
 enum StageResourceUsage : uint32_t {

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -90,6 +90,7 @@ Patches:
 - `0003-remove-tinydds-qoi.patch` (GH-97582)
 - `0004-clang-warning-exclude.patch` (GH-111346)
 - `0005-unused-typedef.patch` (GH-111445)
+- `0006-explicit-includes.patch` (GH-111557)
 
 
 ## brotli
@@ -220,6 +221,7 @@ Patches:
 - `0003-emscripten-nthreads.patch` (GH-69799)
 - `0004-mingw-no-cpuidex.patch` (GH-92488)
 - `0005-mingw-llvm-arm64.patch` (GH-93364)
+- `0006-explicit-includes.patch` (GH-111557)
 
 The `modules/raycast/godot_update_embree.py` script can be used to pull the
 relevant files from the latest Embree release and apply patches automatically.
@@ -707,6 +709,7 @@ Patches:
 
 - `0001-disable-exceptions.patch` (GH-85039)
 - `0002-clang-std-replacements-leak.patch` (GH-85208)
+- `0003-explicit-includes.patch` (GH-111557)
 
 
 ## minimp3
@@ -1046,6 +1049,7 @@ Patches:
 
 - `0001-revert-tvglines-bezier-precision.patch` (GH-96658)
 - `0002-use-heap-alloc.patch` (GH-109530)
+- `0003-explicit-includes.patch` (GH-111557)
 
 
 ## tinyexr

--- a/thirdparty/basis_universal/patches/0006-explicit-includes.patch
+++ b/thirdparty/basis_universal/patches/0006-explicit-includes.patch
@@ -1,12 +1,13 @@
 diff --git a/thirdparty/basis_universal/transcoder/basisu_containers_impl.h b/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
-index d4d3eb23bc..3d7aaddcad 100644
+index 3d7aaddcad..db3a567450 100644
 --- a/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
 +++ b/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
-@@ -1,6 +1,8 @@
+@@ -1,6 +1,9 @@
  // basisu_containers_impl.h
  // Do not include directly
  
 +#include <ctype.h>
++#include <exception>
 +
  #ifdef _MSC_VER
  #pragma warning (disable:4127) // warning C4127: conditional expression is constant

--- a/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
+++ b/thirdparty/basis_universal/transcoder/basisu_containers_impl.h
@@ -2,6 +2,7 @@
 // Do not include directly
 
 #include <ctype.h>
+#include <exception>
 
 #ifdef _MSC_VER
 #pragma warning (disable:4127) // warning C4127: conditional expression is constant

--- a/thirdparty/embree/common/sys/vector.h
+++ b/thirdparty/embree/common/sys/vector.h
@@ -5,6 +5,7 @@
 
 #include "alloc.h"
 #include <algorithm>
+#include <type_traits>
 
 namespace embree
 {

--- a/thirdparty/embree/common/tasking/taskschedulerinternal.h
+++ b/thirdparty/embree/common/tasking/taskschedulerinternal.h
@@ -14,6 +14,7 @@
 #include "../sys/atomic.h"
 #include "../math/range.h"
 
+#include <exception>
 #include <list>
 
 namespace embree

--- a/thirdparty/embree/patches/0006-explicit-includes.patch
+++ b/thirdparty/embree/patches/0006-explicit-includes.patch
@@ -1,0 +1,24 @@
+diff --git a/thirdparty/embree/common/sys/vector.h b/thirdparty/embree/common/sys/vector.h
+index 2d30d6725b..a8138de832 100644
+--- a/thirdparty/embree/common/sys/vector.h
++++ b/thirdparty/embree/common/sys/vector.h
+@@ -5,6 +5,7 @@
+ 
+ #include "alloc.h"
+ #include <algorithm>
++#include <type_traits>
+ 
+ namespace embree
+ {
+diff --git a/thirdparty/embree/common/tasking/taskschedulerinternal.h b/thirdparty/embree/common/tasking/taskschedulerinternal.h
+index d4e0c7386b..99e47608d6 100644
+--- a/thirdparty/embree/common/tasking/taskschedulerinternal.h
++++ b/thirdparty/embree/common/tasking/taskschedulerinternal.h
+@@ -14,6 +14,7 @@
+ #include "../sys/atomic.h"
+ #include "../math/range.h"
+ 
++#include <exception>
+ #include <list>
+ 
+ namespace embree

--- a/thirdparty/jolt_physics/Jolt/Core/Core.h
+++ b/thirdparty/jolt_physics/Jolt/Core/Core.h
@@ -453,6 +453,7 @@ JPH_SUPPRESS_WARNINGS_STD_BEGIN
 #include <functional>
 #include <algorithm>
 #include <cstdint>
+#include <type_traits>
 #if defined(JPH_COMPILER_MSVC) || (defined(JPH_COMPILER_CLANG) && defined(_MSC_VER)) // MSVC or clang-cl
 	#include <malloc.h> // for alloca
 #endif

--- a/thirdparty/mingw-std-threads/mingw.condition_variable.h
+++ b/thirdparty/mingw-std-threads/mingw.condition_variable.h
@@ -29,6 +29,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <exception>
 #include <system_error>
 
 #include <sdkddkver.h>  //  Detect Windows version.

--- a/thirdparty/mingw-std-threads/mingw.mutex.h
+++ b/thirdparty/mingw-std-threads/mingw.mutex.h
@@ -37,6 +37,7 @@
 #include <chrono>
 #include <system_error>
 #include <atomic>
+#include <exception>
 #include <mutex> //need for call_once()
 
 #if STDMUTEX_RECURSION_CHECKS || !defined(NDEBUG)

--- a/thirdparty/mingw-std-threads/patches/0003-explicit-includes.patch
+++ b/thirdparty/mingw-std-threads/patches/0003-explicit-includes.patch
@@ -1,0 +1,24 @@
+diff --git a/thirdparty/mingw-std-threads/mingw.condition_variable.h b/thirdparty/mingw-std-threads/mingw.condition_variable.h
+index d099fad2ec..d2982fb087 100644
+--- a/thirdparty/mingw-std-threads/mingw.condition_variable.h
++++ b/thirdparty/mingw-std-threads/mingw.condition_variable.h
+@@ -29,6 +29,7 @@
+ 
+ #include <cassert>
+ #include <chrono>
++#include <exception>
+ #include <system_error>
+ 
+ #include <sdkddkver.h>  //  Detect Windows version.
+diff --git a/thirdparty/mingw-std-threads/mingw.mutex.h b/thirdparty/mingw-std-threads/mingw.mutex.h
+index 1e881e6c7d..d9802ea2ae 100644
+--- a/thirdparty/mingw-std-threads/mingw.mutex.h
++++ b/thirdparty/mingw-std-threads/mingw.mutex.h
+@@ -37,6 +37,7 @@
+ #include <chrono>
+ #include <system_error>
+ #include <atomic>
++#include <exception>
+ #include <mutex> //need for call_once()
+ 
+ #if STDMUTEX_RECURSION_CHECKS || !defined(NDEBUG)

--- a/thirdparty/thorvg/patches/0003-explicit-includes.patch
+++ b/thirdparty/thorvg/patches/0003-explicit-includes.patch
@@ -1,0 +1,36 @@
+diff --git a/thirdparty/thorvg/src/common/tvgCompressor.cpp b/thirdparty/thorvg/src/common/tvgCompressor.cpp
+index 714f21e07c..d97ae85705 100644
+--- a/thirdparty/thorvg/src/common/tvgCompressor.cpp
++++ b/thirdparty/thorvg/src/common/tvgCompressor.cpp
+@@ -57,6 +57,7 @@
+ 
+ 
+ 
++#include <cstdlib>
+ #include <string>
+ #include <memory.h>
+ #include "tvgCompressor.h"
+diff --git a/thirdparty/thorvg/src/common/tvgStr.cpp b/thirdparty/thorvg/src/common/tvgStr.cpp
+index 957fe18d53..fe2e13bc71 100644
+--- a/thirdparty/thorvg/src/common/tvgStr.cpp
++++ b/thirdparty/thorvg/src/common/tvgStr.cpp
+@@ -22,6 +22,7 @@
+ 
+ #include "config.h"
+ #include <cmath>
++#include <cstdlib>
+ #include <cstring>
+ #include <memory.h>
+ #include "tvgMath.h"
+diff --git a/thirdparty/thorvg/src/loaders/svg/tvgSvgUtil.cpp b/thirdparty/thorvg/src/loaders/svg/tvgSvgUtil.cpp
+index 542cd17e56..45fdc9cf0d 100644
+--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgUtil.cpp
++++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgUtil.cpp
+@@ -20,6 +20,7 @@
+  * SOFTWARE.
+  */
+ 
++#include <cstdlib>
+ #include <cstring>
+ #include "tvgSvgUtil.h"
+ 

--- a/thirdparty/thorvg/src/common/tvgCompressor.cpp
+++ b/thirdparty/thorvg/src/common/tvgCompressor.cpp
@@ -57,6 +57,7 @@
 
 
 
+#include <cstdlib>
 #include <string>
 #include <memory.h>
 #include "tvgCompressor.h"

--- a/thirdparty/thorvg/src/common/tvgStr.cpp
+++ b/thirdparty/thorvg/src/common/tvgStr.cpp
@@ -22,6 +22,7 @@
 
 #include "config.h"
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <memory.h>
 #include "tvgMath.h"

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgUtil.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgUtil.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include <cstdlib>
 #include <cstring>
 #include "tvgSvgUtil.h"
 


### PR DESCRIPTION
- Helps address #111218
- Supersedes #111557 

I *really* like the idea of the above PR, but the implementation via `typedefs.h` would be inconsistent. It relies on all stdlib headers being defined *after* this header, which is unlikely when it's usually sorted so late in header chains & isn't a universal include for our repo. In order to guarantee this is applied for ALL scripts equally, the define is setup via SCons instead.

While this does the trick of catching overlooked cases early, that's proving to be a bit of a double-edged sword. Most notably: some thirdparty headers are caught in the crossfire, which I'll be gradually cleaning up over the next few days. This implementation currently excludes thirdparty compilation files, but could be expanded to include them as well, given we're already having to touch thirdparty code to *some* extent.