### PR TITLE
Stretch inline buttons & center text to full property header height

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -436,6 +436,7 @@ void EditorProperty::_notification(int p_what) {
 			}
 
 			Size2 rs = right_container->get_combined_minimum_size();
+			rs.y = MAX(rs.y, rect.size.y);
 			if (is_layout_rtl()) {
 				fit_child_in_rect(right_container, Rect2(0, 0, rs.width, rs.y));
 			} else {
@@ -444,6 +445,7 @@ void EditorProperty::_notification(int p_what) {
 
 			Size2 ls = left_container->get_combined_minimum_size();
 			real_t right_size = rect.size.x + rs.x;
+			ls.y = MAX(ls.y, rect.size.y);
 			if (is_layout_rtl()) {
 				fit_child_in_rect(left_container, Rect2(right_size, 0, size.x - right_size, ls.y));
 			} else {
@@ -463,9 +465,8 @@ void EditorProperty::_notification(int p_what) {
 				size.height = bottom_editor->get_offset(SIDE_TOP) - _get_v_separation();
 			} else if (label_reference) {
 				size.height = label_reference->get_size().height;
-			} else if (label_overlayed) {
-				size.height = left_container->get_size().height;
 			}
+			size.height = MAX(size.height, left_container->get_size().height);
 
 			// Only draw the label if it's not empty.
 			if (label.is_empty()) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
This makes inline buttons take up the full size of the property's header, rather than just sitting at the top. It also centers label text. Fixes this comment https://github.com/godotengine/godot/pull/111118#issuecomment-3463079302

Before:
<img width="396" height="183" alt="before-arr-vec" src="https://github.com/user-attachments/assets/eddcdf65-8d6d-4741-9b73-96d83c28b9c6" />

After:
<img width="384" height="256" alt="image" src="https://github.com/user-attachments/assets/816e0308-c6bb-4466-a387-4089be08a0a0" />