### PR TITLE
Improve visibility of separators in modern theme

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -175,7 +175,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_config.selection_color = p_config.accent_color * Color(1, 1, 1, 0.4);
 		p_config.disabled_border_color = p_config.mono_color.inverted().lerp(p_config.base_color, 0.7);
 		p_config.disabled_bg_color = p_config.mono_color.inverted().lerp(p_config.base_color, 0.9);
-		p_config.separator_color = p_config.dark_theme ? Color(0, 0, 0, 0.3) : Color(0, 0, 0, 0.1);
+		p_config.separator_color = p_config.dark_theme ? Color(0, 0, 0, 0.4) : Color(0, 0, 0, 0.2);
 
 		p_theme->set_color("selection_color", EditorStringName(Editor), p_config.selection_color);
 		p_theme->set_color("disabled_border_color", EditorStringName(Editor), p_config.disabled_border_color);
@@ -991,7 +991,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 			p_theme->set_stylebox(SceneStringName(hover), "PopupMenu", p_config.flat_button_hover);
 
-			Ref<StyleBoxLine> style_popup_separator = EditorThemeManager::make_line_stylebox(Color(0, 0, 0, p_config.dark_theme ? 0.2 : 0.1), Math::round(2 * EDSCALE), p_config.base_margin * -1.5 * EDSCALE, p_config.base_margin * -1.5 * EDSCALE);
+			Ref<StyleBoxLine> style_popup_separator = EditorThemeManager::make_line_stylebox(p_config.mono_color * Color(1, 1, 1, p_config.dark_theme ? 0.075 : 0.125), Math::round(2 * EDSCALE), p_config.base_margin * -2 * EDSCALE, p_config.base_margin * -2 * EDSCALE);
 
 			p_theme->set_stylebox("separator", "PopupMenu", style_popup_separator);
 			p_theme->set_stylebox("labeled_separator_left", "PopupMenu", style_popup_separator);


### PR DESCRIPTION
Tweaks to separator colors to help address https://github.com/godotengine/godot/issues/112258#issuecomment-3477637754.

Separators in popup menus now use the opposite color to the popup background and the contrast of regular separators is slighly increased

| Master | PR |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/a890516c-7feb-40e1-89c5-9df9151b1a23) | ![2](https://github.com/user-attachments/assets/4c7ca4ab-ac85-4055-8dfa-f96ce1022915) |
| ![3](https://github.com/user-attachments/assets/df99035a-7e26-4f35-b94d-fb5909ce8a65) | ![4](https://github.com/user-attachments/assets/89546a65-df4a-4248-952d-0307ee7c5628) | 





