### PR TITLE
Fix IME input in multiple windows at once

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1638,6 +1638,9 @@ void LineEdit::_notification(int p_what) {
 				if (ime_text == new_ime_text && ime_selection == new_ime_selection) {
 					break;
 				}
+				if (!window_has_focus && !new_ime_text.is_empty()) {
+					break;
+				}
 
 				ime_text = new_ime_text;
 				ime_selection = new_ime_selection;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1978,6 +1978,9 @@ void TextEdit::_notification(int p_what) {
 				if (ime_text == new_ime_text && ime_selection == new_ime_selection) {
 					break;
 				}
+				if (!window_has_focus && !new_ime_text.is_empty()) {
+					break;
+				}
 
 				bool had_ime_text = has_ime_text();
 				ime_text = new_ime_text;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/111864

Events that stop the IME (when text is empty) are still needed even if window isn't focused.


