### PR TITLE
Show the arrow cursor on disabled `LinkButton`s

### DIFF
--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -151,6 +151,10 @@ Size2 LinkButton::get_minimum_size() const {
 	return text_buf->get_size();
 }
 
+Control::CursorShape LinkButton::get_cursor_shape(const Point2 &p_pos) const {
+	return is_disabled() ? CURSOR_ARROW : get_default_cursor_shape();
+}
+
 void LinkButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -105,6 +105,8 @@ public:
 
 	Ref<Font> get_button_font() const;
 
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+
 	LinkButton(const String &p_text = String());
 };
 


### PR DESCRIPTION
This improves feedback for links that can't be clicked. _Technically_ a breaking change, but a very minor one.