### PR TITLE
Fix TileMapLayer over-generalizing constraints causing problems #112025

### DIFF
--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -90,6 +90,11 @@ public:
 		return priority;
 	}
 
+	constexpr static int NO_TERRAIN = -1;
+	constexpr static int NON_PAINT_TERRAIN = -2;
+	constexpr static int CONNECTING_SIDE = -3;
+	constexpr static int DISCONNECTING_SIDE = -4;
+
 	TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, int p_terrain); // For the center terrain bit
 	TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit, int p_terrain); // For peering bits
 	TerrainConstraint() {}


### PR DESCRIPTION
Fixes #112025

The `TileMapLayer` constraint system was over-generalizing, forcing corners to apply terrain to un-intended cells.

It will now flag corners and edges as non-painting, causing the logic to obtain the correct terrain for the cell **opposite** the constraining edge/corner (rather than assuming the value of the corner/edge applies to all concerned cells).

> The peering bits determine which tile will be placed depending on neighboring tiles.
[docs](https://docs.godotengine.org/en/stable/tutorials/2d/using_tilesets.html#doc-using-tilesets-creating-terrain-sets)

This was causing problems anytime multiple Terrains were used.

(I haven't checked if this solves any other issues, will search tomorrow)