### PR TITLE
Update `DirAccessUnix::change_dir` to also call `simplify_path` for absolute paths

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -352,12 +352,11 @@ Error DirAccessUnix::change_dir(String p_dir) {
 	// try_dir is the directory we are trying to change into
 	String try_dir = "";
 	if (p_dir.is_relative_path()) {
-		String next_dir = current_dir.path_join(p_dir);
-		next_dir = next_dir.simplify_path();
-		try_dir = next_dir;
+		try_dir = current_dir.path_join(p_dir);
 	} else {
 		try_dir = p_dir;
 	}
+	try_dir = try_dir.simplify_path();
 
 	bool worked = (chdir(try_dir.utf8().get_data()) == 0); // we can only give this utf8
 	if (!worked) {


### PR DESCRIPTION
Update to call `simplify_path()` on `p_dir` argument for both relative and absolute paths, to avoid storing unnecessary "." and "..".

Fixes #105312

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
