### PR TITLE
Fix BaseMaterial3D UV Offset/Scale and Emission on UV2 ignored when baking VoxelGI

### DIFF
--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -90,6 +90,12 @@ private:
 		//128x128 textures
 		Vector<Color> albedo;
 		Vector<Color> emission;
+
+		Vector3 uv1_scale;
+		Vector3 uv1_offset;
+		Vector3 uv2_scale;
+		Vector3 uv2_offset;
+		bool emission_on_uv2 = false;
 	};
 
 	HashMap<Ref<Material>, MaterialCache> material_cache;
@@ -110,7 +116,7 @@ private:
 	Vector<Color> _get_bake_texture(Ref<Image> p_image, const Color &p_color_mul, const Color &p_color_add);
 	MaterialCache _get_material_cache(Ref<Material> p_material);
 
-	void _plot_face(int p_idx, int p_level, int p_x, int p_y, int p_z, const Vector3 *p_vtx, const Vector3 *p_normal, const Vector2 *p_uv, const MaterialCache &p_material, const AABB &p_aabb);
+	void _plot_face(int p_idx, int p_level, int p_x, int p_y, int p_z, const Vector3 *p_vtx, const Vector3 *p_normal, const Vector2 *p_uv, const Vector2 *p_uv2, const MaterialCache &p_material, const AABB &p_aabb);
 	void _fixup_plot(int p_idx, int p_level);
 	void _debug_mesh(int p_idx, int p_level, const AABB &p_aabb, Ref<MultiMesh> &p_multimesh, int &idx);
 


### PR DESCRIPTION
**UV1/UV2 Triplanar** properties are still ignored, but implementing them is much more involved as triplanar sampling would have to be reimplemented from scratch in the voxelizer.

Note that adjusting UV2 Scale/Offset will affect baking, but it doesn't affect the real-time emission map in either Forward+ or Compatibility here. I'm not sure if this is a bug (and whether we should remove the UV2 Scale/Offset adjustment from the voxelizer).

- See https://github.com/godotengine/godot/issues/64124#issuecomment-3436043754.
- Remember to update [documentation](https://github.com/godotengine/godot-docs/pull/11408) after this is merged.

**Testing project:** [test_voxelgi_uv.zip](https://github.com/user-attachments/files/23109731/test_voxelgi_uv.zip)

cc @betalars

## Preview

*The source texture has 3 colored dots at 1:1 scale, but the plane uses an UV scale and offset to repeat it.*

### Before

<img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/bfa61877-8301-4186-b530-6ce6afd72bd7" />

### After

<img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/1179f3bd-d774-4362-8c9d-3a0da1f8dc6f" />
