### PR TITLE
Improve `TileMapLayer` terrain code

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -2525,19 +2525,7 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTerrainsPlugin::_draw_terrain_p
 			output[kv.key] = tile_set->get_random_tile_from_terrains_pattern(p_terrain_set, kv.value);
 		} else {
 			// Avoids updating the painted path from the output if the new pattern is the same as before.
-			TileSet::TerrainsPattern in_map_terrain_pattern = TileSet::TerrainsPattern(*tile_set, p_terrain_set);
-			TileMapCell cell = edited_layer->get_cell(kv.key);
-			if (cell.source_id != TileSet::INVALID_SOURCE) {
-				TileSetSource *source = *tile_set->get_source(cell.source_id);
-				TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
-				if (atlas_source) {
-					// Get tile data.
-					TileData *tile_data = atlas_source->get_tile_data(cell.get_atlas_coords(), cell.alternative_tile);
-					if (tile_data && tile_data->get_terrain_set() == p_terrain_set) {
-						in_map_terrain_pattern = tile_data->get_terrains_pattern();
-					}
-				}
-			}
+			TileSet::TerrainsPattern in_map_terrain_pattern = edited_layer->get_terrain_pattern_of_cell(kv.key, p_terrain_set);
 			if (in_map_terrain_pattern != kv.value) {
 				output[kv.key] = tile_set->get_random_tile_from_terrains_pattern(p_terrain_set, kv.value);
 			}
@@ -2572,19 +2560,7 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTerrainsPlugin::_draw_terrain_p
 			output[kv.key] = tile_set->get_random_tile_from_terrains_pattern(p_terrain_set, kv.value);
 		} else {
 			// Avoids updating the painted path from the output if the new pattern is the same as before.
-			TileSet::TerrainsPattern in_map_terrain_pattern = TileSet::TerrainsPattern(*tile_set, p_terrain_set);
-			TileMapCell cell = edited_layer->get_cell(kv.key);
-			if (cell.source_id != TileSet::INVALID_SOURCE) {
-				TileSetSource *source = *tile_set->get_source(cell.source_id);
-				TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
-				if (atlas_source) {
-					// Get tile data.
-					TileData *tile_data = atlas_source->get_tile_data(cell.get_atlas_coords(), cell.alternative_tile);
-					if (tile_data && tile_data->get_terrain_set() == p_terrain_set) {
-						in_map_terrain_pattern = tile_data->get_terrains_pattern();
-					}
-				}
-			}
+			TileSet::TerrainsPattern in_map_terrain_pattern = edited_layer->get_terrain_pattern_of_cell(kv.key, p_terrain_set);
 			if (in_map_terrain_pattern != kv.value) {
 				output[kv.key] = tile_set->get_random_tile_from_terrains_pattern(p_terrain_set, kv.value);
 			}
@@ -2695,18 +2671,7 @@ RBSet<Vector2i> TileMapLayerEditorTerrainsPlugin::_get_cells_for_bucket_fill(Vec
 			to_check.pop_back();
 			if (!already_checked.has(coords)) {
 				// Get the candidate cell pattern.
-				TileSet::TerrainsPattern candidate_pattern(*tile_set, selected_terrain_set);
-				if (edited_layer->get_cell_source_id(coords) != TileSet::INVALID_SOURCE) {
-					TileData *tile_data = nullptr;
-					Ref<TileSetSource> source = tile_set->get_source(edited_layer->get_cell_source_id(coords));
-					Ref<TileSetAtlasSource> atlas_source = source;
-					if (atlas_source.is_valid()) {
-						tile_data = atlas_source->get_tile_data(edited_layer->get_cell_atlas_coords(coords), edited_layer->get_cell_alternative_tile(coords));
-					}
-					if (tile_data) {
-						candidate_pattern = tile_data->get_terrains_pattern();
-					}
-				}
+				TileSet::TerrainsPattern candidate_pattern = edited_layer->get_terrain_pattern_of_cell(coords, selected_terrain_set);
 
 				// Draw.
 				if (candidate_pattern == source_pattern && (!source_pattern.is_erase_pattern() || boundaries.has_point(coords))) {
@@ -2740,18 +2705,7 @@ RBSet<Vector2i> TileMapLayerEditorTerrainsPlugin::_get_cells_for_bucket_fill(Vec
 		for (int i = 0; i < to_check.size(); i++) {
 			Vector2i coords = to_check[i];
 			// Get the candidate cell pattern.
-			TileSet::TerrainsPattern candidate_pattern;
-			if (edited_layer->get_cell_source_id(coords) != TileSet::INVALID_SOURCE) {
-				TileData *tile_data = nullptr;
-				Ref<TileSetSource> source = tile_set->get_source(edited_layer->get_cell_source_id(coords));
-				Ref<TileSetAtlasSource> atlas_source = source;
-				if (atlas_source.is_valid()) {
-					tile_data = atlas_source->get_tile_data(edited_layer->get_cell_atlas_coords(coords), edited_layer->get_cell_alternative_tile(coords));
-				}
-				if (tile_data) {
-					candidate_pattern = tile_data->get_terrains_pattern();
-				}
-			}
+			TileSet::TerrainsPattern candidate_pattern = edited_layer->get_terrain_pattern_of_cell(coords, selected_terrain_set);
 
 			// Draw.
 			if (candidate_pattern == source_pattern && (!source_pattern.is_erase_pattern() || boundaries.has_point(coords))) {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -570,7 +570,7 @@ void TileMap::set_pattern(int p_layer, const Vector2i &p_position, const Ref<Til
 	TILEMAP_CALL_FOR_LAYER(p_layer, set_pattern, p_position, p_pattern);
 }
 
-HashMap<Vector2i, TileSet::TerrainsPattern> TileMap::terrain_fill_constraints(int p_layer, const Vector<Vector2i> &p_to_replace, int p_terrain_set, const RBSet<TerrainConstraint> &p_constraints) {
+HashMap<Vector2i, TileSet::TerrainsPattern> TileMap::terrain_fill_constraints(int p_layer, const Vector<Vector2i> &p_to_replace, int p_terrain_set, const TerrainConstraints &p_constraints) {
 	TILEMAP_CALL_FOR_LAYER_V(p_layer, (HashMap<Vector2i, TileSet::TerrainsPattern>()), terrain_fill_constraints, p_to_replace, p_terrain_set, p_constraints);
 }
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -39,7 +39,7 @@ class Control;
 class NavigationMeshSourceGeometryData2D;
 #endif // NAVIGATION_2D_DISABLED
 class TileMapLayer;
-class TerrainConstraint;
+class TerrainConstraints;
 
 enum TileMapDataFormat {
 	TILE_MAP_DATA_FORMAT_1 = 0,
@@ -185,7 +185,7 @@ public:
 	void set_pattern(int p_layer, const Vector2i &p_position, const Ref<TileMapPattern> p_pattern);
 
 	// Terrains (Not exposed).
-	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_constraints(int p_layer, const Vector<Vector2i> &p_to_replace, int p_terrain_set, const RBSet<TerrainConstraint> &p_constraints);
+	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_constraints(int p_layer, const Vector<Vector2i> &p_to_replace, int p_terrain_set, const TerrainConstraints &p_constraints);
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_connect(int p_layer, const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true);
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_path(int p_layer, const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true);
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_pattern(int p_layer, const Vector<Vector2i> &p_coords_array, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern, bool p_ignore_empty_terrains = true);

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1889,7 +1889,7 @@ TileSet::TerrainsPattern TileMapLayer::_get_best_terrain_pattern_for_constraints
 
 		// Check the center bit constraint.
 		if (cell_constraints[TileSet::CELL_NEIGHBOR_MAX].is_targetted() && cell_constraints[TileSet::CELL_NEIGHBOR_MAX].get_terrain() != terrain_pattern.get_terrain()) {
-			score += cell_constraints[TileSet::CELL_NEIGHBOR_MAX].get_priority(); // Increase score if pattern does not match targetted terrain
+			score += cell_constraints[TileSet::CELL_NEIGHBOR_MAX].get_priority(); // Increase score if pattern does not match targeted terrain
 		}
 		if (cell_constraints[TileSet::CELL_NEIGHBOR_MAX].is_unconstrained() && p_current_pattern.get_terrain() != terrain_pattern.get_terrain()) {
 			continue; // Ignore a pattern that cannot keep bits without constraints unmodified.
@@ -1902,7 +1902,7 @@ TileSet::TerrainsPattern TileMapLayer::_get_best_terrain_pattern_for_constraints
 			if (cell_constraints[i].is_valid()) {
 				// Check if the bit is compatible with the constraints.
 				if (cell_constraints[i].is_targetted() && cell_constraints[i].get_terrain() != terrain_pattern.get_terrain_peering_bit(bit)) {
-					score += cell_constraints[i].get_priority(); // Increase score if pattern does not match targetted terrain
+					score += cell_constraints[i].get_priority(); // Increase score if pattern does not match targeted terrain
 				}
 				if (cell_constraints[i].is_unconstrained() && p_current_pattern.get_terrain_peering_bit(bit) != terrain_pattern.get_terrain_peering_bit(bit)) {
 					invalid_pattern = true; // Ignore a pattern that cannot keep bits without constraints unmodified.

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -48,6 +48,8 @@ public:
 	class Action;
 	class Bit {
 		friend class RBMap<Bit, Action>;
+		friend class RBSet<Bit>;
+
 		Vector2i base_cell_coords;
 		int bit = -1;
 
@@ -569,8 +571,8 @@ private:
 	// Terrains.
 	void _prepare_terrain_fill(const Vector<Vector2i> &p_coords_array, Vector<Vector2i> &r_can_modify_list, RBSet<Vector2i> &r_can_modify_set, RBSet<Vector2i> &r_painted_set) const;
 	TileSet::TerrainsPattern _get_best_terrain_pattern_for_constraints(int p_terrain_set, const Vector2i &p_position, const TerrainConstraints &p_constraints, TileSet::TerrainsPattern p_current_pattern) const;
-	TerrainConstraints _get_terrain_constraints_from_added_pattern(const Vector2i &p_position, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern) const;
-	TerrainConstraints _get_terrain_constraints_from_painted_cells_list(const RBSet<Vector2i> &p_painted, int p_terrain_set, bool p_ignore_empty_terrains) const;
+	void _add_terrain_pattern_as_constraints(const Vector2i &p_position, int p_terrain_set, const TileSet::TerrainsPattern &p_terrains_pattern, TerrainConstraints &r_constraints, int p_priority) const;
+	void _add_terrain_constraints_from_painted_cells_list(const RBSet<Vector2i> &p_painted, int p_terrain_set, bool p_ignore_empty_terrains, TerrainConstraints &r_constraints) const;
 
 	void _tile_set_changed();
 

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -72,17 +72,20 @@ public:
 		HashMap<Vector2i, TileSet::CellNeighbor> get_overlapping_coords_and_peering_bits(const Ref<TileSet> &p_tile_set) const;
 
 	protected:
-		explicit Bit(const Vector2i &p_position) : base_cell_coords(p_position), bit(0) {} // For the center terrain bit
+		explicit Bit(const Vector2i &p_position) :
+				base_cell_coords(p_position), bit(0) {} // For the center terrain bit
 		Bit(const Ref<TileSet> &p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit); // For peering bits
 		Bit() {}
 	};
 	class CenterBit : public Bit {
 	public:
-		explicit CenterBit(const Vector2i &p_position) : Bit(p_position) {}
+		explicit CenterBit(const Vector2i &p_position) :
+				Bit(p_position) {}
 	};
 	class PeeringBit : public Bit {
 	public:
-		PeeringBit(const Ref<TileSet> &p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit) : Bit(p_tile_set, p_position, p_bit) {}
+		PeeringBit(const Ref<TileSet> &p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit) :
+				Bit(p_tile_set, p_position, p_bit) {}
 	};
 
 	class Action {
@@ -126,17 +129,20 @@ public:
 
 	protected:
 		// Protected constructor ensures use of child classes to better communicate intent
-		constexpr Action(int p_terrain, int p_priority) : terrain(p_terrain), priority(p_priority) {}
+		constexpr Action(int p_terrain, int p_priority) :
+				terrain(p_terrain), priority(p_priority) {}
 	};
 	class TargetTerrain : public Action {
 	public:
-		explicit TargetTerrain(int p_terrain, int p_priority = 1) : Action(p_terrain, p_priority) {
+		explicit TargetTerrain(int p_terrain, int p_priority = 1) :
+				Action(p_terrain, p_priority) {
 			ERR_FAIL_COND(p_terrain < -1);
 		}
 	};
 	class Unconstrained : public Action {
 	public:
-		Unconstrained() : Action(-2, 0) {}
+		Unconstrained() :
+				Action(-2, 0) {}
 	};
 
 private:

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -567,6 +567,7 @@ private:
 #endif // DEBUG_ENABLED
 
 	// Terrains.
+	void _prepare_terrain_fill(const Vector<Vector2i> &p_coords_array, Vector<Vector2i> &r_can_modify_list, RBSet<Vector2i> &r_can_modify_set, RBSet<Vector2i> &r_painted_set) const;
 	TileSet::TerrainsPattern _get_best_terrain_pattern_for_constraints(int p_terrain_set, const Vector2i &p_position, const TerrainConstraints &p_constraints, TileSet::TerrainsPattern p_current_pattern) const;
 	TerrainConstraints _get_terrain_constraints_from_added_pattern(const Vector2i &p_position, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern) const;
 	TerrainConstraints _get_terrain_constraints_from_painted_cells_list(const RBSet<Vector2i> &p_painted, int p_terrain_set, bool p_ignore_empty_terrains) const;

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -610,6 +610,7 @@ public:
 	Rect2 get_rect(bool &r_changed) const;
 
 	// Terrains.
+	TileSet::TerrainsPattern get_terrain_pattern_of_cell(const Vector2i &p_position, int p_terrain_set) const;
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_constraints(const Vector<Vector2i> &p_to_replace, int p_terrain_set, const TerrainConstraints &p_constraints) const; // Not exposed.
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_connect(const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true) const; // Not exposed.
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_path(const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true) const; // Not exposed.

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -43,56 +43,129 @@ enum TileMapLayerDataFormat {
 	TILE_MAP_LAYER_DATA_FORMAT_MAX,
 };
 
-class TerrainConstraint {
-private:
-	Ref<TileSet> tile_set;
-	Vector2i base_cell_coords;
-	int bit = -1;
-	int terrain = -1;
+class TerrainConstraints {
+public:
+	class Action;
+	class Bit {
+		friend class RBMap<Bit, Action>;
+		Vector2i base_cell_coords;
+		int bit = -1;
 
-	int priority = 1;
+	public:
+		bool operator<(const Bit &p_other) const {
+			if (base_cell_coords == p_other.base_cell_coords) {
+				return bit < p_other.bit;
+			}
+			return base_cell_coords < p_other.base_cell_coords;
+		}
+
+		Vector2i get_base_cell_coords() const {
+			return base_cell_coords;
+		}
+
+		bool is_center_bit() const {
+			return bit == 0;
+		}
+
+		HashMap<Vector2i, TileSet::CellNeighbor> get_overlapping_coords_and_peering_bits(const Ref<TileSet> &p_tile_set) const;
+
+	protected:
+		explicit Bit(const Vector2i &p_position) : base_cell_coords(p_position), bit(0) {} // For the center terrain bit
+		Bit(const Ref<TileSet> &p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit); // For peering bits
+		Bit() {}
+	};
+	class CenterBit : public Bit {
+	public:
+		explicit CenterBit(const Vector2i &p_position) : Bit(p_position) {}
+	};
+	class PeeringBit : public Bit {
+	public:
+		PeeringBit(const Ref<TileSet> &p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit) : Bit(p_tile_set, p_position, p_bit) {}
+	};
+
+	class Action {
+		static constexpr int INVALID_TERRAIN_MAGIC_NUMBER = -99999;
+		int terrain = INVALID_TERRAIN_MAGIC_NUMBER;
+		int priority = 0;
+
+	public:
+		bool is_valid() const {
+			return terrain != INVALID_TERRAIN_MAGIC_NUMBER;
+		}
+
+		bool is_unconstrained() const {
+			return terrain == -2;
+		}
+
+		bool is_targetted() const {
+			return terrain >= -1;
+		}
+
+		void set_terrain(int p_terrain) {
+			ERR_FAIL_COND(terrain < -1 || p_terrain < -1);
+			terrain = p_terrain;
+		}
+
+		int get_terrain() const {
+			ERR_FAIL_COND_V(terrain < -1, -1);
+			return terrain;
+		}
+
+		void set_priority(int p_priority) {
+			priority = p_priority;
+		}
+
+		int get_priority() const {
+			return priority;
+		}
+
+		// Public constructor always creates an invalid action
+		constexpr Action() {}
+
+	protected:
+		// Protected constructor ensures use of child classes to better communicate intent
+		constexpr Action(int p_terrain, int p_priority) : terrain(p_terrain), priority(p_priority) {}
+	};
+	class TargetTerrain : public Action {
+	public:
+		explicit TargetTerrain(int p_terrain, int p_priority = 1) : Action(p_terrain, p_priority) {
+			ERR_FAIL_COND(p_terrain < -1);
+		}
+	};
+	class Unconstrained : public Action {
+	public:
+		Unconstrained() : Action(-2, 0) {}
+	};
+
+private:
+	RBMap<Bit, Action> _data;
 
 public:
-	bool operator<(const TerrainConstraint &p_other) const {
-		if (base_cell_coords == p_other.base_cell_coords) {
-			return bit < p_other.bit;
+	const Action get(Bit p_target) const {
+		const RBMap<Bit, Action>::Element *E = _data.find(p_target);
+		return E ? E->value() : Unconstrained();
+	}
+
+	void set(Bit p_target, Action p_action) {
+		_data.insert(p_target, p_action); // RBMap::insert replaces value if key already exists
+	}
+
+	void add_if_unset(Bit p_target, Action p_action) {
+		Action &a = _data[p_target];
+		if (!a.is_valid()) {
+			a = p_action;
 		}
-		return base_cell_coords < p_other.base_cell_coords;
 	}
 
-	String to_string() const {
-		return vformat("Constraint {pos:%s, bit:%d, terrain:%d, priority:%d}", base_cell_coords, bit, terrain, priority);
+	using ConstIterator = RBMap<Bit, Action>::ConstIterator;
+	ConstIterator begin() const {
+		return _data.begin();
+	}
+	ConstIterator end() const {
+		return _data.end();
 	}
 
-	Vector2i get_base_cell_coords() const {
-		return base_cell_coords;
-	}
-
-	bool is_center_bit() const {
-		return bit == 0;
-	}
-
-	HashMap<Vector2i, TileSet::CellNeighbor> get_overlapping_coords_and_peering_bits() const;
-
-	void set_terrain(int p_terrain) {
-		terrain = p_terrain;
-	}
-
-	int get_terrain() const {
-		return terrain;
-	}
-
-	void set_priority(int p_priority) {
-		priority = p_priority;
-	}
-
-	int get_priority() const {
-		return priority;
-	}
-
-	TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, int p_terrain); // For the center terrain bit
-	TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit, int p_terrain); // For peering bits
-	TerrainConstraint() {}
+	TerrainConstraints() {}
 };
 
 #ifdef DEBUG_ENABLED
@@ -494,9 +567,9 @@ private:
 #endif // DEBUG_ENABLED
 
 	// Terrains.
-	TileSet::TerrainsPattern _get_best_terrain_pattern_for_constraints(int p_terrain_set, const Vector2i &p_position, const RBSet<TerrainConstraint> &p_constraints, TileSet::TerrainsPattern p_current_pattern) const;
-	RBSet<TerrainConstraint> _get_terrain_constraints_from_added_pattern(const Vector2i &p_position, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern) const;
-	RBSet<TerrainConstraint> _get_terrain_constraints_from_painted_cells_list(const RBSet<Vector2i> &p_painted, int p_terrain_set, bool p_ignore_empty_terrains) const;
+	TileSet::TerrainsPattern _get_best_terrain_pattern_for_constraints(int p_terrain_set, const Vector2i &p_position, const TerrainConstraints &p_constraints, TileSet::TerrainsPattern p_current_pattern) const;
+	TerrainConstraints _get_terrain_constraints_from_added_pattern(const Vector2i &p_position, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern) const;
+	TerrainConstraints _get_terrain_constraints_from_painted_cells_list(const RBSet<Vector2i> &p_painted, int p_terrain_set, bool p_ignore_empty_terrains) const;
 
 	void _tile_set_changed();
 
@@ -537,7 +610,7 @@ public:
 	Rect2 get_rect(bool &r_changed) const;
 
 	// Terrains.
-	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_constraints(const Vector<Vector2i> &p_to_replace, int p_terrain_set, const RBSet<TerrainConstraint> &p_constraints) const; // Not exposed.
+	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_constraints(const Vector<Vector2i> &p_to_replace, int p_terrain_set, const TerrainConstraints &p_constraints) const; // Not exposed.
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_connect(const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true) const; // Not exposed.
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_path(const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true) const; // Not exposed.
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_pattern(const Vector<Vector2i> &p_coords_array, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern, bool p_ignore_empty_terrains = true) const; // Not exposed.


### PR DESCRIPTION
This PR introduces several changes to the terrain related systems. None of these changes impact the behaviour, but they are a significant difference in implementation. Altogether, these changes should improve both performance and clarity. My hope is that this can be the springboard towards further improvements in this area of the engine.

Changes introduced by this PR:

**Replaced `TerrainConstraint` with `TerrainConstraints::Bit` and `TerrainConstraints::Action`. Also replaced `RBSet<TerrainConstraint>` with `TerrainConstraints` which functions as a wrapper around `RBMap<TerrainConstraints::Bit, TerrainConstraints::Action>`**

This doesn't change performance very much, however it does significantly improve code clarity. The previous behaviour using RBSet was to function practically as an RBMap. This is now explicit and clearer. As part of this restructuring, we no longer store a `Ref<TileSet>`, which should improve performance due to the many ref count operations involved.

**DRY principles for obtaining cell patterns and for preparing to fill terrain**

Not a lot to say to either of these changes. Just identified decently sized chunks of repeated code that could have been functions to reduce on repition while improving clarity.

**Improved performance by reducing redundant operations**

A couple functions were repeating operations, and some others were making frequent repeated calls to information that could have more easily been cached. These changes should improve performance, especially when performing very large terrain fill operations.