### PR TITLE
Improve the appearance of material thumbnails

### DIFF
--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -38,6 +38,7 @@
 #include "editor/file_system/editor_paths.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/resources/3d/sky_material.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/bit_map.h"
 #include "scene/resources/font.h"
@@ -367,6 +368,9 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
 	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
+	// Use 4× MSAA and 4× SSAA to avoid aliasing on edges and improve texture quality, which helps with thumbnail recognition.
+	RS::get_singleton()->viewport_set_msaa_3d(viewport, RSE::VIEWPORT_MSAA_4X);
+	RS::get_singleton()->viewport_set_scaling_3d_scale(viewport, 2.0f);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
 
@@ -375,10 +379,21 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	RS::get_singleton()->camera_set_transform(camera, Transform3D(Basis(), Vector3(0, 0, 3)));
 	RS::get_singleton()->camera_set_perspective(camera, 45, 0.1, 10);
 
+	sky = RS::get_singleton()->sky_create();
+	sky_material.instantiate();
+	RS::get_singleton()->sky_set_radiance_size(sky, 128);
+	RS::get_singleton()->sky_set_material(sky, sky_material->get_rid());
+
+	environment = RS::get_singleton()->environment_create();
+	RS::get_singleton()->environment_set_background(environment, RSE::ENV_BG_SKY);
+	RS::get_singleton()->environment_set_sky(environment, sky);
+	RS::get_singleton()->camera_set_environment(camera, environment);
+
 	if (GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
 		camera_attributes = RS::get_singleton()->camera_attributes_create();
 		RS::get_singleton()->camera_attributes_set_exposure(camera_attributes, 1.0, 0.000032552); // Matches default CameraAttributesPhysical to work well with default DirectionalLight3Ds.
 		RS::get_singleton()->camera_set_camera_attributes(camera, camera_attributes);
+		RS::get_singleton()->environment_set_bg_energy(environment, 1.0f, 30000.0f);
 	}
 
 	light = RS::get_singleton()->directional_light_create();
@@ -387,7 +402,6 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 
 	light2 = RS::get_singleton()->directional_light_create();
 	RS::get_singleton()->light_set_color(light2, Color(0.7, 0.7, 0.7));
-	//RS::get_singleton()->light_set_color(light2, Color(0.7, 0.7, 0.7));
 
 	light_instance2 = RS::get_singleton()->instance_create2(light2, scenario);
 
@@ -396,7 +410,7 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	sphere = RS::get_singleton()->mesh_create();
 	sphere_instance = RS::get_singleton()->instance_create2(sphere, scenario);
 
-	int lats = 32;
+	int lats = 16;
 	int lons = 32;
 	const double lat_step = Math::PI / lats;
 	const double lon_step = Math::TAU / lons;
@@ -487,6 +501,8 @@ EditorMaterialPreviewPlugin::~EditorMaterialPreviewPlugin() {
 	RS::get_singleton()->free_rid(camera);
 	RS::get_singleton()->free_rid(camera_attributes);
 	RS::get_singleton()->free_rid(scenario);
+	RS::get_singleton()->free_rid(sky);
+	RS::get_singleton()->free_rid(environment);
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/editor/inspector/editor_preview_plugins.h
+++ b/editor/inspector/editor_preview_plugins.h
@@ -34,6 +34,7 @@
 #include "editor/inspector/editor_resource_preview.h"
 
 class ScriptLanguage;
+class ProceduralSkyMaterial;
 
 void post_process_preview(Ref<Image> p_image);
 
@@ -87,6 +88,9 @@ class EditorMaterialPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID light_instance2;
 	RID camera;
 	RID camera_attributes;
+	RID environment;
+	RID sky;
+	Ref<ProceduralSkyMaterial> sky_material;
 	mutable DrawRequester draw_requester;
 
 public:


### PR DESCRIPTION
Depends on #112046

Adds a simple environment and applies 4x MSAA for material thumbnail generation. This improves their appearance, especially when the materials are reflective or metallic.

Comparison:
| Before | After |
|--------|-------|
| <img width="130" height="142" alt="old" src="https://github.com/user-attachments/assets/f594b986-2ca1-4c7c-9c5a-e4fabac8944c" /> | <img width="133" height="151" alt="new" src="https://github.com/user-attachments/assets/f0e56e4c-1074-4379-b935-7e70cdbfec45" />|
| <img width="133" height="150" alt="met_old" src="https://github.com/user-attachments/assets/0e45fca4-0f07-40dd-a596-fb137b6e195b" /> | <img width="131" height="147" alt="met_new" src="https://github.com/user-attachments/assets/16e6c5a8-d30f-491b-9692-706225ae10a4" />|

TODO:
- [x] Measure the performance difference