### PR TITLE
Improve validation for adding transition in StateMachine

### DIFF
--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -1010,8 +1010,20 @@ void AnimationNodeStateMachineEditor::_connect_to(int p_index) {
 
 void AnimationNodeStateMachineEditor::_add_transition(const bool p_nested_action) {
 	if (connecting_from != StringName() && connecting_to_node != StringName()) {
+		if (connecting_to_node == SceneStringName(Start)) {
+			EditorNode::get_singleton()->show_warning(TTR("Cannot transition to \"Start\"!"));
+			connecting = false;
+			return;
+		}
+
+		if (connecting_from == SceneStringName(End)) {
+			EditorNode::get_singleton()->show_warning(TTR("Cannot transition from \"End\"!"));
+			connecting = false;
+			return;
+		}
+
 		if (state_machine->has_transition(connecting_from, connecting_to_node)) {
-			EditorNode::get_singleton()->show_warning("Transition exists!");
+			EditorNode::get_singleton()->show_warning(TTR("Transition already exists!"));
 			connecting = false;
 			return;
 		}
@@ -1039,11 +1051,13 @@ void AnimationNodeStateMachineEditor::_add_transition(const bool p_nested_action
 
 		_select_transition(connecting_from, connecting_to_node);
 
-		if (!state_machine->is_transition_across_group(selected_transition_index)) {
-			EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
-		} else {
-			EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
-			EditorNode::get_singleton()->push_item(nullptr, "", true);
+		if (selected_transition_index >= 0) {
+			if (!state_machine->is_transition_across_group(selected_transition_index)) {
+				EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
+			} else {
+				EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
+				EditorNode::get_singleton()->push_item(nullptr, "", true);
+			}
 		}
 		_update_mode();
 	}


### PR DESCRIPTION
Fixes a couple of errors in StateMachine, that cropped up after #109534:
1. If a new node was created in a fresh StateMachine by shift-dragging out of Start, the editor would print error `INTERNAL ERROR: Index p_transition = -1 is out of bounds (transitions.size() = 0).`
2. When creating a transition by shift-dragging directly out of End or into Start, there was no prevention like what was added for reconnections, so in addition to the error above, we'd also get `INTERNAL ERROR: Condition "p_from == SceneStringNames::get_singleton()->End || p_to == SceneStringNames::get_singleton()->Start" is true.` Popups "Cannot transition from "End"! and "Cannot transition to "Start"! have been added here too, to gracefully stop the creation of invalid transitions.
- Additionally, changes popup "Transition exists!" to "Transition already exists!" to make it a bit clearer, and wraps it in a TTR like the rest.