### PR TITLE
Fix switch to GameView when closing game window

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -1160,6 +1160,9 @@ void GameView::_update_arguments_for_instance(int p_idx, List<String> &r_argumen
 
 void GameView::_window_close_request() {
 	if (window_wrapper->get_window_enabled()) {
+		// Stop the embedded process timer before closing the window wrapper,
+		// so the signal to focus EDITOR_GAME isn't sent when the window is not enabled.
+		embedded_process->reset();
 		window_wrapper->set_window_enabled(false);
 	}
 
@@ -1169,7 +1172,6 @@ void GameView::_window_close_request() {
 		// When the embedding is not complete, we need to kill the process.
 		// If the game is paused, the close request will not be processed by the game, so it's better to kill the process.
 		if (paused || embedded_process->is_embedding_in_progress()) {
-			embedded_process->reset();
 			// Call deferred to prevent the _stop_pressed callback to be executed before the wrapper window
 			// actually closes.
 			callable_mp(EditorRunBar::get_singleton(), &EditorRunBar::stop_playing).call_deferred();


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/110840*

## Issue Description

Godot added a function to jump to GameView for debugging at Dec 30, 2024.

- https://github.com/godotengine/godot/pull/100916
- https://github.com/godotengine/godot/issues/100902

This feature add a timer into `embedded_process` to watch whether the `EDITOR_GAME` focused. This time will be triggered each `0.1 second`.

https://github.com/godotengine/godot/blob/7864ac80192e9e91bf56176af9f04cc013b580aa/editor/run/game_view_plugin.cpp#L497-L501

It will switch to `EDITOR_GAME` when `get_window_enabled() == false`.

When we close testing game window, it will trigger `_window_close_request()`.

https://github.com/godotengine/godot/blob/7864ac80192e9e91bf56176af9f04cc013b580aa/editor/run/game_view_plugin.cpp#L1071-L1092

At first, we invoke `set_window_enabled(false)`, then consider to invoke `embedded_process.reset()`. Unfortunately, when the condition doesnot match, e.g. `is_embedding_completed`, we wont `reset` `embedded_process` immediately. That  makes the timer keep alive for a short time.

If the timer success trigger a signal in that short time, it will find `get_window_enabled()` is false, and control editor switch to `EDITOR_GAME`. 

So, invoke `reset()` before `set_enabled(false)` can solve this issue.


