### PR TITLE
Fix LinkButton color in Modern theme

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -542,7 +542,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 		p_theme->set_stylebox("focus", "LinkButton", p_config.base_empty_style);
 
-		p_theme->set_color(SceneStringName(font), "LinkButton", p_config.font_color);
+		p_theme->set_color(SceneStringName(font_color), "LinkButton", p_config.font_color);
 		p_theme->set_color("font_hover_color", "LinkButton", p_config.font_hover_color);
 		p_theme->set_color("font_hover_pressed_color", "LinkButton", p_config.font_hover_pressed_color);
 		p_theme->set_color("font_focus_color", "LinkButton", p_config.font_focus_color);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/112253


<img width="795" height="541" alt="Screenshot_20251031_193323" src="https://github.com/user-attachments/assets/095f8715-ad73-4ec3-a158-b85b8b3fce4c" />


