### PR TITLE
Add better Renaming alternatives to Resources

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -36,6 +36,7 @@
 #include "editor/docks/scene_tree_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_quick_open_dialog.h"
 #include "editor/inspector/editor_inspector.h"
@@ -312,6 +313,9 @@ void EditorResourcePicker::_update_menu_items() {
 			edit_menu->add_item(TTR("Paste"), OBJ_MENU_PASTE);
 			edit_menu->add_item(TTRC("Paste as Unique"), OBJ_MENU_PASTE_AS_UNIQUE);
 		}
+		if (edited_resource.is_valid()) {
+			edit_menu->add_item(TTR("Rename"), OBJ_MENU_RENAME);
+		}
 	}
 
 	// Add options to convert existing resource to another type of resource.
@@ -502,6 +506,23 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			FileSystemDock::get_singleton()->navigate_to_path(edited_resource->get_path());
 		} break;
 
+		case OBJ_MENU_RENAME: {
+			if (Ref<Script>(edited_resource).is_valid()) {
+				return;
+			}
+			assign_button->set_visible(false);
+			rename_line = memnew(LineEdit);
+			rename_line->set_h_size_flags(SIZE_EXPAND_FILL);
+			add_child(rename_line);
+			move_child(rename_line, quick_load_button->get_index());
+			rename_line->set_text(edited_resource->get_name());
+			rename_line->select_all();
+			rename_line->grab_focus();
+			rename_line->connect(SNAME("text_submitted"), callable_mp(this, &EditorResourcePicker::_perform_resource_rename));
+			rename_line->connect(SNAME("editing_toggled"), callable_mp(this, &EditorResourcePicker::_clean_up_resource_rename));
+
+		} break;
+
 		default: {
 			// Allow subclasses to handle their own options first, only then fallback on the default branch logic.
 			if (handle_menu_selected(p_which)) {
@@ -629,6 +650,21 @@ void EditorResourcePicker::_button_input(const Ref<InputEvent> &p_event) {
 			edit_menu->set_position(pos);
 			edit_menu->popup();
 		}
+	}
+}
+
+void EditorResourcePicker::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!p_event->is_pressed() || p_event->is_echo()) {
+		return;
+	}
+
+	if (edited_resource.is_null()) {
+		return;
+	}
+
+	if (ED_IS_SHORTCUT("inspector/resource/rename", p_event) && assign_button->has_focus()) {
+		_edit_menu_cbk(OBJ_MENU_RENAME);
+		accept_event();
 	}
 }
 
@@ -1280,6 +1316,24 @@ void EditorResourcePicker::_duplicate_selected_resources() {
 	}
 }
 
+void EditorResourcePicker::_perform_resource_rename(String new_name) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	Resource *res = edited_resource.ptr();
+	undo_redo->create_action(TTR("Rename Node"), UndoRedo::MERGE_DISABLE, res);
+	undo_redo->add_undo_method(res, "set_name", res->get_name());
+	undo_redo->add_do_method(res, "set_name", new_name);
+	undo_redo->commit_action();
+	_update_resource();
+}
+
+void EditorResourcePicker::_clean_up_resource_rename(bool toggled_on) {
+	if (toggled_on) {
+		return;
+	}
+	rename_line->queue_free();
+	assign_button->set_visible(true);
+}
+
 EditorResourcePicker::EditorResourcePicker(bool p_hide_assign_button_controls) {
 	assign_button = memnew(Button);
 	assign_button->set_flat(true);
@@ -1320,6 +1374,9 @@ EditorResourcePicker::EditorResourcePicker(bool p_hide_assign_button_controls) {
 	edit_button->connect(SceneStringName(gui_input), callable_mp(this, &EditorResourcePicker::_button_input));
 
 	add_theme_constant_override("separation", 0);
+	set_process_shortcut_input(true);
+
+	ED_SHORTCUT("inspector/resource/rename", "Rename Selected Resource", Key::F2);
 }
 
 // EditorScriptPicker

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/gui/box_container.h"
+#include "scene/gui/line_edit.h"
 #include "scene/resources/material.h"
 
 class Button;
@@ -62,6 +63,7 @@ class EditorResourcePicker : public HBoxContainer {
 
 	ConfirmationDialog *duplicate_resources_dialog = nullptr;
 	Tree *duplicate_resources_tree = nullptr;
+	LineEdit *rename_line = nullptr;
 
 	Size2i assign_button_min_size = Size2i(1, 1);
 
@@ -78,6 +80,7 @@ class EditorResourcePicker : public HBoxContainer {
 		OBJ_MENU_PASTE,
 		OBJ_MENU_PASTE_AS_UNIQUE,
 		OBJ_MENU_SHOW_IN_FILE_SYSTEM,
+		OBJ_MENU_RENAME,
 
 		TYPE_BASE_ID = 100,
 		CONVERT_BASE_ID = 1000,
@@ -102,6 +105,7 @@ class EditorResourcePicker : public HBoxContainer {
 
 	void _button_draw();
 	void _button_input(const Ref<InputEvent> &p_event);
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	String _get_owner_path() const;
 	String _get_resource_type(const Ref<Resource> &p_resource) const;
@@ -117,6 +121,8 @@ class EditorResourcePicker : public HBoxContainer {
 	void _ensure_resource_menu();
 	void _gather_resources_to_duplicate(const Ref<Resource> p_resource, TreeItem *p_item, const String &p_property_name = "") const;
 	void _duplicate_selected_resources();
+	void _perform_resource_rename(String new_name);
+	void _clean_up_resource_rename(bool toggled_on);
 
 protected:
 	virtual void _update_resource();


### PR DESCRIPTION
My intent behind this PR is to allow the user to (re)name their Resources more easily without going to the Resource's drop-down menu. imo it feels rather weird to head there only for a name change, specially since Nodes in the SceneTree allow themselves to renamed on the spot. thus this allows a more consistent workflow and ux. 

- You can use F2 to do this or 
- You can use the option in the edit menu

![whybother](https://github.com/user-attachments/assets/eb7ac4f4-3c92-49b7-b51a-c20b90ab74be)


~Currently it's pretty buggy and I need some help tweaking the Control settings.  It either expands or shrinks vertically and also the LineEdit goes way above the focus rect.~

- [ ] call `_update_resource` as soon as the - user undos renaming 
- [x] Fix that silly vertical misalignment 
- [ ] Allow renaming multiple nodes
