### PR TITLE
[DRAFT] XR Editor: Proof-of-concept immersive editing using the debugger

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -44,6 +44,7 @@
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/editor_undo_redo_manager.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_toaster.h"
@@ -448,6 +449,38 @@ void ScriptEditorDebugger::_msg_scene_inspect_object(uint64_t p_thread_id, const
 	_msg_scene_inspect_objects(p_thread_id, wrapped_data);
 }
 #endif // DISABLE_DEPRECATED
+
+void ScriptEditorDebugger::_msg_scene_select_path(uint64_t p_thread_id, const Array &p_data) {
+	ERR_FAIL_COND(p_data.is_empty());
+	String scene_path = p_data[0];
+	String node_path = p_data[1];
+	if (EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path() == scene_path) {
+		Node *n = EditorNode::get_singleton()->get_edited_scene()->get_node_or_null(node_path);
+		if (n) {
+			EditorSelection *selection = EditorNode::get_singleton()->get_editor_selection();
+			selection->clear();
+			selection->add_node(n);
+		}
+	}
+}
+
+void ScriptEditorDebugger::_msg_scene_set_object_property(uint64_t p_thread_id, const Array &p_data) {
+	ERR_FAIL_COND(p_data.is_empty());
+	String scene_path = p_data[0];
+	String node_path = p_data[1];
+	String property_path = p_data[2];
+	Variant value = p_data[3];
+	if (EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path() == scene_path) {
+		Node *n = EditorNode::get_singleton()->get_edited_scene()->get_node_or_null(node_path);
+		if (n) {
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action("Update property remotely");
+			undo_redo->add_do_property(n, property_path, value);
+			undo_redo->add_undo_property(n, property_path, n->get(property_path));
+			undo_redo->commit_action();
+		}
+	}
+}
 
 void ScriptEditorDebugger::_msg_scene_debug_mute_audio(uint64_t p_thread_id, const Array &p_data) {
 	ERR_FAIL_COND(p_data.is_empty());
@@ -974,6 +1007,8 @@ void ScriptEditorDebugger::_init_parse_message_handlers() {
 #ifndef DISABLE_DEPRECATED
 	parse_message_handlers["scene:inspect_object"] = &ScriptEditorDebugger::_msg_scene_inspect_object;
 #endif // DISABLE_DEPRECATED
+	parse_message_handlers["scene:select_path"] = &ScriptEditorDebugger::_msg_scene_select_path;
+	parse_message_handlers["scene:set_object_property"] = &ScriptEditorDebugger::_msg_scene_set_object_property;
 	parse_message_handlers["scene:debug_mute_audio"] = &ScriptEditorDebugger::_msg_scene_debug_mute_audio;
 	parse_message_handlers["servers:memory_usage"] = &ScriptEditorDebugger::_msg_servers_memory_usage;
 	parse_message_handlers["servers:drawn"] = &ScriptEditorDebugger::_msg_servers_drawn;

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -209,6 +209,8 @@ private:
 #ifndef DISABLE_DEPRECATED
 	void _msg_scene_inspect_object(uint64_t p_thread_id, const Array &p_data);
 #endif // DISABLE_DEPRECATED
+	void _msg_scene_select_path(uint64_t p_thread_id, const Array &p_data);
+	void _msg_scene_set_object_property(uint64_t p_thread_id, const Array &p_data);
 	void _msg_scene_debug_mute_audio(uint64_t p_thread_id, const Array &p_data);
 	void _msg_servers_memory_usage(uint64_t p_thread_id, const Array &p_data);
 	void _msg_servers_drawn(uint64_t p_thread_id, const Array &p_data);

--- a/scene/3d/xr/xr_debugger.cpp
+++ b/scene/3d/xr/xr_debugger.cpp
@@ -1,0 +1,405 @@
+/**************************************************************************/
+/*  xr_debugger.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef DEBUG_ENABLED
+
+#include "xr_debugger.h"
+
+#include "core/debugger/engine_debugger.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/xr/xr_nodes.h"
+#include "scene/debugger/scene_debugger.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h"
+#include "scene/resources/3d/primitive_meshes.h"
+
+XRDebuggerRuntimeEditor *XRDebugger::get_runtime_editor() {
+	return runtime_editor_id.is_valid() ? ObjectDB::get_instance<XRDebuggerRuntimeEditor>(runtime_editor_id) : nullptr;
+}
+
+void XRDebugger::initialize() {
+	SceneTree *scene_tree = SceneTree::get_singleton();
+	ERR_FAIL_NULL(scene_tree);
+
+	XRDebuggerRuntimeEditor *runtime_editor = get_runtime_editor();
+	if (runtime_editor) {
+		return;
+	}
+
+	runtime_editor = memnew(XRDebuggerRuntimeEditor);
+	runtime_editor_id = runtime_editor->get_instance_id();
+
+	scene_tree->get_root()->add_child(runtime_editor);
+}
+
+void XRDebugger::deinitialize() {
+	SceneTree *scene_tree = SceneTree::get_singleton();
+	ERR_FAIL_NULL(scene_tree);
+
+	XRDebuggerRuntimeEditor *runtime_editor = get_runtime_editor();
+	if (!runtime_editor) {
+		return;
+	}
+
+	runtime_editor_id = ObjectID();
+	runtime_editor->queue_free();
+	scene_tree->get_root()->remove_child(runtime_editor);
+}
+
+XRDebugger::XRDebugger() {
+}
+
+XRDebugger::~XRDebugger() {
+	deinitialize();
+}
+
+void XRDebuggerRuntimeEditor::_on_controller_button_pressed(const String &p_name, XRController3D *p_controller) {
+	// @todo We need to have an action set for OpenXR, and it needs to know to switch to it - not sure how to handle that yet.
+
+	if (p_controller == xr_controller_left && p_name == "menu_button") {
+		set_enabled(!enabled);
+	} else if (p_controller == xr_controller_right && p_name == "trigger_click") {
+		select_pressed = true;
+	} else if (p_controller == xr_controller_right && p_name == "grip_click") {
+		grab_pressed = true;
+		if (selected_node != ObjectID()) {
+			Node3D *n = Object::cast_to<Node3D>(ObjectDB::get_instance(selected_node));
+			if (n) {
+				selected_node_orig_gt = n->get_global_transform();
+				grab_orig_t = xr_controller_right->get_transform();
+			}
+		}
+	}
+}
+
+void XRDebuggerRuntimeEditor::_on_controller_button_released(const String &p_name, XRController3D *p_controller) {
+	// @todo We need to have an action set for OpenXR, and it needs to know to switch to it - not sure how to handle that yet.
+
+	if (p_controller == xr_controller_right && p_name == "grip_click") {
+		grab_pressed = false;
+
+		if (selected_node != ObjectID()) {
+			Node3D *n = Object::cast_to<Node3D>(ObjectDB::get_instance(selected_node));
+			if (n) {
+				Node3D *scene_node = _find_nearest_scene_node(n);
+				if (scene_node) {
+					NodePath scene_path = scene_node->get_owner()->get_path_to(scene_node);
+					Transform3D gt = (xr_controller_right->get_transform() * grab_orig_t.affine_inverse()) * selected_node_orig_gt;
+
+					// Make the position relative to the parent.
+					Node3D *parent = Object::cast_to<Node3D>(scene_node->get_parent());
+					if (parent) {
+						gt = parent->get_global_transform().affine_inverse() * gt;
+					}
+
+					Array message;
+					message.push_back(LiveEditor::get_singleton()->get_live_edit_scene());
+					message.push_back(scene_path.operator String());
+					message.push_back("transform");
+					message.push_back(gt);
+					EngineDebugger::get_singleton()->send_message("scene:set_object_property", message);
+				}
+			}
+		}
+	}
+}
+
+bool XRDebuggerRuntimeEditor::_is_descendent(Node *p_node) {
+	Node *parent = p_node->get_parent();
+	while (parent) {
+		if (parent == this) {
+			return true;
+		}
+		parent = parent->get_parent();
+	}
+	return false;
+}
+
+void XRDebuggerRuntimeEditor::_select_with_ray() {
+	Window *root = SceneTree::get_singleton()->get_root();
+
+	Transform3D controller_transform = xr_controller_right->get_global_transform();
+	Vector3 pos = controller_transform.origin;
+	Vector3 ray = -controller_transform.get_basis().get_column(2);
+	// @todo This is 10m ahead - how far should this be?
+	Vector3 to = pos + (ray * 10.0);
+
+	Node3D *closest_node = nullptr;
+	float closest_distance = 0.0;
+
+#ifndef PHYSICS_3D_DISABLED
+	// @todo Try with physics objects first...
+#endif
+
+	Vector<ObjectID> items = RS::get_singleton()->instances_cull_ray(pos, to, root->get_world_3d()->get_scenario());
+	for (int i = 0; i < items.size(); i++) {
+		Object *obj = ObjectDB::get_instance(items[i]);
+
+		GeometryInstance3D *geo_instance = Object::cast_to<GeometryInstance3D>(obj);
+		if (geo_instance) {
+			if (_is_descendent(geo_instance)) {
+				// Discard our child nodes, those are part of the UI.
+				continue;
+			}
+
+			Ref<TriangleMesh> mesh_collision = geo_instance->generate_triangle_mesh();
+			if (mesh_collision.is_valid()) {
+				Transform3D gt = geo_instance->get_global_transform();
+				Transform3D ai = gt.affine_inverse();
+				Vector3 point, normal;
+				if (mesh_collision->intersect_ray(ai.xform(pos), ai.basis.xform(ray).normalized(), point, normal)) {
+					float distance = pos.distance_to(point);
+					if (!closest_node || distance < closest_distance) {
+						closest_node = geo_instance;
+						closest_distance = distance;
+					}
+				}
+			}
+		}
+	}
+
+	Vector<Node *> selected_nodes;
+
+	if (closest_node) {
+		Node3D *scene_node = _find_nearest_scene_node(closest_node);
+		NodePath scene_path;
+		if (scene_node) {
+			scene_path = scene_node->get_owner()->get_path_to(scene_node);
+			closest_node = scene_node;
+		}
+		selected_node = closest_node->get_instance_id();
+		selected_nodes.push_back(closest_node);
+
+		if (!scene_path.is_empty()) {
+			Array message2;
+			message2.push_back(LiveEditor::get_singleton()->get_live_edit_scene());
+			message2.push_back(scene_path.operator String());
+			EngineDebugger::get_singleton()->send_message("scene:select_path", message2);
+		}
+
+		SceneDebuggerObject obj(selected_node);
+		Array arr;
+		obj.serialize(arr);
+
+		Array message;
+		message.append(arr);
+		EngineDebugger::get_singleton()->send_message("remote_objects_selected", message);
+	} else {
+		selected_node = ObjectID();
+		EngineDebugger::get_singleton()->send_message("remote_nothing_selected", Array());
+	}
+
+	RuntimeNodeSelect::get_singleton()->_set_selected_nodes(selected_nodes);
+}
+
+Node3D *XRDebuggerRuntimeEditor::_find_nearest_scene_node(Node3D *p_node) {
+	String live_edit_scene = LiveEditor::get_singleton()->get_live_edit_scene();
+	if (live_edit_scene.is_empty()) {
+		return nullptr;
+	}
+
+	Node *cur_node = p_node;
+	while (cur_node) {
+		Node *owner = cur_node->get_owner();
+		if (owner && owner->get_scene_file_path() == live_edit_scene) {
+			return Object::cast_to<Node3D>(cur_node);
+		}
+
+		cur_node = cur_node->get_parent();
+	}
+
+	return nullptr;
+}
+
+void XRDebuggerRuntimeEditor::set_enabled(bool p_enable) {
+	if (enabled == p_enable) {
+		return;
+	}
+	enabled = p_enable;
+
+	set_physics_process(enabled);
+	xr_controller_left->set_visible(enabled);
+	xr_controller_right->set_visible(enabled);
+
+	if (enabled) {
+		SceneTree *scene_tree = SceneTree::get_singleton();
+		Window *root = scene_tree->get_root();
+		XROrigin3D *current_xr_origin = nullptr;
+
+		TypedArray<Node> potential_origins = root->find_children("*", "XROrigin3D", true, false);
+		for (const Variant &item : potential_origins) {
+			XROrigin3D *potential_origin = Object::cast_to<XROrigin3D>(item);
+			if (!potential_origin || potential_origin == this) {
+				continue;
+			}
+
+			if (potential_origin->is_current()) {
+				current_xr_origin = potential_origin;
+				break;
+			}
+		}
+
+		if (current_xr_origin) {
+			original_xr_origin_id = current_xr_origin->get_instance_id();
+			set_global_transform(current_xr_origin->get_global_transform());
+
+			XRCamera3D *current_xr_camera = nullptr;
+			TypedArray<XRCamera3D> potential_cameras = current_xr_origin->find_children("*", "XRCamera3D", true, false);
+			for (const Variant &item : potential_cameras) {
+				XRCamera3D *potential_camera = Object::cast_to<XRCamera3D>(item);
+				if (!potential_camera || _is_descendent(potential_camera)) {
+					continue;
+				}
+
+				if (potential_camera->is_current()) {
+					current_xr_camera = potential_camera;
+					break;
+				}
+			}
+			if (current_xr_camera) {
+				original_xr_camera_id = current_xr_camera->get_instance_id();
+			}
+
+			TypedArray<XRController3D> controllers = current_xr_origin->find_children("*", "XRController3D", true, false);
+			for (const Variant &item : controllers) {
+				XRController3D *controller = Object::cast_to<XRController3D>(item);
+				if (!controller || _is_descendent(controller)) {
+					continue;
+				}
+
+				original_xr_controllers.push_back({
+						controller->get_tracker(), // tracker
+						controller->get_instance_id(), // controller_id
+				});
+
+				controller->set_tracker("/disabled/by/xr/debugger");
+			}
+		}
+
+		set_current(true);
+		xr_camera->set_current(true);
+	} else {
+		XROrigin3D *original_xr_origin = ObjectDB::get_instance<XROrigin3D>(original_xr_origin_id);
+		if (original_xr_origin) {
+			original_xr_origin->set_current(true);
+		} else {
+			set_current(false);
+		}
+		original_xr_origin_id = ObjectID();
+
+		XRCamera3D *original_xr_camera = ObjectDB::get_instance<XRCamera3D>(original_xr_camera_id);
+		if (original_xr_camera) {
+			original_xr_camera->set_current(true);
+		} else {
+			xr_camera->set_current(false);
+		}
+		original_xr_camera_id = ObjectID();
+
+		for (const ControllerInfo &ci : original_xr_controllers) {
+			XRController3D *xr_controller = ObjectDB::get_instance<XRController3D>(ci.controller_id);
+			if (xr_controller) {
+				xr_controller->set_tracker(ci.tracker);
+			}
+		}
+		original_xr_controllers.clear();
+	}
+}
+
+void XRDebuggerRuntimeEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			// Ensure that we don't take over from the user's XROrigin3D.
+			callable_mp(static_cast<XROrigin3D *>(this), &XROrigin3D::set_current).bind(false);
+		} break;
+
+		case NOTIFICATION_PHYSICS_PROCESS: {
+			if (enabled) {
+				if (grab_pressed) {
+					if (selected_node != ObjectID()) {
+						Node3D *n = Object::cast_to<Node3D>(ObjectDB::get_instance(selected_node));
+						if (n) {
+							Transform3D gt = (xr_controller_right->get_transform() * grab_orig_t.affine_inverse()) * selected_node_orig_gt;
+							n->set_global_transform(gt);
+						}
+					}
+				} else if (select_pressed) {
+					select_pressed = false;
+					_select_with_ray();
+				}
+			}
+		} break;
+	}
+}
+
+XRDebuggerRuntimeEditor::XRDebuggerRuntimeEditor() {
+	set_name("XRDebuggerRuntimeEditor");
+	set_current(false);
+	set_process_mode(Node::PROCESS_MODE_ALWAYS);
+
+	xr_camera = memnew(XRCamera3D);
+	xr_camera->set_current(false);
+	add_child(xr_camera);
+
+	xr_controller_left = memnew(XRController3D);
+	xr_controller_left->set_tracker("left_hand");
+	xr_controller_left->set_visible(false);
+	xr_controller_left->connect("button_pressed", callable_mp(this, &XRDebuggerRuntimeEditor::_on_controller_button_pressed).bind(xr_controller_left));
+	xr_controller_left->connect("button_released", callable_mp(this, &XRDebuggerRuntimeEditor::_on_controller_button_released).bind(xr_controller_left));
+	add_child(xr_controller_left);
+
+	Ref<BoxMesh> box_mesh;
+	box_mesh.instantiate();
+	box_mesh->set_size(Vector3(0.4, 0.4, 0.05));
+
+	MeshInstance3D *left_mesh_instance = memnew(MeshInstance3D);
+	left_mesh_instance->set_mesh(box_mesh);
+	xr_controller_left->add_child(left_mesh_instance);
+
+	xr_controller_right = memnew(XRController3D);
+	xr_controller_right->set_tracker("right_hand");
+	xr_controller_right->set_visible(false);
+	xr_controller_right->connect("button_pressed", callable_mp(this, &XRDebuggerRuntimeEditor::_on_controller_button_pressed).bind(xr_controller_right));
+	xr_controller_right->connect("button_released", callable_mp(this, &XRDebuggerRuntimeEditor::_on_controller_button_released).bind(xr_controller_right));
+	add_child(xr_controller_right);
+
+	Ref<BoxMesh> ray_mesh;
+	ray_mesh.instantiate();
+	ray_mesh->set_size(Vector3(0.01, 0.01, 10.0));
+
+	MeshInstance3D *right_mesh_instance = memnew(MeshInstance3D);
+	right_mesh_instance->set_mesh(ray_mesh);
+	right_mesh_instance->set_position(Vector3(0.0, 0.0, -5.0));
+	xr_controller_right->add_child(right_mesh_instance);
+}
+
+XRDebuggerRuntimeEditor::~XRDebuggerRuntimeEditor() {
+}
+
+#endif

--- a/scene/3d/xr/xr_debugger.h
+++ b/scene/3d/xr/xr_debugger.h
@@ -1,0 +1,103 @@
+/**************************************************************************/
+/*  xr_debugger.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef DEBUG_ENABLED
+
+#include "core/templates/local_vector.h"
+#include "scene/3d/xr/xr_nodes.h"
+
+class SceneDebugger;
+class XRDebuggerRuntimeEditor;
+
+class XRDebugger : public Object {
+	GDSOFTCLASS(XRDebugger, Object);
+
+	friend class SceneDebugger;
+
+	inline static XRDebugger *singleton = nullptr;
+
+	ObjectID runtime_editor_id;
+
+	XRDebuggerRuntimeEditor *get_runtime_editor();
+
+public:
+	static XRDebugger *get_singleton() { return singleton; }
+
+	void initialize();
+	void deinitialize();
+
+	XRDebugger();
+	~XRDebugger();
+};
+
+class XRDebuggerRuntimeEditor : public XROrigin3D {
+	GDCLASS(XRDebuggerRuntimeEditor, XROrigin3D);
+
+	bool enabled = false;
+
+	ObjectID original_xr_origin_id;
+	ObjectID original_xr_camera_id;
+
+	struct ControllerInfo {
+		StringName tracker;
+		ObjectID controller_id;
+	};
+	LocalVector<ControllerInfo> original_xr_controllers;
+
+	XRCamera3D *xr_camera = nullptr;
+	XRController3D *xr_controller_left = nullptr;
+	XRController3D *xr_controller_right = nullptr;
+
+	bool select_pressed = false;
+	bool grab_pressed = false;
+	ObjectID selected_node;
+	Transform3D selected_node_orig_gt;
+	Transform3D grab_orig_t;
+
+	void _on_controller_button_pressed(const String &p_name, XRController3D *p_controller);
+	void _on_controller_button_released(const String &p_name, XRController3D *p_controller);
+	bool _is_descendent(Node *p_node);
+	void _select_with_ray();
+
+	void set_enabled(bool p_enable);
+
+	Node3D *_find_nearest_scene_node(Node3D *p_node);
+
+protected:
+	void _notification(int p_what);
+
+public:
+	XRDebuggerRuntimeEditor();
+	~XRDebuggerRuntimeEditor();
+};
+
+#endif

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -788,7 +788,7 @@ void XROrigin3D::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			if (!Engine::get_singleton()->is_editor_hint()) {
+			if (!Engine::get_singleton()->is_editor_hint() && get_class_name() != "XRDebuggerRuntimeEditor") {
 				if (origin_nodes.is_empty()) {
 					// first entry always becomes current
 					current = true;

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -64,6 +64,9 @@
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/3d/convex_polygon_shape_3d.h"
 #include "scene/resources/surface_tool.h"
+#ifndef XR_DISABLED
+#include "scene/3d/xr/xr_debugger.h"
+#endif
 #endif // _3D_DISABLED
 
 SceneDebugger::SceneDebugger() {
@@ -72,6 +75,9 @@ SceneDebugger::SceneDebugger() {
 #ifdef DEBUG_ENABLED
 	LiveEditor::singleton = memnew(LiveEditor);
 	RuntimeNodeSelect::singleton = memnew(RuntimeNodeSelect);
+#ifndef XR_DISABLED
+	XRDebugger::singleton = memnew(XRDebugger);
+#endif // XR_DISABLED
 
 	EngineDebugger::register_message_capture("scene", EngineDebugger::Capture(nullptr, SceneDebugger::parse_message));
 #endif // DEBUG_ENABLED
@@ -89,6 +95,12 @@ SceneDebugger::~SceneDebugger() {
 		memdelete(RuntimeNodeSelect::singleton);
 		RuntimeNodeSelect::singleton = nullptr;
 	}
+#ifndef XR_DISABLED
+	if (XRDebugger::singleton) {
+		memdelete(XRDebugger::singleton);
+		XRDebugger::singleton = nullptr;
+	}
+#endif // XR_DISABLED
 #endif // DEBUG_ENABLED
 
 	singleton = nullptr;
@@ -143,6 +155,9 @@ void SceneDebugger::_handle_embed_input(const Ref<InputEvent> &p_event, const Di
 
 Error SceneDebugger::_msg_setup_scene(const Array &p_args) {
 	SceneTree::get_singleton()->get_root()->connect(SceneStringName(window_input), callable_mp_static(SceneDebugger::_handle_input).bind(DebuggerMarshalls::deserialize_key_shortcut(p_args)));
+#ifndef XR_DISABLED
+	XRDebugger::get_singleton()->initialize();
+#endif
 	return OK;
 }
 

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -230,6 +230,8 @@ private:
 	inline static LiveEditor *singleton = nullptr;
 
 public:
+	String get_live_edit_scene() const { return live_edit_scene; }
+
 	static LiveEditor *get_singleton();
 };
 
@@ -252,6 +254,7 @@ public:
 
 private:
 	friend class SceneDebugger;
+	friend class XRDebuggerRuntimeEditor;
 
 	NodeType node_select_type = NODE_TYPE_2D;
 	SelectMode node_select_mode = SELECT_MODE_SINGLE;


### PR DESCRIPTION
In the Godot XR editor running standalone on the Meta Quest headset, you can launch your game immersively, and then bring the 2D editor window back up, and make edits to the current scene which will be immediately reflected in the immersive environment.

This is [great](https://www.youtube.com/watch?v=6RE8KuCspqw)! It's super helpful for doing level design, so you can see exactly how something will look in VR, especially when precise spacing is important.

However, even though the objects you're manipulating may be directly in front of you in the immersive environment, you still need to use the editor in the 2D panel to manipulate them.

Wouldn't it be great if you could just grab the objects in the immersive environment and move them around?

This PR is a proof-of-concept which shows how that could be implemented :-)

**Check out a quick video demo here:**

https://www.youtube.com/watch?v=S_VliP5-3OU

**How to use it:**

- You press the "Menu" button to switch into "immersive editing mode", which puts a ray in your right hand and a flat panel in your left hand
- You can point the ray at an object in the scene, and press the trigger to select it - it'll get a selection box around it
- You can then press and hold the grip button, and move the controller to move the object immersively
- If the object you selected is from the current scene that's open in the editor, once you release the grip button, it'll update that object in the scene in the editor. If it's where you want it, you can just save those changes! It does its updates using the normal undo/redo system, so you can easily undo it in the editor too, if you want

_NOTE: The idea I had for the flat panel in your left hand, is that maybe it could show the inspector with the properties of the selected object and you could do some light editing there, but it's not implemented and I don't know if that's even a good idea._

**How this works:**

- It's using the debugger protocol to do the selection and send the edits back to the editor. This is very similar to how the current game view works, where you can select objects in the game view, and then it selects them in the editor. I think this overall approach is a good way to do this, and so is the main focus of the PoC. (Of course, the specific implementation of this approach is very early.)
- It's doing some unholy things with `XROrigin3D` and other XR nodes to enable/disable the immersive editing mode, and doesn't take the OpenXR Action Map into account at all. This will probably need to be completely redone in a real implementation - please don't pay too much attention to this part :-)

**Some things I'd like to have in the finished implementation:**

- Objects selected in immersive editing mode should show the same object selected in the scene in the editor
- A 3D transform gizmo that can be used to only translate or rotate on a specific axis, for fine-tuned editing. (It still makes sense to have a mode to just grab and freely move the object, but just not as the only option)
- The ability to launch a single scene, and have it inject the `XROrigin3D` and related nodes, and initialize OpenXR. Maybe this could even start in immersive editing mode? This way you could directly edit a specific scene, rather than launching the full game and having to find your way to the scene you want to edit
- Some form of locomotion that isn't connected with the game. Sometimes you may want to edit something that you can't physically reach, or the game's locomotion won't let you move to
- The ability to scale the immersive environment. When doing level design, it can be very useful to "zoom out" or "zoom in", and in an immersive context, I think that means scaling the world! Although, this would need to actually be tested to see just how useful it is
- The ability to place a cursor in the immersive environment, which can be used as a position to spawn a new node from the editor. This way you can create new things near yourself without having manually move them there in the 2D panel 
- Proper integration with the OpenXR Action Map. I think a special Action Set should be injected when the game is launched with immersive editing enabled (and this code should only exist in editor builds) and these actions should be used rather than the default Godot ones

Not all those things need to be in one big PR though :-)