### PR TITLE
Add Parallax2D Preview

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -358,6 +358,11 @@
 		<member name="editors/2d/locked_selection_rectangle_color" type="Color" setter="" getter="">
 			The color to use for the selection rectangle that surrounds selected locked nodes in the 2D editor viewport.
 		</member>
+		<member name="editors/2d/parallax_preview_mode" type="int" setter="" getter="">
+			Controls the editor preview mode for [Parallax2D] nodes.
+			If set to [b]Centered[/b], the preview will center around the 2D editor viewport's center.
+			If set to [b]Top Left[/b], the preview will align with the top-left corner of the 2D editor viewport.
+		</member>
 		<member name="editors/2d/ruler_width" type="float" setter="" getter="">
 			The thickness of the coordinate ruler in the 2D editor. Increasing this will also increase the size of the ruler font, improving readability when using a lower editor scale. The editor may force a minimum size to keep the ruler numbers legible.
 		</member>

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -80,6 +80,7 @@
 #include "editor/scene/2d/camera_2d_editor_plugin.h"
 #include "editor/scene/2d/light_occluder_2d_editor_plugin.h"
 #include "editor/scene/2d/line_2d_editor_plugin.h"
+#include "editor/scene/2d/parallax_2d_editor_plugin.h"
 #include "editor/scene/2d/particles_2d_editor_plugin.h"
 #include "editor/scene/2d/path_2d_editor_plugin.h"
 #include "editor/scene/2d/physics/cast_2d_editor_plugin.h"
@@ -278,6 +279,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<GPUParticles2DEditorPlugin>();
 	EditorPlugins::add_by_type<LightOccluder2DEditorPlugin>();
 	EditorPlugins::add_by_type<Line2DEditorPlugin>();
+	EditorPlugins::add_by_type<Parallax2DEditorPlugin>();
 	EditorPlugins::add_by_type<Path2DEditorPlugin>();
 	EditorPlugins::add_by_type<Polygon2DEditorPlugin>();
 	EditorPlugins::add_by_type<Cast2DEditorPlugin>();

