### PR TITLE
CI: Add hook to validate includes, label invalid cases

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,7 +90,11 @@ BreakConstructorInitializers: AfterColon
 # BreakInheritanceList: BeforeColon
 # BreakStringLiterals: true
 ColumnLimit: 0
-# CommentPragmas: "^ IWYU pragma:"
+CommentPragmas: |
+  (?x)^(
+    IWYU pragma:
+    validator:
+  )
 # CompactNamespaces: false
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,12 @@ repos:
         pass_filenames: false
         files: ^(gles3|glsl)_builders\.py$
 
+      - id: validate-includes
+        name: validate-includes
+        language: python
+        entry: python misc/scripts/validate_includes.py
+        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc)$
+
       - id: eslint
         name: eslint
         language: node

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -36,7 +36,7 @@
 #include "core/license.gen.h"
 #include "core/variant/typed_array.h"
 #include "core/version.h"
-#include "servers/rendering/rendering_device.h"
+#include "servers/rendering/rendering_device.h" // validator: ignore // FIXME: Legacy include.
 
 void Engine::_update_time_scale() {
 	_time_scale = _user_time_scale * _game_time_scale;

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -43,10 +43,10 @@
 #include "core/variant/typed_array.h"
 #include "core/variant/variant_parser.h"
 #include "core/version.h"
-#include "servers/rendering/rendering_server.h"
+#include "servers/rendering/rendering_server.h" // validator: ignore // FIXME: Legacy include.
 
 #ifdef TOOLS_ENABLED
-#include "modules/modules_enabled.gen.h" // For mono.
+#include "modules/modules_enabled.gen.h" // For mono. // validator: ignore // FIXME: Legacy include.
 #endif // TOOLS_ENABLED
 
 ProjectSettings *ProjectSettings::get_singleton() {

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -40,7 +40,7 @@
 #include "core/math/expression.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
-#include "servers/display/display_server.h"
+#include "servers/display/display_server.h" // validator: ignore // FIXME: Legacy include.
 
 class RemoteDebugger::PerformanceProfiler : public EngineProfiler {
 	Object *performance = nullptr;

--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -39,7 +39,7 @@
 // Optional physics interpolation warnings try to include the path to the relevant node.
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
 #include "core/config/project_settings.h"
-#include "scene/main/node.h"
+#include "scene/main/node.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 static ErrorHandlerList *error_handler_list = nullptr;

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -39,7 +39,7 @@
 #include "core/version.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/doc/editor_help.h"
+#include "editor/doc/editor_help.h" // validator: ignore // FIXME: Legacy include.
 
 static String get_builtin_or_variant_type_name(const Variant::Type p_type) {
 	if (p_type == Variant::NIL) {

--- a/core/extension/godot_instance.cpp
+++ b/core/extension/godot_instance.cpp
@@ -32,8 +32,8 @@
 
 #include "core/extension/gdextension_manager.h"
 #include "core/os/main_loop.h"
-#include "main/main.h"
-#include "servers/display/display_server.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
+#include "servers/display/display_server.h" // validator: ignore // FIXME: Legacy include.
 
 void GodotInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("start"), &GodotInstance::start);

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -37,10 +37,10 @@
 #include "core/os/time.h"
 #include "core/templates/rb_set.h"
 
-#include "modules/modules_enabled.gen.h" // For regex.
+#include "modules/modules_enabled.gen.h" // For regex. // validator: ignore // FIXME: Legacy include.
 
 #ifdef MODULE_REGEX_ENABLED
-#include "modules/regex/regex.h"
+#include "modules/regex/regex.h" // validator: ignore // FIXME: Legacy include.
 #endif // MODULE_REGEX_ENABLED
 
 #if defined(MINGW_ENABLED) || defined(_MSC_VER)

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -35,7 +35,7 @@
 #include "core/math/random_pcg.h"
 #include "core/os/os.h"
 #include "core/variant/container_type_validate.h"
-#include "scene/main/node.h" //only so casting works
+#include "scene/main/node.h" //only so casting works // validator: ignore // FIXME: Legacy include.
 
 void Resource::emit_changed() {
 	if (emit_changed_state != EMIT_CHANGED_UNBLOCKED) {

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -36,8 +36,8 @@
 #include "core/io/missing_resource.h"
 #include "core/object/script_language.h"
 #include "core/version.h"
-#include "scene/property_utils.h"
-#include "scene/resources/packed_scene.h"
+#include "scene/property_utils.h" // validator: ignore // FIXME: Legacy include.
+#include "scene/resources/packed_scene.h" // validator: ignore // FIXME: Legacy include.
 
 //#define print_bl(m_what) print_line(m_what)
 #define print_bl(m_what) (void)(m_what)

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -43,7 +43,7 @@
 #include "core/string/translation_server.h"
 #include "core/templates/rb_set.h"
 #include "core/variant/variant_parser.h"
-#include "servers/rendering/rendering_server.h"
+#include "servers/rendering/rendering_server.h" // validator: ignore // FIXME: Legacy include.
 
 #ifdef DEBUG_LOAD_THREADED
 #define print_lt(m_text) print_line(m_text)

--- a/drivers/apple/joypad_apple.mm
+++ b/drivers/apple/joypad_apple.mm
@@ -34,7 +34,7 @@
 #import <os/log.h>
 
 #include "core/config/project_settings.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 
 class API_AVAILABLE(macos(11), ios(14.0), tvos(14.0)) RumbleMotor {
 	CHHapticEngine *engine;

--- a/drivers/apple_embedded/app_delegate_service.mm
+++ b/drivers/apple_embedded/app_delegate_service.mm
@@ -37,7 +37,7 @@
 #include "core/config/project_settings.h"
 #include "core/os/main_loop.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 
 #import <AVFoundation/AVFoundation.h>
 #import <AudioToolbox/AudioServices.h>

--- a/drivers/apple_embedded/godot_view_renderer.mm
+++ b/drivers/apple_embedded/godot_view_renderer.mm
@@ -35,7 +35,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/keyboard.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/audio/audio_server.h"
 
 #import <AudioToolbox/AudioServices.h>

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -42,7 +42,7 @@
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
 #import "drivers/apple/os_log_logger.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 
 #import <AVFoundation/AVFAudio.h>
 #import <AudioToolbox/AudioServices.h>

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -37,9 +37,9 @@
 #include "thirdparty/misc/smolv.h"
 
 #if defined(ANDROID_ENABLED)
-#include "platform/android/java_godot_wrapper.h"
-#include "platform/android/os_android.h"
-#include "platform/android/thread_jandroid.h"
+#include "platform/android/java_godot_wrapper.h" // validator: ignore // FIXME: Legacy include.
+#include "platform/android/os_android.h" // validator: ignore // FIXME: Legacy include.
+#include "platform/android/thread_jandroid.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 #if defined(SWAPPY_FRAME_PACING_ENABLED)

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -35,7 +35,7 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
-#include "main/performance.h"
+#include "main/performance.h" // validator: ignore // FIXME: Legacy include.
 
 EditorPerformanceProfiler::Monitor::Monitor(const String &p_name, const String &p_base, int p_frame_index, Performance::MonitorType p_type, TreeItem *p_item) {
 	type = p_type;

--- a/editor/debugger/editor_performance_profiler.h
+++ b/editor/debugger/editor_performance_profiler.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/templates/hash_map.h"
-#include "main/performance.h"
+#include "main/performance.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/split_container.h"

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -52,7 +52,7 @@
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "main/performance.h"
+#include "main/performance.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/3d/camera_3d.h"
 #include "scene/debugger/scene_debugger.h"
 #include "scene/gui/button.h"

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -45,7 +45,7 @@
 #include "scene/theme/theme_db.h"
 
 // Used for a hack preserving Mono properties on non-Mono builds.
-#include "modules/modules_enabled.gen.h" // For mono.
+#include "modules/modules_enabled.gen.h" // For mono. // validator: ignore // FIXME: Legacy include.
 
 static String _get_indent(const String &p_text) {
 	String indent;

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -53,17 +53,17 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/line_edit.h"
 
-#include "modules/modules_enabled.gen.h" // For gdscript, mono.
+#include "modules/modules_enabled.gen.h" // For gdscript, mono. // validator: ignore // FIXME: Legacy include.
 
 // For syntax highlighting.
 #ifdef MODULE_GDSCRIPT_ENABLED
-#include "modules/gdscript/editor/gdscript_highlighter.h"
-#include "modules/gdscript/gdscript.h"
+#include "modules/gdscript/editor/gdscript_highlighter.h" // validator: ignore // FIXME: Legacy include.
+#include "modules/gdscript/gdscript.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 // For syntax highlighting.
 #ifdef MODULE_MONO_ENABLED
-#include "modules/mono/csharp_script.h"
+#include "modules/mono/csharp_script.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 #define CONTRIBUTE_URL "https://contributing.godotengine.org/en/latest/documentation/class_reference.html"

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -53,7 +53,7 @@
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/box_container.h"

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -40,7 +40,7 @@
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "modules/regex/regex.h"
+#include "modules/regex/regex.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/gui/separator.h"
 #include "scene/main/timer.h"
 #include "scene/resources/font.h"

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -47,7 +47,7 @@
 #include "core/version.h"
 #include "editor/editor_string_names.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/2d/node_2d.h"
 #include "scene/3d/bone_attachment_3d.h"
 #include "scene/animation/animation_tree.h"
@@ -182,7 +182,7 @@
 #include "editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.h"
 #endif
 
-#include "modules/modules_enabled.gen.h" // For gdscript, mono.
+#include "modules/modules_enabled.gen.h" // For gdscript, mono. // validator: ignore // FIXME: Legacy include.
 
 #ifndef PHYSICS_2D_DISABLED
 #include "servers/physics_2d/physics_server_2d.h"

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -37,7 +37,7 @@
 #include "lipo.h"
 #include "macho.h"
 
-#include "modules/regex/regex.h"
+#include "modules/regex/regex.h" // validator: ignore // FIXME: Legacy include.
 
 #include <ctime>
 

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -42,10 +42,10 @@
 #include "editor/import/resource_importer_texture_settings.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 
-#include "modules/modules_enabled.gen.h" // For mono.
-#include "modules/svg/image_loader_svg.h"
+#include "modules/modules_enabled.gen.h" // For mono. // validator: ignore // FIXME: Legacy include.
+#include "modules/svg/image_loader_svg.h" // validator: ignore // FIXME: Legacy include.
 
 void EditorExportPlatformAppleEmbedded::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	// Vulkan and OpenGL ES 3.0 both mandate ETC2 support.

--- a/editor/export/editor_export_platform_apple_embedded.h
+++ b/editor/export/editor_export_platform_apple_embedded.h
@@ -42,7 +42,7 @@
 #include "core/templates/safe_refcount.h"
 #include "editor/export/editor_export_platform.h"
 #include "editor/settings/editor_settings.h"
-#include "main/splash.gen.h"
+#include "main/splash.gen.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/resources/image_texture.h"
 
 #include <sys/stat.h>

--- a/editor/file_system/editor_paths.cpp
+++ b/editor/file_system/editor_paths.cpp
@@ -35,7 +35,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/os/os.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 
 EditorPaths *EditorPaths::singleton = nullptr;
 

--- a/editor/gui/progress_dialog.cpp
+++ b/editor/gui/progress_dialog.cpp
@@ -34,7 +34,7 @@
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/themes/editor_scale.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/gui/panel_container.h"
 #include "scene/main/window.h"
 #include "servers/display/display_server.h"

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -51,7 +51,7 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/gui/check_box.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/line_edit.h"

--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -40,7 +40,7 @@
 #include "core/templates/list.h"
 #include "editor/project_upgrade/renames_map_3_to_4.h"
 
-#include "modules/regex/regex.h"
+#include "modules/regex/regex.h" // validator: ignore // FIXME: Legacy include.
 
 // Find "OS.set_property(x)", capturing x into $1.
 static String make_regex_gds_os_property_set(const String &name_set) {

--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -36,7 +36,7 @@
 #include "editor/editor_node.h"
 #include "editor/run/run_instances_dialog.h"
 #include "editor/settings/editor_settings.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/display/display_server.h"
 
 EditorRun::Status EditorRun::get_status() const {

--- a/editor/scene/3d/bone_map_editor_plugin.cpp
+++ b/editor/scene/3d/bone_map_editor_plugin.cpp
@@ -41,7 +41,7 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/texture_rect.h"
 
-#include "modules/regex/regex.h"
+#include "modules/regex/regex.h" // validator: ignore // FIXME: Legacy include.
 
 void BoneMapperButton::fetch_textures() {
 	if (selected) {

--- a/editor/scene/3d/lightmap_gi_editor_plugin.cpp
+++ b/editor/scene/3d/lightmap_gi_editor_plugin.cpp
@@ -34,7 +34,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
 
-#include "modules/modules_enabled.gen.h" // For lightmapper_rd.
+#include "modules/modules_enabled.gen.h" // For lightmapper_rd. // validator: ignore // FIXME: Legacy include.
 
 void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 	if (lightmap) {

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -37,7 +37,7 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/navigation/navigation_region_3d.h"
 #include "scene/3d/physics/static_body_3d.h"

--- a/editor/scene/rename_dialog.cpp
+++ b/editor/scene/rename_dialog.cpp
@@ -44,7 +44,7 @@
 #include "scene/gui/spin_box.h"
 #include "scene/gui/tab_container.h"
 
-#include "modules/regex/regex.h"
+#include "modules/regex/regex.h" // validator: ignore // FIXME: Legacy include.
 
 RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor) {
 	scene_tree_editor = p_scene_tree_editor;

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -42,7 +42,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/separator.h"
 
-#include "modules/modules_enabled.gen.h" // For mono.
+#include "modules/modules_enabled.gen.h" // For mono. // validator: ignore // FIXME: Legacy include.
 
 const char *EditorBuildProfile::build_option_identifiers[BUILD_OPTION_MAX] = {
 	// This maps to SCons build options.

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -50,8 +50,8 @@
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/project_manager/engine_update_label.h"
 #include "editor/translations/editor_translation.h"
-#include "main/main.h"
-#include "modules/regex/regex.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
+#include "modules/regex/regex.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/gui/color_picker.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_d3d12.cpp
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_d3d12.cpp
@@ -30,7 +30,7 @@
 
 #include "shader_baker_export_plugin_platform_d3d12.h"
 
-#include "drivers/d3d12/rendering_shader_container_d3d12.h"
+#include "drivers/d3d12/rendering_shader_container_d3d12.h" // validator: ignore // FIXME: Legacy include.
 
 #include <windows.h>
 

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.cpp
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.cpp
@@ -30,7 +30,7 @@
 
 #include "shader_baker_export_plugin_platform_metal.h"
 
-#include "drivers/metal/rendering_shader_container_metal.h"
+#include "drivers/metal/rendering_shader_container_metal.h" // validator: ignore // FIXME: Legacy include.
 
 RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformMetal::create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) {
 	const String &os_name = p_platform->get_os_name();

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_vulkan.cpp
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_vulkan.cpp
@@ -30,7 +30,7 @@
 
 #include "shader_baker_export_plugin_platform_vulkan.h"
 
-#include "drivers/vulkan/rendering_shader_container_vulkan.h"
+#include "drivers/vulkan/rendering_shader_container_vulkan.h" // validator: ignore // FIXME: Legacy include.
 
 RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformVulkan::create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) {
 	return memnew(RenderingShaderContainerFormatVulkan);

--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -37,7 +37,7 @@
 #include "scene/resources/dpi_texture.h"
 #include "scene/resources/image_texture.h"
 
-#include "modules/svg/image_loader_svg.h"
+#include "modules/svg/image_loader_svg.h" // validator: ignore // FIXME: Legacy include.
 
 void editor_configure_icons(bool p_dark_theme) {
 	if (p_dark_theme) {

--- a/misc/scripts/validate_includes.py
+++ b/misc/scripts/validate_includes.py
@@ -1,0 +1,140 @@
+if __name__ != "__main__":
+    raise ImportError(f"{__name__} should not be used as a module.")
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Assumed to run from repository root
+BASE_FOLDER = Path(__file__).resolve().parent.parent.parent
+RE_INCLUDES = re.compile(
+    r"^[^\S\n]*"  # Begin matching at newline, but allow non-newline whitespace beforehand.
+    r"#\s*(?P<keyword>include|import)\s*"  # Both `include` and `import` keywords valid.
+    r'(?P<sequence>[<"])'  # Handle both styles of char wrappers. Does NOT handle macro expansion.
+    r'(?P<path>.*)[>"]'  # Resolve path of include itself. Can safely assume the sequence matches.
+    r"(?:.*/[/\*] validator: "  # `validator: ` serves as our comment pragma declaration.
+    r"(?P<instructions>\S+)"  # Assume instructions will be one-word.
+    r")?",  # Pragmas are not required, can be safely excluded.
+    re.MULTILINE,
+)
+
+
+@dataclass
+class IncludeData:
+    path: str
+    instructions: str
+    is_angle: bool
+    is_import: bool
+
+    @staticmethod
+    def from_match(match: re.Match[str]):
+        items = match.groupdict()
+        return IncludeData(
+            items["path"],
+            items["instructions"] or "",
+            items["sequence"] == "<",
+            items["keyword"] == "import",
+        )
+
+
+def is_relative_to(base: Path, other: Path):
+    if sys.version_info > (3, 9):
+        return base.is_relative_to(other)
+    else:
+        try:
+            base.relative_to(other)
+        except ValueError:
+            return False
+        return True
+
+
+def get_encapsulation_level(path: Path):
+    # Necessitates earlier check.
+    if "tests" in path.parts:
+        return 8
+
+    resolved = path.resolve()
+    if not is_relative_to(resolved, BASE_FOLDER) or is_relative_to(resolved, BASE_FOLDER / "thirdparty"):
+        return 0
+    elif is_relative_to(resolved, BASE_FOLDER / "core"):
+        return 1
+    elif is_relative_to(resolved, BASE_FOLDER / "servers"):
+        return 2
+    elif is_relative_to(resolved, BASE_FOLDER / "scene"):
+        return 3
+    elif is_relative_to(resolved, BASE_FOLDER / "editor"):
+        return 4
+    elif is_relative_to(resolved, BASE_FOLDER / "drivers"):
+        return 5
+    elif is_relative_to(resolved, BASE_FOLDER / "platform") and resolved.parent == BASE_FOLDER / "platform":
+        return 6
+    elif is_relative_to(resolved, BASE_FOLDER / "modules"):
+        return 7
+    elif is_relative_to(resolved, BASE_FOLDER / "tests"):
+        return 8
+    elif is_relative_to(resolved, BASE_FOLDER / "main"):
+        return 9
+    else:
+        return 10
+
+
+def parse_file(path: Path) -> int:
+    ret = 0
+    level = get_encapsulation_level(path)
+
+    if level == 0:
+        return ret
+
+    with open(path) as file:
+        matches = RE_INCLUDES.finditer(file.read())
+
+    for data in map(IncludeData.from_match, matches):
+        if "\\" in data.path:
+            print(f'"{path.as_posix()}" contains Windows-style path separators in include: "{data.path}"!')
+            ret += 1
+            continue
+
+        if data.is_angle:
+            # Angle-bracket resolution is much trickier; skip for now.
+            continue
+
+        include = path.parent / data.path
+        if include.exists():
+            # FIXME: Relative includes are currently outside the scope of this validator.
+            continue
+        else:
+            include = BASE_FOLDER / data.path
+            if not include.exists():
+                # Assume special case (eg: `platform.h`).
+                continue
+
+        if data.instructions != "ignore" and level < get_encapsulation_level(include):
+            print(f'"{path.as_posix()}" violates encapsulation, should not include "{data.path}"!')
+            ret += 1
+
+    return ret
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate `#include` encapsulation in the provided C/C++ files")
+    parser.add_argument("paths", nargs="*", help="Paths of files to validate")
+    args = parser.parse_args()
+
+    ret = 0
+
+    for path in args.paths:
+        ret += parse_file(Path(path))
+
+    return ret
+
+
+try:
+    raise SystemExit(main())
+except KeyboardInterrupt:
+    import os
+    import signal
+
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    os.kill(os.getpid(), signal.SIGINT)

--- a/misc/utility/clang_format_glsl.yml
+++ b/misc/utility/clang_format_glsl.yml
@@ -15,6 +15,11 @@ AttributeMacros:
   - _NO_INLINE_
 BreakConstructorInitializers: AfterColon
 ColumnLimit: 0
+CommentPragmas: |
+  (?x)^(
+    IWYU pragma:
+    validator:
+  )
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 Cpp11BracedListStyle: false

--- a/modules/camera/camera_android.cpp
+++ b/modules/camera/camera_android.cpp
@@ -31,9 +31,9 @@
 #include "camera_android.h"
 
 #include "core/os/os.h"
-#include "platform/android/display_server_android.h"
-#include "platform/android/java_godot_io_wrapper.h"
-#include "platform/android/os_android.h"
+#include "platform/android/display_server_android.h" // validator: ignore // FIXME: Legacy include.
+#include "platform/android/java_godot_io_wrapper.h" // validator: ignore // FIXME: Legacy include.
+#include "platform/android/os_android.h" // validator: ignore // FIXME: Legacy include.
 
 //////////////////////////////////////////////////////////////////////////
 // Helper functions

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -63,7 +63,7 @@
 #endif // TOOLS_ENABLED
 
 #ifdef TESTS_ENABLED
-#include "tests/test_macros.h"
+#include "tests/test_macros.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 GDScriptLanguage *script_language_gd = nullptr;

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -40,7 +40,7 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 #include "scene/gui/line_edit.h"
 
 #ifdef WINDOWS_ENABLED

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -43,7 +43,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/os/os.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 
 StringBuilder &operator<<(StringBuilder &r_sb, const String &p_string) {
 	r_sb.append(p_string);

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -49,7 +49,7 @@
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 
 #ifdef UNIX_ENABLED
 #include <unistd.h> // access

--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -36,7 +36,7 @@
 #endif
 
 #include "openxr_fb_update_swapchain_extension.h"
-#include "platform/android/api/java_class_wrapper.h"
+#include "platform/android/api/java_class_wrapper.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/rendering/rendering_server_globals.h"
 
 ////////////////////////////////////////////////////////////////////////////

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -90,7 +90,7 @@
 #endif
 
 #include "core/config/project_settings.h"
-#include "main/main.h"
+#include "main/main.h" // validator: ignore // FIXME: Legacy include.
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"

--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -38,7 +38,7 @@
 #include "scene/3d/xr/xr_nodes.h"
 #include "scene/main/viewport.h"
 
-#include "platform/android/api/java_class_wrapper.h"
+#include "platform/android/api/java_class_wrapper.h" // validator: ignore // FIXME: Legacy include.
 
 Vector<OpenXRCompositionLayer *> OpenXRCompositionLayer::composition_layer_nodes;
 

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -35,7 +35,7 @@
 #include "scene/resources/mesh.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/themes/editor_scale.h"
+#include "editor/themes/editor_scale.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 #ifdef DEBUG_ENABLED

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -33,9 +33,9 @@
 #include "core/math/transform_interpolator.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/editor_data.h"
-#include "editor/scene/canvas_item_editor_plugin.h"
-#include "editor/settings/editor_settings.h"
+#include "editor/editor_data.h" // validator: ignore // FIXME: Legacy include.
+#include "editor/scene/canvas_item_editor_plugin.h" // validator: ignore // FIXME: Legacy include.
+#include "editor/settings/editor_settings.h" // validator: ignore // FIXME: Legacy include.
 #endif //TOOLS_ENABLED
 
 bool Bone2D::_set(const StringName &p_path, const Variant &p_value) {

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -41,7 +41,7 @@
 #include "scene/resources/image_texture.h"
 #include "scene/resources/sky.h"
 
-#include "modules/modules_enabled.gen.h" // For lightmapper_rd.
+#include "modules/modules_enabled.gen.h" // For lightmapper_rd. // validator: ignore // FIXME: Legacy include.
 
 void LightmapGIData::add_user(const NodePath &p_path, const Rect2 &p_uv_scale, int p_slice_index, int32_t p_sub_instance) {
 	User user;

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -40,7 +40,7 @@
 #include "scene/resources/surface_tool.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/editor_node.h"
+#include "editor/editor_node.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 RID Occluder3D::get_rid() const {

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -49,7 +49,7 @@
 #endif // _3D_DISABLED
 
 #ifdef TOOLS_ENABLED
-#include "editor/editor_undo_redo_manager.h"
+#include "editor/editor_undo_redo_manager.h" // validator: ignore // FIXME: Legacy include.
 #endif // TOOLS_ENABLED
 
 bool AnimationMixer::_set(const StringName &p_name, const Variant &p_value) {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -45,7 +45,7 @@
 #include "servers/text/text_server.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/scene/gui/control_editor_plugin.h"
+#include "editor/scene/gui/control_editor_plugin.h" // validator: ignore // FIXME: Legacy include.
 #endif // TOOLS_ENABLED
 
 // Editor plugin interoperability.

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -44,7 +44,7 @@
 #include "servers/text/text_server.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/settings/editor_settings.h"
+#include "editor/settings/editor_settings.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 void LineEdit::edit(bool p_hide_focus) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -43,9 +43,9 @@
 #include "scene/theme/theme_db.h"
 #include "servers/display/display_server.h"
 
-#include "modules/modules_enabled.gen.h" // For regex.
+#include "modules/modules_enabled.gen.h" // For regex. // validator: ignore // FIXME: Legacy include.
 #ifdef MODULE_REGEX_ENABLED
-#include "modules/regex/regex.h"
+#include "modules/regex/regex.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 RichTextLabel::ItemCustomFX::ItemCustomFX() {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -38,7 +38,7 @@
 #include "scene/resources/text_paragraph.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/themes/editor_scale.h"
+#include "editor/themes/editor_scale.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 class CharFXTransform;

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -37,7 +37,7 @@
 #include "scene/resources/packed_scene.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/editor_node.h"
+#include "editor/editor_node.h" // validator: ignore // FIXME: Legacy include.
 #endif // TOOLS_ENABLED
 
 bool PropertyUtils::is_property_value_different(const Object *p_object, const Variant &p_a, const Variant &p_b) {

--- a/scene/resources/2d/skeleton/skeleton_modification_2d.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d.cpp
@@ -32,7 +32,7 @@
 #include "scene/2d/skeleton_2d.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/settings/editor_settings.h"
+#include "editor/settings/editor_settings.h" // validator: ignore // FIXME: Legacy include.
 #endif // TOOLS_ENABLED
 
 ///////////////////////////////////////

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
@@ -32,7 +32,7 @@
 #include "scene/2d/skeleton_2d.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/settings/editor_settings.h"
+#include "editor/settings/editor_settings.h" // validator: ignore // FIXME: Legacy include.
 #endif // TOOLS_ENABLED
 
 bool SkeletonModification2DTwoBoneIK::_set(const StringName &p_path, const Variant &p_value) {

--- a/scene/resources/dpi_texture.cpp
+++ b/scene/resources/dpi_texture.cpp
@@ -36,9 +36,9 @@
 #include "scene/resources/bit_map.h"
 #include "scene/resources/placeholder_textures.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
+#include "modules/modules_enabled.gen.h" // For svg. // validator: ignore // FIXME: Legacy include.
 #ifdef MODULE_SVG_ENABLED
-#include "modules/svg/image_loader_svg.h"
+#include "modules/svg/image_loader_svg.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 Mutex DPITexture::mutex;

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -39,11 +39,11 @@
 #include "texture.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/doc/editor_help.h"
+#include "editor/doc/editor_help.h" // validator: ignore // FIXME: Legacy include.
 
-#include "modules/modules_enabled.gen.h" // For regex.
+#include "modules/modules_enabled.gen.h" // For regex. // validator: ignore // FIXME: Legacy include.
 #ifdef MODULE_REGEX_ENABLED
-#include "modules/regex/regex.h"
+#include "modules/regex/regex.h" // validator: ignore // FIXME: Legacy include.
 #endif
 #endif
 

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -38,7 +38,7 @@
 #include "core/os/os.h"
 #include "core/string/string_name.h"
 #include "core/templates/pair.h"
-#include "scene/scene_string_names.h"
+#include "scene/scene_string_names.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/audio/audio_driver_dummy.h"
 #include "servers/audio/audio_stream.h"
 #include "servers/audio/effects/audio_effect_compressor.h"

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "scene/property_list_helper.h"
+#include "scene/property_list_helper.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/audio/audio_server.h"
 
 #include "core/object/gdvirtual.gen.inc"

--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/os/thread.h"
-#include "scene/resources/audio_stream_wav.h"
+#include "scene/resources/audio_stream_wav.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/audio/audio_effect.h"
 #include "servers/audio/audio_server.h"
 

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -32,18 +32,18 @@
 #include "display_server.compat.inc"
 
 #include "core/input/input.h"
-#include "scene/resources/texture.h"
+#include "scene/resources/texture.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/display/display_server_headless.h"
 
 #if defined(VULKAN_ENABLED)
-#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+#include "drivers/vulkan/rendering_context_driver_vulkan.h" // validator: ignore // FIXME: Legacy include.
 #undef CursorShape
 #endif
 #if defined(D3D12_ENABLED)
-#include "drivers/d3d12/rendering_context_driver_d3d12.h"
+#include "drivers/d3d12/rendering_context_driver_d3d12.h" // validator: ignore // FIXME: Legacy include.
 #endif
 #if defined(METAL_ENABLED)
-#include "drivers/metal/rendering_context_driver_metal.h"
+#include "drivers/metal/rendering_context_driver_metal.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 DisplayServer *DisplayServer::singleton = nullptr;

--- a/servers/display/native_menu.cpp
+++ b/servers/display/native_menu.cpp
@@ -30,7 +30,7 @@
 
 #include "native_menu.h"
 
-#include "scene/resources/image_texture.h"
+#include "scene/resources/image_texture.h" // validator: ignore // FIXME: Legacy include.
 
 NativeMenu *NativeMenu::singleton = nullptr;
 

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -32,7 +32,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/time.h"
-#include "scene/main/window.h"
+#include "scene/main/window.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/audio/audio_driver_dummy.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"

--- a/servers/navigation_2d/navigation_server_2d.cpp
+++ b/servers/navigation_2d/navigation_server_2d.cpp
@@ -32,7 +32,7 @@
 #include "navigation_server_2d.compat.inc"
 
 #include "core/config/project_settings.h"
-#include "scene/main/node.h"
+#include "scene/main/node.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/navigation_2d/navigation_server_2d_dummy.h"
 
 NavigationServer2D *NavigationServer2D::singleton = nullptr;

--- a/servers/navigation_2d/navigation_server_2d.h
+++ b/servers/navigation_2d/navigation_server_2d.h
@@ -33,8 +33,8 @@
 #include "core/object/class_db.h"
 #include "core/templates/rid.h"
 
-#include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
-#include "scene/resources/2d/navigation_polygon.h"
+#include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h" // validator: ignore // FIXME: Legacy include.
+#include "scene/resources/2d/navigation_polygon.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/navigation_2d/navigation_path_query_parameters_2d.h"
 #include "servers/navigation_2d/navigation_path_query_result_2d.h"
 

--- a/servers/navigation_3d/navigation_server_3d.cpp
+++ b/servers/navigation_3d/navigation_server_3d.cpp
@@ -32,7 +32,7 @@
 #include "navigation_server_3d.compat.inc"
 
 #include "core/config/project_settings.h"
-#include "scene/main/node.h"
+#include "scene/main/node.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/navigation_3d/navigation_server_3d_dummy.h"
 
 NavigationServer3D *NavigationServer3D::singleton = nullptr;

--- a/servers/navigation_3d/navigation_server_3d.h
+++ b/servers/navigation_3d/navigation_server_3d.h
@@ -33,8 +33,8 @@
 #include "core/object/class_db.h"
 #include "core/templates/rid.h"
 
-#include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
-#include "scene/resources/navigation_mesh.h"
+#include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h" // validator: ignore // FIXME: Legacy include.
+#include "scene/resources/navigation_mesh.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/navigation_3d/navigation_path_query_parameters_3d.h"
 #include "servers/navigation_3d/navigation_path_query_result_3d.h"
 

--- a/servers/rendering/dummy/rasterizer_dummy.h
+++ b/servers/rendering/dummy/rasterizer_dummy.h
@@ -32,7 +32,7 @@
 
 #include "core/templates/rid_owner.h"
 #include "core/templates/self_list.h"
-#include "scene/resources/mesh.h"
+#include "scene/resources/mesh.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/rendering/dummy/environment/fog.h"
 #include "servers/rendering/dummy/environment/gi.h"
 #include "servers/rendering/dummy/rasterizer_canvas_dummy.h"

--- a/servers/rendering/renderer_rd/effects/metal_fx.mm
+++ b/servers/rendering/renderer_rd/effects/metal_fx.mm
@@ -31,8 +31,8 @@
 #import "metal_fx.h"
 
 #import "../storage_rd/render_scene_buffers_rd.h"
-#import "drivers/metal/pixel_formats.h"
-#import "drivers/metal/rendering_device_driver_metal.h"
+#import "drivers/metal/pixel_formats.h" // validator: ignore // FIXME: Legacy include.
+#import "drivers/metal/rendering_device_driver_metal.h" // validator: ignore // FIXME: Legacy include.
 
 #import <Metal/Metal.h>
 #import <MetalFX/MetalFX.h>

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -37,7 +37,7 @@
 
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
 // This is used only to obtain node paths for user-friendly physics interpolation warnings.
-#include "scene/main/node.h"
+#include "scene/main/node.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 /* HALTON SEQUENCE */

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -37,11 +37,11 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
-#include "modules/modules_enabled.gen.h"
+#include "modules/modules_enabled.gen.h" // validator: ignore // FIXME: Legacy include.
 #include "servers/rendering/rendering_shader_container.h"
 
 #ifdef MODULE_GLSLANG_ENABLED
-#include "modules/glslang/shader_compile.h"
+#include "modules/glslang/shader_compile.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 #define FORCE_SEPARATE_PRESENT_QUEUE 0

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -30,9 +30,9 @@
 
 #include "rendering_device_binds.h"
 
-#include "modules/modules_enabled.gen.h" // For glslang.
+#include "modules/modules_enabled.gen.h" // For glslang. // validator: ignore // FIXME: Legacy include.
 #ifdef MODULE_GLSLANG_ENABLED
-#include "modules/glslang/shader_compile.h"
+#include "modules/glslang/shader_compile.h" // validator: ignore // FIXME: Legacy include.
 #endif
 
 #include "shader_include_db.h"

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -38,7 +38,7 @@
 #include "core/templates/safe_refcount.h"
 #include "core/typedefs.h"
 #include "core/variant/variant.h"
-#include "scene/resources/shader_include.h"
+#include "scene/resources/shader_include.h" // validator: ignore // FIXME: Legacy include.
 
 #ifdef DEBUG_ENABLED
 #include "shader_warnings.h"

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -37,7 +37,7 @@
 #include "core/templates/rb_set.h"
 
 #include "core/object/script_language.h"
-#include "scene/resources/shader_include.h"
+#include "scene/resources/shader_include.h" // validator: ignore // FIXME: Legacy include.
 
 class ShaderPreprocessor {
 public:


### PR DESCRIPTION
- Helps address #53295 

This PR is divided into two commits:
- Adding a pre-commit hook to scan and report on any files that break encapsulation
- Labeling the specific `#include` violations that were detected

Breaking encapsulation across the repo has been a common problem, as it's never been strictly enforced. While that should be eventually feasible with a custom emitter, we should first eliminate existing instances where this paradigm is broken. With how integrated some of this breakage actually is, it may warrant a deeper discussion on our overall structure, but this PR simply aims to address and identify what's already there