### PR TITLE
Make `utterance_id` 64-bit.

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -142,7 +142,7 @@ public:
 	virtual bool tts_is_paused() const override;
 	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
-	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
+	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;

--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -413,7 +413,7 @@ TypedArray<Dictionary> DisplayServerAppleEmbedded::tts_get_voices() const {
 	return [tts getVoices];
 }
 
-void DisplayServerAppleEmbedded::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void DisplayServerAppleEmbedded::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	if (unlikely(!tts)) {
 		initialize_tts();
 	}

--- a/drivers/apple_embedded/tts_apple_embedded.h
+++ b/drivers/apple_embedded/tts_apple_embedded.h
@@ -44,7 +44,7 @@
 
 @interface GDTTTS : NSObject <AVSpeechSynthesizerDelegate> {
 	bool speaking;
-	HashMap<id, int> ids;
+	HashMap<id, int64_t> ids;
 
 	AVSpeechSynthesizer *av_synth;
 	List<DisplayServer::TTSUtterance> queue;
@@ -55,6 +55,6 @@
 - (void)stopSpeaking;
 - (bool)isSpeaking;
 - (bool)isPaused;
-- (void)speak:(const String &)text voice:(const String &)voice volume:(int)volume pitch:(float)pitch rate:(float)rate utterance_id:(int)utterance_id interrupt:(bool)interrupt;
+- (void)speak:(const String &)text voice:(const String &)voice volume:(int)volume pitch:(float)pitch rate:(float)rate utterance_id:(int64_t)utterance_id interrupt:(bool)interrupt;
 - (Array)getVoices;
 @end

--- a/drivers/apple_embedded/tts_apple_embedded.mm
+++ b/drivers/apple_embedded/tts_apple_embedded.mm
@@ -87,10 +87,9 @@
 
 		ids[new_utterance] = message.id;
 		[av_synth speakUtterance:new_utterance];
+		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_STARTED, message.id);
 
 		queue.pop_front();
-
-		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_STARTED, message.id);
 		speaking = true;
 	}
 }
@@ -120,7 +119,7 @@
 	return [av_synth isPaused];
 }
 
