### PR TITLE
[DRAFT] GDExtension: Allow extensions to give information about their source code

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -720,6 +720,15 @@ void GDExtension::_register_main_loop_callbacks(GDExtensionClassLibraryPtr p_lib
 	self->frame_callback = p_callbacks->frame_func;
 }
 
+void GDExtension::_register_source_code_info(GDExtensionClassLibraryPtr p_library, const GDExtensionEditorSourceCodeInfo *p_info) {
+#ifdef TOOLS_ENABLED
+	GDExtension *self = reinterpret_cast<GDExtension *>(p_library);
+	self->extension_binding_name = *reinterpret_cast<const String *>(p_info->binding_name);
+	self->source_code_base_path = *reinterpret_cast<const String *>(p_info->source_base_path);
+	self->get_class_source_path_callback = p_info->get_class_source_path_func;
+#endif
+}
+
 void GDExtension::register_interface_function(const StringName &p_function_name, GDExtensionInterfaceFunctionPtr p_function_pointer) {
 	ERR_FAIL_COND_MSG(gdextension_interface_functions.has(p_function_name), vformat("Attempt to register interface function '%s', which appears to be already registered.", p_function_name));
 	gdextension_interface_functions.insert(p_function_name, p_function_pointer);
@@ -768,6 +777,33 @@ bool GDExtension::is_library_open() const {
 	return loader.is_valid() && loader->is_library_open();
 }
 
+String GDExtension::get_extension_binding_name() const {
+#ifdef TOOLS_ENABLED
+	return extension_binding_name;
+#else
+	return String();
+#endif
+}
+
+String GDExtension::get_source_base_path() const {
+#ifdef TOOLS_ENABLED
+	return source_code_base_path;
+#else
+	return String();
+#endif
+}
+
+String GDExtension::get_class_source_path(const StringName &p_class_name) const {
+#ifdef TOOLS_ENABLED
+	if (get_class_source_path_callback) {
+		String source_path;
+		get_class_source_path_callback(reinterpret_cast<GDExtensionConstStringNamePtr>(&p_class_name), reinterpret_cast<GDExtensionStringPtr *>(&source_path));
+		return source_path;
+	}
+#endif
+	return String();
+}
+
 GDExtension::InitializationLevel GDExtension::get_minimum_library_initialization_level() const {
 	ERR_FAIL_COND_V(!is_library_open(), INITIALIZATION_LEVEL_CORE);
 	return InitializationLevel(initialization.minimum_initialization_level);
@@ -797,6 +833,10 @@ void GDExtension::deinitialize_library(InitializationLevel p_level) {
 void GDExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_library_open"), &GDExtension::is_library_open);
 	ClassDB::bind_method(D_METHOD("get_minimum_library_initialization_level"), &GDExtension::get_minimum_library_initialization_level);
+
+	ClassDB::bind_method(D_METHOD("get_extension_binding_name"), &GDExtension::get_extension_binding_name);
+	ClassDB::bind_method(D_METHOD("get_source_base_path"), &GDExtension::get_source_base_path);
+	ClassDB::bind_method(D_METHOD("get_class_source_path", "class_name"), &GDExtension::get_class_source_path);
 
 	BIND_ENUM_CONSTANT(INITIALIZATION_LEVEL_CORE);
 	BIND_ENUM_CONSTANT(INITIALIZATION_LEVEL_SERVERS);
@@ -838,6 +878,7 @@ void GDExtension::initialize_gdextensions() {
 	register_interface_function("get_library_path", (GDExtensionInterfaceFunctionPtr)&GDExtension::_get_library_path);
 	register_interface_function("editor_register_get_classes_used_callback", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_get_classes_used_callback);
 	register_interface_function("register_main_loop_callbacks", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_main_loop_callbacks);
+	register_interface_function("editor_register_source_code_info", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_source_code_info);
 }
 
 void GDExtension::finalize_gdextensions() {

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -95,6 +95,7 @@ class GDExtension : public Resource {
 	static void _get_library_path(GDExtensionClassLibraryPtr p_library, GDExtensionStringPtr r_path);
 	static void _register_get_classes_used_callback(GDExtensionClassLibraryPtr p_library, GDExtensionEditorGetClassesUsedCallback p_callback);
 	static void _register_main_loop_callbacks(GDExtensionClassLibraryPtr p_library, const GDExtensionMainLoopCallbacks *p_callbacks);
+	static void _register_source_code_info(GDExtensionClassLibraryPtr p_library, const GDExtensionEditorSourceCodeInfo *p_info);
 
 	GDExtensionInitialization initialization;
 	int32_t level_initialized = -1;
@@ -114,6 +115,10 @@ class GDExtension : public Resource {
 	void prepare_reload();
 	void finish_reload();
 	void clear_instance_bindings();
+
+	String extension_binding_name;
+	String source_code_base_path;
+	GDExtensionEditorGetClassSourcePathCallback get_class_source_path_callback = nullptr;
 #endif
 
 	GDExtensionMainLoopStartupCallback startup_callback = nullptr;
@@ -137,6 +142,10 @@ public:
 	Error open_library(const String &p_path, const Ref<GDExtensionLoader> &p_loader);
 	void close_library();
 	bool is_library_open() const;
+
+	String get_extension_binding_name() const;
+	String get_source_base_path() const;
+	String get_class_source_path(const StringName &p_class_name) const;
 
 	enum InitializationLevel {
 		INITIALIZATION_LEVEL_CORE = GDEXTENSION_INITIALIZATION_CORE,

--- a/core/extension/gdextension_interface.json
+++ b/core/extension/gdextension_interface.json
@@ -3488,6 +3488,41 @@
                     ]
                 }
             ]
+        },
+        {
+            "name": "GDExtensionEditorGetClassSourcePathCallback",
+            "kind": "function",
+            "arguments": [
+                {
+                    "name": "p_class_name",
+                    "type": "GDExtensionConstStringNamePtr"
+                },
+                {
+                    "name": "r_source_path",
+                    "type": "GDExtensionStringPtr*"
+                }
+            ],
+            "description": [
+                "Called to get the source code path for the given class."
+            ]
+        },
+        {
+            "name": "GDExtensionEditorSourceCodeInfo",
+            "kind": "struct",
+            "members": [
+                {
+                    "name": "binding_name",
+                    "type": "GDExtensionConstStringPtr"
+                },
+                {
+                    "name": "source_base_path",
+                    "type": "GDExtensionConstStringPtr"
+                },
+                {
+                    "name": "get_class_source_path_func",
+                    "type": "GDExtensionEditorGetClassSourcePathCallback"
+                }
+            ]
         }
     ],
     "interface": [
@@ -9060,6 +9095,29 @@
                 "Registers callbacks to be called at different phases of the main loop."
             ],
             "since": "4.5"
+        },
+        {
+            "name": "editor_register_source_code_info",
+            "arguments": [
+                {
+                    "name": "p_library",
+                    "type": "GDExtensionClassLibraryPtr",
+                    "description": [
+                        "A pointer the library received by the GDExtension's entry point function."
+                    ]
+                },
+                {
+                    "name": "p_info",
+                    "type": "const GDExtensionEditorSourceCodeInfo*",
+                    "description": [
+                        "A pointer to the structure that contains the info."
+                    ]
+                }
+            ],
+            "description": [
+                "Registers information about the extensions source code for use in the editor."
+            ],
+            "since": "4.7"
         }
     ]
 }

