### PR TITLE
Support using editor particle function "Create Emission Points From Node" in code during runtime

### DIFF
--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -24,6 +24,15 @@
 				Sets this node's properties to match a given [GPUParticles3D] node with an assigned [ParticleProcessMaterial].
 			</description>
 		</method>
+		<method name="generate_emission_points">
+			<return type="void" />
+			<param index="0" name="path" type="NodePath" />
+			<param index="1" name="emission_amount" type="int" />
+			<param index="2" name="emission_source" type="int" />
+			<description>
+				Generates emission points on the mesh, taking a number of emission points and the emission sources. See [enum EmissionSources].
+			</description>
+		</method>
 		<method name="get_param_curve" qualifiers="const">
 			<return type="Curve" />
 			<param index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
@@ -431,6 +440,15 @@
 		</constant>
 		<constant name="EMISSION_SHAPE_MAX" value="7" enum="EmissionShape">
 			Represents the size of the [enum EmissionShape] enum.
+		</constant>
+		<constant name="SURFACE_POINTS" value="0" enum="EmissionSources">
+			When using [method generate_emission_points], sets the particles spawn points to the surface of the mesh.
+		</constant>
+		<constant name="SURFACE_POINTS_AND_NORMAL" value="1" enum="EmissionSources">
+			When using [method generate_emission_points], sets the particles spawn points and normals to the surface of the mesh.
+		</constant>
+		<constant name="VOLUME" value="2" enum="EmissionSources">
+			When using [method generate_emission_points], sets the particles spawn points to a position inside the mesh.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -39,6 +39,15 @@
 				[b]Note:[/b] [method emit_particle] is only supported on the Forward+ and Mobile rendering methods, not Compatibility.
 			</description>
 		</method>
+		<method name="generate_emission_points">
+			<return type="void" />
+			<param index="0" name="path" type="NodePath" />
+			<param index="1" name="emission_amount" type="int" />
+			<param index="2" name="emission_source" type="int" />
+			<description>
+				Generates emission points on the mesh, taking a number of emission points and the emission sources. See [enum EmissionSources].
+			</description>
+		</method>
 		<method name="get_draw_pass_mesh" qualifiers="const">
 			<return type="Mesh" />
 			<param index="0" name="pass" type="int" />
@@ -222,6 +231,15 @@
 		<constant name="TRANSFORM_ALIGN_Y_TO_VELOCITY" value="2" enum="TransformAlign">
 		</constant>
 		<constant name="TRANSFORM_ALIGN_Z_BILLBOARD_Y_TO_VELOCITY" value="3" enum="TransformAlign">
+		</constant>
+		<constant name="SURFACE_POINTS" value="0" enum="EmissionSources">
+			When using [method generate_emission_points], sets the particles spawn points to the surface of the mesh.
+		</constant>
+		<constant name="SURFACE_POINTS_AND_NORMAL" value="1" enum="EmissionSources">
+			When using [method generate_emission_points], sets the particles spawn points and normals to the surface of the mesh.
+		</constant>
+		<constant name="VOLUME" value="2" enum="EmissionSources">
+			When using [method generate_emission_points], sets the particles spawn points to a position inside the mesh.
 		</constant>
 	</constants>
 </class>

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -31,12 +31,15 @@
 #include "cpu_particles_3d.h"
 #include "cpu_particles_3d.compat.inc"
 
+#include "core/io/resource_loader.h"
 #include "core/math/random_number_generator.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/gpu_particles_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/curve_texture.h"
 #include "scene/resources/gradient_texture.h"
+#include "scene/resources/image_texture.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/particle_process_material.h"
 
