### PR TITLE
Make editor theme previewing faster

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -765,6 +765,11 @@ void EditorNode::update_preview_themes(int p_mode) {
 	}
 }
 
+void EditorNode::set_updated_theme(const Ref<Theme> &p_theme) {
+	theme = p_theme;
+	_update_theme(true);
+}
+
 bool EditorNode::_is_project_data_missing() {
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	const String project_data_dir = EditorPaths::get_singleton()->get_project_data_dir();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -958,6 +958,7 @@ public:
 
 	Ref<Theme> get_editor_theme() const { return theme; }
 	void update_preview_themes(int p_mode);
+	void set_updated_theme(const Ref<Theme> &p_theme);
 
 	Ref<Script> get_object_custom_type_base(const Object *p_object) const;
 	StringName get_object_custom_type_name(const Object *p_object) const;

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -71,7 +71,14 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 
 	bool changed = _set_only(p_name, p_value);
 	if (changed && initialized) {
-		changed_settings.insert(p_name);
+		const String sname = p_name;
+		changed_settings.insert(sname);
+
+		if (sname.begins_with("interface/theme/")) {
+			emit_signal(SNAME("_editor_theme_changed"));
+			return true;
+		}
+
 		if (p_name == SNAME("text_editor/external/exec_path")) {
 			const StringName exec_args_name = "text_editor/external/exec_flags";
 			const String exec_args_value = _guess_exec_args_for_extenal_editor(p_value);
@@ -2293,6 +2300,7 @@ void EditorSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("mark_setting_changed", "setting"), &EditorSettings::mark_setting_changed);
 
 	ADD_SIGNAL(MethodInfo("settings_changed"));
+	ADD_SIGNAL(MethodInfo("_editor_theme_changed"));
 	ADD_SIGNAL(MethodInfo("_favorites_changed"));
 
 	BIND_CONSTANT(NOTIFICATION_EDITOR_SETTINGS_CHANGED);

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -65,6 +65,15 @@ void EditorSettingsDialog::_settings_changed() {
 	timer->start();
 }
 
+void EditorSettingsDialog::_editor_theme_changed() {
+	if (is_visible()) {
+		theme_timer->start();
+	} else {
+		_push_theme_changes();
+		timer->start();
+	}
+}
+
 void EditorSettingsDialog::_settings_property_edited(const String &p_name) {
 	String full_name = inspector->get_full_item_path(p_name);
 
@@ -181,6 +190,18 @@ void EditorSettingsDialog::_settings_save() {
 	EditorSettings::get_singleton()->save();
 }
 
+void EditorSettingsDialog::_preview_theme() {
+	set_theme(EditorThemeManager::generate_theme());
+}
+
+void EditorSettingsDialog::_push_theme_changes() {
+	if (get_theme().is_valid()) {
+		EditorNode::get_singleton()->set_updated_theme(get_theme());
+		set_theme(Ref<Theme>());
+	}
+	EditorSettings::get_singleton()->emit_signal(SNAME("settings_changed"));
+}
+
 void EditorSettingsDialog::cancel_pressed() {
 	if (!EditorSettings::get_singleton()) {
 		return;
@@ -201,7 +222,6 @@ void EditorSettingsDialog::popup_edit_settings() {
 	inspector->edit(EditorSettings::get_singleton());
 	inspector->get_inspector()->update_tree();
 
-	_update_shortcuts();
 	set_process_shortcut_input(true);
 
 	// Restore valid window bounds or pop up at default size.
@@ -231,6 +251,10 @@ void EditorSettingsDialog::_notification(int p_what) {
 			if (!is_visible() && !_is_in_project_manager()) {
 				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "editor_settings", Rect2(get_position(), get_size()));
 				set_process_shortcut_input(false);
+
+				if (get_theme().is_valid()) {
+					_push_theme_changes();
+				}
 			}
 		} break;
 
@@ -251,7 +275,9 @@ void EditorSettingsDialog::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			_update_shortcuts();
+			if (shortcuts->is_visible_in_tree()) {
+				_update_shortcuts();
+			}
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
@@ -673,6 +699,13 @@ void EditorSettingsDialog::_update_shortcuts() {
 	}
 }
 
+void EditorSettingsDialog::_update_shortcuts_if_dirty() {
+	if (shortcuts_dirty) {
+		_update_shortcuts();
+		shortcuts_dirty = false;
+	}
+}
+
 void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button) {
 	if (p_button != MouseButton::LEFT) {
 		return;
@@ -926,6 +959,11 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	set_title(TTRC("Editor Settings"));
 	set_flag(FLAG_MAXIMIZE_DISABLED, false);
 	set_clamp_to_embedder(true);
+	set_hide_on_ok(true);
+	set_ok_button_text(TTRC("Close"));
+
+	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorSettingsDialog::_settings_changed));
+	EditorSettings::get_singleton()->connect("_editor_theme_changed", callable_mp(this, &EditorSettingsDialog::_editor_theme_changed));
 
 	tabs = memnew(TabContainer);
 	tabs->set_theme_type_variation("TabContainerOdd");
@@ -1023,6 +1061,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcuts->set_column_title(1, TTRC("Binding"));
 	shortcuts->connect("button_clicked", callable_mp(this, &EditorSettingsDialog::_shortcut_button_pressed));
 	shortcuts->connect("item_activated", callable_mp(this, &EditorSettingsDialog::_shortcut_cell_double_clicked));
+	shortcuts->connect("visibility_changed", callable_mp(this, &EditorSettingsDialog::_update_shortcuts_if_dirty));
 	mc->add_child(shortcuts);
 
 	SET_DRAG_FORWARDING_GCD(shortcuts, EditorSettingsDialog);
@@ -1033,15 +1072,17 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcut_editor->set_allowed_input_types(INPUT_KEY);
 	add_child(shortcut_editor);
 
-	set_hide_on_ok(true);
-
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);
 	timer->connect("timeout", callable_mp(this, &EditorSettingsDialog::_settings_save));
 	timer->set_one_shot(true);
 	add_child(timer);
-	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorSettingsDialog::_settings_changed));
-	set_ok_button_text(TTRC("Close"));
+
+	theme_timer = memnew(Timer);
+	theme_timer->set_wait_time(0.5);
+	theme_timer->set_one_shot(true);
+	theme_timer->connect("timeout", callable_mp(this, &EditorSettingsDialog::_preview_theme));
+	add_child(theme_timer);
 
 	Ref<EditorSettingsInspectorPlugin> plugin;
 	plugin.instantiate();

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -65,6 +65,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	};
 
 	Tree *shortcuts = nullptr;
