### PR TITLE
Refactor rendering driver copy APIs to fix D3D12 issues.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -364,7 +364,6 @@ private:
 
 		TextureInfo *main_texture = nullptr;
 
-		UINT mapped_subresource = UINT_MAX;
 #ifdef DEBUG_ENABLED
 		bool created_from_extension = false;
 #endif
@@ -393,8 +392,6 @@ public:
 	virtual uint64_t texture_get_allocation_size(TextureID p_texture) override final;
 	virtual void texture_get_copyable_layout(TextureID p_texture, const TextureSubresource &p_subresource, TextureCopyableLayout *r_layout) override final;
 	virtual Vector<uint8_t> texture_get_data(TextureID p_texture, uint32_t p_layer) override final;
-	virtual uint8_t *texture_map(TextureID p_texture, const TextureSubresource &p_subresource) override final;
-	virtual void texture_unmap(TextureID p_texture) override final;
 	virtual BitField<TextureUsageBits> texture_get_usages_supported_by_format(DataFormat p_format, bool p_cpu_readable) override final;
 	virtual bool texture_can_make_shared_with_format(TextureID p_texture, DataFormat p_format, bool &r_raw_reinterpretation) override final;
 

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -149,8 +149,6 @@ public:
 	virtual uint64_t texture_get_allocation_size(TextureID p_texture) override final;
 	virtual void texture_get_copyable_layout(TextureID p_texture, const TextureSubresource &p_subresource, TextureCopyableLayout *r_layout) override final;
 	virtual Vector<uint8_t> texture_get_data(TextureID p_texture, uint32_t p_layer) override final;
-	virtual uint8_t *texture_map(TextureID p_texture, const TextureSubresource &p_subresource) override final;
-	virtual void texture_unmap(TextureID p_texture) override final;
 	virtual BitField<TextureUsageBits> texture_get_usages_supported_by_format(DataFormat p_format, bool p_cpu_readable) override final;
 	virtual bool texture_can_make_shared_with_format(TextureID p_texture, DataFormat p_format, bool &r_raw_reinterpretation) override final;
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -260,8 +260,6 @@ public:
 	virtual uint64_t texture_get_allocation_size(TextureID p_texture) override final;
 	virtual void texture_get_copyable_layout(TextureID p_texture, const TextureSubresource &p_subresource, TextureCopyableLayout *r_layout) override final;
 	virtual Vector<uint8_t> texture_get_data(TextureID p_texture, uint32_t p_layer) override final;
-	virtual uint8_t *texture_map(TextureID p_texture, const TextureSubresource &p_subresource) override final;
-	virtual void texture_unmap(TextureID p_texture) override final;
 	virtual BitField<TextureUsageBits> texture_get_usages_supported_by_format(DataFormat p_format, bool p_cpu_readable) override final;
 	virtual bool texture_can_make_shared_with_format(TextureID p_texture, DataFormat p_format, bool &r_raw_reinterpretation) override final;
 

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -268,11 +268,8 @@ public:
 	};
 
 	struct TextureCopyableLayout {
-		uint64_t offset = 0;
 		uint64_t size = 0;
 		uint64_t row_pitch = 0;
-		uint64_t depth_pitch = 0;
-		uint64_t layer_pitch = 0;
 	};
 
 	virtual TextureID texture_create(const TextureFormat &p_format, const TextureView &p_view) = 0;
@@ -282,11 +279,11 @@ public:
 	virtual TextureID texture_create_shared_from_slice(TextureID p_original_texture, const TextureView &p_view, TextureSliceType p_slice_type, uint32_t p_layer, uint32_t p_layers, uint32_t p_mipmap, uint32_t p_mipmaps) = 0;
 	virtual void texture_free(TextureID p_texture) = 0;
 	virtual uint64_t texture_get_allocation_size(TextureID p_texture) = 0;
+	// Returns a texture layout for buffer <-> texture copies. If you are copying multiple texture subresources to/from the same buffer,
+	// you are responsible for correctly aligning the start offset for every buffer region. See API_TRAIT_TEXTURE_TRANSFER_ALIGNMENT.
 	virtual void texture_get_copyable_layout(TextureID p_texture, const TextureSubresource &p_subresource, TextureCopyableLayout *r_layout) = 0;
 	// Returns the data of a texture layer for a CPU texture that was created with TEXTURE_USAGE_CPU_READ_BIT.
 	virtual Vector<uint8_t> texture_get_data(TextureID p_texture, uint32_t p_layer) = 0;
-	virtual uint8_t *texture_map(TextureID p_texture, const TextureSubresource &p_subresource) = 0;
-	virtual void texture_unmap(TextureID p_texture) = 0;
 	virtual BitField<TextureUsageBits> texture_get_usages_supported_by_format(DataFormat p_format, bool p_cpu_readable) = 0;
 	virtual bool texture_can_make_shared_with_format(TextureID p_texture, DataFormat p_format, bool &r_raw_reinterpretation) = 0;
 
@@ -547,7 +544,8 @@ public:
 
 	struct BufferTextureCopyRegion {
 		uint64_t buffer_offset = 0;
-		TextureSubresourceLayers texture_subresources;
+		uint64_t row_pitch = 0;
+		TextureSubresource texture_subresource;
 		Vector3i texture_offset;
 		Vector3i texture_region_size;
 	};


### PR DESCRIPTION
This PR refactors the texture <-> buffer copying APIs in the rendering device driver to fix D3D12 issues:
- Row pitch is now explicitly provided by the caller. Previously, the backends automatically computed this value with their own alignment requirements, which was a very unsafe assumption that didn't hold true in a few existing cases.
- `texture_get_copyable_layout` now only returns the size and the row pitch.
    - The offset value was very unclear, so the responsibility of laying out textures in the buffer has been delegated to the caller. 
    - The depth pitch value has been removed, since it's expected to be tightly packed in all backends.
    - The layer pitch value has been removed, since it was just the mip size divided by the amount of layers, which didn't make any sense.
    - This function was also used for getting the layout for the texture mapping function, but now it's only explicitly used for buffer <-> texture transfers.
- CPU readable textures have been disallowed in D3D12, since they are not actually supported.
    - Now that gathering the data from CPU readable textures has been moved to a driver-specific function, the texture map/unmap functions have been removed.
    - While I was at it, I also fixed texture_get_data on Vulkan since it wasn't working.
- Buffer copy regions now accept only one layer and copy aspect. Copying multiple layers in one continuous stream in D3D12 is impossible due to the transfer alignment requirements. From what I checked in radv, it basically just loops over the layers manually anyway, so this method shouldn't be any less efficient.

Issues this PR does not address:
- Inability to copy depth if the depth attachment bit isn't set, or the stencil altogether. All the rendering APIs expect you to copy depth and stencil separately, but user exposed functions in Godot do not allow specifying the copy aspect. I made it match the existing behavior in this PR, but I want to fix it in a follow-up.
- The race condition in texture_get_data when the texture is CPU readable. There is no wait for the GPU to finish, it just maps while the GPU is still potentially writing to the resource.

## TODO

- [x] Metal backend. I can't do this one myself since I don't have the system for it.

---

Fixes #98527.
Fixes #109957.
Fixes #111497.
Supersedes #111328.
Supersedes #111525.