### PR TITLE
Implement `get_applied_force` and `get_applied_torque` for 3D joints

### DIFF
--- a/doc/classes/ConeTwistJoint3D.xml
+++ b/doc/classes/ConeTwistJoint3D.xml
@@ -24,6 +24,18 @@
 				Sets the value of the specified parameter.
 			</description>
 		</method>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="bias" type="float" setter="set_param" getter="get_param" default="0.3">

--- a/doc/classes/ConeTwistJoint3D.xml
+++ b/doc/classes/ConeTwistJoint3D.xml
@@ -9,6 +9,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="ConeTwistJoint3D.Param" />
@@ -22,18 +34,6 @@
 			<param index="1" name="value" type="float" />
 			<description>
 				Sets the value of the specified parameter.
-			</description>
-		</method>
-		<method name="get_applied_force" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
-			</description>
-		</method>
-		<method name="get_applied_torque" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ConeTwistJoint3D.xml
+++ b/doc/classes/ConeTwistJoint3D.xml
@@ -12,13 +12,13 @@
 		<method name="get_applied_force" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="get_applied_torque" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied torque to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="get_param" qualifiers="const">

--- a/doc/classes/Generic6DOFJoint3D.xml
+++ b/doc/classes/Generic6DOFJoint3D.xml
@@ -10,6 +10,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="get_flag_x" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag" />
@@ -86,18 +98,6 @@
 			<param index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param" />
 			<param index="1" name="value" type="float" />
 			<description>
-			</description>
-		</method>
-		<method name="get_applied_force" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
-			</description>
-		</method>
-		<method name="get_applied_torque" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Generic6DOFJoint3D.xml
+++ b/doc/classes/Generic6DOFJoint3D.xml
@@ -13,13 +13,13 @@
 		<method name="get_applied_force" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="get_applied_torque" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied torque to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="get_flag_x" qualifiers="const">

--- a/doc/classes/Generic6DOFJoint3D.xml
+++ b/doc/classes/Generic6DOFJoint3D.xml
@@ -88,6 +88,18 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="angular_limit_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="1.0">

--- a/doc/classes/HingeJoint3D.xml
+++ b/doc/classes/HingeJoint3D.xml
@@ -12,13 +12,13 @@
 		<method name="get_applied_force" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="get_applied_torque" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied torque to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="get_flag" qualifiers="const">

--- a/doc/classes/HingeJoint3D.xml
+++ b/doc/classes/HingeJoint3D.xml
@@ -39,6 +39,18 @@
 				Sets the value of the specified parameter.
 			</description>
 		</method>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="angular_limit/bias" type="float" setter="set_param" getter="get_param" default="0.3">

--- a/doc/classes/HingeJoint3D.xml
+++ b/doc/classes/HingeJoint3D.xml
@@ -9,6 +9,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="get_flag" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="flag" type="int" enum="HingeJoint3D.Flag" />
@@ -37,18 +49,6 @@
 			<param index="1" name="value" type="float" />
 			<description>
 				Sets the value of the specified parameter.
-			</description>
-		</method>
-		<method name="get_applied_force" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
-			</description>
-		</method>
-		<method name="get_applied_torque" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -716,6 +716,20 @@
 				Creates a 3D concave polygon shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the concave polygon's triangles.
 			</description>
 		</method>
+		<method name="cone_twist_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="cone_twist_joint_get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="cone_twist_joint_get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
@@ -757,6 +771,20 @@
 			<param index="0" name="rid" type="RID" />
 			<description>
 				Destroys any of the objects created by PhysicsServer3D. If the [RID] passed is not one of the objects that can be created by PhysicsServer3D, an error will be sent to the console.
+			</description>
+		</method>
+		<method name="generic_6dof_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="generic_6dof_joint_get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="generic_6dof_joint_get_flag" qualifiers="const">
@@ -808,6 +836,20 @@
 			<return type="RID" />
 			<description>
 				Creates a 3D heightmap shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the heightmap's data.
+			</description>
+		</method>
+		<method name="hinge_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="hinge_joint_get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="hinge_joint_get_flag" qualifiers="const">
@@ -943,6 +985,13 @@
 				Sets the priority value of the Joint3D.
 			</description>
 		</method>
+		<method name="pin_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="pin_joint_get_local_a" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="joint" type="RID" />
@@ -1051,6 +1100,20 @@
 			<description>
 				Sets the collision margin for the shape.
 				[b]Note:[/b] This is not used in Godot Physics.
+			</description>
+		</method>
+		<method name="slider_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="slider_joint_get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="slider_joint_get_param" qualifiers="const">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1102,20 +1102,6 @@
 				[b]Note:[/b] This is not used in Godot Physics.
 			</description>
 		</method>
-		<method name="slider_joint_get_applied_force" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="joint" type="RID" />
-			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
-			</description>
-		</method>
-		<method name="slider_joint_get_applied_torque" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="joint" type="RID" />
-			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
-			</description>
-		</method>
 		<method name="slider_joint_get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
@@ -1131,6 +1117,18 @@
 			<param index="2" name="value" type="float" />
 			<description>
 				Gets a slider joint parameter.
+			</description>
+		</method>
+		<method name="slider_twist_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="slider_twist_joint_get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
 			</description>
 		</method>
 		<method name="soft_body_add_collision_exception">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -720,14 +720,14 @@
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="cone_twist_joint_get_applied_torque" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied torque to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="cone_twist_joint_get_param" qualifiers="const">
@@ -777,14 +777,14 @@
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="generic_6dof_joint_get_applied_torque" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied torque to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="generic_6dof_joint_get_flag" qualifiers="const">
@@ -842,14 +842,14 @@
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="hinge_joint_get_applied_torque" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied torque to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="hinge_joint_get_flag" qualifiers="const">
@@ -989,7 +989,7 @@
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="pin_joint_get_local_a" qualifiers="const">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -633,7 +633,7 @@
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="_cone_twist_joint_get_applied_torque" qualifiers="virtual required const">
@@ -698,7 +698,7 @@
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="_generic_6dof_joint_get_applied_torque" qualifiers="virtual required const">
@@ -757,7 +757,7 @@
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="_hinge_joint_get_applied_torque" qualifiers="virtual required const">
@@ -916,7 +916,7 @@
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="_pin_joint_get_local_a" qualifiers="virtual required const">
@@ -1020,7 +1020,7 @@
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="_slider_joint_get_applied_torque" qualifiers="virtual required const">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -629,14 +629,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_cone_twist_joint_get_applied_force" qualifiers="const">
+		<method name="_cone_twist_joint_get_applied_force" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
-		<method name="_cone_twist_joint_get_applied_torque" qualifiers="const">
+		<method name="_cone_twist_joint_get_applied_torque" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
@@ -694,14 +694,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_generic_6dof_joint_get_applied_force" qualifiers="const">
+		<method name="_generic_6dof_joint_get_applied_force" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
-		<method name="_generic_6dof_joint_get_applied_torque" qualifiers="const">
+		<method name="_generic_6dof_joint_get_applied_torque" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
@@ -753,14 +753,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_hinge_joint_get_applied_force" qualifiers="const">
+		<method name="_hinge_joint_get_applied_force" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
-		<method name="_hinge_joint_get_applied_torque" qualifiers="const">
+		<method name="_hinge_joint_get_applied_torque" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
@@ -912,7 +912,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_pin_joint_get_applied_force" qualifiers="const">
+		<method name="_pin_joint_get_applied_force" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
@@ -1016,14 +1016,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_slider_joint_get_applied_force" qualifiers="const">
+		<method name="_slider_joint_get_applied_force" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
-		<method name="_slider_joint_get_applied_torque" qualifiers="const">
+		<method name="_slider_joint_get_applied_torque" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<description>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -629,6 +629,20 @@
 			<description>
 			</description>
 		</method>
+		<method name="_cone_twist_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="_cone_twist_joint_get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_torque to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="_cone_twist_joint_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
@@ -680,6 +694,20 @@
 			<description>
 			</description>
 		</method>
+		<method name="_generic_6dof_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="_generic_6dof_joint_get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_torque to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="_generic_6dof_joint_get_flag" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
@@ -723,6 +751,20 @@
 		<method name="_heightmap_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
+			</description>
+		</method>
+		<method name="_hinge_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="_hinge_joint_get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_torque to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="_hinge_joint_get_flag" qualifiers="virtual required const">
@@ -870,6 +912,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_pin_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="_pin_joint_get_local_a" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="joint" type="RID" />
@@ -965,6 +1014,20 @@
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="margin" type="float" />
 			<description>
+			</description>
+		</method>
+		<method name="_slider_joint_get_applied_force" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="_slider_joint_get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns the applied_torque to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="_slider_joint_get_param" qualifiers="virtual required const">

--- a/doc/classes/PinJoint3D.xml
+++ b/doc/classes/PinJoint3D.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="PinJoint3D.Param" />
@@ -22,12 +28,6 @@
 			<param index="1" name="value" type="float" />
 			<description>
 				Sets the value of the specified parameter.
-			</description>
-		</method>
-		<method name="get_applied_force" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PinJoint3D.xml
+++ b/doc/classes/PinJoint3D.xml
@@ -12,7 +12,7 @@
 		<method name="get_applied_force" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="get_param" qualifiers="const">

--- a/doc/classes/PinJoint3D.xml
+++ b/doc/classes/PinJoint3D.xml
@@ -24,6 +24,12 @@
 				Sets the value of the specified parameter.
 			</description>
 		</method>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="params/bias" type="float" setter="set_param" getter="get_param" default="0.3">

--- a/doc/classes/SliderJoint3D.xml
+++ b/doc/classes/SliderJoint3D.xml
@@ -24,6 +24,18 @@
 				Assigns [param value] to the given parameter.
 			</description>
 		</method>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="angular_limit/damping" type="float" setter="set_param" getter="get_param" default="0.0">

--- a/doc/classes/SliderJoint3D.xml
+++ b/doc/classes/SliderJoint3D.xml
@@ -9,6 +9,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_applied_force" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
+		<method name="get_applied_torque" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+			</description>
+		</method>
 		<method name="get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="SliderJoint3D.Param" />
@@ -22,18 +34,6 @@
 			<param index="1" name="value" type="float" />
 			<description>
 				Assigns [param value] to the given parameter.
-			</description>
-		</method>
-		<method name="get_applied_force" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
-			</description>
-		</method>
-		<method name="get_applied_torque" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SliderJoint3D.xml
+++ b/doc/classes/SliderJoint3D.xml
@@ -12,13 +12,13 @@
 		<method name="get_applied_force" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the applied_force to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied force to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="get_applied_torque" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the applied_torqu to the joint. Notice: This only returns a correct value in Jolt Physics
+				Returns the applied torque to the joint. Notice: This only returns a correct value in Jolt Physics
 			</description>
 		</method>
 		<method name="get_param" qualifiers="const">

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1334,7 +1334,7 @@ Vector3 GodotPhysicsServer3D::pin_joint_get_local_b(RID p_joint) const {
 	return pin_joint->get_position_b();
 }
 
-real_t GodotPhysicsServer3D::pin_joint_get_applied_force(RID p_joint) const {
+float GodotPhysicsServer3D::pin_joint_get_applied_force(RID p_joint) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_PIN, false);
@@ -1422,7 +1422,7 @@ bool GodotPhysicsServer3D::hinge_joint_get_flag(RID p_joint, HingeJointFlag p_fl
 	return hinge_joint->get_flag(p_flag);
 }
 
-real_t GodotPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
+float GodotPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_HINGE, false);
@@ -1430,7 +1430,7 @@ real_t GodotPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
 	return hinge_joint->get_applied_force();
 }
 
-real_t GodotPhysicsServer3D::hinge_joint_get_applied_torque(RID p_joint) const {
+float GodotPhysicsServer3D::hinge_joint_get_applied_torque(RID p_joint) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_HINGE, false);
@@ -1523,7 +1523,7 @@ real_t GodotPhysicsServer3D::slider_joint_get_param(RID p_joint, SliderJointPara
 	return slider_joint->get_param(p_param);
 }
 
