### PR TITLE
Add `zip_shortest` and `enumerate` iteration helpers.

### DIFF
--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -71,7 +71,7 @@ class CommandQueueMT {
 
 		// This method exists so we can call it in the parameter pack expansion in call_impl.
 		template <size_t I>
-		_FORCE_INLINE_ auto &get() { return ::tuple_get<I>(args); }
+		_FORCE_INLINE_ auto &get() { return args.template get<I>(); }
 	};
 
 	// Separate class from Command so we can save the space of the ret pointer for commands that don't return.
@@ -98,7 +98,7 @@ class CommandQueueMT {
 
 		// This method exists so we can call it in the parameter pack expansion in call_impl.
 		template <size_t I>
-		_FORCE_INLINE_ auto &get() { return ::tuple_get<I>(args); }
+		_FORCE_INLINE_ auto &get() { return args.template get<I>(); }
 	};
 
 	/***** BASE *******/

--- a/core/templates/iterable.h
+++ b/core/templates/iterable.h
@@ -30,6 +30,53 @@
 
 #pragma once
 
+#include "core/templates/tuple.h"
+#include "core/typedefs.h"
+
+// Like std::begin, but without an expensive include.
+template <class T, size_t SIZE>
+T *std_begin(T (&array)[SIZE]) {
+	return array;
+}
+
+template <class T, size_t SIZE>
+T *std_end(T (&array)[SIZE]) {
+	return array + SIZE;
+}
+
+template <class T, size_t SIZE>
+const T *std_begin(const T (&array)[SIZE]) {
+	return array;
+}
+
+template <class T, size_t SIZE>
+const T *std_end(const T (&array)[SIZE]) {
+	return array + SIZE;
+}
+
+template <class T>
+auto std_begin(T &t) -> decltype(t.begin()) {
+	return t.begin();
+}
+
+template <class T>
+auto std_end(T &t) -> decltype(t.end()) {
+	return t.end();
+}
+
+template <class T>
+auto std_begin(const T &t) -> decltype(t.begin()) {
+	return t.begin();
+}
+
+template <class T>
+auto std_end(const T &t) -> decltype(t.end()) {
+	return t.end();
+}
+
+/// Can be returned from a function and directly iterated.
+/// Example usage:
+/// for (int i : object.get_iterable()) { ... }
 template <typename I>
 class Iterable {
 	I _begin;
@@ -44,3 +91,92 @@ public:
 	Iterable(const I &begin, const I &end) :
 			_begin(begin), _end(end) {}
 };
+
+template <typename T>
+struct IteratorType {
+	using type = decltype(std_begin(std::declval<T>()));
+};
+
+template <typename T>
+using IteratorTypeT = typename IteratorType<T>::type;
+
+template <typename T, typename... Rest>
+bool _tuple_any_elements_equal(const Tuple<T, Rest...> &p_lhs, const Tuple<T, Rest...> &p_rhs) {
+	if constexpr (sizeof...(Rest) == 0) {
+		return p_lhs.value == p_rhs.value;
+	} else {
+		return p_lhs.value == p_rhs.value || _tuple_any_elements_equal(static_cast<const Tuple<Rest...> &>(p_lhs), static_cast<const Tuple<Rest...> &>(p_rhs));
+	}
+}
+
+template <typename T, typename... Rest>
+void _tuple_increment(Tuple<T, Rest...> &p_tuple) {
+	p_tuple.value++;
+	if constexpr (sizeof...(Rest) > 0) {
+		_tuple_increment<Rest...>(p_tuple);
+	}
+}
+
+template <typename... T, typename... T1, size_t... Is>
+Tuple<T...> _tuple_dereference_impl(Tuple<T1...> &p_tuple, IndexSequence<Is...>) {
+	return Tuple<T...>{ *p_tuple.template get<Is>()... };
+}
+
+template <typename TUPLE, typename... T>
+struct ZipShortestIterator {
+	TUPLE iterators;
+
+	Tuple<T...> operator*() {
+		return _tuple_dereference_impl<T...>(iterators, BuildIndexSequence<sizeof...(T)>{});
+	}
+	ZipShortestIterator &operator++() {
+		_tuple_increment(iterators);
+		return *this;
+	}
+	bool operator!=(const ZipShortestIterator &iter) const {
+		return !_tuple_any_elements_equal(iterators, iter.iterators);
+	}
+};
+
+/// Can be used to iterate multiple iterables together.
+/// The iteration stops with the shortest iterator.
+/// Example usage:
+/// for (auto [ai, bi, ci] : zip_shortest<A, B, C>(a, b, c)) { ... }
+template <typename... T, typename... ITER>
+Iterable<ZipShortestIterator<Tuple<IteratorTypeT<ITER>...>, T...>> zip_shortest(ITER &&...t) {
+	static_assert(sizeof...(T) == sizeof...(ITER));
+	using TUPLE = Tuple<IteratorTypeT<ITER>...>;
+	return Iterable<ZipShortestIterator<TUPLE, T...>>{
+		ZipShortestIterator<TUPLE, T...>{ TUPLE{ std_begin(t)... } },
+		ZipShortestIterator<TUPLE, T...>{ TUPLE{ std_end(t)... } }
+	};
+}
+
+template <typename IDX, typename VALUE, typename T>
+struct EnumerateIterator {
+	size_t index;
+	T iterator;
+
+	Tuple<IDX, VALUE> operator*() {
+		return { index, *iterator };
+	}
+	EnumerateIterator &operator++() {
+		index++;
+		iterator++;
+		return *this;
+	}
+	bool operator!=(const EnumerateIterator &iter) {
+		return iterator != iter.iterator;
+	}
+};
+
+/// Can be used to count an index with an iterable.
+/// Example usage:
+/// for (auto [index, ai] : enumerate<size_t, A>(a)) { ... }
+template <typename IDX, typename VALUE, typename ITER>
+Iterable<EnumerateIterator<IDX, VALUE, IteratorTypeT<ITER>>> enumerate(ITER &&t) {
+	return Iterable{
+		EnumerateIterator<IDX, VALUE, IteratorTypeT<ITER>>{ 0, std_begin(t) },
+		EnumerateIterator<IDX, VALUE, IteratorTypeT<ITER>>{ 0, std_end(t) }
+	};
+}

