### PR TITLE
Make possible to select remote canvas items inside subviewports

### DIFF
--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -747,7 +747,7 @@ void RuntimeNodeSelect::_update_selection() {
 			continue;
 		}
 
-		Transform2D xform = ci->get_global_transform_with_canvas();
+		Transform2D xform = ci->get_screen_transform();
 
 		// Fallback.
 		Rect2 rect = Rect2(Vector2(), Vector2(10, 10));
@@ -971,21 +971,34 @@ void RuntimeNodeSelect::_set_prefer_group(bool p_enabled) {
 
 // Copied and trimmed from the CanvasItemEditor implementation.
 void RuntimeNodeSelect::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<SelectResult> &r_items, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform) {
-	if (!p_node || Object::cast_to<Viewport>(p_node)) {
+	if (!p_node || Object::cast_to<Window>(p_node)) {
 		return;
 	}
 
 	CanvasItem *ci = Object::cast_to<CanvasItem>(p_node);
+	Transform2D xform = p_canvas_xform;
+
+	if (CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node)) {
+		xform = cl->get_transform();
+	} else if (Viewport *vp = Object::cast_to<Viewport>(p_node)) {
+		if (!vp->is_visible_subviewport()) {
+			return;
+		}
+		xform = vp->get_popup_base_transform();
+		if (!vp->get_visible_rect().has_point(xform.affine_inverse().xform(p_pos))) {
+			return;
+		}
+	}
+
 	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
 		if (ci) {
 			if (!ci->is_set_as_top_level()) {
-				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, p_parent_xform * ci->get_transform(), p_canvas_xform);
+				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, p_parent_xform * ci->get_transform(), xform);
 			} else {
-				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, ci->get_transform(), p_canvas_xform);
+				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, ci->get_transform(), xform);
 			}
 		} else {
-			CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
-			_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, Transform2D(), cl ? cl->get_transform() : p_canvas_xform);
+			_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, Transform2D(), xform);
 		}
 	}
 
@@ -993,19 +1006,15 @@ void RuntimeNodeSelect::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_n
 		return;
 	}
 
-	Transform2D xform = p_canvas_xform;
 	if (!ci->is_set_as_top_level()) {
 		xform *= p_parent_xform;
 	}
 
-	Window *root = SceneTree::get_singleton()->get_root();
-	Point2 pos;
-
+	Point2 pos = p_pos;
 	// Cameras don't affect `CanvasLayer`s.
 	if (!ci->get_canvas_layer_node() || ci->get_canvas_layer_node()->is_following_viewport()) {
-		pos = root->get_canvas_transform().affine_inverse().xform(p_pos);
-	} else {
-		pos = p_pos;
+		Viewport *vp = ci->get_viewport();
+		pos = vp->get_canvas_transform().affine_inverse().xform(p_pos);
 	}
 
 	xform = (xform * ci->get_transform()).affine_inverse();
@@ -1034,21 +1043,35 @@ void RuntimeNodeSelect::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_n
 
 // Copied and trimmed from the CanvasItemEditor implementation.
 void RuntimeNodeSelect::_find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_node, Vector<SelectResult> &r_items, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform) {
-	if (!p_node || Object::cast_to<Viewport>(p_node)) {
+	if (!p_node || Object::cast_to<Window>(p_node)) {
 		return;
 	}
 
 	CanvasItem *ci = Object::cast_to<CanvasItem>(p_node);
+	Transform2D xform = p_canvas_xform;
+
+	if (CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node)) {
+		xform = cl->get_transform();
+	} else if (Viewport *vp = Object::cast_to<Viewport>(p_node)) {
+		if (!vp->is_visible_subviewport()) {
+			return;
+		}
+		xform = vp->get_popup_base_transform();
+		if (!vp->get_visible_rect().intersects(xform.affine_inverse().xform(p_rect))) {
+			return;
+		}
+	}
+
 	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
 		if (ci) {
 			if (!ci->is_set_as_top_level()) {
-				_find_canvas_items_at_rect(p_rect, p_node->get_child(i), r_items, p_parent_xform * ci->get_transform(), p_canvas_xform);
+				_find_canvas_items_at_rect(p_rect, p_node->get_child(i), r_items, p_parent_xform * ci->get_transform(), xform);
 			} else {
-				_find_canvas_items_at_rect(p_rect, p_node->get_child(i), r_items, ci->get_transform(), p_canvas_xform);
+				_find_canvas_items_at_rect(p_rect, p_node->get_child(i), r_items, ci->get_transform(), xform);
 			}
 		} else {
 			CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
-			_find_canvas_items_at_rect(p_rect, p_node->get_child(i), r_items, Transform2D(), cl ? cl->get_transform() : p_canvas_xform);
+			_find_canvas_items_at_rect(p_rect, p_node->get_child(i), r_items, Transform2D(), cl ? cl->get_transform() : xform);
 		}
 	}
 
@@ -1056,18 +1079,15 @@ void RuntimeNodeSelect::_find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_
 		return;
 	}
 
-	Transform2D xform = p_canvas_xform;
 	if (!ci->is_set_as_top_level()) {
 		xform *= p_parent_xform;
 	}
 
-	Window *root = SceneTree::get_singleton()->get_root();
-	Rect2 rect;
+	Rect2 rect = p_rect;
 	// Cameras don't affect `CanvasLayer`s.
 	if (!ci->get_canvas_layer_node() || ci->get_canvas_layer_node()->is_following_viewport()) {
-		rect = root->get_canvas_transform().affine_inverse().xform(p_rect);
-	} else {
-		rect = p_rect;
+		Viewport *vp = ci->get_viewport();
+		rect = vp->get_canvas_transform().affine_inverse().xform(p_rect);
 	}
 	rect = (xform * ci->get_transform()).affine_inverse().xform(rect);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4267,7 +4267,6 @@ bool Viewport::get_canvas_cull_mask_bit(uint32_t p_layer) const {
 	return (canvas_cull_mask & (1 << p_layer));
 }
 
-#ifdef TOOLS_ENABLED
 bool Viewport::is_visible_subviewport() const {
 	if (!is_sub_viewport()) {
 		return true;
@@ -4275,7 +4274,6 @@ bool Viewport::is_visible_subviewport() const {
 	SubViewportContainer *container = Object::cast_to<SubViewportContainer>(get_parent());
 	return container && container->is_visible_in_tree();
 }
-#endif // TOOLS_ENABLED
 
 void Viewport::_update_audio_listener_2d() {
 	if (AudioServer::get_singleton()) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -720,9 +720,7 @@ public:
 	void set_canvas_cull_mask_bit(uint32_t p_layer, bool p_enable);
 	bool get_canvas_cull_mask_bit(uint32_t p_layer) const;
 
-#ifdef TOOLS_ENABLED
 	bool is_visible_subviewport() const;
-#endif // TOOLS_ENABLED
 
 	virtual bool is_size_2d_override_stretch_enabled() const { return true; }
 


### PR DESCRIPTION
This is basically attempting to do #99401 but via runtime remote selection. However, I'm having trouble with the transform math, so there are still plenty of issues:
- ~Selection square is at the wrong location.~
- ~Items can be selected from two different positions (one inside the subviewport, the other relative to the root viewport).~
- Either zooming with the overridden camera or using the `stretch_shrink` feature of `SubViewportContainer` while there's a camera inside the `SubViewport` results in incorrect locations for clicking.

Any help is appreciated.

Project for testing: [subviewport_select_test.zip](https://github.com/user-attachments/files/25381143/subviewport_select_test.zip)