### PR TITLE
[4.5] Core: Sidestep MinGW-GCC false-positive warnings

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2357,6 +2357,12 @@ void Image::initialize_data(const char **p_xpm) {
 			} break;
 			case READING_PIXELS: {
 				int y = line - colormap_size - 1;
+#ifdef __MINGW32__
+				// False positive only with MinGW-GCC. Don't silence for regular GCC/Clang
+				// as this is code that _could_ exhibit actual overflow bugs.
+				GODOT_GCC_WARNING_PUSH
+				GODOT_GCC_PRAGMA(GCC diagnostic warning "-Wstringop-overflow=0")
+#endif
 				for (int x = 0; x < size_width; x++) {
 					char pixelstr[6] = { 0, 0, 0, 0, 0, 0 };
 					for (int i = 0; i < pixelchars; i++) {
@@ -2371,6 +2377,9 @@ void Image::initialize_data(const char **p_xpm) {
 					}
 					_put_pixelb(x, y, pixel_size, data_write, pixel);
 				}
+#ifdef __MINGW32__
+				GODOT_GCC_WARNING_POP
+#endif
 
 				if (y == (size_height - 1)) {
 					status = DONE;

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -30,7 +30,9 @@
 
 #include "geometry_2d.h"
 
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Walloc-zero")
 #include "thirdparty/clipper2/include/clipper2/clipper.h"
+GODOT_GCC_WARNING_POP
 #include "thirdparty/misc/polypartition.h"
 #define STB_RECT_PACK_IMPLEMENTATION
 #include "thirdparty/misc/stb_rect_pack.h"

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5855,6 +5855,15 @@ String String::unquote() const {
 	return substr(1, length() - 2);
 }
 
+// MinGW-GCC false positives because CharStringT::length() is int (so possibly < 0).
+// Don't silence for regular GCC/Clang as this is code that _could_ exhibit actual overflow bugs.
+#ifdef __MINGW32__
+GODOT_GCC_WARNING_PUSH
+GODOT_GCC_PRAGMA(GCC diagnostic warning "-Wstringop-overflow=0")
+GODOT_GCC_WARNING_IGNORE("-Warray-bounds")
+GODOT_GCC_WARNING_IGNORE("-Wrestrict")
+#endif
+
 Vector<uint8_t> String::to_ascii_buffer() const {
 	const String *s = this;
 	if (s->is_empty()) {
@@ -5902,6 +5911,10 @@ Vector<uint8_t> String::to_utf16_buffer() const {
 
 	return retval;
 }
+
+#ifdef __MINGW32__
+GODOT_GCC_WARNING_POP
+#endif
 
 Vector<uint8_t> String::to_utf32_buffer() const {
 	const String *s = this;

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -32,6 +32,8 @@
 
 #include "core/templates/span.h"
 
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Warray-bounds")
+
 /**
  * A high performance Vector of fixed capacity.
  * Especially useful if you need to create an array on the stack, to
@@ -163,3 +165,5 @@ public:
 	_FORCE_INLINE_ constexpr const T *begin() const { return ptr(); }
 	_FORCE_INLINE_ constexpr const T *end() const { return ptr() + _size; }
 };
+
+GODOT_GCC_WARNING_POP

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -151,6 +151,7 @@ Error MultiplayerPeerExtension::get_packet(const uint8_t **r_buffer, int &r_buff
 }
 
 Error MultiplayerPeerExtension::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
+	ERR_FAIL_COND_V(p_buffer_size < 0, ERR_INVALID_PARAMETER);
 	Error err;
 	if (GDVIRTUAL_CALL(_put_packet, p_buffer, p_buffer_size, err)) {
 		return err;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -158,6 +158,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	const NodeData *nd = &nodes[0];
 
 	Node **ret_nodes = (Node **)alloca(sizeof(Node *) * nc);
+	ret_nodes[0] = nullptr; // Sidesteps "maybe uninitialized" false-positives on GCC.
 
 	bool gen_node_path_cache = p_edit_state != GEN_EDIT_STATE_DISABLED && node_path_cache.is_empty();
 


### PR DESCRIPTION
Cherry-pick of #111771 and #111761, with additional fixes for `4.5`. Making a PR to validate that it passes CI.