### PR TITLE
Use only one edit menu for TextEditors

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -919,7 +919,6 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save, bool p_history_back) {
 
 	int idx = tab_container->get_current_tab();
 	if (current) {
-		current->clear_edit_menu();
 		_save_editor_state(current);
 	}
 	memdelete(tselected);
@@ -2080,7 +2079,7 @@ void ScriptEditor::ensure_select_current() {
 	if (tab_container->get_tab_count() && tab_container->get_current_tab() >= 0) {
 		ScriptEditorBase *se = _get_current_editor();
 		if (se) {
-			se->enable_editor(this);
+			se->enable_editor();
 
 			if (!grab_focus_block && is_visible_in_tree()) {
 				se->ensure_focus();
@@ -2499,7 +2498,7 @@ void ScriptEditor::_update_script_names() {
 
 			ScriptEditorBase *se = _get_current_editor();
 			if (se) {
-				se->enable_editor(this);
+				se->enable_editor();
 				_update_selected_editor_menu();
 			}
 		}
@@ -2624,7 +2623,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 
 		if ((scr.is_valid() && se->get_edited_resource() == p_resource) || se->get_edited_resource()->get_path() == p_resource->get_path()) {
 			if (should_open) {
-				se->enable_editor(this);
+				se->enable_editor();
 
 				if (tab_container->get_current_tab() != i) {
 					_go_to_tab(i);
@@ -2689,7 +2688,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	tab_container->add_child(se);
 
 	if (p_grab_focus) {
-		se->enable_editor(this);
+		se->enable_editor();
 	}
 
 	// If we delete a script within the filesystem, the original resource path
@@ -2699,10 +2698,18 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 
 	se->set_tooltip_request_func(callable_mp(this, &ScriptEditor::_get_debug_tooltip));
 
-	if (se->get_edit_menu()) {
-		se->get_edit_menu()->hide();
-		menu_hb->add_child(se->get_edit_menu());
-		menu_hb->move_child(se->get_edit_menu(), 1);
+	Control *editor_edit_menu = se->get_edit_menu();
+	if (editor_edit_menu && !editor_edit_menu->get_parent()) {
+		editor_edit_menu->hide();
+		editor_menus.push_back(editor_edit_menu);
+		menu_hb->add_child(editor_edit_menu);
+		menu_hb->move_child(editor_edit_menu, 1);
+		for (int i = 0; i < editor_edit_menu->get_child_count(); ++i) {
+			Control *c = Object::cast_to<Control>(editor_edit_menu->get_child(i));
+			if (c) {
+				c->set_shortcut_context(this);
+			}
+		}
 	}
 
 	if (p_grab_focus) {
@@ -3829,17 +3836,9 @@ void ScriptEditor::update_docs_from_script(const Ref<Script> &p_script) {
 }
 
 void ScriptEditor::_update_selected_editor_menu() {
-	for (int i = 0; i < tab_container->get_tab_count(); i++) {
-		bool current = tab_container->get_current_tab() == i;
-
-		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
-		if (se && se->get_edit_menu()) {
-			if (current) {
-				se->get_edit_menu()->show();
-			} else {
-				se->get_edit_menu()->hide();
-			}
-		}
+	ScriptEditorBase *current_editor = _get_current_editor();
+	for (Control *editor_menu : editor_menus) {
+		editor_menu->set_visible(current_editor && editor_menu == current_editor->get_edit_menu());
 	}
 
 	EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_current_tab_control());

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -207,7 +207,7 @@ public:
 	virtual Ref<Resource> get_edited_resource() const = 0;
 	virtual Vector<String> get_functions() = 0;
 	virtual void set_edited_resource(const Ref<Resource> &p_res) = 0;
-	virtual void enable_editor(Control *p_shortcut_context = nullptr) = 0;
+	virtual void enable_editor() = 0;
 	virtual void reload_text() = 0;
 	virtual String get_name() = 0;
 	virtual Ref<Texture2D> get_theme_icon() = 0;
@@ -237,7 +237,6 @@ public:
 
 	virtual void set_tooltip_request_func(const Callable &p_toolip_callback) = 0;
 	virtual Control *get_edit_menu() = 0;
-	virtual void clear_edit_menu() = 0;
 	virtual void set_find_replace_bar(FindReplaceBar *p_bar) = 0;
 
 	virtual Control *get_base_editor() const = 0;
@@ -322,11 +321,11 @@ class ScriptEditor : public PanelContainer {
 
 	HBoxContainer *menu_hb = nullptr;
 	MenuButton *file_menu = nullptr;
-	MenuButton *edit_menu = nullptr;
 	MenuButton *script_search_menu = nullptr;
 	MenuButton *debug_menu = nullptr;
 	PopupMenu *context_menu = nullptr;
 	Timer *autosave_timer = nullptr;
+	LocalVector<Control *> editor_menus;
 
 	PopupMenu *recent_scripts = nullptr;
 	PopupMenu *theme_submenu = nullptr;
@@ -605,6 +604,8 @@ public:
 
 	void set_scene_root_script(Ref<Script> p_script);
 	Vector<Ref<Script>> get_open_scripts() const;
+
+	ScriptEditorBase *get_current_editor() const { return _get_current_editor(); }
 
 	bool script_goto_method(Ref<Script> p_script, const String &p_method);
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -128,6 +128,244 @@ ConnectionInfoDialog::ConnectionInfoDialog() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ScriptTextEditor *ScriptTextEditor::EditMenusSTE::_get_active_editor() {
+	return Object::cast_to<ScriptTextEditor>(ScriptEditor::get_singleton()->get_current_editor());
+}
+
+void ScriptTextEditor::EditMenusSTE::_edit_option(int p_op) {
+	ScriptTextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	script_text_editor->_edit_option(p_op);
+}
+
+void ScriptTextEditor::EditMenusSTE::_prepare_edit_menu() {
+	ScriptTextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	const CodeEdit *tx = script_text_editor->code_editor->get_text_editor();
+	PopupMenu *popup = edit_menu->get_popup();
+	popup->set_item_disabled(popup->get_item_index(EDIT_UNDO), !tx->has_undo());
+	popup->set_item_disabled(popup->get_item_index(EDIT_REDO), !tx->has_redo());
+}
+
+void ScriptTextEditor::EditMenusSTE::_update_highlighter_menu() {
+	ScriptTextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+
+	Ref<EditorSyntaxHighlighter> current_highlighter = script_text_editor->get_code_editor()->get_text_editor()->get_syntax_highlighter();
+	highlighter_menu->clear();
+	for (const Ref<EditorSyntaxHighlighter> &highlighter : script_text_editor->highlighters) {
+		highlighter_menu->add_radio_check_item(highlighter->_get_name());
+		highlighter_menu->set_item_checked(-1, highlighter == current_highlighter);
+	}
+}
+
+void ScriptTextEditor::EditMenusSTE::_change_syntax_highlighter(int p_idx) {
+	ScriptTextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	ERR_FAIL_INDEX(p_idx, (int)script_text_editor->highlighters.size());
+	script_text_editor->set_syntax_highlighter(script_text_editor->highlighters[p_idx]);
+}
+
+void ScriptTextEditor::EditMenusSTE::_update_bookmark_list() {
+	ScriptTextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	bookmarks_menu->clear();
+	bookmarks_menu->reset_size();
+
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_bookmarks"), BOOKMARK_REMOVE_ALL);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
+
+	PackedInt32Array bookmark_list = script_text_editor->code_editor->get_text_editor()->get_bookmarked_lines();
+	if (bookmark_list.is_empty()) {
+		return;
+	}
+
+	bookmarks_menu->add_separator();
+
+	for (int i = 0; i < bookmark_list.size(); i++) {
+		// Strip edges to remove spaces or tabs.
+		// Also replace any tabs by spaces, since we can't print tabs in the menu.
+		String line = script_text_editor->code_editor->get_text_editor()->get_line(bookmark_list[i]).replace("\t", "  ").strip_edges();
+
+		// Limit the size of the line if too big.
+		if (line.length() > 50) {
+			line = line.substr(0, 50);
+		}
+
+		bookmarks_menu->add_item(String::num_int64(bookmark_list[i] + 1) + " - `" + line + "`");
+		bookmarks_menu->set_item_metadata(-1, bookmark_list[i]);
+	}
+}
+
+void ScriptTextEditor::EditMenusSTE::_bookmark_item_pressed(int p_idx) {
+	ScriptTextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	if (p_idx < 4) { // Any item before the separator.
+		script_text_editor->_edit_option(bookmarks_menu->get_item_id(p_idx));
+	} else {
+		script_text_editor->code_editor->goto_line_centered(bookmarks_menu->get_item_metadata(p_idx));
+	}
+}
+
+void ScriptTextEditor::EditMenusSTE::_update_breakpoint_list() {
+	ScriptTextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	breakpoints_menu->clear();
+	breakpoints_menu->reset_size();
+
+	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_breakpoint"), DEBUG_TOGGLE_BREAKPOINT);
+	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_breakpoints"), DEBUG_REMOVE_ALL_BREAKPOINTS);
+	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_breakpoint"), DEBUG_GOTO_NEXT_BREAKPOINT);
+	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_breakpoint"), DEBUG_GOTO_PREV_BREAKPOINT);
+
+	PackedInt32Array breakpoint_list = script_text_editor->code_editor->get_text_editor()->get_breakpointed_lines();
+	if (breakpoint_list.is_empty()) {
+		return;
+	}
+
+	breakpoints_menu->add_separator();
+
+	for (int i = 0; i < breakpoint_list.size(); i++) {
+		// Strip edges to remove spaces or tabs.
+		// Also replace any tabs by spaces, since we can't print tabs in the menu.
+		String line = script_text_editor->code_editor->get_text_editor()->get_line(breakpoint_list[i]).replace("\t", "  ").strip_edges();
+
+		// Limit the size of the line if too big.
+		if (line.length() > 50) {
+			line = line.substr(0, 50);
+		}
+
+		breakpoints_menu->add_item(String::num_int64(breakpoint_list[i] + 1) + " - `" + line + "`");
+		breakpoints_menu->set_item_metadata(-1, breakpoint_list[i]);
+	}
+}
+
+void ScriptTextEditor::EditMenusSTE::_breakpoint_item_pressed(int p_idx) {
+	ScriptTextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	if (p_idx < 4) { // Any item before the separator.
+		script_text_editor->_edit_option(breakpoints_menu->get_item_id(p_idx));
+	} else {
+		script_text_editor->code_editor->goto_line_centered(breakpoints_menu->get_item_metadata(p_idx));
+	}
+}
+
+ScriptTextEditor::EditMenusSTE::EditMenusSTE() {
+	edit_menu = memnew(MenuButton);
+	edit_menu->set_flat(false);
+	edit_menu->set_theme_type_variation("FlatMenuButton");
+	edit_menu->set_text(TTRC("Edit"));
+	edit_menu->set_switch_on_hover(true);
+
+	add_child(edit_menu);
+	edit_menu->connect("about_to_popup", callable_mp(this, &EditMenusSTE::_prepare_edit_menu));
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
+	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
+	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_selection"), EDIT_DUPLICATE_SELECTION);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_lines"), EDIT_DUPLICATE_LINES);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/evaluate_selection"), EDIT_EVALUATE);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_word_wrap"), EDIT_TOGGLE_WORD_WRAP);
+	edit_menu->get_popup()->add_separator();
+	{
+		PopupMenu *sub_menu = memnew(PopupMenu);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_up"), EDIT_MOVE_LINE_UP);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_down"), EDIT_MOVE_LINE_DOWN);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent"), EDIT_INDENT);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unindent"), EDIT_UNINDENT);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/delete_line"), EDIT_DELETE_LINE);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
+		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenusSTE::_edit_option));
+		edit_menu->get_popup()->add_submenu_node_item(TTRC("Line"), sub_menu);
+	}
+	{
+		PopupMenu *sub_menu = memnew(PopupMenu);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_fold_line"), EDIT_TOGGLE_FOLD_LINE);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/fold_all_lines"), EDIT_FOLD_ALL_LINES);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unfold_all_lines"), EDIT_UNFOLD_ALL_LINES);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/create_code_region"), EDIT_CREATE_CODE_REGION);
+		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenusSTE::_edit_option));
+		edit_menu->get_popup()->add_submenu_node_item(TTRC("Folding"), sub_menu);
+	}
+	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_completion_query"), EDIT_COMPLETE);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_trailing_whitespace"), EDIT_TRIM_TRAILING_WHITESAPCE);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_final_newlines"), EDIT_TRIM_FINAL_NEWLINES);
+	{
+		PopupMenu *sub_menu = memnew(PopupMenu);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_spaces"), EDIT_CONVERT_INDENT_TO_SPACES);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_tabs"), EDIT_CONVERT_INDENT_TO_TABS);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/auto_indent"), EDIT_AUTO_INDENT);
+		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenusSTE::_edit_option));
+		edit_menu->get_popup()->add_submenu_node_item(TTRC("Indentation"), sub_menu);
+	}
+	edit_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenusSTE::_edit_option));
+	edit_menu->get_popup()->add_separator();
+	{
+		PopupMenu *sub_menu = memnew(PopupMenu);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_uppercase"), EDIT_TO_UPPERCASE);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_lowercase"), EDIT_TO_LOWERCASE);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/capitalize"), EDIT_CAPITALIZE);
+		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenusSTE::_edit_option));
+		edit_menu->get_popup()->add_submenu_node_item(TTRC("Convert Case"), sub_menu);
+	}
+	highlighter_menu = memnew(PopupMenu);
+	edit_menu->get_popup()->add_submenu_node_item(TTRC("Syntax Highlighter"), highlighter_menu);
+
+	highlighter_menu->connect("about_to_popup", callable_mp(this, &EditMenusSTE::_update_highlighter_menu));
+	highlighter_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenusSTE::_change_syntax_highlighter));
+
+	search_menu = memnew(MenuButton);
+	search_menu->set_flat(false);
+	search_menu->set_theme_type_variation("FlatMenuButton");
+	search_menu->set_text(TTRC("Search"));
+	search_menu->set_switch_on_hover(true);
+
+	add_child(search_menu);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_previous"), SEARCH_FIND_PREV);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace"), SEARCH_REPLACE);
+	search_menu->get_popup()->add_separator();
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("editor/find_in_files"), SEARCH_IN_FILES);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace_in_files"), REPLACE_IN_FILES);
+	search_menu->get_popup()->add_separator();
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/contextual_help"), HELP_CONTEXTUAL);
+	search_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenusSTE::_edit_option));
+
+	goto_menu = memnew(MenuButton);
+	goto_menu->set_flat(false);
+	goto_menu->set_theme_type_variation("FlatMenuButton");
+	goto_menu->set_text(TTRC("Go To"));
+	goto_menu->set_switch_on_hover(true);
+	add_child(goto_menu);
+	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_function"), SEARCH_LOCATE_FUNCTION);
+	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
+	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_symbol"), LOOKUP_SYMBOL);
+	goto_menu->get_popup()->add_separator();
+
+	bookmarks_menu = memnew(PopupMenu);
+	goto_menu->get_popup()->add_submenu_node_item(TTRC("Bookmarks"), bookmarks_menu);
+	bookmarks_menu->connect("about_to_popup", callable_mp(this, &EditMenusSTE::_update_bookmark_list));
+	bookmarks_menu->connect("index_pressed", callable_mp(this, &EditMenusSTE::_bookmark_item_pressed));
+
+	breakpoints_menu = memnew(PopupMenu);
+	goto_menu->get_popup()->add_submenu_node_item(TTRC("Breakpoints"), breakpoints_menu);
+	breakpoints_menu->connect("about_to_popup", callable_mp(this, &EditMenusSTE::_update_breakpoint_list));
+	breakpoints_menu->connect("index_pressed", callable_mp(this, &EditMenusSTE::_breakpoint_item_pressed));
+
+	goto_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenusSTE::_edit_option));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 Vector<String> ScriptTextEditor::get_functions() {
 	CodeEdit *te = code_editor->get_text_editor();
 	String text = te->get_text();
@@ -175,7 +413,7 @@ void ScriptTextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 	code_editor->update_line_and_column();
 }
 
