### PR TITLE
Explain `Dictionary.set()` return value in docs

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -508,7 +508,7 @@
 			<param index="0" name="key" type="Variant" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Sets the value of the element at the given [param key] to the given [param value]. This is the same as using the [code][][/code] operator ([code]dict[key] = value[/code]).
+				Sets the value of the element at the given [param key] to the given [param value]. This is the same as using the [code][][/code] operator ([code]dict[key] = value[/code]). Returns [code]true[/code] if the value is set successfully. Fails and returns [code]false[/code] if the dictionary is read-only, or if [param key] and [param value] don't match the dictionary's types.
 			</description>
 		</method>
 		<method name="size" qualifiers="const">


### PR DESCRIPTION
Adding a description after seeing a comment on the `Dictionary` documentation page mentioning this return value.  My first thought before looking into it was that it might be based on whether the key already existed, not thinking about cases where it could fail, so I think spelling it out in the docs could be helpful.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
