### PR TITLE
 Fix `_validate_property()` implementation in scripting

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -408,6 +408,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
+				[b]Note:[/b] Unlike other virtual methods, this method is called automatically for every script that overrides it. This means that the base implementation should not be called via [code]super[/code] in GDScript or its equivalents in other languages. The bottom-most sub-class will be called first, with subsequent calls ascending the class hierarchy.
 			</description>
 		</method>
 		<method name="add_user_signal">

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1695,20 +1695,19 @@ Variant::Type GDScriptInstance::get_property_type(const StringName &p_name, bool
 	return Variant::NIL;
 }
 
-void GDScriptInstance::validate_property(PropertyInfo &p_property) const {
+void GDScriptInstance::validate_property(PropertyInfo &r_property) const {
 	const GDScript *sptr = script.ptr();
 	while (sptr) {
 		if (likely(sptr->valid)) {
 			HashMap<StringName, GDScriptFunction *>::ConstIterator E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._validate_property);
 			if (E) {
-				Variant property = (Dictionary)p_property;
+				Variant property = (Dictionary)r_property;
 				const Variant *args[1] = { &property };
 
 				Callable::CallError err;
 				Variant ret = E->value->call(const_cast<GDScriptInstance *>(this), args, 1, err);
 				if (err.error == Callable::CallError::CALL_OK) {
-					p_property = PropertyInfo::from_dict(property);
-					return;
+					r_property = PropertyInfo::from_dict(property);
 				}
 			}
 		}
@@ -1777,8 +1776,10 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 
 		msort.sort();
 		msort.reverse();
-		for (int i = 0; i < msort.size(); i++) {
-			props.push_front(sptr->member_indices[msort[i].name].property_info);
+		for (_GDScriptMemberSort &member : msort) {
+			PropertyInfo info = sptr->member_indices[member.name].property_info;
+			validate_property(info);
+			props.push_front(info);
 		}
 
 #ifdef TOOLS_ENABLED
@@ -1786,7 +1787,6 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 #endif // TOOLS_ENABLED
 
 		for (PropertyInfo &prop : props) {
-			validate_property(prop);
 			p_properties->push_back(prop);
 		}
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -377,7 +377,7 @@ public:
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = nullptr) const;
-	virtual void validate_property(PropertyInfo &p_property) const;
+	virtual void validate_property(PropertyInfo &r_property) const;
 
 	virtual bool property_can_revert(const StringName &p_name) const;
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const;

--- a/modules/gdscript/tests/scripts/runtime/features/multilevel_methods.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/multilevel_methods.gd
@@ -1,0 +1,121 @@
+class A:
+	func _notification(what: int) -> void:
+		if what == Node.NOTIFICATION_ENTER_TREE:
+			print("A")
+
+	func _get_property_list() -> Array[Dictionary]:
+		var ret: Array[Dictionary]
+		ret.append({ "name": "password", "type": TYPE_INT, "usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SCRIPT_VARIABLE })
+		return ret
+
+	func _set(property: StringName, _value: Variant) -> bool:
+		if property == &"password":
+			# Should not be reached.
+			Utils.check(false)
+		return false
+
+	func _get(property: StringName) -> Variant:
+		if property == &"surname":
+			# Should not be reached.
+			Utils.check(false)
+		elif property == &"password":
+			return 2137
+		return null
+
+	func _validate_property(property: Dictionary) -> void:
+		if property["name"] == "exported_property":
+			property["usage"] |= PROPERTY_USAGE_ARRAY
+		elif property["name"] == "surname":
+			# Dynamic property, should not be validated.
+			Utils.check(false)
+
+	func _property_can_revert(property: StringName) -> bool:
+		if property == &"fake":
+			Utils.check(false)
+		return false
+
+	func _property_get_revert(property: StringName) -> Variant:
+		if property == &"fake":
+			Utils.check(false)
+		return null
+
+class B extends A:
+	func _notification(what: int) -> void:
+		if what == Node.NOTIFICATION_PAUSED:
+			print("B")
+
+	func _get_property_list() -> Array[Dictionary]:
+		var ret: Array[Dictionary]
+		return ret
+
+	func _set(property: StringName, value: Variant) -> bool:
+		if property == &"password":
+			prints("Setting password to:", value)
+			return true
+		return false
+
+	func _get(property: StringName) -> Variant:
+		if property == &"surname":
+			return "B-man"
+		return null
+
+	func _validate_property(_property: Dictionary) -> void:
+		pass
+
+	func _property_can_revert(property: StringName) -> bool:
+		return property == &"fake"
+
+	func _property_get_revert(property: StringName) -> Variant:
+		if property == &"fake":
+			return "fake"
+		return null
+
+class C extends B:
+	@export var exported_property: int
+
+	func _notification(what: int) -> void:
+		if what == Node.NOTIFICATION_ENTER_TREE:
+			print("C")
+
+	func _get_property_list() -> Array[Dictionary]:
+		var ret: Array[Dictionary]
+		ret.append({ "name": "surname", "type": TYPE_STRING, "usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SCRIPT_VARIABLE })
+		return ret
+
+	func _set(_property: StringName, _value: Variant) -> bool:
+		return false
+
+	func _get(_property: StringName) -> Variant:
+		# Returning `null` allows to call super method.
+		return null
+
+	func _validate_property(property: Dictionary) -> void:
+		if property["name"] == "exported_property":
+			property["type"] = TYPE_ARRAY
+
+	func _property_can_revert(_property: StringName) -> bool:
+		return false
+
+	func _property_get_revert(_property: StringName) -> Variant:
+		prints("get revert C:", _property)
+		return null
+
+func test():
+	var c := C.new()
+
+	c.notification(Node.NOTIFICATION_ENTER_TREE)
+	c.notification(Node.NOTIFICATION_PAUSED)
+
+	# Uses var_to_str() for better formatting.
+	for property in c.get_property_list():
+		if not (property["usage"] & PROPERTY_USAGE_CATEGORY) and (property["usage"] & PROPERTY_USAGE_SCRIPT_VARIABLE):
+			Utils.print_property_extended_info(property)
+
+	prints("surname:", c.get("surname"))
+	prints("password:", c.get("password"))
+	c.set("password", 420)
+
+	prints("can revert fake:", c.property_can_revert(&"fake"))
+	prints("can revert fake2:", c.property_can_revert(&"fake2"))
+	prints("get revert fake:", c.property_get_revert(&"fake"))
+	prints("get revert fake2:", c.property_get_revert(&"fake2"))

--- a/modules/gdscript/tests/scripts/runtime/features/multilevel_methods.out
+++ b/modules/gdscript/tests/scripts/runtime/features/multilevel_methods.out
@@ -1,0 +1,19 @@
+GDTEST_OK
+A
+C
+B
+var exported_property: Array
+  hint=NONE hint_string="" usage=DEFAULT|SCRIPT_VARIABLE|ARRAY class_name=&""
+var surname: String
+  hint=NONE hint_string="" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
+var password: int
+  hint=NONE hint_string="" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
+surname: B-man
+password: 2137
+Setting password to: 420
+can revert fake: true
+can revert fake2: false
+get revert C: fake
+get revert fake: fake
+get revert C: fake2
+get revert fake2: <null>

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1605,17 +1605,19 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 	while (top != nullptr) {
 		props.clear();
 #ifdef TOOLS_ENABLED
-		for (const PropertyInfo &prop : top->exported_members_cache) {
+		for (PropertyInfo prop : top->exported_members_cache) {
+			validate_property(prop);
 			props.push_back(prop);
 		}
 #else
 		for (const KeyValue<StringName, PropertyInfo> &E : top->member_info) {
-			props.push_front(E.value);
+			PropertyInfo info = E.value;
+			validate_property(info);
+			props.push_front(info);
 		}
 #endif
 
 		for (PropertyInfo &prop : props) {
-			validate_property(prop);
 			p_properties->push_back(prop);
 		}
 


### PR DESCRIPTION
Related to #107604

`_validate_property()` is multilevel method in core, but GDScript implementation has invalid `return` that made it consider only the first valid call. This is wrong and so I fixed it.

I decided to add unit tests for all multilevel methods and discovered another bug in the process. `_validate_property()` was called for properties from `get_property_list()`, while it shouldn't. Both GDScript and C# had this bug, not sure about GDExtension.