### PR TITLE
Fix embedded window frame oversampling, fix DPITexture using uninitialized size in some conditions.

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -143,18 +143,13 @@ void CanvasItem::_redraw_callback() {
 
 	if (is_visible_in_tree()) {
 		drawing = true;
-		Ref<TextServer> ts = TextServerManager::get_singleton()->get_primary_interface();
-		if (ts.is_valid()) {
-			ts->set_current_drawn_item_oversampling(get_viewport()->get_oversampling());
-		}
+		TextServer::set_current_drawn_item_oversampling(get_viewport()->get_oversampling());
 		current_item_drawn = this;
 		notification(NOTIFICATION_DRAW);
 		emit_signal(SceneStringName(draw));
 		GDVIRTUAL_CALL(_draw);
 		current_item_drawn = nullptr;
-		if (ts.is_valid()) {
-			ts->set_current_drawn_item_oversampling(0.0);
-		}
+		TextServer::set_current_drawn_item_oversampling(0.0);
 		drawing = false;
 		draw_commands_dirty = true;
 	}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -356,6 +356,8 @@ void Viewport::_sub_window_update(Window *p_window) {
 	const Rect2i r = Rect2i(p_window->get_position(), p_window->get_size());
 
 	if (!p_window->get_flag(Window::FLAG_BORDERLESS)) {
+		TextServer::set_current_drawn_item_oversampling(get_oversampling());
+
 		Ref<StyleBox> panel = gui.subwindow_focused == p_window ? p_window->theme_cache.embedded_border : p_window->theme_cache.embedded_unfocused_border;
 		panel->draw(sw.canvas_item, r);
 
@@ -386,6 +388,8 @@ void Viewport::_sub_window_update(Window *p_window) {
 		bool pressed = gui.subwindow_focused == sw.window && gui.subwindow_drag == SUB_WINDOW_DRAG_CLOSE && gui.subwindow_drag_close_inside;
 		Ref<Texture2D> close_icon = pressed ? p_window->theme_cache.close_pressed : p_window->theme_cache.close;
 		close_icon->draw(sw.canvas_item, r.position + Vector2(r.size.width - close_h_ofs, -close_v_ofs));
+
+		TextServer::set_current_drawn_item_oversampling(0.0);
 	}
 
 	const Transform2D xform = sw.window->window_transform * sw.window->stretch_transform;
@@ -3034,7 +3038,8 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 
 					int close_h_ofs = sw.window->theme_cache.close_h_offset;
 					int close_v_ofs = sw.window->theme_cache.close_v_offset;
-					Ref<Texture2D> close_icon = sw.window->theme_cache.close;
+					bool pressed = gui.subwindow_focused == sw.window && gui.subwindow_drag == SUB_WINDOW_DRAG_CLOSE && gui.subwindow_drag_close_inside;
+					Ref<Texture2D> close_icon = pressed ? sw.window->theme_cache.close_pressed : sw.window->theme_cache.close;
 
 					Rect2 close_rect;
 					close_rect.position = Vector2(r.position.x + r.size.x - close_h_ofs, r.position.y - close_v_ofs);

--- a/scene/resources/dpi_texture.cpp
+++ b/scene/resources/dpi_texture.cpp
@@ -204,14 +204,14 @@ RID DPITexture::_load_at_scale(double p_scale, bool p_set_size) const {
 	}
 
 	Size2 current_size = size;
-	if (p_set_size) {
-		size.x = img->get_width();
-		base_size.x = img->get_width();
+	if (p_set_size || size.is_zero_approx()) {
+		size.x = img->get_width() / p_scale;
+		base_size.x = size.x;
 		if (size_override.x != 0) {
 			size.x = size_override.x;
 		}
-		size.y = img->get_height();
-		base_size.y = img->get_height();
+		size.y = img->get_height() / p_scale;
+		base_size.y = size.y;
 		if (size_override.y != 0) {
 			size.y = size_override.y;
 		}
@@ -274,19 +274,16 @@ bool DPITexture::has_alpha() const {
 }
 
 RID DPITexture::get_scaled_rid() const {
-	double scale = 1.0;
-	CanvasItem *ci = CanvasItem::get_current_item_drawn();
-	if (ci) {
-		Viewport *vp = ci->get_viewport();
-		if (vp) {
-			scale = vp->get_oversampling();
-		}
+	double scale = TextServer::get_current_drawn_item_oversampling();
+	if (scale == 0.0) {
+		scale = 1.0;
 	}
 	return _ensure_scale(scale);
 }
 
 void DPITexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
-	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, Rect2(p_pos, size), get_scaled_rid(), false, p_modulate, p_transpose);
+	RID rid = get_scaled_rid(); // Note: call `get_scaled_rid` before using `size` to ensure it is loaded.
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, Rect2(p_pos, size), rid, false, p_modulate, p_transpose);
 }
 
 void DPITexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) const {

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -496,13 +496,9 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 	real_t aa_size_scaled = 1.0f;
 	if (aa_on) {
-		real_t scale_factor = 1.0f;
-		CanvasItem *ci = CanvasItem::get_current_item_drawn();
-		if (ci) {
-			Viewport *vp = ci->get_viewport();
-			if (vp) {
-				scale_factor = vp->get_oversampling();
-			}
+		real_t scale_factor = TextServer::get_current_drawn_item_oversampling();
+		if (scale_factor == 0.0) {
+			scale_factor = 1.0;
 		}
 
 		// Adjust AA feather size to account for the 2D scale factor, so that

--- a/servers/text/text_server.cpp
+++ b/servers/text/text_server.cpp
@@ -189,6 +189,8 @@ bool Glyph::operator>(const Glyph &p_a) const {
 	return p_a.start > start;
 }
 
+double TextServer::vp_oversampling = 0.0;
+
 void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_feature", "feature"), &TextServer::has_feature);
 	ClassDB::bind_method(D_METHOD("get_name"), &TextServer::get_name);

--- a/servers/text/text_server.h
+++ b/servers/text/text_server.h
@@ -229,7 +229,7 @@ public:
 	void _draw_hex_code_box_number(const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, uint8_t p_index, const Color &p_color) const;
 
 protected:
-	double vp_oversampling = 0.0;
+	static double vp_oversampling;
 	HashMap<char32_t, char32_t> diacritics_map;
 	void _diacritics_map_add(const String &p_from, char32_t p_to);
 	void _init_diacritics_map();
@@ -605,7 +605,8 @@ public:
 
 	TypedArray<Vector3i> parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;
 
-	virtual void set_current_drawn_item_oversampling(double p_vp_oversampling) { vp_oversampling = p_vp_oversampling; }
+	static void set_current_drawn_item_oversampling(double p_vp_oversampling) { vp_oversampling = p_vp_oversampling; }
+	static double get_current_drawn_item_oversampling() { return vp_oversampling; }
 
 	virtual void cleanup() {}
 


### PR DESCRIPTION
- Fixes embedded window frame and title, not using oversampling.
- Fixes `DPITexture` using uninitialized size in some conditions.
- Replaces unnecessary `TextServerManager`, `CanvasItem` and `Viewport` calls with static `TextServer` property.

Fixes https://github.com/godotengine/godot/issues/111981
Fixes https://github.com/godotengine/godot/issues/110483

<img width="840" height="244" alt="Screenshot 2025-10-25 at 17 28 40" src="https://github.com/user-attachments/assets/0cd2059d-6452-4586-8986-30648e304bdc" />
