### PR TITLE
Core: Delete implicit `Variant` comparison by default

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -639,7 +639,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 			d["is_keyed"] = Variant::is_keyed(type);
 
 			DocData::ClassDoc *builtin_doc = nullptr;
-			if (p_include_docs && d["name"] != "Nil") {
+			if (p_include_docs && d["name"] != Variant("Nil")) {
 				builtin_doc = EditorHelp::get_doc_data()->class_list.getptr(d["name"]);
 				CRASH_COND_MSG(!builtin_doc, vformat("Could not find '%s' in DocData.", d["name"]));
 			}
@@ -1358,7 +1358,7 @@ static bool compare_value(const String &p_path, const String &p_field, const Var
 				print_error(vformat("Validate extension JSON: Error: Field '%s': %s was removed.", p_path, kv.key));
 				continue;
 			}
-			if (p_allow_name_change && kv.key == "name") {
+			if (p_allow_name_change && kv.key == Variant("name")) {
 				continue;
 			}
 			if (!compare_value(path, kv.key, kv.value, new_dict[kv.key], p_allow_name_change)) {

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -836,10 +836,25 @@ public:
 	static int get_utility_function_count();
 
 	//argsVariant call()
-
 	bool operator==(const Variant &p_variant) const;
 	bool operator!=(const Variant &p_variant) const;
 	bool operator<(const Variant &p_variant) const;
+
+#ifdef STRICT_CHECKS // We want to gradually move away from implicit conversions to/from Variant.
+	template <typename T>
+	bool operator==(const T &p_value) const = delete;
+	template <typename T>
+	bool operator!=(const T &p_value) const = delete;
+	template <typename T>
+	bool operator<(const T &p_value) const = delete;
+	template <typename T>
+	bool operator<=(const T &p_value) const = delete;
+	template <typename T>
+	bool operator>(const T &p_value) const = delete;
+	template <typename T>
+	bool operator>=(const T &p_value) const = delete;
+#endif // STRICT_CHECKS
+
 	uint32_t hash() const;
 	uint32_t recursive_hash(int recursion_count) const;
 

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1213,11 +1213,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			bool got_comma_token = false;
 			if (builtin_types.has(token.value)) {
 				key_type = builtin_types.get(token.value);
-			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
+			} else if (token.value == Variant("Resource") || token.value == Variant("SubResource") || token.value == Variant("ExtResource")) {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
 				if (err) {
-					if (token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_COMMA) {
+					if (token.value == Variant("Resource") && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_COMMA) {
 						err = OK;
 						r_err_str = String();
 						key_type = Variant::OBJECT;
@@ -1259,11 +1259,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			bool got_bracket_token = false;
 			if (builtin_types.has(token.value)) {
 				value_type = builtin_types.get(token.value);
-			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
+			} else if (token.value == Variant("Resource") || token.value == Variant("SubResource") || token.value == Variant("ExtResource")) {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
 				if (err) {
-					if (token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
+					if (token.value == Variant("Resource") && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
 						err = OK;
 						r_err_str = String();
 						value_type = Variant::OBJECT;
@@ -1350,11 +1350,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			bool got_bracket_token = false;
 			if (builtin_types.has(token.value)) {
 				array.set_typed(builtin_types.get(token.value), StringName(), Variant());
-			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
+			} else if (token.value == Variant("Resource") || token.value == Variant("SubResource") || token.value == Variant("ExtResource")) {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
 				if (err) {
-					if (token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
+					if (token.value == Variant("Resource") && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
 						err = OK;
 						r_err_str = String();
 						array.set_typed(Variant::OBJECT, token.value, Variant());

--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -901,7 +901,7 @@ Vector<uint64_t> AnimationLibraryEditor::_load_mixer_libs_folding() {
 
 		for (const String &section : sections) {
 			Variant mixer_id = config->get_value(section, "mixer");
-			if ((mixer_id.get_type() == Variant::INT && uint64_t(mixer_id) == current_mixer_id) || config->get_value(section, "mixer_signature") == current_mixer_signature) { // Ensure value exists and is correct type
+			if ((mixer_id.get_type() == Variant::INT && uint64_t(mixer_id) == current_mixer_id) || config->get_value(section, "mixer_signature") == (Variant)current_mixer_signature) { // Ensure value exists and is correct type
 				// Found the mixer in a different section!
 				_load_config_libs_folding(collapsed_lib_ids, config.ptr(), section);
 

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3495,7 +3495,7 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 	if (get_editor()->is_grouping_tracks()) {
 		String base_path = String(animation->track_get_path(track));
 		base_path = base_path.get_slicec(':', 0); // Remove sub-path.
-		if (d["group"] != base_path) {
+		if (d["group"] != (Variant)base_path) {
 			return false;
 		}
 	}
@@ -3526,7 +3526,7 @@ void AnimationTrackEdit::drop_data(const Point2 &p_point, const Variant &p_data)
 	if (get_editor()->is_grouping_tracks()) {
 		String base_path = String(animation->track_get_path(track));
 		base_path = base_path.get_slicec(':', 0); // Remove sub-path.
-		if (d["group"] != base_path) {
+		if (d["group"] != (Variant)base_path) {
 			return;
 		}
 	}

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3039,7 +3039,7 @@ void EditorHelp::remove_class(const String &p_class) {
 void EditorHelp::_load_doc_thread(void *p_udata) {
 	bool use_script_cache = (bool)p_udata;
 	Ref<Resource> cache_res = ResourceLoader::load(get_cache_full_path());
-	if (cache_res.is_valid() && cache_res->get_meta("version_hash", "") == doc_version_hash) {
+	if (cache_res.is_valid() && cache_res->get_meta("version_hash", "") == (Variant)doc_version_hash) {
 		Array classes = cache_res->get_meta("classes", Array());
 		for (int i = 0; i < classes.size(); i++) {
 			doc->add_doc(DocData::ClassDoc::from_dict(classes[i]));

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -837,7 +837,7 @@ void FileSystemDock::navigate_to_path(const String &p_path) {
 
 void FileSystemDock::_file_list_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_index, const String &p_filename) {
 	if (p_preview.is_valid()) {
-		if (p_index < files->get_item_count() && files->get_item_text(p_index) == p_filename && files->get_item_metadata(p_index) == p_path) {
+		if (p_index < files->get_item_count() && files->get_item_text(p_index) == p_filename && files->get_item_metadata(p_index) == (Variant)p_path) {
 			if (file_list_display_mode == FILE_LIST_DISPLAY_LIST) {
 				if (p_small_preview.is_valid()) {
 					files->set_item_icon(p_index, p_small_preview);
@@ -1314,7 +1314,7 @@ void FileSystemDock::_tree_activate_file() {
 	if (selected) {
 		String file_path = selected->get_metadata(0);
 		TreeItem *parent = selected->get_parent();
-		bool is_favorite = parent != nullptr && parent->get_metadata(0) == "Favorites";
+		bool is_favorite = parent != nullptr && parent->get_metadata(0) == Variant("Favorites");
 		bool is_folder = file_path.ends_with("/");
 
 		if ((!is_favorite && is_folder) || file_path == "Favorites") {
@@ -1333,7 +1333,7 @@ void FileSystemDock::_file_list_activate_file(int p_idx) {
 void FileSystemDock::_preview_invalidated(const String &p_path) {
 	if (file_list_display_mode == FILE_LIST_DISPLAY_THUMBNAILS && p_path.get_base_dir() == current_path && searched_tokens.is_empty() && file_list_vb->is_visible_in_tree()) {
 		for (int i = 0; i < files->get_item_count(); i++) {
-			if (files->get_item_metadata(i) == p_path) {
+			if (files->get_item_metadata(i) == (Variant)p_path) {
 				// Re-request preview.
 				EditorResourcePreview::get_singleton()->queue_resource_preview(p_path, callable_mp(this, &FileSystemDock::_file_list_thumbnail_done).bind(i, files->get_item_text(i)));
 				break;

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -213,7 +213,7 @@ void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_
 	params->update();
 	_update_preset_menu();
 
-	bool was_imported = p_config.is_valid() && p_config->get_value("remap", "importer") != "skip" && p_config->get_value("remap", "importer") != "keep";
+	bool was_imported = p_config.is_valid() && p_config->get_value("remap", "importer") != Variant("skip") && p_config->get_value("remap", "importer") != Variant("keep");
 	if (was_imported && params->importer.is_valid() && params->paths.size() == 1 && params->importer->has_advanced_options()) {
 		advanced->show();
 		advanced_spacer->show();
@@ -640,7 +640,7 @@ void ImportDock::_reimport() {
 		if (params->importer.is_valid()) {
 			String importer_name = params->importer->get_importer_name();
 
-			if (params->checking && config->get_value("remap", "importer") == params->importer->get_importer_name()) {
+			if (params->checking && config->get_value("remap", "importer") == (Variant)params->importer->get_importer_name()) {
 				//update only what is edited (checkboxes) if the importer is the same
 				for (const PropertyInfo &E : params->properties) {
 					if (params->checked.has(E.name)) {

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -774,7 +774,7 @@ bool EditorExportPlatform::_export_customize_object(Object *p_object, LocalVecto
 			case Variant::DICTIONARY: {
 				Dictionary d = p_object->get(E.name);
 				if (_export_customize_dictionary(d, customize_resources_plugins)) {
-					if (p_object->get(E.name) != d) {
+					if (p_object->get(E.name) != (Variant)d) {
 						p_object->set(E.name, d);
 					}
 
@@ -784,7 +784,7 @@ bool EditorExportPlatform::_export_customize_object(Object *p_object, LocalVecto
 			case Variant::ARRAY: {
 				Array a = p_object->get(E.name);
 				if (_export_customize_array(a, customize_resources_plugins)) {
-					if (p_object->get(E.name) != a) {
+					if (p_object->get(E.name) != (Variant)a) {
 						p_object->set(E.name, a);
 					}
 
@@ -979,9 +979,9 @@ Dictionary EditorExportPlatform::get_internal_export_files(const Ref<EditorExpor
 			} else {
 				String current_version = GODOT_VERSION_FULL_CONFIG;
 				String template_path = EditorPaths::get_singleton()->get_export_templates_dir().path_join(current_version);
-				if (p_debug && p_preset->has("custom_template/debug") && p_preset->get("custom_template/debug") != "") {
+				if (p_debug && p_preset->has("custom_template/debug") && p_preset->get("custom_template/debug") != Variant("")) {
 					template_path = p_preset->get("custom_template/debug").operator String().get_base_dir();
-				} else if (!p_debug && p_preset->has("custom_template/release") && p_preset->get("custom_template/release") != "") {
+				} else if (!p_debug && p_preset->has("custom_template/release") && p_preset->get("custom_template/release") != Variant("")) {
 					template_path = p_preset->get("custom_template/release").operator String().get_base_dir();
 				}
 				String data_file_name = template_path.path_join(ts_name);

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2149,13 +2149,13 @@ bool EditorExportPlatformAppleEmbedded::has_valid_export_configuration(const Ref
 	bool dvalid = exists_export_template(get_platform_name() + ".zip", &err);
 	bool rvalid = dvalid; // Both in the same ZIP.
 
-	if (p_preset->get("custom_template/debug") != "") {
+	if (p_preset->get("custom_template/debug") != Variant("")) {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-	if (p_preset->get("custom_template/release") != "") {
+	if (p_preset->get("custom_template/release") != Variant("")) {
 		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";
@@ -2370,12 +2370,12 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 						Array devices = data["devices"];
 						for (int i = 0; i < devices.size(); i++) {
 							Dictionary device_event = devices[i];
-							if (device_event["Event"] == "DeviceDetected") {
+							if (device_event["Event"] == Variant("DeviceDetected")) {
 								Dictionary device_info = device_event["Device"];
 								Device nd;
 								nd.id = device_info["DeviceIdentifier"];
-								nd.name = device_info["DeviceName"].operator String() + " (ios_deploy, " + ((device_event["Interface"] == "WIFI") ? "network" : "wired") + ")";
-								nd.wifi = device_event["Interface"] == "WIFI";
+								nd.name = device_info["DeviceName"].operator String() + " (ios_deploy, " + ((device_event["Interface"] == Variant("WIFI")) ? "network" : "wired") + ")";
+								nd.wifi = device_event["Interface"] == Variant("WIFI");
 								nd.use_ios_deploy = true;
 								ldevices.push_back(nd);
 							}
@@ -2414,11 +2414,11 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 						const Dictionary &device_info = devices[i];
 						const Dictionary &conn_props = device_info["connectionProperties"];
 						const Dictionary &dev_props = device_info["deviceProperties"];
-						if (conn_props["pairingState"] == "paired" && dev_props["developerModeStatus"] == "enabled") {
+						if (conn_props["pairingState"] == Variant("paired") && dev_props["developerModeStatus"] == Variant("enabled")) {
 							Device nd;
 							nd.id = device_info["identifier"];
-							nd.name = dev_props["name"].operator String() + " (devicectl, " + ((conn_props["transportType"] == "localNetwork") ? "network" : "wired") + ")";
-							nd.wifi = conn_props["transportType"] == "localNetwork";
+							nd.name = dev_props["name"].operator String() + " (devicectl, " + ((conn_props["transportType"] == Variant("localNetwork")) ? "network" : "wired") + ")";
+							nd.wifi = conn_props["transportType"] == Variant("localNetwork");
 							ldevices.push_back(nd);
 						}
 					}

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -101,13 +101,13 @@ bool EditorExportPlatformPC::has_valid_export_configuration(const Ref<EditorExpo
 	bool dvalid = exists_export_template(get_template_file_name("debug", arch), &err);
 	bool rvalid = exists_export_template(get_template_file_name("release", arch), &err);
 
-	if (p_preset->get("custom_template/debug") != "") {
+	if (p_preset->get("custom_template/debug") != Variant("")) {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-	if (p_preset->get("custom_template/release") != "") {
+	if (p_preset->get("custom_template/release") != Variant("")) {
 		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -835,7 +835,7 @@ bool ProjectExportDialog::can_drop_data_fw(const Point2 &p_point, const Variant 
 		}
 	} else if (p_from == patches) {
 		Dictionary d = p_data;
-		if (d.get("type", "") != "export_patch") {
+		if (d.get("type", "") != Variant("export_patch")) {
 			return false;
 		}
 

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1183,7 +1183,7 @@ void EditorFileDialog::update_file_list() {
 	fav_down->set_disabled(true);
 	get_ok_button()->set_disabled(_is_open_should_be_disabled());
 	for (int i = 0; i < favorites->get_item_count(); i++) {
-		if (favorites->get_item_metadata(i) == cdir || favorites->get_item_metadata(i) == cdir + "/") {
+		if (favorites->get_item_metadata(i) == (Variant)cdir || favorites->get_item_metadata(i) == Variant(cdir + "/")) {
 			favorites->select(i);
 			favorite->set_pressed(true);
 			if (i > 0) {

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3223,7 +3223,7 @@ bool EditorInspectorArray::can_drop_data_fw(const Point2 &p_point, const Variant
 	}
 	Dictionary dict = p_data;
 	int drop_position = (p_point == Vector2(Math::INF, Math::INF)) ? selected : _drop_position();
-	if (!dict.has("type") || dict["type"] != "property_array_element" || String(dict["property_array_prefix"]) != array_element_prefix || drop_position < 0) {
+	if (!dict.has("type") || dict["type"] != Variant("property_array_element") || String(dict["property_array_prefix"]) != array_element_prefix || drop_position < 0) {
 		return false;
 	}
 
@@ -3304,7 +3304,7 @@ void EditorInspectorArray::_notification(int p_what) {
 
 		case NOTIFICATION_DRAG_BEGIN: {
 			Dictionary dict = get_viewport()->gui_get_drag_data();
-			if (dict.has("type") && dict["type"] == "property_array_element" && String(dict["property_array_prefix"]) == array_element_prefix) {
+			if (dict.has("type") && dict["type"] == Variant("property_array_element") && String(dict["property_array_prefix"]) == array_element_prefix) {
 				dropping = true;
 				control_dropping->queue_redraw();
 			}

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3018,7 +3018,7 @@ void EditorPropertyNodePath::drop_data_fw(const Point2 &p_point, const Variant &
 }
 
 bool EditorPropertyNodePath::is_drop_valid(const Dictionary &p_drag_data) const {
-	if (!p_drag_data.has("type") || p_drag_data["type"] != "nodes") {
+	if (!p_drag_data.has("type") || p_drag_data["type"] != Variant("nodes")) {
 		return false;
 	}
 	Array nodes = p_drag_data["nodes"];

--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -53,7 +53,7 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 	}
 
 	Node *node_path_target = nullptr;
-	if (p_value.get_type() == Variant::NODE_PATH && p_value != NodePath()) {
+	if (p_value.get_type() == Variant::NODE_PATH && p_value != (Variant)NodePath()) {
 		node_path_target = es->get_node(p_value);
 	}
 

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -905,7 +905,7 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 					List<BaseButton *> buttons;
 					renderer_button_group->get_buttons(&buttons);
 					for (BaseButton *button : buttons) {
-						if (button->get_meta(SNAME("rendering_method")) == "gl_compatibility") {
+						if (button->get_meta(SNAME("rendering_method")) == Variant("gl_compatibility")) {
 							button->set_pressed(true);
 							break;
 						}

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -356,7 +356,7 @@ void TileMapLayerEditorTilesPlugin::_patterns_item_list_gui_input(const Ref<Inpu
 void TileMapLayerEditorTilesPlugin::_pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture) {
 	// TODO optimize ?
 	for (int i = 0; i < patterns_item_list->get_item_count(); i++) {
-		if (patterns_item_list->get_item_metadata(i) == p_pattern) {
+		if (patterns_item_list->get_item_metadata(i) == (Variant)p_pattern) {
 			patterns_item_list->set_item_icon(i, p_texture);
 			break;
 		}

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -428,7 +428,7 @@ void TileSetEditor::_patterns_item_list_gui_input(const Ref<InputEvent> &p_event
 void TileSetEditor::_pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture) {
 	// TODO optimize ?
 	for (int i = 0; i < patterns_item_list->get_item_count(); i++) {
-		if (patterns_item_list->get_item_metadata(i) == p_pattern) {
+		if (patterns_item_list->get_item_metadata(i) == (Variant)p_pattern) {
 			patterns_item_list->set_item_icon(i, p_texture);
 			break;
 		}

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -709,7 +709,7 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 	}
 
 	TreeItem *item;
-	if (I->value.item && I->value.item->get_metadata(0) == p_node->get_path()) {
+	if (I->value.item && I->value.item->get_metadata(0) == (Variant)p_node->get_path()) {
 		item = I->value.item;
 	} else {
 		item = _find(tree->get_root(), p_node->get_path());

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -2198,7 +2198,7 @@ bool ScriptTextEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_
 }
 
 static Node *_find_script_node(Node *p_current_node, const Ref<Script> &script) {
-	if (p_current_node->get_script() == script) {
+	if (p_current_node->get_script() == (Variant)script) {
 		return p_current_node;
 	}
 
@@ -2544,7 +2544,7 @@ Vector<ObjectID> ScriptTextEditor::_get_objects_for_export_assignment() const {
 		MultiNodeEdit *multi_node_edit = Object::cast_to<MultiNodeEdit>(edited_object);
 
 		if (node_edit != nullptr) {
-			if (node_edit->get_script() == script) {
+			if (node_edit->get_script() == (Variant)script) {
 				objects.push_back(node_edit->get_instance_id());
 			}
 		} else if (multi_node_edit != nullptr) {
@@ -2552,7 +2552,7 @@ Vector<ObjectID> ScriptTextEditor::_get_objects_for_export_assignment() const {
 			for (int i = 0; i < multi_node_edit->get_node_count(); i++) {
 				NodePath np = multi_node_edit->get_node(i);
 				Node *node = es->get_node(np);
-				if (node->get_script() == script) {
+				if (node->get_script() == (Variant)script) {
 					objects.push_back(node->get_instance_id());
 				}
 			}

--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -294,12 +294,12 @@ bool ActionMapEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 	}
 
 	// Don't allow moving an action in-between events.
-	if (d["input_type"] == "action" && item->has_meta("__event")) {
+	if (d["input_type"] == Variant("action") && item->has_meta("__event")) {
 		return false;
 	}
 
 	// Don't allow moving an event to a different action.
-	if (d["input_type"] == "event" && item->get_parent() != selected->get_parent()) {
+	if (d["input_type"] == Variant("event") && item->get_parent() != selected->get_parent()) {
 		return false;
 	}
 
@@ -320,13 +320,13 @@ void ActionMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 	bool drop_above = ((p_point == Vector2(Math::INF, Math::INF)) ? action_tree->get_drop_section_at_position(action_tree->get_item_rect(target).position) : action_tree->get_drop_section_at_position(p_point)) == -1;
 
 	Dictionary d = p_data;
-	if (d["input_type"] == "action") {
+	if (d["input_type"] == Variant("action")) {
 		// Change action order.
 		String relative_to = target->get_meta("__name");
 		String action_name = selected->get_meta("__name");
 		emit_signal(SNAME("action_reordered"), action_name, relative_to, drop_above);
 
-	} else if (d["input_type"] == "event") {
+	} else if (d["input_type"] == Variant("event")) {
 		// Change event order
 		int current_index = selected->get_meta("__index");
 		int target_index = target->get_meta("__index");

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -890,7 +890,7 @@ void EditorFeatureProfileManager::set_current_profile(const String &p_profile_na
 		// Change profile selection to emulate the UI interaction. Otherwise, the wrong profile would get activated.
 		// FIXME: Ideally, _update_selected_profile() should not rely on the user interface state to function properly.
 		for (int i = 0; i < profile_list->get_item_count(); i++) {
-			if (profile_list->get_item_metadata(i) == p_profile_name) {
+			if (profile_list->get_item_metadata(i) == (Variant)p_profile_name) {
 				profile_list->select(i);
 				break;
 			}

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -1815,7 +1815,7 @@ void VisualShaderEditor::_update_custom_script(const Ref<Script> &p_script) {
 						continue;
 					}
 					Ref<VisualShaderNodeCustom> custom_node = vsnode;
-					if (custom_node.is_null() || custom_node->get_script() != p_script) {
+					if (custom_node.is_null() || custom_node->get_script() != (Variant)p_script) {
 						continue;
 					}
 					need_rebuild = true;
@@ -1927,7 +1927,7 @@ void VisualShaderEditor::_resources_removed() {
 								continue;
 							}
 							Ref<VisualShaderNodeCustom> custom_node = vsnode;
-							if (custom_node.is_null() || custom_node->get_script() != scr) {
+							if (custom_node.is_null() || custom_node->get_script() != (Variant)scr) {
 								continue;
 							}
 							visual_shader->remove_node(type, node_id);
@@ -2270,7 +2270,7 @@ void VisualShaderEditor::_update_options_menu() {
 	Color unsupported_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
 	Color supported_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
 
-	static bool low_driver = GLOBAL_GET("rendering/renderer/rendering_method") == "gl_compatibility";
+	static bool low_driver = GLOBAL_GET("rendering/renderer/rendering_method") == Variant("gl_compatibility");
 
 	HashMap<String, TreeItem *> folders;
 

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -563,7 +563,7 @@ bool LocalizationEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 	ERR_FAIL_COND_V(trees.find(tree) == -1, false);
 
 	Dictionary drop_data = p_data;
-	return drop_data.get("type", "") == tree_data_types[tree];
+	return drop_data.get("type", "") == (Variant)tree_data_types[tree];
 }
 
 void LocalizationEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2078,7 +2078,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 							if (!_guess_expression_type(c, dn->elements[i].key, key)) {
 								continue;
 							}
-							if (key.value == String(subscript->attribute->name)) {
+							if (key.value == (Variant)String(subscript->attribute->name)) {
 								r_type.assigned_expression = dn->elements[i].value;
 								found = _guess_expression_type(c, dn->elements[i].value, r_type);
 								break;

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -53,10 +53,10 @@
 namespace GDScriptTests {
 
 static bool match_option(const Dictionary p_expected, const ScriptLanguage::CodeCompletionOption p_got) {
-	if (p_expected.get("display", p_got.display) != p_got.display) {
+	if (p_expected.get("display", p_got.display) != (Variant)p_got.display) {
 		return false;
 	}
-	if (p_expected.get("insert_text", p_got.insert_text) != p_got.insert_text) {
+	if (p_expected.get("insert_text", p_got.insert_text) != (Variant)p_got.insert_text) {
 		return false;
 	}
 	if (p_expected.get("kind", p_got.kind) != Variant(p_got.kind)) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6759,7 +6759,7 @@ NodePath GLTFDocument::_find_material_node_path(Ref<GLTFState> p_state, Ref<Mate
 	for (Ref<GLTFMesh> gltf_mesh : p_state->meshes) {
 		TypedArray<Material> materials = gltf_mesh->get_instance_materials();
 		for (int mat_index = 0; mat_index < materials.size(); mat_index++) {
-			if (materials[mat_index] == p_material) {
+			if (materials[mat_index] == (Variant)p_material) {
 				for (Ref<GLTFNode> gltf_node : p_state->nodes) {
 					if (gltf_node->mesh == mesh_index) {
 						NodePath node_path = gltf_node->get_scene_node_path(p_state);

--- a/modules/gltf/tests/test_gltf_extras.h
+++ b/modules/gltf/tests/test_gltf_extras.h
@@ -92,20 +92,20 @@ TEST_CASE("[SceneTree][Node] GLTF test mesh and material meta export and import"
 	// Compare the results.
 	CHECK(loaded->get_name() == "node3d");
 	CHECK(Dictionary(loaded->get_meta("extras")).size() == 1);
-	CHECK(Dictionary(loaded->get_meta("extras"))["node_type"] == "node3d");
+	CHECK(Dictionary(loaded->get_meta("extras"))["node_type"] == Variant("node3d"));
 	CHECK_FALSE(loaded->has_meta("meta_not_nested_under_extras"));
 	CHECK_FALSE(Dictionary(loaded->get_meta("extras")).has("meta_not_nested_under_extras"));
 
 	MeshInstance3D *mesh_instance_3d = Object::cast_to<MeshInstance3D>(loaded->find_child("mesh_instance_3d", false, true));
 	CHECK(mesh_instance_3d->get_name() == "mesh_instance_3d");
-	CHECK(Dictionary(mesh_instance_3d->get_meta("extras"))["node_type"] == "mesh_instance_3d");
+	CHECK(Dictionary(mesh_instance_3d->get_meta("extras"))["node_type"] == Variant("mesh_instance_3d"));
 
 	Ref<Mesh> mesh = mesh_instance_3d->get_mesh();
-	CHECK(Dictionary(mesh->get_meta("extras"))["node_type"] == "planemesh");
+	CHECK(Dictionary(mesh->get_meta("extras"))["node_type"] == Variant("planemesh"));
 
 	Ref<Material> material = mesh->surface_get_material(0);
 	CHECK(material->get_name() == "material");
-	CHECK(Dictionary(material->get_meta("extras"))["node_type"] == "material");
+	CHECK(Dictionary(material->get_meta("extras"))["node_type"] == Variant("material"));
 
 	memdelete(original_mesh_instance);
 	memdelete(original);
@@ -161,9 +161,9 @@ TEST_CASE("[SceneTree][Node] GLTF test skeleton and bone export and import") {
 	CHECK(loaded->get_name() == "node3d");
 	Skeleton3D *result = Object::cast_to<Skeleton3D>(loaded->find_child("Skeleton3D", false, true));
 	CHECK(result->get_bone_name(0) == "parent");
-	CHECK(Dictionary(result->get_bone_meta(0, "extras"))["bone"] == "i_am_parent_bone");
+	CHECK(Dictionary(result->get_bone_meta(0, "extras"))["bone"] == Variant("i_am_parent_bone"));
 	CHECK(result->get_bone_name(1) == "child");
-	CHECK(Dictionary(result->get_bone_meta(1, "extras"))["bone"] == "i_am_child_bone");
+	CHECK(Dictionary(result->get_bone_meta(1, "extras"))["bone"] == Variant("i_am_child_bone"));
 
 	memdelete(skeleton);
 	memdelete(mesh);

--- a/modules/jsonrpc/tests/test_jsonrpc.cpp
+++ b/modules/jsonrpc/tests/test_jsonrpc.cpp
@@ -35,7 +35,7 @@
 namespace TestJSONRPC {
 
 void check_error_code(const Dictionary &p_dict, const JSONRPC::ErrorCode &p_code) {
-	CHECK(p_dict["jsonrpc"] == "2.0");
+	CHECK(p_dict["jsonrpc"] == Variant("2.0"));
 	REQUIRE(p_dict.has("error"));
 	const Dictionary &err_body = p_dict["error"];
 	const int &code = err_body["code"];

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
@@ -877,7 +877,7 @@ void OpenXRSpatialAnchorCapability::_process_discovery_snapshot(RID p_snapshot) 
 	se_extension->free_spatial_snapshot(p_snapshot);
 
 	// And if this was our discovery snapshot, let's reset it.
-	if (discovery_query_result.is_valid() && discovery_query_result->get_result_value() == p_snapshot) {
+	if (discovery_query_result.is_valid() && discovery_query_result->get_result_value() == (Variant)p_snapshot) {
 		discovery_query_result.unref();
 	}
 }

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -782,7 +782,7 @@ void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, bo
 	se_extension->free_spatial_snapshot(p_snapshot);
 
 	// And if this was our discovery snapshot, let's reset it.
-	if (p_is_discovery && discovery_query_result.is_valid() && discovery_query_result->get_result_value() == p_snapshot) {
+	if (p_is_discovery && discovery_query_result.is_valid() && discovery_query_result->get_result_value() == (Variant)p_snapshot) {
 		discovery_query_result.unref();
 	}
 }

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -873,7 +873,7 @@ void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot) {
 	se_extension->free_spatial_snapshot(p_snapshot);
 
 	// And if this was our discovery snapshot, lets reset it
-	if (discovery_query_result.is_valid() && discovery_query_result->get_result_value() == p_snapshot) {
+	if (discovery_query_result.is_valid() && discovery_query_result->get_result_value() == (Variant)p_snapshot) {
 		discovery_query_result.unref();
 	}
 }

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5321,7 +5321,7 @@ bool TextServerAdvanced::_shape_substr(ShapedTextDataAdvanced *p_new_sd, const S
 							if (index == 0) { // Try other fonts in the span.
 								const ShapedTextDataAdvanced::Span &span = p_sd->spans[gl.span_index + p_new_sd->first_span];
 								for (int k = 0; k < span.fonts.size(); k++) {
-									if (span.fonts[k] != gl.font_rid) {
+									if (span.fonts[k] != (Variant)gl.font_rid) {
 										index = font_get_glyph_index(span.fonts[k], gl.font_size, 0x00ad, 0);
 										if (index != 0) {
 											gl.font_rid = span.fonts[k];

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2857,7 +2857,7 @@ bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<Edito
 		bool rvalid = false;
 		bool has_export_templates = false;
 
-		if (p_preset->get("custom_template/debug") != "") {
+		if (p_preset->get("custom_template/debug") != Variant("")) {
 			dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 			if (!dvalid) {
 				template_err += TTR("Custom debug template not found.") + "\n";
@@ -2867,7 +2867,7 @@ bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<Edito
 			has_export_templates |= exists_export_template("android_debug.apk", &template_err);
 		}
 
-		if (p_preset->get("custom_template/release") != "") {
+		if (p_preset->get("custom_template/release") != Variant("")) {
 			rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 			if (!rvalid) {
 				template_err += TTR("Custom release template not found.") + "\n";

--- a/platform/ios/display_layer_ios.mm
+++ b/platform/ios/display_layer_ios.mm
@@ -90,7 +90,7 @@
 			nil];
 
 	// Create GL ES 3 context
-	if (GLOBAL_GET("rendering/renderer/rendering_method") == "gl_compatibility") {
+	if (GLOBAL_GET("rendering/renderer/rendering_method") == Variant("gl_compatibility")) {
 		context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
 		NSLog(@"Setting up an OpenGL ES 3.0 context.");
 		if (!context) {

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3483,7 +3483,7 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 		HashMap<CursorShape, Vector<Variant>>::Iterator cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
-			if (cursor_c->value[0] == p_cursor && cursor_c->value[1] == p_hotspot) {
+			if (cursor_c->value[0] == (Variant)p_cursor && cursor_c->value[1] == (Variant)p_hotspot) {
 				cursor_set_shape(p_shape);
 				return;
 			}

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3072,7 +3072,7 @@ void DisplayServerMacOS::cursor_set_custom_image(const Ref<Resource> &p_cursor, 
 		HashMap<CursorShape, Vector<Variant>>::Iterator cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
-			if (cursor_c->value[0] == p_cursor && cursor_c->value[1] == p_hotspot) {
+			if (cursor_c->value[0] == (Variant)p_cursor && cursor_c->value[1] == (Variant)p_hotspot) {
 				cursor_set_shape(p_shape);
 				return;
 			}

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -88,7 +88,7 @@ String EditorExportPlatformMacOS::get_export_option_warning(const EditorExportPr
 			} break;
 #ifdef MACOS_ENABLED
 			case 3: { // "codesign"
-				ad_hoc = (p_preset->get("codesign/identity") == "" || p_preset->get("codesign/identity") == "-");
+				ad_hoc = (p_preset->get("codesign/identity") == Variant("") || p_preset->get("codesign/identity") == Variant("-"));
 			} break;
 #endif
 			default: {
@@ -1039,11 +1039,11 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 
 			args.push_back("notary-submit");
 
-			if (p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) == "") {
+			if (p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) == Variant("")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("App Store Connect issuer ID name not specified."));
 				return Error::FAILED;
 			}
-			if (p_preset->get_or_env("notarization/api_key", ENV_MAC_NOTARIZATION_KEY) == "") {
+			if (p_preset->get_or_env("notarization/api_key", ENV_MAC_NOTARIZATION_KEY) == Variant("")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("App Store Connect API key ID not specified."));
 				return Error::FAILED;
 			}
@@ -1103,17 +1103,17 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 
 			args.push_back(p_path);
 
-			if (p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID) == "" && p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) == "") {
+			if (p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID) == Variant("") && p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) == Variant("")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("Neither Apple ID name nor App Store Connect issuer ID name not specified."));
 				return Error::FAILED;
 			}
-			if (p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID) != "" && p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) != "") {
+			if (p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID) != Variant("") && p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) != Variant("")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("Both Apple ID name and App Store Connect issuer ID name are specified, only one should be set at the same time."));
 				return Error::FAILED;
 			}
 
-			if (p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID) != "") {
-				if (p_preset->get_or_env("notarization/apple_id_password", ENV_MAC_NOTARIZATION_APPLE_PASS) == "") {
+			if (p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID) != Variant("")) {
+				if (p_preset->get_or_env("notarization/apple_id_password", ENV_MAC_NOTARIZATION_APPLE_PASS) == Variant("")) {
 					add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("Apple ID password not specified."));
 					return Error::FAILED;
 				}
@@ -1123,7 +1123,7 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 				args.push_back("--password");
 				args.push_back(p_preset->get_or_env("notarization/apple_id_password", ENV_MAC_NOTARIZATION_APPLE_PASS));
 			} else {
-				if (p_preset->get_or_env("notarization/api_key_id", ENV_MAC_NOTARIZATION_KEY_ID) == "") {
+				if (p_preset->get_or_env("notarization/api_key_id", ENV_MAC_NOTARIZATION_KEY_ID) == Variant("")) {
 					add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("App Store Connect API key ID not specified."));
 					return Error::FAILED;
 				}
@@ -1256,7 +1256,7 @@ void EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pres
 				return;
 			}
 
-			bool ad_hoc = (p_preset->get("codesign/identity") == "" || p_preset->get("codesign/identity") == "-");
+			bool ad_hoc = (p_preset->get("codesign/identity") == Variant("") || p_preset->get("codesign/identity") == Variant("-"));
 
 			List<String> args;
 			if (!ad_hoc) {
@@ -1973,9 +1973,9 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		if (file == "Contents/Resources/icon.icns") {
 			// See if there is an icon.
 			String icon_path;
-			if (p_preset->get("application/icon") != "") {
+			if (p_preset->get("application/icon") != Variant("")) {
 				icon_path = p_preset->get("application/icon");
-			} else if (get_project_setting(p_preset, "application/config/macos_native_icon") != "") {
+			} else if (get_project_setting(p_preset, "application/config/macos_native_icon") != Variant("")) {
 				icon_path = get_project_setting(p_preset, "application/config/macos_native_icon");
 			} else {
 				icon_path = get_project_setting(p_preset, "application/config/icon");
@@ -2075,7 +2075,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			} break;
 #ifdef MACOS_ENABLED
 			case 3: { // "codesign"
-				ad_hoc = (p_preset->get("codesign/identity") == "" || p_preset->get("codesign/identity") == "-");
+				ad_hoc = (p_preset->get("codesign/identity") == Variant("") || p_preset->get("codesign/identity") == Variant("-"));
 			} break;
 #endif
 			default: {
@@ -2449,13 +2449,13 @@ bool EditorExportPlatformMacOS::has_valid_export_configuration(const Ref<EditorE
 	bool dvalid = exists_export_template("macos.zip", &err);
 	bool rvalid = dvalid; // Both in the same ZIP.
 
-	if (p_preset->get("custom_template/debug") != "") {
+	if (p_preset->get("custom_template/debug") != Variant("")) {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-	if (p_preset->get("custom_template/release") != "") {
+	if (p_preset->get("custom_template/release") != Variant("")) {
 		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";
@@ -2506,7 +2506,7 @@ bool EditorExportPlatformMacOS::has_valid_project_configuration(const Ref<Editor
 		} break;
 #ifdef MACOS_ENABLED
 		case 3: { // "codesign"
-			ad_hoc = (p_preset->get("codesign/identity") == "" || p_preset->get("codesign/identity") == "-");
+			ad_hoc = (p_preset->get("codesign/identity") == Variant("") || p_preset->get("codesign/identity") == Variant("-"));
 		} break;
 #endif
 		default: {

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -435,13 +435,13 @@ bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExp
 	bool dvalid = exists_export_template(_get_template_name(extensions, thread_support, true), &err);
 	bool rvalid = exists_export_template(_get_template_name(extensions, thread_support, false), &err);
 
-	if (p_preset->get("custom_template/debug") != "") {
+	if (p_preset->get("custom_template/debug") != Variant("")) {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-	if (p_preset->get("custom_template/release") != "") {
+	if (p_preset->get("custom_template/release") != Variant("")) {
 		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2999,7 +2999,7 @@ void DisplayServerWindows::cursor_set_custom_image(const Ref<Resource> &p_cursor
 		RBMap<CursorShape, Vector<Variant>>::Element *cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
-			if (cursor_c->get()[0] == p_cursor && cursor_c->get()[1] == p_hotspot) {
+			if (cursor_c->get()[0] == (Variant)p_cursor && cursor_c->get()[1] == (Variant)p_hotspot) {
 				cursor_set_shape(p_shape);
 				return;
 			}

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -507,9 +507,9 @@ void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_optio
 
 Error EditorExportPlatformWindows::_add_data(const Ref<EditorExportPreset> &p_preset, const String &p_path, bool p_console_icon) {
 	String icon_path;
-	if (p_preset->get("application/icon") != "") {
+	if (p_preset->get("application/icon") != Variant("")) {
 		icon_path = p_preset->get("application/icon");
-	} else if (get_project_setting(p_preset, "application/config/windows_native_icon") != "") {
+	} else if (get_project_setting(p_preset, "application/config/windows_native_icon") != Variant("")) {
 		icon_path = get_project_setting(p_preset, "application/config/windows_native_icon");
 	} else {
 		icon_path = get_project_setting(p_preset, "application/config/icon");
@@ -571,7 +571,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 	if (id_type == 0) { //auto select
 		args.push_back("/a");
 	} else if (id_type == 1) { //pkcs12
-		if (p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID) != "") {
+		if (p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID) != Variant("")) {
 			args.push_back("/f");
 			args.push_back(p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID));
 		} else {
@@ -579,7 +579,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 			return FAILED;
 		}
 	} else if (id_type == 2) { //Windows certificate store
-		if (p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID) != "") {
+		if (p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID) != Variant("")) {
 			args.push_back("/sha1");
 			args.push_back(p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID));
 		} else {
@@ -592,7 +592,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 	}
 #else
 	int id_type = 1;
-	if (p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID) != "") {
+	if (p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID) != Variant("")) {
 		args.push_back("-pkcs12");
 		args.push_back(p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID));
 	} else {
@@ -602,7 +602,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 #endif
 
 	//password
-	if ((id_type == 1) && (p_preset->get_or_env("codesign/password", ENV_WIN_CODESIGN_PASS) != "")) {
+	if ((id_type == 1) && (p_preset->get_or_env("codesign/password", ENV_WIN_CODESIGN_PASS) != Variant(""))) {
 #ifdef WINDOWS_ENABLED
 		args.push_back("/p");
 #else
@@ -613,7 +613,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 
 	//timestamp
 	if (p_preset->get("codesign/timestamp")) {
-		if (p_preset->get("codesign/timestamp_server") != "") {
+		if (p_preset->get("codesign/timestamp_server") != Variant("")) {
 #ifdef WINDOWS_ENABLED
 			args.push_back("/tr");
 			args.push_back(p_preset->get("codesign/timestamp_server_url"));
@@ -646,7 +646,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 	}
 
 	//description
-	if (p_preset->get("codesign/description") != "") {
+	if (p_preset->get("codesign/description") != Variant("")) {
 #ifdef WINDOWS_ENABLED
 		args.push_back("/d");
 #else

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1726,7 +1726,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							start_ofs += time - a->track_get_key_time(i, idx);
 						}
 
-						if (t_obj->call(SNAME("get_stream")) != t->audio_stream) {
+						if (t_obj->call(SNAME("get_stream")) != (Variant)t->audio_stream) {
 							t_obj->call(SNAME("set_stream"), t->audio_stream);
 							t->audio_stream_playback.unref();
 							if (!playing_audio_stream_players.has(asp)) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -425,7 +425,7 @@ void FileDialog::_action_pressed() {
 		int selected = _get_selected_file_idx();
 		if (selected > -1) {
 			Dictionary d = file_list->get_item_metadata(selected);
-			if (d["dir"] && d["name"] != "..") {
+			if (d["dir"] && d["name"] != Variant("..")) {
 				path = path.path_join(d["name"]);
 			}
 		}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -8041,7 +8041,7 @@ Ref<RichTextEffect> RichTextLabel::_get_custom_effect_by_code(String p_bbcode_id
 			continue;
 		}
 
-		if (effect->get_bbcode() == p_bbcode_identifier) {
+		if (effect->get_bbcode() == (Variant)p_bbcode_identifier) {
 			return effect;
 		}
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6843,7 +6843,7 @@ void TextEdit::merge_gutters(int p_from_line, int p_to_line) {
 			text.set_line_gutter_item_color(p_to_line, i, text.get_line_gutter_item_color(p_from_line, i));
 		}
 
-		if (text.get_line_gutter_metadata(p_from_line, i) != "") {
+		if (text.get_line_gutter_metadata(p_from_line, i) != Variant("")) {
 			text.set_line_gutter_metadata(p_to_line, i, text.get_line_gutter_metadata(p_from_line, i));
 		}
 

--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -767,9 +767,9 @@ SceneTreeFTI::SceneTreeFTI() {
 
 	data.traversal_mode = TM_DEFAULT;
 
-	if (traversal_mode_string == "Legacy") {
+	if (traversal_mode_string == Variant("Legacy")) {
 		data.traversal_mode = TM_LEGACY;
-	} else if (traversal_mode_string == "Debug") {
+	} else if (traversal_mode_string == Variant("Debug")) {
 		// Don't allow debug mode in final exports,
 		// it will almost certainly be a mistake.
 #ifdef DEBUG_ENABLED

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -49,7 +49,7 @@ bool PropertyUtils::is_property_value_different(const Object *p_object, const Va
 		const Node *base_node = Object::cast_to<Node>(p_object);
 		const Node *target_node = Object::cast_to<Node>(p_b);
 		if (base_node && target_node) {
-			return p_a != base_node->get_path_to(target_node);
+			return p_a != (Variant)base_node->get_path_to(target_node);
 		}
 	}
 
@@ -62,7 +62,7 @@ bool PropertyUtils::is_property_value_different(const Object *p_object, const Va
 			// Like above, but NodePaths/Nodes are inside arrays.
 			for (int i = 0; i < array1.size(); i++) {
 				const Node *target_node = Object::cast_to<Node>(array2[i]);
-				if (!target_node || array1[i] != base_node->get_path_to(target_node)) {
+				if (!target_node || array1[i] != (Variant)base_node->get_path_to(target_node)) {
 					return true;
 				}
 			}

--- a/servers/xr/xr_server.cpp
+++ b/servers/xr/xr_server.cpp
@@ -331,7 +331,7 @@ void XRServer::add_tracker(const Ref<XRTracker> &p_tracker) {
 
 	StringName tracker_name = p_tracker->get_tracker_name();
 	if (trackers.has(tracker_name)) {
-		if (trackers[tracker_name] != p_tracker) {
+		if (trackers[tracker_name] != (Variant)p_tracker) {
 			// We already have a tracker with this name, we're going to replace it
 			trackers[tracker_name] = p_tracker;
 			emit_signal(SNAME("tracker_updated"), tracker_name, p_tracker->get_tracker_type());

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -205,7 +205,7 @@ TEST_CASE("[JSON] Parsing single data types") {
 			json.get_error_line() == 0,
 			"Parsing a double quoted string as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			json.get_data() == "hello",
+			json.get_data() == Variant("hello"),
 			"Parsing a double quoted string as JSON should return the expected value.");
 }
 
@@ -220,21 +220,21 @@ TEST_CASE("[JSON] Parsing arrays") {
 			json.get_error_line() == 0,
 			"Parsing a JSON array should parse successfully.");
 	CHECK_MESSAGE(
-			array[0] == "Hello",
+			array[0] == Variant("Hello"),
 			"The parsed JSON should contain the expected values.");
 	const Array sub_array = array[3];
 	CHECK_MESSAGE(
 			sub_array.size() == 4,
 			"The parsed JSON should contain the expected values.");
 	CHECK_MESSAGE(
-			sub_array[1] == "json",
+			sub_array[1] == Variant("json"),
 			"The parsed JSON should contain the expected values.");
 	CHECK_MESSAGE(
 			sub_array[3].hash() == Array().hash(),
 			"The parsed JSON should contain the expected values.");
 	const Array deep_array = Array(Array(array[5])[0])[0];
 	CHECK_MESSAGE(
-			deep_array[0] == "Gotcha!",
+			deep_array[0] == Variant("Gotcha!"),
 			"The parsed JSON should contain the expected values.");
 }
 
@@ -245,7 +245,7 @@ TEST_CASE("[JSON] Parsing objects (dictionaries)") {
 
 	const Dictionary dictionary = json.get_data();
 	CHECK_MESSAGE(
-			dictionary["name"] == "Godot Engine",
+			dictionary["name"] == Variant("Godot Engine"),
 			"The parsed JSON should contain the expected values.");
 	CHECK_MESSAGE(
 			dictionary["is_free"],

--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -524,8 +524,8 @@ TEST_CASE("[Resource] Duplication") {
 		}
 
 		// Ensure all the usages are of the same resource.
-		CHECK(((Dictionary)dupe_a[1]).get_key_at_index(0) == dupe_res);
-		CHECK(((Dictionary)dupe_a[1]).get_value_at_index(0) == dupe_res);
+		CHECK(((Dictionary)dupe_a[1]).get_key_at_index(0) == (Variant)dupe_res);
+		CHECK(((Dictionary)dupe_a[1]).get_value_at_index(0) == (Variant)dupe_res);
 	}
 }
 
@@ -547,10 +547,10 @@ TEST_CASE("[Resource] Saving and loading") {
 			loaded_resource_binary->get_name() == "Hello world",
 			"The loaded resource name should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_binary->get_meta("ExampleMetadata") == Vector2i(40, 80),
+			loaded_resource_binary->get_meta("ExampleMetadata") == (Variant)Vector2i(40, 80),
 			"The loaded resource metadata should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_binary->get_meta("string") == "The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks",
+			loaded_resource_binary->get_meta("string") == Variant("The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks"),
 			"The loaded resource metadata should be equal to the expected value.");
 	const Ref<Resource> &loaded_child_resource_binary = loaded_resource_binary->get_meta("other_resource");
 	CHECK_MESSAGE(
@@ -562,10 +562,10 @@ TEST_CASE("[Resource] Saving and loading") {
 			loaded_resource_text->get_name() == "Hello world",
 			"The loaded resource name should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_text->get_meta("ExampleMetadata") == Vector2i(40, 80),
+			loaded_resource_text->get_meta("ExampleMetadata") == (Variant)Vector2i(40, 80),
 			"The loaded resource metadata should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_text->get_meta("string") == "The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks",
+			loaded_resource_text->get_meta("string") == Variant("The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks"),
 			"The loaded resource metadata should be equal to the expected value.");
 	const Ref<Resource> &loaded_child_resource_text = loaded_resource_text->get_meta("other_resource");
 	CHECK_MESSAGE(

--- a/tests/core/io/test_stream_peer.h
+++ b/tests/core/io/test_stream_peer.h
@@ -186,7 +186,7 @@ TEST_CASE("[StreamPeer] Get and sets through StreamPeerBuffer") {
 		spb->put_var(value);
 		spb->seek(0);
 
-		CHECK_EQ(spb->get_var(), value);
+		CHECK_EQ(spb->get_var(), (Variant)value);
 	}
 }
 

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -191,7 +191,7 @@ TEST_CASE("[Object] Metadata") {
 			"Not conflicting meta on destination should be kept intact.");
 
 	CHECK_MESSAGE(
-			object.get_meta("other_meta", String()) == "other",
+			object.get_meta("other_meta", String()) == Variant("other"),
 			"Not conflicting meta name on source should merged.");
 
 	List<StringName> meta_list3;

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -2088,7 +2088,7 @@ TEST_CASE("[String] Variant validated indexed get") {
 	getter(&s, 1, &r, &oob);
 
 	CHECK_FALSE(oob);
-	CHECK_EQ(r, String("b"));
+	CHECK_EQ(r, (Variant)String("b"));
 }
 
 TEST_CASE("[String] Variant ptr indexed get") {
@@ -2111,7 +2111,7 @@ TEST_CASE("[String] Variant indexed set") {
 
 	CHECK(valid);
 	CHECK_FALSE(oob);
-	CHECK_EQ(s, String("azcd"));
+	CHECK_EQ(s, (Variant)String("azcd"));
 }
 
 TEST_CASE("[String] Variant validated indexed set") {
@@ -2124,7 +2124,7 @@ TEST_CASE("[String] Variant validated indexed set") {
 	setter(&s, 1, &v, &oob);
 
 	CHECK_FALSE(oob);
-	CHECK_EQ(s, String("azcd"));
+	CHECK_EQ(s, (Variant)String("azcd"));
 }
 
 TEST_CASE("[String] Variant ptr indexed set") {

--- a/tests/core/templates/test_fixed_vector.h
+++ b/tests/core/templates/test_fixed_vector.h
@@ -94,7 +94,7 @@ TEST_CASE("[FixedVector] Basic Checks") {
 	vector_variant[1] = 1;
 	CHECK_EQ(vector_variant.capacity(), 3);
 	CHECK_EQ(vector_variant.size(), 3);
-	CHECK_EQ(vector_variant[0], "Test");
+	CHECK_EQ(vector_variant[0], Variant("Test"));
 	CHECK_EQ(vector_variant[1], Variant(1));
 	CHECK_EQ(vector_variant[2].get_type(), Variant::NIL);
 

--- a/tests/core/templates/test_list.h
+++ b/tests/core/templates/test_list.h
@@ -519,13 +519,13 @@ TEST_CASE("[List] Swap front and back (values check)") {
 	Variant color = Color(0, 0, 1);
 	List<Variant>::Element *n_color = list.push_back(color);
 
-	CHECK(list.front()->get() == "Godot");
-	CHECK(list.back()->get() == Color(0, 0, 1));
+	CHECK(list.front()->get() == Variant("Godot"));
+	CHECK(list.back()->get() == (Variant)Color(0, 0, 1));
 
 	list.swap(n_str, n_color);
 
-	CHECK(list.front()->get() == Color(0, 0, 1));
-	CHECK(list.back()->get() == "Godot");
+	CHECK(list.front()->get() == (Variant)Color(0, 0, 1));
+	CHECK(list.back()->get() == Variant("Godot"));
 }
 
 TEST_CASE("[List] Swap adjacent back and front (reverse order of elements)") {

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -82,10 +82,10 @@ TEST_CASE("[Dictionary] List init") {
 		{ Vector2(), "v2" },
 	};
 	CHECK(dict.size() == 4);
-	CHECK(dict[0] == "int");
+	CHECK(dict[0] == Variant("int"));
 	CHECK(PackedStringArray(dict["packed_string_array"])[2] == "values");
 	CHECK(Dictionary(dict["key"])["nested"] == Variant(200));
-	CHECK(dict[Vector2()] == "v2");
+	CHECK(dict[Vector2()] == Variant("v2"));
 
 	TypedDictionary<double, double> tdict{
 		{ 0.0, 1.0 },

--- a/tests/core/variant/test_variant_utility.h
+++ b/tests/core/variant/test_variant_utility.h
@@ -80,11 +80,11 @@ TEST_CASE("[VariantUtility] Type conversion") {
 
 		converted = VariantUtilityFunctions::type_convert(transform, Variant::Type::BASIS);
 		CHECK(converted.get_type() == Variant::Type::BASIS);
-		CHECK(converted == basis);
+		CHECK(converted == (Variant)basis);
 
 		converted = VariantUtilityFunctions::type_convert(basis, Variant::Type::TRANSFORM3D);
 		CHECK(converted.get_type() == Variant::Type::TRANSFORM3D);
-		CHECK(converted == transform);
+		CHECK(converted == (Variant)transform);
 
 		converted = VariantUtilityFunctions::type_convert(basis, Variant::Type::STRING);
 		CHECK(converted.get_type() == Variant::Type::STRING);
@@ -97,11 +97,11 @@ TEST_CASE("[VariantUtility] Type conversion") {
 
 		converted = VariantUtilityFunctions::type_convert(arr, Variant::Type::PACKED_FLOAT64_ARRAY);
 		CHECK(converted.get_type() == Variant::Type::PACKED_FLOAT64_ARRAY);
-		CHECK(converted == packed);
+		CHECK(converted == (Variant)packed);
 
 		converted = VariantUtilityFunctions::type_convert(packed, Variant::Type::ARRAY);
 		CHECK(converted.get_type() == Variant::Type::ARRAY);
-		CHECK(converted == arr);
+		CHECK(converted == (Variant)arr);
 	}
 
 	{

--- a/tests/scene/test_animation.h
+++ b/tests/scene/test_animation.h
@@ -58,12 +58,12 @@ TEST_CASE("[Animation] Create value track") {
 	CHECK(int(animation->track_get_key_value(0, 0)) == 0);
 	CHECK(int(animation->track_get_key_value(0, 1)) == 100);
 
-	CHECK(animation->value_track_interpolate(0, -0.2) == doctest::Approx(0.0));
-	CHECK(animation->value_track_interpolate(0, 0.0) == doctest::Approx(0.0));
-	CHECK(animation->value_track_interpolate(0, 0.2) == doctest::Approx(40.0));
-	CHECK(animation->value_track_interpolate(0, 0.4) == doctest::Approx(80.0));
-	CHECK(animation->value_track_interpolate(0, 0.5) == doctest::Approx(100.0));
-	CHECK(animation->value_track_interpolate(0, 0.6) == doctest::Approx(100.0));
+	CHECK((double)animation->value_track_interpolate(0, -0.2) == doctest::Approx(0.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.0) == doctest::Approx(0.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.2) == doctest::Approx(40.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.4) == doctest::Approx(80.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.5) == doctest::Approx(100.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.6) == doctest::Approx(100.0));
 
 	CHECK(animation->track_get_key_transition(0, 0) == doctest::Approx(real_t(1.0)));
 	CHECK(animation->track_get_key_transition(0, 1) == doctest::Approx(real_t(1.0)));

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3741,10 +3741,10 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		auto_brace_completion_pairs["'''"] = "'''";
 		code_edit->set_auto_brace_completion_pairs(auto_brace_completion_pairs);
 		CHECK(code_edit->get_auto_brace_completion_pairs().size() == 4);
-		CHECK(code_edit->get_auto_brace_completion_pairs()["["] == "]");
-		CHECK(code_edit->get_auto_brace_completion_pairs()["'"] == "'");
-		CHECK(code_edit->get_auto_brace_completion_pairs()[";"] == "'");
-		CHECK(code_edit->get_auto_brace_completion_pairs()["'''"] == "'''");
+		CHECK(code_edit->get_auto_brace_completion_pairs()["["] == Variant("]"));
+		CHECK(code_edit->get_auto_brace_completion_pairs()["'"] == Variant("'"));
+		CHECK(code_edit->get_auto_brace_completion_pairs()[";"] == Variant("'"));
+		CHECK(code_edit->get_auto_brace_completion_pairs()["'''"] == Variant("'''"));
 
 		ERR_PRINT_OFF;
 
@@ -4081,11 +4081,11 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			/* Check data. */
 			Dictionary option = code_edit->get_code_completion_option(0);
 			CHECK((int)option["kind"] == (int)CodeEdit::CodeCompletionKind::KIND_CLASS);
-			CHECK(option["display_text"] == "item_0.");
-			CHECK(option["insert_text"] == "item_0");
-			CHECK(option["font_color"] == Color(1, 0, 0));
-			CHECK(option["icon"] == Ref<Resource>());
-			CHECK(option["default_value"] == Color(1, 0, 0));
+			CHECK(option["display_text"] == Variant("item_0."));
+			CHECK(option["insert_text"] == Variant("item_0"));
+			CHECK(option["font_color"] == (Variant)Color(1, 0, 0));
+			CHECK(option["icon"] == (Variant)Ref<Resource>());
+			CHECK(option["default_value"] == (Variant)Color(1, 0, 0));
 
 			/* Set size for mouse input. */
 			code_edit->set_size(Size2(100, 100));

--- a/tests/scene/test_gltf_document.h
+++ b/tests/scene/test_gltf_document.h
@@ -169,8 +169,8 @@ void test_gltf_document_values(Ref<GLTFDocument> &p_gltf_document, Ref<GLTFState
 	}
 
 	CHECK(p_gltf_state->get_copyright() == p_test_case.copyright);
-	CHECK(((Dictionary)p_gltf_state->get_json()["asset"])["generator"] == p_test_case.generator);
-	CHECK(((Dictionary)p_gltf_state->get_json()["asset"])["version"] == p_test_case.version);
+	CHECK(((Dictionary)p_gltf_state->get_json()["asset"])["generator"] == (Variant)p_test_case.generator);
+	CHECK(((Dictionary)p_gltf_state->get_json()["asset"])["version"] == (Variant)p_test_case.version);
 }
 
 void test_gltf_save(Node *p_node) {

--- a/tests/scene/test_option_button.h
+++ b/tests/scene/test_option_button.h
@@ -142,7 +142,7 @@ TEST_CASE("[SceneTree][OptionButton] Many items") {
 		m["bool"] = true;
 		m["String"] = "yes";
 		test_opt->set_item_metadata(1, m);
-		CHECK(test_opt->get_item_metadata(1) == m);
+		CHECK(test_opt->get_item_metadata(1) == (Variant)m);
 
 		// item_tooltip.
 		test_opt->set_item_tooltip(0, "tooltip guide");

--- a/tests/scene/test_skeleton_3d.h
+++ b/tests/scene/test_skeleton_3d.h
@@ -44,12 +44,12 @@ TEST_CASE("[Skeleton3D] Test per-bone meta") {
 	// Adding meta to bone.
 	skeleton->set_bone_meta(0, "key1", "value1");
 	skeleton->set_bone_meta(0, "key2", 12345);
-	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key1") == "value1", "Bone meta missing.");
+	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key1") == Variant("value1"), "Bone meta missing.");
 	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key2") == Variant(12345), "Bone meta missing.");
 
 	// Rename bone and check if meta persists.
 	skeleton->set_bone_name(0, "renamed_root");
-	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key1") == "value1", "Bone meta missing.");
+	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key1") == Variant("value1"), "Bone meta missing.");
 	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key2") == Variant(12345), "Bone meta missing.");
 
 	// Retrieve list of keys.

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -2396,7 +2396,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("drag"));
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 4);
@@ -2436,7 +2436,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "'drag'");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("'drag'"));
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_KEY_EVENT(Key::CMD_OR_CTRL);
@@ -2459,7 +2459,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection(true, 1));
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 12).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "test\nop");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("test\nop"));
 			// Carets aren't removed from dragging, only dropping.
 			CHECK(text_edit->get_caret_count() == 3);
 			CHECK(text_edit->has_selection(0));
@@ -2492,7 +2492,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "here");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("here"));
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
@@ -2526,7 +2526,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("drag"));
 			SEND_GUI_KEY_EVENT(Key::ESCAPE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
@@ -2542,7 +2542,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("drag"));
 			SEND_GUI_KEY_EVENT(Key::RIGHT);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
@@ -2556,7 +2556,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("drag"));
 			SEND_GUI_KEY_EVENT(Key::A);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'A' \ndr heretest\nop 'drag'");
@@ -2590,7 +2590,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag me");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("drag me"));
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 7);
@@ -2677,7 +2677,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection(true, 0));
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 6).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "d\nte");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("d\nte"));
 			CHECK(text_edit->has_selection());
 			SEND_GUI_KEY_EVENT(Key::CMD_OR_CTRL);
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
@@ -2709,7 +2709,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection(true, 0));
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "test");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("test"));
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -2736,7 +2736,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == " ");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant(" "));
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -2761,7 +2761,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "rag");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("rag"));
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -2779,7 +2779,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(text_edit->get_viewport()->gui_get_drag_data() == Variant("drag"));
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -8157,11 +8157,11 @@ TEST_CASE("[SceneTree][TextEdit] gutters") {
 		text_edit->set_line_gutter_metadata(2, 0, "test");
 		text_edit->set_line_gutter_metadata(-1, 0, "test");
 
-		CHECK(text_edit->get_line_gutter_metadata(1, 0) == "test");
-		CHECK(text_edit->get_line_gutter_metadata(0, -1) == "");
-		CHECK(text_edit->get_line_gutter_metadata(0, 2) == "");
-		CHECK(text_edit->get_line_gutter_metadata(2, 0) == "");
-		CHECK(text_edit->get_line_gutter_metadata(-1, 0) == "");
+		CHECK(text_edit->get_line_gutter_metadata(1, 0) == Variant("test"));
+		CHECK(text_edit->get_line_gutter_metadata(0, -1) == Variant(""));
+		CHECK(text_edit->get_line_gutter_metadata(0, 2) == Variant(""));
+		CHECK(text_edit->get_line_gutter_metadata(2, 0) == Variant(""));
+		CHECK(text_edit->get_line_gutter_metadata(-1, 0) == Variant(""));
 
 		text_edit->set_line_gutter_text(1, 0, "test");
 		text_edit->set_line_gutter_text(0, -1, "test");

--- a/tests/servers/test_navigation_server_2d.h
+++ b/tests/servers/test_navigation_server_2d.h
@@ -392,7 +392,7 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 0);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 1);
-		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector2(0, 0));
+		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, (Variant)Vector2(0, 0));
 
 		navigation_server->free_rid(agent);
 		navigation_server->free_rid(map);

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -367,7 +367,7 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 0);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 1);
-		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector3(0, 0, 0));
+		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, (Variant)Vector3(0, 0, 0));
 
 		navigation_server->free_rid(agent);
 		navigation_server->free_rid(map);


### PR DESCRIPTION
Adds deleted template comparison operators behind `STRICT_CHECKS` macros

In practice, this makes all Variant comparison operations entirely self-contained, necessitating they be called explicitly. We already had to do this with certain ambiguous types (arithmetic types most obviously), so this is just enforcing that for all other types. It also helps showcase some areas with questionable `Variant` arguments/returns, that were otherwise being quietly converted. Keeping it behind the `STRICT_CHECKS` macro means that we aren't breaking compatibility out of the gate, so modules/extensions can gradually adopt this convention.