-real_t GodotPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
+float GodotPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_SLIDER, false);
@@ -1531,7 +1531,7 @@ real_t GodotPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
 	return slider_joint->get_applied_force();
 }
 
-real_t GodotPhysicsServer3D::slider_joint_get_applied_torque(RID p_joint) const {
+float GodotPhysicsServer3D::slider_joint_get_applied_torque(RID p_joint) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_SLIDER, false);
@@ -1579,7 +1579,7 @@ real_t GodotPhysicsServer3D::cone_twist_joint_get_param(RID p_joint, ConeTwistJo
 	return cone_twist_joint->get_param(p_param);
 }
 
-real_t GodotPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) const {
+float GodotPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_CONE_TWIST, false);
@@ -1587,7 +1587,7 @@ real_t GodotPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) con
 	return cone_twist_joint->get_applied_force();
 }
 
-real_t GodotPhysicsServer3D::cone_twist_joint_get_applied_torque(RID p_joint) const {
+float GodotPhysicsServer3D::cone_twist_joint_get_applied_torque(RID p_joint) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_CONE_TWIST, false);
@@ -1651,7 +1651,7 @@ bool GodotPhysicsServer3D::generic_6dof_joint_get_flag(RID p_joint, Vector3::Axi
 	return generic_6dof_joint->get_flag(p_axis, p_flag);
 }
 
-real_t GodotPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) const {
+float GodotPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_6DOF, false);
@@ -1659,7 +1659,7 @@ real_t GodotPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) c
 	return generic_6dof_joint->get_applied_force();
 }
 
-real_t GodotPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) const {
+float GodotPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_6DOF, false);

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1334,6 +1334,14 @@ Vector3 GodotPhysicsServer3D::pin_joint_get_local_b(RID p_joint) const {
 	return pin_joint->get_position_b();
 }
 
+real_t GodotPhysicsServer3D::pin_joint_get_applied_force(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_PIN, false);
+	GodotPinJoint3D *pin_joint = static_cast<GodotPinJoint3D *>(joint);
+	return pin_joint->get_applied_force();
+}
+
 void GodotPhysicsServer3D::joint_make_hinge(RID p_joint, RID p_body_A, const Transform3D &p_frame_A, RID p_body_B, const Transform3D &p_frame_B) {
 	GodotBody3D *body_A = body_owner.get_or_null(p_body_A);
 	ERR_FAIL_NULL(body_A);
@@ -1412,6 +1420,22 @@ bool GodotPhysicsServer3D::hinge_joint_get_flag(RID p_joint, HingeJointFlag p_fl
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_HINGE, false);
 	GodotHingeJoint3D *hinge_joint = static_cast<GodotHingeJoint3D *>(joint);
 	return hinge_joint->get_flag(p_flag);
+}
+
+real_t GodotPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_HINGE, false);
+	GodotHingeJoint3D *hinge_joint = static_cast<GodotHingeJoint3D *>(joint);
+	return hinge_joint->get_applied_force();
+}
+
+real_t GodotPhysicsServer3D::hinge_joint_get_applied_torque(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_HINGE, false);
+	GodotHingeJoint3D *hinge_joint = static_cast<GodotHingeJoint3D *>(joint);
+	return hinge_joint->get_applied_torque();
 }
 
 void GodotPhysicsServer3D::joint_set_solver_priority(RID p_joint, int p_priority) {
@@ -1499,6 +1523,22 @@ real_t GodotPhysicsServer3D::slider_joint_get_param(RID p_joint, SliderJointPara
 	return slider_joint->get_param(p_param);
 }
 
+real_t GodotPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_SLIDER, false);
+	GodotSliderJoint3D *slider_joint = static_cast<GodotSliderJoint3D *>(joint);
+	return slider_joint->get_applied_force();
+}
+
+real_t GodotPhysicsServer3D::slider_joint_get_applied_torque(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_SLIDER, false);
+	GodotSliderJoint3D *slider_joint = static_cast<GodotSliderJoint3D *>(joint);
+	return slider_joint->get_applied_torque();
+}
+
 void GodotPhysicsServer3D::joint_make_cone_twist(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) {
 	GodotBody3D *body_A = body_owner.get_or_null(p_body_A);
 	ERR_FAIL_NULL(body_A);
@@ -1537,6 +1577,22 @@ real_t GodotPhysicsServer3D::cone_twist_joint_get_param(RID p_joint, ConeTwistJo
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_CONE_TWIST, 0);
 	GodotConeTwistJoint3D *cone_twist_joint = static_cast<GodotConeTwistJoint3D *>(joint);
 	return cone_twist_joint->get_param(p_param);
+}
+
+real_t GodotPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_CONE_TWIST, false);
+	GodotConeTwistJoint3D *cone_twist_joint = static_cast<GodotConeTwistJoint3D *>(joint);
+	return cone_twist_joint->get_applied_force();
+}
+
+real_t GodotPhysicsServer3D::cone_twist_joint_get_applied_torque(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_CONE_TWIST, false);
+	GodotConeTwistJoint3D *cone_twist_joint = static_cast<GodotConeTwistJoint3D *>(joint);
+	return cone_twist_joint->get_applied_torque();
 }
 
 void GodotPhysicsServer3D::joint_make_generic_6dof(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) {
@@ -1593,6 +1649,22 @@ bool GodotPhysicsServer3D::generic_6dof_joint_get_flag(RID p_joint, Vector3::Axi
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_6DOF, false);
 	GodotGeneric6DOFJoint3D *generic_6dof_joint = static_cast<GodotGeneric6DOFJoint3D *>(joint);
 	return generic_6dof_joint->get_flag(p_axis, p_flag);
+}
+
+real_t GodotPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_6DOF, false);
+	GodotGeneric6DOFJoint3D *generic_6dof_joint = static_cast<GodotGeneric6DOFJoint3D *>(joint);
+	return generic_6dof_joint->get_applied_force();
+}
+
+real_t GodotPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_6DOF, false);
+	GodotGeneric6DOFJoint3D *generic_6dof_joint = static_cast<GodotGeneric6DOFJoint3D *>(joint);
+	return generic_6dof_joint->get_applied_torque();
 }
 
 void GodotPhysicsServer3D::free_rid(RID p_rid) {

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -334,7 +334,7 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_B) override;
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const override;
 
-	virtual real_t pin_joint_get_applied_force(RID p_joint) const override;
+	virtual float pin_joint_get_applied_force(RID p_joint) const override;
 
 	virtual void joint_make_hinge(RID p_joint, RID p_body_A, const Transform3D &p_frame_A, RID p_body_B, const Transform3D &p_frame_B) override;
 	virtual void joint_make_hinge_simple(RID p_joint, RID p_body_A, const Vector3 &p_pivot_A, const Vector3 &p_axis_A, RID p_body_B, const Vector3 &p_pivot_B, const Vector3 &p_axis_B) override;
@@ -345,24 +345,24 @@ public:
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_value) override;
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const override;
 
-	virtual real_t hinge_joint_get_applied_force(RID p_joint) const override;
-	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const override;
+	virtual float hinge_joint_get_applied_force(RID p_joint) const override;
+	virtual float hinge_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual void joint_make_slider(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override; //reference frame is A
 
 	virtual void slider_joint_set_param(RID p_joint, SliderJointParam p_param, real_t p_value) override;
 	virtual real_t slider_joint_get_param(RID p_joint, SliderJointParam p_param) const override;
 
-	virtual real_t slider_joint_get_applied_force(RID p_joint) const override;
-	virtual real_t slider_joint_get_applied_torque(RID p_joint) const override;
+	virtual float slider_joint_get_applied_force(RID p_joint) const override;
+	virtual float slider_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual void joint_make_cone_twist(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override; //reference frame is A
 
 	virtual void cone_twist_joint_set_param(RID p_joint, ConeTwistJointParam p_param, real_t p_value) override;
 	virtual real_t cone_twist_joint_get_param(RID p_joint, ConeTwistJointParam p_param) const override;
 
-	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const override;
-	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const override;
+	virtual float cone_twist_joint_get_applied_force(RID p_joint) const override;
+	virtual float cone_twist_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override; //reference frame is A
 
@@ -372,8 +372,8 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override;
 
-	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const override;
-	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const override;
+	virtual float generic_6dof_joint_get_applied_force(RID p_joint) const override;
+	virtual float generic_6dof_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual JointType joint_get_type(RID p_joint) const override;
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -334,6 +334,8 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_B) override;
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const override;
 
+	virtual real_t pin_joint_get_applied_force(RID p_joint) const override;
+
 	virtual void joint_make_hinge(RID p_joint, RID p_body_A, const Transform3D &p_frame_A, RID p_body_B, const Transform3D &p_frame_B) override;
 	virtual void joint_make_hinge_simple(RID p_joint, RID p_body_A, const Vector3 &p_pivot_A, const Vector3 &p_axis_A, RID p_body_B, const Vector3 &p_pivot_B, const Vector3 &p_axis_B) override;
 
@@ -343,15 +345,24 @@ public:
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_value) override;
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const override;
 
+	virtual real_t hinge_joint_get_applied_force(RID p_joint) const override;
+	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const override;
+
 	virtual void joint_make_slider(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override; //reference frame is A
 
 	virtual void slider_joint_set_param(RID p_joint, SliderJointParam p_param, real_t p_value) override;
 	virtual real_t slider_joint_get_param(RID p_joint, SliderJointParam p_param) const override;
 
+	virtual real_t slider_joint_get_applied_force(RID p_joint) const override;
+	virtual real_t slider_joint_get_applied_torque(RID p_joint) const override;
+
 	virtual void joint_make_cone_twist(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override; //reference frame is A
 
 	virtual void cone_twist_joint_set_param(RID p_joint, ConeTwistJointParam p_param, real_t p_value) override;
 	virtual real_t cone_twist_joint_get_param(RID p_joint, ConeTwistJointParam p_param) const override;
+
+	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const override;
+	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override; //reference frame is A
 
@@ -360,6 +371,9 @@ public:
 
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override;
+
+	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const override;
+	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual JointType joint_get_type(RID p_joint) const override;
 

--- a/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
@@ -325,12 +325,12 @@ real_t GodotConeTwistJoint3D::get_param(PhysicsServer3D::ConeTwistJointParam p_p
 	return 0;
 }
 
-real_t GodotConeTwistJoint3D::get_applied_force() const {
+float GodotConeTwistJoint3D::get_applied_force() const {
 	WARN_PRINT_ONCE("ConeTwistJoint3D->get_applied_force only works with Jolt Physics.");
 	return 0;
 }
 
-real_t GodotConeTwistJoint3D::get_applied_torque() const {
+float GodotConeTwistJoint3D::get_applied_torque() const {
 	WARN_PRINT_ONCE("ConeTwistJoint3D->get_applied_torque only works with Jolt Physics.");
 	return 0;
 }

--- a/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
@@ -324,3 +324,13 @@ real_t GodotConeTwistJoint3D::get_param(PhysicsServer3D::ConeTwistJointParam p_p
 
 	return 0;
 }
+
+real_t GodotConeTwistJoint3D::get_applied_force() const {
+	WARN_PRINT_ONCE("ConeTwistJoint3D->get_applied_force only works with Jolt Physics.");
+	return 0;
+}
+
+real_t GodotConeTwistJoint3D::get_applied_torque() const {
+	WARN_PRINT_ONCE("ConeTwistJoint3D->get_applied_torque only works with Jolt Physics.");
+	return 0;
+}

--- a/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.h
@@ -136,4 +136,7 @@ public:
 
 	void set_param(PhysicsServer3D::ConeTwistJointParam p_param, real_t p_value);
 	real_t get_param(PhysicsServer3D::ConeTwistJointParam p_param) const;
+
+	real_t get_applied_force() const;
+	real_t get_applied_torque() const;
 };

--- a/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.h
@@ -137,6 +137,6 @@ public:
 	void set_param(PhysicsServer3D::ConeTwistJointParam p_param, real_t p_value);
 	real_t get_param(PhysicsServer3D::ConeTwistJointParam p_param) const;
 
-	real_t get_applied_force() const;
-	real_t get_applied_torque() const;
+	float get_applied_force() const;
+	float get_applied_torque() const;
 };

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
@@ -674,12 +674,12 @@ bool GodotGeneric6DOFJoint3D::get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6
 	return false;
 }
 
-real_t GodotGeneric6DOFJoint3D::get_applied_force() const {
+float GodotGeneric6DOFJoint3D::get_applied_force() const {
 	WARN_PRINT_ONCE("Generic6DOFJoint3D->get_applied_force only works with Jolt Physics.");
 	return 0;
 }
 
-real_t GodotGeneric6DOFJoint3D::get_applied_torque() const {
+float GodotGeneric6DOFJoint3D::get_applied_torque() const {
 	WARN_PRINT_ONCE("Generic6DOFJoint3D->get_applied_torque only works with Jolt Physics.");
 	return 0;
 }

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
@@ -673,3 +673,13 @@ bool GodotGeneric6DOFJoint3D::get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6
 
 	return false;
 }
+
+real_t GodotGeneric6DOFJoint3D::get_applied_force() const {
+	WARN_PRINT_ONCE("Generic6DOFJoint3D->get_applied_force only works with Jolt Physics.");
+	return 0;
+}
+
+real_t GodotGeneric6DOFJoint3D::get_applied_torque() const {
+	WARN_PRINT_ONCE("Generic6DOFJoint3D->get_applied_torque only works with Jolt Physics.");
+	return 0;
+}

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
@@ -317,6 +317,6 @@ public:
 	void set_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_value);
 	bool get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const;
 
-	real_t get_applied_force() const;
-	real_t get_applied_torque() const;
+	float get_applied_force() const;
+	float get_applied_torque() const;
 };

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
@@ -316,4 +316,7 @@ public:
 
 	void set_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_value);
 	bool get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const;
