### PR TITLE
Fix visual shader editor crash while convert constant to parameter

### DIFF
--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -4552,6 +4552,9 @@ void VisualShaderEditor::_update_constant(VisualShader::Type p_type_id, int p_no
 	if (p_preview_port != -1) {
 		node->set_output_port_for_preview(p_preview_port);
 	}
+
+	// remember clean parameter_name when convert parameter to constant
+	graph_plugin->register_parameter_name(p_node_id, nullptr);
 }
 
 void VisualShaderEditor::_update_parameter(VisualShader::Type p_type_id, int p_node_id, const Variant &p_var, int p_preview_port) {


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/97431*

## Issue Description

When we convert `FloatParameter` to `FloatConstant`, then convert `FloatConstant` to `FloatParameter` in visual shader editor, editor crashed.

First, we create a `FloatParameter`, it will create `LineEdit` and saved as `parameter_name`.

https://github.com/godotengine/godot/blob/2cb2c1fb5bbeb2afbac7255841f9c66d9611bf55/editor/shader/visual_shader_editor_plugin.cpp#L827-L828

Second, we convert `FloatParameter` to `FloatConstant`, it change node type, but forget to clean `parameter_name` registered in first step.

Third, we convert `FloatConstant` back to `FloatParameter`, it will check if there is already a `parameter_name` and update its text. But in this time, `parameter_name` related `LineEdit` already is freed in second step. So crashed.

https://github.com/godotengine/godot/blob/2cb2c1fb5bbeb2afbac7255841f9c66d9611bf55/editor/shader/visual_shader_editor_plugin.cpp#L330-L334

## Solution

We need clean `parameter_name` when convert `FloatParamter` to `FloatConstant`. Next time converting `FloatConstant` to `FloatParameter`, it will re-create `parameter_name`.

[visual-shader.webm](https://github.com/user-attachments/assets/e77f3a09-e50d-47bc-96be-30c376cec65f)


