### PR TITLE
Fix scale factor applied twice

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1786,7 +1786,7 @@ Size2 Window::_get_contents_minimum_size() const {
 		}
 	}
 
-	return max * content_scale_factor;
+	return max;
 }
 
 void Window::child_controls_changed() {


### PR DESCRIPTION
Fixes #111467
You can test the bug with MRP from #91960, it's broken again on master.

This change does not seem to re-introduce #106090, but either way #110080 will make it irrelevant I think.