### PR TITLE
Fix un-init base path when switch AnimationNode in BlendSpace2D

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -383,6 +383,13 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(const AnimationM
 					na_n->process_state = process_state;
 					na_c->process_state = process_state;
 
+					if (na_n->node_state.get_base_path() == String()) {
+						// Create the base path before setting parameters during the first switch
+						StringName subpath = blend_points[new_closest].name;
+						String new_path = String(node_state.get_base_path()) + String(subpath) + "/";
+						na_n->set_node_state_base_path(new_path);
+					}
+
 					na_n->set_backward(na_c->is_backward());
 
 					na_n = nullptr;

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -557,6 +557,13 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(const AnimationM
 					na_n->process_state = process_state;
 					na_c->process_state = process_state;
 
+					if (na_n->node_state.get_base_path() == String()) {
+						// Create the base path before setting parameters during the first switch
+						StringName subpath = blend_points[new_closest].name;
+						String new_path = String(node_state.get_base_path()) + String(subpath) + "/";
+						na_n->set_node_state_base_path(new_path);
+					}
+
 					na_n->set_backward(na_c->is_backward());
 
 					na_n = nullptr;


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/112053*
- *Related: https://github.com/godotengine/godot/pull/104018*
- *Related: https://github.com/godotengine/godot/issues/111893*
- Forum: https://forum.godotengine.org/t/possible-permanence-of-issue-104018/106174 

## Issue Description

When we move position in `BlenderSpace2D` with `capture`, it will try to copy `backward` property from `current_animation` to `new_animation` when switch animation.

```
E 0:00:04:817   set_parameter: Condition "!process_state->tree->property_parent_map.has(node_state.base_path)" is true.
  <Origem C++>  scene/animation/animation_tree.cpp:84 @ set_parameter()
```

That caused by `new_animation` hasnot init `base_path`.

## Solution

This patch inited `base_path` for `new_animation`.