### PR TITLE
Fix `StaticBody2D` not triggering collisions when waking up

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -141,7 +141,8 @@ void GodotBody2D::set_active(bool p_active) {
 		if (mode == PhysicsServer2D::BODY_MODE_STATIC) {
 			// Static bodies can't be active.
 			active = false;
-		} else if (get_space()) {
+		}
+		if (get_space()) {
 			get_space()->body_add_to_active_list(&active_list);
 		}
 	} else if (get_space()) {

--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -285,7 +285,7 @@ public:
 	_FORCE_INLINE_ bool is_active() const { return active; }
 
 	_FORCE_INLINE_ void wakeup() {
-		if ((!get_space()) || mode == PhysicsServer2D::BODY_MODE_STATIC || mode == PhysicsServer2D::BODY_MODE_KINEMATIC) {
+		if ((!get_space()) || mode == PhysicsServer2D::BODY_MODE_KINEMATIC) {
 			return;
 		}
 		set_active(true);


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/111823*

## Issue Description

Because `StaticBody2D` cannot be set active and cannot be add to `active_list`. So the `StaticBody2D` wont trigger actively collision itself.

https://github.com/godotengine/godot/blob/f50d7fa1e8ed5fb2e074624c19262b5376ea1cac/modules/godot_physics_2d/godot_body_2d.h#L287-L292

https://github.com/godotengine/godot/blob/f50d7fa1e8ed5fb2e074624c19262b5376ea1cac/modules/godot_physics_2d/godot_body_2d.cpp#L140-L146

Please notice this PR is just a demo to fix relevant issue. I am not sure it is the correct solution. Maybe current behavior is expected.

## Explaination

In PhysicsServer2D, it decides which body need be detected collision depends on `get_active_body_list()` and `get_moved_area_list()`.

https://github.com/godotengine/godot/blob/9cd297b6f2a0ee660b8f1a6b385582cccf3a9d10/modules/godot_physics_2d/godot_step_2d.cpp#L139

https://github.com/godotengine/godot/blob/9cd297b6f2a0ee660b8f1a6b385582cccf3a9d10/modules/godot_physics_2d/godot_step_2d.cpp#L170

If there is no `active_list` or `moved_area`, the collision detection wont execute.

When we changed `layer` or `mask`, it invoke parent class `GodotCollisionBody2D`. It is the parent class of `GodotBody2D` and `GodotArea2D`. Then `GodotArea2D` added itself to `moved_area_list`, so next iteration will detect collision. But `GodotBody2D` wont add **static body** to `active_list`, so it can only wait other body to trigger collision detection.

It looks like `StaticBody2D` wont participate with `integrate_force` or `integrate_velocity`, maybe only add it to `active_list` is safe. But still need test for confirming.
