### PR TITLE
Add `sorted()` method to Array and Dictionary

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -163,6 +163,12 @@ public:
 		sort_custom<Comparator<T>>();
 	}
 
+	Vector<T> sorted() const {
+		Vector<T> result = *this;
+		result.sort();
+		return result;
+	}
+
 	template <typename Comparator, bool Validate = SORT_ARRAY_VALIDATE_ENABLED, typename... Args>
 	void sort_custom(Args &&...args) {
 		Size len = _cowdata.size();

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -735,9 +735,21 @@ void Array::sort() {
 	_p->array.sort_custom<_ArrayVariantSort>();
 }
 
+Array Array::sorted() const {
+	Array ret = duplicate();
+	ret.sort();
+	return ret;
+}
+
 void Array::sort_custom(const Callable &p_callable) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
 	_p->array.sort_custom<CallableComparator, true>(p_callable);
+}
+
+Array Array::sorted_custom(const Callable &p_callable) const {
+	Array ret = duplicate();
+	ret.sort_custom(p_callable);
+	return ret;
 }
 
 void Array::shuffle() {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -133,7 +133,9 @@ public:
 	Variant pick_random() const;
 
 	void sort();
+	Array sorted() const;
 	void sort_custom(const Callable &p_callable);
+	Array sorted_custom(const Callable &p_callable) const;
 	void shuffle();
 	int bsearch(const Variant &p_value, bool p_before = true) const;
 	int bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before = true) const;

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -333,6 +333,12 @@ void Dictionary::sort() {
 	_p->variant_map.sort_custom<_DictionaryVariantSort>();
 }
 
+Dictionary Dictionary::sorted() const {
+	Dictionary ret = duplicate();
+	ret.sort();
+	return ret;
+}
+
 void Dictionary::merge(const Dictionary &p_dictionary, bool p_overwrite) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Dictionary is in read-only state.");
 	for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -75,6 +75,7 @@ public:
 	void reserve(int p_new_capacity);
 	void clear();
 	void sort();
+	Dictionary sorted() const;
 	void merge(const Dictionary &p_dictionary, bool p_overwrite = false);
 	Dictionary merged(const Dictionary &p_dictionary, bool p_overwrite = false) const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2457,6 +2457,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Dictionary, clear, sarray(), varray());
 	bind_method(Dictionary, assign, sarray("dictionary"), varray());
 	bind_method(Dictionary, sort, sarray(), varray());
+	bind_method(Dictionary, sorted, sarray(), varray());
 	bind_method(Dictionary, merge, sarray("dictionary", "overwrite"), varray(false));
 	bind_method(Dictionary, merged, sarray("dictionary", "overwrite"), varray(false));
 	bind_method(Dictionary, has, sarray("key"), varray());
@@ -2520,7 +2521,9 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(Array, pop_front, sarray(), varray());
 	bind_method(Array, pop_at, sarray("position"), varray());
 	bind_method(Array, sort, sarray(), varray());
+	bind_method(Array, sorted, sarray(), varray());
 	bind_method(Array, sort_custom, sarray("func"), varray());
+	bind_method(Array, sorted_custom, sarray("func"), varray());
 	bind_method(Array, shuffle, sarray(), varray());
 	bind_method(Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(Array, bsearch_custom, sarray("value", "func", "before"), varray(true));
@@ -2581,6 +2584,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedByteArray, reverse, sarray(), varray());
 	bind_method(PackedByteArray, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedByteArray, sort, sarray(), varray());
+	bind_method(PackedByteArray, sorted, sarray(), varray());
 	bind_method(PackedByteArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedByteArray, duplicate, sarray(), varray());
 	bind_method(PackedByteArray, find, sarray("value", "from"), varray(0));
@@ -2657,6 +2661,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedInt32Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedInt32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt32Array, sort, sarray(), varray());
+	bind_method(PackedInt32Array, sorted, sarray(), varray());
 	bind_method(PackedInt32Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedInt32Array, duplicate, sarray(), varray());
 	bind_method(PackedInt32Array, find, sarray("value", "from"), varray(0));
@@ -2681,6 +2686,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedInt64Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedInt64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt64Array, sort, sarray(), varray());
+	bind_method(PackedInt64Array, sorted, sarray(), varray());
 	bind_method(PackedInt64Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedInt64Array, duplicate, sarray(), varray());
 	bind_method(PackedInt64Array, find, sarray("value", "from"), varray(0));
@@ -2705,6 +2711,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedFloat32Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedFloat32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat32Array, sort, sarray(), varray());
+	bind_method(PackedFloat32Array, sorted, sarray(), varray());
 	bind_method(PackedFloat32Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedFloat32Array, duplicate, sarray(), varray());
 	bind_method(PackedFloat32Array, find, sarray("value", "from"), varray(0));
@@ -2729,6 +2736,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedFloat64Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedFloat64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat64Array, sort, sarray(), varray());
+	bind_method(PackedFloat64Array, sorted, sarray(), varray());
 	bind_method(PackedFloat64Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedFloat64Array, duplicate, sarray(), varray());
 	bind_method(PackedFloat64Array, find, sarray("value", "from"), varray(0));
@@ -2753,6 +2761,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedStringArray, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_function(PackedStringArray, to_byte_array, _VariantCall::func_PackedStringArray_to_byte_array, sarray(), varray());
 	bind_method(PackedStringArray, sort, sarray(), varray());
