### PR TITLE
Scene Dock: Simplify Filter Nodes related UI

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1729,11 +1729,6 @@ void SceneTreeDock::_notification(int p_what) {
 
 			filter->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 
-			PopupMenu *filter_menu = filter->get_menu();
-			filter_menu->set_item_icon(filter_menu->get_item_idx_from_text(TTR("Filters")), get_editor_theme_icon(SNAME("Search")));
-			filter_menu->set_item_icon(filter_menu->get_item_index(FILTER_BY_TYPE), get_editor_theme_icon(SNAME("Node")));
-			filter_menu->set_item_icon(filter_menu->get_item_index(FILTER_BY_GROUP), get_editor_theme_icon(SNAME("Groups")));
-
 			// These buttons are created on READY, because reasons...
 			if (button_2d) {
 				button_2d->set_button_icon(get_editor_theme_icon(SNAME("Node2D")));
@@ -4028,9 +4023,6 @@ void SceneTreeDock::_update_tree_menu() {
 	PopupMenu *tree_menu = button_tree_menu->get_popup();
 	tree_menu->clear();
 
-	_append_filter_options_to(tree_menu);
-
-	tree_menu->add_separator();
 	tree_menu->add_check_item(TTR("Auto Expand to Selected"), TOOL_AUTO_EXPAND);
 	tree_menu->set_item_checked(-1, EDITOR_GET("docks/scene_tree/auto_expand_to_selected"));
 
@@ -4050,6 +4042,8 @@ void SceneTreeDock::_update_tree_menu() {
 	resource_list->connect("about_to_popup", callable_mp(this, &SceneTreeDock::_list_all_subresources).bind(resource_list));
 	resource_list->connect("index_pressed", callable_mp(this, &SceneTreeDock::_edit_subresource).bind(resource_list));
 	tree_menu->add_submenu_node_item(TTR("All Scene Sub-Resources"), resource_list);
+
+	_append_filter_options_to(tree_menu);
 }
 
 void SceneTreeDock::_filter_changed(const String &p_filter) {
@@ -4072,9 +4066,14 @@ void SceneTreeDock::_filter_gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (mb->is_pressed() && mb->get_button_index() == MouseButton::MIDDLE) {
-		filter_quick_menu->clear();
+		if (filter_quick_menu == nullptr) {
+			filter_quick_menu = memnew(PopupMenu);
+			filter_quick_menu->set_theme_type_variation("FlatMenuButton");
+			_append_filter_options_to(filter_quick_menu);
+			filter_quick_menu->connect(SceneStringName(id_pressed), callable_mp(this, &SceneTreeDock::_filter_option_selected));
+			filter->add_child(filter_quick_menu);
+		}
 
-		_append_filter_options_to(filter_quick_menu, false);
 		filter_quick_menu->set_position(get_screen_position() + get_local_mouse_position());
 		filter_quick_menu->reset_size();
 		filter_quick_menu->popup();
@@ -4101,15 +4100,16 @@ void SceneTreeDock::_filter_option_selected(int p_option) {
 	}
 }
 
-void SceneTreeDock::_append_filter_options_to(PopupMenu *p_menu, bool p_include_separator) {
-	if (p_include_separator) {
-		p_menu->add_separator(TTR("Filters"));
+void SceneTreeDock::_append_filter_options_to(PopupMenu *p_menu) {
+	if (p_menu->get_item_count() > 0) {
+		p_menu->add_separator();
 	}
 
-	p_menu->add_item(TTR("Filter by Type"), FILTER_BY_TYPE);
-	p_menu->add_item(TTR("Filter by Group"), FILTER_BY_GROUP);
-	p_menu->set_item_tooltip(p_menu->get_item_index(FILTER_BY_TYPE), TTR("Selects all Nodes of the given type."));
-	p_menu->set_item_tooltip(p_menu->get_item_index(FILTER_BY_GROUP), TTR("Selects all Nodes belonging to the given group.\nIf empty, selects any Node belonging to any group."));
+	p_menu->add_item(TTRC("Filter by Type"), FILTER_BY_TYPE);
+	p_menu->set_item_tooltip(-1, TTRC("Selects all Nodes of the given type.\nInserts \"type:\". You can also use the shorthand \"t:\"."));
+
+	p_menu->add_item(TTRC("Filter by Group"), FILTER_BY_GROUP);
+	p_menu->set_item_tooltip(-1, TTRC("Selects all Nodes belonging to the given group.\nIf empty, selects any Node belonging to any group.\nInserts \"group:\". You can also use the shorthand \"g:\"."));
 }
 
 String SceneTreeDock::get_filter() {
@@ -4760,7 +4760,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	// The "Filter Nodes" text input above the Scene Tree Editor.
 	filter = memnew(LineEdit);
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
-	filter->set_placeholder(TTRC("Filter: name, t:type, g:group"));
+	filter->set_placeholder(TTRC("Filter Nodes"));
 	filter->set_accessibility_name(TTRC("Filter Nodes"));
 	filter->set_tooltip_text(TTRC("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\")\nor group (if prefixed with \"group:\" or \"g:\"). Filtering is case-insensitive."));
 	filter_hbc->add_child(filter);
@@ -4769,11 +4769,6 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	filter->connect(SceneStringName(gui_input), callable_mp(this, &SceneTreeDock::_filter_gui_input));
 	filter->get_menu()->connect(SceneStringName(id_pressed), callable_mp(this, &SceneTreeDock::_filter_option_selected));
 	_append_filter_options_to(filter->get_menu());
-
-	filter_quick_menu = memnew(PopupMenu);
-	filter_quick_menu->set_theme_type_variation("FlatMenuButton");
-	filter_quick_menu->connect(SceneStringName(id_pressed), callable_mp(this, &SceneTreeDock::_filter_option_selected));
-	filter->add_child(filter_quick_menu);
 
 	button_create_script = memnew(Button);
 	button_create_script->set_theme_type_variation("FlatMenuButton");

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -274,7 +274,7 @@ class SceneTreeDock : public EditorDock {
 	void _filter_changed(const String &p_filter);
 	void _filter_gui_input(const Ref<InputEvent> &p_event);
 	void _filter_option_selected(int option);
-	void _append_filter_options_to(PopupMenu *p_menu, bool p_include_separator = true);
+	void _append_filter_options_to(PopupMenu *p_menu);
 
 	void _perform_instantiate_scenes(const Vector<String> &p_files, Node *p_parent, int p_pos);
 	void _perform_create_audio_stream_players(const Vector<String> &p_files, Node *p_parent, int p_pos);


### PR DESCRIPTION
The current placeholder is too long for regular usage.

It was introduced to enhance the discoverability of the filtering syntax. But nowadays, the filter options are available in the related menus. It's no longer necessary to use this placeholder I think.

| Before | After |
|----|----|
| <img width="277" height="109" alt="placeholder-before" src="https://github.com/user-attachments/assets/3bbeb818-f150-4e4e-8315-cd19bcd984c6" /> | <img width="277" height="109" alt="placeholder-after" src="https://github.com/user-attachments/assets/3c698316-e3a0-45a5-b97f-8e5c2cec420e" /> |

The syntax is already mentioned in the LineEdit's tooltip. It is now also added to the tooltip of the related menu items:

<img width="529" height="86" alt="tooltip" src="https://github.com/user-attachments/assets/e1b2f68e-2734-4f97-a9df-2436362fc246" />

Options in the context menu:

- The "Filters" text is removed from the separator. It's redundant, already in "Filter by Type" & "Filter by Group".
- Icons are removed. Together with the checkbox above, they create confusing empty spaces.

| Before | After |
|----|----|
| <img width="361" height="353" alt="context-menu-before" src="https://github.com/user-attachments/assets/374bbd20-a0d1-4875-91b2-268c8eb02edf" /> | <img width="345" height="339" alt="context-menu-after" src="https://github.com/user-attachments/assets/b23c18e1-80e2-477a-a570-fdebd069f60b" /> |

Options in the three-dots menu:

- The "Filters" text is removed from the separator. The reason is the same as above.
- Moved to the end of the menu, the same place as the context menu.

| Before | After |
|----|----|
| <img width="262" height="247" alt="dots-menu-before" src="https://github.com/user-attachments/assets/d0b8b727-4c2a-4b04-9c7f-8e8c9572cbc0" /> | <img width="262" height="224" alt="dots-menu-after" src="https://github.com/user-attachments/assets/d7c6df6f-89d1-49a3-9dc8-b98ef4d44ca2" /> |

There is also a filters popup menu for middle mouse button click in the LineEdit. This PR makes it created on demand.