### PR TITLE
Add bracket pair colorization for GDScriptSyntaxHighlighter

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1675,6 +1675,9 @@
 		<member name="text_editor/theme/highlighting/gdscript/annotation_color" type="Color" setter="" getter="">
 			The GDScript syntax highlighter text color for annotations (e.g. [code]@export[/code]).
 		</member>
+		<member name="text_editor/theme/highlighting/gdscript/bracket_pair_colors" type="PackedColorArray" setter="" getter="">
+			The list of colors to use to color each pair of brackets. The color for a bracket pair is determined by its nesting level. The first color in the array is used for the outermost level, the second for the first nested level, and so on. If the nesting level exceeds the number of colors in the array, the colors will repeat from the beginning. An empty array disables this feature.
+		</member>
 		<member name="text_editor/theme/highlighting/gdscript/function_definition_color" type="Color" setter="" getter="">
 			The GDScript syntax highlighter text color for function definitions (e.g. the [code]_ready[/code] in [code]func _ready():[/code]).
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -753,6 +753,15 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/theme/highlighting/comment_markers/warning_list", "BUG,DEPRECATED,FIXME,HACK,TASK,TBD,TODO,WARNING");
 	_initial_set("text_editor/theme/highlighting/comment_markers/notice_list", "INFO,NOTE,NOTICE,TEST,TESTING");
 
+	PackedColorArray bracket_pair_colors_defaults;
+
+	bracket_pair_colors_defaults.push_back(Color::from_ok_hsl(252.5 / 360.0, 0.65, 0.7));
+	bracket_pair_colors_defaults.push_back(Color::from_ok_hsl(200.0 / 360.0, 0.65, 0.7));
+	bracket_pair_colors_defaults.push_back(Color::from_ok_hsl(337.5 / 360.0, 0.65, 0.7));
+	bracket_pair_colors_defaults.push_back(Color::from_ok_hsl(115.0 / 360.0, 0.65, 0.7));
+
+	EDITOR_SETTING_BASIC(Variant::PACKED_COLOR_ARRAY, PROPERTY_HINT_NONE, "text_editor/theme/highlighting/gdscript/bracket_pair_colors", bracket_pair_colors_defaults, "")
+
 	// Appearance
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/appearance/enable_inline_color_picker", true, "");
 

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -76,6 +76,12 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 	int in_declaration_param_dicts = 0; // The number of opened `{` inside func params.
 	int in_type_params = 0; // The number of opened `[` after type name.
 
+	int bracket_level_round = 0;
+	int bracket_level_curly = 0;
+	int bracket_level_square = 0;
+
+	bool use_bracket_pair_colorization = !bracket_pair_colors.is_empty();
+
 	Color keyword_color;
 	Color color;
 
@@ -93,6 +99,24 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			get_line_syntax_highlighting(p_line - 1);
 		}
 		in_region = color_region_cache[p_line - 1];
+
+		if (use_bracket_pair_colorization) {
+			if (!bracket_level_cache.has(p_line - 1)) {
+				int prev_line = p_line - 1;
+				while (prev_line > 0 && !bracket_level_cache.has(prev_line)) {
+					prev_line--;
+				}
+
+				for (int i = prev_line; i < p_line; i++) {
+					get_line_syntax_highlighting(i);
+				}
+			}
+
+			const LocalVector<int> &prev_levels = bracket_level_cache[p_line - 1];
+			bracket_level_square = prev_levels[BRACKET_TYPE_SQUARE];
+			bracket_level_round = prev_levels[BRACKET_TYPE_ROUND];
+			bracket_level_curly = prev_levels[BRACKET_TYPE_CURLY];
+		}
 	}
 
 	const String &str = text_edit->get_line_with_ime(p_line);
@@ -704,6 +728,51 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			next_type = IDENTIFIER;
 		}
 
