### PR TITLE
Fix Input modifiers released condition

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -582,6 +582,22 @@ bool InputEventKey::action_match(const Ref<InputEvent> &p_event, bool p_exact_ma
 	Key key_mask = (Key)(int64_t)key->get_modifiers_mask();
 	if (key->is_pressed()) {
 		match &= (action_mask & key_mask) == action_mask;
+	} else if (!match) {
+		// released and mismatch keycode
+		BitField<KeyModifierMask> mask = {};
+		if (key->get_keycode() == Key::CTRL) {
+			mask.set_flag(KeyModifierMask::CTRL);
+		} else if (key->get_keycode() == Key::SHIFT) {
+			mask.set_flag(KeyModifierMask::SHIFT);
+		} else if (key->get_keycode() == Key::ALT) {
+			mask.set_flag(KeyModifierMask::ALT);
+		} else if (key->get_keycode() == Key::META) {
+			mask.set_flag(KeyModifierMask::META);
+		}
+		Key functional_key_mask = (Key)(int64_t)mask;
+
+		// exactly matches functional key
+		match |= functional_key_mask != Key::NONE && (action_mask & functional_key_mask) == functional_key_mask;
 	}
 	if (p_exact_match) {
 		match &= action_mask == key_mask;

--- a/tests/core/input/test_input_event_key.cpp
+++ b/tests/core/input/test_input_event_key.cpp
@@ -76,6 +76,47 @@ TEST_CASE("[InputEventKey] Key correctly stores and retrieves keycode with modif
 	CHECK(key.get_physical_keycode_with_modifiers() != Key::SPACE);
 }
 
+TEST_CASE("[InputEventKey] keycode and modifier matches") {
+	InputEventKey spaceKeyAction;
+	InputEventKey shiftKeyAction;
+	InputEventKey shiftSpaceKeyAction;
+
+	spaceKeyAction.set_keycode(Key::SPACE);
+	shiftKeyAction.set_keycode(Key::SHIFT);
+	shiftKeyAction.set_shift_pressed(true);
+	shiftSpaceKeyAction.set_keycode(Key::SPACE);
+	shiftSpaceKeyAction.set_shift_pressed(true);
+
+	InputEventKey key;
+	bool p_exact_match = false;
+	float deadzone = 0.5;
+	bool r_pressed = false;
+	float r_strength = 0.0;
+	float r_raw_strength = 0.0;
+
+	Ref<InputEventKey> p_event;
+
+	p_event = key.create_reference(Key::SPACE);
+	p_event->set_pressed(true);
+	CHECK(spaceKeyAction.action_match(p_event, p_exact_match, deadzone, &r_pressed, &r_strength, &r_raw_strength) == true);
+
+	p_event = key.create_reference(Key::SHIFT | KeyModifierMask::SHIFT);
+	p_event->set_pressed(true);
+	CHECK(shiftKeyAction.action_match(p_event, p_exact_match, deadzone, &r_pressed, &r_strength, &r_raw_strength) == true);
+
+	p_event = key.create_reference(Key::SPACE | KeyModifierMask::SHIFT);
+	p_event->set_pressed(true);
+	CHECK(shiftSpaceKeyAction.action_match(p_event, p_exact_match, deadzone, &r_pressed, &r_strength, &r_raw_strength) == true);
+
+	p_event = key.create_reference(Key::SHIFT | KeyModifierMask::SHIFT);
+	p_event->set_pressed(false);
+	CHECK(shiftKeyAction.action_match(p_event, p_exact_match, deadzone, &r_pressed, &r_strength, &r_raw_strength) == true);
+
+	p_event = key.create_reference(Key::SPACE);
+	p_event->set_pressed(false);
+	CHECK(spaceKeyAction.action_match(p_event, p_exact_match, deadzone, &r_pressed, &r_strength, &r_raw_strength) == true);
+}
+
 TEST_CASE("[InputEventKey] Key correctly stores and retrieves unicode") {
 	InputEventKey key;
 


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/71671*

## Issue Description

This is an interesting issue, but I think we should discuss about whether we need to deal with it.

Currently, the combination key behavior is as follows:

1. Press and hold `W`, `InputEventKey: keycode=87 (W), mods=none, pressed=true`
2. Press and hold `Shift`, `InputEventKey: keycode=4194325 (Shift), mods=none, pressed=true`
3. `InputEventKey: keycode=87 (W), mods=shift, pressed=true`, please notice there is **mods=shift**
4. Release `Shift`, `InputEventKey: keycode=4194325 (Shift), mods=none, pressed=false`
5. Release `W`, `InputEventKey: keycode=87 (W), mods=none, pressed=false`

Relevant result of `is_input_pressed()` is:

1. W
2. W, Shift
3. W, Shift, Shift+W
4. W, Shift+W
5. none

Because `InputEvent` used `keycode` to decide which `InputEvent` may be pressed, and the modifier of `InputEvent` must cover the whole modifer of predefined action, it can be decided to **pressed**. But when the `keycode` related key released, it doesnot evaluate this modifier, just equals `keycode` will decide to whole combination key released.

Let us see another scenario:

1. Press and hold `Shift`, `InputEventKey: keycode=4194325 (Shift), mods=none, pressed=true`
2. Press and hold `W`, `InputEventKey: keycode=87 (W), mods=shift, pressed=true`, please notice there is **mods=shift**
3. Release `W`, `InputEventKey: keycode=87 (W), mods=shift, pressed=false`, please notice there is **mods=shift**
4. Release `Shift`, `InputEventKey: keycode=4194325 (Shift), mods=none, pressed=false`

Relevant result of `is_input_pressed()` is:

1. Shift
2. W, Shift, Shift+W
4. Shift
5. none

As described above. The pressed condition is the same, the whole modifier have to cover the action. But the `shift` is trivial. The keycode is more important to the combination key when released.

## Solution

We should discuss about whether we should modify the behavior of releasing condition.

I updated to decide whether requested modifier is part of action modifier when key released. It can change this first scenario to better result.

1. W
2. W, Shift
3. W, Shift, Shift+W
4. W
5. none

But I am not sure if this change has any other impact. e.g. it may cause Shift+W combination key triggered multiple-time released events.

It is appreciate for any advice. Thank you.