### PR TITLE
Fix duplicating ShaderMaterial reverts certain shader parameters

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -550,6 +550,20 @@ bool ShaderMaterial::_can_use_render_priority() const {
 	return shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;
 }
 
+Ref<Resource> ShaderMaterial::_duplicate(const DuplicateParams &p_params) const {
+	Ref<ShaderMaterial> dup;
+	dup.instantiate();
+
+	dup->set_shader(shader);
+	dup->set_next_pass(get_next_pass());
+	dup->set_render_priority(get_render_priority());
+
+	dup->param_cache = param_cache;
+	dup->remap_cache = remap_cache;
+
+	return dup;
+}
+
 Shader::Mode ShaderMaterial::get_shader_mode() const {
 	if (shader.is_valid()) {
 		return shader->get_mode();

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -132,6 +132,8 @@ public:
 	virtual RID get_rid() const override;
 	virtual RID get_shader_rid() const override;
 
+	virtual Ref<Resource> _duplicate(const DuplicateParams &p_params) const override;
+
 	ShaderMaterial();
 	~ShaderMaterial();
 };

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -132,6 +132,7 @@ public:
 	virtual RID get_rid() const override;
 	virtual RID get_shader_rid() const override;
 
+	// Use a custom `_duplicate()` method to ensure shader parameters are kept (see GH-110498).
 	virtual Ref<Resource> _duplicate(const DuplicateParams &p_params) const override;
 
 	ShaderMaterial();


### PR DESCRIPTION
Fixes #110498 

Added a custom duplicate function for ShaderMaterial.