### PR TITLE
Fix TextEdit IME error on mouse over

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4974,7 +4974,7 @@ String TextEdit::get_word(int p_line, int p_column) const {
 	}
 	ERR_FAIL_INDEX_V(p_line, text.size(), String());
 
-	const String &text_line = text[p_line];
+	const String &text_line = text.get_text_with_ime(p_line);
 	if (text_line.is_empty()) {
 		return String();
 	}
@@ -6386,24 +6386,20 @@ int TextEdit::get_line_wrap_count(int p_line) const {
 int TextEdit::get_line_wrap_index_at_column(int p_line, int p_column) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), 0);
 	ERR_FAIL_COND_V(p_column < 0, 0);
-	ERR_FAIL_COND_V(p_column > text[p_line].length(), 0);
+	ERR_FAIL_COND_V(p_column > text.get_text_with_ime(p_line).length(), 0);
 
 	if (!is_line_wrapped(p_line)) {
 		return 0;
 	}
 
-	/* Loop through wraps in the line text until we get to the column. */
-	int wrap_index = 0;
-	int col = 0;
-	Vector<String> lines = get_line_wrapped_text(p_line);
-	for (int i = 0; i < lines.size(); i++) {
-		wrap_index = i;
-		col += lines[wrap_index].length();
-		if (col > p_column) {
-			break;
+	// Loop through wraps in the line text until we get to the column.
+	const Vector<Vector2i> line_ranges = text.get_line_wrap_ranges(p_line);
+	for (int i = 0; i < line_ranges.size(); i++) {
+		if (line_ranges[i].y > p_column) {
+			return i;
 		}
 	}
-	return wrap_index;
+	return line_ranges.is_empty() ? 0 : line_ranges.size() - 1;
 }
 
 Vector<String> TextEdit::get_line_wrapped_text(int p_line) const {
@@ -6411,12 +6407,13 @@ Vector<String> TextEdit::get_line_wrapped_text(int p_line) const {
 
 	Vector<String> lines;
 	if (!is_line_wrapped(p_line)) {
-		lines.push_back(text[p_line]);
+		lines.push_back(text.get_text_with_ime(p_line));
 		return lines;
 	}
 
-	const String &line_text = text[p_line];
-	Vector<Vector2i> line_ranges = text.get_line_wrap_ranges(p_line);
+	const String &line_text = text.get_text_with_ime(p_line);
+	const Vector<Vector2i> line_ranges = text.get_line_wrap_ranges(p_line);
+	lines.reserve(line_ranges.size());
 	for (int i = 0; i < line_ranges.size(); i++) {
 		lines.push_back(line_text.substr(line_ranges[i].x, line_ranges[i].y - line_ranges[i].x));
 	}


### PR DESCRIPTION
- Fixes hovering over a line with IME text causing errors `ERROR: scene/gui/text_edit.cpp:6402 - Condition "p_column > text[p_line].length()" is true. Returning: 0`
- Fixes search highlight being offset when there is IME text before it
- Fixes minimap not being correct when using IME (wrapped lines were messed up)
- Fixes (maybe) https://github.com/godotengine/godot/issues/110316 - I'm not sure if this is the same issue or not
- Supersedes https://github.com/godotengine/godot/pull/110787 since that fixes the mouse over issue
	- But I don't think it actually fixes () https://github.com/godotengine/godot/issues/110138 since that describes Chinese IME specific issues and does not mention mouse movement.

Fixed `get_line_wrap_index_at_column` not accepting column with IME. 
`get_line_wrapped_text` used `text.get_line_wrap_ranges` which uses `data_buf` for the line wraps, which is uses IME text. So it was using the non-IME text string with IME line wraps, which was causing the minimap and search highlight issues.
Also made `get_line_wrap_index_at_column` use the `get_line_wrap_ranges` directly, it doesn't need to get the text first.

There are lots more issues with IME here, anything using the TextServer or `data_buf` is using the text with the IME, but some functions use those together with things that don't use the IME text, like the carets, selections, and text strings. Such as `get_rect_at_line_column`, `get_word`, most places that use `get_line_column_at_pos`, and more.

Search highlight issue (with an open find panel):

<img width="275" height="69" alt="Pasted image 20251020153030" src="https://github.com/user-attachments/assets/4d91c30b-1ed2-4c90-b279-d80953fd55ea" />