-void ScriptTextEditor::enable_editor(Control *p_shortcut_context) {
+void ScriptTextEditor::enable_editor() {
 	if (editor_enabled) {
 		return;
 	}
@@ -189,15 +427,6 @@ void ScriptTextEditor::enable_editor(Control *p_shortcut_context) {
 	if (pending_state != Variant()) {
 		code_editor->set_edit_state(pending_state);
 		pending_state = Variant();
-	}
-
-	if (p_shortcut_context) {
-		for (int i = 0; i < edit_hb->get_child_count(); ++i) {
-			Control *c = cast_to<Control>(edit_hb->get_child(i));
-			if (c) {
-				c->set_shortcut_context(p_shortcut_context);
-			}
-		}
 	}
 }
 
@@ -731,9 +960,11 @@ void ScriptTextEditor::set_edit_state(const Variant &p_state) {
 
 	Dictionary state = p_state;
 	if (state.has("syntax_highlighter")) {
-		int idx = highlighter_menu->get_item_idx_from_text(state["syntax_highlighter"]);
-		if (idx >= 0) {
-			_change_syntax_highlighter(idx);
+		for (const Ref<EditorSyntaxHighlighter> &highlighter : highlighters) {
+			if (highlighter->_get_name() == String(state["syntax_highlighter"])) {
+				set_syntax_highlighter(highlighter);
+				break;
+			}
 		}
 	}
 
@@ -1061,45 +1292,6 @@ void ScriptTextEditor::_update_errors() {
 	}
 }
 
-void ScriptTextEditor::_update_bookmark_list() {
-	bookmarks_menu->clear();
-	bookmarks_menu->reset_size();
-
-	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
-	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_bookmarks"), BOOKMARK_REMOVE_ALL);
-	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
-	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
-
-	PackedInt32Array bookmark_list = code_editor->get_text_editor()->get_bookmarked_lines();
-	if (bookmark_list.is_empty()) {
-		return;
-	}
-
-	bookmarks_menu->add_separator();
-
-	for (int i = 0; i < bookmark_list.size(); i++) {
-		// Strip edges to remove spaces or tabs.
-		// Also replace any tabs by spaces, since we can't print tabs in the menu.
-		String line = code_editor->get_text_editor()->get_line(bookmark_list[i]).replace("\t", "  ").strip_edges();
-
-		// Limit the size of the line if too big.
-		if (line.length() > 50) {
-			line = line.substr(0, 50);
-		}
-
-		bookmarks_menu->add_item(String::num_int64(bookmark_list[i] + 1) + " - `" + line + "`");
-		bookmarks_menu->set_item_metadata(-1, bookmark_list[i]);
-	}
-}
-
-void ScriptTextEditor::_bookmark_item_pressed(int p_idx) {
-	if (p_idx < 4) { // Any item before the separator.
-		_edit_option(bookmarks_menu->get_item_id(p_idx));
-	} else {
-		code_editor->goto_line_centered(bookmarks_menu->get_item_metadata(p_idx));
-	}
-}
-
 static Vector<Node *> _find_all_node_for_script(Node *p_base, Node *p_current, const Ref<Script> &p_script) {
 	Vector<Node *> nodes;
 
@@ -1213,45 +1405,6 @@ void ScriptTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 
 	if (err == OK) {
 		code_editor->get_text_editor()->set_code_hint(hint);
-	}
-}
-
-void ScriptTextEditor::_update_breakpoint_list() {
-	breakpoints_menu->clear();
-	breakpoints_menu->reset_size();
-
-	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_breakpoint"), DEBUG_TOGGLE_BREAKPOINT);
-	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_breakpoints"), DEBUG_REMOVE_ALL_BREAKPOINTS);
-	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_breakpoint"), DEBUG_GOTO_NEXT_BREAKPOINT);
-	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_breakpoint"), DEBUG_GOTO_PREV_BREAKPOINT);
-
-	PackedInt32Array breakpoint_list = code_editor->get_text_editor()->get_breakpointed_lines();
-	if (breakpoint_list.is_empty()) {
-		return;
-	}
-
-	breakpoints_menu->add_separator();
-
-	for (int i = 0; i < breakpoint_list.size(); i++) {
-		// Strip edges to remove spaces or tabs.
-		// Also replace any tabs by spaces, since we can't print tabs in the menu.
-		String line = code_editor->get_text_editor()->get_line(breakpoint_list[i]).replace("\t", "  ").strip_edges();
-
-		// Limit the size of the line if too big.
-		if (line.length() > 50) {
-			line = line.substr(0, 50);
-		}
-
-		breakpoints_menu->add_item(String::num_int64(breakpoint_list[i] + 1) + " - `" + line + "`");
-		breakpoints_menu->set_item_metadata(-1, breakpoint_list[i]);
-	}
-}
-
-void ScriptTextEditor::_breakpoint_item_pressed(int p_idx) {
-	if (p_idx < 4) { // Any item before the separator.
-		_edit_option(breakpoints_menu->get_item_id(p_idx));
-	} else {
-		code_editor->goto_line_centered(breakpoints_menu->get_item_metadata(p_idx));
 	}
 }
 
@@ -2089,27 +2242,15 @@ void ScriptTextEditor::_edit_option_toggle_inline_comment() {
 void ScriptTextEditor::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());
 
-	highlighters[p_highlighter->_get_name()] = p_highlighter;
-	highlighter_menu->add_radio_check_item(p_highlighter->_get_name());
+	highlighters.push_back(p_highlighter);
 }
 
 void ScriptTextEditor::set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());
 
-	HashMap<String, Ref<EditorSyntaxHighlighter>>::Iterator el = highlighters.begin();
-	while (el) {
-		int highlighter_index = highlighter_menu->get_item_idx_from_text(el->key);
-		highlighter_menu->set_item_checked(highlighter_index, el->value == p_highlighter);
-		++el;
-	}
-
 	CodeEdit *te = code_editor->get_text_editor();
 	p_highlighter->_set_edited_resource(script);
 	te->set_syntax_highlighter(p_highlighter);
-}
-
-void ScriptTextEditor::_change_syntax_highlighter(int p_idx) {
-	set_syntax_highlighter(highlighters[highlighter_menu->get_item_text(p_idx)]);
 }
 
 void ScriptTextEditor::_notification(int p_what) {
@@ -2141,13 +2282,10 @@ void ScriptTextEditor::_notification(int p_what) {
 }
 
 Control *ScriptTextEditor::get_edit_menu() {
-	return edit_hb;
-}
-
-void ScriptTextEditor::clear_edit_menu() {
-	if (editor_enabled) {
-		memdelete(edit_hb);
+	if (!edit_menus) {
+		edit_menus = memnew(EditMenusSTE);
 	}
+	return edit_menus;
 }
 
 void ScriptTextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {
@@ -2800,13 +2938,6 @@ void ScriptTextEditor::_color_changed(const Color &p_color) {
 	code_editor->get_text_editor()->end_complex_operation();
 }
 
-void ScriptTextEditor::_prepare_edit_menu() {
-	const CodeEdit *tx = code_editor->get_text_editor();
-	PopupMenu *popup = edit_menu->get_popup();
-	popup->set_item_disabled(popup->get_item_index(EDIT_UNDO), !tx->has_undo());
-	popup->set_item_disabled(popup->get_item_index(EDIT_REDO), !tx->has_redo());
-}
-
 void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, bool p_goto_definition, Vector2 p_pos) {
 	context_menu->clear();
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_EMOJI_AND_SYMBOL_PICKER)) {
@@ -2915,97 +3046,7 @@ void ScriptTextEditor::_enable_code_editor() {
 
 	add_child(connection_info_dialog);
 
-	edit_hb->add_child(edit_menu);
-	edit_menu->connect("about_to_popup", callable_mp(this, &ScriptTextEditor::_prepare_edit_menu));
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_selection"), EDIT_DUPLICATE_SELECTION);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_lines"), EDIT_DUPLICATE_LINES);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/evaluate_selection"), EDIT_EVALUATE);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_word_wrap"), EDIT_TOGGLE_WORD_WRAP);
-	edit_menu->get_popup()->add_separator();
-	{
-		PopupMenu *sub_menu = memnew(PopupMenu);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_up"), EDIT_MOVE_LINE_UP);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_down"), EDIT_MOVE_LINE_DOWN);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent"), EDIT_INDENT);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unindent"), EDIT_UNINDENT);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/delete_line"), EDIT_DELETE_LINE);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
-		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptTextEditor::_edit_option));
-		edit_menu->get_popup()->add_submenu_node_item(TTRC("Line"), sub_menu);
-	}
-	{
-		PopupMenu *sub_menu = memnew(PopupMenu);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_fold_line"), EDIT_TOGGLE_FOLD_LINE);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/fold_all_lines"), EDIT_FOLD_ALL_LINES);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unfold_all_lines"), EDIT_UNFOLD_ALL_LINES);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/create_code_region"), EDIT_CREATE_CODE_REGION);
-		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptTextEditor::_edit_option));
-		edit_menu->get_popup()->add_submenu_node_item(TTRC("Folding"), sub_menu);
-	}
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_completion_query"), EDIT_COMPLETE);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_trailing_whitespace"), EDIT_TRIM_TRAILING_WHITESAPCE);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_final_newlines"), EDIT_TRIM_FINAL_NEWLINES);
-	{
-		PopupMenu *sub_menu = memnew(PopupMenu);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_spaces"), EDIT_CONVERT_INDENT_TO_SPACES);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_tabs"), EDIT_CONVERT_INDENT_TO_TABS);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/auto_indent"), EDIT_AUTO_INDENT);
-		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptTextEditor::_edit_option));
-		edit_menu->get_popup()->add_submenu_node_item(TTRC("Indentation"), sub_menu);
-	}
-	edit_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptTextEditor::_edit_option));
-	edit_menu->get_popup()->add_separator();
-	{
-		PopupMenu *sub_menu = memnew(PopupMenu);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_uppercase"), EDIT_TO_UPPERCASE);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_lowercase"), EDIT_TO_LOWERCASE);
-		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/capitalize"), EDIT_CAPITALIZE);
-		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptTextEditor::_edit_option));
-		edit_menu->get_popup()->add_submenu_node_item(TTRC("Convert Case"), sub_menu);
-	}
-	edit_menu->get_popup()->add_submenu_node_item(TTRC("Syntax Highlighter"), highlighter_menu);
-	highlighter_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptTextEditor::_change_syntax_highlighter));
-
-	edit_hb->add_child(search_menu);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_previous"), SEARCH_FIND_PREV);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace"), SEARCH_REPLACE);
-	search_menu->get_popup()->add_separator();
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("editor/find_in_files"), SEARCH_IN_FILES);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace_in_files"), REPLACE_IN_FILES);
-	search_menu->get_popup()->add_separator();
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/contextual_help"), HELP_CONTEXTUAL);
-	search_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptTextEditor::_edit_option));
-
 	_load_theme_settings();
