### PR TITLE
Remove unused variable is_class_name_valid from ScriptCreateDialog

### DIFF
--- a/editor/script/script_create_dialog.h
+++ b/editor/script/script_create_dialog.h
@@ -75,7 +75,6 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool supports_built_in = false;
 	bool can_inherit_from_file = false;
 	bool is_parent_name_valid = false;
-	bool is_class_name_valid = false;
 	bool is_built_in = false;
 	bool is_using_templates = true;
 	bool built_in_enabled = true;


### PR DESCRIPTION
This member variable was declared but never read from or written to. 
This pr removes it.