### PR TITLE
Allow Spring / IK to set mutable bone axes

### DIFF
--- a/doc/classes/IKModifier3D.xml
+++ b/doc/classes/IKModifier3D.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		Base class of [SkeletonModifier3D]s that has some joint lists and applies inverse kinematics. This class has some structs, enums, and helper methods which are useful to solve inverse kinematics.
-		[b]Note:[/b] The IK classes that extend this handle rotation only, with bone lengths cached. It means that a position movement between processed chains can cause unintended movement.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -36,4 +35,10 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="mutable_bone_axes" type="bool" setter="set_mutable_bone_axes" getter="are_bone_axes_mutable" default="true">
+			If [code]true[/code], the solver retrieves the bone axis from the bone pose every frame.
+			If [code]false[/code], the solver retrieves the bone axis from the bone rest and caches it, which increases performance slightly, but position changes in the bone pose made before processing this [IKModifier3D] are ignored.
+		</member>
+	</members>
 </class>

--- a/doc/classes/SpringBoneSimulator3D.xml
+++ b/doc/classes/SpringBoneSimulator3D.xml
@@ -637,6 +637,10 @@
 			The constant force that always affected bones. It is equal to the result when the parent [Skeleton3D] moves at this speed in the opposite direction.
 			This is useful for effects such as wind and anti-gravity.
 		</member>
+		<member name="mutable_bone_axes" type="bool" setter="set_mutable_bone_axes" getter="are_bone_axes_mutable" default="true">
+			If [code]true[/code], the solver retrieves the bone axis from the bone pose every frame.
+			If [code]false[/code], the solver retrieves the bone axis from the bone rest and caches it, which increases performance slightly, but position changes in the bone pose made before processing this [SpringBoneSimulator3D] are ignored.
+		</member>
 		<member name="setting_count" type="int" setter="set_setting_count" getter="get_setting_count" default="0">
 			The number of settings.
 		</member>

--- a/editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.cpp
@@ -142,8 +142,10 @@ Ref<ArrayMesh> SpringBoneSimulator3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_s
 			Transform3D global_pose = p_skeleton->get_bone_global_rest(current_bone);
 			if (j > 0) {
 				Transform3D parent_global_pose = p_skeleton->get_bone_global_rest(prev_bone);
-				draw_line(surface_tool, parent_global_pose.origin, global_pose.origin, bone_color);
-				draw_sphere(surface_tool, global_pose.basis, global_pose.origin, p_simulator->get_joint_radius(i, j - 1), bone_color);
+				Vector3 bone_vector = p_simulator->get_bone_vector(i, j - 1);
+				Vector3 center = parent_global_pose.translated_local(bone_vector).origin;
+				draw_line(surface_tool, parent_global_pose.origin, center, bone_color);
+				draw_sphere(surface_tool, global_pose.basis, center, p_simulator->get_joint_radius(i, j - 1), bone_color);
 
 				// Draw rotation axis vector if not ROTATION_AXIS_ALL.
 				if (j != joint_end || (j == joint_end && is_extended)) {
@@ -153,22 +155,22 @@ Ref<ArrayMesh> SpringBoneSimulator3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_s
 						if (!axis_vector.is_zero_approx()) {
 							float line_length = p_simulator->get_joint_radius(i, j - 1) * 2.0;
 							Vector3 axis = global_pose.basis.xform(axis_vector.normalized()) * line_length;
-							draw_line(surface_tool, global_pose.origin - axis, global_pose.origin + axis, bone_color);
+							draw_line(surface_tool, center - axis, center + axis, bone_color);
 						}
 					}
 				}
 			}
 			if (j == joint_end && is_extended) {
-				Vector3 axis = p_simulator->get_end_bone_axis(current_bone, p_simulator->get_end_bone_direction(i));
-				if (axis.is_zero_approx()) {
+				Vector3 bone_vector = p_simulator->get_bone_vector(i, j);
+				if (bone_vector.is_zero_approx()) {
 					continue;
 				}
 				bones[0] = current_bone;
 				surface_tool->set_bones(Vector<int>(bones));
 				surface_tool->set_weights(Vector<float>(weights));
-				axis = global_pose.xform(axis * p_simulator->get_end_bone_length(i));
-				draw_line(surface_tool, global_pose.origin, axis, bone_color);
-				draw_sphere(surface_tool, global_pose.basis, axis, p_simulator->get_joint_radius(i, j), bone_color);
+				Vector3 center = global_pose.translated_local(bone_vector).origin;
+				draw_line(surface_tool, global_pose.origin, center, bone_color);
+				draw_sphere(surface_tool, global_pose.basis, center, p_simulator->get_joint_radius(i, j), bone_color);
 			} else {
 				bones[0] = current_bone;
 				surface_tool->set_bones(Vector<int>(bones));

--- a/editor/scene/3d/gizmos/two_bone_ik_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/two_bone_ik_3d_gizmo_plugin.cpp
@@ -134,35 +134,28 @@ Ref<ArrayMesh> TwoBoneIK3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_skeleton, T
 
 		int root_bone = p_ik->get_root_bone(i);
 		int middle_bone = p_ik->get_middle_bone(i);
-		int end_bone = p_ik->get_end_bone(i);
-
-		bool is_extended = p_ik->is_end_bone_extended(i) && p_ik->get_end_bone_length(i) > 0.0f;
 
 		Transform3D root_gp = p_skeleton->get_bone_global_rest(root_bone);
 		Transform3D mid_gp = p_skeleton->get_bone_global_rest(middle_bone);
-		Transform3D end_gp = p_skeleton->get_bone_global_rest(end_bone);
-
-		Vector3 end_point = end_gp.origin;
-		if (is_extended) {
-			end_point += end_gp.basis.get_rotation_quaternion().xform(p_ik->get_bone_axis(end_bone, p_ik->get_end_bone_direction(i))).normalized() * p_ik->get_end_bone_length(i);
-		}
+		Vector3 root_vec = p_ik->get_root_bone_vector(i);
+		Vector3 mid_vec = p_ik->get_middle_bone_vector(i);
 
 		bones.write[0] = root_bone;
 		surface_tool->set_bones(bones);
 		surface_tool->set_weights(weights);
-		draw_line(surface_tool, root_gp.origin, mid_gp.origin, bone_color);
+		draw_line(surface_tool, root_gp.origin, root_gp.translated_local(root_vec).origin, bone_color);
 
 		bones.write[0] = middle_bone;
 		surface_tool->set_bones(bones);
 		surface_tool->set_weights(weights);
-		draw_line(surface_tool, mid_gp.origin, end_point, bone_color);
+		draw_line(surface_tool, mid_gp.origin, mid_gp.translated_local(mid_vec).origin, bone_color);
 
 		Vector3 pole_vector = p_ik->get_pole_direction_vector(i);
 		if (pole_vector.is_zero_approx()) {
 			continue;
 		}
 
-		float pole_length = MIN(root_gp.origin.distance_to(mid_gp.origin), mid_gp.origin.distance_to(end_point)) * 0.25;
+		float pole_length = MIN(root_vec.length(), mid_vec.length()) * 0.25;
 		draw_arrow(surface_tool, mid_gp.origin, mid_gp.basis.get_rotation_quaternion().xform(pole_vector).normalized(), pole_length, bone_color);
 	}
 

--- a/scene/3d/bone_constraint_3d.cpp
+++ b/scene/3d/bone_constraint_3d.cpp
@@ -191,7 +191,7 @@ void BoneConstraint3D::set_apply_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (settings[p_index]->apply_bone <= -1 || settings[p_index]->apply_bone >= sk->get_bone_count()) {
-			WARN_PRINT("apply bone index out of range!");
+			WARN_PRINT("Apply bone index out of range!");
 			settings[p_index]->apply_bone = -1;
 		} else {
 			settings[p_index]->apply_bone_name = sk->get_bone_name(settings[p_index]->apply_bone);

--- a/scene/3d/chain_ik_3d.h
+++ b/scene/3d/chain_ik_3d.h
@@ -37,6 +37,15 @@ class ChainIK3D : public IKModifier3D {
 
 public:
 	struct ChainIK3DSetting : public IKModifier3DSetting {
+#ifdef TOOLS_ENABLED
+		// Note:
+		// To cache global rest on global pose in SkeletonModifier process.
+		// Since gizmo drawing might be processed after SkeletonModifier process,
+		// so the gizmo which depend on modified pose is not drawn correctly.
+		// Especially, limitation sphere is needed this since it bound mutable bone axis which retrieve by bone pose to the parent bone rest.
+		Transform3D root_global_rest;
+#endif // TOOLS_ENABLED
+
 		BoneJoint root_bone;
 		BoneJoint end_bone;
 
@@ -121,12 +130,18 @@ public:
 			int cur_head = p_index - 1;
 			int cur_tail = p_index;
 			if (cur_head >= 0) {
-				solver_info_list[cur_head]->current_vector = (chain[cur_tail] - chain[cur_head]).normalized();
+				IKModifier3DSolverInfo *solver_info = solver_info_list[cur_head];
+				if (solver_info) {
+					solver_info->current_vector = (chain[cur_tail] - chain[cur_head]).normalized();
+				}
 			}
 			cur_head = p_index;
 			cur_tail = p_index + 1;
 			if (cur_tail < (int)chain.size()) {
-				solver_info_list[cur_head]->current_vector = (chain[cur_tail] - chain[cur_head]).normalized();
+				IKModifier3DSolverInfo *solver_info = solver_info_list[cur_head];
+				if (solver_info) {
+					solver_info->current_vector = (chain[cur_tail] - chain[cur_head]).normalized();
+				}
 			}
 		}
 
@@ -182,6 +197,10 @@ public:
 	};
 
 protected:
+#ifdef TOOLS_ENABLED
+	virtual void _update_mutable_info() override;
+#endif // TOOLS_ENABLED
+
 	LocalVector<ChainIK3DSetting *> chain_settings; // For caching.
 
 	bool _get(const StringName &p_path, Variant &r_ret) const;
@@ -238,6 +257,13 @@ public:
 
 	void set_joint_count(int p_index, int p_count);
 	int get_joint_count(int p_index) const;
+
+#ifdef TOOLS_ENABLED
+	// Helper.
+	static Transform3D get_bone_global_rest_mutable(Skeleton3D *p_skeleton, int p_bone);
+	Transform3D get_chain_root_global_rest(int p_index);
+	virtual Vector3 get_bone_vector(int p_index, int p_joint) const;
+#endif // TOOLS_ENABLED
 
 	~ChainIK3D();
 };

--- a/scene/3d/ik_modifier_3d.h
+++ b/scene/3d/ik_modifier_3d.h
@@ -40,6 +40,7 @@ protected:
 	bool saving = false;
 #endif // TOOLS_ENABLED
 
+	bool mutable_bone_axes = true;
 	Transform3D cached_space;
 	bool joints_dirty = false;
 
@@ -79,6 +80,14 @@ protected:
 	virtual void _init_joints(Skeleton3D *p_skeleton, int p_index);
 	virtual void _update_joints(int p_index);
 	virtual void _make_simulation_dirty(int p_index);
+	virtual void _update_bone_axis(Skeleton3D *p_skeleton, int p_index);
+
+#ifdef TOOLS_ENABLED
+	bool gizmo_dirty = false;
+	void _make_gizmo_dirty();
+	virtual void _update_mutable_info();
+	void _redraw_gizmo();
+#endif // TOOLS_ENABLED
 
 	virtual void _process_modification(double p_delta) override;
 	virtual void _process_ik(Skeleton3D *p_skeleton, double p_delta);
@@ -121,9 +130,12 @@ public:
 		_set_setting_count<IKModifier3DSetting>(0);
 	}
 
