### PR TITLE
Correct Array `remove_at()` class reference

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -684,7 +684,6 @@
 				Removes the element from the array at the given index ([param position]). If the index is out of bounds, this method fails. If the index is negative, [param position] is considered relative to the end of the array.
 				If you need to return the removed element, use [method pop_at]. To remove an element by value, use [method erase] instead.
 				[b]Note:[/b] This method shifts every element's index after [param position] back, which may have a noticeable performance cost, especially on larger arrays.
-				[b]Note:[/b] The [param position] cannot be negative. To remove an element relative to the end of the array, use [code]arr.remove_at(arr.size() - (i + 1))[/code]. To remove the last element from the array, use [code]arr.resize(arr.size() - 1)[/code].
 			</description>
 		</method>
 		<method name="resize">


### PR DESCRIPTION
fixes https://github.com/godotengine/godot-docs/issues/11386

`remove_at` **can** take negative positions as relative to the end of the array. 

The note is no longer needed and contradictory to the first paragraph.


