### PR TITLE
Orient JPEG images according to Exif

### DIFF
--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  image.compat.inc                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Error Image::_load_jpg_from_buffer_compat_111851(const Vector<uint8_t> &p_array) {
+	return load_jpg_from_buffer(p_array, false);
+}
+
+void Image::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("load_jpg_from_buffer", "buffer"), &Image::_load_jpg_from_buffer_compat_111851);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -50,6 +50,7 @@ typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, floa
 typedef Vector<uint8_t> (*SaveJPGBufferFunc)(const Ref<Image> &p_img, float p_quality);
 
 typedef Ref<Image> (*ImageMemLoadFunc)(const uint8_t *p_data, int p_size);
+typedef Ref<Image> (*JPGImageMemLoadFunc)(const uint8_t *p_data, int p_size, bool p_fix_orientation);
 typedef Ref<Image> (*ScalableImageMemLoadFunc)(const uint8_t *p_data, int p_size, float p_scale);
 
 typedef Error (*SaveWebPFunc)(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
@@ -212,7 +213,7 @@ public:
 
 	static inline ImageMemLoadFunc _png_mem_loader_func = nullptr;
 	static inline ImageMemLoadFunc _png_mem_unpacker_func = nullptr;
-	static inline ImageMemLoadFunc _jpg_mem_loader_func = nullptr;
+	static inline JPGImageMemLoadFunc _jpg_mem_loader_func = nullptr;
 	static inline ImageMemLoadFunc _webp_mem_loader_func = nullptr;
 	static inline ImageMemLoadFunc _tga_mem_loader_func = nullptr;
 	static inline ImageMemLoadFunc _bmp_mem_loader_func = nullptr;
@@ -255,6 +256,11 @@ protected:
 	virtual Ref<Resource> _duplicate(const DuplicateParams &p_params) const override;
 
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	Error _load_jpg_from_buffer_compat_111851(const Vector<uint8_t> &p_array);
+	static void _bind_compatibility_methods();
+#endif
 
 private:
 	Format format = FORMAT_L8;
@@ -425,7 +431,7 @@ public:
 	static uint32_t get_format_component_mask(Format p_format);
 
 	Error load_png_from_buffer(const Vector<uint8_t> &p_array);
-	Error load_jpg_from_buffer(const Vector<uint8_t> &p_array);
+	Error load_jpg_from_buffer(const Vector<uint8_t> &p_array, bool p_fix_orientation = false);
 	Error load_webp_from_buffer(const Vector<uint8_t> &p_array);
 	Error load_tga_from_buffer(const Vector<uint8_t> &p_array);
 	Error load_bmp_from_buffer(const Vector<uint8_t> &p_array);

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -34,6 +34,7 @@ void ImageFormatLoader::_bind_methods() {
 	BIND_BITFIELD_FLAG(FLAG_NONE);
 	BIND_BITFIELD_FLAG(FLAG_FORCE_LINEAR);
 	BIND_BITFIELD_FLAG(FLAG_CONVERT_COLORS);
+	BIND_BITFIELD_FLAG(FLAG_FIX_ORIENTATION);
 }
 
 bool ImageFormatLoader::recognize(const String &p_extension) const {

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -52,6 +52,7 @@ public:
 		FLAG_NONE = 0,
 		FLAG_FORCE_LINEAR = 1,
 		FLAG_CONVERT_COLORS = 2,
+		FLAG_FIX_ORIENTATION = 4,
 	};
 
 protected:

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -366,8 +366,10 @@
 		<method name="load_jpg_from_buffer">
 			<return type="int" enum="Error" />
 			<param index="0" name="buffer" type="PackedByteArray" />
+			<param index="1" name="fix_orientation" type="bool" default="false" />
 			<description>
 				Loads an image from the binary contents of a JPEG file.
+				If [param fix_orientation] is [code]true[/code], orients the loaded image according to its Exif data.
 			</description>
 		</method>
 		<method name="load_ktx_from_buffer">

--- a/doc/classes/ImageFormatLoader.xml
+++ b/doc/classes/ImageFormatLoader.xml
@@ -15,5 +15,7 @@
 		</constant>
 		<constant name="FLAG_CONVERT_COLORS" value="2" enum="LoaderFlags" is_bitfield="true">
 		</constant>
+		<constant name="FLAG_FIX_ORIENTATION" value="4" enum="LoaderFlags" is_bitfield="true">
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -63,6 +63,9 @@
 			If [code]true[/code], scales the imported image to match [member EditorSettings.interface/editor/custom_display_scale]. This should be enabled for editor plugin icons and custom class icons, but should be left disabled otherwise.
 			[b]Note:[/b] Only available for SVG images.
 		</member>
+		<member name="jpeg/fix_orientation" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], orients the imported image according to its Exif data.
+		</member>
 		<member name="mipmaps/generate" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], smaller versions of the texture are generated on import. For example, a 64×64 texture will generate 6 mipmaps (32×32, 16×16, 8×8, 4×4, 2×2, 1×1). This has several benefits:
 			- Textures will not become grainy in the distance (in 3D), or if scaled down due to [Camera2D] zoom or [CanvasItem] scale (in 2D).

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -857,7 +857,7 @@ void EditorAssetLibrary::_image_update(bool p_use_cache, bool p_final, const Pac
 		if ((memcmp(&r[0], &png_signature[0], 8) == 0) && Image::_png_mem_loader_func) {
 			parsed_image = Image::_png_mem_loader_func(r, len);
 		} else if ((memcmp(&r[0], &jpg_signature[0], 3) == 0) && Image::_jpg_mem_loader_func) {
-			parsed_image = Image::_jpg_mem_loader_func(r, len);
+			parsed_image = Image::_jpg_mem_loader_func(r, len, true);
 		} else if ((memcmp(&r[0], &webp_signature[0], 4) == 0) && Image::_webp_mem_loader_func) {
 			parsed_image = Image::_webp_mem_loader_func(r, len);
 		} else if ((memcmp(&r[0], &bmp_signature[0], 2) == 0) && Image::_bmp_mem_loader_func) {

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -269,6 +269,9 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 		r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "editor/scale_with_editor_scale"), false));
 		r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "editor/convert_colors_with_editor_theme"), false));
 	}
