### PR TITLE
Decouple `SeparationRayShape2D/3D` configuration of collision detection and collision resolution

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -903,7 +903,7 @@
 		<method name="separation_ray_shape_create">
 			<return type="RID" />
 			<description>
-				Creates a 2D separation ray shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the shape's [code]length[/code] and [code]slide_on_slope[/code] properties.
+				Creates a 2D separation ray shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the shape's [member SeparationRayShape2D.length], [member SeparationRayShape2D.stops_motion], and [member SeparationRayShape2D.separate_along_ray] properties.
 			</description>
 		</method>
 		<method name="set_active">
@@ -934,7 +934,7 @@
 			<description>
 				Sets the shape data that defines the configuration of the shape. The [param data] to be passed depends on the shape's type (see [method shape_get_type]):
 				- [constant SHAPE_WORLD_BOUNDARY]: an array of length two containing a [Vector2] [code]normal[/code] direction and a [float] distance [code]d[/code],
-				- [constant SHAPE_SEPARATION_RAY]: a dictionary containing the key [code]length[/code] with a [float] value and the key [code]slide_on_slope[/code] with a [bool] value,
+				- [constant SHAPE_SEPARATION_RAY]: a dictionary containing the key [code]length[/code] with a [float] value, a key [code]stops_motion[/code] with a [bool] value, and the key [code]separate_along_ray[/code] with a [bool] value,
 				- [constant SHAPE_SEGMENT]: a [Rect2] [code]rect[/code] containing the first point of the segment in [code]rect.position[/code] and the second point of the segment in [code]rect.size[/code],
 				- [constant SHAPE_CIRCLE]: a [float] [code]radius[/code],
 				- [constant SHAPE_RECTANGLE]: a [Vector2] [code]half_extents[/code],

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -722,7 +722,7 @@
 			<param index="1" name="from" type="Transform2D" />
 			<param index="2" name="motion" type="Vector2" />
 			<param index="3" name="margin" type="float" />
-			<param index="4" name="collide_separation_ray" type="bool" />
+			<param index="4" name="separation_rays_stop_motion" type="bool" />
 			<param index="5" name="recovery_as_collision" type="bool" />
 			<param index="6" name="result" type="PhysicsServer2DExtensionMotionResult*" />
 			<description>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -993,7 +993,7 @@
 		<method name="separation_ray_shape_create">
 			<return type="RID" />
 			<description>
-				Creates a 3D separation ray shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the shape's [code]length[/code] and [code]slide_on_slope[/code] properties.
+				Creates a 3D separation ray shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the shape's [member SeparationRayShape3D.length], [member SeparationRayShape3D.stops_motion], and [member SeparationRayShape3D.separate_along_ray] properties.
 			</description>
 		</method>
 		<method name="set_active">
@@ -1032,7 +1032,7 @@
 			<description>
 				Sets the shape data that configures the shape. The [param data] to be passed depends on the shape's type (see [method shape_get_type]):
 				- [constant SHAPE_WORLD_BOUNDARY]: a [Plane],
-				- [constant SHAPE_SEPARATION_RAY]: a dictionary containing the key [code]"length"[/code] with a [float] value and the key [code]"slide_on_slope"[/code] with a [bool] value,
+				- [constant SHAPE_SEPARATION_RAY]: a dictionary containing the key [code]"length"[/code] with a [float] value, a key [code]"stops_motion"[/code] with a [bool] value, and the key [code]"separate_along_ray"[/code] with a [bool] value,
 				- [constant SHAPE_SPHERE]: a [float] that is the radius of the sphere,
 				- [constant SHAPE_BOX]: a [Vector3] containing the half-extents of the box,
 				- [constant SHAPE_CAPSULE]: a dictionary containing the keys [code]"height"[/code] and [code]"radius"[/code] with [float] values,

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -608,7 +608,7 @@
 			<param index="2" name="motion" type="Vector3" />
 			<param index="3" name="margin" type="float" />
 			<param index="4" name="max_collisions" type="int" />
-			<param index="5" name="collide_separation_ray" type="bool" />
+			<param index="5" name="separation_rays_stop_motion" type="bool" />
 			<param index="6" name="recovery_as_collision" type="bool" />
 			<param index="7" name="result" type="PhysicsServer3DExtensionMotionResult*" />
 			<description>

--- a/doc/classes/PhysicsTestMotionParameters2D.xml
+++ b/doc/classes/PhysicsTestMotionParameters2D.xml
@@ -9,10 +9,6 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="collide_separation_ray" type="bool" setter="set_collide_separation_ray_enabled" getter="is_collide_separation_ray_enabled" default="false">
-			If set to [code]true[/code], shapes of type [constant PhysicsServer2D.SHAPE_SEPARATION_RAY] are used to detect collisions and can stop the motion. Can be useful when snapping to the ground.
-			If set to [code]false[/code], shapes of type [constant PhysicsServer2D.SHAPE_SEPARATION_RAY] are only used for separation when overlapping with other bodies. That's the main use for separation ray shapes.
-		</member>
 		<member name="exclude_bodies" type="RID[]" setter="set_exclude_bodies" getter="get_exclude_bodies" default="[]">
 			Optional array of body [RID] to exclude from collision. Use [method CollisionObject2D.get_rid] to get the [RID] associated with a [CollisionObject2D]-derived node.
 		</member>
@@ -31,6 +27,10 @@
 		<member name="recovery_as_collision" type="bool" setter="set_recovery_as_collision_enabled" getter="is_recovery_as_collision_enabled" default="false">
 			If set to [code]true[/code], any depenetration from the recovery phase is reported as a collision; this is used e.g. by [CharacterBody2D] for improving floor detection during floor snapping.
 			If set to [code]false[/code], only collisions resulting from the motion are reported, which is generally the desired behavior.
+		</member>
+		<member name="separation_rays_stop_motion" type="bool" setter="set_separation_rays_stop_motion_enabled" getter="is_separation_rays_stop_motion_enabled" default="false">
+			If set to [code]true[/code], shapes of type [constant PhysicsServer2D.SHAPE_SEPARATION_RAY] are used to detect collisions and can stop the motion. Can be useful when snapping to the ground.
+			If set to [code]false[/code], shapes of type [constant PhysicsServer2D.SHAPE_SEPARATION_RAY] are only used for separation when overlapping with other bodies. That's the main use for separation ray shapes.
 		</member>
 	</members>
 </class>

