### PR TITLE
Modern Style: Use a StyleBox in signals and groups

### DIFF
--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -204,6 +204,7 @@ void GroupsEditor::_update_tree() {
 	local_root->set_text(0, TTR("Scene Groups"));
 	local_root->set_icon(0, get_editor_theme_icon(SNAME("PackedScene")));
 	local_root->set_custom_bg_color(0, get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor)));
+	local_root->set_custom_stylebox(0, get_theme_stylebox(SNAME("prop_subsection_stylebox"), EditorStringName(Editor)));
 	local_root->set_selectable(0, false);
 
 	List<StringName> scene_keys;
@@ -241,6 +242,7 @@ void GroupsEditor::_update_tree() {
 	global_root->set_text(0, TTR("Global Groups"));
 	global_root->set_icon(0, get_editor_theme_icon(SNAME("Environment")));
 	global_root->set_custom_bg_color(0, get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor)));
+	global_root->set_custom_stylebox(0, get_theme_stylebox(SNAME("prop_subsection_stylebox"), EditorStringName(Editor)));
 	global_root->set_selectable(0, false);
 
 	for (const StringName &E : keys) {

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1627,6 +1627,7 @@ void ConnectionsDock::update_tree() {
 			section_item->set_selectable(0, false);
 			section_item->set_editable(0, false);
 			section_item->set_custom_bg_color(0, get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor)));
+			section_item->set_custom_stylebox(0, get_theme_stylebox(SNAME("prop_subsection_stylebox"), EditorStringName(Editor)));
 			section_item->set_metadata(0, doc_class_name);
 		}
 


### PR DESCRIPTION
Applies the StyleBox from #112233 on signal and group subsections.

| Before | After |
|--------|-------|
|![before_dark](https://github.com/user-attachments/assets/1357b627-de41-4221-b43a-cf1855abeb78) ![before_groups](https://github.com/user-attachments/assets/3d060251-8f06-418a-ba18-2beb9e998c56) | ![after_dark](https://github.com/user-attachments/assets/9331c1f5-a4f6-496f-96ed-a358f339fa34) ![after_groups](https://github.com/user-attachments/assets/ccba0b5c-9b85-4c8b-8eab-956b22eb175e) |


Classic for comparison:
![classic](https://github.com/user-attachments/assets/c4cfc110-2bfb-4296-ae7f-f981a183d76a)
