### PR TITLE
Add custom `StyleBox` to `TreeItem`

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -203,6 +203,13 @@
 				Returns custom font size used to draw text in the column [param column].
 			</description>
 		</method>
+		<method name="get_custom_stylebox" qualifiers="const">
+			<return type="StyleBox" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns the given column's custom [StyleBox] used to draw the background.
+			</description>
+		</method>
 		<method name="get_description" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="column" type="int" />
@@ -614,6 +621,7 @@
 			<param index="2" name="just_outline" type="bool" default="false" />
 			<description>
 				Sets the given column's custom background color and whether to just use it as an outline.
+				[b]Note:[/b] If a custom [StyleBox] is set, the background color will be drawn behind it.
 			</description>
 		</method>
 		<method name="set_custom_color">
@@ -657,6 +665,15 @@
 			<param index="1" name="font_size" type="int" />
 			<description>
 				Sets custom font size used to draw text in the given [param column].
+			</description>
+		</method>
+		<method name="set_custom_stylebox">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="stylebox" type="StyleBox" />
+			<description>
+				Sets the given column's custom [StyleBox] used to draw the background.
+				[b]Note:[/b] If a custom background color is set, the [StyleBox] will be drawn in front of it.
 			</description>
 		</method>
 		<method name="set_description">

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -878,6 +878,17 @@ int TreeItem::get_custom_minimum_height() const {
 	return custom_min_height;
 }
 
+void TreeItem::set_custom_stylebox(int p_column, const Ref<StyleBox> &p_stylebox) {
+	ERR_FAIL_INDEX(p_column, cells.size());
+	cells.write[p_column].custom_stylebox = p_stylebox;
+	_changed_notify(p_column);
+}
+
+Ref<StyleBox> TreeItem::get_custom_stylebox(int p_column) const {
+	ERR_FAIL_INDEX_V(p_column, cells.size(), Ref<StyleBox>());
+	return cells[p_column].custom_stylebox;
+}
+
 TreeItem *TreeItem::create_child(int p_index) {
 	TreeItem *ti = memnew(TreeItem(tree));
 	if (tree) {
@@ -1843,6 +1854,9 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_custom_draw_callback", "column", "callback"), &TreeItem::set_custom_draw_callback);
 	ClassDB::bind_method(D_METHOD("get_custom_draw_callback", "column"), &TreeItem::get_custom_draw_callback);
 
+	ClassDB::bind_method(D_METHOD("set_custom_stylebox", "column", "stylebox"), &TreeItem::set_custom_stylebox);
+	ClassDB::bind_method(D_METHOD("get_custom_stylebox", "column"), &TreeItem::get_custom_stylebox);
+
 	ClassDB::bind_method(D_METHOD("set_collapsed", "enable"), &TreeItem::set_collapsed);
 	ClassDB::bind_method(D_METHOD("is_collapsed"), &TreeItem::is_collapsed);
 
@@ -2434,6 +2448,16 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				} else {
 					RenderingServer::get_singleton()->canvas_item_add_rect(ci, r, p_item->cells[i].bg_color);
 				}
+			}
+
+			if (p_item->cells[i].custom_stylebox.is_valid()) {
+				Rect2 r = cell_rect;
+				if (i == 0) {
+					r.position.x = p_draw_ofs.x;
+					r.size.x = item_width + ofs;
+				}
+				r = convert_rtl_rect(r);
+				draw_style_box(p_item->cells[i].custom_stylebox, r);
 			}
 
 			if (drop_mode_flags && drop_mode_over) {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -98,6 +98,7 @@ private:
 		bool custom_button = false;
 		bool expand_right = false;
 		Color icon_color = Color(1, 1, 1);
+		Ref<StyleBox> custom_stylebox;
 
 		Size2i cached_minimum_size;
 		bool cached_minimum_size_dirty = true;
@@ -358,6 +359,9 @@ public:
 
 	void set_custom_minimum_height(int p_height);
 	int get_custom_minimum_height() const;
+
+	void set_custom_stylebox(int p_column, const Ref<StyleBox> &p_stylebox);
+	Ref<StyleBox> get_custom_stylebox(int p_column) const;
 
 	void set_selectable(int p_column, bool p_selectable);
 	bool is_selectable(int p_column) const;


### PR DESCRIPTION
Allows setting a custom `StyleBox` in `TreeItem` cells in a similar way you would set a custom BG color, text or icon:

```gdscript

const MY_STYLEBOX = preload("res://path/to/my_stylebox.tres")

func _ready():
var tree = Tree.new()
var root = tree.create_item()
var child = tree.create_item(root)
child.set_custom_stylebox(0, MY_STYLEBOX)
```

Draw order should be:
1. Custom BG color
2. Custom StyleBox
3. The rest of the components (including StyleBoxes drawn through the custom draw callback)

This could have the potential to deprecate the custom BG color, but I'm leaving it as it is as they can coexist.

Weird demonstration I made for testing, with 4 different `StyleBox`es (start, middle, end, full, and all cell types in each row):
<img width="1120" height="546" alt="image" src="https://github.com/user-attachments/assets/7386028b-fedf-409b-9a41-c7a281639ed8" />

This should allow implementing #112360 and reimplementing #112233 without having to do workarounds (not part of this PR):
<img width="935" height="554" alt="image" src="https://github.com/user-attachments/assets/e302d055-09df-45ad-86ae-1770e96caa72" />
