### PR TITLE
Apply viewport oversampling to Polygon2D.

### DIFF
--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -398,7 +398,7 @@ void Polygon2D::_notification(int p_what) {
 				}
 
 				RS::get_singleton()->mesh_add_surface(mesh, sd);
-				RS::get_singleton()->canvas_item_add_mesh(get_canvas_item(), mesh, Transform2D(), Color(1, 1, 1), texture.is_valid() ? texture->get_rid() : RID());
+				RS::get_singleton()->canvas_item_add_mesh(get_canvas_item(), mesh, Transform2D(), Color(1, 1, 1), texture.is_valid() ? texture->get_scaled_rid() : RID());
 			}
 
 		} break;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/discussions/13542

| Before | After |
|--|--|
| <img width="270" height="182" alt="Screenshot 2025-11-03 at 22 32 22" src="https://github.com/user-attachments/assets/e66857ce-4c7f-48ab-8484-835b026c767e" /> | <img width="270" height="182" alt="Screenshot 2025-11-03 at 22 31 57" src="https://github.com/user-attachments/assets/33673f84-0e80-4f6b-8f18-2b5e3819ee4d" /> |