### PR TITLE
fix(metal): add MTLGPUAddress fallback and write gpuAddress as uint64_t

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -65,6 +65,11 @@
 #import <os/signpost.h>
 #include <algorithm>
 
+// Compat: Older SDKs may not define MTLGPUAddress. Define it as 64-bit.
+#ifndef MTLGPUAddress
+typedef uint64_t MTLGPUAddress;
+#endif
+
 #pragma mark - Logging
 
 extern os_log_t LOG_DRIVER;
@@ -1409,7 +1414,7 @@ RDD::UniformSetID RenderingDeviceDriverMetal::uniform_set_create(VectorView<Boun
 						if (idx.buffer != UINT32_MAX) {
 							// Emulated atomic image access.
 							id<MTLBuffer> buffer = (texture.parentTexture ? texture.parentTexture : texture).buffer;
-							*(MTLGPUAddress *)(ptr + idx.buffer + j) = buffer.gpuAddress;
+							*(uint64_t *)(ptr + idx.buffer + j) = buffer.gpuAddress;
 
 							add_usage(buffer, ui.active_stages, ui.usage);
 						}


### PR DESCRIPTION
when i compiled with target maxos , errors:
```
[ 43%] drivers/metal/rendering_device_driver_metal.mm:1412:10: error: use of undeclared identifier 'MTLGPUAddress'
 1412 |                                                         *(MTLGPUAddress *)(ptr + idx.buffer + j) = buffer.gpuAddress;
      |                                                           ^
[ 43%] drivers/metal/rendering_device_driver_metal.mm:1412:25: error: expected expression
 1412 |                                                         *(MTLGPUAddress *)(ptr + idx.buffer + j) = buffer.gpuAddress;
      |                                                                          ^
[ 44%] drivers/metal/rendering_device_driver_metal.mm:1430:8: error: use of undeclared identifier 'MTLGPUAddress'
 1430 |                                         *(MTLGPUAddress *)(ptr + idx.buffer) = buffer->metal_buffer.gpuAddress;
      |                                           ^
drivers/metal/rendering_device_driver_metal.mm:1430:23: error: expected expression
 1430 |                                         *(MTLGPUAddress *)(ptr + idx.buffer) = buffer->metal_buffer.gpuAddress;
      |
```

so:
Define a fallback typedef for MTLGPUAddress as uint64_t on older Apple SDKs and write gpuAddress via uint64_t where used. This fixes build failures with undeclared MTLGPUAddress while preserving behavior (gpuAddress is 64-bit).