+	bool shortcuts_dirty = true;
 
 	InputEventConfigurationDialog *shortcut_editor = nullptr;
 
@@ -74,13 +75,17 @@ class EditorSettingsDialog : public AcceptDialog {
 	int current_event_index = -1;
 
 	Timer *timer = nullptr;
+	Timer *theme_timer = nullptr;
 
 	virtual void cancel_pressed() override;
 	virtual void ok_pressed() override;
 
 	void _settings_changed();
+	void _editor_theme_changed();
 	void _settings_property_edited(const String &p_name);
 	void _settings_save();
+	void _preview_theme();
+	void _push_theme_changes();
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
@@ -110,6 +115,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	bool _should_display_shortcut(const String &p_name, const Array &p_events, bool p_match_localized_name) const;
 
 	void _update_shortcuts();
+	void _update_shortcuts_if_dirty();
 	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button = MouseButton::LEFT);
 	void _shortcut_cell_double_clicked();
 	static void _set_shortcut_input(const String &p_name, Ref<InputEventKey> &p_event);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3956,10 +3956,12 @@ void Control::_notification(int p_notification) {
 
 			_invalidate_theme_cache();
 			_update_theme_item_cache();
-			queue_redraw();
 
-			update_minimum_size();
-			_size_changed();
+			if (is_visible_in_tree()) {
+				queue_redraw();
+				update_minimum_size();
+				_size_changed();
+			}
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {


### PR DESCRIPTION
Doing anything with editor theme is annoying slow. There is a 1.5 Timer. Once it times out, the whole editor freezes for a long time. If you want to check out different colors you have to be quick, if you want to check out different color themes, well...

This PR aims to improve that. The main change is that changing theme no longer applies to the whole editor at once, but for the settings dialog only. The editor updates once dialog is closed.

https://github.com/user-attachments/assets/3864f90b-353f-4e7e-84df-cfc34934a032

I also applied some changes that makes the theme update itself faster:
- Invisible Controls no longer update size on theme change (they do it anyway once made visible)
- The settings' shortcuts tree is only updated when visible.

I managed to reduce the update time quite a bit (the video is taken in a non-optimized dev build), but it still takes a bit, so I added a shorter timer for the dialog update. Otherwise color pickers would be unusable.

There is some bug where the theme does not always apply though.