### PR TITLE
TAA adjustment to reduce ghosting

### DIFF
--- a/servers/rendering/renderer_rd/effects/taa.cpp
+++ b/servers/rendering/renderer_rd/effects/taa.cpp
@@ -58,12 +58,17 @@ void TAA::resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_pr
 
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
+	float base_variance = 1.1f;
+	float base_variance_min = 0.75f;
+	float base_variance_max = 1.00f;
+	float variance_scale = 1080.0f / p_resolution.height; // 1080p taken as baseline for calculation, as this is most commonly used resolution
+
 	TAAResolvePushConstant push_constant;
 	memset(&push_constant, 0, sizeof(TAAResolvePushConstant));
 	push_constant.resolution_width = p_resolution.width;
 	push_constant.resolution_height = p_resolution.height;
 	push_constant.disocclusion_threshold = 2.5f; // If velocity changes by less than this amount of texels we can retain the accumulation buffer.
-	push_constant.disocclusion_scale = 0.01f; // Scale the weight of this pixel calculated as (change in velocity - threshold) * scale.
+	push_constant.variance_dynamic = CLAMP(base_variance * variance_scale, base_variance_min, base_variance_max); // Variance dynamically scales based on resolution
 
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, pipeline);

--- a/servers/rendering/renderer_rd/effects/taa.h
+++ b/servers/rendering/renderer_rd/effects/taa.h
@@ -47,7 +47,7 @@ private:
 		float resolution_width;
 		float resolution_height;
 		float disocclusion_threshold;
-		float disocclusion_scale;
+		float variance_dynamic;
 	};
 
 	TaaResolveShaderRD taa_shader;

--- a/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
@@ -19,6 +19,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 // File changes (yyyy-mm-dd)
+// 2025-11-05: Jakub Brzyski: Added dynamic variance, base variance value adjusted to reduce ghosting
 // 2022-05-06: Panos Karabelas: first commit
 // 2020-12-05: Joan Fons: convert to Vulkan and Godot
 ///////////////////////////////////////////////////////////////////////////////////
@@ -38,6 +39,8 @@
 #define RPC_9 0.11111111111
 #define RPC_16 0.0625
 
+#define DISOCCLUSION_SCALE 0.01 // Scale the weight of this pixel calculated as (change in velocity - threshold) * scale.
+
 layout(local_size_x = GROUP_SIZE, local_size_y = GROUP_SIZE, local_size_z = 1) in;
 
 layout(rgba16f, set = 0, binding = 0) uniform restrict readonly image2D color_buffer;
@@ -49,8 +52,8 @@ layout(rgba16f, set = 0, binding = 5) uniform restrict writeonly image2D output_
 
 layout(push_constant, std430) uniform Params {
 	vec2 resolution;
-	float disocclusion_threshold; // 0.1 / max(params.resolution.x, params.resolution.y
-	float disocclusion_scale;
+	float disocclusion_threshold; // 0.1 / max(params.resolution.x, params.resolution.y)
+	float variance_dynamic;
 }
 params;
 
@@ -273,7 +276,8 @@ vec3 clip_history_3x3(uvec2 group_pos, vec3 color_history, vec2 velocity_closest
 	// Compute min and max (with an adaptive box size, which greatly reduces ghosting)
 	vec3 color_avg = (s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9) * RPC_9;
 	vec3 color_avg2 = ((s1 * s1) + (s2 * s2) + (s3 * s3) + (s4 * s4) + (s5 * s5) + (s6 * s6) + (s7 * s7) + (s8 * s8) + (s9 * s9)) * RPC_9;
-	float box_size = mix(0.0f, 2.5f, smoothstep(0.02f, 0.0f, length(velocity_closest)));
+	// Use variance clipping as described in https://developer.download.nvidia.com/gameworks/events/GDC2016/msalvi_temporal_supersampling.pdf
+	float box_size = mix(0.0f, params.variance_dynamic, smoothstep(0.02f, 0.0f, length(velocity_closest)));
 	vec3 dev = sqrt(abs(color_avg2 - (color_avg * color_avg))) * box_size;
 	vec3 color_min = color_avg - dev;
 	vec3 color_max = color_avg + dev;
@@ -304,7 +308,7 @@ float get_factor_disocclusion(vec2 uv_reprojected, vec2 velocity) {
 	vec2 velocity_texels = velocity * params.resolution;
 	vec2 prev_velocity_texels = velocity_previous * params.resolution;
 	float disocclusion = length(prev_velocity_texels - velocity_texels) - params.disocclusion_threshold;
-	return clamp(disocclusion * params.disocclusion_scale, 0.0, 1.0);
+	return clamp(disocclusion * DISOCCLUSION_SCALE, 0.0, 1.0);
 }
 
 vec3 temporal_antialiasing(uvec2 pos_group_top_left, uvec2 pos_group, uvec2 pos_screen, vec2 uv, sampler2D tex_history) {


### PR DESCRIPTION
This PR aims to reduce the ghosting effect of TAA method, while still making TAA work.

In a high fidelity project, with lots of moving vegetation like grass, this change makes ghosting almost non-existent.

Change is easily visible in empty 3D scene with editor grid, when you rotate the camera. Screenshots below were captured from video, where camera was being rotated left and right

Before:
<img width="1508" height="928" alt="4_5_1" src="https://github.com/user-attachments/assets/0631cbe3-1c14-42d5-beed-8b9a63e951e1" />

After:
<img width="1507" height="928" alt="pr" src="https://github.com/user-attachments/assets/6b6ff7e0-8d9c-46f0-bb29-3c349f05fc53" />
