### PR TITLE
Fix black reflections when using a plain color as reflection source

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1561,6 +1561,12 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 		scene_state.data.ambient_light_color_energy[1] = 1;
 		scene_state.data.ambient_light_color_energy[2] = 1;
 		scene_state.data.ambient_light_color_energy[3] = 1.0;
+
+		scene_state.data.reflection_color[0] = 0.0;
+		scene_state.data.reflection_color[1] = 0.0;
+		scene_state.data.reflection_color[2] = 0.0;
+		scene_state.data.use_reflection_color = false;
+
 		scene_state.data.use_ambient_cubemap = false;
 		scene_state.data.use_reflection_cubemap = false;
 	} else if (is_environment(p_render_data->environment)) {
@@ -1598,13 +1604,16 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 			scene_state.data.use_ambient_light = scene_state.data.use_ambient_cubemap || ambient_src == RSE::ENV_AMBIENT_SOURCE_COLOR;
 		}
 
-		//specular
-		RSE::EnvironmentReflectionSource ref_src = environment_get_reflection_source(p_render_data->environment);
-		if ((ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_SKY) || ref_src == RSE::ENV_REFLECTION_SOURCE_SKY) {
-			scene_state.data.use_reflection_cubemap = true;
-		} else {
-			scene_state.data.use_reflection_cubemap = false;
-		}
+		// Specular.
+		Color color = env_bg == RSE::ENV_BG_CLEAR_COLOR ? p_default_bg_color : environment_get_bg_color(p_render_data->environment);
+		color = color.srgb_to_linear();
+		scene_state.data.reflection_color[0] = color.r;
+		scene_state.data.reflection_color[1] = color.g;
+		scene_state.data.reflection_color[2] = color.b;
+
+		const RSE::EnvironmentReflectionSource ref_src = environment_get_reflection_source(p_render_data->environment);
+		scene_state.data.use_reflection_color = (ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_COLOR) || (ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_CLEAR_COLOR);
+		scene_state.data.use_reflection_cubemap = (ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_SKY) || ref_src == RSE::ENV_REFLECTION_SOURCE_SKY;
 
 		scene_state.data.fog_enabled = environment_get_fog_enabled(p_render_data->environment);
 		scene_state.data.fog_mode = environment_get_fog_mode(p_render_data->environment);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1619,6 +1619,12 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 		scene_state.data.ambient_light_color_energy[1] = 1;
 		scene_state.data.ambient_light_color_energy[2] = 1;
 		scene_state.data.ambient_light_color_energy[3] = 1.0;
+
+		scene_state.data.reflection_color[0] = 0.0;
+		scene_state.data.reflection_color[1] = 0.0;
+		scene_state.data.reflection_color[2] = 0.0;
+		scene_state.data.use_reflection_color = false;
+
 		scene_state.data.use_ambient_cubemap = false;
 		scene_state.data.use_reflection_cubemap = false;
 	} else if (is_environment(p_render_data->environment)) {
@@ -1656,13 +1662,16 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 			scene_state.data.use_ambient_light = scene_state.data.use_ambient_cubemap || ambient_src == RSE::ENV_AMBIENT_SOURCE_COLOR;
 		}
 
-		//specular
-		RSE::EnvironmentReflectionSource ref_src = environment_get_reflection_source(p_render_data->environment);
-		if ((ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_SKY) || ref_src == RSE::ENV_REFLECTION_SOURCE_SKY) {
-			scene_state.data.use_reflection_cubemap = true;
-		} else {
-			scene_state.data.use_reflection_cubemap = false;
-		}
+		// Specular.
+		Color color = env_bg == RSE::ENV_BG_CLEAR_COLOR ? p_default_bg_color : environment_get_bg_color(p_render_data->environment);
+		color = color.srgb_to_linear();
+		scene_state.data.reflection_color[0] = color.r;
+		scene_state.data.reflection_color[1] = color.g;
+		scene_state.data.reflection_color[2] = color.b;
+
+		const RSE::EnvironmentReflectionSource ref_src = environment_get_reflection_source(p_render_data->environment);
+		scene_state.data.use_reflection_color = (ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_COLOR) || (ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_CLEAR_COLOR);
+		scene_state.data.use_reflection_cubemap = (ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_SKY) || ref_src == RSE::ENV_REFLECTION_SOURCE_SKY;
 
 		scene_state.data.fog_enabled = environment_get_fog_enabled(p_render_data->environment);
 		scene_state.data.fog_mode = environment_get_fog_mode(p_render_data->environment);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -403,6 +403,9 @@ private:
 
 			float ambient_light_color_energy[4];
 
+			float reflection_color[3];
+			uint32_t use_reflection_color = 0;
+
 			float ambient_color_sky_mix;
 			uint32_t directional_shadow_count;
 			float emissive_exposure_normalization;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -422,6 +422,9 @@ private:
 
 			float ambient_light_color_energy[4];
 
