### PR TITLE
Add support for delta encoding to patch PCKs

### DIFF
--- a/core/io/delta_encoding.cpp
+++ b/core/io/delta_encoding.cpp
@@ -1,0 +1,110 @@
+/**************************************************************************/
+/*  delta_encoding.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "delta_encoding.h"
+
+#include <zstd.h>
+
+#define ERR_FAIL_ZSTD_V_MSG(m_result, m_retval, m_msg) \
+	ERR_FAIL_COND_V_MSG(ZSTD_isError(m_result), m_retval, vformat("%s Zstandard reported error code %d: \"%s\".", m_msg, ZSTD_getErrorCode(m_result), ZSTD_getErrorString(ZSTD_getErrorCode(m_result))))
+
+struct ZstdCompressionContext {
+	ZSTD_CCtx *context = ZSTD_createCCtx();
+	~ZstdCompressionContext() { ZSTD_freeCCtx(context); }
+	operator ZSTD_CCtx *() { return context; }
+};
+
+struct ZstdDecompressionContext {
+	ZSTD_DCtx *context = ZSTD_createDCtx();
+	~ZstdDecompressionContext() { ZSTD_freeDCtx(context); }
+	operator ZSTD_DCtx *() { return context; }
+};
+
+static constexpr uint8_t DELTA_MAGIC[4] = { 'G', 'D', 'D', 'L' };
+static constexpr uint8_t DELTA_VERSION_NUMBER = 1;
+static constexpr size_t DELTA_HEADER_SIZE = 5;
+
+Error DeltaEncoding::encode_delta(Span<uint8_t> p_old_data, Span<uint8_t> p_new_data, Vector<uint8_t> &r_delta, int p_compression_level) {
+	size_t zstd_result = ZSTD_compressBound(p_new_data.size());
+	ERR_FAIL_ZSTD_V_MSG(zstd_result, FAILED, "Failed to encode delta. Calculating compression bounds failed.");
+
+	r_delta.reserve_exact(DELTA_HEADER_SIZE + zstd_result);
+	r_delta.resize(DELTA_HEADER_SIZE + zstd_result);
+
+	memcpy(r_delta.ptrw(), DELTA_MAGIC, 4);
+	r_delta.write[4] = DELTA_VERSION_NUMBER;
+
+	ZstdCompressionContext zstd_context;
+
+	ZSTD_parameters zstd_params = ZSTD_getParams(p_compression_level, p_new_data.size(), p_old_data.size());
+	zstd_params.fParams.contentSizeFlag = 1;
+	zstd_params.fParams.checksumFlag = 1;
+
+	zstd_result = ZSTD_CCtx_setParams(zstd_context, zstd_params);
+	ERR_FAIL_ZSTD_V_MSG(zstd_result, FAILED, "Failed to encode delta. Setting compression parameters failed.");
+
+	zstd_result = ZSTD_CCtx_refPrefix(zstd_context, p_old_data.ptr(), p_old_data.size());
+	ERR_FAIL_ZSTD_V_MSG(zstd_result, FAILED, "Failed to encode delta. Setting prefix dictionary failed.");
+
+	zstd_result = ZSTD_compress2(zstd_context, r_delta.ptrw() + DELTA_HEADER_SIZE, r_delta.size() - DELTA_HEADER_SIZE, p_new_data.ptr(), p_new_data.size());
+	ERR_FAIL_ZSTD_V_MSG(zstd_result, FAILED, "Failed to encode delta. Compression failed.");
+
+	r_delta.resize(DELTA_HEADER_SIZE + zstd_result);
+
+	return OK;
+}
+
+Error DeltaEncoding::decode_delta(Span<uint8_t> p_old_data, Span<uint8_t> p_delta, Vector<uint8_t> &r_new_data) {
+	ERR_FAIL_COND_V_MSG(p_delta.size() < DELTA_HEADER_SIZE, ERR_INVALID_DATA, vformat("Failed to decode delta. File size (%d) is too small.", p_delta.size()));
+
+	uint8_t magic[4];
+	memcpy(magic, p_delta.ptr(), sizeof(magic));
+	uint8_t version = p_delta[4];
+
+	ERR_FAIL_COND_V_MSG(memcmp(magic, DELTA_MAGIC, 4) != 0, ERR_FILE_CORRUPT, "Failed to decode delta. Header is invalid.");
+	ERR_FAIL_COND_V_MSG(version != DELTA_VERSION_NUMBER, ERR_FILE_UNRECOGNIZED, vformat("Failed to decode delta. Expected version %d but found %d.", DELTA_VERSION_NUMBER, version));
+
+	size_t zstd_result = ZSTD_findDecompressedSize(p_delta.ptr() + DELTA_HEADER_SIZE, p_delta.size() - DELTA_HEADER_SIZE);
+	ERR_FAIL_ZSTD_V_MSG(zstd_result, FAILED, "Failed to decode delta. Unable to find decompressed size.");
+
+	r_new_data.reserve_exact(zstd_result);
+	r_new_data.resize(zstd_result);
+
+	ZstdDecompressionContext zstd_context;
+
+	zstd_result = ZSTD_DCtx_refPrefix(zstd_context, p_old_data.ptr(), p_old_data.size());
+	ERR_FAIL_ZSTD_V_MSG(zstd_result, FAILED, "Failed to decode delta. Setting prefix dictionary failed.");
+
+	zstd_result = ZSTD_decompressDCtx(zstd_context, r_new_data.ptrw(), r_new_data.size(), p_delta.ptr() + DELTA_HEADER_SIZE, p_delta.size() - DELTA_HEADER_SIZE);
+	ERR_FAIL_ZSTD_V_MSG(zstd_result, FAILED, "Failed to decode delta. Decompression failed.");
+	ERR_FAIL_COND_V(zstd_result != (size_t)r_new_data.size(), ERR_FILE_CORRUPT);
+
+	return OK;
+}

--- a/core/io/delta_encoding.h
+++ b/core/io/delta_encoding.h
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  delta_encoding.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/file_access.h"
+
+class DeltaEncoding {
+public:
+	static Error encode_delta(Span<uint8_t> p_old_data, Span<uint8_t> p_new_data, Vector<uint8_t> &r_delta, int p_compression_level = 19);
+	static Error decode_delta(Span<uint8_t> p_old_data, Span<uint8_t> p_delta, Vector<uint8_t> &r_new_data);
+};

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -31,6 +31,7 @@
 #include "file_access_pack.h"
 
 #include "core/io/file_access_encrypted.h"
+#include "core/io/file_access_patched.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "core/version.h"
@@ -45,7 +46,7 @@ Error PackedData::add_pack(const String &p_path, bool p_replace_files, uint64_t 
 	return ERR_FILE_UNRECOGNIZED;
 }
 
-void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted, bool p_bundle) {
+void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted, bool p_bundle, bool p_delta) {
 	String simplified_path = p_path.simplify_path().trim_prefix("res://");
 	PathMD5 pmd5(simplified_path.md5_buffer());
 
@@ -54,6 +55,7 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 	PackedFile pf;
 	pf.encrypted = p_encrypted;
 	pf.bundle = p_bundle;
+	pf.delta = p_delta;
 	pf.pack = p_pkg_path;
 	pf.offset = p_ofs;
 	pf.size = p_size;
@@ -62,8 +64,11 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 	}
 	pf.src = p_src;
 
-	if (!exists || p_replace_files) {
+	if (p_delta) {
+		delta_patches[pmd5].push_back(pf);
+	} else if (!exists || p_replace_files) {
 		files[pmd5] = pf;
+		delta_patches[pmd5].clear();
 	}
 
 	if (!exists) {
@@ -137,6 +142,28 @@ uint8_t *PackedData::get_file_hash(const String &p_path) {
 	return E->value.md5;
 }
 
+Vector<PackedData::PackedFile> PackedData::get_delta_patches(const String &p_path) const {
+	String simplified_path = p_path.simplify_path().trim_prefix("res://");
+	PathMD5 pmd5(simplified_path.md5_buffer());
+	HashMap<PathMD5, Vector<PackedFile>, PathMD5>::ConstIterator E = delta_patches.find(pmd5);
+	if (!E) {
+		return Vector<PackedFile>();
+	}
+
+	return E->value;
+}
+
+bool PackedData::has_delta_patches(const String &p_path) const {
+	String simplified_path = p_path.simplify_path().trim_prefix("res://");
+	PathMD5 pmd5(simplified_path.md5_buffer());
+	HashMap<PathMD5, Vector<PackedFile>, PathMD5>::ConstIterator E = delta_patches.find(pmd5);
+	if (!E) {
+		return false;
+	}
+
+	return !E->value.is_empty();
+}
+
 HashSet<String> PackedData::get_file_paths() const {
 	HashSet<String> file_paths;
 	_get_file_paths(root, root->name, file_paths);
@@ -155,6 +182,7 @@ void PackedData::_get_file_paths(PackedDir *p_dir, const String &p_parent_dir, H
 
 void PackedData::clear() {
 	files.clear();
+	delta_patches.clear();
 	_free_packed_dirs(root);
 	root = memnew(PackedDir);
 }
@@ -322,7 +350,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		if (flags & PACK_FILE_REMOVAL) { // The file was removed.
 			PackedData::get_singleton()->remove_path(path);
 		} else {
-			PackedData::get_singleton()->add_path(p_path, path, file_base + ofs, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED), sparse_bundle);
+			PackedData::get_singleton()->add_path(p_path, path, file_base + ofs, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED), sparse_bundle, (flags & PACK_FILE_DELTA));
 		}
 	}
 
@@ -330,7 +358,17 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 }
 
 Ref<FileAccess> PackedSourcePCK::get_file(const String &p_path, PackedData::PackedFile *p_file) {
-	return memnew(FileAccessPack(p_path, *p_file));
+	Ref<FileAccess> file(memnew(FileAccessPack(p_path, *p_file)));
+
+	if (PackedData::get_singleton()->has_delta_patches(p_path)) {
+		Ref<FileAccessPatched> file_patched;
+		file_patched.instantiate();
+		Error err = file_patched->open_custom(file);
+		ERR_FAIL_COND_V(err != OK, Ref<FileAccess>());
+		file = file_patched;
+	}
+
+	return file;
 }
 
 //////////////////////////////////////////////////////////////////
@@ -362,7 +400,7 @@ void PackedSourceDirectory::add_directory(const String &p_path, bool p_replace_f
 	for (const String &file_name : da->get_files()) {
 		String file_path = p_path.path_join(file_name);
 		uint8_t md5[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-		PackedData::get_singleton()->add_path(p_path, file_path, 0, 0, md5, this, p_replace_files, false, false);
+		PackedData::get_singleton()->add_path(p_path, file_path, 0, 0, md5, this, p_replace_files, false, false, false);
 	}
 
 	for (const String &sub_dir_name : da->get_directories()) {
@@ -470,6 +508,7 @@ void FileAccessPack::close() {
 }
 
 FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFile &p_file) {
+	path = p_path;
 	pf = p_file;
 	if (pf.bundle) {
 		String simplified_path = p_path.simplify_path();

--- a/core/io/file_access_patched.cpp
+++ b/core/io/file_access_patched.cpp
@@ -1,0 +1,203 @@
+/**************************************************************************/
+/*  file_access_patched.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "file_access_patched.h"
+
+#include "file_access_pack.h"
+
+#include "core/io/delta_encoding.h"
+#include "core/os/os.h"
+
+Error FileAccessPatched::_apply_patch() const {
+	ERR_FAIL_COND_V(!is_open(), FAILED);
+
+	String path = old_file->get_path();
+	Vector<PackedData::PackedFile> delta_patches = PackedData::get_singleton()->get_delta_patches(path);
+	Vector<uint8_t> old_file_data = old_file->get_buffer(old_file->get_length());
+
+	for (int i = 0; i < delta_patches.size(); ++i) {
+		const PackedData::PackedFile &delta_patch = delta_patches[i];
+		ERR_FAIL_COND_V(delta_patch.bundle, FAILED);
+
+		Error err = OK;
+
+		uint64_t total_usec_start = OS::get_singleton()->get_ticks_usec();
+		uint64_t io_usec_start = OS::get_singleton()->get_ticks_usec();
+
+		Ref<FileAccess> patch_file = FileAccess::open(delta_patch.pack, FileAccess::READ, &err);
+		ERR_FAIL_COND_V(err != OK, err);
+
+		patch_file->seek(delta_patch.offset);
+		ERR_FAIL_COND_V(patch_file->get_error() != OK, patch_file->get_error());
+
+		Vector<uint8_t> patch_data = patch_file->get_buffer(delta_patch.size);
+		ERR_FAIL_COND_V(patch_data.is_empty(), ERR_FILE_CANT_READ);
+
+		uint64_t io_usec_end = OS::get_singleton()->get_ticks_usec();
+		uint64_t decode_usec_start = OS::get_singleton()->get_ticks_usec();
+
+		Vector<uint8_t> new_file_data;
+		err = DeltaEncoding::decode_delta(old_file_data, patch_data, new_file_data);
+		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to apply delta patch (%d of %d) to \"%s\".", i + 1, delta_patches.size(), path));
+
+		uint64_t decode_usec_end = OS::get_singleton()->get_ticks_usec();
+
+		old_file_data = new_file_data;
+
+		uint64_t total_usec_end = OS::get_singleton()->get_ticks_usec();
+
+		print_verbose(vformat(U"Applied delta patch to \"%s\" from \"%s\" in %d μs (%d μs I/O, %d μs decoding).", path, delta_patch.pack.get_file(), total_usec_end - total_usec_start, io_usec_end - io_usec_start, decode_usec_end - decode_usec_start));
+	}
+
+	patched_file_data = old_file_data;
+	patched_file.instantiate();
+	return patched_file->open_custom(patched_file_data.ptr(), patched_file_data.size());
+}
+
+bool FileAccessPatched::_try_apply_patch() const {
+	if (last_error != OK) {
+		return false;
+	}
+
+	if (patched_file.is_valid()) {
+		return true;
+	}
+
+	last_error = _apply_patch();
+	return last_error == OK;
+}
+
+Error FileAccessPatched::open_custom(const Ref<FileAccess> &p_old_file) {
+	close();
+
+	if (!p_old_file->is_open()) {
+		last_error = ERR_FILE_CANT_OPEN;
+		return last_error;
+	}
+
+	old_file = p_old_file;
+
+	return OK;
+}
+
+bool FileAccessPatched::is_open() const {
+	return old_file.is_valid() && old_file->is_open();
+}
+
+void FileAccessPatched::seek(uint64_t p_position) {
+	if (!_try_apply_patch()) {
+		return;
+	}
+
+	patched_file->seek(p_position);
+}
+
+void FileAccessPatched::seek_end(int64_t p_position) {
+	if (!_try_apply_patch()) {
+		return;
+	}
+
+	patched_file->seek_end(p_position);
+}
+
+uint64_t FileAccessPatched::get_position() const {
+	if (!_try_apply_patch()) {
+		return 0;
+	}
+
+	return patched_file->get_position();
+}
+
+uint64_t FileAccessPatched::get_length() const {
+	if (!_try_apply_patch()) {
+		return 0;
+	}
+
+	return patched_file->get_length();
+}
+
+bool FileAccessPatched::eof_reached() const {
+	if (!_try_apply_patch()) {
+		return true;
+	}
+
+	return patched_file->eof_reached();
+}
+
+Error FileAccessPatched::get_error() const {
+	if (last_error != OK) {
+		return last_error;
+	}
+
+	if (patched_file.is_valid()) {
+		Error inner_error = patched_file->get_error();
+		if (inner_error != OK) {
+			return inner_error;
+		}
+	}
+
+	return last_error;
+}
+
+bool FileAccessPatched::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	if (!_try_apply_patch()) {
+		return false;
+	}
+
+	return patched_file->store_buffer(p_src, p_length);
+}
+
+uint64_t FileAccessPatched::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+	if (!_try_apply_patch()) {
+		return 0;
+	}
+
+	return patched_file->get_buffer(p_dst, p_length);
+}
+
+void FileAccessPatched::flush() {
+	if (!_try_apply_patch()) {
+		return;
+	}
+
+	patched_file->flush();
+}
+
+void FileAccessPatched::close() {
+	old_file = Ref<FileAccess>();
+	patched_file = Ref<FileAccessMemory>();
+	patched_file_data.clear();
+	last_error = OK;
+}
+
+bool FileAccessPatched::file_exists(const String &p_name) {
+	ERR_FAIL_COND_V(old_file.is_null(), false);
+	return old_file->file_exists(p_name);
+}

--- a/core/io/file_access_patched.h
+++ b/core/io/file_access_patched.h
@@ -1,0 +1,84 @@
+/**************************************************************************/
+/*  file_access_patched.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "file_access.h"
+#include "file_access_memory.h"
+
+class FileAccessPatched : public FileAccess {
+	GDSOFTCLASS(FileAccessPatched, FileAccess);
+
+	Ref<FileAccess> old_file;
+	mutable Vector<uint8_t> patched_file_data;
+	mutable Ref<FileAccessMemory> patched_file;
+	mutable Error last_error = OK;
+
+	Error _apply_patch() const;
+	bool _try_apply_patch() const;
+
+protected:
+	virtual BitField<UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
+	virtual Error _set_unix_permissions(const String &p_file, BitField<UnixPermissionFlags> p_permissions) override { return FAILED; }
+
+	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
+	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
+
+	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
+	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
+
+	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
+	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
+	virtual int64_t _get_size(const String &p_file) override { return -1; }
+
+	virtual Error open_internal(const String &p_path, int p_mode_flags) override { return ERR_UNAVAILABLE; }
+
+public:
+	Error open_custom(const Ref<FileAccess> &p_old_file);
+
+	virtual bool is_open() const override;
+
+	virtual void seek(uint64_t p_position) override;
+	virtual void seek_end(int64_t p_position = 0) override;
+
+	virtual uint64_t get_position() const override;
+	virtual uint64_t get_length() const override;
+	virtual bool eof_reached() const override;
+	virtual Error get_error() const override;
+
+	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override;
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
+	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
+
+	virtual void flush() override;
+	virtual void close() override;
+
+	virtual bool file_exists(const String &p_name) override;
+};

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -83,7 +83,13 @@ void EditorExport::_save() {
 		config->set_value(section, "include_filter", preset->get_include_filter());
 		config->set_value(section, "exclude_filter", preset->get_exclude_filter());
 		config->set_value(section, "export_path", preset->get_export_path());
+
 		config->set_value(section, "patches", preset->get_patches());
+		config->set_value(section, "patch_delta_encoding", preset->is_patch_delta_encoding_enabled());
+		config->set_value(section, "patch_delta_compression_level_zstd", preset->get_patch_delta_zstd_level());
+		config->set_value(section, "patch_delta_min_reduction", preset->get_patch_delta_min_reduction());
+		config->set_value(section, "patch_delta_include_filters", preset->get_patch_delta_include_filter());
+		config->set_value(section, "patch_delta_exclude_filters", preset->get_patch_delta_exclude_filter());
 
 		config->set_value(section, "encryption_include_filters", preset->get_enc_in_filter());
 		config->set_value(section, "encryption_exclude_filters", preset->get_enc_ex_filter());
@@ -331,6 +337,22 @@ void EditorExport::load_config() {
 		preset->set_export_path(config->get_value(section, "export_path", ""));
 		preset->set_script_export_mode(config->get_value(section, "script_export_mode", EditorExportPreset::MODE_SCRIPT_BINARY_TOKENS_COMPRESSED));
 		preset->set_patches(config->get_value(section, "patches", Vector<String>()));
+
+		if (config->has_section_key(section, "patch_delta_encoding")) {
+			preset->set_patch_delta_encoding_enabled(config->get_value(section, "patch_delta_encoding"));
+		}
+		if (config->has_section_key(section, "patch_delta_compression_level_zstd")) {
+			preset->set_patch_delta_zstd_level(config->get_value(section, "patch_delta_compression_level_zstd"));
+		}
+		if (config->has_section_key(section, "patch_delta_min_reduction")) {
+			preset->set_patch_delta_min_reduction(config->get_value(section, "patch_delta_min_reduction"));
+		}
+		if (config->has_section_key(section, "patch_delta_include_filters")) {
+			preset->set_patch_delta_include_filter(config->get_value(section, "patch_delta_include_filters"));
+		}
+		if (config->has_section_key(section, "patch_delta_exclude_filters")) {
+			preset->set_patch_delta_exclude_filter(config->get_value(section, "patch_delta_exclude_filters"));
+		}
 
 		if (config->has_section_key(section, "seed")) {
 			preset->set_seed(config->get_value(section, "seed"));

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -35,6 +35,7 @@
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/extension/gdextension.h"
+#include "core/io/delta_encoding.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access_encrypted.h"
 #include "core/io/file_access_pack.h" // PACK_HEADER_MAGIC, PACK_FORMAT_VERSION
@@ -66,12 +67,12 @@ class EditorExportSaveProxy {
 public:
 	bool has_saved(const String &p_path) const { return saved_paths.has(p_path); }
 
-	Error save_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+	Error save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 		if (tracking_saves) {
 			saved_paths.insert(p_path.simplify_path().trim_prefix("res://"));
 		}
 
-		return save_func(p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed);
+		return save_func(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta);
 	}
 
 	EditorExportSaveProxy(EditorExportPlatform::EditorExportSaveFunction p_save_func, bool p_track_saves) :
@@ -218,26 +219,6 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err) 
 	return has_messages;
 }
 
-bool EditorExportPlatform::_check_hash(const uint8_t *p_hash, const Vector<uint8_t> &p_data) {
-	if (p_hash == nullptr) {
-		return false;
-	}
-
-	unsigned char hash[16];
-	Error err = CryptoCore::md5(p_data.ptr(), p_data.size(), hash);
-	if (err != OK) {
-		return false;
-	}
-
-	for (int i = 0; i < 16; i++) {
-		if (p_hash[i] != hash[i]) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 Error EditorExportPlatform::_load_patches(const Vector<String> &p_patches) {
 	Error err = OK;
 	if (!p_patches.is_empty()) {
@@ -310,7 +291,7 @@ Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const 
 	return OK;
 }
 
-Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	ERR_FAIL_COND_V_MSG(p_total < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
 
 	PackData *pd = (PackData *)p_userdata;
@@ -328,6 +309,7 @@ Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_pa
 	sd.path_utf8 = simplified_path.trim_prefix("res://").utf8();
 	sd.ofs = (pd->use_sparse_pck) ? 0 : pd->f->get_position();
 	sd.size = p_data.size();
+	sd.delta = p_delta;
 	Error err = _encrypt_and_store_data(ftmp, simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, sd.encrypted);
 	if (err != OK) {
 		return err;
@@ -363,15 +345,67 @@ Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_pa
 	return OK;
 }
 
-Error EditorExportPlatform::_save_pack_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
-	if (_check_hash(PackedData::get_singleton()->get_file_hash(p_path), p_data)) {
-		return OK;
+Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_path);
+	if (old_file.is_null()) {
+		return _save_pack_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, false);
 	}
 
-	return _save_pack_file(p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed);
+	Vector<uint8_t> old_data = old_file->get_buffer(old_file->get_length());
+
+	// We can't rely on the MD5 as stored in the PCKs, since delta patches could have made it stale.
+	if (p_data == old_data) {
+		return OK; // Do nothing if the file hasn't changed.
+	}
+
+	if (!p_preset->is_patch_delta_encoding_enabled()) {
+		return _save_pack_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, false);
+	}
+
+	bool delta = false;
+
+	for (const String &filter : p_preset->get_patch_delta_include_filter().split(",", false)) {
+		String filter_stripped = filter.strip_edges();
+		if (p_path.matchn(filter_stripped) || p_path.trim_prefix("res://").matchn(filter_stripped)) {
+			delta = true;
+			break;
+		}
+	}
+
+	for (const String &filter : p_preset->get_patch_delta_exclude_filter().split(",", false)) {
+		String filter_stripped = filter.strip_edges();
+		if (p_path.matchn(filter_stripped) || p_path.trim_prefix("res://").matchn(filter_stripped)) {
+			delta = false;
+			break;
+		}
+	}
+
+	Vector<uint8_t> patch_data = p_data;
+
+	if (delta) {
+		Error err = DeltaEncoding::encode_delta(old_data, p_data, patch_data, p_preset->get_patch_delta_zstd_level());
+		if (err != OK) {
+			return err;
+		}
+
+		int64_t reduction_bytes = MAX(0, p_data.size() - patch_data.size());
+		double reduction_ratio = reduction_bytes / (double)p_data.size();
+
+		if (reduction_ratio >= p_preset->get_patch_delta_min_reduction()) {
+			print_verbose(vformat("Used delta encoding for patch of \"%s\", resulting in a patch of %d bytes, which reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+		} else {
+			print_verbose(vformat("Skipped delta encoding for patch of \"%s\", as it resulted in a patch of %d bytes, which only reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+			patch_data = p_data;
+			delta = false;
+		}
+	} else {
+		print_verbose(vformat("Skipped delta encoding for patch of \"%s\", due to include/exclude filters.", p_path));
+	}
+
+	return _save_pack_file(p_preset, p_userdata, p_path, patch_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, delta);
 }
 
-Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatform::_save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	ERR_FAIL_COND_V_MSG(p_total < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
 
 	const String path = simplify_path(p_path).replace_first("res://", "");
@@ -403,12 +437,18 @@ Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_pat
 	return OK;
 }
 
-Error EditorExportPlatform::_save_zip_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
-	if (_check_hash(PackedData::get_singleton()->get_file_hash(p_path), p_data)) {
-		return OK;
+Error EditorExportPlatform::_save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_path);
+	if (old_file.is_valid()) {
+		Vector<uint8_t> old_data = old_file->get_buffer(old_file->get_length());
+
+		// We can't rely on the MD5 as stored in the PCKs, since delta patches could have made it stale.
+		if (p_data == old_data) {
+			return OK; // Do nothing if the file hasn't changed.
+		}
 	}
 
-	return _save_zip_file(p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed);
+	return _save_zip_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta);
 }
 
 Ref<Texture2D> EditorExportPlatform::get_option_icon(int p_index) const {
@@ -1036,7 +1076,7 @@ Vector<String> EditorExportPlatform::get_forced_export_files(const Ref<EditorExp
 	return files;
 }
 
-Error EditorExportPlatform::_script_save_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatform::_script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	Callable cb = ((ScriptCallbackData *)p_userdata)->file_cb;
 	ERR_FAIL_COND_V(!cb.is_valid(), FAILED);
 
@@ -1060,7 +1100,7 @@ Error EditorExportPlatform::_script_save_file(void *p_userdata, const String &p_
 	return (Error)ret.operator int();
 }
 
-Error EditorExportPlatform::_script_add_shared_object(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatform::_script_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	Callable cb = ((ScriptCallbackData *)p_userdata)->so_cb;
 	if (!cb.is_valid()) {
 		return OK; // Optional.
@@ -1216,14 +1256,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		for (int i = 0; i < export_plugins.size(); i++) {
 			if (p_so_func) {
 				for (int j = 0; j < export_plugins[i]->shared_objects.size(); j++) {
-					err = p_so_func(p_udata, export_plugins[i]->shared_objects[j]);
+					err = p_so_func(p_preset, p_udata, export_plugins[i]->shared_objects[j]);
 					if (err != OK) {
 						return err;
 					}
 				}
 			}
 			for (int j = 0; j < export_plugins[i]->extra_files.size(); j++) {
-				err = save_proxy.save_file(p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, 0, paths.size(), enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, 0, paths.size(), enc_in_filters, enc_ex_filters, key, seed, false);
 				if (err != OK) {
 					return err;
 				}
@@ -1315,9 +1355,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	// for continue statements without accidentally skipping an increment.
 	int idx = total > 0 ? -1 : 0;
 
-	for (const String &E : paths) {
+	for (const String &path : paths) {
 		idx++;
-		String path = E;
 		String type = ResourceLoader::get_resource_type(path);
 
 		bool has_import_file = FileAccess::exists(path + ".import");
@@ -1347,7 +1386,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			}
 			if (p_so_func) {
 				for (int j = 0; j < export_plugins[i]->shared_objects.size(); j++) {
-					err = p_so_func(p_udata, export_plugins[i]->shared_objects[j]);
+					err = p_so_func(p_preset, p_udata, export_plugins[i]->shared_objects[j]);
 					if (err != OK) {
 						return err;
 					}
@@ -1355,7 +1394,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			}
 
 			for (int j = 0; j < export_plugins[i]->extra_files.size(); j++) {
-				err = save_proxy.save_file(p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 				if (err != OK) {
 					return err;
 				}
@@ -1385,7 +1424,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			if (importer_type == "keep") {
 				// Just keep file as-is.
 				Vector<uint8_t> array = FileAccess::get_file_as_bytes(path);
-				err = save_proxy.save_file(p_udata, path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 
 				if (err != OK) {
 					return err;
@@ -1427,13 +1466,13 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				sarr.resize(cs.size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
-				err = save_proxy.save_file(p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 				if (err != OK) {
 					return err;
 				}
 				// Now actual remapped file:
 				sarr = FileAccess::get_file_as_bytes(export_path);
-				err = save_proxy.save_file(p_udata, export_path, sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, export_path, sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 				if (err != OK) {
 					return err;
 				}
@@ -1461,14 +1500,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 					if (remap == "path") {
 						String remapped_path = config->get_value("remap", remap);
 						Vector<uint8_t> array = FileAccess::get_file_as_bytes(remapped_path);
-						err = save_proxy.save_file(p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+						err = save_proxy.save_file(p_preset, p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 					} else if (remap.begins_with("path.")) {
 						String feature = remap.get_slicec('.', 1);
 
 						if (remap_features.has(feature)) {
 							String remapped_path = config->get_value("remap", remap);
 							Vector<uint8_t> array = FileAccess::get_file_as_bytes(remapped_path);
-							err = save_proxy.save_file(p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+							err = save_proxy.save_file(p_preset, p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 						} else {
 							// Remove paths if feature not enabled.
 							config->erase_section_key("remap", remap);
@@ -1494,7 +1533,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				sarr.resize(cs.size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
-				err = save_proxy.save_file(p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				err = save_proxy.save_file(p_preset, p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 
 				if (err != OK) {
 					return err;
@@ -1515,7 +1554,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			}
 
 			Vector<uint8_t> array = FileAccess::get_file_as_bytes(export_path);
-			err = save_proxy.save_file(p_udata, export_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+			err = save_proxy.save_file(p_preset, p_udata, export_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 			if (err != OK) {
 				return err;
 			}
@@ -1584,7 +1623,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				new_file.write[j] = utf8[j];
 			}
 
-			err = save_proxy.save_file(p_udata, from + ".remap", new_file, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+			err = save_proxy.save_file(p_preset, p_udata, from + ".remap", new_file, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 			if (err != OK) {
 				return err;
 			}
@@ -1602,7 +1641,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		} else {
 			array = FileAccess::get_file_as_bytes(forced_export[i]);
 		}
-		err = save_proxy.save_file(p_udata, forced_export[i], array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+		err = save_proxy.save_file(p_preset, p_udata, forced_export[i], array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 		if (err != OK) {
 			return err;
 		}
@@ -1611,7 +1650,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	Dictionary int_export = get_internal_export_files(p_preset, p_debug);
 	for (const KeyValue<Variant, Variant> &int_export_kv : int_export) {
 		const PackedByteArray &array = int_export_kv.value;
-		err = save_proxy.save_file(p_udata, int_export_kv.key, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+		err = save_proxy.save_file(p_preset, p_udata, int_export_kv.key, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 		if (err != OK) {
 			return err;
 		}
@@ -1624,7 +1663,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	Vector<uint8_t> data = FileAccess::get_file_as_bytes(engine_cfb);
 	DirAccess::remove_file_or_error(engine_cfb);
 
-	err = save_proxy.save_file(p_udata, "res://" + config_file, data, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+	err = save_proxy.save_file(p_preset, p_udata, "res://" + config_file, data, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
 	if (err != OK) {
 		return err;
 	}
@@ -1633,7 +1672,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		HashSet<String> currently_loaded_paths = PackedData::get_singleton()->get_file_paths();
 		for (const String &path : currently_loaded_paths) {
 			if (!save_proxy.has_saved(path)) {
-				err = p_remove_func(p_udata, path);
+				err = p_remove_func(p_preset, p_udata, path);
 				if (err != OK) {
 					return err;
 				}
@@ -1660,7 +1699,7 @@ Vector<uint8_t> EditorExportPlatform::_filter_extension_list_config_file(const S
 	return data;
 }
 
-Error EditorExportPlatform::_pack_add_shared_object(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatform::_pack_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	PackData *pack_data = (PackData *)p_userdata;
 	if (pack_data->so_files) {
 		pack_data->so_files->push_back(p_so);
@@ -1669,7 +1708,7 @@ Error EditorExportPlatform::_pack_add_shared_object(void *p_userdata, const Shar
 	return OK;
 }
 
-Error EditorExportPlatform::_remove_pack_file(void *p_userdata, const String &p_path) {
+Error EditorExportPlatform::_remove_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path) {
 	PackData *pd = (PackData *)p_userdata;
 
 	SavedData sd;
@@ -1691,7 +1730,7 @@ Error EditorExportPlatform::_remove_pack_file(void *p_userdata, const String &p_
 	return OK;
 }
 
-Error EditorExportPlatform::_zip_add_shared_object(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatform::_zip_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	ZipData *zip_data = (ZipData *)p_userdata;
 	if (zip_data->so_files) {
 		zip_data->so_files->push_back(p_so);
@@ -1995,6 +2034,9 @@ bool EditorExportPlatform::_encrypt_and_store_directory(Ref<FileAccess> p_fd, Pa
 		}
 		if (p_pack_data.file_ofs[i].removal) {
 			flags |= PACK_FILE_REMOVAL;
+		}
+		if (p_pack_data.file_ofs[i].delta) {
+			flags |= PACK_FILE_DELTA;
 		}
 		fhead->store_32(flags);
 	}

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -53,9 +53,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	typedef Error (*EditorExportRemoveFunction)(void *p_userdata, const String &p_path);
-	typedef Error (*EditorExportSaveSharedObject)(void *p_userdata, const SharedObject &p_so);
+	typedef Error (*EditorExportSaveFunction)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	typedef Error (*EditorExportRemoveFunction)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path);
+	typedef Error (*EditorExportSaveSharedObject)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	enum DebugFlags {
 		DEBUG_FLAG_DUMB_CLIENT = 1,
@@ -83,6 +83,7 @@ public:
 		uint64_t size = 0;
 		bool encrypted = false;
 		bool removal = false;
+		bool delta = false;
 		Vector<uint8_t> md5;
 		CharString path_utf8;
 
@@ -119,25 +120,23 @@ private:
 	void _export_find_customized_resources(const Ref<EditorExportPreset> &p_preset, EditorFileSystemDirectory *p_dir, EditorExportPreset::FileExportMode p_mode, HashSet<String> &p_paths);
 	void _export_find_dependencies(const String &p_path, HashSet<String> &p_paths);
 
-	static bool _check_hash(const uint8_t *p_hash, const Vector<uint8_t> &p_data);
+	static Error _save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _pack_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
-	static Error _save_pack_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _save_pack_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _pack_add_shared_object(void *p_userdata, const SharedObject &p_so);
+	static Error _remove_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path);
 
-	static Error _remove_pack_file(void *p_userdata, const String &p_path);
-
-	static Error _save_zip_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _save_zip_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _zip_add_shared_object(void *p_userdata, const SharedObject &p_so);
+	static Error _save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _zip_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	struct ScriptCallbackData {
 		Callable file_cb;
 		Callable so_cb;
 	};
 
-	static Error _script_save_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-	static Error _script_add_shared_object(void *p_userdata, const SharedObject &p_so);
+	static Error _script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _script_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	void _edit_files_with_filter(Ref<DirAccess> &da, const Vector<String> &p_filters, HashSet<String> &r_list, bool exclude);
 	void _edit_filter_list(HashSet<String> &r_list, const String &p_filter, bool exclude);

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -28,10 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_export.h"
+#include "editor_export_preset.h"
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "editor/export/editor_export.h"
 #include "editor/settings/editor_settings.h"
 
 bool EditorExportPreset::_set(const StringName &p_name, const Variant &p_value) {
@@ -438,6 +439,51 @@ void EditorExportPreset::set_patches(const Vector<String> &p_patches) {
 
 Vector<String> EditorExportPreset::get_patches() const {
 	return patches;
+}
+
+void EditorExportPreset::set_patch_delta_encoding_enabled(bool p_enable) {
+	patch_delta_encoding_enabled = p_enable;
+	EditorExport::singleton->save_presets();
+}
+
+bool EditorExportPreset::is_patch_delta_encoding_enabled() const {
+	return patch_delta_encoding_enabled;
+}
+
+void EditorExportPreset::set_patch_delta_zstd_level(int p_level) {
+	patch_delta_zstd_level = p_level;
+	EditorExport::singleton->save_presets();
+}
+
+int EditorExportPreset::get_patch_delta_zstd_level() const {
+	return patch_delta_zstd_level;
+}
+
+void EditorExportPreset::set_patch_delta_min_reduction(double p_ratio) {
+	patch_delta_min_reduction = p_ratio;
+	EditorExport::singleton->save_presets();
+}
+
+double EditorExportPreset::get_patch_delta_min_reduction() const {
+	return patch_delta_min_reduction;
+}
+
+void EditorExportPreset::set_patch_delta_include_filter(const String &p_filter) {
+	patch_delta_include_filter = p_filter;
+	EditorExport::singleton->save_presets();
+}
+
+String EditorExportPreset::get_patch_delta_include_filter() const {
+	return patch_delta_include_filter;
+}
+
+void EditorExportPreset::set_patch_delta_exclude_filter(const String &p_filter) {
+	patch_delta_exclude_filter = p_filter;
+	EditorExport::singleton->save_presets();
+}
+
+String EditorExportPreset::get_patch_delta_exclude_filter() const {
+	return patch_delta_exclude_filter;
 }
 
 void EditorExportPreset::set_custom_features(const String &p_custom_features) {

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -73,6 +73,11 @@ private:
 	bool dedicated_server = false;
 
 	Vector<String> patches;
+	bool patch_delta_encoding_enabled = false;
+	int patch_delta_zstd_level = 19;
+	double patch_delta_min_reduction = 0.1;
+	String patch_delta_include_filter = "*";
+	String patch_delta_exclude_filter;
 
 	friend class EditorExport;
 	friend class EditorExportPlatform;
@@ -148,10 +153,27 @@ public:
 
 	void add_patch(const String &p_path, int p_at_pos = -1);
 	void set_patch(int p_index, const String &p_path);
+
 	String get_patch(int p_index);
 	void remove_patch(int p_index);
+
 	void set_patches(const Vector<String> &p_patches);
 	Vector<String> get_patches() const;
+
+	void set_patch_delta_encoding_enabled(bool p_enable);
+	bool is_patch_delta_encoding_enabled() const;
+
+	void set_patch_delta_zstd_level(int p_level);
+	int get_patch_delta_zstd_level() const;
+
+	void set_patch_delta_min_reduction(double p_ratio);
+	double get_patch_delta_min_reduction() const;
+
+	void set_patch_delta_include_filter(const String &p_filter);
+	String get_patch_delta_include_filter() const;
+
+	void set_patch_delta_exclude_filter(const String &p_filter);
+	String get_patch_delta_exclude_filter() const;
 
 	void set_custom_features(const String &p_custom_features);
 	String get_custom_features() const;

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -51,10 +51,13 @@
 #include "scene/gui/option_button.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/rich_text_label.h"
+#include "scene/gui/spin_box.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
+
+#include <zstd.h>
 
 void ProjectExportTextureFormatError::_on_fix_texture_format_pressed() {
 	export_dialog->hide();
@@ -300,6 +303,19 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	include_label->set_text(_get_resource_export_header(current->get_export_filter()));
 	exclude_filters->set_text(current->get_exclude_filter());
 	server_strip_message->set_visible(current->get_export_filter() == EditorExportPreset::EXPORT_CUSTOMIZED);
+
+	bool patch_delta_encoding_enabled = current->is_patch_delta_encoding_enabled();
+	patch_delta_encoding->set_pressed(patch_delta_encoding_enabled);
+	patch_delta_zstd_level->set_editable(patch_delta_encoding_enabled);
+	patch_delta_zstd_level->set_value(current->get_patch_delta_zstd_level());
+	patch_delta_min_reduction->set_editable(patch_delta_encoding_enabled);
+	patch_delta_min_reduction->set_value(current->get_patch_delta_min_reduction() * 100);
+	patch_delta_include_filter->set_editable(patch_delta_encoding_enabled);
+	patch_delta_exclude_filter->set_editable(patch_delta_encoding_enabled);
+	if (!updating_patch_delta_filters) {
+		patch_delta_include_filter->set_text(current->get_patch_delta_include_filter());
+		patch_delta_exclude_filter->set_text(current->get_patch_delta_exclude_filter());
+	}
 
 	patches->clear();
 	TreeItem *patch_root = patches->create_item();
@@ -745,6 +761,11 @@ void ProjectExportDialog::_duplicate_preset() {
 	preset->set_include_filter(current->get_include_filter());
 	preset->set_exclude_filter(current->get_exclude_filter());
 	preset->set_patches(current->get_patches());
+	preset->set_patch_delta_encoding_enabled(current->is_patch_delta_encoding_enabled());
+	preset->set_patch_delta_zstd_level(current->get_patch_delta_zstd_level());
+	preset->set_patch_delta_min_reduction(current->get_patch_delta_min_reduction());
+	preset->set_patch_delta_include_filter(current->get_patch_delta_include_filter());
+	preset->set_patch_delta_exclude_filter(current->get_patch_delta_exclude_filter());
 	preset->set_custom_features(current->get_custom_features());
 	preset->set_enc_in_filter(current->get_enc_in_filter());
 	preset->set_enc_ex_filter(current->get_enc_ex_filter());
@@ -1199,6 +1220,75 @@ void ProjectExportDialog::_set_file_export_mode(int p_id) {
 	current->set_file_export_mode(path, file_export_mode);
 	item->set_metadata(1, file_export_mode);
 	_propagate_file_export_mode(include_files->get_root(), EditorExportPreset::MODE_FILE_NOT_CUSTOMIZED);
+}
+
+void ProjectExportDialog::_patch_delta_encoding_changed(bool p_pressed) {
+	if (updating) {
+		return;
+	}
+
+	Ref<EditorExportPreset> current = get_current_preset();
+	ERR_FAIL_COND(current.is_null());
+
+	current->set_patch_delta_encoding_enabled(p_pressed);
+
+	_update_current_preset();
+}
+
+void ProjectExportDialog::_patch_delta_include_filter_changed(const String &p_filter) {
+	if (updating) {
+		return;
+	}
+
+	Ref<EditorExportPreset> current = get_current_preset();
+	ERR_FAIL_COND(current.is_null());
+
+	current->set_patch_delta_include_filter(patch_delta_include_filter->get_text());
+
+	updating_patch_delta_filters = true;
+	_update_current_preset();
+	updating_patch_delta_filters = false;
+}
+
+void ProjectExportDialog::_patch_delta_exclude_filter_changed(const String &p_filter) {
+	if (updating) {
+		return;
+	}
+
+	Ref<EditorExportPreset> current = get_current_preset();
+	ERR_FAIL_COND(current.is_null());
+
+	current->set_patch_delta_exclude_filter(patch_delta_exclude_filter->get_text());
+
+	updating_patch_delta_filters = true;
+	_update_current_preset();
+	updating_patch_delta_filters = false;
+}
+
+void ProjectExportDialog::_patch_delta_zstd_level_changed(double p_value) {
+	if (updating) {
+		return;
+	}
+
+	Ref<EditorExportPreset> current = get_current_preset();
+	ERR_FAIL_COND(current.is_null());
+
+	current->set_patch_delta_zstd_level((int)p_value);
+
+	_update_current_preset();
+}
+
+void ProjectExportDialog::_patch_delta_min_reduction_changed(double p_value) {
+	if (updating) {
+		return;
+	}
+
+	Ref<EditorExportPreset> current = get_current_preset();
+	ERR_FAIL_COND(current.is_null());
+
+	current->set_patch_delta_min_reduction(p_value / 100.0);
+
+	_update_current_preset();
 }
 
 void ProjectExportDialog::_patch_tree_button_clicked(Object *p_item, int p_column, int p_id, int p_mouse_button_index) {
@@ -1657,11 +1747,52 @@ ProjectExportDialog::ProjectExportDialog() {
 			exclude_filters);
 	exclude_filters->connect(SceneStringName(text_changed), callable_mp(this, &ProjectExportDialog::_filter_changed));
 
-	// Patch packages.
+	// Patching.
 
 	VBoxContainer *patch_vb = memnew(VBoxContainer);
 	sections->add_child(patch_vb);
-	patch_vb->set_name(TTR("Patches"));
+	patch_vb->set_name(TTRC("Patching"));
+
+	patch_delta_encoding = memnew(CheckButton);
+	patch_delta_encoding->connect(SceneStringName(toggled), callable_mp(this, &ProjectExportDialog::_patch_delta_encoding_changed));
+	patch_delta_encoding->set_text(TTRC("Enable Delta Encoding"));
+	patch_delta_encoding->set_tooltip_text(TTRC("If checked, any change to a file already present in the base packs will be exported as the difference between the old file and the new file.\n"
+												"Enabling this comes at the cost of longer export times as well as longer load times for patched resources."));
+	patch_vb->add_child(patch_delta_encoding);
+
+	patch_delta_zstd_level = memnew(SpinBox);
+	patch_delta_zstd_level->set_min(ZSTD_minCLevel());
+	patch_delta_zstd_level->set_max(ZSTD_maxCLevel());
+	patch_delta_zstd_level->set_step(1);
+	patch_delta_zstd_level->set_tooltip_text(
+			vformat(TTR("The Zstandard compression level to use when generating delta-encoded patches.\n"
+						"Higher positive levels will reduce patch sizes, at the cost of longer export time, but do not affect the time it takes to apply patches.\n"
+						"Negative levels will reduce the time it takes to apply patches, at the cost of worse compression.\n"
+						"Levels above 19 require more memory both during export and when applying patches, usually for very little benefit.\n"
+						"Level 0 will cause Zstandard to use its default compression level, which is currently level %d."),
+					ZSTD_CLEVEL_DEFAULT));
+	patch_delta_zstd_level->connect(SceneStringName(value_changed), callable_mp(this, &ProjectExportDialog::_patch_delta_zstd_level_changed));
+	patch_vb->add_margin_child(TTRC("Delta Encoding Compression Level"), patch_delta_zstd_level);
+
+	patch_delta_min_reduction = memnew(SpinBox);
+	patch_delta_min_reduction->set_min(0.0);
+	patch_delta_min_reduction->set_max(100.0);
+	patch_delta_min_reduction->set_step(1.0);
+	patch_delta_min_reduction->set_suffix("%");
+	patch_delta_min_reduction->set_tooltip_text(TTRC("How much smaller, when compared to the new file, a delta-encoded patch needs to be for it to be exported.\n"
+													 "If the patch is not at least this much smaller, the new file will be exported as-is."));
+	patch_delta_min_reduction->connect(SceneStringName(value_changed), callable_mp(this, &ProjectExportDialog::_patch_delta_min_reduction_changed));
+	patch_vb->add_margin_child(TTRC("Delta Encoding Minimum Size Reduction"), patch_delta_min_reduction);
+
+	patch_delta_include_filter = memnew(LineEdit);
+	patch_delta_include_filter->set_accessibility_name(TTRC("Delta Encoding Include Filters"));
+	patch_delta_include_filter->connect(SceneStringName(text_changed), callable_mp(this, &ProjectExportDialog::_patch_delta_include_filter_changed));
+	patch_vb->add_margin_child(TTRC("Filters to include files/folders from being delta-encoded\n(comma-separated, e.g: *.gdc, scripts/*)"), patch_delta_include_filter);
+
+	patch_delta_exclude_filter = memnew(LineEdit);
+	patch_delta_exclude_filter->set_accessibility_name(TTRC("Delta Encoding Exclude Filters"));
+	patch_delta_exclude_filter->connect(SceneStringName(text_changed), callable_mp(this, &ProjectExportDialog::_patch_delta_exclude_filter_changed));
+	patch_vb->add_margin_child(TTRC("Filters to exclude files/folders from being delta-encoded\n(comma-separated, e.g: *.ctex, textures/*)"), patch_delta_exclude_filter);
 
 	patches = memnew(Tree);
 	patches->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -46,6 +46,7 @@ class OptionButton;
 class PopupMenu;
 class ProjectExportDialog;
 class RichTextLabel;
+class SpinBox;
 class TabContainer;
 class Tree;
 class TreeItem;
@@ -107,6 +108,11 @@ class ProjectExportDialog : public ConfirmationDialog {
 
 	RBSet<String> feature_set;
 
+	CheckButton *patch_delta_encoding = nullptr;
+	SpinBox *patch_delta_zstd_level = nullptr;
+	SpinBox *patch_delta_min_reduction = nullptr;
+	LineEdit *patch_delta_include_filter = nullptr;
+	LineEdit *patch_delta_exclude_filter = nullptr;
 	Tree *patches = nullptr;
 	int patch_index = -1;
 	EditorFileDialog *patch_dialog = nullptr;
@@ -158,6 +164,12 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _tree_popup_edited(bool p_arrow_clicked);
 	void _set_file_export_mode(int p_id);
 
+	bool updating_patch_delta_filters = false;
+	void _patch_delta_encoding_changed(bool p_pressed);
+	void _patch_delta_include_filter_changed(const String &p_filter);
+	void _patch_delta_exclude_filter_changed(const String &p_filter);
+	void _patch_delta_zstd_level_changed(double p_value);
+	void _patch_delta_min_reduction_changed(double p_value);
 	void _patch_tree_button_clicked(Object *p_item, int p_column, int p_id, int p_mouse_button_index);
 	void _patch_tree_item_edited();
 	void _patch_file_selected(const String &p_path);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -767,7 +767,7 @@ Error EditorExportPlatformAndroid::store_in_apk(APKExportData *ed, const String 
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::save_apk_so(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatformAndroid::save_apk_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	if (!p_so.path.get_file().begins_with("lib")) {
 		String err = "Android .so file names must start with \"lib\", but got: " + p_so.path;
 		ERR_PRINT(err);
@@ -801,14 +801,14 @@ Error EditorExportPlatformAndroid::save_apk_so(void *p_userdata, const SharedObj
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::save_apk_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	APKExportData *ed = static_cast<APKExportData *>(p_userdata);
 
 	const String simplified_path = simplify_path(p_path);
 
 	Vector<uint8_t> enc_data;
 	EditorExportPlatform::SavedData sd;
-	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, enc_data, sd);
+	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd);
 	if (err != OK) {
 		return err;
 	}
@@ -822,11 +822,11 @@ Error EditorExportPlatformAndroid::save_apk_file(void *p_userdata, const String 
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::ignore_apk_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+Error EditorExportPlatformAndroid::ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::copy_gradle_so(void *p_userdata, const SharedObject &p_so) {
+Error EditorExportPlatformAndroid::copy_gradle_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so) {
 	ERR_FAIL_COND_V_MSG(!p_so.path.get_file().begins_with("lib"), FAILED,
 			"Android .so file names must start with \"lib\", but got: " + p_so.path);
 	Vector<ABI> abis = get_abis();

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -151,13 +151,13 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	static Error store_in_apk(APKExportData *ed, const String &p_path, const Vector<uint8_t> &p_data, int compression_method = Z_DEFLATED);
 
-	static Error save_apk_so(void *p_userdata, const SharedObject &p_so);
+	static Error save_apk_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
-	static Error save_apk_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
+	static Error save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
 
-	static Error ignore_apk_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
+	static Error ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
 
-	static Error copy_gradle_so(void *p_userdata, const SharedObject &p_so);
+	static Error copy_gradle_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	bool _has_read_write_storage_permission(const Vector<String> &p_permissions);
 

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -85,7 +85,7 @@ int _get_app_category_value(int category_index);
 
 String _get_app_category_label(int category_index);
 
-Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd);
+Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd);
 
 // Utility method used to create a directory.
 Error create_directory(const String &p_dir);
@@ -103,7 +103,7 @@ Error store_string_at_path(const String &p_path, const String &p_data);
 // It is used by the export_project_files method to save all the asset files into the gradle project.
 // It's functionality mirrors that of the method save_apk_file.
 // This method will be called ONLY when gradle build is enabled.
-Error rename_and_store_file_in_gradle_project(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
+Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
 
 // Creates strings.xml files inside the gradle project for different locales.
 Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &p_project_name, const String &p_gradle_build_dir, const Dictionary &p_appnames);


### PR DESCRIPTION
Resolves godotengine/godot-proposals#13404.
Supersedes #111731.

## Overview

This pull request adds the ability to use delta encoding (sometimes referred to as binary patching or binary diffing) when exporting patch PCKs, first introduced in #97118.

This means that only the parts of the files that have actually changed (or some close approximation of that) will end up being exported, often resulting in much smaller patch exports, which can benefit games that distribute patches by their own means, reducing bandwidth cost and storage usage for all parties involved.

This is especially true when dealing with changes to things like `*.translation` files, `uid_cache.bin` or `global_script_class_cache.cfg`, which often end up being included in patch exports and which together can easily make your patch several megabytes large despite very little having actually changed.

<img width="872" height="740" alt="Screenshot_20251024_130226" src="https://github.com/user-attachments/assets/260f9d34-e3cc-4589-b06b-b8e9c5f5802e" />

## Implementation

This is (unlike #111731) achieved by utilizing Zstandard's `--patch-from` functionality (thanks to @fire for pointing me towards it) which is basically an alias for providing the old file as the dictionary to be used in its dictionary-matching stage, resulting in compressed deltas that are very similar to those of other delta encoding tools like bsdiff (when also paired with Zstandard) but with much lower export-time memory usage and (at least on average) lower decompression/runtime overhead as well.

With the help of Zstandard we generate a delta between the old file (as found in the "Base Packs" entries) and the new file, which then gets exported instead of the actual file, along with a new `PACK_FILE_DELTA` PCK flag.

As a result of using compression, exporting a patch PCK with this feature enabled will take slightly longer, especially when leaving the compression level set to its default of 19. This can however mostly be resolved by just lowering the compression level, at the cost of export size. Decompression speed should largely remain the same for Zstandard across all compression levels, but you can also set a *negative* compression limit, which will enable its "fast mode", where it sacrifices even more compression for the sake of (de)compression speeds.

We also allow the user to tweak the "minimum size reduction", which is a threshold for how much smaller (10% by default) the patch would need to be compared to the new file in order to be exported as a delta. The reason for this being that applying these patches comes at a slight runtime cost during resource loading, not just from decompressing the patch but also the I/O overhead from loading it in the first place, so it needs to be justified with some amount of space saving.

Once exported, patch PCKs (much like before) look and behave just like any other PCK, where you load them through `ProjectSettings.load_resource_pack`, ideally through some bootstrap script where nothing else has had a chance to be loaded yet.

We then store any delta patches alongside the regular files in `PackedData`, and whenever a file is loaded from `PackedData` we wrap the resulting `FileAccessPack` inside of the newly introduced `FileAccessPatched`, which will lazily apply all the patches as needed, meaning it's completely transparent and should hopefully just work with any existing file/resource loading.

> [!IMPORTANT]
> Note that this means you pay the cost of applying these patches every time you load a patched resource that isn't already cached by `ResourceLoader`. The patches are not applied to the original PCKs in any way, nor are the patched resources cached anywhere on disk.

## Performance

Export size will mostly depend on whether the original file is compressed or not. So things like textures or even GDScript files, when using its default export mode of "Compressed binary tokens", will diff poorly and often fall below the size reduction threshold. The same mostly goes for compressed localization files as well.

> [!IMPORTANT]
> Disabling compression on anything you intend to patch is key to getting good results, as compression scrambles data in a way where the old and the new file will look almost nothing alike.

In the real-world projects I've tested with you usually see an average reduction of around 60-90%, depending on the ratio of compressed resources, and an average runtime overhead of about 0.1 milliseconds per individual patch being applied, with patches to larger files sometimes being in the order of a few milliseconds.

### DOGWALK

In the interest of showing a real-world example from an actual game, I've generated patches for the two updates of [DOGWALK](https://store.steampowered.com/app/3775050/DOGWALK/) that have been published since its initial release. You can find the Godot project available through its [Supporter Pack](https://store.steampowered.com/app/3833380/DOGWALK__Supporter_Pack/), with earlier versions being downloadable with the help of the Steam console and [SteamDB](https://steamdb.info/depot/3833380/manifests/).

These numbers are from using a compression level of 19. As mentioned already, faster (de)compression speeds can be had by using a negative compression level, at the cost of compression ratio.

*(Also note that the files listed here will be slightly different compared to in #111731.)*

#### v1.0.1 to v1.0.2

<details><summary>[Click to expand/collapse]</summary>
<p>

The first patch contains modifications to the following file types:

- 8x texture files
- 5x `*.tscn` files
- 2x glTF files
- 2x `.json` files
- 1x `*.tres` files
- 1x `*.gd` file
- 1x `global_script_class_cache.cfg`
- 1x `uid_cache.bin`
- 1x `project.godot`

Out of those changes, 7 files (6 textures and 1 glTF file) fell below the reduction threshold and were not exported as a delta.

Without delta encoding the patch PCK ended up being 8.55 MiB, and with delta encoding the patch PCK ended up being 2.11 MiB, which is a reduction in size of roughly 75%.

For a breakdown of the individual files, see the output from the `--verbose` export:

```txt
Used delta encoding for patch of 'res://.godot/exported/133200997/export-99b6d6e785812c481ec56f0c19253d65-pine_cuts_atlas_albedo_01.res', resulting in a patch of 88 bytes, which reduced the size by 96.5% (2429 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-75cc15c6f96624c92a89cd4ea423aab0-SE-clearing.scn', resulting in a patch of 811 bytes, which reduced the size by 84.5% (4410 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/SL-clearing_terrain.gltf-6c7bfff97231b94de231cd87b0a043cc.scn', resulting in a patch of 317184 bytes, which reduced the size by 45.2% (261137 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/SL-fence-paths.gltf-5301a3dc110611ca08d2d765b45cc210.scn', as it resulted in a patch of 101353 bytes, which only reduced the size by 1.1% (1128 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/c1_0.png-633c826446b972eb64aa7ce688537a89.s3tc.ctex', resulting in a patch of 5996 bytes, which reduced the size by 99.8% (2998616 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/c1_1.png-f4d5442a5958d63be4969f9c43b55385.s3tc.ctex', resulting in a patch of 2922 bytes, which reduced the size by 99.9% (3001690 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/c1_2.png-9836fb6c6208e9abc7dd976d1dfb2114.ctex', as it resulted in a patch of 12362 bytes, which only reduced the size by 3.9% (498 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/c1_3.png-242aee2106e53d55e5258038d675c5d2.ctex', as it resulted in a patch of 11149 bytes, which only reduced the size by 3.9% (455 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/c1_4.png-a2aaa3eae0a8fc20dc1fb8b773a2a2fc.ctex', as it resulted in a patch of 20890 bytes, which only reduced the size by 1.5% (314 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/c1_5.png-13279df50fab7cb69d9d4b5c4cf35607.ctex', as it resulted in a patch of 12173 bytes, which only reduced the size by 2.7% (335 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/c1_6.png-58b98eacb8e3e715db9592bbc6721513.ctex', as it resulted in a patch of 19576 bytes, which only reduced the size by 1.6% (320 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/c1_7.png-cbe2618dd59d397fdcd297bc57e2a89a.ctex', as it resulted in a patch of 19487 bytes, which only reduced the size by 1.1% (221 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/entities/player_entities/pinda.gdc', resulting in a patch of 19361 bytes, which reduced the size by 89.7% (168843 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-4810a76f52cab761a40b217606f3b3f7-world.scn', resulting in a patch of 2491 bytes, which reduced the size by 96.6% (70578 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/sequences/credits/credits.json', resulting in a patch of 128 bytes, which reduced the size by 97.4% (4880 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-1ba630fc40b6c6f9f6410e00a7d23a6e-credits.scn', resulting in a patch of 477 bytes, which reduced the size by 94.7% (8439 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-f7d1d2a6eca5754467a7d6172d8ffd11-credit_slide.scn', resulting in a patch of 82 bytes, which reduced the size by 96.4% (2207 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-06339610f1a89a2edfbfa400f9fe80ce-menu_ui.scn', resulting in a patch of 474 bytes, which reduced the size by 84.4% (2558 bytes) compared to the actual file.
Used delta encoding for patch of 'res://material_index.json', resulting in a patch of 68 bytes, which reduced the size by 99.7% (25938 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/global_script_class_cache.cfg', resulting in a patch of 141 bytes, which reduced the size by 98.0% (6779 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/uid_cache.bin', resulting in a patch of 210 bytes, which reduced the size by 99.9% (175366 bytes) compared to the actual file.
Used delta encoding for patch of 'res://project.binary', resulting in a patch of 33 bytes, which reduced the size by 99.9% (26852 bytes) compared to the actual file.
```

</p>
</details>

#### v1.0.2 to v1.0.4

<details><summary>[Click to expand/collapse]</summary>
<p>

The second patch contains modifications to the following file types:

- 64x glTF files
- 7x `*.gd` files
- 3x texture files
- 4x `*.tres` files
- 4x `*.tscn` files
- 1x `*.json` file
- 1x `global_script_class_cache.cfg`
- 1x `uid_cache.bin`
- 1x `project.godot`

Out of those changes, 10 files (9 glTF files and 1 texture) fell below the reduction threshold and were not exported as a delta.

Without delta encoding the patch PCK ended up being 14.64 MiB, and with delta encoding the patch PCK ended up being 5.03 MiB, which is a reduction in size of roughly 66%.

For a breakdown of the individual files, see the output from the `--verbose` export:

```txt
Used delta encoding for patch of 'res://.godot/imported/LI-bush_001.gltf-40b8180f1a8db565195bb533fe5b3b60.scn', resulting in a patch of 1276 bytes, which reduced the size by 96.9% (40252 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_002.gltf-046eef6042349a872843bd2bad57871d.scn', resulting in a patch of 393 bytes, which reduced the size by 99.0% (37576 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_003.gltf-d8b6330d3fbe3be54b19ef784d826f6f.scn', resulting in a patch of 131 bytes, which reduced the size by 99.7% (42750 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_004.gltf-44dfe26583b38b9bacbc865c65056616.scn', resulting in a patch of 126 bytes, which reduced the size by 99.7% (43311 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_small_001.gltf-fd7ac3b286c919a158b306ecbdb65c35.scn', resulting in a patch of 107 bytes, which reduced the size by 99.6% (30384 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_small_002.gltf-4c9d050b1c074ff3d5423d3e5923b648.scn', resulting in a patch of 337 bytes, which reduced the size by 98.9% (30131 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_small_003.gltf-c5f1b275891f4c31b9784b8fc30cad59.scn', resulting in a patch of 99 bytes, which reduced the size by 99.7% (30922 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage-snowy_001.gltf-556d234ef38f9ddf45c29e8e2fbd3bda.scn', resulting in a patch of 236 bytes, which reduced the size by 92.4% (2858 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage-snowy_002.gltf-fcb65cf55f75e73cf40e47ccc7e74694.scn', resulting in a patch of 247 bytes, which reduced the size by 90.7% (2415 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage-snowy_003.gltf-ff44781b0785aff6e0f0fba2504a5904.scn', resulting in a patch of 1638 bytes, which reduced the size by 26.6% (593 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage-snowy_004.gltf-0b9ac5457a4160af4672287ac31606df.scn', resulting in a patch of 1996 bytes, which reduced the size by 26.3% (714 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage-snowy_005.gltf-bf1c764613b8fbc17f3c09534ddc67e4.scn', resulting in a patch of 154 bytes, which reduced the size by 94.9% (2848 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage-snowy_006.gltf-fe91dd6bc077731e9831797c06039603.scn', resulting in a patch of 447 bytes, which reduced the size by 81.7% (1998 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage-snowy_small_001.gltf-189c3413a03374f594c5fd1da5f290fe.scn', resulting in a patch of 1480 bytes, which reduced the size by 26.4% (530 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage-snowy_small_002.gltf-36a183595198521e77f51fb267bbe794.scn', resulting in a patch of 268 bytes, which reduced the size by 91.4% (2860 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage-snowy_small_003.gltf-df154c9af2225b4e10e2a899bc5d401c.scn', resulting in a patch of 150 bytes, which reduced the size by 94.8% (2729 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_001.gltf-27d68679ea3dfb3c0bcb765feb133896.scn', resulting in a patch of 179 bytes, which reduced the size by 93.6% (2632 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_002.gltf-fa162cd4cdb0eeea6328f050e8d6ef75.scn', resulting in a patch of 1760 bytes, which reduced the size by 30.9% (788 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_003.gltf-47ffef07e418a23b9f05bed81fafafe4.scn', resulting in a patch of 155 bytes, which reduced the size by 94.2% (2534 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_004.gltf-ba2cb17ac74eb94060ddd32ab8207ff7.scn', resulting in a patch of 1802 bytes, which reduced the size by 25.4% (613 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_005.gltf-0f77c124e37bed036c3a7d999dceb178.scn', resulting in a patch of 343 bytes, which reduced the size by 89.6% (2963 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_006.gltf-316c5c718168f980bb653f8cd4644a67.scn', resulting in a patch of 133 bytes, which reduced the size by 94.6% (2341 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_007.gltf-ab10a69cdb3259654a86117e6b1f268a.scn', resulting in a patch of 2050 bytes, which reduced the size by 26.5% (739 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_008.gltf-5c1b2b549e76a49e9329055a815afd41.scn', resulting in a patch of 1760 bytes, which reduced the size by 24.6% (575 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_009.gltf-86062acae855ef8da4f0192b18566a14.scn', resulting in a patch of 1599 bytes, which reduced the size by 33.5% (805 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_010.gltf-e7890f91e8ee4789ab125803c3cabf69.scn', resulting in a patch of 461 bytes, which reduced the size by 85.4% (2705 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_011.gltf-8a6eed4426edd1f2d08e02acda003b1e.scn', resulting in a patch of 1451 bytes, which reduced the size by 34.9% (779 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_012.gltf-8f12950bd8b25dc07d659e0c22f604e0.scn', resulting in a patch of 128 bytes, which reduced the size by 95.3% (2608 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_small_001.gltf-884d1bc365df4345b1f0a67137c33d94.scn', resulting in a patch of 971 bytes, which reduced the size by 76.4% (3148 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_small_002.gltf-83f8fb5bbfe90f84f7601ee69c0ab163.scn', resulting in a patch of 1598 bytes, which reduced the size by 38.2% (986 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_small_003.gltf-33bc06b77915fc3a7da9d3145a566af4.scn', resulting in a patch of 184 bytes, which reduced the size by 93.3% (2576 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_small_004.gltf-b6c8e7c7acafc669df48bb8769618cb1.scn', resulting in a patch of 1923 bytes, which reduced the size by 22.7% (565 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_top_001.gltf-ed2c90ebad7fca378f6c6c5ad107b353.scn', resulting in a patch of 42 bytes, which reduced the size by 99.8% (18505 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_top_002.gltf-67d330a74fc8f5d641e040adec30e1c8.scn', resulting in a patch of 999 bytes, which reduced the size by 75.2% (3026 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_top_003.gltf-9ef1a3dc5dc9965df4429232a5984d9a.scn', resulting in a patch of 747 bytes, which reduced the size by 82.5% (3521 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-bush_foliage_top_004.gltf-7b5bd6068a817dd027a42f82d80e22ea.scn', resulting in a patch of 824 bytes, which reduced the size by 79.2% (3138 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-e17e8915be33ba3caa7e4c702c918edc-bush.res', resulting in a patch of 41 bytes, which reduced the size by 98.4% (2460 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/LI-fence_plank_01.gltf-e13215b4301c7b31a0949889125e2a89.scn', as it resulted in a patch of 7154 bytes, which only reduced the size by 3.8% (280 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/LI-fence_plank_02.gltf-6c1a23e046402ba81b318a02d735da28.scn', as it resulted in a patch of 7808 bytes, which only reduced the size by 2.9% (232 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/LI-fence_plank_03.gltf-0db9a0a5e23e0cdb2a27b16f295d7913.scn', as it resulted in a patch of 7511 bytes, which only reduced the size by 0.6% (42 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/LI-fence_plank_04.gltf-2ac84343d96045227a99e36057e94150.scn', as it resulted in a patch of 8435 bytes, which only reduced the size by 1.1% (92 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/LI-fence_plank_05.gltf-48c19d68954b8336cc05a17fefda8146.scn', as it resulted in a patch of 7223 bytes, which only reduced the size by 1.5% (111 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/LI-fence_plank_06.gltf-7402b271f99e4981e1d342f5000e25b6.scn', as it resulted in a patch of 7670 bytes, which only reduced the size by 1.1% (84 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/LI-stone_plateau_001.gltf-81ce09b4a5ed8da31a696426534976cf.scn', as it resulted in a patch of 45568 bytes, which only reduced the size by 8.0% (3945 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/LI-stone_plateau_002.gltf-574959712e3c543d31ad36128a2b6dc0.scn', as it resulted in a patch of 37499 bytes, which only reduced the size by 6.8% (2723 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/LI-stone_plateau_003.gltf-37026e870d8fb0a798544f0dccc7b496.scn', as it resulted in a patch of 35427 bytes, which only reduced the size by 9.3% (3649 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-293680cc51e9cd0486e497a8eb604d9d-stone_wall_snowy.res', resulting in a patch of 46 bytes, which reduced the size by 98.2% (2449 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_001.gltf-6c68ad4d827d2b7e25c8ec1694a9da78.scn', resulting in a patch of 24679 bytes, which reduced the size by 23.2% (7459 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_002.gltf-3999d05482c9e000e4436ec5e6510ca9.scn', resulting in a patch of 19573 bytes, which reduced the size by 33.2% (9724 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_003.gltf-8f877b58d5015175bf038b80b67f27c7.scn', resulting in a patch of 16707 bytes, which reduced the size by 32.6% (8092 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_004.gltf-dfd11977b987307e51beb8311c1ce28c.scn', resulting in a patch of 26682 bytes, which reduced the size by 23.9% (8374 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_005.gltf-b3c147109498a6276fff778d55741fda.scn', resulting in a patch of 34375 bytes, which reduced the size by 18.8% (7961 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_006.gltf-d1dd2bfefcf060652e63c3d0e5781138.scn', resulting in a patch of 19784 bytes, which reduced the size by 35.6% (10938 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_007.gltf-a3603ba590e9d8f97ea68bbb95e0a776.scn', resulting in a patch of 4841 bytes, which reduced the size by 73.2% (13240 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_008.gltf-624b84d84206001949001db0306e0295.scn', resulting in a patch of 11429 bytes, which reduced the size by 56.0% (14544 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_009.gltf-1e8816b13883295f833fb7319071709f.scn', resulting in a patch of 4774 bytes, which reduced the size by 81.9% (21665 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_010.gltf-2362d3699279fcc9458103e49cc790e8.scn', resulting in a patch of 545 bytes, which reduced the size by 97.3% (19327 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_0011.gltf-ae3bd59c7d1d082cdb0fdb86508668ed.scn', resulting in a patch of 4800 bytes, which reduced the size by 77.2% (16242 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_012.gltf-e8446df129f613e4df46c3cdf8589041.scn', resulting in a patch of 12062 bytes, which reduced the size by 55.2% (14882 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/LI-stone_wall_013.gltf-7e139cd3a8ca569ca6b10c933d1c3b81.scn', resulting in a patch of 9597 bytes, which reduced the size by 51.9% (10362 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-8751d5cceb104760e2f281683e020794-stone_wall.res', resulting in a patch of 44 bytes, which reduced the size by 98.2% (2454 bytes) compared to the actual file.
Skipped delta encoding for patch of 'res://.godot/imported/stone_plateau_albedo.png-090b3b252fbd6390538b00add7a29c3b.ctex', as it resulted in a patch of 2307541 bytes, which only reduced the size by 4.1% (97877 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/stone_plateau_albedo.png-4e0e64b2e65449c1344dc953e684fdd1.s3tc.ctex', resulting in a patch of 985202 bytes, which reduced the size by 82.4% (4607282 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/PR-traffic_cone.gltf-fe0a84d532dd8a51f807efa767a4fb5e.scn', resulting in a patch of 7857 bytes, which reduced the size by 11.3% (1001 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-3943d6ae2e8b37b6d9da82a68c5f8ec7-traffic_cone.res', resulting in a patch of 48 bytes, which reduced the size by 97.9% (2286 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/bush_foliage_atlas_albedo_01.png-08ce4663401c96283ce790aed759bd1b.s3tc.ctex', resulting in a patch of 1352345 bytes, which reduced the size by 75.8% (4240139 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/SL-clearing-bushes.gltf-47565441b9825109bba0dbc787560a44.scn', resulting in a patch of 25695 bytes, which reduced the size by 45.9% (21834 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/SL-clearing_shrubs.gltf-d979ffa9eda7d4d041d54adcf325b78a.scn', resulting in a patch of 3539 bytes, which reduced the size by 78.1% (12643 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/SL-fence-boulders.gltf-8f9ed2988aaf279616f03b0bd45b9280.scn', resulting in a patch of 2506 bytes, which reduced the size by 47.4% (2256 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/imported/SL-fence-vegetation.gltf-2b0c3486f9d852252ed746c8c54f60c9.scn', resulting in a patch of 53437 bytes, which reduced the size by 10.8% (6494 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/audio/sfx/pinda/pinda_sfx.gdc', resulting in a patch of 1267 bytes, which reduced the size by 94.5% (21837 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/entities/player_entities/camera.gdc', resulting in a patch of 2973 bytes, which reduced the size by 86.2% (18631 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/entities/player_entities/chocomel.gdc', resulting in a patch of 9015 bytes, which reduced the size by 88.5% (69185 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-6d7bc4d39f8b5352d8abad820bf44d70-chocomel.scn', resulting in a patch of 424 bytes, which reduced the size by 97.6% (17404 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/entities/player_entities/leash.gdc', resulting in a patch of 288 bytes, which reduced the size by 99.3% (39588 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/entities/player_entities/pinda.gdc', resulting in a patch of 8067 bytes, which reduced the size by 95.7% (181161 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/entities/camera_magnet_zone.gdc', resulting in a patch of 33 bytes, which reduced the size by 99.2% (4035 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-4810a76f52cab761a40b217606f3b3f7-world.scn', resulting in a patch of 3608 bytes, which reduced the size by 95.1% (70323 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/sequences/credits/credits.json', resulting in a patch of 73 bytes, which reduced the size by 98.5% (4952 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-1ba630fc40b6c6f9f6410e00a7d23a6e-credits.scn', resulting in a patch of 324 bytes, which reduced the size by 96.4% (8582 bytes) compared to the actual file.
Used delta encoding for patch of 'res://source/user_interface/menus/settings_menu.gdc', resulting in a patch of 742 bytes, which reduced the size by 97.4% (27554 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/exported/133200997/export-3b7d2a6a20074e4b07b060ce359c7ebe-settings_menu.scn', resulting in a patch of 655 bytes, which reduced the size by 94.9% (12253 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/global_script_class_cache.cfg', resulting in a patch of 144 bytes, which reduced the size by 97.9% (6776 bytes) compared to the actual file.
Used delta encoding for patch of 'res://.godot/uid_cache.bin', resulting in a patch of 65 bytes, which reduced the size by 100.0% (175587 bytes) compared to the actual file.
Used delta encoding for patch of 'res://project.binary', resulting in a patch of 33 bytes, which reduced the size by 99.9% (26852 bytes) compared to the actual file.
```

</p>
</details>

#### Runtime overhead

<details><summary>[Click to expand/collapse]</summary>
<p>

On my machine (AMD 9950X3D) the overhead from applying the above mentioned patches averages around 66 µs, with roughly 60% of that being spent actually decoding the patches, and the rest being I/O. The median is 13 µs, with a worst-case of 1858 µs. In total the two patch PCKs added 3722 µs (3.7 ms) of overhead to resource loading across 56 resources when starting a new game.

I've seen very similar numbers on Android (OnePlus 8T from 2020, Snapdragon 865) in another real-world project, with averages hovering around 80 µs, with roughly half of that being spent on I/O.

For a breakdown of the individual files, see the output from a `--verbose` startup of the game:

```txt
Applied delta patch to 'res://.godot/global_script_class_cache.cfg' from 'v1.0.2.pck' in 14 μs (4 μs I/O, 9 μs decoding).
Applied delta patch to 'res://.godot/uid_cache.bin' from 'v1.0.2.pck' in 20 μs (6 μs I/O, 14 μs decoding).
Applied delta patch to 'res://.godot/global_script_class_cache.cfg' from 'v1.0.2.pck' in 6 μs (3 μs I/O, 3 μs decoding).
Applied delta patch to 'res://.godot/global_script_class_cache.cfg' from 'v1.0.4.pck' in 4 μs (3 μs I/O, 1 μs decoding).
Applied delta patch to 'res://.godot/uid_cache.bin' from 'v1.0.2.pck' in 14 μs (4 μs I/O, 10 μs decoding).
Applied delta patch to 'res://.godot/uid_cache.bin' from 'v1.0.4.pck' in 13 μs (4 μs I/O, 9 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/camera.gdc' from 'v1.0.4.pck' in 43 μs (7 μs I/O, 36 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/chocomel.gdc' from 'v1.0.4.pck' in 78 μs (6 μs I/O, 72 μs decoding).
Applied delta patch to 'res://.godot/imported/c1_0.png-633c826446b972eb64aa7ce688537a89.s3tc.ctex' from 'v1.0.2.pck' in 255 μs (8 μs I/O, 247 μs decoding).
Applied delta patch to 'res://.godot/imported/c1_1.png-f4d5442a5958d63be4969f9c43b55385.s3tc.ctex' from 'v1.0.2.pck' in 222 μs (6 μs I/O, 216 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-06339610f1a89a2edfbfa400f9fe80ce-menu_ui.scn' from 'v1.0.2.pck' in 12 μs (5 μs I/O, 7 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/camera.gdc' from 'v1.0.4.pck' in 36 μs (6 μs I/O, 30 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-3b7d2a6a20074e4b07b060ce359c7ebe-settings_menu.scn' from 'v1.0.4.pck' in 22 μs (8 μs I/O, 13 μs decoding).
Applied delta patch to 'res://source/user_interface/menus/settings_menu.gdc' from 'v1.0.4.pck' in 21 μs (5 μs I/O, 16 μs decoding).
Applied delta patch to 'res://source/user_interface/menus/settings_menu.gdc' from 'v1.0.4.pck' in 14 μs (4 μs I/O, 10 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/pinda.gdc' from 'v1.0.2.pck' in 126 μs (6 μs I/O, 120 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/pinda.gdc' from 'v1.0.4.pck' in 65 μs (5 μs I/O, 59 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-4810a76f52cab761a40b217606f3b3f7-world.scn' from 'v1.0.2.pck' in 27 μs (8 μs I/O, 18 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-4810a76f52cab761a40b217606f3b3f7-world.scn' from 'v1.0.4.pck' in 21 μs (5 μs I/O, 16 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/pinda.gdc' from 'v1.0.2.pck' in 125 μs (9 μs I/O, 116 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/pinda.gdc' from 'v1.0.4.pck' in 68 μs (7 μs I/O, 61 μs decoding).
Applied delta patch to 'res://.godot/imported/SL-fence-boulders.gltf-8f9ed2988aaf279616f03b0bd45b9280.scn' from 'v1.0.4.pck' in 10 μs (6 μs I/O, 4 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-293680cc51e9cd0486e497a8eb604d9d-stone_wall_snowy.res' from 'v1.0.4.pck' in 5 μs (3 μs I/O, 2 μs decoding).
Applied delta patch to 'res://.godot/imported/stone_plateau_albedo.png-4e0e64b2e65449c1344dc953e684fdd1.s3tc.ctex' from 'v1.0.4.pck' in 1858 μs (46 μs I/O, 1811 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-bush_001.gltf-40b8180f1a8db565195bb533fe5b3b60.scn' from 'v1.0.4.pck' in 8 μs (4 μs I/O, 4 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-e17e8915be33ba3caa7e4c702c918edc-bush.res' from 'v1.0.4.pck' in 4 μs (3 μs I/O, 1 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-bush_small_002.gltf-4c9d050b1c074ff3d5423d3e5923b648.scn' from 'v1.0.4.pck' in 9 μs (5 μs I/O, 4 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-bush_002.gltf-046eef6042349a872843bd2bad57871d.scn' from 'v1.0.4.pck' in 7 μs (4 μs I/O, 3 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-bush_003.gltf-d8b6330d3fbe3be54b19ef784d826f6f.scn' from 'v1.0.4.pck' in 7 μs (4 μs I/O, 3 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-bush_small_003.gltf-c5f1b275891f4c31b9784b8fc30cad59.scn' from 'v1.0.4.pck' in 7 μs (4 μs I/O, 3 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-bush_004.gltf-44dfe26583b38b9bacbc865c65056616.scn' from 'v1.0.4.pck' in 7 μs (4 μs I/O, 3 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-bush_small_001.gltf-fd7ac3b286c919a158b306ecbdb65c35.scn' from 'v1.0.4.pck' in 6 μs (4 μs I/O, 2 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-bush_foliage_top_004.gltf-7b5bd6068a817dd027a42f82d80e22ea.scn' from 'v1.0.4.pck' in 5 μs (4 μs I/O, 1 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-stone_wall_008.gltf-624b84d84206001949001db0306e0295.scn' from 'v1.0.4.pck' in 9 μs (5 μs I/O, 4 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-8751d5cceb104760e2f281683e020794-stone_wall.res' from 'v1.0.4.pck' in 5 μs (4 μs I/O, 1 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-stone_wall_007.gltf-a3603ba590e9d8f97ea68bbb95e0a776.scn' from 'v1.0.4.pck' in 9 μs (5 μs I/O, 4 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-stone_wall_006.gltf-d1dd2bfefcf060652e63c3d0e5781138.scn' from 'v1.0.4.pck' in 11 μs (5 μs I/O, 6 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-stone_wall_005.gltf-b3c147109498a6276fff778d55741fda.scn' from 'v1.0.4.pck' in 20 μs (7 μs I/O, 13 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-stone_wall_004.gltf-dfd11977b987307e51beb8311c1ce28c.scn' from 'v1.0.4.pck' in 17 μs (6 μs I/O, 11 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-99b6d6e785812c481ec56f0c19253d65-pine_cuts_atlas_albedo_01.res' from 'v1.0.2.pck' in 8 μs (6 μs I/O, 2 μs decoding).
Applied delta patch to 'res://.godot/imported/SL-fence-vegetation.gltf-2b0c3486f9d852252ed746c8c54f60c9.scn' from 'v1.0.4.pck' in 25 μs (6 μs I/O, 17 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-stone_wall_0011.gltf-ae3bd59c7d1d082cdb0fdb86508668ed.scn' from 'v1.0.4.pck' in 10 μs (6 μs I/O, 4 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-stone_wall_010.gltf-2362d3699279fcc9458103e49cc790e8.scn' from 'v1.0.4.pck' in 6 μs (4 μs I/O, 2 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-stone_wall_009.gltf-1e8816b13883295f833fb7319071709f.scn' from 'v1.0.4.pck' in 8 μs (5 μs I/O, 3 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-75cc15c6f96624c92a89cd4ea423aab0-SE-clearing.scn' from 'v1.0.2.pck' in 17 μs (8 μs I/O, 9 μs decoding).
Applied delta patch to 'res://.godot/imported/LI-stone_wall_012.gltf-e8446df129f613e4df46c3cdf8589041.scn' from 'v1.0.4.pck' in 11 μs (6 μs I/O, 5 μs decoding).
Applied delta patch to 'res://.godot/imported/SL-clearing-bushes.gltf-47565441b9825109bba0dbc787560a44.scn' from 'v1.0.4.pck' in 24 μs (10 μs I/O, 14 μs decoding).
Applied delta patch to 'res://.godot/imported/SL-clearing_terrain.gltf-6c7bfff97231b94de231cd87b0a043cc.scn' from 'v1.0.2.pck' in 169 μs (40 μs I/O, 129 μs decoding).
Applied delta patch to 'res://.godot/imported/SL-clearing_shrubs.gltf-d979ffa9eda7d4d041d54adcf325b78a.scn' from 'v1.0.4.pck' in 13 μs (8 μs I/O, 5 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-6d7bc4d39f8b5352d8abad820bf44d70-chocomel.scn' from 'v1.0.4.pck' in 12 μs (7 μs I/O, 5 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/chocomel.gdc' from 'v1.0.4.pck' in 79 μs (7 μs I/O, 71 μs decoding).
Applied delta patch to 'res://source/entities/camera_magnet_zone.gdc' from 'v1.0.4.pck' in 11 μs (8 μs I/O, 3 μs decoding).
Applied delta patch to 'res://.godot/imported/PR-traffic_cone.gltf-fe0a84d532dd8a51f807efa767a4fb5e.scn' from 'v1.0.4.pck' in 10 μs (5 μs I/O, 5 μs decoding).
Applied delta patch to 'res://.godot/exported/133200997/export-3943d6ae2e8b37b6d9da82a68c5f8ec7-traffic_cone.res' from 'v1.0.4.pck' in 4 μs (3 μs I/O, 1 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/camera.gdc' from 'v1.0.4.pck' in 34 μs (5 μs I/O, 29 μs decoding).
Applied delta patch to 'res://source/entities/player_entities/chocomel.gdc' from 'v1.0.4.pck' in 71 μs (6 μs I/O, 64 μs decoding).
```

</p>
</details>

## Potential improvements

- Have the include/exclude filtering use the actual resource paths rather than the exported paths.
- Provide some other way than `--verbose` for logging delta encoding details during export.
- Add profiling monitors for time spent applying patches.
- Emit warnings during export if compression is enabled on applicable resource types.
- Provide an export setting for actually caching patched resources in the `user://` folder.
- Rewrite `DeltaEncoding` to use zstd's streaming API instead, to allow passing `FileAccess` for inputs and outputs.
- Expose `DeltaEncoding` to scripts and allow `PCKPacker` to add file deltas as well.

---

**Contributed by [W4 Games](https://w4games.com)** 🍀