### PR TITLE
Check for tiles outside texture on TileSet atlas settings changes

### DIFF
--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -2254,6 +2254,7 @@ void TileSetAtlasSourceEditor::init_new_atlases(const Vector<Ref<TileSetAtlasSou
 
 void TileSetAtlasSourceEditor::_update_source_texture() {
 	if (tile_set_atlas_source && tile_set_atlas_source->get_texture() == atlas_source_texture) {
+		_check_outside_tiles();
 		return;
 	}
 
@@ -2272,8 +2273,9 @@ void TileSetAtlasSourceEditor::_update_source_texture() {
 
 void TileSetAtlasSourceEditor::_check_outside_tiles() {
 	ERR_FAIL_NULL(tile_set_atlas_source);
-	outside_tiles_warning->set_visible(!read_only && tile_set_atlas_source->has_tiles_outside_texture());
-	tool_advanced_menu_button->get_popup()->set_item_disabled(tool_advanced_menu_button->get_popup()->get_item_index(ADVANCED_CLEANUP_TILES), !tile_set_atlas_source->has_tiles_outside_texture());
+	bool has_tiles_outside = tile_set_atlas_source->has_tiles_outside_texture();
+	outside_tiles_warning->set_visible(!read_only && has_tiles_outside);
+	tool_advanced_menu_button->get_popup()->set_item_disabled(tool_advanced_menu_button->get_popup()->get_item_index(ADVANCED_CLEANUP_TILES), !has_tiles_outside);
 }
 
 void TileSetAtlasSourceEditor::_cleanup_outside_tiles() {


### PR DESCRIPTION
Fixes #85661.
AFAICT also fixes #98991.

When `TileSetAtlasSource.changed` signal was emitted the callback would early return if the source `texture` was not swapped, skipping the check for whether there are tiles outside the texture.
Hence on changes to `texture_region`, `margins`, `separation` it was not updated whether some tiles ended up outside the texture. Added such check.

Before:

https://github.com/user-attachments/assets/14f0bc4b-1fe0-425f-af68-05f7c6504df7

After:

https://github.com/user-attachments/assets/14822b36-2486-4bb6-ab90-08e7aa88e880

