### PR TITLE
Fix sub_emitter does not process during `request_particles_process`

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -158,6 +158,7 @@ private:
 	};
 
 	struct Particles {
+		RID self;
 		RS::ParticlesMode mode = RS::PARTICLES_MODE_3D;
 		bool inactive = true;
 		double inactive_time = 0.0;
@@ -266,12 +267,26 @@ private:
 		}
 	};
 
+	struct ParticlesSubEmitterSort {
+		_FORCE_INLINE_ bool operator()(const Particles &p_left, const Particles &p_right) const {
+			return p_left.sub_emitter == p_right.self;
+		}
+	};
+
+	struct ParticlesTreeNode {
+		Particles *particles;
+		Particles *sub_emitter;
+	};
+
+	bool _particles_check(Particles *particles);
+	void _particles_init(Particles *particles);
 	void _particles_process(Particles *p_particles, double p_delta);
 	void _particles_allocate_emission_buffer(Particles *particles);
 	void _particles_ensure_unused_emission_buffer(Particles *particles);
 	void _particles_ensure_unused_trail_buffer(Particles *particles);
 	void _particles_free_data(Particles *particles);
 	void _particles_update_buffers(Particles *particles);
+	void _particles_post_process(Particles *particles);
 
 	struct ParticlesShader {
 		struct PushConstant {


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/111885*

## Issue Description

This issue caused by processing order.  When we config a `sub_emitter`, we want the `sub_emitter` will process just after every parent step.

But when we use `request_particles_process` to skip a short of time, `ParticlesStorage` process first parent before sub_emitter. That means if we want to delay 1 second before render particles, `ParticlesStorage` first let parent particles process 1 seconds, then handle the sub_emitter, so sub_emitter always start from parent particles ended. The sub_emitter can only be emitted from the parent's last position of `request_particles_process` time.

- fixed_fps: 30 (30 frame per seconds)
- request_particles_process(1.0) (process particles 1 second before start)
- first, let parent particles process 30 frames
- second, let sub_emitter particles process 30 frames.

What we want is processing parent and sub_emitter one by one during the `request_particles_process` time.

## Solution

After the '_particles_process' is executed, if there is a `sub_emtter`, it will continue to execute the `sub_emitter` and save it in the `processed_particles`. If it is found that the particles have already been processed, it will jump out to avoid duplicate processing.

[particles.webm](https://github.com/user-attachments/assets/717dbe02-23a2-416d-b847-79009e5d501d)

## Etc

I am not sure the `processed_particles.has(particles->particle_buffer)` is suitable for `HashSet` matching. Any advice?
