### PR TITLE
Sync final frame after finalizing RD to ensure that nothing is in use on the GPU when we free the RD

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6591,6 +6591,8 @@ void RenderingDevice::_flush_and_stall_for_all_frames(bool p_begin_frame) {
 
 	if (p_begin_frame) {
 		_begin_frame();
+	} else {
+		_stall_for_frame(frame);
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/111879
Fixes: https://github.com/godotengine/godot/issues/111949 (still need to test)
Fixes: https://github.com/godotengine/godot/issues/111904 (still need to test)

Begin frame does three things:
1. Stalls to ensure that the frame being acquired has finished
2. Restarts per-frame resources
3. Begins command buffers for the following frame

On shut down, we need to avoid 2 and 3. 2 is done later in the finalize function, while 3 doesn't need to be done at all. 

However, since `_flush_and_stall_for_all_frames()` submits a frame after calling `_stall_for_previous_frames();` it leaves a frame executing on the GPU. Previously this was fine since `_begin_frame();` would implicitly synchronize that last frame. However, since `_begin_frame();` isn't called on finalize anymore, we left a frame executing on the GPU as we started the shutdown procedure which has led to GPU hangs on some devices. 

This issue _only_ occurs when creating a test RD device using `--test-rd-support`, `--test-rd-creation`, `can_create_rendering_device()` or `is_rendering_device_supported()` because these options explicitly create a RenderingDevice with only one frame. The hang doesn't happen during normal shutdown because there are multiple frames simultaneously.