### PR TITLE
Fix `memnew_placement` with `char *` arguments

### DIFF
--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -95,6 +95,10 @@ public:
 	_FORCE_INLINE_ static void free(void *p_ptr) { Memory::free_static(p_ptr, false); }
 };
 
+// Works around an issue where memnew_placement (char *) would call the p_description version.
+inline void *operator new(size_t p_size, char *p_dest) {
+	return operator new(p_size, (void *)p_dest);
+}
 void *operator new(size_t p_size, const char *p_description); ///< operator new that takes a description and uses MemoryStaticPool
 void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)); ///< operator new that takes a description and uses MemoryStaticPool
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/112022

This fixes an issue where `memnew_placement(some_char_ptr, 'c')` would not assign the new value correctly to `some_char_ptr`, instead allocating new memory.

This fixes https://github.com/godotengine/godot/issues/112022, because it's using a `Vector<char>`, which triggered the bug. In this case, the bug causes data loss, which makes this a high priority fix.
https://github.com/godotengine/godot/pull/105928 triggered the issue because the refactor started to use `memnew_placement` with a `char *` argument (from `Vector<char>::push_back` in `ConservativeGetLine`), causing the regression.

This might also fix a few other obscure bugs.

## Explanation

We have a few `new` overloads in `memory.h`.
One of them takes a `const char *` argument, which is meant to be the description (although unused as of now).

When using `memnew_placement(some_char_ptr, 'c')`, it would call this overload by accident, because it matches better with the argument signature than `new(size_t, void *)`, which is the standard [placement new](https://en.cppreference.com/w/cpp/language/new.html#Placement_new) overload.
In effect, this means that it would allocate new memory for a `char` instead of placing the char in the given memory.
Notably, this bug has existed since Godot was made open source, and might have caused other so far unresolved bugs with `char` placement.

This PR works around the bug by providing a `char *` overload, which correctly calls the placement new version.

## Alternative solution

I initially tried to solve the issue by removing the unneeded `p_description` parameter, but this didn't work (crashing the editor on startup). This would be a better solution, and should be investigated in a follow-up. But it is not necessary to resolve the issue.