### PR TITLE
Add C# Bindings for GDExtension types and correct numeric literals.

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3277,6 +3277,7 @@ void EditorHelp::generate_doc(bool p_use_cache, bool p_use_script_cache) {
 	} else {
 		print_verbose("Regenerating editor help cache");
 		doc->generate();
+		_gen_extensions_docs();
 		worker_thread.start(_gen_doc_thread, (void *)p_use_script_cache);
 	}
 }

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1392,43 +1392,45 @@ void BindingsGenerator::_append_xml_undeclared(StringBuilder &p_xml_output, cons
 }
 
 bool BindingsGenerator::_validate_api_type(const TypeInterface *p_target_itype, const TypeInterface *p_source_itype) {
-	static constexpr const char *api_types[5] = {
-		"Core",
-		"Editor",
-		"Extension",
-		"Editor Extension",
-		"None",
-	};
-
 	const ClassDB::APIType target_api = p_target_itype ? p_target_itype->api_type : ClassDB::API_NONE;
 	ERR_FAIL_INDEX_V((int)target_api, 5, false);
 	const ClassDB::APIType source_api = p_source_itype ? p_source_itype->api_type : ClassDB::API_NONE;
 	ERR_FAIL_INDEX_V((int)source_api, 5, false);
 	bool validate = false;
 
-	switch (target_api) {
-		case ClassDB::API_NONE:
-		case ClassDB::API_CORE:
-		default:
-			validate = true;
-			break;
-		case ClassDB::API_EDITOR:
-			validate = source_api == ClassDB::API_EDITOR || source_api == ClassDB::API_EDITOR_EXTENSION;
-			break;
-		case ClassDB::API_EXTENSION:
-			validate = source_api == ClassDB::API_EXTENSION || source_api == ClassDB::API_EDITOR_EXTENSION;
-			break;
-		case ClassDB::API_EDITOR_EXTENSION:
-			validate = source_api == ClassDB::API_EDITOR_EXTENSION;
-			break;
-	}
-	if (!validate) {
+	if (!_api_type_can_reference_other(source_api, target_api)) {
 		const String target_name = p_target_itype ? p_target_itype->proxy_name : "@GlobalScope";
 		const String source_name = p_source_itype ? p_source_itype->proxy_name : "@GlobalScope";
 		WARN_PRINT(vformat("Type '%s' has API level '%s'; it cannot be referenced by type '%s' with API level '%s'.",
-				target_name, api_types[target_api], source_name, api_types[source_api]));
+				target_name, api_type_names[target_api], source_name, api_type_names[source_api]));
 	}
 	return validate;
