### PR TITLE
Always create a `.gitignore` in `.godot`

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -840,6 +840,17 @@ Error ExportTemplateManager::install_android_template_from_file(const String &p_
 		f->store_line(get_android_template_identifier(p_preset));
 	}
 
+	// This directory should never be committed to git.
+	const String parent_dir_gitignore = parent_dir.path_join(".gitignore");
+	if (!FileAccess::exists(parent_dir_gitignore)) {
+		Ref<FileAccess> f = FileAccess::open(parent_dir_gitignore, FileAccess::WRITE);
+		if (f.is_valid()) {
+			f->store_line("*");
+		} else {
+			ERR_PRINT("Failed to create file " + parent_dir_gitignore.quote() + ".");
+		}
+	}
+
 	// Create the android build directory.
 	Error err = da->make_dir_recursive(build_dir);
 	ERR_FAIL_COND_V(err != OK, err);

--- a/editor/file_system/editor_paths.cpp
+++ b/editor/file_system/editor_paths.cpp
@@ -276,6 +276,17 @@ EditorPaths::EditorPaths() {
 			}
 		}
 
+		// This directory should never be committed to git.
+		String project_data_gitignore_file_path = project_data_dir.path_join(".gitignore");
+		if (!FileAccess::exists(project_data_gitignore_file_path)) {
+			Ref<FileAccess> f = FileAccess::open(project_data_gitignore_file_path, FileAccess::WRITE);
+			if (f.is_valid()) {
+				f->store_line("*");
+			} else {
+				ERR_PRINT("Failed to create file " + project_data_gitignore_file_path.quote() + ".");
+			}
+		}
+
 		Engine::get_singleton()->set_shader_cache_path(project_data_dir);
 
 		// Editor metadata dir.

--- a/editor/version_control/editor_vcs_interface.cpp
+++ b/editor/version_control/editor_vcs_interface.cpp
@@ -366,8 +366,9 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 			ERR_FAIL_MSG("Couldn't create .gitignore in project path.");
 		} else {
 			f->store_line("# Godot 4+ specific ignores");
-			f->store_line(".godot/");
-			f->store_line("/android/");
+			f->store_line("# The following directories are ignored in each directory's `.gitignore`.");
+			f->store_line("#.godot/");
+			f->store_line("#/android/");
 		}
 		f = FileAccess::open(p_dir.path_join(".gitattributes"), FileAccess::WRITE);
 		if (f.is_null()) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/discussions/13468

Always create res://.godot/.gitignore with * as its content.

This way, even if Git metadata isn't added when the project is created, adding the project to Git later is still safe by default.