### PR TITLE
Revert "Fix visual shader items not applying the correct theme components"

### DIFF
--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -174,9 +174,7 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 		} else {
 			es.shader_editor = memnew(TextShaderEditor);
 		}
-		// Needs to be deferred so it's called after entering the scene tree,
-		// otherwise it won't be able to correctly fetch the editor theme.
-		callable_mp(es.shader_editor, &ShaderEditor::edit_shader).call_deferred(es.shader);
+		es.shader_editor->edit_shader(es.shader);
 	}
 
 	// TextShaderEditor-specific setup code.


### PR DESCRIPTION
- This reverts commit e0cb03a3710e97d4f8b9201ceb1a36c7adac8eeb / PR #112322.

This causes a crash when opening the editor with the shader editor pre-opened in the layout.