### PR TITLE
Fix Light2D none shadow filter to use nearest sampling

### DIFF
--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -407,7 +407,9 @@ vec4 light_shadow_compute(uint light_base, vec4 light_color, vec4 shadow_uv
 	uint shadow_mode = light_array.data[light_base].flags & LIGHT_FLAGS_FILTER_MASK;
 
 	if (shadow_mode == LIGHT_FLAGS_SHADOW_NEAREST) {
-		shadow = texture_shadow(shadow_uv);
+		vec2 unit_p = floor(shadow_uv.xy / canvas_data.shadow_pixel_size) * canvas_data.shadow_pixel_size;
+		float depth_sample = texture(sampler2D(shadow_atlas_texture, shadow_sampler), unit_p.xy).r;
+		shadow = step(depth_sample, shadow_uv.z);
 	} else if (shadow_mode == LIGHT_FLAGS_SHADOW_PCF5) {
 		vec4 shadow_pixel_size = vec4(light_array.data[light_base].shadow_pixel_size, 0.0, 0.0, 0.0);
 		shadow = 0.0;


### PR DESCRIPTION
Fixes #101312

Changes Light2D none shadow filter to use nearest sampling instead of interpolation for the forward renderer. This then matches behavior with the compatibility renderer.

Tested using: [NEWShadowAcneGD4.3MRP.zip](https://github.com/user-attachments/files/23241643/NEWShadowAcneGD4.3MRP.zip)

Before:
<img width="492" height="284" alt="Screenshot from 2025-10-30 14-55-00" src="https://github.com/user-attachments/assets/94166677-5dfe-40f4-89df-3c43f32a5ed4" />

After:
<img width="492" height="284" alt="Screenshot from 2025-10-30 14-57-29" src="https://github.com/user-attachments/assets/d8e97e41-6801-4bac-b204-af4cda830f63" />

Compatibility:
<img width="492" height="284" alt="Screenshot from 2025-10-30 19-18-51" src="https://github.com/user-attachments/assets/798c3508-d04a-43d7-b53a-c6c0ac157a61" />

> Godot v4.6.dev (ebd32c15e) - Ubuntu 24.04.3 LTS 24.04 on X11 - X11 display driver, Multi-window, 2 monitors - OpenGL 3 (Compatibility) - NVIDIA GeForce RTX 2070 SUPER (nvidia; 570.195.03) - AMD Ryzen 7 3700X 8-Core Processor (16 threads) - 15.52 GiB memory