### PR TITLE
[macOS] Offload RenderingDevice creation test to subprocess.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1029,7 +1029,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String project_path = ".";
 	bool upwards = false;
 	String debug_uri = "";
-#if defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED))
+#if defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED))
 	bool test_rd_creation = false;
 	bool test_rd_support = false;
 #endif
@@ -1761,7 +1761,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "--debug-mute-audio") {
 			debug_mute_audio = true;
 #endif
-#if defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED))
+#if defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED))
 		} else if (arg == "--test-rd-support") {
 			test_rd_support = true;
 		} else if (arg == "--test-rd-creation") {
@@ -1999,7 +1999,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			"DISABLE_VKBASALT",
 		};
 
-#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED)
+#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED)
 		if (editor || project_manager || test_rd_support || test_rd_creation) {
 #else
 		if (editor || project_manager) {
@@ -2017,7 +2017,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 #endif
 
-#if defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED))
+#if defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED))
 	if (test_rd_support) {
 		// Test Rendering Device creation and exit.
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -1276,7 +1276,7 @@ bool OS_LinuxBSD::_test_create_rendering_device_and_gl(const String &p_display_d
 #endif
 	return _test_create_rendering_device(p_display_driver);
 }
-#endif
+#endif // TOOLS_ENABLED
 
 OS_LinuxBSD::OS_LinuxBSD() {
 	main_loop = nullptr;

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -71,6 +71,8 @@ int main(int argc, char **argv) {
 		"--convert-3to4",
 		"--validate-conversion-3to4",
 		"--doctool",
+		"--test-rd-creation",
+		"--test-rd-support",
 	};
 
 	for (int i = 0; i < argc; i++) {

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -149,6 +149,11 @@ public:
 
 	virtual void run() = 0;
 
+#ifdef TOOLS_ENABLED
+	virtual bool _test_create_rendering_device_and_gl(const String &p_display_driver) const override;
+	virtual bool _test_create_rendering_device(const String &p_display_driver) const override;
+#endif
+
 	OS_MacOS(const char *p_execpath, int p_argc, char **p_argv);
 };
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2734,7 +2734,7 @@ bool OS_Windows::_test_create_rendering_device_and_gl(const String &p_display_dr
 	UnregisterClassW(L"Engine probe window", GetModuleHandle(nullptr));
 	return ok;
 }
-#endif
+#endif // TOOLS_ENABLED
 
 OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	hInstance = _hInstance;

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -1983,7 +1983,7 @@ bool DisplayServer::is_rendering_device_supported() {
 
 	Error err;
 
-#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED)
+#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED)
 	// On some drivers combining OpenGL and RenderingDevice can result in crash, offload the check to the subprocess.
 	List<String> arguments;
 	arguments.push_back("--test-rd-support");
@@ -2001,7 +2001,7 @@ bool DisplayServer::is_rendering_device_supported() {
 	} else {
 		supported_rendering_device = RenderingDeviceCreationStatus::FAILURE;
 	}
-#else // WINDOWS_ENABLED
+#else // defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED)
 
 	RenderingContextDriver *rcd = nullptr;
 
@@ -2045,7 +2045,7 @@ bool DisplayServer::is_rendering_device_supported() {
 		rcd = nullptr;
 	}
 
-#endif // WINDOWS_ENABLED
+#endif // defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED)
 #endif // RD_ENABLED
 	return false;
 }
@@ -2069,7 +2069,7 @@ bool DisplayServer::can_create_rendering_device() {
 
 	Error err;
 
-#ifdef WINDOWS_ENABLED
+#if defined(WINDOWS_ENABLED) || defined(MACOS_ENABLED)
 	// On some NVIDIA drivers combining OpenGL and RenderingDevice can result in crash, offload the check to the subprocess.
 	List<String> arguments;
 	arguments.push_back("--test-rd-creation");
@@ -2083,7 +2083,7 @@ bool DisplayServer::can_create_rendering_device() {
 	} else {
 		created_rendering_device = RenderingDeviceCreationStatus::FAILURE;
 	}
-#else // WINDOWS_ENABLED
+#else // defined(WINDOWS_ENABLED) || defined(MACOS_ENABLED)
 
 	RenderingContextDriver *rcd = nullptr;
 
@@ -2127,7 +2127,7 @@ bool DisplayServer::can_create_rendering_device() {
 		rcd = nullptr;
 	}
 
-#endif // WINDOWS_ENABLED
+#endif // defined(WINDOWS_ENABLED) || defined(MACOS_ENABLED)
 #endif // RD_ENABLED
 	return false;
 }


### PR DESCRIPTION
Should fix https://github.com/godotengine/godot/issues/111904

Same as similar checks on Linux and Windows.