### PR TITLE
Add text trimming in `LinkButton`

### DIFF
--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -27,6 +27,9 @@
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="Control.TextDirection" default="0">
 			Base text writing direction.
 		</member>
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
+			Sets the clipping behavior when the text exceeds the node's bounding rectangle.
+		</member>
 		<member name="underline" type="int" setter="set_underline_mode" getter="get_underline_mode" enum="LinkButton.UnderlineMode" default="0">
 			The underline mode to use for the text.
 		</member>

--- a/editor/asset_library/asset_library_editor_plugin.h
+++ b/editor/asset_library/asset_library_editor_plugin.h
@@ -76,8 +76,6 @@ protected:
 public:
 	void configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, const String &p_cost);
 
-	void clamp_width(int p_max_width);
-
 	EditorAssetLibraryItem(bool p_clickable = false);
 };
 
@@ -311,8 +309,6 @@ class EditorAssetLibrary : public PanelContainer {
 	void _support_toggled(int p_support);
 
 	void _install_external_asset(String p_zip_path, String p_title);
-
-	int asset_items_column_width = 0;
 
 	void _update_asset_items_columns();
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -37,6 +37,7 @@ void LinkButton::_shape() {
 	int font_size = theme_cache.font_size;
 
 	text_buf->clear();
+	text_buf->set_width(-1);
 	if (text_direction == Control::TEXT_DIRECTION_INHERITED) {
 		text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
 	} else {
@@ -45,6 +46,7 @@ void LinkButton::_shape() {
 	TS->shaped_text_set_bidi_override(text_buf->get_rid(), structured_text_parser(st_parser, st_args, xl_text));
 	const String &lang = language.is_empty() ? _get_locale() : language;
 	text_buf->add_string(xl_text, font, font_size, lang);
+	text_buf->set_text_overrun_behavior(overrun_behavior);
 
 	queue_accessibility_update();
 }
@@ -62,6 +64,19 @@ void LinkButton::set_text(const String &p_text) {
 
 String LinkButton::get_text() const {
 	return text;
+}
+
+void LinkButton::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
+	if (overrun_behavior != p_behavior) {
+		overrun_behavior = p_behavior;
+		_shape();
+		update_minimum_size();
+		queue_redraw();
+	}
+}
+
+TextServer::OverrunBehavior LinkButton::get_text_overrun_behavior() const {
+	return overrun_behavior;
 }
 
 void LinkButton::set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser) {
@@ -148,7 +163,12 @@ void LinkButton::pressed() {
 }
 
 Size2 LinkButton::get_minimum_size() const {
-	return text_buf->get_size();
+	Size2 minsize = text_buf->get_size();
+	if (overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
+		minsize.width = 0;
+	}
+
+	return minsize;
 }
 
 void LinkButton::_notification(int p_what) {
@@ -178,6 +198,7 @@ void LinkButton::_notification(int p_what) {
 			queue_redraw();
 		} break;
 
+		case NOTIFICATION_RESIZED:
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
 			update_minimum_size();
@@ -228,6 +249,9 @@ void LinkButton::_notification(int p_what) {
 				style->draw(ci, Rect2(Point2(), size));
 			}
 
+			if (overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
+				text_buf->set_width(MAX(1.0f, size.width));
+			}
 			int width = text_buf->get_line_width();
 
 			Color font_outline_color = theme_cache.font_outline_color;
@@ -262,6 +286,8 @@ void LinkButton::_notification(int p_what) {
 void LinkButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &LinkButton::set_text);
 	ClassDB::bind_method(D_METHOD("get_text"), &LinkButton::get_text);
+	ClassDB::bind_method(D_METHOD("set_text_overrun_behavior", "overrun_behavior"), &LinkButton::set_text_overrun_behavior);
+	ClassDB::bind_method(D_METHOD("get_text_overrun_behavior"), &LinkButton::get_text_overrun_behavior);
 	ClassDB::bind_method(D_METHOD("set_text_direction", "direction"), &LinkButton::set_text_direction);
 	ClassDB::bind_method(D_METHOD("get_text_direction"), &LinkButton::get_text_direction);
 	ClassDB::bind_method(D_METHOD("set_language", "language"), &LinkButton::set_language);
@@ -282,6 +308,9 @@ void LinkButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text"), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "underline", PROPERTY_HINT_ENUM, "Always,On Hover,Never"), "set_underline_mode", "get_underline_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "uri"), "set_uri", "get_uri");
+
+	ADD_GROUP("Text Behavior", "");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim Nothing,Trim Characters,Trim Words,Ellipsis (6+ Characters),Word Ellipsis (6+ Characters),Ellipsis (Always),Word Ellipsis (Always)"), "set_text_overrun_behavior", "get_text_overrun_behavior");
 
 	ADD_GROUP("BiDi", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -54,6 +54,7 @@ private:
 	TextDirection text_direction = TEXT_DIRECTION_AUTO;
 	TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
 	Array st_args;
+	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
 
 	struct ThemeCache {
 		Ref<StyleBox> focus;
@@ -87,6 +88,9 @@ public:
 	String get_text() const;
 	void set_uri(const String &p_uri);
 	String get_uri() const;
+
+	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
+	TextServer::OverrunBehavior get_text_overrun_behavior() const;
 
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;

--- a/scene/resources/text_line.cpp
+++ b/scene/resources/text_line.cpp
@@ -321,6 +321,9 @@ String TextLine::get_ellipsis_char() const {
 }
 
 void TextLine::set_width(float p_width) {
+	if (width == p_width) {
+		return;
+	}
 	width = p_width;
 	if (alignment == HORIZONTAL_ALIGNMENT_FILL || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 		dirty = true;


### PR DESCRIPTION
Mostly an excuse to fix #84471.

While having only one property inside a category is odd, I opted for consistency with other nodes that have the same property. I can remove it if undesirable.

**ATTENTION:** If this is cherry-picked, #112208 and #113017 should be too.