### PR TITLE
Generate unique modules header per build target and type

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1160,6 +1160,8 @@ if "c_compiler_launcher" in env:
 if "cpp_compiler_launcher" in env:
     env["CXX"] = " ".join([env["cpp_compiler_launcher"], env["CXX"]])
 
+env.Prepend(CPPPATH=["#modules/.generated/%s/%s" % (env["platform"], env["target"])])
+
 # Build subdirs, the build order is dependent on link order.
 Export("env")
 

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -17,7 +17,9 @@ Export("env_modules")
 
 # Header with MODULE_*_ENABLED defines.
 modules_enabled = env.CommandNoCache(
-    "modules_enabled.gen.h", env.Value(env.module_list), env.Run(modules_builders.modules_enabled_builder)
+    ".generated/%s/%s/modules/modules_enabled.gen.h" % (env["platform"], env["target"]),
+    env.Value(env.module_list),
+    env.Run(modules_builders.modules_enabled_builder),
 )
 
 
@@ -52,7 +54,11 @@ for name, path in env.module_list.items():
 
 # Generate header to be included in `tests/test_main.cpp` to run module-specific tests.
 if env["tests"]:
-    env.CommandNoCache("modules_tests.gen.h", test_headers, env.Run(modules_builders.modules_tests_builder))
+    env.CommandNoCache(
+        ".generated/%s/%s/modules/modules_tests.gen.h" % (env["platform"], env["target"]),
+        test_headers,
+        env.Run(modules_builders.modules_tests_builder),
+    )
 
 # libmodules.a with only register_module_types.
 # Must be last so that all libmodule_<name>.a libraries are on the right side


### PR DESCRIPTION
The modules header has different content that is dependent on the build target and build type. This means that its contents only reflect the last build target+type that the user did, because the location of the generated header is the same regardless of build configuration. This creates two problems:

1. Even when nothing has changed in the source, the header is always regenerated if the last build was different than the current build. This adds extra time to the build.

2. When loading the Visual Studio solution, the defines coming from the generated header will be wrong for all build configurations except for the most recently built one. This can cause code to resolve incorrectly in the IDE, potentially causing confusion. ~~We're~~ I'm recording the module defines in a custom VS-only property (I have local patches), so VS ignores the header in favor of what's defined in the project, but code navigation from the define is then broken because it resolved to the harcoded define in the project, not the generated header. Including the module defines in the project was my local way to get around this generated header issue, and I would prefer having the header control the defines rather patching the VS project generation to include this data.

This PR moves the generated header into a `.generated/BUILD TARGET/BUILD TYPE` folder so that every build will have its own header. The path to this folder is added to the includes paths, so existing code can continue to include the header as normal, getting the header that corresponds to that particular build configuration. The VS projects generated per build target/type already include the corresponding include paths configured by scons, so VS will automatically load the correct header and resolve the defines properly for the corresponding build configuration.

**Note**: The reason the folder is called `.generated` is to make sure it doesn't conflict with any custom modules that might be out there in the wild.

This fixes #112162