### PR TITLE
Editor: Add OpenType feature settings to Main Font

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -924,6 +924,10 @@
 			The font to use for bold text in the editor interface. Must be a resource of a [Font] type such as a [code].ttf[/code] or [code].otf[/code] font file.
 			[b]Note:[/b] If the provided font is variable, a weight of 700 (bold) will be used.
 		</member>
+		<member name="interface/editor/main_font_custom_opentype_features" type="String" setter="" getter="">
+			List of custom OpenType features to use, if supported by the currently configured main font. Check what OpenType features are supported by your font first.
+			The string should follow the OpenType specification, e.g. [code]ss01,tnum,calt=false[/code]. Microsoft's documentation contains a list of [url=https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist]all registered features[/url].
+		</member>
 		<member name="interface/editor/main_font_size" type="int" setter="" getter="">
 			The size of the font in the editor interface.
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -488,6 +488,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/main_font_size", 14, "8,48,1")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/code_font_size", 14, "8,48,1")
+	_initial_set("interface/editor/main_font_custom_opentype_features", "");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/code_font_contextual_ligatures", 1, "Enabled,Disable Contextual Alternates (Coding Ligatures),Use Custom OpenType Feature Set")
 	_initial_set("interface/editor/code_font_custom_opentype_features", "");
 	_initial_set("interface/editor/code_font_custom_variations", "");

--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -327,6 +327,25 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	bold_fc_msdf->set_spacing(TextServer::SPACING_BOTTOM, -EDSCALE);
 	bold_fc_msdf->set_variation_opentype(bold_fc_opentype);
 
+	if (!String(EDITOR_GET("interface/editor/main_font_custom_opentype_features")).is_empty()) {
+		Vector<String> subtag = String(EDITOR_GET("interface/editor/main_font_custom_opentype_features")).split(",");
+		if (!subtag.is_empty()) {
+			Dictionary ftrs;
+			for (int i = 0; i < subtag.size(); i++) {
+				Vector<String> subtag_a = subtag[i].split("=");
+				if (subtag_a.size() == 2) {
+					ftrs[TS->name_to_tag(subtag_a[0])] = subtag_a[1].to_int();
+				} else if (subtag_a.size() == 1) {
+					ftrs[TS->name_to_tag(subtag_a[0])] = 1;
+				}
+			}
+			default_fc->set_opentype_features(ftrs);
+			default_fc_msdf->set_opentype_features(ftrs);
+			bold_fc->set_opentype_features(ftrs);
+			bold_fc_msdf->set_opentype_features(ftrs);
+		}
+	}
+
 	Ref<FontVariation> mono_fc;
 	mono_fc.instantiate();
 	if (custom_font_path_source.length() > 0 && dir->file_exists(custom_font_path_source)) {


### PR DESCRIPTION
Code font has two settings: one where you can choose between nothing, contextual alternates and custom OpenType settings. I basically copypasted the latter for the Main Font.

Testing with the Inter font:

- No settings:
<img width="670" height="87" alt="image" src="https://github.com/user-attachments/assets/dcecbd96-668d-4cd4-8f78-b8370b46b82b" />

- With features:
<img width="659" height="85" alt="image" src="https://github.com/user-attachments/assets/5a14275b-e09a-4ad5-91a7-f66d0dd13d03" />

- Description:
<img width="638" height="113" alt="image" src="https://github.com/user-attachments/assets/9b3317e8-d327-43cd-ada2-1e0b000ca0b5" />


The setting has a description telling the user to check what OpenType features are supported by the font they are using, with an example at the end.

By the way, Code Font Custom Variations seems to be unused. Was it removed by mistake somehow?