+
+	real_t get_applied_force() const;
+	real_t get_applied_torque() const;
 };

--- a/modules/godot_physics_3d/joints/godot_hinge_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_hinge_joint_3d.cpp
@@ -440,12 +440,12 @@ bool GodotHingeJoint3D::get_flag(PhysicsServer3D::HingeJointFlag p_flag) const {
 	return false;
 }
 
-real_t GodotHingeJoint3D::get_applied_force() const {
+float GodotHingeJoint3D::get_applied_force() const {
 	WARN_PRINT_ONCE("HingeJoint3D->get_applied_force only works with Jolt Physics.");
 	return 0;
 }
 
-real_t GodotHingeJoint3D::get_applied_torque() const {
+float GodotHingeJoint3D::get_applied_torque() const {
 	WARN_PRINT_ONCE("HingeJoint3D->get_applied_torque only works with Jolt Physics.");
 	return 0;
 }

--- a/modules/godot_physics_3d/joints/godot_hinge_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_hinge_joint_3d.cpp
@@ -439,3 +439,13 @@ bool GodotHingeJoint3D::get_flag(PhysicsServer3D::HingeJointFlag p_flag) const {
 
 	return false;
 }
+
+real_t GodotHingeJoint3D::get_applied_force() const {
+	WARN_PRINT_ONCE("HingeJoint3D->get_applied_force only works with Jolt Physics.");
+	return 0;
+}
+
+real_t GodotHingeJoint3D::get_applied_torque() const {
+	WARN_PRINT_ONCE("HingeJoint3D->get_applied_torque only works with Jolt Physics.");
+	return 0;
+}

--- a/modules/godot_physics_3d/joints/godot_hinge_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_hinge_joint_3d.h
@@ -108,6 +108,9 @@ public:
 	void set_flag(PhysicsServer3D::HingeJointFlag p_flag, bool p_value);
 	bool get_flag(PhysicsServer3D::HingeJointFlag p_flag) const;
 
+	real_t get_applied_force() const;
+	real_t get_applied_torque() const;
+
 	GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Transform3D &frameA, const Transform3D &frameB);
 	GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Vector3 &pivotInA, const Vector3 &pivotInB, const Vector3 &axisInA, const Vector3 &axisInB);
 };

--- a/modules/godot_physics_3d/joints/godot_hinge_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_hinge_joint_3d.h
@@ -108,8 +108,8 @@ public:
 	void set_flag(PhysicsServer3D::HingeJointFlag p_flag, bool p_value);
 	bool get_flag(PhysicsServer3D::HingeJointFlag p_flag) const;
 
-	real_t get_applied_force() const;
-	real_t get_applied_torque() const;
+	float get_applied_force() const;
+	float get_applied_torque() const;
 
 	GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Transform3D &frameA, const Transform3D &frameB);
 	GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Vector3 &pivotInA, const Vector3 &pivotInB, const Vector3 &axisInA, const Vector3 &axisInB);

--- a/modules/godot_physics_3d/joints/godot_pin_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_pin_joint_3d.cpp
@@ -166,12 +166,12 @@ real_t GodotPinJoint3D::get_param(PhysicsServer3D::PinJointParam p_param) const 
 	return 0;
 }
 
