### PR TITLE
[3.x] Add proper flags when using external recast

### DIFF
--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -259,6 +259,9 @@ def configure(env):
         # mbedTLS does not provide a pkgconfig config yet. See https://github.com/ARMmbed/mbedtls/issues/228
         env.Append(LIBS=["mbedtls", "mbedcrypto", "mbedx509"])
 
+    if not env["builtin_recast"]:
+        env.ParseConfig("pkg-config recastnavigation --cflags --libs")
+
     if not env["builtin_wslay"]:
         env.ParseConfig("pkg-config libwslay --cflags --libs")
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -344,6 +344,9 @@ def configure(env):
         # mbedTLS does not provide a pkgconfig config yet. See https://github.com/ARMmbed/mbedtls/issues/228
         env.Append(LIBS=["mbedtls", "mbedcrypto", "mbedx509"])
 
+    if not env["builtin_recast"]:
+        env.ParseConfig("pkg-config recastnavigation --cflags --libs")
+
     if not env["builtin_wslay"]:
         env.ParseConfig("pkg-config libwslay --cflags --libs")
 


### PR DESCRIPTION
Forwarding a patch Debian is using to build 3.x using the Debian-provided recast.