### PR TITLE
Use monospaced font for code names (methods, signals, properties) in UI

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1241,6 +1241,9 @@
 		<member name="interface/theme/style" type="String" setter="" getter="">
 			The editor theme style to use.
 		</member>
+		<member name="interface/theme/use_monospace_font_for_editor_symbols" type="bool" setter="" getter="">
+			If [code]true[/code], use the monospace font for some labels in the editor that display code symbols, such as signals, properties, and methods.
+		</member>
 		<member name="interface/theme/use_system_accent_color" type="bool" setter="" getter="">
 			If [code]true[/code], set accent color based on system settings.
 			[b]Note:[/b] This setting is only effective on Windows, MacOS, and Android.

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -2181,7 +2181,9 @@ void AnimationTrackEdit::_notification(int p_what) {
 			}
 
 			const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+			const Ref<Font> source_font = get_theme_font(SNAME("source"), EditorStringName(EditorFonts));
 			const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+			const int source_font_size = get_theme_font_size(SNAME("source_size"), EditorStringName(EditorFonts));
 			const Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
 
 			const Color dc = get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor));
@@ -2189,6 +2191,9 @@ void AnimationTrackEdit::_notification(int p_what) {
 			// Names and icons.
 
 			{
+				Ref<Font> font_to_use = font;
+				int font_size_to_use = font_size;
+
 				Ref<Texture2D> check = animation->track_is_enabled(track) ? get_theme_icon(SNAME("checked"), SNAME("CheckBox")) : get_theme_icon(SNAME("unchecked"), SNAME("CheckBox"));
 
 				int ofs = in_group ? outer_margin : 0;
@@ -2223,6 +2228,13 @@ void AnimationTrackEdit::_notification(int p_what) {
 					} else {
 						text += anim_path.get_concatenated_subnames();
 					}
+
+					bool use_monospace_font = EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols");
+					if (animation->track_get_type(track) == Animation::TYPE_VALUE && use_monospace_font) {
+						font_to_use = source_font;
+						font_size_to_use = source_font_size;
+					}
+
 					text_color.a *= 0.7;
 				} else if (node) {
 					Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(node);
@@ -2246,9 +2258,9 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				path_rect = Rect2(ofs, 0, limit - ofs - h_separation, get_size().height);
 
-				Vector2 string_pos = Point2(ofs, (get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size));
+				Vector2 string_pos = Point2(ofs, (get_size().height - font_to_use->get_height(font_size_to_use)) / 2 + font_to_use->get_ascent(font_size_to_use));
 				string_pos = string_pos.floor();
-				draw_string(font, string_pos, text, HORIZONTAL_ALIGNMENT_LEFT, limit - ofs - h_separation, font_size, text_color);
+				draw_string(font_to_use, string_pos, text, HORIZONTAL_ALIGNMENT_LEFT, limit - ofs - h_separation, font_size_to_use, text_color);
 
 				draw_line(Point2(limit, 0), Point2(limit, get_size().height), h_line_color, Math::round(EDSCALE));
 			}
@@ -2625,8 +2637,15 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 	Vector2 ofs(p_x - icon_to_draw->get_width() / 2, (get_size().height - icon_to_draw->get_height()) / 2);
 
 	if (animation->track_get_type(track) == Animation::TYPE_METHOD) {
-		const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-		const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+		bool use_monospace_font = EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols");
+
+		Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+		int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+		if (use_monospace_font) {
+			font = get_theme_font(SNAME("source"), EditorStringName(EditorFonts));
+			font_size = get_theme_font_size(SNAME("source_size"), EditorStringName(EditorFonts));
+		}
+
 		Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
 		color.a = 0.5;
 

--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -32,7 +32,9 @@
 
 #include "editor/doc/editor_help.h"
 #include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
 #include "editor/gui/filter_line_edit.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/tree.h"
@@ -57,6 +59,10 @@ void PropertySelector::_update_search() {
 
 	// Allow using spaces in place of underscores in the search string (makes the search more fault-tolerant).
 	const String search_text = search_box->get_text().replace_char(' ', '_');
+
+	// Set up font.
+	bool use_monospace_font = EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols");
+	Ref<Font> monospace_font = get_theme_font(SNAME("source"), EditorStringName(EditorFonts));
 
 	if (properties) {
 		List<PropertyInfo> props;
@@ -120,6 +126,9 @@ void PropertySelector::_update_search() {
 
 			TreeItem *item = search_options->create_item(category ? category : root);
 			item->set_text(0, E.name);
+			if (use_monospace_font) {
+				item->set_custom_font(0, monospace_font);
+			}
 			item->set_metadata(0, E.name);
 			item->set_icon(0, search_options->get_editor_theme_icon(Variant::get_type_name(E.type)));
 
@@ -281,6 +290,9 @@ void PropertySelector::_update_search() {
 			}
 
 			item->set_text(0, desc);
+			if (use_monospace_font) {
+				item->set_custom_font(0, monospace_font);
+			}
 			item->set_metadata(0, name);
 			item->set_selectable(0, true);
 
@@ -479,6 +491,11 @@ void PropertySelector::_create_subproperty(TreeItem *p_parent_item, const String
 
 	TreeItem *item = search_options->create_item(p_parent_item);
 	item->set_text(0, p_name);
+
+	bool use_monospace_font = EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols");
+	if (use_monospace_font) {
+		item->set_custom_font(0, get_theme_font(SNAME("source"), EditorStringName(EditorFonts)));
+	}
 	item->set_metadata(0, String(p_parent_item->get_metadata(0)) + ":" + p_name);
 	item->set_icon(0, search_options->get_editor_theme_icon(Variant::get_type_name(p_type)));
 

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -296,9 +296,14 @@ StringName ConnectDialog::generate_method_callback_name(Object *p_source, const 
 }
 
 void ConnectDialog::_create_method_tree_items(const List<MethodInfo> &p_methods, TreeItem *p_parent_item) {
+	bool use_monospace_font = EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols");
+	Ref<Font> monospace_font = get_theme_font(SNAME("source"), EditorStringName(EditorFonts));
 	for (const MethodInfo &mi : p_methods) {
 		TreeItem *method_item = method_tree->create_item(p_parent_item);
 		method_item->set_text(0, get_signature(mi));
+		if (use_monospace_font) {
+			method_item->set_custom_font(0, monospace_font);
+		}
 		method_item->set_metadata(0, mi.name);
 	}
 }
@@ -518,6 +523,18 @@ void ConnectDialog::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			method_search->set_right_icon(get_editor_theme_icon("Search"));
 			open_method_tree->set_button_icon(get_editor_theme_icon("Edit"));
+
+			bool use_monospace_font = EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols");
+			Ref<Font> monospace_font = get_theme_font(SNAME("source"), EditorStringName(EditorFonts));
+
+			if (use_monospace_font) {
+				from_signal->add_theme_font_override(SceneStringName(font), monospace_font);
+				dst_method->add_theme_font_override(SceneStringName(font), monospace_font);
+			} else {
+				from_signal->remove_theme_font_override(SceneStringName(font));
+				dst_method->remove_theme_font_override(SceneStringName(font));
+			}
+
 		} break;
 	}
 }
@@ -1534,6 +1551,9 @@ void ConnectionsDock::update_tree() {
 	StringName native_base = selected_object->get_class();
 	Ref<Script> script_base = selected_object->get_script();
 
+	bool use_monospace_font = EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols");
+	Ref<Font> monospace_font = get_theme_font(SNAME("source"), EditorStringName(EditorFonts));
+
 	while (native_base != StringName()) {
 		String class_name;
 		String doc_class_name;
@@ -1631,6 +1651,10 @@ void ConnectionsDock::update_tree() {
 			String signame = connect_dialog->get_signature(mi, &argnames);
 			signal_item->set_text(0, signame);
 
+			if (use_monospace_font) {
+				signal_item->set_custom_font(0, monospace_font);
+			}
+
 			if (signame == prev_selected) {
 				signal_item->select(0);
 				prev_selected = "";
@@ -1690,6 +1714,9 @@ void ConnectionsDock::update_tree() {
 				connection_item->set_text(0, path);
 				connection_item->set_metadata(0, connection);
 				connection_item->set_icon(0, get_editor_theme_icon(SNAME("Slot")));
+				if (use_monospace_font) {
+					connection_item->set_custom_font(0, monospace_font);
+				}
 
 				if (_is_connection_inherited(connection)) {
 					// The scene inherits this connection.

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1459,6 +1459,14 @@ void ScriptEditor::_notification(int p_what) {
 
 			members_overview_alphabeta_sort_button->set_button_icon(get_editor_theme_icon(SNAME("Sort")));
 
+			bool use_monospace_font = EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols");
+			Ref<Font> monospace_font = get_theme_font(SNAME("source"), EditorStringName(EditorFonts));
+			if (use_monospace_font) {
+				members_overview->add_theme_font_override(SceneStringName(font), monospace_font);
+			} else {
+				members_overview->remove_theme_font_override(SceneStringName(font));
+			}
+
 			filter_scripts->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			filter_methods->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -601,6 +601,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/corner_radius", 4, "0,6,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/base_spacing", 4, "0,8,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/additional_spacing", 0, "0,8,1")
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/theme/use_monospace_font_for_editor_symbols", true, "")
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "interface/theme/custom_theme", "", "*.res,*.tres,*.theme", PROPERTY_USAGE_DEFAULT)
 
 	// Touchscreen


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13514 .

This PR displays code names (such as methods, signals, and properties) in a monospaced font throughout the editor. This fits better with their being written out in `snake_case` and otherwise representing code functions/values, where they are often seen in a monospaced font.

## Covered cases
- [x] Signal list
- [x] List of methods to connect signal to
- [x] "Edit Connection" dialog
- [x] Dialogs for adding methods and properties to Animation
- [x] AnimationPlayer Call Method track keyframes
- [x] AnimationPlayer property names
- [x] Method names in script editor list

<img width="1166" height="890" alt="CleanShot 2025-10-30 at 12 52 46@2x" src="https://github.com/user-attachments/assets/c6b863c9-bb1d-4a13-9bcd-25ef41289f89" />
<img width="1490" height="1094" alt="CleanShot 2025-10-30 at 12 53 09@2x" src="https://github.com/user-attachments/assets/c5c1a406-e35c-4b75-9eaf-995b2f4f1b63" />
<img width="872" height="296" alt="CleanShot 2025-10-30 at 19 40 09@2x" src="https://github.com/user-attachments/assets/562869b0-1d22-432f-9d08-b880a5879b7f" />
<img width="916" height="886" alt="CleanShot 2025-10-30 at 19 40 25@2x" src="https://github.com/user-attachments/assets/0e13a0de-10dd-4045-ba9d-cb046987cb63" />