### PR TITLE
Fix verbose running message

### DIFF
--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -168,10 +168,13 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 		}
 
 		if (OS::get_singleton()->is_stdout_verbose()) {
-			print_line(vformat("Running: %s", exec));
+			PackedStringArray output;
+			output.reserve_exact(instance_args.size() + 1);
+			output.append(vformat("Running: %s", exec));
 			for (const String &E : instance_args) {
-				print_line(" %s", E);
+				output.append(E);
 			}
+			print_line(String(" ").join(output));
 		}
 
 		OS::ProcessID pid = 0;


### PR DESCRIPTION
Fixes #111989

The new message is like

> Running: C:/godot_source/bin/godot.windows.editor.dev.x86_64.exe --path C:/Program%20Files/Godot/BugReports/Repro --remote-debug tcp://127.0.0.1:9000 --editor-pid 16860 --debug-collisions --position 384,191 --scene uid://bqxg1acw1j6ep
