### PR TITLE
Add `SizeContainer`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -117,6 +117,14 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="_get_maximum_size" qualifiers="virtual const">
+			<return type="Vector2" />
+			<description>
+				Virtual method to be implemented by the user. Returns the maximum size for this control. Alternative to [member custom_maximum_size] for controlling maximum size via code. The actual maximum size will be the max value of these two (in each axis separately).
+				If not overridden, defaults to [constant Vector2.ZERO].
+				[b]Note:[/b] This method will not be called when the script is attached to a [Control] node that already overrides its maximum size (e.g. [ScrollContainer]).
+			</description>
+		</method>
 		<method name="_get_minimum_size" qualifiers="virtual const">
 			<return type="Vector2" />
 			<description>
@@ -403,6 +411,13 @@
 				Returns [member offset_left] and [member offset_top]. See also [member position].
 			</description>
 		</method>
+		<method name="get_combined_maximum_size" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns combined maximum size from [member custom_maximum_size] and [method get_maximum_size].
+				[b]Note:[/b] This method will always return a size greater than or equal to that returned by [method get_combined_minimum_size].
+			</description>
+		</method>
 		<method name="get_combined_minimum_size" qualifiers="const">
 			<return type="Vector2" />
 			<description>
@@ -448,6 +463,12 @@
 				Returns the position and size of the control relative to the containing canvas. See [member global_position] and [member size].
 				[b]Note:[/b] If the node itself or any parent [CanvasItem] between the node and the canvas have a non default rotation or skew, the resulting size is likely not meaningful.
 				[b]Note:[/b] Setting [member Viewport.gui_snap_controls_to_pixels] to [code]true[/code] can lead to rounding inaccuracies between the displayed control and the returned [Rect2].
+			</description>
+		</method>
+		<method name="get_maximum_size" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the maximum size for this control. See [member custom_maximum_size].
 			</description>
 		</method>
 		<method name="get_minimum_size" qualifiers="const">
@@ -963,7 +984,13 @@
 				If [param keep_offsets] is [code]true[/code], control's anchors will be updated instead of offsets.
 			</description>
 		</method>
-		<method name="update_minimum_size">
+		<method name="update_minimum_size" deprecated="Use [method update_size_bounds] instead.">
+			<return type="void" />
+			<description>
+				Invalidates the size cache in this node and in parent nodes up to top level. Intended to be used with [method get_minimum_size] when the return value is changed. Setting [member custom_minimum_size] directly calls this method automatically.
+			</description>
+		</method>
+		<method name="update_size_bounds">
 			<return type="void" />
 			<description>
 				Invalidates the size cache in this node and in parent nodes up to top level. Intended to be used with [method get_minimum_size] when the return value is changed. Setting [member custom_minimum_size] directly calls this method automatically.
@@ -1017,6 +1044,11 @@
 		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" default="false">
 			Enables whether rendering of [CanvasItem] based children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visibly outside of this control's rectangle will not be rendered and won't receive input.
+		</member>
+		<member name="custom_maximum_size" type="Vector2" setter="set_custom_maximum_size" getter="get_custom_maximum_size" default="Vector2(0, 0)">
+			The maximum size of the node's bounding rectangle. If set to a value greater than [code](0, 0)[/code], the node's bounding rectangle will never exceed this size. A value of [code](0, 0)[/code] means there is no maximum size.
+					[b]Note:[/b] This property is only accessible in code and not in the Inspector.
+					[b]Note:[/b] Not all [Control] subtypes handle this gracefully, which may lead to unexpected behavior if the control's contents exceed this size.
 		</member>
 		<member name="custom_minimum_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" default="Vector2(0, 0)">
 			The minimum size of the node's bounding rectangle. If you set it to a value greater than [code](0, 0)[/code], the node's bounding rectangle will always have at least this size. Note that [Control] nodes have their internal minimum size returned by [method get_minimum_size]. It depends on the control's contents, like text, textures, or style boxes. The actual minimum size is the maximum value of this property and the internal minimum size (see [method get_combined_minimum_size]).
@@ -1189,9 +1221,10 @@
 				Emitted when the node receives an [InputEvent].
 			</description>
 		</signal>
-		<signal name="minimum_size_changed">
+		<signal name="minimum_size_changed" deprecated="Use [signal size_bounds_changed] instead.">
 			<description>
 				Emitted when the node's minimum size changes.
+				[b]Note:[/b] This is also emitted when the node's maximum size changes.
 			</description>
 		</signal>
 		<signal name="mouse_entered">
@@ -1215,6 +1248,11 @@
 		<signal name="resized">
 			<description>
 				Emitted when the control changes size.
+			</description>
+		</signal>
+		<signal name="size_bounds_changed">
+			<description>
+				Emitted when the node's minimum or maximum size changes.
 			</description>
 		</signal>
 		<signal name="size_flags_changed">

