### PR TITLE
Fix MSVC version parsing for Visual Studio in methods.py

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -730,10 +730,15 @@ def get_compiler_version(env):
             for line in version.splitlines():
                 split = line.split(":", 1)
                 if split[0] == "catalog_productDisplayVersion":
+                    import re
                     sem_ver = split[1].split(".")
-                    ret["major"] = int(sem_ver[0])
-                    ret["minor"] = int(sem_ver[1])
-                    ret["patch"] = int(sem_ver[2].split()[0])
+                    # Extract only the leading digits for each version part
+                    major_match = re.search(r'\d+', sem_ver[0])
+                    minor_match = re.search(r'\d+', sem_ver[1]) if len(sem_ver) > 1 else None
+                    patch_match = re.search(r'\d+', sem_ver[2]) if len(sem_ver) > 2 else None
+                    ret["major"] = int(major_match.group()) if major_match else -1
+                    ret["minor"] = int(minor_match.group()) if minor_match else -1
+                    ret["patch"] = int(patch_match.group()) if patch_match else -1
                 # Could potentially add section for determining preview version, but
                 # that can wait until metadata is actually used for something.
                 if split[0] == "catalog_buildVersion":


### PR DESCRIPTION
Description:
This PR updates the version parsing logic in methods.py to robustly extract only the numeric parts of the MSVC version string. This prevents a ValueError when building Godot with Visual Studio 2026 (Insiders) or newer, whose version strings include non-numeric text (e.g., "Insiders").

Details:

Uses regex to extract leading digits for major, minor, and patch version numbers.
Fixes build failure on new Visual Studio releases where the version string format changed.
Testing:

Verified that Godot now builds successfully with Visual Studio 2026 Developer Command Prompt.
Confirmed that the fix does not affect builds with previous Visual Studio versions.
Related issues:

Fixes build error: [ValueError: invalid literal for int() with base 10: ' Insiders [ValueError: invalid literal for int() with base 10: ' Insiders [11123'](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)