### PR TITLE
Add a style option button to quick settings

### DIFF
--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -47,6 +47,7 @@ void QuickSettingsDialog::_fetch_setting_values() {
 #ifndef ANDROID_ENABLED
 	editor_languages.clear();
 #endif
+	editor_styles.clear();
 	editor_themes.clear();
 	editor_scales.clear();
 	editor_network_modes.clear();
@@ -62,6 +63,8 @@ void QuickSettingsDialog::_fetch_setting_values() {
 #ifndef ANDROID_ENABLED
 				editor_languages = pi.hint_string.split(";", false);
 #endif
+			} else if (pi.name == "interface/theme/style") {
+				editor_styles = pi.hint_string.split(",");
 			} else if (pi.name == "interface/theme/color_preset") {
 				editor_themes = pi.hint_string.split(",");
 			} else if (pi.name == "interface/editor/display_scale") {
@@ -93,6 +96,17 @@ void QuickSettingsDialog::_update_current_values() {
 		}
 	}
 #endif
+	// Style options.
+	{
+		const String current_style = EDITOR_GET("interface/theme/style");
+
+		for (int i = 0; i < editor_styles.size(); i++) {
+			const String &style_value = editor_styles[i];
+			if (current_style == style_value) {
+				style_option_button->select(i);
+			}
+		}
+	}
 
 	// Theme options.
 	{
@@ -184,6 +198,11 @@ void QuickSettingsDialog::_language_selected(int p_id) {
 	_set_setting_value("interface/editor/editor_language", selected_language);
 }
 #endif
+
+void QuickSettingsDialog::_style_selected(int p_id) {
+	const String selected_style = style_option_button->get_item_text(p_id);
+	_set_setting_value("interface/theme/style", selected_style);
+}
 
 void QuickSettingsDialog::_theme_selected(int p_id) {
 	const String selected_theme = theme_option_button->get_item_text(p_id);
@@ -316,6 +335,19 @@ QuickSettingsDialog::QuickSettingsDialog() {
 			_add_setting_control(TTRC("Language"), language_option_button);
 		}
 #endif
+		// Style options.
+		{
+			style_option_button = memnew(OptionButton);
+			style_option_button->set_fit_to_longest_item(false);
+			style_option_button->connect(SceneStringName(item_selected), callable_mp(this, &QuickSettingsDialog::_style_selected));
+
+			for (int i = 0; i < editor_styles.size(); i++) {
+				const String &style_value = editor_styles[i];
+				style_option_button->add_item(style_value, i);
+			}
+
+			_add_setting_control(TTRC("Style"), style_option_button);
+		}
 
 		// Theme options.
 		{

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -46,6 +46,7 @@ class QuickSettingsDialog : public AcceptDialog {
 #ifndef ANDROID_ENABLED
 	Vector<String> editor_languages;
 #endif
+	Vector<String> editor_styles;
 	Vector<String> editor_themes;
 	Vector<String> editor_scales;
 	Vector<String> editor_network_modes;
@@ -65,6 +66,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	// Also, the dropdown it spawns is very tall and can't be scrolled without a hardware mouse.
 	OptionButton *language_option_button = nullptr;
 #endif
+	OptionButton *style_option_button = nullptr;
 	OptionButton *theme_option_button = nullptr;
 	OptionButton *scale_option_button = nullptr;
 	OptionButton *network_mode_option_button = nullptr;
@@ -77,6 +79,7 @@ class QuickSettingsDialog : public AcceptDialog {
 #ifndef ANDROID_ENABLED
 	void _language_selected(int p_id);
 #endif
+	void _style_selected(int p_id);
 	void _theme_selected(int p_id);
 	void _scale_selected(int p_id);
 	void _network_mode_selected(int p_id);


### PR DESCRIPTION
I think this is a good option to provide in quick settings + developers can easily check a difference in style of project manager (without entering to an editor to change it via editor settings).


![style](https://github.com/user-attachments/assets/ad64a2d6-07a8-4887-aeb3-1be079f887ee)
