### PR TITLE
Add `reversed()` method to Array

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -86,6 +86,7 @@ public:
 	}
 
 	void reverse();
+	Vector<T> reversed() const;
 
 	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
@@ -347,6 +348,13 @@ void Vector<T>::reverse() {
 	for (Size i = 0; i < size() / 2; i++) {
 		SWAP(p[i], p[size() - i - 1]);
 	}
+}
+
+template <typename T>
+Vector<T> Vector<T>::reversed() const {
+	Vector<T> result = *this;
+	result.reverse();
+	return result;
 }
 
 template <typename T>

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -771,6 +771,12 @@ void Array::reverse() {
 	_p->array.reverse();
 }
 
+Array Array::reversed() const {
+	Array ret = duplicate();
+	ret.reverse();
+	return ret;
+}
+
 void Array::push_front(const Variant &p_value) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
 	Variant value = p_value;

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -138,6 +138,7 @@ public:
 	int bsearch(const Variant &p_value, bool p_before = true) const;
 	int bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before = true) const;
 	void reverse();
+	Array reversed() const;
 
 	int find(const Variant &p_value, int p_from = 0) const;
 	int find_custom(const Callable &p_callable, int p_from = 0) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2525,6 +2525,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(Array, bsearch_custom, sarray("value", "func", "before"), varray(true));
 	bind_method(Array, reverse, sarray(), varray());
+	bind_method(Array, reversed, sarray(), varray());
 	bind_method(Array, duplicate, sarray("deep"), varray(false));
 	bind_method(Array, duplicate_deep, sarray("deep_subresources_mode"), varray(RESOURCE_DEEP_DUPLICATE_INTERNAL));
 	bind_method(Array, slice, sarray("begin", "end", "step", "deep"), varray(INT_MAX, 1, false));
@@ -2579,6 +2580,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedByteArray, clear, sarray(), varray());
 	bind_method(PackedByteArray, has, sarray("value"), varray());
 	bind_method(PackedByteArray, reverse, sarray(), varray());
+	bind_method(PackedByteArray, reversed, sarray(), varray());
 	bind_method(PackedByteArray, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedByteArray, sort, sarray(), varray());
 	bind_method(PackedByteArray, bsearch, sarray("value", "before"), varray(true));
@@ -2654,6 +2656,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedInt32Array, clear, sarray(), varray());
 	bind_method(PackedInt32Array, has, sarray("value"), varray());
 	bind_method(PackedInt32Array, reverse, sarray(), varray());
+	bind_method(PackedInt32Array, reversed, sarray(), varray());
 	bind_method(PackedInt32Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedInt32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt32Array, sort, sarray(), varray());
@@ -2678,6 +2681,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedInt64Array, clear, sarray(), varray());
 	bind_method(PackedInt64Array, has, sarray("value"), varray());
 	bind_method(PackedInt64Array, reverse, sarray(), varray());
+	bind_method(PackedInt64Array, reversed, sarray(), varray());
 	bind_method(PackedInt64Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedInt64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt64Array, sort, sarray(), varray());
@@ -2702,6 +2706,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedFloat32Array, clear, sarray(), varray());
 	bind_method(PackedFloat32Array, has, sarray("value"), varray());
 	bind_method(PackedFloat32Array, reverse, sarray(), varray());
+	bind_method(PackedFloat32Array, reversed, sarray(), varray());
 	bind_method(PackedFloat32Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedFloat32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat32Array, sort, sarray(), varray());
@@ -2726,6 +2731,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedFloat64Array, clear, sarray(), varray());
 	bind_method(PackedFloat64Array, has, sarray("value"), varray());
 	bind_method(PackedFloat64Array, reverse, sarray(), varray());
+	bind_method(PackedFloat64Array, reversed, sarray(), varray());
 	bind_method(PackedFloat64Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedFloat64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat64Array, sort, sarray(), varray());
@@ -2750,6 +2756,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedStringArray, clear, sarray(), varray());
 	bind_method(PackedStringArray, has, sarray("value"), varray());
 	bind_method(PackedStringArray, reverse, sarray(), varray());
+	bind_method(PackedStringArray, reversed, sarray(), varray());
 	bind_method(PackedStringArray, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_function(PackedStringArray, to_byte_array, _VariantCall::func_PackedStringArray_to_byte_array, sarray(), varray());
 	bind_method(PackedStringArray, sort, sarray(), varray());
@@ -2774,6 +2781,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector2Array, clear, sarray(), varray());
 	bind_method(PackedVector2Array, has, sarray("value"), varray());
 	bind_method(PackedVector2Array, reverse, sarray(), varray());
+	bind_method(PackedVector2Array, reversed, sarray(), varray());
 	bind_method(PackedVector2Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedVector2Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector2Array, sort, sarray(), varray());
@@ -2798,6 +2806,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector3Array, clear, sarray(), varray());
 	bind_method(PackedVector3Array, has, sarray("value"), varray());
 	bind_method(PackedVector3Array, reverse, sarray(), varray());
+	bind_method(PackedVector3Array, reversed, sarray(), varray());
 	bind_method(PackedVector3Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedVector3Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector3Array, sort, sarray(), varray());
@@ -2822,6 +2831,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedColorArray, clear, sarray(), varray());
 	bind_method(PackedColorArray, has, sarray("value"), varray());
 	bind_method(PackedColorArray, reverse, sarray(), varray());
+	bind_method(PackedColorArray, reversed, sarray(), varray());
 	bind_method(PackedColorArray, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedColorArray, to_byte_array, sarray(), varray());
 	bind_method(PackedColorArray, sort, sarray(), varray());
@@ -2846,6 +2856,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector4Array, clear, sarray(), varray());
 	bind_method(PackedVector4Array, has, sarray("value"), varray());
 	bind_method(PackedVector4Array, reverse, sarray(), varray());
+	bind_method(PackedVector4Array, reversed, sarray(), varray());
 	bind_method(PackedVector4Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedVector4Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector4Array, sort, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -701,6 +701,12 @@
 				Reverses the order of all elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="what" type="Variant" />

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -459,6 +459,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -158,6 +158,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedColorArray" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Color" />

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -159,6 +159,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedFloat32Array" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="float" />

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -160,6 +160,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedFloat64Array" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="float" />

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -154,6 +154,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedInt32Array" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -155,6 +155,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedInt64Array" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -161,6 +161,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="String" />

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -164,6 +164,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector2" />

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -163,6 +163,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector3" />

--- a/doc/classes/PackedVector4Array.xml
+++ b/doc/classes/PackedVector4Array.xml
@@ -163,6 +163,13 @@
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
+		<method name="reversed" qualifiers="const">
+			<return type="PackedVector4Array" />
+			<description>
+				Returns a reversed copy of this array. See also [method reverse].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place reversal instead, use [method reverse].
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector4" />


### PR DESCRIPTION
I commonly find myself annoyed that while ```Dictionary``` has ```merge()``` and ```merged()```, ```Array``` has ```reverse()``` but no ```reversed()```. This makes some things much uglier than they have to be.

For example:
```gdscript
var reversed_array: Array[int] = array.duplicate()
reversed_array.reverse()
for x: int in reversed_array: ...
```
vs.
```gdscript
for x: int in array.reversed(): ...
```
Another example:
```gdscript
for x: int in range(array.size() - 1, -1, -1): ...
```
vs.
```gdscript
for x: int in range(array.size()).reversed(): ...
```

I've also added the method to the ```Packed*Array```s

Closes https://github.com/godotengine/godot-proposals/issues/13511