### PR TITLE
Improve `length` and `open` state handling for pipes.

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -986,6 +986,8 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_path"), &FileAccess::get_path);
 	ClassDB::bind_method(D_METHOD("get_path_absolute"), &FileAccess::get_path_absolute);
 	ClassDB::bind_method(D_METHOD("is_open"), &FileAccess::is_open);
+	ClassDB::bind_method(D_METHOD("is_read_end_open"), &FileAccess::is_read_end_open);
+	ClassDB::bind_method(D_METHOD("is_write_end_open"), &FileAccess::is_write_end_open);
 	ClassDB::bind_method(D_METHOD("seek", "position"), &FileAccess::seek);
 	ClassDB::bind_method(D_METHOD("seek_end", "position"), &FileAccess::seek_end, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_position"), &FileAccess::get_position);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -161,6 +161,8 @@ public:
 	static void set_file_close_fail_notify_callback(FileCloseFailNotify p_cbk) { close_fail_notify = p_cbk; }
 
 	virtual bool is_open() const = 0; ///< true when file is open
+	virtual bool is_read_end_open() const { return is_open(); }
+	virtual bool is_write_end_open() const { return is_open(); }
 
 	virtual String get_path() const { return ""; } /// returns the path for the current open file
 	virtual String get_path_absolute() const { return ""; } /// returns the absolute path for the current open file

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -317,6 +317,18 @@
 				Returns [code]true[/code] if the file is currently opened.
 			</description>
 		</method>
+		<method name="is_read_end_open" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the reading end of the pipe is currently opened. Same as [method is_open] if the file is not a pipe.
+			</description>
+		</method>
+		<method name="is_write_end_open" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the writing end of the pipe is currently opened. Same as [method is_open] if the file is not a pipe.
+			</description>
+		</method>
 		<method name="open" qualifiers="static">
 			<return type="FileAccess" />
 			<param index="0" name="path" type="String" />

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -36,6 +36,7 @@
 #include "core/string/print_string.h"
 
 #include <fcntl.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -122,7 +123,15 @@ void FileAccessUnixPipe::_close() {
 }
 
 bool FileAccessUnixPipe::is_open() const {
-	return (fd[0] >= 0 || fd[1] >= 0);
+	return _check_handle(fd[0], true) || _check_handle(fd[1], false);
+}
+
+bool FileAccessUnixPipe::is_read_end_open() const {
+	return _check_handle(fd[0], true);
+}
+
+bool FileAccessUnixPipe::is_write_end_open() const {
+	return _check_handle(fd[1], false);
 }
 
 String FileAccessUnixPipe::get_path() const {
@@ -133,11 +142,38 @@ String FileAccessUnixPipe::get_path_absolute() const {
 	return path_src;
 }
 
+bool FileAccessUnixPipe::_check_handle(int p_fd, bool p_peek) const {
+	if (p_fd < 0) {
+		return false;
+	}
+	int buf_rem = 0;
+	if (p_peek && ioctl(fd[0], FIONREAD, &buf_rem) != 0) {
+		return false;
+	}
+	if (p_peek && buf_rem > 0) {
+		return true;
+	}
+	struct pollfd pfd = { p_fd, POLLIN | POLLOUT, 0 };
+	if ((poll(&pfd, 1, 0) < 0) || (pfd.revents & POLLHUP) || (pfd.revents & POLLERR) || (pfd.revents & POLLNVAL)) {
+		return false;
+	}
+	return true;
+}
+
 uint64_t FileAccessUnixPipe::get_length() const {
 	ERR_FAIL_COND_V_MSG(fd[0] < 0, 0, "Pipe must be opened before use.");
 
 	int buf_rem = 0;
-	ERR_FAIL_COND_V(ioctl(fd[0], FIONREAD, &buf_rem) != 0, 0);
+	if (ioctl(fd[0], FIONREAD, &buf_rem) != 0) {
+		last_error = ERR_FILE_CANT_READ;
+	} else if (buf_rem == 0) {
+		struct pollfd pfd = { fd[0], POLLIN | POLLOUT, 0 };
+		if ((poll(&pfd, 1, 0) < 0) || (pfd.revents & POLLHUP) || (pfd.revents & POLLERR) || (pfd.revents & POLLNVAL)) {
+			last_error = ERR_FILE_CANT_READ;
+		} else {
+			last_error = OK;
+		}
+	}
 	return buf_rem;
 }
 

--- a/drivers/unix/file_access_unix_pipe.h
+++ b/drivers/unix/file_access_unix_pipe.h
@@ -48,12 +48,15 @@ class FileAccessUnixPipe : public FileAccess {
 	String path_src;
 
 	void _close();
+	bool _check_handle(int p_fd, bool p_peek) const;
 
 public:
 	Error open_existing(int p_rfd, int p_wfd, bool p_blocking);
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 
 	virtual bool is_open() const override; ///< true when file is open
+	virtual bool is_read_end_open() const override;
+	virtual bool is_write_end_open() const override;
 
 	virtual String get_path() const override; /// returns the path for the current open file
 	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -40,7 +40,7 @@
 
 class FileAccessWindowsPipe : public FileAccess {
 	GDSOFTCLASS(FileAccessWindowsPipe, FileAccess);
-	HANDLE fd[2] = { nullptr, nullptr };
+	HANDLE fd[2] = { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE };
 
 	mutable Error last_error = OK;
 
@@ -48,12 +48,15 @@ class FileAccessWindowsPipe : public FileAccess {
 	String path_src;
 
 	void _close();
+	bool _check_handle(HANDLE p_fd, bool p_peek) const;
 
 public:
 	Error open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_blocking);
 
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
+	virtual bool is_read_end_open() const override;
+	virtual bool is_write_end_open() const override;
 
 	virtual String get_path() const override; /// returns the path for the current open file
 	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112114

- Adds remote end status checks for `is_open` and `get_length`.
- Fixes unnecessary error spam when `get_length` is used on closed pipe on Windows.
- Changes Windows code to use `INVALID_HANDLE_VALUE` instead of `NULL` (should not be an issue, but this is more correct).
- Adds dedicated `is_read_end_open` and `is_read_end_open` methods, since each of the ends can be closed on the other side individually, and `is_open` is still checking if either is open.