-
-	edit_hb->add_child(goto_menu);
-	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_function"), SEARCH_LOCATE_FUNCTION);
-	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
-	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_symbol"), LOOKUP_SYMBOL);
-	goto_menu->get_popup()->add_separator();
-
-	goto_menu->get_popup()->add_submenu_node_item(TTRC("Bookmarks"), bookmarks_menu);
-	_update_bookmark_list();
-	bookmarks_menu->connect("about_to_popup", callable_mp(this, &ScriptTextEditor::_update_bookmark_list));
-	bookmarks_menu->connect("index_pressed", callable_mp(this, &ScriptTextEditor::_bookmark_item_pressed));
-
-	goto_menu->get_popup()->add_submenu_node_item(TTRC("Breakpoints"), breakpoints_menu);
-	_update_breakpoint_list();
-	breakpoints_menu->connect("about_to_popup", callable_mp(this, &ScriptTextEditor::_update_breakpoint_list));
-	breakpoints_menu->connect("index_pressed", callable_mp(this, &ScriptTextEditor::_breakpoint_item_pressed));
-
-	goto_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptTextEditor::_edit_option));
 }
 
 ScriptTextEditor::ScriptTextEditor() {
@@ -3056,17 +3097,6 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	color_panel = memnew(PopupPanel);
 
-	edit_hb = memnew(HBoxContainer);
-
-	edit_menu = memnew(MenuButton);
-	edit_menu->set_flat(false);
-	edit_menu->set_theme_type_variation("FlatMenuButton");
-	edit_menu->set_text(TTRC("Edit"));
-	edit_menu->set_switch_on_hover(true);
-	edit_menu->set_shortcut_context(this);
-
-	highlighter_menu = memnew(PopupMenu);
-
 	Ref<EditorPlainTextSyntaxHighlighter> plain_highlighter;
 	plain_highlighter.instantiate();
 	add_syntax_highlighter(plain_highlighter);
@@ -3075,23 +3105,6 @@ ScriptTextEditor::ScriptTextEditor() {
 	highlighter.instantiate();
 	add_syntax_highlighter(highlighter);
 	set_syntax_highlighter(highlighter);
-
-	search_menu = memnew(MenuButton);
-	search_menu->set_flat(false);
-	search_menu->set_theme_type_variation("FlatMenuButton");
-	search_menu->set_text(TTRC("Search"));
-	search_menu->set_switch_on_hover(true);
-	search_menu->set_shortcut_context(this);
-
-	goto_menu = memnew(MenuButton);
-	goto_menu->set_flat(false);
-	goto_menu->set_theme_type_variation("FlatMenuButton");
-	goto_menu->set_text(TTRC("Go To"));
-	goto_menu->set_switch_on_hover(true);
-	goto_menu->set_shortcut_context(this);
-
-	bookmarks_menu = memnew(PopupMenu);
-	breakpoints_menu = memnew(PopupMenu);
 
 	inline_color_popup = memnew(PopupPanel);
 	add_child(inline_color_popup);
@@ -3124,13 +3137,6 @@ ScriptTextEditor::~ScriptTextEditor() {
 		memdelete(errors_panel);
 		memdelete(context_menu);
 		memdelete(color_panel);
-		memdelete(edit_hb);
-		memdelete(edit_menu);
-		memdelete(highlighter_menu);
-		memdelete(search_menu);
-		memdelete(goto_menu);
-		memdelete(bookmarks_menu);
-		memdelete(breakpoints_menu);
 		memdelete(connection_info_dialog);
 	}
 }

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -57,6 +57,29 @@ public:
 class ScriptTextEditor : public ScriptEditorBase {
 	GDCLASS(ScriptTextEditor, ScriptEditorBase);
 
+	class EditMenusSTE : public HBoxContainer {
+		GDCLASS(EditMenusSTE, HBoxContainer);
+		MenuButton *edit_menu = nullptr;
+		MenuButton *search_menu = nullptr;
+		MenuButton *goto_menu = nullptr;
+		PopupMenu *bookmarks_menu = nullptr;
+		PopupMenu *breakpoints_menu = nullptr;
+		PopupMenu *highlighter_menu = nullptr;
+
+		ScriptTextEditor *_get_active_editor();
+		void _edit_option(int p_op);
+		void _prepare_edit_menu();
+		void _update_highlighter_menu();
+		void _change_syntax_highlighter(int p_idx);
+		void _update_bookmark_list();
+		void _bookmark_item_pressed(int p_idx);
+		void _update_breakpoint_list();
+		void _breakpoint_item_pressed(int p_idx);
+
+	public:
+		EditMenusSTE();
+	};
+
 	CodeTextEditor *code_editor = nullptr;
 	RichTextLabel *warnings_panel = nullptr;
 	RichTextLabel *errors_panel = nullptr;
@@ -74,14 +97,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 
 	List<Connection> missing_connections;
 
-	HBoxContainer *edit_hb = nullptr;
-
-	MenuButton *edit_menu = nullptr;
-	MenuButton *search_menu = nullptr;
-	MenuButton *goto_menu = nullptr;
-	PopupMenu *bookmarks_menu = nullptr;
-	PopupMenu *breakpoints_menu = nullptr;
-	PopupMenu *highlighter_menu = nullptr;
+	static inline EditMenusSTE *edit_menus = nullptr;
 	PopupMenu *context_menu = nullptr;
 
 	int inline_color_line = -1;
@@ -115,6 +131,8 @@ class ScriptTextEditor : public ScriptEditorBase {
 	String color_args;
 
 	bool theme_loaded = false;
+
+	LocalVector<Ref<EditorSyntaxHighlighter>> highlighters;
 
 	enum {
 		EDIT_UNDO,
@@ -193,8 +211,6 @@ class ScriptTextEditor : public ScriptEditorBase {
 	void _assign_dragged_export_variables();
 
 protected:
-	void _update_breakpoint_list();
-	void _breakpoint_item_pressed(int p_idx);
 	void _breakpoint_toggled(int p_row);
 
 	void _on_caret_moved();
@@ -202,8 +218,6 @@ protected:
 	void _validate_script(); // No longer virtual.
 	void _update_warnings();
 	void _update_errors();
-	void _update_bookmark_list();
-	void _bookmark_item_pressed(int p_idx);
 
 	static void _code_complete_scripts(void *p_ud, const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force);
 	void _code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force);
@@ -227,15 +241,11 @@ protected:
 
 	void _notification(int p_what);
 
-	HashMap<String, Ref<EditorSyntaxHighlighter>> highlighters;
-	void _change_syntax_highlighter(int p_idx);
-
 	void _edit_option(int p_op);
 	void _edit_option_toggle_inline_comment();
 	void _make_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, bool p_goto_definition, Vector2 p_pos);
 	void _text_edit_gui_input(const Ref<InputEvent> &ev);
 	void _color_changed(const Color &p_color);
-	void _prepare_edit_menu();
 
 	void _goto_line(int p_line) { goto_line(p_line); }
 	void _lookup_symbol(const String &p_symbol, int p_row, int p_column);
@@ -261,7 +271,7 @@ public:
 	virtual void apply_code() override;
 	virtual Ref<Resource> get_edited_resource() const override;
 	virtual void set_edited_resource(const Ref<Resource> &p_res) override;
-	virtual void enable_editor(Control *p_shortcut_context = nullptr) override;
+	virtual void enable_editor() override;
 	virtual Vector<String> get_functions() override;
 	virtual void reload_text() override;
 	virtual String get_name() override;
@@ -297,8 +307,7 @@ public:
 
 	virtual void set_debugger_active(bool p_active) override;
 
-	Control *get_edit_menu() override;
-	virtual void clear_edit_menu() override;
+	virtual Control *get_edit_menu() override;
 	virtual void set_find_replace_bar(FindReplaceBar *p_bar) override;
 
 	static void register_editor();

--- a/editor/script/text_editor.cpp
+++ b/editor/script/text_editor.cpp
@@ -36,29 +36,199 @@
 #include "scene/gui/menu_button.h"
 #include "scene/gui/split_container.h"
 
+TextEditor *TextEditor::EditMenus::_get_active_editor() {
+	return Object::cast_to<TextEditor>(ScriptEditor::get_singleton()->get_current_editor());
+}
+
+void TextEditor::EditMenus::_edit_option(int p_op) {
+	TextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	script_text_editor->_edit_option(p_op);
+}
+
+void TextEditor::EditMenus::_prepare_edit_menu() {
+	TextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	const CodeEdit *tx = script_text_editor->code_editor->get_text_editor();
+	PopupMenu *popup = edit_menu->get_popup();
+	popup->set_item_disabled(popup->get_item_index(EDIT_UNDO), !tx->has_undo());
+	popup->set_item_disabled(popup->get_item_index(EDIT_REDO), !tx->has_redo());
+}
+
+void TextEditor::EditMenus::_update_highlighter_menu() {
+	TextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+
+	Ref<EditorSyntaxHighlighter> current_highlighter = script_text_editor->get_code_editor()->get_text_editor()->get_syntax_highlighter();
+	highlighter_menu->clear();
+	for (const Ref<EditorSyntaxHighlighter> &highlighter : script_text_editor->highlighters) {
+		highlighter_menu->add_radio_check_item(highlighter->_get_name());
+		highlighter_menu->set_item_checked(-1, highlighter == current_highlighter);
+	}
+}
+
+void TextEditor::EditMenus::_change_syntax_highlighter(int p_idx) {
+	TextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	ERR_FAIL_INDEX(p_idx, (int)script_text_editor->highlighters.size());
+	script_text_editor->set_syntax_highlighter(script_text_editor->highlighters[p_idx]);
+}
+
+void TextEditor::EditMenus::_update_bookmark_list() {
+	TextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	bookmarks_menu->clear();
+	bookmarks_menu->reset_size();
+
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_bookmarks"), BOOKMARK_REMOVE_ALL);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
+	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
+
+	PackedInt32Array bookmark_list = script_text_editor->code_editor->get_text_editor()->get_bookmarked_lines();
+	if (bookmark_list.is_empty()) {
+		return;
+	}
+
+	bookmarks_menu->add_separator();
+
+	for (int i = 0; i < bookmark_list.size(); i++) {
+		// Strip edges to remove spaces or tabs.
+		// Also replace any tabs by spaces, since we can't print tabs in the menu.
+		String line = script_text_editor->code_editor->get_text_editor()->get_line(bookmark_list[i]).replace("\t", "  ").strip_edges();
+
+		// Limit the size of the line if too big.
+		if (line.length() > 50) {
+			line = line.substr(0, 50);
+		}
+
+		bookmarks_menu->add_item(String::num_int64(bookmark_list[i] + 1) + " - `" + line + "`");
+		bookmarks_menu->set_item_metadata(-1, bookmark_list[i]);
+	}
+}
+
+void TextEditor::EditMenus::_bookmark_item_pressed(int p_idx) {
+	TextEditor *script_text_editor = _get_active_editor();
+	ERR_FAIL_NULL(script_text_editor);
+	if (p_idx < 4) { // Any item before the separator.
+		script_text_editor->_edit_option(bookmarks_menu->get_item_id(p_idx));
+	} else {
+		script_text_editor->code_editor->goto_line_centered(bookmarks_menu->get_item_metadata(p_idx));
+	}
+}
+
+TextEditor::EditMenus::EditMenus() {
+	edit_menu = memnew(MenuButton);
+	edit_menu->set_flat(false);
+	edit_menu->set_theme_type_variation("FlatMenuButton");
+	edit_menu->set_text(TTRC("Edit"));
+	edit_menu->set_switch_on_hover(true);
+
+	add_child(edit_menu);
+	edit_menu->connect("about_to_popup", callable_mp(this, &EditMenus::_prepare_edit_menu));
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
+	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
+	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_selection"), EDIT_DUPLICATE_SELECTION);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_lines"), EDIT_DUPLICATE_LINES);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_word_wrap"), EDIT_TOGGLE_WORD_WRAP);
+	edit_menu->get_popup()->add_separator();
+	{
+		PopupMenu *sub_menu = memnew(PopupMenu);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_up"), EDIT_MOVE_LINE_UP);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_down"), EDIT_MOVE_LINE_DOWN);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent"), EDIT_INDENT);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unindent"), EDIT_UNINDENT);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/delete_line"), EDIT_DELETE_LINE);
+		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenus::_edit_option));
+		edit_menu->get_popup()->add_submenu_node_item(TTRC("Line"), sub_menu);
+	}
+	{
+		PopupMenu *sub_menu = memnew(PopupMenu);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_fold_line"), EDIT_TOGGLE_FOLD_LINE);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/fold_all_lines"), EDIT_FOLD_ALL_LINES);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unfold_all_lines"), EDIT_UNFOLD_ALL_LINES);
+		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenus::_edit_option));
+		edit_menu->get_popup()->add_submenu_node_item(TTRC("Folding"), sub_menu);
+	}
+	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_trailing_whitespace"), EDIT_TRIM_TRAILING_WHITESAPCE);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_final_newlines"), EDIT_TRIM_FINAL_NEWLINES);
+	{
+		PopupMenu *sub_menu = memnew(PopupMenu);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_spaces"), EDIT_CONVERT_INDENT_TO_SPACES);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_tabs"), EDIT_CONVERT_INDENT_TO_TABS);
+		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenus::_edit_option));
+		edit_menu->get_popup()->add_submenu_node_item(TTRC("Indentation"), sub_menu);
+	}
+	edit_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenus::_edit_option));
+	edit_menu->get_popup()->add_separator();
+	{
+		PopupMenu *sub_menu = memnew(PopupMenu);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_uppercase"), EDIT_TO_UPPERCASE);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_lowercase"), EDIT_TO_LOWERCASE);
+		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/capitalize"), EDIT_CAPITALIZE);
+		sub_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenus::_edit_option));
+		edit_menu->get_popup()->add_submenu_node_item(TTRC("Convert Case"), sub_menu);
+	}
+	highlighter_menu = memnew(PopupMenu);
+	edit_menu->get_popup()->add_submenu_node_item(TTRC("Syntax Highlighter"), highlighter_menu);
+
+	highlighter_menu->connect("about_to_popup", callable_mp(this, &EditMenus::_update_highlighter_menu));
+	highlighter_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenus::_change_syntax_highlighter));
+
+	search_menu = memnew(MenuButton);
+	search_menu->set_flat(false);
+	search_menu->set_theme_type_variation("FlatMenuButton");
+	search_menu->set_text(TTRC("Search"));
+	search_menu->set_switch_on_hover(true);
+
+	add_child(search_menu);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_previous"), SEARCH_FIND_PREV);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace"), SEARCH_REPLACE);
+	search_menu->get_popup()->add_separator();
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("editor/find_in_files"), SEARCH_IN_FILES);
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace_in_files"), REPLACE_IN_FILES);
+	search_menu->get_popup()->add_separator();
+	search_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenus::_edit_option));
+
+	goto_menu = memnew(MenuButton);
+	goto_menu->set_flat(false);
+	goto_menu->set_theme_type_variation("FlatMenuButton");
+	goto_menu->set_text(TTRC("Go To"));
+	goto_menu->set_switch_on_hover(true);
+	add_child(goto_menu);
+	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
+	goto_menu->get_popup()->add_separator();
+
+	bookmarks_menu = memnew(PopupMenu);
+	goto_menu->get_popup()->add_submenu_node_item(TTRC("Bookmarks"), bookmarks_menu);
+	bookmarks_menu->connect("about_to_popup", callable_mp(this, &EditMenus::_update_bookmark_list));
+	bookmarks_menu->connect("index_pressed", callable_mp(this, &EditMenus::_bookmark_item_pressed));
+
+	goto_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenus::_edit_option));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void TextEditor::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());
 
