### PR TITLE
Add ALPHA built-in as input to visual fragment shader

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3302,6 +3302,7 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "viewport_size", "VIEWPORT_SIZE" },
 
 	// Node3D, Fragment
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "ALPHA" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_3D, "binormal", "BINORMAL" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_3D, "camera_direction_world", "CAMERA_DIRECTION_WORLD" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_3D, "camera_position_world", "CAMERA_POSITION_WORLD" },


### PR DESCRIPTION
The default value of ALPHA can be changed by e.g. the transparency property of GeometryInstance3D. Text based shaders can access this value directly with the ALPHA built-in, but for visual shaders ALPHA is only available as an output. This one-liner PR adds it to the list of built-ins available in the Visual Shader Input node.

This is necessary for advanced effects, e.g. when your fragment shader has other ways of writing to ALPHA you generally want to multiply it by the existing value instead of overwriting it in order to not break GeometryInstance3D's transparency feature.