### PR TITLE
MSVC: Check `catalog_productSemanticVersion` instead of `catalog_productDisplayVersion`

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -729,11 +729,14 @@ def get_compiler_version(env):
             version = subprocess.check_output(args, encoding="utf-8").strip()
             for line in version.splitlines():
                 split = line.split(":", 1)
-                if split[0] == "catalog_productDisplayVersion":
-                    sem_ver = split[1].split(".")
-                    ret["major"] = int(sem_ver[0])
-                    ret["minor"] = int(sem_ver[1])
-                    ret["patch"] = int(sem_ver[2].split()[0])
+                if split[0] == "catalog_productSemanticVersion":
+                    match = re.match(r" ([0-9]*).([0-9]*).([0-9]*)-?([a-z0-9.+]*)", split[1])
+                    if match is not None:
+                        ret["major"] = int(match.group(1))
+                        ret["minor"] = int(match.group(2))
+                        ret["patch"] = int(match.group(3))
+                        # Semantic suffix (i.e. insiders+11116.177)
+                        ret["metadata2"] = match.group(4)
                 # Could potentially add section for determining preview version, but
                 # that can wait until metadata is actually used for something.
                 if split[0] == "catalog_buildVersion":


### PR DESCRIPTION
Currently, when you have an Insiders (pre-release) version of Visual Studio 2026 installed, you will get the following error when trying to build Godot (or at least, I did when I tried that):
```
ValueError: invalid literal for int() with base 10: ' Insiders [11116':
1>    File "C:\Users\user\Git\godot\SConstruct", line 668:
1>      cc_version = methods.get_compiler_version(env)
1>    File "C:\Users\user\Git\godot\methods.py", line 734:
1>      ret["major"] = int(sem_ver[0])
```

This is because the build script currently checks the `catalog_productDisplayVersion` property of the newest version of Visual Studio currently installed, including pre-release versions. While for most stable releases this property actually is set as the semantic version, for the Insiders versions this version is set as `Insiders [xxx.yyy]`.
Running `vswhere.exe -latest -prerelease -products * -requires Microsoft.Component.MSBuild -utf8` gives some version strings which could work better as semantic versions, especially `catalog_productSemanticVersion`  since it actually follows the `x.y.z[-suffix]` format:
```
installationName: VisualStudioPreview/18.0.0-insiders+11116.177
installationPath: C:\Program Files\Microsoft Visual Studio\18\Insiders
installationVersion: 18.0.11116.177
productPath: C:\Program Files\Microsoft Visual Studio\18\Insiders\Common7\IDE\devenv.exe
isComplete: 1
isLaunchable: 1
isPrerelease: 1
isRebootRequired: 0
displayName: Visual Studio Community 2026
description: Everything you need to build modern apps – free for you, built for impact.
channelId: VisualStudio.18.Preview
channelUri: https://aka.ms/vs/18/insiders/channel
installedChannelId: VisualStudio.18.Preview
catalog_buildBranch: d18.0
catalog_buildVersion: 18.0.11116.177
catalog_expirationDate: 12/05/2025 17:00:00 +00:00
catalog_id: VisualStudioPreview/18.0.0-insiders+11116.177
catalog_includeBuildVersionInDisplayVersion: True
catalog_localBuild: build-lab
catalog_manifestName: VisualStudioPreview
catalog_manifestType: installer
catalog_productDisplayVersion: Insiders [11116.177]                        <--- Not a semantic version right now
catalog_productLine: Dev18
catalog_productLineVersion: 18
catalog_productMilestone: Insiders
catalog_productMilestoneIsPreRelease: True
catalog_productName: Visual Studio
catalog_productPatchVersion: 0
catalog_productRelease: RTW
catalog_productSemanticVersion: 18.0.0-insiders+11116.177                  <--- Semantic version with suffix
catalog_requiredEngineVersion: 4.0.2153.56108
properties_channelManifestId: VisualStudio.18.Preview/18.0.0-insiders+11116.177
properties_includeRecommended: 0
[some mostly irrelevant and empty lines removed]
```