-real_t GodotPinJoint3D::get_applied_force() const {
+float GodotPinJoint3D::get_applied_force() const {
 	WARN_PRINT_ONCE("PinJoint3D->get_applied_force only works with Jolt Physics.");
 	return 0;
 }
 
-real_t GodotPinJoint3D::get_applied_torque() const {
+float GodotPinJoint3D::get_applied_torque() const {
 	WARN_PRINT_ONCE("PinJoint3D does not have a value for get_applied_torque()");
 	return 0;
 }

--- a/modules/godot_physics_3d/joints/godot_pin_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_pin_joint_3d.cpp
@@ -166,6 +166,16 @@ real_t GodotPinJoint3D::get_param(PhysicsServer3D::PinJointParam p_param) const 
 	return 0;
 }
 
+real_t GodotPinJoint3D::get_applied_force() const {
+	WARN_PRINT_ONCE("PinJoint3D->get_applied_force only works with Jolt Physics.");
+	return 0;
+}
+
+real_t GodotPinJoint3D::get_applied_torque() const {
+	WARN_PRINT_ONCE("PinJoint3D does not have a value for get_applied_torque()");
+	return 0;
+}
+
 GodotPinJoint3D::GodotPinJoint3D(GodotBody3D *p_body_a, const Vector3 &p_pos_a, GodotBody3D *p_body_b, const Vector3 &p_pos_b) :
 		GodotJoint3D(_arr, 2) {
 	A = p_body_a;

--- a/modules/godot_physics_3d/joints/godot_pin_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_pin_joint_3d.cpp
@@ -171,11 +171,6 @@ float GodotPinJoint3D::get_applied_force() const {
 	return 0;
 }
 
-float GodotPinJoint3D::get_applied_torque() const {
-	WARN_PRINT_ONCE("PinJoint3D does not have a value for get_applied_torque()");
-	return 0;
-}
-
 GodotPinJoint3D::GodotPinJoint3D(GodotBody3D *p_body_a, const Vector3 &p_pos_a, GodotBody3D *p_body_b, const Vector3 &p_pos_b) :
 		GodotJoint3D(_arr, 2) {
 	A = p_body_a;

--- a/modules/godot_physics_3d/joints/godot_pin_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_pin_joint_3d.h
@@ -87,6 +87,9 @@ public:
 	Vector3 get_position_a() { return m_pivotInA; }
 	Vector3 get_position_b() { return m_pivotInB; }
 
+	real_t get_applied_force() const;
+	real_t get_applied_torque() const;
+
 	GodotPinJoint3D(GodotBody3D *p_body_a, const Vector3 &p_pos_a, GodotBody3D *p_body_b, const Vector3 &p_pos_b);
 	~GodotPinJoint3D();
 };

--- a/modules/godot_physics_3d/joints/godot_pin_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_pin_joint_3d.h
@@ -88,7 +88,6 @@ public:
 	Vector3 get_position_b() { return m_pivotInB; }
 
 	float get_applied_force() const;
-	float get_applied_torque() const;
 
 	GodotPinJoint3D(GodotBody3D *p_body_a, const Vector3 &p_pos_a, GodotBody3D *p_body_b, const Vector3 &p_pos_b);
 	~GodotPinJoint3D();

--- a/modules/godot_physics_3d/joints/godot_pin_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_pin_joint_3d.h
@@ -87,8 +87,8 @@ public:
 	Vector3 get_position_a() { return m_pivotInA; }
 	Vector3 get_position_b() { return m_pivotInB; }
 
-	real_t get_applied_force() const;
-	real_t get_applied_torque() const;
+	float get_applied_force() const;
+	float get_applied_torque() const;
 
 	GodotPinJoint3D(GodotBody3D *p_body_a, const Vector3 &p_pos_a, GodotBody3D *p_body_b, const Vector3 &p_pos_b);
 	~GodotPinJoint3D();

--- a/modules/godot_physics_3d/joints/godot_slider_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_slider_joint_3d.cpp
@@ -477,12 +477,12 @@ real_t GodotSliderJoint3D::get_param(PhysicsServer3D::SliderJointParam p_param) 
 	return 0;
 }
 
-real_t GodotSliderJoint3D::get_applied_force() const {
+float GodotSliderJoint3D::get_applied_force() const {
 	WARN_PRINT_ONCE("SliderJoint3D->get_applied_force only works with Jolt Physics.");
 	return 0;
 }
 
-real_t GodotSliderJoint3D::get_applied_torque() const {
+float GodotSliderJoint3D::get_applied_torque() const {
 	WARN_PRINT_ONCE("SliderJoint3D->get_applied_torque only works with Jolt Physics.");
 	return 0;
 }

--- a/modules/godot_physics_3d/joints/godot_slider_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_slider_joint_3d.cpp
@@ -476,3 +476,13 @@ real_t GodotSliderJoint3D::get_param(PhysicsServer3D::SliderJointParam p_param) 
 
 	return 0;
 }
+
+real_t GodotSliderJoint3D::get_applied_force() const {
+	WARN_PRINT_ONCE("SliderJoint3D->get_applied_force only works with Jolt Physics.");
+	return 0;
+}
+
+real_t GodotSliderJoint3D::get_applied_torque() const {
+	WARN_PRINT_ONCE("SliderJoint3D->get_applied_torque only works with Jolt Physics.");
+	return 0;
+}

--- a/modules/godot_physics_3d/joints/godot_slider_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_slider_joint_3d.h
@@ -236,8 +236,8 @@ public:
 	void set_param(PhysicsServer3D::SliderJointParam p_param, real_t p_value);
 	real_t get_param(PhysicsServer3D::SliderJointParam p_param) const;
 
-	real_t get_applied_force() const;
-	real_t get_applied_torque() const;
+	float get_applied_force() const;
+	float get_applied_torque() const;
 
 	virtual bool setup(real_t p_step) override;
 	virtual void solve(real_t p_step) override;

--- a/modules/godot_physics_3d/joints/godot_slider_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_slider_joint_3d.h
@@ -236,6 +236,9 @@ public:
 	void set_param(PhysicsServer3D::SliderJointParam p_param, real_t p_value);
 	real_t get_param(PhysicsServer3D::SliderJointParam p_param) const;
 
+	real_t get_applied_force() const;
+	real_t get_applied_torque() const;
+
 	virtual bool setup(real_t p_step) override;
 	virtual void solve(real_t p_step) override;
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1768,7 +1768,7 @@ void JoltPhysicsServer3D::joint_set_solver_position_iterations(RID p_joint, int 
 	return joint->set_solver_position_iterations(p_value);
 }
 
-float JoltPhysicsServer3D::pin_joint_get_applied_force(RID p_joint) {
+float JoltPhysicsServer3D::pin_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1818,7 +1818,7 @@ void JoltPhysicsServer3D::hinge_joint_set_jolt_flag(RID p_joint, HingeJointFlagJ
 	return hinge_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-float JoltPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) {
+float JoltPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1828,7 +1828,7 @@ float JoltPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) {
 	return hinge_joint->get_applied_force();
 }
 
-float JoltPhysicsServer3D::hinge_joint_get_applied_torque(RID p_joint) {
+float JoltPhysicsServer3D::hinge_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1878,7 +1878,7 @@ void JoltPhysicsServer3D::slider_joint_set_jolt_flag(RID p_joint, SliderJointFla
 	return slider_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-float JoltPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) {
+float JoltPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1888,7 +1888,7 @@ float JoltPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) {
 	return slider_joint->get_applied_force();
 }
 
-float JoltPhysicsServer3D::slider_joint_get_applied_torque(RID p_joint) {
+float JoltPhysicsServer3D::slider_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1938,7 +1938,7 @@ void JoltPhysicsServer3D::cone_twist_joint_set_jolt_flag(RID p_joint, ConeTwistJ
 	return cone_twist_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-float JoltPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) {
+float JoltPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1948,7 +1948,7 @@ float JoltPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) {
 	return cone_twist_joint->get_applied_force();
 }
 
-float JoltPhysicsServer3D::cone_twist_joint_get_applied_torque(RID p_joint) {
+float JoltPhysicsServer3D::cone_twist_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1998,7 +1998,7 @@ void JoltPhysicsServer3D::generic_6dof_joint_set_jolt_flag(RID p_joint, Vector3:
 	return g6dof_joint->set_jolt_flag(p_axis, p_flag, p_enabled);
 }
 
-float JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) {
+float JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -2008,7 +2008,7 @@ float JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) {
 	return g6dof_joint->get_applied_force();
 }
 
-float JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) {
+float JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1768,7 +1768,7 @@ void JoltPhysicsServer3D::joint_set_solver_position_iterations(RID p_joint, int 
 	return joint->set_solver_position_iterations(p_value);
 }
 
-real_t JoltPhysicsServer3D::pin_joint_get_applied_force(RID p_joint) const {
+float JoltPhysicsServer3D::pin_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1818,7 +1818,7 @@ void JoltPhysicsServer3D::hinge_joint_set_jolt_flag(RID p_joint, HingeJointFlagJ
 	return hinge_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-real_t JoltPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
+float JoltPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1828,7 +1828,7 @@ real_t JoltPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
 	return hinge_joint->get_applied_force();
 }
 
-real_t JoltPhysicsServer3D::hinge_joint_get_applied_torque(RID p_joint) const {
+float JoltPhysicsServer3D::hinge_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1878,7 +1878,7 @@ void JoltPhysicsServer3D::slider_joint_set_jolt_flag(RID p_joint, SliderJointFla
 	return slider_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-real_t JoltPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
+float JoltPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1888,7 +1888,7 @@ real_t JoltPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
 	return slider_joint->get_applied_force();
 }
 
-real_t JoltPhysicsServer3D::slider_joint_get_applied_torque(RID p_joint) const {
+float JoltPhysicsServer3D::slider_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1938,7 +1938,7 @@ void JoltPhysicsServer3D::cone_twist_joint_set_jolt_flag(RID p_joint, ConeTwistJ
 	return cone_twist_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-real_t JoltPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) const {
+float JoltPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1948,7 +1948,7 @@ real_t JoltPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) cons
 	return cone_twist_joint->get_applied_force();
 }
 
-real_t JoltPhysicsServer3D::cone_twist_joint_get_applied_torque(RID p_joint) const {
+float JoltPhysicsServer3D::cone_twist_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1998,7 +1998,7 @@ void JoltPhysicsServer3D::generic_6dof_joint_set_jolt_flag(RID p_joint, Vector3:
 	return g6dof_joint->set_jolt_flag(p_axis, p_flag, p_enabled);
 }
 
-real_t JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) const {
+float JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -2008,7 +2008,7 @@ real_t JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) co
 	return g6dof_joint->get_applied_force();
 }
 
-real_t JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) const {
+float JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1768,7 +1768,7 @@ void JoltPhysicsServer3D::joint_set_solver_position_iterations(RID p_joint, int 
 	return joint->set_solver_position_iterations(p_value);
 }
 
-float JoltPhysicsServer3D::pin_joint_get_applied_force(RID p_joint) const {
+real_t JoltPhysicsServer3D::pin_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1818,7 +1818,7 @@ void JoltPhysicsServer3D::hinge_joint_set_jolt_flag(RID p_joint, HingeJointFlagJ
 	return hinge_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-float JoltPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
+real_t JoltPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1828,7 +1828,7 @@ float JoltPhysicsServer3D::hinge_joint_get_applied_force(RID p_joint) const {
 	return hinge_joint->get_applied_force();
 }
 
-float JoltPhysicsServer3D::hinge_joint_get_applied_torque(RID p_joint) const {
+real_t JoltPhysicsServer3D::hinge_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1878,7 +1878,7 @@ void JoltPhysicsServer3D::slider_joint_set_jolt_flag(RID p_joint, SliderJointFla
 	return slider_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-float JoltPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
+real_t JoltPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1888,7 +1888,7 @@ float JoltPhysicsServer3D::slider_joint_get_applied_force(RID p_joint) const {
 	return slider_joint->get_applied_force();
 }
 
-float JoltPhysicsServer3D::slider_joint_get_applied_torque(RID p_joint) const {
+real_t JoltPhysicsServer3D::slider_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1938,7 +1938,7 @@ void JoltPhysicsServer3D::cone_twist_joint_set_jolt_flag(RID p_joint, ConeTwistJ
 	return cone_twist_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-float JoltPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) const {
+real_t JoltPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1948,7 +1948,7 @@ float JoltPhysicsServer3D::cone_twist_joint_get_applied_force(RID p_joint) const
 	return cone_twist_joint->get_applied_force();
 }
 
-float JoltPhysicsServer3D::cone_twist_joint_get_applied_torque(RID p_joint) const {
+real_t JoltPhysicsServer3D::cone_twist_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -1998,7 +1998,7 @@ void JoltPhysicsServer3D::generic_6dof_joint_set_jolt_flag(RID p_joint, Vector3:
 	return g6dof_joint->set_jolt_flag(p_axis, p_flag, p_enabled);
 }
 
-float JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) const {
+real_t JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 
@@ -2008,7 +2008,7 @@ float JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(RID p_joint) con
 	return g6dof_joint->get_applied_force();
 }
 
-float JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) const {
+real_t JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(RID p_joint) const {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0.0f);
 

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -375,6 +375,8 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_local_b) override;
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const override;
 
+	virtual real_t pin_joint_get_applied_force(RID p_joint) const override;
+
 	virtual void joint_make_hinge(RID p_joint, RID p_body_a, const Transform3D &p_hinge_a, RID p_body_b, const Transform3D &p_hinge_b) override;
 
 	virtual void joint_make_hinge_simple(RID p_joint, RID p_body_a, const Vector3 &p_pivot_a, const Vector3 &p_axis_a, RID p_body_b, const Vector3 &p_pivot_b, const Vector3 &p_axis_b) override;
@@ -385,15 +387,24 @@ public:
 	virtual void hinge_joint_set_flag(RID p_joint, PhysicsServer3D::HingeJointFlag p_flag, bool p_enabled) override;
 	virtual bool hinge_joint_get_flag(RID p_joint, PhysicsServer3D::HingeJointFlag p_flag) const override;
 
+	virtual real_t hinge_joint_get_applied_force(RID p_joint) const override;
+	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const override;
+
 	virtual void joint_make_slider(RID p_joint, RID p_body_a, const Transform3D &p_local_ref_a, RID p_body_b, const Transform3D &p_local_ref_b) override;
 
 	virtual void slider_joint_set_param(RID p_joint, PhysicsServer3D::SliderJointParam p_param, real_t p_value) override;
 	virtual real_t slider_joint_get_param(RID p_joint, PhysicsServer3D::SliderJointParam p_param) const override;
 
+	virtual real_t slider_joint_get_applied_force(RID p_joint) const override;
+	virtual real_t slider_joint_get_applied_torque(RID p_joint) const override;
+
 	virtual void joint_make_cone_twist(RID p_joint, RID p_body_a, const Transform3D &p_local_ref_a, RID p_body_b, const Transform3D &p_local_ref_b) override;
 
 	virtual void cone_twist_joint_set_param(RID p_joint, PhysicsServer3D::ConeTwistJointParam p_param, real_t p_value) override;
 	virtual real_t cone_twist_joint_get_param(RID p_joint, PhysicsServer3D::ConeTwistJointParam p_param) const override;
+
+	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const override;
+	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_a, const Transform3D &p_local_ref_a, RID p_body_b, const Transform3D &p_local_ref_b) override;
 
@@ -402,6 +413,9 @@ public:
 
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_enable) override;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const override;
+
+	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const override;
+	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual PhysicsServer3D::JointType joint_get_type(RID p_joint) const override;
 
@@ -459,16 +473,11 @@ public:
 	int joint_get_solver_position_iterations(RID p_joint);
 	void joint_set_solver_position_iterations(RID p_joint, int p_value);
 
-	float pin_joint_get_applied_force(RID p_joint);
-
 	double hinge_joint_get_jolt_param(RID p_joint, HingeJointParamJolt p_param) const;
 	void hinge_joint_set_jolt_param(RID p_joint, HingeJointParamJolt p_param, double p_value);
 
 	bool hinge_joint_get_jolt_flag(RID p_joint, HingeJointFlagJolt p_flag) const;
 	void hinge_joint_set_jolt_flag(RID p_joint, HingeJointFlagJolt p_flag, bool p_enabled);
-
-	float hinge_joint_get_applied_force(RID p_joint);
-	float hinge_joint_get_applied_torque(RID p_joint);
 
 	double slider_joint_get_jolt_param(RID p_joint, SliderJointParamJolt p_param) const;
 	void slider_joint_set_jolt_param(RID p_joint, SliderJointParamJolt p_param, double p_value);
@@ -476,26 +485,17 @@ public:
 	bool slider_joint_get_jolt_flag(RID p_joint, SliderJointFlagJolt p_flag) const;
 	void slider_joint_set_jolt_flag(RID p_joint, SliderJointFlagJolt p_flag, bool p_enabled);
 
-	float slider_joint_get_applied_force(RID p_joint);
-	float slider_joint_get_applied_torque(RID p_joint);
-
 	double cone_twist_joint_get_jolt_param(RID p_joint, ConeTwistJointParamJolt p_param) const;
 	void cone_twist_joint_set_jolt_param(RID p_joint, ConeTwistJointParamJolt p_param, double p_value);
 
 	bool cone_twist_joint_get_jolt_flag(RID p_joint, ConeTwistJointFlagJolt p_flag) const;
 	void cone_twist_joint_set_jolt_flag(RID p_joint, ConeTwistJointFlagJolt p_flag, bool p_enabled);
 
-	float cone_twist_joint_get_applied_force(RID p_joint);
-	float cone_twist_joint_get_applied_torque(RID p_joint);
-
 	double generic_6dof_joint_get_jolt_param(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisParamJolt p_param) const;
 	void generic_6dof_joint_set_jolt_param(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisParamJolt p_param, double p_value);
 
 	bool generic_6dof_joint_get_jolt_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlagJolt p_flag) const;
 	void generic_6dof_joint_set_jolt_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlagJolt p_flag, bool p_enabled);
-
-	float generic_6dof_joint_get_applied_force(RID p_joint);
-	float generic_6dof_joint_get_applied_torque(RID p_joint);
 };
 
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointParamJolt)

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -375,7 +375,7 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_local_b) override;
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const override;
 
-	virtual real_t pin_joint_get_applied_force(RID p_joint) const override;
+	virtual float pin_joint_get_applied_force(RID p_joint) const override;
 
 	virtual void joint_make_hinge(RID p_joint, RID p_body_a, const Transform3D &p_hinge_a, RID p_body_b, const Transform3D &p_hinge_b) override;
 
@@ -387,24 +387,24 @@ public:
 	virtual void hinge_joint_set_flag(RID p_joint, PhysicsServer3D::HingeJointFlag p_flag, bool p_enabled) override;
 	virtual bool hinge_joint_get_flag(RID p_joint, PhysicsServer3D::HingeJointFlag p_flag) const override;
 
-	virtual real_t hinge_joint_get_applied_force(RID p_joint) const override;
-	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const override;
+	virtual float hinge_joint_get_applied_force(RID p_joint) const override;
+	virtual float hinge_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual void joint_make_slider(RID p_joint, RID p_body_a, const Transform3D &p_local_ref_a, RID p_body_b, const Transform3D &p_local_ref_b) override;
 
 	virtual void slider_joint_set_param(RID p_joint, PhysicsServer3D::SliderJointParam p_param, real_t p_value) override;
 	virtual real_t slider_joint_get_param(RID p_joint, PhysicsServer3D::SliderJointParam p_param) const override;
 
-	virtual real_t slider_joint_get_applied_force(RID p_joint) const override;
-	virtual real_t slider_joint_get_applied_torque(RID p_joint) const override;
+	virtual float slider_joint_get_applied_force(RID p_joint) const override;
+	virtual float slider_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual void joint_make_cone_twist(RID p_joint, RID p_body_a, const Transform3D &p_local_ref_a, RID p_body_b, const Transform3D &p_local_ref_b) override;
 
 	virtual void cone_twist_joint_set_param(RID p_joint, PhysicsServer3D::ConeTwistJointParam p_param, real_t p_value) override;
 	virtual real_t cone_twist_joint_get_param(RID p_joint, PhysicsServer3D::ConeTwistJointParam p_param) const override;
 
-	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const override;
-	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const override;
+	virtual float cone_twist_joint_get_applied_force(RID p_joint) const override;
+	virtual float cone_twist_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_a, const Transform3D &p_local_ref_a, RID p_body_b, const Transform3D &p_local_ref_b) override;
 
@@ -414,8 +414,8 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_enable) override;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const override;
 
-	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const override;
-	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const override;
+	virtual float generic_6dof_joint_get_applied_force(RID p_joint) const override;
+	virtual float generic_6dof_joint_get_applied_torque(RID p_joint) const override;
 
 	virtual PhysicsServer3D::JointType joint_get_type(RID p_joint) const override;
 

--- a/scene/3d/physics/joints/cone_twist_joint_3d.cpp
+++ b/scene/3d/physics/joints/cone_twist_joint_3d.cpp
@@ -67,11 +67,11 @@ real_t ConeTwistJoint3D::get_param(Param p_param) const {
 	return params[p_param];
 }
 
-real_t ConeTwistJoint3D::get_applied_force() const {
+float ConeTwistJoint3D::get_applied_force() const {
 	return PhysicsServer3D::get_singleton()->cone_twist_joint_get_applied_force(get_rid());
 }
 
-real_t ConeTwistJoint3D::get_applied_torque() const {
+float ConeTwistJoint3D::get_applied_torque() const {
 	return PhysicsServer3D::get_singleton()->cone_twist_joint_get_applied_torque(get_rid());
 }
 

--- a/scene/3d/physics/joints/cone_twist_joint_3d.cpp
+++ b/scene/3d/physics/joints/cone_twist_joint_3d.cpp
@@ -34,6 +34,9 @@ void ConeTwistJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &ConeTwistJoint3D::set_param);
 	ClassDB::bind_method(D_METHOD("get_param", "param"), &ConeTwistJoint3D::get_param);
 
+	ClassDB::bind_method(D_METHOD("get_applied_force"), &ConeTwistJoint3D::get_applied_force);
+	ClassDB::bind_method(D_METHOD("get_applied_torque"), &ConeTwistJoint3D::get_applied_torque);
+
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "swing_span", PROPERTY_HINT_RANGE, "-180,180,0.1,radians_as_degrees"), "set_param", "get_param", PARAM_SWING_SPAN);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "twist_span", PROPERTY_HINT_RANGE, "-40000,40000,0.1,radians_as_degrees"), "set_param", "get_param", PARAM_TWIST_SPAN);
 
