### PR TITLE
Change `Go to Line` default shortcut to `Ctrl+G`

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -3164,7 +3164,8 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT("script_text_editor/goto_function", TTRC("Go to Function..."), KeyModifierMask::ALT | KeyModifierMask::CTRL | Key::F);
 	ED_SHORTCUT_OVERRIDE("script_text_editor/goto_function", "macos", KeyModifierMask::CTRL | KeyModifierMask::META | Key::J);
 
-	ED_SHORTCUT("script_text_editor/goto_line", TTRC("Go to Line..."), KeyModifierMask::CMD_OR_CTRL | Key::L);
+	ED_SHORTCUT("script_text_editor/goto_line", TTRC("Go to Line..."), KeyModifierMask::CMD_OR_CTRL | Key::G);
+	ED_SHORTCUT_OVERRIDE("script_text_editor/goto_line", "macos", KeyModifierMask::CMD_OR_CTRL | Key::L);
 	ED_SHORTCUT("script_text_editor/goto_symbol", TTRC("Lookup Symbol"));
 
 	ED_SHORTCUT("script_text_editor/toggle_breakpoint", TTRC("Toggle Breakpoint"), Key::F9);


### PR DESCRIPTION
- Supersedes https://github.com/godotengine/godot/pull/57678

Changes default Go to Line shortcut to Ctrl+G (except on macOS)

This is for consistency with other IDEs. VSCode, Rider, Kate, and Sublime Text all use Ctrl+G for Go to Line.

On macOS it is sometimes Cmd+G, but it seems like it is Cmd+L is more common, so I added an override for it to keep the same shortcut as before.
But I can change it here too if we want.

`editor/group_selected_nodes` also uses Ctrl+G, but it didn't work when the Script Editor was open anyway, and it still works in the 2D/3D editors now.
