### PR TITLE
Fix broken screenshot link in Appstream metadata

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.appdata.xml
+++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml
@@ -20,9 +20,9 @@
     </p>
   </description>
   <screenshots>
-    <screenshot type="default" width="1330" height="720">
+    <screenshot type="default" width="1279" height="758">
       <caption>3D project loaded in the Godot Engine editor</caption>
-      <image>https://download.tuxfamily.org/godotengine/media/screenshots/editor_3d_fracteed-720p.jpg</image>
+      <image>https://docs.godotengine.org/en/stable/_images/introduction_editor.webp</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://godotengine.org</url>


### PR DESCRIPTION
Debian's AppStream lint service noticed that the screenshot link is broken. I chose a new one that showcases the UI from the docs. Happy to change it to anything else, but wasn't sure what the original was since it isn't even on the Internet Archive. (Maybe it was [this one](https://dl.flathub.org/media/org/godotengine/Godot.desktop/bbec87dce707241a07e7ed56444b4ead/screenshots/image-1_orig.webp) from Flathub?)