### PR TITLE
Remove error when creating Tween directly

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -532,11 +532,12 @@ void Tween::_bind_methods() {
 }
 
 Tween::Tween() {
-	ERR_FAIL_MSG("Tween can't be created directly. Use create_tween() method.");
+	dead = true;
 }
 
 Tween::Tween(SceneTree *p_parent_tree) {
 	parent_tree = p_parent_tree;
+	running = true;
 	valid = true;
 }
 

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -122,7 +122,7 @@ private:
 
 	bool is_bound = false;
 	bool started = false;
-	bool running = true;
+	bool running = false;
 	bool in_step = false;
 	bool dead = false;
 	bool valid = false;


### PR DESCRIPTION
The issue I have with this error is that I believe there is one valid use case for instantiating a tween without attaching it to a tree, which is during initialization of another object which has tween properties. Otherwise I either need to check that ```tween != null``` every time I need to do an operation on the tween to avoid race conditions, or create a tween attached to the tree for no reason and then immediately kill it so I don't get a different error for creating an empty tween. This is pointless if I'm never going to set the property to ```null```.

An error is still printed if you try to append a tweener to a tween created with ```Tween.new()``` which says that the tween could have been created outside the scene tree. I could make that error more specific if the tween is created using ```Tween.new()``` if necessary.