### PR TITLE
Fix deadlock when running out of object slots

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2485,7 +2485,10 @@ int ObjectDB::get_object_count() {
 ObjectID ObjectDB::add_instance(Object *p_object) {
 	spin_lock.lock();
 	if (unlikely(slot_count == slot_max)) {
-		CRASH_COND(slot_count == (1 << OBJECTDB_SLOT_MAX_COUNT_BITS));
+		if (unlikely(slot_count == (1 << OBJECTDB_SLOT_MAX_COUNT_BITS))) {
+			spin_lock.unlock();
+			CRASH_NOW_MSG("Out of object slots. Cannot allocate more objects.");
+		}
 
 		uint32_t new_slot_max = slot_max > 0 ? slot_max * 2 : 1;
 		object_slots = (ObjectSlot *)memrealloc(object_slots, sizeof(ObjectSlot) * new_slot_max);


### PR DESCRIPTION
Problem:
Running out of object slots causes a deadlock instead of a clean crash. The error handler tries to capture script backtraces which requires creating new objects, but since we're out of slots and the spin lock is still held, the engine deadlocks.

Solution:
Unlock the ObjectDB spin lock before crashing when the slot limit is reached. This allows the error handler to attempt creating backtrace objects, and if that fails, it falls back to a simpler error message before crashing cleanly.

Happy to hear any feedback you might have. Hope you're having a great day!

Fixes #111836
