### PR TITLE
Improve VRAM compression format in Detect 3D editor message

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -132,8 +132,31 @@ void ResourceImporterTexture::update_imports() {
 
 			String compress_string;
 			if (compress_to == 1) {
+				// In practice, either (or both) of these values will always be `true`,
+				// since every platform has a preferred texture format.
+				const bool import_s3tc_bptc = GLOBAL_GET("rendering/textures/vram_compression/import_s3tc_bptc") || OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_S3TC_BPTC;
+				const bool import_etc2_astc = GLOBAL_GET("rendering/textures/vram_compression/import_etc2_astc") || OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_ETC2_ASTC;
+
+				compress_string = "VRAM Compressed";
+				if (bool(cf->get_value("params", "compress/high_quality"))) {
+					if (import_s3tc_bptc && import_etc2_astc) {
+						compress_string += " (BPTC/ASTC)";
+					} else if (import_s3tc_bptc) {
+						compress_string += " (BPTC)";
+					} else if (import_etc2_astc) {
+						compress_string += " (ASTC)";
+					}
+				} else {
+					if (import_s3tc_bptc && import_etc2_astc) {
+						compress_string += " (S3TC/ETC2)";
+					} else if (import_s3tc_bptc) {
+						compress_string += " (S3TC)";
+					} else if (import_etc2_astc) {
+						compress_string += " (ETC2)";
+					}
+				}
+
 				cf->set_value("params", "compress/mode", COMPRESS_VRAM_COMPRESSED);
-				compress_string = "VRAM Compressed (S3TC/ETC/BPTC)";
 
 			} else if (compress_to == 2) {
 				cf->set_value("params", "compress/mode", COMPRESS_BASIS_UNIVERSAL);

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/io/image_loader.h"
+#include "core/os/os.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/import/resource_importer_texture_settings.h"
 #include "editor/settings/editor_settings.h"
@@ -130,8 +131,31 @@ void ResourceImporterTexture::update_imports() {
 
 			String compress_string;
 			if (compress_to == 1) {
+				// In practice, either (or both) of these values will always be `true`,
+				// since every platform has a preferred texture format.
+				const bool import_s3tc_bptc = GLOBAL_GET("rendering/textures/vram_compression/import_s3tc_bptc") || OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_S3TC_BPTC;
+				const bool import_etc2_astc = GLOBAL_GET("rendering/textures/vram_compression/import_etc2_astc") || OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_ETC2_ASTC;
+
+				compress_string = "VRAM Compressed";
+				if (bool(cf->get_value("params", "compress/high_quality"))) {
+					if (import_s3tc_bptc && import_etc2_astc) {
+						compress_string += " (BPTC/ASTC)";
+					} else if (import_s3tc_bptc) {
+						compress_string += " (BPTC)";
+					} else if (import_etc2_astc) {
+						compress_string += " (ASTC)";
+					}
+				} else {
+					if (import_s3tc_bptc && import_etc2_astc) {
+						compress_string += " (S3TC/ETC2)";
+					} else if (import_s3tc_bptc) {
+						compress_string += " (S3TC)";
+					} else if (import_etc2_astc) {
+						compress_string += " (ETC2)";
+					}
+				}
+
 				cf->set_value("params", "compress/mode", COMPRESS_VRAM_COMPRESSED);
-				compress_string = "VRAM Compressed (S3TC/ETC/BPTC)";
 
 			} else if (compress_to == 2) {
 				cf->set_value("params", "compress/mode", COMPRESS_BASIS_UNIVERSAL);


### PR DESCRIPTION
Previously, the format displayed was always S3TC/ETC/BPTC. It now matches what is defined in the project settings, the current platform and import defaults.

## Preview

On desktop platforms by default:

> res://example.jpg: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to VRAM Compressed (S3TC).

On desktop platforms, with **High Quality** enabled in the import defaults:

> res://example.jpg: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to VRAM Compressed (BPTC).