### PR TITLE
Fix `CollisionPolygon3D` debug shape rendering.

### DIFF
--- a/editor/scene/3d/gizmos/physics/collision_polygon_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_polygon_3d_gizmo_plugin.cpp
@@ -168,7 +168,7 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			Vector<Color> cap_colours_bottom;
 			Vector<int> cap_indices_bottom;
 
-			const int index_offset = verts_size;
+			const int index_offset = verts.size();
 
 			const Vector<Vector2> &convex = decomp[i];
 			const int convex_size = convex.size();
@@ -198,7 +198,7 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			Vector<Color> cap_colours_top;
 			Vector<int> cap_indices_top;
 
-			const int index_offset = verts_size;
+			const int index_offset = verts.size();
 
 			const Vector<Vector2> &convex = decomp[i];
 			const int convex_size = convex.size();


### PR DESCRIPTION
When a CollisionPolygon3D is drawn with a concave area, it fails to render the surface of the top and bottom.

Steps to reproduce the bug in the editor:
1. Create a new scene
2. Create CollisionPolygon3D
3. Make sure debug fill is checked in the CollisionPolygon3D inspector.
4. Add these vertices to the the polygon (0,0), (1,-1), (1,1), (-1, 1), (-1, 0.3).

You should see that only one triangle from the top and bottom of the polygon is drawn and the reset are missing.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