@@ -62,6 +65,14 @@ void ConeTwistJoint3D::set_param(Param p_param, real_t p_value) {
 real_t ConeTwistJoint3D::get_param(Param p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 	return params[p_param];
+}
+
+real_t ConeTwistJoint3D::get_applied_force() const {
+	return PhysicsServer3D::get_singleton()->cone_twist_joint_get_applied_force(get_rid());
+}
+
+real_t ConeTwistJoint3D::get_applied_torque() const {
+	return PhysicsServer3D::get_singleton()->cone_twist_joint_get_applied_torque(get_rid());
 }
 
 void ConeTwistJoint3D::_configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) {

--- a/scene/3d/physics/joints/cone_twist_joint_3d.h
+++ b/scene/3d/physics/joints/cone_twist_joint_3d.h
@@ -54,8 +54,8 @@ public:
 	void set_param(Param p_param, real_t p_value);
 	real_t get_param(Param p_param) const;
 
-	real_t get_applied_force() const;
-	real_t get_applied_torque() const;
+	float get_applied_force() const;
+	float get_applied_torque() const;
 
 	ConeTwistJoint3D();
 };

--- a/scene/3d/physics/joints/cone_twist_joint_3d.h
+++ b/scene/3d/physics/joints/cone_twist_joint_3d.h
@@ -54,6 +54,9 @@ public:
 	void set_param(Param p_param, real_t p_value);
 	real_t get_param(Param p_param) const;
 
+	real_t get_applied_force() const;
+	real_t get_applied_torque() const;
+
 	ConeTwistJoint3D();
 };
 

--- a/scene/3d/physics/joints/generic_6dof_joint_3d.cpp
+++ b/scene/3d/physics/joints/generic_6dof_joint_3d.cpp
@@ -242,11 +242,11 @@ real_t Generic6DOFJoint3D::get_param_z(Param p_param) const {
 	return params_z[p_param];
 }
 
-real_t Generic6DOFJoint3D::get_applied_force() const {
+float Generic6DOFJoint3D::get_applied_force() const {
 	return PhysicsServer3D::get_singleton()->generic_6dof_joint_get_applied_force(get_rid());
 }
 
-real_t Generic6DOFJoint3D::get_applied_torque() const {
+float Generic6DOFJoint3D::get_applied_torque() const {
 	return PhysicsServer3D::get_singleton()->generic_6dof_joint_get_applied_torque(get_rid());
 }
 

--- a/scene/3d/physics/joints/generic_6dof_joint_3d.cpp
+++ b/scene/3d/physics/joints/generic_6dof_joint_3d.cpp
@@ -49,6 +49,9 @@ void Generic6DOFJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flag_z", "flag", "value"), &Generic6DOFJoint3D::set_flag_z);
 	ClassDB::bind_method(D_METHOD("get_flag_z", "flag"), &Generic6DOFJoint3D::get_flag_z);
 
+	ClassDB::bind_method(D_METHOD("get_applied_force"), &Generic6DOFJoint3D::get_applied_force);
+	ClassDB::bind_method(D_METHOD("get_applied_torque"), &Generic6DOFJoint3D::get_applied_torque);
+
 	ADD_GROUP("Linear Limit", "linear_limit_");
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "linear_limit_x/enabled"), "set_flag_x", "get_flag_x", FLAG_ENABLE_LINEAR_LIMIT);
@@ -237,6 +240,14 @@ void Generic6DOFJoint3D::set_param_z(Param p_param, real_t p_value) {
 real_t Generic6DOFJoint3D::get_param_z(Param p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 	return params_z[p_param];
+}
+
+real_t Generic6DOFJoint3D::get_applied_force() const {
+	return PhysicsServer3D::get_singleton()->generic_6dof_joint_get_applied_force(get_rid());
+}
+
+real_t Generic6DOFJoint3D::get_applied_torque() const {
+	return PhysicsServer3D::get_singleton()->generic_6dof_joint_get_applied_torque(get_rid());
 }
 
 void Generic6DOFJoint3D::set_flag_x(Flag p_flag, bool p_enabled) {

--- a/scene/3d/physics/joints/generic_6dof_joint_3d.h
+++ b/scene/3d/physics/joints/generic_6dof_joint_3d.h
@@ -102,8 +102,8 @@ public:
 	void set_flag_z(Flag p_flag, bool p_enabled);
 	bool get_flag_z(Flag p_flag) const;
 
-	real_t get_applied_force() const;
-	real_t get_applied_torque() const;
+	float get_applied_force() const;
+	float get_applied_torque() const;
 
 	Generic6DOFJoint3D();
 };

--- a/scene/3d/physics/joints/generic_6dof_joint_3d.h
+++ b/scene/3d/physics/joints/generic_6dof_joint_3d.h
@@ -102,6 +102,9 @@ public:
 	void set_flag_z(Flag p_flag, bool p_enabled);
 	bool get_flag_z(Flag p_flag) const;
 
+	real_t get_applied_force() const;
+	real_t get_applied_torque() const;
+
 	Generic6DOFJoint3D();
 };
 

--- a/scene/3d/physics/joints/hinge_joint_3d.cpp
+++ b/scene/3d/physics/joints/hinge_joint_3d.cpp
@@ -37,6 +37,9 @@ void HingeJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flag", "flag", "enabled"), &HingeJoint3D::set_flag);
 	ClassDB::bind_method(D_METHOD("get_flag", "flag"), &HingeJoint3D::get_flag);
 
+	ClassDB::bind_method(D_METHOD("get_applied_force"), &HingeJoint3D::get_applied_force);
+	ClassDB::bind_method(D_METHOD("get_applied_torque"), &HingeJoint3D::get_applied_torque);
+
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/bias", PROPERTY_HINT_RANGE, "0.00,0.99,0.01"), "set_param", "get_param", PARAM_BIAS);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "angular_limit/enable"), "set_flag", "get_flag", FLAG_USE_LIMIT);
@@ -93,6 +96,14 @@ void HingeJoint3D::set_flag(Flag p_flag, bool p_value) {
 bool HingeJoint3D::get_flag(Flag p_flag) const {
 	ERR_FAIL_INDEX_V(p_flag, FLAG_MAX, false);
 	return flags[p_flag];
+}
+
+real_t HingeJoint3D::get_applied_force() const {
+	return PhysicsServer3D::get_singleton()->hinge_joint_get_applied_force(get_rid());
+}
+
+real_t HingeJoint3D::get_applied_torque() const {
+	return PhysicsServer3D::get_singleton()->hinge_joint_get_applied_torque(get_rid());
 }
 
 void HingeJoint3D::_configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) {

--- a/scene/3d/physics/joints/hinge_joint_3d.cpp
+++ b/scene/3d/physics/joints/hinge_joint_3d.cpp
@@ -98,11 +98,11 @@ bool HingeJoint3D::get_flag(Flag p_flag) const {
 	return flags[p_flag];
 }
 
-real_t HingeJoint3D::get_applied_force() const {
+float HingeJoint3D::get_applied_force() const {
 	return PhysicsServer3D::get_singleton()->hinge_joint_get_applied_force(get_rid());
 }
 
-real_t HingeJoint3D::get_applied_torque() const {
+float HingeJoint3D::get_applied_torque() const {
 	return PhysicsServer3D::get_singleton()->hinge_joint_get_applied_torque(get_rid());
 }
 

--- a/scene/3d/physics/joints/hinge_joint_3d.h
+++ b/scene/3d/physics/joints/hinge_joint_3d.h
@@ -67,8 +67,8 @@ public:
 	void set_flag(Flag p_flag, bool p_value);
 	bool get_flag(Flag p_flag) const;
 
-	real_t get_applied_force() const;
-	real_t get_applied_torque() const;
+	float get_applied_force() const;
+	float get_applied_torque() const;
 
 	HingeJoint3D();
 };

--- a/scene/3d/physics/joints/hinge_joint_3d.h
+++ b/scene/3d/physics/joints/hinge_joint_3d.h
@@ -67,6 +67,9 @@ public:
 	void set_flag(Flag p_flag, bool p_value);
 	bool get_flag(Flag p_flag) const;
 
+	real_t get_applied_force() const;
+	real_t get_applied_torque() const;
+
 	HingeJoint3D();
 };
 

--- a/scene/3d/physics/joints/pin_joint_3d.cpp
+++ b/scene/3d/physics/joints/pin_joint_3d.cpp
@@ -34,6 +34,8 @@ void PinJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &PinJoint3D::set_param);
 	ClassDB::bind_method(D_METHOD("get_param", "param"), &PinJoint3D::get_param);
 