--- a/doc/classes/PhysicsTestMotionParameters3D.xml
+++ b/doc/classes/PhysicsTestMotionParameters3D.xml
@@ -9,10 +9,6 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="collide_separation_ray" type="bool" setter="set_collide_separation_ray_enabled" getter="is_collide_separation_ray_enabled" default="false">
-			If set to [code]true[/code], shapes of type [constant PhysicsServer3D.SHAPE_SEPARATION_RAY] are used to detect collisions and can stop the motion. Can be useful when snapping to the ground.
-			If set to [code]false[/code], shapes of type [constant PhysicsServer3D.SHAPE_SEPARATION_RAY] are only used for separation when overlapping with other bodies. That's the main use for separation ray shapes.
-		</member>
 		<member name="exclude_bodies" type="RID[]" setter="set_exclude_bodies" getter="get_exclude_bodies" default="[]">
 			Optional array of body [RID] to exclude from collision. Use [method CollisionObject3D.get_rid] to get the [RID] associated with a [CollisionObject3D]-derived node.
 		</member>
@@ -34,6 +30,10 @@
 		<member name="recovery_as_collision" type="bool" setter="set_recovery_as_collision_enabled" getter="is_recovery_as_collision_enabled" default="false">
 			If set to [code]true[/code], any depenetration from the recovery phase is reported as a collision; this is used e.g. by [CharacterBody3D] for improving floor detection during floor snapping.
 			If set to [code]false[/code], only collisions resulting from the motion are reported, which is generally the desired behavior.
+		</member>
+		<member name="separation_rays_stop_motion" type="bool" setter="set_separation_rays_stop_motion_enabled" getter="is_separation_rays_stop_motion_enabled" default="false">
+			If set to [code]true[/code], shapes of type [constant PhysicsServer3D.SHAPE_SEPARATION_RAY] are used to detect collisions and can stop the motion. Can be useful when snapping to the ground.
+			If set to [code]false[/code], shapes of type [constant PhysicsServer3D.SHAPE_SEPARATION_RAY] are only used for separation when overlapping with other bodies. That's the main use for separation ray shapes.
 		</member>
 	</members>
 </class>

--- a/doc/classes/SeparationRayShape2D.xml
+++ b/doc/classes/SeparationRayShape2D.xml
@@ -12,9 +12,13 @@
 		<member name="length" type="float" setter="set_length" getter="get_length" default="20.0">
 			The ray's length.
 		</member>
-		<member name="slide_on_slope" type="bool" setter="set_slide_on_slope" getter="get_slide_on_slope" default="false">
-			If [code]false[/code] (default), the shape always separates and returns a normal along its own direction.
-			If [code]true[/code], the shape can return the correct normal and separate in any direction, allowing sliding motion on slopes.
+		<member name="separate_along_ray" type="bool" setter="set_separate_along_ray" getter="get_separate_along_ray" default="true">
+			If [code]false[/code], the shape can return the correct normal and separate in any direction.
+			If [code]true[/code] (default), the shape always separates and returns a normal along its own direction.
+		</member>
+		<member name="stops_motion" type="bool" setter="set_stops_motion" getter="get_stops_motion" default="false">
+			If [code]false[/code](default), the shape will only be used for depenetration.
+			If [code]true[/code], the shape will be used in collision detection.
 		</member>
 	</members>
 </class>

--- a/doc/classes/SeparationRayShape3D.xml
+++ b/doc/classes/SeparationRayShape3D.xml
@@ -12,9 +12,13 @@
 		<member name="length" type="float" setter="set_length" getter="get_length" default="1.0">
 			The ray's length.
 		</member>
-		<member name="slide_on_slope" type="bool" setter="set_slide_on_slope" getter="get_slide_on_slope" default="false">
-			If [code]false[/code] (default), the shape always separates and returns a normal along its own direction.
-			If [code]true[/code], the shape can return the correct normal and separate in any direction, allowing sliding motion on slopes.
+		<member name="separate_along_ray" type="bool" setter="set_separate_along_ray" getter="get_separate_along_ray" default="true">
+			If [code]false[/code], the shape can return the correct normal and separate in any direction.
+			If [code]true[/code] (default), the shape always separates and returns a normal along its own direction.
+		</member>
+		<member name="stops_motion" type="bool" setter="set_stops_motion" getter="get_stops_motion" default="false">
+			If [code]false[/code](default), the shape will only be used for depenetration.
+			If [code]true[/code], the shape will be used in collision detection.
 		</member>
 	</members>
 </class>

--- a/modules/godot_physics_2d/godot_collision_solver_2d.cpp
+++ b/modules/godot_physics_2d/godot_collision_solver_2d.cpp
@@ -119,7 +119,7 @@ bool GodotCollisionSolver2D::solve_separation_ray(const GodotShape2D *p_shape_A,
 	}
 
 	Vector2 support_B = p_transform_B.xform(p);
