### PR TITLE
Increase minimum editor size

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7717,7 +7717,7 @@ EditorNode::EditorNode() {
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
 	if (w) {
-		const Size2 minimum_size = Size2(1024, 600) * EDSCALE;
+		const Size2 minimum_size = Size2(1240, 600) * EDSCALE;
 		w->set_min_size(minimum_size); // Calling it this early doesn't sync the property with DS.
 		DisplayServer::get_singleton()->window_set_min_size(minimum_size);
 	}


### PR DESCRIPTION
Fixes #102359

Makes the editor just big enough to not get clipped.

https://github.com/user-attachments/assets/45f04fe8-b2fe-42e7-8bd9-8d840e269f62

It would be better to decrease the minimum size of the contents instead, but for now this works too I think.