### PR TITLE
[Windows] Fix legacy border when toggling borderless while fullscreen

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2623,6 +2623,9 @@ void DisplayServerWindows::window_set_flag(WindowFlags p_flag, bool p_enabled, W
 		} break;
 		case WINDOW_FLAG_BORDERLESS: {
 			wd.borderless = p_enabled;
+			if (wd.fullscreen) {
+				return;
+			}
 			_update_window_mouse_passthrough(p_window);
 			_update_window_style(p_window);
 			ShowWindow(wd.hWnd, (wd.no_focus || wd.is_popup) ? SW_SHOWNOACTIVATE : SW_SHOW); // Show the window.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/111038 by skipping updating window style and calling ShowWindow when toggling borderless while fullscreen.

Tested on windows 11 using the MRP ([fullscreen-bug.zip](https://github.com/user-attachments/files/23287031/fullscreen-bug.zip)).
Issue appeared after pressing "Toggle Fullscreen" twice.

Before fix:
<img width="1239" height="763" alt="image" src="https://github.com/user-attachments/assets/56f677fd-c611-46b1-b647-26dbb42b8feb" />


After fix:
<img width="1261" height="778" alt="image" src="https://github.com/user-attachments/assets/61caee10-80e7-4d80-832b-30e0b247bda1" />
