### PR TITLE
Make `memnew(RefCounted)` return `Ref`, to improve ownership safety

### DIFF
--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -138,8 +138,8 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, bo
 		CreatePeerFunc *create_fn = protocols.getptr(proto);
 		ERR_FAIL_NULL_MSG(create_fn, vformat("Invalid protocol: %s.", proto));
 
-		RemoteDebuggerPeer *peer = (*create_fn)(p_uri);
-		if (!peer) {
+		Ref<RemoteDebuggerPeer> peer = (*create_fn)(p_uri);
+		if (peer.is_null()) {
 			return;
 		}
 		singleton = memnew(RemoteDebugger(Ref<RemoteDebuggerPeer>(peer)));

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/ref_counted.h"
 #include "core/string/string_name.h"
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
@@ -47,7 +48,7 @@ public:
 
 	typedef Error (*CaptureFunc)(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);
 
-	typedef RemoteDebuggerPeer *(*CreatePeerFunc)(const String &p_uri);
+	typedef Ref<RemoteDebuggerPeer> (*CreatePeerFunc)(const String &p_uri);
 
 	class Profiler {
 		friend class EngineDebugger;

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -211,7 +211,7 @@ void RemoteDebuggerPeerTCP::_poll() {
 	}
 }
 
-RemoteDebuggerPeer *RemoteDebuggerPeerTCP::create_tcp(const String &p_uri) {
+Ref<RemoteDebuggerPeer> RemoteDebuggerPeerTCP::create_tcp(const String &p_uri) {
 	ERR_FAIL_COND_V(!p_uri.begins_with("tcp://"), nullptr);
 
 	String debug_host = p_uri.replace("tcp://", "");
@@ -237,7 +237,7 @@ RemoteDebuggerPeer *RemoteDebuggerPeerTCP::create_tcp(const String &p_uri) {
 	return memnew(RemoteDebuggerPeerTCP(stream));
 }
 
-RemoteDebuggerPeer *RemoteDebuggerPeerTCP::create_unix(const String &p_uri) {
+Ref<RemoteDebuggerPeer> RemoteDebuggerPeerTCP::create_unix(const String &p_uri) {
 	ERR_FAIL_COND_V(!p_uri.begins_with("unix://"), nullptr);
 
 	String debug_path = p_uri.replace("unix://", "");

--- a/core/debugger/remote_debugger_peer.h
+++ b/core/debugger/remote_debugger_peer.h
@@ -82,8 +82,8 @@ private:
 	static Error _try_connect(Ref<StreamPeerSocket> p_stream);
 
 public:
-	static RemoteDebuggerPeer *create_tcp(const String &p_uri);
-	static RemoteDebuggerPeer *create_unix(const String &p_uri);
+	static Ref<RemoteDebuggerPeer> create_tcp(const String &p_uri);
+	static Ref<RemoteDebuggerPeer> create_unix(const String &p_uri);
 
 	bool is_peer_connected() override;
 	int get_max_message_size() const override;

--- a/core/io/net_socket.cpp
+++ b/core/io/net_socket.cpp
@@ -30,9 +30,9 @@
 
 #include "net_socket.h"
 
-NetSocket *(*NetSocket::_create)() = nullptr;
+Ref<NetSocket> (*NetSocket::_create)() = nullptr;
 
-NetSocket *NetSocket::create() {
+Ref<NetSocket> NetSocket::create() {
 	if (_create) {
 		return _create();
 	}

--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -37,10 +37,10 @@ class NetSocket : public RefCounted {
 	GDSOFTCLASS(NetSocket, RefCounted);
 
 protected:
-	static NetSocket *(*_create)();
+	static Ref<NetSocket> (*_create)();
 
 public:
-	static NetSocket *create();
+	static Ref<NetSocket> create();
 
 	enum PollType : int32_t {
 		POLL_TYPE_IN,

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -750,7 +750,7 @@ Error ResourceLoaderBinary::load() {
 		Ref<Resource> res;
 		Resource *r = nullptr;
 
-		MissingResource *missing_resource = nullptr;
+		Ref<MissingResource> missing_resource;
 
 		if (main) {
 			res = ResourceLoader::get_resource_ref_override(local_path);
@@ -776,7 +776,7 @@ Error ResourceLoaderBinary::load() {
 						missing_resource = memnew(MissingResource);
 						missing_resource->set_original_class(t);
 						missing_resource->set_recording_properties(true);
-						obj = missing_resource;
+						obj = missing_resource.ptr();
 					} else {
 						error = ERR_FILE_CORRUPT;
 						ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, vformat("'%s': Resource of unrecognized type in file: '%s'.", local_path, t));
@@ -832,7 +832,7 @@ Error ResourceLoaderBinary::load() {
 			}
 
 			bool set_valid = true;
-			if (value.get_type() == Variant::OBJECT && missing_resource == nullptr && ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
+			if (value.get_type() == Variant::OBJECT && missing_resource.is_null() && ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
 				// If the property being set is a missing resource (and the parent is not),
 				// then setting it will most likely not work.
 				// Instead, save it as metadata.
@@ -874,7 +874,7 @@ Error ResourceLoaderBinary::load() {
 			}
 		}
 
-		if (missing_resource) {
+		if (missing_resource.is_valid()) {
 			missing_resource->set_recording_properties(false);
 		}
 

--- a/core/io/udp_server.cpp
+++ b/core/io/udp_server.cpp
@@ -149,7 +149,6 @@ void UDPServer::set_max_pending_connections(int p_max) {
 		if (!E) {
 			break;
 		}
-		memdelete(E->get().peer);
 		pending.erase(E);
 	}
 }
@@ -192,7 +191,6 @@ void UDPServer::stop() {
 	E = pending.front();
 	while (E) {
 		E->get().peer->disconnect_shared_socket();
-		memdelete(E->get().peer);
 		E = E->next();
 	}
 	peers.clear();

--- a/core/io/udp_server.h
+++ b/core/io/udp_server.h
@@ -42,7 +42,7 @@ protected:
 	};
 
 	struct Peer {
-		PacketPeerUDP *peer = nullptr;
+		Ref<PacketPeerUDP> peer;
 		IPAddress ip;
 		uint16_t port = 0;
 

--- a/core/math/static_raycaster.cpp
+++ b/core/math/static_raycaster.cpp
@@ -30,7 +30,7 @@
 
 #include "static_raycaster.h"
 
-StaticRaycaster *(*StaticRaycaster::create_function)() = nullptr;
+Ref<StaticRaycaster> (*StaticRaycaster::create_function)() = nullptr;
 
 Ref<StaticRaycaster> StaticRaycaster::create() {
 	if (create_function) {

--- a/core/math/static_raycaster.h
+++ b/core/math/static_raycaster.h
@@ -35,7 +35,7 @@
 class StaticRaycaster : public RefCounted {
 	GDCLASS(StaticRaycaster, RefCounted)
 protected:
-	static StaticRaycaster *(*create_function)();
+	static Ref<StaticRaycaster> (*create_function)();
 
 public:
 	// Compatible with embree4 rays.

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -212,7 +212,9 @@ public:
 
 	template <typename... VarArgs>
 	void instantiate(VarArgs... p_params) {
-		ref(memnew(T(p_params...)));
+		Ref<T> ref = memnew(T(p_params...));
+		// Appropriate the new Ref, and if the previous one was set, free it.
+		SWAP(reference, ref.reference);
 	}
 
 	uint32_t hash() const { return HashMapHasherDefault::hash(reference); }
@@ -223,6 +225,16 @@ public:
 		unref();
 	}
 };
+
+template <typename T>
+struct memnew_result<T, std::enable_if_t<std::is_base_of_v<RefCounted, T>>> {
+	using class_name = Ref<T>;
+};
+
+template <typename T>
+void postinitialize_handler(Ref<T> &p_object) {
+	postinitialize_handler(p_object.ptr());
+}
 
 class WeakRef : public RefCounted {
 	GDCLASS(WeakRef, RefCounted);

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -126,12 +126,21 @@ void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_d
 #define memrealloc(m_mem, m_size) Memory::realloc_static(m_mem, m_size)
 #define memfree(m_mem) Memory::free_static(m_mem)
 
+template <typename T, typename Enable = void>
+struct memnew_result {
+	using class_name = T *;
+};
+
+template <typename T>
+using memnew_result_t = typename memnew_result<T>::class_name;
+
 _ALWAYS_INLINE_ void postinitialize_handler(void *) {}
 
 template <typename T>
-_ALWAYS_INLINE_ T *_post_initialize(T *p_obj) {
-	postinitialize_handler(p_obj);
-	return p_obj;
+_ALWAYS_INLINE_ memnew_result_t<T> _post_initialize(T *p_obj) {
+	memnew_result_t<T> result{ p_obj };
+	postinitialize_handler(result);
+	return result;
 }
 
 #define memnew(m_class) _post_initialize(::new ("") m_class)

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -130,7 +130,7 @@ void NetSocketUnix::_set_ip_port(struct sockaddr_storage *p_addr, IPAddress *r_i
 	}
 }
 
-NetSocket *NetSocketUnix::_create_func() {
+Ref<NetSocket> NetSocketUnix::_create_func() {
 	return memnew(NetSocketUnix);
 }
 
@@ -796,7 +796,8 @@ Ref<NetSocket> NetSocketUnix::_inet_accept(IPAddress &r_ip, uint16_t &r_port) {
 
 	_set_ip_port(&their_addr, &r_ip, &r_port);
 
-	NetSocketUnix *ns = memnew(NetSocketUnix);
+	Ref<NetSocketUnix> ns;
+	ns.instantiate();
 	ns->_set_socket(fd, _ip_type, _is_stream);
 	ns->set_blocking_enabled(false);
 	return Ref<NetSocket>(ns);
@@ -813,7 +814,7 @@ Ref<NetSocket> NetSocketUnix::_unix_accept() {
 		return Ref<NetSocket>();
 	}
 
-	NetSocketUnix *ret = memnew(NetSocketUnix);
+	Ref<NetSocketUnix> ret = memnew(NetSocketUnix);
 	ret->_sock = fd;
 	ret->_family = _family;
 	ret->_unix_path = _unix_path;

--- a/drivers/unix/net_socket_unix.h
+++ b/drivers/unix/net_socket_unix.h
@@ -65,7 +65,7 @@ private:
 	_FORCE_INLINE_ void _set_close_exec_enabled(bool p_enabled);
 
 protected:
-	static NetSocket *_create_func();
+	static Ref<NetSocket> _create_func();
 
 	bool _can_use_ip(const IPAddress &p_ip, const bool p_for_bind) const;
 	bool _can_use_path(const CharString &p_path) const;

--- a/drivers/windows/net_socket_winsock.cpp
+++ b/drivers/windows/net_socket_winsock.cpp
@@ -96,7 +96,7 @@ void NetSocketWinSock::_set_ip_port(struct sockaddr_storage *p_addr, IPAddress *
 	}
 }
 
-NetSocket *NetSocketWinSock::_create_func() {
+Ref<NetSocket> NetSocketWinSock::_create_func() {
 	return memnew(NetSocketWinSock);
 }
 
@@ -607,7 +607,7 @@ Ref<NetSocket> NetSocketWinSock::accept(Address &r_addr) {
 	_set_ip_port(&their_addr, &ip, &port);
 	r_addr = Address(ip, port);
 
-	NetSocketWinSock *ns = memnew(NetSocketWinSock);
+	Ref<NetSocketWinSock> ns = memnew(NetSocketWinSock);
 	ns->_set_socket(fd, _ip_type, _is_stream);
 	ns->set_blocking_enabled(false);
 	return Ref<NetSocket>(ns);

--- a/drivers/windows/net_socket_winsock.h
+++ b/drivers/windows/net_socket_winsock.h
@@ -60,7 +60,7 @@ private:
 	_FORCE_INLINE_ Error _change_multicast_group(IPAddress p_ip, String p_if_name, bool p_add);
 
 protected:
-	static NetSocket *_create_func();
+	static Ref<NetSocket> _create_func();
 
 	bool _can_use_ip(const IPAddress &p_ip, const bool p_for_bind) const;
 

--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -817,7 +817,7 @@ void AnimationNodeBlendSpace1DEditor::_start_inline_edit(int p_point) {
 	inline_editor->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
 	inline_editor->add_theme_color_override("font_selected_color", Color::named("white"));
 	inline_editor->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
-	StyleBoxEmpty *empty_style = memnew(StyleBoxEmpty);
+	Ref<StyleBoxEmpty> empty_style = memnew(StyleBoxEmpty);
 	empty_style->set_content_margin_all(0);
 	inline_editor->add_theme_style_override(CoreStringName(normal), empty_style);
 	inline_editor->add_theme_style_override("focus", memnew(StyleBoxEmpty));

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -1082,7 +1082,7 @@ void AnimationNodeBlendSpace2DEditor::_start_inline_edit(int p_point) {
 	inline_editor->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
 	inline_editor->add_theme_color_override("font_selected_color", Color::named("white"));
 	inline_editor->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
-	StyleBoxEmpty *empty_style = memnew(StyleBoxEmpty);
+	Ref<StyleBoxEmpty> empty_style = memnew(StyleBoxEmpty);
 	empty_style->set_content_margin_all(0);
 	inline_editor->add_theme_style_override(CoreStringName(normal), empty_style);
 	inline_editor->add_theme_style_override("focus", memnew(StyleBoxEmpty));

--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -331,7 +331,7 @@ public:
 class AnimationTrackKeyEditEditorPlugin : public EditorPlugin {
 	GDCLASS(AnimationTrackKeyEditEditorPlugin, EditorPlugin);
 
-	EditorInspectorPluginAnimationTrackKeyEdit *atk_plugin = nullptr;
+	Ref<EditorInspectorPluginAnimationTrackKeyEdit> atk_plugin;
 
 public:
 	virtual bool handles(Object *p_object) const override;
@@ -356,7 +356,7 @@ public:
 class AnimationMarkerKeyEditEditorPlugin : public EditorPlugin {
 	GDCLASS(AnimationMarkerKeyEditEditorPlugin, EditorPlugin);
 
-	EditorInspectorPluginAnimationMarkerKeyEdit *amk_plugin = nullptr;
+	Ref<EditorInspectorPluginAnimationMarkerKeyEdit> amk_plugin;
 
 public:
 	virtual bool handles(Object *p_object) const override;

--- a/editor/debugger/editor_debugger_server.cpp
+++ b/editor/debugger/editor_debugger_server.cpp
@@ -58,12 +58,12 @@ public:
 
 class EditorDebuggerServerTCP : public EditorDebuggerServerSocket<TCPServer> {
 public:
-	static EditorDebuggerServer *create(const String &p_protocol);
+	static Ref<EditorDebuggerServer> create(const String &p_protocol);
 
 	virtual Error start(const String &p_uri) override;
 };
 
-EditorDebuggerServer *EditorDebuggerServerTCP::create(const String &p_protocol) {
+Ref<EditorDebuggerServer> EditorDebuggerServerTCP::create(const String &p_protocol) {
 	ERR_FAIL_COND_V(p_protocol != "tcp://", nullptr);
 	return memnew(EditorDebuggerServerTCP);
 }
@@ -138,12 +138,12 @@ Ref<RemoteDebuggerPeer> EditorDebuggerServerSocket<T>::take_connection() {
 
 class EditorDebuggerServerUDS : public EditorDebuggerServerSocket<UDSServer> {
 public:
-	static EditorDebuggerServer *create(const String &p_protocol);
+	static Ref<EditorDebuggerServer> create(const String &p_protocol);
 
 	virtual Error start(const String &p_uri) override;
 };
 
-EditorDebuggerServer *EditorDebuggerServerUDS::create(const String &p_protocol) {
+Ref<EditorDebuggerServer> EditorDebuggerServerUDS::create(const String &p_protocol) {
 	ERR_FAIL_COND_V(p_protocol != "unix://", nullptr);
 	return memnew(EditorDebuggerServerUDS);
 }
@@ -163,7 +163,7 @@ Error EditorDebuggerServerUDS::start(const String &p_uri) {
 /// EditorDebuggerServer
 HashMap<StringName, EditorDebuggerServer::CreateServerFunc> EditorDebuggerServer::protocols;
 
-EditorDebuggerServer *EditorDebuggerServer::create(const String &p_protocol) {
+Ref<EditorDebuggerServer> EditorDebuggerServer::create(const String &p_protocol) {
 	CreateServerFunc *create_fn = protocols.getptr(p_protocol);
 	ERR_FAIL_NULL_V(create_fn, nullptr);
 	return (*create_fn)(p_protocol);

--- a/editor/debugger/editor_debugger_server.h
+++ b/editor/debugger/editor_debugger_server.h
@@ -37,7 +37,7 @@ class EditorDebuggerServer : public RefCounted {
 	GDSOFTCLASS(EditorDebuggerServer, RefCounted);
 
 public:
-	typedef EditorDebuggerServer *(*CreateServerFunc)(const String &p_uri);
+	typedef Ref<EditorDebuggerServer> (*CreateServerFunc)(const String &p_uri);
 
 private:
 	static HashMap<StringName, CreateServerFunc> protocols;
@@ -47,7 +47,7 @@ public:
 	static void deinitialize();
 
 	static void register_protocol_handler(const String &p_protocol, CreateServerFunc p_func);
-	static EditorDebuggerServer *create(const String &p_protocol);
+	static Ref<EditorDebuggerServer> create(const String &p_protocol);
 
 	virtual String get_uri() const = 0;
 	virtual void poll() = 0;

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -827,19 +827,23 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 			p_node = sb;
 			CollisionShape3D *colshape = memnew(CollisionShape3D);
 			if (empty_draw_type == "CUBE") {
-				BoxShape3D *boxShape = memnew(BoxShape3D);
+				Ref<BoxShape3D> boxShape;
+				boxShape.instantiate();
 				boxShape->set_size(Vector3(2, 2, 2));
 				colshape->set_shape(boxShape);
 			} else if (empty_draw_type == "SINGLE_ARROW") {
-				SeparationRayShape3D *rayShape = memnew(SeparationRayShape3D);
+				Ref<SeparationRayShape3D> rayShape;
+				rayShape.instantiate();
 				rayShape->set_length(1);
 				colshape->set_shape(rayShape);
 				Object::cast_to<Node3D>(sb)->rotate_x(Math::PI / 2);
 			} else if (empty_draw_type == "IMAGE") {
-				WorldBoundaryShape3D *world_boundary_shape = memnew(WorldBoundaryShape3D);
+				Ref<WorldBoundaryShape3D> world_boundary_shape;
+				world_boundary_shape.instantiate();
 				colshape->set_shape(world_boundary_shape);
 			} else {
-				SphereShape3D *sphereShape = memnew(SphereShape3D);
+				Ref<SphereShape3D> sphereShape;
+				sphereShape.instantiate();
 				sphereShape->set_radius(1);
 				colshape->set_shape(sphereShape);
 			}

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -79,7 +79,7 @@ class SceneImportSettingsData : public Object {
 				SceneImportSettingsDialog::get_singleton()->request_generate_collider();
 			}
 
-			ResourceImporterScene *resource_importer_scene = SceneImportSettingsDialog::get_singleton()->get_resource_importer_scene();
+			Ref<ResourceImporterScene> resource_importer_scene = SceneImportSettingsDialog::get_singleton()->get_resource_importer_scene();
 			if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX) {
 				if (resource_importer_scene->get_option_visibility(path, p_name, current)) {
 					SceneImportSettingsDialog::get_singleton()->update_view();
@@ -164,7 +164,7 @@ class SceneImportSettingsData : public Object {
 		if (hide_options) {
 			return;
 		}
-		ResourceImporterScene *resource_importer_scene = SceneImportSettingsDialog::get_singleton()->get_resource_importer_scene();
+		Ref<ResourceImporterScene> resource_importer_scene = SceneImportSettingsDialog::get_singleton()->get_resource_importer_scene();
 		for (const ResourceImporter::ImportOption &E : options) {
 			PropertyInfo option = E.option;
 			if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX) {
@@ -2000,5 +2000,4 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 
 SceneImportSettingsDialog::~SceneImportSettingsDialog() {
 	memdelete(scene_import_settings_data);
-	memdelete(_resource_importer_scene);
 }

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -204,7 +204,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	HashMap<StringName, Variant> defaults;
 
 	SceneImportSettingsData *scene_import_settings_data = nullptr;
-	ResourceImporterScene *_resource_importer_scene = nullptr;
+	Ref<ResourceImporterScene> _resource_importer_scene;
 
 	void _re_import();
 
@@ -244,7 +244,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	ResourceImporterScene *get_resource_importer_scene() const { return _resource_importer_scene; }
+	const Ref<ResourceImporterScene> &get_resource_importer_scene() const { return _resource_importer_scene; }
 	void request_generate_collider();
 	void update_view();
 	void open_settings(const String &p_path, const String &p_scene_import_type = "PackedScene");

--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -134,16 +134,16 @@ public:
 	RegEx keyword_csharp_mastersync = RegEx("\\[MasterSync(Attribute)?(\\(\\))?\\]");
 
 	// Colors.
-	LocalVector<RegEx *> color_regexes;
+	LocalVector<Ref<RegEx>> color_regexes;
 	LocalVector<String> color_renamed;
 
 	RegEx color_hexadecimal_short_constructor = RegEx("Color\\(\"#?([a-fA-F0-9]{1})([a-fA-F0-9]{3})\\b");
 	RegEx color_hexadecimal_full_constructor = RegEx("Color\\(\"#?([a-fA-F0-9]{2})([a-fA-F0-9]{6})\\b");
 
 	// Classes.
-	LocalVector<RegEx *> class_tscn_regexes;
-	LocalVector<RegEx *> class_gd_regexes;
-	LocalVector<RegEx *> class_shader_regexes;
+	LocalVector<Ref<RegEx>> class_tscn_regexes;
+	LocalVector<Ref<RegEx>> class_gd_regexes;
+	LocalVector<Ref<RegEx>> class_shader_regexes;
 
 	// Keycode.
 	RegEx input_map_keycode = RegEx("\\b,\"((physical_)?)scancode\":(\\d+)\\b");
@@ -160,7 +160,7 @@ public:
 	// Animation suffixes.
 	RegEx animation_suffix = RegEx("([\"'])([a-zA-Z0-9_-]+)(-(?:loop|cycle))([\"'])");
 
-	LocalVector<RegEx *> class_regexes;
+	LocalVector<Ref<RegEx>> class_regexes;
 
 	RegEx class_temp_tscn = RegEx("\\bTEMP_RENAMED_CLASS.tscn\\b");
 	RegEx class_temp_gd = RegEx("\\bTEMP_RENAMED_CLASS.gd\\b");
@@ -171,19 +171,19 @@ public:
 	LocalVector<String> class_temp_shader_renames;
 
 	// Common.
-	LocalVector<RegEx *> enum_regexes;
-	LocalVector<RegEx *> gdscript_function_regexes;
-	LocalVector<RegEx *> project_settings_regexes;
-	LocalVector<RegEx *> project_godot_regexes;
-	LocalVector<RegEx *> input_map_regexes;
-	LocalVector<RegEx *> gdscript_properties_regexes;
-	LocalVector<RegEx *> gdscript_signals_regexes;
-	LocalVector<RegEx *> shaders_regexes;
-	LocalVector<RegEx *> builtin_types_regexes;
-	LocalVector<RegEx *> theme_override_regexes;
-	LocalVector<RegEx *> csharp_function_regexes;
-	LocalVector<RegEx *> csharp_properties_regexes;
-	LocalVector<RegEx *> csharp_signal_regexes;
+	LocalVector<Ref<RegEx>> enum_regexes;
+	LocalVector<Ref<RegEx>> gdscript_function_regexes;
+	LocalVector<Ref<RegEx>> project_settings_regexes;
+	LocalVector<Ref<RegEx>> project_godot_regexes;
+	LocalVector<Ref<RegEx>> input_map_regexes;
+	LocalVector<Ref<RegEx>> gdscript_properties_regexes;
+	LocalVector<Ref<RegEx>> gdscript_signals_regexes;
+	LocalVector<Ref<RegEx>> shaders_regexes;
+	LocalVector<Ref<RegEx>> builtin_types_regexes;
+	LocalVector<Ref<RegEx>> theme_override_regexes;
+	LocalVector<Ref<RegEx>> csharp_function_regexes;
+	LocalVector<Ref<RegEx>> csharp_properties_regexes;
+	LocalVector<Ref<RegEx>> csharp_signal_regexes;
 
 	RegExContainer() {
 		// Common.
@@ -263,56 +263,6 @@ public:
 				class_temp_gd_renames.push_back(class_name + ".gd");
 				class_temp_shader_renames.push_back(class_name + ".shader");
 			}
-		}
-	}
-	~RegExContainer() {
-		for (RegEx *regex : color_regexes) {
-			memdelete(regex);
-		}
-		for (unsigned int i = 0; i < class_tscn_regexes.size(); i++) {
-			memdelete(class_tscn_regexes[i]);
-			memdelete(class_gd_regexes[i]);
-			memdelete(class_shader_regexes[i]);
-			memdelete(class_regexes[i]);
-		}
-		for (RegEx *regex : enum_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : gdscript_function_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : project_settings_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : project_godot_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : input_map_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : gdscript_properties_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : gdscript_signals_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : shaders_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : builtin_types_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : theme_override_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : csharp_function_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : csharp_properties_regexes) {
-			memdelete(regex);
-		}
-		for (RegEx *regex : csharp_signal_regexes) {
-			memdelete(regex);
 		}
 	}
 };
@@ -772,7 +722,7 @@ bool ProjectConverter3To4::test_conversion_with_regex(const String &name, const 
 	return true;
 }
 
-bool ProjectConverter3To4::test_conversion_basic(const String &name, const String &expected, const char *array[][2], LocalVector<RegEx *> &regex_cache, const String &what) {
+bool ProjectConverter3To4::test_conversion_basic(const String &name, const String &expected, const char *array[][2], LocalVector<Ref<RegEx>> &regex_cache, const String &what) {
 	Vector<SourceLine> got = split_lines(name);
 
 	rename_common(array, regex_cache, got);
@@ -2912,7 +2862,7 @@ Vector<String> ProjectConverter3To4::check_for_custom_rename(Vector<String> &lin
 	return found_renames;
 }
 
-void ProjectConverter3To4::rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<SourceLine> &source_lines) {
+void ProjectConverter3To4::rename_common(const char *array[][2], LocalVector<Ref<RegEx>> &cached_regexes, Vector<SourceLine> &source_lines) {
 	for (SourceLine &source_line : source_lines) {
 		if (source_line.is_comment) {
 			continue;
@@ -2929,7 +2879,7 @@ void ProjectConverter3To4::rename_common(const char *array[][2], LocalVector<Reg
 	}
 }
 
-Vector<String> ProjectConverter3To4::check_for_rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<String> &lines) {
+Vector<String> ProjectConverter3To4::check_for_rename_common(const char *array[][2], LocalVector<Ref<RegEx>> &cached_regexes, Vector<String> &lines) {
 	Vector<String> found_renames;
 
 	int current_line = 1;

--- a/editor/project_upgrade/project_converter_3_to_4.h
+++ b/editor/project_upgrade/project_converter_3_to_4.h
@@ -42,6 +42,8 @@ struct SourceLine {
 };
 
 class RegEx;
+template <typename T>
+class Ref;
 
 class ProjectConverter3To4 {
 	class RegExContainer;
@@ -85,8 +87,8 @@ class ProjectConverter3To4 {
 	void custom_rename(Vector<SourceLine> &source_lines, const String &from, const String &to);
 	Vector<String> check_for_custom_rename(Vector<String> &lines, const String &from, const String &to);
 
-	void rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<SourceLine> &source_lines);
-	Vector<String> check_for_rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<String> &lines);
+	void rename_common(const char *array[][2], LocalVector<Ref<RegEx>> &cached_regexes, Vector<SourceLine> &source_lines);
+	Vector<String> check_for_rename_common(const char *array[][2], LocalVector<Ref<RegEx>> &cached_regexes, Vector<String> &lines);
 
 	Vector<String> check_for_files();
 
@@ -105,7 +107,7 @@ class ProjectConverter3To4 {
 	bool test_single_array(const char *array[][2], bool ignore_second_check = false);
 	bool test_conversion_gdscript_builtin(const String &name, const String &expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &, bool), const String &what, const RegExContainer &reg_container, bool builtin);
 	bool test_conversion_with_regex(const String &name, const String &expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &), const String &what, const RegExContainer &reg_container);
-	bool test_conversion_basic(const String &name, const String &expected, const char *array[][2], LocalVector<RegEx *> &regex_cache, const String &what);
+	bool test_conversion_basic(const String &name, const String &expected, const char *array[][2], LocalVector<Ref<RegEx>> &regex_cache, const String &what);
 	bool test_array_names();
 	bool test_conversion(RegExContainer &reg_container);
 

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -6740,7 +6740,6 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 Node3DEditorViewport::~Node3DEditorViewport() {
 	memdelete(ruler);
-	memdelete(frame_time_gradient);
 }
 
 //////////////////////////////////////////////////////////////

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -259,7 +259,7 @@ private:
 	ViewportNavigationControl *position_control = nullptr;
 	ViewportNavigationControl *look_control = nullptr;
 	ViewportRotationControl *rotation_control = nullptr;
-	Gradient *frame_time_gradient = nullptr;
+	Ref<Gradient> frame_time_gradient;
 	PanelContainer *frame_time_panel = nullptr;
 	VBoxContainer *frame_time_vbox = nullptr;
 	Label *cpu_time_label = nullptr;

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -622,7 +622,8 @@ PhysicalBone3D *Skeleton3DEditor::create_physical_bone(int bone_id, int bone_chi
 	const real_t half_height(child_rest.origin.length() * 0.5);
 	const real_t radius(half_height * 0.2);
 
-	CapsuleShape3D *bone_shape_capsule = memnew(CapsuleShape3D);
+	Ref<CapsuleShape3D> bone_shape_capsule;
+	bone_shape_capsule.instantiate();
 	bone_shape_capsule->set_height(half_height * 2);
 	bone_shape_capsule->set_radius(radius);
 

--- a/editor/scene/3d/skeleton_3d_editor_plugin.h
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.h
@@ -268,7 +268,7 @@ public:
 class Skeleton3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Skeleton3DEditorPlugin, EditorPlugin);
 
-	EditorInspectorPluginSkeleton *skeleton_plugin = nullptr;
+	Ref<EditorInspectorPluginSkeleton> skeleton_plugin;
 
 public:
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override;

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2126,8 +2126,8 @@ Ref<TextFile> ScriptEditor::_load_text_file(const String &p_path, Error *r_error
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	String path = ResourceLoader::path_remap(local_path);
 
-	TextFile *text_file = memnew(TextFile);
-	Ref<TextFile> text_res(text_file);
+	Ref<TextFile> text_file;
+	text_file.instantiate();
 	Error err = text_file->load_text(path);
 
 	ERR_FAIL_COND_V_MSG(err != OK, Ref<Resource>(), "Cannot load text file '" + path + "'.");
@@ -2143,7 +2143,7 @@ Ref<TextFile> ScriptEditor::_load_text_file(const String &p_path, Error *r_error
 		*r_error = OK;
 	}
 
-	return text_res;
+	return text_file;
 }
 
 Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_path) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -226,15 +226,16 @@ Variant GDScript::_new(const Variant **p_args, int p_argcount, Callable::CallErr
 	ERR_FAIL_COND_V(_baseptr->native.is_null(), Variant());
 	if (_baseptr->native.ptr()) {
 		owner = _baseptr->native->instantiate();
+
+		RefCounted *r = Object::cast_to<RefCounted>(owner);
+		if (r) {
+			ref = Ref<RefCounted>(r);
+		}
 	} else {
-		owner = memnew(RefCounted); //by default, no base means use reference
+		ref = memnew(RefCounted); // By default, no base means use reference.
+		owner = ref.ptr();
 	}
 	ERR_FAIL_NULL_V_MSG(owner, Variant(), "Can't inherit from a virtual class.");
-
-	RefCounted *r = Object::cast_to<RefCounted>(owner);
-	if (r) {
-		ref = Ref<RefCounted>(r);
-	}
 
 	GDScriptInstance *instance = _create_instance(p_args, p_argcount, owner, r_error);
 	if (!instance) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4289,7 +4289,8 @@ void GLTFDocument::_convert_grid_map_to_gltf(GridMap *p_grid_map, GLTFNodeIndex 
 #else
 	const Array &cells = p_grid_map->get_used_cells();
 	for (int32_t k = 0; k < cells.size(); k++) {
-		GLTFNode *new_gltf_node = memnew(GLTFNode);
+		Ref<GLTFNode> new_gltf_node;
+		new_gltf_node.instantiate();
 		p_gltf_node->children.push_back(p_state->nodes.size());
 		p_state->nodes.push_back(new_gltf_node);
 		Vector3 cell_location = cells[k];

--- a/modules/lightmapper_rd/register_types.cpp
+++ b/modules/lightmapper_rd/register_types.cpp
@@ -37,7 +37,7 @@
 #include "scene/3d/lightmapper.h"
 
 #ifndef _3D_DISABLED
-static Lightmapper *create_lightmapper_rd() {
+static Ref<Lightmapper> create_lightmapper_rd() {
 	return memnew(LightmapperRD);
 }
 #endif

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -321,10 +321,7 @@ void CryptoMbedTLS::initialize_crypto() {
 void CryptoMbedTLS::finalize_crypto() {
 	Crypto::_create = nullptr;
 	Crypto::_load_default_certificates = nullptr;
-	if (default_certs) {
-		memdelete(default_certs);
-		default_certs = nullptr;
-	}
+	default_certs = nullptr;
 	X509CertificateMbedTLS::finalize();
 	CryptoKeyMbedTLS::finalize();
 	HMACContextMbedTLS::finalize();
@@ -344,17 +341,17 @@ CryptoMbedTLS::~CryptoMbedTLS() {
 	mbedtls_entropy_free(&entropy);
 }
 
-X509CertificateMbedTLS *CryptoMbedTLS::default_certs = nullptr;
+Ref<X509CertificateMbedTLS> CryptoMbedTLS::default_certs;
 
-X509CertificateMbedTLS *CryptoMbedTLS::get_default_certificates() {
+Ref<X509CertificateMbedTLS> CryptoMbedTLS::get_default_certificates() {
 	return default_certs;
 }
 
 void CryptoMbedTLS::load_default_certificates(const String &p_path) {
-	ERR_FAIL_COND(default_certs != nullptr);
+	ERR_FAIL_COND(default_certs.is_valid());
 
 	default_certs = memnew(X509CertificateMbedTLS);
-	ERR_FAIL_NULL(default_certs);
+	ERR_FAIL_COND(default_certs.is_null());
 
 	if (!p_path.is_empty()) {
 		// Use certs defined in project settings.

--- a/modules/mbedtls/crypto_mbedtls.h
+++ b/modules/mbedtls/crypto_mbedtls.h
@@ -132,13 +132,13 @@ class CryptoMbedTLS : public Crypto {
 private:
 	mbedtls_entropy_context entropy;
 	mbedtls_ctr_drbg_context ctr_drbg;
-	static X509CertificateMbedTLS *default_certs;
+	static Ref<X509CertificateMbedTLS> default_certs;
 
 public:
 	static Crypto *create(bool p_notify_postinitialize = true);
 	static void initialize_crypto();
 	static void finalize_crypto();
-	static X509CertificateMbedTLS *get_default_certificates();
+	static Ref<X509CertificateMbedTLS> get_default_certificates();
 	static void load_default_certificates(const String &p_path);
 	static mbedtls_md_type_t md_type_from_hashtype(HashingContext::HashType p_hash_type, int &r_size);
 

--- a/modules/mbedtls/tls_context_mbedtls.cpp
+++ b/modules/mbedtls/tls_context_mbedtls.cpp
@@ -193,17 +193,17 @@ Error TLSContextMbedTLS::init_client(int p_transport, const String &p_hostname, 
 		mbedtls_ssl_set_hostname(&tls, cn.utf8().get_data());
 	}
 
-	X509CertificateMbedTLS *cas = nullptr;
+	Ref<X509CertificateMbedTLS> cas;
 
 	if (p_options->get_trusted_ca_chain().is_valid()) {
 		// Locking CA certificates
 		certs = p_options->get_trusted_ca_chain();
 		certs->lock();
-		cas = certs.ptr();
+		cas = certs;
 	} else {
 		// Fall back to default certificates (no need to lock those).
 		cas = CryptoMbedTLS::get_default_certificates();
-		if (cas == nullptr) {
+		if (cas.is_null()) {
 			clear();
 			ERR_FAIL_V_MSG(ERR_UNCONFIGURED, "SSL module failed to initialize!");
 		}

--- a/modules/raycast/lightmap_raycaster_embree.cpp
+++ b/modules/raycast/lightmap_raycaster_embree.cpp
@@ -36,7 +36,7 @@
 #include <pmmintrin.h>
 #endif
 
-LightmapRaycaster *LightmapRaycasterEmbree::create_embree_raycaster() {
+Ref<LightmapRaycaster> LightmapRaycasterEmbree::create_embree_raycaster() {
 	return memnew(LightmapRaycasterEmbree);
 }
 

--- a/modules/raycast/lightmap_raycaster_embree.h
+++ b/modules/raycast/lightmap_raycaster_embree.h
@@ -69,7 +69,7 @@ public:
 	virtual void set_mesh_filter(const HashSet<int> &p_mesh_ids) override;
 	virtual void clear_mesh_filter() override;
 
-	static LightmapRaycaster *create_embree_raycaster();
+	static Ref<LightmapRaycaster> create_embree_raycaster();
 	static void make_default_raycaster();
 
 	LightmapRaycasterEmbree();

--- a/modules/raycast/static_raycaster_embree.cpp
+++ b/modules/raycast/static_raycaster_embree.cpp
@@ -38,7 +38,7 @@
 
 RTCDevice StaticRaycasterEmbree::embree_device;
 
-StaticRaycaster *StaticRaycasterEmbree::create_embree_raycaster() {
+Ref<StaticRaycaster> StaticRaycasterEmbree::create_embree_raycaster() {
 	return memnew(StaticRaycasterEmbree);
 }
 

--- a/modules/raycast/static_raycaster_embree.h
+++ b/modules/raycast/static_raycaster_embree.h
@@ -55,7 +55,7 @@ public:
 	virtual void set_mesh_filter(const HashSet<int> &p_mesh_ids) override;
 	virtual void clear_mesh_filter() override;
 
-	static StaticRaycaster *create_embree_raycaster();
+	static Ref<StaticRaycaster> create_embree_raycaster();
 	static void make_default_raycaster();
 	static void free();
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -799,7 +799,8 @@ Ref<Resource> ResourceFormatLoaderTheora::load(const String &p_path, const Strin
 		return Ref<Resource>();
 	}
 
-	VideoStreamTheora *stream = memnew(VideoStreamTheora);
+	Ref<VideoStreamTheora> stream;
+	stream.instantiate();
 	stream->set_file(p_path);
 
 	Ref<VideoStreamTheora> ogv_stream = Ref<VideoStreamTheora>(stream);

--- a/modules/websocket/editor/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor/editor_debugger_server_websocket.cpp
@@ -117,7 +117,7 @@ bool EditorDebuggerServerWebSocket::is_connection_available() const {
 
 Ref<RemoteDebuggerPeer> EditorDebuggerServerWebSocket::take_connection() {
 	ERR_FAIL_COND_V(!is_connection_available(), Ref<RemoteDebuggerPeer>());
-	RemoteDebuggerPeer *peer = memnew(RemoteDebuggerPeerWebSocket(pending_peer));
+	Ref<RemoteDebuggerPeer> peer = memnew(RemoteDebuggerPeerWebSocket(pending_peer));
 	pending_peer.unref();
 	return peer;
 }
@@ -130,7 +130,7 @@ EditorDebuggerServerWebSocket::~EditorDebuggerServerWebSocket() {
 	stop();
 }
 
-EditorDebuggerServer *EditorDebuggerServerWebSocket::create(const String &p_protocol) {
+Ref<EditorDebuggerServer> EditorDebuggerServerWebSocket::create(const String &p_protocol) {
 	ERR_FAIL_COND_V(p_protocol != "ws://", nullptr);
 	return memnew(EditorDebuggerServerWebSocket);
 }

--- a/modules/websocket/editor/editor_debugger_server_websocket.h
+++ b/modules/websocket/editor/editor_debugger_server_websocket.h
@@ -45,7 +45,7 @@ private:
 	String endpoint;
 
 public:
-	static EditorDebuggerServer *create(const String &p_protocol);
+	static Ref<EditorDebuggerServer> create(const String &p_protocol);
 
 	void _peer_connected(int p_peer, const String &p_protocol);
 	void _peer_disconnected(int p_peer, bool p_was_clean);

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -129,12 +129,12 @@ RemoteDebuggerPeerWebSocket::RemoteDebuggerPeerWebSocket(const Ref<WebSocketPeer
 	}
 }
 
-RemoteDebuggerPeer *RemoteDebuggerPeerWebSocket::create(const String &p_uri) {
+Ref<RemoteDebuggerPeer> RemoteDebuggerPeerWebSocket::create(const String &p_uri) {
 	ERR_FAIL_COND_V(!p_uri.begins_with("ws://") && !p_uri.begins_with("wss://"), nullptr);
-	RemoteDebuggerPeerWebSocket *peer = memnew(RemoteDebuggerPeerWebSocket);
+	Ref<RemoteDebuggerPeerWebSocket> peer;
+	peer.instantiate();
 	Error err = peer->connect_to_host(p_uri);
 	if (err != OK) {
-		memdelete(peer);
 		return nullptr;
 	}
 	return peer;

--- a/modules/websocket/remote_debugger_peer_websocket.h
+++ b/modules/websocket/remote_debugger_peer_websocket.h
@@ -44,7 +44,7 @@ class RemoteDebuggerPeerWebSocket : public RemoteDebuggerPeer {
 	int max_queued_messages;
 
 public:
-	static RemoteDebuggerPeer *create(const String &p_uri);
+	static Ref<RemoteDebuggerPeer> create(const String &p_uri);
 
 	Error connect_to_host(const String &p_uri);
 

--- a/platform/android/net_socket_android.cpp
+++ b/platform/android/net_socket_android.cpp
@@ -71,7 +71,7 @@ void NetSocketAndroid::multicast_lock_release() {
 	}
 }
 
-NetSocket *NetSocketAndroid::_create_func() {
+Ref<NetSocket> NetSocketAndroid::_create_func() {
 	return memnew(NetSocketAndroid);
 }
 

--- a/platform/android/net_socket_android.h
+++ b/platform/android/net_socket_android.h
@@ -59,7 +59,7 @@ private:
 	static void multicast_lock_release();
 
 protected:
-	static NetSocket *_create_func();
+	static Ref<NetSocket> _create_func();
 
 public:
 	static void make_default();

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2700,11 +2700,11 @@ void WaylandThread::_wp_image_description_on_ready2(void *data, struct wp_image_
 
 	struct wp_image_description_info_v1 *image_info = wp_image_description_v1_get_information(image_descriptor);
 	if (image_info != nullptr) {
-		ColorProfileMessage *msg = memnew(ColorProfileMessage);
+		Ref<ColorProfileMessage> msg = memnew(ColorProfileMessage);
 		msg->id = ws->id;
 		msg->wayland_thread = ws->wayland_thread;
 
-		wp_image_description_info_v1_add_listener(image_info, &wp_image_description_info_listener, msg);
+		wp_image_description_info_v1_add_listener(image_info, &wp_image_description_info_listener, msg.ptr());
 		wp_image_description_v1_destroy(image_descriptor);
 	}
 }

--- a/platform/web/net_socket_web.h
+++ b/platform/web/net_socket_web.h
@@ -38,7 +38,7 @@ class NetSocketWeb : public NetSocket {
 	GDSOFTCLASS(NetSocketWeb, NetSocket);
 
 protected:
-	static NetSocket *_create_func() {
+	static Ref<NetSocket> _create_func() {
 		return memnew(NetSocketWeb);
 	}
 

--- a/scene/3d/lightmapper.cpp
+++ b/scene/3d/lightmapper.cpp
@@ -30,7 +30,7 @@
 
 #include "lightmapper.h"
 
-LightmapDenoiser *(*LightmapDenoiser::create_function)() = nullptr;
+Ref<LightmapDenoiser> (*LightmapDenoiser::create_function)() = nullptr;
 
 Ref<LightmapDenoiser> LightmapDenoiser::create() {
 	if (create_function) {
@@ -39,7 +39,7 @@ Ref<LightmapDenoiser> LightmapDenoiser::create() {
 	return Ref<LightmapDenoiser>();
 }
 
-LightmapRaycaster *(*LightmapRaycaster::create_function)() = nullptr;
+Ref<LightmapRaycaster> (*LightmapRaycaster::create_function)() = nullptr;
 
 Ref<LightmapRaycaster> LightmapRaycaster::create() {
 	if (create_function) {
@@ -53,19 +53,19 @@ Lightmapper::CreateFunc Lightmapper::create_gpu = nullptr;
 Lightmapper::CreateFunc Lightmapper::create_cpu = nullptr;
 
 Ref<Lightmapper> Lightmapper::create() {
-	Lightmapper *lm = nullptr;
+	Ref<Lightmapper> lm;
 	if (create_custom) {
 		lm = create_custom();
 	}
 
-	if (!lm && create_gpu) {
+	if (lm.is_null() && create_gpu) {
 		lm = create_gpu();
 	}
 
-	if (!lm && create_cpu) {
+	if (lm.is_null() && create_cpu) {
 		lm = create_cpu();
 	}
-	if (!lm) {
+	if (lm.is_null()) {
 		return Ref<Lightmapper>();
 	} else {
 		return Ref<Lightmapper>(lm);

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -37,7 +37,7 @@ class Image;
 class LightmapDenoiser : public RefCounted {
 	GDCLASS(LightmapDenoiser, RefCounted)
 protected:
-	static LightmapDenoiser *(*create_function)();
+	static Ref<LightmapDenoiser> (*create_function)();
 
 public:
 	virtual Ref<Image> denoise_image(const Ref<Image> &p_image) = 0;
@@ -47,7 +47,7 @@ public:
 class LightmapRaycaster : public RefCounted {
 	GDCLASS(LightmapRaycaster, RefCounted)
 protected:
-	static LightmapRaycaster *(*create_function)();
+	static Ref<LightmapRaycaster> (*create_function)();
 
 public:
 	// Compatible with embree4 rays.
@@ -145,7 +145,7 @@ public:
 		BAKE_QUALITY_ULTRA,
 	};
 
-	typedef Lightmapper *(*CreateFunc)();
+	typedef Ref<Lightmapper> (*CreateFunc)();
 
 	static CreateFunc create_custom;
 	static CreateFunc create_gpu;

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -3355,8 +3355,9 @@ void TileSet::_compatibility_conversion() {
 		CompatibilityTileData *ctd = E.value;
 
 		// Add the texture
-		TileSetAtlasSource *atlas_source = memnew(TileSetAtlasSource);
-		int source_id = add_source(Ref<TileSetSource>(atlas_source));
+		Ref<TileSetAtlasSource> atlas_source;
+		atlas_source.instantiate();
+		int source_id = add_source(atlas_source);
 
 		atlas_source->set_texture(ctd->texture);
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -583,7 +583,7 @@ Error ResourceLoaderText::load() {
 			}
 		}
 
-		MissingResource *missing_resource = nullptr;
+		Ref<MissingResource> missing_resource;
 
 		if (res.is_null()) { //not reuse
 			Ref<Resource> cache = ResourceCache::get_ref(path);
@@ -599,7 +599,7 @@ Error ResourceLoaderText::load() {
 						missing_resource = memnew(MissingResource);
 						missing_resource->set_original_class(type);
 						missing_resource->set_recording_properties(true);
-						obj = missing_resource;
+						obj = missing_resource.ptr();
 					} else {
 						error_text = vformat("Can't create sub resource of type '%s'", type);
 						_printerr();
@@ -654,7 +654,7 @@ Error ResourceLoaderText::load() {
 				if (do_assign) {
 					bool set_valid = true;
 
-					if (value.get_type() == Variant::OBJECT && missing_resource == nullptr && ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
+					if (value.get_type() == Variant::OBJECT && missing_resource.is_null() && ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
 						// If the property being set is a missing resource (and the parent is not),
 						// then setting it will most likely not work.
 						// Instead, save it as metadata.
@@ -707,7 +707,7 @@ Error ResourceLoaderText::load() {
 			}
 		}
 
-		if (missing_resource) {
+		if (missing_resource.is_valid()) {
 			missing_resource->set_recording_properties(false);
 		}
 
@@ -728,7 +728,7 @@ Error ResourceLoaderText::load() {
 			return error;
 		}
 
-		MissingResource *missing_resource = nullptr;
+		Ref<MissingResource> missing_resource;
 
 		resource = ResourceLoader::get_resource_ref_override(local_path);
 		if (resource.is_null()) {
@@ -745,7 +745,7 @@ Error ResourceLoaderText::load() {
 						missing_resource = memnew(MissingResource);
 						missing_resource->set_original_class(res_type);
 						missing_resource->set_recording_properties(true);
-						obj = missing_resource;
+						obj = missing_resource.ptr();
 					} else {
 						error_text = vformat("Can't create sub resource of type '%s'", res_type);
 						_printerr();
@@ -795,7 +795,7 @@ Error ResourceLoaderText::load() {
 			if (!assign.is_empty()) {
 				bool set_valid = true;
 
-				if (value.get_type() == Variant::OBJECT && missing_resource == nullptr && ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
+				if (value.get_type() == Variant::OBJECT && missing_resource.is_null() && ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
 					// If the property being set is a missing resource (and the parent is not),
 					// then setting it will most likely not work.
 					// Instead, save it as metadata.
@@ -852,7 +852,7 @@ Error ResourceLoaderText::load() {
 			*progress = resource_current / float(resources_total);
 		}
 
-		if (missing_resource) {
+		if (missing_resource.is_valid()) {
 			missing_resource->set_recording_properties(false);
 		}
 

--- a/tests/core/io/test_resource.cpp
+++ b/tests/core/io/test_resource.cpp
@@ -350,7 +350,7 @@ public:
 		} \
 \
 	public: \
-		static m_class_name *register_and_instantiate() { \
+		static Ref<m_class_name> register_and_instantiate() { \
 			static bool registered = false; \
 			if (!registered) { \
 				GDREGISTER_CLASS(m_class_name); \

--- a/tests/core/io/test_stream_peer_tcp.cpp
+++ b/tests/core/io/test_stream_peer_tcp.cpp
@@ -81,7 +81,7 @@ public:
 	~MockNetSocket() override;
 
 protected:
-	static NetSocket *_create_func();
+	static Ref<NetSocket> _create_func();
 
 private:
 	bool _is_open = false;
@@ -90,7 +90,7 @@ private:
 	uint8_t *_recv_data = nullptr;
 };
 
-NetSocket *MockNetSocket::_create_func() {
+Ref<NetSocket> MockNetSocket::_create_func() {
 	return memnew(MockNetSocket);
 }
 

--- a/tests/scene/test_packed_scene.cpp
+++ b/tests/scene/test_packed_scene.cpp
@@ -267,14 +267,15 @@ TEST_CASE("[PackedScene] Recreate State") {
 	scene->set_name("TestScene");
 
 	// Pack the scene.
-	PackedScene packed_scene;
-	packed_scene.pack(scene);
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+	packed_scene->pack(scene);
 
 	// Recreate the state.
-	packed_scene.recreate_state();
+	packed_scene->recreate_state();
 
 	// Check if the state has been recreated.
-	Ref<SceneState> state = packed_scene.get_state();
+	Ref<SceneState> state = packed_scene->get_state();
 	CHECK(state.is_valid());
 	CHECK(state->get_node_count() == 0); // Since the state was recreated, it should be empty.
 


### PR DESCRIPTION
This PR improves `RefCounted` ownership semantics for newly created objects, preventing potential crashes and other footguns at build time.

## Background

When `memnew` initializes `RefCounted` subclasses, they start with an (effective) allocation count of 0.

This creates two ownership related problems:

- When stored as `RefCounted *` initially, some code may increase and later decrease the refcount (e.g. when passing as `Variant`). This destructs the object, because the refcount is decreased to 0. The actual owner's `RefCounted *` will be a dangling pointer. The owner should have stored `Ref<RefCounted>` instead.
- When in the `postinitialize_handler` / `NOTIFICATION_POSTINITIALIZE`, `RefCounted` objects still have an allocation count of 0, because the caller of `memnew` didn't claim a reference yet. If the allocation count is increased and later decreased during this function, the object will unexpectedly destruct (see https://github.com/godotengine/godot/issues/108395).

The ideal (only?) way to fix this is to start `RefCounted` with a refcount of 1. The `memnew` caller must take ownership of the refcount after the call. This just means we return `Ref` from `memnew`. Most callers already store the result in a `Ref`, so they are compatible with this change.

## Overview

Implementing the change was fairly straight-forward; I add and specialize `memnew_result_t` such that for `RefCounted` types, `memnew` returns `Ref<T>`.

The rest of the changes are fixing current ownership problems. Mostly, it just involves changing `T *` to `Ref<T>`. It has some inherent risk, but I don't think it's huge.