### PR TITLE
Improve `Environment` adjustments (favor old behavior and quality).

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -36,19 +36,19 @@
 	</methods>
 	<members>
 		<member name="adjustment_brightness" type="float" setter="set_adjustment_brightness" getter="get_adjustment_brightness" default="1.0">
-			The global brightness value of the rendered scene. Effective only if [member adjustment_enabled] is [code]true[/code].
+			Applies a simple brightness adjustment to the rendered image after tonemaping. To adjust scene brightness use [member tonemap_exposure] instead, which is applied before tonemapping and thus less prone to issues with bright colors. Effective only if [member adjustment_enabled] is [code]true[/code].
 		</member>
 		<member name="adjustment_color_correction" type="Texture" setter="set_adjustment_color_correction" getter="get_adjustment_color_correction">
 			The [Texture2D] or [Texture3D] lookup table (LUT) to use for the built-in post-process color grading. Can use a [GradientTexture1D] for a 1-dimensional LUT, or a [Texture3D] for a more complex LUT. Effective only if [member adjustment_enabled] is [code]true[/code].
 		</member>
 		<member name="adjustment_contrast" type="float" setter="set_adjustment_contrast" getter="get_adjustment_contrast" default="1.0">
-			The global contrast value of the rendered scene (default value is 1). Effective only if [member adjustment_enabled] is [code]true[/code].
+			Increasing [member adjustment_contrast] will make dark values darker and bright values brighter. This simple adjustment is applied to the rendered image after tonemaping. When set to a value greater than [code]1.0[/code], [member adjustment_contrast] is prone to clipping colors that become too bright or too dark. Effective only if [member adjustment_enabled] is [code]true[/code].
 		</member>
 		<member name="adjustment_enabled" type="bool" setter="set_adjustment_enabled" getter="is_adjustment_enabled" default="false">
 			If [code]true[/code], enables the [code]adjustment_*[/code] properties provided by this resource. If [code]false[/code], modifications to the [code]adjustment_*[/code] properties will have no effect on the rendered scene.
 		</member>
 		<member name="adjustment_saturation" type="float" setter="set_adjustment_saturation" getter="get_adjustment_saturation" default="1.0">
-			The global color saturation value of the rendered scene (default value is 1). Effective only if [member adjustment_enabled] is [code]true[/code].
+			Applies a simple saturation adjustment to the rendered image after tonemaping. When [member adjustment_saturation] is set to [code]0.0[/code], the rendered image will be fully converted to a grayscale image. Effective only if [member adjustment_enabled] is [code]true[/code].
 		</member>
 		<member name="ambient_light_color" type="Color" setter="set_ambient_light_color" getter="get_ambient_light_color" default="Color(0, 0, 0, 1)">
 			The ambient light's [Color]. Only effective if [member ambient_light_sky_contribution] is lower than [code]1.0[/code] (exclusive).

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1246,7 +1246,7 @@ void Environment::_bind_methods() {
 
 	ADD_GROUP("Tonemap", "tonemap_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tonemap_mode", PROPERTY_HINT_ENUM, "Linear,Reinhard,Filmic,ACES,AgX"), "set_tonemapper", "get_tonemapper");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_exposure", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_exposure", "get_tonemap_exposure");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_exposure", PROPERTY_HINT_RANGE, "0,4,0.01,or_greater"), "set_tonemap_exposure", "get_tonemap_exposure");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_white", PROPERTY_HINT_RANGE, "1,16,0.01,or_greater"), "set_tonemap_white", "get_tonemap_white");
 
 	// SSR
