### PR TITLE
Add global way of accessing Delta time and Unscaled Delta time

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -83,6 +83,10 @@ private:
 #endif
 	int32_t gpu_idx = -1;
 
+	double _delta_time = 0.0;
+	double _physics_delta_time = 0.0;
+	double _unscaled_physics_delta_time = 0.0;
+
 	uint64_t _process_frames = 0;
 	bool _in_physics = false;
 
@@ -141,6 +145,11 @@ public:
 	uint64_t get_frame_ticks() const { return _frame_ticks; }
 	double get_process_step() const { return _process_step; }
 	double get_physics_interpolation_fraction() const { return _physics_interpolation_fraction; }
+
+	double get_delta_time() const { return _delta_time; }
+	double get_unscaled_delta_time() const { return _process_step; }
+	double get_physics_delta_time() const { return _physics_delta_time; }
+	double get_unscaled_physics_delta_time() const { return _unscaled_physics_delta_time; }
 
 	void set_time_scale(double p_scale);
 	double get_time_scale() const;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1928,6 +1928,22 @@ uint64_t Engine::get_process_frames() const {
 	return ::Engine::get_singleton()->get_process_frames();
 }
 
+double Engine::get_delta_time() {
+	return ::Engine::get_singleton()->get_delta_time();
+}
+
+double Engine::get_unscaled_delta_time() {
+	return ::Engine::get_singleton()->get_unscaled_delta_time();
+}
+
+double Engine::get_physics_delta_time() {
+	return ::Engine::get_singleton()->get_physics_delta_time();
+}
+
+double Engine::get_unscaled_physics_delta_time() {
+	return ::Engine::get_singleton()->get_unscaled_physics_delta_time();
+}
+
 void Engine::set_time_scale(double p_scale) {
 	::Engine::get_singleton()->set_time_scale(p_scale);
 }
@@ -2092,6 +2108,11 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_physics_interpolation_fraction"), &Engine::get_physics_interpolation_fraction);
 	ClassDB::bind_method(D_METHOD("set_max_fps", "max_fps"), &Engine::set_max_fps);
 	ClassDB::bind_method(D_METHOD("get_max_fps"), &Engine::get_max_fps);
+
+	ClassDB::bind_method(D_METHOD("get_delta_time"), &Engine::get_delta_time);
+	ClassDB::bind_method(D_METHOD("get_unscaled_delta_time"), &Engine::get_unscaled_delta_time);
+	ClassDB::bind_method(D_METHOD("get_physics_delta_time"), &Engine::get_physics_delta_time);
+	ClassDB::bind_method(D_METHOD("get_unscaled_physics_delta_time"), &Engine::get_unscaled_physics_delta_time);
 
 	ClassDB::bind_method(D_METHOD("set_time_scale", "time_scale"), &Engine::set_time_scale);
 	ClassDB::bind_method(D_METHOD("get_time_scale"), &Engine::get_time_scale);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -591,6 +591,11 @@ public:
 
 	int get_frames_drawn();
 
+	double get_delta_time();
+	double get_unscaled_delta_time();
+	double get_physics_delta_time();
+	double get_unscaled_physics_delta_time();
+
 	void set_time_scale(double p_scale);
 	double get_time_scale();
 

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -43,6 +43,13 @@
 				- [code]license[/code] - The license applied to this component (such as "[url=https://en.wikipedia.org/wiki/MIT_License#Ambiguity_and_variants]Expat[/url]" or "[url=https://creativecommons.org/licenses/by/4.0/]CC-BY-4.0[/url]").
 			</description>
 		</method>
+		<method name="get_delta_time">
+			<return type="float" />
+			<description>
+				Returns the time spent between the last two rendered frames in seconds. This functions identically to the [code]delta[/code] parameter in [method Node._process], meaning this is affected by [member time_scale]. Use [method get_unscaled_delta_time] for an unscaled delta time.
+				See also [method get_physics_delta_time].
+			</description>
+		</method>
 		<method name="get_donor_info" qualifiers="const">
 			<return type="Dictionary" />
 			<description>
