### PR TITLE
Add method to get max allowed peers to ENetConnection

### DIFF
--- a/modules/enet/doc_classes/ENetConnection.xml
+++ b/modules/enet/doc_classes/ENetConnection.xml
@@ -118,6 +118,12 @@
 				Returns the maximum number of channels allowed for connected peers.
 			</description>
 		</method>
+		<method name="get_max_peers" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the maximum number of peers that can be connected at once.
+			</description>
+		</method>
 		<method name="get_peers">
 			<return type="ENetPacketPeer[]" />
 			<description>

--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -245,6 +245,11 @@ double ENetConnection::pop_statistic(HostStatistic p_stat) {
 	return ret;
 }
 
+int ENetConnection::get_max_peers() const {
+	ERR_FAIL_NULL_V_MSG(host, 0, "The ENetConnection instance isn't currently active.");
+	return host->peerCount;
+}
+
 int ENetConnection::get_max_channels() const {
 	ERR_FAIL_NULL_V_MSG(host, 0, "The ENetConnection instance isn't currently active.");
 	return host->channelLimit;
@@ -386,6 +391,7 @@ void ENetConnection::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("dtls_client_setup", "hostname", "client_options"), &ENetConnection::dtls_client_setup, DEFVAL(Ref<TLSOptions>()));
 	ClassDB::bind_method(D_METHOD("refuse_new_connections", "refuse"), &ENetConnection::refuse_new_connections);
 	ClassDB::bind_method(D_METHOD("pop_statistic", "statistic"), &ENetConnection::pop_statistic);
+	ClassDB::bind_method(D_METHOD("get_max_peers"), &ENetConnection::get_max_peers);
 	ClassDB::bind_method(D_METHOD("get_max_channels"), &ENetConnection::get_max_channels);
 	ClassDB::bind_method(D_METHOD("get_local_port"), &ENetConnection::get_local_port);
 	ClassDB::bind_method(D_METHOD("get_peers"), &ENetConnection::_get_peers);

--- a/modules/enet/enet_connection.h
+++ b/modules/enet/enet_connection.h
@@ -121,6 +121,7 @@ public:
 	void bandwidth_throttle();
 	void compress(CompressionMode p_mode);
 	double pop_statistic(HostStatistic p_stat);
+	int get_max_peers() const;
 	int get_max_channels() const;
 
 	// Extras


### PR DESCRIPTION
There is currently no way that I could find to get the maximum allowed peers from a connection after creating it.