### PR TITLE
Fix error when deleting trailing lines removed breakpoints

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1242,7 +1242,9 @@ void ScriptTextEditor::_breakpoint_item_pressed(int p_idx) {
 }
 
 void ScriptTextEditor::_breakpoint_toggled(int p_row) {
-	EditorDebuggerNode::get_singleton()->set_breakpoint(script->get_path(), p_row + 1, code_editor->get_text_editor()->is_line_breakpointed(p_row));
+	const CodeEdit *ce = code_editor->get_text_editor();
+	bool enabled = p_row < ce->get_line_count() && ce->is_line_breakpointed(p_row);
+	EditorDebuggerNode::get_singleton()->set_breakpoint(script->get_path(), p_row + 1, enabled);
 }
 
 void ScriptTextEditor::_on_caret_moved() {


### PR DESCRIPTION
To reproduce the problem:

1. Set a breakpoint on the last line.
2. Delete the last line.

then you get an error like this:

> ERROR: Index p_line = 12 is out of bounds (text.size() = 12).
>   at: get_line_gutter_metadata (scene/gui/text_edit.cpp:6876)

This error appears as long as a breakpoint is removed due to deleting lines and the breakpoint is outside the resulting script.

This is because the `breakpoint_toggled` signal is emitted for every breakpoint removed when text changes. Therefore, when handling this signal, we should consider cases where the breakpoint is located outside the existing lines.
