### PR TITLE
Fix the material preview sphere model

### DIFF
--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -393,7 +393,7 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 
 	int lats = 32;
 	int lons = 32;
-	const double lat_step = Math::TAU / lats;
+	const double lat_step = Math::PI / lats;
 	const double lon_step = Math::TAU / lons;
 	real_t radius = 1.0;
 
@@ -428,22 +428,27 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 				Vector3(x0 * zr0, z0, y0 * zr0)
 			};
 
-#define ADD_POINT(m_idx)                                                                       \
-	normals.push_back(v[m_idx]);                                                               \
-	vertices.push_back(v[m_idx] * radius);                                                     \
-	{                                                                                          \
-		Vector2 uv(Math::atan2(v[m_idx].x, v[m_idx].z), Math::atan2(-v[m_idx].y, v[m_idx].z)); \
-		uv /= Math::PI;                                                                        \
-		uv *= 4.0;                                                                             \
-		uv = uv * 0.5 + Vector2(0.5, 0.5);                                                     \
-		uvs.push_back(uv);                                                                     \
-	}                                                                                          \
-	{                                                                                          \
-		Vector3 t = tt.xform(v[m_idx]);                                                        \
-		tangents.push_back(t.x);                                                               \
-		tangents.push_back(t.y);                                                               \
-		tangents.push_back(t.z);                                                               \
-		tangents.push_back(1.0);                                                               \
+#define ADD_POINT(m_idx)                                                                               \
+	normals.push_back(v[m_idx]);                                                                       \
+	vertices.push_back(v[m_idx] * radius);                                                             \
+	{                                                                                                  \
+		Vector2 uv;                                                                                    \
+		if (j >= lons / 2) {                                                                           \
+			uv = Vector2(Math::atan2(-v[m_idx].x, -v[m_idx].z), Math::atan2(v[m_idx].y, -v[m_idx].z)); \
+		} else {                                                                                       \
+			uv = Vector2(Math::atan2(v[m_idx].x, v[m_idx].z), Math::atan2(-v[m_idx].y, v[m_idx].z));   \
+		}                                                                                              \
+		uv /= Math::PI;                                                                                \
+		uv *= 4.0;                                                                                     \
+		uv = uv * 0.5 + Vector2(0.5, 0.5);                                                             \
+		uvs.push_back(uv);                                                                             \
+	}                                                                                                  \
+	{                                                                                                  \
+		Vector3 t = tt.xform(v[m_idx]);                                                                \
+		tangents.push_back(t.x);                                                                       \
+		tangents.push_back(t.y);                                                                       \
+		tangents.push_back(t.z);                                                                       \
+		tangents.push_back(1.0);                                                                       \
 	}
 
 			ADD_POINT(0);


### PR DESCRIPTION
Related to #109332

The material preview sphere's mesh used to have two sets of faces, one for the exterior and one for the interior, which caused Z-fighting on materials with culling set to disabled.
The UVs on the backside of the mesh are now also generated based on inverted vertex positions, which makes the material look correct with the cull mode set to front.

The thumbnail for a material with culling disabled:

|Before|After|
|-------|------|
| <img width="102" height="82" alt="before" src="https://github.com/user-attachments/assets/60e6443d-bab8-4c8d-804c-b49627dfd323" /> | <img width="126" height="88" alt="after" src="https://github.com/user-attachments/assets/ac2c0fd1-b40a-43b7-9de5-b7c3e54373f0" />|