### PR TITLE
Fix incorrect failure code in `screen_get_framebuffer_format`

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -4260,7 +4260,7 @@ RenderingDevice::FramebufferFormatID RenderingDevice::screen_get_framebuffer_for
 	_THREAD_SAFE_METHOD_
 
 	HashMap<DisplayServer::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
-	ERR_FAIL_COND_V_MSG(it == screen_swap_chains.end(), FAILED, "Screen was never prepared.");
+	ERR_FAIL_COND_V_MSG(it == screen_swap_chains.end(), INVALID_ID, "Screen was never prepared.");
 
 	DataFormat format = driver->swap_chain_get_format(it->value);
 	ERR_FAIL_COND_V(format == DATA_FORMAT_MAX, INVALID_ID);


### PR DESCRIPTION
`RenderingDevice::screen_get_framebuffer_format` should return a value of type `RenderingDevice::FramebufferFormatID` which is an alias of `int64_t` but it returns `Error::FAILED` which has a value of 1. The compiler does not complain because both types are integers but 1 corresponds to a valid `FramebufferFormatID`, meaning a certain failure condition is missed.

This commit changes it to the correct value, `INVALID_ID`.
