### PR TITLE
Fix autoset of `text_editor/external/exec_flags` not working properly

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1171,18 +1171,14 @@ void EditorSettings::_load_default_visual_shader_editor_theme() {
 }
 
 String EditorSettings::_guess_exec_args_for_extenal_editor(const String &p_path) {
-	Ref<RegEx> regex;
-	regex.instantiate();
-
-	const String editor_pattern = R"([\\/]((?:jetbrains\s*)?rider(?:\s*(eap|\d{4}\.\d+|\d{4}\.\d+\s*dev)?)?|visual\s*studio\s*code|subl(ime\s*text)?|sublime_text|(g)?vim|emacs|atom|geany|kate|code|(vs)?codium)(?:\.app|\.exe|\.bat|\.sh)?)";
-	regex->compile(editor_pattern);
-	Ref<RegExMatch> editor_match = regex->search(p_path.to_lower());
+	Ref<RegEx> regex = RegEx::create_from_string(R"((?:jetbrains\s*)?rider(?:\s*(eap|\d{4}\.\d+|\d{4}\.\d+\s*dev)?)?|visual\s*studio\s*code|subl(ime\s*text)?|sublime_text|(g)?vim|emacs|atom|geany|kate|code|(vs)?codium)");
+	Ref<RegExMatch> editor_match = regex->search(p_path.to_lower().get_file().get_basename());
 
 	if (editor_match.is_null()) {
 		return String();
 	}
 
-	const String editor = editor_match->get_string(1).to_lower();
+	const String editor = editor_match->get_string(0).to_lower();
 	String new_exec_flags = "{file}";
 
 	if (editor.begins_with("rider")) {


### PR DESCRIPTION
Fixes an issue with #98846 not getting the paths correctly, especially PATH commands.

The current way seems to RegEx the entire path, including the path leading to the binary and the extension, just to find a pattern in the binary name. It doesn't seem to detect anything unless it starts with a slash.

My change uses `get_file().get_basename()`, with the RegEx being used solely to find a valid binary name. This version merely tries to read whatever name is in the Exec Path field and match, no need for slashes.

If the resulting file has "code", it will be treated as Visual Studio Code. "subl" will be treated as Sublime Text, "rider" will be treated as JetBrains Rider, etc.

Before:
1. Open editor settings
2. At External Editor, set Exec Path to "code" or "code.exe"
3. Nothing else happens (a.k.a. not working)
4. Set Exec Path to "/usr/bin/kate"
5. Exec Flags will change to `{file} --line {line} --column {col}` (working).

After:
1. Open editor settings
2. At External Editor, set Exec Path to "code" or "code.exe"
3. Exec Flags will change to `{project} --goto {file}:{line}:{col}` (working)
4. Set Exec Path to "/usr/bin/kate"
5. Exec Flags will change to `{file} --line {line} --column {col}` (still working)

I found this while trying to make #111821. I didn't even know this feature was in until I read the documentation.