--- a/doc/classes/GDExtension.xml
+++ b/doc/classes/GDExtension.xml
@@ -12,10 +12,32 @@
 		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/cpp/gdextension_cpp_example.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_class_source_path" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="class_name" type="StringName" />
+			<description>
+				Gets the path to the source code for a given class.
+				[b]Note:[/b] Only works in editor builds, and requires that the extension provides this information.
+			</description>
+		</method>
+		<method name="get_extension_binding_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Gets the name of the GDExtension binding used by this extension.
+				[b]Note:[/b] Only works in editor builds, and requires that the extension provides this information.
+			</description>
+		</method>
 		<method name="get_minimum_library_initialization_level" qualifiers="const">
 			<return type="int" enum="GDExtension.InitializationLevel" />
 			<description>
 				Returns the lowest level required for this extension to be properly initialized (see the [enum InitializationLevel] enum).
+			</description>
+		</method>
+		<method name="get_source_base_path" qualifiers="const">
+			<return type="String" />
+			<description>
+				Gets the base path for this extension's source code.
+				[b]Note:[/b] Only works in editor builds, and requires that the extension provides this information.
 			</description>
 		</method>
 		<method name="is_library_open" qualifiers="const">


### PR DESCRIPTION
This is just a quick, untested sketch of how GDExtensions could provide information about their source code, which could be used when implementing an `EditorExtensionSourceCodePlugin` as added in PR https://github.com/godotengine/godot/pull/110171

My thinking is that if you build your GDExtension in a particular way (for example, making a dev build via `scons dev_build=yes` in godot-cpp), then the language binding will register this extra information about the extension's source code with the editor

This way the editor can distinguish between GDExtensions with available source code that the developer is editing as part of their game project, and just third-party GDExtensions that they downloaded. And then find the necessary source code to allow creating and editing classes from the Godot editor