+	ClassDB::bind_method(D_METHOD("get_applied_force"), &PinJoint3D::get_applied_force);
+
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/bias", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"), "set_param", "get_param", PARAM_BIAS);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/damping", PROPERTY_HINT_RANGE, "0.01,8.0,0.01"), "set_param", "get_param", PARAM_DAMPING);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/impulse_clamp", PROPERTY_HINT_RANGE, "0.0,64.0,0.01"), "set_param", "get_param", PARAM_IMPULSE_CLAMP);
@@ -54,6 +56,10 @@ void PinJoint3D::set_param(Param p_param, real_t p_value) {
 real_t PinJoint3D::get_param(Param p_param) const {
 	ERR_FAIL_INDEX_V(p_param, 3, 0);
 	return params[p_param];
+}
+
+real_t PinJoint3D::get_applied_force() const {
+	return PhysicsServer3D::get_singleton()->pin_joint_get_applied_force(get_rid());
 }
 
 void PinJoint3D::_configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) {

--- a/scene/3d/physics/joints/pin_joint_3d.cpp
+++ b/scene/3d/physics/joints/pin_joint_3d.cpp
@@ -58,7 +58,7 @@ real_t PinJoint3D::get_param(Param p_param) const {
 	return params[p_param];
 }
 
-real_t PinJoint3D::get_applied_force() const {
+float PinJoint3D::get_applied_force() const {
 	return PhysicsServer3D::get_singleton()->pin_joint_get_applied_force(get_rid());
 }
 

--- a/scene/3d/physics/joints/pin_joint_3d.h
+++ b/scene/3d/physics/joints/pin_joint_3d.h
@@ -51,7 +51,7 @@ public:
 	void set_param(Param p_param, real_t p_value);
 	real_t get_param(Param p_param) const;
 
-	real_t get_applied_force() const;
+	float get_applied_force() const;
 
 	PinJoint3D();
 };

--- a/scene/3d/physics/joints/pin_joint_3d.h
+++ b/scene/3d/physics/joints/pin_joint_3d.h
@@ -51,6 +51,8 @@ public:
 	void set_param(Param p_param, real_t p_value);
 	real_t get_param(Param p_param) const;
 
+	real_t get_applied_force() const;
+
 	PinJoint3D();
 };
 

--- a/scene/3d/physics/joints/slider_joint_3d.cpp
+++ b/scene/3d/physics/joints/slider_joint_3d.cpp
@@ -102,11 +102,11 @@ real_t SliderJoint3D::get_param(Param p_param) const {
 	return params[p_param];
 }
 
-real_t SliderJoint3D::get_applied_force() const {
+float SliderJoint3D::get_applied_force() const {
 	return PhysicsServer3D::get_singleton()->slider_joint_get_applied_force(get_rid());
 }
 
-real_t SliderJoint3D::get_applied_torque() const {
+float SliderJoint3D::get_applied_torque() const {
 	return PhysicsServer3D::get_singleton()->slider_joint_get_applied_torque(get_rid());
 }
 

--- a/scene/3d/physics/joints/slider_joint_3d.cpp
+++ b/scene/3d/physics/joints/slider_joint_3d.cpp
@@ -34,6 +34,9 @@ void SliderJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &SliderJoint3D::set_param);
 	ClassDB::bind_method(D_METHOD("get_param", "param"), &SliderJoint3D::get_param);
 
+	ClassDB::bind_method(D_METHOD("get_applied_force"), &SliderJoint3D::get_applied_force);
+	ClassDB::bind_method(D_METHOD("get_applied_torque"), &SliderJoint3D::get_applied_torque);
+
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/upper_distance", PROPERTY_HINT_RANGE, "-1024,1024,0.01,suffix:m"), "set_param", "get_param", PARAM_LINEAR_LIMIT_UPPER);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/lower_distance", PROPERTY_HINT_RANGE, "-1024,1024,0.01,suffix:m"), "set_param", "get_param", PARAM_LINEAR_LIMIT_LOWER);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_limit/softness", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_param", "get_param", PARAM_LINEAR_LIMIT_SOFTNESS);
@@ -97,6 +100,14 @@ void SliderJoint3D::set_param(Param p_param, real_t p_value) {
 real_t SliderJoint3D::get_param(Param p_param) const {
 	ERR_FAIL_INDEX_V(p_param, PARAM_MAX, 0);
 	return params[p_param];
+}
+
+real_t SliderJoint3D::get_applied_force() const {
+	return PhysicsServer3D::get_singleton()->slider_joint_get_applied_force(get_rid());
+}
+
+real_t SliderJoint3D::get_applied_torque() const {
+	return PhysicsServer3D::get_singleton()->slider_joint_get_applied_torque(get_rid());
 }
 
 void SliderJoint3D::_configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) {

--- a/scene/3d/physics/joints/slider_joint_3d.h
+++ b/scene/3d/physics/joints/slider_joint_3d.h
@@ -73,8 +73,8 @@ public:
 	void set_param(Param p_param, real_t p_value);
 	real_t get_param(Param p_param) const;
 
-	real_t get_applied_force() const;
-	real_t get_applied_torque() const;
+	float get_applied_force() const;
+	float get_applied_torque() const;
 
 	SliderJoint3D();
 };

--- a/scene/3d/physics/joints/slider_joint_3d.h
+++ b/scene/3d/physics/joints/slider_joint_3d.h
@@ -73,6 +73,9 @@ public:
 	void set_param(Param p_param, real_t p_value);
 	real_t get_param(Param p_param) const;
 
+	real_t get_applied_force() const;
+	real_t get_applied_torque() const;
+
 	SliderJoint3D();
 };
 

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -930,6 +930,8 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("pin_joint_set_local_b", "joint", "local_B"), &PhysicsServer3D::pin_joint_set_local_b);
 	ClassDB::bind_method(D_METHOD("pin_joint_get_local_b", "joint"), &PhysicsServer3D::pin_joint_get_local_b);
 
+	ClassDB::bind_method(D_METHOD("pin_joint_get_applied_force", "joint"), &PhysicsServer3D::pin_joint_get_applied_force);
+
 	BIND_ENUM_CONSTANT(PIN_JOINT_BIAS);
 	BIND_ENUM_CONSTANT(PIN_JOINT_DAMPING);
 	BIND_ENUM_CONSTANT(PIN_JOINT_IMPULSE_CLAMP);
@@ -954,10 +956,16 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("hinge_joint_set_flag", "joint", "flag", "enabled"), &PhysicsServer3D::hinge_joint_set_flag);
 	ClassDB::bind_method(D_METHOD("hinge_joint_get_flag", "joint", "flag"), &PhysicsServer3D::hinge_joint_get_flag);
 
+	ClassDB::bind_method(D_METHOD("hinge_joint_get_applied_force", "joint"), &PhysicsServer3D::hinge_joint_get_applied_force);
+	ClassDB::bind_method(D_METHOD("hinge_joint_get_applied_torque", "joint"), &PhysicsServer3D::hinge_joint_get_applied_torque);
+
 	ClassDB::bind_method(D_METHOD("joint_make_slider", "joint", "body_A", "local_ref_A", "body_B", "local_ref_B"), &PhysicsServer3D::joint_make_slider);
 
 	ClassDB::bind_method(D_METHOD("slider_joint_set_param", "joint", "param", "value"), &PhysicsServer3D::slider_joint_set_param);
 	ClassDB::bind_method(D_METHOD("slider_joint_get_param", "joint", "param"), &PhysicsServer3D::slider_joint_get_param);
+
+	ClassDB::bind_method(D_METHOD("slider_twist_joint_get_applied_force", "joint"), &PhysicsServer3D::slider_joint_get_applied_force);
+	ClassDB::bind_method(D_METHOD("slider_twist_joint_get_applied_torque", "joint"), &PhysicsServer3D::slider_joint_get_applied_torque);
 
 	BIND_ENUM_CONSTANT(SLIDER_JOINT_LINEAR_LIMIT_UPPER);
 	BIND_ENUM_CONSTANT(SLIDER_JOINT_LINEAR_LIMIT_LOWER);
@@ -988,6 +996,9 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("cone_twist_joint_set_param", "joint", "param", "value"), &PhysicsServer3D::cone_twist_joint_set_param);
 	ClassDB::bind_method(D_METHOD("cone_twist_joint_get_param", "joint", "param"), &PhysicsServer3D::cone_twist_joint_get_param);
+
+	ClassDB::bind_method(D_METHOD("cone_twist_joint_get_applied_force", "joint"), &PhysicsServer3D::cone_twist_joint_get_applied_force);
+	ClassDB::bind_method(D_METHOD("cone_twist_joint_get_applied_torque", "joint"), &PhysicsServer3D::cone_twist_joint_get_applied_torque);
 
 	BIND_ENUM_CONSTANT(CONE_TWIST_JOINT_SWING_SPAN);
 	BIND_ENUM_CONSTANT(CONE_TWIST_JOINT_TWIST_SPAN);
@@ -1042,6 +1053,9 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_set_flag", "joint", "axis", "flag", "enable"), &PhysicsServer3D::generic_6dof_joint_set_flag);
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_get_flag", "joint", "axis", "flag"), &PhysicsServer3D::generic_6dof_joint_get_flag);
+
+	ClassDB::bind_method(D_METHOD("generic_6dof_joint_get_applied_force", "joint"), &PhysicsServer3D::generic_6dof_joint_get_applied_force);
+	ClassDB::bind_method(D_METHOD("generic_6dof_joint_get_applied_torque", "joint"), &PhysicsServer3D::generic_6dof_joint_get_applied_torque);
 
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer3D::free_rid);
 

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -676,6 +676,8 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_B) = 0;
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const = 0;
 
