### PR TITLE
Editor: add "Reload Saved Scene" option to the context menu of scene tabs

### DIFF
--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -192,13 +192,17 @@ void EditorSceneTabs::_update_context_menu() {
 	DISABLE_LAST_OPTION_IF(!can_save_all_scenes);
 
 	if (tab_id >= 0) {
+		bool not_in_file_system = !ResourceLoader::exists(EditorNode::get_editor_data().get_scene_path(tab_id));
+
 		scene_tabs_context_menu->add_separator();
 		scene_tabs_context_menu->add_item(TTR("Show in FileSystem"), SCENE_SHOW_IN_FILESYSTEM);
-		DISABLE_LAST_OPTION_IF(!ResourceLoader::exists(EditorNode::get_editor_data().get_scene_path(tab_id)));
+		DISABLE_LAST_OPTION_IF(not_in_file_system);
 		scene_tabs_context_menu->add_item(TTR("Play This Scene"), SCENE_RUN);
 		DISABLE_LAST_OPTION_IF(no_root_node);
 
 		scene_tabs_context_menu->add_separator();
+		scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/reload_saved_scene"), EditorNode::SCENE_RELOAD_SAVED_SCENE);
+		DISABLE_LAST_OPTION_IF(not_in_file_system);
 		scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/close_scene"), EditorNode::SCENE_CLOSE);
 		scene_tabs_context_menu->set_item_text(-1, TTR("Close Tab"));
 		scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/reopen_closed_scene"), EditorNode::SCENE_OPEN_PREV);


### PR DESCRIPTION
This command already existed, but it was not present in the context menu of scene tabs.
The option is disabled when the scene is not present in the file system, as reloading the scene is not possible in that situation.

This addition is for convenience: when a user wants to reload a specific scene, they can right click the scene tab and then click on the option.