### PR TITLE
Add method to get bound local address to ENetConnection

### DIFF
--- a/modules/enet/doc_classes/ENetConnection.xml
+++ b/modules/enet/doc_classes/ENetConnection.xml
@@ -106,6 +106,12 @@
 				Sends any queued packets on the host specified to its designated peers.
 			</description>
 		</method>
+		<method name="get_local_address" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the local address to which this peer is bound.
+			</description>
+		</method>
 		<method name="get_local_port" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -250,11 +250,29 @@ int ENetConnection::get_max_channels() const {
 	return host->channelLimit;
 }
 
+IPAddress ENetConnection::get_local_address() const {
+	ERR_FAIL_NULL_V_MSG(host, IPAddress(), "The ENetConnection instance isn't currently active.");
+	ERR_FAIL_COND_V_MSG(!(host->socket), IPAddress(), "The ENetConnection instance isn't currently bound.");
+	ENetAddress address;
+	ERR_FAIL_COND_V_MSG(enet_socket_get_address(host->socket, &address), IPAddress(), "Unable to get socket address.");
+
+	IPAddress out;
+#ifdef GODOT_ENET
+	out.set_ipv6((uint8_t *)&(address.host));
+	if (out == IPAddress("::")) {
+		return IPAddress("*");
+	}
+#else
+	out.set_ipv4((uint8_t *)&(address.host));
+#endif
+	return out;
+}
+
 int ENetConnection::get_local_port() const {
 	ERR_FAIL_NULL_V_MSG(host, 0, "The ENetConnection instance isn't currently active.");
 	ERR_FAIL_COND_V_MSG(!(host->socket), 0, "The ENetConnection instance isn't currently bound.");
 	ENetAddress address;
-	ERR_FAIL_COND_V_MSG(enet_socket_get_address(host->socket, &address), 0, "Unable to get socket address");
+	ERR_FAIL_COND_V_MSG(enet_socket_get_address(host->socket, &address), 0, "Unable to get socket address.");
 	return address.port;
 }
 
@@ -387,6 +405,7 @@ void ENetConnection::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("refuse_new_connections", "refuse"), &ENetConnection::refuse_new_connections);
 	ClassDB::bind_method(D_METHOD("pop_statistic", "statistic"), &ENetConnection::pop_statistic);
 	ClassDB::bind_method(D_METHOD("get_max_channels"), &ENetConnection::get_max_channels);
+	ClassDB::bind_method(D_METHOD("get_local_address"), &ENetConnection::get_local_address);
 	ClassDB::bind_method(D_METHOD("get_local_port"), &ENetConnection::get_local_port);
 	ClassDB::bind_method(D_METHOD("get_peers"), &ENetConnection::_get_peers);
 	ClassDB::bind_method(D_METHOD("socket_send", "destination_address", "destination_port", "packet"), &ENetConnection::socket_send);

--- a/modules/enet/enet_connection.h
+++ b/modules/enet/enet_connection.h
@@ -125,6 +125,7 @@ public:
 
 	// Extras
 	void get_peers(List<Ref<ENetPacketPeer>> &r_peers);
+	IPAddress get_local_address() const;
 	int get_local_port() const;
 
 	// Godot additions


### PR DESCRIPTION
There was already a method to get the port but I could not find a way to get the address. I noticed that the wildcard addresses have weird behaviour, not sure if I need to document that or where I would.

According to `ss` on Linux, when using the built-in ENet using `*` or `::` as the bind address will actually bind to `*` and be accessible over IPv4 and 6, but using `enet_socket_get_address` will return `::`. When using `0.0.0.0` as the bind address, `enet_socket_get_address` will return `0.0.0.0` but the socket will be bound to `::ffff:0.0.0.0` and will be accessible over IPv4 normally, but can only be accessed by IPv6 using an IPv4-mapped IPv6 address (e.g. `::ffff:7f00:1` / `::ffff:127.0.0.1`).

When not using the built-in ENet, `*` and `0.0.0.0` will bind to `0.0.0.0` and `enet_socket_get_address` will return `0.0.0.0`.

Given that setting `::` and `*` both result in `*` being bound I chose to always return `*`. I also chose to leave `0.0.0.0` because its functionality is actually different from `*` and `::`.