### PR TITLE
Improve `Environment` saturation color adjustment.

### DIFF
--- a/drivers/gles3/shaders/effects/post.glsl
+++ b/drivers/gles3/shaders/effects/post.glsl
@@ -173,6 +173,13 @@ void main() {
 	// to be performed on linear-encoded values.
 	color.rgb = color.rgb * brightness;
 
+	// Apply saturation:
+	// Luminance weights of the current primaries must be used to prevent blues from
+	// brightening when saturation is decreased and darkening when saturation is increased.
+	// This approach approximately matches Photoshop 26.1's camera raw filter behavior.
+	const vec3 rec709_luminance_weights = vec3(0.2126, 0.7152, 0.0722);
+	color = mix(vec3(dot(rec709_luminance_weights, color)), color, saturation);
+
 	color.rgb = linear_to_srgb(color.rgb);
 
 	// Apply contrast:
@@ -181,12 +188,6 @@ void main() {
 	// higher quality contrast adjustment and maintains compatibility with
 	// existing projects.
 	color.rgb = mix(vec3(0.5), color.rgb, contrast);
-
-	// Apply saturation:
-	// By applying saturation adjustment to nonlinear sRGB-encoded values with
-	// even weights the preceived brightness of blues are affected, but this
-	// maintains compatibility with existing projects.
-	color.rgb = mix(vec3(dot(vec3(1.0), color.rgb) * (1.0 / 3.0)), color.rgb, saturation);
 #else
 	color.rgb = linear_to_srgb(color.rgb);
 #endif // USE_BCS

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1522,18 +1522,18 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_adjustment_enabled"), &Environment::is_adjustment_enabled);
 	ClassDB::bind_method(D_METHOD("set_adjustment_brightness", "brightness"), &Environment::set_adjustment_brightness);
 	ClassDB::bind_method(D_METHOD("get_adjustment_brightness"), &Environment::get_adjustment_brightness);
-	ClassDB::bind_method(D_METHOD("set_adjustment_contrast", "contrast"), &Environment::set_adjustment_contrast);
-	ClassDB::bind_method(D_METHOD("get_adjustment_contrast"), &Environment::get_adjustment_contrast);
 	ClassDB::bind_method(D_METHOD("set_adjustment_saturation", "saturation"), &Environment::set_adjustment_saturation);
 	ClassDB::bind_method(D_METHOD("get_adjustment_saturation"), &Environment::get_adjustment_saturation);
+	ClassDB::bind_method(D_METHOD("set_adjustment_contrast", "contrast"), &Environment::set_adjustment_contrast);
+	ClassDB::bind_method(D_METHOD("get_adjustment_contrast"), &Environment::get_adjustment_contrast);
 	ClassDB::bind_method(D_METHOD("set_adjustment_color_correction", "color_correction"), &Environment::set_adjustment_color_correction);
 	ClassDB::bind_method(D_METHOD("get_adjustment_color_correction"), &Environment::get_adjustment_color_correction);
 
 	ADD_GROUP("Adjustments", "adjustment_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "adjustment_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_adjustment_enabled", "is_adjustment_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_brightness", PROPERTY_HINT_RANGE, "0.0,2.0,0.01,or_greater"), "set_adjustment_brightness", "get_adjustment_brightness");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_contrast", PROPERTY_HINT_RANGE, "0.75,1.25,0.005,or_less,or_greater"), "set_adjustment_contrast", "get_adjustment_contrast");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_saturation", PROPERTY_HINT_RANGE, "0.0,2.0,0.01,or_less,or_greater"), "set_adjustment_saturation", "get_adjustment_saturation");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_contrast", PROPERTY_HINT_RANGE, "0.75,1.25,0.005,or_less,or_greater"), "set_adjustment_contrast", "get_adjustment_contrast");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "adjustment_color_correction", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D,Texture3D"), "set_adjustment_color_correction", "get_adjustment_color_correction");
 
 	// Constants

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -901,6 +901,13 @@ void main() {
 		// to be performed on linear-encoded values.
 		color.rgb = color.rgb * params.bcs.x;
 
+		// Apply saturation:
+		// Luminance weights of the current primaries must be used to prevent blues from
+		// brightening when saturation is decreased and darkening when saturation is increased.
+		// This approach approximately matches Photoshop 26.1's camera raw filter behavior.
+		const vec3 rec709_luminance_weights = vec3(0.2126, 0.7152, 0.0722);
+		color.rgb = mix(vec3(dot(rec709_luminance_weights, color.rgb)), color.rgb, params.bcs.z);
+
 		color.rgb = linear_to_srgb(color.rgb);
 
 		// Apply contrast:
@@ -909,12 +916,6 @@ void main() {
 		// higher quality contrast adjustment and maintains compatibility with
 		// existing projects.
 		color.rgb = mix(vec3(0.5), color.rgb, params.bcs.y);
-
-		// Apply saturation:
-		// By applying saturation adjustment to nonlinear sRGB-encoded values with
-		// even weights the preceived brightness of blues are affected, but this
-		// maintains compatibility with existing projects.
-		color.rgb = mix(vec3(dot(vec3(1.0), color.rgb) * (1.0 / 3.0)), color.rgb, params.bcs.z);
 
 		if (bool(params.flags & FLAG_USE_COLOR_CORRECTION)) {
 			color.rgb = clamp(color.rgb, vec3(0.0), vec3(1.0));


### PR DESCRIPTION
- Closes godotengine/godot-proposals#13195 (the remaining item relating to saturation)

This commit changes the saturation color adjustment to behave as follows for all rendering configurations:

- Apply saturation with luminance weights on linear-encoded values, preventing brightness from changing with certain colors.
- Apply contrast after saturation to avoid a performance regression when HDR 2D is disabled. This ordering is reversed compared to Godot 4.5 and earlier.

# Rationale and screenshots

Rationale and screenshots for this PR can be found in godotengine/godot-proposals#13195.

# Changes and improvements

**Problem:** Low-luminance colours change in apparent brightness when saturation is changed. A prime example is deep blue colours which appear to brighten when saturation is decreased and darken when saturation is increased.

The solution to this problem is to simply apply saturation to linear-encoded values using CIE luminance weights for the Rec. BT.709 primaries that Godot uses:

| Original | Even weights (Godot 4.5 HDR 2D enabled) | This PR (Rec. 709 luminance weights)
| -- | -- | --
| <img width="576" height="324" alt="Image" src="https://github.com/user-attachments/assets/a04f116b-2458-4197-8f1b-1c981cfadf24" /> | <img width="576" height="324" alt="Image" src="https://github.com/user-attachments/assets/8bbf2fbe-7f68-4aaf-af09-9030eb1d6076" /> | <img width="576" height="324" alt="Image" src="https://github.com/user-attachments/assets/d0350846-e5c8-4da6-9307-4fd3f767a399" />