### PR TITLE
Add Resolution Presets for the embedded game window

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -436,6 +436,19 @@ bool Engine::is_embedded_in_editor() const {
 	return embedded_in_editor;
 }
 
+Engine::SafeAreaInsets Engine::get_safe_area_override() const {
+	return safe_area_override;
+}
+
+void Engine::set_safe_area_override(const SafeAreaInsets &p_safe_area) {
+	has_safe_area_override = true;
+	safe_area_override = p_safe_area;
+}
+
+bool Engine::has_safe_area_override_set() const {
+	return has_safe_area_override;
+}
+
 Engine::Engine() {
 	singleton = this;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -53,6 +53,13 @@ public:
 		Singleton(const StringName &p_name = StringName(), Object *p_ptr = nullptr, const StringName &p_class_name = StringName());
 	};
 
+	struct SafeAreaInsets {
+		int left = 0;
+		int top = 0;
+		int right = 0;
+		int bottom = 0;
+	};
+
 private:
 	friend class Main;
 
@@ -107,6 +114,9 @@ private:
 	bool frame_server_synced = false;
 
 	bool freeze_time_scale = false;
+
+	bool has_safe_area_override = false;
+	SafeAreaInsets safe_area_override;
 
 protected:
 	void _update_time_scale();
@@ -223,6 +233,10 @@ public:
 	void set_freeze_time_scale(bool p_frozen);
 	void set_embedded_in_editor(bool p_enabled);
 	bool is_embedded_in_editor() const;
+
+	SafeAreaInsets get_safe_area_override() const;
+	void set_safe_area_override(const SafeAreaInsets &p_safe_area);
+	bool has_safe_area_override_set() const;
 
 	Engine();
 	virtual ~Engine();

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1410,6 +1410,14 @@
 		<member name="run/platforms/linuxbsd/prefer_wayland" type="bool" setter="" getter="">
 			If [code]true[/code], on Linux/BSD, the editor will check for Wayland first instead of X11 (if available).
 		</member>
+		<member name="run/resolution_presets/resolutions" type="Dictionary" setter="" getter="">
+			Custom resolution presets you can choose from in the Game Tab.
+		</member>
+		<member name="run/resolution_presets/safe_areas" type="Dictionary" setter="" getter="">
+			Safe areas for the resolution presets defined in [member run/resolution_presets/resolutions].
+			The key needs to match with the key in [member run/resolution_presets/resolutions] plus a ".landscape" for landscape or ".portrait" for portrait.
+			The value is a [PackedInt32Array] with four values: left, top, right, bottom safe area margins in pixels.
+		</member>
 		<member name="run/window_placement/android_window" type="int" setter="" getter="">
 			Specifies how the Play window is launched relative to the Android editor.
 			- [b]Auto (based on screen size)[/b] (default) will automatically choose how to launch the Play window based on the device and screen metrics. Defaults to [b]Same as Editor[/b] on phones and [b]Side-by-side with Editor[/b] on tablets.

--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -144,6 +144,24 @@ Size2 EmbeddedProcessBase::get_margins_size() const {
 	return margin_top_left + margin_bottom_right;
 }
 
+Engine::SafeAreaInsets EmbeddedProcessBase::get_adjusted_safe_area_insets(Engine::SafeAreaInsets p_insets) const {
+	Engine::SafeAreaInsets adjusted_insets;
+	Rect2i control_rect = get_adjusted_embedded_window_rect(get_rect());
+	float ratio = 1.0f;
+	if (keep_aspect) {
+		ratio = MIN((float)control_rect.size.x / window_size.x, (float)control_rect.size.y / window_size.y);
+	} else {
+		ratio = (float)control_rect.size.x / window_size.x;
+	}
+
+	adjusted_insets.left = int(Math::round(float(p_insets.left) * ratio));
+	adjusted_insets.top = int(Math::round(float(p_insets.top) * ratio));
+	adjusted_insets.right = int(Math::round(float(p_insets.right) * ratio));
+	adjusted_insets.bottom = int(Math::round(float(p_insets.bottom) * ratio));
+
+	return adjusted_insets;
+}
+
 EmbeddedProcessBase::EmbeddedProcessBase() {
 	set_focus_mode(FOCUS_ALL);
 }

