### PR TITLE
LSP: Fix remaining unsafe dict access

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -177,7 +177,7 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 
 		String root;
 		Variant root_uri_var = p_params["rootUri"];
-		Variant root_var = p_params["rootPath"];
+		Variant root_var = p_params.get("rootPath", Variant());
 		if (root_uri_var.is_string()) {
 			root = get_workspace()->get_file_path(root_uri_var);
 		} else if (root_var.is_string()) {
@@ -194,7 +194,7 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 	}
 
 	String root_uri = p_params["rootUri"];
-	String root = p_params["rootPath"];
+	String root = p_params.get("rootPath", "");
 	bool is_same_workspace;
 #ifndef WINDOWS_ENABLED
 	is_same_workspace = root.to_lower() == workspace->root.to_lower();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112099

I did check all dictionary access against the spec and this should be all remaining unsave access problems in the LSP code. Everything else is either required by the spec or protected by contracts from the spec.
