### PR TITLE
Fixed invalid ping-pong in AnimationTree

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -272,7 +272,7 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 			pi.time = cur_playback_time;
 			pi.delta = cur_delta;
 		} else {
-			pi.time = anim_size - cur_playback_time;
+			pi.time = cur_playback_time;
 			pi.delta = -cur_delta;
 		}
 		pi.weight = 1.0;


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/111719*
- *Fixes: https://github.com/godotengine/godot/issues/111737*
- *Related: https://github.com/godotengine/godot/pull/110982*

## Issue Description

The `cur_time` is already processed as `pingpong`, it need not be subtract by `anim_size` again. 

https://github.com/godotengine/godot/blob/5950fca36cb311edcc72e479effed5c477d20adb/scene/animation/animation_blend_tree.cpp#L177

https://github.com/godotengine/godot/blob/5950fca36cb311edcc72e479effed5c477d20adb/scene/animation/animation_blend_tree.cpp#L213

https://github.com/godotengine/godot/blob/5950fca36cb311edcc72e479effed5c477d20adb/scene/animation/animation_blend_tree.cpp#L271-L277

- When `cur_time` reached `anim_size`, e.g. `anim_size = 1.0`, `cur_time = 1.1`
- Processed by `pingpong` related function, `cur_time = 0.9`, and `cur_backward=true`
- The original code re-subtract `pi.time = anim_size - cur_playback_time`, then `pi.time` results `0.1`. So we cannot get `pingpong` function, and it looks like Sprite2D loop start from front.

## BTW

In my testing, I suspects the `else` branch never be covered in original codes. The #110982 fixed condition issue, then the `else` branch issue is exposed.

[pingpong.webm](https://github.com/user-attachments/assets/94f1b991-3181-464f-bb6c-587fad73df72)




