### PR TITLE
Add virtual `_get_cursor_shape()` method in Control

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -92,6 +92,14 @@
 				Override this method to return a human-readable description of the position of the child [param node] in the custom container, added to the [member accessibility_name].
 			</description>
 		</method>
+		<method name="_get_cursor_shape" qualifiers="virtual const">
+			<return type="int" />
+			<param index="0" name="at_position" type="Vector2" />
+			<description>
+				Virtual method to be implemented by the user. Returns the cursor shape for the position [param at_position] in the control's local coordinates, which will typically be used while hovering over this control. See [method get_cursor_shape].
+				If not overridden, defaults to [member mouse_default_cursor_shape].
+			</description>
+		</method>
 		<method name="_get_drag_data" qualifiers="virtual">
 			<return type="Variant" />
 			<param index="0" name="at_position" type="Vector2" />
@@ -129,7 +137,7 @@
 			<return type="String" />
 			<param index="0" name="at_position" type="Vector2" />
 			<description>
-				Virtual method to be implemented by the user. Returns the tooltip text for the position [param at_position] in control's local coordinates, which will typically appear when the cursor is resting over this control. See [method get_tooltip].
+				Virtual method to be implemented by the user. Returns the tooltip text for the position [param at_position] in the control's local coordinates, which will typically appear when the cursor is resting over this control. See [method get_tooltip].
 				[b]Note:[/b] If this method returns an empty [String] and [method _make_custom_tooltip] is not overridden, no tooltip is displayed.
 			</description>
 		</method>
@@ -173,7 +181,7 @@
 			<param index="0" name="point" type="Vector2" />
 			<description>
 				Virtual method to be implemented by the user. Returns whether the given [param point] is inside this control.
-				If not overridden, default behavior is checking if the point is within control's Rect.
+				If not overridden, default behavior is checking if the point is within the control's Rect.
 				[b]Note:[/b] If you want to check if a point is inside the control, you can use [code]Rect2(Vector2.ZERO, size).has_point(point)[/code].
 			</description>
 		</method>
@@ -417,9 +425,10 @@
 		</method>
 		<method name="get_cursor_shape" qualifiers="const">
 			<return type="int" enum="Control.CursorShape" />
-			<param index="0" name="position" type="Vector2" default="Vector2(0, 0)" />
+			<param index="0" name="at_position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Returns the mouse cursor shape for this control when hovered over [param position] in local coordinates. For most controls, this is the same as [member mouse_default_cursor_shape], but some built-in controls implement more complex logic.
+				Returns the mouse cursor shape for this control when hovered over [param at_position] in local coordinates. For most controls, this is the same as [member mouse_default_cursor_shape], but some built-in controls implement more complex logic.
+				You can override [method _get_cursor_shape] to implement custom behavior for this method.
 			</description>
 		</method>
 		<method name="get_end" qualifiers="const">
@@ -603,8 +612,8 @@
 			<return type="String" />
 			<param index="0" name="at_position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Returns the tooltip text for the position [param at_position] in control's local coordinates, which will typically appear when the cursor is resting over this control. By default, it returns [member tooltip_text].
-				This method can be overridden to customize its behavior. See [method _get_tooltip].
+				Returns the tooltip text for the position [param at_position] in the control's local coordinates, which will typically appear when the cursor is resting over this control. By default, it returns [member tooltip_text].
+				You can override [method _get_tooltip] to implement custom behavior for this method.
 				[b]Note:[/b] If this method returns an empty [String] and [method _make_custom_tooltip] is not overridden, no tooltip is displayed.
 			</description>
 		</method>

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2895,6 +2895,10 @@ Control::CursorShape Control::get_default_cursor_shape() const {
 
 Control::CursorShape Control::get_cursor_shape(const Point2 &p_pos) const {
 	ERR_READ_THREAD_GUARD_V(CURSOR_ARROW);
+	int ret;
+	if (GDVIRTUAL_CALL(_get_cursor_shape, p_pos, ret)) {
+		return (CursorShape)ret;
+	}
 	return data.default_cursor;
 }
 
@@ -4129,7 +4133,7 @@ void Control::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Control::set_default_cursor_shape);
 	ClassDB::bind_method(D_METHOD("get_default_cursor_shape"), &Control::get_default_cursor_shape);
-	ClassDB::bind_method(D_METHOD("get_cursor_shape", "position"), &Control::get_cursor_shape, DEFVAL(Point2()));
+	ClassDB::bind_method(D_METHOD("get_cursor_shape", "at_position"), &Control::get_cursor_shape, DEFVAL(Point2()));
 
 	ClassDB::bind_method(D_METHOD("set_focus_neighbor", "side", "neighbor"), &Control::set_focus_neighbor);
 	ClassDB::bind_method(D_METHOD("get_focus_neighbor", "side"), &Control::get_focus_neighbor);
@@ -4432,6 +4436,8 @@ void Control::_bind_methods() {
 	GDVIRTUAL_BIND(_can_drop_data, "at_position", "data");
 	GDVIRTUAL_BIND(_drop_data, "at_position", "data");
 	GDVIRTUAL_BIND(_make_custom_tooltip, "for_text");
+
+	GDVIRTUAL_BIND(_get_cursor_shape, "at_position");
 
 	GDVIRTUAL_BIND(_accessibility_get_contextual_info);
 	GDVIRTUAL_BIND(_get_accessibility_container_name, "node");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -414,6 +414,8 @@ protected:
 	GDVIRTUAL2(_drop_data, Vector2, Variant)
 	GDVIRTUAL1RC(Object *, _make_custom_tooltip, String)
 
+	GDVIRTUAL1RC(int, _get_cursor_shape, Vector2)
+
 	GDVIRTUAL0RC(String, _accessibility_get_contextual_info);
 	GDVIRTUAL1RC(String, _get_accessibility_container_name, RequiredParam<const Node>)
 
@@ -649,7 +651,7 @@ public:
 
 	void set_default_cursor_shape(CursorShape p_shape);
 	CursorShape get_default_cursor_shape() const;
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const;
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2()) const;
 
 	void set_clip_contents(bool p_clip);
 	bool is_clipping_contents();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13158. In a nutshell, this democratizes the ability to have multiple cursor shapes in a single control, something Godot already uses internally but which is not exposed.

https://github.com/user-attachments/assets/2bc5b571-5aa6-4d68-8692-b8270a5e6b89

Autocompletes as int instead of Control.CursorShape, sadly, but it seems like this is a GDVIRTUAL limitation.