--- a/editor/run/embedded_process.h
+++ b/editor/run/embedded_process.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/config/engine.h"
 #include "core/os/process_id.h"
 #include "scene/gui/control.h"
 
@@ -77,6 +78,8 @@ public:
 	Rect2i get_screen_embedded_window_rect() const;
 	int get_margin_size(Side p_side) const;
 	Size2 get_margins_size() const;
+
+	Engine::SafeAreaInsets get_adjusted_safe_area_insets(Engine::SafeAreaInsets p_insets) const;
 
 	EmbeddedProcessBase();
 	virtual ~EmbeddedProcessBase();

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -35,6 +35,7 @@
 #include "core/object/callable_mp.h"
 #include "core/os/process_id.h"
 #include "core/string/translation_server.h"
+#include "core/variant/typed_dictionary.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_interface.h"
@@ -58,6 +59,7 @@
 #include "scene/gui/separator.h"
 #include "scene/main/scene_tree.h"
 #include "servers/display/display_server.h"
+#include "servers/display/display_server_enums.h"
 
 void GameViewDebugger::_session_started(Ref<EditorDebuggerSession> p_session) {
 	if (!is_feature_enabled) {
@@ -630,6 +632,40 @@ void GameView::_editor_or_project_settings_changed() {
 		return;
 	}
 
+	PopupMenu *menu = game_window_options_menu->get_popup();
+	for (int i = menu->get_item_count() - 1; i >= 0; i--) {
+		int item_id = menu->get_item_id(i);
+		if (item_id >= 100) {
+			menu->remove_item(i);
+		}
+	}
+
+	int hdr_sep_index = menu->get_item_index(WINDOW_SEPARATOR_DYNAMIC_RANGE);
+	menu->add_radio_check_item(vformat(TTR("Default (%dx%d)"), EditorRun::get_window_placement().size.x, EditorRun::get_window_placement().size.y), 100);
+	if (hdr_sep_index >= 0) {
+		menu->set_item_index(menu->get_item_count() - 1, hdr_sep_index);
+		hdr_sep_index++;
+	}
+
+	TypedDictionary<String, Vector2i> resolution_presets = EditorSettings::get_singleton()->get_setting("run/resolution_presets/resolutions");
+	int i = 101;
+	for (const KeyValue<Variant, Variant> &kv : resolution_presets) {
+		String name = kv.key;
+		Vector2i size = kv.value;
+		menu->add_radio_check_item(name + " (" + itos(size.x) + "x" + itos(size.y) + ")", i);
+		if (hdr_sep_index >= 0) {
+			menu->set_item_index(menu->get_item_count() - 1, hdr_sep_index);
+			hdr_sep_index++;
+		}
+		i++;
+	}
+
+	if (resolution_preset_index == 0) {
+		custom_resolution = EditorRun::get_window_placement().size;
+	}
+
+	_update_embed_menu_options();
+
 	// Update the window size and aspect ratio.
 	_update_embed_window_size();
 
@@ -824,6 +860,33 @@ void GameView::_game_window_options_menu_menu_id_pressed(int p_id) {
 		case WINDOW_REQUEST_HDR_OUTPUT: {
 			debugger->toggle_hdr_output_requested();
 		} break;
+		default: {
+			if (p_id < 100) {
+				break;
+			}
+
+			int preset_index = p_id - 100;
+
+			if (embed_size_mode == SIZE_MODE_STRETCH) {
+				embed_size_mode = EmbedSizeMode::SIZE_MODE_KEEP_ASPECT;
+			}
+
+			if (resolution_preset_index == preset_index) {
+				break;
+			}
+
+			resolution_preset_index = preset_index;
+
+			EditorSettings::get_singleton()->set_project_metadata("game_view", "resolution_preset", resolution_preset_index);
+
+			if (resolution_preset_index == 0) {
+				custom_resolution = EditorRun::get_window_placement().size;
+			} else {
+				TypedDictionary<String, Vector2i> resolution_presets = EditorSettings::get_singleton()->get_setting("run/resolution_presets/resolutions");
+				custom_resolution = resolution_presets[resolution_presets.get_key_at_index(resolution_preset_index - 1)];
+			}
+			_update_embed_window_size();
+		} break;
 	}
 	_update_embed_menu_options();
 	_update_ui();
@@ -1000,6 +1063,13 @@ void GameView::_update_embed_menu_options() {
 	menu->set_item_checked(menu->get_item_index(WINDOW_SIZE_MODE_FIXED), embed_size_mode == SIZE_MODE_FIXED);
 	menu->set_item_checked(menu->get_item_index(WINDOW_SIZE_MODE_KEEP_ASPECT), embed_size_mode == SIZE_MODE_KEEP_ASPECT);
 	menu->set_item_checked(menu->get_item_index(WINDOW_SIZE_MODE_STRETCH), embed_size_mode == SIZE_MODE_STRETCH);
+
+	for (int i = 0; i < menu->get_item_count(); i++) {
+		int item_id = menu->get_item_id(i);
+		if (item_id >= 100) {
+			menu->set_item_checked(i, resolution_preset_index == item_id - 100 && embed_size_mode != SIZE_MODE_STRETCH);
+		}
+	}
 }
 
 void GameView::_update_embed_buttons() {
@@ -1035,9 +1105,30 @@ void GameView::_update_embed_window_size() {
 
 	} else {
 		if (embed_size_mode == SIZE_MODE_FIXED || embed_size_mode == SIZE_MODE_KEEP_ASPECT) {
-			// The embedded process control will need the desired window size.
-			EditorRun::WindowPlacement placement = EditorRun::get_window_placement();
-			embedded_process->set_window_size(placement.size);
+			const DisplayServerEnums::ScreenOrientation screen_orientation = DisplayServerEnums::ScreenOrientation(int(ProjectSettings::get_singleton()->get("display/window/handheld/orientation")));
+			Size2i window_size;
+
+			if (resolution_preset_index == 0) {
+				window_size = custom_resolution;
+			} else {
+				switch (screen_orientation) {
+					case DisplayServerEnums::ScreenOrientation::SCREEN_LANDSCAPE:
+					case DisplayServerEnums::ScreenOrientation::SCREEN_REVERSE_LANDSCAPE:
+					case DisplayServerEnums::ScreenOrientation::SCREEN_SENSOR_LANDSCAPE:
+						window_size = Size2i(custom_resolution.y, custom_resolution.x);
+						break;
+					case DisplayServerEnums::ScreenOrientation::SCREEN_PORTRAIT:
+					case DisplayServerEnums::ScreenOrientation::SCREEN_REVERSE_PORTRAIT:
+					case DisplayServerEnums::ScreenOrientation::SCREEN_SENSOR_PORTRAIT:
+						window_size = custom_resolution;
+						break;
+					default:
+						window_size = custom_resolution;
+						break;
+				}
+			}
+
+			embedded_process->set_window_size(window_size);
 		} else {
 			// Stretch... No need for the window size.
 			embedded_process->set_window_size(Size2i());
@@ -1222,6 +1313,16 @@ void GameView::_notification(int p_what) {
 				}
 				embed_size_mode = (EmbedSizeMode)(int)EditorSettings::get_singleton()->get_project_metadata("game_view", "embed_size_mode", SIZE_MODE_FIXED);
 				_update_embed_buttons();
+
+				resolution_preset_index = (int)EditorSettings::get_singleton()->get_project_metadata("game_view", "resolution_preset", 0);
+				TypedDictionary<String, Vector2i> resolution_presets = EditorSettings::get_singleton()->get_setting("run/resolution_presets/resolutions");
+				if (resolution_preset_index >= 1 && resolution_preset_index < resolution_presets.size() + 1) {
+					custom_resolution = resolution_presets[resolution_presets.get_key_at_index(resolution_preset_index - 1)];
+				} else {
+					custom_resolution = EditorRun::get_window_placement().size;
+					resolution_preset_index = 0;
+				}
+
 				_update_embed_menu_options();
 
 				EditorRunBar::get_singleton()->connect("play_pressed", callable_mp(this, &GameView::_play_pressed));
@@ -1419,7 +1520,38 @@ void GameView::_update_arguments_for_instance(int p_idx, List<String> &r_argumen
 	N = r_arguments.insert_after(N, "--position");
 	N = r_arguments.insert_after(N, itos(rect.position.x) + "," + itos(rect.position.y));
 	N = r_arguments.insert_after(N, "--resolution");
-	r_arguments.insert_after(N, itos(rect.size.x) + "x" + itos(rect.size.y));
+	N = r_arguments.insert_after(N, itos(rect.size.x) + "x" + itos(rect.size.y));
+
+	TypedDictionary<String, Size2i> resolution_presets = EditorSettings::get_singleton()->get_setting("run/resolution_presets/resolutions");
+	String resolution_name = resolution_presets.get_key_at_index(resolution_preset_index - 1);
+	TypedDictionary<String, PackedInt32Array> safe_areas = EditorSettings::get_singleton()->get_setting("run/resolution_presets/safe_areas");
+
+	const DisplayServerEnums::ScreenOrientation screen_orientation = (DisplayServerEnums::ScreenOrientation)(int(ProjectSettings::get_singleton()->get("display/window/handheld/orientation")));
+	switch (screen_orientation) {
+		case DisplayServerEnums::ScreenOrientation::SCREEN_LANDSCAPE:
+		case DisplayServerEnums::ScreenOrientation::SCREEN_REVERSE_LANDSCAPE:
+		case DisplayServerEnums::ScreenOrientation::SCREEN_SENSOR_LANDSCAPE:
+			resolution_name = String(resolution_name) + ".landscape";
+			break;
+		case DisplayServerEnums::ScreenOrientation::SCREEN_PORTRAIT:
+		case DisplayServerEnums::ScreenOrientation::SCREEN_REVERSE_PORTRAIT:
+		case DisplayServerEnums::ScreenOrientation::SCREEN_SENSOR_PORTRAIT:
+			resolution_name = String(resolution_name) + ".portrait";
+			break;
+		default:
+			break;
+	}
+	PackedInt32Array safe_area = safe_areas.get(resolution_name, PackedInt32Array());
+	if (safe_area.size() != 4) {
+		return;
+	}
+
+	Engine::SafeAreaInsets insets = { safe_area[0], safe_area[1], safe_area[2], safe_area[3] };
+	Engine::SafeAreaInsets adjusted_insets = embedded_process->get_adjusted_safe_area_insets(insets);
+
+	String sval = itos(adjusted_insets.left) + "," + itos(adjusted_insets.top) + "," + itos(adjusted_insets.right) + "," + itos(adjusted_insets.bottom);
+	N = r_arguments.insert_after(N, "--safe-area");
+	r_arguments.insert_after(N, sval);
 }
 
 void GameView::_window_close_request() {
@@ -1716,6 +1848,18 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	menu->set_item_tooltip(menu->get_item_index(WINDOW_SIZE_MODE_KEEP_ASPECT), TTRC("Keep the aspect ratio of the embedded game."));
 	menu->add_radio_check_item(TTRC("Stretch to Fit"), WINDOW_SIZE_MODE_STRETCH);
 	menu->set_item_tooltip(menu->get_item_index(WINDOW_SIZE_MODE_STRETCH), TTRC("Embedded game size stretches to fit the Game workspace."));
+
+	menu->add_separator(TTRC("Resolution Presets"));
+
+	TypedDictionary<String, Vector2i> resolution_presets = EditorSettings::get_singleton()->get_setting("run/resolution_presets/resolutions");
+	menu->add_radio_check_item(vformat(TTR("Default (%dx%d)"), EditorRun::get_window_placement().size.x, EditorRun::get_window_placement().size.y), 100);
+	int i = 101;
+	for (const KeyValue<Variant, Variant> &kv : resolution_presets) {
+		String name = kv.key;
+		Vector2i size = kv.value;
+		menu->add_radio_check_item(name + " (" + itos(size.x) + "x" + itos(size.y) + ")", i);
+		i++;
+	}
 
 	panel = memnew(Panel);
 	add_child(panel);

--- a/editor/run/game_view_plugin.h
+++ b/editor/run/game_view_plugin.h
@@ -181,6 +181,10 @@ class GameView : public VBoxContainer {
 	bool debug_mute_audio = false;
 
 	bool selection_hide = true;
+
+	int resolution_preset_index = 0;
+	Vector2i custom_resolution;
+
 	bool selection_avoid_locked = false;
 	bool selection_prefer_group = false;
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -47,6 +47,7 @@
 #include "core/os/os.h"
 #include "core/string/translation_server.h"
 #include "core/templates/rb_set.h"
+#include "core/variant/typed_dictionary.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
 #include "editor/file_system/editor_paths.h"
@@ -1137,6 +1138,57 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Platform
 	_initial_set("run/platforms/linuxbsd/prefer_wayland", false, true);
 	set_restart_if_changed("run/platforms/linuxbsd/prefer_wayland", true);
+
+	// Resolution presets
+	TypedDictionary<String, Size2i> default_resolutions;
+	default_resolutions[String("iPhone 16")] = Size2i(1179, 2556);
+	default_resolutions[String("iPhone 16 Plus")] = Size2i(1290, 2796);
+	default_resolutions[String("iPhone 16 Pro")] = Size2i(1206, 2622);
+	default_resolutions[String("iPhone 16 Pro Max")] = Size2i(1320, 2868);
+	default_resolutions[String("iPhone 17")] = Size2i(1206, 2622);
+	default_resolutions[String("iPhone 17 Pro")] = Size2i(1206, 2622);
+	default_resolutions[String("iPhone 17 Pro Max")] = Size2i(1320, 2868);
+	default_resolutions[String("iPhone Air")] = Size2i(1260, 2736);
+	default_resolutions[String("iPad Air 11")] = Size2i(1640, 2360);
+	default_resolutions[String("iPad Air 13")] = Size2i(2048, 2732);
+	default_resolutions[String("iPad Pro 11")] = Size2i(1668, 2420);
+	default_resolutions[String("iPad Pro 13")] = Size2i(2064, 2752);
+	default_resolutions[String("Samsung Galaxy S26")] = Size2i(1080, 2340);
+	default_resolutions[String("Samsung Galaxy S26+")] = Size2i(1440, 3120);
+	default_resolutions[String("Samsung Galaxy S26 Ultra")] = Size2i(1440, 3120);
+	default_resolutions[String("Google Pixel 9")] = Size2i(1080, 2424);
+	default_resolutions[String("Google Pixel 9 Pro")] = Size2i(1280, 2856);
+	default_resolutions[String("Google Pixel 9 Pro XL")] = Size2i(1344, 2992);
+	default_resolutions[String("OnePlus 13")] = Size2i(1440, 3168);
+	EDITOR_SETTING(Variant::DICTIONARY, PROPERTY_HINT_DICTIONARY_TYPE, "run/resolution_presets/resolutions", default_resolutions, "String;Vector2i");
+
+	// Safe area
+	TypedDictionary<String, PackedInt32Array> default_safe_areas;
+	default_safe_areas[String("iPhone 16.portrait")] = PackedInt32Array({ 0, 177, 0, 102 });
+	default_safe_areas[String("iPhone 16.landscape")] = PackedInt32Array({ 177, 0, 177, 63 });
+	default_safe_areas[String("iPhone 16 Plus.portrait")] = PackedInt32Array({ 0, 177, 0, 102 });
+	default_safe_areas[String("iPhone 16 Plus.landscape")] = PackedInt32Array({ 177, 0, 177, 63 });
+	default_safe_areas[String("iPhone 16 Pro.portrait")] = PackedInt32Array({ 0, 186, 0, 102 });
+	default_safe_areas[String("iPhone 16 Pro.landscape")] = PackedInt32Array({ 186, 0, 186, 63 });
+	default_safe_areas[String("iPhone 16 Pro Max.portrait")] = PackedInt32Array({ 0, 186, 0, 102 });
+	default_safe_areas[String("iPhone 16 Pro Max.landscape")] = PackedInt32Array({ 186, 0, 186, 63 });
+	default_safe_areas[String("iPhone 17.portrait")] = PackedInt32Array({ 0, 186, 0, 102 });
+	default_safe_areas[String("iPhone 17.landscape")] = PackedInt32Array({ 186, 60, 186, 60 });
+	default_safe_areas[String("iPhone 17 Pro.portrait")] = PackedInt32Array({ 0, 186, 0, 102 });
+	default_safe_areas[String("iPhone 17 Pro.landscape")] = PackedInt32Array({ 186, 60, 186, 60 });
+	default_safe_areas[String("iPhone 17 Pro Max.portrait")] = PackedInt32Array({ 0, 186, 0, 102 });
+	default_safe_areas[String("iPhone 17 Pro Max.landscape")] = PackedInt32Array({ 186, 60, 186, 60 });
+	default_safe_areas[String("iPhone Air.portrait")] = PackedInt32Array({ 0, 204, 0, 102 });
+	default_safe_areas[String("iPhone Air.landscape")] = PackedInt32Array({ 204, 60, 204, 87 });
+	default_safe_areas[String("iPad Air 11.portrait")] = PackedInt32Array({ 0, 48, 0, 40 });
+	default_safe_areas[String("iPad Air 11.landscape")] = PackedInt32Array({ 0, 48, 0, 40 });
+	default_safe_areas[String("iPad Air 13.portrait")] = PackedInt32Array({ 0, 48, 0, 40 });
+	default_safe_areas[String("iPad Air 13.landscape")] = PackedInt32Array({ 0, 48, 0, 40 });
+	default_safe_areas[String("iPad Pro 11.portrait")] = PackedInt32Array({ 0, 48, 0, 40 });
+	default_safe_areas[String("iPad Pro 11.landscape")] = PackedInt32Array({ 0, 48, 0, 40 });
+	default_safe_areas[String("iPad Pro 13.portrait")] = PackedInt32Array({ 0, 48, 0, 40 });
+	default_safe_areas[String("iPad Pro 13.landscape")] = PackedInt32Array({ 0, 48, 0, 40 });
+	EDITOR_SETTING(Variant::DICTIONARY, PROPERTY_HINT_DICTIONARY_TYPE, "run/resolution_presets/safe_areas", default_safe_areas, "String;PackedInt32Array")
 
 	/* Network */
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -265,6 +265,9 @@ static bool init_expand_to_title_found = false;
 static bool use_custom_res = true;
 static bool force_res = false;
 
+static bool has_safe_area_override = false;
+static Engine::SafeAreaInsets safe_area_override;
+
 // Debug
 
 static bool use_debug_profiler = false;
@@ -640,6 +643,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--position <X>,<Y>", "Request window position.\n");
 	print_help_option("--screen <N>", "Request window screen.\n");
 	print_help_option("--single-window", "Use a single window (no separate subwindows).\n");
+	print_help_option("--safe-area <L>,<T>,<R>,<B>", "Simulate a display safe area for testing mobile-like insets.\n");
 #ifndef _3D_DISABLED
 	print_help_option("--xr-mode <mode>", "Select XR (Extended Reality) mode [\"default\", \"off\", \"on\"].\n");
 #endif
@@ -1474,7 +1478,28 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing screen argument, aborting.\n");
 				goto error;
 			}
+		} else if (arg == "--safe-area") { // simulate display safe area for testing
+			if (N) {
+				String vm = N->get();
+				Vector<String> parts = vm.split(",");
+				if (parts.size() != 4) {
+					OS::get_singleton()->print("Invalid --safe-area '%s', it should be e.g. '20,10,20,10'.\n",
+							vm.utf8().get_data());
+					goto error;
+				}
+				int left = parts[0].to_int();
+				int top = parts[1].to_int();
+				int right = parts[2].to_int();
+				int bottom = parts[3].to_int();
 
+				safe_area_override = { left, top, right, bottom };
+				has_safe_area_override = true;
+
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing argument for --safe-area, aborting.\n");
+				goto error;
+			}
 		} else if (arg == "--position") { // set window position
 
 			if (N) {
@@ -2821,6 +2846,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		// If the requested driver wasn't found, pick the first entry.
 		// If all else failed it would be the dummy driver (no sound).
 		audio_driver_idx = 0;
+	}
+
+	if (has_safe_area_override) {
+		Engine::get_singleton()->set_safe_area_override(safe_area_override);
 	}
 
 	if (Engine::get_singleton()->get_write_movie_path() != String()) {


### PR DESCRIPTION
Partial implementation of [#13287](https://github.com/godotengine/godot-proposals/issues/13287).

This adds a dictionary to the editor settings to define new resolution presetes.
In the embeded game window you can select one of them to change the resolution.


https://github.com/user-attachments/assets/d30cf8d6-f1b9-4f1b-a730-497e8f8849eb


