### PR TITLE
[4.4] Generate unique modules header per build target and type

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1051,6 +1051,8 @@ if env["ninja"]:
 if env["threads"]:
     env.Append(CPPDEFINES=["THREADS_ENABLED"])
 
+env.Prepend(CPPPATH=["#modules/.generated/%s/%s" % (env["platform"], env["target"])])
+
 # Build subdirs, the build order is dependent on link order.
 Export("env")
 

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -23,7 +23,9 @@ def modules_enabled_builder(target, source, env):
 
 
 modules_enabled = env.CommandNoCache(
-    "modules_enabled.gen.h", env.Value(env.module_list), env.Run(modules_enabled_builder)
+    ".generated/%s/%s/modules/modules_enabled.gen.h" % (env["platform"], env["target"]),
+    env.Value(env.module_list),
+    env.Run(modules_enabled_builder),
 )
 
 
@@ -92,7 +94,11 @@ if env["tests"]:
             for header in source:
                 file.write('#include "{}"\n'.format(os.path.normpath(header.path).replace("\\", "/")))
 
-    env.CommandNoCache("modules_tests.gen.h", test_headers, env.Run(modules_tests_builder))
+    modules_enabled = env.CommandNoCache(
+        ".generated/%s/%s/modules/modules_tests.gen.h" % (env["platform"], env["target"]),
+        test_headers,
+        env.Run(modules_tests_builder),
+    )
 
 # libmodules.a with only register_module_types.
 # Must be last so that all libmodule_<name>.a libraries are on the right side


### PR DESCRIPTION
## About 4.4

This is the PR below adapted for 4.4, because the code around it has changed and it's not a straightforward cherry-pick. I think it's a nice candidate for a cherry-pick, but it's not earth-shattering if it doesn't get picked, just leaving this here in case you want to.

- https://github.com/godotengine/godot/pull/112154

## Original PR description

The modules header has different content that is dependent on the build target and build type. This means that its contents only reflect the last build target+type that the user did, because the location of the generated header is the same regardless of build configuration. This creates two problems:

1. Even when nothing has changed in the source, the header is always regenerated if the last build was different than the current build. This adds extra time to the build.

2. When loading the Visual Studio solution, the defines coming from the generated header will be wrong for all build configurations except for the most recently built one. This can cause code to resolve incorrectly in the IDE, potentially causing confusion. We're recording the module defines in a custom VS-only property, so VS ignores the header in favor of what's defined in the project, but code navigation from the define is then broken because it resolved to the harcoded define in the project, not the generated header. Including the module defines in the project was my local way to get around this generated header issue, and I would prefer having the header control the defines rather patching the VS project generation to include this data.

This PR moves the generated header into a `.generated/BUILD TARGET/BUILD TYPE` folder so that every build will have its own header. The path to this folder is added to the includes paths, so existing code can continue to include the header as normal, getting the header that corresponds to that particular build configuration. The VS projects generated per build target/type already include the corresponding include paths configured by scons, so VS will automatically load the correct header and resolve the defines properly for the corresponding build configuration.

**Note**: The reason the folder is called `.generated` is to make sure it doesn't conflict with any custom modules that might be out there in the wild.