### PR TITLE
Revise fog blending to fix over-darkening/borders.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -281,7 +281,7 @@ void main() {
 
 	if (sky_scene_data.volumetric_fog_enabled) {
 		vec4 fog = volumetric_fog_process(uv);
-		frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a * sky_scene_data.volumetric_fog_sky_affect);
+		frag_color.rgb = frag_color.rgb * (1.0 - fog.a * sky_scene_data.volumetric_fog_sky_affect) + fog.rgb * sky_scene_data.volumetric_fog_sky_affect;
 	}
 
 	if (custom_fog.a > 0.0) {

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1443,20 +1443,21 @@ void fragment_shader(in SceneData scene_data) {
 #else
 		vec4 volumetric_fog = volumetric_fog_process(screen_uv, -vertex.z);
 #endif
+		vec4 res = vec4(0.0);
 		if (bool(scene_data.flags & SCENE_DATA_FLAGS_USE_FOG)) {
 			//must use the full blending equation here to blend fogs
-			vec4 res;
 			float sa = 1.0 - volumetric_fog.a;
 			res.a = fog.a * sa + volumetric_fog.a;
-			if (res.a == 0.0) {
-				res.rgb = vec3(0.0);
-			} else {
-				res.rgb = (fog.rgb * fog.a * sa + volumetric_fog.rgb * volumetric_fog.a) / res.a;
+			if (res.a > 0.0) {
+				res.rgb = (fog.rgb * fog.a * sa + volumetric_fog.rgb) / res.a;
 			}
-			fog = res;
 		} else {
-			fog = volumetric_fog;
+			res.a = volumetric_fog.a;
+			if (res.a > 0.0) {
+				res.rgb = volumetric_fog.rgb / res.a;
+			}
 		}
+		fog = res;
 	}
 #endif //!CUSTOM_FOG_USED
 


### PR DESCRIPTION
This can result in low fog densities being a bit brighter, which may need slight adjustment in your scenes.

In exchange, volumetrics now blend smoothly together with the scene and regular fog.

Fixes #101514. Tested locally against 4.5 branch and current master (084d5d407e62efcd5be9de44148c5dedce3b9386 at PR time).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