-	if (ray->get_slide_on_slope()) {
+	if (!ray->get_separate_along_ray()) {
 		Vector2 global_n = invb.basis_xform_inv(n).normalized();
 		support_B = support_A + (support_B - support_A).length() * global_n;
 	}

--- a/modules/godot_physics_2d/godot_shape_2d.cpp
+++ b/modules/godot_physics_2d/godot_shape_2d.cpp
@@ -162,14 +162,16 @@ real_t GodotSeparationRayShape2D::get_moment_of_inertia(real_t p_mass, const Siz
 void GodotSeparationRayShape2D::set_data(const Variant &p_data) {
 	Dictionary d = p_data;
 	length = d["length"];
-	slide_on_slope = d["slide_on_slope"];
+	stops_motion = d["stops_motion"];
+	separate_along_ray = d["separate_along_ray"];
 	configure(Rect2(0, 0, 0.001, length));
 }
 
 Variant GodotSeparationRayShape2D::get_data() const {
 	Dictionary d;
 	d["length"] = length;
-	d["slide_on_slope"] = slide_on_slope;
+	d["stops_motion"] = stops_motion;
+	d["separate_along_ray"] = separate_along_ray;
 	return d;
 }
 

--- a/modules/godot_physics_2d/godot_shape_2d.h
+++ b/modules/godot_physics_2d/godot_shape_2d.h
@@ -182,11 +182,13 @@ public:
 
 class GodotSeparationRayShape2D : public GodotShape2D {
 	real_t length = 0.0;
-	bool slide_on_slope = false;
+	bool stops_motion = false;
+	bool separate_along_ray = true;
 
 public:
 	_FORCE_INLINE_ real_t get_length() const { return length; }
-	_FORCE_INLINE_ bool get_slide_on_slope() const { return slide_on_slope; }
+	_FORCE_INLINE_ bool get_stops_motion() const { return stops_motion; }
+	_FORCE_INLINE_ bool get_separate_along_ray() const { return separate_along_ray; }
 
 	virtual PhysicsServer2D::ShapeType get_type() const override { return PhysicsServer2D::SHAPE_SEPARATION_RAY; }
 

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -752,11 +752,9 @@ bool GodotSpace2D::test_body_motion(GodotBody2D *p_body, const PhysicsServer2D::
 
 			GodotShape2D *body_shape = p_body->get_shape(body_shape_idx);
 
-			// Colliding separation rays allows to properly snap to the ground,
-			// otherwise it's not needed in regular motion.
-			if (!p_parameters.collide_separation_ray && (body_shape->get_type() == PhysicsServer2D::SHAPE_SEPARATION_RAY)) {
-				// When slide on slope is on, separation ray shape acts like a regular shape.
-				if (!static_cast<GodotSeparationRayShape2D *>(body_shape)->get_slide_on_slope()) {
+			// Forcing separation ray to stop motion allows to properly snap to the ground
+			if (!p_parameters.separation_rays_stop_motion && (body_shape->get_type() == PhysicsServer2D::SHAPE_SEPARATION_RAY)) {
+				if (!static_cast<GodotSeparationRayShape2D *>(body_shape)->get_stops_motion()) {
 					continue;
 				}
 			}

--- a/modules/godot_physics_3d/godot_collision_solver_3d.cpp
+++ b/modules/godot_physics_3d/godot_collision_solver_3d.cpp
@@ -122,7 +122,7 @@ bool GodotCollisionSolver3D::solve_separation_ray(const GodotShape3D *p_shape_A,
 	}
 
 	Vector3 support_B = p_transform_B.xform(p);
-	if (ray->get_slide_on_slope()) {
+	if (!ray->get_separate_along_ray()) {
 		Vector3 global_n = ai.basis.xform_inv(n).normalized();
 		support_B = support_A + (support_B - support_A).length() * global_n;
 	}

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -172,8 +172,12 @@ real_t GodotSeparationRayShape3D::get_length() const {
 	return length;
 }
 
-bool GodotSeparationRayShape3D::get_slide_on_slope() const {
-	return slide_on_slope;
+bool GodotSeparationRayShape3D::get_stops_motion() const {
+	return stops_motion;
+}
+
+bool GodotSeparationRayShape3D::get_separate_along_ray() const {
+	return separate_along_ray;
 }
 
 void GodotSeparationRayShape3D::project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const {
@@ -223,21 +227,23 @@ Vector3 GodotSeparationRayShape3D::get_moment_of_inertia(real_t p_mass) const {
 	return Vector3();
 }
 
-void GodotSeparationRayShape3D::_setup(real_t p_length, bool p_slide_on_slope) {
+void GodotSeparationRayShape3D::_setup(real_t p_length, bool p_stops_motion, bool p_separate_along_ray) {
 	length = p_length;
-	slide_on_slope = p_slide_on_slope;
+	stops_motion = p_stops_motion;
+	separate_along_ray = p_separate_along_ray;
 	configure(AABB(Vector3(0, 0, 0), Vector3(0.1, 0.1, length)));
 }
 
 void GodotSeparationRayShape3D::set_data(const Variant &p_data) {
 	Dictionary d = p_data;
-	_setup(d["length"], d["slide_on_slope"]);
+	_setup(d["length"], d["stops_motion"], d["separate_along_ray"]);
 }
 
 Variant GodotSeparationRayShape3D::get_data() const {
 	Dictionary d;
 	d["length"] = length;
-	d["slide_on_slope"] = slide_on_slope;
+	d["stops_motion"] = stops_motion;
+	d["separate_along_ray"] = separate_along_ray;
 	return d;
 }
 

--- a/modules/godot_physics_3d/godot_shape_3d.h
+++ b/modules/godot_physics_3d/godot_shape_3d.h
@@ -138,13 +138,15 @@ public:
 
 class GodotSeparationRayShape3D : public GodotShape3D {
 	real_t length = 1.0;
-	bool slide_on_slope = false;
+	bool stops_motion = false;
+	bool separate_along_ray = true;
 
-	void _setup(real_t p_length, bool p_slide_on_slope);
+	void _setup(real_t p_length, bool p_stops_motion, bool p_separate_along_ray);
 
 public:
 	real_t get_length() const;
-	bool get_slide_on_slope() const;
+	bool get_stops_motion() const;
+	bool get_separate_along_ray() const;
 
 	virtual real_t get_volume() const override { return 0.0; }
 	virtual PhysicsServer3D::ShapeType get_type() const override { return PhysicsServer3D::SHAPE_SEPARATION_RAY; }

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -815,11 +815,9 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 
 			GodotShape3D *body_shape = p_body->get_shape(j);
 
-			// Colliding separation rays allows to properly snap to the ground,
-			// otherwise it's not needed in regular motion.
-			if (!p_parameters.collide_separation_ray && (body_shape->get_type() == PhysicsServer3D::SHAPE_SEPARATION_RAY)) {
-				// When slide on slope is on, separation ray shape acts like a regular shape.
-				if (!static_cast<GodotSeparationRayShape3D *>(body_shape)->get_slide_on_slope()) {
+			// Forcing separation ray to stop motion allows to properly snap to the ground
+			if (!p_parameters.separation_rays_stop_motion && (body_shape->get_type() == PhysicsServer3D::SHAPE_SEPARATION_RAY)) {
+				if (!static_cast<GodotSeparationRayShape3D *>(body_shape)->get_stops_motion()) {
 					continue;
 				}
 			}

--- a/modules/jolt_physics/shapes/jolt_custom_ray_shape.cpp
+++ b/modules/jolt_physics/shapes/jolt_custom_ray_shape.cpp
@@ -125,15 +125,15 @@ void collide_ray_vs_shape(const JPH::Shape *p_shape1, const JPH::Shape *p_shape2
 
 	JPH::Vec3 hit_normal2 = JPH::Vec3::sZero();
 
-	if (shape1->slide_on_slope) {
+	if (shape1->separate_along_ray) {
+		hit_normal2 = -ray_direction2;
+	} else {
 		hit_normal2 = p_shape2->GetSurfaceNormal(local_sub_shape_id2, hit_point2);
 
 		// If we got a back-face normal we need to flip it.
 		if (hit_normal2.Dot(ray_direction2) > 0) {
 			hit_normal2 = -hit_normal2;
 		}
-	} else {
-		hit_normal2 = -ray_direction2;
 	}
 
 	const JPH::Vec3 hit_normal = transform2.Multiply3x3(hit_normal2);

--- a/modules/jolt_physics/shapes/jolt_custom_ray_shape.h
+++ b/modules/jolt_physics/shapes/jolt_custom_ray_shape.h
@@ -40,11 +40,12 @@ class JoltCustomRayShapeSettings final : public JPH::ConvexShapeSettings {
 public:
 	JPH::RefConst<JPH::PhysicsMaterial> material;
 	float length = 1.0f;
-	bool slide_on_slope = false;
+	bool stops_motion = false;
+	bool separate_along_ray = true;
 
 	JoltCustomRayShapeSettings() = default;
-	JoltCustomRayShapeSettings(float p_length, bool p_slide_on_slope, const JPH::PhysicsMaterial *p_material = nullptr) :
-			material(p_material), length(p_length), slide_on_slope(p_slide_on_slope) {}
+	JoltCustomRayShapeSettings(float p_length, bool p_stops_motion, bool p_separate_along_ray, const JPH::PhysicsMaterial *p_material = nullptr) :
+			material(p_material), length(p_length), stops_motion(p_stops_motion), separate_along_ray(p_separate_along_ray) {}
 
 	virtual JPH::ShapeSettings::ShapeResult Create() const override;
 };
@@ -53,7 +54,8 @@ class JoltCustomRayShape final : public JPH::ConvexShape {
 public:
 	JPH::RefConst<JPH::PhysicsMaterial> material;
 	float length = 0.0f;
-	bool slide_on_slope = false;
+	bool stops_motion = false;
+	bool separate_along_ray = true;
 
 	static void register_type();
 
@@ -61,14 +63,14 @@ public:
 			JPH::ConvexShape(JoltCustomShapeSubType::RAY) {}
 
 	JoltCustomRayShape(const JoltCustomRayShapeSettings &p_settings, JPH::Shape::ShapeResult &p_result) :
-			JPH::ConvexShape(JoltCustomShapeSubType::RAY, p_settings, p_result), material(p_settings.material), length(p_settings.length), slide_on_slope(p_settings.slide_on_slope) {
+			JPH::ConvexShape(JoltCustomShapeSubType::RAY, p_settings, p_result), material(p_settings.material), length(p_settings.length), stops_motion(p_settings.stops_motion), separate_along_ray(p_settings.separate_along_ray) {
 		if (!p_result.HasError()) {
 			p_result.Set(this);
 		}
 	}
 
-	JoltCustomRayShape(float p_length, bool p_slide_on_slope, const JPH::PhysicsMaterial *p_material = nullptr) :
-			JPH::ConvexShape(JoltCustomShapeSubType::RAY), material(p_material), length(p_length), slide_on_slope(p_slide_on_slope) {}
+	JoltCustomRayShape(float p_length, bool p_stops_motion, bool p_separate_along_ray, const JPH::PhysicsMaterial *p_material = nullptr) :
+			JPH::ConvexShape(JoltCustomShapeSubType::RAY), material(p_material), length(p_length), stops_motion(p_stops_motion), separate_along_ray(p_separate_along_ray) {}
 
 	virtual JPH::AABox GetLocalBounds() const override;
 

--- a/modules/jolt_physics/shapes/jolt_separation_ray_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_separation_ray_shape_3d.cpp
@@ -36,7 +36,7 @@
 JPH::ShapeRefC JoltSeparationRayShape3D::_build() const {
 	ERR_FAIL_COND_V_MSG(length <= 0.0f, nullptr, vformat("Failed to build Jolt Physics separation ray shape with %s. Its length must be greater than 0. This shape belongs to %s.", to_string(), _owners_to_string()));
 
-	const JoltCustomRayShapeSettings shape_settings(length, slide_on_slope);
+	const JoltCustomRayShapeSettings shape_settings(length, stops_motion, separate_along_ray);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics separation ray shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
 
@@ -46,7 +46,8 @@ JPH::ShapeRefC JoltSeparationRayShape3D::_build() const {
 Variant JoltSeparationRayShape3D::get_data() const {
 	Dictionary data;
 	data["length"] = length;
-	data["slide_on_slope"] = slide_on_slope;
+	data["stops_motion"] = stops_motion;
+	data["separate_along_ray"] = separate_along_ray;
 	return data;
 }
 
@@ -58,18 +59,23 @@ void JoltSeparationRayShape3D::set_data(const Variant &p_data) {
 	const Variant maybe_length = data.get("length", Variant());
 	ERR_FAIL_COND(maybe_length.get_type() != Variant::FLOAT);
 
-	const Variant maybe_slide_on_slope = data.get("slide_on_slope", Variant());
-	ERR_FAIL_COND(maybe_slide_on_slope.get_type() != Variant::BOOL);
+	const Variant maybe_stops_motion = data.get("stops_motion", Variant());
+	ERR_FAIL_COND(maybe_stops_motion.get_type() != Variant::BOOL);
+
+	const Variant maybe_separate_along_ray = data.get("separate_along_ray", Variant());
+	ERR_FAIL_COND(maybe_separate_along_ray.get_type() != Variant::BOOL);
 
 	const float new_length = maybe_length;
-	const bool new_slide_on_slope = maybe_slide_on_slope;
+	const bool new_stops_motion = maybe_stops_motion;
+	const bool new_separate_along_ray = maybe_separate_along_ray;
 
-	if (unlikely(new_length == length && new_slide_on_slope == slide_on_slope)) {
+	if (unlikely(new_length == length && new_stops_motion == stops_motion && new_separate_along_ray == separate_along_ray)) {
 		return;
 	}
 
 	length = new_length;
-	slide_on_slope = new_slide_on_slope;
+	stops_motion = new_stops_motion;
+	separate_along_ray = new_separate_along_ray;
 
 	destroy();
 }
@@ -81,5 +87,5 @@ AABB JoltSeparationRayShape3D::get_aabb() const {
 }
 
 String JoltSeparationRayShape3D::to_string() const {
-	return vformat("{length=%f slide_on_slope=%s}", length, slide_on_slope);
+	return vformat("{length=%f stops_motion=%s separate_along_ray=%s}", length, stops_motion, separate_along_ray);
 }

--- a/modules/jolt_physics/shapes/jolt_separation_ray_shape_3d.h
+++ b/modules/jolt_physics/shapes/jolt_separation_ray_shape_3d.h
@@ -34,7 +34,8 @@
 
 class JoltSeparationRayShape3D final : public JoltShape3D {
 	float length = 0.0f;
-	bool slide_on_slope = false;
+	bool stops_motion = false;
+	bool separate_along_ray = false;
 
 	virtual JPH::ShapeRefC _build() const override;
 

--- a/modules/jolt_physics/spaces/jolt_motion_filter_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_motion_filter_3d.cpp
@@ -39,12 +39,12 @@
 #include "jolt_broad_phase_layer.h"
 #include "jolt_space_3d.h"
 
-JoltMotionFilter3D::JoltMotionFilter3D(const JoltBody3D &p_body, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, bool p_collide_separation_ray) :
+JoltMotionFilter3D::JoltMotionFilter3D(const JoltBody3D &p_body, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, bool p_separation_rays_stop_motion) :
 		body_self(p_body),
 		space(*body_self.get_space()),
 		excluded_bodies(p_excluded_bodies),
 		excluded_objects(p_excluded_objects),
-		collide_separation_ray(p_collide_separation_ray) {
+		separation_rays_stop_motion(p_separation_rays_stop_motion) {
 }
 
 bool JoltMotionFilter3D::ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer) const {
@@ -98,15 +98,15 @@ bool JoltMotionFilter3D::ShouldCollide(const JPH::Shape *p_jolt_shape, const JPH
 }
 
 bool JoltMotionFilter3D::ShouldCollide(const JPH::Shape *p_jolt_shape_self, const JPH::SubShapeID &p_jolt_shape_id_self, const JPH::Shape *p_jolt_shape_other, const JPH::SubShapeID &p_jolt_shape_id_other) const {
-	if (collide_separation_ray) {
+	if (separation_rays_stop_motion) {
 		return true;
 	}
 
 	const JoltCustomMotionShape *motion_shape = static_cast<const JoltCustomMotionShape *>(p_jolt_shape_self);
 	const JPH::ConvexShape &actual_shape_self = motion_shape->get_inner_shape();
 	if (actual_shape_self.GetSubType() == JoltCustomShapeSubType::RAY) {
-		// When `slide_on_slope` is enabled the ray shape acts as a regular shape.
-		return static_cast<const JoltCustomRayShape &>(actual_shape_self).slide_on_slope;
+		// When `stops_motion` is enabled the ray shape acts as a regular shape.
+		return static_cast<const JoltCustomRayShape &>(actual_shape_self).stops_motion;
 	}
 
 	return true;

--- a/modules/jolt_physics/spaces/jolt_motion_filter_3d.h
+++ b/modules/jolt_physics/spaces/jolt_motion_filter_3d.h
@@ -55,10 +55,10 @@ class JoltMotionFilter3D final
 	const JoltSpace3D &space;
 	const HashSet<RID> &excluded_bodies;
 	const HashSet<ObjectID> &excluded_objects;
-	bool collide_separation_ray = false;
+	bool separation_rays_stop_motion = false;
 
 public:
-	explicit JoltMotionFilter3D(const JoltBody3D &p_body, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, bool p_collide_separation_ray = true);
+	explicit JoltMotionFilter3D(const JoltBody3D &p_body, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, bool p_separation_rays_stop_motion = true);
 
 	virtual bool ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer) const override;
 	virtual bool ShouldCollide(JPH::ObjectLayer p_object_layer) const override;

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -254,11 +254,11 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(const JoltBody3D &p_bod
 	return recovered;
 }
 
-bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(const JoltBody3D &p_body, const Transform3D &p_transform, const Vector3 &p_scale, const Vector3 &p_motion, bool p_collide_separation_ray, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, real_t &r_safe_fraction, real_t &r_unsafe_fraction) const {
+bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(const JoltBody3D &p_body, const Transform3D &p_transform, const Vector3 &p_scale, const Vector3 &p_motion, bool p_separation_rays_stop_motion, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, real_t &r_safe_fraction, real_t &r_unsafe_fraction) const {
 	const Transform3D body_transform = p_transform.scaled_local(p_scale);
 
 	const JPH::CollideShapeSettings settings;
-	const JoltMotionFilter3D motion_filter(p_body, p_excluded_bodies, p_excluded_objects, p_collide_separation_ray);
+	const JoltMotionFilter3D motion_filter(p_body, p_excluded_bodies, p_excluded_objects, p_separation_rays_stop_motion);
 
 	bool collided = false;
 
@@ -884,7 +884,7 @@ bool JoltPhysicsDirectSpaceState3D::body_test_motion(const JoltBody3D &p_body, c
 	real_t safe_fraction = 1.0;
 	real_t unsafe_fraction = 1.0;
 
-	const bool hit = _body_motion_cast(p_body, transform, scale, p_parameters.motion, p_parameters.collide_separation_ray, p_parameters.exclude_bodies, p_parameters.exclude_objects, safe_fraction, unsafe_fraction);
+	const bool hit = _body_motion_cast(p_body, transform, scale, p_parameters.motion, p_parameters.separation_rays_stop_motion, p_parameters.exclude_bodies, p_parameters.exclude_objects, safe_fraction, unsafe_fraction);
 
 	bool collided = false;
 

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
@@ -56,7 +56,7 @@ class JoltPhysicsDirectSpaceState3D final : public PhysicsDirectSpaceState3D {
 	bool _cast_motion_impl(const JPH::Shape &p_jolt_shape, const Transform3D &p_transform_com, const Vector3 &p_scale, const Vector3 &p_motion, bool p_use_edge_removal, bool p_ignore_overlaps, const JPH::CollideShapeSettings &p_settings, const JPH::BroadPhaseLayerFilter &p_broad_phase_layer_filter, const JPH::ObjectLayerFilter &p_object_layer_filter, const JPH::BodyFilter &p_body_filter, const JPH::ShapeFilter &p_shape_filter, real_t &r_closest_safe, real_t &r_closest_unsafe) const;
 
 	bool _body_motion_recover(const JoltBody3D &p_body, const Transform3D &p_transform, float p_margin, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, Vector3 &r_recovery) const;
-	bool _body_motion_cast(const JoltBody3D &p_body, const Transform3D &p_transform, const Vector3 &p_scale, const Vector3 &p_motion, bool p_collide_separation_ray, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, real_t &r_safe_fraction, real_t &r_unsafe_fraction) const;
+	bool _body_motion_cast(const JoltBody3D &p_body, const Transform3D &p_transform, const Vector3 &p_scale, const Vector3 &p_motion, bool p_separation_rays_stop_motion, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, real_t &r_safe_fraction, real_t &r_unsafe_fraction) const;
 	bool _body_motion_collide(const JoltBody3D &p_body, const Transform3D &p_transform, const Vector3 &p_motion, float p_margin, int p_max_collisions, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, PhysicsServer3D::MotionResult *r_result) const;
 
 	int _try_get_face_index(const JPH::Body &p_body, const JPH::SubShapeID &p_sub_shape_id);

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -346,7 +346,7 @@ void CharacterBody2D::_apply_floor_snap(bool p_wall_as_floor) {
 
 	PhysicsServer2D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
 	parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
-	parameters.collide_separation_ray = true;
+	parameters.separation_rays_stop_motion = true;
 
 	PhysicsServer2D::MotionResult result;
 	if (move_and_collide(parameters, result, true, false)) {
@@ -390,7 +390,7 @@ bool CharacterBody2D::_on_floor_if_snapped(bool p_was_on_floor, bool p_vel_dir_f
 
 	PhysicsServer2D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
 	parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
-	parameters.collide_separation_ray = true;
+	parameters.separation_rays_stop_motion = true;
 
 	PhysicsServer2D::MotionResult result;
 	if (move_and_collide(parameters, result, true, false)) {

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -464,7 +464,7 @@ void CharacterBody3D::apply_floor_snap() {
 	PhysicsServer3D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
 	parameters.max_collisions = 4;
 	parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
-	parameters.collide_separation_ray = true;
+	parameters.separation_rays_stop_motion = true;
 
 	PhysicsServer3D::MotionResult result;
 	if (move_and_collide(parameters, result, true, false)) {
@@ -508,7 +508,7 @@ bool CharacterBody3D::_on_floor_if_snapped(bool p_was_on_floor, bool p_vel_dir_f
 	PhysicsServer3D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
 	parameters.max_collisions = 4;
 	parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
-	parameters.collide_separation_ray = true;
+	parameters.separation_rays_stop_motion = true;
 
 	PhysicsServer3D::MotionResult result;
 	if (move_and_collide(parameters, result, true, false)) {

--- a/scene/resources/2d/separation_ray_shape_2d.cpp
+++ b/scene/resources/2d/separation_ray_shape_2d.cpp
@@ -36,7 +36,8 @@
 void SeparationRayShape2D::_update_shape() {
 	Dictionary d;
 	d["length"] = length;
-	d["slide_on_slope"] = slide_on_slope;
+	d["stops_motion"] = stops_motion;
+	d["separate_along_ray"] = separate_along_ray;
 	PhysicsServer2D::get_singleton()->shape_set_data(get_rid(), d);
 	emit_changed();
 }
@@ -86,11 +87,15 @@ void SeparationRayShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_length", "length"), &SeparationRayShape2D::set_length);
 	ClassDB::bind_method(D_METHOD("get_length"), &SeparationRayShape2D::get_length);
 
-	ClassDB::bind_method(D_METHOD("set_slide_on_slope", "active"), &SeparationRayShape2D::set_slide_on_slope);
-	ClassDB::bind_method(D_METHOD("get_slide_on_slope"), &SeparationRayShape2D::get_slide_on_slope);
+	ClassDB::bind_method(D_METHOD("set_stops_motion", "active"), &SeparationRayShape2D::set_stops_motion);
+	ClassDB::bind_method(D_METHOD("get_stops_motion"), &SeparationRayShape2D::get_stops_motion);
+
+	ClassDB::bind_method(D_METHOD("set_separate_along_ray", "active"), &SeparationRayShape2D::set_separate_along_ray);
+	ClassDB::bind_method(D_METHOD("get_separate_along_ray"), &SeparationRayShape2D::get_separate_along_ray);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "length", PROPERTY_HINT_RANGE, "0.01,1024,0.01,or_greater,suffix:px"), "set_length", "get_length");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "slide_on_slope"), "set_slide_on_slope", "get_slide_on_slope");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stops_motion"), "set_stops_motion", "get_stops_motion");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "separate_along_ray"), "set_separate_along_ray", "get_separate_along_ray");
 }
 
 void SeparationRayShape2D::set_length(real_t p_length) {
@@ -105,16 +110,28 @@ real_t SeparationRayShape2D::get_length() const {
 	return length;
 }
 
-void SeparationRayShape2D::set_slide_on_slope(bool p_active) {
-	if (slide_on_slope == p_active) {
+void SeparationRayShape2D::set_stops_motion(bool p_active) {
+	if (stops_motion == p_active) {
 		return;
 	}
-	slide_on_slope = p_active;
+	stops_motion = p_active;
 	_update_shape();
 }
 
-bool SeparationRayShape2D::get_slide_on_slope() const {
-	return slide_on_slope;
+bool SeparationRayShape2D::get_stops_motion() const {
+	return stops_motion;
+}
+
+void SeparationRayShape2D::set_separate_along_ray(bool p_active) {
+	if (separate_along_ray == p_active) {
+		return;
+	}
+	separate_along_ray = p_active;
+	_update_shape();
+}
+
+bool SeparationRayShape2D::get_separate_along_ray() const {
+	return separate_along_ray;
 }
 
 SeparationRayShape2D::SeparationRayShape2D() :

--- a/scene/resources/2d/separation_ray_shape_2d.h
+++ b/scene/resources/2d/separation_ray_shape_2d.h
@@ -36,7 +36,8 @@ class SeparationRayShape2D : public Shape2D {
 	GDCLASS(SeparationRayShape2D, Shape2D);
 
 	real_t length = 20.0;
-	bool slide_on_slope = false;
+	bool stops_motion = false;
+	bool separate_along_ray = true;
 
 	void _update_shape();
 
@@ -47,8 +48,11 @@ public:
 	void set_length(real_t p_length);
 	real_t get_length() const;
 
-	void set_slide_on_slope(bool p_active);
-	bool get_slide_on_slope() const;
+	void set_stops_motion(bool p_active);
+	bool get_stops_motion() const;
+
+	void set_separate_along_ray(bool p_active);
+	bool get_separate_along_ray() const;
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;

--- a/scene/resources/3d/separation_ray_shape_3d.cpp
+++ b/scene/resources/3d/separation_ray_shape_3d.cpp
@@ -53,7 +53,8 @@ real_t SeparationRayShape3D::get_enclosing_radius() const {
 void SeparationRayShape3D::_update_shape() {
 	Dictionary d;
 	d["length"] = length;
-	d["slide_on_slope"] = slide_on_slope;
+	d["stops_motion"] = stops_motion;
+	d["separate_along_ray"] = separate_along_ray;
 	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), d);
 	Shape3D::_update_shape();
 }
@@ -68,25 +69,39 @@ float SeparationRayShape3D::get_length() const {
 	return length;
 }
 
-void SeparationRayShape3D::set_slide_on_slope(bool p_active) {
-	slide_on_slope = p_active;
+void SeparationRayShape3D::set_stops_motion(bool p_active) {
+	stops_motion = p_active;
 	_update_shape();
 	emit_changed();
 }
 
-bool SeparationRayShape3D::get_slide_on_slope() const {
-	return slide_on_slope;
+bool SeparationRayShape3D::get_stops_motion() const {
+	return stops_motion;
+}
+
+void SeparationRayShape3D::set_separate_along_ray(bool p_active) {
+	separate_along_ray = p_active;
+	_update_shape();
+	emit_changed();
+}
+
+bool SeparationRayShape3D::get_separate_along_ray() const {
+	return separate_along_ray;
 }
 
 void SeparationRayShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_length", "length"), &SeparationRayShape3D::set_length);
 	ClassDB::bind_method(D_METHOD("get_length"), &SeparationRayShape3D::get_length);
 
-	ClassDB::bind_method(D_METHOD("set_slide_on_slope", "active"), &SeparationRayShape3D::set_slide_on_slope);
-	ClassDB::bind_method(D_METHOD("get_slide_on_slope"), &SeparationRayShape3D::get_slide_on_slope);
+	ClassDB::bind_method(D_METHOD("set_stops_motion", "active"), &SeparationRayShape3D::set_stops_motion);
+	ClassDB::bind_method(D_METHOD("get_stops_motion"), &SeparationRayShape3D::get_stops_motion);
+
+	ClassDB::bind_method(D_METHOD("set_separate_along_ray", "active"), &SeparationRayShape3D::set_separate_along_ray);
+	ClassDB::bind_method(D_METHOD("get_separate_along_ray"), &SeparationRayShape3D::get_separate_along_ray);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "length", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_length", "get_length");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "slide_on_slope"), "set_slide_on_slope", "get_slide_on_slope");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stops_motion"), "set_stops_motion", "get_stops_motion");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "separate_along_ray"), "set_separate_along_ray", "get_separate_along_ray");
 }
 
 SeparationRayShape3D::SeparationRayShape3D() :

--- a/scene/resources/3d/separation_ray_shape_3d.h
+++ b/scene/resources/3d/separation_ray_shape_3d.h
@@ -37,7 +37,8 @@ class ArrayMesh;
 class SeparationRayShape3D : public Shape3D {
 	GDCLASS(SeparationRayShape3D, Shape3D);
 	float length = 1.0;
-	bool slide_on_slope = false;
+	bool stops_motion = false;
+	bool separate_along_ray = true;
 
 protected:
 	static void _bind_methods();
@@ -47,8 +48,11 @@ public:
 	void set_length(float p_length);
 	float get_length() const;
 
-	void set_slide_on_slope(bool p_active);
-	bool get_slide_on_slope() const;
+	void set_stops_motion(bool p_active);
+	bool get_stops_motion() const;
+
+	void set_separate_along_ray(bool p_active);
+	bool get_separate_along_ray() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -520,8 +520,8 @@ void PhysicsTestMotionParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_margin"), &PhysicsTestMotionParameters2D::get_margin);
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &PhysicsTestMotionParameters2D::set_margin);
 
-	ClassDB::bind_method(D_METHOD("is_collide_separation_ray_enabled"), &PhysicsTestMotionParameters2D::is_collide_separation_ray_enabled);
-	ClassDB::bind_method(D_METHOD("set_collide_separation_ray_enabled", "enabled"), &PhysicsTestMotionParameters2D::set_collide_separation_ray_enabled);
+	ClassDB::bind_method(D_METHOD("is_separation_rays_stop_motion_enabled"), &PhysicsTestMotionParameters2D::is_separation_rays_stop_motion_enabled);
+	ClassDB::bind_method(D_METHOD("set_separation_rays_stop_motion_enabled", "enabled"), &PhysicsTestMotionParameters2D::set_separation_rays_stop_motion_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_exclude_bodies"), &PhysicsTestMotionParameters2D::get_exclude_bodies);
 	ClassDB::bind_method(D_METHOD("set_exclude_bodies", "exclude_list"), &PhysicsTestMotionParameters2D::set_exclude_bodies);
@@ -535,7 +535,7 @@ void PhysicsTestMotionParameters2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "from"), "set_from", "get_from");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "motion"), "set_motion", "get_motion");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin"), "set_margin", "get_margin");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_separation_ray"), "set_collide_separation_ray_enabled", "is_collide_separation_ray_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "separation_rays_stop_motion"), "set_separation_rays_stop_motion_enabled", "is_separation_rays_stop_motion_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude_bodies", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude_bodies", "get_exclude_bodies");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude_objects"), "set_exclude_objects", "get_exclude_objects");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "recovery_as_collision"), "set_recovery_as_collision_enabled", "is_recovery_as_collision_enabled");

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -495,7 +495,7 @@ public:
 		Transform2D from;
 		Vector2 motion;
 		real_t margin = 0.08;
-		bool collide_separation_ray = false;
+		bool separation_rays_stop_motion = false;
 		HashSet<RID> exclude_bodies;
 		HashSet<ObjectID> exclude_objects;
 		bool recovery_as_collision = false;
@@ -750,8 +750,8 @@ public:
 	real_t get_margin() const { return parameters.margin; }
 	void set_margin(real_t p_margin) { parameters.margin = p_margin; }
 
-	bool is_collide_separation_ray_enabled() const { return parameters.collide_separation_ray; }
-	void set_collide_separation_ray_enabled(bool p_enabled) { parameters.collide_separation_ray = p_enabled; }
+	bool is_separation_rays_stop_motion_enabled() const { return parameters.separation_rays_stop_motion; }
+	void set_separation_rays_stop_motion_enabled(bool p_enabled) { parameters.separation_rays_stop_motion = p_enabled; }
 
 	TypedArray<RID> get_exclude_bodies() const;
 	void set_exclude_bodies(const TypedArray<RID> &p_exclude);

--- a/servers/physics_2d/physics_server_2d_extension.cpp
+++ b/servers/physics_2d/physics_server_2d_extension.cpp
@@ -305,7 +305,7 @@ void PhysicsServer2DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_get_direct_state, "body");
 
-	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "collide_separation_ray", "recovery_as_collision", "result");
+	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "separation_rays_stop_motion", "recovery_as_collision", "result");
 
 	/* JOINT API */
 

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -402,7 +402,7 @@ public:
 		bool ret = false;
 		exclude_bodies = &p_parameters.exclude_bodies;
 		exclude_objects = &p_parameters.exclude_objects;
-		GDVIRTUAL_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.collide_separation_ray, p_parameters.recovery_as_collision, r_result, ret);
+		GDVIRTUAL_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.separation_rays_stop_motion, p_parameters.recovery_as_collision, r_result, ret);
 		exclude_bodies = nullptr;
 		exclude_objects = nullptr;
 		return ret;

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -548,8 +548,8 @@ void PhysicsTestMotionParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_max_collisions"), &PhysicsTestMotionParameters3D::get_max_collisions);
 	ClassDB::bind_method(D_METHOD("set_max_collisions", "max_collisions"), &PhysicsTestMotionParameters3D::set_max_collisions);
 
-	ClassDB::bind_method(D_METHOD("is_collide_separation_ray_enabled"), &PhysicsTestMotionParameters3D::is_collide_separation_ray_enabled);
-	ClassDB::bind_method(D_METHOD("set_collide_separation_ray_enabled", "enabled"), &PhysicsTestMotionParameters3D::set_collide_separation_ray_enabled);
+	ClassDB::bind_method(D_METHOD("is_separation_rays_stop_motion_enabled"), &PhysicsTestMotionParameters3D::is_separation_rays_stop_motion_enabled);
+	ClassDB::bind_method(D_METHOD("set_separation_rays_stop_motion_enabled", "enabled"), &PhysicsTestMotionParameters3D::set_separation_rays_stop_motion_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_exclude_bodies"), &PhysicsTestMotionParameters3D::get_exclude_bodies);
 	ClassDB::bind_method(D_METHOD("set_exclude_bodies", "exclude_list"), &PhysicsTestMotionParameters3D::set_exclude_bodies);
@@ -564,7 +564,7 @@ void PhysicsTestMotionParameters3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "motion"), "set_motion", "get_motion");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin"), "set_margin", "get_margin");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_collisions"), "set_max_collisions", "get_max_collisions");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_separation_ray"), "set_collide_separation_ray_enabled", "is_collide_separation_ray_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "separation_rays_stop_motion"), "set_separation_rays_stop_motion_enabled", "is_separation_rays_stop_motion_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude_bodies", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude_bodies", "get_exclude_bodies");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude_objects"), "set_exclude_objects", "get_exclude_objects");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "recovery_as_collision"), "set_recovery_as_collision_enabled", "is_recovery_as_collision_enabled");

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -529,7 +529,7 @@ public:
 		Vector3 motion;
 		real_t margin = 0.001;
 		int max_collisions = 1;
-		bool collide_separation_ray = false;
+		bool separation_rays_stop_motion = false;
 		HashSet<RID> exclude_bodies;
 		HashSet<ObjectID> exclude_objects;
 		bool recovery_as_collision = false;
@@ -960,8 +960,8 @@ public:
 	int get_max_collisions() const { return parameters.max_collisions; }
 	void set_max_collisions(int p_max_collisions) { parameters.max_collisions = p_max_collisions; }
 
-	bool is_collide_separation_ray_enabled() const { return parameters.collide_separation_ray; }
-	void set_collide_separation_ray_enabled(bool p_enabled) { parameters.collide_separation_ray = p_enabled; }
+	bool is_separation_rays_stop_motion_enabled() const { return parameters.separation_rays_stop_motion; }
+	void set_separation_rays_stop_motion_enabled(bool p_enabled) { parameters.separation_rays_stop_motion = p_enabled; }
 
 	TypedArray<RID> get_exclude_bodies() const;
 	void set_exclude_bodies(const TypedArray<RID> &p_exclude);

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -305,7 +305,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_set_ray_pickable, "body", "enable");
 
-	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "max_collisions", "collide_separation_ray", "recovery_as_collision", "result");
+	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "max_collisions", "separation_rays_stop_motion", "recovery_as_collision", "result");
 
 	GDVIRTUAL_BIND(_body_get_direct_state, "body");
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -399,7 +399,7 @@ public:
 		bool ret = false;
 		exclude_bodies = &p_parameters.exclude_bodies;
 		exclude_objects = &p_parameters.exclude_objects;
-		GDVIRTUAL_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.max_collisions, p_parameters.collide_separation_ray, p_parameters.recovery_as_collision, r_result, ret);
+		GDVIRTUAL_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.max_collisions, p_parameters.separation_rays_stop_motion, p_parameters.recovery_as_collision, r_result, ret);
 		exclude_bodies = nullptr;
 		exclude_objects = nullptr;
 		return ret;


### PR DESCRIPTION
This is an alternate solution to #111822 in addressing #111763 and #110407
This solution attempts to address the limitations of the engine rather than just explaining the limitations in the documentation.
Regardless of if they are reasonable, these changes are breaking and so I understand them not being eligible for a 4.x release.

This pull requests breaks the responsibility of `SeparationRayShape2D/3D.slide_on_slope` into two separate properties, `stops_motion` and `separate_along_ray`. The idea behind this is that `slide_on_slope` is currently responsible for controlling two unrelated aspects of separation ray collision.
* First, it determines if collisions should be resolved by separating along the length of the ray or along the collision normal.
* Second, it is responsible for determining whether separation rays are used for collision detection.

While this implementation makes sense within the context of solely allowing separation rays to slide on slopes, it is not farfetched to think that a users might want to control both of these aspects independently. In fact the inability to control these aspects independently is even being worked around inside the engine. The `CharacterBody2D/3D` floor snapping logic uses `PhysicsTestMotionParameters2D/3D.collide_separation_ray` to disable the second effect of `slide_on_slope` (I have renamed this property to `separation_rays_stop_motion` for consistency with the other changes).

I have attempted to update the documentation where applicable but I do not feel confident enough to update the translations. This is a large reason I am leaving this as a draft.
The other reason being that I am aware that this implementation increases the memory footprint of each shape. I though to remedy this by using an Enum but coming up with intuitive and concise names for each state escaped me.

I additionally question whether `PhysicsTestMotionParameters2D/3D.collide_separation_ray` is necessary if users are able to individually toggle which rays stop motion.