### PR TITLE
Use HingeJoint instead of PinJoint in Create Physical Skeleton editor tool

### DIFF
--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -547,7 +547,10 @@ void Skeleton3DEditor::create_physical_skeleton() {
 
 						// Create joint between parent of parent.
 						if (parent_parent != -1) {
-							ur->add_do_method(physical_bone, "set_joint_type", PhysicalBone3D::JOINT_TYPE_PIN);
+							// Use HingeJoint with angular constraint enabled for more realistic simulation out of the box,
+							// especially with humanoid characters.
+							ur->add_do_method(physical_bone, "set_joint_type", PhysicalBone3D::JOINT_TYPE_HINGE);
+							ur->add_do_method(physical_bone, "set", "joint_constraints/angular_limit_enabled", true);
 						}
 
 						ur->add_do_method(Node3DEditor::get_singleton(), SceneStringName(_request_gizmo), physical_bone);


### PR DESCRIPTION
This also enables angular constraint for more realistic behavior out of the box (no more crumpling upon itself).

This is backwards-compatible, as it's an editor-only tool that sets properties once when used.

See [Ragdoll system](https://docs.godotengine.org/en/stable/tutorials/physics/ragdoll_system.html) which features updated recommendations for joint types as per https://github.com/godotengine/godot-docs/pull/11392.

- See https://github.com/godotengine/godot-proposals/issues/3925#issuecomment-3443717474
and https://github.com/godotengine/godot-proposals/discussions/14085.
