### PR TITLE
`ClassDB`: Use `AHashMap` for `property_setget` and `constant/signal_map`

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -38,6 +38,7 @@
 // Makes callable_mp readily available in all classes connecting signals.
 // Needs to come after method_bind and object have been included.
 #include "core/object/callable_method_pointer.h"
+#include "core/templates/a_hash_map.h"
 #include "core/templates/hash_set.h"
 
 #include <type_traits>
@@ -127,14 +128,14 @@ public:
 
 		HashMap<StringName, MethodBind *> method_map;
 		HashMap<StringName, LocalVector<MethodBind *>> method_map_compatibility;
-		HashMap<StringName, int64_t> constant_map;
+		AHashMap<StringName, int64_t> constant_map;
 		struct EnumInfo {
 			List<StringName> constants;
 			bool is_bitfield = false;
 		};
 
 		HashMap<StringName, EnumInfo> enum_map;
-		HashMap<StringName, MethodInfo> signal_map;
+		AHashMap<StringName, MethodInfo> signal_map;
 		List<PropertyInfo> property_list;
 		HashMap<StringName, PropertyInfo> property_map;
 
@@ -152,7 +153,7 @@ public:
 		List<StringName> dependency_list;
 #endif
 
-		HashMap<StringName, PropertySetGet> property_setget;
+		AHashMap<StringName, PropertySetGet> property_setget;
 		HashMap<StringName, Vector<uint32_t>> virtual_methods_compat;
 
 		StringName inherits;

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4250,7 +4250,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 		// Populate signals
 
-		const HashMap<StringName, MethodInfo> &signal_map = class_info->signal_map;
+		const AHashMap<StringName, MethodInfo> &signal_map = class_info->signal_map;
 
 		for (const KeyValue<StringName, MethodInfo> &E : signal_map) {
 			SignalInterface isignal;

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -714,7 +714,7 @@ void add_exposed_classes(Context &r_context) {
 
 		// Add signals
 
-		const HashMap<StringName, MethodInfo> &signal_map = class_info->signal_map;
+		const AHashMap<StringName, MethodInfo> &signal_map = class_info->signal_map;
 
 		for (const KeyValue<StringName, MethodInfo> &K : signal_map) {
 			SignalData signal;


### PR DESCRIPTION
(During testing I found this is part of #101340, but this is a simple and harmless change that wouldn't require a whole rewrite and has a very low chance of regressions, so I opened it anyway)

> **Note**: Might conflict with #106646, which also touches the same HashMaps. As long as the proposed `property_cache` is also an `AHashMap`, it's possible to gain around 0.9% more FPS. If anything, that one has priority over this.
___
`ClassDB::get_property()` is one of the biggest bottlenecks in GDScript (actually, in `Variant` itself) as seen when profiling.

I did a bit of experimenting by making `property_setget`, `constant_map` and `signal_map` `AHashMap` instead of `HashMap`. Tests were run on a modified version of [Gaijin's BunnyMark](https://github.com/GaijinEntertainment/godot-das/tree/master/examples/bunnymark) (stress test of many GDScript instances) in a release production build, 3 times, with the average FPS of 20 seconds written down:

500 bunnies:

| Build    | Lowest | Highest |
|----------|--------|---------|
| `master` | 2157   | 2175    |
| PR       | 2320   | 2337    |

1000 bunnies:

| Build    | Lowest | Highest |
|----------|--------|---------|
| `master` | 1445   | 1446    |
| PR       | 1567   | 1582    |

5000 bunnies:

| Build    | Lowest | Highest |
|----------|--------|---------|
| `master` | 311    | 312     |
| PR       | 340    | 349     |

Overall, FPS was increased between a minimum of 2.8%.

During profiling on a `template_debug` build with debug symbols, `ClassDB::get_property()` almost doubled in cycles, but it was mostly caused by `MethodBindTRC::call()`, which I believe means a bottleneck removed rather than a bottleneck added.

Build sizes did not change.