-	highlighters[p_highlighter->_get_name()] = p_highlighter;
-	highlighter_menu->add_radio_check_item(p_highlighter->_get_name());
+	highlighters.push_back(p_highlighter);
 }
 
 void TextEditor::set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());
 
-	HashMap<String, Ref<EditorSyntaxHighlighter>>::Iterator el = highlighters.begin();
-	while (el) {
-		int highlighter_index = highlighter_menu->get_item_idx_from_text(el->key);
-		highlighter_menu->set_item_checked(highlighter_index, el->value == p_highlighter);
-		++el;
-	}
-
 	CodeEdit *te = code_editor->get_text_editor();
 	te->set_syntax_highlighter(p_highlighter);
-}
-
-void TextEditor::_change_syntax_highlighter(int p_idx) {
-	set_syntax_highlighter(highlighters[highlighter_menu->get_item_text(p_idx)]);
 }
 
 void TextEditor::_load_theme_settings() {
@@ -119,7 +289,7 @@ void TextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 	code_editor->update_line_and_column();
 }
 
-void TextEditor::enable_editor(Control *p_shortcut_context) {
+void TextEditor::enable_editor() {
 	if (editor_enabled) {
 		return;
 	}
@@ -129,15 +299,6 @@ void TextEditor::enable_editor(Control *p_shortcut_context) {
 	_load_theme_settings();
 
 	_validate_script();
-
-	if (p_shortcut_context) {
-		for (int i = 0; i < edit_hb->get_child_count(); ++i) {
-			Control *c = cast_to<Control>(edit_hb->get_child(i));
-			if (c) {
-				c->set_shortcut_context(p_shortcut_context);
-			}
-		}
-	}
 }
 
 void TextEditor::add_callback(const String &p_function, const PackedStringArray &p_args) {
@@ -207,41 +368,6 @@ void TextEditor::_validate_script() {
 	}
 }
 
-void TextEditor::_update_bookmark_list() {
-	bookmarks_menu->clear();
-
-	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
-	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_bookmarks"), BOOKMARK_REMOVE_ALL);
-	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
-	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
-
-	PackedInt32Array bookmark_list = code_editor->get_text_editor()->get_bookmarked_lines();
-	if (bookmark_list.is_empty()) {
-		return;
-	}
-
-	bookmarks_menu->add_separator();
-
-	for (int i = 0; i < bookmark_list.size(); i++) {
-		String line = code_editor->get_text_editor()->get_line(bookmark_list[i]).strip_edges();
-		// Limit the size of the line if too big.
-		if (line.length() > 50) {
-			line = line.substr(0, 50);
-		}
-
-		bookmarks_menu->add_item(String::num_int64(bookmark_list[i] + 1) + " - \"" + line + "\"");
-		bookmarks_menu->set_item_metadata(-1, bookmark_list[i]);
-	}
-}
-
-void TextEditor::_bookmark_item_pressed(int p_idx) {
-	if (p_idx < 4) { // Any item before the separator.
-		_edit_option(bookmarks_menu->get_item_id(p_idx));
-	} else {
-		code_editor->goto_line(bookmarks_menu->get_item_metadata(p_idx));
-	}
-}
-
 void TextEditor::apply_code() {
 	Ref<TextFile> text_file = edited_res;
 	if (text_file.is_valid()) {
@@ -271,9 +397,11 @@ void TextEditor::set_edit_state(const Variant &p_state) {
 
 	Dictionary state = p_state;
 	if (state.has("syntax_highlighter")) {
-		int idx = highlighter_menu->get_item_idx_from_text(state["syntax_highlighter"]);
-		if (idx >= 0) {
-			_change_syntax_highlighter(idx);
+		for (const Ref<EditorSyntaxHighlighter> &highlighter : highlighters) {
+			if (highlighter->_get_name() == String(state["syntax_highlighter"])) {
+				set_syntax_highlighter(highlighter);
+				break;
+			}
 		}
 	}
 
@@ -344,11 +472,10 @@ void TextEditor::set_tooltip_request_func(const Callable &p_toolip_callback) {
 }
 
 Control *TextEditor::get_edit_menu() {
-	return edit_hb;
-}
-
-void TextEditor::clear_edit_menu() {
-	memdelete(edit_hb);
+	if (!edit_menus) {
+		edit_menus = memnew(EditMenus);
+	}
+	return edit_menus;
 }
 
 void TextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {
@@ -553,13 +680,6 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	}
 }
 
-void TextEditor::_prepare_edit_menu() {
-	const CodeEdit *tx = code_editor->get_text_editor();
-	PopupMenu *popup = edit_menu->get_popup();
-	popup->set_item_disabled(popup->get_item_index(EDIT_UNDO), !tx->has_undo());
-	popup->set_item_disabled(popup->get_item_index(EDIT_REDO), !tx->has_redo());
-}
-
 void TextEditor::_make_context_menu(bool p_selection, bool p_can_fold, bool p_is_folded, Vector2 p_position) {
 	context_menu->clear();
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_EMOJI_AND_SYMBOL_PICKER)) {
@@ -622,56 +742,6 @@ TextEditor::TextEditor() {
 	add_child(context_menu);
 	context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &TextEditor::_edit_option));
 
-	edit_hb = memnew(HBoxContainer);
-
-	edit_menu = memnew(MenuButton);
-	edit_menu->set_flat(false);
-	edit_menu->set_theme_type_variation("FlatMenuButton");
-	edit_menu->set_shortcut_context(this);
-	edit_hb->add_child(edit_menu);
-	edit_menu->set_text(TTRC("Edit"));
-	edit_menu->set_switch_on_hover(true);
-	edit_menu->connect("about_to_popup", callable_mp(this, &TextEditor::_prepare_edit_menu));
-	edit_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &TextEditor::_edit_option));
-
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_up"), EDIT_MOVE_LINE_UP);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_down"), EDIT_MOVE_LINE_DOWN);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent"), EDIT_INDENT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unindent"), EDIT_UNINDENT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/delete_line"), EDIT_DELETE_LINE);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_fold_line"), EDIT_TOGGLE_FOLD_LINE);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/fold_all_lines"), EDIT_FOLD_ALL_LINES);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unfold_all_lines"), EDIT_UNFOLD_ALL_LINES);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_selection"), EDIT_DUPLICATE_SELECTION);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_lines"), EDIT_DUPLICATE_LINES);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_word_wrap"), EDIT_TOGGLE_WORD_WRAP);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_trailing_whitespace"), EDIT_TRIM_TRAILING_WHITESAPCE);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_final_newlines"), EDIT_TRIM_FINAL_NEWLINES);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_spaces"), EDIT_CONVERT_INDENT_TO_SPACES);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_tabs"), EDIT_CONVERT_INDENT_TO_TABS);
-
-	edit_menu->get_popup()->add_separator();
-	PopupMenu *convert_case = memnew(PopupMenu);
-	edit_menu->get_popup()->add_submenu_node_item(TTRC("Convert Case"), convert_case);
-	convert_case->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_uppercase"), EDIT_TO_UPPERCASE);
-	convert_case->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_lowercase"), EDIT_TO_LOWERCASE);
-	convert_case->add_shortcut(ED_GET_SHORTCUT("script_text_editor/capitalize"), EDIT_CAPITALIZE);
-	convert_case->connect(SceneStringName(id_pressed), callable_mp(this, &TextEditor::_edit_option));
-
-	highlighter_menu = memnew(PopupMenu);
-	edit_menu->get_popup()->add_submenu_node_item(TTRC("Syntax Highlighter"), highlighter_menu);
-	highlighter_menu->connect(SceneStringName(id_pressed), callable_mp(this, &TextEditor::_change_syntax_highlighter));
-
 	Ref<EditorPlainTextSyntaxHighlighter> plain_highlighter;
 	plain_highlighter.instantiate();
 	add_syntax_highlighter(plain_highlighter);
