### PR TITLE
Fix `PopupMenu` losing item highlight when hovering submenus

### DIFF
--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -228,6 +228,8 @@ class PopupMenu : public Popup {
 	String _atr(int p_idx, const String &p_text) const;
 
 protected:
+	void _hover_active_submenu_item();
+
 	virtual void _pre_popup() override;
 	virtual Rect2i _popup_adjust_rect() const override;
 


### PR DESCRIPTION
Used to work before, but broke somewhere down the road.

|Before|After|
|-|-|
|<img width="624" height="120" alt="Screenshot_20251027_120040" src="https://github.com/user-attachments/assets/a04f1d42-3526-4460-96d2-65e8035c67ea" />|<img width="619" height="133" alt="Screenshot_20251027_115726" src="https://github.com/user-attachments/assets/602fe0b8-aeb8-4e02-82bc-7905923b75f8" />|