### PR TITLE
Convert Theme Overrides to Type Variation

### DIFF
--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -34,17 +34,21 @@
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/inspector/editor_properties.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/check_button.h"
+#include "scene/gui/dialogs.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/texture_rect.h"
+#include "scene/theme/theme_db.h"
 
 // Inspector controls.
 
@@ -447,6 +451,133 @@ EditorPropertySizeFlags::EditorPropertySizeFlags() {
 	flag_expand->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertySizeFlags::_expand_toggled));
 }
 
+PushOverridesToTypeVariationDialog::PushOverridesToTypeVariationDialog() {
+	set_title(TTRC("Push Overrides to Type Variation"));
+	set_min_size(Size2(256, 64) * EDSCALE);
+
+	GridContainer *gc = memnew(GridContainer);
+	gc->set_columns(2);
+
+	Label *l1 = memnew(Label);
+	l1->set_text("Theme:");
+	gc->add_child(l1);
+
+	theme_option_button = memnew(OptionButton);
+	theme_option_button->connect(SceneStringName(item_selected), callable_mp(this, &PushOverridesToTypeVariationDialog::_on_theme_selected));
+	gc->add_child(theme_option_button);
+
+	Label *l2 = memnew(Label);
+	l2->set_text("Type Variation:");
+	gc->add_child(l2);
+
+	name_line_edit = memnew(LineEdit);
+	name_line_edit->set_select_all_on_focus(true);
+	name_line_edit->connect(SceneStringName(text_changed), callable_mp(this, &PushOverridesToTypeVariationDialog::_on_name_changed));
+	register_text_enter(name_line_edit);
+	gc->add_child(name_line_edit);
+
+	validation_panel = memnew(EditorValidationPanel);
+	validation_panel->add_line(0, TTR("Type Variation name is valid."));
+	validation_panel->add_line(1, TTR("Will create a new Type Variation."));
+	validation_panel->set_update_callback(callable_mp(this, &PushOverridesToTypeVariationDialog::_update_validation_panel));
+	validation_panel->set_accept_button(get_ok_button());
+
+	VBoxContainer *c = memnew(VBoxContainer);
+	c->add_child(gc);
+	c->add_child(validation_panel);
+	add_child(c);
+}
+
+void PushOverridesToTypeVariationDialog::_on_theme_selected(int p_index) {
+	validation_panel->update();
+}
+
+void PushOverridesToTypeVariationDialog::_on_name_changed(const String &p_new_text) {
+	validation_panel->update();
+}
+
+void PushOverridesToTypeVariationDialog::setup(Control *p_control) {
+	current_control = p_control;
+
+	theme_option_button->clear();
+	// Find all of the potential themes.
+	// First, we go up the scene tree and find all of the themes there.
+	Node *found_control = current_control;
+	candidate_themes.clear();
+	bool nearest_found = false;
+	Ref<Texture2D> theme_icon = theme_option_button->get_editor_theme_icon(SNAME("Theme"));
+	while (true) {
+		Control *as_control = Object::cast_to<Control>(found_control);
+		if (as_control == nullptr) {
+			break;
+		}
+
+		if (as_control->get_theme().is_valid()) {
+			String label = as_control->get_theme()->get_path();
+			if (!nearest_found) {
+				nearest_found = true;
+				label += TTRC(" (Nearest)");
+			}
+			theme_option_button->add_icon_item(theme_icon, label);
+			candidate_themes.append(as_control->get_theme());
+		}
+
+		found_control = found_control->get_parent();
+	}
+
+	// Project and default themes.
+	Ref<Theme> project_theme = ThemeDB::get_singleton()->get_project_theme();
+	if (project_theme.is_valid()) {
+		String label = vformat(TTRC("%s (Project)"), project_theme->get_path());
+		theme_option_button->add_icon_item(theme_icon, label);
+		candidate_themes.append(project_theme);
+	}
+
+	name_line_edit->set_text(current_control->get_theme_type_variation());
+	reset_size();
+	popup_centered();
+	name_line_edit->grab_focus();
+
+	validation_panel->update();
+}
+
+Ref<Theme> PushOverridesToTypeVariationDialog::get_target_theme() const {
+	return candidate_themes[theme_option_button->get_selected()];
+}
+
+String PushOverridesToTypeVariationDialog::get_target_type_variation() const {
+	return name_line_edit->get_text();
+}
+
+void PushOverridesToTypeVariationDialog::_update_validation_panel() {
+	const Ref<Theme> target_theme = get_target_theme();
+	const String type_variation_name = get_target_type_variation();
+
+	if (type_variation_name == StringName()) {
+		validation_panel->set_message(0, TTR("Type Variation name is empty."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(1, "", EditorValidationPanel::MSG_INFO);
+	} else if (!Theme::is_valid_type_name(type_variation_name)) {
+		validation_panel->set_message(0, TTR("Type Variation name is invalid."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(1, "", EditorValidationPanel::MSG_INFO);
+	} else {
+		validation_panel->set_message(0, TTR("Type Variation name is valid."), EditorValidationPanel::MSG_OK);
+
+		if (target_theme->is_type_variation(type_variation_name, current_control->get_class_name())) {
+			validation_panel->set_message(1, TTR("Will modify an existing Type Variation."), EditorValidationPanel::MSG_OK);
+		} else {
+			validation_panel->set_message(1, TTR("Will create a new Type Variation."), EditorValidationPanel::MSG_OK);
+		}
+	}
+}
+
+EditorInspectorPluginControl::EditorInspectorPluginControl() {
+	create_new_variation_dialog = memnew(PushOverridesToTypeVariationDialog);
+	create_new_variation_dialog->set_title(TTRC("Create Theme Variation"));
+	create_new_variation_dialog->set_min_size(Size2(256, 64) * EDSCALE);
+	EditorNode::get_singleton()->add_child(create_new_variation_dialog);
+	create_new_variation_dialog->connect(SceneStringName(confirmed), callable_mp(this, &EditorInspectorPluginControl::_on_create_variation_confirmed));
+}
+
 bool EditorInspectorPluginControl::can_handle(Object *p_object) {
 	return Object::cast_to<Control>(p_object) != nullptr;
 }
@@ -461,13 +592,149 @@ void EditorInspectorPluginControl::parse_group(Object *p_object, const String &p
 	}
 
 	Control *control = Object::cast_to<Control>(p_object);
-	if (!control || p_group != "Layout") {
+	if (!control) {
 		return;
 	}
 
-	ControlPositioningWarning *pos_warning = memnew(ControlPositioningWarning);
-	pos_warning->set_control(control);
-	add_custom_control(pos_warning);
+	if (p_group == "Layout") {
+		ControlPositioningWarning *pos_warning = memnew(ControlPositioningWarning);
+		pos_warning->set_control(control);
+		add_custom_control(pos_warning);
+	}
+}
+
+void EditorInspectorPluginControl::_on_convert_theme_overrides_to_variation(Control *p_control) {
+	current_control = p_control;
+	create_new_variation_dialog->setup(current_control);
+}
+
+void EditorInspectorPluginControl::_on_create_variation_confirmed() {
+	Ref<Theme> target_theme = create_new_variation_dialog->get_target_theme();
+	StringName variation_name = create_new_variation_dialog->get_target_type_variation();
+	_create_variation_from_overrides(target_theme, current_control->get_class_name(), variation_name);
+	current_control->notify_property_list_changed();
+}
+
+/// Pushing Theme Overrides to Type Variations.
+void EditorInspectorPluginControl::_create_variation_from_overrides(Ref<Theme> p_theme, const StringName &p_base_name, const StringName &p_variation_name) const {
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+
+	ur->create_action(vformat(TTRC("Push Overrides to Type Variation \"%s\""), p_variation_name), UndoRedo::MERGE_DISABLE, *p_theme);
+
+	// If this type variation doesn't already exist on this theme, then add it.
+	if (!p_theme->is_type_variation(p_variation_name, p_base_name)) {
+		ur->add_do_method(*p_theme, "set_type_variation", p_variation_name, p_base_name);
+		ur->add_undo_method(*p_theme, "clear_type_variation", p_variation_name);
+
+		ur->force_fixed_history();
+		ur->add_do_method(current_control, "set_theme_type_variation", p_variation_name);
+
+		ur->force_fixed_history();
+		ur->add_undo_method(current_control, "set_theme_type_variation", "");
+	}
+
+	List<ThemeDB::ThemeItemBind> theme_items;
+	ThemeDB::get_singleton()->get_class_items(p_base_name, &theme_items, true);
+
+	for (const ThemeDB::ThemeItemBind &item : theme_items) {
+		switch (item.data_type) {
+			case Theme::DATA_TYPE_COLOR:
+				if (current_control->has_theme_color_override(item.item_name)) {
+					ur->add_do_method(*p_theme, "set_color", item.item_name, p_variation_name, current_control->get_theme_color(item.item_name));
+					ur->force_fixed_history();
+					ur->add_do_method(current_control, "remove_theme_color_override", item.item_name);
+
+					ur->force_fixed_history();
+					ur->add_undo_method(current_control, "add_theme_color_override", item.item_name, current_control->get_theme_color(item.item_name));
+					if (p_theme->has_color(item.item_name, p_variation_name)) {
+						ur->add_undo_method(*p_theme, "set_color", item.item_name, p_variation_name, p_theme->get_color(item.item_name, p_variation_name));
+					} else {
+						ur->add_undo_method(*p_theme, "clear_color", item.item_name, p_variation_name);
+					}
+				}
+				break;
+			case Theme::DATA_TYPE_CONSTANT:
+				if (current_control->has_theme_constant_override(item.item_name)) {
+					ur->add_do_method(*p_theme, "set_constant", item.item_name, p_variation_name, current_control->get_theme_constant(item.item_name));
+					ur->force_fixed_history();
+					ur->add_do_method(current_control, "remove_theme_constant_override", item.item_name);
+
+					ur->force_fixed_history();
+					ur->add_undo_method(current_control, "add_theme_constant_override", item.item_name, current_control->get_theme_constant(item.item_name));
+					if (p_theme->has_constant(item.item_name, p_variation_name)) {
+						ur->add_undo_method(*p_theme, "set_constant", item.item_name, p_variation_name, p_theme->get_constant(item.item_name, p_variation_name));
+					} else {
+						ur->add_undo_method(*p_theme, "clear_constant", item.item_name, p_variation_name);
+					}
+				}
+				break;
+			case Theme::DATA_TYPE_FONT:
+				if (current_control->has_theme_font_override(item.item_name)) {
+					ur->add_do_method(*p_theme, "set_font", item.item_name, p_variation_name, current_control->get_theme_font(item.item_name));
+					ur->force_fixed_history();
+					ur->add_do_method(current_control, "remove_theme_font_override", item.item_name);
+
+					ur->force_fixed_history();
+					ur->add_undo_method(current_control, "add_theme_font_override", item.item_name, current_control->get_theme_font(item.item_name));
+					if (p_theme->has_font(item.item_name, p_variation_name)) {
+						ur->add_undo_method(*p_theme, "set_font", item.item_name, p_variation_name, p_theme->get_font(item.item_name, p_variation_name));
+					} else {
+						ur->add_undo_method(*p_theme, "clear_font", item.item_name, p_variation_name);
+					}
+				}
+				break;
+			case Theme::DATA_TYPE_FONT_SIZE:
+				if (current_control->has_theme_font_size_override(item.item_name)) {
+					ur->add_do_method(*p_theme, "set_font_size", item.item_name, p_variation_name, current_control->get_theme_font_size(item.item_name));
+					ur->force_fixed_history();
+					ur->add_do_method(current_control, "remove_theme_font_size_override", item.item_name);
+
+					ur->force_fixed_history();
+					ur->add_undo_method(current_control, "add_theme_font_size_override", item.item_name, current_control->get_theme_font_size(item.item_name));
+					if (p_theme->has_font_size(item.item_name, p_variation_name)) {
+						ur->add_undo_method(*p_theme, "set_font_size", item.item_name, p_variation_name, p_theme->get_font_size(item.item_name, p_variation_name));
+					} else {
+						ur->add_undo_method(*p_theme, "clear_font_size", item.item_name, p_variation_name);
+					}
+				}
+				break;
+			case Theme::DATA_TYPE_ICON:
+				if (current_control->has_theme_icon_override(item.item_name)) {
+					ur->add_do_method(*p_theme, "set_icon", item.item_name, p_variation_name, current_control->get_theme_icon(item.item_name));
+					ur->force_fixed_history();
+					ur->add_do_method(current_control, "remove_theme_icon_override", item.item_name);
+
+					ur->force_fixed_history();
+					ur->add_undo_method(current_control, "add_theme_icon_override", item.item_name, current_control->get_theme_icon(item.item_name));
+					if (p_theme->has_icon(item.item_name, p_variation_name)) {
+						ur->add_undo_method(*p_theme, "set_icon", item.item_name, p_variation_name, p_theme->get_icon(item.item_name, p_variation_name));
+					} else {
+						ur->add_undo_method(*p_theme, "clear_icon", item.item_name, p_variation_name);
+					}
+				}
+				break;
+			case Theme::DATA_TYPE_STYLEBOX:
+				if (current_control->has_theme_stylebox_override(item.item_name)) {
+					ur->add_do_method(*p_theme, "set_stylebox", item.item_name, p_variation_name, current_control->get_theme_stylebox(item.item_name));
+					ur->force_fixed_history();
+					ur->add_do_method(current_control, "remove_theme_stylebox_override", item.item_name);
+
+					ur->force_fixed_history();
+					ur->add_undo_method(current_control, "add_theme_stylebox_override", item.item_name, current_control->get_theme_stylebox(item.item_name));
+					if (p_theme->has_stylebox(item.item_name, p_variation_name)) {
+						ur->add_undo_method(*p_theme, "set_stylebox", item.item_name, p_variation_name, p_theme->get_stylebox(item.item_name, p_variation_name));
+					} else {
+						ur->add_undo_method(*p_theme, "clear_stylebox", item.item_name, p_variation_name);
+					}
+				}
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	ur->commit_action();
 }
 
 bool EditorInspectorPluginControl::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
@@ -493,6 +760,50 @@ bool EditorInspectorPluginControl::parse_property(Object *p_object, const Varian
 		}
 		prop_editor->setup(options, p_path == "size_flags_vertical");
 		add_property_editor(p_path, prop_editor);
+
+		return true;
+	}
+
+	if (p_path == "theme_type_variation") {
+		EditorPropertyTextEnum *prop_editor = memnew(EditorPropertyTextEnum);
+		PackedStringArray arr;
+		for (const StringName &s : control->get_all_type_variation_names()) {
+			arr.append(s);
+		}
+		prop_editor->setup(arr, arr, true, true);
+		add_property_editor(p_path, prop_editor);
+
+		String hint_text = TTRC("Push Overrides to Type Variation...");
+		String hint_icon = TTRC("Theme");
+		EditorInspectorActionButton *convert_button = memnew(EditorInspectorActionButton(hint_text, hint_icon));
+		convert_button->connect(SceneStringName(pressed), callable_mp(this, &EditorInspectorPluginControl::_on_convert_theme_overrides_to_variation).bind(control));
+		add_custom_control(convert_button);
+
+		// Confirm that there are themes we could push to.
+		Node *found_control = current_control;
+		Vector<Ref<Theme>> candidate_themes;
+		bool theme_found = false;
+		while (true) {
+			Control *as_control = Object::cast_to<Control>(found_control);
+			if (as_control == nullptr) {
+				break;
+			}
+
+			if (as_control->get_theme().is_valid()) {
+				theme_found = true;
+				break;
+			}
+
+			found_control = found_control->get_parent();
+		}
+
+		// Project and default themes.
+		Ref<Theme> project_theme = ThemeDB::get_singleton()->get_project_theme();
+		if (project_theme.is_valid()) {
+			theme_found = true;
+		}
+
+		convert_button->set_disabled(!theme_found);
 
 		return true;
 	}

--- a/editor/scene/gui/control_editor_plugin.h
+++ b/editor/scene/gui/control_editor_plugin.h
@@ -30,17 +30,21 @@
 
 #pragma once
 
+#include "editor/gui/editor_validation_panel.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
+#include "scene/gui/dialogs.h"
 #include "scene/gui/margin_container.h"
 
 class CheckBox;
 class CheckButton;
+class ConfirmationDialog;
 class EditorSelection;
 class GridContainer;
 class Label;
+class LineEdit;
 class OptionButton;
 class PanelContainer;
 class PopupPanel;
@@ -124,16 +128,47 @@ public:
 	EditorPropertySizeFlags();
 };
 
+class PushOverridesToTypeVariationDialog : public ConfirmationDialog {
+	GDCLASS(PushOverridesToTypeVariationDialog, ConfirmationDialog);
+
+	Control *current_control = nullptr;
+	Vector<Ref<Theme>> candidate_themes;
+
+	LineEdit *name_line_edit = nullptr;
+	OptionButton *theme_option_button = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
+
+	void _on_theme_selected(int p_index);
+	void _on_name_changed(const String &p_new_text);
+	void _update_validation_panel();
+
+public:
+	void setup(Control *p_control);
+	Ref<Theme> get_target_theme() const;
+	String get_target_type_variation() const;
+	PushOverridesToTypeVariationDialog();
+};
+
 class EditorInspectorPluginControl : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorPluginControl, EditorInspectorPlugin);
 
+	PushOverridesToTypeVariationDialog *create_new_variation_dialog = nullptr;
 	bool inside_control_category = false;
+
+	Ref<Theme> theme;
+	Control *current_control = nullptr;
+	void _on_create_variation_confirmed();
+	void _on_convert_theme_overrides_to_variation(Control *p_control);
+	void _create_variation_from_overrides(Ref<Theme> p_theme, const StringName &p_base_name, const StringName &p_variation_name) const;
+	void _on_create_variation_name_changed(const String &p_new_text);
+	void _update_create_variation_dialog();
 
 public:
 	virtual bool can_handle(Object *p_object) override;
 	virtual void parse_category(Object *p_object, const String &p_category) override;
 	virtual void parse_group(Object *p_object, const String &p_group) override;
 	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide = false) override;
+	EditorInspectorPluginControl();
 };
 
 // Toolbar controls.

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -475,50 +475,56 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
+Vector<StringName> Control::get_all_type_variation_names() const {
+	List<StringName> names;
+
+	ThemeDB::get_singleton()->get_default_theme()->get_type_variation_list(get_class_name(), &names);
+
+	// Iterate to find all themes.
+	Control *tmp_control = Object::cast_to<Control>(get_parent());
+	Window *tmp_window = Object::cast_to<Window>(get_parent());
+	while (tmp_control || tmp_window) {
+		// We go up and any non Control/Window will break the chain.
+		if (tmp_control) {
+			if (tmp_control->get_theme().is_valid()) {
+				tmp_control->get_theme()->get_type_variation_list(get_class_name(), &names);
+			}
+			tmp_window = Object::cast_to<Window>(tmp_control->get_parent());
+			tmp_control = Object::cast_to<Control>(tmp_control->get_parent());
+		} else { // Window.
+			if (tmp_window->get_theme().is_valid()) {
+				tmp_window->get_theme()->get_type_variation_list(get_class_name(), &names);
+			}
+			tmp_control = Object::cast_to<Control>(tmp_window->get_parent());
+			tmp_window = Object::cast_to<Window>(tmp_window->get_parent());
+		}
+	}
+	if (get_theme().is_valid()) {
+		get_theme()->get_type_variation_list(get_class_name(), &names);
+	}
+	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
+		ThemeDB::get_singleton()->get_project_theme()->get_type_variation_list(get_class_name(), &names);
+	}
+	names.sort_custom<StringName::AlphCompare>();
+
+	Vector<StringName> unique_names;
+	for (const StringName &E : names) {
+		// Skip duplicate values.
+		if (unique_names.has(E)) {
+			continue;
+		}
+		unique_names.append(E);
+	}
+	return unique_names;
+}
+
 void Control::_validate_property(PropertyInfo &p_property) const {
 	// Update theme type variation options.
 	if (Engine::get_singleton()->is_editor_hint() && p_property.name == "theme_type_variation") {
-		List<StringName> names;
-
-		ThemeDB::get_singleton()->get_default_theme()->get_type_variation_list(get_class_name(), &names);
-
-		// Iterate to find all themes.
-		Control *tmp_control = Object::cast_to<Control>(get_parent());
-		Window *tmp_window = Object::cast_to<Window>(get_parent());
-		while (tmp_control || tmp_window) {
-			// We go up and any non Control/Window will break the chain.
-			if (tmp_control) {
-				if (tmp_control->get_theme().is_valid()) {
-					tmp_control->get_theme()->get_type_variation_list(get_class_name(), &names);
-				}
-				tmp_window = Object::cast_to<Window>(tmp_control->get_parent());
-				tmp_control = Object::cast_to<Control>(tmp_control->get_parent());
-			} else { // Window.
-				if (tmp_window->get_theme().is_valid()) {
-					tmp_window->get_theme()->get_type_variation_list(get_class_name(), &names);
-				}
-				tmp_control = Object::cast_to<Control>(tmp_window->get_parent());
-				tmp_window = Object::cast_to<Window>(tmp_window->get_parent());
-			}
-		}
-		if (get_theme().is_valid()) {
-			get_theme()->get_type_variation_list(get_class_name(), &names);
-		}
-		if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-			ThemeDB::get_singleton()->get_project_theme()->get_type_variation_list(get_class_name(), &names);
-		}
-		names.sort_custom<StringName::AlphCompare>();
-
-		Vector<StringName> unique_names;
+		Vector<StringName> unique_names = get_all_type_variation_names();
 		String hint_string;
-		for (const StringName &E : names) {
-			// Skip duplicate values.
-			if (unique_names.has(E)) {
-				continue;
-			}
-
+		for (const StringName &E : unique_names) {
 			hint_string += String(E) + ",";
-			unique_names.append(E);
 		}
 
 		p_property.hint_string = hint_string;
@@ -3307,6 +3313,7 @@ void Control::set_theme_type_variation(const StringName &p_theme_type) {
 	if (is_inside_tree()) {
 		notification(NOTIFICATION_THEME_CHANGED);
 	}
+	notify_property_list_changed();
 }
 
 StringName Control::get_theme_type_variation() const {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -724,6 +724,7 @@ public:
 
 	void set_theme_type_variation(const StringName &p_theme_type);
 	StringName get_theme_type_variation() const;
+	Vector<StringName> get_all_type_variation_names() const;
 
 	void begin_bulk_theme_override();
 	void end_bulk_theme_override();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12714 .

This PR adds a button to the Control inspector, which pushes the Control's current theme overrides to the theme it is using as a type variation. More specifically:
- If the Control currently does not have a type variation, the user is prompted to enter a name for one. The type variation is created for the theme with the Control's overrides applied, the overrides are removed from the Control, and the type variation is applied to the Control:

https://github.com/user-attachments/assets/d12e697f-44ad-4299-8d66-e4a210c71da1

- If the Control does have a type variation, the Control's overrides are applied to the type variation and removed from the Control itself:

https://github.com/user-attachments/assets/fb0c6b61-cd9c-4c92-905d-478241cb4fa3

## To do
- [x] If the Control already has a Type Variation, then update the Type Variation with those overrides.
- [x] Immediately refresh the Inspector so that it shows the new Type Variation and lack of overrides.
  - Use `notify_property_list_changed()` for this.
- [x] Disable button if no theme exists.
- [x] In dialog box, ask user which theme they want to apply changes to (current, ancestors, project default).
  - Note that if they create variation on theme other than closest one, results on other controls may be unexpected.
- [x] Figure out a better location for the button itself.
  - Place it as a tool button at the end of the "Theme Overrides" properties?
- [ ] Looks possible that the Theme itself is saving the changes to it, even if we don't save the project? Might need to investigate further
	- [ ] Try this:
		- Edit a label using overrides, then apply those overrides to its variation
		- **Without saving**, quit Godot
		- When you open the project, the label will be back to what it was before the overrides, but the variation will still have the overrides?