### PR TITLE
CodeEdit: Add line number gutter minimum digits

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -562,6 +562,9 @@
 		<member name="gutters_draw_line_numbers" type="bool" setter="set_draw_line_numbers" getter="is_draw_line_numbers_enabled" default="false">
 			If [code]true[/code], the line number gutter is drawn. Line numbers start at [code]1[/code] and are incremented for each line of text. Clicking and dragging in the line number gutter will select entire lines of text.
 		</member>
+		<member name="gutters_line_numbers_min_digits" type="int" setter="set_line_numbers_min_digits" getter="get_line_numbers_min_digits" default="3">
+			The minimum width in digits reserved for the line number gutter.
+		</member>
 		<member name="gutters_zero_pad_line_numbers" type="bool" setter="set_line_numbers_zero_padded" getter="is_line_numbers_zero_padded" default="false">
 			If [code]true[/code], line numbers drawn in the gutter are zero padded based on the total line count. Requires [member gutters_draw_line_numbers] to be set to [code]true[/code].
 		</member>

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1511,6 +1511,26 @@ bool CodeEdit::is_line_numbers_zero_padded() const {
 	return line_number_padding == "0";
 }
 
+void CodeEdit::set_line_numbers_min_digits(int p_count) {
+	if (line_numbers_min_digits == p_count) {
+		return;
+	}
+	line_numbers_min_digits = p_count;
+
+	int digits = MAX(line_numbers_min_digits, std::log10(get_line_count()) + 1);
+	if (digits == line_number_digits) {
+		return;
+	}
+	line_number_digits = digits;
+	_clear_line_number_text_cache();
+	_update_line_number_gutter_width();
+	queue_redraw();
+}
+
+int CodeEdit::get_line_numbers_min_digits() const {
+	return line_numbers_min_digits;
+}
+
 void CodeEdit::_line_number_draw_callback(int p_line, int p_gutter, const Rect2 &p_region) {
 	if (!Rect2(Vector2(0, 0), get_size()).intersects(p_region)) {
 		return;
@@ -2800,6 +2820,8 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_draw_line_numbers_enabled"), &CodeEdit::is_draw_line_numbers_enabled);
 	ClassDB::bind_method(D_METHOD("set_line_numbers_zero_padded", "enable"), &CodeEdit::set_line_numbers_zero_padded);
 	ClassDB::bind_method(D_METHOD("is_line_numbers_zero_padded"), &CodeEdit::is_line_numbers_zero_padded);
+	ClassDB::bind_method(D_METHOD("set_line_numbers_min_digits", "count"), &CodeEdit::set_line_numbers_min_digits);
+	ClassDB::bind_method(D_METHOD("get_line_numbers_min_digits"), &CodeEdit::get_line_numbers_min_digits);
 
 	/* Fold Gutter */
 	ClassDB::bind_method(D_METHOD("set_draw_fold_gutter", "enable"), &CodeEdit::set_draw_fold_gutter);
@@ -2944,6 +2966,7 @@ void CodeEdit::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_line_numbers"), "set_draw_line_numbers", "is_draw_line_numbers_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_zero_pad_line_numbers"), "set_line_numbers_zero_padded", "is_line_numbers_zero_padded");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "gutters_line_numbers_min_digits", PROPERTY_HINT_RANGE, "1,5,1"), "set_line_numbers_min_digits", "get_line_numbers_min_digits");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_fold_gutter"), "set_draw_fold_gutter", "is_drawing_fold_gutter");
 
@@ -3823,7 +3846,7 @@ void CodeEdit::_text_changed() {
 	}
 
 	int lc = get_line_count();
-	int new_line_number_digits = std::log10(lc) + 1;
+	int new_line_number_digits = MAX(line_numbers_min_digits, std::log10(lc) + 1);
 	if (line_number_digits != new_line_number_digits) {
 		_clear_line_number_text_cache();
 	}

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -111,6 +111,7 @@ private:
 	/* Line numbers */
 	int line_number_gutter = -1;
 	int line_number_digits = 1;
+	int line_numbers_min_digits = 3;
 	String line_number_padding = " ";
 	HashMap<int, RID> line_number_text_cache;
 	void _clear_line_number_text_cache();
@@ -413,6 +414,8 @@ public:
 	bool is_draw_line_numbers_enabled() const;
 	void set_line_numbers_zero_padded(bool p_zero_padded);
 	bool is_line_numbers_zero_padded() const;
+	void set_line_numbers_min_digits(int p_count);
+	int get_line_numbers_min_digits() const;
 
 	/* Fold gutter */
 	void set_draw_fold_gutter(bool p_draw);


### PR DESCRIPTION
The problem: When editing scripts, I often notice this kind of jump caused by line numbers.

![Peek 2025-10-28 16-56](https://github.com/user-attachments/assets/1f43c93d-793b-45f2-bd63-4cbf5288f94e)

This PR:

- Adds a `line_numbers_min_digits` property to `CodeEdit`. It defaults to 1 to be compatible with existing projects.
- Adds an editor setting `text_editor/appearance/gutters/line_numbers_min_digits` which defaults to 3.