### PR TITLE
Fix buffer over-read in `FileAccessMemory::get_buffer`

### DIFF
--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -98,12 +98,14 @@ bool FileAccessMemory::is_open() const {
 
 void FileAccessMemory::seek(uint64_t p_position) {
 	ERR_FAIL_NULL(data);
+	ERR_FAIL_COND(p_position > length);
 	pos = p_position;
 }
 
 void FileAccessMemory::seek_end(int64_t p_position) {
 	ERR_FAIL_NULL(data);
-	pos = length + p_position;
+	ERR_FAIL_COND((int64_t)length + p_position < 0);
+	seek(length + p_position);
 }
 
 uint64_t FileAccessMemory::get_position() const {


### PR DESCRIPTION
The bounds check for FileAccessMemory::get_buffer is `length - pos`, but it is saved to a unsigned integer. This means that if `pos` is greater than `length` (which the user can very easily do by `seek`ing past the end), `left` will underflow and the bounds check will fail, causing a buffer over-read.

Casting the result to an int64_t and clamping it at >= 0 fixes the issue.