### PR TITLE
Fix RichTextLabel formatting when scrollbar is removed

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3740,7 +3740,6 @@ _FORCE_INLINE_ float RichTextLabel::_update_scroll_exceeds(float p_total_height,
 			vscroll->show();
 		} else {
 			scroll_visible = false;
-			scroll_w = 0;
 		}
 
 		main->first_resized_line.store(0);


### PR DESCRIPTION
Fixes #112226

Setting scroll_w to 0 is unnecessary.

https://github.com/user-attachments/assets/5d370243-1039-4b48-8c7e-65c25901e618

