### PR TITLE
[GUI] Implment `Slider::respect_grabber_area_min_size`

### DIFF
--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -13,6 +13,9 @@
 			If [code]true[/code], the slider can be interacted with. If [code]false[/code], the value can be changed only by code.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="respect_grabber_area_min_size" type="bool" setter="set_respect_grabber_area_min_size" getter="is_respecting_grabber_area_min_size" default="false">
+			If [code]true[/code], the slider will ensure that the grabber area's minimum size is always respected, potentially reducing the usable range of the slider.
+		</member>
 		<member name="scrollable" type="bool" setter="set_scrollable" getter="is_scrollable" default="true">
 			If [code]true[/code], the value can be changed using the mouse wheel.
 		</member>

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -477,6 +477,9 @@ bool Slider::is_scrollable() const {
 }
 
 void Slider::set_respect_grabber_area_min_size(bool p_respect) {
+	if (respect_grabber_area_min_size == p_respect) {
+		return;
+	}
 	respect_grabber_area_min_size = p_respect;
 	queue_redraw();
 }

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -59,6 +59,7 @@ private:
 	double custom_step = -1.0;
 	bool editable = true;
 	bool scrollable = true;
+	bool respect_grabber_area_min_size = false;
 
 	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 0.5;
 	const float GAMEPAD_EVENT_REPEAT_RATE_MS = 1.0 / 20;
@@ -84,6 +85,7 @@ protected:
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
+	Size2i &NewFunction(int p, int widget_height);
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
@@ -107,6 +109,9 @@ public:
 
 	void set_scrollable(bool p_scrollable);
 	bool is_scrollable() const;
+
+	void set_respect_grabber_area_min_size(bool p_respect);
+	bool is_respecting_grabber_area_min_size() const;
 
 	Slider(Orientation p_orientation = VERTICAL);
 };


### PR DESCRIPTION
Implement 
- godotengine/godot-proposals#13484

Adds an option to the Slider that, when enabled, will respect the min-size reported by the stylebox when rendering the grabber area.

https://github.com/user-attachments/assets/6a8ecb08-e23f-4564-8194-6dce0f799bb9

* *Bugsquad edit, closes: godotengine/godot-proposals#13484*