### PR TITLE
CI: Run instrumented tests on Firebase Test Lab

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,6 +1,10 @@
 name: 🤖 Android Builds
 on:
   workflow_call:
+    secrets:
+      SERVICE_ACCOUNT_KEY:
+        required: true
+
   workflow_dispatch:
 
 # Global Settings
@@ -22,6 +26,7 @@ jobs:
           - name: Editor (target=editor)
             cache-name: android-editor
             target: editor
+            instrumented_tests: false
             scons-flags: >-
               arch=arm64
               production=yes
@@ -29,11 +34,13 @@ jobs:
           - name: Template arm32 (target=template_debug, arch=arm32)
             cache-name: android-template-arm32
             target: template_debug
+            instrumented_tests: false
             scons-flags: arch=arm32
 
           - name: Template arm64 (target=template_debug, arch=arm64)
             cache-name: android-template-arm64
             target: template_debug
+            instrumented_tests: true
             scons-flags: arch=arm64
 
     steps:
@@ -115,3 +122,41 @@ jobs:
         with:
           name: ${{ matrix.cache-name }}-picoos
           path: picoos
+
+      - name: Generate Instrumented test APKs
+        if: matrix.instrumented_tests && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+        run: |
+          cd platform/android/java
+          ./gradlew :app:assembleAndroidTest :app:assembleInstrumentedDebug -Pperform_signing=true
+          cd ../../..
+
+      - name: Create credentials file
+        if: matrix.instrumented_tests && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+
+      - name: Set up gcloud CLI
+        if: matrix.instrumented_tests && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Run tests on Firebase Test Lab
+        if: matrix.instrumented_tests && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+        run: |
+          set +e
+          output=$(gcloud firebase test android run \
+            --type instrumentation \
+            --app platform/android/java/app/build/outputs/apk/instrumented/debug/android_debug.apk \
+            --test platform/android/java/app/build/outputs/apk/androidTest/instrumented/debug/app-instrumented-debug-androidTest.apk \
+            --device model=pa3q,version=35,orientation=landscape \
+            --device model=java,version=30,orientation=landscape \
+            --device model=MediumPhone.arm,version=26,orientation=landscape \
+            --use-orchestrator \
+            --timeout 2m 2>&1)
+          exit_code=$?
+          echo "$output"
+          if [[ $exit_code -eq 1 && "$output" == *"TEST_QUOTA_EXCEEDED"* ]]; then
+            echo "::warning title=Firebase Test Lab::Test quota exceeded."
+            exit_code=0
+          fi
+          exit "$exit_code"

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -20,6 +20,8 @@ jobs:
     needs: static-checks
     if: needs.static-checks.outputs.sources-changed == 'true' || github.event_name != 'pull_request'
     uses: ./.github/workflows/android_builds.yml
+    secrets:
+      SERVICE_ACCOUNT_KEY: ${{ secrets.SERVICE_ACCOUNT_KEY }}
 
   ios-build:
     name: 🍏 iOS


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/110829

- Tests on three devices:
    - Galaxy S25 Ultra | API 35 | Physical
    - Motorola G20 | API 30 | Physical
    - Medium Phone, 6.4in/16cm (Arm) | API 26 | Virtual
- Does not fail the CI when a TEST_QUOTA_EXCEEDED error occurs; instead, it only issues a warning.
- Restrict test runs to the `merge_group` event to stay within limits.