+	if (p_path.is_empty() || p_path.get_extension() == "jpg" || p_path.get_extension() == "jpeg") {
+		r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "jpeg/fix_orientation"), false));
+	}
 }
 
 void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<Image> &p_image, CompressMode p_compress_mode, Image::UsedChannels p_channels, Image::CompressMode p_compress_format, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params) {
@@ -762,12 +765,18 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 	// SVG-specific options.
 	float scale = p_options.has("svg/scale") ? float(p_options["svg/scale"]) : 1.0f;
 
+	// JPEG-specific options.
+	bool fix_orientation = p_options.has("jpeg/fix_orientation") ? bool(p_options["jpeg/fix_orientation"]) : false;
+
 	// Editor-specific options.
 	bool use_editor_scale = p_options.has("editor/scale_with_editor_scale") && p_options["editor/scale_with_editor_scale"];
 	bool convert_editor_colors = p_options.has("editor/convert_colors_with_editor_theme") && p_options["editor/convert_colors_with_editor_theme"];
 
 	if (hdr_as_srgb) {
 		loader_flags |= ImageFormatLoader::FLAG_FORCE_LINEAR;
+	}
+	if (fix_orientation) {
+		loader_flags |= ImageFormatLoader::FLAG_FIX_ORIENTATION;
 	}
 
 	// Start importing images.

--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -225,6 +225,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["ir"] = "IR";
 	capitalize_string_remaps["itunes"] = "iTunes";
 	capitalize_string_remaps["jit"] = "JIT";
+	capitalize_string_remaps["jpeg"] = "JPEG";
 	capitalize_string_remaps["k1"] = "K1";
 	capitalize_string_remaps["k2"] = "K2";
 	capitalize_string_remaps["kb"] = "(KB)"; // Unit.

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -54,3 +54,10 @@ Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/set_curre
 Validate extension JSON: Error: Field 'classes/AnimationPlayer/signals/current_animation_changed/arguments/0': type changed value in new API, from "String" to "StringName".
 
 Return types and parameters changed to StringName to improve performance. Compatibility methods registered; No compatibility system for signal arguments.
+
+
+GH-111851
+---------
+Validate extension JSON: Error: Field 'classes/Image/methods/load_jpg_from_buffer/arguments': size changed value in new API, from 1 to 2.
+
+Optional argument added. Compatibility method registered.


### PR DESCRIPTION
Closes #111831

This PR tries to orient the `Image` after loading from JPEG.

- Added `jpeg/fix_orientation` import option. Disabled by default.
- Added an optional parameter `fix_orientation` to `Image.load_jpg_from_buffer()`. Defaults to false. A compatibility method is registered.

This feature is disabled by default except for usages in the editor. For example, it's enabled when loading plugin thumbnail in the AssetLib page.

I'm not sure if the original behavior is intended. But it does make it difficult to show user-provided images correctly (in a game / app developed with Godot).

---

Test project: [exif.zip](https://github.com/user-attachments/files/23003906/exif.zip)

The "F" test images are taken from https://github.com/noell/jpg-exif-test-images: It includes images for all 8 orientation values and 3 invalid ones.

You can find the description of orientation values here (page 36): https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf