### PR TITLE
Fix transparent panel in Tilset polygon editor using Classic theme

### DIFF
--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -2295,5 +2295,8 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_theme->set_color("playback_color", "GraphStateMachine", p_config.font_color);
 			p_theme->set_color("playback_background_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
 		}
+
+		// TileSet editor.
+		p_theme->set_stylebox("expand_panel", "TileSetEditor", p_config.tree_panel_style);
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/112326


Before:

<img width="1975" height="543" alt="Screenshot_20251102_234531" src="https://github.com/user-attachments/assets/e13e09fd-c5a7-48e3-a376-986a2ce85bfc" />


After:

<img width="1975" height="543" alt="Screenshot_20251103_000202" src="https://github.com/user-attachments/assets/9ceec85b-151a-4cd3-83e8-ed231fcfa389" />


4.6.Dev2:

<img width="1975" height="543" alt="Screenshot_20251102_234318" src="https://github.com/user-attachments/assets/c2ef9295-dad8-4702-a3f7-fa2081011701" />