### PR TITLE
Make some classes `GDSOFTCLASS` to avoid registering them

### DIFF
--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -168,7 +168,7 @@ public:
 VARIANT_ENUM_CAST(ResourceImporter::ImportOrder);
 
 class ResourceFormatImporterSaver : public ResourceFormatSaver {
-	GDCLASS(ResourceFormatImporterSaver, ResourceFormatSaver)
+	GDSOFTCLASS(ResourceFormatImporterSaver, ResourceFormatSaver)
 
 public:
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;

--- a/drivers/unix/ip_unix.h
+++ b/drivers/unix/ip_unix.h
@@ -35,7 +35,7 @@
 #include "core/io/ip.h"
 
 class IPUnix : public IP {
-	GDCLASS(IPUnix, IP);
+	GDSOFTCLASS(IPUnix, IP);
 
 	virtual void _resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const override;
 

--- a/drivers/windows/ip_windows.h
+++ b/drivers/windows/ip_windows.h
@@ -35,7 +35,7 @@
 #include "core/io/ip.h"
 
 class IPWindows : public IP {
-	GDCLASS(IPWindows, IP);
+	GDSOFTCLASS(IPWindows, IP);
 
 	virtual void _resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const override;
 

--- a/editor/gui/editor_about.h
+++ b/editor/gui/editor_about.h
@@ -44,7 +44,7 @@ class Tree;
  * EditorAbout is also used from the project manager where EditorNode isn't initialized.
  */
 class EditorAbout : public AcceptDialog {
-	GDCLASS(EditorAbout, AcceptDialog);
+	GDSOFTCLASS(EditorAbout, AcceptDialog);
 
 private:
 	enum SectionFlags {

--- a/editor/gui/editor_title_bar.h
+++ b/editor/gui/editor_title_bar.h
@@ -34,7 +34,7 @@
 #include "scene/main/window.h"
 
 class EditorTitleBar : public HBoxContainer {
-	GDCLASS(EditorTitleBar, HBoxContainer);
+	GDSOFTCLASS(EditorTitleBar, HBoxContainer);
 
 	Point2i click_pos;
 	bool moving = false;

--- a/editor/gui/editor_version_button.h
+++ b/editor/gui/editor_version_button.h
@@ -33,7 +33,7 @@
 #include "scene/gui/link_button.h"
 
 class EditorVersionButton : public LinkButton {
-	GDCLASS(EditorVersionButton, LinkButton);
+	GDSOFTCLASS(EditorVersionButton, LinkButton);
 
 public:
 	enum VersionFormat {

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -52,7 +52,7 @@ class TabContainer;
 class VBoxContainer;
 
 class ProjectManager : public Control {
-	GDCLASS(ProjectManager, Control);
+	GDSOFTCLASS(ProjectManager, Control);
 
 	static ProjectManager *singleton;
 

--- a/editor/themes/editor_theme.h
+++ b/editor/themes/editor_theme.h
@@ -33,7 +33,7 @@
 #include "scene/resources/theme.h"
 
 class EditorTheme : public Theme {
-	GDCLASS(EditorTheme, Theme);
+	GDSOFTCLASS(EditorTheme, Theme);
 
 	static Vector<StringName> editor_theme_types;
 

--- a/editor/translations/packed_scene_translation_parser_plugin.h
+++ b/editor/translations/packed_scene_translation_parser_plugin.h
@@ -33,7 +33,7 @@
 #include "editor/translations/editor_translation_parser.h"
 
 class PackedSceneEditorTranslationParserPlugin : public EditorTranslationParserPlugin {
-	GDCLASS(PackedSceneEditorTranslationParserPlugin, EditorTranslationParserPlugin);
+	GDSOFTCLASS(PackedSceneEditorTranslationParserPlugin, EditorTranslationParserPlugin);
 
 	// Scene Node's properties that contain translation strings.
 	HashSet<String> lookup_properties;

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.h
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.h
@@ -38,7 +38,7 @@
 #include "editor/translations/editor_translation_parser.h"
 
 class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlugin {
-	GDCLASS(GDScriptEditorTranslationParserPlugin, EditorTranslationParserPlugin);
+	GDSOFTCLASS(GDScriptEditorTranslationParserPlugin, EditorTranslationParserPlugin);
 
 	const HashMap<int, GDScriptTokenizer::CommentData> *comment_data = nullptr;
 

--- a/modules/gltf/extensions/gltf_document_extension_texture_ktx.h
+++ b/modules/gltf/extensions/gltf_document_extension_texture_ktx.h
@@ -33,7 +33,7 @@
 #include "gltf_document_extension.h"
 
 class GLTFDocumentExtensionTextureKTX : public GLTFDocumentExtension {
-	GDCLASS(GLTFDocumentExtensionTextureKTX, GLTFDocumentExtension);
+	GDSOFTCLASS(GLTFDocumentExtensionTextureKTX, GLTFDocumentExtension);
 
 public:
 	// Import process.

--- a/modules/gltf/extensions/gltf_document_extension_texture_webp.h
+++ b/modules/gltf/extensions/gltf_document_extension_texture_webp.h
@@ -33,7 +33,7 @@
 #include "gltf_document_extension.h"
 
 class GLTFDocumentExtensionTextureWebP : public GLTFDocumentExtension {
-	GDCLASS(GLTFDocumentExtensionTextureWebP, GLTFDocumentExtension);
+	GDSOFTCLASS(GLTFDocumentExtensionTextureWebP, GLTFDocumentExtension);
 
 public:
 	// Import process.

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.h
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.h
@@ -35,7 +35,7 @@
 #include "gltf_physics_shape.h"
 
 class GLTFDocumentExtensionPhysics : public GLTFDocumentExtension {
-	GDCLASS(GLTFDocumentExtensionPhysics, GLTFDocumentExtension);
+	GDSOFTCLASS(GLTFDocumentExtensionPhysics, GLTFDocumentExtension);
 
 public:
 	// Import process.

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -39,7 +39,7 @@
 #include "servers/physics_2d/physics_server_2d.h"
 
 class GodotPhysicsServer2D : public PhysicsServer2D {
-	GDCLASS(GodotPhysicsServer2D, PhysicsServer2D);
+	GDSOFTCLASS(GodotPhysicsServer2D, PhysicsServer2D);
 
 	friend class GodotPhysicsDirectSpaceState2D;
 	friend class GodotPhysicsDirectBodyState2D;

--- a/modules/godot_physics_2d/godot_space_2d.h
+++ b/modules/godot_physics_2d/godot_space_2d.h
@@ -38,7 +38,7 @@
 #include "core/typedefs.h"
 
 class GodotPhysicsDirectSpaceState2D : public PhysicsDirectSpaceState2D {
-	GDCLASS(GodotPhysicsDirectSpaceState2D, PhysicsDirectSpaceState2D);
+	GDSOFTCLASS(GodotPhysicsDirectSpaceState2D, PhysicsDirectSpaceState2D);
 
 public:
 	GodotSpace2D *space = nullptr;

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -39,7 +39,7 @@
 #include "servers/physics_3d/physics_server_3d.h"
 
 class GodotPhysicsServer3D : public PhysicsServer3D {
-	GDCLASS(GodotPhysicsServer3D, PhysicsServer3D);
+	GDSOFTCLASS(GodotPhysicsServer3D, PhysicsServer3D);
 
 	friend class GodotPhysicsDirectSpaceState3D;
 	bool active = true;

--- a/modules/godot_physics_3d/godot_space_3d.h
+++ b/modules/godot_physics_3d/godot_space_3d.h
@@ -39,7 +39,7 @@
 #include "core/typedefs.h"
 
 class GodotPhysicsDirectSpaceState3D : public PhysicsDirectSpaceState3D {
-	GDCLASS(GodotPhysicsDirectSpaceState3D, PhysicsDirectSpaceState3D);
+	GDSOFTCLASS(GodotPhysicsDirectSpaceState3D, PhysicsDirectSpaceState3D);
 
 public:
 	GodotSpace3D *space = nullptr;

--- a/modules/jpg/movie_writer_mjpeg.h
+++ b/modules/jpg/movie_writer_mjpeg.h
@@ -33,7 +33,7 @@
 #include "servers/movie_writer/movie_writer.h"
 
 class MovieWriterMJPEG : public MovieWriter {
-	GDCLASS(MovieWriterMJPEG, MovieWriter)
+	GDSOFTCLASS(MovieWriterMJPEG, MovieWriter)
 
 	uint32_t mix_rate = 48000;
 	AudioServer::SpeakerMode speaker_mode = AudioServer::SPEAKER_MODE_STEREO;

--- a/modules/multiplayer/scene_cache_interface.h
+++ b/modules/multiplayer/scene_cache_interface.h
@@ -36,7 +36,7 @@ class Node;
 class SceneMultiplayer;
 
 class SceneCacheInterface : public RefCounted {
-	GDCLASS(SceneCacheInterface, RefCounted);
+	GDSOFTCLASS(SceneCacheInterface, RefCounted);
 
 private:
 	SceneMultiplayer *multiplayer = nullptr;

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -40,7 +40,7 @@ class SceneMultiplayer;
 class SceneCacheInterface;
 
 class SceneReplicationInterface : public RefCounted {
-	GDCLASS(SceneReplicationInterface, RefCounted);
+	GDSOFTCLASS(SceneReplicationInterface, RefCounted);
 
 private:
 	struct TrackedNode {

--- a/modules/multiplayer/scene_rpc_interface.h
+++ b/modules/multiplayer/scene_rpc_interface.h
@@ -39,7 +39,7 @@ class SceneReplicationInterface;
 class Node;
 
 class SceneRPCInterface : public RefCounted {
-	GDCLASS(SceneRPCInterface, RefCounted);
+	GDSOFTCLASS(SceneRPCInterface, RefCounted);
 
 private:
 	struct RPCConfig {

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.h
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.h
@@ -68,7 +68,7 @@ struct SetCommand2D {
 
 // This server exposes the `NavigationServer3D` features in the 2D world.
 class GodotNavigationServer2D : public NavigationServer2D {
-	GDCLASS(GodotNavigationServer2D, NavigationServer2D);
+	GDSOFTCLASS(GodotNavigationServer2D, NavigationServer2D);
 
 	Mutex commands_mutex;
 	/// Mutex used to make any operation threadsafe.

--- a/modules/theora/editor/movie_writer_ogv.h
+++ b/modules/theora/editor/movie_writer_ogv.h
@@ -38,7 +38,7 @@
 #include <vorbis/vorbisenc.h>
 
 class MovieWriterOGV : public MovieWriter {
-	GDCLASS(MovieWriterOGV, MovieWriter)
+	GDSOFTCLASS(MovieWriterOGV, MovieWriter)
 
 	uint32_t mix_rate = 48000;
 	AudioServer::SpeakerMode speaker_mode = AudioServer::SPEAKER_MODE_STEREO;

--- a/platform/macos/native_menu_macos.h
+++ b/platform/macos/native_menu_macos.h
@@ -38,7 +38,7 @@
 #import <ApplicationServices/ApplicationServices.h>
 
 class NativeMenuMacOS : public NativeMenu {
-	GDCLASS(NativeMenuMacOS, NativeMenu)
+	GDSOFTCLASS(NativeMenuMacOS, NativeMenu)
 
 	struct MenuData {
 		NSMenu *menu = nullptr;

--- a/platform/web/ip_web.h
+++ b/platform/web/ip_web.h
@@ -33,7 +33,7 @@
 #include "core/io/ip.h"
 
 class IPWeb : public IP {
-	GDCLASS(IPWeb, IP);
+	GDSOFTCLASS(IPWeb, IP);
 
 	virtual void _resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const override;
 

--- a/platform/windows/native_menu_windows.h
+++ b/platform/windows/native_menu_windows.h
@@ -39,7 +39,7 @@
 #include <windows.h>
 
 class NativeMenuWindows : public NativeMenu {
-	GDCLASS(NativeMenuWindows, NativeMenu)
+	GDSOFTCLASS(NativeMenuWindows, NativeMenu)
 
 	enum GlobalMenuCheckType {
 		CHECKABLE_TYPE_NONE,

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -35,7 +35,7 @@
 class TextureRect;
 
 class SplitContainerDragger : public Control {
-	GDCLASS(SplitContainerDragger, Control);
+	GDSOFTCLASS(SplitContainerDragger, Control);
 	friend class SplitContainer;
 	Rect2 split_bar_rect;
 

--- a/servers/movie_writer/movie_writer_pngwav.h
+++ b/servers/movie_writer/movie_writer_pngwav.h
@@ -33,7 +33,7 @@
 #include "servers/movie_writer/movie_writer.h"
 
 class MovieWriterPNGWAV : public MovieWriter {
-	GDCLASS(MovieWriterPNGWAV, MovieWriter)
+	GDSOFTCLASS(MovieWriterPNGWAV, MovieWriter)
 
 	enum {
 		MAX_TRAILING_ZEROS = 8 // more than 10 days at 60fps, no hard drive can put up with this anyway :)


### PR DESCRIPTION
* Prepares for #106873

On `master`, when running the godot executable, multiple class registration warnings appear. 
Some of these, which this PR focuses on, are simply a matter of being made `GDSOFTCLASS` instead of `GDCLASS`. This eleminates the requirement to register them in `ClassDB`.
* Note: this can only be applied to classes which are not accessible by users, which was referenced from the latest documentation.


<details>

Make Translation Parser subclasses `GDSOFTCLASS`
Make `ResourceFormatImporterSaver` `GDSOFTCLASS` to avoid registration issues Make Godot Physics Servers `GDSOFTCLASS`
Make SceneInterfaces `GDSOFTCLASS`
Add missing editor  registrations and some to `GDSOFTCLASS` Make `SplitContainerDragger` `GDSOFTCLASS`
Make platform `IP` and `NativeMenu` implementations `GDSOFTCLASS` Make SpaceStates `GDSOFTCLASS`
Make `ProjectManager` `GDSOFTCLASS`
Make some `GLTFDocumentExtension*` classes `GDSOFTCLASS` Make `MovieWriter*` classes `GDSOFTCLASS`
</details>