### PR TITLE
Round values after renormalization when generating mipmaps.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -4575,9 +4575,9 @@ void Image::renormalize_uint8(uint8_t *p_rgb) {
 	n += Vector3(1, 1, 1);
 	n *= 0.5;
 	n *= 255;
-	p_rgb[0] = CLAMP(int(n.x), 0, 255);
-	p_rgb[1] = CLAMP(int(n.y), 0, 255);
-	p_rgb[2] = CLAMP(int(n.z), 0, 255);
+	p_rgb[0] = CLAMP(int(Math::round(n.x)), 0, 255);
+	p_rgb[1] = CLAMP(int(Math::round(n.y)), 0, 255);
+	p_rgb[2] = CLAMP(int(Math::round(n.z)), 0, 255);
 }
 
 void Image::renormalize_float(float *p_rgb) {
@@ -4604,9 +4604,9 @@ void Image::renormalize_uint16(uint16_t *p_rgb) {
 	n += Vector3(1, 1, 1);
 	n *= 0.5;
 	n *= 65535;
-	p_rgb[0] = CLAMP(int(n.x), 0, 65535);
-	p_rgb[1] = CLAMP(int(n.y), 0, 65535);
-	p_rgb[2] = CLAMP(int(n.z), 0, 65535);
+	p_rgb[0] = CLAMP(int(Math::round(n.x)), 0, 65535);
+	p_rgb[1] = CLAMP(int(Math::round(n.y)), 0, 65535);
+	p_rgb[2] = CLAMP(int(Math::round(n.z)), 0, 65535);
 }
 
 Image::Image(const uint8_t *p_mem_png_jpg, int p_len) {


### PR DESCRIPTION
This prevents flat regions of normal maps from progressively getting darker, and causing the normal to distort by distance as a result.

For example, when the pixel value is [128, 128, 255], the renormalization makes it [127.999~, 127.999~, 254.999~], which gets floored to [127, 127, 254]. When that also gets normalized, the X and Y become 126.996~, and it progressively gets smaller with each mip level, which causes distortion. Rounding fixes this.

|Upstream|This PR|
|-|-|
|<img width="1146" height="844" alt="master" src="https://github.com/user-attachments/assets/a5fa22da-7d95-4417-bdc3-82e391c465ed" />|<img width="1150" height="848" alt="pr" src="https://github.com/user-attachments/assets/e0dd3269-c429-4128-91fe-71e443e4efc4" />|

Test scene is from [here](https://github.com/godotengine/godot/pull/111210#issuecomment-3418374108).
