### PR TITLE
Change `new` overloads to use a tag instead of a pointer

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -158,7 +158,8 @@ public:
 
 	template <typename T>
 	static Object *creator(bool p_notify_postinitialize) {
-		Object *ret = new ("") T;
+		// Cannot use memnew here because memnew calls _postinitialize automatically.
+		Object *ret = new (DefaultAllocator{}) T;
 		ret->_initialize();
 		if (p_notify_postinitialize) {
 			ret->_postinitialize();

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -39,28 +39,6 @@
 
 #include <cstdlib>
 
-void *operator new(size_t p_size, const char *p_description) {
-	return Memory::alloc_static(p_size, false);
-}
-
-void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)) {
-	return p_allocfunc(p_size);
-}
-
-#ifdef _MSC_VER
-void operator delete(void *p_mem, const char *p_description) {
-	CRASH_NOW_MSG("Call to placement delete should not happen.");
-}
-
-void operator delete(void *p_mem, void *(*p_allocfunc)(size_t p_size)) {
-	CRASH_NOW_MSG("Call to placement delete should not happen.");
-}
-
-void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_description) {
-	CRASH_NOW_MSG("Call to placement delete should not happen.");
-}
-#endif
-
 #ifdef DEBUG_ENABLED
 static SafeNumeric<uint64_t> _current_mem_usage;
 static SafeNumeric<uint64_t> _max_mem_usage;

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -104,22 +104,26 @@ public:
 	_FORCE_INLINE_ static void free(void *p_ptr) { Memory::free_static(p_ptr, false); }
 };
 
-// Works around an issue where memnew_placement (char *) would call the p_description version.
-inline void *operator new(size_t p_size, char *p_dest) {
-	return operator new(p_size, (void *)p_dest);
+// Overload of new operator to use the Memory::alloc_static function.
+// The DefaultAllocator parameter is just a tag to select this overload.
+inline void *operator new(size_t p_size, DefaultAllocator p_allocator) {
+	return Memory::alloc_static(p_size);
 }
-void *operator new(size_t p_size, const char *p_description); ///< operator new that takes a description and uses MemoryStaticPool
-void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)); ///< operator new that takes a description and uses MemoryStaticPool
+// Overload of new operator to use a custom allocation function.
+inline void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)) {
+	return p_allocfunc(p_size);
+}
 
-void *operator new(size_t p_size, void *p_pointer, size_t check, const char *p_description); ///< operator new that takes a description and uses a pointer to the preallocated memory
-
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 // When compiling with VC++ 2017, the above declarations of placement new generate many irrelevant warnings (C4291).
 // The purpose of the following definitions is to muffle these warnings, not to provide a usable implementation of placement delete.
-void operator delete(void *p_mem, const char *p_description);
-void operator delete(void *p_mem, void *(*p_allocfunc)(size_t p_size));
-void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_description);
-#endif
+inline void operator delete(void *p_mem, DefaultAllocator p_allocator) {
+	CRASH_NOW_MSG("Call to placement delete should not happen.");
+}
+inline void operator delete(void *p_mem, void *(*p_allocfunc)(size_t p_size)) {
+	CRASH_NOW_MSG("Call to placement delete should not happen.");
+}
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #define memalloc(m_size) Memory::alloc_static(m_size)
 #define memalloc_zeroed(m_size) Memory::alloc_static_zeroed(m_size)
@@ -143,7 +147,7 @@ _ALWAYS_INLINE_ memnew_result_t<T> _post_initialize(T *p_obj) {
 	return result;
 }
 
-#define memnew(m_class) _post_initialize(::new ("") m_class)
+#define memnew(m_class) _post_initialize(::new (DefaultAllocator{}) m_class)
 
 #define memnew_allocator(m_class, m_allocator) _post_initialize(::new (m_allocator::alloc) m_class)
 #define memnew_placement(m_placement, m_class) _post_initialize(::new (m_placement) m_class)


### PR DESCRIPTION
- Follow-up of #112033 

I've figured it out - the reason we can't remove the `p_description` parameter is that overloading the default `operator new` is not an option for us because it breaks contracts with other dynamic libraries (in my case, `MoltenVK`).
The motivation for this change, beside the (probably minor) optimization, is to avoid unexpected behavior introduced through the `::new (some_char_ptr)` overload, like #112033.

Instead of a `char *`, I'm using the 'function tag' paradigm, which allows calling our function in a more appropriate manner through `new (DefaultAllocator())`. I expect the allocator, being empty, to be optimized away as the function is inlined (though even if it isn't, this should generally perform better than before, because the allocator would be one byte instead of a full `size_t`).
In addition, inlining the `new` operator should save an indirection / a call since it is known that `alloc_static` is called.

I'm also taking the opportunity to remove the unused `new` overload, and refresh the outdated comments.