### PR TITLE
Improve `PROPERTY_USAGE_ARRAY` description

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -3024,7 +3024,15 @@
 			If property has [code]nil[/code] as default value, its type will be [Variant].
 		</constant>
 		<constant name="PROPERTY_USAGE_ARRAY" value="262144" enum="PropertyUsageFlags" is_bitfield="true">
-			The property is an array.
+			The property is the element count of a property array, i.e. a list of groups of related properties. Properties defined with this usage also need a specific [code]class_name[/code] field in the form of [code]label,prefix[/code]. The field may also include additional comma-separated options:
+			- [code]page_size=N[/code]: Overrides [member EditorSettings.interface/inspector/max_array_dictionary_items_per_page] for this array.
+			- [code]add_button_text=text[/code]: The text displayed by the "Add Element" button.
+			- [code]static[/code]: The elements can't be re-arranged.
+			- [code]const[/code]: New elements can't be added.
+			- [code]numbered[/code]: An index will appear next to each element.
+			- [code]unfoldable[/code]: The array can't be folded.
+			- [code]swap_method=method_name[/code]: The method that will be called when two elements switch places. The method should take 2 [int] parameters, which will be indices of the elements being swapped.
+			Note that making a full-fledged property array requires boilerplate code involving [method Object._get_property_list].
 		</constant>
 		<constant name="PROPERTY_USAGE_ALWAYS_DUPLICATE" value="524288" enum="PropertyUsageFlags" is_bitfield="true">
 			When duplicating a resource with [method Resource.duplicate], and this flag is set on a property of that resource, the property should always be duplicated, regardless of the [code]subresources[/code] bool parameter.


### PR DESCRIPTION
The old description was misleading and lacking detail.
The new description... is better, but the usage of this flag is very complex. I added more details, but a complete usage example probably deserves its own tutorial in the manual. The boilerplate mentioned looks more or less like this:
https://github.com/godotengine/godot-proposals/issues/13471#issuecomment-3448900476
or this
https://github.com/godotengine/godot-proposals/issues/13471#issuecomment-3448930661
(although these examples are somewhat a metaprogramming and were designed for ease of usage, normally these properties would be more hard-coded and require more code)