### PR TITLE
Fix TileSet editor crash on terrain pick in paint mode

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -870,6 +870,10 @@ void EditorPropertyEnum::set_option_button_clip(bool p_enable) {
 	options->set_clip_text(p_enable);
 }
 
+OptionButton *EditorPropertyEnum::get_option_button() {
+	return options;
+}
+
 EditorPropertyEnum::EditorPropertyEnum() {
 	options = memnew(OptionButton);
 	options->set_clip_text(true);

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -272,6 +272,7 @@ public:
 	void setup(const Vector<String> &p_options);
 	virtual void update_property() override;
 	void set_option_button_clip(bool p_enable);
+	OptionButton *get_option_button(); // Hack to allow setting icons.
 	EditorPropertyEnum();
 };
 

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -1887,7 +1887,7 @@ void TileDataTerrainsEditor::_update_terrain_selector() {
 
 		// Kind of a hack to set icons.
 		// We could provide a way to modify that in the EditorProperty.
-		OptionButton *option_button = Object::cast_to<OptionButton>(terrain_property_editor->get_child(0));
+		OptionButton *option_button = terrain_property_editor->get_option_button();
 		for (int terrain = 0; terrain < tile_set->get_terrains_count(terrain_set); terrain++) {
 			option_button->set_item_icon(terrain + 1, icons[terrain_set][terrain]);
 		}


### PR DESCRIPTION
Fixes #112345.

That's a regression from #103257, which added some child Containers to EditorProperty, which made the assumption that OptionButton is the first child of EditorPropertyEnum no longer true.