### PR TITLE
Rework scene preview thumbnails - take 2

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -491,6 +491,7 @@
 			<param index="1" name="with_preview" type="bool" default="true" />
 			<description>
 				Saves the currently active scene as a file at [param path].
+				[b]Note:[/b] The [param with_preview] parameter has no effect.
 			</description>
 		</method>
 		<method name="select_file">

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -296,6 +296,12 @@
 		<member name="docks/filesystem/textfile_extensions" type="String" setter="" getter="">
 			A comma separated list of file extensions to consider as editable text files in the FileSystem dock (by double-clicking on the files), e.g. [code]"txt,md,cfg,ini,log,json,yml,yaml,toml,xml"[/code].
 		</member>
+		<member name="docks/filesystem/thumbnail_file_size_threshold" type="int" setter="" getter="">
+			If the total file size of all resources used by any given scene exceeds this value (in mibibytes), the editor will not generate a thumbnail for that scene. Generally, a higher value will allow bigger scenes to generate thumbnails in the background, at the cost of more noticeable stutters.
+		</member>
+		<member name="docks/filesystem/thumbnail_resource_count_threshold" type="int" setter="" getter="">
+			If the dependency count of a scene exceeds this value, the editor will not generate a thumbnail for that scene. This check runs before checking on [code]thumbnail_file_size_threshold[/code].
+		</member>
 		<member name="docks/filesystem/thumbnail_size" type="int" setter="" getter="">
 			The thumbnail size to use in the FileSystem dock (in pixels). See also [member filesystem/file_dialog/thumbnail_size].
 		</member>

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -913,6 +913,10 @@ void FileSystemDock::_tree_thumbnail_done(const String &p_path, const Ref<Textur
 	if (item && tree_update_id == p_update_id && p_small_preview.is_valid()) {
 		item->set_icon(0, _apply_thumbnail_filter(p_small_preview, p_path));
 	}
+	if (file_list_vb->is_visible() && file_list_display_mode == FILE_LIST_DISPLAY_THUMBNAILS) {
+		// So we can see thumbnail creation in real-time, it'll eventually use the cached thumbnail, no worries.
+		_update_file_list(true);
+	}
 }
 
 Ref<Texture2D> FileSystemDock::_apply_thumbnail_filter(const Ref<Texture2D> &p_thumbnail, const String &p_file_path) const {

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -252,75 +252,75 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 		return;
 	}
 	ERR_FAIL_COND_MSG(p_path.is_empty(), "Path is empty, cannot generate preview.");
-	ERR_FAIL_NULL_MSG(p_scene, "The provided scene is null, cannot generate preview.");
+	ERR_FAIL_NULL_MSG(p_scene, "The provided scene is null.");
 	ERR_FAIL_COND_MSG(p_scene->is_inside_tree(), "The scene must not be inside the tree.");
 	ERR_FAIL_NULL_MSG(EditorNode::get_singleton(), "EditorNode doesn't exist.");
+	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint(), "This function can only be called from the editor.");
 
 	SubViewport *sub_viewport_node = memnew(SubViewport);
+	EditorNode::get_singleton()->add_child(sub_viewport_node);
 	AABB scene_aabb = AABB(Vector3(-0.001f, -0.001f, -0.001f), Vector3(0.002f, 0.002f, 0.002f));
 	scene_aabb = _calculate_aabb_for_scene(p_scene, scene_aabb);
 
-	sub_viewport_node->set_update_mode(SubViewport::UPDATE_ALWAYS);
+	sub_viewport_node->set_update_mode(SubViewport::UPDATE_ONCE);
 	sub_viewport_node->set_size(Vector2i(p_preview_size, p_preview_size));
 	sub_viewport_node->set_transparent_background(false);
-	Ref<World3D> world;
-	world.instantiate();
-	sub_viewport_node->set_world_3d(world);
+	sub_viewport_node->set_use_own_world_3d(true);
 
-	EditorNode::get_singleton()->add_child(sub_viewport_node);
+	// Supersampling x2
+	if (p_preview_size < 2048) { // Universal baseline for textures in Godot 4 is 4K
+		sub_viewport_node->set_scaling_3d_scale(2.0);
+	}
+
+	// MSAA if using forward renderer
+	if (RS::get_singleton()->get_current_rendering_method() != "gl_compatibility") {
+		sub_viewport_node->set_msaa_3d(Viewport::MSAA::MSAA_8X);
+	}
+
 	Ref<Environment> env;
 	env.instantiate();
+	Color default_clear_color = GLOBAL_GET("rendering/environment/defaults/default_clear_color");
 	env->set_background(Environment::BG_CLEAR_COLOR);
-
-	Ref<CameraAttributesPractical> camera_attributes;
-	camera_attributes.instantiate();
+	env->set_bg_color(default_clear_color);
 
 	Node3D *root = memnew(Node3D);
-	root->set_name("Root");
 	sub_viewport_node->add_child(root);
+	root->add_child(p_scene);
 
 	Camera3D *camera = memnew(Camera3D);
-	camera->set_environment(env);
-	camera->set_attributes(camera_attributes);
-	camera->set_name("Camera3D");
 	root->add_child(camera);
+	camera->set_environment(env);
 	camera->set_current(true);
 
-	camera->set_position(Vector3(0.0, 0.0, 3.0));
+	DirectionalLight3D *light_1 = memnew(DirectionalLight3D);
+	DirectionalLight3D *light_2 = memnew(DirectionalLight3D);
+	root->add_child(light_1);
+	root->add_child(light_2);
 
-	DirectionalLight3D *light = memnew(DirectionalLight3D);
-	light->set_name("Light");
-	DirectionalLight3D *light2 = memnew(DirectionalLight3D);
-	light2->set_name("Light2");
-	light2->set_color(Color(0.7, 0.7, 0.7, 1.0));
+	// Setup preview camera
+	float bound_sphere_radius = (scene_aabb.get_end() - scene_aabb.get_position()).length() / 2.0;
+	if (bound_sphere_radius <= 0.0) {
+		// The scene has no volume, define a minimal size instead.
+		bound_sphere_radius = 1.0;
+	}
 
-	root->add_child(light);
-	root->add_child(light2);
+	const float cam_fov = 30.0;
+	const float cam_distance = bound_sphere_radius / Math::tan(Math::deg_to_rad(cam_fov) / 2.0);
+	const float cam_near = cam_distance * 0.01;
+	const float cam_far = cam_distance * 2.0;
 
-	sub_viewport_node->add_child(p_scene);
+	camera->set_perspective(cam_fov, cam_near, cam_far);
 
-	// Calculate the camera and lighting position based on the size of the scene.
-	Vector3 center = scene_aabb.get_center();
-	float camera_size = scene_aabb.get_longest_axis_size();
+	Transform3D cam_t3d;
+	cam_t3d.set_origin(scene_aabb.get_center() + Vector3(1.0f, 0.25f, 1.0f).normalized() * cam_distance);
+	cam_t3d.set_look_at(cam_t3d.origin, scene_aabb.get_center());
+	camera->set_transform(cam_t3d);
 
-	const float cam_rot_x = -Math::PI / 4;
-	const float cam_rot_y = -Math::PI / 4;
-
-	camera->set_orthogonal(camera_size * 2.0, 0.0001, camera_size * 2.0);
-
-	Transform3D xf;
-	xf.basis = Basis(Vector3(0, 1, 0), cam_rot_y) * Basis(Vector3(1, 0, 0), cam_rot_x);
-	xf.origin = center;
-	xf.translate_local(0, 0, camera_size);
-
-	camera->set_transform(xf);
-
-	Transform3D xform;
-	xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math::PI / 6);
-	xform.basis = Basis().rotated(Vector3(1, 0, 0), Math::PI / 6) * xform.basis;
-
-	light->set_transform(xform * Transform3D().looking_at(Vector3(-2, -1, -1), Vector3(0, 1, 0)));
-	light2->set_transform(xform * Transform3D().looking_at(Vector3(+1, -1, -2), Vector3(0, 1, 0)));
+	// Setup preview lighting
+	light_1->set_color(Color(1.0, 1.0, 1.0, 1.0));
+	light_2->set_color(Color(0.7, 0.7, 0.7, 1.0));
+	light_1->set_transform(Transform3D(Basis().rotated(Vector3(0, 1, 0), -Math::PI / 6), Vector3(0.0, 0.0, 0.0)));
+	light_2->set_transform(Transform3D(Basis().rotated(Vector3(1, 0, 0), -Math::PI / 6), Vector3(0.0, 0.0, 0.0)));
 
 	// Update the renderer to get the screenshot.
 	DisplayServer::get_singleton()->process_events();
@@ -329,53 +329,31 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 
 	// Get the texture.
 	Ref<Texture2D> texture = sub_viewport_node->get_texture();
-	ERR_FAIL_COND_MSG(texture.is_null(), "Failed to get texture from sub_viewport_node.");
 
-	// Remove the initial scene node.
-	sub_viewport_node->remove_child(p_scene);
-
-	// Cleanup the viewport.
-	if (sub_viewport_node) {
-		if (sub_viewport_node->get_parent()) {
-			sub_viewport_node->get_parent()->remove_child(sub_viewport_node);
-		}
+	if (texture.is_null()) {
+		ERR_PRINT(vformat(R"(Failed to create preview for "%s", preview SubViewport texture is invalid.)", p_path));
 		sub_viewport_node->queue_free();
-		sub_viewport_node = nullptr;
+		return;
 	}
 
-	// Now generate the cache image.
+	// Retrieve and save preview image
 	Ref<Image> img = texture->get_image();
 	if (img.is_valid() && img->get_width() > 0 && img->get_height() > 0) {
 		img = img->duplicate();
-
-		int preview_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
-		preview_size *= EDSCALE;
-
-		int vp_size = MIN(img->get_width(), img->get_height());
-		int x = (img->get_width() - vp_size) / 2;
-		int y = (img->get_height() - vp_size) / 2;
-
-		if (vp_size < preview_size) {
-			img->crop_from_point(x, y, vp_size, vp_size);
-		} else {
-			int ratio = vp_size / preview_size;
-			int size = preview_size * MAX(1, ratio / 2);
-
-			x = (img->get_width() - size) / 2;
-			y = (img->get_height() - size) / 2;
-
-			img->crop_from_point(x, y, size, size);
-			img->resize(preview_size, preview_size, Image::INTERPOLATE_LANCZOS);
-		}
-		img->convert(Image::FORMAT_RGB8);
+		img->convert(Image::FORMAT_RGBA8);
 
 		String temp_path = EditorPaths::get_singleton()->get_cache_dir();
 		String cache_base = ProjectSettings::get_singleton()->globalize_path(p_path).md5_text();
 		cache_base = temp_path.path_join("resthumb-" + cache_base);
 
 		post_process_preview(img);
-		img->save_png(cache_base + ".png");
+
+		// Save as fallback thumbnail (PR-112060)
+		img->save_png(cache_base + ".fallback.png");
 	}
+
+	// Cleanup the viewport.
+	sub_viewport_node->queue_free();
 
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_path);
 	EditorFileSystem::get_singleton()->filesystem_changed();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2279,7 +2279,7 @@ void EditorNode::_save_edited_subresources(Node *scene, HashMap<Ref<Resource>, b
 	}
 }
 
