### PR TITLE
Fix NOTIFICATION_TRANSFORM_CHANGED only once

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1077,11 +1077,11 @@ void CanvasItem::_notify_transform(CanvasItem *p_node) {
 	 * notification anyway).
 	 */
 
-	if (/*p_node->xform_change.in_list() &&*/ p_node->_is_global_invalid()) {
+	p_node->_set_global_invalid(true);
+
+	if (p_node->xform_change.in_list()) {
 		return; //nothing to do
 	}
-
-	p_node->_set_global_invalid(true);
 
 	if (p_node->notify_transform && !p_node->xform_change.in_list()) {
 		if (!p_node->block_transform_notify) {


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/67640*

## Issue Description

https://github.com/godotengine/godot/blob/f50d7fa1e8ed5fb2e074624c19262b5376ea1cac/scene/main/canvas_item.cpp#L1073-L1080

From comment, this is a specific design. If user didn't refresh global transform after receiving `NOTIFICATION_TRANSFORM_CHANGED`, it means user don't care about global transform changed, so won't notify again.

I cannot understand this design. In my opinion, no matter of user reaction, framework should always send notification when the event occurred.

## Solution

I prefer to use `p_node->xform_change.in_list()` to decide whether there is duplicated notification or not. Leave `is_global_invalid()` to control whether we need refresh parent transform.

It is appreciate for any advice. Thank you. 