### PR TITLE
Add `h`/`v_separation` theme properties to ScrollContainer

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -110,6 +110,12 @@
 		</constant>
 	</constants>
 	<theme_items>
+		<theme_item name="scrollbar_h_separation" data_type="constant" type="int" default="0">
+			The space between the ScrollContainer's vertical scroll bar and its content, in pixels. No space will be added when the content's minimum size is larger than the ScrollContainer's size.
+		</theme_item>
+		<theme_item name="scrollbar_v_separation" data_type="constant" type="int" default="0">
+			The space between the ScrollContainer's horizontal scroll bar and its content, in pixels. No space will be added when the content's minimum size is larger than the ScrollContainer's size.
+		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
 			The focus border [StyleBox] of the [ScrollContainer]. Only used if [member draw_focus_border] is [code]true[/code].
 		</theme_item>

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -353,11 +353,11 @@ void ScrollContainer::_reposition_children() {
 	bool reserve_vscroll = _is_v_scroll_visible() || vertical_scroll_mode == SCROLL_MODE_RESERVE;
 
 	if (_is_h_scroll_visible() || horizontal_scroll_mode == SCROLL_MODE_RESERVE) {
-		size.y -= h_scroll->get_minimum_size().y;
+		size.y -= h_scroll->get_minimum_size().y + theme_cache.scrollbar_v_separation;
 	}
 
 	if (reserve_vscroll) {
-		size.x -= v_scroll->get_minimum_size().x;
+		size.x -= v_scroll->get_minimum_size().x + theme_cache.scrollbar_h_separation;
 	}
 
 	for (int i = 0; i < get_child_count(); i++) {
@@ -772,6 +772,9 @@ void ScrollContainer::_bind_methods() {
 	BIND_ENUM_CONSTANT(SCROLL_MODE_SHOW_ALWAYS);
 	BIND_ENUM_CONSTANT(SCROLL_MODE_SHOW_NEVER);
 	BIND_ENUM_CONSTANT(SCROLL_MODE_RESERVE);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, scrollbar_h_separation);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, scrollbar_v_separation);
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollContainer, panel_style, "panel");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollContainer, focus_style, "focus");

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -78,6 +78,9 @@ private:
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;
 		Ref<StyleBox> focus_style;
+
+		int scrollbar_h_separation = 0;
+		int scrollbar_v_separation = 0;
 	} theme_cache;
 
 	void _cancel_drag();


### PR DESCRIPTION
In the image below, I've set the h_separation to 8px. The VBoxContainer has horizontal size flags of expand+fill, and has a bunch of buttons as children all set to fill width.
Before, the buttons would go all the way to the scroll bar, but now they stop h_separation before it:
<img width="1357" height="695" alt="image" src="https://github.com/user-attachments/assets/1209c365-2545-450f-8311-3f08ca9c73fb" />

Resolves godotengine/godot-proposals#13452