### PR TITLE
Save project metadata less often

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -900,6 +900,7 @@ void EditorNode::_notification(int p_what) {
 			}
 			EditorHelp::save_script_doc_cache();
 			editor_data.save_editor_external_data();
+			EditorSettings::get_singleton()->save_project_metadata();
 			FileAccess::set_file_close_fail_notify_callback(nullptr);
 			log->deinit(); // Do not get messages anymore.
 			editor_data.clear_edited_scenes();
@@ -2118,6 +2119,7 @@ int EditorNode::_save_external_resources(bool p_also_save_external_data) {
 		}
 	}
 
+	EditorSettings::get_singleton()->save_project_metadata();
 	EditorUndoRedoManager::get_singleton()->set_history_as_saved(EditorUndoRedoManager::GLOBAL_HISTORY);
 	_update_unsaved_cache();
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1555,9 +1555,7 @@ void EditorSettings::set_project_metadata(const String &p_section, const String 
 		}
 	}
 	project_metadata->set_value(p_section, p_key, p_data);
-
-	Error err = project_metadata->save(path);
-	ERR_FAIL_COND_MSG(err != OK, "Cannot save project metadata to file '" + path + "'.");
+	project_metadata_dirty = true;
 }
 
 Variant EditorSettings::get_project_metadata(const String &p_section, const String &p_key, const Variant &p_default) const {
@@ -1569,6 +1567,16 @@ Variant EditorSettings::get_project_metadata(const String &p_section, const Stri
 		ERR_FAIL_COND_V_MSG(err != OK && err != ERR_FILE_NOT_FOUND, p_default, "Cannot load project metadata from file '" + path + "'.");
 	}
 	return project_metadata->get_value(p_section, p_key, p_default);
+}
+
+void EditorSettings::save_project_metadata() {
+	if (!project_metadata_dirty) {
+		return;
+	}
+	const String path = _get_project_metadata_path();
+	Error err = project_metadata->save(path);
+	ERR_FAIL_COND_MSG(err != OK, "Cannot save project metadata to file '" + path + "'.");
+	project_metadata_dirty = false;
 }
 
 void EditorSettings::set_favorites(const Vector<String> &p_favorites) {

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -91,6 +91,7 @@ private:
 	HashSet<String> changed_settings;
 
 	mutable Ref<ConfigFile> project_metadata;
+	bool project_metadata_dirty = false;
 	HashMap<String, PropertyInfo> hints;
 	HashMap<String, VariantContainer> props;
 	int last_order;
@@ -170,6 +171,7 @@ public:
 
 	void set_project_metadata(const String &p_section, const String &p_key, const Variant &p_data);
 	Variant get_project_metadata(const String &p_section, const String &p_key, const Variant &p_default) const;
+	void save_project_metadata();
 
 	void set_favorites(const Vector<String> &p_favorites);
 	Vector<String> get_favorites() const;


### PR DESCRIPTION
Right now `set_project_metadata()` will always save the file. This is rather wasteful, toggling a checkbox will result in disk write.

This PR defers the saving until editor saves external resources (e.g. when saving a scene) or exits, so writing the file should be much less frequent.