### PR TITLE
Improve error message when `_EDITOR_GET` fails

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1514,7 +1514,8 @@ Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_re
 }
 
 Variant _EDITOR_GET(const String &p_setting) {
-	ERR_FAIL_COND_V(!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting), Variant());
+	ERR_FAIL_NULL_V_MSG(EditorSettings::get_singleton(), Variant(), vformat(R"(EditorSettings not instantiated yet when getting setting "%s".)", p_setting));
+	ERR_FAIL_COND_V_MSG(!EditorSettings::get_singleton()->has_setting(p_setting), Variant(), vformat(R"(Editor setting "%s" does not exist.)", p_setting));
 	return EditorSettings::get_singleton()->get_setting(p_setting);
 }
 


### PR DESCRIPTION
Recently, I encountered the following error while running a custom build:

```
ERROR: Condition "!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting)" is true. Returning: Variant()
   at: _EDITOR_GET (editor/settings/editor_settings.cpp:1517)
```

It's frustrating that the value of `p_setting` is not shown.

This PR changes the error to something like this:

```
ERROR: Editor setting "name/of/the_missing_setting" does not exist.
   at: _EDITOR_GET (editor/settings/editor_settings.cpp:1518)
```