### PR TITLE
Add GridMap item categories

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -32,6 +32,13 @@
 				Returns the first item with the given name, or [code]-1[/code] if no item is found.
 			</description>
 		</method>
+		<method name="get_item_category" qualifiers="const">
+			<return type="StringName" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns the item category for a specific item [param id]. See also [method set_item_category].
+			</description>
+		</method>
 		<method name="get_item_list" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<description>
@@ -113,6 +120,14 @@
 			<param index="0" name="id" type="int" />
 			<description>
 				Removes the item.
+			</description>
+		</method>
+		<method name="set_item_category">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="category" type="StringName" />
+			<description>
+				Sets the [param category] for a specific item [param id]. A category string can include "/" as a delimiter to create sub categories for the category tree view.
 			</description>
 		</method>
 		<method name="set_item_mesh">

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -140,6 +140,14 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 		item_id = p_library->get_last_unused_item_id();
 		p_library->create_item(item_id);
 		p_library->set_item_name(item_id, mesh_instance_node->get_name());
+
+		// Try to decipher some Node meta Variant data that can potentially be exported as item meta.
+		Variant _variant = mesh_instance_node->get_meta(SNAME("category"), StringName());
+		StringName category = _variant;
+		if (category) {
+			p_library->set_item_category(item_id, category);
+		}
+
 	} else if (!p_merge) {
 		WARN_PRINT(vformat("MeshLibrary export found a MeshInstance3D with a duplicated name '%s' in the exported scene that overrides a previously parsed MeshInstance3D item with the same name.", mesh_instance_node->get_name()));
 	}

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -34,9 +34,6 @@
 
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/item_list.h"
-#include "scene/gui/slider.h"
-#include "scene/gui/spin_box.h"
 
 class ConfirmationDialog;
 class MenuButton;
@@ -44,6 +41,13 @@ class Node3DEditorPlugin;
 class ButtonGroup;
 class EditorZoomWidget;
 class BaseButton;
+class CheckBox;
+class HSlider;
+class ItemList;
+class LineEdit;
+class SpinBox;
+class Tree;
+class TreeItem;
 
 class GridMapEditor : public VBoxContainer {
 	GDCLASS(GridMapEditor, VBoxContainer);
@@ -210,6 +214,9 @@ class GridMapEditor : public VBoxContainer {
 		RID instance;
 	};
 
+	VBoxContainer *item_palette_container = nullptr;
+	Tree *item_tree = nullptr;
+
 	ItemList *mesh_library_palette = nullptr;
 	Label *info_message = nullptr;
 
@@ -253,6 +260,16 @@ class GridMapEditor : public VBoxContainer {
 	bool do_input_action(Camera3D *p_camera, const Point2 &p_point, bool p_click);
 
 	friend class GridMapEditorPlugin;
+
+	struct ItemCategoryMapping {
+		AHashMap<StringName, HashSet<StringName>> category_to_category_children;
+		AHashMap<StringName, HashSet<int>> category_to_items;
+	};
+
+	void _on_item_tree_item_activated();
+
+	void _rebuild_item_tree();
+	void _add_child_categories_recursive(Tree *p_item_tree, TreeItem *p_ti_parent, const StringName &p_category, const ItemCategoryMapping &p_mapping);
 
 protected:
 	void _notification(int p_what);

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -45,6 +45,8 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 
 		if (what == "name") {
 			set_item_name(idx, p_value);
+		} else if (what == "category") {
+			set_item_category(idx, p_value);
 		} else if (what == "mesh") {
 			set_item_mesh(idx, p_value);
 		} else if (what == "mesh_transform") {
@@ -109,6 +111,8 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 
 	if (what == "name") {
 		r_ret = get_item_name(idx);
+	} else if (what == "category") {
+		r_ret = get_item_category(idx);
 	} else if (what == "mesh") {
 		r_ret = get_item_mesh(idx);
 	} else if (what == "mesh_transform") {
@@ -144,6 +148,7 @@ void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const KeyValue<int, Item> &E : item_map) {
 		String prop_name = vformat("%s/%d/", PNAME("item"), E.key);
 		p_list->push_back(PropertyInfo(Variant::STRING, prop_name + PNAME("name")));
+		p_list->push_back(PropertyInfo(Variant::STRING_NAME, prop_name + PNAME("category")));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, "Mesh"));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
 		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("mesh_cast_shadow"), PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"));
@@ -166,6 +171,12 @@ void MeshLibrary::create_item(int p_item) {
 void MeshLibrary::set_item_name(int p_item, const String &p_name) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].name = p_name;
+	emit_changed();
+}
+
+void MeshLibrary::set_item_category(int p_item, const StringName &p_category) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].category = p_category;
 	emit_changed();
 }
 