-void EditorNode::_find_node_types(Node *p_node, int &count_2d, int &count_3d) {
+void EditorNode::_count_node_types(Node *p_node, int &count_2d, int &count_3d) {
 	if (p_node->is_class("Viewport") || (p_node != editor_data.get_edited_scene_root() && p_node->get_owner() != editor_data.get_edited_scene_root())) {
 		return;
 	}
@@ -2291,7 +2291,18 @@ void EditorNode::_find_node_types(Node *p_node, int &count_2d, int &count_3d) {
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
-		_find_node_types(p_node->get_child(i), count_2d, count_3d);
+		_count_node_types(p_node->get_child(i), count_2d, count_3d);
+	}
+}
+
+void EditorNode::_calculate_aabb_merged(Node *p_node, AABB &r_aabb) {
+	if (p_node->is_class("VisualInstance3D")) {
+		VisualInstance3D *v3d = Object::cast_to<VisualInstance3D>(p_node);
+		AABB node_aabb = v3d->get_global_transform().xform(v3d->get_aabb());
+		r_aabb.merge_with(node_aabb);
+	}
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_calculate_aabb_merged(p_node->get_child(i), r_aabb);
 	}
 }
 
@@ -2304,7 +2315,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 		int c2d = 0;
 		int c3d = 0;
 
-		_find_node_types(editor_data.get_edited_scene_root(), c2d, c3d);
+		_count_node_types(editor_data.get_edited_scene_root(), c2d, c3d);
 
 		save_scene_progress->step(TTR("Creating Thumbnail"), 1);
 		// Current view?
@@ -2327,7 +2338,24 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			// The preview will be generated if no feature profile is set (as the 3D editor is enabled by default).
 			Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
 			if (profile.is_null() || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
+				Camera3D *vpcam = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_camera_3d();
+				Transform3D prev_trans_3d = vpcam->get_transform();
+
+				// Move camera to fit 3d scene
+				AABB scene_aabb = AABB();
+				_calculate_aabb_merged(editor_data.get_edited_scene_root(), scene_aabb);
+				Vector3 scene_center = scene_aabb.get_center();
+				Transform3D thumbnail_cam_trans_3d = Transform3D();
+				float bound_sphere_radius = scene_aabb.get_longest_axis_size() / 2.0f;
+				float cam_distance = (bound_sphere_radius * 2.0f) / Math::tan(vpcam->get_fov() / 2.0f);
+				thumbnail_cam_trans_3d.set_origin(scene_center + Vector3(1.0f, 0.25f, 1.0f).normalized() * cam_distance);
+				thumbnail_cam_trans_3d.set_look_at(thumbnail_cam_trans_3d.origin, scene_center);
+				RenderingServer::get_singleton()->camera_set_transform(vpcam->get_camera(), thumbnail_cam_trans_3d);
+				RenderingServer::get_singleton()->draw(false); // Redraw without glitching the viewport
+
+				// Move back camera after captured image
 				img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_image();
+				RenderingServer::get_singleton()->camera_set_transform(vpcam->get_camera(), prev_trans_3d);
 			}
 		}
 
@@ -2359,19 +2387,17 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			}
 			img->convert(Image::FORMAT_RGB8);
 
-			// Save thumbnail directly, as thumbnailer may not update due to actual scene not changing md5.
+			// Save thumbnail as a fallback image (let EditorPreviewPlugins decide the usage) (PR-112060)
 			String temp_path = EditorPaths::get_singleton()->get_cache_dir();
 			String cache_base = ProjectSettings::get_singleton()->globalize_path(p_file).md5_text();
 			cache_base = temp_path.path_join("resthumb-" + cache_base);
-
-			// Does not have it, try to load a cached thumbnail.
 			post_process_preview(img);
-			img->save_png(cache_base + ".png");
+			img->save_png(cache_base + ".fallback.png");
 		}
 	}
 
 	save_scene_progress->step(TTR("Saving Scene"), 4);
-	_save_scene(p_file, p_idx);
+	_save_scene(p_file, p_idx, false);
 
 	if (!singleton->cmdline_mode) {
 		EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
@@ -2478,7 +2504,7 @@ void EditorNode::_save_scene_silently() {
 	// when Save on Focus Loss kicks in.
 	Node *scene = editor_data.get_edited_scene_root();
 	if (scene && !scene->get_scene_file_path().is_empty() && DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
-		_save_scene(scene->get_scene_file_path());
+		_save_scene(scene->get_scene_file_path(), -1, false);
 		save_editor_layout_delayed();
 	}
 }
@@ -2506,18 +2532,25 @@ static void _reset_animation_mixers(Node *p_node, List<Pair<AnimationMixer *, Re
 	}
 }
 