@@ -680,41 +750,6 @@ TextEditor::TextEditor() {
 	highlighter.instantiate();
 	add_syntax_highlighter(highlighter);
 	set_syntax_highlighter(plain_highlighter);
-
-	search_menu = memnew(MenuButton);
-	search_menu->set_flat(false);
-	search_menu->set_theme_type_variation("FlatMenuButton");
-	search_menu->set_shortcut_context(this);
-	edit_hb->add_child(search_menu);
-	search_menu->set_text(TTRC("Search"));
-	search_menu->set_switch_on_hover(true);
-	search_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &TextEditor::_edit_option));
-
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_previous"), SEARCH_FIND_PREV);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace"), SEARCH_REPLACE);
-	search_menu->get_popup()->add_separator();
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("editor/find_in_files"), SEARCH_IN_FILES);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace_in_files"), REPLACE_IN_FILES);
-
-	MenuButton *goto_menu = memnew(MenuButton);
-	goto_menu->set_flat(false);
-	goto_menu->set_theme_type_variation("FlatMenuButton");
-	goto_menu->set_shortcut_context(this);
-	edit_hb->add_child(goto_menu);
-	goto_menu->set_text(TTRC("Go To"));
-	goto_menu->set_switch_on_hover(true);
-	goto_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &TextEditor::_edit_option));
-
-	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
-	goto_menu->get_popup()->add_separator();
-
-	bookmarks_menu = memnew(PopupMenu);
-	goto_menu->get_popup()->add_submenu_node_item(TTRC("Bookmarks"), bookmarks_menu);
-	_update_bookmark_list();
-	bookmarks_menu->connect("about_to_popup", callable_mp(this, &TextEditor::_update_bookmark_list));
-	bookmarks_menu->connect("index_pressed", callable_mp(this, &TextEditor::_bookmark_item_pressed));
 
 	goto_line_popup = memnew(GotoLinePopup);
 	add_child(goto_line_popup);

