### PR TITLE
Allow drag setting flags in layers property editor

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1067,6 +1067,9 @@ void EditorPropertyLayersGrid::_on_hover_exit() {
 		hovered_index = HOVERED_INDEX_NONE;
 		queue_redraw();
 	}
+	if (dragging) {
+		dragging = false;
+	}
 }
 
 void EditorPropertyLayersGrid::_update_flag(bool p_replace) {
@@ -1103,13 +1106,26 @@ void EditorPropertyLayersGrid::gui_input(const Ref<InputEvent> &p_ev) {
 	const Ref<InputEventMouseMotion> mm = p_ev;
 	if (mm.is_valid()) {
 		_update_hovered(mm->get_position());
+		if (dragging && hovered_index != HOVERED_INDEX_NONE && dragging_value_to_set != bool(value & (1u << hovered_index))) {
+			value ^= 1u << hovered_index;
+			emit_signal(SNAME("flag_changed"), value);
+			queue_redraw();
+		}
 		return;
 	}
 
 	const Ref<InputEventMouseButton> mb = p_ev;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
 		_update_hovered(mb->get_position());
-		_update_flag(mb->is_command_or_control_pressed());
+		bool replace_mode = mb->is_command_or_control_pressed();
+		_update_flag(replace_mode);
+		if (!replace_mode && hovered_index != HOVERED_INDEX_NONE) {
+			dragging = true;
+			dragging_value_to_set = bool(value & (1u << hovered_index));
+		}
+	}
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed()) {
+		dragging = false;
 	}
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
 		if (hovered_index != HOVERED_INDEX_NONE) {

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -306,6 +306,8 @@ private:
 	int expansion_rows = 0;
 	const uint32_t HOVERED_INDEX_NONE = UINT32_MAX;
 	uint32_t hovered_index = HOVERED_INDEX_NONE;
+	bool dragging = false;
+	bool dragging_value_to_set = false;
 	bool read_only = false;
 	int renamed_layer_index = -1;
 	PopupMenu *layer_rename = nullptr;


### PR DESCRIPTION
Adds support for drag-enabling/disabling flags in the EditorPropertyLayersGrid.

Before|After
-|-
![Godot_v4 5 1-stable_win64_ri5JwzGnub](https://github.com/user-attachments/assets/4f1be879-007c-4f01-8e7b-198327bae55f)|![godot windows editor dev x86_64_UHLTYdiZJf](https://github.com/user-attachments/assets/72169735-98be-4276-acdd-35843875f674)
![Godot_v4 5 1-stable_win64_Fl3ntiuveI](https://github.com/user-attachments/assets/26f6697d-b214-46b7-acbe-40e8be3dca69)|![godot windows editor dev x86_64_N2LWg8WhJs](https://github.com/user-attachments/assets/3baf4882-6dfe-4404-9a95-63f77635c532)

