### PR TITLE
Reorder registration of some classes in `main.cpp`

### DIFF
--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -134,17 +134,24 @@
 #include "editor/scene/3d/skeleton_ik_3d_editor_plugin.h"
 #endif
 
+void register_early_editor_types() {
+	OS::get_singleton()->benchmark_begin_measure("Editor", "Early Register Types");
+
+	EditorStringNames::create();
+
+	GDREGISTER_CLASS(EditorPaths);
+	GDREGISTER_CLASS(EditorTranslationParserPlugin);
+
+	OS::get_singleton()->benchmark_end_measure("Editor", "Early Register Types");
+}
+
 void register_editor_types() {
 	OS::get_singleton()->benchmark_begin_measure("Editor", "Register Types");
 
 	ResourceLoader::set_timestamp_on_load(true);
 	ResourceSaver::set_timestamp_on_save(true);
 
-	EditorStringNames::create();
-
-	GDREGISTER_CLASS(EditorPaths);
 	GDREGISTER_CLASS(EditorPlugin);
-	GDREGISTER_CLASS(EditorTranslationParserPlugin);
 	GDREGISTER_CLASS(EditorImportPlugin);
 	GDREGISTER_CLASS(EditorScript);
 	GDREGISTER_CLASS(EditorDock);

--- a/editor/register_editor_types.h
+++ b/editor/register_editor_types.h
@@ -30,5 +30,6 @@
 
 #pragma once
 
+void register_early_editor_types();
 void register_editor_types();
 void unregister_editor_types();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -748,6 +748,7 @@ Error Main::test_setup() {
 
 	// From `Main::setup2()`.
 	register_early_core_singletons();
+	register_early_scene_types();
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	register_core_extensions();
 
@@ -770,6 +771,7 @@ Error Main::test_setup() {
 
 	// Initialize ThemeDB early so that scene types can register their theme items.
 	// Default theme will be initialized later, after modules and ScriptServer are ready.
+	register_scene_singletons();
 	initialize_theme_db();
 
 #ifndef NAVIGATION_3D_DISABLED
@@ -782,13 +784,12 @@ Error Main::test_setup() {
 	register_scene_types();
 	register_driver_types();
 
-	register_scene_singletons();
-
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_SCENE);
 	GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SCENE);
 
 #ifdef TOOLS_ENABLED
 	ClassDB::set_current_api(ClassDB::API_EDITOR);
+	register_early_editor_types();
 	register_editor_types();
 
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_EDITOR);
@@ -2101,6 +2102,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	register_early_core_singletons();
+	register_early_scene_types();
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	register_core_extensions(); // core extensions must be registered after globals setup and before display
 
@@ -2852,6 +2854,12 @@ Error Main::setup2(bool p_show_boot_logo) {
 	print_header(false);
 
 #ifdef TOOLS_ENABLED
+	ClassDB::set_current_api(ClassDB::API_EDITOR);
+	register_early_editor_types();
+	ClassDB::set_current_api(ClassDB::API_CORE);
+#endif
+
+#ifdef TOOLS_ENABLED
 	int accessibility_mode_editor = 0;
 	int tablet_driver_editor = -1;
 	if (editor || project_manager || cmdline_tool) {
@@ -3520,6 +3528,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 	// Initialize ThemeDB early so that scene types can register their theme items.
 	// Default theme will be initialized later, after modules and ScriptServer are ready.
+	register_scene_singletons();
 	initialize_theme_db();
 
 #if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
@@ -3535,8 +3544,6 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 	register_scene_types();
 	register_driver_types();
-
-	register_scene_singletons();
 
 	{
 		OS::get_singleton()->benchmark_begin_measure("Scene", "Modules and Extensions");

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -60,7 +60,7 @@ static void _editor_init() {
 	FBXDocument::register_gltf_document_extension(extension_##m_doc_ext_class);
 
 void initialize_fbx_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 		GDREGISTER_CLASS(FBXDocument);
 		GDREGISTER_CLASS(FBXState);
 		bool is_editor = Engine::get_singleton()->is_editor_hint();

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -362,10 +362,18 @@ static Ref<ResourceFormatLoaderShader> resource_loader_shader;
 static Ref<ResourceFormatSaverShaderInclude> resource_saver_shader_include;
 static Ref<ResourceFormatLoaderShaderInclude> resource_loader_shader_include;
 
-void register_scene_types() {
-	OS::get_singleton()->benchmark_begin_measure("Scene", "Register Types");
+void register_early_scene_types() {
+	OS::get_singleton()->benchmark_begin_measure("Scene", "Register Early Types");
 
 	SceneStringNames::create();
+
+	GDREGISTER_ABSTRACT_CLASS(MultiplayerPeer);
+
+	OS::get_singleton()->benchmark_end_measure("Scene", "Register Early Types");
+}
+
+void register_scene_types() {
+	OS::get_singleton()->benchmark_begin_measure("Scene", "Register Types");
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -428,7 +436,6 @@ void register_scene_types() {
 
 	GDREGISTER_VIRTUAL_CLASS(CompositorEffect);
 
-	GDREGISTER_ABSTRACT_CLASS(MultiplayerPeer);
 	GDREGISTER_CLASS(MultiplayerPeerExtension);
 	GDREGISTER_ABSTRACT_CLASS(MultiplayerAPI);
 	GDREGISTER_CLASS(MultiplayerAPIExtension);
@@ -1450,6 +1457,7 @@ void register_scene_singletons() {
 	OS::get_singleton()->benchmark_begin_measure("Scene", "Register Singletons");
 
 	GDREGISTER_CLASS(ThemeDB);
+	GDREGISTER_INTERNAL_CLASS(ThemeContext);
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ThemeDB", ThemeDB::get_singleton()));
 

--- a/scene/register_scene_types.h
+++ b/scene/register_scene_types.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+void register_early_scene_types();
 void register_scene_types();
 void unregister_scene_types();
 void register_scene_singletons();


### PR DESCRIPTION
* Prepares for #106873

On `master`, when running the godot executable, multiple class registration warnings appear. 
Some of these, which this PR focuses on, need to have their registration happen earlier than was currently the case. The changes in this PR are a bit more involved. 

* `register_early_scene_types` and `register_early_editor_types` were added as they were the most minimal change I figured out that would fix the registration order issues for `MultiplayerPeer` and `EditorPaths`/`EditorTranslationParserPlugin` respectively. 
* FBX module delayed to initialize after GLTF module since it needs some of its classes. 
  * I wanted to reorder the module initialization order list itself, but looking at the SCons section responsible for generating the module initialization file, it is currently just an alphabetic order generation. Modifying this to be a custom order would be more involved and more prone to breaking than delaying the module initialization. 

<details>

Add `register_early_scene_types` and move `MultiplayerPeer` registration 
Needs to happen before `intialize_websocket_module()` which is called through `initialize_modules()`

Add missing `ThemeContext` registration and reorder `ThemeDB` & `ThemeContext` before instantiation

delay fbx module initialization to Editor phase
It needs GLTF module initialized first which is done in the Scene phase, before the Editor phase

Add `register_early_editor_types` and move `EditorPaths` registration Needs to happen before `EditorPaths::create()`
`EditorTranslationParserPlugin` moved to early phase too
</details>
