### PR TITLE
Add is_finished() to Tween

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -161,6 +161,12 @@
 				[b]Note:[/b] If [param duration] is equal to [code]0[/code], the method will always return the final value, regardless of [param elapsed_time] provided.
 			</description>
 		</method>
+		<method name="is_finished">
+			<return type="bool" />
+			<description>
+				Returns whether the [Tween] is finished, i.e. all [Tweener]s have completed or it was killed.
+			</description>
+		</method>
 		<method name="is_running">
 			<return type="bool" />
 			<description>
@@ -170,7 +176,7 @@
 		<method name="is_valid">
 			<return type="bool" />
 			<description>
-				Returns whether the [Tween] is valid. A valid [Tween] is a [Tween] contained by the scene tree (i.e. the array from [method SceneTree.get_processed_tweens] will contain this [Tween]). A [Tween] might become invalid when it has finished tweening, is killed, or when created with [code]Tween.new()[/code]. Invalid [Tween]s can't have [Tweener]s appended.
+				Returns whether the [Tween] is valid. A valid [Tween] is a [Tween] contained by the scene tree (i.e. the array from [method SceneTree.get_processed_tweens] will contain this [Tween]). A [Tween] will become invalid when it is killed, when created with [code]Tween.new()[/code], or after it finishes if it is not reset by [method stop] during [signal finished]. Invalid [Tween]s can't have [Tweener]s appended.
 			</description>
 		</method>
 		<method name="kill">

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -77,7 +77,7 @@ void Tweener::_bind_methods() {
 
 void Tween::_start_tweeners() {
 	if (tweeners.is_empty()) {
-		dead = true;
+		finished = true;
 		ERR_FAIL_MSG("Tween without commands, aborting.");
 	}
 
@@ -90,7 +90,7 @@ void Tween::_stop_internal(bool p_reset) {
 	running = false;
 	if (p_reset) {
 		started = false;
-		dead = false;
+		finished = false;
 		total_time = 0;
 	}
 }
@@ -193,14 +193,14 @@ void Tween::pause() {
 
 void Tween::play() {
 	ERR_FAIL_COND_MSG(!valid, "Tween invalid. Either finished or created outside scene tree.");
-	ERR_FAIL_COND_MSG(dead, "Can't play finished Tween, use stop() first to reset its state.");
+	ERR_FAIL_COND_MSG(finished, "Can't play finished Tween, use stop() first to reset its state.");
 	running = true;
 }
 
 void Tween::kill() {
 	running = false; // For the sake of is_running().
 	valid = false;
-	dead = true;
+	finished = true;
 
 	// Kill all subtweens of this tween.
 	for (Ref<Tween> &st : subtweens) {
@@ -214,6 +214,10 @@ bool Tween::is_running() {
 
 bool Tween::is_valid() {
 	return valid;
+}
+
+bool Tween::is_finished() {
+	return finished;
 }
 
 void Tween::clear() {
@@ -319,7 +323,7 @@ bool Tween::custom_step(double p_delta) {
 }
 
 bool Tween::step(double p_delta) {
-	if (dead) {
+	if (finished) {
 		return false;
 	}
 
@@ -389,7 +393,7 @@ bool Tween::step(double p_delta) {
 				loops_done++;
 				if (loops_done == loops) {
 					running = false;
-					dead = true;
+					finished = true;
 					emit_signal(SceneStringName(finished));
 					break;
 				} else {
@@ -484,6 +488,7 @@ void Tween::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_running"), &Tween::is_running);
 	ClassDB::bind_method(D_METHOD("is_valid"), &Tween::is_valid);
+	ClassDB::bind_method(D_METHOD("is_finished"), &Tween::is_finished);
 	ClassDB::bind_method(D_METHOD("bind_node", "node"), &Tween::bind_node);
 	ClassDB::bind_method(D_METHOD("set_process_mode", "mode"), &Tween::set_process_mode);
 	ClassDB::bind_method(D_METHOD("set_pause_mode", "mode"), &Tween::set_pause_mode);

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -124,7 +124,7 @@ private:
 	bool started = false;
 	bool running = true;
 	bool in_step = false;
-	bool dead = false;
+	bool finished = false;
 	bool valid = false;
 	bool default_parallel = false;
 	bool parallel_enabled = false;
@@ -158,6 +158,7 @@ public:
 
 	bool is_running();
 	bool is_valid();
+	bool is_finished();
 	void clear();
 
 	Ref<Tween> bind_node(const Node *p_node);


### PR DESCRIPTION
Tween already had a ```dead``` variable which can be useful if relying on the ```finished``` signal of a tween. This provides functionality similar to ```custom_step(0)``` but is less prone to issues.

The reason why ```is_finished()``` is needed is because:
- ```is_valid()``` does not return false until after the scene tree has finished processing tweens, therefore returns true immediately after ```finished``` is emitted.
- ```is_running()``` returns false if the tween is paused.
- ```custom_step(0)``` cannot be called from inside a call to ```custom_step()```, which becomes a problem when waiting on ```finished``` and then the tween is manually finished by ```custom_step()```:

  ```
  print_here()
  tween.custom_step(INF)
  ...
  func print_here() -> void:
    await tween.finished
    if tween.custom_step(0): print("here")
  ```

Closes https://github.com/godotengine/godot-proposals/issues/13268
Closes https://github.com/godotengine/godot/issues/110905