### PR TITLE
Increase stack size for all secondary threads on Apple platforms

### DIFF
--- a/drivers/apple/thread_apple.h
+++ b/drivers/apple/thread_apple.h
@@ -57,8 +57,6 @@ public:
 
 	struct Settings {
 		Priority priority;
-		/// Override the default stack size (0 means default)
-		uint64_t stack_size = 0;
 		Settings() { priority = PRIORITY_NORMAL; }
 	};
 


### PR DESCRIPTION
Fixes #112093.

This moves the increasing of stack size that happens for `WorkerThreadPool` on Apple platforms to instead be done for all secondary threads, meaning all threads (spawned through `Thread`) now use at least 1 MiB of stack size, as opposed to the default 512 KiB.

This means that Apple platforms now conform better with other platforms, where the stack size of secondary threads is usually at least 1 MiB in size (e.g. Windows, Linux, Android).

I also threw in even more stack size for ASan/TSan builds, since that's already being done for the main thread but not secondary threads. I'll admit I haven't tested this much to see if we should perhaps give it even more, but 4x is the same ratio as the main thread, and should be plenty.