### PR TITLE
Fix unwanted blend position movement

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -187,13 +187,19 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	// *set* the blend
-	if (mb.is_valid() && !mb->is_pressed() && !dragging_selected_attempt && ((tool_select->is_pressed() && mb->is_shift_pressed()) || tool_blend->is_pressed()) && mb->get_button_index() == MouseButton::LEFT) {
+	if (mb.is_valid() && mb->is_pressed() && !dragging_selected_attempt && ((tool_select->is_pressed() && mb->is_shift_pressed()) || tool_blend->is_pressed()) && mb->get_button_index() == MouseButton::LEFT) {
 		float blend_pos = mb->get_position().x / blend_space_draw->get_size().x;
 		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
 		blend_pos += blend_space->get_min_space();
 
 		tree->set(get_blend_position_path(), blend_pos);
+
+		dragging_blend_position = true;
 		blend_space_draw->queue_redraw();
+	}
+
+	if (mb.is_valid() && !mb->is_pressed() && dragging_blend_position && mb->get_button_index() == MouseButton::LEFT) {
+		dragging_blend_position = false;
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
@@ -205,7 +211,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 		_update_edited_point_pos();
 	}
 
-	if (mm.is_valid() && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
+	if (mm.is_valid() && dragging_blend_position && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 		float blend_pos = mm->get_position().x / blend_space_draw->get_size().x;
 		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
 		blend_pos += blend_space->get_min_space();

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -98,6 +98,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	float add_point_pos = 0.0f;
 	Vector<real_t> points;
 
+	bool dragging_blend_position = false;
 	bool dragging_selected_attempt = false;
 	bool dragging_selected = false;
 	Vector2 drag_from;

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -288,7 +288,12 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 		tree->set(get_blend_position_path(), blend_pos);
 
+		dragging_blend_position = true;
 		blend_space_draw->queue_redraw();
+	}
+
+	if (mb.is_valid() && !mb->is_pressed() && dragging_blend_position && mb->get_button_index() == MouseButton::LEFT) {
+		dragging_blend_position = false;
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
@@ -311,7 +316,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 		blend_space_draw->queue_redraw();
 	}
 
-	if (mm.is_valid() && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
+	if (mm.is_valid() && dragging_blend_position && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 		Vector2 blend_pos = (mm->get_position() / blend_space_draw->get_size());
 		blend_pos.y = 1.0 - blend_pos.y;
 		blend_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
@@ -1118,4 +1123,5 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	dragging_selected = false;
 	dragging_selected_attempt = false;
+	dragging_blend_position = false;
 }

--- a/editor/animation/animation_blend_space_2d_editor.h
+++ b/editor/animation/animation_blend_space_2d_editor.h
@@ -103,6 +103,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	Vector2 add_point_pos;
 	Vector<Vector2> points;
 
+	bool dragging_blend_position;
 	bool dragging_selected_attempt;
 	bool dragging_selected;
 	Vector2 drag_from;


### PR DESCRIPTION
When entering `BlendSpace1D` or `BlendSpace2D` editor, unwanted crosshair movement may occur if you do not release the left mouse button in time and still move the mouse slightly. In this PR, you can only move crosshair after pressing the left mouse button inside the editor, not outside it. Also, in `BlendSpace1D` editor, you could move crosshair after releasing the left mouse button. I replaced the release with a press.

Before:

https://github.com/user-attachments/assets/0ebbb08b-91c7-4ef5-88a2-6be2bba618ec

After:

https://github.com/user-attachments/assets/b2c83f37-fd95-4143-8cad-a5fddea46648

