### PR TITLE
Restore tab highlighting

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -709,6 +709,9 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		Ref<StyleBoxFlat> style_tab_selected = p_config.base_style->duplicate();
 		style_tab_selected->set_content_margin_individual(p_config.base_margin * 4 * EDSCALE, p_config.base_margin * 2.1 * EDSCALE, p_config.base_margin * 4 * EDSCALE, p_config.base_margin * 2.1 * EDSCALE);
 		style_tab_selected->set_corner_radius_individual(p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE, 0, 0);
+		style_tab_selected->set_border_width(SIDE_TOP, Math::ceil(EDSCALE));
+		Color tab_highlight = p_config.dark_color_2.lerp(p_config.accent_color, 0.75);
+		style_tab_selected->set_border_color(tab_highlight);
 
 		Ref<StyleBoxFlat> style_tab_focus = style_tab_selected->duplicate();
 		style_tab_focus->set_bg_color(p_config.base_color);


### PR DESCRIPTION
~~closes #112323~~

This PR returns the tab highlighting, but in a more understated fashion compared to the original theme, ensuring the aesthetic aligns with the new theme.

|Before|After|
|----------|----------|
|<img width="480" height="252" alt="editor_screenshot_2025-11-02T115803" src="https://github.com/user-attachments/assets/d821d9bf-9337-4859-9cae-e7d36d699786" />|<img width="480" height="252" alt="editor_screenshot_2025-11-02T121638" src="https://github.com/user-attachments/assets/e34bb838-5a19-485a-b28c-56f494c10ad2" />|

|Classic|Modern|
|-----------|-----------|
|<img width="480" height="252" alt="editor_screenshot_2025-11-02T120033" src="https://github.com/user-attachments/assets/acf80cfc-99c0-474d-9d0e-99bc0a6b4c5f" />|<img width="480" height="252" alt="editor_screenshot_2025-11-02T121638" src="https://github.com/user-attachments/assets/e34bb838-5a19-485a-b28c-56f494c10ad2" />|

**Note: This [PR](https://github.com/godotengine/godot/pull/112350) has already solved the issue of poor tab visibility, but this PR can still be relevant purely as an aesthetic change. If the majority of people are already satisfied with the current appearance of the modern theme, we can close this.**