### PR TITLE
Use `AHashMap` in `GDScript::member_indices`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1553,7 +1553,7 @@ GDScript::~GDScript() {
 
 bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 	{
-		HashMap<StringName, GDScript::MemberInfo>::Iterator E = script->member_indices.find(p_name);
+		AHashMap<StringName, GDScript::MemberInfo>::Iterator E = script->member_indices.find(p_name);
 		if (E) {
 			const GDScript::MemberInfo *member = &E->value;
 			Variant value = p_value;
@@ -1626,7 +1626,7 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 
 bool GDScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 	{
-		HashMap<StringName, GDScript::MemberInfo>::ConstIterator E = script->member_indices.find(p_name);
+		AHashMap<StringName, GDScript::MemberInfo>::ConstIterator E = script->member_indices.find(p_name);
 		if (E) {
 			if (likely(script->valid) && E->value.getter) {
 				Callable::CallError err;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -84,7 +84,7 @@ class GDScript : public Script {
 	GDScript *_owner = nullptr; //for subclasses
 
 	// Members are just indices to the instantiated script.
-	HashMap<StringName, MemberInfo> member_indices; // Includes member info of all base GDScript classes.
+	AHashMap<StringName, MemberInfo> member_indices; // Includes member info of all base GDScript classes.
 	HashSet<StringName> members; // Only members of the current class.
 
 	// Only static variables of the current class.
@@ -261,7 +261,7 @@ public:
 	bool is_abstract() const override { return _is_abstract; }
 	Ref<GDScript> get_base() const;
 
-	const HashMap<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }
+	const AHashMap<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }
 	const HashMap<StringName, GDScriptFunction *> &debug_get_member_functions() const; //this is debug only
 	StringName debug_get_member_by_index(int p_idx) const;
 	StringName debug_get_static_var_by_index(int p_idx) const;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -799,7 +799,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			if (subscript->is_attribute) {
 				if (subscript->base->type == GDScriptParser::Node::SELF && codegen.script) {
 					GDScriptParser::IdentifierNode *identifier = subscript->attribute;
-					HashMap<StringName, GDScript::MemberInfo>::Iterator MI = codegen.script->member_indices.find(identifier->name);
+					AHashMap<StringName, GDScript::MemberInfo>::Iterator MI = codegen.script->member_indices.find(identifier->name);
 
 #ifdef DEBUG_ENABLED
 					if (MI && MI->value.getter == codegen.function_name) {
@@ -990,7 +990,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				const GDScriptParser::SubscriptNode *subscript = static_cast<GDScriptParser::SubscriptNode *>(assignment->assignee);
 #ifdef DEBUG_ENABLED
 				if (subscript->is_attribute && subscript->base->type == GDScriptParser::Node::SELF && codegen.script) {
-					HashMap<StringName, GDScript::MemberInfo>::Iterator MI = codegen.script->member_indices.find(subscript->attribute->name);
+					AHashMap<StringName, GDScript::MemberInfo>::Iterator MI = codegen.script->member_indices.find(subscript->attribute->name);
 					if (MI && MI->value.setter == codegen.function_name) {
 						String n = subscript->attribute->name;
 						_set_error("Must use '" + n + "' instead of 'self." + n + "' in setter.", subscript);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -379,7 +379,7 @@ void GDScriptLanguage::debug_get_stack_level_members(int p_level, List<String> *
 	Ref<GDScript> scr = instance->get_script();
 	ERR_FAIL_COND(scr.is_null());
 
-	const HashMap<StringName, GDScript::MemberInfo> &mi = scr->debug_get_member_indices();
+	const AHashMap<StringName, GDScript::MemberInfo> &mi = scr->debug_get_member_indices();
 
 	for (const KeyValue<StringName, GDScript::MemberInfo> &E : mi) {
 		p_members->push_back(E.key);


### PR DESCRIPTION
Modifies `GDScript`'s `member_indices` to use `AHashMap` instead of `HashMap`. 

I did try to replace other `HashMap`s, but other than these they all resulted in worse FPS.

> A previous version of this PR also modified `static_variables_indices`, but for the benchmark below it seems to bottleneck the case, so I kept it only on `member_indices`.

All I did was drop-in replace the hash map type, so this PR should remain harmless as it doesn't use `getptr` or `erase`.

Test project: [bunnymark_custom.tar.gz](https://github.com/user-attachments/files/30023157/bunnymark_custom.tar.gz), with 10000 bunnies.

| Run | `master` | PR |
|-|-|-|
| 1 | 163.53 | 178.87 |
| 2 | 162.93 | 178.40 |
| 3 | 162.60 | 180.20 |