### PR TITLE
[macOS/iOS] Fix build with Xcode older than 26.

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -65,6 +65,10 @@
 #import <os/signpost.h>
 #include <algorithm>
 
+#ifndef MTLGPUAddress
+typedef uint64_t MTLGPUAddress;
+#endif
+
 #pragma mark - Logging
 
 extern os_log_t LOG_DRIVER;


### PR DESCRIPTION
Regressions from #111976, `MTLGPUAddress.h` and new type definition were added in macOS/iOS 26 SDK.

Tested with Xcode 16.1 on macOS 15.7.1.