@@ -540,6 +543,175 @@ void CPUParticles3D::set_gravity(const Vector3 &p_gravity) {
 
 Vector3 CPUParticles3D::get_gravity() const {
 	return gravity;
+}
+
+void CPUParticles3D::set_node_selected(const NodePath &p_path) {
+	Node *sel = get_node(p_path);
+	if (!sel) {
+		return;
+	}
+
+	if (!sel->is_class("Node3D")) {
+		return;
+	}
+
+	MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(sel);
+	if (!mi || mi->get_mesh().is_null()) {
+		return;
+	}
+
+	geometry = mi->get_mesh()->get_faces();
+
+	if (geometry.size() == 0) {
+		return;
+	}
+
+	Transform3D geom_xform = get_global_transform().affine_inverse() * mi->get_global_transform();
+
+	int gc = geometry.size();
+	Face3 *w = geometry.ptrw();
+
+	for (int i = 0; i < gc; i++) {
+		for (int j = 0; j < 3; j++) {
+			w[i].vertex[j] = geom_xform.xform(w[i].vertex[j]);
+		}
+	}
+
+	update_configuration_warnings();
+}
+
+bool CPUParticles3D::_generate(Vector<Vector3> &r_points, Vector<Vector3> &r_normals, int &emission_amount, int &emission_fill) {
+	bool use_normals = emission_fill == 1;
+
+	if (emission_fill < 2) {
+		float area_accum = 0;
+		RBMap<float, int> triangle_area_map;
+
+		for (int i = 0; i < geometry.size(); i++) {
+			float area = geometry[i].get_area();
+			if (area < CMP_EPSILON) {
+				continue;
+			}
+			triangle_area_map[area_accum] = i;
+			area_accum += area;
+		}
+
+		if (!triangle_area_map.size() || area_accum == 0) {
+			return false;
+		}
+
+		int emissor_count = emission_amount;
+
+		for (int i = 0; i < emissor_count; i++) {
+			float areapos = Math::random(0.0f, area_accum);
+
+			RBMap<float, int>::Iterator E = triangle_area_map.find_closest(areapos);
+			ERR_FAIL_COND_V(!E, false);
+			int index = E->value;
+			ERR_FAIL_INDEX_V(index, geometry.size(), false);
+
+			// ok FINALLY get face
+			Face3 face = geometry[index];
+			//now compute some position inside the face...
+
+			Vector3 pos = face.get_random_point_inside();
+
+			r_points.push_back(pos);
+
+			if (use_normals) {
+				Vector3 normal = face.get_plane().normal;
+				r_normals.push_back(normal);
+			}
+		}
+	} else {
+		int gcount = geometry.size();
+
+		if (gcount == 0) {
+			return false;
+		}
+
+		const Face3 *r = geometry.ptr();
+
+		AABB aabb;
+
+		for (int i = 0; i < gcount; i++) {
+			for (int j = 0; j < 3; j++) {
+				if (i == 0 && j == 0) {
+					aabb.position = r[i].vertex[j];
+				} else {
+					aabb.expand_to(r[i].vertex[j]);
+				}
+			}
+		}
+
+		int emissor_count = emission_amount;
+
+		for (int i = 0; i < emissor_count; i++) {
+			int attempts = 5;
+
+			for (int j = 0; j < attempts; j++) {
+				Vector3 dir;
+				dir[Math::rand() % 3] = 1.0;
+				Vector3 ofs = (Vector3(1, 1, 1) - dir) * Vector3(Math::randf(), Math::randf(), Math::randf()) * aabb.size + aabb.position;
+
+				Vector3 ofsv = ofs + aabb.size * dir;
+
+				//space it a little
+				ofs -= dir;
+				ofsv += dir;
+
+				float max = -1e7, min = 1e7;
+
+				for (int k = 0; k < gcount; k++) {
+					const Face3 &f3 = r[k];
+
+					Vector3 res;
+					if (f3.intersects_segment(ofs, ofsv, &res)) {
+						res -= ofs;
+						float d = dir.dot(res);
+
+						if (d < min) {
+							min = d;
+						}
+						if (d > max) {
+							max = d;
+						}
+					}
+				}
+
+				if (max < min) {
+					continue; //lost attempt
+				}
+
+				float val = min + (max - min) * Math::randf();
+
+				Vector3 point = ofs + dir * val;
+
+				r_points.push_back(point);
+				break;
+			}
+		}
+	}
+	return true;
+}
+
+void CPUParticles3D::generate_emission_points(const NodePath &p_path, int p_emission_amount, int p_emission_source) {
+	set_node_selected(p_path);
+
+	Vector<Vector3> points;
+	Vector<Vector3> normals;
+
+	if (!_generate(points, normals, p_emission_amount, p_emission_source)) {
+		return;
+	}
+
+	if (normals.is_empty()) {
+		emission_shape = CPUParticles3D::EMISSION_SHAPE_POINTS;
+	} else {
+		emission_shape = CPUParticles3D::EMISSION_SHAPE_DIRECTED_POINTS;
+		emission_normals = normals;
+	}
+	emission_points = points;
 }
 
 Ref<Curve> CPUParticles3D::get_scale_curve_x() const {
@@ -1655,6 +1827,8 @@ void CPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_scale_curve_z"), &CPUParticles3D::get_scale_curve_z);
 	ClassDB::bind_method(D_METHOD("set_scale_curve_z", "scale_curve"), &CPUParticles3D::set_scale_curve_z);
 
+	ClassDB::bind_method(D_METHOD("generate_emission_points", "path", "emission_amount", "emission_source"), &CPUParticles3D::generate_emission_points);
+
 	ClassDB::bind_method(D_METHOD("convert_from_particles", "particles"), &CPUParticles3D::convert_from_particles);
 
 	ADD_SIGNAL(MethodInfo("finished"));
@@ -1764,6 +1938,10 @@ void CPUParticles3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_DIRECTED_POINTS);
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_RING);
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_MAX);
+
+	BIND_ENUM_CONSTANT(SURFACE_POINTS);
+	BIND_ENUM_CONSTANT(SURFACE_POINTS_AND_NORMAL);
+	BIND_ENUM_CONSTANT(VOLUME);
 }
 
 CPUParticles3D::CPUParticles3D() {

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -81,6 +81,12 @@ public:
 		EMISSION_SHAPE_MAX
 	};
 
