### PR TITLE
Create HWND swap chain when window transparency is disabled on D3D12.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2387,9 +2387,11 @@ void DisplayServerWindows::_get_window_style(bool p_main_window, bool p_initiali
 	r_style |= WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
 	r_style_ex |= WS_EX_ACCEPTFILES;
 
-	if (OS::get_singleton()->get_current_rendering_driver_name() == "d3d12") {
+#ifdef DCOMP_ENABLED
+	if (OS::get_singleton()->is_layered_allowed() && OS::get_singleton()->get_current_rendering_driver_name() == "d3d12") {
 		r_style_ex |= WS_EX_NOREDIRECTIONBITMAP;
 	}
+#endif
 }
 
 void DisplayServerWindows::_update_window_style(WindowID p_window, bool p_repaint) {


### PR DESCRIPTION
Fixes #104457.

FillRect does not work when using DirectComposition swap chains. We can at least fix it for opaque windows by using traditional HWND swap chains when window transparency is disabled.

FillRect not working for transparent windows is a separate problem to handle for the future.