### PR TITLE
Fix 64-bit integers being truncated to 32-bit in JNI

### DIFF
--- a/platform/android/java/app/src/instrumented/assets/test/javaclasswrapper/java_class_wrapper_tests.gd
+++ b/platform/android/java/app/src/instrumented/assets/test/javaclasswrapper/java_class_wrapper_tests.gd
@@ -16,6 +16,8 @@ func run_tests():
 
 	__exec_test(test_variant_conversion_safe_from_stack_overflow)
 
+	__exec_test(test_big_integers)
+
 	print("JavaClassWrapper tests finished.")
 	print("Tests started: " + str(_test_started))
 	print("Tests completed: " + str(_test_completed))
@@ -134,3 +136,9 @@ func test_variant_conversion_safe_from_stack_overflow():
 	arr.append(dict)
 	# The following line will crash with stack overflow if not handled property:
 	TestClass.testDictionary(dict)
+
+func test_big_integers():
+	var TestClass: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass')
+	assert_equal(TestClass.testArgLong(4242424242), "4242424242")
+	assert_equal(TestClass.testArgLong(-4242424242), "-4242424242")
+	assert_equal(TestClass.testDictionary({a = 4242424242, b = -4242424242}), "{a=4242424242, b=-4242424242}")

--- a/platform/android/java/app/src/instrumented/java/com/godot/game/test/javaclasswrapper/TestClass.kt
+++ b/platform/android/java/app/src/instrumented/java/com/godot/game/test/javaclasswrapper/TestClass.kt
@@ -104,6 +104,11 @@ class TestClass {
 		}
 
 		@JvmStatic
+		fun testArgLong(a: Long): String {
+			return "${a}"
+		}
+
+		@JvmStatic
 		fun testArgBoolArray(a: BooleanArray): String {
 			return a.contentToString();
 		}

--- a/platform/android/jni_utils.cpp
+++ b/platform/android/jni_utils.cpp
@@ -116,16 +116,15 @@ jvalue _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_ar
 		} break;
 		case Variant::INT: {
 			if (force_jobject) {
-				jclass bclass = jni_find_class(env, "java/lang/Integer");
-				jmethodID ctor = env->GetMethodID(bclass, "<init>", "(I)V");
+				jclass bclass = jni_find_class(env, "java/lang/Long");
+				jmethodID ctor = env->GetMethodID(bclass, "<init>", "(J)V");
 				jvalue val;
-				val.i = (int)(*p_arg);
+				val.j = (jlong)(*p_arg);
 				jobject obj = env->NewObjectA(bclass, ctor, &val);
 				value.l = obj;
 				env->DeleteLocalRef(bclass);
-
 			} else {
-				value.i = *p_arg;
+				value.j = (jlong)(*p_arg);
 			}
 		} break;
 		case Variant::FLOAT: {


### PR DESCRIPTION
This PR fixes integers being truncated to 32-bits in `_variant_to_jvalue()`.