### PR TITLE
Name all engine threads

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -179,6 +179,7 @@ Error RemoteDebuggerPeerTCP::_try_connect(Ref<StreamPeerSocket> tcp_client) {
 }
 
 void RemoteDebuggerPeerTCP::_thread_func(void *p_ud) {
+	Thread::set_name("TCP remote debug");
 	// Update in time for 144hz monitors
 	const uint64_t min_tick = 6900;
 	RemoteDebuggerPeerTCP *peer = static_cast<RemoteDebuggerPeerTCP *>(p_ud);

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -107,6 +107,7 @@ struct _IP_ResolverPrivate {
 	}
 
 	static void _thread_function(void *self) {
+		Thread::set_name("IP resolver");
 		_IP_ResolverPrivate *ipr = static_cast<_IP_ResolverPrivate *>(self);
 
 		while (!ipr->thread_abort.is_set()) {

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -194,6 +194,7 @@ Error AudioDriverALSA::init() {
 }
 
 void AudioDriverALSA::thread_func(void *p_udata) {
+	Thread::set_name("Audio ALSA");
 	AudioDriverALSA *ad = static_cast<AudioDriverALSA *>(p_udata);
 
 	while (!ad->exit_thread.is_set()) {

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -59,6 +59,7 @@ void MIDIDriverALSAMidi::InputConnection::read() {
 }
 
 void MIDIDriverALSAMidi::thread_func(void *p_udata) {
+	Thread::set_name("MIDI ALSA");
 	MIDIDriverALSAMidi *md = static_cast<MIDIDriverALSAMidi *>(p_udata);
 
 	while (!md->exit_thread.is_set()) {

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -391,6 +391,7 @@ float AudioDriverPulseAudio::get_latency() {
 }
 
 void AudioDriverPulseAudio::thread_func(void *p_udata) {
+	Thread::set_name("Audio PulseAudio");
 	AudioDriverPulseAudio *ad = static_cast<AudioDriverPulseAudio *>(p_udata);
 	unsigned int write_ofs = 0;
 	size_t avail_bytes = 0;

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -733,6 +733,7 @@ void AudioDriverWASAPI::write_sample(WORD format_tag, int bits_per_sample, BYTE 
 }
 
 void AudioDriverWASAPI::thread_func(void *p_udata) {
+	Thread::set_name("Audio WASAPI");
 	CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
 
 	AudioDriverWASAPI *ad = static_cast<AudioDriverWASAPI *>(p_udata);

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -80,6 +80,7 @@ Error AudioDriverXAudio2::init() {
 }
 
 void AudioDriverXAudio2::thread_func(void *p_udata) {
+	Thread::set_name("Audio XAudio2");
 	AudioDriverXAudio2 *ad = static_cast<AudioDriverXAudio2 *>(p_udata);
 
 	while (!ad->exit_thread.is_set()) {

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3038,6 +3038,7 @@ void EditorHelp::remove_class(const String &p_class) {
 }
 
 void EditorHelp::_load_doc_thread(void *p_udata) {
+	Thread::set_name("Load doc");
 	bool use_script_cache = (bool)p_udata;
 	Ref<Resource> cache_res = ResourceLoader::load(get_cache_full_path());
 	if (cache_res.is_valid() && cache_res->get_meta("version_hash", "") == doc_version_hash) {
@@ -3059,6 +3060,7 @@ void EditorHelp::_load_doc_thread(void *p_udata) {
 }
 
 void EditorHelp::_gen_doc_thread(void *p_udata) {
+	Thread::set_name("Gen doc");
 	DocTools compdoc;
 	compdoc.load_compressed(_doc_data_compressed, _doc_data_compressed_size, _doc_data_uncompressed_size);
 	doc->merge_from(compdoc); // Ensure all is up to date.
@@ -3146,6 +3148,7 @@ void EditorHelp::_process_postponed_docs() {
 }
 
 void EditorHelp::_load_script_doc_cache_thread(void *p_udata) {
+	Thread::set_name("Load script doc cache");
 	ERR_FAIL_COND_MSG(!ProjectSettings::get_singleton()->is_project_loaded(), "Error: cannot load script doc cache without a project.");
 	ERR_FAIL_COND_MSG(!ResourceLoader::exists(get_script_doc_cache_full_path()), "Error: cannot load script doc cache from inexistent file.");
 
@@ -3191,6 +3194,7 @@ void EditorHelp::regenerate_script_doc_cache() {
 
 // Runs on worker_thread since it writes to DocData.
 void EditorHelp::_finish_regen_script_doc_thread(void *p_udata) {
+	Thread::set_name("Finish regen script doc");
 	loader_thread.wait_to_finish();
 	_process_postponed_docs();
 	_script_docs_loaded.set();
@@ -3201,6 +3205,7 @@ void EditorHelp::_finish_regen_script_doc_thread(void *p_udata) {
 // Runs on loader_thread since _reload_scripts_documentation calls ResourceLoader::load().
 // Avoids deadlocks of worker_thread needing main thread for load task dispatching, but main thread waiting on worker_thread.
 void EditorHelp::_regen_script_doc_thread(void *p_udata) {
+	Thread::set_name("Regen script doc");
 	OS::get_singleton()->benchmark_begin_measure("EditorHelp", "Generate Script Documentation");
 
 	EditorFileSystemDirectory *dir = static_cast<EditorFileSystemDirectory *>(p_udata);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7655,6 +7655,7 @@ void EditorNode::_print_handler_impl(const String &p_string, bool p_error, bool 
 }
 
 static void _execute_thread(void *p_ud) {
+	Thread::set_name("EditorNode execute");
 	EditorNode::ExecuteThreadArgs *eta = (EditorNode::ExecuteThreadArgs *)p_ud;
 	Error err = OS::get_singleton()->execute(eta->path, eta->args, &eta->output, &eta->exitcode, true, &eta->execute_output_mutex);
 	print_verbose("Thread exit status: " + itos(eta->exitcode));

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2318,6 +2318,7 @@ bool EditorExportPlatformAppleEmbedded::_check_xcode_install() {
 }
 
 void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud) {
+	Thread::set_name("iOS/visionOS device detection");
 	EditorExportPlatformAppleEmbedded *ea = static_cast<EditorExportPlatformAppleEmbedded *>(ud);
 
 	String device_types;

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -546,6 +546,7 @@ void EditorFileSystem::_save_filesystem_cache() {
 }
 
 void EditorFileSystem::_thread_func(void *_userdata) {
+	Thread::set_name("EditorFileSystem scan");
 	EditorFileSystem *sd = (EditorFileSystem *)_userdata;
 	sd->_scan_filesystem();
 }
@@ -1637,6 +1638,7 @@ int EditorFileSystem::_insert_actions_delete_files_directory(EditorFileSystemDir
 }
 
 void EditorFileSystem::_thread_func_sources(void *_userdata) {
+	Thread::set_name("EditorFileSystem scan sources");
 	EditorFileSystem *efs = (EditorFileSystem *)_userdata;
 	if (efs->filesystem) {
 		EditorProgressBG pr("sources", TTR("ScanSources"), 1000);

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -128,6 +128,7 @@ bool EditorResourcePreview::is_threaded() const {
 }
 
 void EditorResourcePreview::_thread_func(void *ud) {
+	Thread::set_name("Resource preview");
 	EditorResourcePreview *erp = (EditorResourcePreview *)ud;
 	erp->_thread();
 }

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -63,6 +63,7 @@ void TilesEditorUtils::_pattern_preview_done() {
 }
 
 void TilesEditorUtils::_thread_func(void *ud) {
+	Thread::set_name("Tile pattern generation");
 	TilesEditorUtils *te = static_cast<TilesEditorUtils *>(ud);
 	set_current_thread_safe_for_nodes(true);
 	te->_thread();

--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -39,6 +39,7 @@
 #include <unistd.h>
 
 void CameraLinux::camera_thread_func(void *p_camera_linux) {
+	Thread::set_name("Linux camera");
 	if (p_camera_linux) {
 		CameraLinux *camera_linux = (CameraLinux *)p_camera_linux;
 		camera_linux->_update_devices();

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -84,6 +84,7 @@ void GDScriptLanguageServer::_notification(int p_what) {
 }
 
 void GDScriptLanguageServer::thread_main(void *p_userdata) {
+	Thread::set_name("GDScript language server");
 	set_current_thread_safe_for_nodes(true);
 	GDScriptLanguageServer *self = static_cast<GDScriptLanguageServer *>(p_userdata);
 	while (self->thread_running) {

--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -139,6 +139,7 @@ void NoiseTexture2D::_thread_done(const Ref<Image> &p_image) {
 }
 
 void NoiseTexture2D::_thread_function(void *p_ud) {
+	Thread::set_name("NoiseTexture2D");
 	NoiseTexture2D *tex = static_cast<NoiseTexture2D *>(p_ud);
 	callable_mp(tex, &NoiseTexture2D::_thread_done).call_deferred(tex->_generate_texture());
 }

--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -126,6 +126,7 @@ void NoiseTexture3D::_thread_done(const TypedArray<Image> &p_data) {
 }
 
 void NoiseTexture3D::_thread_function(void *p_ud) {
+	Thread::set_name("NoiseTexture3D");
 	NoiseTexture3D *tex = static_cast<NoiseTexture3D *>(p_ud);
 	callable_mp(tex, &NoiseTexture3D::_thread_done).call_deferred(tex->_generate_texture());
 }

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -291,6 +291,7 @@ static const int DEFAULT_TARGET_SDK_VERSION = 35; // Should match the value in '
 
 #ifndef ANDROID_ENABLED
 void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
+	Thread::set_name("Android device detection");
 	EditorExportPlatformAndroid *ea = static_cast<EditorExportPlatformAndroid *>(ud);
 
 	while (!ea->quit_request.is_set()) {

--- a/platform/android/tts_android.cpp
+++ b/platform/android/tts_android.cpp
@@ -55,6 +55,7 @@ jmethodID TTS_Android::_stop_speaking = nullptr;
 HashMap<int64_t, Char16String> TTS_Android::ids;
 
 void TTS_Android::_thread_function(void *self) {
+	Thread::set_name("TTS initialization");
 	JNIEnv *env = get_jni_env();
 	ERR_FAIL_NULL(env);
 

--- a/platform/linuxbsd/freedesktop_at_spi_monitor.cpp
+++ b/platform/linuxbsd/freedesktop_at_spi_monitor.cpp
@@ -48,6 +48,7 @@
 #define BUS_INTERFACE_PROPERTIES "org.freedesktop.DBus.Properties"
 
 void FreeDesktopAtSPIMonitor::monitor_thread_func(void *p_userdata) {
+	Thread::set_name("AT-SPI accessibility status monitor");
 	FreeDesktopAtSPIMonitor *mon = (FreeDesktopAtSPIMonitor *)p_userdata;
 
 	DBusError error;

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -900,6 +900,7 @@ void FreeDesktopPortalDesktop::process_callbacks() {
 }
 
 void FreeDesktopPortalDesktop::_thread_monitor(void *p_ud) {
+	Thread::set_name("FreeDesktop portal");
 	FreeDesktopPortalDesktop *portal = (FreeDesktopPortalDesktop *)p_ud;
 
 	while (!portal->monitor_thread_abort.is_set()) {

--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -36,6 +36,7 @@
 TTS_Linux *TTS_Linux::singleton = nullptr;
 
 void TTS_Linux::speech_init_thread_func(void *p_userdata) {
+	Thread::set_name("TTS initialization");
 	TTS_Linux *tts = (TTS_Linux *)p_userdata;
 	if (tts) {
 		MutexLock thread_safe_method(tts->_thread_safe_);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4508,6 +4508,7 @@ void DisplayServerX11::_set_input_focus(Window p_window, int p_revert_to) {
 }
 
 void DisplayServerX11::_poll_events_thread(void *ud) {
+	Thread::set_name("X11 events");
 	DisplayServerX11 *display_server = static_cast<DisplayServerX11 *>(ud);
 	display_server->_poll_events();
 }

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -435,6 +435,7 @@ Error AudioDriverWorklet::create(int &p_buffer_size, int p_channels) {
 }
 
 void AudioDriverWorklet::start(float *p_out_buf, int p_out_buf_size, float *p_in_buf, int p_in_buf_size) {
+	Thread::set_name("Audio Worklet");
 	godot_audio_worklet_start(p_in_buf, p_in_buf_size, p_out_buf, p_out_buf_size, state);
 	thread.start(_audio_thread_func, this);
 }

--- a/platform/web/export/editor_http_server.cpp
+++ b/platform/web/export/editor_http_server.cpp
@@ -31,6 +31,7 @@
 #include "editor_http_server.h"
 
 void EditorHTTPServer::_server_thread_poll(void *data) {
+	Thread::set_name("Editor HTTP server");
 	EditorHTTPServer *web_server = static_cast<EditorHTTPServer *>(data);
 	while (!web_server->server_quit.is_set()) {
 		OS::get_singleton()->delay_usec(6900);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -491,6 +491,7 @@ LRESULT DisplayServerWindows::WndProcFileDialog(HWND hWnd, UINT uMsg, WPARAM wPa
 }
 
 void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
+	Thread::set_name("Windows native file dialog monitor");
 	DisplayServerWindows *ds = static_cast<DisplayServerWindows *>(get_singleton());
 	FileDialogData *fd = (FileDialogData *)p_ud;
 

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -164,6 +164,7 @@ Error HTTPRequest::request_raw(const String &p_url, const Vector<String> &p_cust
 }
 
 void HTTPRequest::_thread_func(void *p_userdata) {
+	Thread::set_name("HTTP request");
 	HTTPRequest *hr = static_cast<HTTPRequest *>(p_userdata);
 
 	Error err = hr->_request();

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -54,6 +54,7 @@ Error AudioDriverDummy::init() {
 }
 
 void AudioDriverDummy::thread_func(void *p_udata) {
+	Thread::set_name("Audio Dummy");
 	AudioDriverDummy *ad = static_cast<AudioDriverDummy *>(p_udata);
 
 	uint64_t usdelay = (ad->buffer_frames / float(ad->mix_rate)) * 1000000;

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -93,6 +93,7 @@ void AudioEffectRecordInstance::_io_store_buffer() {
 }
 
 void AudioEffectRecordInstance::_thread_callback(void *_instance) {
+	Thread::set_name("AudioEffectRecord");
 	AudioEffectRecordInstance *aeri = reinterpret_cast<AudioEffectRecordInstance *>(_instance);
 
 	aeri->_io_thread_process();


### PR DESCRIPTION
Added names for all threads spawned by the engine. It's helpful for debugging and profiling. Although seems like most of the threads are extras outside engine's control, so there are still many random names.

<img width="249" height="1178" alt="image" src="https://github.com/user-attachments/assets/5ae0d9c2-af0d-439e-a20e-feb10a530696" />