### PR TITLE
Expose `SO_REUSEADDR` and `SO_REUSEPORT` socket options to PacketPeerUDP

### DIFF
--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -115,6 +115,7 @@ public:
 	virtual void set_ipv6_only_enabled(bool p_enabled) = 0;
 	virtual void set_tcp_no_delay_enabled(bool p_enabled) = 0;
 	virtual void set_reuse_address_enabled(bool p_enabled) = 0;
+	virtual void set_reuse_port_enabled(bool p_enabled) = 0;
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) = 0;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) = 0;
 

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -46,6 +46,16 @@ void PacketPeerUDP::set_broadcast_enabled(bool p_enabled) {
 	}
 }
 
+void PacketPeerUDP::set_reuse_address_enabled(bool p_reuse_addr) {
+	ERR_FAIL_COND(udp_server);
+	reuse_addr = p_reuse_addr;
+}
+
+void PacketPeerUDP::set_reuse_port_enabled(bool p_reuse_port) {
+	ERR_FAIL_COND(udp_server);
+	reuse_port = p_reuse_port;
+}
+
 Error PacketPeerUDP::join_multicast_group(IPAddress p_multi_address, const String &p_if_name) {
 	ERR_FAIL_COND_V(udp_server, ERR_LOCKED);
 	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
@@ -195,6 +205,9 @@ Error PacketPeerUDP::bind(int p_port, const IPAddress &p_bind_address, int p_rec
 
 	_sock->set_blocking_enabled(false);
 	_sock->set_broadcasting_enabled(broadcast);
+	_sock->set_reuse_address_enabled(reuse_addr);
+	_sock->set_reuse_port_enabled(reuse_port);
+
 	NetSocket::Address addr(p_bind_address, p_port);
 	err = _sock->bind(addr);
 
@@ -371,6 +384,8 @@ void PacketPeerUDP::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_local_port"), &PacketPeerUDP::get_local_port);
 	ClassDB::bind_method(D_METHOD("set_dest_address", "host", "port"), &PacketPeerUDP::_set_dest_address);
 	ClassDB::bind_method(D_METHOD("set_broadcast_enabled", "enabled"), &PacketPeerUDP::set_broadcast_enabled);
+	ClassDB::bind_method(D_METHOD("set_reuse_address_enabled", "reuse_address"), &PacketPeerUDP::set_reuse_address_enabled);
+	ClassDB::bind_method(D_METHOD("set_reuse_port_enabled", "reuse_port"), &PacketPeerUDP::set_reuse_port_enabled);
 	ClassDB::bind_method(D_METHOD("join_multicast_group", "multicast_address", "interface_name"), &PacketPeerUDP::join_multicast_group);
 	ClassDB::bind_method(D_METHOD("leave_multicast_group", "multicast_address", "interface_name"), &PacketPeerUDP::leave_multicast_group);
 }

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -56,6 +56,8 @@ protected:
 	bool connected = false;
 	bool blocking = true;
 	bool broadcast = false;
+	bool reuse_addr = false;
+	bool reuse_port = false;
 	UDPServer *udp_server = nullptr;
 	Ref<NetSocket> _sock;
 
@@ -90,6 +92,8 @@ public:
 	int get_available_packet_count() const override;
 	int get_max_packet_size() const override;
 	void set_broadcast_enabled(bool p_enabled);
+	void set_reuse_address_enabled(bool p_reuse_addr);
+	void set_reuse_port_enabled(bool p_reuse_port);
 	Error join_multicast_group(IPAddress p_multi_address, const String &p_if_name);
 	Error leave_multicast_group(IPAddress p_multi_address, const String &p_if_name);
 

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -127,6 +127,21 @@
 				[b]Note:[/b] [method set_broadcast_enabled] must be enabled before sending packets to a broadcast address (e.g. [code]255.255.255.255[/code]).
 			</description>
 		</method>
+		<method name="set_reuse_address_enabled">
+			<return type="void" />
+			<param index="0" name="reuse_address" type="bool" />
+			<description>
+				Enable or disable [code]SO_REUSEADDR[/code] on the underlying socket. This option is disabled by default.
+			</description>
+		</method>
+		<method name="set_reuse_port_enabled">
+			<return type="void" />
+			<param index="0" name="reuse_port" type="bool" />
+			<description>
+				Enable or disable [code]SO_REUSEPORT[/code] on the underlying socket. This option is disabled by default.
+				[b]Note:[/b] Not supported on Windows, use [method set_reuse_address_enabled] instead.
+			</description>
+		</method>
 		<method name="wait">
 			<return type="int" enum="Error" />
 			<description>

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -721,11 +721,20 @@ void NetSocketUnix::set_tcp_no_delay_enabled(bool p_enabled) {
 }
 
 void NetSocketUnix::set_reuse_address_enabled(bool p_enabled) {
-	ERR_FAIL_COND(!is_open());
+	ERR_FAIL_COND(_sock < 0);
 
 	int par = p_enabled ? 1 : 0;
 	if (setsockopt(_sock, SOL_SOCKET, SO_REUSEADDR, &par, sizeof(int)) < 0) {
-		WARN_PRINT("Unable to set socket REUSEADDR option.");
+		WARN_PRINT("Unable to set socket SO_REUSEADDR option.");
+	}
+}
+
+void NetSocketUnix::set_reuse_port_enabled(bool p_enabled) {
+	ERR_FAIL_COND(_sock < 0);
+
+	int par = p_enabled ? 1 : 0;
+	if (setsockopt(_sock, SOL_SOCKET, SO_REUSEPORT, &par, sizeof(int)) < 0) {
+		WARN_PRINT("Unable to set socket SO_REUSEPORT option.");
 	}
 }
 

--- a/drivers/unix/net_socket_unix.h
+++ b/drivers/unix/net_socket_unix.h
@@ -109,6 +109,8 @@ public:
 	virtual void set_ipv6_only_enabled(bool p_enabled) override;
 	virtual void set_tcp_no_delay_enabled(bool p_enabled) override;
 	virtual void set_reuse_address_enabled(bool p_enabled) override;
+	virtual void set_reuse_port_enabled(bool p_enabled) override;
+
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 

--- a/drivers/windows/net_socket_winsock.cpp
+++ b/drivers/windows/net_socket_winsock.cpp
@@ -547,10 +547,18 @@ void NetSocketWinSock::set_tcp_no_delay_enabled(bool p_enabled) {
 }
 
 void NetSocketWinSock::set_reuse_address_enabled(bool p_enabled) {
-	ERR_FAIL_COND(!is_open());
+	ERR_FAIL_COND(_sock == INVALID_SOCKET);
 
-	// On Windows, enabling SO_REUSEADDR actually would also enable reuse port, very bad on TCP. Denying...
-	// Windows does not have this option, SO_REUSEADDR in this magical world means SO_REUSEPORT
+	int par = p_enabled ? 1 : 0;
+	if (setsockopt(_sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&par, sizeof(int)) < 0) {
+		WARN_PRINT("Unable to set socket REUSEADDR option.");
+	}
+}
+
+void NetSocketWinSock::set_reuse_port_enabled(bool p_enabled) {
+	ERR_FAIL_COND(_sock == INVALID_SOCKET);
+
+	// SO_REUSEPORT is not supported on windows, as its features are implemented as part of SO_REUSEADDR
 }
 
 bool NetSocketWinSock::is_open() const {

--- a/drivers/windows/net_socket_winsock.h
+++ b/drivers/windows/net_socket_winsock.h
@@ -91,6 +91,7 @@ public:
 	virtual void set_ipv6_only_enabled(bool p_enabled) override;
 	virtual void set_tcp_no_delay_enabled(bool p_enabled) override;
 	virtual void set_reuse_address_enabled(bool p_enabled) override;
+	virtual void set_reuse_port_enabled(bool p_enabled) override;
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 

--- a/platform/web/net_socket_web.h
+++ b/platform/web/net_socket_web.h
@@ -68,6 +68,7 @@ public:
 	virtual void set_ipv6_only_enabled(bool p_enabled) override {}
 	virtual void set_tcp_no_delay_enabled(bool p_enabled) override {}
 	virtual void set_reuse_address_enabled(bool p_enabled) override {}
+	virtual void set_reuse_port_enabled(bool p_enabled) override {}
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override { return ERR_UNAVAILABLE; }
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override { return ERR_UNAVAILABLE; }
 };

--- a/tests/core/io/test_stream_peer_tcp.cpp
+++ b/tests/core/io/test_stream_peer_tcp.cpp
@@ -65,6 +65,7 @@ public:
 	virtual void set_ipv6_only_enabled(bool p_enabled) override;
 	virtual void set_tcp_no_delay_enabled(bool p_enabled) override;
 	virtual void set_reuse_address_enabled(bool p_enabled) override;
+	virtual void set_reuse_port_enabled(bool p_enabled) override;
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 
@@ -198,6 +199,8 @@ void MockNetSocket::set_ipv6_only_enabled(bool p_enabled) {}
 void MockNetSocket::set_tcp_no_delay_enabled(bool p_enabled) {}
 
 void MockNetSocket::set_reuse_address_enabled(bool p_enabled) {}
+
+void MockNetSocket::set_reuse_port_enabled(bool p_enabled) {}
 
 Error MockNetSocket::join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
 	return OK;


### PR DESCRIPTION
Allows setting the `SO_REUSEADDR` and `SO_REUSEPORT` option on the underlying socket when using PacketPeerUDP.

See https://github.com/godotengine/godot-proposals/issues/13519 for details.

See it in action: https://github.com/not-my-username/UdpMulticastDiscoveryDemo