### PR TITLE
[TextServer] Fix range for zero-width glyphs extra spacing.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -6859,8 +6859,8 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_star
 
 		unsigned int last_non_zero_w = glyph_count - 1;
 		if (last_run) {
-			for (unsigned int i = glyph_count - 1; i > 0; i--) {
-				last_non_zero_w = i;
+			for (int64_t i = glyph_count - 1; i >= 0; i--) {
+				last_non_zero_w = (unsigned int)i;
 				if (p_sd->orientation == ORIENTATION_HORIZONTAL) {
 					if (glyph_pos[i].x_advance != 0) {
 						break;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -4822,7 +4822,7 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 			// Text span.
 			int last_non_zero_w = sd->end - 1;
 			if (i == sd->spans.size() - 1) {
-				for (int j = span.end - 1; j > span.start; j--) {
+				for (int j = span.end - 1; j >= span.start; j--) {
 					last_non_zero_w = j;
 					uint32_t idx = (int32_t)sd->text[j - sd->start];
 					if (!is_control(idx) && !(idx >= 0x200B && idx <= 0x200D)) {


### PR DESCRIPTION
Fixes wrong range used https://github.com/godotengine/godot/pull/110317

Fixes https://github.com/godotengine/godot/issues/110301 for single character text.