### PR TITLE
Core: use `reserve()` to reduce `HashMap` and `HashSet` allocations where possible

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1472,7 +1472,7 @@ void ProjectSettings::load_scene_groups_cache() {
 		Vector<String> scene_paths = cf->get_sections();
 		for (const String &E : scene_paths) {
 			Array scene_groups = cf->get_value(E, "groups", Array());
-			HashSet<StringName> cache;
+			HashSet<StringName> cache(scene_groups.size());
 			for (const Variant &scene_group : scene_groups) {
 				cache.insert(scene_group);
 			}

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1561,7 +1561,7 @@ static void gdextension_placeholder_script_instance_update(GDExtensionScriptInst
 	const Dictionary &values = *reinterpret_cast<const Dictionary *>(p_values);
 
 	List<PropertyInfo> properties_list;
-	HashMap<StringName, Variant> values_map;
+	HashMap<StringName, Variant> values_map(values.size());
 
 	for (int i = 0; i < properties.size(); i++) {
 		Dictionary d = properties[i];

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -144,6 +144,7 @@ HashSet<String> PackedData::get_file_paths() const {
 }
 
 void PackedData::_get_file_paths(PackedDir *p_dir, const String &p_parent_dir, HashSet<String> &r_paths) const {
+	r_paths.reserve(r_paths.size() + p_dir->files.size());
 	for (const String &E : p_dir->files) {
 		r_paths.insert(p_parent_dir.path_join(E));
 	}

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -841,7 +841,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 			if (key_type.builtin_type != Variant::NIL || value_type.builtin_type != Variant::NIL) {
 				dict.set_typed(key_type, value_type);
 			}
-
+			dict.reserve(count);
 			for (int i = 0; i < count; i++) {
 				Variant key, value;
 

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -245,7 +245,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 
 	Vector<FileCache> temp_file_cache;
 
-	HashSet<String> files_processed;
+	HashSet<String> files_processed(file_count);
 	for (uint32_t i = 0; i < file_count; i++) {
 		String file = tcp_client->get_utf8_string();
 		ERR_FAIL_COND_V_MSG(file == String(), ERR_CONNECTION_ERROR, "Invalid file name received from remote filesystem.");

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -338,6 +338,7 @@ Variant Resource::_duplicate_recursive(const Variant &p_variant, const Duplicate
 			if (src.is_typed()) {
 				dst.set_typed(src.get_typed_key_builtin(), src.get_typed_key_class_name(), src.get_typed_key_script(), src.get_typed_value_builtin(), src.get_typed_value_class_name(), src.get_typed_value_script());
 			}
+			dst.reserve(src.size());
 			for (const Variant &k : src.get_key_list()) {
 				const Variant &v = src[k];
 				dst.set(

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -481,6 +481,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			uint32_t len = f->get_32();
 			Dictionary d; //last bit means shared
 			len &= 0x7FFFFFFF;
+			d.reserve(len);
 			for (uint32_t i = 0; i < len; i++) {
 				Variant key;
 				Error err = parse_variant(key);

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -189,6 +189,7 @@ void ResourceFormatLoader::get_dependencies(const String &p_path, List<String> *
 
 Error ResourceFormatLoader::rename_dependencies(const String &p_path, const HashMap<String, String> &p_map) {
 	Dictionary deps_dict;
+	deps_dict.reserve(p_map.size());
 	for (KeyValue<String, String> E : p_map) {
 		deps_dict[E.key] = E.value;
 	}

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -418,6 +418,7 @@ int Color::find_named_color(const String &p_name) {
 	static HashMap<String, int> named_colors_hashmap;
 	if (unlikely(named_colors_hashmap.is_empty())) {
 		const int named_color_count = get_named_color_count();
+		named_colors_hashmap.reserve(named_color_count);
 		for (int i = 0; i < named_color_count; i++) {
 			named_colors_hashmap[String(named_colors[i].name).remove_char('_')] = i;
 		}

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -106,6 +106,7 @@ Dictionary Script::_get_script_constant_map() {
 	Dictionary ret;
 	HashMap<StringName, Variant> map;
 	get_constants(&map);
+	ret.reserve(map.size());
 	for (const KeyValue<StringName, Variant> &E : map) {
 		ret[E.key] = E.value;
 	}

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -780,6 +780,7 @@ void OS::benchmark_dump() {
 		Ref<FileAccess> f = FileAccess::open(benchmark_file, FileAccess::WRITE);
 		if (f.is_valid()) {
 			Dictionary benchmark_marks;
+			benchmark_marks.reserve(benchmark_marks_final.size());
 			for (const KeyValue<Pair<String, String>, double> &E : benchmark_marks_final) {
 				const String mark_key = vformat("[%s] %s", E.key.first, E.key.second);
 				benchmark_marks[mark_key] = E.value;
@@ -791,6 +792,7 @@ void OS::benchmark_dump() {
 		}
 	} else {
 		HashMap<String, String> results;
+		results.reserve(benchmark_marks_final.size());
 		for (const KeyValue<Pair<String, String>, double> &E : benchmark_marks_final) {
 			if (E.key.first == "Startup" && !results.has(E.key.first)) {
 				results.insert(E.key.first, "", true); // Hack to make sure "Startup" always comes first.

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -58,6 +58,7 @@ void _check_for_incompatibility(const String &p_msgctxt, const String &p_msgid) 
 
 Dictionary Translation::_get_messages() const {
 	Dictionary d;
+	d.reserve(translation_map.size());
 	for (const KeyValue<MessageKey, Vector<StringName>> &E : translation_map) {
 		const Array &storage_key = { E.key.msgctxt, E.key.msgid };
 
@@ -73,7 +74,7 @@ Dictionary Translation::_get_messages() const {
 
 void Translation::_set_messages(const Dictionary &p_messages) {
 	translation_map.clear();
-
+	translation_map.reserve(p_messages.size());
 	for (const KeyValue<Variant, Variant> &kv : p_messages) {
 		switch (kv.key.get_type()) {
 			// Old version, no context or plural support.

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -177,6 +177,7 @@ String Variant::get_type_name(Variant::Type p_type) {
 Variant::Type Variant::get_type_by_name(const String &p_type_name) {
 	static HashMap<String, Type> type_names;
 	if (unlikely(type_names.is_empty())) {
+		type_names.reserve(Variant::VARIANT_MAX);
 		for (int i = 0; i < VARIANT_MAX; i++) {
 			type_names[get_type_name((Type)i)] = (Type)i;
 		}

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1201,6 +1201,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 			static HashMap<StringName, Variant::Type> builtin_types;
 			if (builtin_types.is_empty()) {
+				builtin_types.reserve(Variant::VARIANT_MAX - 1);
 				for (int i = 1; i < Variant::VARIANT_MAX; i++) {
 					builtin_types[Variant::get_type_name((Variant::Type)i)] = (Variant::Type)i;
 				}
@@ -1341,6 +1342,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 			static HashMap<String, Variant::Type> builtin_types;
 			if (builtin_types.is_empty()) {
+				builtin_types.reserve(Variant::VARIANT_MAX - 1);
 				for (int i = 1; i < Variant::VARIANT_MAX; i++) {
 					builtin_types[Variant::get_type_name((Variant::Type)i)] = (Variant::Type)i;
 				}


### PR DESCRIPTION
Adds a `reserve()` call for occurrences of `HashMap`, `HashSet` and `Dictionary` in core where their final sizes are known.

I have only touched fill loops that may be called more than once during a game runtime and startup.

As much as I wanted to apply this to `Vector`s and `Array`s too, I avoided them in order to keep the changes simple and focused on a specific thing.

One of the changes modified `Resource` duplication with `Dictionary`, so I wrote a stress test for it.

<details>
<summary><strong>Script</strong></summary>
<br>

```gdscript
extends Node

func _ready() -> void:
	var time_start := Time.get_ticks_usec()
	var r := BigDictResource.new()
	for i in pow(2, 21):
		r.duplicate_deep()
	var time_end := Time.get_ticks_usec()
	print("Time taken: %dms" % ((time_end - time_start) / 1000))


class BigDictResource extends Resource:
	var x := {
		1: 1,
		2: 2,
		3: 4,
		4: 8,
		5: 16,
		6: 32,
		7: 64,
		8: 128,
		9: 256,
		10: 512,
		11: 1024,
		12: 2048,
		13: 4096,
		14: 8192,
		15: 16384,
		16: 32768,
		17: 65536,
		18: 131072,
		19: 262144,
		20: 524288,
		21: 1048576,
		22: 2097152,
		23: 4194304,
		24: 8388608,
		25: 16777216,
		26: 33554432,
		27: 67108864,
		28: 134217728,
		29: 268435456,
		30: 536870912,
		31: 1073741824,
		32: 2147483648,
		33: 4294967296,
		34: 8589934592,
		35: 17179869184,
		36: 34359738368,
		37: 68719476736,
		38: 137438953472,
		39: 274877906944,
		40: 549755813888,
		41: 1099511627776,
		42: 2199023255552,
		43: 4398046511104,
		44: 8796093022208,
		45: 17592186044416,
		46: 35184372088832,
		47: 70368744177664,
		48: 140737488355328,
		49: 281474976710656,
		50: 562949953421312,
		51: 1125899906842624,
		52: 2251799813685248,
		53: 4503599627370496,
		54: 9007199254740992,
		55: 18014398509481984,
		56: 36028797018963968,
		57: 72057594037927936,
		58: 144115188075855872,
		59: 288230376151711744,
		60: 576460752303423488,
		61: 1152921504606846976,
		62: 2305843009213693952,
		63: 4611686018427387904,
	}

```

</details>

With two template release builds:

Before: 8479ms
After: 8291ms