### PR TITLE
Fix SDFGI dynamic light culling with Y-scaled cascades

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -1928,8 +1928,8 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 		}
 
 		AABB cascade_aabb;
-		cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascade.position)) * cascade.cell_size;
-		cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cascade.cell_size;
+		cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascade.position)) * cascade.cell_size * Vector3(1, 1.0 / y_mult, 1);
+		cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cascade.cell_size * Vector3(1, 1.0 / y_mult, 1);
 
 		for (uint32_t j = 0; j < p_render_data->sdfgi_update_data->positional_light_count; j++) {
 			if (idx == SDFGI::MAX_DYNAMIC_LIGHTS) {

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -1881,6 +1881,8 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 
 	/* Update dynamic lights in SDFGI cascades */
 
+	const Vector3 y_scale = Vector3(1, 1.0 / y_mult, 1);
+
 	for (uint32_t i = 0; i < cascades.size(); i++) {
 		SDFGI::Cascade &cascade = cascades[i];
 
@@ -1928,8 +1930,9 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 		}
 
 		AABB cascade_aabb;
-		cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascade.position)) * cascade.cell_size * Vector3(1, 1.0 / y_mult, 1);
-		cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cascade.cell_size * Vector3(1, 1.0 / y_mult, 1);
+
+		cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascade.position)) * cascade.cell_size * y_scale;
+		cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cascade.cell_size * y_scale;
 
 		for (uint32_t j = 0; j < p_render_data->sdfgi_update_data->positional_light_count; j++) {
 			if (idx == SDFGI::MAX_DYNAMIC_LIGHTS) {


### PR DESCRIPTION
Resolves #111723

SDFGI dynamic lights are incorrectly culled when positioned at high or low Y coordinates (e.g., Y=±200) with non-100% Y scale settings.

### Root Cause

SDFGI stores cascade positions in Y-scaled grid space. When a world position is processed, it's transformed by multiplying Y by `y_mult`:

```cpp
world_position.y *= y_mult;  // Enter Y-scaled grid space
cascade.position = ...; // Stored in Y-scaled space
```

When converting back to world space for bounds checking, the inverse transform `* Vector3(1, 1.0 / y_mult, 1)` must be applied. This pattern is used correctly throughout the codebase (e.g., `get_pending_region_data()` at line ~2101).

However, `pre_process_gi()` at line ~1931 was missing this inverse transform when constructing the `cascade_aabb` for light culling:

```cpp
cascade_aabb.position = Vector3(...) * cascade.cell_size;
// Missing: * Vector3(1, 1.0 / y_mult, 1)
```

This caused `cascade_aabb` (in Y-scaled grid space) and `light_aabb` (in world space) to be compared in different coordinate systems, resulting in incorrect culling.

### The Fix

Apply the inverse Y-scale transform to convert cascade bounds to world space:

```cpp
cascade_aabb.position = Vector3(...) * cascade.cell_size * Vector3(1, 1.0 / y_mult, 1);
cascade_aabb.size = Vector3(...) * cascade.cell_size * Vector3(1, 1.0 / y_mult, 1);
```

This matches the pattern used in `get_pending_region_data()` and ensures both AABBs are in the same coordinate space for intersection testing.

Note: This bug was masked when `y_mult=1.0` (100% Y-scale), as the inverse transform becomes a no-op.