### PR TITLE
Make editor language setting default to Auto

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -96,6 +96,12 @@
 				Returns the edited (current) scene's root [Node].
 			</description>
 		</method>
+		<method name="get_editor_language" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the language currently used for the editor interface.
+			</description>
+		</method>
 		<method name="get_editor_main_screen" qualifiers="const">
 			<return type="VBoxContainer" />
 			<description>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -880,7 +880,7 @@
 			During a drag-and-drop, this is how long to wait over a UI element before it triggers a reaction (e.g. a section unfolds to show nested items).
 		</member>
 		<member name="interface/editor/editor_language" type="String" setter="" getter="">
-			The language to use for the editor interface.
+			The language to use for the editor interface. If set to [b]Auto[/b], the language is automatically determined based on the system locale. See also [method EditorInterface.get_editor_language].
 			Translations are provided by the community. If you spot a mistake, [url=https://contributing.godotengine.org/en/latest/documentation/translation/index.html]contribute to editor translations on Weblate![/url]
 		</member>
 		<member name="interface/editor/editor_screen" type="int" setter="" getter="">

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -442,6 +442,10 @@ float EditorInterface::get_editor_scale() const {
 	return EDSCALE;
 }
 
+String EditorInterface::get_editor_language() const {
+	return EditorSettings::get_singleton()->get_language();
+}
+
 bool EditorInterface::is_node_3d_snap_enabled() const {
 	return Node3DEditor::get_singleton()->is_snap_enabled();
 }
@@ -846,6 +850,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_multi_window_enabled"), &EditorInterface::is_multi_window_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
+	ClassDB::bind_method(D_METHOD("get_editor_language"), &EditorInterface::get_editor_language);
 
 	ClassDB::bind_method(D_METHOD("is_node_3d_snap_enabled"), &EditorInterface::is_node_3d_snap_enabled);
 	ClassDB::bind_method(D_METHOD("get_node_3d_translate_snap"), &EditorInterface::get_node_3d_translate_snap);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -131,6 +131,7 @@ public:
 	bool is_multi_window_enabled() const;
 
 	float get_editor_scale() const;
+	String get_editor_language() const;
 
 	bool is_node_3d_snap_enabled() const;
 	real_t get_node_3d_translate_snap() const;

--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -59,7 +59,7 @@ EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_tooltip_styl
 }
 
 bool EditorPropertyNameProcessor::is_localization_available() {
-	return EditorSettings::get_singleton() && EDITOR_GET("interface/editor/editor_language") != "en";
+	return EditorSettings::get_singleton() && EditorSettings::get_singleton()->get_language() != "en";
 }
 
 String EditorPropertyNameProcessor::_capitalize_name(const String &p_name) const {

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -89,6 +89,7 @@ private:
 	static Ref<EditorSettings> singleton;
 
 	HashSet<String> changed_settings;
+	mutable String auto_language;
 
 	mutable Ref<ConfigFile> project_metadata;
 	HashMap<String, PropertyInfo> hints;
@@ -186,6 +187,7 @@ public:
 	Vector<String> get_script_templates(const String &p_extension, const String &p_custom_path = String());
 	String get_editor_layouts_config() const;
 	static float get_auto_display_scale();
+	String get_language() const;
 
 	void _add_shortcut_default(const String &p_name, const Ref<Shortcut> &p_shortcut);
 	void add_shortcut(const String &p_name, const Ref<Shortcut> &p_shortcut);

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -41,7 +41,7 @@ namespace GodotTools.Build
             startInfo.UseShellExecute = false;
             startInfo.CreateNoWindow = true;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
-                = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
+                = ((string)EditorInterface.Singleton.GetEditorLanguage()).Replace('_', '-');
 
             if (OperatingSystem.IsWindows())
             {
@@ -111,7 +111,7 @@ namespace GodotTools.Build
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
-                = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
+                = ((string)EditorInterface.Singleton.GetEditorLanguage()).Replace('_', '-');
 
             if (OperatingSystem.IsWindows())
             {


### PR DESCRIPTION
Currently, `interface/editor/editor_language` defaults to the system language. This creates the problem that it's technically impossible to pin a language, as the setting is not saved when being same as the default value.

You can use the following steps to reproduce the problem.

> [!WARNING]
> Don't use Project Manager's quick settings dialog when testing the problem. It somehow saves _all_ properties it sees on `EditorSettings`, including those that are not meant to be saved :(

1. Run Godot with `LANG=es` for the first time
    - It displays in Spanish, which is expected
    - Now I want to always run the editor in French, I set the editor setting to `fr`
        - `interface/editor/editor_language = "fr"` setting is saved.
2. Run Godot with `LANG=es` again
    - It displays French, which is expected
3. Run Godot with `LANG=fr`
    - It displays French, which is expected
4. Run Godot with `LANG=es` again
    - It displays in Spanish, unexpected
        - `interface/editor/editor_language = "fr"` setting is removed in the third run


This PR adds a dedicated `Auto` option as the default value.

Tool scripts can use `EditorInterface.get_editor_language()` to get the effective language instead of reading `interface/editor/editor_language`.