### PR TITLE
Enhance contrast on Modern theme

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -356,7 +356,7 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 				preset_contrast = light_contrast;
 			} else { // Default
 				preset_accent_color = Color(0.337, 0.62, 1.0);
-				preset_base_color = Color(0.145, 0.145, 0.145);
+				preset_base_color = Color(0.153, 0.153, 0.153);
 			}
 
 			config.accent_color = preset_accent_color;

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -84,7 +84,7 @@ public:
 		// Make sure to keep those in sync with the definitions in the editor settings.
 		const float default_icon_saturation = 2.0;
 		const int default_relationship_lines = RELATIONSHIP_SELECTED_ONLY;
-		const float default_contrast = 0.3;
+		const float default_contrast = 0.35;
 		const int default_corner_radius = 4;
 
 		// Generated properties.


### PR DESCRIPTION
As per @passivestar's recommendation (https://github.com/godotengine/godot/issues/112258#issuecomment-3480337080), this changes the default base color from `#252525` to `#272727`, and the contrast from `0.3` to `0.35`.