### PR TITLE
Fix dotnet class lookup returning modified names instead of engine names

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -250,7 +250,8 @@ namespace Godot.Bridge
                 }
                 if (!foundGlobalBaseScript)
                 {
-                    *outBaseType = Marshaling.ConvertStringToNative(native.Name);
+                    string nativeName = native.GetCustomAttribute<GodotClassNameAttribute>(false)?.Name ?? native.Name;
+                    *outBaseType = Marshaling.ConvertStringToNative(nativeName);
                 }
             }
 


### PR DESCRIPTION
Fixes #111247
Fixes #111990

Side effect of #87890 combined with #69547 which lines up with the versions that had the issues.

Issue was that the script bridge was returning the C# names instead of the engine names, so inheritance checks fail from using the wrong name. This affected anything renamed in #69547, which thankfully already set up the needed data to fix the bug.

<img width="1014" height="525" alt="image" src="https://github.com/user-attachments/assets/de4767c7-c0db-4fc2-8d80-f420210e4178" />


Also confirmed classes that don't have `GodotClassNameAttribute` are unaffected by this change. (See `TestControl`)
<img width="896" height="521" alt="image" src="https://github.com/user-attachments/assets/2a93bec4-5834-4b54-8cb6-184202f11e9b" />


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
