### PR TITLE
Fix not replacing .scn file with final result when renaming dependencies 

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1502,9 +1502,8 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	}
 
 	fw.unref();
-
-	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	if (da->exists(p_path + ".depren")) {
+	if (FileAccess::exists(p_path + ".depren")) {
+		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		da->remove(p_path);
 		da->rename(p_path + ".depren", p_path);
 	}


### PR DESCRIPTION
Currently in Godot there is a bug that causes "Edit Dependencies" dialog not working for .scn files. This has been introduced in 4.3-dev.1.

If a user need to use the "Fix Dependencies" dialog, changing dependencies in that dialog will work fine when working on a .tscn file. When working on .scn, after choosing a resource with which we want to replace the original, non-existing resource, nothing happens.

It seems that when trying to change a dependency, Godot creates "*.scn.depren" file, which should be renamed to *.scn at the end of the process. With 4.3-dev.1, someone added if block present below:
```diff
@@ -1454,8 +1454,10 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
        fw.unref();

        Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-       da->remove(p_path);
-       da->rename(p_path + ".depren", p_path);
+       if (da->exists(p_path + ".depren")) {
+               da->remove(p_path);
+               da->rename(p_path + ".depren", p_path);
+       }
        return OK;
 }
```
To my understanding, this if block will always fail, as .scn.depren is not a directory and thus the process of renaming dependencies never finish properly.

I fixed this bug by using static FileAccess::exists and after building the editor, I can confirm that now renaming dependencies on .scn works as expected.
