### PR TITLE
Fix 2D editor stuck in dragging state

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -2524,7 +2524,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 					}
 				}
 
-				if (selection2.size() > 0) {
+				if (drag_selection.size() > 0) {
 					drag_type = DRAG_MOVE;
 					drag_from = drag_start_origin;
 					_save_canvas_item_state(drag_selection);


### PR DESCRIPTION
To reproduce the problem, try dragging a child control of a container in the 2D editor.

Only reproducible on master, not in dev2.