### PR TITLE
Fix cannot edit property material for new Instance PackedScene

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -641,8 +641,12 @@ String EditorResourcePicker::_get_owner_path() const {
 
 	Node *node = Object::cast_to<Node>(obj);
 	if (node) {
+		Node *p_edited_scene_root = EditorNode::get_singleton()->get_editor_data().get_edited_scene_root();
 		if (node->get_scene_file_path().is_empty()) {
 			node = node->get_owner();
+		} else if (p_edited_scene_root != nullptr && p_edited_scene_root->get_scene_file_path() != node->get_scene_file_path()) {
+			// PackedScene should use root scene path.
+			return p_edited_scene_root->get_scene_file_path();
 		}
 		if (node) {
 			return node->get_scene_file_path();


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/112013*

## Issue Description

When we create a new instance `PackedScene`, then create a new Material for this embedded node. The properties of the new material will all read-only, until we save and reopen the scene.

The reason is `EditorResourcePicker` try to get scene_path from node to locate the resource of material. But embedded node returns its own scene_path, which is different from root scene_path.

https://github.com/godotengine/godot/blob/0fdbf050e0c7fc7e0a9d42c2a41ee3bfdffbd8f1/editor/inspector/editor_resource_picker.cpp#L643-L646

The inspector determines we cannot edit embedded scene's property, then mark them as read-only. After saving and reopening scene, the relevant scene path will be corrected, so we can edit these properties.

https://github.com/godotengine/godot/blob/0fdbf050e0c7fc7e0a9d42c2a41ee3bfdffbd8f1/editor/inspector/editor_inspector.cpp#L3886

## Solution

We can use the root scene path of editing scene, when current node path is different.

[material.webm](https://github.com/user-attachments/assets/196422ee-72e6-4214-8e40-8452ef863cb8)