--- a/doc/classes/SizeContainer.xml
+++ b/doc/classes/SizeContainer.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SizeContainer" inherits="Container" keywords="size" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A container that supports a maximum size for itself.
+	</brief_description>
+	<description>
+		[SizeContainer] allows setting a maximum size for itself, both in code and in the editor. When the container's size exceeds the defined maximum size, it will not grow any larger, effectively capping its dimensions. This is useful for creating UI elements that should not exceed a certain size regardless of their content or parent container's size.
+		To control the [SizeContainer]'s maximum size, use the [code skip-lint]custom_maximum_size[/code] property as shown below.
+		[codeblocks]
+		[gdscript]
+		# This code sample assumes the current script is extending SizeContainer.
+		var max_size_value = Vector2(400, 300)
+		set_custom_maximum_size(max_size_value)
+		[/gdscript]
+		[csharp]
+		// This code sample assumes the current script is extending SizeContainer.
+		Vector2 maxSizeValue = new Vector2(400, 300);
+		SetCustomMaximumSize(maxSizeValue);
+		[/csharp]
+		[/codeblocks]
+	</description>
+	<tutorials>
+		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
+	</tutorials>
+	<members>
+		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
+	</members>
+</class>

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3865,7 +3865,7 @@ void AnimationTrackEditGroup::set_type_and_name(const Ref<Texture2D> &p_type, co
 	node_name = p_name;
 	node = p_node;
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 Size2 AnimationTrackEditGroup::get_minimum_size() const {

--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -270,7 +270,7 @@ void EditorMainScreen::add_main_plugin(EditorPlugin *p_editor) {
 	if (icon.is_valid()) {
 		tb->set_button_icon(icon);
 		// Make sure the control is updated if the icon is reimported.
-		icon->connect_changed(callable_mp((Control *)tb, &Control::update_minimum_size));
+		icon->connect_changed(callable_mp((Control *)tb, &Control::update_size_bounds));
 	}
 
 	tb->connect(SceneStringName(pressed), callable_mp(this, &EditorMainScreen::select).bind(buttons.size()));

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1096,7 +1096,7 @@ void EditorPropertyLayersGrid::_update_flag(bool p_replace) {
 		queue_redraw();
 	} else if (expand_hovered) {
 		expanded = !expanded;
-		update_minimum_size();
+		update_size_bounds();
 		queue_redraw();
 	}
 }
@@ -1229,7 +1229,7 @@ void EditorPropertyLayersGrid::_notification(int p_what) {
 			}
 
 			if ((expansion_rows != prev_expansion_rows) && expanded) {
-				update_minimum_size();
+				update_size_bounds();
 			}
 
 			if ((expansion_rows == 0) && (layer_index == layer_count)) {

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -339,13 +339,13 @@ void ProjectManager::_set_main_view_icon(MainViewTab p_id, const Ref<Texture2D> 
 
 	Ref<Texture2D> old_icon = toggle_button->get_button_icon();
 	if (old_icon.is_valid()) {
-		old_icon->disconnect_changed(callable_mp((Control *)toggle_button, &Control::update_minimum_size));
+		old_icon->disconnect_changed(callable_mp((Control *)toggle_button, &Control::update_size_bounds));
 	}
 
 	if (p_icon.is_valid()) {
 		toggle_button->set_button_icon(p_icon);
 		// Make sure the control is updated if the icon is reimported.
-		p_icon->connect_changed(callable_mp((Control *)toggle_button, &Control::update_minimum_size));
+		p_icon->connect_changed(callable_mp((Control *)toggle_button, &Control::update_size_bounds));
 	} else {
 		toggle_button->set_button_icon(Ref<Texture2D>());
 	}

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -830,7 +830,7 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		item->set_custom_color(0, disabled_color);
 	}
 
-	tile_data_editors_tree->update_minimum_size();
+	tile_data_editors_tree->update_size_bounds();
 
 #undef ADD_TILE_DATA_EDITOR_GROUP
 #undef ADD_TILE_DATA_EDITOR

--- a/editor/scene/curve_editor_plugin.cpp
+++ b/editor/scene/curve_editor_plugin.cpp
@@ -986,7 +986,7 @@ void CurveEditor::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_RESIZED:
-			curve_editor_rect->update_minimum_size();
+			curve_editor_rect->update_size_bounds();
 			break;
 	}
 }

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -68,7 +68,7 @@ void ThemeEditorPreview::add_preview_overlay(Control *p_overlay) {
 
 void ThemeEditorPreview::_propagate_redraw(Control *p_at) {
 	p_at->notification(NOTIFICATION_THEME_CHANGED);
-	p_at->update_minimum_size();
+	p_at->update_size_bounds();
 	p_at->queue_redraw();
 	for (int i = 0; i < p_at->get_child_count(); i++) {
 		Control *a = Object::cast_to<Control>(p_at->get_child(i));

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -1325,7 +1325,7 @@ void SpriteFramesEditor::_animation_loop_changed() {
 }
 
 void SpriteFramesEditor::_animation_speed_resized() {
-	anim_speed->update_minimum_size();
+	anim_speed->update_size_bounds();
 }
 
 void SpriteFramesEditor::_animation_speed_changed(double p_value) {

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -274,7 +274,7 @@ void BaseButton::set_disabled(bool p_disabled) {
 	}
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool BaseButton::is_disabled() const {

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -280,7 +280,7 @@ void BoxContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			update_minimum_size();
+			update_size_bounds();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED:
@@ -311,7 +311,7 @@ BoxContainer::AlignmentMode BoxContainer::get_alignment() const {
 void BoxContainer::set_vertical(bool p_vertical) {
 	ERR_FAIL_COND_MSG(is_fixed, "Can't change orientation of " + get_class() + ".");
 	vertical = p_vertical;
-	update_minimum_size();
+	update_size_bounds();
 	_resort();
 }
 

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -179,7 +179,7 @@ void Button::_notification(int p_what) {
 			xl_text = _get_translated_text(text);
 			_shape();
 
-			update_minimum_size();
+			update_size_bounds();
 			queue_accessibility_update();
 			queue_redraw();
 		} break;
@@ -187,7 +187,7 @@ void Button::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
 
-			update_minimum_size();
+			update_size_bounds();
 			queue_redraw();
 		} break;
 
@@ -195,7 +195,7 @@ void Button::_notification(int p_what) {
 			if (autowrap_mode != TextServer::AUTOWRAP_OFF) {
 				_shape();
 
-				update_minimum_size();
+				update_size_bounds();
 				queue_redraw();
 			}
 		} break;
@@ -205,7 +205,7 @@ void Button::_notification(int p_what) {
 			if (text_buf.is_valid() && !TS->shaped_text_is_ready(text_buf->get_rid())) {
 				_shape();
 
-				update_minimum_size();
+				update_size_bounds();
 			}
 
 			const RID ci = get_canvas_item();
@@ -427,7 +427,7 @@ void Button::_notification(int p_what) {
 
 				float text_buf_width = Math::ceil(MAX(1.0f, drawable_size_remained.width)); // The space's width filled by the text_buf.
 				if (autowrap_mode != TextServer::AUTOWRAP_OFF && !Math::is_equal_approx(text_buf_width, text_buf->get_width())) {
-					update_minimum_size();
+					update_size_bounds();
 				}
 				text_buf->set_width(text_buf_width);
 
@@ -581,7 +581,7 @@ void Button::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 			_queue_update_size_cache();
 		}
 		queue_redraw();
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -600,7 +600,7 @@ void Button::set_text(const String &p_text) {
 
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 String Button::get_text() const {
@@ -612,7 +612,7 @@ void Button::set_autowrap_mode(TextServer::AutowrapMode p_mode) {
 		autowrap_mode = p_mode;
 		_shape();
 		queue_redraw();
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -625,7 +625,7 @@ void Button::set_autowrap_trim_flags(BitField<TextServer::LineBreakFlag> p_flags
 		autowrap_flags_trim = p_flags & TextServer::BREAK_TRIM_MASK;
 		_shape();
 		queue_redraw();
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -676,12 +676,12 @@ void Button::set_button_icon(const Ref<Texture2D> &p_icon) {
 	}
 
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 void Button::_texture_changed() {
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 void Button::_update_style_margins(const Ref<StyleBox> &p_stylebox) {
@@ -701,7 +701,7 @@ void Button::set_expand_icon(bool p_enabled) {
 		expand_icon = p_enabled;
 		_queue_update_size_cache();
 		queue_redraw();
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -726,7 +726,7 @@ void Button::set_clip_text(bool p_enabled) {
 
 		_queue_update_size_cache();
 		queue_redraw();
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -752,7 +752,7 @@ void Button::set_icon_alignment(HorizontalAlignment p_alignment) {
 	}
 
 	horizontal_icon_alignment = p_alignment;
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -766,7 +766,7 @@ void Button::set_vertical_icon_alignment(VerticalAlignment p_alignment) {
 	if (need_update_cache) {
 		_queue_update_size_cache();
 	}
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -54,7 +54,7 @@ void CenterContainer::set_use_top_left(bool p_enable) {
 
 	use_top_left = p_enable;
 
-	update_minimum_size();
+	update_size_bounds();
 	queue_sort();
 }
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2475,7 +2475,7 @@ void ColorPickerButton::_update_picker() {
 		popup->connect("about_to_popup", callable_mp(this, &ColorPickerButton::_about_to_popup));
 		popup->connect("popup_hide", callable_mp(this, &ColorPickerButton::_modal_closed));
 		popup->connect("tree_exiting", callable_mp(this, &ColorPickerButton::_modal_closed));
-		picker->connect(SceneStringName(minimum_size_changed), callable_mp((Window *)popup, &Window::reset_size));
+		picker->connect(SceneStringName(size_bounds_changed), callable_mp((Window *)popup, &Window::reset_size));
 		picker->set_pick_color(color);
 		picker->set_edit_alpha(edit_alpha);
 		picker->set_edit_intensity(edit_intensity);

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -30,8 +30,8 @@
 
 #include "container.h"
 
-void Container::_child_minsize_changed() {
-	update_minimum_size();
+void Container::_child_size_bounds_changed() {
+	update_size_bounds();
 	queue_sort();
 }
 
@@ -44,10 +44,10 @@ void Container::add_child_notify(Node *p_child) {
 	}
 
 	control->connect(SceneStringName(size_flags_changed), callable_mp(this, &Container::queue_sort));
-	control->connect(SceneStringName(minimum_size_changed), callable_mp(this, &Container::_child_minsize_changed));
-	control->connect(SceneStringName(visibility_changed), callable_mp(this, &Container::_child_minsize_changed));
+	control->connect(SceneStringName(size_bounds_changed), callable_mp(this, &Container::_child_size_bounds_changed));
+	control->connect(SceneStringName(visibility_changed), callable_mp(this, &Container::_child_size_bounds_changed));
 
-	update_minimum_size();
+	update_size_bounds();
 	queue_sort();
 }
 
@@ -58,7 +58,7 @@ void Container::move_child_notify(Node *p_child) {
 		return;
 	}
 
-	update_minimum_size();
+	update_size_bounds();
 	queue_sort();
 }
 
@@ -71,10 +71,10 @@ void Container::remove_child_notify(Node *p_child) {
 	}
 
 	control->disconnect(SceneStringName(size_flags_changed), callable_mp(this, &Container::queue_sort));
-	control->disconnect(SceneStringName(minimum_size_changed), callable_mp(this, &Container::_child_minsize_changed));
-	control->disconnect(SceneStringName(visibility_changed), callable_mp(this, &Container::_child_minsize_changed));
+	control->disconnect(SceneStringName(size_bounds_changed), callable_mp(this, &Container::_child_size_bounds_changed));
+	control->disconnect(SceneStringName(visibility_changed), callable_mp(this, &Container::_child_size_bounds_changed));
 
-	update_minimum_size();
+	update_size_bounds();
 	queue_sort();
 }
 

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -37,7 +37,7 @@ class Container : public Control {
 
 	bool pending_sort = false;
 	void _sort_children();
-	void _child_minsize_changed();
+	void _child_size_bounds_changed();
 
 protected:
 	enum class SortableVisibilityMode {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -216,12 +216,17 @@ private:
 
 		Point2 pos_cache;
 		Size2 size_cache;
+
 		mutable Size2 minimum_size_cache;
 		mutable bool minimum_size_valid = false;
-
 		Size2 last_minimum_size;
-		bool updating_last_minimum_size = false;
-		bool block_minimum_size_adjust = false;
+
+		mutable Size2 maximum_size_cache;
+		mutable bool maximum_size_valid = false;
+		Size2 last_maximum_size;
+
+		bool updating_last_size_bounds = false;
+		bool block_size_bounds_adjust = false;
 
 		bool size_warning = true;
 
@@ -230,7 +235,8 @@ private:
 		BitField<SizeFlags> h_size_flags = SIZE_FILL;
 		BitField<SizeFlags> v_size_flags = SIZE_FILL;
 		real_t expand = 1.0;
-		Point2 custom_minimum_size;
+		Size2 custom_minimum_size;
+		Size2 custom_maximum_size;
 
 		// Input events and rendering.
 
@@ -329,7 +335,8 @@ private:
 	int _get_anchors_layout_preset() const;
 
 	void _update_minimum_size_cache() const;
-	void _update_minimum_size();
+	void _update_maximum_size_cache() const;
+	void _update_size_bounds();
 	void _size_changed();
 
 	void _top_level_changed() override {} // Controls don't need to do anything, only other CanvasItems.
@@ -407,6 +414,7 @@ protected:
 	GDVIRTUAL1RC(bool, _has_point, Vector2)
 	GDVIRTUAL2RC(TypedArray<Vector3i>, _structured_text_parser, Array, String)
 	GDVIRTUAL0RC(Vector2, _get_minimum_size)
+	GDVIRTUAL0RC(Vector2, _get_maximum_size)
 	GDVIRTUAL1RC(String, _get_tooltip, Vector2)
 
 	GDVIRTUAL1R(Variant, _get_drag_data, Vector2)
@@ -509,7 +517,7 @@ public:
 	void set_v_grow_direction(GrowDirection p_direction);
 	GrowDirection get_v_grow_direction() const;
 
-	void set_anchors_preset(LayoutPreset p_preset, bool p_keep_offsets = true);
+	virtual void set_anchors_preset(LayoutPreset p_preset, bool p_keep_offsets = true);
 	void set_offsets_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode = PRESET_MODE_MINSIZE, int p_margin = 0);
 	void set_anchors_and_offsets_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode = PRESET_MODE_MINSIZE, int p_margin = 0);
 	void set_grow_direction_preset(LayoutPreset p_preset);
@@ -542,15 +550,24 @@ public:
 	Vector2 get_pivot_offset() const;
 	Vector2 get_combined_pivot_offset() const;
 
-	void update_minimum_size();
+#ifndef DISABLE_DEPRECATED
+	void update_minimum_size() { update_size_bounds(); }
+#endif // DISABLE_DEPRECATED
+	void update_size_bounds();
 
-	void set_block_minimum_size_adjust(bool p_block);
+	void set_block_size_bounds_adjust(bool p_block);
 
 	virtual Size2 get_minimum_size() const;
 	virtual Size2 get_combined_minimum_size() const;
 
 	void set_custom_minimum_size(const Size2 &p_custom);
 	Size2 get_custom_minimum_size() const;
+
+	void set_custom_maximum_size(const Size2 &p_custom);
+	Size2 get_custom_maximum_size() const;
+
+	virtual Size2 get_maximum_size() const;
+	virtual Size2 get_combined_maximum_size() const;
 
 	// Container sizing.
 

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -316,11 +316,11 @@ void FlowContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
 			_resort();
-			update_minimum_size();
+			update_size_bounds();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			update_minimum_size();
+			update_size_bounds();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED:
@@ -371,7 +371,7 @@ FlowContainer::LastWrapAlignmentMode FlowContainer::get_last_wrap_alignment() co
 void FlowContainer::set_vertical(bool p_vertical) {
 	ERR_FAIL_COND_MSG(is_fixed, "Can't change orientation of " + get_class() + ".");
 	vertical = p_vertical;
-	update_minimum_size();
+	update_size_bounds();
 	_resort();
 }
 

--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -75,7 +75,7 @@ void FoldableContainer::set_folded(bool p_folded) {
 		}
 		folded = p_folded;
 
-		update_minimum_size();
+		update_size_bounds();
 		queue_sort();
 		queue_redraw();
 	}
@@ -116,7 +116,7 @@ void FoldableContainer::set_title(const String &p_text) {
 	}
 	title = p_text;
 	_shape();
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -144,7 +144,7 @@ void FoldableContainer::set_language(const String &p_language) {
 	}
 	language = p_language;
 	_shape();
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -172,7 +172,7 @@ void FoldableContainer::set_title_text_overrun_behavior(TextServer::OverrunBehav
 	}
 	overrun_behavior = p_overrun_behavior;
 	_shape();
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -390,7 +390,7 @@ void FoldableContainer::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
-			update_minimum_size();
+			update_size_bounds();
 			queue_redraw();
 		} break;
 	}

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -443,7 +443,7 @@ void GraphEdit::_scrollbar_moved(double) {
 void GraphEdit::_update_scroll_offset() {
 	ERR_FAIL_NULL_MSG(connections_layer, "connections_layer is missing.");
 
-	set_block_minimum_size_adjust(true);
+	set_block_size_bounds_adjust(true);
 
 	for (int i = 0; i < get_child_count(); i++) {
 		GraphElement *graph_element = Object::cast_to<GraphElement>(get_child(i));
@@ -460,7 +460,7 @@ void GraphEdit::_update_scroll_offset() {
 	}
 
 	connections_layer->set_position(-scroll_offset);
-	set_block_minimum_size_adjust(false);
+	set_block_size_bounds_adjust(false);
 	awaiting_scroll_offset_update = false;
 
 	// In Godot, signals on value change are avoided by convention.
@@ -478,7 +478,7 @@ void GraphEdit::_update_scrollbars() {
 	h_scrollbar->set_value_no_signal(scroll_offset.x);
 	v_scrollbar->set_value_no_signal(scroll_offset.y);
 
-	set_block_minimum_size_adjust(true);
+	set_block_size_bounds_adjust(true);
 
 	// Determine the graph "canvas" size in screen space.
 	Rect2 screen_rect;
@@ -526,7 +526,7 @@ void GraphEdit::_update_scrollbars() {
 	h_scrollbar->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, v_scrollbar->is_visible() ? -vmin.width : 0);
 	v_scrollbar->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, h_scrollbar->is_visible() ? -hmin.height : 0);
 
-	set_block_minimum_size_adjust(false);
+	set_block_size_bounds_adjust(false);
 
 	if (!awaiting_scroll_offset_update) {
 		callable_mp(this, &GraphEdit::_update_scroll_offset).call_deferred();

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -81,7 +81,7 @@ void GraphElement::_notification(int p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
-			update_minimum_size();
+			update_size_bounds();
 			queue_redraw();
 		} break;
 	}

--- a/scene/gui/graph_frame.cpp
+++ b/scene/gui/graph_frame.cpp
@@ -224,7 +224,7 @@ void GraphFrame::set_title(const String &p_title) {
 	if (title_label) {
 		title_label->set_text(title);
 	}
-	update_minimum_size();
+	update_size_bounds();
 }
 
 String GraphFrame::get_title() const {

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -1150,7 +1150,7 @@ void GraphNode::set_title(const String &p_title) {
 	if (title_label) {
 		title_label->set_text(title);
 	}
-	update_minimum_size();
+	update_size_bounds();
 }
 
 String GraphNode::get_title() const {

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -230,7 +230,7 @@ void GridContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			update_minimum_size();
+			update_size_bounds();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED:
@@ -249,7 +249,7 @@ void GridContainer::set_columns(int p_columns) {
 
 	columns = p_columns;
 	queue_sort();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 int GridContainer::get_columns() const {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1892,7 +1892,7 @@ void ItemList::force_update_list_size() {
 		}
 	}
 
-	update_minimum_size();
+	update_size_bounds();
 	shape_changed = false;
 }
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -47,7 +47,7 @@ void Label::set_autowrap_mode(TextServer::AutowrapMode p_mode) {
 	update_configuration_warnings();
 
 	if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -68,7 +68,7 @@ void Label::set_autowrap_trim_flags(BitField<TextServer::LineBreakFlag> p_flags)
 	update_configuration_warnings();
 
 	if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -338,7 +338,7 @@ void Label::_shape() const {
 	_update_visible();
 
 	if (autowrap_mode == TextServer::AUTOWRAP_OFF || !clip || overrun_behavior == TextServer::OVERRUN_NO_TRIMMING) {
-		const_cast<Label *>(this)->update_minimum_size();
+		const_cast<Label *>(this)->update_size_bounds();
 	}
 }
 
@@ -1102,7 +1102,7 @@ void Label::set_text(const String &p_string) {
 	}
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 	update_configuration_warnings();
 }
 
@@ -1209,7 +1209,7 @@ void Label::set_clip_text(bool p_clip) {
 
 	clip = p_clip;
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool Label::is_clipping_text() const {
@@ -1241,7 +1241,7 @@ void Label::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 	}
 	queue_redraw();
 	if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -1264,7 +1264,7 @@ void Label::set_ellipsis_char(const String &p_char) {
 	}
 	queue_redraw();
 	if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2516,7 +2516,7 @@ void LineEdit::set_editable(bool p_editable) {
 	}
 	_validate_caret_can_draw();
 
-	update_minimum_size();
+	update_size_bounds();
 	queue_accessibility_update();
 	queue_redraw();
 }
@@ -2811,7 +2811,7 @@ void LineEdit::_editor_settings_changed() {
 
 void LineEdit::set_expand_to_text_length_enabled(bool p_enabled) {
 	expand_to_text_length = p_enabled;
-	update_minimum_size();
+	update_size_bounds();
 	set_caret_column(caret_column);
 }
 
@@ -2825,7 +2825,7 @@ void LineEdit::set_clear_button_enabled(bool p_enabled) {
 	}
 	clear_button_enabled = p_enabled;
 	_fit_to_width();
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -2914,7 +2914,7 @@ bool LineEdit::is_drag_and_drop_selection_enabled() const {
 
 void LineEdit::_texture_changed() {
 	_fit_to_width();
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -2934,7 +2934,7 @@ void LineEdit::set_right_icon(const Ref<Texture2D> &p_icon) {
 	}
 
 	_fit_to_width();
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -3023,7 +3023,7 @@ void LineEdit::_shape() {
 	Size2 size = TS->shaped_text_get_size(text_rid);
 
 	if ((expand_to_text_length && old_size.x != size.x) || (old_size.y != size.y)) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 
 	if (accessibility_text_root_element.is_valid()) {

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -59,7 +59,7 @@ void LinkButton::set_text(const String &p_text) {
 	text = p_text;
 	xl_text = atr(text);
 	_shape();
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -71,7 +71,7 @@ void LinkButton::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavio
 	if (overrun_behavior != p_behavior) {
 		overrun_behavior = p_behavior;
 		_shape();
-		update_minimum_size();
+		update_size_bounds();
 		queue_redraw();
 	}
 }
@@ -103,7 +103,7 @@ void LinkButton::set_ellipsis_char(const String &p_char) {
 	if (overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 		_shape();
 		queue_redraw();
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -218,7 +218,7 @@ void LinkButton::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			xl_text = atr(text);
 			_shape();
-			update_minimum_size();
+			update_size_bounds();
 			queue_redraw();
 		} break;
 
@@ -229,7 +229,7 @@ void LinkButton::_notification(int p_what) {
 		case NOTIFICATION_RESIZED:
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
-			update_minimum_size();
+			update_size_bounds();
 			queue_redraw();
 		} break;
 

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -109,7 +109,7 @@ void MarginContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			update_minimum_size();
+			update_size_bounds();
 		} break;
 	}
 }

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -321,7 +321,7 @@ void MenuBar::_notification(int p_what) {
 				}
 			}
 			if (!is_global) {
-				update_minimum_size();
+				update_size_bounds();
 			}
 		} break;
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
@@ -330,7 +330,7 @@ void MenuBar::_notification(int p_what) {
 				shape(menu_cache.write[i]);
 			}
 			if (global_menu_tag.is_empty()) {
-				update_minimum_size();
+				update_size_bounds();
 			}
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -545,7 +545,7 @@ void MenuBar::_refresh_menu_names() {
 
 	if (dirty && !is_global) {
 		queue_redraw();
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -589,7 +589,7 @@ void MenuBar::_popup_changed(ObjectID p_menu) {
 	menu_cache.write[idx].name = menu_name;
 	shape(menu_cache.write[idx]);
 
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -621,7 +621,7 @@ void MenuBar::add_child_notify(Node *p_child) {
 			menu_cache.write[menu_cache.size() - 1].submenu_rid = submenu_rid;
 		}
 	}
-	update_minimum_size();
+	update_size_bounds();
 }
 
 void MenuBar::move_child_notify(Node *p_child) {
@@ -700,7 +700,7 @@ void MenuBar::remove_child_notify(Node *p_child) {
 	p_child->disconnect("about_to_popup", callable_mp(this, &MenuBar::_popup_visibility_changed));
 	p_child->disconnect("popup_hide", callable_mp(this, &MenuBar::_popup_visibility_changed));
 
-	update_minimum_size();
+	update_size_bounds();
 }
 
 void MenuBar::_bind_methods() {
@@ -790,7 +790,7 @@ void MenuBar::set_text_direction(Control::TextDirection p_text_direction) {
 	ERR_FAIL_COND((int)p_text_direction < -1 || (int)p_text_direction > 3);
 	if (text_direction != p_text_direction) {
 		text_direction = p_text_direction;
-		update_minimum_size();
+		update_size_bounds();
 		queue_redraw();
 	}
 }
@@ -802,7 +802,7 @@ Control::TextDirection MenuBar::get_text_direction() const {
 void MenuBar::set_language(const String &p_language) {
 	if (language != p_language) {
 		language = p_language;
-		update_minimum_size();
+		update_size_bounds();
 		queue_redraw();
 	}
 }
@@ -896,7 +896,7 @@ void MenuBar::set_menu_title(int p_menu, const String &p_title) {
 			nmenu->set_item_text(main_menu, item_idx, atr(menu_cache[p_menu].name));
 		}
 	}
-	update_minimum_size();
+	update_size_bounds();
 }
 
 String MenuBar::get_menu_title(int p_menu) const {
@@ -953,7 +953,7 @@ void MenuBar::set_menu_hidden(int p_menu, bool p_hidden) {
 			nmenu->set_item_hidden(main_menu, item_idx, p_hidden);
 		}
 	}
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool MenuBar::is_menu_hidden(int p_menu) const {

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -90,7 +90,7 @@ void NinePatchRect::_bind_methods() {
 
 void NinePatchRect::_texture_changed() {
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 void NinePatchRect::set_texture(const Ref<Texture2D> &p_tex) {
@@ -109,7 +109,7 @@ void NinePatchRect::set_texture(const Ref<Texture2D> &p_tex) {
 	}
 
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 	emit_signal(SceneStringName(texture_changed));
 }
 
@@ -126,7 +126,7 @@ void NinePatchRect::set_patch_margin(Side p_side, int p_size) {
 
 	margin[p_side] = p_size;
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 int NinePatchRect::get_patch_margin(Side p_side) const {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -451,7 +451,7 @@ void OptionButton::_refresh_size_cache() {
 			_cached_size = _cached_size.max(get_minimum_size_for_text_and_icon(popup->get_item_xl_text(i), get_item_icon(i)));
 		}
 	}
-	update_minimum_size();
+	update_size_bounds();
 }
 
 void OptionButton::_queue_update_size_cache() {

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -211,7 +211,7 @@ void ProgressBar::set_show_percentage(bool p_visible) {
 		return;
 	}
 	show_percentage = p_visible;
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 
@@ -230,7 +230,7 @@ void ProgressBar::set_indeterminate(bool p_indeterminate) {
 	set_process_internal(indeterminate && should_process);
 
 	notify_property_list_changed();
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3872,7 +3872,7 @@ bool RichTextLabel::_validate_line_caches() {
 		main->first_resized_line.store(main->lines.size());
 
 		if (fit_content) {
-			update_minimum_size();
+			update_size_bounds();
 		}
 		validating.store(false);
 		if (!scroll_visible) {
@@ -3974,7 +3974,7 @@ void RichTextLabel::_process_line_caches() {
 	updating.store(false);
 
 	if (fit_content) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 	emit_signal(SceneStringName(finished));
 }
@@ -4104,7 +4104,7 @@ void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline)
 	_invalidate_current_line(current_frame);
 
 	if (fit_content) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 	queue_accessibility_update();
 	queue_redraw();
@@ -5108,7 +5108,7 @@ void RichTextLabel::clear() {
 	}
 
 	if (fit_content) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 	queue_accessibility_update();
 	update_configuration_warnings();
@@ -5138,7 +5138,7 @@ void RichTextLabel::set_fit_content(bool p_enabled) {
 	}
 
 	fit_content = p_enabled;
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool RichTextLabel::is_fit_content_enabled() const {

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -96,6 +96,7 @@ private:
 
 protected:
 	Size2 get_minimum_size() const override;
+	Size2 get_maximum_size() const override;
 
 	void _gui_focus_changed(Control *p_control);
 	void _reposition_children();

--- a/scene/gui/size_container.cpp
+++ b/scene/gui/size_container.cpp
@@ -1,0 +1,169 @@
+/**************************************************************************/
+/*  size_container.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "size_container.h"
+
+Size2 SizeContainer::get_minimum_size() const {
+	Size2 ms;
+	Size2 maximum_size = get_custom_maximum_size();
+	bool expand_horizontal = false;
+	bool expand_vertical = false;
+	for (int i = 0; i < get_child_count(); i++) {
+		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
+		if (!c) {
+			continue;
+		}
+		// Make sure the children are up to date
+		c->set_custom_maximum_size(get_custom_maximum_size());
+
+		Size2 minsize = c->get_combined_minimum_size();
+		Size2 maxsize = c->get_combined_maximum_size();
+		ms = ms.max(minsize).max(maxsize);
+		expand_horizontal = expand_horizontal || (c->get_h_size_flags() & SIZE_EXPAND);
+		expand_vertical = expand_vertical || (c->get_v_size_flags() & SIZE_EXPAND);
+	}
+
+	if (maximum_size.x > 0 && expand_horizontal) {
+		ms.x = MAX(ms.x, maximum_size.x);
+	}
+	if (maximum_size.y > 0 && expand_vertical) {
+		ms.y = MAX(ms.y, maximum_size.y);
+	}
+
+	return ms;
+}
+
+void SizeContainer::add_child_notify(Node *p_child) {
+	Container::add_child_notify(p_child);
+
+	Control *control = Object::cast_to<Control>(p_child);
+	if (!control) {
+		return;
+	}
+
+	control->set_custom_maximum_size(get_custom_maximum_size());
+	control->connect("size_flags_changed", Callable(this, "_child_size_bounds_changed"));
+}
+
+void SizeContainer::remove_child_notify(Node *p_child) {
+	Container::remove_child_notify(p_child);
+
+	Control *control = Object::cast_to<Control>(p_child);
+	if (!control) {
+		return;
+	}
+
+	control->set_custom_maximum_size(Size2());
+	control->disconnect("size_flags_changed", Callable(this, "_child_size_bounds_changed"));
+}
+
+void SizeContainer::_validate_property(PropertyInfo &p_property) const {
+	// Remove FULL_RECT and other wide presets from the anchors_preset options
+	// since they conflict with the maximum_size constraint.
+	if (p_property.name == "anchors_preset") {
+		Vector<String> options = p_property.hint_string.split(",");
+		String new_hint_string;
+
+		for (int i = 0; i < options.size(); i++) {
+			Vector<String> parts = options[i].split(":");
+			if (parts.size() == 2) {
+				int preset_value = parts[1].to_int();
+				if (preset_value != PRESET_LEFT_WIDE &&
+						preset_value != PRESET_TOP_WIDE &&
+						preset_value != PRESET_RIGHT_WIDE &&
+						preset_value != PRESET_BOTTOM_WIDE &&
+						preset_value != PRESET_VCENTER_WIDE &&
+						preset_value != PRESET_HCENTER_WIDE &&
+						preset_value != PRESET_FULL_RECT) {
+					if (!new_hint_string.is_empty()) {
+						new_hint_string += ",";
+					}
+					new_hint_string += options[i];
+				}
+			}
+		}
+
+		p_property.hint_string = new_hint_string;
+	} else if (p_property.name == "custom_maximum_size") {
+		p_property.usage = PROPERTY_USAGE_DEFAULT;
+	}
+}
+
+void SizeContainer::set_anchors_preset(LayoutPreset p_preset, bool p_keep_offsets) {
+	// Prevent setting wide presets that would conflict with maximum_size
+	if (p_preset == PRESET_LEFT_WIDE || p_preset == PRESET_TOP_WIDE ||
+			p_preset == PRESET_RIGHT_WIDE || p_preset == PRESET_BOTTOM_WIDE ||
+			p_preset == PRESET_VCENTER_WIDE || p_preset == PRESET_HCENTER_WIDE ||
+			p_preset == PRESET_FULL_RECT) {
+		WARN_PRINT("SizeContainer does not support wide anchor presets (including FULL_RECT) as they conflict with maximum_size constraints.");
+		return;
+	}
+
+	Control::set_anchors_preset(p_preset, p_keep_offsets);
+}
+
+void SizeContainer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_SORT_CHILDREN: {
+			update_size_bounds();
+			Size2 size = get_size();
+			Size2 maximum_size = get_custom_maximum_size();
+
+			// Clamp container size to max_size if set
+			if (maximum_size.x > 0) {
+				size.x = MIN(size.x, maximum_size.x);
+			}
+			if (maximum_size.y > 0) {
+				size.y = MIN(size.y, maximum_size.y);
+			}
+
+			for (int i = 0; i < get_child_count(); i++) {
+				Control *c = as_sortable_control(get_child(i));
+				if (!c) {
+					continue;
+				}
+
+				// Fit child within the constrained size
+				fit_child_in_rect(c, Rect2(Point2(), size));
+			}
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			update_size_bounds();
+		} break;
+	}
+}
+
+void SizeContainer::_bind_methods() {
+}
+
+SizeContainer::SizeContainer() {
+	set_clip_contents(true);
+}

--- a/scene/gui/size_container.h
+++ b/scene/gui/size_container.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  size_container.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/container.h"
+
+class SizeContainer : public Container {
+	GDCLASS(SizeContainer, Container);
+
+protected:
+	void _notification(int p_what);
+	void _validate_property(PropertyInfo &p_property) const;
+	static void _bind_methods();
+
+public:
+	virtual Size2 get_minimum_size() const override;
+	virtual void set_anchors_preset(LayoutPreset p_preset, bool p_keep_offsets = true) override;
+
+	virtual void add_child_notify(Node *p_child) override;
+	virtual void remove_child_notify(Node *p_child) override;
+
+	SizeContainer();
+};

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -247,7 +247,7 @@ void Slider::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			update_minimum_size();
+			update_size_bounds();
 			queue_redraw();
 		} break;
 

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -522,8 +522,8 @@ void SpinBox::_notification(int p_what) {
 #ifndef DISABLE_DEPRECATED
 			theme_cache.is_updown_assigned = !theme_cache.updown_icon->get_size().is_zero_approx();
 #endif
-			callable_mp((Control *)this, &Control::update_minimum_size).call_deferred();
-			callable_mp((Control *)get_line_edit(), &Control::update_minimum_size).call_deferred();
+			callable_mp((Control *)this, &Control::update_size_bounds).call_deferred();
+			callable_mp((Control *)get_line_edit(), &Control::update_size_bounds).call_deferred();
 		} break;
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -375,7 +375,7 @@ void SplitContainer::_notification(int p_what) {
 			_resort();
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			update_minimum_size();
+			update_size_bounds();
 			if (touch_dragger) {
 				touch_dragger->set_modulate(theme_cache.touch_dragger_color);
 				touch_dragger->set_texture(_get_touch_dragger_icon());
@@ -439,7 +439,7 @@ void SplitContainer::set_vertical(bool p_vertical) {
 		touch_dragger->set_anchors_and_offsets_preset(Control::PRESET_CENTER);
 		touch_dragger->set_default_cursor_shape(vertical ? CURSOR_VSPLIT : CURSOR_HSPLIT);
 	}
-	update_minimum_size();
+	update_size_bounds();
 	_resort();
 }
 

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -58,7 +58,7 @@ void SubViewportContainer::set_stretch(bool p_enable) {
 
 	stretch = p_enable;
 	recalc_force_viewport_sizes();
-	update_minimum_size();
+	update_size_bounds();
 	queue_sort();
 	queue_redraw();
 }

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -481,7 +481,7 @@ void TabBar::_notification(int p_what) {
 
 			queue_accessibility_update();
 			queue_redraw();
-			update_minimum_size();
+			update_size_bounds();
 
 			[[fallthrough]];
 		}
@@ -787,7 +787,7 @@ void TabBar::set_tab_count(int p_count) {
 
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 	notify_property_list_changed();
 }
 
@@ -917,7 +917,7 @@ void TabBar::set_tab_title(int p_tab, const String &p_title) {
 	}
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 String TabBar::get_tab_title(int p_tab) const {
@@ -968,7 +968,7 @@ void TabBar::set_tab_language(int p_tab, const String &p_language) {
 		}
 		queue_accessibility_update();
 		queue_redraw();
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -992,7 +992,7 @@ void TabBar::set_tab_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 		ensure_tab_visible(current);
 	}
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 Ref<Texture2D> TabBar::get_tab_icon(int p_tab) const {
@@ -1015,7 +1015,7 @@ void TabBar::set_tab_icon_max_width(int p_tab, int p_width) {
 		ensure_tab_visible(current);
 	}
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 int TabBar::get_tab_icon_max_width(int p_tab) const {
@@ -1070,7 +1070,7 @@ void TabBar::set_tab_disabled(int p_tab, bool p_disabled) {
 	}
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool TabBar::is_tab_disabled(int p_tab) const {
@@ -1094,7 +1094,7 @@ void TabBar::set_tab_hidden(int p_tab, bool p_hidden) {
 	}
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool TabBar::is_tab_hidden(int p_tab) const {
@@ -1127,7 +1127,7 @@ void TabBar::set_tab_button_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 		ensure_tab_visible(current);
 	}
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 Ref<Texture2D> TabBar::get_tab_button_icon(int p_tab) const {
@@ -1322,7 +1322,7 @@ void TabBar::add_tab(const String &p_str, const Ref<Texture2D> &p_icon) {
 	}
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 
 	if (!deselect_enabled && tabs.size() == 1) {
 		if (is_inside_tree()) {
@@ -1353,7 +1353,7 @@ void TabBar::clear_tabs() {
 
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 	notify_property_list_changed();
 }
 
@@ -1415,7 +1415,7 @@ void TabBar::remove_tab(int p_idx) {
 
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 	notify_property_list_changed();
 
 	if (is_tab_changing && is_inside_tree()) {
@@ -1623,7 +1623,7 @@ void TabBar::_move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_in
 	}
 
 	queue_accessibility_update();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 int TabBar::get_tab_idx_at_point(const Point2 &p_point) const {
@@ -1703,7 +1703,7 @@ void TabBar::set_clip_tabs(bool p_clip_tabs) {
 		ensure_tab_visible(current);
 	}
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool TabBar::get_clip_tabs() const {
@@ -1953,7 +1953,7 @@ void TabBar::set_tab_close_display_policy(CloseButtonDisplayPolicy p_policy) {
 		ensure_tab_visible(current);
 	}
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 TabBar::CloseButtonDisplayPolicy TabBar::get_tab_close_display_policy() const {
@@ -1975,7 +1975,7 @@ void TabBar::set_max_tab_width(int p_width) {
 		ensure_tab_visible(current);
 	}
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 int TabBar::get_max_tab_width() const {

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -296,7 +296,7 @@ void TabContainer::_on_theme_changed() {
 	if (get_tab_count() > 0) {
 		_repaint();
 	} else {
-		update_minimum_size();
+		update_size_bounds();
 	}
 	queue_redraw();
 
@@ -346,7 +346,7 @@ void TabContainer::_repaint() {
 	}
 	updating_visibility = false;
 
-	update_minimum_size();
+	update_size_bounds();
 }
 
 void TabContainer::_update_margins() {
@@ -899,7 +899,7 @@ void TabContainer::set_tab_disabled(int p_tab, bool p_disabled) {
 
 	_update_margins();
 	if (!get_clip_tabs()) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -920,7 +920,7 @@ void TabContainer::set_tab_hidden(int p_tab, bool p_hidden) {
 
 	_update_margins();
 	if (!get_clip_tabs()) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 	callable_mp(this, &TabContainer::_repaint).call_deferred();
 }
@@ -1004,7 +1004,7 @@ void TabContainer::set_popup(Node *p_popup) {
 		queue_redraw();
 		_update_margins();
 		if (!get_clip_tabs()) {
-			update_minimum_size();
+			update_size_bounds();
 		}
 	}
 }
@@ -1055,7 +1055,7 @@ void TabContainer::set_use_hidden_tabs_for_min_size(bool p_use_hidden_tabs) {
 	}
 
 	use_hidden_tabs_for_min_size = p_use_hidden_tabs;
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool TabContainer::get_use_hidden_tabs_for_min_size() const {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3729,7 +3729,7 @@ void TextEdit::set_editable(bool p_editable) {
 	editable = p_editable;
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool TextEdit::is_editable() const {
@@ -6499,7 +6499,7 @@ void TextEdit::set_fit_content_height_enabled(bool p_enabled) {
 		return;
 	}
 	fit_content_height = p_enabled;
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool TextEdit::is_fit_content_height_enabled() const {
@@ -6511,7 +6511,7 @@ void TextEdit::set_fit_content_width_enabled(bool p_enabled) {
 		return;
 	}
 	fit_content_width = p_enabled;
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool TextEdit::is_fit_content_width_enabled() const {
@@ -8603,7 +8603,7 @@ void TextEdit::_update_scrollbars() {
 
 	content_size_cache = Vector2i(total_width + 10, MAX(total_rows, 1) * get_line_height());
 	if (fit_content_height || fit_content_width) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 
 	updating_scrolls = true;

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -363,7 +363,7 @@ void TextureButton::_set_texture(Ref<Texture2D> *p_destination, const Ref<Textur
 
 void TextureButton::_texture_changed() {
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool TextureButton::get_ignore_texture_size() const {
@@ -376,7 +376,7 @@ void TextureButton::set_ignore_texture_size(bool p_ignore) {
 	}
 
 	ignore_texture_size = p_ignore;
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -55,7 +55,7 @@ void TextureProgressBar::set_stretch_margin(Side p_side, int p_size) {
 
 	stretch_margin[p_side] = p_size;
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 int TextureProgressBar::get_stretch_margin(Side p_side) const {
@@ -70,7 +70,7 @@ void TextureProgressBar::set_nine_patch_stretch(bool p_stretch) {
 
 	nine_patch_stretch = p_stretch;
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 	notify_property_list_changed();
 }
 
@@ -174,7 +174,7 @@ void TextureProgressBar::_set_texture(Ref<Texture2D> *p_destination, const Ref<T
 }
 
 void TextureProgressBar::_texture_changed() {
-	update_minimum_size();
+	update_size_bounds();
 	queue_redraw();
 }
 

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -99,7 +99,7 @@ void TextureRect::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_RESIZED: {
-			update_minimum_size();
+			update_size_bounds();
 		} break;
 	}
 }
@@ -178,7 +178,7 @@ bool TextureRect::_set(const StringName &p_name, const Variant &p_value) {
 
 void TextureRect::_texture_changed() {
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 void TextureRect::set_texture(const Ref<Texture2D> &p_tex) {
@@ -197,7 +197,7 @@ void TextureRect::set_texture(const Ref<Texture2D> &p_tex) {
 	}
 
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 Ref<Texture2D> TextureRect::get_texture() const {
@@ -211,7 +211,7 @@ void TextureRect::set_expand_mode(ExpandMode p_mode) {
 
 	expand_mode = p_mode;
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 TextureRect::ExpandMode TextureRect::get_expand_mode() const {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5302,7 +5302,7 @@ void Tree::update_min_size_for_item_change() {
 	// Only need to update when any scroll bar is disabled because that's the only time item size
 	// affects tree size.
 	if (!h_scroll_enabled || !v_scroll_enabled) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -5378,7 +5378,7 @@ void Tree::set_hide_root(bool p_enabled) {
 	hide_root = p_enabled;
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool Tree::is_root_hidden() const {
@@ -5830,7 +5830,7 @@ void Tree::set_column_titles_visible(bool p_show) {
 	show_column_titles = p_show;
 	queue_accessibility_update();
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool Tree::are_column_titles_visible() const {
@@ -5969,7 +5969,7 @@ void Tree::set_h_scroll_enabled(bool p_enable) {
 	}
 
 	h_scroll_enabled = p_enable;
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool Tree::is_h_scroll_enabled() const {
@@ -5982,7 +5982,7 @@ void Tree::set_v_scroll_enabled(bool p_enable) {
 	}
 
 	v_scroll_enabled = p_enable;
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool Tree::is_v_scroll_enabled() const {

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -225,7 +225,7 @@ void VideoStreamPlayer::texture_changed(const Ref<Texture2D> &p_texture) {
 	queue_redraw();
 
 	if (!expand) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 
@@ -244,7 +244,7 @@ void VideoStreamPlayer::set_expand(bool p_expand) {
 
 	expand = p_expand;
 	queue_redraw();
-	update_minimum_size();
+	update_size_bounds();
 }
 
 bool VideoStreamPlayer::has_expand() const {
@@ -320,7 +320,7 @@ void VideoStreamPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 	queue_redraw();
 
 	if (!expand) {
-		update_minimum_size();
+		update_size_bounds();
 	}
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5403,7 +5403,7 @@ void SubViewport::_internal_set_size(const Size2i &p_size, bool p_force) {
 	_set_size(p_size, _get_size_2d_override(), true);
 
 	if (c) {
-		c->update_minimum_size();
+		c->update_size_bounds();
 		c->queue_redraw();
 	}
 }

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -82,6 +82,7 @@
 #include "scene/gui/scroll_bar.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
+#include "scene/gui/size_container.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/split_container.h"
@@ -505,6 +506,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(HFlowContainer);
 	GDREGISTER_CLASS(VFlowContainer);
 	GDREGISTER_CLASS(MarginContainer);
+	GDREGISTER_CLASS(SizeContainer);
 
 	OS::get_singleton()->yield(); // may take time to init
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -63,7 +63,10 @@ public:
 
 	const StringName item_rect_changed = "item_rect_changed";
 	const StringName size_flags_changed = "size_flags_changed";
+#ifndef DISABLE_DEPRECATED
 	const StringName minimum_size_changed = "minimum_size_changed";
+#endif // DISABLE_DEPRECATED
+	const StringName size_bounds_changed = "size_bounds_changed";
 	const StringName sleeping_state_changed = "sleeping_state_changed";
 	const StringName node_configuration_warning_changed = "node_configuration_warning_changed";
 	const StringName update = "update";

--- a/tests/scene/test_control.h
+++ b/tests/scene/test_control.h
@@ -1139,14 +1139,14 @@ TEST_CASE("[SceneTree][Control] Grow direction") {
 		CHECK(test_control->get_v_grow_direction() == Control::GROW_DIRECTION_END);
 	}
 
-	SIGNAL_WATCH(test_control, SNAME("minimum_size_changed"))
+	SIGNAL_WATCH(test_control, SNAME("size_bounds_changed"))
 	Array signal_args = { {} };
 
 	SUBCASE("Horizontal grow direction begin") {
 		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
 		test_control->set_custom_minimum_size(Size2(2, 2));
 		SceneTree::get_singleton()->process(0);
-		SIGNAL_CHECK("minimum_size_changed", signal_args)
+		SIGNAL_CHECK("size_bounds_changed", signal_args)
 		CHECK_MESSAGE(
 				test_control->get_rect().is_equal_approx(
 						Rect2(Vector2(-1, 0), Size2(2, 2))),
@@ -1157,7 +1157,7 @@ TEST_CASE("[SceneTree][Control] Grow direction") {
 		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BEGIN);
 		test_control->set_custom_minimum_size(Size2(4, 3));
 		SceneTree::get_singleton()->process(0);
-		SIGNAL_CHECK("minimum_size_changed", signal_args);
+		SIGNAL_CHECK("size_bounds_changed", signal_args);
 		CHECK_MESSAGE(
 				test_control->get_rect().is_equal_approx(
 						Rect2(Vector2(0, -2), Size2(4, 3))),
@@ -1168,7 +1168,7 @@ TEST_CASE("[SceneTree][Control] Grow direction") {
 		test_control->set_h_grow_direction(Control::GROW_DIRECTION_END);
 		test_control->set_custom_minimum_size(Size2(5, 3));
 		SceneTree::get_singleton()->process(0);
-		SIGNAL_CHECK("minimum_size_changed", signal_args);
+		SIGNAL_CHECK("size_bounds_changed", signal_args);
 		CHECK_MESSAGE(
 				test_control->get_rect().is_equal_approx(
 						Rect2(Vector2(0, 0), Size2(5, 3))),
@@ -1179,7 +1179,7 @@ TEST_CASE("[SceneTree][Control] Grow direction") {
 		test_control->set_v_grow_direction(Control::GROW_DIRECTION_END);
 		test_control->set_custom_minimum_size(Size2(4, 4));
 		SceneTree::get_singleton()->process(0);
-		SIGNAL_CHECK("minimum_size_changed", signal_args);
+		SIGNAL_CHECK("size_bounds_changed", signal_args);
 		CHECK_MESSAGE(
 				test_control->get_rect().is_equal_approx(
 						Rect2(Vector2(0, 0), Size2(4, 4))),
@@ -1191,7 +1191,7 @@ TEST_CASE("[SceneTree][Control] Grow direction") {
 		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BOTH);
 		test_control->set_custom_minimum_size(Size2(2, 4));
 		SceneTree::get_singleton()->process(0);
-		SIGNAL_CHECK("minimum_size_changed", signal_args);
+		SIGNAL_CHECK("size_bounds_changed", signal_args);
 		CHECK_MESSAGE(
 				test_control->get_rect().is_equal_approx(
 						Rect2(Vector2(-0.5, 0), Size2(2, 4))),
@@ -1202,7 +1202,7 @@ TEST_CASE("[SceneTree][Control] Grow direction") {
 		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BOTH);
 		test_control->set_custom_minimum_size(Size2(6, 3));
 		SceneTree::get_singleton()->process(0);
-		SIGNAL_CHECK("minimum_size_changed", signal_args);
+		SIGNAL_CHECK("size_bounds_changed", signal_args);
 		CHECK_MESSAGE(
 				test_control->get_rect().is_equal_approx(
 						Rect2(Vector2(0, -1), Size2(6, 3))),


### PR DESCRIPTION
* Closes https://github.com/godotengine/godot-proposals/issues/8333
* Supersedes/Implements internally https://github.com/godotengine/godot-proposals/issues/13534
* Supersedes #94171
* Includes the fix in #112525 (Noted such that if that PR causes any issues, the fix to said issues gets ported here)
  * Note: This will not be true in the final version of the PR, as #112741 has replaced #112525 as a much more elegant solution, and this PR will thus adapt around that. 

Adds a `custom_maximum_size` internal property to `Control`. The `maximum_size` will serve as a cap on the container's size. 

The `custom_maximum_size` is a `Size2`, and will apply dimension-wise if that dimension's value is greater than 0.
* e.g. `custom_maximum_size= (100,0)` will cap the width to 100 but will not cap the height

~ 

Adds a `SizeContainer` which exposes the `custom_maximum_size` property. This container will also apply this property to all of its children Controls. 
If a child has the `Expand` size flag, the container will expand to its maximum size in the specified axis.
Cannot have specific anchor flags, which would cause it to expand to be larger than its designated maximum size (namely, all of the Wide types and the Full Rect). This can technically still be overridden by using Custom anchoring, but that's A. beyond my control, B. an advanced-user thing -- use it at your own risk.

Additional feature:
* A `ScrollContainer` with a `custom_maximum_size` (i.e. within a `SizeContainer`) will first expand as much as it can until it reaches the maximum size, and then will start showing scrollbars as needed. 

Future work:
* Expose the horizontal component of `custom_maximum_size` in `Label` as `autowrap_width`, implementing https://github.com/godotengine/godot-proposals/issues/13568 