### PR TITLE
Fix incorrect reference to _spawn_custom callback in error message

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -238,7 +238,7 @@ Error SceneReplicationInterface::on_replication_start(Object *p_obj, Variant p_c
 
 	if (pending_spawn == p_obj->get_instance_id() && sync->get_multiplayer_authority() == pending_spawn_remote) {
 		// Try to apply synchronizer Net ID
-		ERR_FAIL_COND_V_MSG(pending_sync_net_ids.is_empty(), ERR_INVALID_DATA, vformat("The MultiplayerSynchronizer at path \"%s\" is unable to process the pending spawn since it has no network ID. This might happen when changing the multiplayer authority during the \"_ready\" callback. Make sure to only change the authority of multiplayer synchronizers during \"_enter_tree\" or the \"_spawn_custom\" callback of their multiplayer spawner.", sync->get_path()));
+		ERR_FAIL_COND_V_MSG(pending_sync_net_ids.is_empty(), ERR_INVALID_DATA, vformat("The MultiplayerSynchronizer at path \"%s\" is unable to process the pending spawn since it has no network ID. This might happen when changing the multiplayer authority during the \"_ready\" callback. Make sure to only change the authority of multiplayer synchronizers during \"_enter_tree\" or the \"spawn_function\" callback of their multiplayer spawner.", sync->get_path()));
 		ERR_FAIL_COND_V(!peers_info.has(pending_spawn_remote), ERR_INVALID_DATA);
 		uint32_t net_id = pending_sync_net_ids.front()->get();
 		pending_sync_net_ids.pop_front();


### PR DESCRIPTION
Fixes #111769

Changes `_spawn_custom` to `spawn_function` in error message for MultiplayerSynchronizer.
The correct property name is `spawn_function` as defined in MultiplayerSpawner.

This fixes an incorrect reference in the error message where it was referencing a non-existent callback name.