### PR TITLE
Remove redundant `EditorQuickOpenDialog` instance

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3867,8 +3867,7 @@ void EditorNode::_update_file_menu_opened() {
 }
 
 void EditorNode::_palette_quick_open_dialog() {
-	quick_open_color_palette->popup_dialog({ "ColorPalette" }, palette_file_selected_callback);
-	quick_open_color_palette->set_title(TTRC("Quick Open Color Palette..."));
+	quick_open_dialog->popup_dialog({ "ColorPalette" }, palette_file_selected_callback);
 }
 
 void EditorNode::replace_resources_in_object(Object *p_object, const Vector<Ref<Resource>> &p_source_resources, const Vector<Ref<Resource>> &p_target_resource) {
@@ -8833,9 +8832,6 @@ EditorNode::EditorNode() {
 
 	quick_open_dialog = memnew(EditorQuickOpenDialog);
 	gui_base->add_child(quick_open_dialog);
-
-	quick_open_color_palette = memnew(EditorQuickOpenDialog);
-	gui_base->add_child(quick_open_color_palette);
 
 	_update_recent_scenes();
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -264,7 +264,6 @@ private:
 	EditorPluginList *editor_plugins_force_input_forwarding = nullptr;
 	EditorPluginList *editor_plugins_force_over = nullptr;
 	EditorPluginList *editor_plugins_over = nullptr;
-	EditorQuickOpenDialog *quick_open_color_palette = nullptr;
 	EditorResourcePreview *resource_preview = nullptr;
 	EditorSelection *editor_selection = nullptr;
 	EditorSettingsDialog *editor_settings_dialog = nullptr;


### PR DESCRIPTION
`EditorNode` has two `EditorQuickOpenDialog` instances: one for picking color palettes, and the other one for picking everything else. However, there is nothing special about picking color palettes.

Also removed the custom window title. `EditorQuickOpenDialog` is intended to generate its title based on the target resource types. Overriding "Select ColorPalette" to "Quick Open Color Palette..." is not worth the inconsistencies it introduces.