-- (void)speak:(const String &)text voice:(const String &)voice volume:(int)volume pitch:(float)pitch rate:(float)rate utterance_id:(int)utterance_id interrupt:(bool)interrupt {
+- (void)speak:(const String &)text voice:(const String &)voice volume:(int)volume pitch:(float)pitch rate:(float)rate utterance_id:(int64_t)utterance_id interrupt:(bool)interrupt {
 	if (interrupt) {
 		[self stopSpeaking];
 	}

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -99,3 +99,10 @@ Validate extension JSON: Error: Field 'builtin_classes/PackedVector3Array/method
 Validate extension JSON: Error: Field 'builtin_classes/PackedVector4Array/methods/duplicate': is_const changed value in new API, from false to true.
 
 Duplicate method made const. Compatibility methods registered.
+
+
+GH-112379
+---------
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/tts_speak/arguments/5': meta changed value in new API, from "int32" to "int64".
+
+`utterance_id` argument changed from `int32` to `int64`. No compatibility method needed.

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -109,7 +109,7 @@ TypedArray<Dictionary> DisplayServerAndroid::tts_get_voices() const {
 	return TTS_Android::get_voices();
 }
 
-void DisplayServerAndroid::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void DisplayServerAndroid::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	TTS_Android::speak(p_text, p_voice, p_volume, p_pitch, p_rate, p_utterance_id, p_interrupt);
 }
 

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -110,7 +110,7 @@ public:
 	virtual bool tts_is_paused() const override;
 	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
-	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
+	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
@@ -105,7 +105,7 @@ public class GodotLib {
 	/**
 	 * TTS callback.
 	 */
-	public static native void ttsCallback(int event, int id, int pos);
+	public static native void ttsCallback(int event, long id, int pos);
 
 	/**
 	 * Forward touch events.

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/tts/GodotTTS.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/tts/GodotTTS.java
@@ -119,7 +119,7 @@ public class GodotTTS extends UtteranceProgressListener implements TextToSpeech.
 	@Override
 	public void onRangeStart(String utteranceId, int start, int end, int frame) {
 		synchronized (lock) {
-			if (lastUtterance != null && Integer.parseInt(utteranceId) == lastUtterance.id) {
+			if (lastUtterance != null && Long.parseLong(utteranceId) == lastUtterance.id) {
 				lastUtterance.offset = start;
 				GodotLib.ttsCallback(EVENT_BOUNDARY, lastUtterance.id, start + lastUtterance.start);
 			}
@@ -132,7 +132,7 @@ public class GodotTTS extends UtteranceProgressListener implements TextToSpeech.
 	@Override
 	public void onStop(String utteranceId, boolean interrupted) {
 		synchronized (lock) {
-			if (lastUtterance != null && !paused && Integer.parseInt(utteranceId) == lastUtterance.id) {
+			if (lastUtterance != null && !paused && Long.parseLong(utteranceId) == lastUtterance.id) {
 				GodotLib.ttsCallback(EVENT_CANCEL, lastUtterance.id, 0);
 				speaking = false;
 				updateTTS();
@@ -146,7 +146,7 @@ public class GodotTTS extends UtteranceProgressListener implements TextToSpeech.
 	@Override
 	public void onStart(String utteranceId) {
 		synchronized (lock) {
-			if (lastUtterance != null && lastUtterance.start == 0 && Integer.parseInt(utteranceId) == lastUtterance.id) {
+			if (lastUtterance != null && lastUtterance.start == 0 && Long.parseLong(utteranceId) == lastUtterance.id) {
 				GodotLib.ttsCallback(EVENT_START, lastUtterance.id, 0);
 			}
 		}
@@ -158,7 +158,7 @@ public class GodotTTS extends UtteranceProgressListener implements TextToSpeech.
 	@Override
 	public void onDone(String utteranceId) {
 		synchronized (lock) {
-			if (lastUtterance != null && !paused && Integer.parseInt(utteranceId) == lastUtterance.id) {
+			if (lastUtterance != null && !paused && Long.parseLong(utteranceId) == lastUtterance.id) {
 				GodotLib.ttsCallback(EVENT_END, lastUtterance.id, 0);
 				speaking = false;
 				updateTTS();
@@ -172,7 +172,7 @@ public class GodotTTS extends UtteranceProgressListener implements TextToSpeech.
 	@Override
 	public void onError(String utteranceId, int errorCode) {
 		synchronized (lock) {
-			if (lastUtterance != null && !paused && Integer.parseInt(utteranceId) == lastUtterance.id) {
+			if (lastUtterance != null && !paused && Long.parseLong(utteranceId) == lastUtterance.id) {
 				GodotLib.ttsCallback(EVENT_CANCEL, lastUtterance.id, 0);
 				speaking = false;
 				updateTTS();
@@ -186,7 +186,7 @@ public class GodotTTS extends UtteranceProgressListener implements TextToSpeech.
 	@Override
 	public void onError(String utteranceId) {
 		synchronized (lock) {
-			if (lastUtterance != null && !paused && Integer.parseInt(utteranceId) == lastUtterance.id) {
+			if (lastUtterance != null && !paused && Long.parseLong(utteranceId) == lastUtterance.id) {
 				GodotLib.ttsCallback(EVENT_CANCEL, lastUtterance.id, 0);
 				speaking = false;
 				updateTTS();
@@ -222,7 +222,7 @@ public class GodotTTS extends UtteranceProgressListener implements TextToSpeech.
 	/**
 	 * Adds an utterance to the queue.
 	 */
-	public void speak(String text, String voice, int volume, float pitch, float rate, int utterance_id, boolean interrupt) {
+	public void speak(String text, String voice, int volume, float pitch, float rate, long utterance_id, boolean interrupt) {
 		synchronized (lock) {
 			if (state != INIT_STATE_SUCCESS) {
 				return;

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/tts/GodotUtterance.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/tts/GodotUtterance.java
@@ -39,12 +39,12 @@ class GodotUtterance {
 	final int volume;
 	final float pitch;
 	final float rate;
-	final int id;
+	final long id;
 
 	int offset = -1;
 	int start = 0;
 
-	GodotUtterance(String text, String voice, int volume, float pitch, float rate, int id) {
+	GodotUtterance(String text, String voice, int volume, float pitch, float rate, long id) {
 		this.text = text;
 		this.voice = voice;
 		this.volume = volume;

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -263,7 +263,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jcl
 	}
 }
 
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jint id, jint pos) {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jlong id, jint pos) {
 	TTS_Android::_java_utterance_callback(event, id, pos);
 }
 

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -42,7 +42,7 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, jclass clazz, jobject p_surface, jint p_width, jint p_height);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_newcontext(JNIEnv *env, jclass clazz, jobject p_surface);
 JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jclass clazz);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jint id, jint pos);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jlong id, jint pos);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jboolean p_double_tap);

--- a/platform/android/tts_android.cpp
+++ b/platform/android/tts_android.cpp
@@ -52,7 +52,7 @@ jmethodID TTS_Android::_pause_speaking = nullptr;
 jmethodID TTS_Android::_resume_speaking = nullptr;
 jmethodID TTS_Android::_stop_speaking = nullptr;
 
-HashMap<int, Char16String> TTS_Android::ids;
+HashMap<int64_t, Char16String> TTS_Android::ids;
 
 void TTS_Android::_thread_function(void *self) {
 	JNIEnv *env = get_jni_env();
@@ -117,7 +117,7 @@ void TTS_Android::setup(jobject p_tts) {
 	_is_paused = env->GetMethodID(cls, "isPaused", "()Z");
 	_get_state = env->GetMethodID(cls, "getState", "()I");
 	_get_voices = env->GetMethodID(cls, "getVoices", "()[Ljava/lang/String;");
-	_speak = env->GetMethodID(cls, "speak", "(Ljava/lang/String;Ljava/lang/String;IFFIZ)V");
+	_speak = env->GetMethodID(cls, "speak", "(Ljava/lang/String;Ljava/lang/String;IFFJZ)V");
 	_pause_speaking = env->GetMethodID(cls, "pauseSpeaking", "()V");
 	_resume_speaking = env->GetMethodID(cls, "resumeSpeaking", "()V");
 	_stop_speaking = env->GetMethodID(cls, "stopSpeaking", "()V");
@@ -145,7 +145,7 @@ void TTS_Android::terminate() {
 	}
 }
 
-void TTS_Android::_java_utterance_callback(int p_event, int p_id, int p_pos) {
+void TTS_Android::_java_utterance_callback(int p_event, int64_t p_id, int p_pos) {
 	if (unlikely(!initialized)) {
 		initialize_tts();
 	}
@@ -230,7 +230,7 @@ Array TTS_Android::get_voices() {
 	return list;
 }
 
-void TTS_Android::speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void TTS_Android::speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	if (unlikely(!initialized)) {
 		initialize_tts();
 	}
@@ -289,7 +289,7 @@ void TTS_Android::stop() {
 		initialize_tts();
 	}
 	ERR_FAIL_COND_MSG(!initialized || tts == nullptr, "Text to Speech not initialized.");
-	for (const KeyValue<int, Char16String> &E : ids) {
+	for (const KeyValue<int64_t, Char16String> &E : ids) {
 		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_CANCELED, E.key);
 	}
 	ids.clear();

--- a/platform/android/tts_android.h
+++ b/platform/android/tts_android.h
@@ -63,19 +63,19 @@ class TTS_Android {
 
 	static void _thread_function(void *self);
 
-	static HashMap<int, Char16String> ids;
+	static HashMap<int64_t, Char16String> ids;
 
 	static void initialize_tts(bool p_wait = true);
 
 public:
 	static void setup(jobject p_tts);
 	static void terminate();
-	static void _java_utterance_callback(int p_event, int p_id, int p_pos);
+	static void _java_utterance_callback(int p_event, int64_t p_id, int p_pos);
 
 	static bool is_speaking();
 	static bool is_paused();
 	static Array get_voices();
-	static void speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt);
+	static void speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt);
 	static void pause();
 	static void resume();
 	static void stop();

--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -207,7 +207,7 @@ Array TTS_Linux::get_voices() const {
 	return list;
 }
 
-void TTS_Linux::speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void TTS_Linux::speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_NULL(synth);

--- a/platform/linuxbsd/tts_linux.h
+++ b/platform/linuxbsd/tts_linux.h
@@ -53,7 +53,7 @@ class TTS_Linux : public Object {
 	bool speaking = false;
 	bool paused = false;
 	int last_msg_id = -1;
-	HashMap<int, int> ids;
+	HashMap<int, int64_t> ids;
 
 	struct VoiceInfo {
 		String language;
@@ -82,7 +82,7 @@ public:
 	bool is_paused() const;
 	Array get_voices() const;
 
-	void speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false);
+	void speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false);
 	void pause();
 	void resume();
 	void stop();

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -264,7 +264,7 @@ TypedArray<Dictionary> DisplayServerWayland::tts_get_voices() const {
 	return tts->get_voices();
 }
 
-void DisplayServerWayland::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void DisplayServerWayland::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	if (unlikely(!tts)) {
 		initialize_tts();
 	}

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -197,7 +197,7 @@ public:
 	virtual bool tts_is_paused() const override;
 	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
-	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
+	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -409,7 +409,7 @@ TypedArray<Dictionary> DisplayServerX11::tts_get_voices() const {
 	return tts->get_voices();
 }
 
-void DisplayServerX11::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void DisplayServerX11::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	if (unlikely(!tts)) {
 		initialize_tts();
 	}

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -415,7 +415,7 @@ public:
 	virtual bool tts_is_paused() const override;
 	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
-	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
+	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;

--- a/platform/macos/display_server_macos_base.h
+++ b/platform/macos/display_server_macos_base.h
@@ -80,7 +80,7 @@ public:
 	virtual bool tts_is_paused() const override;
 	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
-	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
+	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -128,7 +128,7 @@ TypedArray<Dictionary> DisplayServerMacOSBase::tts_get_voices() const {
 	return [tts getVoices];
 }
 
-void DisplayServerMacOSBase::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void DisplayServerMacOSBase::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	if (unlikely(!tts)) {
 		initialize_tts();
 	}

--- a/platform/macos/tts_macos.h
+++ b/platform/macos/tts_macos.h
@@ -47,12 +47,12 @@
 @interface TTS_MacOS : NSObject <AVSpeechSynthesizerDelegate> {
 	// AVSpeechSynthesizer
 	bool speaking;
-	HashMap<id, int> ids;
+	HashMap<id, int64_t> ids;
 
 	// NSSpeechSynthesizer
 	bool paused;
 	bool have_utterance;
-	int last_utterance;
+	int64_t last_utterance;
 
 	id synth; // NSSpeechSynthesizer or AVSpeechSynthesizer
 	List<DisplayServer::TTSUtterance> queue;
@@ -63,6 +63,6 @@
 - (void)stopSpeaking;
 - (bool)isSpeaking;
 - (bool)isPaused;
-- (void)speak:(const String &)text voice:(const String &)voice volume:(int)volume pitch:(float)pitch rate:(float)rate utterance_id:(int)utterance_id interrupt:(bool)interrupt;
+- (void)speak:(const String &)text voice:(const String &)voice volume:(int)volume pitch:(float)pitch rate:(float)rate utterance_id:(int64_t)utterance_id interrupt:(bool)interrupt;
 - (Array)getVoices;
 @end

--- a/platform/macos/tts_macos.mm
+++ b/platform/macos/tts_macos.mm
@@ -148,9 +148,9 @@
 			have_utterance = true;
 			[ns_synth startSpeakingString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
 		}
+		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_STARTED, message.id);
 		queue.pop_front();
 
-		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_STARTED, message.id);
 		speaking = true;
 	}
 }
