### PR TITLE
Add custom shader template support to rendering server (core)

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3712,6 +3712,31 @@
 				Sets the path hint for the specified shader. This should generally match the [Shader] resource's [member Resource.resource_path].
 			</description>
 		</method>
+		<method name="shader_set_shader_template" experimental="">
+			<return type="void" />
+			<param index="0" name="shader" type="RID" />
+			<param index="1" name="shader_template" type="RID" default="RID()" />
+			<param index="2" name="clear_code" type="bool" default="false" />
+			<description>
+				Sets the shader template to be used when compiling this shader.
+			</description>
+		</method>
+		<method name="shader_template_create" experimental="">
+			<return type="RID" />
+			<description>
+				Creates a new shader template.
+			</description>
+		</method>
+		<method name="shader_template_set_raster_code" experimental="">
+			<return type="void" />
+			<param index="0" name="shader_template" type="RID" />
+			<param index="1" name="vertex_code" type="String" />
+			<param index="2" name="fragment_code" type="String" />
+			<param index="3" name="name" type="String" />
+			<description>
+				Sets the vertex and fragment base code for the template into which the user shader is injected. [param name] is used when caching this shader.
+			</description>
+		</method>
 		<method name="skeleton_allocate_data">
 			<return type="void" />
 			<param index="0" name="skeleton" type="RID" />

--- a/doc/classes/ShaderTemplate.xml
+++ b/doc/classes/ShaderTemplate.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ShaderTemplate" inherits="Resource" api_type="core" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A shader template implementing the core vertex and fragment shaders.
+	</brief_description>
+	<description>
+		A shader template can be used to override Godot's built-in shader code with a custom implementation.
+		[b]Note:[/b] This feature is currently only available for spatial shaders on the Mobile and Forward+ renderers.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_mode" qualifiers="const">
+			<return type="int" enum="Shader.Mode" />
+			<description>
+				Returns the shader mode for this shader template.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="code" type="String" setter="set_code" getter="get_code" default="&quot;&quot;">
+			The shader template GLSL code for both vertex and fragment shaders.
+		</member>
+	</members>
+</class>

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2227,6 +2227,37 @@ void MaterialStorage::_update_global_shader_uniforms() {
 	}
 }
 
