### PR TITLE
Modern Style: Use a style box for Input Map actions

### DIFF
--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -418,6 +418,18 @@ bool ActionMapEditor::_should_display_action(const String &p_name, const Array &
 	return event_match && action_list_search_bar->get_name().is_subsequence_ofn(p_name);
 }
 
+void ActionMapEditor::_highlight_subsection_action(Object *p_item, const Rect2 p_rect) {
+	TreeItem *item = Object::cast_to<TreeItem>(p_item);
+	ERR_FAIL_NULL(item);
+
+	if (item->is_selected(0)) {
+		return;
+	}
+
+	const Ref<StyleBox> &stylebox = get_theme_stylebox(SNAME("style_highlight_subsection"), EditorStringName(Editor));
+	stylebox->draw(action_tree->get_canvas_item(), p_rect);
+}
+
 void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_infos) {
 	if (!p_action_infos.is_empty()) {
 		actions_cache = p_action_infos;
@@ -458,6 +470,8 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 
 		// First Column - Action Name
 		action_item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
+		action_item->set_cell_mode(0, TreeItem::CELL_MODE_CUSTOM);
+		action_item->set_custom_draw_callback(0, callable_mp(this, &ActionMapEditor::_highlight_subsection_action));
 		action_item->set_text(0, action_info.name);
 		action_item->set_editable(0, action_info.editable);
 		action_item->set_icon(0, action_info.icon);

--- a/editor/settings/action_map_editor.h
+++ b/editor/settings/action_map_editor.h
@@ -108,6 +108,7 @@ private:
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 	void _set_show_builtin_actions(bool p_show);
+	void _highlight_subsection_action(Object *p_item, const Rect2 p_rect);
 
 protected:
 	void _notification(int p_what);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1963,6 +1963,13 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_constant("indent_size", "EditorInspectorSection", 6.0 * EDSCALE);
 		p_theme->set_constant("h_separation", "EditorInspectorSection", 2.0 * EDSCALE);
 
+		Color prop_subsection_stylebox_color = Color(1, 1, 1, 0);
+		p_theme->set_color("prop_subsection_stylebox", EditorStringName(Editor), prop_subsection_stylebox_color);
+
+		Ref<StyleBoxFlat> style_highlight_subsection = p_config.base_style->duplicate();
+		style_highlight_subsection->set_bg_color(prop_subsection_stylebox_color);
+		p_theme->set_stylebox("style_highlight_subsection", EditorStringName(Editor), style_highlight_subsection);
+
 		Color prop_category_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.12);
 		Color prop_subsection_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.06);
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1923,6 +1923,14 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_constant("indent_size", "EditorInspectorSection", 6.0 * EDSCALE);
 		p_theme->set_constant("h_separation", "EditorInspectorSection", p_config.base_margin * EDSCALE);
 
+		Color prop_subsection_stylebox_color = p_config.dark_color_1.lerp(p_config.mono_color_font, p_config.dark_icon_and_font ? 0.09 : 0.16);
+		p_theme->set_color("prop_subsection_stylebox", EditorStringName(Editor), prop_subsection_stylebox_color);
+
+		Ref<StyleBoxFlat> style_highlight_subsection = p_config.base_style->duplicate();
+		style_highlight_subsection->set_bg_color(prop_subsection_stylebox_color);
+		style_highlight_subsection->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		p_theme->set_stylebox("style_highlight_subsection", EditorStringName(Editor), style_highlight_subsection);
+
 		p_theme->set_color("prop_subsection", EditorStringName(Editor), Color(1, 1, 1, 0));
 #ifndef DISABLE_DEPRECATED // Used before 4.3.
 		p_theme->set_color("property_color", EditorStringName(Editor), p_config.dark_color_1.lerp(p_config.mono_color_font, 0.12));


### PR DESCRIPTION
Addresses [one of the complains about the new style](https://github.com/godotengine/godot/pull/111118#issuecomment-3463630628). One which I couldn't disagree.

The new style makes the Input Map editor too flat. I modified it so it at least highlights the actions.

This is done by using `TreeItem::CELL_MODE_CUSTOM` alongside a callback that draws a StyleBox, which I named `style_highlight_subsection`. The Deadzone column uses `TreeItem::CELL_MODE_RANGE`, meaning it can't be applied to them, unfortunately.

I avoided picking a color too bright as it would make the contrast between the text and the background too low, so it's just a tiny increase to work as a separator.

The StyleBox is fully transparent in the Classic theme, therefore it should not be affected.

### Dark theme

| Before | After |
|--------|-------|
| ![before_dark](https://github.com/user-attachments/assets/66afb4f0-2c83-45ad-bd6b-27268508c261) | ![after_dark](https://github.com/user-attachments/assets/c7e2c7c2-e6a9-4f0a-b733-3ee4f609fcc5) |


### Light theme

| Before | After |
|--------|-------|
| ![before_light](https://github.com/user-attachments/assets/db7bf0e5-b549-44d1-94c9-47adec420ebe) | ![after_light](https://github.com/user-attachments/assets/4f060c06-e8c0-4450-b5ca-bef52620006f) |

Classic style for reference:
![old](https://github.com/user-attachments/assets/5091dccd-d41a-42fb-b38c-3a065e26220f)