### PR TITLE
Update documentation for `SeparationRayShape2D` and `SeparationRayShape3` to make explicit the behavior around motion

### DIFF
--- a/doc/classes/SeparationRayShape2D.xml
+++ b/doc/classes/SeparationRayShape2D.xml
@@ -4,7 +4,7 @@
 		A 2D ray shape used for physics collision that tries to separate itself from any collider.
 	</brief_description>
 	<description>
-		A 2D ray shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape2D]. When a [SeparationRayShape2D] collides with an object, it tries to separate itself from it by moving its endpoint to the collision point. For example, a [SeparationRayShape2D] next to a character can allow it to instantly move up when touching stairs.
+		A 2D ray shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape2D]. When a [SeparationRayShape2D] collides with an object, it tries to separate itself from it by moving its endpoint to the collision point. For example, a [SeparationRayShape2D] next to a character can allow it to instantly move up when touching stairs. [SeparationRayShape2D] is intended mainly for depenetation and thus will not prevent motion unless [member slide_on_slope] or [member PhysicsTestMotionParameters2D.collide_separation_ray] is [code]true[/code].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,8 +13,8 @@
 			The ray's length.
 		</member>
 		<member name="slide_on_slope" type="bool" setter="set_slide_on_slope" getter="get_slide_on_slope" default="false">
-			If [code]false[/code] (default), the shape always separates and returns a normal along its own direction.
-			If [code]true[/code], the shape can return the correct normal and separate in any direction, allowing sliding motion on slopes.
+			If [code]false[/code] (default), the shape only resolves collisions by moving along the direction of the ray. Normals are only reported along the ray. The shape will only be used for depenetation.
+			If [code]true[/code], the shape resolves collisions in any direction based on the correct collision normal. The shape will be able to stop motion like a regular shape.
 		</member>
 	</members>
 </class>

--- a/doc/classes/SeparationRayShape3D.xml
+++ b/doc/classes/SeparationRayShape3D.xml
@@ -4,7 +4,7 @@
 		A 3D ray shape used for physics collision that tries to separate itself from any collider.
 	</brief_description>
 	<description>
-		A 3D ray shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape3D]. When a [SeparationRayShape3D] collides with an object, it tries to separate itself from it by moving its endpoint to the collision point. For example, a [SeparationRayShape3D] next to a character can allow it to instantly move up when touching stairs.
+		A 3D ray shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape3D]. When a [SeparationRayShape3D] collides with an object, it tries to separate itself from it by moving its endpoint to the collision point. For example, a [SeparationRayShape3D] next to a character can allow it to instantly move up when touching stairs. [SeparationRayShape3D] is intended mainly for depenetation and thus will not prevent motion unless [member slide_on_slope] or [member PhysicsTestMotionParameters3D.collide_separation_ray] is [code]true[/code].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,8 +13,8 @@
 			The ray's length.
 		</member>
 		<member name="slide_on_slope" type="bool" setter="set_slide_on_slope" getter="get_slide_on_slope" default="false">
-			If [code]false[/code] (default), the shape always separates and returns a normal along its own direction.
-			If [code]true[/code], the shape can return the correct normal and separate in any direction, allowing sliding motion on slopes.
+			If [code]false[/code] (default), the shape only resolves collisions by moving along the direction of the ray. Normals are only reported along the ray. The shape will only be used for depenetation.
+			If [code]true[/code], the shape resolves collisions in any direction based on the correct collision normal. The shape will be able to stop motion like a regular shape.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Relates to https://github.com/godotengine/godot/issues/111763 and https://github.com/godotengine/godot/issues/110407

As discussed in the linked issue, `SeparationRayShape2D` resolves collisions differently than other `Shape2D`. Specifically, when `slide_on_slope` is `false` (the default value) the shape is only used for depenetration. This is also true for `SeparationRayShape3D`.
This pull request updates the documentation to reflect this divergence in behavior. Additionally it updates `slide_on_slope` documentation to reflect that it is used to determine if the `SeparationRayShape2D` is used for collision detection.

Edit:
After some more thought I have revised this to focus more around SeparationRayShape2D being intended for depenetration.
