### PR TITLE
Fix FileAccess::open returning valid FileAccess when opening a pack file fails

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -160,19 +160,24 @@ Error FileAccess::reopen(const String &p_path, int p_mode_flags) {
 Ref<FileAccess> FileAccess::open(const String &p_path, int p_mode_flags, Error *r_error) {
 	//try packed data first
 
+	Error err = OK;
 	Ref<FileAccess> ret;
 	if (!(p_mode_flags & WRITE) && !(p_mode_flags & SKIP_PACK) && PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled()) {
 		ret = PackedData::get_singleton()->try_open_path(p_path);
 		if (ret.is_valid()) {
+			err = ret->get_error();
 			if (r_error) {
-				*r_error = OK;
+				*r_error = err;
+			}
+			if (err != OK) {
+				ret.unref();
 			}
 			return ret;
 		}
 	}
 
 	ret = create_for_path(p_path);
-	Error err = ret->open_internal(p_path, p_mode_flags & ~SKIP_PACK);
+	err = ret->open_internal(p_path, p_mode_flags & ~SKIP_PACK);
 
 	if (r_error) {
 		*r_error = err;

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -501,7 +501,11 @@ void FileAccessPack::set_big_endian(bool p_big_endian) {
 }
 
 Error FileAccessPack::get_error() const {
-	if (eof) {
+	if (encryption_error) {
+		return encryption_error;
+	} else if (f.is_null()) {
+		return ERR_FILE_CANT_OPEN;
+	} else if (eof) {
 		return ERR_FILE_EOF;
 	}
 	return OK;
@@ -572,8 +576,8 @@ FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFil
 			memcpy(key.ptrw(), script_encryption_key, 32);
 		}
 
-		Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
-		ERR_FAIL_COND_MSG(err != OK, vformat(R"(Can't open encrypted pack-referenced file "%s" from pack "%s" due to error "%s".)", p_path, pf.pack, error_names[err]));
+		encryption_error = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
+		ERR_FAIL_COND_MSG(encryption_error, vformat(R"(Can't open encrypted pack-referenced file "%s" from pack "%s" due to error "%s".)", p_path, pf.pack, error_names[encryption_error]));
 		f = fae;
 		off = 0;
 	}

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -186,6 +186,7 @@ class FileAccessPack : public FileAccess {
 	String path;
 	mutable uint64_t pos;
 	mutable bool eof;
+	Error encryption_error = OK;
 	uint64_t off;
 
 	Ref<FileAccess> f;


### PR DESCRIPTION
FileAccess::open currently returns valid FileAccess files if the packed file has an error while opening (e.g. if the encrypted file fails to be decrypted) because it is currently not checking `get_error()` before returning. With FileAccessPack in particular, this can lead to buffer overreads due to reading parts of the PCK that aren't valid data.

This changes FileAccessPack to return valid errors with `get_error()` if there were errors opening the file, and changes `FileAccess::open` to check `get_error()` before returning.