### PR TITLE
Add `get_joint_rid()` to `PhysicalBone3D`.

### DIFF
--- a/doc/classes/PhysicalBone3D.xml
+++ b/doc/classes/PhysicalBone3D.xml
@@ -42,6 +42,12 @@
 				Returns the unique identifier of the PhysicsBone3D.
 			</description>
 		</method>
+		<method name="get_joint_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the joint's internal [RID] from the [PhysicsServer3D].
+			</description>
+		</method>
 		<method name="get_simulate_physics">
 			<return type="bool" />
 			<description>

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -835,6 +835,8 @@ void PhysicalBone3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_joint_type", "joint_type"), &PhysicalBone3D::set_joint_type);
 	ClassDB::bind_method(D_METHOD("get_joint_type"), &PhysicalBone3D::get_joint_type);
 
+	ClassDB::bind_method(D_METHOD("get_joint_rid"), &PhysicalBone3D::get_joint_rid);
+
 	ClassDB::bind_method(D_METHOD("set_joint_offset", "offset"), &PhysicalBone3D::set_joint_offset);
 	ClassDB::bind_method(D_METHOD("get_joint_offset"), &PhysicalBone3D::get_joint_offset);
 	ClassDB::bind_method(D_METHOD("set_joint_rotation", "euler"), &PhysicalBone3D::set_joint_rotation);

--- a/scene/3d/physics/physical_bone_3d.h
+++ b/scene/3d/physics/physical_bone_3d.h
@@ -239,6 +239,10 @@ public:
 		return bone_id;
 	}
 
+	RID get_joint_rid() const {
+		return joint;
+	}
+
 	void set_joint_type(JointType p_joint_type);
 	JointType get_joint_type() const;
 


### PR DESCRIPTION
Based on Riordan-DCs approach and **proposal**, reflecting code found in the joint3D counterparts.

Given I was keen to see if this helps me in a project I'm currently developing, I implemented locally and gave it a test. Functions as I would expect, and doesn't appear to break anything. PR provided here just in case the engine *does* want to include the functionality.

Fixes https://github.com/godotengine/godot-proposals/issues/13392