### PR TITLE
Fix `NOTIFICATION_OS_IME_UPDATE` docs on platform availability

### DIFF
--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -121,7 +121,7 @@
 		</constant>
 		<constant name="NOTIFICATION_OS_IME_UPDATE" value="2013">
 			Notification received from the OS when an update of the Input Method Engine occurs (e.g. change of IME cursor position or composition string).
-			Specific to the macOS platform.
+			Implemented on desktop and web platforms.
 		</constant>
 		<constant name="NOTIFICATION_APPLICATION_RESUMED" value="2014">
 			Notification received from the OS when the application is resumed.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1298,7 +1298,7 @@
 		</constant>
 		<constant name="NOTIFICATION_OS_IME_UPDATE" value="2013">
 			Notification received from the OS when an update of the Input Method Engine occurs (e.g. change of IME cursor position or composition string).
-			Implemented only on macOS.
+			Implemented on desktop and web platforms.
 		</constant>
 		<constant name="NOTIFICATION_APPLICATION_RESUMED" value="2014">
 			Notification received from the OS when the application is resumed.


### PR DESCRIPTION
This IME notification NOTIFICATION_OS_IME_UPDATE is supported on all desktop and web platforms since 4.3.

- Windows and X11 IME support since at least 4.0 https://github.com/godotengine/godot/pull/70052 (there was some IME support beforehand)
- Web IME support added in 4.3 https://github.com/godotengine/godot/pull/79362
- Wayland IME support added in 4.3 https://github.com/godotengine/godot/pull/93021
- And macOS had it first. 