@@ -223,6 +234,11 @@ void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) 
 String MeshLibrary::get_item_name(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), "", "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].name;
+}
+
+StringName MeshLibrary::get_item_category(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), StringName(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].category;
 }
 
 Ref<Mesh> MeshLibrary::get_item_mesh(int p_item) const {
@@ -370,6 +386,7 @@ void MeshLibrary::reset_state() {
 void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_item", "id"), &MeshLibrary::create_item);
 	ClassDB::bind_method(D_METHOD("set_item_name", "id", "name"), &MeshLibrary::set_item_name);
+	ClassDB::bind_method(D_METHOD("set_item_category", "id", "category"), &MeshLibrary::set_item_category);
 	ClassDB::bind_method(D_METHOD("set_item_mesh", "id", "mesh"), &MeshLibrary::set_item_mesh);
 	ClassDB::bind_method(D_METHOD("set_item_mesh_transform", "id", "mesh_transform"), &MeshLibrary::set_item_mesh_transform);
 	ClassDB::bind_method(D_METHOD("set_item_mesh_cast_shadow", "id", "shadow_casting_setting"), &MeshLibrary::set_item_mesh_cast_shadow);
@@ -381,6 +398,7 @@ void MeshLibrary::_bind_methods() {
 #endif // PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
 	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
+	ClassDB::bind_method(D_METHOD("get_item_category", "id"), &MeshLibrary::get_item_category);
 	ClassDB::bind_method(D_METHOD("get_item_mesh", "id"), &MeshLibrary::get_item_mesh);
 	ClassDB::bind_method(D_METHOD("get_item_mesh_transform", "id"), &MeshLibrary::get_item_mesh_transform);
 	ClassDB::bind_method(D_METHOD("get_item_mesh_cast_shadow", "id"), &MeshLibrary::get_item_mesh_cast_shadow);

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -53,6 +53,7 @@ public:
 #endif // PHYSICS_3D_DISABLED
 	struct Item {
 		String name;
+		StringName category;
 		Ref<Mesh> mesh;
 		Transform3D mesh_transform;
 		RS::ShadowCastingSetting mesh_cast_shadow = RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON;
@@ -83,6 +84,7 @@ protected:
 public:
 	void create_item(int p_item);
 	void set_item_name(int p_item, const String &p_name);
+	void set_item_category(int p_item, const StringName &p_category);
 	void set_item_mesh(int p_item, const Ref<Mesh> &p_mesh);
 	void set_item_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_mesh_cast_shadow(int p_item, RS::ShadowCastingSetting p_shadow_casting_setting);
@@ -94,6 +96,7 @@ public:
 #endif // PHYSICS_3D_DISABLED
 	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
 	String get_item_name(int p_item) const;
+	StringName get_item_category(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Transform3D get_item_mesh_transform(int p_item) const;
 	RS::ShadowCastingSetting get_item_mesh_cast_shadow(int p_item) const;


### PR DESCRIPTION
Adds GridMap item categories and category tree view.

<img width="840" height="380" alt="gridmap_categories" src="https://github.com/user-attachments/assets/44239e5d-35f7-4bb2-9ac0-da0bc8426d15" />

### How does it work?

`MeshLibrary` has a new item property `category` and related setgets `set_item_category(`) and `get_item_category().`

<img width="454" height="124" alt="category_prop" src="https://github.com/user-attachments/assets/5414e024-bdc5-4780-9b19-fef028ff949a" />

This string is used to create the new category tree view.

If the value is left empty (default) the item will be added to the default "All" tree root item.

A category string can include "`/`" as a delimiter. This delimiter splits the string and turns the splits into tree sub categories.

For a quick overview how many items exist in a category the number of the available items in each category is shown to the right of the item tree view in the secondary column.

The search box was updated to filter for both item names and item categories.

### MeshLibrary  scene exporter

The MeshLibrary scene exporter now reads the node metadata of each exported `MeshInstance3D` node.

<img width="469" height="94" alt="node_metadata" src="https://github.com/user-attachments/assets/377ff8e5-2435-4b45-8597-1d8b846c1283" />

If it finds a `category` key with String(Name) value this string will be added as the category for the exported item.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