+	void set_mutable_bone_axes(bool p_enabled);
+	bool are_bone_axes_mutable() const;
+
 	// Helper.
 	static Quaternion get_local_pose_rotation(Skeleton3D *p_skeleton, int p_bone, const Quaternion &p_global_pose_rotation);
-	Vector3 get_bone_axis(int p_end_bone, BoneDirection p_direction) const;
+	static Vector3 get_bone_axis(Skeleton3D *p_skeleton, int p_end_bone, BoneDirection p_direction, bool p_mutable_bone_axes);
 
 	// To process manually.
 	void reset();

--- a/scene/3d/iterate_ik_3d.cpp
+++ b/scene/3d/iterate_ik_3d.cpp
@@ -207,7 +207,7 @@ NodePath IterateIK3D::get_target_node(int p_index) const {
 
 void IterateIK3D::set_joint_rotation_axis(int p_index, int p_joint, RotationAxis p_axis) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
 	joint_settings[p_joint]->rotation_axis = p_axis;
 	Skeleton3D *sk = get_skeleton();
@@ -215,10 +215,7 @@ void IterateIK3D::set_joint_rotation_axis(int p_index, int p_joint, RotationAxis
 		_validate_axis(sk, p_index, p_joint);
 	}
 	notify_property_list_changed();
-	iterate_settings[p_index]->simulation_dirty = true; // Snapping to planes is needed in the initialization, so need to restructure.
-#ifdef TOOLS_ENABLED
-	update_gizmos();
-#endif // TOOLS_ENABLED
+	_make_simulation_dirty(p_index); // Snapping to planes is needed in the initialization, so need to restructure.
 }
 
 SkeletonModifier3D::RotationAxis IterateIK3D::get_joint_rotation_axis(int p_index, int p_joint) const {
@@ -230,17 +227,14 @@ SkeletonModifier3D::RotationAxis IterateIK3D::get_joint_rotation_axis(int p_inde
 
 void IterateIK3D::set_joint_rotation_axis_vector(int p_index, int p_joint, const Vector3 &p_vector) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
 	joint_settings[p_joint]->rotation_axis_vector = p_vector;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		_validate_axis(sk, p_index, p_joint);
 	}
-	iterate_settings[p_index]->simulation_dirty = true; // Snapping to planes is needed in the initialization, so need to restructure.
-#ifdef TOOLS_ENABLED
-	update_gizmos();
-#endif // TOOLS_ENABLED
+	_make_simulation_dirty(p_index); // Snapping to planes is needed in the initialization, so need to restructure.
 }
 
 Vector3 IterateIK3D::get_joint_rotation_axis_vector(int p_index, int p_joint) const {
@@ -259,7 +253,7 @@ Quaternion IterateIK3D::get_joint_limitation_space(int p_index, int p_joint, con
 
 void IterateIK3D::set_joint_limitation(int p_index, int p_joint, const Ref<JointLimitation3D> &p_limitation) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
 	_unbind_joint_limitation(p_index, p_joint);
 	joint_settings[p_joint]->limitation = p_limitation;
@@ -277,7 +271,7 @@ Ref<JointLimitation3D> IterateIK3D::get_joint_limitation(int p_index, int p_join
 
 void IterateIK3D::set_joint_limitation_right_axis(int p_index, int p_joint, SecondaryDirection p_direction) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
 	joint_settings[p_joint]->limitation_right_axis = p_direction;
 	notify_property_list_changed();
@@ -293,7 +287,7 @@ IKModifier3D::SecondaryDirection IterateIK3D::get_joint_limitation_right_axis(in
 
 void IterateIK3D::set_joint_limitation_right_axis_vector(int p_index, int p_joint, const Vector3 &p_vector) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
 	joint_settings[p_joint]->limitation_right_axis_vector = p_vector;
 	_update_joint_limitation(p_index, p_joint);
@@ -308,7 +302,7 @@ Vector3 IterateIK3D::get_joint_limitation_right_axis_vector(int p_index, int p_j
 
 void IterateIK3D::set_joint_limitation_rotation_offset(int p_index, int p_joint, const Quaternion &p_offset) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
 	joint_settings[p_joint]->limitation_rotation_offset = p_offset;
 	_update_joint_limitation(p_index, p_joint);
@@ -350,7 +344,7 @@ void IterateIK3D::_validate_axis(Skeleton3D *p_skeleton, int p_index, int p_join
 	if (p_joint < (int)iterate_settings[p_index]->joints.size() - 1) {
 		fwd = p_skeleton->get_bone_rest(iterate_settings[p_index]->joints[p_joint + 1].bone).origin;
 	} else if (iterate_settings[p_index]->extend_end_bone) {
-		fwd = get_bone_axis(iterate_settings[p_index]->end_bone.bone, iterate_settings[p_index]->end_bone_direction);
+		fwd = IKModifier3D::get_bone_axis(p_skeleton, iterate_settings[p_index]->end_bone.bone, iterate_settings[p_index]->end_bone_direction, mutable_bone_axes);
 		if (fwd.is_zero_approx()) {
 			return;
 		}
@@ -393,10 +387,9 @@ void IterateIK3D::_bind_methods() {
 	ADD_ARRAY_COUNT("Settings", "setting_count", "set_setting_count", "get_setting_count", "settings/");
 }
 
-void IterateIK3D::_init_joints(Skeleton3D *p_skeleton, int p_index) {
+void IterateIK3D::_clear_joints(int p_index) {
 	IterateIK3DSetting *setting = iterate_settings[p_index];
-	cached_space = p_skeleton->get_global_transform_interpolated();
-	if (!setting->simulation_dirty) {
+	if (!setting) {
 		return;
 	}
 	_unbind_joint_limitations(p_index);
@@ -408,35 +401,27 @@ void IterateIK3D::_init_joints(Skeleton3D *p_skeleton, int p_index) {
 	}
 	setting->solver_info_list.clear();
 	setting->solver_info_list.resize_initialized(setting->joints.size());
-	setting->chain.clear();
-	bool extend_end_bone = setting->extend_end_bone && setting->end_bone_length > 0;
-	for (uint32_t i = 0; i < setting->joints.size(); i++) {
-		setting->chain.push_back(p_skeleton->get_bone_global_pose(setting->joints[i].bone).origin);
-		bool last = i == setting->joints.size() - 1;
-		if (last && extend_end_bone && setting->end_bone_length > 0) {
-			Vector3 axis = get_bone_axis(setting->end_bone.bone, setting->end_bone_direction);
-			if (axis.is_zero_approx()) {
-				continue;
-			}
-			setting->solver_info_list[i] = memnew(IKModifier3DSolverInfo);
-			setting->solver_info_list[i]->forward_vector = snap_vector_to_plane(setting->joint_settings[i]->get_rotation_axis_vector(), axis.normalized());
-			setting->solver_info_list[i]->length = setting->end_bone_length;
-			setting->chain.push_back(p_skeleton->get_bone_global_pose(setting->joints[i].bone).xform(axis * setting->end_bone_length));
-		} else if (!last) {
-			Vector3 axis = p_skeleton->get_bone_rest(setting->joints[i + 1].bone).origin;
-			if (axis.is_zero_approx()) {
-				continue; // Means always we need to check solver info, but `!solver_info` means that the bone is zero length, so IK should skip it in the all process.
-			}
-			setting->solver_info_list[i] = memnew(IKModifier3DSolverInfo);
-			setting->solver_info_list[i]->forward_vector = snap_vector_to_plane(setting->joint_settings[i]->get_rotation_axis_vector(), axis.normalized());
-			setting->solver_info_list[i]->length = axis.length();
-		}
-	}
 	_bind_joint_limitations(p_index);
+}
 
-	setting->init_current_joint_rotations(p_skeleton);
+void IterateIK3D::_init_joints(Skeleton3D *p_skeleton, int p_index) {
+	IterateIK3DSetting *setting = iterate_settings[p_index];
+	if (!setting) {
+		return;
+	}
+	cached_space = p_skeleton->get_global_transform_interpolated();
+	if (setting->simulation_dirty) {
+		_clear_joints(p_index);
+		setting->init_joints(p_skeleton, mutable_bone_axes);
+		setting->simulation_dirty = false;
+	}
 
-	setting->simulation_dirty = false;
+	if (mutable_bone_axes) {
+#ifdef TOOLS_ENABLED
+		_update_mutable_info();
+#endif // TOOLS_ENABLED
+		_update_bone_axis(p_skeleton, p_index);
+	}
 	setting->simulated = false;
 }
 
@@ -446,6 +431,63 @@ void IterateIK3D::_make_simulation_dirty(int p_index) {
 		return;
 	}
 	setting->simulation_dirty = true;
+#ifdef TOOLS_ENABLED
+	if (!mutable_bone_axes) {
+		_make_gizmo_dirty();
+	}
+#endif // TOOLS_ENABLED
+}
+
+void IterateIK3D::_update_bone_axis(Skeleton3D *p_skeleton, int p_index) {
+#ifdef TOOLS_ENABLED
+	bool changed = false;
+#endif // TOOLS_ENABLED
+	IterateIK3DSetting *setting = iterate_settings[p_index];
+	const LocalVector<BoneJoint> &joints = setting->joints;
+	const LocalVector<IKModifier3DSolverInfo *> &solver_info_list = setting->solver_info_list;
+	int len = (int)solver_info_list.size() - 1;
+	for (int j = 0; j < len; j++) {
+		IterateIK3DJointSetting *joint_setting = setting->joint_settings[j];
+		if (!joint_setting || !solver_info_list[j]) {
+			continue;
+		}
+		Vector3 axis = p_skeleton->get_bone_pose(joints[j + 1].bone).origin;
+		if (axis.is_zero_approx()) {
+			continue;
+		}
+		// Less computing.
+#ifdef TOOLS_ENABLED
+		if (!changed) {
+			Vector3 old_v = solver_info_list[j]->forward_vector;
+			solver_info_list[j]->forward_vector = snap_vector_to_plane(joint_setting->get_rotation_axis_vector(), axis.normalized());
+			changed = changed || !old_v.is_equal_approx(solver_info_list[j]->forward_vector);
+			float old_l = solver_info_list[j]->length;
+			solver_info_list[j]->length = axis.length();
+			changed = changed || !Math::is_equal_approx(old_l, solver_info_list[j]->length);
+		} else {
+			solver_info_list[j]->forward_vector = snap_vector_to_plane(joint_setting->get_rotation_axis_vector(), axis.normalized());
+			solver_info_list[j]->length = axis.length();
+		}
+#else
+		solver_info_list[j]->forward_vector = snap_vector_to_plane(joint_setting->get_rotation_axis_vector(), axis.normalized());
+		solver_info_list[j]->length = axis.length();
+#endif // TOOLS_ENABLED
+	}
+	if (setting->extend_end_bone && len >= 0) {
+		IterateIK3DJointSetting *joint_setting = setting->joint_settings[len];
+		if (joint_setting && solver_info_list[len]) {
+			Vector3 axis = IKModifier3D::get_bone_axis(p_skeleton, setting->end_bone.bone, setting->end_bone_direction, mutable_bone_axes);
+			if (!axis.is_zero_approx()) {
+				solver_info_list[len]->forward_vector = snap_vector_to_plane(joint_setting->get_rotation_axis_vector(), axis.normalized());
+				solver_info_list[len]->length = setting->end_bone_length;
+			}
+		}
+	}
+#ifdef TOOLS_ENABLED
+	if (changed) {
+		_make_gizmo_dirty();
+	}
+#endif // TOOLS_ENABLED
 }
 
 void IterateIK3D::_process_ik(Skeleton3D *p_skeleton, double p_delta) {
@@ -505,7 +547,7 @@ void IterateIK3D::_solve_iteration(double p_delta, Skeleton3D *p_skeleton, Itera
 void IterateIK3D::_update_joint_limitation(int p_index, int p_joint) {
 	ERR_FAIL_INDEX(p_index, (int)iterate_settings.size());
 	iterate_settings[p_index]->simulated = false;
-	LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size()); // p_joint is unused directly, but need to identify bound index.
 #ifdef TOOLS_ENABLED
 	update_gizmos();
@@ -514,7 +556,7 @@ void IterateIK3D::_update_joint_limitation(int p_index, int p_joint) {
 
 void IterateIK3D::_bind_joint_limitation(int p_index, int p_joint) {
 	ERR_FAIL_INDEX(p_index, (int)iterate_settings.size());
-	LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
 	if (joint_settings[p_joint]->limitation.is_valid()) {
 		joint_settings[p_joint]->limitation->connect_changed(callable_mp(this, &IterateIK3D::_update_joint_limitation).bind(p_index, p_joint));
@@ -523,7 +565,7 @@ void IterateIK3D::_bind_joint_limitation(int p_index, int p_joint) {
 
 void IterateIK3D::_unbind_joint_limitation(int p_index, int p_joint) {
 	ERR_FAIL_INDEX(p_index, (int)iterate_settings.size());
-	LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
 	if (joint_settings[p_joint]->limitation.is_valid()) {
 		joint_settings[p_joint]->limitation->disconnect_changed(callable_mp(this, &IterateIK3D::_update_joint_limitation).bind(p_index, p_joint));
@@ -545,6 +587,30 @@ void IterateIK3D::_unbind_joint_limitations(int p_index) {
 		}
 	}
 }
+
+#ifdef TOOLS_ENABLED
+Vector3 IterateIK3D::get_bone_vector(int p_index, int p_joint) const {
+	Skeleton3D *skeleton = get_skeleton();
+	if (!skeleton) {
+		return Vector3();
+	}
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3());
+	IterateIK3DSetting *setting = iterate_settings[p_index];
+	if (!setting) {
+		return Vector3();
+	}
+	const LocalVector<BoneJoint> &joints = setting->joints;
+	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), Vector3());
+	const LocalVector<IKModifier3DSolverInfo *> &solver_info_list = setting->solver_info_list;
+	if (p_joint >= (int)solver_info_list.size() || !solver_info_list[p_joint]) {
+		if (p_joint == (int)joints.size() - 1) {
+			return IKModifier3D::get_bone_axis(skeleton, setting->end_bone.bone, setting->end_bone_direction, mutable_bone_axes) * setting->end_bone_length;
+		}
+		return mutable_bone_axes ? skeleton->get_bone_pose(joints[p_joint + 1].bone).origin : skeleton->get_bone_rest(joints[p_joint + 1].bone).origin;
+	}
+	return solver_info_list[p_joint]->forward_vector * solver_info_list[p_joint]->length;
+}
+#endif // TOOLS_ENABLED
 
 IterateIK3D::~IterateIK3D() {
 	for (uint32_t i = 0; i < iterate_settings.size(); i++) {

--- a/scene/3d/spline_ik_3d.h
+++ b/scene/3d/spline_ik_3d.h
@@ -151,6 +151,7 @@ protected:
 
 	virtual void _init_joints(Skeleton3D *p_skeleton, int p_index) override;
 	virtual void _make_simulation_dirty(int p_index) override;
+	virtual void _update_bone_axis(Skeleton3D *p_skeleton, int p_index) override;
 
 	virtual void _process_ik(Skeleton3D *p_skeleton, double p_delta) override;
 	void _process_joints(double p_delta, Skeleton3D *p_skeleton, SplineIK3DSetting *p_setting, Ref<Curve3D> p_curve, const Transform3D &p_curve_space);
@@ -182,6 +183,10 @@ public:
 
 	// Helper.
 	double get_bezier_arc_length();
+
+#ifdef TOOLS_ENABLED
+	virtual Vector3 get_bone_vector(int p_index, int p_joint) const override;
+#endif // TOOLS_ENABLED
 
 	~SplineIK3D();
 };

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -427,7 +427,7 @@ void SpringBoneSimulator3D::_notification(int p_what) {
 		} break;
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			update_gizmos();
+			_make_gizmo_dirty();
 		} break;
 		case NOTIFICATION_EDITOR_PRE_SAVE: {
 			saving = true;
@@ -531,6 +531,12 @@ bool SpringBoneSimulator3D::is_end_bone_extended(int p_index) const {
 void SpringBoneSimulator3D::set_end_bone_direction(int p_index, BoneDirection p_bone_direction) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	settings[p_index]->end_bone_direction = p_bone_direction;
+#ifdef TOOLS_ENABLED
+	_make_gizmo_dirty();
+#endif // TOOLS_ENABLED
+	if (mutable_bone_axes) {
+		return; // Chain dir will be recaluclated in _update_bone_axis().
+	}
 	_make_joints_dirty(p_index);
 }
 
@@ -541,7 +547,14 @@ SkeletonModifier3D::BoneDirection SpringBoneSimulator3D::get_end_bone_direction(
 
 void SpringBoneSimulator3D::set_end_bone_length(int p_index, float p_length) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	float old = settings[p_index]->end_bone_length;
 	settings[p_index]->end_bone_length = p_length;
+#ifdef TOOLS_ENABLED
+	_make_gizmo_dirty();
+#endif // TOOLS_ENABLED
+	if (mutable_bone_axes && Math::is_zero_approx(old) == Math::is_zero_approx(p_length)) {
+		return; // If chain size is not changed, length will be recaluclated in _update_bone_axis().
+	}
 	_make_joints_dirty(p_index);
 }
 
@@ -555,7 +568,7 @@ Vector3 SpringBoneSimulator3D::get_end_bone_axis(int p_end_bone, BoneDirection p
 	if (p_direction == BONE_DIRECTION_FROM_PARENT) {
 		Skeleton3D *sk = get_skeleton();
 		if (sk) {
-			axis = sk->get_bone_rest(p_end_bone).basis.xform_inv(sk->get_bone_rest(p_end_bone).origin);
+			axis = sk->get_bone_rest(p_end_bone).basis.xform_inv(mutable_bone_axes ? sk->get_bone_pose(p_end_bone).origin : sk->get_bone_rest(p_end_bone).origin);
 			axis.normalize();
 		}
 	} else {
@@ -873,7 +886,7 @@ bool SpringBoneSimulator3D::is_config_individual(int p_index) const {
 void SpringBoneSimulator3D::set_joint_bone_name(int p_index, int p_joint, const String &p_bone_name) {
 	// Exists only for indicate bone name on the inspector, no needs to make dirty joint array.
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->bone_name = p_bone_name;
 	Skeleton3D *sk = get_skeleton();
@@ -891,7 +904,7 @@ String SpringBoneSimulator3D::get_joint_bone_name(int p_index, int p_joint) cons
 
 void SpringBoneSimulator3D::set_joint_bone(int p_index, int p_joint, int p_bone) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->bone = p_bone;
 	Skeleton3D *sk = get_skeleton();
@@ -917,11 +930,11 @@ void SpringBoneSimulator3D::set_joint_radius(int p_index, int p_joint, float p_r
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->radius = p_radius;
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 }
 
@@ -937,7 +950,7 @@ void SpringBoneSimulator3D::set_joint_stiffness(int p_index, int p_joint, float 
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->stiffness = p_stiffness;
 }
@@ -954,7 +967,7 @@ void SpringBoneSimulator3D::set_joint_drag(int p_index, int p_joint, float p_dra
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->drag = p_drag;
 }
@@ -971,7 +984,7 @@ void SpringBoneSimulator3D::set_joint_gravity(int p_index, int p_joint, float p_
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->gravity = p_gravity;
 }
@@ -989,7 +1002,7 @@ void SpringBoneSimulator3D::set_joint_gravity_direction(int p_index, int p_joint
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->gravity_direction = p_gravity_direction;
 }
@@ -1006,7 +1019,7 @@ void SpringBoneSimulator3D::set_joint_rotation_axis(int p_index, int p_joint, Ro
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->rotation_axis = p_axis;
 	Skeleton3D *sk = get_skeleton();
@@ -1016,7 +1029,7 @@ void SpringBoneSimulator3D::set_joint_rotation_axis(int p_index, int p_joint, Ro
 	notify_property_list_changed();
 	settings[p_index]->simulation_dirty = true;
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 }
 
@@ -1032,7 +1045,7 @@ void SpringBoneSimulator3D::set_joint_rotation_axis_vector(int p_index, int p_jo
 	if (!is_config_individual(p_index) || settings[p_index]->rotation_axis != ROTATION_AXIS_CUSTOM) {
 		return; // Joints are read-only.
 	}
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->rotation_axis_vector = p_vector;
 	Skeleton3D *sk = get_skeleton();
@@ -1041,7 +1054,7 @@ void SpringBoneSimulator3D::set_joint_rotation_axis_vector(int p_index, int p_jo
 	}
 	settings[p_index]->simulation_dirty = true;
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 }
 
@@ -1220,6 +1233,17 @@ Vector3 SpringBoneSimulator3D::get_external_force() const {
 	return external_force;
 }
 
+void SpringBoneSimulator3D::set_mutable_bone_axes(bool p_enabled) {
+	mutable_bone_axes = p_enabled;
+	for (SpringBone3DSetting *setting : settings) {
+		setting->simulation_dirty = true;
+	}
+}
+
+bool SpringBoneSimulator3D::are_bone_axes_mutable() const {
+	return mutable_bone_axes;
+}
+
 void SpringBoneSimulator3D::_bind_methods() {
 	// Setting.
 	ClassDB::bind_method(D_METHOD("set_root_bone_name", "index", "bone_name"), &SpringBoneSimulator3D::set_root_bone_name);
@@ -1319,10 +1343,14 @@ void SpringBoneSimulator3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_external_force", "force"), &SpringBoneSimulator3D::set_external_force);
 	ClassDB::bind_method(D_METHOD("get_external_force"), &SpringBoneSimulator3D::get_external_force);
 
+	ClassDB::bind_method(D_METHOD("set_mutable_bone_axes", "enabled"), &SpringBoneSimulator3D::set_mutable_bone_axes);
+	ClassDB::bind_method(D_METHOD("are_bone_axes_mutable"), &SpringBoneSimulator3D::are_bone_axes_mutable);
+
 	// To process manually.
 	ClassDB::bind_method(D_METHOD("reset"), &SpringBoneSimulator3D::reset);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "external_force", PROPERTY_HINT_RANGE, "-99999,99999,or_greater,or_less,hide_control,suffix:m/s"), "set_external_force", "get_external_force");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mutable_bone_axes"), "set_mutable_bone_axes", "are_bone_axes_mutable");
 	ADD_ARRAY_COUNT("Settings", "setting_count", "set_setting_count", "get_setting_count", "settings/");
 
 	BIND_ENUM_CONSTANT(CENTER_FROM_WORLD_ORIGIN);
@@ -1601,9 +1629,93 @@ void SpringBoneSimulator3D::_update_joints() {
 		_validate_rotation_axes(sk);
 	}
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 }
+
+void SpringBoneSimulator3D::_update_bone_axis(Skeleton3D *p_skeleton, SpringBone3DSetting *p_setting) {
+#ifdef TOOLS_ENABLED
+	bool changed = false;
+#endif // TOOLS_ENABLED
+	const LocalVector<SpringBone3DJointSetting *> &joints = p_setting->joints;
+	int len = (int)joints.size() - 1;
+	for (int j = 0; j < len; j++) {
+		if (!joints[j]->verlet) {
+			continue;
+		}
+		Vector3 axis = p_skeleton->get_bone_pose(joints[j + 1]->bone).origin;
+		if (axis.is_zero_approx()) {
+			continue;
+		}
+		// Less computing.
+#ifdef TOOLS_ENABLED
+		if (!changed) {
+			Vector3 old_v = joints[j]->verlet->forward_vector;
+			joints[j]->verlet->forward_vector = snap_vector_to_plane(joints[j]->get_rotation_axis_vector(), axis.normalized());
+			changed = changed || !old_v.is_equal_approx(joints[j]->verlet->forward_vector);
+			float old_l = joints[j]->verlet->length;
+			joints[j]->verlet->length = axis.length();
+			changed = changed || !Math::is_equal_approx(old_l, joints[j]->verlet->length);
+		} else {
+			joints[j]->verlet->forward_vector = snap_vector_to_plane(joints[j]->get_rotation_axis_vector(), axis.normalized());
+			joints[j]->verlet->length = axis.length();
+		}
+#else
+		joints[j]->verlet->forward_vector = snap_vector_to_plane(joints[j]->get_rotation_axis_vector(), axis.normalized());
+		joints[j]->verlet->length = axis.length();
+#endif // TOOLS_ENABLED
+	}
+	if (p_setting->extend_end_bone && len >= 0) {
+		if (joints[len]->verlet) {
+			Vector3 axis = get_end_bone_axis(p_setting->end_bone, p_setting->end_bone_direction);
+			if (!axis.is_zero_approx()) {
+				joints[len]->verlet->forward_vector = snap_vector_to_plane(joints[len]->get_rotation_axis_vector(), axis.normalized());
+				joints[len]->verlet->length = p_setting->end_bone_length;
+			}
+		}
+	}
+#ifdef TOOLS_ENABLED
+	if (changed) {
+		_make_gizmo_dirty();
+	}
+#endif // TOOLS_ENABLED
+}
+
+#ifdef TOOLS_ENABLED
+Vector3 SpringBoneSimulator3D::get_bone_vector(int p_index, int p_joint) const {
+	Skeleton3D *skeleton = get_skeleton();
+	if (!skeleton) {
+		return Vector3();
+	}
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3());
+	SpringBone3DSetting *setting = settings[p_index];
+	if (!setting) {
+		return Vector3();
+	}
+	const LocalVector<SpringBone3DJointSetting *> &joints = setting->joints;
+	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), Vector3());
+	if (!joints[p_joint]->verlet) {
+		if (p_joint == (int)joints.size() - 1) {
+			return get_end_bone_axis(setting->end_bone, setting->end_bone_direction) * setting->end_bone_length;
+		}
+		return mutable_bone_axes ? skeleton->get_bone_pose(joints[p_joint + 1]->bone).origin : skeleton->get_bone_rest(joints[p_joint + 1]->bone).origin;
+	}
+	return joints[p_joint]->verlet->forward_vector * joints[p_joint]->verlet->length;
+}
+
+void SpringBoneSimulator3D::_make_gizmo_dirty() {
+	if (gizmo_dirty) {
+		return;
+	}
+	gizmo_dirty = true;
+	callable_mp(this, &SpringBoneSimulator3D::_redraw_gizmo).call_deferred();
+}
+
+void SpringBoneSimulator3D::_redraw_gizmo() {
+	update_gizmos();
+	gizmo_dirty = false;
+}
+#endif
 
 void SpringBoneSimulator3D::_set_active(bool p_active) {
 	if (p_active) {
@@ -1671,6 +1783,9 @@ void SpringBoneSimulator3D::_init_joints(Skeleton3D *p_skeleton, SpringBone3DSet
 	setting->cached_inverted_center = setting->cached_center.affine_inverse();
 
 	if (!setting->simulation_dirty) {
+		if (mutable_bone_axes) {
+			_update_bone_axis(p_skeleton, setting);
+		}
 		return;
 	}
 	for (uint32_t i = 0; i < setting->joints.size(); i++) {
@@ -1679,8 +1794,11 @@ void SpringBoneSimulator3D::_init_joints(Skeleton3D *p_skeleton, SpringBone3DSet
 			setting->joints[i]->verlet = nullptr;
 		}
 		if (i < setting->joints.size() - 1) {
-			setting->joints[i]->verlet = memnew(SpringBone3DVerletInfo);
 			Vector3 axis = p_skeleton->get_bone_rest(setting->joints[i + 1]->bone).origin;
+			if (axis.is_zero_approx()) {
+				continue;
+			}
+			setting->joints[i]->verlet = memnew(SpringBone3DVerletInfo);
 			setting->joints[i]->verlet->current_tail = setting->cached_center.xform(p_skeleton->get_bone_global_pose(setting->joints[i]->bone).xform(axis));
 			setting->joints[i]->verlet->prev_tail = setting->joints[i]->verlet->current_tail;
 			setting->joints[i]->verlet->forward_vector = snap_vector_to_plane(setting->joints[i]->get_rotation_axis_vector(), axis.normalized());
@@ -1698,6 +1816,13 @@ void SpringBoneSimulator3D::_init_joints(Skeleton3D *p_skeleton, SpringBone3DSet
 			setting->joints[i]->verlet->prev_tail = setting->joints[i]->verlet->current_tail;
 			setting->joints[i]->verlet->current_rot = Quaternion(0, 0, 0, 1);
 		}
+	}
+	if (mutable_bone_axes) {
+		_update_bone_axis(p_skeleton, setting);
+#ifdef TOOLS_ENABLED
+	} else {
+		_make_gizmo_dirty();
+#endif // TOOLS_ENABLED
 	}
 	setting->simulation_dirty = false;
 }

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -64,8 +64,8 @@ public:
 	struct SpringBone3DVerletInfo {
 		Vector3 prev_tail;
 		Vector3 current_tail;
-		Vector3 forward_vector;
 		Quaternion current_rot;
+		Vector3 forward_vector;
 		float length = 0.0;
 	};
 
@@ -156,6 +156,7 @@ public:
 protected:
 	LocalVector<SpringBone3DSetting *> settings;
 	Vector3 external_force;
+	bool mutable_bone_axes = true;
 
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
@@ -179,6 +180,14 @@ protected:
 
 	void _update_joint_array(int p_index);
 	void _update_joints();
+
+	void _update_bone_axis(Skeleton3D *p_skeleton, SpringBone3DSetting *p_setting);
+
+#ifdef TOOLS_ENABLED
+	bool gizmo_dirty = false;
+	void _make_gizmo_dirty();
+	void _redraw_gizmo();
+#endif // TOOLS_ENABLED
 
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void move_child_notify(Node *p_child) override;
@@ -304,12 +313,16 @@ public:
 	void set_external_force(const Vector3 &p_force);
 	Vector3 get_external_force() const;
 
+	void set_mutable_bone_axes(bool p_enabled);
+	bool are_bone_axes_mutable() const;
+
 	// To process manually.
 	void reset();
 
 #ifdef TOOLS_ENABLED
+	Vector3 get_bone_vector(int p_index, int p_joint) const;
 	virtual bool is_processed_on_saving() const override { return true; }
-#endif
+#endif // TOOLS_ENABLED
 
 	~SpringBoneSimulator3D();
 };

--- a/scene/3d/two_bone_ik_3d.cpp
+++ b/scene/3d/two_bone_ik_3d.cpp
@@ -352,7 +352,7 @@ void TwoBoneIK3D::set_extend_end_bone(int p_index, bool p_enabled) {
 	}
 	notify_property_list_changed();
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 }
 
@@ -364,14 +364,17 @@ bool TwoBoneIK3D::is_end_bone_extended(int p_index) const {
 void TwoBoneIK3D::set_end_bone_direction(int p_index, BoneDirection p_bone_direction) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	tb_settings[p_index]->end_bone_direction = p_bone_direction;
-	tb_settings[p_index]->simulation_dirty = true;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		_validate_pole_direction(sk, p_index);
 	}
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
+	if (mutable_bone_axes) {
+		return; // Chain dir will be recaluclated in _update_bone_axis().
+	}
+	tb_settings[p_index]->simulation_dirty = true;
 }
 
 SkeletonModifier3D::BoneDirection TwoBoneIK3D::get_end_bone_direction(int p_index) const {
@@ -381,11 +384,15 @@ SkeletonModifier3D::BoneDirection TwoBoneIK3D::get_end_bone_direction(int p_inde
 
 void TwoBoneIK3D::set_end_bone_length(int p_index, float p_length) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	float old = tb_settings[p_index]->end_bone_length;
 	tb_settings[p_index]->end_bone_length = p_length;
-	tb_settings[p_index]->simulation_dirty = true;
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
+	if (mutable_bone_axes && Math::is_zero_approx(old) == Math::is_zero_approx(p_length)) {
+		return; // If chain size is not changed, length will be recaluclated in _update_bone_axis().
+	}
+	tb_settings[p_index]->simulation_dirty = true;
 }
 
 float TwoBoneIK3D::get_end_bone_length(int p_index) const {
@@ -425,7 +432,7 @@ void TwoBoneIK3D::set_pole_direction(int p_index, SecondaryDirection p_direction
 	}
 	notify_property_list_changed();
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 }
 
@@ -446,7 +453,7 @@ void TwoBoneIK3D::set_pole_direction_vector(int p_index, const Vector3 &p_vector
 		_validate_pole_direction(sk, p_index);
 	}
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 }
 
@@ -539,7 +546,7 @@ void TwoBoneIK3D::_validate_pole_direction(Skeleton3D *p_skeleton, int p_index) 
 
 	// End bone.
 	int valid_end_bone = setting->get_end_bone();
-	Vector3 axis = get_bone_axis(valid_end_bone, setting->end_bone_direction);
+	Vector3 axis = IKModifier3D::get_bone_axis(p_skeleton, valid_end_bone, setting->end_bone_direction, mutable_bone_axes);
 	Vector3 global_rest_origin;
 	if (setting->extend_end_bone && setting->end_bone_length > 0 && !axis.is_zero_approx()) {
 		global_rest_origin = p_skeleton->get_bone_global_rest(valid_end_bone).xform(axis * setting->end_bone_length);
@@ -571,6 +578,27 @@ void TwoBoneIK3D::_init_joints(Skeleton3D *p_skeleton, int p_index) {
 	TwoBoneIK3DSetting *setting = tb_settings[p_index];
 	cached_space = p_skeleton->get_global_transform_interpolated();
 	if (!setting->simulation_dirty) {
+		if (mutable_bone_axes) {
+			_update_bone_axis(p_skeleton, p_index);
+		}
+		return;
+	}
+	_clear_joints(p_index);
+	if (setting->root_bone.bone == -1 || setting->middle_bone.bone == -1 || !setting->is_end_valid()) {
+		return;
+	}
+	setting->mid_joint_solver_info = memnew(IKModifier3DSolverInfo);
+	setting->root_joint_solver_info = memnew(IKModifier3DSolverInfo);
+	_update_bone_axis(p_skeleton, p_index);
+
+	setting->init_current_joint_rotations(p_skeleton);
+
+	setting->simulation_dirty = false;
+}
+
+void TwoBoneIK3D::_clear_joints(int p_index) {
+	TwoBoneIK3DSetting *setting = tb_settings[p_index];
+	if (!setting) {
 		return;
 	}
 	setting->root_pos = Vector3();
@@ -584,62 +612,75 @@ void TwoBoneIK3D::_init_joints(Skeleton3D *p_skeleton, int p_index) {
 		memdelete(setting->mid_joint_solver_info);
 		setting->mid_joint_solver_info = nullptr;
 	}
-	if (setting->root_bone.bone == -1 || setting->middle_bone.bone == -1 || !setting->is_end_valid()) {
+}
+
+void TwoBoneIK3D::_update_bone_axis(Skeleton3D *p_skeleton, int p_index) {
+	TwoBoneIK3DSetting *setting = tb_settings[p_index];
+	if (!setting || !setting->mid_joint_solver_info || !setting->root_joint_solver_info) {
 		return;
 	}
+#ifdef TOOLS_ENABLED
+	Vector3 old_mv = setting->mid_joint_solver_info->forward_vector;
+	float old_ml = setting->mid_joint_solver_info->length;
+	Vector3 old_rv = setting->root_joint_solver_info->forward_vector;
+	float old_rl = setting->root_joint_solver_info->length;
+#endif // TOOLS_ENABLED
 
 	// End bone.
 	int valid_end_bone = setting->get_end_bone();
-	Vector3 axis = get_bone_axis(valid_end_bone, setting->end_bone_direction);
+	Vector3 axis = IKModifier3D::get_bone_axis(p_skeleton, valid_end_bone, setting->end_bone_direction, mutable_bone_axes);
 	Vector3 global_rest_origin;
 	if (setting->extend_end_bone && setting->end_bone_length > 0 && !axis.is_zero_approx()) {
 		setting->end_pos = p_skeleton->get_bone_global_pose(valid_end_bone).xform(axis * setting->end_bone_length);
-		global_rest_origin = p_skeleton->get_bone_global_rest(valid_end_bone).xform(axis * setting->end_bone_length);
+		global_rest_origin = _get_bone_global_rest(p_skeleton, valid_end_bone, setting->root_bone.bone).xform(axis * setting->end_bone_length);
 	} else {
 		// Shouldn't be using virtual end.
 		setting->end_pos = p_skeleton->get_bone_global_pose(valid_end_bone).origin;
-		global_rest_origin = p_skeleton->get_bone_global_rest(valid_end_bone).origin;
+		global_rest_origin = _get_bone_global_rest(p_skeleton, valid_end_bone, setting->root_bone.bone).origin;
 	}
 
 	// Middle bone.
-	axis = global_rest_origin - p_skeleton->get_bone_global_rest(setting->middle_bone.bone).origin;
-	global_rest_origin = p_skeleton->get_bone_global_rest(setting->middle_bone.bone).origin;
+	Vector3 orig = _get_bone_global_rest(p_skeleton, setting->middle_bone.bone, setting->root_bone.bone).origin;
+	axis = global_rest_origin - orig;
+	global_rest_origin = orig;
 	if (!axis.is_zero_approx()) {
 		setting->mid_pos = p_skeleton->get_bone_global_pose(setting->middle_bone.bone).origin;
 		setting->mid_joint_solver_info = memnew(IKModifier3DSolverInfo);
 		setting->mid_joint_solver_info->forward_vector = p_skeleton->get_bone_global_rest(setting->middle_bone.bone).basis.get_rotation_quaternion().xform_inv(axis).normalized();
 		setting->mid_joint_solver_info->length = axis.length();
 	} else {
+		_clear_joints(p_index);
 		return;
 	}
 
 	// Root bone.
-	axis = global_rest_origin - p_skeleton->get_bone_global_rest(setting->root_bone.bone).origin;
-	global_rest_origin = p_skeleton->get_bone_global_rest(setting->root_bone.bone).origin;
+	orig = _get_bone_global_rest(p_skeleton, setting->root_bone.bone, setting->root_bone.bone).origin;
+	axis = global_rest_origin - orig;
+	global_rest_origin = orig;
 	if (!axis.is_zero_approx()) {
 		setting->root_pos = p_skeleton->get_bone_global_pose(setting->root_bone.bone).origin;
 		setting->root_joint_solver_info = memnew(IKModifier3DSolverInfo);
 		setting->root_joint_solver_info->forward_vector = p_skeleton->get_bone_global_rest(setting->root_bone.bone).basis.get_rotation_quaternion().xform_inv(axis).normalized();
 		setting->root_joint_solver_info->length = axis.length();
-	} else if (setting->mid_joint_solver_info) {
-		memdelete(setting->mid_joint_solver_info);
-		setting->mid_joint_solver_info = nullptr;
+	} else {
+		_clear_joints(p_index);
 		return;
 	}
 
-	setting->init_current_joint_rotations(p_skeleton);
-
 	double total_length = setting->root_joint_solver_info->length + setting->mid_joint_solver_info->length;
 	setting->cached_length_sq = total_length * total_length;
-
-	setting->simulation_dirty = false;
+#ifdef TOOLS_ENABLED
+	if (!Math::is_equal_approx(old_ml, setting->mid_joint_solver_info->length) || !Math::is_equal_approx(old_rl, setting->root_joint_solver_info->length) || !old_mv.is_equal_approx(setting->mid_joint_solver_info->forward_vector) || !old_rv.is_equal_approx(setting->root_joint_solver_info->forward_vector)) {
+		_make_gizmo_dirty();
+	}
+#endif // TOOLS_ENABLED
 }
 
 void TwoBoneIK3D::_update_joints(int p_index) {
 	tb_settings[p_index]->simulation_dirty = true;
 
 #ifdef TOOLS_ENABLED
-	update_gizmos(); // To clear invalid setting.
+	_make_gizmo_dirty(); // To clear invalid setting.
 #endif // TOOLS_ENABLED
 
 	Skeleton3D *sk = get_skeleton();
@@ -679,9 +720,29 @@ void TwoBoneIK3D::_update_joints(int p_index) {
 		_validate_pole_directions(sk);
 	}
 
+	if (mutable_bone_axes) {
+		_update_bone_axis(sk, p_index);
 #ifdef TOOLS_ENABLED
-	update_gizmos();
+	} else {
+		_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
+	}
+}
+
+Transform3D TwoBoneIK3D::_get_bone_global_rest(Skeleton3D *p_skeleton, int p_bone, int p_root) const {
+	if (!mutable_bone_axes) {
+		return p_skeleton->get_bone_global_rest(p_bone);
+	}
+	Transform3D tr = Transform3D(p_skeleton->get_bone_rest(p_root).basis, p_skeleton->get_bone_pose(p_root).origin);
+	LocalVector<int> path;
+	for (int bone = p_bone; bone != p_root && bone != -1; bone = p_skeleton->get_bone_parent(bone)) {
+		path.push_back(bone);
+	}
+	path.reverse();
+	for (int bone : path) {
+		tr = tr * Transform3D(p_skeleton->get_bone_rest(bone).basis, p_skeleton->get_bone_pose(bone).origin);
+	}
+	return tr;
 }
 
 void TwoBoneIK3D::_make_simulation_dirty(int p_index) {
@@ -772,6 +833,49 @@ void TwoBoneIK3D::_process_joints(double p_delta, Skeleton3D *p_skeleton, TwoBon
 	// Mid joint pose is relative to the root joint pose for the case root-mid or mid-end have more than 1 joints.
 	p_skeleton->set_bone_pose_rotation(p_setting->middle_bone.bone, get_local_pose_rotation(p_skeleton, p_setting->middle_bone.bone, p_setting->mid_joint_solver_info->current_gpose));
 }
+
+#ifdef TOOLS_ENABLED
+Vector3 TwoBoneIK3D::get_root_bone_vector(int p_index) const {
+	Skeleton3D *skeleton = get_skeleton();
+	if (!skeleton) {
+		return Vector3();
+	}
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3());
+	TwoBoneIK3DSetting *setting = tb_settings[p_index];
+	if (!setting) {
+		return Vector3();
+	}
+	if (!setting->root_joint_solver_info) {
+		return _get_bone_global_rest(skeleton, setting->middle_bone.bone, setting->root_bone.bone).origin - _get_bone_global_rest(skeleton, setting->root_bone.bone, setting->root_bone.bone).origin;
+	}
+	return setting->root_joint_solver_info->forward_vector * setting->root_joint_solver_info->length;
+}
+
+Vector3 TwoBoneIK3D::get_middle_bone_vector(int p_index) const {
+	Skeleton3D *skeleton = get_skeleton();
+	if (!skeleton) {
+		return Vector3();
+	}
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3());
+	TwoBoneIK3DSetting *setting = tb_settings[p_index];
+	if (!setting) {
+		return Vector3();
+	}
+	if (!setting->mid_joint_solver_info) {
+		int valid_end_bone = setting->get_end_bone();
+		Vector3 axis = IKModifier3D::get_bone_axis(skeleton, valid_end_bone, setting->end_bone_direction, mutable_bone_axes);
+		Vector3 global_rest_origin;
+		if (setting->extend_end_bone && setting->end_bone_length > 0 && !axis.is_zero_approx()) {
+			global_rest_origin = _get_bone_global_rest(skeleton, valid_end_bone, setting->root_bone.bone).xform(axis * setting->end_bone_length);
+		} else {
+			// Shouldn't be using virtual end.
+			global_rest_origin = _get_bone_global_rest(skeleton, valid_end_bone, setting->root_bone.bone).origin;
+		}
+		return global_rest_origin - _get_bone_global_rest(skeleton, setting->middle_bone.bone, setting->root_bone.bone).origin;
+	}
+	return setting->mid_joint_solver_info->forward_vector * setting->mid_joint_solver_info->length;
+}
+#endif // TOOLS_ENABLED
 
 TwoBoneIK3D::~TwoBoneIK3D() {
 	clear_settings();

--- a/scene/3d/two_bone_ik_3d.h
+++ b/scene/3d/two_bone_ik_3d.h
@@ -252,11 +252,15 @@ protected:
 
 	virtual void _make_all_joints_dirty() override;
 	virtual void _init_joints(Skeleton3D *p_skeleton, int p_index) override;
+	void _clear_joints(int p_index);
 	virtual void _update_joints(int p_index) override;
 	virtual void _make_simulation_dirty(int p_index) override;
+	virtual void _update_bone_axis(Skeleton3D *p_skeleton, int p_index) override;
 
 	virtual void _process_ik(Skeleton3D *p_skeleton, double p_delta) override;
 	void _process_joints(double p_delta, Skeleton3D *p_skeleton, TwoBoneIK3DSetting *p_setting, const Vector3 &p_destination, const Vector3 &p_pole_destination);
+
+	Transform3D _get_bone_global_rest(Skeleton3D *p_skeleton, int p_bone, int p_root) const;
 
 public:
 	virtual PackedStringArray get_configuration_warnings() const override;
@@ -306,6 +310,11 @@ public:
 	Vector3 get_pole_direction_vector(int p_index) const;
 
 	bool is_valid(int p_index) const; // Helper for editor and validation.
+
+#ifdef TOOLS_ENABLED
+	Vector3 get_root_bone_vector(int p_index) const;
+	Vector3 get_middle_bone_vector(int p_index) const;
+#endif // TOOLS_ENABLED
 
 	~TwoBoneIK3D();
 };


### PR DESCRIPTION
We omit the BoneExpander from this PR to prioritize adding mutable_bone_axes to 4.6 based on the meeting. I will send it as separate PR.

<details>

<summary>BoneExpander (outdated)</summary>

~Add a BoneExpander. This applies scaling to the bone pose position and skin bind matrix, enabling visual scaling without 
modifying the bone pose basis.~

~Compared to #83903, this approach minimizes impact on projects that do not utilize scaling. Furthermore, by handling scaling settings externally, it should keep the  Skeleton system itself clean.~

~There are several methods for scaling while avoiding global shearing. Other game engines like Unity typically solve this by using BoneConstraints for parent-child relationships without hierarchical parent-child relationships. Another approach involves using the inverse of the CopyTransformModifier to add a cancel bone without length as a child to the bone you want to scale.~

https://github.com/user-attachments/assets/94780781-d85d-4bfd-9485-3a9c1ecb3845

~However, those three methods, including #83903, all use scaling, and adopting this result in IK or SpringBone is not straightforward.~

~One way to handle this is to convert the scale into bone translation (pose position)  and change the SkeletonModifier's ForwardAxis retrieval from bone rest to bone pose. This is similar to what is done internally in several places within the glTF importer. Then, the restriction that scaling may cause breakage remains unchanged from previous versions.~

~While calculations might be possible in cases involving cancel bones, but we cannot guarantee the presence of cancel bones. And since Godot will never remove cases where global shears occur, I think it's safer to maintain consistency regarding the potential for breakage when scaling is used.~

### How to work

~Modifications to the skin are not managed by the SkeletonModifier, so they are managed using signals.~

~To enable this, the list of skin references can be retrieved from the skeleton using get_skin_bindings(). However, since this API returns a HashSet and carries some risk, it is published only to the C++ core (not exposed to GDScript). Additionally, the `skeleton_rendered` and `skin_changed` signals are added to restore the original, unscaled skin after rendering. These signals are considered safe and are published to GDScript.~

~During SkeletonModifier iteration, only the transformed translate is applied to the bone pose, and only the undeformed skin is retrieved. Then, scaling is applied to the skin when the skeleton_updated signal fires immediately before rendering. This method prevents skin corruption because even if multiple BoneExpanders process the same bone, the scaled skin is never retrieved. Finally, the unscaled skin is restored after rendering.~

```
UpdateProcess
↓
skeleton dirty PoseUpdate
↓
ModifierProcess
↓
BoneExpander (change only pose position)
↓
IK
↓
skeleton updated signal (change skin bind pose scale)
↓
ApplySkin
↓
skeleton rendered singal (restore skin bind pose)
↓
NextFrame
```

~This implementation is quite experimental, but I believe it represents the best compromise currently available to keep Skeleton's internal processing clean and resolve issues externally.~

~However, be aware that performance issues may arise due to the extensive use of arrays for skin changes. Additionally, since skin changes are not inherited, combining this with RetargetModifier3D or baking IK animation to FK animation may result in unintended movement. These restrictions have been added to the documentation and as an experimental flag.~

<img width="898" height="282" alt="image" src="https://github.com/user-attachments/assets/99d78671-ad5f-4809-855d-1e5ec2c20df9" />

</details>

### mutable_bone_axes

Add the `mutable_bone_axes` option to handle bones have deformed position to the following SkeletonModifier.

- SpringBoneSimulator3D
- ManyBoneIK3D

**Disabled:**
<img width="1282" height="680" alt="image" src="https://github.com/user-attachments/assets/92b87e1e-16ad-43a1-8017-48c93e4f2f3a" />

**Enabled:**
<img width="1282" height="680" alt="image" src="https://github.com/user-attachments/assets/420f5a7d-c560-44c8-a9d7-98fb03f4aece" />

[bone_expander_demo.zip](https://github.com/user-attachments/files/22989455/bone_expander_demo.zip)

This means using the bone pose origin instead of the bone rest origin. Enabling this option indicates an increase in computational cost and may slightly impact performance. Since SpringBone and IK cached bone lengths that were not dynamically changed.

Performance comparisons with the option enabled are as follows:

```
[CCDIK 5 joint x 1000 instance]
Mutable disabled: 42.0 FPS
Mutable enabled: 41.25 FPS

[SpringBone 5 joint x 1000 instance]
Mutable disabled 84.0 FPS
Mutable enabled: 82.25 FPS
```

[spring_and_ik_bench.zip](https://github.com/user-attachments/files/22989457/spring_and_ik_bench.zip)

~*Note for reviewer:* The `mutable_bone_axes` option is implemented for IK that hasn't been merged yet, so this PR exists in a commit that bases on all related PRs.~ Merged.