### PR TITLE
Update documentation pages when switching themes

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3315,6 +3315,12 @@ void EditorHelp::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			if (is_inside_tree()) {
+				if (is_visible_in_tree()) {
+					_update_doc();
+				} else {
+					update_pending = true;
+				}
+
 				_class_desc_resized(true);
 			}
 			update_toggle_files_button();


### PR DESCRIPTION
Otherwise, already opened pages will look incorrect:

<img width="925" height="625" alt="image" src="https://github.com/user-attachments/assets/a3df8134-f690-416b-a93d-5e224475ce3d" />