+	enum EmissionSources {
+		SURFACE_POINTS,
+		SURFACE_POINTS_AND_NORMAL,
+		VOLUME
+	};
+
 private:
 	bool emitting = false;
 	bool active = false;
@@ -145,6 +151,7 @@ private:
 	bool local_coords = false;
 	int fixed_fps = 0;
 	bool fractional_delta = true;
+	NodePath node_selected;
 	uint32_t seed = 0;
 	bool use_fixed_seed = false;
 
@@ -206,9 +213,14 @@ private:
 	void _set_redraw(bool p_redraw);
 
 protected:
+	Vector<Face3> geometry;
+
 	static void _bind_methods();
 	void _notification(int p_what);
 	void _validate_property(PropertyInfo &p_property) const;
+
+	bool _generate(Vector<Vector3> &points, Vector<Vector3> &p_normals, int &p_emission_amount, int &p_emission_source);
+	void set_node_selected(const NodePath &p_path);
 
 #ifndef DISABLE_DEPRECATED
 	void _restart_bind_compat_92089();
@@ -331,6 +343,8 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
+	void generate_emission_points(const NodePath &p_path, int p_emission_amount, int p_emission_source);
+
 	void restart(bool p_keep_seed = false);
 
 	void convert_from_particles(Node *p_particles);
@@ -345,3 +359,4 @@ VARIANT_ENUM_CAST(CPUParticles3D::DrawOrder)
 VARIANT_ENUM_CAST(CPUParticles3D::Parameter)
 VARIANT_ENUM_CAST(CPUParticles3D::ParticleFlags)
 VARIANT_ENUM_CAST(CPUParticles3D::EmissionShape)
+VARIANT_ENUM_CAST(CPUParticles3D::EmissionSources)

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -56,6 +56,12 @@ public:
 		MAX_DRAW_PASSES = 4
 	};
 
+	enum EmissionSources {
+		SURFACE_POINTS,
+		SURFACE_POINTS_AND_NORMAL,
+		VOLUME
+	};
+
 private:
 	RID particles;
 
@@ -75,6 +81,7 @@ private:
 	int fixed_fps = 0;
 	bool fractional_delta = false;
 	bool interpolate = true;
+	NodePath node_selected;
 	NodePath sub_emitter;
 	real_t collision_base_size = 0.01;
 	uint32_t seed = 0;
@@ -104,9 +111,13 @@ private:
 	void _skinning_changed();
 
 protected:
+	Vector<Face3> geometry;
+
 	static void _bind_methods();
 	void _notification(int p_what);
 	void _validate_property(PropertyInfo &p_property) const;
+	bool _generate(Vector<Vector3> &points, Vector<Vector3> &normals, int &emission_amount, int &emission_fill);
+	void set_node_selected(const NodePath &p_path);
 
 #ifndef DISABLE_DEPRECATED
 	void _restart_bind_compat_92089();
@@ -172,6 +183,8 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
+	void generate_emission_points(const NodePath &p_path, int p_emission_amount, int p_emission_source);
+
 	void set_sub_emitter(const NodePath &p_path);
 	NodePath get_sub_emitter() const;
 
@@ -210,3 +223,4 @@ public:
 VARIANT_ENUM_CAST(GPUParticles3D::DrawOrder)
 VARIANT_ENUM_CAST(GPUParticles3D::TransformAlign)
 VARIANT_ENUM_CAST(GPUParticles3D::EmitFlags)
+VARIANT_ENUM_CAST(GPUParticles3D::EmissionSources)


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8106 as this functionality is very helpful to my current project.

This mostly ports over the code in editor/scene/3d/particles_3d_editor_plugin.cpp, in particular the [_node_selected](https://github.com/godotengine/godot/blob/master/editor/scene/3d/particles_3d_editor_plugin.cpp#L87) method, the [_generate](https://github.com/godotengine/godot/blob/master/editor/scene/3d/particles_3d_editor_plugin.cpp#L150) method and both GPUParticle's [generate_emission_particles](https://github.com/godotengine/godot/blob/master/editor/scene/3d/particles_3d_editor_plugin.cpp#L339) method and CPUParticle's [generate_emission_particles](https://github.com/godotengine/godot/blob/master/editor/scene/3d/particles_3d_editor_plugin.cpp#L430) method.

The only tweaks are removing any editor-only messages and a slight tweak so _node_selected is called when doing generate_emission_points.

I have also added corresponding documentation for the new generate_emission_points methods and enums and also provided a minimum test project to try out these changes:

[generateEmissionPointsTest.zip](https://github.com/user-attachments/files/23046218/generateEmissionPointsTest.zip)