### PR TITLE
Main: Fix typo in `--gpu-profile` CLI argument

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1818,7 +1818,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "--editor-pseudolocalization") {
 			editor_pseudolocalization = true;
 #endif // TOOLS_ENABLED
-		} else if (arg == "--profile-gpu") {
+		} else if (arg == "--gpu-profile") {
 			profile_gpu = true;
 		} else if (arg == "--disable-crash-handler") {
 			OS::get_singleton()->disable_crash_handler();


### PR DESCRIPTION
main.cpp uses "profile-gpu" in one place, whereas all other occurrences in the codebase use "gpu-profile". This fixes the gpu profiler not being configurable via CLI.

Fixes https://github.com/godotengine/godot/issues/112112