### PR TITLE
Autoloads with UIDs

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4258,7 +4258,7 @@ int Main::start() {
 						// Cache the scene reference before loading it (for cyclic references)
 						Ref<PackedScene> scn;
 						scn.instantiate();
-						scn->set_path(info.path);
+						scn->set_path(ResourceUID::ensure_path(info.path));
 						scn->reload_from_file();
 						ERR_CONTINUE_MSG(scn.is_null(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
 

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -76,7 +76,7 @@ void init_autoloads() {
 			// Cache the scene reference before loading it (for cyclic references)
 			Ref<PackedScene> scn;
 			scn.instantiate();
-			scn->set_path(info.path);
+			scn->set_path(ResourceUID::ensure_path(info.path));
 			scn->reload_from_file();
 			ERR_CONTINUE_MSG(scn.is_null(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
 


### PR DESCRIPTION
Closes: [#111720](https://github.com/godotengine/godot/issues/111720)

Autoloads can now use UIDs for `Scripts` and `Scenes`.

<img width="401" height="130" alt="Screenshot 2025-10-30 154258" src="https://github.com/user-attachments/assets/c3fa911c-a3af-4b2e-9a5d-c198acb94256" />

Autoload Using UIDs:

[Autoload UIDs](https://github.com/user-attachments/assets/76d9bad5-80f4-438d-9d1a-177f9c75c8ff)

When Autoloads files moved Externally:

[Moving Autoload Files Externally](https://github.com/user-attachments/assets/161c6f31-31e9-456b-8515-a08832f90b08)