@@ -1522,9 +1522,9 @@ void Environment::_bind_methods() {
 
 	ADD_GROUP("Adjustments", "adjustment_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "adjustment_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_adjustment_enabled", "is_adjustment_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_brightness", PROPERTY_HINT_RANGE, "0.01,8,0.01"), "set_adjustment_brightness", "get_adjustment_brightness");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_contrast", PROPERTY_HINT_RANGE, "0.01,8,0.01"), "set_adjustment_contrast", "get_adjustment_contrast");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_saturation", PROPERTY_HINT_RANGE, "0.01,8,0.01"), "set_adjustment_saturation", "get_adjustment_saturation");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_brightness", PROPERTY_HINT_RANGE, "0.0,2.0,0.01,or_greater"), "set_adjustment_brightness", "get_adjustment_brightness");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_contrast", PROPERTY_HINT_RANGE, "0.75,1.25,0.005,or_less,or_greater"), "set_adjustment_contrast", "get_adjustment_contrast");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_saturation", PROPERTY_HINT_RANGE, "0.0,2.0,0.01,or_less,or_greater"), "set_adjustment_saturation", "get_adjustment_saturation");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "adjustment_color_correction", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D,Texture3D"), "set_adjustment_color_correction", "get_adjustment_color_correction");
 
 	// Constants

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -329,11 +329,13 @@ vec3 tonemap_agx(vec3 color) {
 }
 
 vec3 linear_to_srgb(vec3 color) {
-	// Clamping is not strictly necessary for floating point nonlinear sRGB encoding,
-	// but many cases that call this function need the result clamped.
-	color = clamp(color, vec3(0.0), vec3(1.0));
 	const vec3 a = vec3(0.055f);
 	return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
+}
+
+vec3 srgb_to_linear(vec3 color) {
+	const vec3 a = vec3(0.055f);
+	return mix(pow((color.rgb + a) * (1.0f / (vec3(1.0f) + a)), vec3(2.4f)), color.rgb * (1.0f / 12.92f), lessThan(color.rgb, vec3(0.04045f)));
 }
 
 #define TONEMAPPER_LINEAR 0
@@ -446,13 +448,6 @@ vec3 apply_glow(vec3 color, vec3 glow, float white) {
 	}
 }
 
