### PR TITLE
Add an easy way to reload editor addons

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6734,6 +6734,57 @@ void EditorNode::_layout_menu_option(int p_id) {
 	}
 }
 
+void EditorNode::_update_plugins_menu() {
+	plugins_menu->clear();
+	plugins_menu->add_shortcut(ED_GET_SHORTCUT("editor/reload_plugins"));
+	const PackedStringArray plugin_addons = EditorPluginSettings::get_plugins("res://addons/");
+	if (plugin_addons.is_empty()) {
+		plugins_menu->add_separator(TTRC("No Plugins Installed"));
+	} else {
+		plugins_menu->add_separator(TTRC("Installed Plugins"));
+	}
+	for (const String &path : plugin_addons) {
+		ConfigFile plugin;
+		String folder = path.get_base_dir().get_file();
+		Error err = plugin.load(path);
+		ERR_FAIL_COND_MSG(err != OK, vformat("Failed to load addon plugin config file: %s", path));
+		String name = plugin.get_value("plugin", "name", folder);
+		plugins_menu->add_check_item(name);
+		plugins_menu->set_item_metadata(-1, folder);
+		plugins_menu->set_item_checked(-1, pending_plugin_reload.has(folder));
+		plugins_menu->set_item_auto_translate_mode(-1, AUTO_TRANSLATE_MODE_DISABLED);
+	}
+	plugins_menu->set_item_disabled(0,
+			plugins_menu->get_item_count() <= 2 || pending_plugin_reload.is_empty());
+}
+
+void EditorNode::_plugins_menu_option(int p_id) {
+	if (p_id == 0) {
+		for (const KeyValue<String, String> &E : pending_plugin_reload) {
+			String plugin = "res://addons/" + E.key + "/plugin.cfg";
+			if (is_addon_plugin_enabled(E.key)) {
+				addon_name_to_plugin[plugin]->disable_plugin();
+				set_addon_plugin_enabled(E.key, false);
+			}
+			set_addon_plugin_enabled(E.key, true);
+			addon_name_to_plugin[plugin]->enable_plugin();
+		}
+		EditorToaster::get_singleton()->popup_str(TTR("Plugins reloaded."));
+	} else if (p_id >= 2) {
+		String folder = plugins_menu->get_item_metadata(p_id);
+		String name = plugins_menu->get_item_text(p_id);
+
+		if (plugins_menu->is_item_checked(p_id)) {
+			pending_plugin_reload.erase(folder);
+			plugins_menu->set_item_checked(p_id, false);
+		} else {
+			pending_plugin_reload[folder] = name;
+			plugins_menu->set_item_checked(p_id, true);
+		}
+		plugins_menu->set_item_disabled(0, pending_plugin_reload.is_empty());
+	}
+}
+
 void EditorNode::_proceed_closing_scene_tabs() {
 	List<String>::Element *E = tabs_to_close.front();
 	if (!E) {
@@ -8156,6 +8207,14 @@ void EditorNode::_build_settings_menu(bool p_dark_mode) {
 		editor_layouts->connect(SceneStringName(id_pressed), callable_mp(this, &EditorNode::_layout_menu_option));
 	}
 	settings_menu->add_submenu_node_item(TTRC("Editor Layout"), editor_layouts);
+
+	if (!plugins_menu) {
+		plugins_menu = memnew(PopupMenu);
+		plugins_menu->set_hide_on_checkable_item_selection(false);
+		plugins_menu->connect("about_to_popup", callable_mp(this, &EditorNode::_update_plugins_menu));
+		plugins_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorNode::_plugins_menu_option));
+	}
+	settings_menu->add_submenu_node_item(TTRC("Plugins"), plugins_menu);
 	settings_menu->add_separator();
 
 	settings_menu->add_shortcut(ED_GET_SHORTCUT("editor/take_screenshot"), EDITOR_TAKE_SCREENSHOT);
