### PR TITLE
Fix crash when using `set_script()`

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3950,7 +3950,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 
 		_err_print_error(err_func.utf8().get_data(), err_file.utf8().get_data(), err_line, err_text.utf8().get_data(), false, ERR_HANDLER_SCRIPT);
-		GDScriptLanguage::get_singleton()->debug_break(err_text, false);
+		if (p_instance->owner_id != ObjectID()) {
+			// skip debug when using set_script() during calling
+			GDScriptLanguage::get_singleton()->debug_break(err_text, false);
+		}
 
 		// Get a default return type in case of failure
 		retvalue = _get_default_variant_for_data_type(return_type);


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/106778*

## Issue Description

The #106778 used `set_script` to transfer states.

I think the `set_script()` is a **dangerous** operation, which will free current script instance memory.

I create a simple project to demonstrate this behavior:

- `Parent` calls `set_script()` function to set `child1.gd` to a node.
- Then calls `on_process()` function of  `child1.gd`
- In `on_process()`
  - First, calling `set_script()` function to set `child2.gd` to the same node. That free `child1.gd` relevant memory
  - Second, after `set_script()`, go on changing the property of itself's member property, which will cause null instance error, that already be free by first step.
  - Third, ScriptDebugger will try to print debug message, which used owner field of `ScriptInstance`, that already be free by first step. then crashed.

```
SCRIPT ERROR: Invalid assignment of property or key 'flip_v' with value of type 'bool' on a base object of type 'null instance'.
          at: on_process (res://child1.gd:6)
          GDScript backtrace (most recent call first):
              [0] on_process (res://child1.gd:6)
              [1] _physics_process (res://parent.gd:16)

```

## Solution

I just skip debug when `owner_id == ObjectID()`. Any advice?

## MRP

[106778.zip](https://github.com/user-attachments/files/23142245/106778.zip) 

