### PR TITLE
Mark writer_pngwav as maybe unused to eliminate compilation warnings

### DIFF
--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -134,7 +134,7 @@ static bool has_server_feature_callback(const String &p_feature) {
 	return false;
 }
 
-static MovieWriterPNGWAV *writer_pngwav = nullptr;
+[[maybe_unused]] static MovieWriterPNGWAV *writer_pngwav = nullptr;
 
 void register_server_types() {
 	OS::get_singleton()->benchmark_begin_measure("Servers", "Register Extensions");


### PR DESCRIPTION
When the MovieWritePNGWAV class is not enabled, the following compilation warning will appear because the related variables are not actually used anywhere:
`servers\register_server_types.cpp:137:27: warning: variable 'writer_pngwav' is not needed and will not be emitted [-Wunneeded-internal-declaration]
137 | static MovieWriterPNGWAV *writer_pngwav = nullptr;
|                           ^~~~~~~~~~~~~
1 warning generated.
`
Using the C++standard [maybe_unused] can solve the problem.