+/* SHADER TEMPLATE API */
+
+void GLES3::ShaderTemplate::cleanup() {
+	if (shader) {
+		memdelete(shader);
+		shader = nullptr;
+	}
+}
+
+RID MaterialStorage::shader_template_allocate() {
+	return shader_template_owner.allocate_rid();
+}
+
+void MaterialStorage::shader_template_initialize(RID p_rid) {
+	ShaderTemplate shader_template;
+	shader_template.shader = nullptr;
+	shader_template_owner.initialize_rid(p_rid, shader_template);
+}
+
+void MaterialStorage::shader_template_free(RID p_rid) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_rid);
+	ERR_FAIL_NULL(shader_template);
+
+	shader_template->cleanup();
+	shader_template_owner.free(p_rid);
+}
+
+void MaterialStorage::shader_template_set_raster_code(RID p_template_shader, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) {
+	// Not supported in Compatibility (yet).
+}
+
 /* SHADER API */
 
 RID MaterialStorage::shader_allocate() {
@@ -2245,14 +2276,25 @@ void MaterialStorage::shader_free(RID p_rid) {
 	GLES3::Shader *shader = shader_owner.get_or_null(p_rid);
 	ERR_FAIL_NULL(shader);
 
-	//make material unreference this
+	// Make material unreference this.
 	while (shader->owners.size()) {
 		material_set_shader((*shader->owners.begin())->self, RID());
 	}
 
-	//clear data if exists
-	memdelete(shader->data);
+	// Clear data if it exists.
+	if (shader->data) {
+		memdelete(shader->data);
+	}
 	shader_owner.free(p_rid);
+}
+
+void MaterialStorage::shader_set_shader_template(RID p_shader, RID p_shader_template, bool p_clear_code) {
+	GLES3::Shader *shader = shader_owner.get_or_null(p_shader);
+	ERR_FAIL_NULL(shader);
+
+	if (shader->shader_template != p_shader_template) {
+		shader->shader_template = p_shader_template;
+	}
 }
 
 void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
@@ -2326,7 +2368,7 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 
 	if (shader->data) {
 		shader->data->set_path_hint(shader->path_hint);
-		shader->data->set_code(p_code);
+		shader->data->set_code(p_code, shader->shader_template);
 	}
 
 	for (Material *E : shader->owners) {
@@ -2646,7 +2688,12 @@ LocalVector<ShaderGLES3::TextureUniformData> get_texture_uniform_data(const Vect
 
 /* Canvas Shader Data */
 
-void CanvasShaderData::set_code(const String &p_code) {
+void CanvasShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for canvas shaders.");
+	}
+
 	// Initialize and compile the shader.
 
 	code = p_code;
@@ -2818,7 +2865,12 @@ GLES3::MaterialData *GLES3::_create_canvas_material_func(ShaderData *p_shader) {
 ////////////////////////////////////////////////////////////////////////////////
 // SKY SHADER
 
-void SkyShaderData::set_code(const String &p_code) {
+void SkyShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for sky shaders.");
+	}
+
 	// Initialize and compile the shader.
 
 	code = p_code;
@@ -2960,7 +3012,12 @@ void SkyMaterialData::bind_uniforms() {
 ////////////////////////////////////////////////////////////////////////////////
 // Scene SHADER
 
-void SceneShaderData::set_code(const String &p_code) {
+void SceneShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported on the Compatibility render.");
+	}
+
 	// Initialize and compile the shader.
 
 	code = p_code;
@@ -3276,7 +3333,11 @@ void SceneMaterialData::bind_uniforms() {
 
 /* Particles SHADER */
 
-void ParticlesShaderData::set_code(const String &p_code) {
+void ParticlesShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for particle shaders.");
+	}
 	// Initialize and compile the shader.
 
 	code = p_code;
@@ -3378,7 +3439,12 @@ void ParticleProcessMaterialData::bind_uniforms() {
 
 /* TextureBlit SHADER */
 
-void TexBlitShaderData::set_code(const String &p_code) {
+void TexBlitShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for texture blit shaders.");
+	}
+
 	// Initialize and compile the shader.
 
 	code = p_code;

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -61,7 +61,7 @@ struct ShaderData {
 	virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 	virtual bool is_parameter_texture(const StringName &p_param) const;
 
-	virtual void set_code(const String &p_Code) = 0;
+	virtual void set_code(const String &p_Code, RID p_shader_template = RID()) = 0;
 	virtual bool is_animated() const = 0;
 	virtual bool casts_shadows() const = 0;
 	virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const { return RenderingServerTypes::ShaderNativeSourceCode(); }
@@ -71,10 +71,19 @@ struct ShaderData {
 
 typedef ShaderData *(*ShaderDataRequestFunction)();
 
+struct Shader;
 struct Material;
+
+struct ShaderTemplate {
+	ShaderGLES3 *shader;
+	HashSet<Shader *> owners;
+
+	void cleanup();
+};
 
 struct Shader {
 	ShaderData *data = nullptr;
+	RID shader_template;
 	String code;
 	String path_hint;
 	RSE::ShaderMode mode;
@@ -171,7 +180,7 @@ struct CanvasShaderData : public ShaderData {
 
 	uint64_t vertex_input_mask;
 
-	virtual void set_code(const String &p_Code);
+	virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 	virtual bool is_animated() const;
 	virtual bool casts_shadows() const;
 	virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;
@@ -216,7 +225,7 @@ struct SkyShaderData : public ShaderData {
 	bool uses_quarter_res;
 	bool uses_light;
 
-	virtual void set_code(const String &p_Code);
+	virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 	virtual bool is_animated() const;
 	virtual bool casts_shadows() const;
 	virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;
@@ -350,7 +359,7 @@ struct SceneShaderData : public ShaderData {
 
 	uint64_t vertex_input_mask;
 
-	virtual void set_code(const String &p_Code);
+	virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 	virtual bool is_animated() const;
 	virtual bool casts_shadows() const;
 	virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;
@@ -402,7 +411,7 @@ struct ParticlesShaderData : public ShaderData {
 	bool userdatas_used[PARTICLES_MAX_USERDATAS] = {};
 	uint32_t userdata_count;
 
-	virtual void set_code(const String &p_Code);
+	virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 	virtual bool is_animated() const;
 	virtual bool casts_shadows() const;
 	virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;
@@ -450,7 +459,7 @@ struct TexBlitShaderData : public ShaderData {
 
 	BlendMode blend_mode;
 
-	virtual void set_code(const String &p_code);
+	virtual void set_code(const String &p_code, RID p_shader_template);
 	virtual bool is_animated() const;
 	virtual bool casts_shadows() const;
 	virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;
@@ -544,6 +553,10 @@ private:
 	int32_t _global_shader_uniform_allocate(uint32_t p_elements);
 	void _global_shader_uniform_store_in_buffer(int32_t p_index, RSE::GlobalShaderParameterType p_type, const Variant &p_value);
 	void _global_shader_uniform_mark_buffer_dirty(int32_t p_index, int32_t p_elements);
+
+	/* SHADER TEMPLATE API */
+
+	mutable RID_Owner<ShaderTemplate, true> shader_template_owner;
 
 	/* SHADER API */
 
@@ -642,6 +655,17 @@ public:
 
 	GLuint global_shader_parameters_get_uniform_buffer() const;
 
+	/* SHADER TEMPLATE API */
+
+	ShaderTemplate *get_shader_template(RID p_rid) { return shader_template_owner.get_or_null(p_rid); }
+	bool owns_template_shader(RID p_rid) { return shader_template_owner.owns(p_rid); }
+
+	virtual RID shader_template_allocate() override;
+	virtual void shader_template_initialize(RID p_rid) override;
+	virtual void shader_template_free(RID p_rid) override;
+
+	virtual void shader_template_set_raster_code(RID p_template_shader, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) override;
+
 	/* SHADER API */
 
 	Shader *get_shader(RID p_rid) { return shader_owner.get_or_null(p_rid); }
@@ -653,6 +677,7 @@ public:
 	virtual void shader_initialize(RID p_rid, bool p_embedded = true) override;
 	virtual void shader_free(RID p_rid) override;
 
+	virtual void shader_set_shader_template(RID p_shader, RID p_shader_template = RID(), bool p_clear_code = false) override;
 	virtual void shader_set_code(RID p_shader, const String &p_code) override;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) override;
 	virtual String shader_get_code(RID p_shader) const override;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -155,6 +155,7 @@
 #include "scene/resources/shader_include.h"
 #include "scene/resources/shader_include_resource_format.h"
 #include "scene/resources/shader_resource_format.h"
+#include "scene/resources/shader_template.h"
 #include "scene/resources/skeleton_profile.h"
 #include "scene/resources/sky.h"
 #include "scene/resources/style_box.h"
@@ -382,6 +383,9 @@ static Ref<ResourceFormatLoaderCompressedTexture2D> resource_loader_stream_textu
 static Ref<ResourceFormatLoaderCompressedTextureLayered> resource_loader_texture_layered;
 static Ref<ResourceFormatLoaderCompressedTexture3D> resource_loader_texture_3d;
 
+static Ref<ResourceFormatSaverShaderTemplate> resource_saver_shader_template;
+static Ref<ResourceFormatLoaderShaderTemplate> resource_loader_shader_template;
+
 static Ref<ResourceFormatSaverShader> resource_saver_shader;
 static Ref<ResourceFormatLoaderShader> resource_loader_shader;
 
@@ -417,6 +421,14 @@ void register_scene_types() {
 
 	resource_loader_text.instantiate();
 	ResourceLoader::add_resource_format_loader(resource_loader_text, true);
+
+	if constexpr (GD_IS_CLASS_ENABLED(ShaderTemplate)) {
+		resource_saver_shader_template.instantiate();
+		ResourceSaver::add_resource_format_saver(resource_saver_shader_template, true);
+
+		resource_loader_shader_template.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_shader_template, true);
+	}
 
 	if constexpr (GD_IS_CLASS_ENABLED(Shader)) {
 		resource_saver_shader.instantiate();
@@ -774,6 +786,10 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); // may take time to init
 #endif // _3D_DISABLED
+
+	/* REGISTER SHADER TEMPLATE */
+
+	GDREGISTER_CLASS(ShaderTemplate);
 
 	/* REGISTER SHADER */
 
@@ -1338,6 +1354,14 @@ void unregister_scene_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_text);
 	resource_loader_text.unref();
+
+	if constexpr (GD_IS_CLASS_ENABLED(ShaderTemplate)) {
+		ResourceSaver::remove_resource_format_saver(resource_saver_shader_template);
+		resource_saver_shader_template.unref();
+
+		ResourceLoader::remove_resource_format_loader(resource_loader_shader_template);
+		resource_loader_shader_template.unref();
+	}
 
 	if constexpr (GD_IS_CLASS_ENABLED(Shader)) {
 		ResourceSaver::remove_resource_format_saver(resource_saver_shader);

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -35,6 +35,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/main/scene_tree.h"
+#include "scene/resources/shader_template.h"
 #include "scene/resources/texture.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/shader_language.h"
@@ -127,6 +128,21 @@ void Shader::set_code(const String &p_code) {
 	}
 
 	if (shader_rid.is_valid()) {
+		Ref<ShaderTemplate> new_shader_template;
+
+		String shader_template_path = ShaderLanguage::get_shader_template(preprocessed_code);
+		if (!shader_template_path.is_empty()) {
+			new_shader_template = ResourceLoader::load(shader_template_path);
+		}
+		if (shader_template != new_shader_template) {
+			shader_template = new_shader_template;
+			if (shader_template.is_valid()) {
+				RenderingServer::get_singleton()->shader_set_shader_template(shader_rid, shader_template->get_rid(), true);
+			} else {
+				RenderingServer::get_singleton()->shader_set_shader_template(shader_rid, RID());
+			}
+		}
+
 		RenderingServer::get_singleton()->shader_set_code(shader_rid, preprocessed_code);
 		preprocessed_code = String();
 	}

--- a/scene/resources/shader_template.cpp
+++ b/scene/resources/shader_template.cpp
@@ -1,0 +1,286 @@
+/**************************************************************************/
+/*  shader_template.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "shader_template.h"
+
+#include "core/io/file_access.h"
+#include "core/object/class_db.h"
+#include "main/main.h"
+#include "servers/rendering/rendering_server.h"
+#include "servers/rendering/shader_include_db.h"
+
+void ShaderTemplate::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_mode"), &ShaderTemplate::get_mode);
+
+	ClassDB::bind_method(D_METHOD("set_code", "code"), &ShaderTemplate::set_code);
+	ClassDB::bind_method(D_METHOD("get_code"), &ShaderTemplate::get_code);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_code", "get_code");
+}
+
+String ShaderTemplate::_load_include_file(const String &p_path, const String &p_base_path) {
+	Error err;
+
+	String include = p_path;
+	if (include.is_relative_path()) {
+		include = p_base_path.path_join(include);
+	}
+
+	Ref<FileAccess> file_inc = FileAccess::open(include, FileAccess::READ, &err);
+	if (err != OK) {
+		return String();
+	}
+	return file_inc->get_as_utf8_string();
+}
+
+void ShaderTemplate::_update_template() {
+	String shader_name = get_path();
+	// We can't guarantee we know the folder location. For now, we assume paths are relative to the project root.
+	String base_path = "res://";
+
+	if (shader_name.is_empty()) {
+		uint64_t id = shader_template.get_id();
+		shader_name = "resource_" + String::num_uint64(id);
+	} else {
+		shader_name = shader_name.replace("res://", "");
+		shader_name = shader_name.replace(".gdtemplate", "");
+		shader_name = shader_name.replace_char('/', '_');
+		shader_name = shader_name.to_camel_case();
+	}
+
+	int shader = -1;
+	mode = Shader::MODE_MAX;
+	String vertex_shader = "";
+	String fragment_shader = "";
+
+	// Note, we only split out our vertex and fragment shader here.
+	// We do not process includes or compile the shaders.
+	// With templates, this happens inside of the rendering engine!
+
+	Vector<String> lines = code.split("\n");
+	String empty_lines;
+	String shader_type;
+	for (int lidx = 0; lidx < lines.size(); lidx++) {
+		String line = lines[lidx];
+		if (line.begins_with("shader_type")) {
+			// Extract shader type.
+			int end_pos = line.find_char(';');
+			if (end_pos != -1) {
+				shader_type = line.substr(12, end_pos - 12);
+			}
+		} else if (line.begins_with("#[")) {
+			int pos = line.find_char(']');
+			ERR_FAIL_COND_MSG(pos == -1, "Incomplete tag found in shader template - " + String::num_int64(lidx) + ": " + line);
+
+			String tag = line.substr(2, pos - 2);
+			if (tag == "vertex") {
+				ERR_FAIL_COND_MSG(shader != -1, "Unexpected vertex shader in shader template - " + String::num_int64(lidx) + ": " + line);
+				shader = 0;
+				empty_lines = "";
+			} else if (tag == "fragment") {
+				ERR_FAIL_COND_MSG(shader != 0, "Unexpected fragment shader in shader template - " + String::num_int64(lidx) + ": " + line);
+				shader = 1;
+				empty_lines = "";
+			} else {
+				ERR_FAIL_MSG("Unexpected fragment in shader template - " + String::num_int64(lidx) + ": " + line);
+			}
+		} else if (line.begins_with("#include")) {
+			ERR_FAIL_COND_MSG(shader == -1, "Unexpected shader template code - " + String::num_int64(lidx) + ": " + line);
+
+			// Process the include.
+			String include = line.replace("#include", "").strip_edges();
+
+			ERR_FAIL_COND_MSG(!include.begins_with("\"") || !include.ends_with("\""), "Malformed #include syntax, expected #include \"<path>\" - " + String::num_int64(lidx) + ": " + line);
+			include = include.substr(1, include.length() - 2).strip_edges();
+
+			String include_code;
+			if (ShaderIncludeDB::has_built_in_include_file(include)) {
+				// Keep the include as-is. We'll insert it later in case our shader supports multiple backends.
+				include_code = line;
+			} else {
+				include_code = _load_include_file(include, base_path);
+			}
+
+			ERR_FAIL_COND_MSG(include_code.is_empty(), "Unexpected include file - " + String::num_int64(lidx) + ": " + line);
+
+			if (shader == 0) {
+				vertex_shader += empty_lines + include_code + "\n";
+			} else if (shader == 1) {
+				fragment_shader += empty_lines + include_code + "\n";
+			}
+			empty_lines = "";
+
+		} else if (line.is_empty()) {
+			// Remove any trailing empty lines.
+			empty_lines += "\n";
+		} else {
+			ERR_FAIL_COND_MSG(shader == -1, "Unexpected shader template code - " + String::num_int64(lidx) + ": " + line);
+
+			if (shader == 0) {
+				vertex_shader += empty_lines + line + "\n";
+			} else if (shader == 1) {
+				fragment_shader += empty_lines + line + "\n";
+			}
+			empty_lines = "";
+		}
+	}
+
+	if (shader_type == "canvas_item") {
+		mode = Shader::MODE_CANVAS_ITEM;
+	} else if (shader_type == "particles") {
+		mode = Shader::MODE_PARTICLES;
+	} else if (shader_type == "sky") {
+		mode = Shader::MODE_SKY;
+	} else if (shader_type == "fog") {
+		mode = Shader::MODE_FOG;
+	} else if (shader_type == "spatial") {
+		mode = Shader::MODE_SPATIAL;
+	} else {
+		ERR_FAIL_MSG("Unknown shader type in shader template.");
+	}
+
+	ERR_FAIL_COND_MSG(vertex_shader.is_empty(), "No vertex shader code found for this shader template.");
+	ERR_FAIL_COND_MSG(fragment_shader.is_empty(), "No vertex shader code found for this shader template.");
+
+	RenderingServer::get_singleton()->shader_template_set_raster_code(shader_template, vertex_shader, fragment_shader, shader_name);
+}
+
+void ShaderTemplate::set_path(const String &p_path, bool p_take_over) {
+	Resource::set_path(p_path, p_take_over);
+
+	_update_template();
+}
+
+Shader::Mode ShaderTemplate::get_mode() const {
+	return mode;
+}
+
+String ShaderTemplate::get_code() const {
+	return code;
+}
+
+void ShaderTemplate::set_code(const String &p_code) {
+	code = p_code;
+
+	_update_template();
+}
+
+RID ShaderTemplate::get_rid() const {
+	return shader_template;
+}
+
+ShaderTemplate::ShaderTemplate() {
+	shader_template = RenderingServer::get_singleton()->shader_template_create();
+}
+
+ShaderTemplate::~ShaderTemplate() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	RenderingServer::get_singleton()->free_rid(shader_template);
+}
+
+////////////
+
+Ref<Resource> ResourceFormatLoaderShaderTemplate::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	if (r_error) {
+		*r_error = ERR_FILE_CANT_OPEN;
+	}
+
+	Error error = OK;
+	Vector<uint8_t> buffer = FileAccess::get_file_as_bytes(p_path, &error);
+	if (r_error) {
+		*r_error = error;
+	}
+	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot load shader: " + p_path);
+
+	String str;
+	if (buffer.size() > 0) {
+		error = str.append_utf8((const char *)buffer.ptr(), buffer.size());
+		if (r_error) {
+			*r_error = error;
+		}
+		ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot parse shader: " + p_path);
+	}
+
+	Ref<ShaderTemplate> shader_template;
+	shader_template.instantiate();
+	shader_template->set_code(str);
+
+	if (r_error) {
+		*r_error = OK;
+	}
+
+	return shader_template;
+}
+
+void ResourceFormatLoaderShaderTemplate::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("gdtemplate");
+}
+
+bool ResourceFormatLoaderShaderTemplate::handles_type(const String &p_type) const {
+	return (p_type == "ShaderTemplate");
+}
+
+String ResourceFormatLoaderShaderTemplate::get_resource_type(const String &p_path) const {
+	String el = p_path.get_extension().to_lower();
+	if (el == "gdtemplate") {
+		return "ShaderTemplate";
+	}
+	return "";
+}
+
+Error ResourceFormatSaverShaderTemplate::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+	Ref<ShaderTemplate> shader_template = p_resource;
+	ERR_FAIL_COND_V(shader_template.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(shader_template->get_mode() >= Shader::MODE_MAX, ERR_INVALID_DATA);
+
+	String code = shader_template->get_code();
+
+	Error err;
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+
+	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader template '" + p_path + "'.");
+
+	file->store_string(code);
+	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
+		return ERR_CANT_CREATE;
+	}
+
+	return OK;
+}
+
+void ResourceFormatSaverShaderTemplate::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+	if (Object::cast_to<ShaderTemplate>(*p_resource)) {
+		p_extensions->push_back("gdtemplate");
+	}
+}
+
+bool ResourceFormatSaverShaderTemplate::recognize(const Ref<Resource> &p_resource) const {
+	return p_resource->get_class_name() == "ShaderTemplate";
+}

--- a/scene/resources/shader_template.h
+++ b/scene/resources/shader_template.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  shader.h                                                              */
+/*  shader_template.h                                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,82 +30,50 @@
 
 #pragma once
 
-#include "core/io/resource.h"
-#include "scene/resources/shader_include.h"
+#include "core/io/resource_loader.h"
+#include "core/io/resource_saver.h"
+#include "scene/resources/shader.h"
 
-class Texture;
-class Texture2D;
-
-class ShaderTemplate;
-
-class Shader : public Resource {
-	GDCLASS(Shader, Resource);
-	OBJ_SAVE_TYPE(Shader);
-
-public:
-	// Must be kept in sync with the List<String> of shader types in `servers/rendering/shader_types.cpp`.
-	enum Mode {
-		MODE_SPATIAL,
-		MODE_CANVAS_ITEM,
-		MODE_PARTICLES,
-		MODE_SKY,
-		MODE_FOG,
-		MODE_TEXTURE_BLIT,
-		MODE_MAX
-	};
+class ShaderTemplate : public Resource {
+	GDCLASS(ShaderTemplate, Resource);
 
 private:
-	mutable RID shader_rid;
-	mutable String preprocessed_code;
-	mutable Mutex shader_rid_mutex;
+	RID shader_template;
 
-	Mode mode = MODE_SPATIAL;
-	Ref<ShaderTemplate> shader_template;
-	HashSet<Ref<ShaderInclude>> include_dependencies;
+	Shader::Mode mode = Shader::MODE_SPATIAL;
 	String code;
-	String include_path;
 
-	HashMap<StringName, HashMap<int, Ref<Texture>>> default_textures;
-
-	void _check_shader_rid() const;
-	void _dependency_changed();
-	void _recompile();
-	virtual void _update_shader() const; //used for visual shader
-	Array _get_shader_uniform_list(bool p_get_groups = false);
+	String _load_include_file(const String &p_path, const String &p_base_path);
+	void _update_template();
 
 protected:
-#ifndef DISABLE_DEPRECATED
-	void _set_default_texture_parameter_bind_compat_95126(const StringName &p_name, const Ref<Texture2D> &p_texture, int p_index = 0);
-	Ref<Texture2D> _get_default_texture_parameter_bind_compat_95126(const StringName &p_name, int p_index = 0) const;
-	static void _bind_compatibility_methods();
-#endif // DISABLE_DEPRECATED
-
 	static void _bind_methods();
 
 public:
-	//void set_mode(Mode p_mode);
-	virtual Mode get_mode() const;
-
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
-	void set_include_path(const String &p_path);
 
-	void set_code(const String &p_code);
+	Shader::Mode get_mode() const;
+
 	String get_code() const;
-
-	void inspect_native_shader_code();
-
-	void get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_groups = false) const;
-
-	void set_default_texture_parameter(const StringName &p_name, const Ref<Texture> &p_texture, int p_index = 0);
-	Ref<Texture> get_default_texture_parameter(const StringName &p_name, int p_index = 0) const;
-	void get_default_texture_parameter_list(List<StringName> *r_textures) const;
-
-	virtual bool is_text_shader() const;
+	void set_code(const String &p_code);
 
 	virtual RID get_rid() const override;
 
-	Shader();
-	~Shader();
+	ShaderTemplate();
+	~ShaderTemplate();
 };
 
-VARIANT_ENUM_CAST(Shader::Mode);
+class ResourceFormatLoaderShaderTemplate : public ResourceFormatLoader {
+public:
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual bool handles_type(const String &p_type) const override;
+	virtual String get_resource_type(const String &p_path) const override;
+};
+
+class ResourceFormatSaverShaderTemplate : public ResourceFormatSaver {
+public:
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual bool recognize(const Ref<Resource> &p_resource) const override;
+};

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -86,6 +86,14 @@ public:
 	virtual void global_shader_parameters_instance_free(RID p_instance) override {}
 	virtual void global_shader_parameters_instance_update(RID p_instance, int p_index, const Variant &p_value, int p_flags_count = 0) override {}
 
+	/* SHADER TEMPLATE API */
+
+	virtual RID shader_template_allocate() override { return RID(); }
+	virtual void shader_template_initialize(RID p_rid) override {}
+	virtual void shader_template_free(RID p_rid) override {}
+
+	virtual void shader_template_set_raster_code(RID p_template_shader, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) override {}
+
 	/* SHADER API */
 
 	bool owns_shader(RID p_rid) { return shader_owner.owns(p_rid); }
@@ -94,6 +102,7 @@ public:
 	virtual void shader_initialize(RID p_rid, bool p_embedded) override;
 	virtual void shader_free(RID p_rid) override;
 
+	virtual void shader_set_shader_template(RID p_shader, RID p_shader_template = RID(), bool p_clear_code = false) override {}
 	virtual void shader_set_code(RID p_shader, const String &p_code) override;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_code) override {}
 

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -354,7 +354,12 @@ void Fog::free_fog_shader() {
 	}
 }
 
-void Fog::FogShaderData::set_code(const String &p_code) {
+void Fog::FogShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for fog shaders.");
+	}
+
 	//compile
 
 	code = p_code;

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -213,7 +213,7 @@ private:
 
 		bool uses_time = false;
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -53,7 +53,12 @@ using namespace RendererRD;
 ////////////////////////////////////////////////////////////////////////////////
 // SKY SHADER
 
-void SkyRD::SkyShaderData::set_code(const String &p_code) {
+void SkyRD::SkyShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for sky shaders.");
+	}
+
 	//compile
 
 	code = p_code;

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -124,7 +124,7 @@ private:
 		bool uses_quarter_res = false;
 		bool uses_light = false;
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1890,7 +1890,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		if (p_render_data->scene_data->view_count > 1) {
 			color_pass_flags |= COLOR_PASS_FLAG_MULTIVIEW;
 			// Try enabling here in case is_xr_enabled() returns false.
-			scene_shader.shader.enable_group(SceneShaderForwardClustered::SHADER_GROUP_MULTIVIEW);
+			RendererRD::MaterialStorage::get_singleton()->shader_template_enable_group_on_all(SceneShaderForwardClustered::SHADER_GROUP_MULTIVIEW);
 
 			// Indicate pipelines for multiview are required.
 			global_pipeline_data_required.use_multiview = true;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -38,7 +38,73 @@
 
 using namespace RendererSceneRenderImplementation;
 
-void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
+void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// get shader template
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+
+	shader_template = p_shader_template;
+	if (shader_template.is_null()) {
+		shader_template = SceneShaderForwardClustered::singleton->default_shader_template;
+	}
+	ERR_FAIL_COND(shader_template.is_null());
+
+	if (!material_storage->shader_template_is_initialized(shader_template)) {
+		// For our default template shader, this will be called when our default material gets created.
+
+		Vector<ShaderRD::VariantDefine> shader_versions;
+		for (uint32_t ubershader = 0; ubershader < 2; ubershader++) {
+			const String base_define = ubershader ? "\n#define UBERSHADER\n" : "";
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n", true)); // SHADER_VERSION_DEPTH_PASS
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_DUAL_PARABOLOID\n", true)); // SHADER_VERSION_DEPTH_PASS_DP
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n", true)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n#define MODE_RENDER_VOXEL_GI\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_AND_VOXEL_GI
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n", false)); // SHADER_VERSION_DEPTH_PASS_MULTIVIEW
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_MULTIVIEW
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n#define MODE_RENDER_VOXEL_GI\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_AND_VOXEL_GI_MULTIVIEW
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_MATERIAL\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_MATERIAL
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_SDF\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_SDF
+		}
+
+		Vector<String> color_pass_flags = {
+			"\n#define UBERSHADER\n", // SHADER_COLOR_PASS_FLAG_UBERSHADER
+			"\n#define MODE_SEPARATE_SPECULAR\n", // SHADER_COLOR_PASS_FLAG_SEPARATE_SPECULAR
+			"\n#define USE_LIGHTMAP\n", // SHADER_COLOR_PASS_FLAG_LIGHTMAP
+			"\n#define USE_MULTIVIEW\n", // SHADER_COLOR_PASS_FLAG_MULTIVIEW
+			"\n#define MOTION_VECTORS\n", // SHADER_COLOR_PASS_FLAG_MOTION_VECTORS
+		};
+
+		for (int i = 0; i < SHADER_COLOR_PASS_FLAG_COUNT; i++) {
+			String version_flags = "";
+			for (int j = 0; (1 << j) < SHADER_COLOR_PASS_FLAG_COUNT; j += 1) {
+				if ((1 << j) & i) {
+					version_flags += color_pass_flags[j];
+				}
+			}
+
+			// Assign a group based on what features this pass contains.
+			ShaderGroup group = SHADER_GROUP_BASE;
+			bool advanced_group = (i & SHADER_COLOR_PASS_FLAG_SEPARATE_SPECULAR) || (i & SHADER_COLOR_PASS_FLAG_LIGHTMAP) || (i & SHADER_COLOR_PASS_FLAG_MOTION_VECTORS);
+			bool multiview_group = i & SHADER_COLOR_PASS_FLAG_MULTIVIEW;
+			if (advanced_group && multiview_group) {
+				group = SHADER_GROUP_ADVANCED_MULTIVIEW;
+			} else if (advanced_group) {
+				group = SHADER_GROUP_ADVANCED;
+			} else if (multiview_group) {
+				group = SHADER_GROUP_MULTIVIEW;
+			}
+
+			shader_versions.push_back(ShaderRD::VariantDefine(group, version_flags, false));
+		}
+
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(ShaderRD::DynamicBuffer::encode(RenderForwardClustered::RENDER_PASS_UNIFORM_SET, 2));
+		material_storage->shader_template_shader_initialize(shader_template, shader_versions, SceneShaderForwardClustered::singleton->default_defines, Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
+
+		if (RendererCompositorRD::get_singleton()->is_xr_enabled()) {
+			material_storage->shader_template_enable_group_on_all(SHADER_GROUP_MULTIVIEW);
+		}
+	}
+
 	//compile
 
 	code = p_code;
@@ -179,14 +245,14 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	if (err != OK) {
 		if (version.is_valid()) {
-			SceneShaderForwardClustered::singleton->shader.version_free(version);
+			material_storage->shader_template_version_free(shader_template, version);
 			version = RID();
 		}
 		ERR_FAIL_MSG("Shader compilation failed.");
 	}
 
 	if (version.is_null()) {
-		version = SceneShaderForwardClustered::singleton->shader.version_create(false);
+		version = material_storage->shader_template_version_create(shader_template, false);
 	}
 
 	depth_draw = DepthDraw(depth_drawi);
@@ -231,7 +297,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	print_line("\n**vertex_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
 	print_line("\n**fragment_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
 #endif
-	SceneShaderForwardClustered::singleton->shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
+	material_storage->shader_template_version_set_code(shader_template, version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
 
 	ubo_size = gen_code.uniform_total_size;
 	ubo_offsets = gen_code.uniform_offsets;
@@ -261,7 +327,8 @@ bool SceneShaderForwardClustered::ShaderData::casts_shadows() const {
 
 RenderingServerTypes::ShaderNativeSourceCode SceneShaderForwardClustered::ShaderData::get_native_source_code() const {
 	if (version.is_valid()) {
-		return SceneShaderForwardClustered::singleton->shader.version_get_native_source_code(version);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		return material_storage->shader_template_version_get_native_source_code(shader_template, version);
 	} else {
 		return RenderingServerTypes::ShaderNativeSourceCode();
 	}
@@ -269,7 +336,8 @@ RenderingServerTypes::ShaderNativeSourceCode SceneShaderForwardClustered::Shader
 
 Pair<ShaderRD *, RID> SceneShaderForwardClustered::ShaderData::get_native_shader_and_version() const {
 	if (version.is_valid()) {
-		return { &SceneShaderForwardClustered::singleton->shader, version };
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		return { material_storage->shader_template_get_shader(shader_template), version };
 	} else {
 		return {};
 	}
@@ -520,8 +588,9 @@ RD::PolygonCullMode SceneShaderForwardClustered::ShaderData::get_cull_mode_from_
 
 RID SceneShaderForwardClustered::ShaderData::_get_shader_variant(uint16_t p_shader_version) const {
 	if (version.is_valid()) {
-		ERR_FAIL_NULL_V(SceneShaderForwardClustered::singleton, RID());
-		return SceneShaderForwardClustered::singleton->shader.version_get_shader(version, p_shader_version);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		ERR_FAIL_NULL_V(material_storage, RID());
+		return material_storage->shader_template_version_get_shader(shader_template, version, p_shader_version);
 	} else {
 		return RID();
 	}
@@ -554,8 +623,9 @@ uint64_t SceneShaderForwardClustered::ShaderData::get_vertex_input_mask(Pipeline
 
 bool SceneShaderForwardClustered::ShaderData::is_valid() const {
 	if (version.is_valid()) {
-		ERR_FAIL_NULL_V(SceneShaderForwardClustered::singleton, false);
-		return SceneShaderForwardClustered::singleton->shader.version_is_valid(version);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		ERR_FAIL_NULL_V(material_storage, false);
+		return material_storage->shader_template_version_is_valid(shader_template, version);
 	} else {
 		return false;
 	}
@@ -571,8 +641,10 @@ SceneShaderForwardClustered::ShaderData::~ShaderData() {
 	pipeline_hash_map.clear_pipelines();
 
 	if (version.is_valid()) {
-		ERR_FAIL_NULL(SceneShaderForwardClustered::singleton);
-		SceneShaderForwardClustered::singleton->shader.version_free(version);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		ERR_FAIL_NULL(material_storage);
+
+		material_storage->shader_template_version_free(shader_template, version);
 	}
 }
 
@@ -593,7 +665,8 @@ void SceneShaderForwardClustered::MaterialData::set_next_pass(RID p_pass) {
 
 bool SceneShaderForwardClustered::MaterialData::update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) {
 	if (shader_data->version.is_valid()) {
-		RID shader_rid = SceneShaderForwardClustered::singleton->shader.version_get_shader(shader_data->version, 0);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		RID shader_rid = material_storage->shader_template_version_get_shader(shader_data->shader_template, shader_data->version, 0);
 
 		MutexLock lock(SceneShaderForwardClustered::singleton_mutex);
 		return update_parameters_uniform_set(p_parameters, p_uniform_dirty, p_textures_dirty, shader_data->uniforms, shader_data->ubo_offsets.ptr(), shader_data->texture_uniforms, shader_data->default_texture_params, shader_data->ubo_size, uniform_set, shader_rid, RenderForwardClustered::MATERIAL_UNIFORM_SET, true, true);
@@ -634,6 +707,8 @@ SceneShaderForwardClustered::~SceneShaderForwardClustered() {
 	material_storage->material_free(overdraw_material);
 	material_storage->material_free(default_material);
 	material_storage->material_free(debug_shadow_splits_material);
+
+	material_storage->shader_template_free(default_shader_template);
 }
 
 void SceneShaderForwardClustered::init(const String p_defines) {
@@ -642,58 +717,10 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 	emulate_point_size = !RD::get_singleton()->has_feature(RD::SUPPORTS_POINT_SIZE);
 
 	{
-		Vector<ShaderRD::VariantDefine> shader_versions;
-		for (uint32_t ubershader = 0; ubershader < 2; ubershader++) {
-			const String base_define = ubershader ? "\n#define UBERSHADER\n" : "";
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n", true)); // SHADER_VERSION_DEPTH_PASS
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_DUAL_PARABOLOID\n", true)); // SHADER_VERSION_DEPTH_PASS_DP
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n", true)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n#define MODE_RENDER_VOXEL_GI\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_AND_VOXEL_GI
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n", false)); // SHADER_VERSION_DEPTH_PASS_MULTIVIEW
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_MULTIVIEW
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n#define MODE_RENDER_VOXEL_GI\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_AND_VOXEL_GI_MULTIVIEW
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_MATERIAL\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_MATERIAL
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_SDF\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_SDF
-		}
-
-		Vector<String> color_pass_flags = {
-			"\n#define UBERSHADER\n", // SHADER_COLOR_PASS_FLAG_UBERSHADER
-			"\n#define MODE_SEPARATE_SPECULAR\n", // SHADER_COLOR_PASS_FLAG_SEPARATE_SPECULAR
-			"\n#define USE_LIGHTMAP\n", // SHADER_COLOR_PASS_FLAG_LIGHTMAP
-			"\n#define USE_MULTIVIEW\n", // SHADER_COLOR_PASS_FLAG_MULTIVIEW
-			"\n#define MOTION_VECTORS\n", // SHADER_COLOR_PASS_FLAG_MOTION_VECTORS
-		};
-
-		for (int i = 0; i < SHADER_COLOR_PASS_FLAG_COUNT; i++) {
-			String version = "";
-			for (int j = 0; (1 << j) < SHADER_COLOR_PASS_FLAG_COUNT; j += 1) {
-				if ((1 << j) & i) {
-					version += color_pass_flags[j];
-				}
-			}
-
-			// Assign a group based on what features this pass contains.
-			ShaderGroup group = SHADER_GROUP_BASE;
-			bool advanced_group = (i & SHADER_COLOR_PASS_FLAG_SEPARATE_SPECULAR) || (i & SHADER_COLOR_PASS_FLAG_LIGHTMAP) || (i & SHADER_COLOR_PASS_FLAG_MOTION_VECTORS);
-			bool multiview_group = i & SHADER_COLOR_PASS_FLAG_MULTIVIEW;
-			if (advanced_group && multiview_group) {
-				group = SHADER_GROUP_ADVANCED_MULTIVIEW;
-			} else if (advanced_group) {
-				group = SHADER_GROUP_ADVANCED;
-			} else if (multiview_group) {
-				group = SHADER_GROUP_MULTIVIEW;
-			}
-
-			shader_versions.push_back(ShaderRD::VariantDefine(group, version, false));
-		}
-
-		Vector<uint64_t> dynamic_buffers;
-		dynamic_buffers.push_back(ShaderRD::DynamicBuffer::encode(RenderForwardClustered::RENDER_PASS_UNIFORM_SET, 2));
-		shader.initialize(shader_versions, p_defines, Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
-
-		if (RendererCompositorRD::get_singleton()->is_xr_enabled()) {
-			shader.enable_group(SHADER_GROUP_MULTIVIEW);
-		}
+		default_defines = p_defines;
+		default_shader_template = material_storage->shader_template_allocate();
+		material_storage->shader_template_initialize(default_shader_template);
+		material_storage->shader_template_set_shader(default_shader_template, memnew(SceneForwardClusteredShaderRD));
 	}
 
 	material_storage->shader_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_3D, _create_shader_funcs);
@@ -1021,25 +1048,30 @@ void SceneShaderForwardClustered::set_default_specialization(const ShaderSpecial
 }
 
 void SceneShaderForwardClustered::enable_multiview_shader_group() {
-	shader.enable_group(SHADER_GROUP_MULTIVIEW);
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+	material_storage->shader_template_enable_group_on_all(SHADER_GROUP_MULTIVIEW);
 }
 
 void SceneShaderForwardClustered::enable_advanced_shader_group(bool p_needs_multiview) {
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+
 	if (p_needs_multiview || RendererCompositorRD::get_singleton()->is_xr_enabled()) {
-		shader.enable_group(SHADER_GROUP_ADVANCED_MULTIVIEW);
+		material_storage->shader_template_enable_group_on_all(SHADER_GROUP_ADVANCED_MULTIVIEW);
 	}
-	shader.enable_group(SHADER_GROUP_ADVANCED);
+	material_storage->shader_template_enable_group_on_all(SHADER_GROUP_ADVANCED);
 }
 
 bool SceneShaderForwardClustered::is_multiview_shader_group_enabled() const {
-	return shader.is_group_enabled(SHADER_GROUP_MULTIVIEW);
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+	return material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_MULTIVIEW);
 }
 
 bool SceneShaderForwardClustered::is_advanced_shader_group_enabled(bool p_multiview) const {
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 	if (p_multiview) {
-		return shader.is_group_enabled(SHADER_GROUP_ADVANCED_MULTIVIEW);
+		return material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_ADVANCED_MULTIVIEW);
 	} else {
-		return shader.is_group_enabled(SHADER_GROUP_ADVANCED);
+		return material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_ADVANCED);
 	}
 }
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -218,6 +218,7 @@ public:
 		void _create_pipeline(PipelineKey p_pipeline_key);
 		PipelineHashMapRD<PipelineKey, ShaderData, void (ShaderData::*)(PipelineKey)> pipeline_hash_map;
 
+		RID shader_template;
 		RID version;
 
 		static const uint32_t VERTEX_INPUT_MASKS_SIZE = ShaderVersion::SHADER_VERSION_COLOR_PASS * 2 + SHADER_COLOR_PASS_FLAG_COUNT;
@@ -300,7 +301,7 @@ public:
 			return !uses_particle_trails && !writes_modelview_or_projection && !uses_vertex && !uses_position && !uses_discard && !uses_depth_prepass_alpha && !uses_alpha_clip && !uses_alpha_antialiasing && backface_culling && !uses_point_size && !uses_world_coordinates && !wireframe && !uses_z_clip_scale && !stencil_enabled;
 		}
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
@@ -344,10 +345,11 @@ public:
 		return static_cast<SceneShaderForwardClustered *>(singleton)->_create_material_func(static_cast<ShaderData *>(p_shader));
 	}
 
-	SceneForwardClusteredShaderRD shader;
+	String default_defines;
 	ShaderCompiler compiler;
 	bool emulate_point_size = false;
 
+	RID default_shader_template;
 	RID default_shader;
 	RID default_material;
 	RID overdraw_material_shader;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -40,7 +40,56 @@ using namespace RendererSceneRenderImplementation;
 
 /* ShaderData */
 
-void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
+void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// get shader template
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+
+	shader_template = p_shader_template;
+	if (shader_template.is_null()) {
+		shader_template = SceneShaderForwardMobile::singleton->default_shader_template;
+	}
+	ERR_FAIL_COND(shader_template.is_null());
+
+	if (!material_storage->shader_template_is_initialized(shader_template)) {
+		Vector<ShaderRD::VariantDefine> shader_versions;
+		for (uint32_t fp16 = 0; fp16 < 2; fp16++) {
+			for (uint32_t ubershader = 0; ubershader < 2; ubershader++) {
+				String base_define = fp16 ? "\n#define EXPLICIT_FP16\n" : "";
+				int shader_group = fp16 ? SHADER_GROUP_FP16 : SHADER_GROUP_FP32;
+				int shader_group_multiview = fp16 ? SHADER_GROUP_FP16_MULTIVIEW : SHADER_GROUP_FP32_MULTIVIEW;
+				base_define += ubershader ? "\n#define UBERSHADER\n" : "";
+
+				bool default_enabled = (uint32_t(SceneShaderForwardMobile::singleton->use_fp16) == fp16);
+				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "", default_enabled)); // SHADER_VERSION_COLOR_PASS
+				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "\n#define USE_LIGHTMAP\n", default_enabled)); // SHADER_VERSION_LIGHTMAP_COLOR_PASS
+				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "\n#define MODE_RENDER_DEPTH\n#define SHADOW_PASS\n", default_enabled)); // SHADER_VERSION_SHADOW_PASS, should probably change this to MODE_RENDER_SHADOW because we don't have a depth pass here...
+				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_DUAL_PARABOLOID\n#define SHADOW_PASS\n", default_enabled)); // SHADER_VERSION_SHADOW_PASS_DP
+				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_MATERIAL\n", default_enabled)); // SHADER_VERSION_DEPTH_PASS_WITH_MATERIAL
+
+				// Multiview versions of our shaders.
+				shader_versions.push_back(ShaderRD::VariantDefine(shader_group_multiview, base_define + "\n#define USE_MULTIVIEW\n", false)); // SHADER_VERSION_COLOR_PASS_MULTIVIEW
+				shader_versions.push_back(ShaderRD::VariantDefine(shader_group_multiview, base_define + "\n#define USE_MULTIVIEW\n#define USE_LIGHTMAP\n", false)); // SHADER_VERSION_LIGHTMAP_COLOR_PASS_MULTIVIEW
+				shader_versions.push_back(ShaderRD::VariantDefine(shader_group_multiview, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define SHADOW_PASS\n", false)); // SHADER_VERSION_SHADOW_PASS_MULTIVIEW
+				shader_versions.push_back(ShaderRD::VariantDefine(shader_group_multiview, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_MOTION_VECTORS\n", false)); // SHADER_VERSION_MOTION_VECTORS_MULTIVIEW
+			}
+		}
+
+		Vector<RD::PipelineImmutableSampler> immutable_samplers;
+		RD::PipelineImmutableSampler immutable_shadow_sampler;
+		immutable_shadow_sampler.binding = 2;
+		immutable_shadow_sampler.append_id(SceneShaderForwardMobile::singleton->shadow_sampler);
+		immutable_shadow_sampler.uniform_type = RenderingDeviceCommons::UNIFORM_TYPE_SAMPLER;
+		immutable_samplers.push_back(immutable_shadow_sampler);
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(ShaderRD::DynamicBuffer::encode(RenderForwardMobile::RENDER_PASS_UNIFORM_SET, 0));
+		dynamic_buffers.push_back(ShaderRD::DynamicBuffer::encode(RenderForwardMobile::RENDER_PASS_UNIFORM_SET, 1));
+		material_storage->shader_template_shader_initialize(shader_template, shader_versions, SceneShaderForwardMobile::singleton->default_defines, immutable_samplers, dynamic_buffers);
+
+		if (RendererCompositorRD::get_singleton()->is_xr_enabled()) {
+			SceneShaderForwardMobile::singleton->enable_multiview_shader_group();
+		}
+	}
+
 	//compile
 
 	code = p_code;
@@ -174,14 +223,14 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 
 	if (err != OK) {
 		if (version.is_valid()) {
-			SceneShaderForwardMobile::singleton->shader.version_free(version);
+			material_storage->shader_template_version_free(shader_template, version);
 			version = RID();
 		}
 		ERR_FAIL_MSG("Shader compilation failed.");
 	}
 
 	if (version.is_null()) {
-		version = SceneShaderForwardMobile::singleton->shader.version_create(false);
+		version = material_storage->shader_template_version_create(shader_template, false);
 	}
 
 	depth_draw = DepthDraw(depth_drawi);
@@ -236,7 +285,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	print_line("\n**fragment_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
 #endif
 
-	SceneShaderForwardMobile::singleton->shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
+	material_storage->shader_template_version_set_code(shader_template, version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
 
 	ubo_size = gen_code.uniform_total_size;
 	ubo_offsets = gen_code.uniform_offsets;
@@ -267,7 +316,9 @@ bool SceneShaderForwardMobile::ShaderData::casts_shadows() const {
 RenderingServerTypes::ShaderNativeSourceCode SceneShaderForwardMobile::ShaderData::get_native_source_code() const {
 	if (version.is_valid()) {
 		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
-		return SceneShaderForwardMobile::singleton->shader.version_get_native_source_code(version);
+
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		return material_storage->shader_template_version_get_native_source_code(shader_template, version);
 	} else {
 		return RenderingServerTypes::ShaderNativeSourceCode();
 	}
@@ -276,7 +327,9 @@ RenderingServerTypes::ShaderNativeSourceCode SceneShaderForwardMobile::ShaderDat
 Pair<ShaderRD *, RID> SceneShaderForwardMobile::ShaderData::get_native_shader_and_version() const {
 	if (version.is_valid()) {
 		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
-		return { &SceneShaderForwardMobile::singleton->shader, version };
+
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		return { material_storage->shader_template_get_shader(shader_template), version };
 	} else {
 		return {};
 	}
@@ -481,8 +534,10 @@ void SceneShaderForwardMobile::ShaderData::_clear_vertex_input_mask_cache() {
 RID SceneShaderForwardMobile::ShaderData::get_shader_variant(ShaderVersion p_shader_version, bool p_ubershader) const {
 	if (version.is_valid()) {
 		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
-		ERR_FAIL_NULL_V(SceneShaderForwardMobile::singleton, RID());
-		return SceneShaderForwardMobile::singleton->shader.version_get_shader(version, p_shader_version + (SceneShaderForwardMobile::singleton->use_fp16 ? SHADER_VERSION_MAX * 2 : 0) + (p_ubershader ? SHADER_VERSION_MAX : 0));
+
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		ERR_FAIL_NULL_V(material_storage, RID());
+		return material_storage->shader_template_version_get_shader(shader_template, version, p_shader_version + (SceneShaderForwardMobile::singleton->use_fp16 ? SHADER_VERSION_MAX * 2 : 0) + (p_ubershader ? SHADER_VERSION_MAX : 0));
 	} else {
 		return RID();
 	}
@@ -507,8 +562,10 @@ uint64_t SceneShaderForwardMobile::ShaderData::get_vertex_input_mask(ShaderVersi
 bool SceneShaderForwardMobile::ShaderData::is_valid() const {
 	if (version.is_valid()) {
 		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
-		ERR_FAIL_NULL_V(SceneShaderForwardMobile::singleton, false);
-		return SceneShaderForwardMobile::singleton->shader.version_is_valid(version);
+
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		ERR_FAIL_NULL_V(material_storage, false);
+		return material_storage->shader_template_version_is_valid(shader_template, version);
 	} else {
 		return false;
 	}
@@ -525,8 +582,10 @@ SceneShaderForwardMobile::ShaderData::~ShaderData() {
 
 	if (version.is_valid()) {
 		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
-		ERR_FAIL_NULL(SceneShaderForwardMobile::singleton);
-		SceneShaderForwardMobile::singleton->shader.version_free(version);
+
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		ERR_FAIL_NULL(material_storage);
+		material_storage->shader_template_version_free(shader_template, version);
 	}
 }
 
@@ -547,8 +606,11 @@ void SceneShaderForwardMobile::MaterialData::set_next_pass(RID p_pass) {
 
 bool SceneShaderForwardMobile::MaterialData::update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) {
 	if (shader_data->version.is_valid()) {
-		RID base_shader = SceneShaderForwardMobile::singleton->shader.version_get_shader(shader_data->version, (SceneShaderForwardMobile::singleton->use_fp16 ? SHADER_VERSION_MAX * 2 : 0));
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		RID base_shader = material_storage->shader_template_version_get_shader(shader_data->shader_template, shader_data->version, (SceneShaderForwardMobile::singleton->use_fp16 ? SHADER_VERSION_MAX * 2 : 0));
+
 		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
+
 		return update_parameters_uniform_set(p_parameters, p_uniform_dirty, p_textures_dirty, shader_data->uniforms, shader_data->ubo_offsets.ptr(), shader_data->texture_uniforms, shader_data->default_texture_params, shader_data->ubo_size, uniform_set, base_shader, RenderForwardMobile::MATERIAL_UNIFORM_SET, true, true);
 	} else {
 		return false;
@@ -594,46 +656,12 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		shadow_sampler = RD::get_singleton()->sampler_create(sampler);
 	}
 
-	/* SCENE SHADER */
-
+	// Setup our default shader template
 	{
-		Vector<ShaderRD::VariantDefine> shader_versions;
-		for (uint32_t fp16 = 0; fp16 < 2; fp16++) {
-			for (uint32_t ubershader = 0; ubershader < 2; ubershader++) {
-				String base_define = fp16 ? "\n#define EXPLICIT_FP16\n" : "";
-				int shader_group = fp16 ? SHADER_GROUP_FP16 : SHADER_GROUP_FP32;
-				int shader_group_multiview = fp16 ? SHADER_GROUP_FP16_MULTIVIEW : SHADER_GROUP_FP32_MULTIVIEW;
-				base_define += ubershader ? "\n#define UBERSHADER\n" : "";
-
-				bool default_enabled = (uint32_t(use_fp16) == fp16);
-				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "", default_enabled)); // SHADER_VERSION_COLOR_PASS
-				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "\n#define USE_LIGHTMAP\n", default_enabled)); // SHADER_VERSION_LIGHTMAP_COLOR_PASS
-				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "\n#define MODE_RENDER_DEPTH\n#define SHADOW_PASS\n", default_enabled)); // SHADER_VERSION_SHADOW_PASS, should probably change this to MODE_RENDER_SHADOW because we don't have a depth pass here...
-				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_DUAL_PARABOLOID\n#define SHADOW_PASS\n", default_enabled)); // SHADER_VERSION_SHADOW_PASS_DP
-				shader_versions.push_back(ShaderRD::VariantDefine(shader_group, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_MATERIAL\n", default_enabled)); // SHADER_VERSION_DEPTH_PASS_WITH_MATERIAL
-
-				// Multiview versions of our shaders.
-				shader_versions.push_back(ShaderRD::VariantDefine(shader_group_multiview, base_define + "\n#define USE_MULTIVIEW\n", false)); // SHADER_VERSION_COLOR_PASS_MULTIVIEW
-				shader_versions.push_back(ShaderRD::VariantDefine(shader_group_multiview, base_define + "\n#define USE_MULTIVIEW\n#define USE_LIGHTMAP\n", false)); // SHADER_VERSION_LIGHTMAP_COLOR_PASS_MULTIVIEW
-				shader_versions.push_back(ShaderRD::VariantDefine(shader_group_multiview, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define SHADOW_PASS\n", false)); // SHADER_VERSION_SHADOW_PASS_MULTIVIEW
-				shader_versions.push_back(ShaderRD::VariantDefine(shader_group_multiview, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_MOTION_VECTORS\n", false)); // SHADER_VERSION_MOTION_VECTORS_MULTIVIEW
-			}
-		}
-
-		Vector<RD::PipelineImmutableSampler> immutable_samplers;
-		RD::PipelineImmutableSampler immutable_shadow_sampler;
-		immutable_shadow_sampler.binding = 2;
-		immutable_shadow_sampler.append_id(shadow_sampler);
-		immutable_shadow_sampler.uniform_type = RenderingDeviceCommons::UNIFORM_TYPE_SAMPLER;
-		immutable_samplers.push_back(immutable_shadow_sampler);
-		Vector<uint64_t> dynamic_buffers;
-		dynamic_buffers.push_back(ShaderRD::DynamicBuffer::encode(RenderForwardMobile::RENDER_PASS_UNIFORM_SET, 0));
-		dynamic_buffers.push_back(ShaderRD::DynamicBuffer::encode(RenderForwardMobile::RENDER_PASS_UNIFORM_SET, 1));
-		shader.initialize(shader_versions, p_defines, immutable_samplers, dynamic_buffers);
-
-		if (RendererCompositorRD::get_singleton()->is_xr_enabled()) {
-			enable_multiview_shader_group();
-		}
+		default_defines = p_defines;
+		default_shader_template = material_storage->shader_template_allocate();
+		material_storage->shader_template_initialize(default_shader_template);
+		material_storage->shader_template_set_shader(default_shader_template, memnew(SceneForwardMobileShaderRD));
 	}
 
 	material_storage->shader_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_3D, _create_shader_funcs);
@@ -877,7 +905,7 @@ void fragment() {
 		material_storage->material_set_shader(default_material, default_shader);
 
 		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(default_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
-		default_shader_rd = shader.version_get_shader(md->shader_data->version, (use_fp16 ? SHADER_VERSION_MAX * 2 : 0) + SHADER_VERSION_COLOR_PASS);
+		default_shader_rd = material_storage->shader_template_version_get_shader(default_shader_template, md->shader_data->version, (use_fp16 ? SHADER_VERSION_MAX * 2 : 0) + SHADER_VERSION_COLOR_PASS);
 
 		default_material_shader_ptr = md->shader_data;
 		default_material_uniform_set = md->uniform_set;
@@ -959,7 +987,9 @@ uint32_t SceneShaderForwardMobile::get_pipeline_compilations(RSE::PipelineSource
 }
 
 void SceneShaderForwardMobile::enable_fp32_shader_group() {
-	shader.enable_group(SHADER_GROUP_FP32);
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+
+	material_storage->shader_template_enable_group_on_all(SHADER_GROUP_FP32);
 
 	if (is_multiview_shader_group_enabled()) {
 		enable_multiview_shader_group();
@@ -967,7 +997,9 @@ void SceneShaderForwardMobile::enable_fp32_shader_group() {
 }
 
 void SceneShaderForwardMobile::enable_fp16_shader_group() {
-	shader.enable_group(SHADER_GROUP_FP16);
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+
+	material_storage->shader_template_enable_group_on_all(SHADER_GROUP_FP16);
 
 	if (is_multiview_shader_group_enabled()) {
 		enable_multiview_shader_group();
@@ -975,17 +1007,20 @@ void SceneShaderForwardMobile::enable_fp16_shader_group() {
 }
 
 void SceneShaderForwardMobile::enable_multiview_shader_group() {
-	if (shader.is_group_enabled(SHADER_GROUP_FP32)) {
-		shader.enable_group(SHADER_GROUP_FP32_MULTIVIEW);
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+
+	if (material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_FP32)) {
+		material_storage->shader_template_enable_group_on_all(SHADER_GROUP_FP32_MULTIVIEW);
 	}
 
-	if (shader.is_group_enabled(SHADER_GROUP_FP16)) {
-		shader.enable_group(SHADER_GROUP_FP16_MULTIVIEW);
+	if (material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_FP16)) {
+		material_storage->shader_template_enable_group_on_all(SHADER_GROUP_FP16_MULTIVIEW);
 	}
 }
 
 bool SceneShaderForwardMobile::is_multiview_shader_group_enabled() const {
-	return shader.is_group_enabled(SHADER_GROUP_FP32_MULTIVIEW) || shader.is_group_enabled(SHADER_GROUP_FP16_MULTIVIEW);
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+	return material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_FP32_MULTIVIEW) || material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_FP16_MULTIVIEW);
 }
 
 RID SceneShaderForwardMobile::get_default_shader_rd(bool p_is_multiview) {
@@ -1002,7 +1037,7 @@ RID SceneShaderForwardMobile::get_default_shader_rd(bool p_is_multiview) {
 		}
 
 		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(default_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
-		shader_rd = shader.version_get_shader(md->shader_data->version, variant);
+		shader_rd = material_storage->shader_template_version_get_shader(default_shader_template, md->shader_data->version, variant);
 	}
 
 	return shader_rd;
@@ -1021,4 +1056,6 @@ SceneShaderForwardMobile::~SceneShaderForwardMobile() {
 	material_storage->material_free(overdraw_material);
 	material_storage->material_free(default_material);
 	material_storage->material_free(debug_shadow_splits_material);
+
+	material_storage->shader_template_free(default_shader_template);
 }

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -223,6 +223,7 @@ public:
 		void _create_pipeline(PipelineKey p_pipeline_key);
 		PipelineHashMapRD<PipelineKey, ShaderData, void (ShaderData::*)(PipelineKey)> pipeline_hash_map;
 
+		RID shader_template;
 		RID version;
 
 		static const uint32_t VERTEX_INPUT_MASKS_SIZE = SHADER_VERSION_MAX * 2;
@@ -303,7 +304,7 @@ public:
 			return !uses_particle_trails && !writes_modelview_or_projection && !uses_vertex && !uses_discard && !uses_depth_prepass_alpha && !uses_alpha_clip && !uses_alpha_antialiasing && !uses_point_size && !uses_world_coordinates && !wireframe && !stencil_enabled && backface_culling;
 		}
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;
@@ -345,11 +346,12 @@ public:
 		return static_cast<SceneShaderForwardMobile *>(singleton)->_create_material_func(static_cast<ShaderData *>(p_shader));
 	}
 
-	SceneForwardMobileShaderRD shader;
+	String default_defines;
 	ShaderCompiler compiler;
 	bool use_fp16 = false;
 	bool emulate_point_size = false;
 
+	RID default_shader_template;
 	RID default_shader;
 	RID default_material;
 	RID overdraw_material_shader;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1539,7 +1539,12 @@ void RendererCanvasRenderRD::CanvasShaderData::_create_pipeline(PipelineKey p_pi
 	pipeline_hash_map.add_compiled_pipeline(p_pipeline_key.hash(), pipeline);
 }
 
-void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code) {
+void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for canvas shaders.");
+	}
+
 	//compile
 
 	code = p_code;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -167,7 +167,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 		void _clear_vertex_input_mask_cache();
 		void _create_pipeline(PipelineKey p_pipeline_key);
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -39,7 +39,15 @@
 
 class StringBuilder;
 
+namespace RendererRD {
+
+class MaterialStorage;
+
+}
+
 class ShaderRD {
+	friend class RendererRD::MaterialStorage;
+
 public:
 	struct VariantDefine {
 		int group = 0;

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -1256,7 +1256,12 @@ void MaterialStorage::MaterialData::set_as_used() {
 
 /* TextureBlit SHADER */
 
-void MaterialStorage::TexBlitShaderData::set_code(const String &p_code) {
+void MaterialStorage::TexBlitShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for texture blit shaders.");
+	}
+
 	TextureStorage *texture_storage = TextureStorage::get_singleton();
 	// Initialize and compile the shader.
 
@@ -1534,7 +1539,10 @@ MaterialStorage::~MaterialStorage() {
 }
 
 bool MaterialStorage::free(RID p_rid) {
-	if (owns_shader(p_rid)) {
+	if (owns_shader_template(p_rid)) {
+		shader_template_free(p_rid);
+		return true;
+	} else if (owns_shader(p_rid)) {
 		shader_free(p_rid);
 		return true;
 	} else if (owns_material(p_rid)) {
@@ -2164,6 +2172,225 @@ void MaterialStorage::_update_global_shader_uniforms() {
 	}
 }
 
+/* SHADER TEMPLATE API */
+
+void MaterialStorage::ShaderTemplate::cleanup() {
+	if (shader) {
+		memdelete(shader);
+		shader = nullptr;
+	}
+	initialized = false;
+}
+
+RID MaterialStorage::shader_template_allocate() {
+	return shader_template_owner.allocate_rid();
+}
+
+void MaterialStorage::shader_template_initialize(RID p_rid) {
+	ShaderTemplate shader_template;
+	shader_template.self = p_rid;
+
+	shader_template_owner.initialize_rid(p_rid, shader_template);
+}
+
+void MaterialStorage::shader_template_free(RID p_rid) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_rid);
+	ERR_FAIL_NULL(shader_template);
+
+	// Make sure our shaders are unreferenced.
+	while (shader_template->owners.size()) {
+		shader_set_shader_template((*shader_template->owners.begin())->self, RID());
+	}
+
+	shader_template->cleanup();
+	shader_template_owner.free(p_rid);
+}
+
+void MaterialStorage::shader_template_set_raster_code(RID p_template_shader, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) {
+	HashMap<Shader *, String> org_code;
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL(shader_template);
+
+	// Remember code for shaders that use this template and clear the shader data.
+	for (Shader *shader : shader_template->owners) {
+		if (shader->data) {
+			// Make a copy, we're about to lose it.
+			org_code[shader] = shader->code;
+
+			// Delete the old shader data.
+			memdelete(shader->data);
+			shader->data = nullptr;
+			shader->type = SHADER_TYPE_MAX;
+		}
+	}
+
+	// Clean up our shader template.
+	shader_template->cleanup();
+
+	// Create our new shader for this template.
+	shader_template->shader = memnew(ShaderRD);
+	if (shader_template->shader) {
+		shader_template->shader->setup(p_vertex_code.utf8().get_data(), p_fragment_code.utf8().get_data(), nullptr, p_name.utf8().get_data());
+	}
+
+	// And recompile the shaders if applicable.
+	for (Shader *shader : shader_template->owners) {
+		if (!org_code[shader].is_empty()) {
+			shader_set_code(shader->self, org_code[shader]);
+		}
+	}
+}
+
+void MaterialStorage::shader_template_set_shader(RID p_template_shader, ShaderRD *p_shader) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL(shader_template);
+
+	// Note: this should only be called for setting up our default shader template.
+	// No dependencies are managed for our default shader template.
+
+	shader_template->cleanup();
+
+	shader_template->shader = p_shader;
+}
+
+bool MaterialStorage::shader_template_is_initialized(RID p_template_shader) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL_V(shader_template, false);
+
+	return shader_template->initialized;
+}
+
+void MaterialStorage::shader_template_shader_initialize(RID p_template_shader, const Vector<String> &p_variant_defines, const String &p_general_defines, const Vector<RD::PipelineImmutableSampler> &p_immutable_samplers, const Vector<uint64_t> &p_dynamic_buffers) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL(shader_template);
+	ERR_FAIL_NULL(shader_template->shader);
+	ERR_FAIL_COND(shader_template->initialized);
+
+	shader_template->shader->initialize(p_variant_defines, p_general_defines, p_immutable_samplers, p_dynamic_buffers);
+
+	shader_template->initialized = true;
+}
+
+void MaterialStorage::shader_template_shader_initialize(RID p_template_shader, const Vector<ShaderRD::VariantDefine> &p_variant_defines, const String &p_general_defines, const Vector<RD::PipelineImmutableSampler> &p_immutable_samplers, const Vector<uint64_t> &p_dynamic_buffers) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL(shader_template);
+	ERR_FAIL_NULL(shader_template->shader);
+	ERR_FAIL_COND(shader_template->initialized);
+
+	shader_template->shader->initialize(p_variant_defines, p_general_defines, p_immutable_samplers, p_dynamic_buffers);
+
+	shader_template->initialized = true;
+}
+
+void MaterialStorage::shader_template_set_variant_enabled(RID p_template_shader, int p_variant, bool p_enabled) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL(shader_template);
+	ERR_FAIL_NULL(shader_template->shader);
+	ERR_FAIL_COND(!shader_template->initialized);
+
+	shader_template->shader->set_variant_enabled(p_variant, p_enabled);
+}
+
+bool MaterialStorage::shader_template_is_variant_enabled(RID p_template_shader, int p_variant) const {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL_V(shader_template, false);
+	ERR_FAIL_NULL_V(shader_template->shader, false);
+	ERR_FAIL_COND_V(!shader_template->initialized, false);
+
+	return shader_template->shader->is_variant_enabled(p_variant);
+}
+
+void MaterialStorage::shader_template_enable_group(RID p_template_shader, int p_group) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL(shader_template);
+	ERR_FAIL_NULL(shader_template->shader);
+	ERR_FAIL_COND(!shader_template->initialized);
+
+	shader_template->shader->enable_group(p_group);
+}
+
+bool MaterialStorage::shader_template_is_any_group_enabled(int p_group) {
+	LocalVector<RID> owned = shader_template_owner.get_owned_list();
+
+	for (RID &rid : owned) {
+		ShaderTemplate *shader_template = shader_template_owner.get_or_null(rid);
+		if (shader_template && shader_template->shader && shader_template->shader->is_group_enabled(p_group)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void MaterialStorage::shader_template_enable_group_on_all(int p_group) {
+	LocalVector<RID> owned = shader_template_owner.get_owned_list();
+
+	for (RID &rid : owned) {
+		shader_template_enable_group(rid, p_group);
+	}
+}
+
+RID MaterialStorage::shader_template_version_create(RID p_template_shader, bool p_embedded) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL_V(shader_template, RID());
+	ERR_FAIL_NULL_V(shader_template->shader, RID());
+	ERR_FAIL_COND_V(!shader_template->initialized, RID());
+
+	return shader_template->shader->version_create(p_embedded);
+}
+
+void MaterialStorage::shader_template_version_free(RID p_template_shader, RID p_version) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL(shader_template);
+	ERR_FAIL_NULL(shader_template->shader);
+	ERR_FAIL_COND(!shader_template->initialized);
+
+	shader_template->shader->version_free(p_version);
+}
+
+void MaterialStorage::shader_template_version_set_code(RID p_template_shader, RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL(shader_template);
+	ERR_FAIL_NULL(shader_template->shader);
+	ERR_FAIL_COND(!shader_template->initialized);
+
+	return shader_template->shader->version_set_code(p_version, p_code, p_uniforms, p_vertex_globals, p_fragment_globals, p_custom_defines);
+}
+
+bool MaterialStorage::shader_template_version_is_valid(RID p_template_shader, RID p_version) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL_V(shader_template, false);
+	ERR_FAIL_NULL_V(shader_template->shader, false);
+	ERR_FAIL_COND_V(!shader_template->initialized, false);
+
+	return shader_template->shader->version_is_valid(p_version);
+}
+
+ShaderRD *MaterialStorage::shader_template_get_shader(RID p_template_shader) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL_V(shader_template, nullptr);
+
+	return shader_template->shader;
+}
+
+RID MaterialStorage::shader_template_version_get_shader(RID p_template_shader, RID p_version, int p_variant) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL_V(shader_template, RID());
+	ERR_FAIL_NULL_V(shader_template->shader, RID());
+	ERR_FAIL_COND_V(!shader_template->initialized, RID());
+
+	return shader_template->shader->version_get_shader(p_version, p_variant);
+}
+
+RenderingServerTypes::ShaderNativeSourceCode MaterialStorage::shader_template_version_get_native_source_code(RID p_template_shader, RID p_version) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_template_shader);
+	ERR_FAIL_NULL_V(shader_template, RenderingServerTypes::ShaderNativeSourceCode());
+	ERR_FAIL_NULL_V(shader_template->shader, RenderingServerTypes::ShaderNativeSourceCode());
+	ERR_FAIL_COND_V(!shader_template->initialized, RenderingServerTypes::ShaderNativeSourceCode());
+
+	return shader_template->shader->version_get_native_source_code(p_version);
+}
+
 /* SHADER API */
 
 RID MaterialStorage::shader_allocate() {
@@ -2172,10 +2399,12 @@ RID MaterialStorage::shader_allocate() {
 
 void MaterialStorage::shader_initialize(RID p_rid, bool p_embedded) {
 	Shader shader;
+	shader.self = p_rid;
 	shader.mutex = memnew(Mutex);
 	shader.data = nullptr;
 	shader.type = SHADER_TYPE_MAX;
 	shader.embedded = p_embedded;
+	shader.self = p_rid;
 
 	shader_owner.initialize_rid(p_rid, shader);
 
@@ -2193,13 +2422,18 @@ void MaterialStorage::shader_free(RID p_rid) {
 	{
 		MutexLock lock(*shader->mutex);
 
-		//make material unreference this
+		// Clear our shader template.
+		shader_set_shader_template(p_rid, RID(), true);
+
+		// Make material unreference this.
 		while (shader->owners.size()) {
 			material_set_shader((*shader->owners.begin())->self, RID());
 		}
 
-		//clear data if exists
-		memdelete(shader->data);
+		// Clear data if exists.
+		if (shader->data) {
+			memdelete(shader->data);
+		}
 	}
 
 	if (shader->embedded) {
@@ -2211,6 +2445,42 @@ void MaterialStorage::shader_free(RID p_rid) {
 	memdelete(shader->mutex);
 
 	shader_owner.free(p_rid);
+}
+
+void MaterialStorage::shader_set_shader_template(RID p_shader, RID p_shader_template, bool p_clear_code) {
+	Shader *shader = shader_owner.get_or_null(p_shader);
+	ERR_FAIL_NULL(shader);
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_shader_template);
+
+	if (shader->shader_template != shader_template) {
+		String org_code;
+
+		if (shader->data) {
+			// Make a copy, we're about to lose it.
+			org_code = shader->code;
+			memdelete(shader->data);
+			shader->type = SHADER_TYPE_MAX;
+			shader->data = nullptr;
+		}
+
+		if (shader->shader_template) {
+			shader->shader_template->owners.erase(shader);
+		}
+		shader->shader_template = shader_template;
+		if (shader->shader_template) {
+			shader->shader_template->owners.insert(shader);
+		}
+
+		// Trigger recompile, but only if we have shader data.
+		// This should prevent a double compile as long as we set our
+		// template before we set our code!
+		// TODO: We do have a problem that if the shader template gets freed
+		// before our shaders get freed during closing, we trigger a recompile
+		// with the built-in shader.
+		if (!org_code.is_empty() && !p_clear_code) {
+			shader_set_code(p_shader, org_code);
+		}
+	}
 }
 
 void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
@@ -2283,8 +2553,13 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 	}
 
 	if (shader->data) {
+		RID shader_template;
+		if (shader->shader_template) {
+			shader_template = shader->shader_template->self;
+		}
+
 		shader->data->set_path_hint(shader->path_hint);
-		shader->data->set_code(p_code);
+		shader->data->set_code(p_code, shader_template);
 	}
 
 	for (Material *E : shader->owners) {

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -33,6 +33,7 @@
 #include "core/templates/rid_owner.h"
 #include "core/templates/self_list.h"
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
+#include "servers/rendering/renderer_rd/shader_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/texture_storage.h"
 #include "servers/rendering/rendering_server_types.h"
 #include "servers/rendering/shader_compiler.h"
@@ -78,7 +79,7 @@ public:
 		virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 		virtual bool is_parameter_texture(const StringName &p_param) const;
 
-		virtual void set_code(const String &p_Code) = 0;
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID()) = 0;
 		virtual bool is_animated() const = 0;
 		virtual bool casts_shadows() const = 0;
 		virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const = 0;
@@ -153,7 +154,7 @@ public:
 
 		BlendMode blend_mode;
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template);
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;
@@ -260,13 +261,32 @@ private:
 	void _global_shader_uniform_store_in_buffer(int32_t p_index, RSE::GlobalShaderParameterType p_type, const Variant &p_value);
 	void _global_shader_uniform_mark_buffer_dirty(int32_t p_index, int32_t p_elements);
 
+	/* SHADER TEMPLATE API */
+
+	struct Shader;
+
+	struct ShaderTemplate {
+		RID self;
+		ShaderRD *shader = nullptr;
+		bool initialized = false;
+
+		HashSet<Shader *> owners;
+
+		void cleanup();
+	};
+
+	mutable RID_Owner<ShaderTemplate, true> shader_template_owner;
+	ShaderTemplate *get_shader_template(RID p_rid) { return shader_template_owner.get_or_null(p_rid); }
+
 	/* SHADER API */
 
 	struct Material;
 
 	struct Shader {
+		RID self;
 		Mutex *mutex = nullptr;
 		ShaderData *data = nullptr;
+		ShaderTemplate *shader_template = nullptr;
 		String code;
 		String path_hint;
 		ShaderType type;
@@ -456,6 +476,36 @@ public:
 
 	RID global_shader_uniforms_get_storage_buffer() const;
 
+	/* SHADER TEMPLATE API */
+
+	bool owns_shader_template(RID p_rid) { return shader_template_owner.owns(p_rid); }
+
+	virtual RID shader_template_allocate() override;
+	virtual void shader_template_initialize(RID p_rid) override;
+	virtual void shader_template_free(RID p_rid) override;
+
+	virtual void shader_template_set_raster_code(RID p_template_shader, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) override;
+	void shader_template_set_shader(RID p_template_shader, ShaderRD *p_shader); // note, this takes ownership of the shader!
+
+	// setup
+	bool shader_template_is_initialized(RID p_template_shader);
+	void shader_template_shader_initialize(RID p_template_shader, const Vector<String> &p_variant_defines, const String &p_general_defines = "", const Vector<RD::PipelineImmutableSampler> &p_immutable_samplers = Vector<RD::PipelineImmutableSampler>(), const Vector<uint64_t> &p_dynamic_buffers = Vector<uint64_t>());
+	void shader_template_shader_initialize(RID p_template_shader, const Vector<ShaderRD::VariantDefine> &p_variant_defines, const String &p_general_defines = "", const Vector<RD::PipelineImmutableSampler> &p_immutable_samplers = Vector<RD::PipelineImmutableSampler>(), const Vector<uint64_t> &p_dynamic_buffers = Vector<uint64_t>());
+	void shader_template_set_variant_enabled(RID p_template_shader, int p_variant, bool p_enabled);
+	bool shader_template_is_variant_enabled(RID p_template_shader, int p_variant) const;
+	void shader_template_enable_group(RID p_template_shader, int p_group);
+	bool shader_template_is_any_group_enabled(int p_group);
+	void shader_template_enable_group_on_all(int p_group);
+
+	// shader version
+	RID shader_template_version_create(RID p_template_shader, bool p_embedded = true);
+	void shader_template_version_free(RID p_template_shader, RID p_version);
+	void shader_template_version_set_code(RID p_template_shader, RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines);
+	bool shader_template_version_is_valid(RID p_template_shader, RID p_version);
+	ShaderRD *shader_template_get_shader(RID p_template_shader);
+	RID shader_template_version_get_shader(RID p_template_shader, RID p_version, int p_variant);
+	RenderingServerTypes::ShaderNativeSourceCode shader_template_version_get_native_source_code(RID p_template_shader, RID p_version);
+
 	/* SHADER API */
 
 	bool owns_shader(RID p_rid) { return shader_owner.owns(p_rid); }
@@ -464,6 +514,7 @@ public:
 	virtual void shader_initialize(RID p_shader, bool p_embedded = true) override;
 	virtual void shader_free(RID p_rid) override;
 
+	virtual void shader_set_shader_template(RID p_shader, RID p_shader_template = RID(), bool p_clear_code = false) override;
 	virtual void shader_set_code(RID p_shader, const String &p_code) override;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) override;
 	virtual String shader_get_code(RID p_shader) const override;

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1738,7 +1738,12 @@ bool ParticlesStorage::particles_is_inactive(RID p_particles) const {
 
 /* Particles SHADER */
 
-void ParticlesStorage::ParticlesShaderData::set_code(const String &p_code) {
+void ParticlesStorage::ParticlesShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for particle shaders.");
+	}
+
 	ParticlesStorage *particles_storage = ParticlesStorage::get_singleton();
 	//compile
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -372,7 +372,7 @@ private:
 		bool userdatas_used[ParticlesShader::MAX_USERDATAS] = {};
 		uint32_t userdata_count = 0;
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RenderingServerTypes::ShaderNativeSourceCode get_native_source_code() const;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2319,9 +2319,15 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(RSE::TEXTURE_DRAWABLE_FORMAT_RGBAH);
 	BIND_ENUM_CONSTANT(RSE::TEXTURE_DRAWABLE_FORMAT_RGBAF);
 
+	/* SHADER TEMPLATE */
+
+	ClassDB::bind_method(D_METHOD("shader_template_create"), &RenderingServer::shader_template_create);
+	ClassDB::bind_method(D_METHOD("shader_template_set_raster_code", "shader_template", "vertex_code", "fragment_code", "name"), &RenderingServer::shader_template_set_raster_code);
+
 	/* SHADER */
 
 	ClassDB::bind_method(D_METHOD("shader_create"), &RenderingServer::shader_create);
+	ClassDB::bind_method(D_METHOD("shader_set_shader_template", "shader", "shader_template", "clear_code"), &RenderingServer::shader_set_shader_template, DEFVAL(RID()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("shader_set_code", "shader", "code"), &RenderingServer::shader_set_code);
 	ClassDB::bind_method(D_METHOD("shader_set_path_hint", "shader", "path"), &RenderingServer::shader_set_path_hint);
 	ClassDB::bind_method(D_METHOD("shader_get_code", "shader"), &RenderingServer::shader_get_code);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -156,11 +156,18 @@ public:
 	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const = 0;
 	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const = 0;
 
+	/* SHADER TEMPLATE API */
+
+	virtual RID shader_template_create() = 0;
+
+	virtual void shader_template_set_raster_code(RID p_shader_template, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) = 0;
+
 	/* SHADER API */
 
 	virtual RID shader_create() = 0;
 	virtual RID shader_create_from_code(const String &p_code, const String &p_path_hint = String()) = 0;
 
+	virtual void shader_set_shader_template(RID p_shader, RID p_shader_template = RID(), bool p_clear_code = false) = 0;
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -275,6 +275,10 @@ public:
 #define ServerName RendererMaterialStorage
 #define server_name RSG::material_storage
 
+	FUNCRIDSPLIT(shader_template)
+
+	FUNC4(shader_template_set_raster_code, RID, const String &, const String &, const String &)
+
 	virtual RID shader_create() override {
 		RID ret = RSG::material_storage->shader_allocate();
 		if (Thread::get_caller_id() == server_thread) {
@@ -284,6 +288,8 @@ public:
 		}
 		return ret;
 	}
+
+	// TODO: Probably need a variant here *with* template.
 
 	virtual RID shader_create_from_code(const String &p_code, const String &p_path_hint = String()) override {
 		RID shader = RSG::material_storage->shader_allocate();
@@ -305,6 +311,7 @@ public:
 		return shader;
 	}
 
+	FUNC3(shader_set_shader_template, RID, RID, bool)
 	FUNC2(shader_set_code, RID, const String &)
 	FUNC2(shader_set_path_hint, RID, const String &)
 	FUNC1RC(String, shader_get_code, RID)

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -344,6 +344,7 @@ const ShaderLanguage::KeyWord ShaderLanguage::keyword_list[] = {
 	{ TK_CONST, "const", CF_BLOCK | CF_GLOBAL_SPACE | CF_CONST_KEYWORD, {}, {} },
 	{ TK_STRUCT, "struct", CF_GLOBAL_SPACE, {}, {} },
 	{ TK_SHADER_TYPE, "shader_type", CF_SHADER_TYPE, {}, {} },
+	{ TK_SHADER_TEMPLATE, "shader_template", CF_GLOBAL_SPACE, {}, {} },
 	{ TK_RENDER_MODE, "render_mode", CF_GLOBAL_SPACE, {}, {} },
 	{ TK_STENCIL_MODE, "stencil_mode", CF_GLOBAL_SPACE, {}, {} },
 
@@ -1315,6 +1316,7 @@ void ShaderLanguage::clear() {
 	current_function = StringName();
 	last_name = StringName();
 	last_type = IDENTIFIER_MAX;
+	shader_template = "";
 	current_uniform_group_name = "";
 	current_uniform_hint = ShaderNode::Uniform::HINT_NONE;
 	current_uniform_filter = FILTER_DEFAULT;
@@ -9398,6 +9400,28 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 	while (tk.type != TK_EOF) {
 		switch (tk.type) {
+			case TK_SHADER_TEMPLATE: {
+				if (!shader_template.is_empty()) {
+					_set_error(RTR("Shader template is already defined."));
+					return ERR_PARSE_ERROR;
+				}
+
+				tk = _get_token();
+				if (tk.type == TK_STRING_CONSTANT) {
+					shader_template = tk.text;
+				} else {
+					_set_error(vformat(RTR("Unexpected token: '%s'."), get_token_text(tk)));
+					return ERR_PARSE_ERROR;
+				}
+
+				tk = _get_token();
+				if (tk.type == TK_SEMICOLON) {
+					break; //done
+				} else {
+					_set_error(vformat(RTR("Unexpected token: '%s'."), get_token_text(tk)));
+					return ERR_PARSE_ERROR;
+				}
+			} break;
 			case TK_RENDER_MODE: {
 #ifdef DEBUG_ENABLED
 				keyword_completion_context = CF_UNSPECIFIED;
@@ -11500,6 +11524,36 @@ String ShaderLanguage::get_shader_type(const String &p_code) {
 	}
 
 	return String();
+}
+
+String ShaderLanguage::get_shader_template(const String &p_code) {
+	int start_pos = p_code.find("shader_template ");
+	if (start_pos == -1) {
+		// No shader template specified, this is OK.
+		return String();
+	}
+
+	start_pos += 16;
+	char32_t quote = p_code[start_pos];
+	while (quote == ' ' || quote == '\t') {
+		start_pos++;
+		quote = p_code[start_pos];
+	}
+
+	if (quote != '\'' && quote != '"') {
+		// No quotes, we don't have a string here.
+		// This will give us a compile error later on.
+		return String();
+	}
+
+	int end_pos = p_code.find_char(quote, start_pos + 1);
+	if (end_pos == -1) {
+		// No closing quote?
+		// This will give us a compile error later on.
+		return String();
+	}
+
+	return p_code.substr(start_pos + 1, end_pos - start_pos - 1);
 }
 
 bool ShaderLanguage::is_builtin_vec_constructor(const String &p_name) {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -199,6 +199,7 @@ public:
 		TK_CURSOR,
 		TK_ERROR,
 		TK_EOF,
+		TK_SHADER_TEMPLATE,
 		TK_MAX
 	};
 
@@ -1065,6 +1066,7 @@ private:
 	StringName last_name;
 	bool is_shader_inc = false;
 
+	String shader_template;
 	String current_uniform_group_name;
 
 	VaryingFunctionNames varying_function_names;
@@ -1259,6 +1261,7 @@ public:
 	void clear();
 
 	static String get_shader_type(const String &p_code);
+	static String get_shader_template(const String &p_code);
 	static bool is_builtin_vec_constructor(const String &p_name);
 	static bool is_builtin_func_out_parameter(const String &p_name, int p_param);
 

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -55,11 +55,21 @@ public:
 	virtual void global_shader_parameters_instance_free(RID p_instance) = 0;
 	virtual void global_shader_parameters_instance_update(RID p_instance, int p_index, const Variant &p_value, int p_flags_count = 0) = 0;
 
+	/* SHADER TEMPLATE API */
+
+	virtual RID shader_template_allocate() = 0;
+	virtual void shader_template_initialize(RID p_rid) = 0;
+	virtual void shader_template_free(RID p_rid) = 0;
+
+	virtual void shader_template_set_raster_code(RID p_template_shader, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) = 0;
+
 	/* SHADER API */
+
 	virtual RID shader_allocate() = 0;
 	virtual void shader_initialize(RID p_rid, bool p_embedded = true) = 0;
 	virtual void shader_free(RID p_rid) = 0;
 
+	virtual void shader_set_shader_template(RID p_shader, RID p_shader_template = RID(), bool p_clear_code = false) = 0;
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;


### PR DESCRIPTION
After discussing during a render meeting some weeks back, we discussed reviving #94427 but breaking it up into parts.

This PR purely adds in the core of the implementation. E.G it introduces the shader template framework and allows us to set a shader template for a `.gdshader` file. It does not touch the `BaseMaterial` class nor does it add the breakup of shaders.

I'm still basing this on the `.gdtemplate` file extension but the logic has been expanded that it can include files though there is still a pathing limitation here. If built-in include files are specified, the include directive remains in the source, but files on disc are loaded immediately and embedded in the imported resource.
For now I've removed the ability to specify multiple renderer shader code, the files just become unwieldy long and its easy for the developer to just switch out shaders. 

Currently only Mobile and Forward+ work, still contemplating to add support for compatibility but that may become a separate PR.

I'm still unsure if we've got a few things in the right place, too much of the previous system assumed there would be only one `ShaderRD` instance centralized and this is no longer the case. Definitely the grouping system and possibly the mutexes applied may need a bit more thought.

Finally we discussed that instead of trying to expose more of the shader code through build-in includes, we build the shader with the complete default template code. In my sample project I've extracted what I need, but the idea was to add a feature to save the built-in shader template so the user can edit it to their hearts content. They will need to be made aware that the code will likely only work with that version of Godot.
This still needs to be added.