--- a/core/templates/tuple.h
+++ b/core/templates/tuple.h
@@ -49,21 +49,6 @@
 // Tuple<int, float>
 // step 1: Tuple T = int, Rest = float. Results in a Tuple<int> : Tuple<float>
 // step 2: Tuple T = float, no Rest. Results in a Tuple<float>
-//
-// tuple_get<I> works through a similar recursion, using the inheritance chain to walk to the right node.
-// In order to tuple_get<1>(my_tuple), from the example tuple above:
-//
-// 1. We want tuple_get<1> to return the float, which is one level "up" from Tuple<int> : Tuple<float>,
-//    (the real type of the Tuple "root").
-// 2. Since index 1 > 0, it casts the tuple to its parent type (Tuple<float>). This works because
-//    we cast to Tuple<Rest...> which in this case is just float.
-// 3. Now we're looking for index 0 in Tuple<float>, which directly returns its value field. Note
-//    how get<0> is a template specialization.
-//
-// At compile time, this gets fully resolved. The compiler sees get<1>(my_tuple) and:
-// 1. Creates TupleGet<1, Tuple<int, float>>::tuple_get which contains the cast to Tuple<float>.
-// 2. Creates TupleGet<0, Tuple<float>>::tuple_get which directly returns the value.
-// 3. The compiler will then simply optimize all of this nonsense away and return the float directly.
 
 #include "core/typedefs.h"
 
@@ -83,40 +68,40 @@ struct Tuple<T, Rest...> : Tuple<Rest...> {
 	_FORCE_INLINE_ Tuple(F &&f, R &&...rest) :
 			Tuple<Rest...>(std::forward<R>(rest)...),
 			value(std::forward<F>(f)) {}
+
+	template <std::size_t Index>
+	std::tuple_element_t<Index, Tuple> &get() {
+		if constexpr (Index == 0) {
+			return value;
+		} else {
+			return Tuple<Rest...>::template get<Index - 1>();
+		}
+	}
+
+	template <std::size_t Index>
+	const std::tuple_element_t<Index, Tuple> &get() const {
+		if constexpr (Index == 0) {
+			return value;
+		} else {
+			return Tuple<Rest...>::template get<Index - 1>();
+		}
+	}
 };
+
+namespace std {
+template <typename... Args>
+struct tuple_size<Tuple<Args...>> : std::integral_constant<std::size_t, sizeof...(Args)> {};
+
+template <typename T, typename... Rest>
+struct tuple_element<0, Tuple<T, Rest...>> {
+	using type = T;
+};
+
+template <std::size_t Index, typename T, typename... Rest>
+struct tuple_element<Index, Tuple<T, Rest...>>
+		: tuple_element<Index - 1, Tuple<Rest...>> {};
+} //namespace std
 
 // Tuple is zero-constructible if and only if all constrained types are zero-constructible.
 template <typename... Types>
 struct is_zero_constructible<Tuple<Types...>> : std::conjunction<is_zero_constructible<Types>...> {};
