### PR TITLE
Fix drawing of slot icons in `GraphNode` when slots are not continuous

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -647,24 +647,24 @@ void GraphNode::_notification(int p_what) {
 
 			// Take the HboxContainer child into account.
 			if (get_child_count(false) > 0) {
-				int slot_index = 0;
 				for (const KeyValue<int, Slot> &E : slot_table) {
-					if (E.key < 0 || E.key >= slot_y_cache.size()) {
+					const int slot_index = E.key;
+
+					if (slot_index < 0 || slot_index >= slot_y_cache.size()) {
 						continue;
 					}
-					if (!slot_table.has(E.key)) {
-						continue;
-					}
-					const Slot &slot = slot_table[E.key];
+
+					const Slot &slot = E.value;
+					const int slot_y = slot_y_cache[slot_index];
 
 					// Left port.
 					if (slot.enable_left) {
-						draw_port(slot_index, Point2i(port_h_offset, slot_y_cache[E.key]), true, slot.color_left);
+						draw_port(slot_index, Point2i(port_h_offset, slot_y), true, slot.color_left);
 					}
 
 					// Right port.
 					if (slot.enable_right) {
-						draw_port(slot_index, Point2i(get_size().x - port_h_offset, slot_y_cache[E.key]), false, slot.color_right);
+						draw_port(slot_index, Point2i(get_size().x - port_h_offset, slot_y), false, slot.color_right);
 					}
 
 					if (slot_index == selected_slot) {
@@ -673,28 +673,25 @@ void GraphNode::_notification(int p_what) {
 							port_icon = theme_cache.port;
 						}
 						Size2i port_sz = port_icon->get_size() + sb_slot_selected->get_minimum_size();
-						draw_style_box(sb_slot_selected, Rect2i(port_h_offset - port_sz.x * 0.5, slot_y_cache[E.key] - port_sz.y * 0.5, port_sz.x, port_sz.y));
+						draw_style_box(sb_slot_selected, Rect2i(port_h_offset - port_sz.x * 0.5, slot_y - port_sz.y * 0.5, port_sz.x, port_sz.y));
 						port_icon = slot.custom_port_icon_right;
 						if (port_icon.is_null()) {
 							port_icon = theme_cache.port;
 						}
 						port_sz = port_icon->get_size() + sb_slot_selected->get_minimum_size();
-						draw_style_box(sb_slot_selected, Rect2i(get_size().x - port_h_offset - port_sz.x * 0.5, slot_y_cache[E.key] - port_sz.y * 0.5, port_sz.x, port_sz.y));
+						draw_style_box(sb_slot_selected, Rect2i(get_size().x - port_h_offset - port_sz.x * 0.5, slot_y - port_sz.y * 0.5, port_sz.x, port_sz.y));
 					}
 
 					// Draw slot stylebox.
 					if (slot.draw_stylebox) {
-						Control *child = Object::cast_to<Control>(get_child(E.key, false));
-						if (!child || !child->is_visible_in_tree()) {
-							continue;
+						Control *child = Object::cast_to<Control>(get_child(slot_index, false));
+						if (child && child->is_visible_in_tree()) {
+							Rect2 child_rect = child->get_rect();
+							child_rect.position.x = sb_panel->get_margin(SIDE_LEFT);
+							child_rect.size.width = width;
+							draw_style_box(sb_slot, child_rect);
 						}
-						Rect2 child_rect = child->get_rect();
-						child_rect.position.x = sb_panel->get_margin(SIDE_LEFT);
-						child_rect.size.width = width;
-						draw_style_box(sb_slot, child_rect);
 					}
-
-					slot_index++;
 				}
 			}
 


### PR DESCRIPTION
Fixes: #107298