### PR TITLE
Force disable SPIRV debug info on D3D12.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -637,7 +637,7 @@ void Main::print_help(const char *p_binary) {
 #ifdef DEBUG_ENABLED
 	print_help_option("--gpu-abort", "Abort on graphics API usage errors (usually validation layer errors). May help see the problem if your system freezes.\n", CLI_OPTION_AVAILABILITY_TEMPLATE_DEBUG);
 #endif
-	print_help_option("--generate-spirv-debug-info", "Generate SPIR-V debug information. This allows source-level shader debugging with RenderDoc.\n");
+	print_help_option("--generate-spirv-debug-info", "Generate SPIR-V debug information (Vulkan only). This allows source-level shader debugging with RenderDoc.\n");
 #if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
 	print_help_option("--extra-gpu-memory-tracking", "Enables additional memory tracking (see class reference for `RenderingDevice.get_driver_and_device_memory_report()` and linked methods). Currently only implemented for Vulkan. Enabling this feature may cause crashes on some systems due to buggy drivers or bugs in the Vulkan Loader. See https://github.com/godotengine/godot/issues/95967\n");
 	print_help_option("--accurate-breadcrumbs", "Force barriers between breadcrumbs. Useful for narrowing down a command causing GPU resets. Currently only implemented for Vulkan.\n");

--- a/modules/glslang/register_types.cpp
+++ b/modules/glslang/register_types.cpp
@@ -31,6 +31,7 @@
 #include "register_types.h"
 
 #include "core/config/engine.h"
+#include "core/os/os.h"
 #include "shader_compile.h"
 
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wshadow")
@@ -71,8 +72,16 @@ Vector<uint8_t> compile_glslang_shader(RenderingDeviceCommons::ShaderStage p_sta
 		shader.setPreamble(preamble.c_str());
 	}
 
+	bool generate_spirv_debug_info = Engine::get_singleton()->is_generate_spirv_debug_info_enabled();
+#ifdef D3D12_ENABLED
+	if (OS::get_singleton()->get_current_rendering_driver_name() == "d3d12") {
+		// SPIRV to DXIL conversion does not support debug info.
+		generate_spirv_debug_info = false;
+	}
+#endif
+
 	EShMessages messages = (EShMessages)(EShMsgSpvRules | EShMsgVulkanRules);
-	if (Engine::get_singleton()->is_generate_spirv_debug_info_enabled()) {
+	if (generate_spirv_debug_info) {
 		messages = (EShMessages)(messages | EShMsgDebugInfo);
 	}
 	const int DefaultVersion = 100;
@@ -107,7 +116,7 @@ Vector<uint8_t> compile_glslang_shader(RenderingDeviceCommons::ShaderStage p_sta
 	spv::SpvBuildLogger logger;
 	glslang::SpvOptions spvOptions;
 
-	if (Engine::get_singleton()->is_generate_spirv_debug_info_enabled()) {
+	if (generate_spirv_debug_info) {
 		spvOptions.generateDebugInfo = true;
 		spvOptions.emitNonSemanticShaderDebugInfo = true;
 		spvOptions.emitNonSemanticShaderDebugSource = true;


### PR DESCRIPTION
Fixes #111869.

Question: I figure there's no way for the OS singleton to be nullptr in this function?