### PR TITLE
OpenXR: Fix resizing viewports used by `OpenXRCompositionLayer`

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2933,9 +2933,11 @@ void TextureStorage::render_target_set_msaa(RID p_render_target, RS::ViewportMSA
 
 	WARN_PRINT("2D MSAA is not yet supported for GLES3.");
 
-	_clear_render_target(rt);
-	rt->msaa = p_msaa;
-	_update_render_target_color(rt);
+	if (rt->overridden.color.is_null()) {
+		_clear_render_target(rt);
+		rt->msaa = p_msaa;
+		_update_render_target_color(rt);
+	}
 }
 
 RS::ViewportMSAA TextureStorage::render_target_get_msaa(RID p_render_target) const {
@@ -2953,9 +2955,11 @@ void TextureStorage::render_target_set_use_hdr(RID p_render_target, bool p_use_h
 		return;
 	}
 
-	_clear_render_target(rt);
-	rt->hdr = p_use_hdr_2d;
-	_update_render_target_color(rt);
+	if (rt->overridden.color.is_null()) {
+		_clear_render_target(rt);
+		rt->hdr = p_use_hdr_2d;
+		_update_render_target_color(rt);
+	}
 }
 
 bool TextureStorage::render_target_is_using_hdr(RID p_render_target) const {

--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -232,6 +232,8 @@ void OpenXRCompositionLayerExtension::CompositionLayer::set_viewport(RID p_viewp
 			free_swapchain();
 			subviewport.viewport_size = Size2i();
 		}
+	} else if (subviewport.viewport_size != p_size) {
+		subviewport.viewport_size = p_size;
 	}
 }
 

--- a/modules/openxr/scene/openxr_composition_layer.h
+++ b/modules/openxr/scene/openxr_composition_layer.h
@@ -115,6 +115,8 @@ private:
 	void _setup_composition_layer();
 	void _clear_composition_layer();
 
+	void _viewport_size_changed();
+
 protected:
 	OpenXRAPI *openxr_api = nullptr;
 	OpenXRCompositionLayerExtension *composition_layer_extension = nullptr;

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3542,6 +3542,10 @@ void TextureStorage::_clear_render_target(RenderTarget *rt) {
 }
 
 void TextureStorage::_update_render_target(RenderTarget *rt) {
+	if (rt->overridden.color.is_valid()) {
+		return;
+	}
+
 	if (rt->texture.is_null()) {
 		//create a placeholder until updated
 		rt->texture = texture_allocate();


### PR DESCRIPTION
Currently, if you change the size of a `SubViewport` that is being used by an `OpenXRCompositionLayer` it will break.

This PR fixes that!

The changes in the OpenGL renderer actually aren't needed to fix the bug (only the Vulkan changes), but after making the Vulkan changes, I checked if OpenGL had similar issues, and it does, but only for changing the MSAA and HDR flags - it already has the correct check when changing the render target size.