+	bind_method(PackedStringArray, sorted, sarray(), varray());
 	bind_method(PackedStringArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedStringArray, duplicate, sarray(), varray());
 	bind_method(PackedStringArray, find, sarray("value", "from"), varray(0));
@@ -2777,6 +2786,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector2Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedVector2Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector2Array, sort, sarray(), varray());
+	bind_method(PackedVector2Array, sorted, sarray(), varray());
 	bind_method(PackedVector2Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedVector2Array, duplicate, sarray(), varray());
 	bind_method(PackedVector2Array, find, sarray("value", "from"), varray(0));
@@ -2801,6 +2811,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector3Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedVector3Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector3Array, sort, sarray(), varray());
+	bind_method(PackedVector3Array, sorted, sarray(), varray());
 	bind_method(PackedVector3Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedVector3Array, duplicate, sarray(), varray());
 	bind_method(PackedVector3Array, find, sarray("value", "from"), varray(0));
@@ -2825,6 +2836,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedColorArray, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedColorArray, to_byte_array, sarray(), varray());
 	bind_method(PackedColorArray, sort, sarray(), varray());
+	bind_method(PackedColorArray, sorted, sarray(), varray());
 	bind_method(PackedColorArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedColorArray, duplicate, sarray(), varray());
 	bind_method(PackedColorArray, find, sarray("value", "from"), varray(0));
@@ -2849,6 +2861,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector4Array, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(PackedVector4Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector4Array, sort, sarray(), varray());
+	bind_method(PackedVector4Array, sorted, sarray(), varray());
 	bind_method(PackedVector4Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedVector4Array, duplicate, sarray(), varray());
 	bind_method(PackedVector4Array, find, sarray("value", "from"), varray(0));

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -812,6 +812,21 @@
 				[b]Note:[/b] You should not randomize the return value of [param func], as the heapsort algorithm expects a consistent result. Randomizing the return value will result in unexpected behavior.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
+		<method name="sorted_custom" qualifiers="const">
+			<return type="Array" />
+			<param index="0" name="func" type="Callable" />
+			<description>
+				Returns a copy of this array sorted using a custom [Callable]. See also [method sort_custom].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort_custom].
+			</description>
+		</method>
 	</methods>
 	<operators>
 		<operator name="operator !=">

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -531,6 +531,13 @@
 				This method ensures that the dictionary's entries are ordered consistently when [method keys] or [method values] are called, or when the dictionary needs to be converted to a string through [method @GlobalScope.str] or [method JSON.stringify].
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns a sorted copy of this dictionary. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="values" qualifiers="const">
 			<return type="Array" />
 			<description>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -497,6 +497,13 @@
 				Sorts the elements of the array in ascending order.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_color_array" qualifiers="const">
 			<return type="PackedColorArray" />
 			<description>

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -196,6 +196,13 @@
 				Sorts the elements of the array in ascending order.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedColorArray" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -199,6 +199,13 @@
 				[b]Note:[/b] [constant @GDScript.NAN] doesn't behave the same as other numbers. Therefore, the results from this method may not be accurate if NaNs are included.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedFloat32Array" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -200,6 +200,13 @@
 				[b]Note:[/b] [constant @GDScript.NAN] doesn't behave the same as other numbers. Therefore, the results from this method may not be accurate if NaNs are included.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedFloat64Array" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -192,6 +192,13 @@
 				Sorts the elements of the array in ascending order.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedInt32Array" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -193,6 +193,13 @@
 				Sorts the elements of the array in ascending order.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedInt64Array" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -199,6 +199,13 @@
 				Sorts the elements of the array in ascending order.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -204,6 +204,13 @@
 				[b]Note:[/b] Vectors with [constant @GDScript.NAN] elements don't behave the same as other vectors. Therefore, the results from this method may not be accurate if NaNs are included.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -203,6 +203,13 @@
 				[b]Note:[/b] Vectors with [constant @GDScript.NAN] elements don't behave the same as other vectors. Therefore, the results from this method may not be accurate if NaNs are included.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>

--- a/doc/classes/PackedVector4Array.xml
+++ b/doc/classes/PackedVector4Array.xml
@@ -203,6 +203,13 @@
 				[b]Note:[/b] Vectors with [constant @GDScript.NAN] elements don't behave the same as other vectors. Therefore, the results from this method may not be accurate if NaNs are included.
 			</description>
 		</method>
+		<method name="sorted" qualifiers="const">
+			<return type="PackedVector4Array" />
+			<description>
+				Returns a sorted copy of this array. See also [method sort].
+				[b]Note:[/b] This method creates a copy, which may have a noticeable performance cost. To perform in-place sorting instead, use [method sort].
+			</description>
+		</method>
 		<method name="to_byte_array" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>


### PR DESCRIPTION
Similar to https://github.com/godotengine/godot/pull/112077 but for ```sort()``` instead of ```reverse()```. This adds the method to ```Array```, the ```Packed*Array```s, and ```Dictionary```. It also adds ```sorted_custom()``` to ```Array```

Haskell has left me feeling like these are missing every time I go to use the ones we already have and remember that they don't return anything.

Closes https://github.com/godotengine/godot-proposals/issues/13509.