### PR TITLE
[3.x] Fix gcc warning packed scene

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -105,6 +105,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 	const NodeData *nd = &nodes[0];
 
 	Node **ret_nodes = (Node **)alloca(sizeof(Node *) * nc);
+	ret_nodes[0] = nullptr; // Sidesteps "maybe uninitialized" false-positives on GCC.
 
 	bool gen_node_path_cache = p_edit_state != GEN_EDIT_STATE_DISABLED && node_path_cache.empty();
 


### PR DESCRIPTION
Backport of #111771

## Notes
* We don't have clipper2 in 3.x, so only require this part.
* This doesn't fail CI in 3.x, but might be useful for newer versions of GCC.
* I'm not completely convinced this is worth changing, but included as an option.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
