### PR TITLE
[Windows] Use separate resource files for export templates.

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -69,8 +69,12 @@ def arrange_program_clean(prog):
 
 
 env["BUILDERS"]["RES"].emitter = redirect_emitter
-res_file = "godot_res.rc"
-res_target = "godot_res" + env["OBJSUFFIX"]
+if env.editor_build:
+    res_file = "godot_res.rc"
+    res_target = "godot_res" + env["OBJSUFFIX"]
+else:
+    res_file = "godot_res_template.rc"
+    res_target = "godot_res_template" + env["OBJSUFFIX"]
 res_obj = env.RES(res_target, res_file)
 env.Depends(res_obj, "#core/version_generated.gen.h")
 
@@ -94,8 +98,12 @@ if env.msvc:
 
 # Build console wrapper app.
 if env["windows_subsystem"] == "gui":
-    res_wrap_file = "godot_res_wrap.rc"
-    res_wrap_target = "godot_res_wrap" + env["OBJSUFFIX"]
+    if env.editor_build:
+        res_wrap_file = "godot_res_wrap.rc"
+        res_wrap_target = "godot_res_wrap" + env["OBJSUFFIX"]
+    else:
+        res_wrap_file = "godot_res_wrap_template.rc"
+        res_wrap_target = "godot_res_wrap_template" + env["OBJSUFFIX"]
     res_wrap_obj = env_wrap.RES(res_wrap_target, res_wrap_file)
     env_wrap.Depends(res_wrap_obj, "#core/version_generated.gen.h")
 

--- a/platform/windows/godot_res_template.rc
+++ b/platform/windows/godot_res_template.rc
@@ -1,0 +1,28 @@
+#include "core/version.h"
+
+#ifndef RT_MANIFEST
+#define RT_MANIFEST 24
+#endif
+
+GODOT_ICON ICON platform/windows/godot.ico
+1 RT_MANIFEST "platform/windows/godot.manifest"
+
+1 VERSIONINFO
+FILEVERSION     GODOT_VERSION_MAJOR,GODOT_VERSION_MINOR,GODOT_VERSION_PATCH,0
+PRODUCTVERSION  GODOT_VERSION_MAJOR,GODOT_VERSION_MINOR,GODOT_VERSION_PATCH,0
+FILEOS          4
+FILETYPE        1
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileDescription",        GODOT_VERSION_NAME
+            VALUE "FileVersion",            GODOT_VERSION_NUMBER
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/platform/windows/godot_res_wrap_template.rc
+++ b/platform/windows/godot_res_wrap_template.rc
@@ -1,0 +1,28 @@
+#include "core/version.h"
+
+#ifndef RT_MANIFEST
+#define RT_MANIFEST 24
+#endif
+
+GODOT_ICON ICON platform/windows/godot_console.ico
+1 RT_MANIFEST "platform/windows/godot.manifest"
+
+1 VERSIONINFO
+FILEVERSION     GODOT_VERSION_MAJOR,GODOT_VERSION_MINOR,GODOT_VERSION_PATCH,0
+PRODUCTVERSION  GODOT_VERSION_MAJOR,GODOT_VERSION_MINOR,GODOT_VERSION_PATCH,0
+FILEOS          4
+FILETYPE        1
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileDescription",        GODOT_VERSION_NAME " (Console)"
+            VALUE "FileVersion",            GODOT_VERSION_NUMBER
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
Only keeping bare minimum info in the templates, since it is intended to be overwritten by exporter in any case.

Fixes https://github.com/godotengine/godot/issues/106034 and allows future customization (if we want to use default project icon for example).