@@ -210,7 +210,7 @@
 	}
 }
 
-- (void)speak:(const String &)text voice:(const String &)voice volume:(int)volume pitch:(float)pitch rate:(float)rate utterance_id:(int)utterance_id interrupt:(bool)interrupt {
+- (void)speak:(const String &)text voice:(const String &)voice volume:(int)volume pitch:(float)pitch rate:(float)rate utterance_id:(int64_t)utterance_id interrupt:(bool)interrupt {
 	if (interrupt) {
 		[self stopSpeaking];
 	}

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -428,7 +428,7 @@ TypedArray<Dictionary> DisplayServerWeb::tts_get_voices() const {
 	return voices;
 }
 
-void DisplayServerWeb::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void DisplayServerWeb::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	if (p_interrupt) {
 		tts_stop();
 	}
@@ -453,14 +453,14 @@ void DisplayServerWeb::tts_resume() {
 }
 
 void DisplayServerWeb::tts_stop() {
-	for (const KeyValue<int, CharString> &E : utterance_ids) {
+	for (const KeyValue<int64_t, CharString> &E : utterance_ids) {
 		tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_CANCELED, E.key);
 	}
 	utterance_ids.clear();
 	godot_js_tts_stop();
 }
 
-void DisplayServerWeb::js_utterance_callback(int p_event, int p_id, int p_pos) {
+void DisplayServerWeb::js_utterance_callback(int p_event, int64_t p_id, int p_pos) {
 #ifdef PROXY_TO_PTHREAD_ENABLED
 	if (!Thread::is_main_thread()) {
 		callable_mp_static(DisplayServerWeb::_js_utterance_callback).call_deferred(p_event, p_id, p_pos);
@@ -471,7 +471,7 @@ void DisplayServerWeb::js_utterance_callback(int p_event, int p_id, int p_pos) {
 	_js_utterance_callback(p_event, p_id, p_pos);
 }
 
-void DisplayServerWeb::_js_utterance_callback(int p_event, int p_id, int p_pos) {
+void DisplayServerWeb::_js_utterance_callback(int p_event, int64_t p_id, int p_pos) {
 	DisplayServerWeb *ds = (DisplayServerWeb *)DisplayServer::get_singleton();
 	if (ds->utterance_ids.has(p_id)) {
 		int pos = 0;

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -58,7 +58,7 @@ private:
 	EMSCRIPTEN_WEBGL_CONTEXT_HANDLE webgl_ctx = 0;
 #endif
 
-	HashMap<int, CharString> utterance_ids;
+	HashMap<int64_t, CharString> utterance_ids;
 
 	WindowMode window_mode = WINDOW_MODE_WINDOWED;
 	ObjectID window_attached_instance_id = {};
@@ -132,8 +132,8 @@ private:
 	static void _vk_input_text_callback(const String &p_text, int p_cursor);
 	WASM_EXPORT static void gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid);
 	static void _gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid);
-	WASM_EXPORT static void js_utterance_callback(int p_event, int p_id, int p_pos);
-	static void _js_utterance_callback(int p_event, int p_id, int p_pos);
+	WASM_EXPORT static void js_utterance_callback(int p_event, int64_t p_id, int p_pos);
+	static void _js_utterance_callback(int p_event, int64_t p_id, int p_pos);
 	WASM_EXPORT static void ime_callback(int p_type, const char *p_text);
 	static void _ime_callback(int p_type, const String &p_text);
 	WASM_EXPORT static void request_quit_callback();
@@ -176,7 +176,7 @@ public:
 	virtual bool tts_is_paused() const override;
 	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
-	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
+	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -83,7 +83,7 @@ extern void godot_js_input_drop_files_cb(void (*p_callback)(const char **p_filev
 extern int godot_js_tts_is_speaking();
 extern int godot_js_tts_is_paused();
 extern int godot_js_tts_get_voices(void (*p_callback)(int p_size, const char **p_voices));
-extern void godot_js_tts_speak(const char *p_text, const char *p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, void (*p_callback)(int p_event, int p_id, int p_pos));
+extern void godot_js_tts_speak(const char *p_text, const char *p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, void (*p_callback)(int p_event, int64_t p_id, int p_pos));
 extern void godot_js_tts_pause();
 extern void godot_js_tts_resume();
 extern void godot_js_tts_stop();

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -301,7 +301,7 @@ TypedArray<Dictionary> DisplayServerWindows::tts_get_voices() const {
 	return tts->get_voices();
 }
 
-void DisplayServerWindows::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void DisplayServerWindows::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	if (unlikely(!tts)) {
 		initialize_tts();
 	}

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -543,7 +543,7 @@ public:
 	virtual bool tts_is_paused() const override;
 	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
-	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
+	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;

--- a/platform/windows/tts_windows.cpp
+++ b/platform/windows/tts_windows.cpp
@@ -186,7 +186,7 @@ Array TTS_Windows::get_voices() const {
 	return list;
 }
 
-void TTS_Windows::speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void TTS_Windows::speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	ERR_FAIL_NULL(synth);
 	if (p_interrupt) {
 		stop();

--- a/platform/windows/tts_windows.h
+++ b/platform/windows/tts_windows.h
@@ -51,7 +51,7 @@ class TTS_Windows {
 	struct UTData {
 		Char16String string;
 		int offset;
-		int id;
+		int64_t id;
 	};
 	HashMap<uint32_t, UTData> ids;
 	bool update_requested = false;
@@ -67,7 +67,7 @@ public:
 	bool is_paused() const;
 	Array get_voices() const;
 
-	void speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false);
+	void speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false);
 	void pause();
 	void resume();
 	void stop();

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -446,7 +446,7 @@ PackedStringArray DisplayServer::tts_get_voices_for_language(const String &p_lan
 	return ret;
 }
 
-void DisplayServer::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int p_utterance_id, bool p_interrupt) {
+void DisplayServer::tts_speak(const String &p_text, const String &p_voice, int p_volume, float p_pitch, float p_rate, int64_t p_utterance_id, bool p_interrupt) {
 	WARN_PRINT("TTS is not supported by this display server.");
 }
 
@@ -459,7 +459,7 @@ void DisplayServer::tts_set_utterance_callback(TTSUtteranceEvent p_event, const 
 	utterance_callback[p_event] = p_callable;
 }
 
-void DisplayServer::tts_post_utterance_event(TTSUtteranceEvent p_event, int p_id, int p_pos) {
+void DisplayServer::tts_post_utterance_event(TTSUtteranceEvent p_event, int64_t p_id, int p_pos) {
 	ERR_FAIL_INDEX(p_event, DisplayServer::TTS_UTTERANCE_MAX);
 	switch (p_event) {
 		case DisplayServer::TTS_UTTERANCE_STARTED:

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -240,7 +240,7 @@ public:
 		int volume = 50;
 		float pitch = 1.f;
 		float rate = 1.f;
-		int id = 0;
+		int64_t id = 0;
 	};
 
 	enum TTSUtteranceEvent {
@@ -260,13 +260,13 @@ public:
 	virtual TypedArray<Dictionary> tts_get_voices() const;
 	virtual PackedStringArray tts_get_voices_for_language(const String &p_language) const;
 
-	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false);
+	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int64_t p_utterance_id = 0, bool p_interrupt = false);
 	virtual void tts_pause();
 	virtual void tts_resume();
 	virtual void tts_stop();
 
 	virtual void tts_set_utterance_callback(TTSUtteranceEvent p_event, const Callable &p_callable);
-	virtual void tts_post_utterance_event(TTSUtteranceEvent p_event, int p_id, int p_pos = 0);
+	virtual void tts_post_utterance_event(TTSUtteranceEvent p_event, int64_t p_id, int p_pos = 0);
 
 	virtual bool is_dark_mode_supported() const { return false; }
 	virtual bool is_dark_mode() const { return false; }

--- a/servers/display/display_server_headless.h
+++ b/servers/display/display_server_headless.h
@@ -165,7 +165,7 @@ public:
 	bool tts_is_speaking() const override { return false; }
 	bool tts_is_paused() const override { return false; }
 	TypedArray<Dictionary> tts_get_voices() const override { return TypedArray<Dictionary>(); }
-	void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.0f, float p_rate = 1.0f, int p_utterance_id = 0, bool p_interrupt = false) override {}
+	void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.0f, float p_rate = 1.0f, int64_t p_utterance_id = 0, bool p_interrupt = false) override {}
 	void tts_pause() override {}
 	void tts_resume() override {}
 	void tts_stop() override {}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112346

TODO:
- [x] Test on Android and Web (since both pass IDs to the Java/JS part).