### PR TITLE
Fix layers property editor last bit value in tooltip

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -930,7 +930,7 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 		if (text_split.size() != 1) {
 			current_val = text_split[1].to_int();
 		} else {
-			current_val = 1 << i;
+			current_val = 1u << i;
 		}
 		flag_values.push_back(current_val);
 
@@ -961,9 +961,7 @@ EditorPropertyFlags::EditorPropertyFlags() {
 
 void EditorPropertyLayersGrid::_rename_pressed(int p_menu) {
 	// Show rename popup for active layer.
-	if (renamed_layer_index == INT32_MAX) {
-		return;
-	}
+	ERR_FAIL_INDEX(renamed_layer_index, names.size());
 	String name = names[renamed_layer_index];
 	rename_dialog->set_title(vformat(TTR("Renaming layer %d:"), renamed_layer_index + 1));
 	rename_dialog_text->set_text(name);
@@ -982,7 +980,7 @@ void EditorPropertyLayersGrid::_rename_operation_confirm() {
 		return;
 	}
 	names.set(renamed_layer_index, new_name);
-	tooltips.set(renamed_layer_index, new_name + "\n" + vformat(TTR("Bit %d, value %d"), renamed_layer_index, 1 << renamed_layer_index));
+	tooltips.set(renamed_layer_index, new_name + "\n" + vformat(TTR("Bit %d, value %d"), renamed_layer_index, 1u << renamed_layer_index));
 	emit_signal(SNAME("rename_confirmed"), renamed_layer_index, new_name);
 }
 
@@ -1054,8 +1052,8 @@ void EditorPropertyLayersGrid::_update_hovered(const Vector2 &p_position) {
 	}
 
 	// Remove highlight when no square is hovered.
-	if (hovered_index != INT32_MAX) {
-		hovered_index = INT32_MAX;
+	if (hovered_index != HOVERED_INDEX_NONE) {
+		hovered_index = HOVERED_INDEX_NONE;
 		queue_redraw();
 	}
 }
@@ -1065,32 +1063,28 @@ void EditorPropertyLayersGrid::_on_hover_exit() {
 		expand_hovered = false;
 		queue_redraw();
 	}
-	if (hovered_index != INT32_MAX) {
-		hovered_index = INT32_MAX;
+	if (hovered_index != HOVERED_INDEX_NONE) {
+		hovered_index = HOVERED_INDEX_NONE;
 		queue_redraw();
 	}
 }
 
 void EditorPropertyLayersGrid::_update_flag(bool p_replace) {
-	if (hovered_index != INT32_MAX) {
+	if (hovered_index != HOVERED_INDEX_NONE) {
 		// Toggle the flag.
 		// We base our choice on the hovered flag, so that it always matches the hovered flag.
 		if (p_replace) {
 			// Replace all flags with the hovered flag ("solo mode"),
 			// instead of toggling the hovered flags while preserving other flags' state.
-			if (value == uint32_t(1 << hovered_index)) {
+			if (value == 1u << hovered_index) {
 				// If the flag is already enabled, enable all other items and disable the current flag.
 				// This allows for quicker toggling.
-				value = INT32_MAX - (1 << hovered_index);
+				value = ~value;
 			} else {
-				value = 1 << hovered_index;
+				value = 1u << hovered_index;
 			}
 		} else {
-			if (value & (1 << hovered_index)) {
-				value &= ~(1 << hovered_index);
-			} else {
-				value |= (1 << hovered_index);
-			}
+			value ^= 1u << hovered_index;
 		}
 
 		emit_signal(SNAME("flag_changed"), value);
@@ -1118,7 +1112,7 @@ void EditorPropertyLayersGrid::gui_input(const Ref<InputEvent> &p_ev) {
 		_update_flag(mb->is_command_or_control_pressed());
 	}
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
-		if (hovered_index != INT32_MAX) {
+		if (hovered_index != HOVERED_INDEX_NONE) {
 			renamed_layer_index = hovered_index;
 			layer_rename->set_position(get_screen_position() + mb->get_position());
 			layer_rename->reset_size();
@@ -1171,7 +1165,7 @@ void EditorPropertyLayersGrid::_notification(int p_what) {
 
 				for (int i = 0; i < 2; i++) {
 					for (int j = 0; j < layer_group_size; j++) {
-						const bool on = value & (1 << layer_index);
+						const bool on = value & (1u << layer_index);
 						Rect2 rect2 = Rect2(ofs, Size2(bsize, bsize));
 
 						color.a = on ? 0.6 : 0.2;
@@ -1361,7 +1355,7 @@ void EditorPropertyLayers::setup(LayerType p_layer_type) {
 		}
 
 		names.push_back(name);
-		tooltips.push_back(name + "\n" + vformat(TTR("Bit %d, value %d"), i, 1 << i));
+		tooltips.push_back(name + "\n" + vformat(TTR("Bit %d, value %d"), i, 1u << i));
 	}
 
 	grid->names = names;
@@ -1396,7 +1390,7 @@ void EditorPropertyLayers::_button_pressed() {
 		}
 		layers->add_check_item(name, i);
 		int idx = layers->get_item_index(i);
-		layers->set_item_checked(idx, grid->value & (1 << i));
+		layers->set_item_checked(idx, grid->value & (1u << i));
 	}
 
 	if (layers->get_item_count() == 0) {
@@ -1418,13 +1412,9 @@ void EditorPropertyLayers::_menu_pressed(int p_menu) {
 		ProjectSettingsEditor::get_singleton()->popup_project_settings(true);
 		ProjectSettingsEditor::get_singleton()->set_general_page(basename);
 	} else {
-		if (grid->value & (1 << p_menu)) {
-			grid->value &= ~(1 << p_menu);
-		} else {
-			grid->value |= (1 << p_menu);
-		}
+		grid->value ^= 1u << p_menu;
 		grid->queue_redraw();
-		layers->set_item_checked(layers->get_item_index(p_menu), grid->value & (1 << p_menu));
+		layers->set_item_checked(layers->get_item_index(p_menu), grid->value & (1u << p_menu));
 		_grid_changed(grid->value);
 	}
 }

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -304,7 +304,8 @@ private:
 	bool expand_hovered = false;
 	bool expanded = false;
 	int expansion_rows = 0;
-	uint32_t hovered_index = INT32_MAX; // Nothing is hovered.
+	const uint32_t HOVERED_INDEX_NONE = UINT32_MAX;
+	uint32_t hovered_index = HOVERED_INDEX_NONE;
 	bool read_only = false;
 	int renamed_layer_index = -1;
 	PopupMenu *layer_rename = nullptr;


### PR DESCRIPTION
- Replaced `1 << shift` to `1u << shift` to not rely on auto casting to unsigned (and to be more explicit). In most cases the change is not really needed as auto casting would happen, but in case of string formatting for the tooltips there was no auto casting to unsigned, hence `%d` format string produced a negative value for the last bit.

Before|After
-|-
<img width="417" height="323" alt="QP1D7vcCGl" src="https://github.com/user-attachments/assets/c9d11fe2-26be-41eb-8248-63acfe5390c4" />|<img width="417" height="323" alt="lVRsmlgS2Y" src="https://github.com/user-attachments/assets/b5713614-bf7e-4110-adbe-a095cb58d627" />

- While looking at the source, I've discovered the `Ctrl/Command`+`LMB` behavior, added in #39364 (I suspect not many users are aware of it). It was buggy, as the last bit would be not enabled when disabling some other bit. Fixed this as well.

Before|After
-|-
![Godot_v4 5 1-stable_win64_fqFwcvLkx3](https://github.com/user-attachments/assets/46b31063-4514-4165-8a46-93a3ec2dfbe9)|![godot windows editor dev x86_64_Mm2AsDYyQs](https://github.com/user-attachments/assets/48c3c649-5d72-4375-a99f-0de312f552b3)




- I've also changed the indicator for _"no hovered index"_ from `INT32_MAX` to `UINT32_MAX`, and factored it out to `HOVERED_INDEX_NONE` constant. In fact any unsigned value greater than `31` could be used as such indicator, it was just a little bit puzzling why specifically `INT32_MAX == 0x7FFFFFFF` was used. Given `hovered_index` is `uint32_t` I think using `UINT32_MAX == 0xFFFFFFFF` makes just a little more sense.