-
-template <size_t I, typename Tuple>
-struct TupleGet;
-
-template <typename First, typename... Rest>
-struct TupleGet<0, Tuple<First, Rest...>> {
-	_FORCE_INLINE_ static First &tuple_get(Tuple<First, Rest...> &t) {
-		return t.value;
-	}
-};
-
-// Rationale for using auto here is that the alternative is writing a
-// helper struct to create an otherwise useless type. we would have to write
-// a second recursive template chain like: TupleGetType<I, Tuple<First, Rest...>>::type
-// just to recover the type in the most baroque way possible.
-
-template <size_t I, typename First, typename... Rest>
-struct TupleGet<I, Tuple<First, Rest...>> {
-	_FORCE_INLINE_ static auto &tuple_get(Tuple<First, Rest...> &t) {
-		return TupleGet<I - 1, Tuple<Rest...>>::tuple_get(static_cast<Tuple<Rest...> &>(t));
-	}
-};
-
-template <size_t I, typename... Types>
-_FORCE_INLINE_ auto &tuple_get(Tuple<Types...> &t) {
-	return TupleGet<I, Tuple<Types...>>::tuple_get(t);
-}
-
-template <size_t I, typename... Types>
-_FORCE_INLINE_ const auto &tuple_get(const Tuple<Types...> &t) {
-	return TupleGet<I, Tuple<Types...>>::tuple_get(t);
-}

--- a/tests/core/templates/test_iterable.h
+++ b/tests/core/templates/test_iterable.h
@@ -1,0 +1,66 @@
+/**************************************************************************/
+/*  test_iterable.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/templates/iterable.h"
+
+#include "tests/test_macros.h"
+
+namespace TestZip {
+TEST_CASE("[zip] Basic tests") {
+	constexpr uint16_t a[5] = { 1, 2, 3, 4, 5 };
+	constexpr uint32_t b[5] = { 2, 3, 4, 5, 6 };
+
+	size_t i = 0;
+	for (auto [ai, bi] : zip_shortest<uint16_t, uint32_t>(a, b)) {
+		CHECK_EQ(ai, i + 1);
+		CHECK_EQ(bi, i + 2);
+		i++;
+	}
+	CHECK_EQ(i, 5);
+}
+} //namespace TestZip
+
+namespace TestEnumerate {
+
+TEST_CASE("[zip] Enumerate tests") {
+	constexpr uint32_t a[5] = { 1, 2, 3, 4, 5 };
+
+	size_t i = 0;
+	for (auto [idx, ai] : enumerate<size_t, uint32_t>(a)) {
+		CHECK_EQ(idx, i);
+		CHECK_EQ(ai, i + 1);
+		i++;
+	}
+	CHECK_EQ(i, 5);
+}
+
+} //namespace TestEnumerate

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -101,6 +101,7 @@
 #include "tests/core/templates/test_fixed_vector.h"
 #include "tests/core/templates/test_hash_map.h"
 #include "tests/core/templates/test_hash_set.h"
+#include "tests/core/templates/test_iterable.h"
 #include "tests/core/templates/test_list.h"
 #include "tests/core/templates/test_local_vector.h"
 #include "tests/core/templates/test_lru.h"


### PR DESCRIPTION
- Alternative to https://github.com/godotengine/godot/pull/111492

Adds `zip_shortest` and `enumerate` iteration helpers.
If they're needed, I'll take this PR out of draft.

Note that I'm not 100% sure we actually want this, due to its trade-offs.

## How to use

```c++
constexpr float a[5] = { 1, 2, 3, 4, 5 };
constexpr int b[5] = { 2, 3, 4, 5, 6 };

for (auto [ai, bi] : zip_shortest<float, int>(a, b)) {
    print_line("a[i]: ", ai, ", b[i]: ", bi);
}
```

```c++
constexpr float a[5] = { 1, 2, 3, 4, 5 };

for (auto [idx, ai] : enumerate<size_t, float>(a)) {
    print_line("a[", idx, "]: ", ai);
}
```

## Trade-off

There are some downsides to the implementation:
- It's fairly complicated "C++ magic". This can be hard to understand and may impact compile time.
- C++ [structured binding](https://en.cppreference.com/w/cpp/language/structured_binding.html) does not support explicit types. It uses `auto`.

That being said, there are upsides:
- Both `enumerate` and `zip` work very similarly as in other languages (e.g. python, Rust), and should be instantly familiar.
- Use of these helpers encourages using iterators, which is often more efficient than index based iteration.

## Notes

Part of the implementation adds `std::get` support to our `Tuple`. This would also allow code like this:

```c++
Tuple<int, bool, float> tuple;

// Direct access
int a = tuple.get<0>();
int b = tuple.get<1>();
float b = tuple.get<2>();

// std-like access
int a = std::get<0>(tuple);
int b = std::get<1>(tuple);
float b = std::get<2>(tuple);

// Destructure
auto [a, b, c] = tuple;
```

We may wish to merge this separately, although there is no explicit reason to do it (and destructuring uses `auto` anyway).
