### PR TITLE
`Container`: Fix minimum size changes after sorting children.

### DIFF
--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -36,8 +36,11 @@ class Container : public Control {
 	GDCLASS(Container, Control);
 
 	bool pending_sort = false;
+	bool update_min_size_requested = false;
+
 	void _sort_children();
 	void _child_minsize_changed();
+	void _update_and_resort();
 
 protected:
 	enum class SortableVisibilityMode {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1697,7 +1697,7 @@ void Control::update_minimum_size() {
 	}
 	data.updating_last_minimum_size = true;
 
-	callable_mp(this, &Control::_update_minimum_size).call_deferred();
+	_update_minimum_size();
 }
 
 void Control::set_block_minimum_size_adjust(bool p_block) {


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/111695