### PR TITLE
Fix crash for classes without an icon

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -471,6 +471,10 @@ void EditorHelp::_add_type(const String &p_type, const String &p_enum, bool p_is
 
 void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &p_fallback) {
 	Ref<Texture2D> icon = EditorNode::get_singleton()->get_class_icon(p_type, p_fallback);
+	if (icon.is_null()) {
+		icon = EditorNode::get_singleton()->get_class_icon("Object");
+		ERR_FAIL_COND(icon.is_null());
+	}
 	Vector2i size = Vector2i(icon->get_width(), icon->get_height());
 	if (p_size > 0) {
 		// Ensures icon scales proportionally on both axes, based on icon height.


### PR DESCRIPTION
Fixes #112304 
The editor would crash due to a null pointer dereference in EditorHelp::_add_type_icon when trying to display the help page for a class that does not have a registered icon (e.g., internal types like `@GlobalScope`).

This PR adds null check to ``EditorHelp::_add_type_icon``