### PR TITLE
[3.x] Disable some unsafe CLI arguments in template builds by default, add project setting and build option to disable `override.cfg`.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -154,6 +154,14 @@ opts.Add(
 )
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
+opts.Add(BoolVariable("disable_overrides", "Disable project settings overrides (override.cfg)", False))
+opts.Add(
+    BoolVariable(
+        "disable_path_overrides",
+        "Disable CLI arguments to override project path/main pack/scene and run scripts (export template only)",
+        True,
+    )
+)
 opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", True))
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
 opts.Add("system_certs_path", "Use this path as SSL certificates default for editor (for package maintainers)", "")
@@ -769,6 +777,12 @@ if selected_platform in platform_list:
                     "only with 'tools=no' (export template)."
                 )
                 sys.exit(255)
+
+    if not env["disable_overrides"]:
+        env.Append(CPPDEFINES=["OVERRIDE_ENABLED"])
+
+    if env["tools"] or not env["disable_path_overrides"]:
+        env.Append(CPPDEFINES=["OVERRIDE_PATH_ENABLED"])
 
     if not env["verbose"]:
         methods.no_verbose(sys, env)

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -198,6 +198,9 @@
 		<member name="application/config/description" type="String" setter="" getter="" default="&quot;&quot;">
 			The project's description, displayed as a tooltip in the Project Manager when hovering the project.
 		</member>
+		<member name="application/config/disable_project_settings_override" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], disables loading of project settings overrides (file defined in [member application/config/project_settings_override] and [code]res://override.cfg[/code]) and related CLI arguments.
+		</member>
 		<member name="application/config/icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon used for the project, set when project loads. Exporters will also use this icon when possible.
 		</member>


### PR DESCRIPTION
Backport of https://github.com/godotengine/godot/pull/111909 and https://github.com/godotengine/godot/pull/108818