### PR TITLE
Set `DONT_PREFER_SMALL_BUFFERS_COMMITTED` when initializing D3D12MA.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -6602,7 +6602,7 @@ Error RenderingDeviceDriverD3D12::_initialize_allocator() {
 	D3D12MA::ALLOCATOR_DESC allocator_desc = {};
 	allocator_desc.pDevice = device.Get();
 	allocator_desc.pAdapter = adapter.Get();
-	allocator_desc.Flags = D3D12MA::ALLOCATOR_FLAG_DEFAULT_POOLS_NOT_ZEROED;
+	allocator_desc.Flags = D3D12MA::ALLOCATOR_FLAG_DEFAULT_POOLS_NOT_ZEROED | D3D12MA::ALLOCATOR_FLAG_DONT_PREFER_SMALL_BUFFERS_COMMITTED;
 
 	HRESULT res = D3D12MA::CreateAllocator(&allocator_desc, &allocator);
 	ERR_FAIL_COND_V_MSG(!SUCCEEDED(res), ERR_CANT_CREATE, "D3D12MA::CreateAllocator failed with error " + vformat("0x%08ux", (uint64_t)res) + ".");


### PR DESCRIPTION
Fixes performance regression introduced in #111183.

This is new behavior in latest D3D12MA. For buffers smaller than 64 KB, D3D12MA creates them as committed resources by default to take advantage of the driver tightly packing them. However, since committed resources can take a long time to create, and the canvas renderer in Godot does a lot of small vertex buffer allocations per frame, D3D12MA version upgrade introduced a huge performance hit. We can disable this unintended behavior by setting the `D3D12MA::ALLOCATOR_FLAG_DONT_PREFER_SMALL_BUFFERS_COMMITTED` flag.