### PR TITLE
Fix hover state for game speed button in game window

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -1155,7 +1155,8 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	speed_state_button = memnew(MenuButton);
 	main_menu_hbox->add_child(speed_state_button);
 	speed_state_button->set_text(U"1.0×");
-	speed_state_button->set_theme_type_variation(SceneStringName(FlatButton));
+	speed_state_button->set_flat(false);
+	speed_state_button->set_theme_type_variation("FlatMenuButton");
 	speed_state_button->set_tooltip_text(TTRC("Change the game speed."));
 	speed_state_button->set_accessibility_name(TTRC("Speed State"));
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/112209

After:

[Screencast_20251030_173214.webm](https://github.com/user-attachments/assets/d29b3004-6c0a-403b-b01c-db8fdaa5a214)
