### PR TITLE
Fix "Match Corners" not correctly updating cells when erasing

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -2601,7 +2601,7 @@ HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_pattern(c
 		// Find the adequate neighbor.
 		for (int j = 0; j < TileSet::CELL_NEIGHBOR_MAX; j++) {
 			TileSet::CellNeighbor bit = TileSet::CellNeighbor(j);
-			if (tile_set->is_valid_terrain_peering_bit(p_terrain_set, bit)) {
+			if (tile_set->is_existing_neighbor(bit)) {
 				Vector2i neighbor = tile_set->get_neighbor_cell(coords, bit);
 				if (!can_modify_set.has(neighbor)) {
 					can_modify_list.push_back(neighbor);


### PR DESCRIPTION
Fixes #112146

This is a relatively minor fix ~~for an undocumented bug~~. I've got a few more I want to do PRs for too, but I figure it's best to do them separately rather than all together.

In my test scenario, my terrain is setup like so:

<img width="301" height="292" alt="image" src="https://github.com/user-attachments/assets/e27ed225-b47e-48cf-86a2-109233023a28" />

if I draw this with the rectangle tool then erase 2 cells...

<img width="213" height="211" alt="image" src="https://github.com/user-attachments/assets/8adba6cf-9c77-46fc-a1bd-3ae3886833e4" />

This is what happens currently

<img width="198" height="201" alt="image" src="https://github.com/user-attachments/assets/517e0c4b-a630-4b7b-b8d5-1a279b2bc6d1" />

The expected outcome should be something like this. This PR changes the behaviour to this.

<img width="210" height="208" alt="image" src="https://github.com/user-attachments/assets/8ce09c69-d421-4352-85ae-556598e879ed" />
