### PR TITLE
Build: Update to Xcode 26.0.1 for Apple builds

### DIFF
--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   ios-template:
+    # From https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-github-hosted-runners
     runs-on: macos-latest
     name: Template (target=template_release)
     timeout-minutes: 60
@@ -21,6 +22,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # From https://github.com/actions/runner-images/blob/main/images/macos
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-macos:
+    # From https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-github-hosted-runners
     runs-on: macos-latest
     name: ${{ matrix.name }}
     timeout-minutes: 120
@@ -35,8 +36,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      # From https://github.com/actions/runner-images/blob/main/images/macos
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore


### PR DESCRIPTION
Update GitHub builds for Apple platforms (macOS and iOS) to use Xcode 26

We officially build with Xcode 26 after the following merged:

* build containers: https://github.com/godotengine/build-containers/pull/155
* build scripts: https://github.com/godotengine/godot-build-scripts/pull/129
* Godot engine (scons): https://github.com/godotengine/godot/pull/111299