+	virtual real_t pin_joint_get_applied_force(RID p_joint) const = 0;
+
 	enum HingeJointParam {
 		HINGE_JOINT_BIAS,
 		HINGE_JOINT_LIMIT_UPPER,
@@ -702,6 +704,9 @@ public:
 
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_enabled) = 0;
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const = 0;
+
+	virtual real_t hinge_joint_get_applied_force(RID p_joint) const = 0;
+	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const = 0;
 
 	enum SliderJointParam {
 		SLIDER_JOINT_LINEAR_LIMIT_UPPER,
@@ -736,6 +741,9 @@ public:
 	virtual void slider_joint_set_param(RID p_joint, SliderJointParam p_param, real_t p_value) = 0;
 	virtual real_t slider_joint_get_param(RID p_joint, SliderJointParam p_param) const = 0;
 
+	virtual real_t slider_joint_get_applied_force(RID p_joint) const = 0;
+	virtual real_t slider_joint_get_applied_torque(RID p_joint) const = 0;
+
 	enum ConeTwistJointParam {
 		CONE_TWIST_JOINT_SWING_SPAN,
 		CONE_TWIST_JOINT_TWIST_SPAN,
@@ -749,6 +757,9 @@ public:
 
 	virtual void cone_twist_joint_set_param(RID p_joint, ConeTwistJointParam p_param, real_t p_value) = 0;
 	virtual real_t cone_twist_joint_get_param(RID p_joint, ConeTwistJointParam p_param) const = 0;
+
+	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const = 0;
+	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const = 0;
 
 	enum G6DOFJointAxisParam {
 		G6DOF_JOINT_LINEAR_LOWER_LIMIT,
@@ -793,6 +804,9 @@ public:
 
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) = 0;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const = 0;
+
+	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const = 0;
+	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const = 0;
 
 	/* QUERY API */
 

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -676,7 +676,7 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_B) = 0;
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const = 0;
 
-	virtual real_t pin_joint_get_applied_force(RID p_joint) const = 0;
+	virtual float pin_joint_get_applied_force(RID p_joint) const = 0;
 
 	enum HingeJointParam {
 		HINGE_JOINT_BIAS,
@@ -705,8 +705,8 @@ public:
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_enabled) = 0;
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const = 0;
 
-	virtual real_t hinge_joint_get_applied_force(RID p_joint) const = 0;
-	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const = 0;
+	virtual float hinge_joint_get_applied_force(RID p_joint) const = 0;
+	virtual float hinge_joint_get_applied_torque(RID p_joint) const = 0;
 
 	enum SliderJointParam {
 		SLIDER_JOINT_LINEAR_LIMIT_UPPER,
@@ -741,8 +741,8 @@ public:
 	virtual void slider_joint_set_param(RID p_joint, SliderJointParam p_param, real_t p_value) = 0;
 	virtual real_t slider_joint_get_param(RID p_joint, SliderJointParam p_param) const = 0;
 
-	virtual real_t slider_joint_get_applied_force(RID p_joint) const = 0;
-	virtual real_t slider_joint_get_applied_torque(RID p_joint) const = 0;
+	virtual float slider_joint_get_applied_force(RID p_joint) const = 0;
+	virtual float slider_joint_get_applied_torque(RID p_joint) const = 0;
 
 	enum ConeTwistJointParam {
 		CONE_TWIST_JOINT_SWING_SPAN,
@@ -758,8 +758,8 @@ public:
 	virtual void cone_twist_joint_set_param(RID p_joint, ConeTwistJointParam p_param, real_t p_value) = 0;
 	virtual real_t cone_twist_joint_get_param(RID p_joint, ConeTwistJointParam p_param) const = 0;
 
-	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const = 0;
-	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const = 0;
+	virtual float cone_twist_joint_get_applied_force(RID p_joint) const = 0;
+	virtual float cone_twist_joint_get_applied_torque(RID p_joint) const = 0;
 
 	enum G6DOFJointAxisParam {
 		G6DOF_JOINT_LINEAR_LOWER_LIMIT,
@@ -805,8 +805,8 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) = 0;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const = 0;
 
-	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const = 0;
-	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const = 0;
+	virtual float generic_6dof_joint_get_applied_force(RID p_joint) const = 0;
+	virtual float generic_6dof_joint_get_applied_torque(RID p_joint) const = 0;
 
 	/* QUERY API */
 

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -396,7 +396,7 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_B) override {}
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const override { return Vector3(); }
 
-	virtual real_t pin_joint_get_applied_force(RID p_joint) const override { return 0; };
+	virtual real_t pin_joint_get_applied_force(RID p_joint) const override { return 0; }
 
 	virtual void joint_make_hinge(RID p_joint, RID p_body_A, const Transform3D &p_hinge_A, RID p_body_B, const Transform3D &p_hinge_B) override {}
 	virtual void joint_make_hinge_simple(RID p_joint, RID p_body_A, const Vector3 &p_pivot_A, const Vector3 &p_axis_A, RID p_body_B, const Vector3 &p_pivot_B, const Vector3 &p_axis_B) override {}
@@ -407,24 +407,24 @@ public:
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_enabled) override {}
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const override { return false; }
 
-	virtual real_t hinge_joint_get_applied_force(RID p_joint) const override { return 0; };
-	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const override { return 0; };
+	virtual real_t hinge_joint_get_applied_force(RID p_joint) const override { return 0; }
+	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const override { return 0; }
 
 	virtual void joint_make_slider(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
 	virtual void slider_joint_set_param(RID p_joint, SliderJointParam p_param, real_t p_value) override {}
 	virtual real_t slider_joint_get_param(RID p_joint, SliderJointParam p_param) const override { return 0; }
 
-	virtual real_t slider_joint_get_applied_force(RID p_joint) const override { return 0; };
-	virtual real_t slider_joint_get_applied_torque(RID p_joint) const override { return 0; };
+	virtual real_t slider_joint_get_applied_force(RID p_joint) const override { return 0; }
+	virtual real_t slider_joint_get_applied_torque(RID p_joint) const override { return 0; }
 
 	virtual void joint_make_cone_twist(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
 	virtual void cone_twist_joint_set_param(RID p_joint, ConeTwistJointParam p_param, real_t p_value) override {}
 	virtual real_t cone_twist_joint_get_param(RID p_joint, ConeTwistJointParam p_param) const override { return 0; }
 
-	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const override { return 0; };
-	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const override { return 0; };
+	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const override { return 0; }
+	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const override { return 0; }
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
@@ -434,8 +434,8 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override {}
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override { return false; }
 
-	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const override { return 0; };
-	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const override { return 0; };
+	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const override { return 0; }
+	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const override { return 0; }
 
 	/* MISC */
 

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -396,6 +396,8 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_B) override {}
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const override { return Vector3(); }
 
+	virtual real_t pin_joint_get_applied_force(RID p_joint) const override { return 0; };
+
 	virtual void joint_make_hinge(RID p_joint, RID p_body_A, const Transform3D &p_hinge_A, RID p_body_B, const Transform3D &p_hinge_B) override {}
 	virtual void joint_make_hinge_simple(RID p_joint, RID p_body_A, const Vector3 &p_pivot_A, const Vector3 &p_axis_A, RID p_body_B, const Vector3 &p_pivot_B, const Vector3 &p_axis_B) override {}
 
@@ -405,15 +407,24 @@ public:
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_enabled) override {}
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const override { return false; }
 
+	virtual real_t hinge_joint_get_applied_force(RID p_joint) const override { return 0; };
+	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const override { return 0; };
+
 	virtual void joint_make_slider(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
 	virtual void slider_joint_set_param(RID p_joint, SliderJointParam p_param, real_t p_value) override {}
 	virtual real_t slider_joint_get_param(RID p_joint, SliderJointParam p_param) const override { return 0; }
 
+	virtual real_t slider_joint_get_applied_force(RID p_joint) const override { return 0; };
+	virtual real_t slider_joint_get_applied_torque(RID p_joint) const override { return 0; };
+
 	virtual void joint_make_cone_twist(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
 	virtual void cone_twist_joint_set_param(RID p_joint, ConeTwistJointParam p_param, real_t p_value) override {}
 	virtual real_t cone_twist_joint_get_param(RID p_joint, ConeTwistJointParam p_param) const override { return 0; }
+
+	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const override { return 0; };
+	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const override { return 0; };
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
@@ -422,6 +433,9 @@ public:
 
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override {}
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override { return false; }
+
+	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const override { return 0; };
+	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const override { return 0; };
 
 	/* MISC */
 

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -396,7 +396,7 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_B) override {}
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const override { return Vector3(); }
 
-	virtual real_t pin_joint_get_applied_force(RID p_joint) const override { return 0; }
+	virtual float pin_joint_get_applied_force(RID p_joint) const override { return 0; }
 
 	virtual void joint_make_hinge(RID p_joint, RID p_body_A, const Transform3D &p_hinge_A, RID p_body_B, const Transform3D &p_hinge_B) override {}
 	virtual void joint_make_hinge_simple(RID p_joint, RID p_body_A, const Vector3 &p_pivot_A, const Vector3 &p_axis_A, RID p_body_B, const Vector3 &p_pivot_B, const Vector3 &p_axis_B) override {}
@@ -407,24 +407,24 @@ public:
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_enabled) override {}
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const override { return false; }
 
-	virtual real_t hinge_joint_get_applied_force(RID p_joint) const override { return 0; }
-	virtual real_t hinge_joint_get_applied_torque(RID p_joint) const override { return 0; }
+	virtual float hinge_joint_get_applied_force(RID p_joint) const override { return 0; }
+	virtual float hinge_joint_get_applied_torque(RID p_joint) const override { return 0; }
 
 	virtual void joint_make_slider(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
 	virtual void slider_joint_set_param(RID p_joint, SliderJointParam p_param, real_t p_value) override {}
 	virtual real_t slider_joint_get_param(RID p_joint, SliderJointParam p_param) const override { return 0; }
 
-	virtual real_t slider_joint_get_applied_force(RID p_joint) const override { return 0; }
-	virtual real_t slider_joint_get_applied_torque(RID p_joint) const override { return 0; }
+	virtual float slider_joint_get_applied_force(RID p_joint) const override { return 0; }
+	virtual float slider_joint_get_applied_torque(RID p_joint) const override { return 0; }
 
 	virtual void joint_make_cone_twist(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
 	virtual void cone_twist_joint_set_param(RID p_joint, ConeTwistJointParam p_param, real_t p_value) override {}
 	virtual real_t cone_twist_joint_get_param(RID p_joint, ConeTwistJointParam p_param) const override { return 0; }
 
-	virtual real_t cone_twist_joint_get_applied_force(RID p_joint) const override { return 0; }
-	virtual real_t cone_twist_joint_get_applied_torque(RID p_joint) const override { return 0; }
+	virtual float cone_twist_joint_get_applied_force(RID p_joint) const override { return 0; }
+	virtual float cone_twist_joint_get_applied_torque(RID p_joint) const override { return 0; }
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
@@ -434,8 +434,8 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override {}
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override { return false; }
 
-	virtual real_t generic_6dof_joint_get_applied_force(RID p_joint) const override { return 0; }
-	virtual real_t generic_6dof_joint_get_applied_torque(RID p_joint) const override { return 0; }
+	virtual float generic_6dof_joint_get_applied_force(RID p_joint) const override { return 0; }
+	virtual float generic_6dof_joint_get_applied_torque(RID p_joint) const override { return 0; }
 
 	/* MISC */
 

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -388,6 +388,8 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_pin_joint_set_local_b, "joint", "local_B");
 	GDVIRTUAL_BIND(_pin_joint_get_local_b, "joint");
 
+	GDVIRTUAL_BIND(_pin_joint_get_applied_force, "joint");
+
 	GDVIRTUAL_BIND(_joint_make_hinge, "joint", "body_A", "hinge_A", "body_B", "hinge_B");
 	GDVIRTUAL_BIND(_joint_make_hinge_simple, "joint", "body_A", "pivot_A", "axis_A", "body_B", "pivot_B", "axis_B");
 
@@ -397,15 +399,24 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_hinge_joint_set_flag, "joint", "flag", "enabled");
 	GDVIRTUAL_BIND(_hinge_joint_get_flag, "joint", "flag");
 
+	GDVIRTUAL_BIND(_hinge_joint_get_applied_force, "joint");
+	GDVIRTUAL_BIND(_hinge_joint_get_applied_torque, "joint");
+
 	GDVIRTUAL_BIND(_joint_make_slider, "joint", "body_A", "local_ref_A", "body_B", "local_ref_B");
 
 	GDVIRTUAL_BIND(_slider_joint_set_param, "joint", "param", "value");
 	GDVIRTUAL_BIND(_slider_joint_get_param, "joint", "param");
 
+	GDVIRTUAL_BIND(_slider_joint_get_applied_force, "joint");
+	GDVIRTUAL_BIND(_slider_joint_get_applied_torque, "joint");
+
 	GDVIRTUAL_BIND(_joint_make_cone_twist, "joint", "body_A", "local_ref_A", "body_B", "local_ref_B");
 
 	GDVIRTUAL_BIND(_cone_twist_joint_set_param, "joint", "param", "value");
 	GDVIRTUAL_BIND(_cone_twist_joint_get_param, "joint", "param");
+
+	GDVIRTUAL_BIND(_cone_twist_joint_get_applied_force, "joint");
+	GDVIRTUAL_BIND(_cone_twist_joint_get_applied_torque, "joint");
 
 	GDVIRTUAL_BIND(_joint_make_generic_6dof, "joint", "body_A", "local_ref_A", "body_B", "local_ref_B");
 
@@ -414,6 +425,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_generic_6dof_joint_set_flag, "joint", "axis", "flag", "enable");
 	GDVIRTUAL_BIND(_generic_6dof_joint_get_flag, "joint", "axis", "flag");
+
+	GDVIRTUAL_BIND(_generic_6dof_joint_get_applied_force, "joint");
+	GDVIRTUAL_BIND(_generic_6dof_joint_get_applied_torque, "joint");
 
 	GDVIRTUAL_BIND(_joint_get_type, "joint");
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -495,7 +495,7 @@ public:
 	EXBIND2(pin_joint_set_local_b, RID, const Vector3 &)
 	EXBIND1RC(Vector3, pin_joint_get_local_b, RID)
 
-	EXBIND1RC(real_t, pin_joint_get_applied_force, RID)
+	EXBIND1RC(float, pin_joint_get_applied_force, RID)
 
 	EXBIND5(joint_make_hinge, RID, RID, const Transform3D &, RID, const Transform3D &)
 	EXBIND7(joint_make_hinge_simple, RID, RID, const Vector3 &, const Vector3 &, RID, const Vector3 &, const Vector3 &)
