### PR TITLE
Use `GL_FRAMEBUFFER` instead of `GL_DRAW_FRAMEBUFFER` when doing final blit to the screen framebuffer to work around OBS bug

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -410,7 +410,7 @@ void RasterizerGLES3::_blit_render_target_to_screen(DisplayServer::WindowID p_sc
 	}
 #endif
 
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
+	glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 
 	if (p_first) {
 		if (p_blit.dst_rect.position != Vector2() || p_blit.dst_rect.size != rt->size) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/110657

@MileyHollenberg Do you mind building from this PR and testing to confirm that it fixes things for you as well?

This is a weird one. But first, this change is 100% safe and technically "correct". This PR should not change behaviour in any way whatsoever.

### Background

`glBindFramebuffer()` binds a given framebuffer to the OpenGL state object. Typically it is used in two ways:
1. With `GL_FRAMEBUFFER` when drawing to that framebuffer. 
2. With `GL_DRAW_FRAMEBUFFER` and `GL_READ_FRAMEBUFFER` when blitting from one framebuffer to another using `glBlitFramebuffer()`

`GL_FRAMEBUFFER` binds the framebuffer for both draw and read operations. 

This line of code was using `GL_DRAW_FRAMEBUFFER` because it _used_ to use `glBlitFramebuffer()`. When I updated to using a regular draw call I didn't touch this line because it didn't need to be touched. The system_fbo was only needed for draw operations so this line was functionally equivalent to `glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);`

### My Theory

I don't know how OBS works, but based on this investigation my assumption is that it initiates a copy operation from whatever is bound as the _read_ framebuffer at the time that the back buffer is swapped. Since the code in 4.5 only sets the _draw_ framebuffer to the system_fbo, OBS ends up reading from our internal offscreen FBO which will still be bound as the read framebuffer. 

By using `GL_FRAMEBUFFER` we ensure that the read framebuffer is updated to the system_fbo and thus OBS is able to find the proper texture for capture. 

So this is a classic example of two things:
1. OpenGL's state machine design being horrible
2. External programs making weird assumptions about how your program operates and then completely failing when those assumptions are not true

### More details

In 4.4 we had this chunk of code at the end of the blit function:

```
if (read_fbo != 0) {
	glBindFramebuffer(GL_READ_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
	glDeleteFramebuffers(1, &read_fbo);
}
```
We were generating an FBO and binding the Viewport's texture to it then binding it as the read framebuffer. Since we were deleting that framebuffer each frame, we needed to bind the system_fbo to the read framebuffer. Which was convenient for OBS since then it was available for OBS to read from it. 
