### PR TITLE
PhysicsServer2D: Correct safe margin in `test_body_motion`

### DIFF
--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -993,7 +993,11 @@ bool GodotSpace2D::test_body_motion(GodotBody2D *p_body, const PhysicsServer2D::
 
 				r_result->travel = safe * p_parameters.motion;
 				r_result->remainder = p_parameters.motion - safe * p_parameters.motion;
-				r_result->travel += (body_transform.get_origin() - p_parameters.from.get_origin());
+				if (recovered) {
+					r_result->travel += (body_transform.get_origin() - p_parameters.from.get_origin());
+				} else {
+					r_result->travel -= margin * motion_normal;
+				}
 			}
 
 			collided = true;


### PR DESCRIPTION
Fixes #111059 in another approach, this may also close #57706

The latter one is not fully tested, it's hard to track the issue with that MRP. My testing results are as follows:

Before fix:
![issue_before](https://github.com/user-attachments/assets/0e17cbd3-ec4e-4560-b120-0e87f276cd87)

After fix:
![issue_after](https://github.com/user-attachments/assets/5a0670d6-c7d6-45f3-b8f8-6110fc2f4210)


You may check explanation in [my previous PR](https://github.com/godotengine/godot/pull/111076#issuecomment-3440909649)
Since it's a change in `PhysicsServer`, It will possibly affect something else, further testings are desired.