+			float reflection_color[3];
+			uint32_t use_reflection_color = 0;
+
 			float ambient_color_sky_mix;
 			uint32_t directional_shadow_count;
 			float emissive_exposure_normalization;

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -194,6 +194,9 @@ struct SceneData {
 
 	mediump vec4 ambient_light_color_energy;
 
+	mediump vec3 reflection_color;
+	bool use_reflection_color;
+
 	mediump float ambient_color_sky_mix;
 	uint directional_shadow_count;
 	float emissive_exposure_normalization;
@@ -1161,6 +1164,9 @@ struct SceneData {
 	vec2 screen_pixel_size;
 
 	mediump vec4 ambient_light_color_energy;
+
+	mediump vec3 reflection_color;
+	bool use_reflection_color;
 
 	mediump float ambient_color_sky_mix;
 	uint directional_shadow_count;
@@ -2249,6 +2255,9 @@ void main() {
 		specular_light = textureLod(radiance_map, ref_vec, sqrt(roughness) * RADIANCE_MAX_LOD).rgb;
 		specular_light = srgb_to_linear(specular_light);
 		specular_light *= horizon * horizon;
+		specular_light *= scene_data_block.data.ambient_light_color_energy.a;
+	} else if (scene_data_block.data.use_reflection_color) {
+		specular_light = scene_data_block.data.reflection_color.rgb;
 		specular_light *= scene_data_block.data.ambient_light_color_energy.a;
 	}
 #endif // USE_RADIANCE_MAP

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -198,6 +198,9 @@ struct SceneData {
 
 	mediump vec4 ambient_light_color_energy;
 
+	mediump vec3 reflection_color;
+	bool use_reflection_color;
+
 	mediump float ambient_color_sky_mix;
 	uint directional_shadow_count;
 	float emissive_exposure_normalization;
@@ -1216,6 +1219,9 @@ struct SceneData {
 	vec2 screen_pixel_size;
 
 	mediump vec4 ambient_light_color_energy;
+
+	mediump vec3 reflection_color;
+	bool use_reflection_color;
 
 	mediump float ambient_color_sky_mix;
 	uint directional_shadow_count;
@@ -2555,6 +2561,9 @@ void main() {
 		specular_light = textureLod(radiance_map, ref_vec, sqrt(roughness) * RADIANCE_MAX_LOD).rgb;
 		specular_light = srgb_to_linear(specular_light);
 		specular_light *= horizon * horizon;
+		specular_light *= scene_data_block.data.ambient_light_color_energy.a;
+	} else if (scene_data_block.data.use_reflection_color) {
+		specular_light = scene_data_block.data.reflection_color.rgb;
 		specular_light *= scene_data_block.data.ambient_light_color_energy.a;
 	}
 #endif // USE_RADIANCE_MAP

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1040,6 +1040,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	bool copy_canvas = false;
 	bool use_ambient_cubemap = false;
 	bool use_reflection_cubemap = false;
+	bool use_reflection_color = false;
 
 	if (get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_OVERDRAW) {
 		clear_color = Color(0, 0, 0, 1); //in overdraw mode, BG should always be black
@@ -1051,6 +1052,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		RSE::EnvironmentReflectionSource reflection_source = environment_get_reflection_source(p_render_data->environment);
 		use_ambient_cubemap = (ambient_source == RSE::ENV_AMBIENT_SOURCE_BG && bg_mode == RSE::ENV_BG_SKY) || ambient_source == RSE::ENV_AMBIENT_SOURCE_SKY;
 		use_reflection_cubemap = (reflection_source == RSE::ENV_REFLECTION_SOURCE_BG && bg_mode == RSE::ENV_BG_SKY) || reflection_source == RSE::ENV_REFLECTION_SOURCE_SKY;
+		use_reflection_color = (reflection_source == RSE::ENV_REFLECTION_SOURCE_BG && bg_mode == RSE::ENV_BG_COLOR) || (reflection_source == RSE::ENV_REFLECTION_SOURCE_BG && bg_mode == RSE::ENV_BG_CLEAR_COLOR);
 
 		if (p_render_data->camera_attributes.is_valid()) {
 			bg_energy_multiplier *= RSG::camera_attributes->camera_attributes_get_exposure_normalization_factor(p_render_data->camera_attributes);
@@ -1149,6 +1151,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		}
 
 		base_specialization.scene_use_ambient_cubemap = use_ambient_cubemap;
+		base_specialization.scene_use_reflection_color = use_reflection_color;
 		base_specialization.scene_use_reflection_cubemap = use_reflection_cubemap;
 		base_specialization.scene_roughness_limiter_enabled = p_render_data->render_buffers.is_valid() && screen_space_roughness_limiter_is_active();
 		base_specialization.luminance_multiplier = p_render_data->render_buffers.is_valid() ? p_render_data->render_buffers->get_luminance_multiplier() : 1.0;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1096,6 +1096,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	bool copy_canvas = false;
 	bool use_ambient_cubemap = false;
 	bool use_reflection_cubemap = false;
+	bool use_reflection_color = false;
 
 	if (get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_OVERDRAW) {
 		clear_color = Color(0, 0, 0, 1); //in overdraw mode, BG should always be black
@@ -1107,6 +1108,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		RSE::EnvironmentReflectionSource reflection_source = environment_get_reflection_source(p_render_data->environment);
 		use_ambient_cubemap = (ambient_source == RSE::ENV_AMBIENT_SOURCE_BG && bg_mode == RSE::ENV_BG_SKY) || ambient_source == RSE::ENV_AMBIENT_SOURCE_SKY;
 		use_reflection_cubemap = (reflection_source == RSE::ENV_REFLECTION_SOURCE_BG && bg_mode == RSE::ENV_BG_SKY) || reflection_source == RSE::ENV_REFLECTION_SOURCE_SKY;
+		use_reflection_color = (reflection_source == RSE::ENV_REFLECTION_SOURCE_BG && bg_mode == RSE::ENV_BG_COLOR) || (reflection_source == RSE::ENV_REFLECTION_SOURCE_BG && bg_mode == RSE::ENV_BG_CLEAR_COLOR);
 
 		if (p_render_data->camera_attributes.is_valid()) {
 			bg_energy_multiplier *= RSG::camera_attributes->camera_attributes_get_exposure_normalization_factor(p_render_data->camera_attributes);
@@ -1205,9 +1207,15 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		}
 
 		base_specialization.scene_use_ambient_cubemap = use_ambient_cubemap;
+		base_specialization.scene_use_reflection_color = use_reflection_color;
 		base_specialization.scene_use_reflection_cubemap = use_reflection_cubemap;
 		base_specialization.scene_roughness_limiter_enabled = p_render_data->render_buffers.is_valid() && screen_space_roughness_limiter_is_active();
-		base_specialization.luminance_multiplier = p_render_data->render_buffers.is_valid() ? p_render_data->render_buffers->get_luminance_multiplier() : 1.0;
+		if (p_render_data->render_buffers.is_valid()) {
+			// Encode as a boolean, as the luminance multiplier is always `2.0` (`true`) or `1.0` (`false`) in the Mobile renderer.
+			base_specialization.luminance_multiplier = p_render_data->render_buffers->get_luminance_multiplier() > (1.0 + CMP_EPSILON);
+		} else {
+			base_specialization.luminance_multiplier = false;
+		}
 	}
 
 	{
@@ -3588,7 +3596,7 @@ void RenderForwardMobile::_update_shader_quality_settings() {
 
 	specialization.use_lightmap_bicubic_filter = lightmap_filter_bicubic_get();
 	specialization.use_material_debanding = material_use_debanding_get();
-	specialization.luminance_multiplier = 2.0f;
+	specialization.luminance_multiplier = true; // `true` is treated as a 2.0 multiplier.
 	scene_shader.set_default_specialization(specialization);
 
 	base_uniforms_changed(); //also need this

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -437,8 +437,8 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 	specialization_constants.push_back(sc);
 
 	sc.constant_id = 2;
-	sc.float_value = p_pipeline_key.shader_specialization.packed_2;
-	sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_FLOAT;
+	sc.int_value = p_pipeline_key.shader_specialization.packed_2;
+	sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_INT;
 	specialization_constants.push_back(sc);
 
 	sc = {}; // Sanitize value bits. "bool_value" only assigns 8 bits and keeps the remaining bits intact.

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -107,9 +107,9 @@ public:
 				uint32_t multimesh_has_custom_data : 1;
 
 				uint32_t scene_use_ambient_cubemap : 1;
+				uint32_t scene_use_reflection_color : 1;
 				uint32_t scene_use_reflection_cubemap : 1;
 				uint32_t scene_roughness_limiter_enabled : 1;
-				uint32_t padding_0 : 1;
 
 				uint32_t soft_shadow_samples : 6;
 				uint32_t penumbra_shadow_samples : 6;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -107,9 +107,9 @@ public:
 				uint32_t multimesh_has_custom_data : 1;
 
 				uint32_t scene_use_ambient_cubemap : 1;
+				uint32_t scene_use_reflection_color : 1;
 				uint32_t scene_use_reflection_cubemap : 1;
 				uint32_t scene_roughness_limiter_enabled : 1;
-				uint32_t material_feedback : 1;
 
 				uint32_t soft_shadow_samples : 6;
 				uint32_t penumbra_shadow_samples : 6;
@@ -134,8 +134,13 @@ public:
 		};
 
 		union {
-			float packed_2;
-			float luminance_multiplier;
+			uint32_t packed_2;
+
+			struct {
+				// `2.0` if `true`, `1.0` if `false`.
+				uint32_t luminance_multiplier : 1;
+				uint32_t material_feedback : 1;
+			};
 		};
 	};
 
@@ -211,7 +216,7 @@ public:
 				h = hash_murmur3_one_32(primitive_type, h);
 				h = hash_murmur3_one_32(shader_specialization.packed_0, h);
 				h = hash_murmur3_one_32(shader_specialization.packed_1, h);
-				h = hash_murmur3_one_float(shader_specialization.packed_2, h);
+				h = hash_murmur3_one_32(shader_specialization.packed_2, h);
 				h = hash_murmur3_one_32(version, h);
 				h = hash_murmur3_one_32(render_pass, h);
 				h = hash_murmur3_one_32(wireframe, h);

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1722,6 +1722,8 @@ void fragment_shader(in SceneData scene_data) {
 		indirect_specular_light *= scene_data.IBL_exposure_normalization;
 		indirect_specular_light *= horizon * horizon;
 		indirect_specular_light *= scene_data.ambient_light_color_energy.a;
+	} else if (bool(scene_data.flags & SCENE_DATA_FLAGS_USE_REFLECTION_COLOR)) {
+		indirect_specular_light = scene_data.reflection_color.rgb;
 	}
 
 #if defined(CUSTOM_RADIANCE_USED)
@@ -1780,6 +1782,8 @@ void fragment_shader(in SceneData scene_data) {
 
 #endif //USE_RADIANCE_OCTMAP_ARRAY
 		cc_specular_light += clearcoat_light * scene_data.IBL_exposure_normalization * scene_data.ambient_light_color_energy.a;
+	} else if (bool(scene_data.flags & SCENE_DATA_FLAGS_USE_REFLECTION_COLOR)) {
+		cc_specular_light = scene_data.reflection_color.rgb;
 	}
 #endif // LIGHT_CLEARCOAT_USED
 #endif // !AMBIENT_LIGHT_DISABLED

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1738,6 +1738,8 @@ void fragment_shader(in SceneData scene_data) {
 		indirect_specular_light *= scene_data.IBL_exposure_normalization;
 		indirect_specular_light *= horizon * horizon;
 		indirect_specular_light *= scene_data.ambient_light_color_energy.a;
+	} else if (bool(scene_data.flags & SCENE_DATA_FLAGS_USE_REFLECTION_COLOR)) {
+		indirect_specular_light = scene_data.reflection_color.rgb;
 	}
 
 #if defined(CUSTOM_RADIANCE_USED)
@@ -1796,6 +1798,8 @@ void fragment_shader(in SceneData scene_data) {
 
 #endif //USE_RADIANCE_OCTMAP_ARRAY
 		cc_specular_light += clearcoat_light * scene_data.IBL_exposure_normalization * scene_data.ambient_light_color_energy.a;
+	} else if (bool(scene_data.flags & SCENE_DATA_FLAGS_USE_REFLECTION_COLOR)) {
+		cc_specular_light = scene_data.reflection_color.rgb;
 	}
 #endif // LIGHT_CLEARCOAT_USED
 #endif // !AMBIENT_LIGHT_DISABLED

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1619,6 +1619,8 @@ void main() {
 		indirect_specular_light *= half(scene_data.IBL_exposure_normalization);
 		indirect_specular_light *= horizon * horizon;
 		indirect_specular_light *= half(scene_data.ambient_light_color_energy.a);
+	} else if (sc_scene_use_reflection_color()) {
+		indirect_specular_light = hvec3(scene_data.reflection_color.rgb);
 	}
 
 #if defined(CUSTOM_RADIANCE_USED)
@@ -1677,6 +1679,8 @@ void main() {
 
 #endif //USE_RADIANCE_OCTMAP_ARRAY
 		cc_specular_light += clearcoat_light * half(scene_data.IBL_exposure_normalization) * half(scene_data.ambient_light_color_energy.a);
+	} else if (sc_scene_use_reflection_color()) {
+		cc_specular_light = hvec3(scene_data.reflection_color.rgb);
 	}
 #endif // LIGHT_CLEARCOAT_USED
 #endif // !AMBIENT_LIGHT_DISABLED

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1632,6 +1632,8 @@ void main() {
 		indirect_specular_light *= half(scene_data.IBL_exposure_normalization);
 		indirect_specular_light *= horizon * horizon;
 		indirect_specular_light *= half(scene_data.ambient_light_color_energy.a);
+	} else if (sc_scene_use_reflection_color()) {
+		indirect_specular_light = hvec3(scene_data.reflection_color.rgb);
 	}
 
 #if defined(CUSTOM_RADIANCE_USED)
@@ -1690,6 +1692,8 @@ void main() {
 
 #endif //USE_RADIANCE_OCTMAP_ARRAY
 		cc_specular_light += clearcoat_light * half(scene_data.IBL_exposure_normalization) * half(scene_data.ambient_light_color_energy.a);
+	} else if (sc_scene_use_reflection_color()) {
+		cc_specular_light = hvec3(scene_data.reflection_color.rgb);
 	}
 #endif // LIGHT_CLEARCOAT_USED
 #endif // !AMBIENT_LIGHT_DISABLED

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -141,12 +141,16 @@ bool sc_scene_use_ambient_cubemap() {
 	return ((sc_packed_0() >> 16) & 1U) != 0;
 }
 
-bool sc_scene_use_reflection_cubemap() {
+bool sc_scene_use_reflection_color() {
 	return ((sc_packed_0() >> 17) & 1U) != 0;
 }
 
-bool sc_scene_roughness_limiter_enabled() {
+bool sc_scene_use_reflection_cubemap() {
 	return ((sc_packed_0() >> 18) & 1U) != 0;
+}
+
+bool sc_scene_roughness_limiter_enabled() {
+	return ((sc_packed_0() >> 19) & 1U) != 0;
 }
 
 uint sc_soft_shadow_samples() {

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -21,7 +21,7 @@ layout(push_constant, std430) uniform DrawCall {
 #ifdef UBERSHADER
 	uint sc_packed_0;
 	uint sc_packed_1;
-	float sc_packed_2;
+	uint sc_packed_2;
 	uint uc_packed_0;
 #endif
 }
@@ -44,7 +44,7 @@ uint sc_packed_1() {
 	return draw_call.sc_packed_1;
 }
 
-float sc_packed_2() {
+uint sc_packed_2() {
 	return draw_call.sc_packed_2;
 }
 
@@ -57,7 +57,7 @@ uint uc_cull_mode() {
 // Pull the constants from the pipeline's specialization constants.
 layout(constant_id = 0) const uint pso_sc_packed_0 = 0;
 layout(constant_id = 1) const uint pso_sc_packed_1 = 0;
-layout(constant_id = 2) const float pso_sc_packed_2 = 2.0;
+layout(constant_id = 2) const uint pso_sc_packed_2 = 0;
 
 uint sc_packed_0() {
 	return pso_sc_packed_0;
@@ -67,7 +67,7 @@ uint sc_packed_1() {
 	return pso_sc_packed_1;
 }
 
-float sc_packed_2() {
+uint sc_packed_2() {
 	return pso_sc_packed_2;
 }
 
@@ -141,24 +141,24 @@ bool sc_scene_use_ambient_cubemap() {
 	return ((sc_packed_0() >> 16) & 1U) != 0;
 }
 
-bool sc_scene_use_reflection_cubemap() {
+bool sc_scene_use_reflection_color() {
 	return ((sc_packed_0() >> 17) & 1U) != 0;
 }
 
-bool sc_scene_roughness_limiter_enabled() {
+bool sc_scene_use_reflection_cubemap() {
 	return ((sc_packed_0() >> 18) & 1U) != 0;
 }
 
-bool sc_material_feedback() {
+bool sc_scene_roughness_limiter_enabled() {
 	return ((sc_packed_0() >> 19) & 1U) != 0;
 }
 
 uint sc_soft_shadow_samples() {
-	return (sc_packed_0() >> 20) & 63U;
+	return (sc_packed_0() >> 24) & 63U;
 }
 
 uint sc_penumbra_shadow_samples() {
-	return (sc_packed_0() >> 26) & 63U;
+	return (sc_packed_0() >> 30) & 63U;
 }
 
 uint sc_directional_soft_shadow_samples() {
@@ -226,7 +226,11 @@ bool sc_use_lightmap_specular() {
 }
 
 half sc_luminance_multiplier() {
-	return half(sc_packed_2());
+	return ((sc_packed_2() >> 0) & 1U) != 0 ? half(2.0) : half(1.0);
+}
+
+bool sc_material_feedback() {
+	return ((sc_packed_2() >> 1) & 1U) != 0;
 }
 
 layout(constant_id = 3) const bool sc_emulate_point_size = false;

--- a/servers/rendering/renderer_rd/shaders/scene_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_data_inc.glsl
@@ -5,12 +5,13 @@
 
 #define SCENE_DATA_FLAGS_USE_AMBIENT_LIGHT (1 << 0)
 #define SCENE_DATA_FLAGS_USE_AMBIENT_CUBEMAP (1 << 1)
-#define SCENE_DATA_FLAGS_USE_REFLECTION_CUBEMAP (1 << 2)
-#define SCENE_DATA_FLAGS_USE_ROUGHNESS_LIMITER (1 << 3)
-#define SCENE_DATA_FLAGS_USE_FOG (1 << 4)
-#define SCENE_DATA_FLAGS_USE_UV2_MATERIAL (1 << 5)
-#define SCENE_DATA_FLAGS_USE_PANCAKE_SHADOWS (1 << 6)
-#define SCENE_DATA_FLAGS_IN_SHADOW_PASS (1 << 7)
+#define SCENE_DATA_FLAGS_USE_REFLECTION_COLOR (1 << 2)
+#define SCENE_DATA_FLAGS_USE_REFLECTION_CUBEMAP (1 << 3)
+#define SCENE_DATA_FLAGS_USE_ROUGHNESS_LIMITER (1 << 4)
+#define SCENE_DATA_FLAGS_USE_FOG (1 << 5)
+#define SCENE_DATA_FLAGS_USE_UV2_MATERIAL (1 << 6)
+#define SCENE_DATA_FLAGS_USE_PANCAKE_SHADOWS (1 << 7)
+#define SCENE_DATA_FLAGS_IN_SHADOW_PASS (1 << 8)
 
 struct SceneData {
 	mat4 projection_matrix;
@@ -59,6 +60,9 @@ struct SceneData {
 	mat3 radiance_inverse_xform;
 
 	vec4 ambient_light_color_energy;
+
+	vec3 reflection_color;
+	uint pad;
 
 	float ambient_color_sky_mix;
 	float fog_density;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -199,6 +199,17 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RSE::ViewportDebugDraw 
 		RSE::EnvironmentReflectionSource ref_src = render_scene_render->environment_get_reflection_source(p_env);
 		if ((ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_SKY) || ref_src == RSE::ENV_REFLECTION_SOURCE_SKY) {
 			ubo.flags |= SCENE_DATA_FLAGS_USE_REFLECTION_CUBEMAP;
+		} else if (
+				(ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_COLOR) ||
+				(ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_CLEAR_COLOR)) {
+			ubo.flags |= SCENE_DATA_FLAGS_USE_REFLECTION_COLOR;
+
+			Color color = env_bg == RSE::ENV_BG_CLEAR_COLOR ? p_default_bg_color : render_scene_render->environment_get_bg_color(p_env);
+			color = color.srgb_to_linear();
+
+			ubo.reflection_color[0] = color.r;
+			ubo.reflection_color[1] = color.g;
+			ubo.reflection_color[2] = color.b;
 		}
 
 		if ((ubo.flags & SCENE_DATA_FLAGS_USE_AMBIENT_CUBEMAP) || (ubo.flags & SCENE_DATA_FLAGS_USE_REFLECTION_CUBEMAP)) {

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -199,6 +199,17 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RSE::ViewportDebugDraw 
 		RSE::EnvironmentReflectionSource ref_src = render_scene_render->environment_get_reflection_source(p_env);
 		if ((ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_SKY) || ref_src == RSE::ENV_REFLECTION_SOURCE_SKY) {
 			ubo.flags |= SCENE_DATA_FLAGS_USE_REFLECTION_CUBEMAP;
+		} else if (
+				(ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_COLOR) ||
+				(ref_src == RSE::ENV_REFLECTION_SOURCE_BG && env_bg == RSE::ENV_BG_CLEAR_COLOR)) {
+			ubo.flags |= SCENE_DATA_FLAGS_USE_REFLECTION_COLOR;
+
+			Color color = env_bg == RSE::ENV_BG_CLEAR_COLOR ? p_default_bg_color : render_scene_render->environment_get_bg_color(p_env);
+			color = color.srgb_to_linear() * bg_energy_multiplier;
+
+			ubo.reflection_color[0] = color.r;
+			ubo.reflection_color[1] = color.g;
+			ubo.reflection_color[2] = color.b;
 		}
 
 		if ((ubo.flags & SCENE_DATA_FLAGS_USE_AMBIENT_CUBEMAP) || (ubo.flags & SCENE_DATA_FLAGS_USE_REFLECTION_CUBEMAP)) {

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -105,12 +105,13 @@ private:
 	enum SceneDataFlags {
 		SCENE_DATA_FLAGS_USE_AMBIENT_LIGHT = 1 << 0,
 		SCENE_DATA_FLAGS_USE_AMBIENT_CUBEMAP = 1 << 1,
-		SCENE_DATA_FLAGS_USE_REFLECTION_CUBEMAP = 1 << 2,
-		SCENE_DATA_FLAGS_USE_ROUGHNESS_LIMITER = 1 << 3,
-		SCENE_DATA_FLAGS_USE_FOG = 1 << 4,
-		SCENE_DATA_FLAGS_USE_UV2_MATERIAL = 1 << 5,
-		SCENE_DATA_FLAGS_USE_PANCAKE_SHADOWS = 1 << 6,
-		SCENE_DATA_FLAGS_IN_SHADOW_PASS = 1 << 7, // Only used by Forward+ renderer.
+		SCENE_DATA_FLAGS_USE_REFLECTION_COLOR = 1 << 2,
+		SCENE_DATA_FLAGS_USE_REFLECTION_CUBEMAP = 1 << 3,
+		SCENE_DATA_FLAGS_USE_ROUGHNESS_LIMITER = 1 << 4,
+		SCENE_DATA_FLAGS_USE_FOG = 1 << 5,
+		SCENE_DATA_FLAGS_USE_UV2_MATERIAL = 1 << 6,
+		SCENE_DATA_FLAGS_USE_PANCAKE_SHADOWS = 1 << 7,
+		SCENE_DATA_FLAGS_IN_SHADOW_PASS = 1 << 8, // Only used by Forward+ renderer.
 		SCENE_DATA_FLAGS_MAX
 	};
 
@@ -159,6 +160,9 @@ private:
 		float radiance_inverse_xform[12];
 
 		float ambient_light_color_energy[4];
+
+		float reflection_color[3];
+		uint32_t pad;
 
 		float ambient_color_sky_mix;
 		float fog_density;


### PR DESCRIPTION
I've also tested VoxelGI/SDFGI in Forward+, and they look correct now.

- This closes https://github.com/godotengine/godot/issues/53817.
- This closes https://github.com/godotengine/godot/pull/77810 by superseding it. Thanks @iw64 for the initial implementation, which I took inspiration from :slightly_smiling_face: 

## Preview

### Forward+

Before | After
-|-
<img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/2dfb4e34-da3b-4f31-bd36-f59445272e4e" /> | <img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/fe0de804-68b8-406d-9c85-f59bfea4c781" />


### Mobile

Before | After
-|-
<img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/9e3a256c-eaed-46da-a449-79b4f31a9d23" /> | <img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/4c909723-0929-4d3c-a320-b596cb91ca39" />

### Compatibility

Before | After
-|-
<img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/b6762d11-7936-4a24-b4a6-d24c92164cdf" /> | <img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/f8a0f6b8-ee8c-4de2-9ba6-e7c888d2e030" />