+}
+
+bool BindingsGenerator::_api_type_can_reference_other(const ClassDB::APIType p_source_api_type, const ClassDB::APIType p_target_api_type) {
+	switch (p_target_api_type) {
+		// Builtins/global ok for all
+		case ClassDB::API_NONE:
+			return true;
+
+		// CORE is visible to all
+		case ClassDB::API_CORE:
+			return true;
+
+		// EDITOR types are visible to both editor and editor extensions.
+		case ClassDB::API_EDITOR:
+			return p_source_api_type == ClassDB::API_EDITOR || p_source_api_type == ClassDB::API_EDITOR_EXTENSION;
+
+		// EXTENSION types are visible to both extensions and editor extensions.
+		case ClassDB::API_EXTENSION:
+			return p_source_api_type == ClassDB::API_EXTENSION || p_source_api_type == ClassDB::API_EDITOR_EXTENSION;
+
+		// EDITOR_EXTENSION types are only visible to editor extension types.
+		case ClassDB::API_EDITOR_EXTENSION:
+			return p_source_api_type == ClassDB::API_EDITOR_EXTENSION;
+	}
+
+	ERR_FAIL_V_MSG(false, "Argument out of range: " + itos(p_target_api_type));
 }
 
 int BindingsGenerator::_determine_enum_prefix(const EnumInterface &p_ienum) {
@@ -1775,7 +1777,8 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 	for (const KeyValue<StringName, TypeInterface> &E : obj_types) {
 		const TypeInterface &itype = E.value;
 
-		if (itype.api_type == ClassDB::API_EDITOR) {
+		const bool is_editor_type = itype.api_type == ClassDB::API_EDITOR || itype.api_type == ClassDB::API_EDITOR_EXTENSION;
+		if (is_editor_type) {
 			continue;
 		}
 
@@ -1820,7 +1823,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		for (const KeyValue<StringName, TypeInterface> &E : obj_types) {
 			const TypeInterface &itype = E.value;
 
-			if (itype.api_type != ClassDB::API_CORE || itype.is_singleton_instance) {
+			if ((itype.api_type != ClassDB::API_CORE && itype.api_type != ClassDB::API_EXTENSION) || itype.is_singleton_instance) {
 				continue;
 			}
 
@@ -1945,7 +1948,8 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 	for (const KeyValue<StringName, TypeInterface> &E : obj_types) {
 		const TypeInterface &itype = E.value;
 
-		if (itype.api_type != ClassDB::API_EDITOR) {
+		const bool is_editor_type = itype.api_type == ClassDB::API_EDITOR || itype.api_type == ClassDB::API_EDITOR_EXTENSION;
+		if (!is_editor_type) {
 			continue;
 		}
 
@@ -1978,7 +1982,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 		for (const KeyValue<StringName, TypeInterface> &E : obj_types) {
 			const TypeInterface &itype = E.value;
 
-			if (itype.api_type != ClassDB::API_EDITOR || itype.is_singleton_instance) {
+			if ((itype.api_type != ClassDB::API_EDITOR && itype.api_type != ClassDB::API_EDITOR_EXTENSION) || itype.is_singleton_instance) {
 				continue;
 			}
 
@@ -2350,7 +2354,9 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 		// Static fields are initialized in order of declaration, but when they're in different
 		// partial class declarations then it becomes harder to tell (Rider warns about this).
 
-		if (itype.is_instantiable) {
+		// Extension types dont use NativeCtor, they are instantiated via ClassDB instead.
+		const bool is_extension_class = itype.api_type == ClassDB::API_EXTENSION || itype.api_type == ClassDB::API_EDITOR_EXTENSION;
+		if (itype.is_instantiable && !is_extension_class) {
 			// Add native constructor static field
 
 			output << MEMBER_BEGIN << "[DebuggerBrowsable(DebuggerBrowsableState.Never)]\n"
@@ -2365,9 +2371,10 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 				output << MEMBER_BEGIN "public " << itype.proxy_name << "() : this("
 					   << (itype.memory_own ? "true" : "false") << ")\n" OPEN_BLOCK_L1
 					   << INDENT2 "unsafe\n" INDENT2 OPEN_BLOCK
-					   << INDENT3 "ConstructAndInitialize(" CS_STATIC_FIELD_NATIVE_CTOR ", "
+					   << INDENT3 "ConstructAndInitialize(" << (is_extension_class ? "null" : CS_STATIC_FIELD_NATIVE_CTOR) << ", "
 					   << BINDINGS_NATIVE_NAME_FIELD ", CachedType, refCounted: "
-					   << (itype.is_ref_counted ? "true" : "false") << ");\n"
+					   << (itype.is_ref_counted ? "true" : "false") << ", isExtensionClass: "
+					   << (is_extension_class ? "true" : "false") << ");\n"
 					   << CLOSE_BLOCK_L2 CLOSE_BLOCK_L1;
 			} else {
 				// Hide the constructor
@@ -2376,7 +2383,8 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 					   << INDENT2 "unsafe\n" INDENT2 OPEN_BLOCK
 					   << INDENT3 "ConstructAndInitialize(null, "
 					   << BINDINGS_NATIVE_NAME_FIELD ", CachedType, refCounted: "
-					   << (itype.is_ref_counted ? "true" : "false") << ");\n"
+					   << (itype.is_ref_counted ? "true" : "false") << ", isExtensionClass: "
+					   << (is_extension_class ? "true" : "false") << ");\n"
 					   << CLOSE_BLOCK_L2 CLOSE_BLOCK_L1;
 			}
 
@@ -2386,7 +2394,8 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 				   << INDENT2 "unsafe\n" INDENT2 OPEN_BLOCK
 				   << INDENT3 "ConstructAndInitialize(null, "
 				   << BINDINGS_NATIVE_NAME_FIELD ", CachedType, refCounted: "
-				   << (itype.is_ref_counted ? "true" : "false") << ");\n"
+				   << (itype.is_ref_counted ? "true" : "false") << ", isExtensionClass: "
+				   << (is_extension_class ? "true" : "false") << ");\n"
 				   << CLOSE_BLOCK_L2 CLOSE_BLOCK_L1;
 
 			// Add.. em.. trick constructor. Sort of.
@@ -4445,22 +4454,125 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 	return true;
 }
 
+bool BindingsGenerator::_type_can_reference_other_type(const TypeInterface &p_owner, const TypeReference &p_other_type_ref, const String &context, String &r_error_message) {
+	const TypeInterface *other_type = obj_types.getptr(p_other_type_ref.cname);
+	if (!other_type) {
+		return true; // Unknown types are always allowed (e.g. String, bool, void, etc).
+	}
+
+	if (_api_type_can_reference_other(p_owner.api_type, other_type->api_type)) {
+		return true;
+	}
+
+	r_error_message = String(api_type_names[p_owner.api_type]) + " Type '" + p_owner.name + "' " +
+			"cannot reference " + api_type_names[other_type->api_type] + " Type '" + other_type->name + "' " +
+			"in " + context + ".";
+
+	return false;
+}
+
+bool BindingsGenerator::_validate_object_type_interfaces() {
+	HashMap<const TypeInterface *, LocalVector<String>> types_with_errors;
+
+#define VALIDATE_TYPE_REF(other_type_ref, context)                                                              \
+	if (String error_message; !_type_can_reference_other_type(itype, other_type_ref, context, error_message)) { \
+		LocalVector<String> *errors = &types_with_errors[&itype];                                               \
+		errors->push_back(error_message);                                                                       \
+	}
+
+	// Make sure that types only reference other types they are allowed to reference
+	for (const KeyValue<StringName, TypeInterface> &E : obj_types) {
+		const TypeInterface &itype = E.value;
+
+		ERR_CONTINUE_MSG(itype.api_type == ClassDB::API_NONE, "Type '" + itype.name + "' has invalid API type.");
+
+		for (const MethodInterface &imethod : itype.methods) {
+			for (const ArgumentInterface &iarg : imethod.arguments) {
+				VALIDATE_TYPE_REF(iarg.type, "method argument of '" + imethod.name + "'");
+			}
+
+			VALIDATE_TYPE_REF(imethod.return_type, "method return type of '" + imethod.name + "'");
+		}
+
+		for (const SignalInterface &isignal : itype.signals_) {
+			for (const ArgumentInterface &iarg : isignal.arguments) {
+				VALIDATE_TYPE_REF(iarg.type, "signal argument of '" + isignal.name + "'");
+			}
+		}
+
+		for (const PropertyInterface &iprop : itype.properties) {
+			if (const MethodInterface *getter = itype.find_method_by_name(iprop.getter)) {
+				VALIDATE_TYPE_REF(getter->return_type, "property getter of '" + iprop.cname + "'");
+			}
+
+			if (const MethodInterface *setter = itype.find_method_by_name(iprop.setter); setter && setter->arguments.size() > 0) {
+				VALIDATE_TYPE_REF(setter->arguments.get(0).type, "property setter of '" + iprop.cname + "'");
+			}
+		}
+	}
+
+	// Report errors
+	for (const KeyValue<const TypeInterface *, LocalVector<String>> &E : types_with_errors) {
+		String full_error_message = "Type '" + E.key->name + "' has invalid references:\n";
+		for (const String &error_message : E.value) {
+			full_error_message += "  - " + error_message + "\n";
+		}
+
+		ERR_PRINT(full_error_message);
+	}
+
+	return types_with_errors.size() == 0;
+}
+
+static String _to_cs_num(const String &p_base_type, const String &p_num_string, const String &p_suffix) {
+	if (p_num_string == "inf") {
+		return p_base_type + ".PositiveInfinity";
+	}
+	if (p_num_string == "-inf") {
+		return p_base_type + ".NegativeInfinity";
+	}
+	if (p_num_string == "nan") {
+		return p_base_type + ".NaN";
+	}
+	return p_num_string + p_suffix;
+}
+
+static String _float_to_cs_declaration(const float p_num, const bool p_trailing = true) {
+	const String num_string = String::num_real(p_num, p_trailing);
+	return _to_cs_num("float", num_string, "f");
+}
+
+#if REAL_T_IS_DOUBLE // Needed to avoid -Wunused-function.
+static String _double_to_cs_declaration(const double p_num, const bool p_trailing = true) {
+	const String num_string = String::num_real(p_num, p_trailing);
+	return _to_cs_num("double", num_string, "d");
+}
+#endif
+
+static String _real_to_cs_declaration(const real_t p_num, const bool p_trailing = true) {
+#if REAL_T_IS_DOUBLE
+	return _double_to_cs_declaration(p_num, p_trailing);
+#else
+	return _float_to_cs_declaration(p_num, p_trailing);
+#endif
+}
+
 static String _get_vector2_cs_ctor_args(const Vector2 &p_vec2) {
-	return String::num_real(p_vec2.x, true) + "f, " +
-			String::num_real(p_vec2.y, true) + "f";
+	return _real_to_cs_declaration(p_vec2.x) + ", " +
+			_real_to_cs_declaration(p_vec2.y);
 }
 
 static String _get_vector3_cs_ctor_args(const Vector3 &p_vec3) {
-	return String::num_real(p_vec3.x, true) + "f, " +
-			String::num_real(p_vec3.y, true) + "f, " +
-			String::num_real(p_vec3.z, true) + "f";
+	return _real_to_cs_declaration(p_vec3.x) + ", " +
+			_real_to_cs_declaration(p_vec3.y) + ", " +
+			_real_to_cs_declaration(p_vec3.z);
 }
 
 static String _get_vector4_cs_ctor_args(const Vector4 &p_vec4) {
-	return String::num_real(p_vec4.x, true) + "f, " +
-			String::num_real(p_vec4.y, true) + "f, " +
-			String::num_real(p_vec4.z, true) + "f, " +
-			String::num_real(p_vec4.w, true) + "f";
+	return _real_to_cs_declaration(p_vec4.x) + ", " +
+			_real_to_cs_declaration(p_vec4.y) + ", " +
+			_real_to_cs_declaration(p_vec4.z) + ", " +
+			_real_to_cs_declaration(p_vec4.w);
 }
 
 static String _get_vector2i_cs_ctor_args(const Vector2i &p_vec2i) {
@@ -4503,7 +4615,7 @@ bool BindingsGenerator::_arg_default_value_from_variant(const Variant &p_val, Ar
 			break;
 		case Variant::FLOAT:
 			r_iarg.default_argument = p_val.operator String();
-
+			// TODO: Does this need to honor REAL_T_IS_DOUBLE?
 			if (r_iarg.type.cname == name_cache.type_float) {
 				r_iarg.default_argument += "f";
 			}
@@ -4678,10 +4790,10 @@ bool BindingsGenerator::_arg_default_value_from_variant(const Variant &p_val, Ar
 				r_iarg.default_argument = "Quaternion.Identity";
 			} else {
 				r_iarg.default_argument = "new Quaternion(" +
-						String::num_real(quaternion.x, false) + "f, " +
-						String::num_real(quaternion.y, false) + "f, " +
-						String::num_real(quaternion.z, false) + "f, " +
-						String::num_real(quaternion.w, false) + "f)";
+						_real_to_cs_declaration(quaternion.x, false) + ", " +
+						_real_to_cs_declaration(quaternion.y, false) + ", " +
+						_real_to_cs_declaration(quaternion.z, false) + ", " +
+						_real_to_cs_declaration(quaternion.w, false) + ")";
 			}
 			r_iarg.def_param_mode = ArgumentInterface::NULLABLE_VAL;
 		} break;
@@ -5214,6 +5326,9 @@ void BindingsGenerator::_initialize() {
 
 	bool obj_type_ok = _populate_object_type_interfaces();
 	ERR_FAIL_COND_MSG(!obj_type_ok, "Failed to generate object type interfaces");
+
+	bool validate_obj_types_ok = _validate_object_type_interfaces();
+	ERR_FAIL_COND_MSG(!validate_obj_types_ok, "Validation of object type interfaces failed");
 
 	_populate_builtin_type_interfaces();
 

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -41,6 +41,14 @@
 #include "editor/doc/editor_help.h"
 
 class BindingsGenerator {
+	static constexpr const char *api_type_names[5] = {
+		"Core",
+		"Editor",
+		"Extension",
+		"Editor Extension",
+		"None",
+	};
+
 	struct ConstantInterface {
 		String name;
 		String proxy_name;
@@ -813,6 +821,8 @@ class BindingsGenerator {
 
 	bool _validate_api_type(const TypeInterface *p_target_itype, const TypeInterface *p_source_itype);
 
+	static bool _api_type_can_reference_other(const ClassDB::APIType p_source_api_type, const ClassDB::APIType p_target_api_type);
+
 	int _determine_enum_prefix(const EnumInterface &p_ienum);
 	void _apply_prefix_to_enum_constants(EnumInterface &p_ienum, int p_prefix_length);
 
@@ -832,6 +842,8 @@ class BindingsGenerator {
 
 	bool _populate_object_type_interfaces();
 	void _populate_builtin_type_interfaces();
+	bool _type_can_reference_other_type(const TypeInterface &p_owner, const TypeReference &p_other_type_ref, const String &context, String &r_error_message);
+	bool _validate_object_type_interfaces();
 
 	void _populate_global_constants();
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
@@ -29,7 +29,7 @@ namespace Godot
         {
             unsafe
             {
-                ConstructAndInitialize(NativeCtor, NativeName, _cachedType, refCounted: false);
+                ConstructAndInitialize(NativeCtor, NativeName, _cachedType, refCounted: false, isExtensionClass: false);
             }
         }
 
@@ -40,7 +40,7 @@ namespace Godot
             NativePtr = nativePtr;
             unsafe
             {
-                ConstructAndInitialize(NativeCtor, NativeName, _cachedType, refCounted: false);
+                ConstructAndInitialize(NativeCtor, NativeName, _cachedType, refCounted: false, isExtensionClass: false);
             }
         }
 
@@ -48,15 +48,24 @@ namespace Godot
             delegate* unmanaged<godot_bool, IntPtr> nativeCtor,
             StringName nativeName,
             Type cachedType,
-            bool refCounted
+            bool refCounted,
+            bool isExtensionClass
         )
         {
             if (NativePtr == IntPtr.Zero)
             {
-                Debug.Assert(nativeCtor != null);
-
-                // Need postinitialization.
-                NativePtr = nativeCtor(godot_bool.True);
+                if (isExtensionClass)
+                {
+                    var typeSelf = (godot_string_name)nativeName.NativeValue;
+                    NativePtr = NativeFuncs.godotsharp_instantiate_class(typeSelf);
+                    Debug.Assert(NativePtr != IntPtr.Zero);
+                }
+                else
+                {
+                    Debug.Assert(nativeCtor != null);
+                    // Need postinitialization.
+                    NativePtr = nativeCtor(godot_bool.True);
+                }
 
                 InteropUtils.TieManagedToUnmanaged(this, NativePtr,
                     nativeName, refCounted, GetType(), cachedType);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -50,6 +50,8 @@ namespace Godot.NativeInterop
         public static partial delegate* unmanaged<godot_bool, IntPtr> godotsharp_get_class_constructor(
             in godot_string_name p_classname);
 
+        public static partial IntPtr godotsharp_instantiate_class(in godot_string_name p_classname);
+
         public static partial IntPtr godotsharp_engine_get_singleton(in godot_string p_name);
 
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -80,6 +80,10 @@ godotsharp_class_creation_func godotsharp_get_class_constructor(const StringName
 	return nullptr;
 }
 
+Object *godotsharp_instantiate_class(const StringName *p_classname) {
+	return ClassDB::instantiate(*p_classname);
+}
+
 Object *godotsharp_engine_get_singleton(const String *p_name) {
 	return Engine::get_singleton()->get_singleton_object(*p_name);
 }
@@ -1623,6 +1627,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_method_bind_get_method,
 	(void *)godotsharp_method_bind_get_method_with_compatibility,
 	(void *)godotsharp_get_class_constructor,
+	(void *)godotsharp_instantiate_class,
 	(void *)godotsharp_engine_get_singleton,
 	(void *)godotsharp_stack_info_vector_resize,
 	(void *)godotsharp_stack_info_vector_destroy,


### PR DESCRIPTION
Use the official [documentation](https://docs.godotengine.org/en/stable/engine_details/development/compiling/compiling_with_dotnet.html
), with these changes:

- Generate glue with `--editor`. Pass your project via `--path`. Use absolute paths to avoid writing glue output into your project folder.
- Make sure you set up a local NuGet source.

```
<godot_binary> --headless --editor \
	--path /absolute/path/to/project \
	--generate-mono-glue /absolute/path/to/godot/modules/mono/glue
```

Limitations: types are generated once at build time, not per project. So if you have many projects, you will need separate managed libraries for each project.