### PR TITLE
Fix resource picker button style

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1306,12 +1306,13 @@ EditorResourcePicker::EditorResourcePicker(bool p_hide_assign_button_controls) {
 	}
 
 	quick_load_button = memnew(Button);
+	quick_load_button->set_theme_type_variation(SceneStringName(FlatButton));
 	quick_load_button->set_tooltip_text(TTRC("Quick Load"));
 	add_child(quick_load_button);
 	quick_load_button->connect(SceneStringName(pressed), callable_mp(this, &EditorResourcePicker::_edit_menu_cbk).bind(OBJ_MENU_QUICKLOAD));
 
 	edit_button = memnew(Button);
-	edit_button->set_flat(false);
+	edit_button->set_theme_type_variation(SceneStringName(FlatButton));
 	edit_button->set_toggle_mode(true);
 	edit_button->set_action_mode(BaseButton::ACTION_MODE_BUTTON_PRESS);
 	edit_button->set_accessibility_name(TTRC("Edit"));


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/112232

Before:

<img width="343" height="306" alt="Screenshot_20251031_135805" src="https://github.com/user-attachments/assets/e86fcf1f-8889-4e90-a39e-093f9d73af9f" />




After:

https://github.com/user-attachments/assets/707391b1-d588-4735-bdfe-151b839a1d72

This change has minimal effect on the classic theme

4.6.dev2:

<img width="372" height="306" alt="Image" src="https://github.com/user-attachments/assets/b48dcaa4-f5eb-42d1-90ba-78264cd3b461" />

After:

<img width="372" height="306" alt="Image" src="https://github.com/user-attachments/assets/78df7e12-b380-428f-8370-199cd379127d" />