+		// Bracket pair colorization.
+		if (!bracket_pair_colors.is_empty()) {
+			int *level_ptr = nullptr;
+			bool is_opening_bracket = false;
+
+			switch (str[j]) {
+				case '(':
+					level_ptr = &bracket_level_round;
+					is_opening_bracket = true;
+					break;
+				case ')':
+					level_ptr = &bracket_level_round;
+					is_opening_bracket = false;
+					break;
+
+				case '[':
+					level_ptr = &bracket_level_square;
+					is_opening_bracket = true;
+					break;
+				case ']':
+					level_ptr = &bracket_level_square;
+					is_opening_bracket = false;
+					break;
+
+				case '{':
+					level_ptr = &bracket_level_curly;
+					is_opening_bracket = true;
+					break;
+				case '}':
+					level_ptr = &bracket_level_curly;
+					is_opening_bracket = false;
+					break;
+			}
+
+			if (level_ptr != nullptr) {
+				if (is_opening_bracket) {
+					color = bracket_pair_colors[*level_ptr % bracket_pair_colors.size()];
+					(*level_ptr)++;
+				} else {
+					*level_ptr = MAX(0, *level_ptr - 1);
+					color = bracket_pair_colors[*level_ptr % bracket_pair_colors.size()];
+				}
+			}
+		}
+
 		if (next_type != current_type) {
 			if (current_type == NONE) {
 				current_type = next_type;
@@ -737,6 +806,15 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			color_map[j] = highlighter_info;
 		}
 	}
+
+	LocalVector<int> final_levels;
+	final_levels.resize(BRACKET_TYPE_MAX);
+	final_levels[BRACKET_TYPE_ROUND] = bracket_level_round;
+	final_levels[BRACKET_TYPE_CURLY] = bracket_level_curly;
+	final_levels[BRACKET_TYPE_SQUARE] = bracket_level_square;
+
+	bracket_level_cache[p_line] = final_levels;
+
 	return color_map;
 }
 
@@ -960,6 +1038,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	annotation_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/annotation_color");
 	string_name_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/string_name_color");
 	type_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
+	bracket_pair_colors = EDITOR_GET("text_editor/theme/highlighting/gdscript/bracket_pair_colors");
 	comment_marker_colors[COMMENT_MARKER_CRITICAL] = EDITOR_GET("text_editor/theme/highlighting/comment_markers/critical_color");
 	comment_marker_colors[COMMENT_MARKER_WARNING] = EDITOR_GET("text_editor/theme/highlighting/comment_markers/warning_color");
 	comment_marker_colors[COMMENT_MARKER_NOTICE] = EDITOR_GET("text_editor/theme/highlighting/comment_markers/notice_color");
@@ -1008,6 +1087,10 @@ void GDScriptSyntaxHighlighter::add_color_region(ColorRegion::Type p_type, const
 	color_region.is_comment = p_type == ColorRegion::TYPE_COMMENT || p_type == ColorRegion::TYPE_CODE_REGION;
 	color_regions.insert(at, color_region);
 	clear_highlighting_cache();
+}
+
+void GDScriptSyntaxHighlighter::_clear_highlighting_cache() {
+	bracket_level_cache.clear();
 }
 
 Ref<EditorSyntaxHighlighter> GDScriptSyntaxHighlighter::_create() const {

--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -79,6 +79,13 @@ private:
 		TYPE,
 	};
 
+	enum BracketType {
+		BRACKET_TYPE_ROUND,
+		BRACKET_TYPE_CURLY,
+		BRACKET_TYPE_SQUARE,
+		BRACKET_TYPE_MAX,
+	};
+
 	// Colors.
 	Color font_color;
 	Color symbol_color;
@@ -96,6 +103,8 @@ private:
 	Color string_name_color;
 	Color type_color;
 
+	PackedColorArray bracket_pair_colors;
+
 	enum CommentMarkerLevel {
 		COMMENT_MARKER_CRITICAL,
 		COMMENT_MARKER_WARNING,
@@ -105,7 +114,12 @@ private:
 	Color comment_marker_colors[COMMENT_MARKER_MAX];
 	HashMap<String, CommentMarkerLevel> comment_markers;
 
+	HashMap<int, LocalVector<int>> bracket_level_cache;
+
 	void add_color_region(ColorRegion::Type p_type, const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only = false, bool p_r_prefix = false);
+
+protected:
+	virtual void _clear_highlighting_cache() override;
 
 public:
 	virtual void _update_cache() override;


### PR DESCRIPTION
EDIT:Fixes godotengine/godot-proposals#4728
This PR Assigns cycling colors to nested pairs of `()`, `[]`, and `{}` to improve code readability.
