### PR TITLE
Fix checkerboard alignment in texture preview

### DIFF
--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -244,14 +244,14 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 	margin_container->add_theme_constant_override("margin_bottom", outline_width);
 	add_child(margin_container);
 
-	centering_container = memnew(AspectRatioContainer);
-	margin_container->add_child(centering_container);
-
 	checkerboard = memnew(TextureRect);
 	checkerboard->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 	checkerboard->set_stretch_mode(TextureRect::STRETCH_TILE);
 	checkerboard->set_texture_repeat(CanvasItem::TEXTURE_REPEAT_ENABLED);
-	centering_container->add_child(checkerboard);
+	margin_container->add_child(checkerboard);
+
+	centering_container = memnew(AspectRatioContainer);
+	margin_container->add_child(centering_container);
 
 	texture_display = memnew(TextureRect);
 	texture_display->set_texture_filter(TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
@@ -263,7 +263,7 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 
 	// Creating a separate control so it is not affected by the filtering shader.
 	outline_overlay = memnew(Control);
-	centering_container->add_child(outline_overlay);
+	margin_container->add_child(outline_overlay);
 
 	outline_overlay->connect(SceneStringName(draw), callable_mp(this, &TexturePreview::_draw_outline));
 


### PR DESCRIPTION
Before:
<img width="532" height="613" alt="image" src="https://github.com/user-attachments/assets/8a1c8967-fd0f-475a-a166-16168df00610" />

After:
<img width="457" height="601" alt="image" src="https://github.com/user-attachments/assets/1999d31c-9b3c-466d-a67a-c33692e4431c" />


I believe this was a regression introduced by https://github.com/godotengine/godot/pull/100157

@Zylann can you check this?