### PR TITLE
Expose the `TextEdit::get_text_canvas_item` binding

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -678,6 +678,12 @@
 				Returns the [TextEdit]'s' tab size.
 			</description>
 		</method>
+		<method name="get_text_canvas_item" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the canvas item [RID] for internal drawn text, available for use by [RenderingServer].
+			</description>
+		</method>
 		<method name="get_total_gutter_width" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7095,6 +7095,7 @@ Color TextEdit::get_font_color() const {
 void TextEdit::_bind_methods() {
 	/* Text */
 	// Text properties
+	ClassDB::bind_method(D_METHOD("get_text_canvas_item"), &TextEdit::get_text_canvas_item);
 	ClassDB::bind_method(D_METHOD("has_ime_text"), &TextEdit::has_ime_text);
 	ClassDB::bind_method(D_METHOD("cancel_ime"), &TextEdit::cancel_ime);
 	ClassDB::bind_method(D_METHOD("apply_ime"), &TextEdit::apply_ime);


### PR DESCRIPTION
Convenient for users to draw custom content in `TextEdit`