### PR TITLE
Make possible to change the ellipsis character in `LinkButton`

### DIFF
--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -10,6 +10,9 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="ellipsis_char" type="String" setter="set_ellipsis_char" getter="get_ellipsis_char" default="&quot;…&quot;">
+			Ellipsis character used for text clipping.
+		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="3" />
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -47,6 +47,7 @@ void LinkButton::_shape() {
 	const String &lang = language.is_empty() ? _get_locale() : language;
 	text_buf->add_string(xl_text, font, font_size, lang);
 	text_buf->set_text_overrun_behavior(overrun_behavior);
+	text_buf->set_ellipsis_char(el_char);
 
 	queue_accessibility_update();
 }
@@ -85,6 +86,29 @@ void LinkButton::set_structured_text_bidi_override(TextServer::StructuredTextPar
 		_shape();
 		queue_redraw();
 	}
+}
+
+void LinkButton::set_ellipsis_char(const String &p_char) {
+	String c = p_char;
+	if (c.length() > 1) {
+		WARN_PRINT("Ellipsis must be exactly one character long (" + itos(c.length()) + " characters given).");
+		c = c.left(1);
+	}
+
+	if (el_char == c) {
+		return;
+	}
+	el_char = c;
+
+	if (overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
+		_shape();
+		queue_redraw();
+		update_minimum_size();
+	}
+}
+
+String LinkButton::get_ellipsis_char() const {
+	return el_char;
 }
 
 TextServer::StructuredTextParser LinkButton::get_structured_text_bidi_override() const {
@@ -292,6 +316,8 @@ void LinkButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_text"), &LinkButton::get_text);
 	ClassDB::bind_method(D_METHOD("set_text_overrun_behavior", "overrun_behavior"), &LinkButton::set_text_overrun_behavior);
 	ClassDB::bind_method(D_METHOD("get_text_overrun_behavior"), &LinkButton::get_text_overrun_behavior);
+	ClassDB::bind_method(D_METHOD("set_ellipsis_char", "char"), &LinkButton::set_ellipsis_char);
+	ClassDB::bind_method(D_METHOD("get_ellipsis_char"), &LinkButton::get_ellipsis_char);
 	ClassDB::bind_method(D_METHOD("set_text_direction", "direction"), &LinkButton::set_text_direction);
 	ClassDB::bind_method(D_METHOD("get_text_direction"), &LinkButton::get_text_direction);
 	ClassDB::bind_method(D_METHOD("set_language", "language"), &LinkButton::set_language);
@@ -315,6 +341,7 @@ void LinkButton::_bind_methods() {
 
 	ADD_GROUP("Text Behavior", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim Nothing,Trim Characters,Trim Words,Ellipsis (6+ Characters),Word Ellipsis (6+ Characters),Ellipsis (Always),Word Ellipsis (Always)"), "set_text_overrun_behavior", "get_text_overrun_behavior");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "ellipsis_char"), "set_ellipsis_char", "get_ellipsis_char");
 
 	ADD_GROUP("BiDi", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -55,6 +55,7 @@ private:
 	TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
 	Array st_args;
 	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
+	String el_char = U"…";
 
 	struct ThemeCache {
 		Ref<StyleBox> focus;
@@ -91,6 +92,9 @@ public:
 
 	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
 	TextServer::OverrunBehavior get_text_overrun_behavior() const;
+
+	void set_ellipsis_char(const String &p_char);
+	String get_ellipsis_char() const;
 
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;


### PR DESCRIPTION
Makes sense to have this, since `LinkButton` now has trimming as well.