@@ -9032,6 +9091,8 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_OVERRIDE("editor/quit_to_project_list", "macos", KeyModifierMask::META + KeyModifierMask::CTRL + KeyModifierMask::ALT + Key::Q);
 
 	ED_SHORTCUT("editor/command_palette", TTRC("Command Palette..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::P);
+
+	ED_SHORTCUT_AND_COMMAND("editor/reload_plugins", TTRC("Reload Selected Plugins"), KeyModifierMask::ALT | KeyModifierMask::SHIFT | Key::R);
 
 	ED_SHORTCUT_AND_COMMAND("editor/take_screenshot", TTRC("Take Screenshot"), KeyModifierMask::CTRL | Key::F12);
 	ED_SHORTCUT_OVERRIDE("editor/take_screenshot", "macos", KeyModifierMask::META | Key::F12);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -391,6 +391,9 @@ private:
 	PopupMenu *editor_layouts = nullptr;
 	EditorLayoutsDialog *layout_dialog = nullptr;
 
+	PopupMenu *plugins_menu = nullptr;
+	HashMap<String, String> pending_plugin_reload;
+
 	ConfirmationDialog *gradle_build_manage_templates = nullptr;
 	ConfirmationDialog *install_android_build_template = nullptr;
 	ConfirmationDialog *remove_android_build_template = nullptr;
@@ -669,6 +672,9 @@ private:
 
 	void _update_layouts_menu();
 	void _layout_menu_option(int p_id);
+
+	void _update_plugins_menu();
+	void _plugins_menu_option(int p_id);
 
 	void _update_addon_config();
 

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -73,7 +73,7 @@ void EditorPluginSettings::update_plugins() {
 	updating = true;
 	TreeItem *root = plugin_list->create_item();
 
-	Vector<String> plugins = _get_plugins("res://addons");
+	Vector<String> plugins = get_plugins("res://addons");
 	plugins.sort();
 
 	for (int i = 0; i < plugins.size(); i++) {
@@ -189,7 +189,7 @@ void EditorPluginSettings::_cell_button_pressed(Object *p_item, int p_column, in
 	}
 }
 
-Vector<String> EditorPluginSettings::_get_plugins(const String &p_dir) {
+Vector<String> EditorPluginSettings::get_plugins(const String &p_dir) {
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	Error err = da->change_dir(p_dir);
 	if (err != OK) {
@@ -208,7 +208,7 @@ Vector<String> EditorPluginSettings::_get_plugins(const String &p_dir) {
 		if (FileAccess::exists(plugin_config)) {
 			plugins.push_back(plugin_config);
 		} else {
-			plugins.append_array(_get_plugins(full_path));
+			plugins.append_array(get_plugins(full_path));
 		}
 	}
 

--- a/editor/plugins/editor_plugin_settings.h
+++ b/editor/plugins/editor_plugin_settings.h
@@ -60,12 +60,12 @@ class EditorPluginSettings : public VBoxContainer {
 	void _create_clicked();
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 
-	static Vector<String> _get_plugins(const String &p_dir);
-
 protected:
 	void _notification(int p_what);
 
 public:
+	static Vector<String> get_plugins(const String &p_dir);
+
 	void update_plugins();
 
 	EditorPluginSettings();


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/13308

Adds a new menu to `Editor`, allowing you to select a plugin and reload it whenever you want

<img width="199" height="204" alt="image" src="https://github.com/user-attachments/assets/7f3b6c45-4572-4f4b-b764-c72fbd88bc36" />
<img width="143" height="67" alt="image" src="https://github.com/user-attachments/assets/b6f1f631-c1dd-4ffa-bccd-00abe853ee9e" />


~Add 3 new menu items to `ScriptEditor`, allowing to `Enable Plugin`, `Disable Plugin`, and `Reload Plugin`~

~Edit:~
~Adds a new submenu to the `FileSystem` context menu called `Plugins...` that shows all selected plugins, and their state as a checkbox. If the `addons` folder is selected, it shows all plugins instead~

<img width="314" height="269" alt="image" src="https://github.com/user-attachments/assets/ff5ad06e-dc35-4676-b356-8428c9d7d994" />

<img width="294" height="268" alt="image" src="https://github.com/user-attachments/assets/feed8cd5-d816-4d3d-b843-3ea2d43c66a8" />

~Also, work with the internal addon files and folders~

<img width="304" height="250" alt="image" src="https://github.com/user-attachments/assets/b2034710-4bb7-4157-b672-561b1f47cade" />
~
