### PR TITLE
Add signals to scrollbar increment/decrement buttons

### DIFF
--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -16,6 +16,26 @@
 		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="0.0" />
 	</members>
 	<signals>
+		<signal name="decrement_pressed">
+			<description>
+				Emitted when the decrement button is pressed.
+			</description>
+		</signal>
+		<signal name="decrement_released">
+			<description>
+				Emitted when the decrement button is released.
+			</description>
+		</signal>
+		<signal name="increment_pressed">
+			<description>
+				Emitted when the increment button is pressed.
+			</description>
+		</signal>
+		<signal name="increment_released">
+			<description>
+				Emitted when the increment button is released.
+			</description>
+		</signal>
 		<signal name="scrolling">
 			<description>
 				Emitted when the scrollbar is being scrolled.

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -77,6 +77,9 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 			double total = orientation == VERTICAL ? get_size().height : get_size().width;
 
 			if (ofs < decr_size) {
+				if (!decr_active) {
+					emit_signal(SNAME("decrement_pressed"));
+				}
 				decr_active = true;
 				scroll(-(custom_step >= 0 ? custom_step : get_step()));
 				queue_redraw();
@@ -84,6 +87,9 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			if (ofs > total - incr_size) {
+				if (!incr_active) {
+					emit_signal(SNAME("increment_pressed"));
+				}
 				incr_active = true;
 				scroll(custom_step >= 0 ? custom_step : get_step());
 				queue_redraw();
@@ -133,6 +139,12 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 		} else {
+			if (incr_active) {
+				emit_signal(SNAME("increment_released"));
+			}
+			if (decr_active) {
+				emit_signal(SNAME("decrement_released"));
+			}
 			incr_active = false;
 			decr_active = false;
 			drag.active = false;
@@ -639,6 +651,10 @@ void ScrollBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_custom_step"), &ScrollBar::get_custom_step);
 
 	ADD_SIGNAL(MethodInfo("scrolling"));
+	ADD_SIGNAL(MethodInfo("increment_pressed"));
+	ADD_SIGNAL(MethodInfo("increment_released"));
+	ADD_SIGNAL(MethodInfo("decrement_pressed"));
+	ADD_SIGNAL(MethodInfo("decrement_released"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_step", PROPERTY_HINT_RANGE, "-1,4096,suffix:px"), "set_custom_step", "get_custom_step");
 


### PR DESCRIPTION
## What
Add signals to scrollbar increment/decrement button press/release:
- `increment_pressed`
- `increment_released`
- `decrement_pressed`
- `decrement_released`

## Why
I wanted to detect when these buttons were being held so that I could auto repeat scrolling on a scrollbar

## Alternatives Considered
I thought about implementing a feature to even more easily configure auto repeat scroll for these buttons e.g. somewhere in inspector with a checkbox and inputs for initial delay/repeat interval but decided on this approach for now because:
- it enables more than just auto repeat scrolling
- implementing auto repeat scrolling on click of these buttons is super easy with this anyways
- it's a much easier change to make! if the inspector scroll auto repeat stuff still sounds valuable I can create an issue and work on it at some point.