--- a/editor/script/text_editor.h
+++ b/editor/script/text_editor.h
@@ -37,22 +37,38 @@
 class TextEditor : public ScriptEditorBase {
 	GDCLASS(TextEditor, ScriptEditorBase);
 
+	class EditMenus : public HBoxContainer {
+		GDCLASS(EditMenus, HBoxContainer);
+		MenuButton *edit_menu = nullptr;
+		MenuButton *search_menu = nullptr;
+		MenuButton *goto_menu = nullptr;
+		PopupMenu *bookmarks_menu = nullptr;
+		PopupMenu *highlighter_menu = nullptr;
+
+		TextEditor *_get_active_editor();
+		void _edit_option(int p_op);
+		void _prepare_edit_menu();
+		void _update_highlighter_menu();
+		void _change_syntax_highlighter(int p_idx);
+		void _update_bookmark_list();
+		void _bookmark_item_pressed(int p_idx);
+
+	public:
+		EditMenus();
+	};
+
 	static ScriptEditorBase *create_editor(const Ref<Resource> &p_resource);
 
-private:
 	CodeTextEditor *code_editor = nullptr;
 
 	Ref<Resource> edited_res;
 	bool editor_enabled = false;
 
-	HBoxContainer *edit_hb = nullptr;
-	MenuButton *edit_menu = nullptr;
-	PopupMenu *highlighter_menu = nullptr;
-	MenuButton *search_menu = nullptr;
-	PopupMenu *bookmarks_menu = nullptr;
+	static inline EditMenus *edit_menus = nullptr;
 	PopupMenu *context_menu = nullptr;
 
 	GotoLinePopup *goto_line_popup = nullptr;
+	LocalVector<Ref<EditorSyntaxHighlighter>> highlighters;
 
 	enum {
 		EDIT_UNDO,
@@ -97,18 +113,12 @@ protected:
 	void _edit_option(int p_op);
 	void _make_context_menu(bool p_selection, bool p_can_fold, bool p_is_folded, Vector2 p_position);
 	void _text_edit_gui_input(const Ref<InputEvent> &ev);
-	void _prepare_edit_menu();
 
-	HashMap<String, Ref<EditorSyntaxHighlighter>> highlighters;
-	void _change_syntax_highlighter(int p_idx);
 	void _load_theme_settings();
 
 	void _convert_case(CodeTextEditor::CaseStyle p_case);
 
 	void _validate_script();
-
-	void _update_bookmark_list();
-	void _bookmark_item_pressed(int p_idx);
 
 public:
 	virtual void add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) override;
@@ -118,7 +128,7 @@ public:
 	virtual Ref<Texture2D> get_theme_icon() override;
 	virtual Ref<Resource> get_edited_resource() const override;
 	virtual void set_edited_resource(const Ref<Resource> &p_res) override;
-	virtual void enable_editor(Control *p_shortcut_context = nullptr) override;
+	virtual void enable_editor() override;
 	virtual void reload_text() override;
 	virtual void apply_code() override;
 	virtual bool is_unsaved() override;
@@ -147,7 +157,6 @@ public:
 	void update_toggle_files_button() override;
 
 	virtual Control *get_edit_menu() override;
-	virtual void clear_edit_menu() override;
 	virtual void set_find_replace_bar(FindReplaceBar *p_bar) override;
 
 	virtual void validate() override;


### PR DESCRIPTION
There does not need to be new Edit, Search, and Go to menus for every single open script and text file.
There only needs to be one for ScriptTextEditor and one for TextEditor, because ScriptTextEditor has some extra options.

The syntax highlighters in (Script)TextEditor now use a LocalVector instead of a Hashmap, since the order matters and it doesn't need to be a Hashmap. The highlighter menu is now created on about_to_popup instead of add/set, since there is only one.

The TextEditor menus are now organized in sub menus, like in ScriptTextEditor.
Most of the code for the menus is now the same, I plan to combine them later.

TextEditor bookmarks go to list now use backticks \` like ScriptTextEditor
TextEditor bookmarks go to list now replaces tabs with spaces for display like ScriptTextEditor (the missing character from https://github.com/godotengine/godot/pull/34091 is not rendered anyway due to other changes, but this change was missed back then).

This makes the menus static in their respective classes, but I may move it in a future PR.

This is about ~28% faster, when opening 100 scripts and 100 text files (9177ms to 7169ms avg, on a debug build). I'm using [se-slow-200-misc.zip](https://github.com/user-attachments/files/23320600/se-slow-200-misc.zip) (Open all by dropping them all in the script list).