@@ -80,6 +87,13 @@
 			<description>
 				Returns the instance of the [MainLoop]. This is usually the main [SceneTree] and is the same as [method Node.get_tree].
 				[b]Note:[/b] The type instantiated as the main loop can changed with [member ProjectSettings.application/run/main_loop_type].
+			</description>
+		</method>
+		<method name="get_physics_delta_time">
+			<return type="float" />
+			<description>
+				Returns the time spent between the last two physics ticks in seconds. This functions identically to the [code]delta[/code] parameter in [method Node._physics_process], meaning this is affected by [member time_scale]. Use [method get_unscaled_physics_delta_time] for an unscaled delta time.
+				See also [method get_delta_time].
 			</description>
 		</method>
 		<method name="get_physics_frames" qualifiers="const">
@@ -163,6 +177,20 @@
 			<return type="PackedStringArray" />
 			<description>
 				Returns a list of names of all available global singletons. See also [method get_singleton].
+			</description>
+		</method>
+		<method name="get_unscaled_delta_time">
+			<return type="float" />
+			<description>
+				Returns the time spent between the last two rendered frames in seconds. Unlike the [code]delta[/code] parameter in [method Node._process], this value is not affected by [member time_scale]. Use [method get_delta_time] for a scaled delta time.
+				See also [method get_unscaled_physics_delta_time].
+			</description>
+		</method>
+		<method name="get_unscaled_physics_delta_time">
+			<return type="float" />
+			<description>
+				Returns the time spent between the last two physics ticks in seconds. Unlike the [code]delta[/code] parameter in [method Node._physics_process], this value is not affected by [member time_scale]. Use [method get_physics_delta_time] for a scaled delta time.
+				See also [method get_unscaled_delta_time].
 			</description>
 		</method>
 		<method name="get_version_info" qualifiers="const">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4802,10 +4802,11 @@ bool Main::iteration() {
 
 	const uint64_t ticks_elapsed = ticks - last_ticks;
 
+	const double time_scale = Engine::get_singleton()->get_effective_time_scale();
+
 	const int physics_ticks_per_second = Engine::get_singleton()->get_user_physics_ticks_per_second();
 	const double physics_step = 1.0 / physics_ticks_per_second;
-
-	const double time_scale = Engine::get_singleton()->get_effective_time_scale();
+	double scaled_physics_step = physics_step * time_scale;
 
 	MainFrameTime advance = main_timer_sync.advance(physics_step, physics_ticks_per_second);
 	double process_step = advance.process_step;
@@ -4813,6 +4814,9 @@ bool Main::iteration() {
 
 	Engine::get_singleton()->_process_step = process_step;
 	Engine::get_singleton()->_physics_interpolation_fraction = advance.interpolation_fraction;
+	Engine::get_singleton()->_delta_time = scaled_step;
+	Engine::get_singleton()->_physics_delta_time = scaled_physics_step;
+	Engine::get_singleton()->_unscaled_physics_delta_time = physics_step;
 
 	uint64_t physics_process_ticks = 0;
 	uint64_t process_ticks = 0;


### PR DESCRIPTION
- This PR aims to close https://github.com/godotengine/godot-proposals/issues/7775
Which seems to be pretty positively received and additionally seems to have a general consensus that both deltas and unscaled variants should be added to the Engine class

As such, I've added the following methods:
```
Engine.get_delta_time()
Engine.get_unscaled_delta_time()
Engine.get_physics_delta_time()
Engine.get_unscaled_physics_delta_time()
```
`get_delta` provides the exact same information the `_process` method provides. 
`get_physics_delta` is the same way but for `_physicsProcess`

The unscaled methods provide the user a unscaled version of both of these deltas, as they are *never* multiplied by timescale in the first place, this is the most accurate and convenient way of getting unscaled deltas. 

## Notes

This is a similar to #86766, just with the extra granularity, and I guess also slightly opinionated, it seemed like the consensus on the proposal was to refer to them as Deltas, makes sense to me and matches what the average user would expect I think. 

[Screencast_20251029_210032.webm](https://github.com/user-attachments/assets/c9f300e1-c96e-43e4-bdf4-67155d3bdc1b)