-vec3 apply_bcs(vec3 color, vec3 bcs) {
-	color = mix(vec3(0.0f), color, bcs.x);
-	color = mix(vec3(0.5f), color, bcs.y);
-	color = mix(vec3(dot(vec3(1.0f), color) * 0.33333f), color, bcs.z);
-
-	return color;
-}
 #ifdef USE_1D_LUT
 vec3 apply_color_correction(vec3 color) {
 	color.r = texture(source_color_correction, vec2(color.r, 0.0f)).r;
@@ -928,23 +923,39 @@ void main() {
 	}
 #endif
 
-	bool convert_to_srgb = bool(params.flags & FLAG_CONVERT_TO_SRGB);
-	if (convert_to_srgb) {
-		color.rgb = linear_to_srgb(color.rgb); // Regular linear -> SRGB conversion.
-	}
-
 	if (bool(params.flags & FLAG_USE_BCS)) {
-		color.rgb = apply_bcs(color.rgb, params.bcs);
-	}
+		// Apply brightness:
+		// Apply to relative luminance. This ensures that the hue and saturation of
+		// colors is not affected by the adjustment, but requires the multiplication
+		// to be performed on linear-encoded values.
+		color.rgb = color.rgb * params.bcs.x;
 
-	if (bool(params.flags & FLAG_USE_COLOR_CORRECTION)) {
-		// apply_color_correction requires nonlinear sRGB encoding
-		if (!convert_to_srgb) {
-			color.rgb = linear_to_srgb(color.rgb);
+		color.rgb = linear_to_srgb(color.rgb);
+
+		// Apply contrast:
+		// By applying contrast to RGB values that are perceptually uniform (nonlinear),
+		// the darkest values are not hard-clipped as badly, which produces a
+		// higher quality contrast adjustment and maintains compatibility with
+		// existing projects.
+		color.rgb = mix(vec3(0.5), color.rgb, params.bcs.y);
+
+		// Apply saturation:
+		// By applying saturation adjustment to nonlinear sRGB-encoded values with
+		// even weights the preceived brightness of blues are affected, but this
+		// maintains compatibility with existing projects.
+		color.rgb = mix(vec3(dot(vec3(1.0), color.rgb) * (1.0 / 3.0)), color.rgb, params.bcs.z);
+
+		if (bool(params.flags & FLAG_USE_COLOR_CORRECTION)) {
+			color.rgb = clamp(color.rgb, vec3(0.0), vec3(1.0));
+			color.rgb = apply_color_correction(color.rgb);
+			// When using color correction and  FLAG_CONVERT_TO_SRGB is false, there
+			// is no need to convert back to linear because the color correction
+			// texture sampling does this for us.
+		} else if (!bool(params.flags & FLAG_CONVERT_TO_SRGB)) {
+			color.rgb = srgb_to_linear(color.rgb);
 		}
-		color.rgb = apply_color_correction(color.rgb);
-		// When convert_to_srgb is false, there is no need to convert back to
-		// linear because the color correction texture sampling does this for us.
+	} else if (bool(params.flags & FLAG_CONVERT_TO_SRGB)) {
+		color.rgb = linear_to_srgb(color.rgb);
 	}
 
 	// Debanding should be done at the end of tonemapping, but before writing to the LDR buffer.

--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -793,7 +793,9 @@ void RendererEnvironmentStorage::environment_set_adjustment(RID p_env, bool p_en
 	ERR_FAIL_NULL(env);
 
 	env->adjustments_enabled = p_enable;
-	env->adjustments_brightness = p_brightness;
+	// Scale brightness via the nonlinear sRGB transfer function to provide a
+	// somewhat perceptually uniform brightness adjustment.
+	env->adjustments_brightness = p_brightness < 0.04045f ? p_brightness * (1.0f / 12.92f) : Math::pow(float((p_brightness + 0.055f) * (1.0f / (1.055f))), 2.4f);
 	env->adjustments_contrast = p_contrast;
 	env->adjustments_saturation = p_saturation;
 	env->use_1d_color_correction = p_use_1d_color_correction;


### PR DESCRIPTION
- Closes godotengine/godot-proposals#13195
- Closes #107682 (partially)

This PR supersedes:
- #106962.

This commit changes adjustments to behave as follows for all rendering configurations:

- Apply brightness to linear-encoded values, preventing hue and saturation from being affected.
- Apply contrast to perceptually uniform (nonlinear sRGB-encoded) values, matching existing behavior when HDR 2D is disabled and producing optimal visual quality.
- Apply saturation with even color channel weights on perceptually uniform (nonlinear sRGB-encoded) values. This causes brightness of certain colors to change, but matches existing behavior when HDR 2D is disabled.

Adjustments are applied after glow and tonemapping to match existing behavior.

# Summary

This PR is an alternative approach to the following:
- #110630

The saturation adjustment can be further improved as a followup PR:
- #111898

HDR 2D Disabled | Status | Summary
-- | -- | --
Brightness | Modified | Improved visual quality
Contrast | No change |  
Saturation | No change | Brightness of some colours changes when saturation changes

HDR 2D Enabled | Status | Summary
-- | -- | --
Brightness | Modified | Now perceptually uniform (better for animations & matches HDR 2D disabled)
Contrast | Modified | Improved visual quality and usability
Saturation | Modified | Now maches HDR 2D disabled

Performance |  
-- | --
HDR 2D (Mobile / Forward+ with no color correction LUT) | **Regression** (full round trip to and from nonlinear sRGB encoding)
Other configurations | No change

# Rationale and screenshots

Rationale and screenshots for this PR can be found in godotengine/godot-proposals#13195.

# Changes and improvements

The following is a summary of the key points that are further detailed in the proposal.

## Brightness

### HDR 2D Disabled

**Problem:** When HDR 2D is disabled in Godot 4.5 and earlier, the brightness adjustment is applied as a scaling of nonlinear sRGB-encoded values. This is incorrect in terms of CIE colorimetry and results in a change in saturation, hue, and contrast when brightness is adjusted.

To correct this issue, scaling is applied to linear-encoded RGB values, which results in relative luminance being scaled directly without affecting hue or saturation:

| Original scene | Godot 4.5 HDR 2D disabled | This PR
| -- | -- | --
|<img width="1600" height="960" alt="2025-10-22 (1)" src="https://github.com/user-attachments/assets/39c68669-1df9-4ffe-a9ca-3f9e17c45f5f" />|<img width="1600" height="960" alt="old-brightness" src="https://github.com/user-attachments/assets/80459178-4cb9-4a38-a945-320ff5e6724b" />|<img width="1600" height="960" alt="fixed" src="https://github.com/user-attachments/assets/6ea65bab-db75-44dc-b381-e26c66e8eb9e" />

This PR also removes clipping from the conversion to nonlinear sRGB encoding, which may have impact on some scenes with bright values. A future PR could add back in explicit user-controlled clipping of bright values before applying adjustments, but I believe that the new behaviour in this PR is generally preferred:

| Original scene | Godot 4.5 HDR 2D disabled | This PR
| -- | -- | --
| <img width="576" height="324" alt="Image" src="https://github.com/user-attachments/assets/a04f116b-2458-4197-8f1b-1c981cfadf24" />| <img width="576" height="324" alt="Image" src="https://github.com/user-attachments/assets/bbd00d1f-63f8-4a1b-8587-653d191c3133" /> | <img width="576" height="324" alt="Image" src="https://github.com/user-attachments/assets/7ff40333-53d7-4e03-bc24-b1df0acd51f2" />

### HDR 2D Enabled

**Problem:** When HDR 2D is enabled in Godot 4.3 through 4.5, the brightness adjustment is not perceptually uniform, which makes it difficult to use as a "fade to black" effect.

In this video I demonstrate the two approaches to the brightness adjustment: brightness fades in and out with the sRGB transfer function and then without (cycling back and forth between the two). Note that without the sRGB transfer function, the image fully darkens very suddenly, making for a more abrupt transition:

https://github.com/user-attachments/assets/88f898fa-3d68-482d-8feb-a939cbb49fd3

This PR corrects this issue by making the brightness adjustment more perceptually uniform when HDR 2D is enabled by using the nonlinear sRGB transfer function. The brightness adjustment is still correctly applied to linear-encoded RGB values.

## Contrast

**Problem:** The contrast adjustment heavily darkens the image when HDR 2D is enabled and is very difficult to use and fine-tune. This problem happens because the contrast pivot is at a linear value of `0.5` instead of a more common value of around `0.18` (middle grey) or `0.214041140482232` (sRGB 50%).

This PR corrects this problem by changing the contrast pivot point to be `0.214` (sRGB 50%), which better matches industry standards. The contrast is further improved by being applied to perceptually uniform R, G, and B values.

| Photoshop 26.1 contrast | Godot 4.5 HDR 2D enabled (`0.5` pivot) | This PR (`0.214` pivot)
| -- | -- | --
| <img width="1152" height="1402" alt="Image" src="https://github.com/user-attachments/assets/cdb2a420-36fa-48b9-a9d2-d0415600b3d8" /> | <img width="1152" height="1402" alt="Image" src="https://github.com/user-attachments/assets/33082ea7-6ef7-431b-81b9-f79cc47ae3e9" /> | <img width="1152" height="1402" alt="Image" src="https://github.com/user-attachments/assets/e62097c8-c31e-441a-aabb-b1ce795d5420" />

## Saturation

**Problem:** Low-luminance colours change in apparent brightness when saturation is changed. A prime example is deep blue colours which appear to brighten when saturation is decreased and darken when saturation is increased.

This problem remains unresolved with this PR, but could be solved in a future PR.

# Docs

I suggest to use `tonemap_exposure` instead of scene brightness because `camera_attributes` exposure does not affect scenes without a camera that target a "canvas" background mode. But currently, `tonemap_exposure` is just not implemented at all for the Compatibility renderer.

# Notes to reviewers

1. This leaves [Image.adjust_bcs](https://docs.godotengine.org/en/stable/classes/class_image.html#class-image-method-adjust-bcs) with the legacy behaviour. It might make sense to update this as well to match the new environment behaviour, but I believe this is better suited for a followup PR if others want this. (My plan is to not touch this existing function; I don't have the time to look into this.)

