### PR TITLE
[RTL] Do not apply scroll offset to empty RTL.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2422,10 +2422,6 @@ void RichTextLabel::_notification(int p_what) {
 			queue_redraw();
 		} break;
 
-		case NOTIFICATION_READY: {
-			_prepare_scroll_anchor();
-		} break;
-
 		case NOTIFICATION_THEME_CHANGED: {
 			_stop_thread();
 			main->first_invalid_font_line.store(0); // Invalidate all lines.
@@ -2598,7 +2594,12 @@ void RichTextLabel::_notification(int p_what) {
 			}
 			if (scroll_follow_visible_characters && scroll_active) {
 				scroll_visible = follow_vc_pos > 0;
-				vscroll->set_visible(follow_vc_pos > 0);
+				if (scroll_visible) {
+					_prepare_scroll_anchor();
+				} else {
+					scroll_w = 0;
+				}
+				vscroll->set_visible(scroll_visible);
 			}
 			if (has_focus() && get_tree()->is_accessibility_enabled()) {
 				RID ae;


### PR DESCRIPTION
Fixes regression caused by https://github.com/godotengine/godot/pull/111552 (scroll bar offset applied to empty RTL on creation, and not updated until overflow).

| Before | After |
| -- | -- |
| <img width="856" height="309" alt="Screenshot 2025-11-01 at 23 27 27" src="https://github.com/user-attachments/assets/a2027d32-cb6d-4366-a956-5311926f72cf" /> | <img width="856" height="309" alt="Screenshot 2025-11-01 at 23 28 49" src="https://github.com/user-attachments/assets/9731bcb3-bf33-4431-bc7c-ef015fe04648" /> |

Fixes https://github.com/godotengine/godot/issues/112610