### PR TITLE
Fix crash when operating on newly created font RIDs

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -379,7 +379,7 @@ class TextServerAdvanced : public TextServerExtension {
 		HashMap<String, bool> script_support_overrides;
 
 		PackedByteArray data;
-		const uint8_t *data_ptr;
+		const uint8_t *data_ptr = nullptr;
 		size_t data_size;
 		int face_index = 0;
 

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -306,7 +306,7 @@ class TextServerFallback : public TextServerExtension {
 		HashMap<String, bool> script_support_overrides;
 
 		PackedByteArray data;
-		const uint8_t *data_ptr;
+		const uint8_t *data_ptr = nullptr;
 		size_t data_size;
 		int face_index = 0;
 


### PR DESCRIPTION
`data_ptr` was not initialized, so null checks won't work as expected.

```gdscript
var ts = TextServerManager.get_primary_interface()
var font = ts.create_font()
print(ts.font_get_name(font))  # Crashes
ts.free_rid(font)
```