### PR TITLE
GLTF: Don't serialize empty material extensions

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4661,7 +4661,9 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 			extensions["KHR_materials_emissive_strength"] = mat_emissive_strength;
 			p_state->add_used_extension("KHR_materials_emissive_strength");
 		}
-		mat_dict["extensions"] = extensions;
+		if (!extensions.is_empty()) {
+			mat_dict["extensions"] = extensions;
+		}
 
 		_attach_meta_to_extras(material, mat_dict);
 		materials.push_back(mat_dict);


### PR DESCRIPTION
When exporting a glTF and serializing a material, Godot writes the `"extensions"` Dictionary even when it's empty:

<img width="400" height="90" alt="Screenshot 2025-10-28 at 3 11 25 PM" src="https://github.com/user-attachments/assets/f2677d61-0f36-4660-9267-124b05eda58c" />

This is useless, so this PR avoids writing it, in the same vain as PR #101275.