@@ -506,24 +506,24 @@ public:
 	EXBIND3(hinge_joint_set_flag, RID, HingeJointFlag, bool)
 	EXBIND2RC(bool, hinge_joint_get_flag, RID, HingeJointFlag)
 
-	EXBIND1RC(real_t, hinge_joint_get_applied_force, RID)
-	EXBIND1RC(real_t, hinge_joint_get_applied_torque, RID)
+	EXBIND1RC(float, hinge_joint_get_applied_force, RID)
+	EXBIND1RC(float, hinge_joint_get_applied_torque, RID)
 
 	EXBIND5(joint_make_slider, RID, RID, const Transform3D &, RID, const Transform3D &)
 
 	EXBIND3(slider_joint_set_param, RID, SliderJointParam, real_t)
 	EXBIND2RC(real_t, slider_joint_get_param, RID, SliderJointParam)
 
-	EXBIND1RC(real_t, slider_joint_get_applied_force, RID)
-	EXBIND1RC(real_t, slider_joint_get_applied_torque, RID)
+	EXBIND1RC(float, slider_joint_get_applied_force, RID)
+	EXBIND1RC(float, slider_joint_get_applied_torque, RID)
 
 	EXBIND5(joint_make_cone_twist, RID, RID, const Transform3D &, RID, const Transform3D &)
 
 	EXBIND3(cone_twist_joint_set_param, RID, ConeTwistJointParam, real_t)
 	EXBIND2RC(real_t, cone_twist_joint_get_param, RID, ConeTwistJointParam)
 
-	EXBIND1RC(real_t, cone_twist_joint_get_applied_force, RID)
-	EXBIND1RC(real_t, cone_twist_joint_get_applied_torque, RID)
+	EXBIND1RC(float, cone_twist_joint_get_applied_force, RID)
+	EXBIND1RC(float, cone_twist_joint_get_applied_torque, RID)
 
 	EXBIND5(joint_make_generic_6dof, RID, RID, const Transform3D &, RID, const Transform3D &)
 
@@ -533,8 +533,8 @@ public:
 	EXBIND4(generic_6dof_joint_set_flag, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
 	EXBIND3RC(bool, generic_6dof_joint_get_flag, RID, Vector3::Axis, G6DOFJointAxisFlag)
 
-	EXBIND1RC(real_t, generic_6dof_joint_get_applied_force, RID)
-	EXBIND1RC(real_t, generic_6dof_joint_get_applied_torque, RID)
+	EXBIND1RC(float, generic_6dof_joint_get_applied_force, RID)
+	EXBIND1RC(float, generic_6dof_joint_get_applied_torque, RID)
 
 	EXBIND1RC(JointType, joint_get_type, RID)
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -495,6 +495,8 @@ public:
 	EXBIND2(pin_joint_set_local_b, RID, const Vector3 &)
 	EXBIND1RC(Vector3, pin_joint_get_local_b, RID)
 
+	EXBIND1RC(real_t, pin_joint_get_applied_force, RID)
+
 	EXBIND5(joint_make_hinge, RID, RID, const Transform3D &, RID, const Transform3D &)
 	EXBIND7(joint_make_hinge_simple, RID, RID, const Vector3 &, const Vector3 &, RID, const Vector3 &, const Vector3 &)
 
@@ -504,15 +506,24 @@ public:
 	EXBIND3(hinge_joint_set_flag, RID, HingeJointFlag, bool)
 	EXBIND2RC(bool, hinge_joint_get_flag, RID, HingeJointFlag)
 
+	EXBIND1RC(real_t, hinge_joint_get_applied_force, RID)
+	EXBIND1RC(real_t, hinge_joint_get_applied_torque, RID)
+
 	EXBIND5(joint_make_slider, RID, RID, const Transform3D &, RID, const Transform3D &)
 
 	EXBIND3(slider_joint_set_param, RID, SliderJointParam, real_t)
 	EXBIND2RC(real_t, slider_joint_get_param, RID, SliderJointParam)
 
+	EXBIND1RC(real_t, slider_joint_get_applied_force, RID)
+	EXBIND1RC(real_t, slider_joint_get_applied_torque, RID)
+
 	EXBIND5(joint_make_cone_twist, RID, RID, const Transform3D &, RID, const Transform3D &)
 
 	EXBIND3(cone_twist_joint_set_param, RID, ConeTwistJointParam, real_t)
 	EXBIND2RC(real_t, cone_twist_joint_get_param, RID, ConeTwistJointParam)
+
+	EXBIND1RC(real_t, cone_twist_joint_get_applied_force, RID)
+	EXBIND1RC(real_t, cone_twist_joint_get_applied_torque, RID)
 
 	EXBIND5(joint_make_generic_6dof, RID, RID, const Transform3D &, RID, const Transform3D &)
 
@@ -521,6 +532,9 @@ public:
 
 	EXBIND4(generic_6dof_joint_set_flag, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
 	EXBIND3RC(bool, generic_6dof_joint_get_flag, RID, Vector3::Axis, G6DOFJointAxisFlag)
+
+	EXBIND1RC(real_t, generic_6dof_joint_get_applied_force, RID)
+	EXBIND1RC(real_t, generic_6dof_joint_get_applied_torque, RID)
 
 	EXBIND1RC(JointType, joint_get_type, RID)
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -357,7 +357,7 @@ public:
 	FUNC2(pin_joint_set_local_b, RID, const Vector3 &)
 	FUNC1RC(Vector3, pin_joint_get_local_b, RID)
 
-	FUNC1RC(real_t, pin_joint_get_applied_force, RID)
+	FUNC1RC(float, pin_joint_get_applied_force, RID)
 
 	FUNC5(joint_make_hinge, RID, RID, const Transform3D &, RID, const Transform3D &)
 	FUNC7(joint_make_hinge_simple, RID, RID, const Vector3 &, const Vector3 &, RID, const Vector3 &, const Vector3 &)
@@ -368,24 +368,24 @@ public:
 	FUNC3(hinge_joint_set_flag, RID, HingeJointFlag, bool)
 	FUNC2RC(bool, hinge_joint_get_flag, RID, HingeJointFlag)
 
-	FUNC1RC(real_t, hinge_joint_get_applied_force, RID)
-	FUNC1RC(real_t, hinge_joint_get_applied_torque, RID)
+	FUNC1RC(float, hinge_joint_get_applied_force, RID)
+	FUNC1RC(float, hinge_joint_get_applied_torque, RID)
 
 	FUNC5(joint_make_slider, RID, RID, const Transform3D &, RID, const Transform3D &)
 
 	FUNC3(slider_joint_set_param, RID, SliderJointParam, real_t)
 	FUNC2RC(real_t, slider_joint_get_param, RID, SliderJointParam)
 
-	FUNC1RC(real_t, slider_joint_get_applied_force, RID)
-	FUNC1RC(real_t, slider_joint_get_applied_torque, RID)
+	FUNC1RC(float, slider_joint_get_applied_force, RID)
+	FUNC1RC(float, slider_joint_get_applied_torque, RID)
 
 	FUNC5(joint_make_cone_twist, RID, RID, const Transform3D &, RID, const Transform3D &)
 
 	FUNC3(cone_twist_joint_set_param, RID, ConeTwistJointParam, real_t)
 	FUNC2RC(real_t, cone_twist_joint_get_param, RID, ConeTwistJointParam)
 
-	FUNC1RC(real_t, cone_twist_joint_get_applied_force, RID)
-	FUNC1RC(real_t, cone_twist_joint_get_applied_torque, RID)
+	FUNC1RC(float, cone_twist_joint_get_applied_force, RID)
+	FUNC1RC(float, cone_twist_joint_get_applied_torque, RID)
 
 	FUNC5(joint_make_generic_6dof, RID, RID, const Transform3D &, RID, const Transform3D &)
 
@@ -395,8 +395,8 @@ public:
 	FUNC4(generic_6dof_joint_set_flag, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
 	FUNC3RC(bool, generic_6dof_joint_get_flag, RID, Vector3::Axis, G6DOFJointAxisFlag)
 
-	FUNC1RC(real_t, generic_6dof_joint_get_applied_force, RID)
-	FUNC1RC(real_t, generic_6dof_joint_get_applied_torque, RID)
+	FUNC1RC(float, generic_6dof_joint_get_applied_force, RID)
+	FUNC1RC(float, generic_6dof_joint_get_applied_torque, RID)
 
 	FUNC1RC(JointType, joint_get_type, RID);
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -357,6 +357,8 @@ public:
 	FUNC2(pin_joint_set_local_b, RID, const Vector3 &)
 	FUNC1RC(Vector3, pin_joint_get_local_b, RID)
 
+	FUNC1RC(real_t, pin_joint_get_applied_force, RID)
+
 	FUNC5(joint_make_hinge, RID, RID, const Transform3D &, RID, const Transform3D &)
 	FUNC7(joint_make_hinge_simple, RID, RID, const Vector3 &, const Vector3 &, RID, const Vector3 &, const Vector3 &)
 
@@ -366,15 +368,24 @@ public:
 	FUNC3(hinge_joint_set_flag, RID, HingeJointFlag, bool)
 	FUNC2RC(bool, hinge_joint_get_flag, RID, HingeJointFlag)
 
+	FUNC1RC(real_t, hinge_joint_get_applied_force, RID)
+	FUNC1RC(real_t, hinge_joint_get_applied_torque, RID)
+
 	FUNC5(joint_make_slider, RID, RID, const Transform3D &, RID, const Transform3D &)
 
 	FUNC3(slider_joint_set_param, RID, SliderJointParam, real_t)
 	FUNC2RC(real_t, slider_joint_get_param, RID, SliderJointParam)
 
+	FUNC1RC(real_t, slider_joint_get_applied_force, RID)
+	FUNC1RC(real_t, slider_joint_get_applied_torque, RID)
+
 	FUNC5(joint_make_cone_twist, RID, RID, const Transform3D &, RID, const Transform3D &)
 
 	FUNC3(cone_twist_joint_set_param, RID, ConeTwistJointParam, real_t)
 	FUNC2RC(real_t, cone_twist_joint_get_param, RID, ConeTwistJointParam)
+
+	FUNC1RC(real_t, cone_twist_joint_get_applied_force, RID)
+	FUNC1RC(real_t, cone_twist_joint_get_applied_torque, RID)
 
 	FUNC5(joint_make_generic_6dof, RID, RID, const Transform3D &, RID, const Transform3D &)
 
@@ -383,6 +394,9 @@ public:
 
 	FUNC4(generic_6dof_joint_set_flag, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
 	FUNC3RC(bool, generic_6dof_joint_get_flag, RID, Vector3::Axis, G6DOFJointAxisFlag)
+
+	FUNC1RC(real_t, generic_6dof_joint_get_applied_force, RID)
+	FUNC1RC(real_t, generic_6dof_joint_get_applied_torque, RID)
 
 	FUNC1RC(JointType, joint_get_type, RID);
 


### PR DESCRIPTION
Hey there!

Since Jolt is directly implemented and Jolt has a lot of features and improvements over default physics, the goal of Godot seems now to integrate Jolt more tightly with Godot and make it a complete replacement long term.

One thing i really miss is the control of joints and how to correctly measure them, so i am able to break them when i decide to do so.

Fortunetely, Jolt already have 2 convenient methods to play with: `get_applied_force` and `get_applied_torque` directly on a joint.

All what was missing is the bridge/expose to Godot and GDScript, which this PR does integrate.

I tried my best to follow all the rules that i've found for godot core development, please review and give feedback on whatever you decide.

My C++ knowledge is a bit rusty and also this is my first time fiddling with the godot engine core.

Hope this helps you out. Would love to see it merged, i for now work my own fork until this (or anything similar) gets merged into master.

I've not found any tests for physics what so ever, so i not have written tests for it.

Documentation (Xmls) however should be updated properly, Warnings are emitted if the feature is not supported (When on default physics).

Proposal: https://github.com/godotengine/godot-proposals/issues/13422

MRP: [physics3d_joints_mrp.zip](https://github.com/user-attachments/files/23000701/physics3d_joints_mrp.zip)

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/13422*