### PR TITLE
Fix GDScript debugger polls too early

### DIFF
--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -180,6 +180,8 @@ void EngineDebugger::deinitialize() {
 		// Flush any remaining message
 		singleton->poll_events(false);
 
+		singleton->ready_to_poll = false;
+
 		memdelete(singleton);
 		singleton = nullptr;
 	}
@@ -188,6 +190,10 @@ void EngineDebugger::deinitialize() {
 	profilers.clear();
 	captures.clear();
 	protocols.clear();
+}
+
+void EngineDebugger::mark_ready_to_poll() {
+	ready_to_poll = true;
 }
 
 EngineDebugger::~EngineDebugger() {

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -90,6 +90,7 @@ private:
 	double physics_frame_time = 0.0;
 
 	uint32_t poll_every = 0;
+	bool ready_to_poll = false;
 
 protected:
 	static inline EngineDebugger *singleton = nullptr;
@@ -124,8 +125,12 @@ public:
 	void iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, double p_physics_frame_time);
 	void profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts = Array());
 	Error capture_parse(const StringName &p_name, const String &p_msg, const Array &p_args, bool &r_captured);
+	void mark_ready_to_poll();
 
 	void line_poll() {
+		if (!ready_to_poll) {
+			return;
+		}
 		// The purpose of this is just processing events every now and then when the script might get too busy otherwise bugs like infinite loops can't be caught.
 		if (unlikely(poll_every % 2048) == 0) {
 			poll_events(false);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4853,6 +4853,11 @@ int Main::start() {
 
 	GDExtensionManager::get_singleton()->startup();
 
+	if (EngineDebugger::is_active()) {
+		// Scene tree is fully set up. Debugger can process messages now.
+		EngineDebugger::get_singleton()->mark_ready_to_poll();
+	}
+
 #ifdef MACOS_ENABLED
 	// TODO: Used to fix full-screen splash drawing on macOS, processing events before main loop is fully initialized cause issues on Wayland, and has no effect on other platforms.
 	if (minimum_time_msec) {


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/111656*

## Issue Description

When there is a theme with gdscript. We need load theme before main scene.

1. Load theme.tres
2. Load sub-resource (gdscript) of theme
3. Set script to theme (Texture2D). And in `set_script()` we will create instance for the script, which will invoke `implicit_new` function of this script.
4. When debugger enabled, `implict_new()` function will call `EngineDebugger::get_singleton()->line_poll()`, I guess it try to refresh the current debug information.
5. The calling of `line_poll()` is too early, we didnot load main scene, yet. So the error messages reported.

https://github.com/godotengine/godot/blob/7864ac80192e9e91bf56176af9f04cc013b580aa/modules/gdscript/gdscript_vm.cpp#L3906

## Solution

I add a `started` flag to `EngineDebugger`, to decide whether main scene had been loaded.
