### PR TITLE
Fix TileMapLayer asymmetry and inconsistency

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1968,6 +1968,7 @@ RBSet<TerrainConstraint> TileMapLayer::_get_terrain_constraints_from_painted_cel
 		if (max > 0) {
 			TerrainConstraint c = E_constraint;
 			c.set_terrain(max_terrain);
+			c.set_priority(8);
 			constraints.insert(c);
 		}
 	}
@@ -1986,7 +1987,9 @@ RBSet<TerrainConstraint> TileMapLayer::_get_terrain_constraints_from_painted_cel
 
 		int terrain = (tile_data && tile_data->get_terrain_set() == p_terrain_set) ? tile_data->get_terrain() : -1;
 		if (!p_ignore_empty_terrains || terrain >= 0) {
-			constraints.insert(TerrainConstraint(tile_set, E_coords, terrain));
+			TerrainConstraint c(tile_set, E_coords, terrain);
+			c.set_priority(8);
+			constraints.insert(c);
 		}
 	}
 
@@ -2393,12 +2396,22 @@ HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_constrain
 		// Update the constraint set with the new ones.
 		RBSet<TerrainConstraint> new_constraints = _get_terrain_constraints_from_added_pattern(coords, p_terrain_set, pattern);
 		for (const TerrainConstraint &E_constraint : new_constraints) {
-			if (constraints.has(E_constraint)) {
-				constraints.erase(E_constraint);
+			RBSet<TerrainConstraint>::Element *in_set_constraint_element = constraints.find(E_constraint);
+			if (in_set_constraint_element) {
+				TerrainConstraint &c = in_set_constraint_element->get();
+				if (c.get_terrain() == E_constraint.get_terrain()) {
+					if (c.get_priority() < 6) {
+						c.set_priority(6);
+					}
+				} else {
+					c.set_terrain(E_constraint.get_terrain());
+					c.set_priority(6);
+				}
+			} else {
+				TerrainConstraint c = E_constraint;
+				c.set_priority(6);
+				constraints.insert(c);
 			}
-			TerrainConstraint c = E_constraint;
-			c.set_priority(5);
-			constraints.insert(c);
 		}
 
 		output[coords] = pattern;


### PR DESCRIPTION
Fixes #112186

In addition to the listed changes, this also updates pattern constraints to use priority 6 so that Godot is less likely to calculate patterns with identical scores. When patterns have identical scores, whichever pattern occured first in memory takes priority. This change should hopefully improve consistency.