-void EditorNode::_save_scene(String p_file, int idx) {
+void EditorNode::_save_scene(String p_file, int idx, bool show_progress) {
 	ERR_FAIL_COND_MSG(!saving_scene.is_empty() && saving_scene == p_file, "Scene saved while already being saved!");
 
 	Node *scene = editor_data.get_edited_scene_root(idx);
 
+	if (show_progress) {
+		save_scene_progress = memnew(EditorProgress("save", TTR("Saving Scene"), 3));
+		save_scene_progress->step(TTR("Analyzing"), 0);
+	}
+
 	if (!scene) {
 		show_warning(TTR("This operation can't be done without a tree root."));
+		_close_save_scene_progress();
 		return;
 	}
 
 	if (!scene->get_scene_file_path().is_empty() && _validate_scene_recursive(scene->get_scene_file_path(), scene)) {
 		show_warning(TTR("This scene can't be saved because there is a cyclic instance inclusion.\nPlease resolve it and then attempt to save again."));
+		_close_save_scene_progress();
 		return;
 	}
 
@@ -2528,6 +2561,10 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	List<Pair<AnimationMixer *, Ref<AnimatedValuesBackup>>> anim_backups;
 	_reset_animation_mixers(scene, &anim_backups);
 	_save_editor_states(p_file, idx);
+
+	if (show_progress) {
+		save_scene_progress->step(TTR("Packing Scene"), 1);
+	}
 
 	Ref<PackedScene> sdata;
 
@@ -2549,7 +2586,14 @@ void EditorNode::_save_scene(String p_file, int idx) {
 
 	if (err != OK) {
 		show_warning(TTR("Couldn't save scene. Likely dependencies (instances or inheritance) couldn't be satisfied."));
+		if (show_progress) {
+			_close_save_scene_progress();
+		}
 		return;
+	}
+
+	if (show_progress) {
+		save_scene_progress->step(TTR("Saving Scene"), 2);
 	}
 
 	int flg = 0;
@@ -2563,6 +2607,10 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	// This needs to be emitted before saving external resources.
 	emit_signal(SNAME("scene_saved"), p_file);
 	editor_data.notify_scene_saved(p_file);
+
+	if (show_progress) {
+		save_scene_progress->step(TTR("Saving External Resources"), 3);
+	}
 
 	_save_external_resources();
 	saving_scene = p_file; // Some editors may save scenes of built-in resources as external data, so avoid saving this scene again.
@@ -2600,6 +2648,9 @@ void EditorNode::_save_scene(String p_file, int idx) {
 
 	scene->propagate_notification(NOTIFICATION_EDITOR_POST_SAVE);
 	_update_unsaved_cache();
+	if (show_progress) {
+		_close_save_scene_progress();
+	}
 }
 
 void EditorNode::save_all_scenes() {
@@ -8543,7 +8594,7 @@ EditorNode::EditorNode() {
 	ResourceLoader::set_dependency_error_notify_func(&EditorNode::_dependency_error_report);
 
 	SceneState::set_instantiation_warning_notify_func([](const String &p_warning) {
-		add_io_warning(p_warning);
+		callable_mp_static(EditorNode::add_io_warning).call_deferred(p_warning);
 		callable_mp(EditorInterface::get_singleton(), &EditorInterface::mark_scene_as_unsaved).call_deferred();
 	});
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -590,7 +590,7 @@ private:
 	void _set_current_scene_nocheck(int p_idx, bool p_ignore_state = false);
 	void _nav_to_selected_scene();
 	bool _validate_scene_recursive(const String &p_filename, Node *p_node);
-	void _save_scene(String p_file, int idx = -1);
+	void _save_scene(String p_file, int idx = -1, bool show_progress = true);
 	void _save_all_scenes();
 	int _next_unsaved_scene(bool p_valid_filename, int p_start = 0);
 	void _discard_changes(const String &p_str = String());
@@ -643,7 +643,8 @@ private:
 	void _save_edited_subresources(Node *scene, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
 	void _mark_unsaved_scenes();
 
-	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);
+	void _count_node_types(Node *p_node, int &count_2d, int &count_3d);
+	void _calculate_aabb_merged(Node *p_node, AABB &r_aabb);
 	void _save_scene_with_preview(String p_file, int p_idx = -1);
 	void _close_save_scene_progress();
 
@@ -981,11 +982,8 @@ public:
 	Control *get_gui_base() { return gui_base; }
 
 	void save_scene_to_path(String p_file, bool p_with_preview = true) {
-		if (p_with_preview) {
-			_save_scene_with_preview(p_file);
-		} else {
-			_save_scene(p_file);
-		}
+		// p_with_preview has no effect, now generates preview at EditorPackedScenePreviewPlugin
+		_save_scene(p_file);
 	}
 
 	bool close_scene();

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -30,6 +30,7 @@
 
 #include "resource_importer_scene.h"
 
+#include "core/config/engine.h"
 #include "core/error/error_macros.h"
 #include "core/io/dir_access.h"
 #include "core/io/resource_loader.h"
@@ -3107,6 +3108,17 @@ void ResourceImporterScene::_optimize_track_usage(AnimationPlayer *p_player, Ani
 	}
 }
 
+void ResourceImporterScene::_generate_editor_preview_for_scene(const String &p_path, Node *p_scene) {
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+	ERR_FAIL_COND_MSG(p_path.is_empty(), "Path is empty, cannot generate preview.");
+	ERR_FAIL_NULL_MSG(p_scene, "Scene is null, cannot generate preview.");
+
+	int thumbnail_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
+	EditorInterface::get_singleton()->make_scene_preview(p_path, p_scene, thumbnail_size);
+}
+
 Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashMap<StringName, Variant> &p_options) {
 	Ref<EditorSceneFormatImporter> importer;
 	String ext = p_source_file.get_extension().to_lower();
@@ -3496,12 +3508,11 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		print_verbose("Saving scene to: " + p_save_path + ".scn");
 		err = ResourceSaver::save(packer, p_save_path + ".scn", flags); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
-		EditorInterface::get_singleton()->make_scene_preview(p_source_file, scene, 1024);
+		_generate_editor_preview_for_scene(p_source_file, scene);
 	} else if (_scene_import_type == "ArrayMesh") {
 		_save_scene_as_single_mesh(p_source_file, p_save_path, scene, p_options, flags);
 	} else if (_scene_import_type == "MeshLibrary") {
 		_save_scene_as_mesh_library(p_source_file, p_save_path, scene, p_options, flags);
-	} else {
 		ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "Unknown scene import type: " + _scene_import_type);
 	}
 

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -230,6 +230,7 @@ class ResourceImporterScene : public ResourceImporter {
 	};
 
 	void _optimize_track_usage(AnimationPlayer *p_player, AnimationImportTracks *p_track_actions);
+	void _generate_editor_preview_for_scene(const String &p_path, Node *p_scene);
 
 	String _scene_import_type = "PackedScene";
 

--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -30,14 +30,37 @@
 
 #include "editor_preview_plugins.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/image.h"
 #include "core/io/resource_loader.h"
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
+#include "core/os/os.h"
+#include "editor/editor_node.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "main/main.h"
+#include "scene/2d/animated_sprite_2d.h"
+#include "scene/2d/camera_2d.h"
+#include "scene/2d/cpu_particles_2d.h"
+#include "scene/2d/gpu_particles_2d.h"
+#include "scene/2d/line_2d.h"
+#include "scene/2d/mesh_instance_2d.h"
+#include "scene/2d/multimesh_instance_2d.h"
+#include "scene/2d/physics/touch_screen_button.h"
+#include "scene/2d/polygon_2d.h"
+#include "scene/2d/sprite_2d.h"
+#include "scene/3d/cpu_particles_3d.h"
+#include "scene/3d/gpu_particles_3d.h"
+#include "scene/3d/light_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/node_3d.h"
+#include "scene/gui/panel.h"
+#include "scene/main/viewport.h"
+#include "scene/main/window.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/audio/audio_stream.h"
 #include "scene/resources/bit_map.h"
@@ -46,8 +69,16 @@
 #include "scene/resources/image_texture.h"
 #include "scene/resources/material.h"
 #include "scene/resources/mesh.h"
+#include "scene/resources/packed_scene.h"
+#include "scene/resources/world_2d.h"
 #include "servers/audio/audio_server.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifdef MODULE_TILEMAP_ENABLED
+#include "modules/tilemap/tile_map_layer.h"
+#endif
+
+Viewport::MSAA supported_msaa_method;
 
 void post_process_preview(Ref<Image> p_image) {
 	if (p_image->get_format() != Image::FORMAT_RGBA8) {
@@ -289,6 +320,13 @@ bool EditorBitmapPreviewPlugin::generate_small_preview_automatically() const {
 
 ///////////////////////////////////////////////////////////////////////////
 
+void EditorPackedScenePreviewPlugin::abort() {
+	draw_requester.abort();
+
+	// Raise abort flag
+	aborted.set();
+}
+
 bool EditorPackedScenePreviewPlugin::handles(const String &p_type) const {
 	return ClassDB::is_parent_class(p_type, "PackedScene");
 }
@@ -298,28 +336,1056 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate(const Ref<Resource> &p_f
 }
 
 Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &p_path, const Size2 &p_size, Dictionary &p_metadata) const {
+	ERR_FAIL_NULL_V_MSG(EditorNode::get_singleton(), Ref<Texture2D>(), "EditorNode doesn't exist.");
+
+	if (!EditorResourcePreview::get_singleton()->is_threaded()) {
+		ERR_PRINT_ONCE("Scene preview can only be generated on a separate thread.");
+		return _get_fallback_thumbnail(p_path);
+	}
+
+	if (aborted.is_set()) {
+		return Ref<Texture2D>();
+	}
+
+	// Fetch cached editor settings
+	editor_settings_mutex.lock();
+	uint64_t file_size_threshold = thumbnail_file_size_threshold;
+	uint64_t resource_count_threshold = thumbnail_resource_count_threshold;
+	editor_settings_mutex.unlock();
+
+	// Use fallback directly if one of the threshold is zero
+	if (file_size_threshold == 0 || resource_count_threshold == 0) {
+		return _get_fallback_thumbnail(p_path);
+	}
+
+	// Get all scene dependencies (recursive)
+	HashSet<String> scene_dependencies = HashSet<String>(100); // Pre-allocate for reasonable sized scene (~100 dependencies)
+	_get_scene_dependencies(p_path, scene_dependencies);
+
+	// If dependency count is high, assume it's a large scene and return
+	if (scene_dependencies.size() > resource_count_threshold) {
+		return _get_fallback_thumbnail(p_path);
+	}
+
+	// Sum depending resource files size
+	uint64_t scene_file_size_total = 0;
+	for (const String &res_path : scene_dependencies) {
+		scene_file_size_total += FileAccess::get_size(res_path);
+
+		// Scene file size too large to handle in background
+		if (scene_file_size_total > file_size_threshold) {
+			return _get_fallback_thumbnail(p_path);
+		}
+
+		if (aborted.is_set()) {
+			print_verbose("Thumbnail creation aborted.");
+			return Ref<Texture2D>();
+		}
+	}
+	scene_dependencies.clear();
+
+	// Load scene
+	Ref<PackedScene> pack = ResourceLoader::load(p_path, "PackedScene", ResourceFormatLoader::CACHE_MODE_IGNORE_DEEP);
+
+	if (pack.is_null()) {
+		ERR_PRINT(vformat(R"(Failed to generate scene thumbnail for "%s": Invalid scene file.)", p_path));
+		return _create_dummy_thumbnail();
+	}
+
+	if (aborted.is_set()) {
+		print_verbose("Thumbnail creation aborted.");
+		return Ref<Texture2D>();
+	}
+
+	// Count node types before instantiating it
+	bool root_is_viewport = ClassDB::is_parent_class(pack->get_state()->get_node_type(0), Viewport::get_class_static());
+	int count_2d = 0;
+	int count_3d = 0;
+	int count_light_3d = 0;
+	_count_node_types(pack, count_2d, count_3d, count_light_3d);
+	node_lookup_tables.clear(); // No longer needed
+
+	if (aborted.is_set()) {
+		print_verbose("Thumbnail creation aborted.");
+		return Ref<Texture2D>();
+	}
+
+	// Prohibit Viewport class as root when generating thumbnails (Causes rendering issues)
+	if (root_is_viewport) {
+		return _create_dummy_thumbnail();
+	}
+
+	if (count_3d > 0) { // Is 3d scene
+		// Call scene instantiation at idle time
+		scene_construct_done.clear();
+		callable_mp((EditorPackedScenePreviewPlugin *)this, &EditorPackedScenePreviewPlugin::_construct_scene_3d).call_deferred(pack, p_size, count_light_3d);
+		// Wait for scene construct
+		while (!scene_construct_done.is_set()) {
+			_wait_frame();
+		}
+
+		if (aborted.is_set() || vp_3d_rid.is_null()) {
+			if (vp_3d_ptr != nullptr) {
+				vp_3d_ptr->queue_free();
+			}
+			print_verbose("Thumbnail creation aborted.");
+			return Ref<Texture2D>();
+		}
+
+		RenderingServer *rs = RS::get_singleton();
+
+		_wait_frame();
+		_wait_frame(); // Wait twice, as the first wait might occur in frame post draw.
+		rs->viewport_set_update_mode(vp_3d_rid, RSE::VIEWPORT_UPDATE_ONCE);
+		_wait_frame(); // HACK - one more frame for CPUParticles to render correctly, don't know why
+
+		if (aborted.is_set()) {
+			if (vp_3d_ptr != nullptr) {
+				vp_3d_ptr->queue_free();
+			}
+			print_verbose("Thumbnail creation aborted.");
+			return Ref<Texture2D>();
+		}
+
+		// Retrieving via RenderingServer as the scene is now inside tree, we can't get texture directly on a thread (will be blocked by thread locks)
+		Ref<Image> capture_img = rs->texture_2d_get(rs->viewport_get_texture(vp_3d_rid));
+
+		// Viewport texture is somehow invalid, abort the process
+		if (capture_img.is_null()) {
+			if (vp_3d_ptr != nullptr) {
+				vp_3d_ptr->queue_free();
+			}
+			WARN_PRINT(vformat(R"(Failed to create thumbnail for scene: "%s".)", p_path));
+			return Ref<Texture2D>();
+		}
+
+		// Retrieve thumbnail
+		post_process_preview(capture_img);
+		Ref<ImageTexture> thumbnail = ImageTexture::create_from_image(capture_img);
+
+		// Clean up
+		if (vp_3d_ptr == nullptr || vp_3d_rid.is_null()) {
+			ERR_PRINT("FIXME: Preview scene is freed unexpectedly before cleanup");
+		} else {
+			vp_3d_ptr->queue_free();
+			vp_3d_rid = RID();
+			vp_3d_ptr = nullptr;
+			print_verbose(vformat(R"(Cleaned up preview scene for: "%s".)", p_path));
+		}
+
+		return thumbnail;
+	}
+
+	if (count_2d > 0) { // Is 2d scene
+		// If anyone want to rewrite this part to call RenderingServer directly, note that at the time of writing (2025-09-24),
+		// there's a limitation where CanvasItem cannot be rendered outside of the tree.
+		// See CanvasItem::queue_redraw() and RenderingServer::draw()
+
+		// Call scene instantiation at idle time
+		scene_construct_done.clear();
+		callable_mp((EditorPackedScenePreviewPlugin *)this, &EditorPackedScenePreviewPlugin::_construct_scene_2d).call_deferred(pack, p_size);
+
+		// Wait for scene construct
+		while (!scene_construct_done.is_set()) {
+			_wait_frame();
+		}
+
+		if (aborted.is_set() || vp_2d_rid.is_null() || vp_gui_rid.is_null()) {
+			if (vp_2d_ptr != nullptr) {
+				vp_2d_ptr->queue_free();
+			}
+			if (vp_gui_ptr != nullptr) {
+				vp_gui_ptr->queue_free();
+			}
+			print_verbose("Thumbnail creation aborted.");
+			return Ref<Texture2D>();
+		}
+
+		_wait_frame();
+		_wait_frame(); // Wait twice, as the first wait might occur in frame post draw.
+
+		if (aborted.is_set()) {
+			if (vp_2d_ptr != nullptr) {
+				vp_2d_ptr->queue_free();
+			}
+			if (vp_gui_ptr != nullptr) {
+				vp_gui_ptr->queue_free();
+			}
+			print_verbose("Thumbnail creation aborted.");
+			return Ref<Texture2D>();
+		}
+
+		// Retrieving via RenderingServer as the scene is now inside tree, we can't get texture directly on a thread (will be blocked by thread locks)
+		RenderingServer *rs = RS::get_singleton();
+		Ref<Image> capture_2d_img = rs->texture_2d_get(rs->viewport_get_texture(vp_2d_rid));
+		Ref<Image> capture_gui_img = rs->texture_2d_get(rs->viewport_get_texture(vp_gui_rid));
+
+		// Viewport texture is somehow invalid, abort the process
+		if (capture_2d_img.is_null() || capture_gui_img.is_null()) {
+			if (vp_2d_ptr != nullptr) {
+				vp_2d_ptr->queue_free();
+			}
+			if (vp_gui_ptr != nullptr) {
+				vp_gui_ptr->queue_free();
+			}
+			WARN_PRINT(vformat(R"(Failed to create thumbnail for scene: "%s".)", p_path));
+			return Ref<Texture2D>();
+		}
+
+		// Retrieve 2D scene capture
+		Ref<ImageTexture> capture_2d = ImageTexture::create_from_image(capture_2d_img);
+		capture_2d->get_image()->resize(p_size.x, p_size.y);
+		capture_2d->get_image()->convert(Image::Format::FORMAT_RGBA8); // ALPHA channel is required for image blending
+
+		// Retrieve GUI capture
+		Ref<ImageTexture> capture_gui = ImageTexture::create_from_image(capture_gui_img);
+		capture_gui->get_image()->resize(p_size.x, p_size.y);
+
+		// Mix 2D, GUI thumbnail images into one
+		Ref<ImageTexture> thumbnail;
+		thumbnail.instantiate();
+		Ref<Image> thumbnail_image = Image::create_empty(p_size.x, p_size.y, false, Image::Format::FORMAT_RGBA8); // blend_rect needs ALPHA channel to work
+		thumbnail_image->blit_rect(capture_2d->get_image(), capture_2d->get_image()->get_used_rect(), Point2i(0, 0));
+		thumbnail_image->blend_rect(capture_gui->get_image(), capture_gui->get_image()->get_used_rect(), Point2i(0, 0));
+		post_process_preview(thumbnail_image);
+		thumbnail->set_image(thumbnail_image);
+
+		// Clean up
+		if (vp_2d_ptr == nullptr || vp_2d_rid.is_null() || vp_gui_ptr == nullptr || vp_gui_rid.is_null()) {
+			ERR_PRINT("FIXME: Preview scene is freed unexpectedly before cleanup");
+		} else {
+			vp_2d_ptr->queue_free();
+			vp_gui_ptr->queue_free();
+			vp_2d_rid = RID();
+			vp_gui_rid = RID();
+			vp_2d_ptr = nullptr;
+			vp_gui_ptr = nullptr;
+			print_verbose(vformat(R"(Cleaned up preview scene for: "%s".)", p_path));
+		}
+
+		return thumbnail;
+	}
+
+	// Is scene without any visuals (No Node2D, Node3D, Control found)
+	return _create_dummy_thumbnail();
+}
+
+void EditorPackedScenePreviewPlugin::_setup_scene_3d(Node *p_node) const {
+	// Do not account any SubViewport at preview scene, as it would not render correctly
+	if (Object::cast_to<SubViewport>(p_node) && p_node->get_parent()) {
+		p_node->get_parent()->remove_child(p_node);
+		p_node->queue_free();
+		return;
+	}
+
+	// Prevent Window nodes from popping up
+	Window *window = Object::cast_to<Window>(p_node);
+	if (window) {
+		window->set_visible(false);
+	}
+
+	// Make sure no Node2D, Control node is visible (Might occupy large proportion of the thumbnail)
+	Node2D *n2d = Object::cast_to<Node2D>(p_node);
+	if (n2d) {
+		n2d->set_visible(false);
+	}
+
+	Control *ctrl = Object::cast_to<Control>(p_node);
+	if (ctrl) {
+		ctrl->set_visible(false);
+	}
+
+	// Disable skinning for skeleton meshes (animations and skeleton scaling might disturb aabb calculation)
+	MeshInstance3D *mesh = Object::cast_to<MeshInstance3D>(p_node);
+	if (mesh && mesh->is_visible_in_tree()) {
+		mesh->set_skeleton_path(NodePath());
+	}
+
+	CPUParticles3D *cpu_particles = Object::cast_to<CPUParticles3D>(p_node);
+	if (cpu_particles && cpu_particles->is_visible_in_tree() && (cpu_particles->is_emitting() || cpu_particles->get_one_shot())) {
+		cpu_particles->set_seed(0);
+		cpu_particles->set_pre_process_time(cpu_particles->get_lifetime() * 0.5);
+		cpu_particles->set_use_local_coordinates(true); // HACK - Now constructs scene outside of tree, using global coords will cause error, might result in visual artifacts, but is the best solution now
+		cpu_particles->set_emitting(true); // For one-shots
+		cpu_particles->restart(true); // Keep seed to make simulation persistent
+	}
+
+	GPUParticles3D *gpu_particles = Object::cast_to<GPUParticles3D>(p_node);
+	if (gpu_particles && gpu_particles->is_visible_in_tree() && (gpu_particles->is_emitting() || gpu_particles->get_one_shot())) {
+		// Convert to CPUParticles (As GPUParticles can't be rendered correctly in thumbnails, don't know why)
+		CPUParticles3D *gtc_particles = memnew(CPUParticles3D); // GPU to CPU particles
+		gtc_particles->convert_from_particles(gpu_particles);
+		gpu_particles->add_child(gtc_particles); // So the created CPUParticles instance will be freed later we call queue_free() on the preview scene
+
+		// Setup the converted CPUParticles
+		gtc_particles->set_seed(0);
+		gtc_particles->set_pre_process_time(gtc_particles->get_lifetime() * 0.5);
+		gtc_particles->set_use_local_coordinates(true);
+		gtc_particles->set_emitting(true);
+		gtc_particles->restart(true);
+	}
+
+	for (Node *child : p_node->iterate_children()) {
+		_setup_scene_3d(child);
+	}
+}
+
+// This should be called at idle time to ensure thread-safe
+void EditorPackedScenePreviewPlugin::_construct_scene_3d(Ref<PackedScene> p_pack, const Size2 &p_size, int p_light_count) const {
+	bool _scene_setup_success = _setup_packed_scene(p_pack);
+	if (!_scene_setup_success) {
+		scene_construct_done.set();
+		ERR_FAIL_MSG(vformat(R"(Failed to generate scene thumbnail for "%s": error in setting up preview scene, thus not safe to create thumbnail image.)", p_pack->get_path()));
+	}
+
+	Node *p_scene = p_pack->instantiate();
+	if (p_scene == nullptr) {
+		scene_construct_done.set();
+		ERR_FAIL_MSG(vformat(R"(Scene "%s" failed to instantiate.)", p_pack->get_path()));
+	}
+
+	SubViewport *sub_viewport = memnew(SubViewport);
+	sub_viewport->set_update_mode(SubViewport::UpdateMode::UPDATE_DISABLED);
+
+	sub_viewport->set_size(p_size.round());
+	sub_viewport->set_transparent_background(false);
+	sub_viewport->set_disable_3d(false);
+
+	if (p_size.x < 2048 && p_size.y < 2048) { // Universal baseline for textures in Godot 4 is 4K
+		sub_viewport->set_scaling_3d_scale(2.0); // Supersampling x2
+	}
+
+	sub_viewport->set_msaa_3d(supported_msaa_method);
+
+	Ref<Environment> environment;
+	Color default_clear_color = GLOBAL_GET("rendering/environment/defaults/default_clear_color");
+	environment.instantiate();
+	environment->set_background(Environment::BGMode::BG_CLEAR_COLOR);
+	environment->set_bg_color(default_clear_color);
+	Ref<World3D> world_3d;
+	sub_viewport->set_world_3d(world_3d);
+	sub_viewport->set_use_own_world_3d(true);
+
+	// Add scene to viewport
+	_setup_scene_3d(p_scene);
+	sub_viewport->add_child(p_scene);
+
+	// Setup preview light
+	DirectionalLight3D *light_1 = nullptr;
+	DirectionalLight3D *light_2 = nullptr;
+
+	if (p_light_count == 0) {
+		light_1 = memnew(DirectionalLight3D);
+		light_2 = memnew(DirectionalLight3D);
+		sub_viewport->add_child(light_1);
+		sub_viewport->add_child(light_2);
+		light_1->set_color(Color(1.0, 1.0, 1.0, 1.0));
+		light_2->set_color(Color(0.7, 0.7, 0.7, 1.0));
+		light_1->set_transform(Transform3D(Basis().rotated(Vector3(0, 1, 0), -Math::PI / 6), Vector3(0.0, 0.0, 0.0)));
+		light_2->set_transform(Transform3D(Basis().rotated(Vector3(1, 0, 0), -Math::PI / 6), Vector3(0.0, 0.0, 0.0)));
+	}
+
+	// Calculate scene AABB
+	AABB scene_aabb;
+	_calculate_scene_aabb(p_scene, scene_aabb);
+	float bound_sphere_radius = (scene_aabb.get_end() - scene_aabb.get_position()).length() / 2.0f;
+	if (bound_sphere_radius <= 0.0f) {
+		// The scene has no volume, define a minimal size instead.
+		bound_sphere_radius = 1.0f;
+	}
+
+	// Setup preview camera
+	const float cam_fov = 30.0;
+	const float cam_distance = bound_sphere_radius / Math::tan(Math::deg_to_rad(cam_fov) / 2.0f);
+	const float cam_near = cam_distance * 0.01;
+	const float cam_far = cam_distance * 2.0;
+
+	Camera3D *camera_3d = memnew(Camera3D);
+	sub_viewport->add_child(camera_3d);
+	camera_3d->set_perspective(cam_fov, cam_near, cam_far);
+
+	Transform3D thumbnail_cam_trans_3d;
+	thumbnail_cam_trans_3d.set_origin(scene_aabb.get_center() + Vector3(1.0f, 0.25f, 1.0f).normalized() * cam_distance);
+	thumbnail_cam_trans_3d.set_look_at(thumbnail_cam_trans_3d.origin, scene_aabb.get_center());
+
+	// // Set camera to orthogonal if distance exceeds camera default far (large scene)
+	//if (thumbnail_cam_trans_3d.origin.length() > camera_3d->get_far()) {
+	//	real_t distance = thumbnail_cam_trans_3d.origin.length();
+	//	camera_3d->set_orthogonal(distance / 2.0, distance / 1000.0, distance); // Approximately contains the whole scene.
+	//}
+
+	camera_3d->set_transform(thumbnail_cam_trans_3d);
+
+	// Attach the preview viewport to MainTree
+	EditorNode::get_singleton()->add_child(sub_viewport);
+	camera_3d->set_current(true);
+	sub_viewport->set_update_mode(SubViewport::UpdateMode::UPDATE_ONCE);
+
+	// Assign GUI viewport
+	vp_3d_rid = sub_viewport->get_viewport_rid();
+	vp_3d_ptr = sub_viewport;
+	scene_construct_done.set();
+}
+
+void EditorPackedScenePreviewPlugin::_calculate_scene_aabb(Node *p_node, AABB &r_aabb) const {
+	GeometryInstance3D *g3d = Object::cast_to<GeometryInstance3D>(p_node);
+	if (g3d && g3d->is_visible_in_tree()) { // Use this because VisualInstance3D may have derived classes that are non-graphical (probes, volumes)
+		AABB node_aabb = _get_global_transform_3d(g3d).xform(g3d->get_aabb());
+		r_aabb.merge_with(node_aabb);
+	}
+
+	CPUParticles3D *cpu_particles = Object::cast_to<CPUParticles3D>(p_node);
+	if (cpu_particles && cpu_particles->is_visible_in_tree() && (cpu_particles->is_emitting() || cpu_particles->get_one_shot())) {
+		// Calculate furthest position where particles can go to use it as bounds
+		Vector3 particle_destination = _get_global_transform_3d(cpu_particles).origin;
+		particle_destination += cpu_particles->get_direction() * cpu_particles->get_param_max(CPUParticles3D::PARAM_INITIAL_LINEAR_VELOCITY);
+		r_aabb.expand_to(particle_destination * 0.5);
+		r_aabb.expand_to(particle_destination * -0.5);
+	}
+
+	GPUParticles3D *gpu_particles = Object::cast_to<GPUParticles3D>(p_node);
+	if (gpu_particles && gpu_particles->is_visible_in_tree() && (gpu_particles->is_emitting() || gpu_particles->get_one_shot())) {
+		r_aabb.merge_with(_get_global_transform_3d(gpu_particles).xform(gpu_particles->get_visibility_aabb()));
+	}
+
+	for (Node *child : p_node->iterate_children()) {
+		_calculate_scene_aabb(child, r_aabb);
+	}
+}
+
+Transform3D EditorPackedScenePreviewPlugin::_get_global_transform_3d(Node3D *p_n3d) const {
+	// Designed to work even if node is outside the tree (is_inside_tree() != true)
+	Transform3D global_transform;
+	Array parents;
+
+	Node *p_loop_node = p_n3d;
+	while (p_loop_node != nullptr) {
+		if (Object::cast_to<Node3D>(p_loop_node)) {
+			parents.append(p_loop_node);
+		}
+		p_loop_node = p_loop_node->get_parent();
+	}
+
+	parents.reverse();
+
+	for (int i = 0; i < parents.size(); i++) {
+		Node3D *p_parent = Object::cast_to<Node3D>(parents[i]);
+		if (i == 0) {
+			global_transform = p_parent->get_transform();
+			continue;
+		}
+		global_transform *= p_parent->get_transform();
+	}
+
+	return global_transform;
+}
+
+void EditorPackedScenePreviewPlugin::_setup_scene_2d(Node *p_node, const bool &p_as_gui) const {
+	// Prevent Window nodes from popping up
+	Window *window = Object::cast_to<Window>(p_node);
+	if (window) {
+		window->set_visible(false);
+	}
+
+	// Below only applies to 2D scene pass (No GUI)
+	if (!p_as_gui) {
+		// Warm up particles
+		CPUParticles2D *cparticles = Object::cast_to<CPUParticles2D>(p_node);
+		if (cparticles && (cparticles->is_emitting() || cparticles->get_one_shot())) {
+			cparticles->set_seed(0);
+			cparticles->set_pre_process_time(cparticles->get_lifetime() * 0.5);
+			cparticles->set_use_local_coordinates(true);
+			cparticles->set_emitting(true); // For one-shots
+			cparticles->restart(true);
+		}
+
+		GPUParticles2D *gparticles = Object::cast_to<GPUParticles2D>(p_node);
+		if (gparticles && (gparticles->is_emitting() || gparticles->get_one_shot())) {
+			gparticles->set_seed(0);
+			gparticles->set_pre_process_time(gparticles->get_lifetime() * 0.5);
+			gparticles->set_use_local_coordinates(true);
+			gparticles->set_emitting(true);
+			gparticles->restart(true);
+		}
+	}
+
+	for (Node *child : p_node->iterate_children()) {
+		_setup_scene_2d(child, p_as_gui);
+	}
+}
+
+// Constructs 2d scene under EditorNode, this should be called at idle time for thread safety
+void EditorPackedScenePreviewPlugin::_construct_scene_2d(Ref<PackedScene> p_pack, const Size2 &p_size) const {
+	bool _scene_setup_success = _setup_packed_scene(p_pack);
+	if (!_scene_setup_success) {
+		scene_construct_done.set();
+		ERR_FAIL_MSG(vformat(R"(Failed to generate scene thumbnail for "%s": error in setting up preview scene, thus not safe to create thumbnail image.)", p_pack->get_path()));
+	}
+
+	Node *preview_scene_2d = p_pack->instantiate();
+	if (preview_scene_2d == nullptr) {
+		scene_construct_done.set();
+		ERR_FAIL_MSG(vformat(R"(Scene "%s" failed to instantiate.)", p_pack->get_path()));
+	}
+
+	int texture_filter = GLOBAL_GET("rendering/textures/canvas_textures/default_texture_filter");
+	int texture_repeat = GLOBAL_GET("rendering/textures/canvas_textures/default_texture_repeat");
+
+	SubViewport *sub_viewport = memnew(SubViewport);
+	sub_viewport->set_update_mode(SubViewport::UpdateMode::UPDATE_DISABLED);
+	sub_viewport->set_disable_3d(true);
+	sub_viewport->set_transparent_background(false);
+	sub_viewport->set_msaa_2d(supported_msaa_method);
+
+	sub_viewport->set_default_canvas_item_texture_filter(Viewport::DefaultCanvasItemTextureFilter(texture_filter));
+	sub_viewport->set_default_canvas_item_texture_repeat(Viewport::DefaultCanvasItemTextureRepeat(texture_repeat));
+	Ref<World2D> world;
+	world.instantiate();
+	sub_viewport->set_world_2d(world);
+	sub_viewport->add_child(preview_scene_2d);
+
+	_setup_scene_2d(preview_scene_2d, false);
+	_hide_gui_in_scene(preview_scene_2d);
+
+	// Preview camera
+	Camera2D *camera = memnew(Camera2D);
+	sub_viewport->add_child(camera);
+	camera->set_enabled(true);
+
+	// Attach subviewport (following process needs scene to be in tree)
+	EditorNode::get_singleton()->add_child(sub_viewport);
+	camera->make_current();
+
+	// Calculate scene rect
+	Rect2 scene_rect;
+	_calculate_scene_rect(preview_scene_2d, scene_rect);
+	Vector2 scene_true_center = scene_rect.get_center();
+
+	// Place camera 2D
+	camera->set_position(Point2(scene_true_center));
+
+	// Set 2D viewport update
+	uint16_t scene_rect_long = MAX(scene_rect.get_size().x, scene_rect.get_size().y);
+	if (scene_rect_long == 0) {
+		scene_rect_long = MAX(p_size.x, p_size.y); // Prevent 0 size rect (which causes error) and defaults to thumbnail size.
+	}
+	sub_viewport->set_size(p_size);
+	camera->set_zoom(Vector2(p_size.x / float(scene_rect_long), p_size.y / float(scene_rect_long)));
+	sub_viewport->set_update_mode(SubViewport::UpdateMode::UPDATE_ONCE);
+
+	// Assign 2D viewport (No GUI)
+	vp_2d_rid = sub_viewport->get_viewport_rid();
+	vp_2d_ptr = sub_viewport;
+
+	// Prepare for gui render
+	Size2i vp_size = Size2i(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+	Node *preview_scene_gui = p_pack->instantiate();
+	_setup_scene_2d(preview_scene_gui, true);
+	_hide_node_2d_in_scene(preview_scene_gui);
+
+	// HACK - Add a panel node that positions at (0,0) and covers the whole viewport, to make anchor system behave normally
+	Panel *dummy_panel = memnew(Panel);
+	dummy_panel->set_size(vp_size);
+	dummy_panel->set_self_modulate(Color(1, 1, 1, 0.01)); // Make it almost invisible (if invisible, anchor will still mess up)
+	preview_scene_gui->add_child(dummy_panel);
+
+	SubViewport *sub_viewport_gui = memnew(SubViewport);
+	sub_viewport_gui->set_size(vp_size);
+	sub_viewport_gui->set_update_mode(SubViewport::UpdateMode::UPDATE_DISABLED);
+	sub_viewport_gui->set_transparent_background(true);
+	sub_viewport_gui->set_msaa_2d(supported_msaa_method);
+	sub_viewport_gui->set_default_canvas_item_texture_filter(Viewport::DefaultCanvasItemTextureFilter(texture_filter));
+	sub_viewport_gui->set_default_canvas_item_texture_repeat(Viewport::DefaultCanvasItemTextureRepeat(texture_repeat));
+	sub_viewport_gui->set_disable_3d(true);
+	sub_viewport_gui->add_child(preview_scene_gui);
+
+	// Set GUI viewport update
+	EditorNode::get_singleton()->add_child(sub_viewport_gui);
+	sub_viewport_gui->set_update_mode(SubViewport::UpdateMode::UPDATE_ONCE);
+
+	// Assign GUI viewport
+	vp_gui_rid = sub_viewport_gui->get_viewport_rid();
+	vp_gui_ptr = sub_viewport_gui;
+	scene_construct_done.set();
+}
+
+void EditorPackedScenePreviewPlugin::_calculate_scene_rect(Node *p_node, Rect2 &r_rect) const {
+	// NOTE: There's no universal way to get the exact global rect as a Node2D, so we dig into subclasses one by one
+
+	// NOTE:
+	// 1. Sprite2D::position by default is at the **center** of the sprite. (with offset == (0,0) AND centered == true)
+	// 2. Rect2::position is at the **up-left** of the rect
+	// 3. AABB::position is at the **bottom-left-forward** of the bounding box
+	//
+	// calculation below is done with these in mind.
+
+	Rect2 n2d_rect; // The rect of the current iterating Node2D
+
+	Sprite2D *sprite = Object::cast_to<Sprite2D>(p_node);
+	if (sprite && sprite->is_visible_in_tree()) {
+		n2d_rect.size = sprite->get_global_scale() * sprite->get_rect().size;
+		n2d_rect.position = sprite->get_global_position() + sprite->get_offset() * sprite->get_global_scale();
+		if (sprite->is_centered()) {
+			n2d_rect.position -= n2d_rect.size / 2.0f;
+		}
+	}
+
+	AnimatedSprite2D *anim_sprite = Object::cast_to<AnimatedSprite2D>(p_node);
+	if (anim_sprite && anim_sprite->is_visible_in_tree()) {
+		if (anim_sprite->get_sprite_frames().is_valid()) {
+			Ref<Texture2D> current_frame_tex = anim_sprite->get_sprite_frames()->get_frame_texture(anim_sprite->get_animation(), anim_sprite->get_frame());
+
+			if (current_frame_tex.is_valid()) {
+				n2d_rect.size = current_frame_tex->get_size() * anim_sprite->get_global_scale();
+				n2d_rect.position = anim_sprite->get_global_position() + anim_sprite->get_offset() * anim_sprite->get_global_scale();
+				if (anim_sprite->is_centered()) {
+					n2d_rect.position -= n2d_rect.size / 2.0f;
+				}
+			}
+		}
+	}
+
+	CPUParticles2D *cparticles = Object::cast_to<CPUParticles2D>(p_node);
+	if (cparticles && cparticles->is_visible_in_tree() && (cparticles->is_emitting() || cparticles->get_one_shot())) {
+		real_t max_travel_dist = cparticles->get_param_max(CPUParticles2D::PARAM_INITIAL_LINEAR_VELOCITY);
+		Size2i texture_size = Size2i(1, 1);
+		if (cparticles->get_texture().is_valid()) {
+			texture_size = cparticles->get_texture()->get_size();
+		}
+		n2d_rect.size = cparticles->get_global_scale() * texture_size + Size2i(max_travel_dist * 0.5, max_travel_dist * 0.5);
+		n2d_rect.position = cparticles->get_global_position() - (n2d_rect.size * 0.5);
+	}
+
+	GPUParticles2D *gparticles = Object::cast_to<GPUParticles2D>(p_node);
+	if (gparticles && gparticles->is_visible_in_tree() && (gparticles->is_emitting() || gparticles->get_one_shot())) {
+		n2d_rect.size = gparticles->get_global_scale() * gparticles->get_visibility_rect().size;
+		n2d_rect.position = gparticles->get_global_position() - (n2d_rect.size * 0.5);
+	}
+
+	MeshInstance2D *mesh2d = Object::cast_to<MeshInstance2D>(p_node);
+	if (mesh2d && mesh2d->is_visible_in_tree()) {
+		// NOTE: Conversion is 1m = 1px (before 2d scale)
+		Ref<Mesh> mesh = mesh2d->get_mesh();
+
+		if (mesh.is_valid()) {
+			// Discard z axis (depth) and only get length of mesh in x,y axis
+			n2d_rect.size.x = (mesh->get_aabb().get_end() - mesh->get_aabb().position).x;
+			n2d_rect.size.y = (mesh->get_aabb().get_end() - mesh->get_aabb().position).y;
+			n2d_rect.size *= mesh2d->get_global_scale();
+
+			// Account for mesh offset in 3d space when calculating rect2
+			n2d_rect.position.x = mesh2d->get_global_position().x + mesh->get_aabb().position.x * mesh2d->get_global_scale().x; // AABB::position is bottom-left
+			n2d_rect.position.y = mesh2d->get_global_position().y + mesh->get_aabb().position.y * mesh2d->get_global_scale().y;
+		}
+	}
+
+	MultiMeshInstance2D *mmesh2d = Object::cast_to<MultiMeshInstance2D>(p_node);
+	if (mmesh2d && mmesh2d->is_visible_in_tree()) {
+		// Basically the same procedure as MeshInstance2D.
+		Ref<MultiMesh> mmesh = mmesh2d->get_multimesh();
+
+		if (mmesh.is_valid()) {
+			n2d_rect.size.x = (mmesh->get_aabb().get_end() - mmesh->get_aabb().position).x;
+			n2d_rect.size.y = (mmesh->get_aabb().get_end() - mmesh->get_aabb().position).y;
+			n2d_rect.size *= mmesh2d->get_global_scale();
+
+			n2d_rect.position.x = mmesh2d->get_global_position().x + mmesh->get_aabb().position.x * mmesh2d->get_global_scale().x;
+			n2d_rect.position.y = mmesh2d->get_global_position().y + mmesh->get_aabb().position.y * mmesh2d->get_global_scale().y;
+		}
+	}
+
+#ifdef MODULE_TILEMAP_ENABLED
+	TileMapLayer *tile_map = Object::cast_to<TileMapLayer>(p_node);
+	if (tile_map && tile_map->is_visible_in_tree()) {
+		// NOTE: TileMapLayer::get_used_rect() only count cells, not their actual pixel size
+
+		if (tile_map->get_tile_set().is_valid()) {
+			Size2 tile_size = tile_map->get_tile_set()->get_tile_size(); // Tile map cell pixel size (x,y).
+			Rect2 tile_rect = tile_map->get_used_rect(); // Unit is in cells, not pixels!
+
+			n2d_rect.position = tile_map->get_global_position() + tile_rect.position * tile_size * tile_map->get_global_scale(); // Accounts tilemap offset
+			n2d_rect.size = tile_rect.size * tile_size * tile_map->get_global_scale();
+		}
+	}
+#endif
+
+	Polygon2D *poly2d = Object::cast_to<Polygon2D>(p_node);
+	if (poly2d && poly2d->is_visible_in_tree()) {
+		PackedVector2Array polygon = poly2d->get_polygon();
+
+		if (polygon.size() > 2) { // Abort if there's no surface (min = 3 verts)
+			// Calculate bounds
+			float max_x = polygon[0].x;
+			float min_x = polygon[0].x;
+			float max_y = polygon[0].y;
+			float min_y = polygon[0].y;
+			for (int i = 0; i < polygon.size(); i++) {
+				if (polygon[i].x > max_x) {
+					max_x = polygon[i].x;
+				}
+				if (polygon[i].x < min_x) {
+					min_x = polygon[i].x;
+				}
+
+				if (polygon[i].y > max_y) {
+					max_y = polygon[i].y;
+				}
+				if (polygon[i].y < min_y) {
+					min_y = polygon[i].y;
+				}
+			}
+
+			Rect2 poly_rect = Rect2(min_x, min_y, max_x - min_x, max_y - min_y);
+
+			n2d_rect.position = poly2d->get_global_position() + poly2d->get_offset() * poly2d->get_global_scale();
+			n2d_rect.position += poly_rect.position * poly2d->get_global_scale();
+			n2d_rect.size = poly_rect.size * poly2d->get_global_scale();
+		}
+	}
+
+	Line2D *line2d = Object::cast_to<Line2D>(p_node);
+	if (line2d && line2d->is_visible_in_tree()) {
+		// The same procedure as Polygon2D
+		PackedVector2Array points = line2d->get_points();
+
+		if (line2d->get_point_count() > 1) { // Abort if there's no line drawn
+			// Calculate bounds
+			float max_x = points[0].x;
+			float min_x = points[0].x;
+			float max_y = points[0].y;
+			float min_y = points[0].y;
+			for (int i = 0; i < points.size(); i++) {
+				if (points[i].x > max_x) {
+					max_x = points[i].x;
+				}
+				if (points[i].x < min_x) {
+					min_x = points[i].x;
+				}
+
+				if (points[i].y > max_y) {
+					max_y = points[i].y;
+				}
+				if (points[i].y < min_y) {
+					min_y = points[i].y;
+				}
+			}
+
+			Rect2 line2d_rect = Rect2(min_x, min_y, max_x - min_x, max_y - min_y);
+
+			n2d_rect.position = line2d->get_global_position();
+			n2d_rect.position += line2d_rect.position * line2d->get_global_scale();
+			n2d_rect.size = line2d_rect.size * line2d->get_global_scale();
+			n2d_rect.size += Size2(line2d->get_width(), line2d->get_width()) / 2.0f; // account for line width
+		}
+	}
+
+	TouchScreenButton *btn = Object::cast_to<TouchScreenButton>(p_node);
+	if (btn && btn->is_visible_in_tree()) {
+		Ref<Texture2D> btn_tex = btn->get_texture_normal();
+
+		if (btn_tex.is_valid()) { // Abort if there's no normal texture for this button (won't display anything)
+			n2d_rect.position = btn->get_global_position(); // It's not possible to offset image in this node
+			n2d_rect.size = btn_tex->get_size() * btn->get_global_scale();
+		}
+	}
+
+	// Merge the calculated node 2d rect
+	if (Math::is_zero_approx(r_rect.get_size().length_squared())) { // Avoid accounting scene origin (0,0) into scene rect.
+		r_rect = n2d_rect.abs();
+	} else {
+		r_rect = r_rect.merge(n2d_rect.abs());
+	}
+
+	for (Node *child : p_node->iterate_children()) {
+		_calculate_scene_rect(child, r_rect);
+	}
+}
+
+void EditorPackedScenePreviewPlugin::_hide_node_2d_in_scene(Node *p_node) const {
+	// NOTE: Irreversible (cannot unhide nodes after this)
+	// We cannot simple hide() since it will affect all its children (may contain Control nodes)
+
+	if (p_node->is_class("Node2D")) {
+		Node2D *n2d = Object::cast_to<Node2D>(p_node);
+		n2d->set_self_modulate(Color(0.0f, 0.0f, 0.0f, 0.0f));
+	}
+
+	for (Node *child : p_node->iterate_children()) {
+		_hide_node_2d_in_scene(child);
+	}
+}
+
+void EditorPackedScenePreviewPlugin::_hide_gui_in_scene(Node *p_node) const {
+	// NOTE: Irreversible (cannot unhide nodes after this)
+	// We cannot simply hide() since it will affect all its children (may contain Node2D nodes)
+
+	if (p_node->is_class("Control")) {
+		Control *ctrl = Object::cast_to<Control>(p_node);
+		ctrl->set_self_modulate(Color(0.0f, 0.0f, 0.0f, 0.0f));
+	}
+
+	for (Node *child : p_node->iterate_children()) {
+		_hide_gui_in_scene(child);
+	}
+}
+
+// HACK - Wait for main process frame
+// Needed for reasons:
+// 1. Scene preview requires waiting for RenderingServer to redraw. (main thread)
+// 2. The first wait might occur after frame post draw, so even when the frame count increments, preview scene viewport might not be updated yet.
+// 3. Because of reason 2. , we need to wait 2 frames for preview to generate correctly
+void EditorPackedScenePreviewPlugin::_wait_frame() const {
+	const uint64_t max_wait_msecs = 3000;
+	const uint64_t prev_msec = OS::get_singleton()->get_ticks_msec();
+	const uint64_t prev_frame = Engine::get_singleton()->get_frames_drawn();
+
+	while (Engine::get_singleton()->get_frames_drawn() - prev_frame < 1) {
+		// So we don't get stuck in here forever if something goes wrong
+		if (OS::get_singleton()->get_ticks_msec() - prev_msec > max_wait_msecs) {
+			break;
+		}
+		if (aborted.is_set()) {
+			break;
+		}
+	}
+}
+
+// Designed to work without instantiating the scene (So we can do this on a thread)
+void EditorPackedScenePreviewPlugin::_count_node_types(Ref<PackedScene> p_pack, int &r_c2d, int &r_c3d, int &r_clight) const {
+	Ref<SceneState> scene_state = p_pack->get_state();
+
+	// Get node lookup table { node_path : node_idx }
+	HashMap<String, int> *map_name_to_idx;
+	if (node_lookup_tables.has(scene_state->get_path())) {
+		// Cache hit
+		map_name_to_idx = &node_lookup_tables[scene_state->get_path()];
+	} else {
+		// Cache miss, create lookup table for scene
+		node_lookup_tables.insert(scene_state->get_path(), HashMap<String, int>(scene_state->get_node_count()));
+		map_name_to_idx = &node_lookup_tables[scene_state->get_path()];
+		for (int i = 0; i < scene_state->get_node_count(); i++) {
+			map_name_to_idx->insert(String(scene_state->get_node_path(i)), i);
+		}
+	}
+
+	// Iterate nodes
+	for (int i = 0; i < scene_state->get_node_count(); i++) {
+		int node_idx = i;
+
+		// Check for node visibility in scene
+		NodePath parent_node_path = scene_state->get_node_path(node_idx);
+		bool self_visible = _scene_get_property_value(scene_state, node_idx, "visible", true);
+		bool parent_visible = true;
+		bool node_under_viewport = false;
+		while (self_visible && parent_node_path.get_name_count() > 1) {
+			parent_node_path = parent_node_path.slice(0, -1); // To next parent
+
+			if (!map_name_to_idx->has(String(parent_node_path))) {
+				continue; // Can happen if Node is under a Editable Children, we keep going until reaches its root
+			}
+			int parent_idx = map_name_to_idx->get(String(parent_node_path));
+			if (!_scene_get_property_value(scene_state, parent_idx, "visible", true)) {
+				parent_visible = false;
+				break;
+			}
+
+			StringName parent_type = scene_state->get_node_type(parent_idx);
+			if (ClassDB::is_parent_class(parent_type, "Viewport")) {
+				node_under_viewport = true;
+				break;
+			}
+		}
+
+		// Don't count if node is not visible
+		if (!self_visible || !parent_visible) {
+			continue;
+		}
+		// Don't count if node is under a Viewport Node
+		if (node_under_viewport) {
+			continue;
+		}
+
+		// Recursive call when node is a scene instance
+		if (scene_state->get_node_instance(node_idx).is_valid()) {
+			_count_node_types(scene_state->get_node_instance(node_idx), r_c2d, r_c3d, r_clight);
+			continue;
+		}
+
+		StringName node_type = scene_state->get_node_type(node_idx);
+
+		if (ClassDB::is_parent_class(node_type, Control::get_class_static())) {
+			r_c2d++;
+		}
+		if (ClassDB::is_parent_class(node_type, Node2D::get_class_static())) {
+			r_c2d++;
+		}
+		if (ClassDB::is_parent_class(node_type, Node3D::get_class_static())) {
+			r_c3d++;
+		}
+		if (ClassDB::is_parent_class(node_type, Light3D::get_class_static())) {
+			r_clight++;
+		}
+	}
+}
+
+// Try get node property in scene state as common Variant, if failed, returns `p_default_value`
+Variant EditorPackedScenePreviewPlugin::_scene_get_property_value(Ref<SceneState> p_state, int &r_node_idx, const StringName &p_property_name, const Variant &p_default_value) const {
+	bool property_found;
+	bool node_deferred;
+	ERR_FAIL_COND_V_MSG(p_property_name == "", p_default_value, "`p_property_name` is not defined, returning default value.");
+
+	if (r_node_idx > p_state->get_node_count() - 1) {
+		ERR_FAIL_V_MSG(p_default_value, vformat("`r_node_idx = %d` is out of bounds (p_state->get_node_count() == %d), returning default value.", r_node_idx, p_state->get_node_count()));
+	}
+
+	Variant value = p_state->get_property_value(r_node_idx, p_property_name, property_found, node_deferred);
+	if (property_found && value.get_type() != Variant::Type::NIL) {
+		return value;
+	}
+	return p_default_value;
+}
+
+// Used for scene file that is valid but not suitable to generate thumbnails (no visuals),
+// providing a dummy thumbnail ensures the file will not be read again until it's changed.
+Ref<ImageTexture> EditorPackedScenePreviewPlugin::_create_dummy_thumbnail() const {
+	Ref<Image> dummy_img = Image::create_empty(2, 2, false, Image::Format::FORMAT_RGBA8);
+	const Color default_clear_color = GLOBAL_GET_CACHED(Color, "rendering/environment/defaults/default_clear_color");
+	dummy_img->fill(default_clear_color);
+	return ImageTexture::create_from_image(dummy_img);
+}
+
+// Try get a fallback thumbnail.
+// Namely from `EditorNode::_save_scene_with_preview` or `EditorInterface::make_scene_preview`
+Ref<ImageTexture> EditorPackedScenePreviewPlugin::_get_fallback_thumbnail(const String &p_path) const {
 	String temp_path = EditorPaths::get_singleton()->get_cache_dir();
 	String cache_base = ProjectSettings::get_singleton()->globalize_path(p_path).md5_text();
 	cache_base = temp_path.path_join("resthumb-" + cache_base);
+	String fallback_thumbnail_path = cache_base + ".fallback.png";
 
-	//does not have it, try to load a cached thumbnail
-
-	String path = cache_base + ".png";
-
-	if (!FileAccess::exists(path)) {
-		return Ref<Texture2D>();
+	// Use fallback image (Created by other thumbnailers)
+	if (FileAccess::exists(fallback_thumbnail_path)) {
+		Ref<Image> img = Image::load_from_file(fallback_thumbnail_path);
+		if (img.is_valid()) {
+			post_process_preview(img);
+			return ImageTexture::create_from_image(img);
+		}
 	}
 
-	Ref<Image> img;
-	img.instantiate();
-	Error err = img->load(path);
-	if (err == OK) {
-		post_process_preview(img);
-		return ImageTexture::create_from_image(img);
+	// No usable image found
+	//
+	// NOTE - Don't use dummy thumbnail here, as we want it to re-visit if fallbacks are available.
+	return Ref<ImageTexture>();
+}
 
+// Get scene dependencies recursively
+void EditorPackedScenePreviewPlugin::_get_scene_dependencies(const String &p_path, HashSet<String> &r_deps) const {
+	// Record file size
+	r_deps.insert(p_path);
+
+	// Is regular resource file
+	if (!p_path.has_extension("tscn") && !p_path.has_extension("scn")) {
+		return;
+	}
+
+	// Is scene file, find resource dependencies
+	List<String> dependencies;
+	ResourceLoader::get_dependencies(p_path, &dependencies);
+
+	for (String &dep : dependencies) {
+		const PackedStringArray uid_res = dep.split("::::"); // uid::::res
+		if (uid_res.size() < 2) {
+			continue;
+		}
+		String child_scene_path = uid_res[1];
+		_get_scene_dependencies(child_scene_path, r_deps);
+	}
+}
+
+// Setup the PackedScene before instantiating it for scene previews
+bool EditorPackedScenePreviewPlugin::_setup_packed_scene(Ref<PackedScene> p_pack) const {
+	// Refer to SceneState in packed_scene.cpp to see how PackedScene is managed underhood.
+
+	// Sanitize
+	Dictionary bundle = p_pack->get_state()->get_bundled_scene();
+	ERR_FAIL_COND_V(!bundle.has("names"), false);
+	ERR_FAIL_COND_V(!bundle.has("variants"), false);
+	ERR_FAIL_COND_V(!bundle.has("node_count"), false);
+	ERR_FAIL_COND_V(!bundle.has("nodes"), false);
+	ERR_FAIL_COND_V(!bundle.has("conn_count"), false);
+	ERR_FAIL_COND_V(!bundle.has("conns"), false);
+
+	const uint8_t supported_version = 3;
+	uint8_t current_version = bundle.get("version", 1);
+
+	if (current_version > supported_version) {
+		WARN_PRINT_ONCE(vformat("Scene thumbnail creation was built on a PackedScene with version %d, but the version has now changed to %d.", supported_version, current_version));
+		// And assume it's safe to continue, there should have no reason to change the main structure of PackedScene
+	}
+
+	// Find and remove variants in scene
+	const Ref<Script> dummy;
+	Array edited_variants = bundle["variants"];
+
+	if (edited_variants.is_empty()) {
+		return true; // Scene has no resources at all
+	}
+
+	for (int i = 0; i < edited_variants.size(); i++) {
+		// Clear script
+		if (edited_variants[i].get_type() == Variant::OBJECT) {
+			if (Object::cast_to<Script>(edited_variants[i])) {
+				edited_variants[i] = dummy;
+			}
+
+			if (Object::cast_to<PackedScene>(edited_variants[i])) {
+				// Recursively apply to all child scenes
+				_setup_packed_scene(edited_variants[i]);
+			}
+		}
+
+		// Clear all properties that can store a NodePath (will cause error)
+		if (edited_variants[i].get_type() == Variant::ARRAY) {
+			edited_variants[i] = 0;
+		}
+
+		if (edited_variants[i].get_type() == Variant::DICTIONARY) {
+			edited_variants[i] = 0;
+		}
+
+		if (edited_variants[i].get_type() == Variant::NODE_PATH) {
+			edited_variants[i] = 0;
+		}
+	}
+
+	// Remove signal bindings (As scripts are all removed)
+	bundle["conns"] = Array();
+	bundle["conn_count"] = Array();
+
+	// Create a new scene state
+	bundle["variants"] = edited_variants;
+	Ref<SceneState> new_state;
+	new_state.instantiate();
+	new_state->set_bundled_scene(bundle);
+	p_pack->replace_state(new_state);
+	return true;
+}
+
+void EditorPackedScenePreviewPlugin::_fetch_editor_settings() const {
+	editor_settings_mutex.lock();
+	thumbnail_file_size_threshold = uint64_t(EDITOR_GET("docks/filesystem/thumbnail_file_size_threshold")) * 1024 * 1024; // MiB to Bytes
+	thumbnail_resource_count_threshold = uint64_t(EDITOR_GET("docks/filesystem/thumbnail_resource_count_threshold"));
+	editor_settings_mutex.unlock();
+}
+
+EditorPackedScenePreviewPlugin::EditorPackedScenePreviewPlugin() {
+	if (RS::get_singleton()->get_current_rendering_method() == "forward_plus" || RS::get_singleton()->get_current_rendering_method() == "mobile") {
+		supported_msaa_method = Viewport::MSAA::MSAA_8X;
 	} else {
-		return Ref<Texture2D>();
+		supported_msaa_method = Viewport::MSAA::MSAA_DISABLED;
 	}
+
+	_fetch_editor_settings();
+	EditorSettings::get_singleton()->connect(SNAME("settings_changed"), callable_mp(this, &EditorPackedScenePreviewPlugin::_fetch_editor_settings));
 }
 
 //////////////////////////////////////////////////////////////////
@@ -344,6 +1410,9 @@ Ref<Texture2D> EditorMaterialPreviewPlugin::generate(const Ref<Resource> &p_from
 		RS::get_singleton()->mesh_surface_set_material(sphere, 0, material->get_rid());
 
 		draw_requester.request_and_wait(viewport);
+		if (EditorResourcePreview::get_singleton()->is_threaded()) {
+			draw_requester.request_and_wait(viewport); // HACK - Prevents incorrect thumbnail assignment when using Forward or Mobile renderer, comment out this line to see the bug.
+		}
 
 		Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
 		RS::get_singleton()->mesh_surface_set_material(sphere, 0, RID());
@@ -759,6 +1828,9 @@ Ref<Texture2D> EditorMeshPreviewPlugin::generate(const Ref<Resource> &p_from, co
 	RS::get_singleton()->instance_set_transform(mesh_instance, xform);
 
 	draw_requester.request_and_wait(viewport);
+	if (EditorResourcePreview::get_singleton()->is_threaded()) {
+		draw_requester.request_and_wait(viewport); // Wait twice when run on thread, or else won't render correctly. comment this line to see the bug
+	}
 
 	Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
 	ERR_FAIL_COND_V(img.is_null(), Ref<ImageTexture>());

--- a/editor/inspector/editor_preview_plugins.h
+++ b/editor/inspector/editor_preview_plugins.h
@@ -34,6 +34,10 @@
 #include "editor/inspector/editor_resource_preview.h"
 
 class ScriptLanguage;
+class Node3D;
+class Viewport;
+class SubViewport;
+class PackedScene;
 
 void post_process_preview(Ref<Image> p_image);
 
@@ -67,10 +71,53 @@ public:
 class EditorPackedScenePreviewPlugin : public EditorResourcePreviewGenerator {
 	GDCLASS(EditorPackedScenePreviewPlugin, EditorResourcePreviewGenerator);
 
+	mutable SafeFlag aborted;
+	mutable SafeFlag scene_construct_done;
+	mutable DrawRequester draw_requester;
+	mutable HashMap<String, HashMap<String, int>> node_lookup_tables;
+	mutable RID vp_3d_rid;
+	mutable RID vp_2d_rid;
+	mutable RID vp_gui_rid;
+	mutable SubViewport *vp_3d_ptr = nullptr;
+	mutable SubViewport *vp_2d_ptr = nullptr;
+	mutable SubViewport *vp_gui_ptr = nullptr;
+	Mutex editor_settings_mutex;
+	mutable uint64_t thumbnail_file_size_threshold; // In bytes
+	mutable uint64_t thumbnail_resource_count_threshold;
+
+protected:
+	// --- 3D preview ---
+	void _setup_scene_3d(Node *p_node) const;
+	void _construct_scene_3d(Ref<PackedScene> p_pack, const Size2 &p_size, int p_light_count) const;
+
+	void _calculate_scene_aabb(Node *p_node, AABB &r_aabb) const;
+	Transform3D _get_global_transform_3d(Node3D *p_n3d) const;
+
+	// --- 2D preview ---
+	void _setup_scene_2d(Node *p_node, const bool &p_as_gui) const;
+	void _construct_scene_2d(Ref<PackedScene> p_pack, const Size2 &p_size) const;
+
+	void _calculate_scene_rect(Node *p_node, Rect2 &r_rect) const;
+	void _hide_node_2d_in_scene(Node *p_node) const;
+	void _hide_gui_in_scene(Node *p_node) const;
+
+	// Utils
+	void _wait_frame() const;
+	void _count_node_types(Ref<PackedScene> p_pack, int &r_c2d, int &r_c3d, int &r_clight) const;
+	Variant _scene_get_property_value(Ref<SceneState> p_state, int &r_node_idx, const StringName &p_property_name, const Variant &p_default_value = Variant()) const;
+	Ref<ImageTexture> _create_dummy_thumbnail() const;
+	Ref<ImageTexture> _get_fallback_thumbnail(const String &p_path) const;
+	void _get_scene_dependencies(const String &p_path, HashSet<String> &r_deps) const;
+	bool _setup_packed_scene(Ref<PackedScene> p_pack) const;
+	void _fetch_editor_settings() const;
+
 public:
+	virtual void abort() override;
 	virtual bool handles(const String &p_type) const override;
 	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const override;
 	virtual Ref<Texture2D> generate_from_path(const String &p_path, const Size2 &p_size, Dictionary &p_metadata) const override;
+
+	EditorPackedScenePreviewPlugin();
 };
 
 class EditorMaterialPreviewPlugin : public EditorResourcePreviewGenerator {

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -49,7 +49,6 @@
 #include "servers/display/display_server.h"
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/rendering_server.h"
-#include "servers/rendering/rendering_server_globals.h"
 
 bool EditorResourcePreviewGenerator::handles(const String &p_type) const {
 	bool success = false;
@@ -99,8 +98,11 @@ void EditorResourcePreviewGenerator::_bind_methods() {
 }
 
 void EditorResourcePreviewGenerator::DrawRequester::request_and_wait(RID p_viewport) {
+	Callable request_prepare_draw = callable_mp(this, &EditorResourcePreviewGenerator::DrawRequester::_prepare_draw).bind(p_viewport);
 	if (EditorResourcePreview::get_singleton()->is_threaded()) {
-		RS::get_singleton()->connect(SNAME("frame_pre_draw"), callable_mp(this, &EditorResourcePreviewGenerator::DrawRequester::_prepare_draw).bind(p_viewport), Object::CONNECT_ONE_SHOT);
+		if (!RS::get_singleton()->is_connected(SNAME("frame_pre_draw"), request_prepare_draw)) {
+			RS::get_singleton()->connect(SNAME("frame_pre_draw"), request_prepare_draw, Object::CONNECT_ONE_SHOT);
+		}
 		semaphore.wait();
 	} else {
 		// Avoid the main viewport and children being redrawn.
@@ -137,8 +139,21 @@ void EditorResourcePreviewGenerator::DrawRequester::_post_semaphore() {
 	semaphore.post();
 }
 
+bool EditorResourcePreview::can_run_on_thread() const {
+	// Now forces all renderers to generate thumbnail on thread for better UX. (See issue ##107736)
+	//
+	// Previously this returns `RSG::rasterizer->can_create_resources_async()` to prevent
+	// threading on Compatibility renderer for some reason (Need rendering team to confirm),
+	// But after testing thumbnail creation on a thread using GLES3 it has no issues.
+
+#ifndef THREADS_ENABLED
+	return false;
+#endif
+	return true;
+}
+
 bool EditorResourcePreview::is_threaded() const {
-	return RSG::rasterizer->can_create_resources_async();
+	return thread.is_started();
 }
 
 void EditorResourcePreview::_thread_func(void *ud) {
@@ -294,11 +309,14 @@ void EditorResourcePreview::_iterate() {
 
 	QueueItem item = queue.front()->get();
 	queue.pop_front();
+	singleton->processing_item = item;
+	singleton->last_process_msec = OS::get_singleton()->get_ticks_msec();
 
 	if (cache.has(item.path)) {
 		Item cached_item = cache[item.path];
 		// Already has it because someone loaded it, just let it know it's ready.
 		_preview_ready(item.path, cached_item.last_hash, cached_item.preview, cached_item.small_preview, item.callback, cached_item.preview_metadata);
+		singleton->processing_item = QueueItem();
 		preview_mutex.unlock();
 		return;
 	}
@@ -314,6 +332,9 @@ void EditorResourcePreview::_iterate() {
 		Dictionary preview_metadata;
 		_generate_preview(texture, small_texture, item, String(), preview_metadata);
 		_preview_ready(item.path, item.resource->hash_edited_version_for_preview(), texture, small_texture, item.callback, preview_metadata);
+		preview_mutex.lock();
+		singleton->processing_item = QueueItem();
+		preview_mutex.unlock();
 		return;
 	}
 
@@ -352,7 +373,7 @@ void EditorResourcePreview::_iterate() {
 			cache_valid = false;
 			f.unref();
 		} else if (last_modtime != modtime) {
-			String last_md5 = f->get_line();
+			String last_md5 = hash;
 			String md5 = FileAccess::get_md5(item.path);
 			f.unref();
 
@@ -402,6 +423,9 @@ void EditorResourcePreview::_iterate() {
 		}
 	}
 	_preview_ready(item.path, 0, texture, small_texture, item.callback, preview_metadata);
+	preview_mutex.lock();
+	singleton->processing_item = QueueItem();
+	preview_mutex.unlock();
 }
 
 void EditorResourcePreview::_write_preview_cache(Ref<FileAccess> p_file, int p_thumbnail_size, bool p_has_small_texture, uint64_t p_modified_time, const String &p_hash, const Dictionary &p_metadata) {
@@ -438,22 +462,25 @@ void EditorResourcePreview::_idle_callback() {
 		return;
 	}
 
+	// Abort if called multiple times in the same process frame
 	static uint64_t prev_process_frame = 0;
-	static uint64_t spent_frame_msec = 0;
-
 	uint64_t current_process_frame = Engine::get_singleton()->get_process_frames();
 	if (current_process_frame != prev_process_frame) {
 		prev_process_frame = current_process_frame;
-		spent_frame_msec = 0;
+	} else {
+		return;
 	}
 
-	// Process preview tasks, trying to leave a little bit of responsiveness worst case.
-	while (!singleton->queue.is_empty() && spent_frame_msec < 100) {
-		uint64_t start_msec = OS::get_singleton()->get_ticks_msec();
-		singleton->_iterate();
-		uint64_t end_msec = OS::get_singleton()->get_ticks_msec();
-		spent_frame_msec += end_msec - start_msec;
+	// Ensure to process one item at a time
+	singleton->preview_mutex.lock();
+	bool processing = !singleton->processing_item.path.is_empty();
+	singleton->preview_mutex.unlock();
+	if (processing) {
+		return;
 	}
+
+	// Process next resource
+	singleton->_iterate();
 }
 
 void EditorResourcePreview::_update_thumbnail_sizes() {
@@ -598,7 +625,7 @@ void EditorResourcePreview::start() {
 		return;
 	}
 
-	if (is_threaded()) {
+	if (can_run_on_thread()) {
 		ERR_FAIL_COND_MSG(thread.is_started(), "Thread already started.");
 		thread.start(_thread_func, this);
 	} else {
@@ -610,23 +637,21 @@ void EditorResourcePreview::start() {
 
 void EditorResourcePreview::stop() {
 	if (is_threaded()) {
-		if (thread.is_started()) {
-			exiting.set();
-			preview_sem.post();
+		exiting.set();
+		preview_sem.post();
 
-			for (int i = 0; i < preview_generators.size(); i++) {
-				preview_generators.write[i]->abort();
-			}
-
-			while (!exited.is_set()) {
-				// Sync pending work.
-				OS::get_singleton()->delay_usec(10000);
-				RenderingServer::get_singleton()->sync();
-				MessageQueue::get_singleton()->flush();
-			}
-
-			thread.wait_to_finish();
+		for (Ref<EditorResourcePreviewGenerator> preview_generator : preview_generators) {
+			preview_generator->abort();
 		}
+
+		while (!exited.is_set()) {
+			// Sync pending work.
+			OS::get_singleton()->delay_usec(10000);
+			RenderingServer::get_singleton()->sync();
+			MessageQueue::get_singleton()->flush();
+		}
+
+		thread.wait_to_finish();
 	}
 }
 

--- a/editor/inspector/editor_resource_preview.h
+++ b/editor/inspector/editor_resource_preview.h
@@ -75,7 +75,7 @@ public:
 class EditorResourcePreview : public Node {
 	GDCLASS(EditorResourcePreview, Node);
 
-	static constexpr int CURRENT_METADATA_VERSION = 1; // Increment this number to invalidate all previews.
+	static constexpr int CURRENT_METADATA_VERSION = 2; // Increment this number to invalidate all previews.
 	inline static EditorResourcePreview *singleton = nullptr;
 
 	struct QueueItem {
@@ -91,6 +91,9 @@ class EditorResourcePreview : public Node {
 	Thread thread;
 	SafeFlag exiting;
 	SafeFlag exited;
+	QueueItem processing_item;
+	int last_process_msec = -1;
+	int progress_total_steps = -1;
 
 	struct Item {
 		Ref<Texture2D> preview;
@@ -147,6 +150,7 @@ public:
 
 	void start();
 	void stop();
+	bool can_run_on_thread() const;
 	bool is_threaded() const;
 
 	EditorResourcePreview();

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -725,6 +725,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,224,16")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_file_size_threshold", 64, "0,1024,1,or_greater,suffix:MiB")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_resource_count_threshold", 200, "0,1000,1,or_greater")
 	_initial_set("docks/filesystem/always_show_folders", true);
 	_initial_set("docks/filesystem/textfile_extensions", "txt,md,cfg,ini,log,json,yml,yaml,toml,xml");
 	_initial_set("docks/filesystem/other_file_extensions", "ico,icns");


### PR DESCRIPTION
Supersedes #102313 and apply related fixes: #107719 #107514 #107676

Addressed issue: #107764

And to address the performance problem mentioned at #107736, this PR adds following changes:

1. Runs all thumbnail creation on a separate thread, no more progress bars
2. Add an editor setting `docks/filesystem/thumbnail_file_size_threshold`. When a scene file (gltf, tscn, fbx) is queued for thumbnail creation, we first interpret the scene file with `FileAccess` directly, check for all external, internal resources it uses, and see if the accumulated size (in bytes) is larger than this threshold, if it is, we don't proceed to generate thumbnail for it, instead we give it a 2x2 dummy thumbnail.

    As scene files could be large levels, and multi-threaded scene loading still isn't possible now, for creating thumbnails, we have to target files that are likely prefabs and can be loaded instantly.

    * NOTE 1: I had tried counting tris and pixels for each resources, it turns out to be too slow which destroys the purpose of quick checking, and also very buggy due to `GLTFDocument` might be stateful. Estimating total file bytes seems to be the only viable option now.

    * NOTE 2: Dummy thumbnail is mandatory to prevent it being queued over again, as the thumbnail generator logic will think it's aborted then proceed to retry if there's no thumbnail present.

    * NOTE 3: Changing `docks/filesystem/thumbnail_file_size_threshold` won't re-queue all the files, you have to edit and re-save individually for it to update.
    <img width="669" height="140" alt="thumbnail_threshold_description" src="https://github.com/user-attachments/assets/9329999f-0a0e-463f-a967-5a6c1787d482" />

    Large levels would likely be ignored by thumbnail generator with the default setting -- **64MB**:

    <img width="1252" height="157" alt="image" src="https://github.com/user-attachments/assets/156f76c3-8973-4768-b4c5-bfb2a40efc45" />


3. For stability reasons, `PackedScene::instantiate()` and `Node::queue_free()` calls are all deferred.

The main caveat of this PR is that if some scene files have ~30MB worth of bytes, it will cause frame lags, but far from rendering the editor unresponsive, suppose this price will only be paid once on a freshly opened project, this should be worth it.

Code could use some clean up, testers are welcome now. I've tested with official template projects, and also a project that has numerous 50MB~100MB gltf files with 4K HDRIs, all looks good to me now.

------
*2025-10-27-08:30 Update*

If the code is stable and testing results are good, I plan to implement following changes by order, but no guarantees, just a list of nice-to-have if I got time.

**TODO:**
- [x] ~Add setting `docks/filesystem/thumbnail_max_scene_node_count`, ignore thumbnail creation if scene has too many nodes. (default 2000?)~
     * ~This should account for scene files that are under file size threshold, but have a huge amount of instanced nodes sharing the same resources, which might take too much time to render in background and cause lags.~
     * (2025-11-09) Edit : Discarded. Not possible to count nodes precisely without loading the files (scenes may contain gltf, fbx resources)

- [x] Implement #102263 as a fallback for scene files that are too large to handle (with no options, just use fixed view)
    <img width="507" height="215" alt="bring_back_save_preview_fixed" src="https://github.com/user-attachments/assets/e1fe5889-277a-487f-9d3d-52bfb9cc14a2" />
- [x] Bring back #96544 as a fallback for imported scene resources that are too large to handle