### PR TITLE
Separate branching ping-pong time and delta

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -268,11 +268,14 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 		AnimationMixer::PlaybackInfo pi = p_playback_info;
 		pi.start = 0.0;
 		pi.end = cur_len;
-		if (node_backward ? cur_backward : !cur_backward) {
+		if (play_mode == PLAY_MODE_FORWARD) {
 			pi.time = cur_playback_time;
-			pi.delta = cur_delta;
 		} else {
 			pi.time = anim_size - cur_playback_time;
+		}
+		if (node_backward ? cur_backward : !cur_backward) {
+			pi.delta = cur_delta;
+		} else {
 			pi.delta = -cur_delta;
 		}
 		pi.weight = 1.0;


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/110982
- Fixes https://github.com/godotengine/godot/issues/111719
- Fixes https://github.com/godotengine/godot/issues/111737
- Supersedes/closes https://github.com/godotengine/godot/pull/111953

The fix https://github.com/godotengine/godot/pull/110982 should be applied only for delta, not time position.