### PR TITLE
GDScript: Fix type check for call returns in void functions

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/errors/return_typed_call_in_void_func.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_typed_call_in_void_func.gd
@@ -1,0 +1,2 @@
+func test() -> void:
+	return randf()

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_typed_call_in_void_func.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_typed_call_in_void_func.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 2: A void function cannot return a value.

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_warnings.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_warnings.gd
@@ -140,9 +140,6 @@ func test_unreachable_pattern():
 		1:
 			print(1)
 
-func test_unsafe_void_return_variant() -> void:
-	return variant_func() # No warning (intended?).
-
 func test_unsafe_void_return() -> void:
 	@warning_ignore("unsafe_method_access", "unsafe_void_return")
 	return variant_func().f()


### PR DESCRIPTION
This pull request fixes an issue where void functions returning hard typed function calls were not raising errors as expected.
#
Example as given in the issue report:
```gdscript
func getRand1() -> void:
    return randf() # No errors were raised.
```

If you assigned the function to a variable and then returned the variable, it noticed the error:

```gdscript
func getRand2() -> void:
    var rand: float = randf()
    return rand # Parser Error: A void function cannot return a value.
```
I've tested my changes by repeating the examples above, and further testing different cases myself. It should work as intended now.
#
The current unit tests seem to pass, but I'd appreciate confirmation on the way they're intended to be done as I'm unsure.

Fixes #108175