--- a/editor/scene/2d/parallax_2d_editor_plugin.cpp
+++ b/editor/scene/2d/parallax_2d_editor_plugin.cpp
@@ -1,0 +1,182 @@
+/**************************************************************************/
+/*  parallax_2d_editor_plugin.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "parallax_2d_editor_plugin.h"
+
+#include "core/config/project_settings.h"
+#include "core/object/callable_mp.h"
+#include "editor/scene/canvas_item_editor_plugin.h"
+#include "editor/settings/editor_settings.h"
+#include "scene/2d/parallax_2d.h"
+#include "scene/gui/option_button.h"
+#include "scene/main/scene_tree.h"
+
+void Parallax2DEditorPlugin::edit(Object *p_object) {
+	parallax_2d = Object::cast_to<Parallax2D>(p_object);
+}
+
+bool Parallax2DEditorPlugin::handles(Object *p_object) const {
+	return Object::cast_to<Parallax2D>(p_object) != nullptr;
+}
+
+void Parallax2DEditorPlugin::make_visible(bool p_visible) {
+	if (p_visible) {
+		toolbar->show();
+	} else {
+		toolbar->hide();
+	}
+
+	update_overlays();
+}
+
+void Parallax2DEditorPlugin::_options_callback(int p_idx) {
+	EditorSettings::get_singleton()->set_setting("editors/2d/parallax_preview_mode", p_idx);
+	EditorSettings::get_singleton()->save();
+	_update_preview_mode();
+}
+
+void Parallax2DEditorPlugin::_update_preview_mode() {
+	int mode = EDITOR_GET("editors/2d/parallax_preview_mode");
+
+	if (mode == OPTION_DISABLED) {
+		set_process_internal(false);
+		Vector<Node *> parallax_list = get_tree()->get_nodes_in_group("_parallax_2d");
+
+		for (Node *E : parallax_list) {
+			Parallax2D *parallax = Object::cast_to<Parallax2D>(E);
+
+			if (parallax) {
+				parallax->set_screen_offset(Vector2());
+			}
+		}
+	} else {
+		set_process_internal(true);
+	}
+}
+
+void Parallax2DEditorPlugin::_update_preview() {
+	Vector<Node *> parallax_list = get_tree()->get_nodes_in_group("_parallax_2d");
+
+	if (parallax_list.is_empty()) {
+		return;
+	}
+
+	int mode = EDITOR_GET("editors/2d/parallax_preview_mode");
+	Size2 vps = Size2(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+	Vector2 screen_offset = Vector2();
+
+	if (mode == OPTION_CENTERED) {
+		Transform2D vp_transform = CanvasItemEditor::get_singleton()->get_canvas_transform();
+		Vector2 vp_pos = vp_transform.get_origin() / vp_transform.get_scale();
+		Rect2 view_rect = Rect2(-vp_pos, Vector2(CanvasItemEditor::get_singleton()->get_viewport_control()->get_size()) / vp_transform.get_scale());
+		Rect2 editor_rect = Rect2(view_rect.position + view_rect.size * 0.5 - vps * 0.5, vps);
+		screen_offset = editor_rect.position;
+	} else if (mode == OPTION_TOP_LEFT) {
+		Transform2D vp_transform = CanvasItemEditor::get_singleton()->get_canvas_transform();
+		Vector2 vp_viewport_pos = -vp_transform.get_origin() / vp_transform.get_scale();
+		screen_offset = vp_viewport_pos;
+	}
+
+	for (Node *E : parallax_list) {
+		Parallax2D *parallax = Object::cast_to<Parallax2D>(E);
+
+		if (parallax) {
+			parallax->set_screen_offset(parallax->is_ignore_camera_scroll() ? Vector2() : screen_offset);
+		}
+	}
+}
+
+void Parallax2DEditorPlugin::_node_added(Node *p_node) {
+	Parallax2D *parallax = Object::cast_to<Parallax2D>(p_node);
+
+	if (parallax) {
+		p_node->add_to_group("_parallax_2d");
+	}
+}
+
+void Parallax2DEditorPlugin::_node_removed(Node *p_node) {
+	Parallax2D *parallax = Object::cast_to<Parallax2D>(p_node);
+
+	if (parallax) {
+		p_node->remove_from_group("_parallax_2d");
+	}
+}
+
+void Parallax2DEditorPlugin::forward_canvas_draw_over_viewport(Control *p_overlay) {
+	int mode = EDITOR_GET("editors/2d/parallax_preview_mode");
+
+	if (mode != OPTION_CENTERED) {
+		return;
+	}
+
+	Size2 vps_cache = Size2(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+	Control *vp_control = CanvasItemEditor::get_singleton()->get_viewport_control();
+	Transform2D vp_transform = CanvasItemEditor::get_singleton()->get_canvas_transform();
+	Vector2 vp_pos = vp_transform.get_origin() / vp_transform.get_scale();
+	Rect2 view_rect = Rect2(-vp_pos, vp_control->get_size() / vp_transform.get_scale());
+	Rect2 editor_rect = Rect2(view_rect.position + view_rect.size * 0.5 - vps_cache * 0.5, vps_cache);
+	editor_rect = CanvasItemEditor::get_singleton()->get_canvas_transform().xform(editor_rect);
+	p_overlay->draw_dashed_line(editor_rect.position, editor_rect.position + Vector2(editor_rect.size.x, 0), Color(1, 1, 0, 0.63), 2);
+	p_overlay->draw_dashed_line(editor_rect.position, editor_rect.position + Vector2(0, editor_rect.size.y), Color(1, 1, 0, 0.63), 2);
+	p_overlay->draw_dashed_line(editor_rect.position + Vector2(editor_rect.size.x, 0), editor_rect.get_end(), Color(1, 1, 0, 0.63), 2);
+	p_overlay->draw_dashed_line(editor_rect.position + Vector2(0, editor_rect.size.y), editor_rect.get_end(), Color(1, 1, 0, 0.63), 2);
+}
+
+void Parallax2DEditorPlugin::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			options->connect(SceneStringName(item_selected), callable_mp(this, &Parallax2DEditorPlugin::_options_callback));
+			get_tree()->connect("node_added", callable_mp(this, &Parallax2DEditorPlugin::_node_added));
+			get_tree()->connect("node_removed", callable_mp(this, &Parallax2DEditorPlugin::_node_removed));
+			_update_preview_mode();
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			get_tree()->disconnect("node_added", callable_mp(this, &Parallax2DEditorPlugin::_node_added));
+			get_tree()->disconnect("node_removed", callable_mp(this, &Parallax2DEditorPlugin::_node_removed));
+		} break;
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			_update_preview();
+		} break;
+	}
+}
+
+Parallax2DEditorPlugin::Parallax2DEditorPlugin() {
+	toolbar = memnew(HBoxContainer);
+	toolbar->hide();
+	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);
+
+	int mode = EDITOR_GET("editors/2d/parallax_preview_mode");
+	options = memnew(OptionButton);
+	options->add_item(TTR("Disabled"), OPTION_DISABLED);
+	options->add_item(TTR("Centered"), OPTION_CENTERED);
+	options->add_item(TTR("Top Left"), OPTION_TOP_LEFT);
+	options->select(mode);
+	toolbar->add_child(options);
+}

--- a/editor/scene/2d/parallax_2d_editor_plugin.h
+++ b/editor/scene/2d/parallax_2d_editor_plugin.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  parallax_2d.h                                                         */
+/*  parallax_2d_editor_plugin.h                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,69 +30,41 @@
 
 #pragma once
 
-#include "scene/2d/node_2d.h"
+#include "editor/plugins/editor_plugin.h"
 
-class Parallax2D : public Node2D {
-	GDCLASS(Parallax2D, Node2D);
+class HBoxContainer;
+class OptionButton;
+class Parallax2D;
 
-	static constexpr real_t DEFAULT_LIMIT = 10000000;
+class Parallax2DEditorPlugin : public EditorPlugin {
+	GDCLASS(Parallax2DEditorPlugin, EditorPlugin);
 
-	String group_name;
-	Size2 scroll_scale = Size2(1, 1);
-	Point2 scroll_offset;
-	Point2 screen_offset;
-	Vector2 repeat_size;
-	int repeat_times = 1;
-	Point2 limit_begin = Point2(-DEFAULT_LIMIT, -DEFAULT_LIMIT);
-	Point2 limit_end = Point2(DEFAULT_LIMIT, DEFAULT_LIMIT);
-	Point2 autoscroll;
-	bool follow_viewport = true;
-	bool ignore_camera_scroll = false;
+	enum {
+		OPTION_DISABLED,
+		OPTION_CENTERED,
+		OPTION_TOP_LEFT,
+	};
 
-	void _update_process();
-	void _update_repeat();
-	void _update_scroll();
-	void _process_autoscroll();
+	Parallax2D *parallax_2d = nullptr;
+	HBoxContainer *toolbar = nullptr;
+	OptionButton *options = nullptr;
+
+	void _node_added(Node *p_node);
+	void _node_removed(Node *p_node);
+	void _options_callback(int p_idx);
+	void _update_preview();
+	void _update_preview_mode();
 
 protected:
-#ifdef TOOLS_ENABLED
-	void _edit_set_position(const Point2 &p_position) override;
-#endif // TOOLS_ENABLED
-	void _validate_property(PropertyInfo &p_property) const;
-	void _camera_moved(const Transform2D &p_transform, const Point2 &p_screen_offset, const Point2 &p_adj_screen_offset);
 	void _notification(int p_what);
-	static void _bind_methods();
 
 public:
-	void set_scroll_scale(const Size2 &p_scale);
-	Size2 get_scroll_scale() const;
+	virtual String get_plugin_name() const override { return "Parallax2D"; }
+	virtual bool has_main_screen() const override { return false; }
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override;
+	virtual void make_visible(bool p_visible) override;
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override;
 
-	void set_repeat_size(const Size2 &p_repeat_size);
-	Size2 get_repeat_size() const;
-
-	void set_repeat_times(int p_repeat_times);
-	int get_repeat_times() const;
-
-	void set_autoscroll(const Point2 &p_autoscroll);
-	Point2 get_autoscroll() const;
-
-	void set_scroll_offset(const Point2 &p_offset);
-	Point2 get_scroll_offset() const;
-
-	void set_screen_offset(const Point2 &p_offset);
-	Point2 get_screen_offset() const;
-
-	void set_limit_begin(const Point2 &p_offset);
-	Point2 get_limit_begin() const;
-
-	void set_limit_end(const Point2 &p_offset);
-	Point2 get_limit_end() const;
-
-	void set_follow_viewport(bool p_follow);
-	bool get_follow_viewport();
-
-	void set_ignore_camera_scroll(bool p_ignore);
-	bool is_ignore_camera_scroll();
-
-	Parallax2D();
+	Parallax2DEditorPlugin();
 };

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1009,6 +1009,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/2d/zoom_speed_factor", 1.1, "1.01,2,0.01")
 	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/2d/ruler_width", 16.0, "12.0,30.0,1.0")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/2d/auto_resample_delay", 0.3, "0.1,2,0.1")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/2d/parallax_preview_mode", 0, "Disabled,Centered,Top Left");
+	set_restart_if_changed("editors/2d/parallax_preview_mode", true);
 
 	// Bone mapper (BoneMapEditorPlugin)
 	_initial_set("editors/bone_mapper/handle_colors/unset", Color(0.3, 0.3, 0.3));

--- a/scene/2d/parallax_2d.cpp
+++ b/scene/2d/parallax_2d.cpp
@@ -42,30 +42,20 @@ void Parallax2D::_notification(int p_what) {
 			add_to_group(group_name);
 			_update_repeat();
 			_update_scroll();
-		} break;
-
-		case NOTIFICATION_READY: {
 			_update_process();
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			Point2 offset = scroll_offset;
-			offset += autoscroll * get_process_delta_time();
-
-			if (repeat_size.x) {
-				offset.x = Math::fposmod(offset.x, repeat_size.x);
-			}
-
-			if (repeat_size.y) {
-				offset.y = Math::fposmod(offset.y, repeat_size.y);
-			}
-
-			scroll_offset = offset;
+			_process_autoscroll();
 			_update_scroll();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
 			remove_from_group(group_name);
+		} break;
+
+		case NOTIFICATION_EDITOR_PRE_SAVE: {
+			set_screen_offset(Vector2());
 		} break;
 	}
 }
@@ -150,6 +140,21 @@ void Parallax2D::_update_repeat() {
 
 	RenderingServer::get_singleton()->canvas_set_item_repeat(get_canvas_item(), repeat_size, repeat_times);
 	RenderingServer::get_singleton()->canvas_item_set_interpolated(get_canvas_item(), false);
+}
+
+void Parallax2D::_process_autoscroll() {
+	Point2 offset = scroll_offset;
+	offset += autoscroll * get_process_delta_time();
+
+	if (repeat_size.x) {
+		offset.x = Math::fposmod(offset.x, repeat_size.x);
+	}
+
+	if (repeat_size.y) {
+		offset.y = Math::fposmod(offset.y, repeat_size.y);
+	}
+
+	scroll_offset = offset;
 }
 
 void Parallax2D::set_scroll_scale(const Size2 &p_scale) {


### PR DESCRIPTION
This implements KoBeWi's parallax preview addon as a built-in editor plugin.
Closes https://github.com/godotengine/godot-proposals/issues/8680

https://github.com/user-attachments/assets/d472b229-5ea8-4cc3-87e5-7978150566c1

I'd like to get some feedback on any improvements, and there's a few things I couldn't find examples of elsewhere to go off of, so until I can find all the sloppy mistakes, I'm going to leave this as a draft for now.

Questions I'd like answered:

- [x] How do we feel about `Disabled`, `Accurate`, and `Basic` as the modes? _EDIT: Change to `Disabled`, `Centered`, and `TopLeft` for clarity._
- [x] Should it remain disabled if `ignore_camera_scroll` is enabled?
- [x] It auto-updates when clicking the toolbar dropdown, but I don't believe that's a feature of project settings (?), is that acceptable?
- [x] Is there a way to have this as an editor setting rather than a project setting? `Parallax2D` needs to access the mode on creation, and scene cannot have editor dependencies. _EDIT: Added as an editor setting._
- [x] Is there a way to avoid adding preview specific code to the node itself? _EDIT: Used an internal group to keep track of the parallax nodes_
- [x] Should there still be a preview guide box since we only go off of viewport size, since we can't know the current camera's transform?