### PR TITLE
Fix `PhysicalBone3D` failing to respect change to `JOINT_TYPE_NONE`.

### DIFF
--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -1029,6 +1029,7 @@ void PhysicalBone3D::_reload_joint() {
 
 		} break;
 		case JOINT_TYPE_NONE: {
+			PhysicsServer3D::get_singleton()->joint_clear(joint);
 		} break;
 	}
 }


### PR DESCRIPTION
Adds a joint_clear() when JOINT_TYPE_NONE selected.
Not sure if it's the *right* solution, but checks out in local testing here.

Addresses / fixes #58638 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
