### PR TITLE
Don't right-align escaped newlines (e.g. for `#define`)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,7 @@ AlignAfterOpenBracket: DontAlign
 #   AcrossEmptyLines: false
 #   AcrossComments: false
 #   AlignCaseColons: false
-# AlignEscapedNewlines: Right
+AlignEscapedNewlines: DontAlign # Aligning leads to long diffs
 AlignOperands: DontAlign
 AlignTrailingComments:
   Kind: Never

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -72,3 +72,6 @@ e06d83860d798b6766b23d6eae48557387a7db85
 
 # Style: Replace header guards with `#pragma once`
 324512e11c1b7663c3cf47bec6ddbe65c6b8db2b
+
+# Style: Don't right-align escaped newlines
+c5df0cb82bc539eff7dcfb2add99d60771fc50c5

--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -69,183 +69,183 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #ifdef DEBUG_ENABLED
 
-#define BIND_CORE_CONSTANT(m_constant)                                                 \
+#define BIND_CORE_CONSTANT(m_constant) \
 	_global_constants.push_back(_CoreConstant(StringName(), #m_constant, m_constant)); \
 	_global_constants_map[#m_constant] = _global_constants.size() - 1;
 
-#define BIND_CORE_ENUM_CONSTANT(m_constant)                                                          \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant));              \
-		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
+#define BIND_CORE_ENUM_CONSTANT(m_constant) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_constant); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant)); \
+		_global_constants_map[#m_constant] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#define BIND_CORE_BITFIELD_FLAG(m_constant)                                                          \
-	{                                                                                                \
-		StringName enum_name = __constant_get_bitfield_name(m_constant);                             \
+#define BIND_CORE_BITFIELD_FLAG(m_constant) \
+	{ \
+		StringName enum_name = __constant_get_bitfield_name(m_constant); \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant, false, true)); \
-		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
+		_global_constants_map[#m_constant] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
 // This just binds enum classes as if they were regular enum constants.
-#define BIND_CORE_ENUM_CLASS_CONSTANT(m_enum, m_prefix, m_member)                                                  \
-	{                                                                                                              \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                                         \
+#define BIND_CORE_ENUM_CLASS_CONSTANT(m_enum, m_prefix, m_member) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member); \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member)); \
-		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                             \
-		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);               \
+		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1; \
+		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#define BIND_CORE_BITFIELD_CLASS_FLAG(m_enum, m_prefix, m_member)                                                               \
-	{                                                                                                                           \
-		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member);                                                  \
+#define BIND_CORE_BITFIELD_CLASS_FLAG(m_enum, m_prefix, m_member) \
+	{ \
+		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member); \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member, false, true)); \
-		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                                          \
-		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);                            \
-	}
-
-#define BIND_CORE_ENUM_CLASS_CONSTANT_CUSTOM(m_enum, m_name, m_member)                               \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                           \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member));   \
-		_global_constants_map[#m_name] = _global_constants.size() - 1;                               \
+		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#define BIND_CORE_BITFIELD_CLASS_FLAG_CUSTOM(m_enum, m_name, m_member)                                          \
-	{                                                                                                           \
-		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member);                                  \
+#define BIND_CORE_ENUM_CLASS_CONSTANT_CUSTOM(m_enum, m_name, m_member) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member)); \
+		_global_constants_map[#m_name] = _global_constants.size() - 1; \
+		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
+	}
+
+#define BIND_CORE_BITFIELD_CLASS_FLAG_CUSTOM(m_enum, m_name, m_member) \
+	{ \
+		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member); \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member, false, true)); \
-		_global_constants_map[#m_name] = _global_constants.size() - 1;                                          \
-		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);            \
-	}
-
-#define BIND_CORE_ENUM_CLASS_CONSTANT_NO_VAL(m_enum, m_prefix, m_member)                                                 \
-	{                                                                                                                    \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                                               \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member, true)); \
-		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                                   \
-		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);                     \
-	}
-
-#define BIND_CORE_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant)                                    \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
-		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant));            \
-		_global_constants_map[m_custom_name] = _global_constants.size() - 1;                         \
+		_global_constants_map[#m_name] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#define BIND_CORE_CONSTANT_NO_VAL(m_constant)                                                \
+#define BIND_CORE_ENUM_CLASS_CONSTANT_NO_VAL(m_enum, m_prefix, m_member) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member, true)); \
+		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1; \
+		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
+	}
+
+#define BIND_CORE_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_constant); \
+		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant)); \
+		_global_constants_map[m_custom_name] = _global_constants.size() - 1; \
+		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
+	}
+
+#define BIND_CORE_CONSTANT_NO_VAL(m_constant) \
 	_global_constants.push_back(_CoreConstant(StringName(), #m_constant, m_constant, true)); \
 	_global_constants_map[#m_constant] = _global_constants.size() - 1;
 
-#define BIND_CORE_ENUM_CONSTANT_NO_VAL(m_constant)                                                   \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant, true));        \
-		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
+#define BIND_CORE_ENUM_CONSTANT_NO_VAL(m_constant) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_constant); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant, true)); \
+		_global_constants_map[#m_constant] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#define BIND_CORE_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant)                             \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
-		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant, true));      \
-		_global_constants_map[m_custom_name] = _global_constants.size() - 1;                         \
+#define BIND_CORE_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_constant); \
+		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant, true)); \
+		_global_constants_map[m_custom_name] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
 #else
 
-#define BIND_CORE_CONSTANT(m_constant)                                                 \
+#define BIND_CORE_CONSTANT(m_constant) \
 	_global_constants.push_back(_CoreConstant(StringName(), #m_constant, m_constant)); \
 	_global_constants_map[#m_constant] = _global_constants.size() - 1;
 
-#define BIND_CORE_ENUM_CONSTANT(m_constant)                                                          \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant));              \
-		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
+#define BIND_CORE_ENUM_CONSTANT(m_constant) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_constant); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant)); \
+		_global_constants_map[#m_constant] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#define BIND_CORE_BITFIELD_FLAG(m_constant)                                                          \
-	{                                                                                                \
-		StringName enum_name = __constant_get_bitfield_name(m_constant);                             \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant));              \
-		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
+#define BIND_CORE_BITFIELD_FLAG(m_constant) \
+	{ \
+		StringName enum_name = __constant_get_bitfield_name(m_constant); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant)); \
+		_global_constants_map[#m_constant] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
 // This just binds enum classes as if they were regular enum constants.
-#define BIND_CORE_ENUM_CLASS_CONSTANT(m_enum, m_prefix, m_member)                                                  \
-	{                                                                                                              \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                                         \
+#define BIND_CORE_ENUM_CLASS_CONSTANT(m_enum, m_prefix, m_member) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member); \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member)); \
-		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                             \
-		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);               \
-	}
-
-#define BIND_CORE_BITFIELD_CLASS_FLAG(m_enum, m_prefix, m_member)                                                  \
-	{                                                                                                              \
-		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member);                                     \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member)); \
-		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                             \
-		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);               \
-	}
-
-#define BIND_CORE_ENUM_CLASS_CONSTANT_CUSTOM(m_enum, m_name, m_member)                               \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                           \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member));   \
-		_global_constants_map[#m_name] = _global_constants.size() - 1;                               \
+		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#define BIND_CORE_BITFIELD_CLASS_FLAG_CUSTOM(m_enum, m_name, m_member)                               \
-	{                                                                                                \
-		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member);                       \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member));   \
-		_global_constants_map[#m_name] = _global_constants.size() - 1;                               \
-		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
-	}
-
-#define BIND_CORE_ENUM_CLASS_CONSTANT_NO_VAL(m_enum, m_prefix, m_member)                                           \
-	{                                                                                                              \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                                         \
+#define BIND_CORE_BITFIELD_CLASS_FLAG(m_enum, m_prefix, m_member) \
+	{ \
+		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member); \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member)); \
-		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                             \
-		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);               \
-	}
-
-#define BIND_CORE_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant)                                    \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
-		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant));            \
-		_global_constants_map[m_custom_name] = _global_constants.size() - 1;                         \
+		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#define BIND_CORE_CONSTANT_NO_VAL(m_constant)                                          \
+#define BIND_CORE_ENUM_CLASS_CONSTANT_CUSTOM(m_enum, m_name, m_member) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member)); \
+		_global_constants_map[#m_name] = _global_constants.size() - 1; \
+		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
+	}
+
+#define BIND_CORE_BITFIELD_CLASS_FLAG_CUSTOM(m_enum, m_name, m_member) \
+	{ \
+		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member)); \
+		_global_constants_map[#m_name] = _global_constants.size() - 1; \
+		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
+	}
+
+#define BIND_CORE_ENUM_CLASS_CONSTANT_NO_VAL(m_enum, m_prefix, m_member) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member)); \
+		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1; \
+		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
+	}
+
+#define BIND_CORE_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_constant); \
+		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant)); \
+		_global_constants_map[m_custom_name] = _global_constants.size() - 1; \
+		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
+	}
+
+#define BIND_CORE_CONSTANT_NO_VAL(m_constant) \
 	_global_constants.push_back(_CoreConstant(StringName(), #m_constant, m_constant)); \
 	_global_constants_map[#m_constant] = _global_constants.size() - 1;
 
-#define BIND_CORE_ENUM_CONSTANT_NO_VAL(m_constant)                                                   \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
-		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant));              \
-		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
+#define BIND_CORE_ENUM_CONSTANT_NO_VAL(m_constant) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_constant); \
+		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant)); \
+		_global_constants_map[#m_constant] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 
-#define BIND_CORE_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant)                             \
-	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
-		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant));            \
-		_global_constants_map[m_custom_name] = _global_constants.size() - 1;                         \
+#define BIND_CORE_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant) \
+	{ \
+		StringName enum_name = __constant_get_enum_name(m_constant); \
+		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant)); \
+		_global_constants_map[m_custom_name] = _global_constants.size() - 1; \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
 	}
 

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -135,32 +135,32 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns.
  */
-#define ERR_FAIL_INDEX(m_index, m_size)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+#define ERR_FAIL_INDEX(m_index, m_size) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                 \
-	} else                                                                                                      \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                     \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return;                                                                                                        \
-	} else                                                                                                             \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_INDEX_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
+#define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return;                                                                                                              \
-	} else                                                                                                                   \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -170,32 +170,32 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                        \
-	} else                                                                                                      \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return m_retval;                                                                                               \
-	} else                                                                                                             \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_INDEX_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
+#define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return m_retval;                                                                                                     \
-	} else                                                                                                                   \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -206,12 +206,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the application crashes.
  */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                      \
+#define CRASH_BAD_INDEX(m_index, m_size) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
-		_err_flush_stdout();                                                                                                     \
-		GENERATE_TRAP();                                                                                                         \
-	} else                                                                                                                       \
+		_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -221,12 +221,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                 \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                         \
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
-		_err_flush_stdout();                                                                                                        \
-		GENERATE_TRAP();                                                                                                            \
-	} else                                                                                                                          \
+		_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 // Unsigned integer index out of bounds error macros.
@@ -238,32 +238,32 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size) \
+	if (unlikely((m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                 \
-	} else                                                                                                      \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                            \
-	if (unlikely((m_index) >= (m_size))) {                                                                             \
+#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return;                                                                                                        \
-	} else                                                                                                             \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg)                                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                                   \
+#define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return;                                                                                                              \
-	} else                                                                                                                   \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -273,32 +273,32 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                    \
-	if (unlikely((m_index) >= (m_size))) {                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval) \
+	if (unlikely((m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                        \
-	} else                                                                                                      \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                             \
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return m_retval;                                                                                               \
-	} else                                                                                                             \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                    \
-	if (unlikely((m_index) >= (m_size))) {                                                                                   \
+#define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return m_retval;                                                                                                     \
-	} else                                                                                                                   \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -309,12 +309,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                                       \
+#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size) \
+	if (unlikely((m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
-		_err_flush_stdout();                                                                                                     \
-		GENERATE_TRAP();                                                                                                         \
-	} else                                                                                                                       \
+		_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -324,12 +324,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                        \
-	if (unlikely((m_index) >= (m_size))) {                                                                                          \
+#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg) \
+	if (unlikely((m_index) >= (m_size))) { \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
-		_err_flush_stdout();                                                                                                        \
-		GENERATE_TRAP();                                                                                                            \
-	} else                                                                                                                          \
+		_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 // Null reference error macros.
@@ -341,32 +341,32 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures a pointer `m_param` is not null.
  * If it is null, the current function returns.
  */
-#define ERR_FAIL_NULL(m_param)                                                                          \
-	if (unlikely(m_param == nullptr)) {                                                                 \
+#define ERR_FAIL_NULL(m_param) \
+	if (unlikely(m_param == nullptr)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-		return;                                                                                         \
-	} else                                                                                              \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                      \
-	if (unlikely(m_param == nullptr)) {                                                                        \
+#define ERR_FAIL_NULL_MSG(m_param, m_msg) \
+	if (unlikely(m_param == nullptr)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
-		return;                                                                                                \
-	} else                                                                                                     \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_NULL_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_NULL_EDMSG(m_param, m_msg)                                                                          \
-	if (unlikely(m_param == nullptr)) {                                                                              \
+#define ERR_FAIL_NULL_EDMSG(m_param, m_msg) \
+	if (unlikely(m_param == nullptr)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
-		return;                                                                                                      \
-	} else                                                                                                           \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -376,32 +376,32 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures a pointer `m_param` is not null.
  * If it is null, the current function returns `m_retval`.
  */
-#define ERR_FAIL_NULL_V(m_param, m_retval)                                                              \
-	if (unlikely(m_param == nullptr)) {                                                                 \
+#define ERR_FAIL_NULL_V(m_param, m_retval) \
+	if (unlikely(m_param == nullptr)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-		return m_retval;                                                                                \
-	} else                                                                                              \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                          \
-	if (unlikely(m_param == nullptr)) {                                                                        \
+#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg) \
+	if (unlikely(m_param == nullptr)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
-		return m_retval;                                                                                       \
-	} else                                                                                                     \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_NULL_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_NULL_V_EDMSG(m_param, m_retval, m_msg)                                                              \
-	if (unlikely(m_param == nullptr)) {                                                                              \
+#define ERR_FAIL_NULL_V_EDMSG(m_param, m_retval, m_msg) \
+	if (unlikely(m_param == nullptr)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
-		return m_retval;                                                                                             \
-	} else                                                                                                           \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -413,11 +413,11 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current function returns.
  */
-#define ERR_FAIL_COND(m_cond)                                                                          \
-	if (unlikely(m_cond)) {                                                                            \
+#define ERR_FAIL_COND(m_cond) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
-		return;                                                                                        \
-	} else                                                                                             \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -427,21 +427,21 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If checking for null use ERR_FAIL_NULL_MSG instead.
  * If checking index bounds use ERR_FAIL_INDEX_MSG instead.
  */
-#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                      \
-	if (unlikely(m_cond)) {                                                                                   \
+#define ERR_FAIL_COND_MSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg); \
-		return;                                                                                               \
-	} else                                                                                                    \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_COND_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_COND_EDMSG(m_cond, m_msg)                                                                          \
-	if (unlikely(m_cond)) {                                                                                         \
+#define ERR_FAIL_COND_EDMSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg, true); \
-		return;                                                                                                     \
-	} else                                                                                                          \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -453,11 +453,11 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current function returns `m_retval`.
  */
-#define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                         \
-	if (unlikely(m_cond)) {                                                                                                       \
+#define ERR_FAIL_COND_V(m_cond, m_retval) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval)); \
-		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -467,21 +467,21 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If checking for null use ERR_FAIL_NULL_V_MSG instead.
  * If checking index bounds use ERR_FAIL_INDEX_V_MSG instead.
  */
-#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                     \
-	if (unlikely(m_cond)) {                                                                                                              \
+#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg); \
-		return m_retval;                                                                                                                 \
-	} else                                                                                                                               \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_COND_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_COND_V_EDMSG(m_cond, m_retval, m_msg)                                                                                         \
-	if (unlikely(m_cond)) {                                                                                                                    \
+#define ERR_FAIL_COND_V_EDMSG(m_cond, m_retval, m_msg) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg, true); \
-		return m_retval;                                                                                                                       \
-	} else                                                                                                                                     \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -491,32 +491,32 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current loop continues.
  */
-#define ERR_CONTINUE(m_cond)                                                                                       \
-	if (unlikely(m_cond)) {                                                                                        \
+#define ERR_CONTINUE(m_cond) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
-		continue;                                                                                                  \
-	} else                                                                                                         \
+		continue; \
+	} else \
 		((void)0)
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop continues.
  */
-#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                   \
-	if (unlikely(m_cond)) {                                                                                               \
+#define ERR_CONTINUE_MSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg); \
-		continue;                                                                                                         \
-	} else                                                                                                                \
+		continue; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_CONTINUE_MSG` but also notifies the editor.
  */
-#define ERR_CONTINUE_EDMSG(m_cond, m_msg)                                                                                       \
-	if (unlikely(m_cond)) {                                                                                                     \
+#define ERR_CONTINUE_EDMSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg, true); \
-		continue;                                                                                                               \
-	} else                                                                                                                      \
+		continue; \
+	} else \
 		((void)0)
 
 /**
@@ -526,32 +526,32 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current loop breaks.
  */
-#define ERR_BREAK(m_cond)                                                                                        \
-	if (unlikely(m_cond)) {                                                                                      \
+#define ERR_BREAK(m_cond) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
-		break;                                                                                                   \
-	} else                                                                                                       \
+		break; \
+	} else \
 		((void)0)
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop breaks.
  */
-#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                    \
-	if (unlikely(m_cond)) {                                                                                             \
+#define ERR_BREAK_MSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg); \
-		break;                                                                                                          \
-	} else                                                                                                              \
+		break; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_BREAK_MSG` but also notifies the editor.
  */
-#define ERR_BREAK_EDMSG(m_cond, m_msg)                                                                                        \
-	if (unlikely(m_cond)) {                                                                                                   \
+#define ERR_BREAK_EDMSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg, true); \
-		break;                                                                                                                \
-	} else                                                                                                                    \
+		break; \
+	} else \
 		((void)0)
 
 /**
@@ -562,12 +562,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the application crashes.
  */
-#define CRASH_COND(m_cond)                                                                                    \
-	if (unlikely(m_cond)) {                                                                                   \
+#define CRASH_COND(m_cond) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
-		_err_flush_stdout();                                                                                  \
-		GENERATE_TRAP();                                                                                      \
-	} else                                                                                                    \
+		_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -577,12 +577,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the application crashes.
  */
-#define CRASH_COND_MSG(m_cond, m_msg)                                                                                \
-	if (unlikely(m_cond)) {                                                                                          \
+#define CRASH_COND_MSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", m_msg); \
-		_err_flush_stdout();                                                                                         \
-		GENERATE_TRAP();                                                                                             \
-	} else                                                                                                           \
+		_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 // Generic error macros.
@@ -594,11 +594,11 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * The current function returns.
  */
-#define ERR_FAIL()                                                                     \
-	if (true) {                                                                        \
+#define ERR_FAIL() \
+	if (true) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed."); \
-		return;                                                                        \
-	} else                                                                             \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -607,21 +607,21 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * Prints `m_msg`, and the current function returns.
  */
-#define ERR_FAIL_MSG(m_msg)                                                                   \
-	if (true) {                                                                               \
+#define ERR_FAIL_MSG(m_msg) \
+	if (true) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg); \
-		return;                                                                               \
-	} else                                                                                    \
+		return; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_EDMSG(m_msg)                                                                       \
-	if (true) {                                                                                     \
+#define ERR_FAIL_EDMSG(m_msg) \
+	if (true) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg, true); \
-		return;                                                                                     \
-	} else                                                                                          \
+		return; \
+	} else \
 		((void)0)
 
 /**
@@ -631,11 +631,11 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * The current function returns `m_retval`.
  */
-#define ERR_FAIL_V(m_retval)                                                                                      \
-	if (true) {                                                                                                   \
+#define ERR_FAIL_V(m_retval) \
+	if (true) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval)); \
-		return m_retval;                                                                                          \
-	} else                                                                                                        \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -644,21 +644,21 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * Prints `m_msg`, and the current function returns `m_retval`.
  */
-#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                  \
-	if (true) {                                                                                                          \
+#define ERR_FAIL_V_MSG(m_retval, m_msg) \
+	if (true) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg); \
-		return m_retval;                                                                                                 \
-	} else                                                                                                               \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_FAIL_V_MSG` but also notifies the editor.
  */
-#define ERR_FAIL_V_EDMSG(m_retval, m_msg)                                                                                      \
-	if (true) {                                                                                                                \
+#define ERR_FAIL_V_EDMSG(m_retval, m_msg) \
+	if (true) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg, true); \
-		return m_retval;                                                                                                       \
-	} else                                                                                                                     \
+		return m_retval; \
+	} else \
 		((void)0)
 
 /**
@@ -680,27 +680,27 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 /**
  * Prints `m_msg` once during the application lifetime.
  */
-#define ERR_PRINT_ONCE(m_msg)                                          \
-	if (true) {                                                        \
-		static bool warning_shown = false;                             \
-		if (unlikely(!warning_shown)) {                                \
-			warning_shown = true;                                      \
+#define ERR_PRINT_ONCE(m_msg) \
+	if (true) { \
+		static bool warning_shown = false; \
+		if (unlikely(!warning_shown)) { \
+			warning_shown = true; \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg); \
-		}                                                              \
-	} else                                                             \
+		} \
+	} else \
 		((void)0)
 
 /**
  * Same as `ERR_PRINT_ONCE` but also notifies the editor.
  */
-#define ERR_PRINT_ONCE_ED(m_msg)                                             \
-	if (true) {                                                              \
-		static bool warning_shown = false;                                   \
-		if (unlikely(!warning_shown)) {                                      \
-			warning_shown = true;                                            \
+#define ERR_PRINT_ONCE_ED(m_msg) \
+	if (true) { \
+		static bool warning_shown = false; \
+		if (unlikely(!warning_shown)) { \
+			warning_shown = true; \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true); \
-		}                                                                    \
-	} else                                                                   \
+		} \
+	} else \
 		((void)0)
 
 // Print warning message macros.
@@ -724,37 +724,37 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
  */
-#define WARN_PRINT_ONCE(m_msg)                                                                     \
-	if (true) {                                                                                    \
-		static bool warning_shown = false;                                                         \
-		if (unlikely(!warning_shown)) {                                                            \
-			warning_shown = true;                                                                  \
+#define WARN_PRINT_ONCE(m_msg) \
+	if (true) { \
+		static bool warning_shown = false; \
+		if (unlikely(!warning_shown)) { \
+			warning_shown = true; \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, false, ERR_HANDLER_WARNING); \
-		}                                                                                          \
-	} else                                                                                         \
+		} \
+	} else \
 		((void)0)
 
 /**
  * Same as `WARN_PRINT_ONCE` but also notifies the editor.
  */
-#define WARN_PRINT_ONCE_ED(m_msg)                                                                 \
-	if (true) {                                                                                   \
-		static bool warning_shown = false;                                                        \
-		if (unlikely(!warning_shown)) {                                                           \
-			warning_shown = true;                                                                 \
+#define WARN_PRINT_ONCE_ED(m_msg) \
+	if (true) { \
+		static bool warning_shown = false; \
+		if (unlikely(!warning_shown)) { \
+			warning_shown = true; \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true, ERR_HANDLER_WARNING); \
-		}                                                                                         \
-	} else                                                                                        \
+		} \
+	} else \
 		((void)0)
 
 /**
  * Warns about `m_msg` only when verbose mode is enabled.
  */
-#define WARN_VERBOSE(m_msg)               \
-	{                                     \
+#define WARN_VERBOSE(m_msg) \
+	{ \
 		if (is_print_verbose_enabled()) { \
-			WARN_PRINT(m_msg);            \
-		}                                 \
+			WARN_PRINT(m_msg); \
+		} \
 	}
 
 // Print deprecated warning message macros.
@@ -762,27 +762,27 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 /**
  * Warns that the current function is deprecated.
  */
-#define WARN_DEPRECATED                                                                                                                                           \
-	if (true) {                                                                                                                                                   \
-		static bool warning_shown = false;                                                                                                                        \
-		if (unlikely(!warning_shown)) {                                                                                                                           \
-			warning_shown = true;                                                                                                                                 \
+#define WARN_DEPRECATED \
+	if (true) { \
+		static bool warning_shown = false; \
+		if (unlikely(!warning_shown)) { \
+			warning_shown = true; \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", false, ERR_HANDLER_WARNING); \
-		}                                                                                                                                                         \
-	} else                                                                                                                                                        \
+		} \
+	} else \
 		((void)0)
 
 /**
  * Warns that the current function is deprecated and prints `m_msg`.
  */
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                       \
-	if (true) {                                                                                                                                                          \
-		static bool warning_shown = false;                                                                                                                               \
-		if (unlikely(!warning_shown)) {                                                                                                                                  \
-			warning_shown = true;                                                                                                                                        \
+#define WARN_DEPRECATED_MSG(m_msg) \
+	if (true) { \
+		static bool warning_shown = false; \
+		if (unlikely(!warning_shown)) { \
+			warning_shown = true; \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, false, ERR_HANDLER_WARNING); \
-		}                                                                                                                                                                \
-	} else                                                                                                                                                               \
+		} \
+	} else \
 		((void)0)
 
 /**
@@ -791,12 +791,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * The application crashes.
  */
-#define CRASH_NOW()                                                                           \
-	if (true) {                                                                               \
+#define CRASH_NOW() \
+	if (true) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed."); \
-		_err_flush_stdout();                                                                  \
-		GENERATE_TRAP();                                                                      \
-	} else                                                                                    \
+		_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -804,12 +804,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *
  * Prints `m_msg`, and then the application crashes.
  */
-#define CRASH_NOW_MSG(m_msg)                                                                         \
-	if (true) {                                                                                      \
+#define CRASH_NOW_MSG(m_msg) \
+	if (true) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed.", m_msg); \
-		_err_flush_stdout();                                                                         \
-		GENERATE_TRAP();                                                                             \
-	} else                                                                                           \
+		_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 
 /**
@@ -828,26 +828,26 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  *    and that can't fail for other contributors once the code is finished and merged.
  */
 #ifdef DEV_ENABLED
-#define DEV_ASSERT(m_cond)                                                                                              \
-	if (unlikely(!(m_cond))) {                                                                                          \
+#define DEV_ASSERT(m_cond) \
+	if (unlikely(!(m_cond))) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
-		_err_flush_stdout();                                                                                            \
-		GENERATE_TRAP();                                                                                                \
-	} else                                                                                                              \
+		_err_flush_stdout(); \
+		GENERATE_TRAP(); \
+	} else \
 		((void)0)
 #else
 #define DEV_ASSERT(m_cond)
 #endif
 
 #ifdef DEV_ENABLED
-#define DEV_CHECK_ONCE(m_cond)                                                                                           \
-	if (true) {                                                                                                          \
-		static bool first_print = true;                                                                                  \
-		if (first_print && unlikely(!(m_cond))) {                                                                        \
+#define DEV_CHECK_ONCE(m_cond) \
+	if (true) { \
+		static bool first_print = true; \
+		if (first_print && unlikely(!(m_cond))) { \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "DEV_CHECK_ONCE failed  \"" _STR(m_cond) "\" is false."); \
-			first_print = false;                                                                                         \
-		}                                                                                                                \
-	} else                                                                                                               \
+			first_print = false; \
+		} \
+	} else \
 		((void)0)
 #else
 #define DEV_CHECK_ONCE(m_cond)

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -281,59 +281,59 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 		// Member offsets, meta types and sizes.
 
 #define REAL_MEMBER_OFFSET(type, member) \
-	{                                    \
-		type,                            \
-		member,                          \
-		"float",                         \
-		sizeof(float),                   \
-		"float",                         \
-		sizeof(float),                   \
-		"double",                        \
-		sizeof(double),                  \
-		"double",                        \
-		sizeof(double),                  \
+	{ \
+		type, \
+		member, \
+		"float", \
+		sizeof(float), \
+		"float", \
+		sizeof(float), \
+		"double", \
+		sizeof(double), \
+		"double", \
+		sizeof(double), \
 	}
 
 #define INT32_MEMBER_OFFSET(type, member) \
-	{                                     \
-		type,                             \
-		member,                           \
-		"int32",                          \
-		sizeof(int32_t),                  \
-		"int32",                          \
-		sizeof(int32_t),                  \
-		"int32",                          \
-		sizeof(int32_t),                  \
-		"int32",                          \
-		sizeof(int32_t),                  \
+	{ \
+		type, \
+		member, \
+		"int32", \
+		sizeof(int32_t), \
+		"int32", \
+		sizeof(int32_t), \
+		"int32", \
+		sizeof(int32_t), \
+		"int32", \
+		sizeof(int32_t), \
 	}
 
 #define INT32_BASED_BUILTIN_MEMBER_OFFSET(type, member, member_type, member_elems) \
-	{                                                                              \
-		type,                                                                      \
-		member,                                                                    \
-		member_type,                                                               \
-		sizeof(int32_t) * member_elems,                                            \
-		member_type,                                                               \
-		sizeof(int32_t) * member_elems,                                            \
-		member_type,                                                               \
-		sizeof(int32_t) * member_elems,                                            \
-		member_type,                                                               \
-		sizeof(int32_t) * member_elems,                                            \
+	{ \
+		type, \
+		member, \
+		member_type, \
+		sizeof(int32_t) * member_elems, \
+		member_type, \
+		sizeof(int32_t) * member_elems, \
+		member_type, \
+		sizeof(int32_t) * member_elems, \
+		member_type, \
+		sizeof(int32_t) * member_elems, \
 	}
 
 #define REAL_BASED_BUILTIN_MEMBER_OFFSET(type, member, member_type, member_elems) \
-	{                                                                             \
-		type,                                                                     \
-				member,                                                           \
-				member_type,                                                      \
-				sizeof(float) * member_elems,                                     \
-				member_type,                                                      \
-				sizeof(float) * member_elems,                                     \
-				member_type,                                                      \
-				sizeof(double) * member_elems,                                    \
-				member_type,                                                      \
-				sizeof(double) * member_elems,                                    \
+	{ \
+		type, \
+				member, \
+				member_type, \
+				sizeof(float) * member_elems, \
+				member_type, \
+				sizeof(float) * member_elems, \
+				member_type, \
+				sizeof(double) * member_elems, \
+				member_type, \
+				sizeof(double) * member_elems, \
 	}
 
 		struct {

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2600,24 +2600,24 @@ void Image::initialize_data(const char **p_xpm) {
 #define DETECT_ALPHA_MAX_THRESHOLD 254
 #define DETECT_ALPHA_MIN_THRESHOLD 2
 
-#define DETECT_ALPHA(m_value)                          \
-	{                                                  \
-		uint8_t value = m_value;                       \
-		if (value < DETECT_ALPHA_MIN_THRESHOLD)        \
-			bit = true;                                \
+#define DETECT_ALPHA(m_value) \
+	{ \
+		uint8_t value = m_value; \
+		if (value < DETECT_ALPHA_MIN_THRESHOLD) \
+			bit = true; \
 		else if (value < DETECT_ALPHA_MAX_THRESHOLD) { \
-			detected = true;                           \
-			break;                                     \
-		}                                              \
+			detected = true; \
+			break; \
+		} \
 	}
 
 #define DETECT_NON_ALPHA(m_value) \
-	{                             \
-		uint8_t value = m_value;  \
-		if (value > 0) {          \
-			detected = true;      \
-			break;                \
-		}                         \
+	{ \
+		uint8_t value = m_value; \
+		if (value > 0) { \
+			detected = true; \
+			break; \
+		} \
 	}
 
 bool Image::is_invisible() const {

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -668,10 +668,10 @@ static bool _encode_container_type(Dictionary &r_dict, const String &p_key, cons
 }
 
 Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_depth) {
-#define RETURN_ARGS                                           \
-	Dictionary ret;                                           \
+#define RETURN_ARGS \
+	Dictionary ret; \
 	ret[TYPE] = Variant::get_type_name(p_variant.get_type()); \
-	ret[ARGS] = args;                                         \
+	ret[ARGS] = args; \
 	return ret
 
 	switch (p_variant.get_type()) {
@@ -1093,18 +1093,18 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 
 			ERR_FAIL_COND_V(!dict.has(TYPE), Variant());
 
-#define LOAD_ARGS()                              \
+#define LOAD_ARGS() \
 	ERR_FAIL_COND_V(!dict.has(ARGS), Variant()); \
 	const Array args = dict[ARGS]
 
-#define LOAD_ARGS_CHECK_SIZE(m_size)             \
+#define LOAD_ARGS_CHECK_SIZE(m_size) \
 	ERR_FAIL_COND_V(!dict.has(ARGS), Variant()); \
-	const Array args = dict[ARGS];               \
+	const Array args = dict[ARGS]; \
 	ERR_FAIL_COND_V(args.size() != (m_size), Variant())
 
-#define LOAD_ARGS_CHECK_FACTOR(m_factor)         \
+#define LOAD_ARGS_CHECK_FACTOR(m_factor) \
 	ERR_FAIL_COND_V(!dict.has(ARGS), Variant()); \
-	const Array args = dict[ARGS];               \
+	const Array args = dict[ARGS]; \
 	ERR_FAIL_COND_V(args.size() % (m_factor) != 0, Variant())
 
 			switch (Variant::get_type_by_name(dict[TYPE])) {

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -373,7 +373,7 @@ Ref<Resource> Resource::_duplicate(const DuplicateParams &p_params) const {
 // These are for avoiding potential duplicates that can happen in custom code
 // from participating in the same duplication session (remap cache).
 #define BEFORE_USER_CODE thread_duplicate_remap_cache = nullptr;
-#define AFTER_USER_CODE                                \
+#define AFTER_USER_CODE \
 	thread_duplicate_remap_cache = remap_cache_backup; \
 	thread_duplicate_remap_cache_needs_deallocation = remap_cache_needs_deallocation_backup;
 

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -39,15 +39,15 @@
 
 class Node;
 
-#define RES_BASE_EXTENSION(m_ext)                                        \
-public:                                                                  \
-	static void register_custom_data_to_otdb() {                         \
+#define RES_BASE_EXTENSION(m_ext) \
+public: \
+	static void register_custom_data_to_otdb() { \
 		ClassDB::add_resource_base_extension(m_ext, get_class_static()); \
-	}                                                                    \
-	virtual String get_base_extension() const override {                 \
-		return m_ext;                                                    \
-	}                                                                    \
-                                                                         \
+	} \
+	virtual String get_base_extension() const override { \
+		return m_ext; \
+	} \
+\
 private:
 
 class Resource : public RefCounted {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -225,16 +225,16 @@ void ResourceFormatLoader::_bind_methods() {
 // something we must treat as a different stack for the purposes
 // of tracking nesting.
 
-#define PREPARE_FOR_WTP_WAIT                                                   \
-	int load_nesting_backup = ResourceLoader::load_nesting;                    \
+#define PREPARE_FOR_WTP_WAIT \
+	int load_nesting_backup = ResourceLoader::load_nesting; \
 	Vector<String> load_paths_stack_backup = ResourceLoader::load_paths_stack; \
-	ResourceLoader::load_nesting = 0;                                          \
+	ResourceLoader::load_nesting = 0; \
 	ResourceLoader::load_paths_stack.clear();
 
-#define RESTORE_AFTER_WTP_WAIT                                  \
-	DEV_ASSERT(ResourceLoader::load_nesting == 0);              \
-	DEV_ASSERT(ResourceLoader::load_paths_stack.is_empty());    \
-	ResourceLoader::load_nesting = load_nesting_backup;         \
+#define RESTORE_AFTER_WTP_WAIT \
+	DEV_ASSERT(ResourceLoader::load_nesting == 0); \
+	DEV_ASSERT(ResourceLoader::load_paths_stack.is_empty()); \
+	ResourceLoader::load_nesting = load_nesting_backup; \
 	ResourceLoader::load_paths_stack = load_paths_stack_backup; \
 	load_paths_stack_backup.clear();
 

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -73,17 +73,17 @@ subject to the following restrictions:
 // -- GODOT end --
 
 #ifdef DEBUG_ENABLED
-#define CHULL_ASSERT(m_cond)                                     \
-	if constexpr (true) {                                        \
-		if (unlikely(!(m_cond))) {                               \
+#define CHULL_ASSERT(m_cond) \
+	if constexpr (true) { \
+		if (unlikely(!(m_cond))) { \
 			ERR_PRINT("Assertion \"" _STR(m_cond) "\" failed."); \
-		}                                                        \
-	} else                                                       \
+		} \
+	} else \
 		((void)0)
 #else
 #define CHULL_ASSERT(m_cond) \
-	if constexpr (true) {    \
-	} else                   \
+	if constexpr (true) { \
+	} else \
 		((void)0)
 #endif
 

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -144,22 +144,22 @@ bool Face3::intersects_aabb(const AABB &p_aabb) const {
 		return false;
 	}
 
-#define TEST_AXIS(m_ax)                                            \
-	/** TEST FACE AXIS */                                          \
-	{                                                              \
-		real_t aabb_min = p_aabb.position.m_ax;                    \
+#define TEST_AXIS(m_ax) \
+	/** TEST FACE AXIS */ \
+	{ \
+		real_t aabb_min = p_aabb.position.m_ax; \
 		real_t aabb_max = p_aabb.position.m_ax + p_aabb.size.m_ax; \
-		real_t tri_min = vertex[0].m_ax;                           \
-		real_t tri_max = vertex[0].m_ax;                           \
-		for (int i = 1; i < 3; i++) {                              \
-			if (vertex[i].m_ax > tri_max)                          \
-				tri_max = vertex[i].m_ax;                          \
-			if (vertex[i].m_ax < tri_min)                          \
-				tri_min = vertex[i].m_ax;                          \
-		}                                                          \
-                                                                   \
-		if (tri_max < aabb_min || aabb_max < tri_min)              \
-			return false;                                          \
+		real_t tri_min = vertex[0].m_ax; \
+		real_t tri_max = vertex[0].m_ax; \
+		for (int i = 1; i < 3; i++) { \
+			if (vertex[i].m_ax > tri_max) \
+				tri_max = vertex[i].m_ax; \
+			if (vertex[i].m_ax < tri_min) \
+				tri_min = vertex[i].m_ax; \
+		} \
+\
+		if (tri_max < aabb_min || aabb_max < tri_min) \
+			return false; \
 	}
 
 	TEST_AXIS(x);

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -102,20 +102,20 @@ bool Face3::intersects_aabb2(const AABB &p_aabb) const {
 		return false; //does not intersect the plane
 	}
 
-#define TEST_AXIS(m_ax)                                            \
-	{                                                              \
-		real_t aabb_min = p_aabb.position.m_ax;                    \
+#define TEST_AXIS(m_ax) \
+	{ \
+		real_t aabb_min = p_aabb.position.m_ax; \
 		real_t aabb_max = p_aabb.position.m_ax + p_aabb.size.m_ax; \
-		real_t tri_min, tri_max;                                   \
-		for (int i = 0; i < 3; i++) {                              \
-			if (i == 0 || vertex[i].m_ax > tri_max)                \
-				tri_max = vertex[i].m_ax;                          \
-			if (i == 0 || vertex[i].m_ax < tri_min)                \
-				tri_min = vertex[i].m_ax;                          \
-		}                                                          \
-                                                                   \
-		if (tri_max < aabb_min || aabb_max < tri_min)              \
-			return false;                                          \
+		real_t tri_min, tri_max; \
+		for (int i = 0; i < 3; i++) { \
+			if (i == 0 || vertex[i].m_ax > tri_max) \
+				tri_max = vertex[i].m_ax; \
+			if (i == 0 || vertex[i].m_ax < tri_min) \
+				tri_min = vertex[i].m_ax; \
+		} \
+\
+		if (tri_max < aabb_min || aabb_max < tri_min) \
+			return false; \
 	}
 
 	TEST_AXIS(x);

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -237,15 +237,15 @@ static inline void _plot_face(uint8_t ***p_cell_status, int x, int y, int z, int
 	int div_z = len_z > 1 ? 2 : 1;
 
 #define SPLIT_DIV(m_i, m_div, m_v, m_len_v, m_new_v, m_new_len_v) \
-	if (m_div == 1) {                                             \
-		m_new_v = m_v;                                            \
-		m_new_len_v = 1;                                          \
-	} else if (m_i == 0) {                                        \
-		m_new_v = m_v;                                            \
-		m_new_len_v = m_len_v / 2;                                \
-	} else {                                                      \
-		m_new_v = m_v + m_len_v / 2;                              \
-		m_new_len_v = m_len_v - m_len_v / 2;                      \
+	if (m_div == 1) { \
+		m_new_v = m_v; \
+		m_new_len_v = 1; \
+	} else if (m_i == 0) { \
+		m_new_v = m_v; \
+		m_new_len_v = m_len_v / 2; \
+	} else { \
+		m_new_v = m_v + m_len_v / 2; \
+		m_new_len_v = m_len_v - m_len_v / 2; \
 	}
 
 	int new_x;

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -601,18 +601,18 @@ Vector<Plane> build_capsule_planes(real_t p_radius, real_t p_height, int p_sides
 Vector<Vector3> compute_convex_mesh_points(const Plane *p_planes, int p_plane_count);
 
 #define FINDMINMAX(x0, x1, x2, min, max) \
-	min = max = x0;                      \
-	if (x1 < min) {                      \
-		min = x1;                        \
-	}                                    \
-	if (x1 > max) {                      \
-		max = x1;                        \
-	}                                    \
-	if (x2 < min) {                      \
-		min = x2;                        \
-	}                                    \
-	if (x2 > max) {                      \
-		max = x2;                        \
+	min = max = x0; \
+	if (x1 < min) { \
+		min = x1; \
+	} \
+	if (x1 > max) { \
+		max = x1; \
+	} \
+	if (x2 < min) { \
+		min = x2; \
+	} \
+	if (x2 > max) { \
+		max = x2; \
 	}
 
 _FORCE_INLINE_ bool planeBoxOverlap(Vector3 normal, real_t d, Vector3 maxbox) {
@@ -638,96 +638,96 @@ _FORCE_INLINE_ bool planeBoxOverlap(Vector3 normal, real_t d, Vector3 maxbox) {
 }
 
 /*======================== X-tests ========================*/
-#define AXISTEST_X01(a, b, fa, fb)                 \
-	p0 = a * v0.y - b * v0.z;                      \
-	p2 = a * v2.y - b * v2.z;                      \
-	if (p0 < p2) {                                 \
-		min = p0;                                  \
-		max = p2;                                  \
-	} else {                                       \
-		min = p2;                                  \
-		max = p0;                                  \
-	}                                              \
+#define AXISTEST_X01(a, b, fa, fb) \
+	p0 = a * v0.y - b * v0.z; \
+	p2 = a * v2.y - b * v2.z; \
+	if (p0 < p2) { \
+		min = p0; \
+		max = p2; \
+	} else { \
+		min = p2; \
+		max = p0; \
+	} \
 	rad = fa * boxhalfsize.y + fb * boxhalfsize.z; \
-	if (min > rad || max < -rad) {                 \
-		return false;                              \
+	if (min > rad || max < -rad) { \
+		return false; \
 	}
 
-#define AXISTEST_X2(a, b, fa, fb)                  \
-	p0 = a * v0.y - b * v0.z;                      \
-	p1 = a * v1.y - b * v1.z;                      \
-	if (p0 < p1) {                                 \
-		min = p0;                                  \
-		max = p1;                                  \
-	} else {                                       \
-		min = p1;                                  \
-		max = p0;                                  \
-	}                                              \
+#define AXISTEST_X2(a, b, fa, fb) \
+	p0 = a * v0.y - b * v0.z; \
+	p1 = a * v1.y - b * v1.z; \
+	if (p0 < p1) { \
+		min = p0; \
+		max = p1; \
+	} else { \
+		min = p1; \
+		max = p0; \
+	} \
 	rad = fa * boxhalfsize.y + fb * boxhalfsize.z; \
-	if (min > rad || max < -rad) {                 \
-		return false;                              \
+	if (min > rad || max < -rad) { \
+		return false; \
 	}
 
 /*======================== Y-tests ========================*/
-#define AXISTEST_Y02(a, b, fa, fb)                 \
-	p0 = -a * v0.x + b * v0.z;                     \
-	p2 = -a * v2.x + b * v2.z;                     \
-	if (p0 < p2) {                                 \
-		min = p0;                                  \
-		max = p2;                                  \
-	} else {                                       \
-		min = p2;                                  \
-		max = p0;                                  \
-	}                                              \
+#define AXISTEST_Y02(a, b, fa, fb) \
+	p0 = -a * v0.x + b * v0.z; \
+	p2 = -a * v2.x + b * v2.z; \
+	if (p0 < p2) { \
+		min = p0; \
+		max = p2; \
+	} else { \
+		min = p2; \
+		max = p0; \
+	} \
 	rad = fa * boxhalfsize.x + fb * boxhalfsize.z; \
-	if (min > rad || max < -rad) {                 \
-		return false;                              \
+	if (min > rad || max < -rad) { \
+		return false; \
 	}
 
-#define AXISTEST_Y1(a, b, fa, fb)                  \
-	p0 = -a * v0.x + b * v0.z;                     \
-	p1 = -a * v1.x + b * v1.z;                     \
-	if (p0 < p1) {                                 \
-		min = p0;                                  \
-		max = p1;                                  \
-	} else {                                       \
-		min = p1;                                  \
-		max = p0;                                  \
-	}                                              \
+#define AXISTEST_Y1(a, b, fa, fb) \
+	p0 = -a * v0.x + b * v0.z; \
+	p1 = -a * v1.x + b * v1.z; \
+	if (p0 < p1) { \
+		min = p0; \
+		max = p1; \
+	} else { \
+		min = p1; \
+		max = p0; \
+	} \
 	rad = fa * boxhalfsize.x + fb * boxhalfsize.z; \
-	if (min > rad || max < -rad) {                 \
-		return false;                              \
+	if (min > rad || max < -rad) { \
+		return false; \
 	}
 
 /*======================== Z-tests ========================*/
-#define AXISTEST_Z12(a, b, fa, fb)                 \
-	p1 = a * v1.x - b * v1.y;                      \
-	p2 = a * v2.x - b * v2.y;                      \
-	if (p2 < p1) {                                 \
-		min = p2;                                  \
-		max = p1;                                  \
-	} else {                                       \
-		min = p1;                                  \
-		max = p2;                                  \
-	}                                              \
+#define AXISTEST_Z12(a, b, fa, fb) \
+	p1 = a * v1.x - b * v1.y; \
+	p2 = a * v2.x - b * v2.y; \
+	if (p2 < p1) { \
+		min = p2; \
+		max = p1; \
+	} else { \
+		min = p1; \
+		max = p2; \
+	} \
 	rad = fa * boxhalfsize.x + fb * boxhalfsize.y; \
-	if (min > rad || max < -rad) {                 \
-		return false;                              \
+	if (min > rad || max < -rad) { \
+		return false; \
 	}
 
-#define AXISTEST_Z0(a, b, fa, fb)                  \
-	p0 = a * v0.x - b * v0.y;                      \
-	p1 = a * v1.x - b * v1.y;                      \
-	if (p0 < p1) {                                 \
-		min = p0;                                  \
-		max = p1;                                  \
-	} else {                                       \
-		min = p1;                                  \
-		max = p0;                                  \
-	}                                              \
+#define AXISTEST_Z0(a, b, fa, fb) \
+	p0 = a * v0.x - b * v0.y; \
+	p1 = a * v1.x - b * v1.y; \
+	if (p0 < p1) { \
+		min = p0; \
+		max = p1; \
+	} else { \
+		min = p1; \
+		max = p0; \
+	} \
 	rad = fa * boxhalfsize.x + fb * boxhalfsize.y; \
-	if (min > rad || max < -rad) {                 \
-		return false;                              \
+	if (min > rad || max < -rad) { \
+		return false; \
 	}
 
 _FORCE_INLINE_ bool triangle_box_overlap(const Vector3 &boxcenter, const Vector3 boxhalfsize, const Vector3 *triverts) {

--- a/core/math/math_fieldwise.cpp
+++ b/core/math/math_fieldwise.cpp
@@ -32,12 +32,12 @@
 
 #include "math_fieldwise.h"
 
-#define SETUP_TYPE(m_type)    \
+#define SETUP_TYPE(m_type) \
 	m_type source = p_source; \
 	m_type target = p_target;
 #define TRY_TRANSFER_FIELD(m_name, m_member) \
-	if (p_field == m_name) {                 \
-		target.m_member = source.m_member;   \
+	if (p_field == m_name) { \
+		target.m_member = source.m_member; \
 	}
 
 Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const String &p_field) {

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -574,24 +574,24 @@ public:
 
 #endif // DEBUG_ENABLED
 
-#define GDREGISTER_CLASS(m_class)                 \
+#define GDREGISTER_CLASS(m_class) \
 	if constexpr (GD_IS_CLASS_ENABLED(m_class)) { \
-		::ClassDB::register_class<m_class>();     \
+		::ClassDB::register_class<m_class>(); \
 	}
-#define GDREGISTER_VIRTUAL_CLASS(m_class)         \
+#define GDREGISTER_VIRTUAL_CLASS(m_class) \
 	if constexpr (GD_IS_CLASS_ENABLED(m_class)) { \
 		::ClassDB::register_class<m_class>(true); \
 	}
-#define GDREGISTER_ABSTRACT_CLASS(m_class)             \
-	if constexpr (GD_IS_CLASS_ENABLED(m_class)) {      \
+#define GDREGISTER_ABSTRACT_CLASS(m_class) \
+	if constexpr (GD_IS_CLASS_ENABLED(m_class)) { \
 		::ClassDB::register_abstract_class<m_class>(); \
 	}
-#define GDREGISTER_INTERNAL_CLASS(m_class)             \
-	if constexpr (GD_IS_CLASS_ENABLED(m_class)) {      \
+#define GDREGISTER_INTERNAL_CLASS(m_class) \
+	if constexpr (GD_IS_CLASS_ENABLED(m_class)) { \
 		::ClassDB::register_internal_class<m_class>(); \
 	}
-#define GDREGISTER_RUNTIME_CLASS(m_class)             \
-	if constexpr (GD_IS_CLASS_ENABLED(m_class)) {     \
+#define GDREGISTER_RUNTIME_CLASS(m_class) \
+	if constexpr (GD_IS_CLASS_ENABLED(m_class)) { \
 		::ClassDB::register_runtime_class<m_class>(); \
 	}
 

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -39,23 +39,23 @@
 #ifdef DEV_ENABLED
 // Includes safety checks to ensure that a queue set as a thread singleton override
 // is only ever called from the thread it was set for.
-#define LOCK_MUTEX                                \
+#define LOCK_MUTEX \
 	if (this != MessageQueue::thread_singleton) { \
-		DEV_ASSERT(!is_current_thread_override);  \
-		mutex.lock();                             \
-	} else {                                      \
-		DEV_ASSERT(is_current_thread_override);   \
+		DEV_ASSERT(!is_current_thread_override); \
+		mutex.lock(); \
+	} else { \
+		DEV_ASSERT(is_current_thread_override); \
 	}
 #else
-#define LOCK_MUTEX                                \
+#define LOCK_MUTEX \
 	if (this != MessageQueue::thread_singleton) { \
-		mutex.lock();                             \
+		mutex.lock(); \
 	}
 #endif
 
-#define UNLOCK_MUTEX                              \
+#define UNLOCK_MUTEX \
 	if (this != MessageQueue::thread_singleton) { \
-		mutex.unlock();                           \
+		mutex.unlock(); \
 	}
 
 void CallQueue::_add_page() {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -399,168 +399,168 @@ struct ObjectGDExtension {
 
 /// `GDSOFTCLASS` provides `Object` functionality, such as being able to use `Object::cast_to()`.
 /// Use this for `Object` subclasses that are not registered in `ClassDB` (use `GDCLASS` otherwise).
-#define GDSOFTCLASS(m_class, m_inherits)                                                                         \
-public:                                                                                                          \
-	using self_type = m_class;                                                                                   \
-	using super_type = m_inherits;                                                                               \
-	static _FORCE_INLINE_ void *get_class_ptr_static() {                                                         \
-		static int ptr;                                                                                          \
-		return &ptr;                                                                                             \
-	}                                                                                                            \
-	virtual bool is_class_ptr(void *p_ptr) const override {                                                      \
-		return (p_ptr == get_class_ptr_static()) || m_inherits::is_class_ptr(p_ptr);                             \
-	}                                                                                                            \
-                                                                                                                 \
-protected:                                                                                                       \
-	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &) const {                 \
-		return (bool (Object::*)(const StringName &, Variant &) const) & m_class::_get;                          \
-	}                                                                                                            \
-	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override {                                \
-		if (m_class::_get_get() != m_inherits::_get_get()) {                                                     \
-			if (_get(p_name, r_ret)) {                                                                           \
-				return true;                                                                                     \
-			}                                                                                                    \
-		}                                                                                                        \
-		return m_inherits::_getv(p_name, r_ret);                                                                 \
-	}                                                                                                            \
-	_FORCE_INLINE_ bool (Object::*_get_set() const)(const StringName &p_name, const Variant &p_property) {       \
-		return (bool (Object::*)(const StringName &, const Variant &)) & m_class::_set;                          \
-	}                                                                                                            \
-	virtual bool _setv(const StringName &p_name, const Variant &p_property) override {                           \
-		if (m_inherits::_setv(p_name, p_property)) {                                                             \
-			return true;                                                                                         \
-		}                                                                                                        \
-		if (m_class::_get_set() != m_inherits::_get_set()) {                                                     \
-			return _set(p_name, p_property);                                                                     \
-		}                                                                                                        \
-		return false;                                                                                            \
-	}                                                                                                            \
-	_FORCE_INLINE_ void (Object::*_get_validate_property() const)(PropertyInfo & p_property) const {             \
-		return (void (Object::*)(PropertyInfo &) const) & m_class::_validate_property;                           \
-	}                                                                                                            \
-	virtual void _validate_propertyv(PropertyInfo &p_property) const override {                                  \
-		m_inherits::_validate_propertyv(p_property);                                                             \
-		if (m_class::_get_validate_property() != m_inherits::_get_validate_property()) {                         \
-			_validate_property(p_property);                                                                      \
-		}                                                                                                        \
-	}                                                                                                            \
-	_FORCE_INLINE_ bool (Object::*_get_property_can_revert() const)(const StringName &p_name) const {            \
-		return (bool (Object::*)(const StringName &) const) & m_class::_property_can_revert;                     \
-	}                                                                                                            \
-	virtual bool _property_can_revertv(const StringName &p_name) const override {                                \
-		if (m_class::_get_property_can_revert() != m_inherits::_get_property_can_revert()) {                     \
-			if (_property_can_revert(p_name)) {                                                                  \
-				return true;                                                                                     \
-			}                                                                                                    \
-		}                                                                                                        \
-		return m_inherits::_property_can_revertv(p_name);                                                        \
-	}                                                                                                            \
+#define GDSOFTCLASS(m_class, m_inherits) \
+public: \
+	using self_type = m_class; \
+	using super_type = m_inherits; \
+	static _FORCE_INLINE_ void *get_class_ptr_static() { \
+		static int ptr; \
+		return &ptr; \
+	} \
+	virtual bool is_class_ptr(void *p_ptr) const override { \
+		return (p_ptr == get_class_ptr_static()) || m_inherits::is_class_ptr(p_ptr); \
+	} \
+\
+protected: \
+	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &) const { \
+		return (bool (Object::*)(const StringName &, Variant &) const) & m_class::_get; \
+	} \
+	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override { \
+		if (m_class::_get_get() != m_inherits::_get_get()) { \
+			if (_get(p_name, r_ret)) { \
+				return true; \
+			} \
+		} \
+		return m_inherits::_getv(p_name, r_ret); \
+	} \
+	_FORCE_INLINE_ bool (Object::*_get_set() const)(const StringName &p_name, const Variant &p_property) { \
+		return (bool (Object::*)(const StringName &, const Variant &)) & m_class::_set; \
+	} \
+	virtual bool _setv(const StringName &p_name, const Variant &p_property) override { \
+		if (m_inherits::_setv(p_name, p_property)) { \
+			return true; \
+		} \
+		if (m_class::_get_set() != m_inherits::_get_set()) { \
+			return _set(p_name, p_property); \
+		} \
+		return false; \
+	} \
+	_FORCE_INLINE_ void (Object::*_get_validate_property() const)(PropertyInfo & p_property) const { \
+		return (void (Object::*)(PropertyInfo &) const) & m_class::_validate_property; \
+	} \
+	virtual void _validate_propertyv(PropertyInfo &p_property) const override { \
+		m_inherits::_validate_propertyv(p_property); \
+		if (m_class::_get_validate_property() != m_inherits::_get_validate_property()) { \
+			_validate_property(p_property); \
+		} \
+	} \
+	_FORCE_INLINE_ bool (Object::*_get_property_can_revert() const)(const StringName &p_name) const { \
+		return (bool (Object::*)(const StringName &) const) & m_class::_property_can_revert; \
+	} \
+	virtual bool _property_can_revertv(const StringName &p_name) const override { \
+		if (m_class::_get_property_can_revert() != m_inherits::_get_property_can_revert()) { \
+			if (_property_can_revert(p_name)) { \
+				return true; \
+			} \
+		} \
+		return m_inherits::_property_can_revertv(p_name); \
+	} \
 	_FORCE_INLINE_ bool (Object::*_get_property_get_revert() const)(const StringName &p_name, Variant &) const { \
-		return (bool (Object::*)(const StringName &, Variant &) const) & m_class::_property_get_revert;          \
-	}                                                                                                            \
-	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_ret) const override {                \
-		if (m_class::_get_property_get_revert() != m_inherits::_get_property_get_revert()) {                     \
-			if (_property_get_revert(p_name, r_ret)) {                                                           \
-				return true;                                                                                     \
-			}                                                                                                    \
-		}                                                                                                        \
-		return m_inherits::_property_get_revertv(p_name, r_ret);                                                 \
-	}                                                                                                            \
-	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {                                              \
-		return (void (Object::*)(int)) & m_class::_notification;                                                 \
-	}                                                                                                            \
-	virtual void _notification_forwardv(int p_notification) override {                                           \
-		m_inherits::_notification_forwardv(p_notification);                                                      \
-		if (m_class::_get_notification() != m_inherits::_get_notification()) {                                   \
-			_notification(p_notification);                                                                       \
-		}                                                                                                        \
-	}                                                                                                            \
-	virtual void _notification_backwardv(int p_notification) override {                                          \
-		if (m_class::_get_notification() != m_inherits::_get_notification()) {                                   \
-			_notification(p_notification);                                                                       \
-		}                                                                                                        \
-		m_inherits::_notification_backwardv(p_notification);                                                     \
-	}                                                                                                            \
-                                                                                                                 \
+		return (bool (Object::*)(const StringName &, Variant &) const) & m_class::_property_get_revert; \
+	} \
+	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_ret) const override { \
+		if (m_class::_get_property_get_revert() != m_inherits::_get_property_get_revert()) { \
+			if (_property_get_revert(p_name, r_ret)) { \
+				return true; \
+			} \
+		} \
+		return m_inherits::_property_get_revertv(p_name, r_ret); \
+	} \
+	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) { \
+		return (void (Object::*)(int)) & m_class::_notification; \
+	} \
+	virtual void _notification_forwardv(int p_notification) override { \
+		m_inherits::_notification_forwardv(p_notification); \
+		if (m_class::_get_notification() != m_inherits::_get_notification()) { \
+			_notification(p_notification); \
+		} \
+	} \
+	virtual void _notification_backwardv(int p_notification) override { \
+		if (m_class::_get_notification() != m_inherits::_get_notification()) { \
+			_notification(p_notification); \
+		} \
+		m_inherits::_notification_backwardv(p_notification); \
+	} \
+\
 private:
 
 /// `GDSOFTCLASS` provides `Object` functionality, such as being able to use `Object::cast_to()`.
 /// Use this for `Object` subclasses that are registered in `ObjectDB` (use `GDSOFTCLASS` otherwise).
-#define GDCLASS(m_class, m_inherits)                                                                                                        \
-	GDSOFTCLASS(m_class, m_inherits)                                                                                                        \
-private:                                                                                                                                    \
-	void operator=(const m_class &p_rval) {}                                                                                                \
-	friend class ::ClassDB;                                                                                                                 \
-                                                                                                                                            \
-public:                                                                                                                                     \
-	virtual const GDType &_get_typev() const override {                                                                                     \
-		return get_gdtype_static();                                                                                                         \
-	}                                                                                                                                       \
-	static const GDType &get_gdtype_static() {                                                                                              \
-		static GDType *_class_static;                                                                                                       \
-		if (unlikely(!_class_static)) {                                                                                                     \
-			assign_type_static(&_class_static, #m_class, &super_type::get_gdtype_static());                                                 \
-		}                                                                                                                                   \
-		return *_class_static;                                                                                                              \
-	}                                                                                                                                       \
-	static const StringName &get_class_static() {                                                                                           \
-		return get_gdtype_static().get_name();                                                                                              \
-	}                                                                                                                                       \
-                                                                                                                                            \
-protected:                                                                                                                                  \
-	_FORCE_INLINE_ static void (*_get_bind_methods())() {                                                                                   \
-		return &m_class::_bind_methods;                                                                                                     \
-	}                                                                                                                                       \
-	_FORCE_INLINE_ static void (*_get_bind_compatibility_methods())() {                                                                     \
-		return &m_class::_bind_compatibility_methods;                                                                                       \
-	}                                                                                                                                       \
-                                                                                                                                            \
-public:                                                                                                                                     \
-	static void initialize_class() {                                                                                                        \
-		static bool initialized = false;                                                                                                    \
-		if (initialized) {                                                                                                                  \
-			return;                                                                                                                         \
-		}                                                                                                                                   \
-		m_inherits::initialize_class();                                                                                                     \
-		_add_class_to_classdb(get_gdtype_static(), &super_type::get_gdtype_static());                                                       \
-		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) {                                                              \
-			_bind_methods();                                                                                                                \
-		}                                                                                                                                   \
-		if (m_class::_get_bind_compatibility_methods() != m_inherits::_get_bind_compatibility_methods()) {                                  \
-			_bind_compatibility_methods();                                                                                                  \
-		}                                                                                                                                   \
-		initialized = true;                                                                                                                 \
-	}                                                                                                                                       \
-                                                                                                                                            \
-protected:                                                                                                                                  \
-	virtual void _initialize_classv() override {                                                                                            \
-		initialize_class();                                                                                                                 \
-	}                                                                                                                                       \
-	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> * p_list) const {                                      \
-		return (void (Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                                \
-	}                                                                                                                                       \
-	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const override {                                          \
-		if (!p_reversed) {                                                                                                                  \
-			m_inherits::_get_property_listv(p_list, p_reversed);                                                                            \
-		}                                                                                                                                   \
+#define GDCLASS(m_class, m_inherits) \
+	GDSOFTCLASS(m_class, m_inherits) \
+private: \
+	void operator=(const m_class &p_rval) {} \
+	friend class ::ClassDB; \
+\
+public: \
+	virtual const GDType &_get_typev() const override { \
+		return get_gdtype_static(); \
+	} \
+	static const GDType &get_gdtype_static() { \
+		static GDType *_class_static; \
+		if (unlikely(!_class_static)) { \
+			assign_type_static(&_class_static, #m_class, &super_type::get_gdtype_static()); \
+		} \
+		return *_class_static; \
+	} \
+	static const StringName &get_class_static() { \
+		return get_gdtype_static().get_name(); \
+	} \
+\
+protected: \
+	_FORCE_INLINE_ static void (*_get_bind_methods())() { \
+		return &m_class::_bind_methods; \
+	} \
+	_FORCE_INLINE_ static void (*_get_bind_compatibility_methods())() { \
+		return &m_class::_bind_compatibility_methods; \
+	} \
+\
+public: \
+	static void initialize_class() { \
+		static bool initialized = false; \
+		if (initialized) { \
+			return; \
+		} \
+		m_inherits::initialize_class(); \
+		_add_class_to_classdb(get_gdtype_static(), &super_type::get_gdtype_static()); \
+		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) { \
+			_bind_methods(); \
+		} \
+		if (m_class::_get_bind_compatibility_methods() != m_inherits::_get_bind_compatibility_methods()) { \
+			_bind_compatibility_methods(); \
+		} \
+		initialized = true; \
+	} \
+\
+protected: \
+	virtual void _initialize_classv() override { \
+		initialize_class(); \
+	} \
+	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> * p_list) const { \
+		return (void (Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list; \
+	} \
+	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const override { \
+		if (!p_reversed) { \
+			m_inherits::_get_property_listv(p_list, p_reversed); \
+		} \
 		p_list->push_back(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, get_class_static(), PROPERTY_USAGE_CATEGORY)); \
-		_get_property_list_from_classdb(#m_class, p_list, true, this);                                                                      \
-		if (m_class::_get_get_property_list() != m_inherits::_get_get_property_list()) {                                                    \
-			_get_property_list(p_list);                                                                                                     \
-		}                                                                                                                                   \
-		if (p_reversed) {                                                                                                                   \
-			m_inherits::_get_property_listv(p_list, p_reversed);                                                                            \
-		}                                                                                                                                   \
-	}                                                                                                                                       \
-                                                                                                                                            \
+		_get_property_list_from_classdb(#m_class, p_list, true, this); \
+		if (m_class::_get_get_property_list() != m_inherits::_get_get_property_list()) { \
+			_get_property_list(p_list); \
+		} \
+		if (p_reversed) { \
+			m_inherits::_get_property_listv(p_list, p_reversed); \
+		} \
+	} \
+\
 private:
 
-#define OBJ_SAVE_TYPE(m_class)                       \
-public:                                              \
+#define OBJ_SAVE_TYPE(m_class) \
+public: \
 	virtual String get_save_class() const override { \
-		return #m_class;                             \
-	}                                                \
-                                                     \
+		return #m_class; \
+	} \
+\
 private:
 
 class ClassDB;
@@ -1340,12 +1340,12 @@ public:
 	}
 };
 
-#define TMPL_EXTRACT_PARAM_OR_FAIL(m_name, m_param, m_retval, m_msg, m_editor)                                                 \
-	if (unlikely(m_param._is_null_dont_use())) {                                                                               \
+#define TMPL_EXTRACT_PARAM_OR_FAIL(m_name, m_param, m_retval, m_msg, m_editor) \
+	if (unlikely(m_param._is_null_dont_use())) { \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Required object \"" _STR(m_param) "\" is null.", m_msg, m_editor); \
-		return m_retval;                                                                                                       \
-	}                                                                                                                          \
-	typename std::decay_t<decltype(m_param)>::extracted_type m_name = m_param._internal_ptr_dont_use();                        \
+		return m_retval; \
+	} \
+	typename std::decay_t<decltype(m_param)>::extracted_type m_name = m_param._internal_ptr_dont_use(); \
 	static_assert(true)
 
 // These macros are equivalent to the ERR_FAIL_NULL*() family of macros, only for RequiredParam<T> instead of raw pointers.

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -168,10 +168,10 @@ void memdelete_allocator(T *p_class) {
 }
 
 #define memdelete_notnull(m_v) \
-	{                          \
-		if (m_v) {             \
-			memdelete(m_v);    \
-		}                      \
+	{ \
+		if (m_v) { \
+			memdelete(m_v); \
+		} \
 	}
 
 #define memnew_arr(m_class, m_count) memnew_arr_template<m_class>(m_count)

--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -79,125 +79,125 @@ static const uint8_t MONTH_DAYS_TABLE[2][12] = {
 	{ 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
 };
 
-#define UNIX_TIME_TO_HMS                                                     \
-	uint8_t hour, minute, second;                                            \
-	{                                                                        \
-		/* The time of the day (in seconds since start of day). */           \
+#define UNIX_TIME_TO_HMS \
+	uint8_t hour, minute, second; \
+	{ \
+		/* The time of the day (in seconds since start of day). */ \
 		uint32_t day_clock = Math::posmod(p_unix_time_val, SECONDS_PER_DAY); \
-		/* On x86 these 4 lines can be optimized to only 2 divisions. */     \
-		second = day_clock % 60;                                             \
-		day_clock /= 60;                                                     \
-		minute = day_clock % 60;                                             \
-		hour = day_clock / 60;                                               \
+		/* On x86 these 4 lines can be optimized to only 2 divisions. */ \
+		second = day_clock % 60; \
+		day_clock /= 60; \
+		minute = day_clock % 60; \
+		hour = day_clock / 60; \
 	}
 
-#define UNIX_TIME_TO_YMD                                                                    \
-	int64_t year;                                                                           \
-	Month month;                                                                            \
-	uint8_t day;                                                                            \
-	/* The day number since Unix epoch (0-index). Days before 1970 are negative. */         \
-	int64_t day_number = Math::floor(p_unix_time_val / (double)SECONDS_PER_DAY);            \
-	{                                                                                       \
-		int64_t day_number_copy = day_number;                                               \
-		day_number_copy += year_to_days(UNIX_EPOCH_YEAR_AD);                                \
-		year = days_to_year(day_number_copy);                                               \
-		day_number_copy -= year_to_days(year);                                              \
-		uint8_t month_zero_index = 0;                                                       \
-		/* After the above, day_number now represents the day of the year (0-index). */     \
+#define UNIX_TIME_TO_YMD \
+	int64_t year; \
+	Month month; \
+	uint8_t day; \
+	/* The day number since Unix epoch (0-index). Days before 1970 are negative. */ \
+	int64_t day_number = Math::floor(p_unix_time_val / (double)SECONDS_PER_DAY); \
+	{ \
+		int64_t day_number_copy = day_number; \
+		day_number_copy += year_to_days(UNIX_EPOCH_YEAR_AD); \
+		year = days_to_year(day_number_copy); \
+		day_number_copy -= year_to_days(year); \
+		uint8_t month_zero_index = 0; \
+		/* After the above, day_number now represents the day of the year (0-index). */ \
 		while (day_number_copy >= MONTH_DAYS_TABLE[IS_LEAP_YEAR(year)][month_zero_index]) { \
-			day_number_copy -= MONTH_DAYS_TABLE[IS_LEAP_YEAR(year)][month_zero_index];      \
-			month_zero_index++;                                                             \
-		}                                                                                   \
-		/* After the above, day_number now represents the day of the month (0-index). */    \
-		month = (Month)(month_zero_index + 1);                                              \
-		day = day_number_copy + 1;                                                          \
+			day_number_copy -= MONTH_DAYS_TABLE[IS_LEAP_YEAR(year)][month_zero_index]; \
+			month_zero_index++; \
+		} \
+		/* After the above, day_number now represents the day of the month (0-index). */ \
+		month = (Month)(month_zero_index + 1); \
+		day = day_number_copy + 1; \
 	}
 
-#define VALIDATE_YMDHMS(ret)                                                                                                                                              \
+#define VALIDATE_YMDHMS(ret) \
 	ERR_FAIL_COND_V_MSG(month == 0, ret, "Invalid month value of: " + itos(month) + ", months are 1-indexed and cannot be 0. See the Time.Month enum for valid values."); \
-	ERR_FAIL_COND_V_MSG(month < 0, ret, "Invalid month value of: " + itos(month) + ".");                                                                                  \
-	ERR_FAIL_COND_V_MSG(month > 12, ret, "Invalid month value of: " + itos(month) + ". See the Time.Month enum for valid values.");                                       \
-	ERR_FAIL_COND_V_MSG(hour > 23, ret, "Invalid hour value of: " + itos(hour) + ".");                                                                                    \
-	ERR_FAIL_COND_V_MSG(hour < 0, ret, "Invalid hour value of: " + itos(hour) + ".");                                                                                     \
-	ERR_FAIL_COND_V_MSG(minute > 59, ret, "Invalid minute value of: " + itos(minute) + ".");                                                                              \
-	ERR_FAIL_COND_V_MSG(minute < 0, ret, "Invalid minute value of: " + itos(minute) + ".");                                                                               \
-	ERR_FAIL_COND_V_MSG(second > 59, ret, "Invalid second value of: " + itos(second) + " (leap seconds are not supported).");                                             \
-	ERR_FAIL_COND_V_MSG(second < 0, ret, "Invalid second value of: " + itos(second) + ".");                                                                               \
-	ERR_FAIL_COND_V_MSG(day == 0, ret, "Invalid day value of: " + itos(day) + ", days are 1-indexed and cannot be 0.");                                                   \
-	ERR_FAIL_COND_V_MSG(day < 0, ret, "Invalid day value of: " + itos(day) + ".");                                                                                        \
-	/* Do this check after month is tested as valid. */                                                                                                                   \
-	uint8_t days_in_this_month = MONTH_DAYS_TABLE[IS_LEAP_YEAR(year)][month - 1];                                                                                         \
+	ERR_FAIL_COND_V_MSG(month < 0, ret, "Invalid month value of: " + itos(month) + "."); \
+	ERR_FAIL_COND_V_MSG(month > 12, ret, "Invalid month value of: " + itos(month) + ". See the Time.Month enum for valid values."); \
+	ERR_FAIL_COND_V_MSG(hour > 23, ret, "Invalid hour value of: " + itos(hour) + "."); \
+	ERR_FAIL_COND_V_MSG(hour < 0, ret, "Invalid hour value of: " + itos(hour) + "."); \
+	ERR_FAIL_COND_V_MSG(minute > 59, ret, "Invalid minute value of: " + itos(minute) + "."); \
+	ERR_FAIL_COND_V_MSG(minute < 0, ret, "Invalid minute value of: " + itos(minute) + "."); \
+	ERR_FAIL_COND_V_MSG(second > 59, ret, "Invalid second value of: " + itos(second) + " (leap seconds are not supported)."); \
+	ERR_FAIL_COND_V_MSG(second < 0, ret, "Invalid second value of: " + itos(second) + "."); \
+	ERR_FAIL_COND_V_MSG(day == 0, ret, "Invalid day value of: " + itos(day) + ", days are 1-indexed and cannot be 0."); \
+	ERR_FAIL_COND_V_MSG(day < 0, ret, "Invalid day value of: " + itos(day) + "."); \
+	/* Do this check after month is tested as valid. */ \
+	uint8_t days_in_this_month = MONTH_DAYS_TABLE[IS_LEAP_YEAR(year)][month - 1]; \
 	ERR_FAIL_COND_V_MSG(day > days_in_this_month, ret, "Invalid day value of: " + itos(day) + " which is larger than the maximum for this month, " + itos(days_in_this_month) + ".");
 
-#define YMD_TO_DAY_NUMBER                                                           \
+#define YMD_TO_DAY_NUMBER \
 	/* The day number since Unix epoch (0-index). Days before 1970 are negative. */ \
-	int64_t day_number = day - 1;                                                   \
-	/* Add the days in the months to day_number. */                                 \
-	for (int i = 0; i < month - 1; i++) {                                           \
-		day_number += MONTH_DAYS_TABLE[IS_LEAP_YEAR(year)][i];                      \
-	}                                                                               \
-	/* Add the days in the years to day_number. */                                  \
-	day_number += year_to_days(year);                                               \
+	int64_t day_number = day - 1; \
+	/* Add the days in the months to day_number. */ \
+	for (int i = 0; i < month - 1; i++) { \
+		day_number += MONTH_DAYS_TABLE[IS_LEAP_YEAR(year)][i]; \
+	} \
+	/* Add the days in the years to day_number. */ \
+	day_number += year_to_days(year); \
 	day_number -= year_to_days(UNIX_EPOCH_YEAR_AD);
 
-#define PARSE_ISO8601_STRING(ret)                                                             \
-	int64_t year = UNIX_EPOCH_YEAR_AD;                                                        \
-	Month month = MONTH_JANUARY;                                                              \
-	int day = 1;                                                                              \
-	int hour = 0;                                                                             \
-	int minute = 0;                                                                           \
-	int second = 0;                                                                           \
-	{                                                                                         \
-		bool has_date = false, has_time = false;                                              \
-		String date, time;                                                                    \
-		if (p_datetime.find_char('T') > 0) {                                                  \
-			has_date = has_time = true;                                                       \
-			PackedStringArray array = p_datetime.split("T");                                  \
+#define PARSE_ISO8601_STRING(ret) \
+	int64_t year = UNIX_EPOCH_YEAR_AD; \
+	Month month = MONTH_JANUARY; \
+	int day = 1; \
+	int hour = 0; \
+	int minute = 0; \
+	int second = 0; \
+	{ \
+		bool has_date = false, has_time = false; \
+		String date, time; \
+		if (p_datetime.find_char('T') > 0) { \
+			has_date = has_time = true; \
+			PackedStringArray array = p_datetime.split("T"); \
 			ERR_FAIL_COND_V_MSG(array.size() < 2, ret, "Invalid ISO 8601 date/time string."); \
-			date = array[0];                                                                  \
-			time = array[1];                                                                  \
-		} else if (p_datetime.find_char(' ') > 0) {                                           \
-			has_date = has_time = true;                                                       \
-			PackedStringArray array = p_datetime.split(" ");                                  \
+			date = array[0]; \
+			time = array[1]; \
+		} else if (p_datetime.find_char(' ') > 0) { \
+			has_date = has_time = true; \
+			PackedStringArray array = p_datetime.split(" "); \
 			ERR_FAIL_COND_V_MSG(array.size() < 2, ret, "Invalid ISO 8601 date/time string."); \
-			date = array[0];                                                                  \
-			time = array[1];                                                                  \
-		} else if (p_datetime.find_char('-', 1) > 0) {                                        \
-			has_date = true;                                                                  \
-			date = p_datetime;                                                                \
-		} else if (p_datetime.find_char(':') > 0) {                                           \
-			has_time = true;                                                                  \
-			time = p_datetime;                                                                \
-		}                                                                                     \
-		/* Set the variables from the contents of the string. */                              \
-		if (has_date) {                                                                       \
-			PackedInt32Array array = date.split_ints("-", false);                             \
-			ERR_FAIL_COND_V_MSG(array.size() < 3, ret, "Invalid ISO 8601 date string.");      \
-			year = array[0];                                                                  \
-			month = (Month)array[1];                                                          \
-			day = array[2];                                                                   \
-			/* Handle negative years. */                                                      \
-			if (p_datetime.find_char('-') == 0) {                                             \
-				year *= -1;                                                                   \
-			}                                                                                 \
-		}                                                                                     \
-		if (has_time) {                                                                       \
-			PackedInt32Array array = time.split_ints(":", false);                             \
-			ERR_FAIL_COND_V_MSG(array.size() < 3, ret, "Invalid ISO 8601 time string.");      \
-			hour = array[0];                                                                  \
-			minute = array[1];                                                                \
-			second = array[2];                                                                \
-		}                                                                                     \
+			date = array[0]; \
+			time = array[1]; \
+		} else if (p_datetime.find_char('-', 1) > 0) { \
+			has_date = true; \
+			date = p_datetime; \
+		} else if (p_datetime.find_char(':') > 0) { \
+			has_time = true; \
+			time = p_datetime; \
+		} \
+		/* Set the variables from the contents of the string. */ \
+		if (has_date) { \
+			PackedInt32Array array = date.split_ints("-", false); \
+			ERR_FAIL_COND_V_MSG(array.size() < 3, ret, "Invalid ISO 8601 date string."); \
+			year = array[0]; \
+			month = (Month)array[1]; \
+			day = array[2]; \
+			/* Handle negative years. */ \
+			if (p_datetime.find_char('-') == 0) { \
+				year *= -1; \
+			} \
+		} \
+		if (has_time) { \
+			PackedInt32Array array = time.split_ints(":", false); \
+			ERR_FAIL_COND_V_MSG(array.size() < 3, ret, "Invalid ISO 8601 time string."); \
+			hour = array[0]; \
+			minute = array[1]; \
+			second = array[2]; \
+		} \
 	}
 
-#define EXTRACT_FROM_DICTIONARY                                                                   \
-	/* Get all time values from the dictionary. If it doesn't exist, set the */                   \
-	/* values to the default values for Unix epoch (1970-01-01 00:00:00). */                      \
+#define EXTRACT_FROM_DICTIONARY \
+	/* Get all time values from the dictionary. If it doesn't exist, set the */ \
+	/* values to the default values for Unix epoch (1970-01-01 00:00:00). */ \
 	int64_t year = p_datetime.has(YEAR_KEY) ? int64_t(p_datetime[YEAR_KEY]) : UNIX_EPOCH_YEAR_AD; \
-	Month month = Month((p_datetime.has(MONTH_KEY)) ? int(p_datetime[MONTH_KEY]) : 1);            \
-	int day = p_datetime.has(DAY_KEY) ? int(p_datetime[DAY_KEY]) : 1;                             \
-	int hour = p_datetime.has(HOUR_KEY) ? int(p_datetime[HOUR_KEY]) : 0;                          \
-	int minute = p_datetime.has(MINUTE_KEY) ? int(p_datetime[MINUTE_KEY]) : 0;                    \
+	Month month = Month((p_datetime.has(MONTH_KEY)) ? int(p_datetime[MONTH_KEY]) : 1); \
+	int day = p_datetime.has(DAY_KEY) ? int(p_datetime[DAY_KEY]) : 1; \
+	int hour = p_datetime.has(HOUR_KEY) ? int(p_datetime[HOUR_KEY]) : 0; \
+	int minute = p_datetime.has(MINUTE_KEY) ? int(p_datetime[MINUTE_KEY]) : 0; \
 	int second = p_datetime.has(SECOND_KEY) ? int(p_datetime[SECOND_KEY]) : 0;
 
 Time *Time::singleton = nullptr;

--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -62,13 +62,13 @@ const SourceLocationData *intern_source_location(const void *p_function_ptr, con
 #define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name) ZoneNamedN(__godot_tracy_zone_##m_group_name, m_zone_name, true)
 #define GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name) __godot_tracy_zone_##m_group_name.~ScopedZone();
 #ifndef TRACY_CALLSTACK
-#define GodotProfileZoneGrouped(m_group_name, m_zone_name)                                                                                                       \
-	GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name);                                                                                                  \
+#define GodotProfileZoneGrouped(m_group_name, m_zone_name) \
+	GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name); \
 	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location, TracyLine){ m_zone_name, TracyFunction, TracyFile, (uint32_t)TracyLine, 0 }; \
 	new (&__godot_tracy_zone_##m_group_name) tracy::ScopedZone(&TracyConcat(__tracy_source_location, TracyLine), true)
 #else
-#define GodotProfileZoneGrouped(m_group_name, m_zone_name)                                                                                                       \
-	GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name);                                                                                                  \
+#define GodotProfileZoneGrouped(m_group_name, m_zone_name) \
+	GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name); \
 	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location, TracyLine){ m_zone_name, TracyFunction, TracyFile, (uint32_t)TracyLine, 0 }; \
 	new (&__godot_tracy_zone_##m_group_name) tracy::ScopedZone(&TracyConcat(__tracy_source_location, TracyLine), TRACY_CALLSTACK, true)
 #endif
@@ -80,9 +80,9 @@ const SourceLocationData *intern_source_location(const void *p_function_ptr, con
 
 // Memory allocation
 #ifdef GODOT_PROFILER_TRACK_MEMORY
-#define GodotProfileAlloc(m_ptr, m_size)                       \
+#define GodotProfileAlloc(m_ptr, m_size) \
 	GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wmaybe-uninitialized") \
-	TracyAlloc(m_ptr, m_size);                                 \
+	TracyAlloc(m_ptr, m_size); \
 	GODOT_GCC_WARNING_POP
 #define GodotProfileFree(m_ptr) TracyFree(m_ptr)
 #else
@@ -118,11 +118,11 @@ struct PerfettoGroupedEventEnder {
 #define GodotProfileFrameMark // TODO
 #define GodotProfileZone(m_zone_name) TRACE_EVENT("godot", m_zone_name);
 #define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name) \
-	TRACE_EVENT_BEGIN("godot", m_zone_name);                    \
+	TRACE_EVENT_BEGIN("godot", m_zone_name); \
 	PerfettoGroupedEventEnder __godot_perfetto_zone_##m_group_name
 #define GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name) __godot_perfetto_zone_##m_group_name.~PerfettoGroupedEventEnder()
 #define GodotProfileZoneGrouped(m_group_name, m_zone_name) \
-	__godot_perfetto_zone_##m_group_name._end_now();       \
+	__godot_perfetto_zone_##m_group_name._end_now(); \
 	TRACE_EVENT_BEGIN("godot", m_zone_name);
 
 #define GodotProfileZoneScript(m_ptr, m_file, m_function, m_name, m_line)
@@ -163,22 +163,22 @@ private:
 #define GodotProfileFrameMark \
 	os_signpost_event_emit(apple::instruments::LOG, OS_SIGNPOST_ID_EXCLUSIVE, "Frame");
 
-#define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name)                                           \
-	os_signpost_interval_begin(apple::instruments::LOG_TRACING, OS_SIGNPOST_ID_EXCLUSIVE, m_zone_name);   \
-	apple::instruments::DeferFunc _GD_VARNAME_CONCAT_(defer__fn, _, m_group_name) = []() {                \
+#define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name) \
+	os_signpost_interval_begin(apple::instruments::LOG_TRACING, OS_SIGNPOST_ID_EXCLUSIVE, m_zone_name); \
+	apple::instruments::DeferFunc _GD_VARNAME_CONCAT_(defer__fn, _, m_group_name) = []() { \
 		os_signpost_interval_end(apple::instruments::LOG_TRACING, OS_SIGNPOST_ID_EXCLUSIVE, m_zone_name); \
-	};                                                                                                    \
+	}; \
 	apple::instruments::Defer _GD_VARNAME_CONCAT_(__instruments_defer_zone_end__, _, m_group_name)(_GD_VARNAME_CONCAT_(defer__fn, _, m_group_name));
 
 #define GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name) \
 	_GD_VARNAME_CONCAT_(__instruments_defer_zone_end__, _, m_group_name).~Defer();
 
-#define GodotProfileZoneGrouped(m_group_name, m_zone_name)                                                \
-	GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name);                                           \
-	os_signpost_interval_begin(apple::instruments::LOG_TRACING, OS_SIGNPOST_ID_EXCLUSIVE, m_zone_name);   \
-	_GD_VARNAME_CONCAT_(defer__fn, _, m_group_name) = []() {                                              \
+#define GodotProfileZoneGrouped(m_group_name, m_zone_name) \
+	GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name); \
+	os_signpost_interval_begin(apple::instruments::LOG_TRACING, OS_SIGNPOST_ID_EXCLUSIVE, m_zone_name); \
+	_GD_VARNAME_CONCAT_(defer__fn, _, m_group_name) = []() { \
 		os_signpost_interval_end(apple::instruments::LOG_TRACING, OS_SIGNPOST_ID_EXCLUSIVE, m_zone_name); \
-	};                                                                                                    \
+	}; \
 	new (&_GD_VARNAME_CONCAT_(__instruments_defer_zone_end__, _, m_group_name)) apple::instruments::Defer(_GD_VARNAME_CONCAT_(defer__fn, _, m_group_name));
 
 #define GodotProfileZone(m_zone_name) \

--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -37,23 +37,23 @@
 static constexpr char hex_char_table_upper[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 static constexpr char hex_char_table_lower[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
-#define BSEARCH_CHAR_RANGE(m_array)                \
-	int low = 0;                                   \
-	int high = std_size(m_array) - 1;              \
-	int middle = (low + high) / 2;                 \
-                                                   \
-	while (low <= high) {                          \
-		if (p_char < m_array[middle].start) {      \
-			high = middle - 1;                     \
+#define BSEARCH_CHAR_RANGE(m_array) \
+	int low = 0; \
+	int high = std_size(m_array) - 1; \
+	int middle = (low + high) / 2; \
+\
+	while (low <= high) { \
+		if (p_char < m_array[middle].start) { \
+			high = middle - 1; \
 		} else if (p_char > m_array[middle].end) { \
-			low = middle + 1;                      \
-		} else {                                   \
-			return true;                           \
-		}                                          \
-                                                   \
-		middle = (low + high) / 2;                 \
-	}                                              \
-                                                   \
+			low = middle + 1; \
+		} else { \
+			return true; \
+		} \
+\
+		middle = (low + high) / 2; \
+	} \
+\
 	return false
 
 constexpr bool is_unicode_identifier_start(char32_t p_char) {

--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -58,11 +58,11 @@ extern void print_error(const String &p_string);
 extern bool is_print_verbose_enabled();
 
 // This version avoids processing the text to be printed until it actually has to be printed, saving some CPU usage.
-#define print_verbose(m_text)             \
-	{                                     \
+#define print_verbose(m_text) \
+	{ \
 		if (is_print_verbose_enabled()) { \
-			print_line(m_text);           \
-		}                                 \
+			print_line(m_text); \
+		} \
 	}
 
 template <typename... Args>

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1645,16 +1645,16 @@ String String::hex_encode_buffer(const uint8_t *p_buffer, int p_len) {
 Vector<uint8_t> String::hex_decode() const {
 	ERR_FAIL_COND_V_MSG(length() % 2 != 0, Vector<uint8_t>(), "Hexadecimal string of uneven length.");
 
-#define HEX_TO_BYTE(m_output, m_index)                                                                                   \
-	uint8_t m_output;                                                                                                    \
-	c = operator[](m_index);                                                                                             \
-	if (is_digit(c)) {                                                                                                   \
-		m_output = c - '0';                                                                                              \
-	} else if (c >= 'a' && c <= 'f') {                                                                                   \
-		m_output = c - 'a' + 10;                                                                                         \
-	} else if (c >= 'A' && c <= 'F') {                                                                                   \
-		m_output = c - 'A' + 10;                                                                                         \
-	} else {                                                                                                             \
+#define HEX_TO_BYTE(m_output, m_index) \
+	uint8_t m_output; \
+	c = operator[](m_index); \
+	if (is_digit(c)) { \
+		m_output = c - '0'; \
+	} else if (c >= 'a' && c <= 'f') { \
+		m_output = c - 'a' + 10; \
+	} else if (c >= 'A' && c <= 'F') { \
+		m_output = c - 'A' + 10; \
+	} else { \
 		ERR_FAIL_V_MSG(Vector<uint8_t>(), "Invalid hexadecimal character \"" + chr(c) + "\" at index " + m_index + "."); \
 	}
 

--- a/core/templates/pass_func.h
+++ b/core/templates/pass_func.h
@@ -30,132 +30,132 @@
 
 #pragma once
 
-#define PASS0R(m_r, m_name)        \
-	m_r m_name() {                 \
+#define PASS0R(m_r, m_name) \
+	m_r m_name() { \
 		return PASSBASE->m_name(); \
 	}
-#define PASS0RC(m_r, m_name)       \
-	m_r m_name() const {           \
+#define PASS0RC(m_r, m_name) \
+	m_r m_name() const { \
 		return PASSBASE->m_name(); \
 	}
-#define PASS1R(m_r, m_name, m_type1)   \
-	m_r m_name(m_type1 arg1) {         \
+#define PASS1R(m_r, m_name, m_type1) \
+	m_r m_name(m_type1 arg1) { \
 		return PASSBASE->m_name(arg1); \
 	}
-#define PASS1RC(m_r, m_name, m_type1)  \
-	m_r m_name(m_type1 arg1) const {   \
+#define PASS1RC(m_r, m_name, m_type1) \
+	m_r m_name(m_type1 arg1) const { \
 		return PASSBASE->m_name(arg1); \
 	}
 #define PASS2R(m_r, m_name, m_type1, m_type2) \
-	m_r m_name(m_type1 arg1, m_type2 arg2) {  \
-		return PASSBASE->m_name(arg1, arg2);  \
+	m_r m_name(m_type1 arg1, m_type2 arg2) { \
+		return PASSBASE->m_name(arg1, arg2); \
 	}
-#define PASS2RC(m_r, m_name, m_type1, m_type2)     \
+#define PASS2RC(m_r, m_name, m_type1, m_type2) \
 	m_r m_name(m_type1 arg1, m_type2 arg2) const { \
-		return PASSBASE->m_name(arg1, arg2);       \
+		return PASSBASE->m_name(arg1, arg2); \
 	}
-#define PASS3R(m_r, m_name, m_type1, m_type2, m_type3)     \
+#define PASS3R(m_r, m_name, m_type1, m_type2, m_type3) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) { \
-		return PASSBASE->m_name(arg1, arg2, arg3);         \
+		return PASSBASE->m_name(arg1, arg2, arg3); \
 	}
-#define PASS3RC(m_r, m_name, m_type1, m_type2, m_type3)          \
+#define PASS3RC(m_r, m_name, m_type1, m_type2, m_type3) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) const { \
-		return PASSBASE->m_name(arg1, arg2, arg3);               \
+		return PASSBASE->m_name(arg1, arg2, arg3); \
 	}
-#define PASS4R(m_r, m_name, m_type1, m_type2, m_type3, m_type4)          \
+#define PASS4R(m_r, m_name, m_type1, m_type2, m_type3, m_type4) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) { \
-		return PASSBASE->m_name(arg1, arg2, arg3, arg4);                 \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4); \
 	}
-#define PASS4RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4)               \
+#define PASS4RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) const { \
-		return PASSBASE->m_name(arg1, arg2, arg3, arg4);                       \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4); \
 	}
-#define PASS5R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5)               \
+#define PASS5R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) { \
-		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5);                         \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5); \
 	}
-#define PASS5RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5)                    \
+#define PASS5RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) const { \
-		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5);                               \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5); \
 	}
-#define PASS6R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6)                    \
+#define PASS6R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) { \
-		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6);                                 \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6); \
 	}
-#define PASS6RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6)                         \
+#define PASS6RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) const { \
-		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6);                                       \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6); \
 	}
 
-#define PASS0(m_name)       \
-	void m_name() {         \
+#define PASS0(m_name) \
+	void m_name() { \
 		PASSBASE->m_name(); \
 	}
-#define PASS1(m_name, m_type1)  \
+#define PASS1(m_name, m_type1) \
 	void m_name(m_type1 arg1) { \
 		PASSBASE->m_name(arg1); \
 	}
-#define PASS1C(m_name, m_type1)       \
+#define PASS1C(m_name, m_type1) \
 	void m_name(m_type1 arg1) const { \
-		PASSBASE->m_name(arg1);       \
+		PASSBASE->m_name(arg1); \
 	}
-#define PASS2(m_name, m_type1, m_type2)       \
+#define PASS2(m_name, m_type1, m_type2) \
 	void m_name(m_type1 arg1, m_type2 arg2) { \
-		PASSBASE->m_name(arg1, arg2);         \
+		PASSBASE->m_name(arg1, arg2); \
 	}
-#define PASS2C(m_name, m_type1, m_type2)            \
+#define PASS2C(m_name, m_type1, m_type2) \
 	void m_name(m_type1 arg1, m_type2 arg2) const { \
-		PASSBASE->m_name(arg1, arg2);               \
+		PASSBASE->m_name(arg1, arg2); \
 	}
-#define PASS3(m_name, m_type1, m_type2, m_type3)            \
+#define PASS3(m_name, m_type1, m_type2, m_type3) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) { \
-		PASSBASE->m_name(arg1, arg2, arg3);                 \
+		PASSBASE->m_name(arg1, arg2, arg3); \
 	}
-#define PASS4(m_name, m_type1, m_type2, m_type3, m_type4)                 \
+#define PASS4(m_name, m_type1, m_type2, m_type3, m_type4) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4);                         \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4); \
 	}
-#define PASS5(m_name, m_type1, m_type2, m_type3, m_type4, m_type5)                      \
+#define PASS5(m_name, m_type1, m_type2, m_type3, m_type4, m_type5) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5);                                 \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5); \
 	}
-#define PASS6(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6)                           \
+#define PASS6(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6);                                         \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6); \
 	}
-#define PASS7(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7)                                \
+#define PASS7(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7);                                                 \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
 	}
-#define PASS8(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8)                                     \
+#define PASS8(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);                                                         \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
 	}
-#define PASS9(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9)                                          \
+#define PASS9(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);                                                                 \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); \
 	}
-#define PASS10(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10)                                               \
+#define PASS10(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);                                                                          \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); \
 	}
-#define PASS11(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11)                                                     \
+#define PASS11(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);                                                                                   \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); \
 	}
-#define PASS12(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12)                                                           \
+#define PASS12(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);                                                                                            \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); \
 	}
-#define PASS13(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13)                                                                 \
+#define PASS13(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12, m_type13 arg13) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);                                                                                                     \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
 	}
-#define PASS14(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13, m_type14)                                                                       \
+#define PASS14(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13, m_type14) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12, m_type13 arg13, m_type14 arg14) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);                                                                                                              \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); \
 	}
-#define PASS15(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13, m_type14, m_type15)                                                                             \
+#define PASS15(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13, m_type14, m_type15) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12, m_type13 arg13, m_type14 arg14, m_type15 arg15) { \
-		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);                                                                                                                       \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); \
 	}

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -50,11 +50,11 @@
 //   even with threads that are already running.
 
 // These are used in very specific areas of the engine where it's critical that these guarantees are held
-#define SAFE_NUMERIC_TYPE_PUN_GUARANTEES(m_type)                    \
-	static_assert(sizeof(SafeNumeric<m_type>) == sizeof(m_type));   \
+#define SAFE_NUMERIC_TYPE_PUN_GUARANTEES(m_type) \
+	static_assert(sizeof(SafeNumeric<m_type>) == sizeof(m_type)); \
 	static_assert(alignof(SafeNumeric<m_type>) == alignof(m_type)); \
 	static_assert(std::is_trivially_destructible_v<std::atomic<m_type>>);
-#define SAFE_FLAG_TYPE_PUN_GUARANTEES                \
+#define SAFE_FLAG_TYPE_PUN_GUARANTEES \
 	static_assert(sizeof(SafeFlag) == sizeof(bool)); \
 	static_assert(alignof(SafeFlag) == alignof(bool));
 

--- a/core/templates/sort_array.h
+++ b/core/templates/sort_array.h
@@ -33,10 +33,10 @@
 #include "core/error/error_macros.h"
 #include "core/typedefs.h"
 
-#define ERR_BAD_COMPARE(cond)                                         \
-	if (unlikely(cond)) {                                             \
+#define ERR_BAD_COMPARE(cond) \
+	if (unlikely(cond)) { \
 		ERR_PRINT("bad comparison function; sorting will be broken"); \
-		break;                                                        \
+		break; \
 	}
 
 #ifdef DEBUG_ENABLED

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -461,7 +461,7 @@ constexpr bool is_fully_defined_v = is_fully_defined<T>::value;
 /// This can be used to reduce include coupling and keep compile times low.
 /// The check must be made at the top of the corresponding .cpp file of a header.
 #define STATIC_ASSERT_INCOMPLETE_TYPE(m_keyword, m_type) \
-	m_keyword m_type;                                    \
+	m_keyword m_type; \
 	static_assert(!is_fully_defined_v<m_type>, #m_type " was unexpectedly fully defined. Please check the include hierarchy of '" __FILE__ "' and remove includes that resolve the " #m_keyword ".");
 #else
 #define STATIC_ASSERT_INCOMPLETE_TYPE(m_keyword, m_type)

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -53,70 +53,70 @@ struct GDExtensionPtr {
 	operator Variant() const { return uint64_t(data); }
 };
 
-#define GDVIRTUAL_NATIVE_PTR(m_type)                                                                          \
-	template <>                                                                                               \
-	struct GDExtensionConstPtr<const m_type> {                                                                \
-		const m_type *data = nullptr;                                                                         \
-		GDExtensionConstPtr() {}                                                                              \
-		GDExtensionConstPtr(const m_type *p_assign) {                                                         \
-			data = p_assign;                                                                                  \
-		}                                                                                                     \
-		static const char *get_name() {                                                                       \
-			return "const " #m_type;                                                                          \
-		}                                                                                                     \
-		operator const m_type *() const {                                                                     \
-			return data;                                                                                      \
-		}                                                                                                     \
-		operator Variant() const {                                                                            \
-			return uint64_t(data);                                                                            \
-		}                                                                                                     \
-	};                                                                                                        \
-	template <>                                                                                               \
-	struct VariantCaster<GDExtensionConstPtr<const m_type>> {                                                 \
-		static _FORCE_INLINE_ GDExtensionConstPtr<const m_type> cast(const Variant &p_variant) {              \
-			return GDExtensionConstPtr<const m_type>((const m_type *)p_variant.operator uint64_t());          \
-		}                                                                                                     \
-	};                                                                                                        \
-	template <>                                                                                               \
-	struct VariantInternalAccessor<GDExtensionConstPtr<const m_type>> {                                       \
-		static _FORCE_INLINE_ const GDExtensionConstPtr<const m_type> &get(const Variant *v) {                \
+#define GDVIRTUAL_NATIVE_PTR(m_type) \
+	template <> \
+	struct GDExtensionConstPtr<const m_type> { \
+		const m_type *data = nullptr; \
+		GDExtensionConstPtr() {} \
+		GDExtensionConstPtr(const m_type *p_assign) { \
+			data = p_assign; \
+		} \
+		static const char *get_name() { \
+			return "const " #m_type; \
+		} \
+		operator const m_type *() const { \
+			return data; \
+		} \
+		operator Variant() const { \
+			return uint64_t(data); \
+		} \
+	}; \
+	template <> \
+	struct VariantCaster<GDExtensionConstPtr<const m_type>> { \
+		static _FORCE_INLINE_ GDExtensionConstPtr<const m_type> cast(const Variant &p_variant) { \
+			return GDExtensionConstPtr<const m_type>((const m_type *)p_variant.operator uint64_t()); \
+		} \
+	}; \
+	template <> \
+	struct VariantInternalAccessor<GDExtensionConstPtr<const m_type>> { \
+		static _FORCE_INLINE_ const GDExtensionConstPtr<const m_type> &get(const Variant *v) { \
 			return *reinterpret_cast<const GDExtensionConstPtr<const m_type> *>(VariantInternal::get_int(v)); \
-		}                                                                                                     \
-		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionConstPtr<const m_type> &p_value) {        \
-			*VariantInternal::get_int(v) = uint64_t(p_value.data);                                            \
-		}                                                                                                     \
-	};                                                                                                        \
-	template <>                                                                                               \
-	struct GDExtensionPtr<m_type> {                                                                           \
-		m_type *data = nullptr;                                                                               \
-		GDExtensionPtr() {}                                                                                   \
-		GDExtensionPtr(m_type *p_assign) {                                                                    \
-			data = p_assign;                                                                                  \
-		}                                                                                                     \
-		static const char *get_name() {                                                                       \
-			return #m_type;                                                                                   \
-		}                                                                                                     \
-		operator m_type *() const {                                                                           \
-			return data;                                                                                      \
-		}                                                                                                     \
-		operator Variant() const {                                                                            \
-			return uint64_t(data);                                                                            \
-		}                                                                                                     \
-	};                                                                                                        \
-	template <>                                                                                               \
-	struct VariantCaster<GDExtensionPtr<m_type>> {                                                            \
-		static _FORCE_INLINE_ GDExtensionPtr<m_type> cast(const Variant &p_variant) {                         \
-			return GDExtensionPtr<m_type>((m_type *)p_variant.operator uint64_t());                           \
-		}                                                                                                     \
-	};                                                                                                        \
-	template <>                                                                                               \
-	struct VariantInternalAccessor<GDExtensionPtr<m_type>> {                                                  \
-		static _FORCE_INLINE_ const GDExtensionPtr<m_type> &get(const Variant *v) {                           \
-			return *reinterpret_cast<const GDExtensionPtr<m_type> *>(VariantInternal::get_int(v));            \
-		}                                                                                                     \
-		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionPtr<m_type> &p_value) {                   \
-			*VariantInternal::get_int(v) = uint64_t(p_value.data);                                            \
-		}                                                                                                     \
+		} \
+		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionConstPtr<const m_type> &p_value) { \
+			*VariantInternal::get_int(v) = uint64_t(p_value.data); \
+		} \
+	}; \
+	template <> \
+	struct GDExtensionPtr<m_type> { \
+		m_type *data = nullptr; \
+		GDExtensionPtr() {} \
+		GDExtensionPtr(m_type *p_assign) { \
+			data = p_assign; \
+		} \
+		static const char *get_name() { \
+			return #m_type; \
+		} \
+		operator m_type *() const { \
+			return data; \
+		} \
+		operator Variant() const { \
+			return uint64_t(data); \
+		} \
+	}; \
+	template <> \
+	struct VariantCaster<GDExtensionPtr<m_type>> { \
+		static _FORCE_INLINE_ GDExtensionPtr<m_type> cast(const Variant &p_variant) { \
+			return GDExtensionPtr<m_type>((m_type *)p_variant.operator uint64_t()); \
+		} \
+	}; \
+	template <> \
+	struct VariantInternalAccessor<GDExtensionPtr<m_type>> { \
+		static _FORCE_INLINE_ const GDExtensionPtr<m_type> &get(const Variant *v) { \
+			return *reinterpret_cast<const GDExtensionPtr<m_type> *>(VariantInternal::get_int(v)); \
+		} \
+		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionPtr<m_type> &p_value) { \
+			*VariantInternal::get_int(v) = uint64_t(p_value.data); \
+		} \
 	};
 
 template <typename T>

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -67,24 +67,24 @@ struct GetTypeInfo;
 template <typename T>
 struct GetTypeInfo<T, std::enable_if_t<!std::is_same_v<T, GetSimpleTypeT<T>>>> : GetTypeInfo<GetSimpleTypeT<T>> {};
 
-#define MAKE_TYPE_INFO(m_type, m_var_type)                                            \
-	template <>                                                                       \
-	struct GetTypeInfo<m_type> {                                                      \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
+#define MAKE_TYPE_INFO(m_type, m_var_type) \
+	template <> \
+	struct GetTypeInfo<m_type> { \
+		static const Variant::Type VARIANT_TYPE = m_var_type; \
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
+		static inline PropertyInfo get_class_info() { \
+			return PropertyInfo(VARIANT_TYPE, String()); \
+		} \
 	};
 
-#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata)    \
-	template <>                                                     \
-	struct GetTypeInfo<m_type> {                                    \
-		static const Variant::Type VARIANT_TYPE = m_var_type;       \
+#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata) \
+	template <> \
+	struct GetTypeInfo<m_type> { \
+		static const Variant::Type VARIANT_TYPE = m_var_type; \
 		static const GodotTypeInfo::Metadata METADATA = m_metadata; \
-		static inline PropertyInfo get_class_info() {               \
-			return PropertyInfo(VARIANT_TYPE, String());            \
-		}                                                           \
+		static inline PropertyInfo get_class_info() { \
+			return PropertyInfo(VARIANT_TYPE, String()); \
+		} \
 	};
 
 MAKE_TYPE_INFO(bool, Variant::BOOL)
@@ -158,14 +158,14 @@ struct GetTypeInfo<Variant> {
 	}
 };
 
-#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)                       \
-	template <>                                                                       \
-	struct GetTypeInfo<m_template<m_type>> {                                          \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
+#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type) \
+	template <> \
+	struct GetTypeInfo<m_template<m_type>> { \
+		static const Variant::Type VARIANT_TYPE = m_var_type; \
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
+		static inline PropertyInfo get_class_info() { \
+			return PropertyInfo(VARIANT_TYPE, String()); \
+		} \
 	};
 
 MAKE_TEMPLATE_TYPE_INFO(Vector, Variant, Variant::ARRAY)
@@ -234,15 +234,15 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 } // namespace Internal
 } // namespace GodotTypeInfo
 
-#define MAKE_ENUM_TYPE_INFO(m_enum)                                                                                                          \
-	template <>                                                                                                                              \
-	struct GetTypeInfo<m_enum> {                                                                                                             \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
-		static inline PropertyInfo get_class_info() {                                                                                        \
+#define MAKE_ENUM_TYPE_INFO(m_enum) \
+	template <> \
+	struct GetTypeInfo<m_enum> { \
+		static const Variant::Type VARIANT_TYPE = Variant::INT; \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, \
-					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                       \
-		}                                                                                                                                    \
+					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum))); \
+		} \
 	};
 
 template <typename T>
@@ -250,24 +250,24 @@ inline StringName __constant_get_enum_name(T param) {
 	return GetTypeInfo<T>::get_class_info().class_name;
 }
 
-#define MAKE_BITFIELD_TYPE_INFO(m_enum)                                                                                                          \
-	template <>                                                                                                                                  \
-	struct GetTypeInfo<m_enum> {                                                                                                                 \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                  \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
-		static inline PropertyInfo get_class_info() {                                                                                            \
+#define MAKE_BITFIELD_TYPE_INFO(m_enum) \
+	template <> \
+	struct GetTypeInfo<m_enum> { \
+		static const Variant::Type VARIANT_TYPE = Variant::INT; \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
-					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                           \
-		}                                                                                                                                        \
-	};                                                                                                                                           \
-	template <>                                                                                                                                  \
-	struct GetTypeInfo<BitField<m_enum>> {                                                                                                       \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                  \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
-		static inline PropertyInfo get_class_info() {                                                                                            \
+					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum))); \
+		} \
+	}; \
+	template <> \
+	struct GetTypeInfo<BitField<m_enum>> { \
+		static const Variant::Type VARIANT_TYPE = Variant::INT; \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() { \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
-					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                           \
-		}                                                                                                                                        \
+					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum))); \
+		} \
 	};
 
 template <typename T>

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3155,18 +3155,18 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 #define hash_compare_packed_array(p_lhs, p_rhs, p_type, p_compare_func) \
 	const Vector<p_type> &l = PackedArrayRef<p_type>::get_array(p_lhs); \
 	const Vector<p_type> &r = PackedArrayRef<p_type>::get_array(p_rhs); \
-                                                                        \
-	if (l.size() != r.size())                                           \
-		return false;                                                   \
-                                                                        \
-	const p_type *lr = l.ptr();                                         \
-	const p_type *rr = r.ptr();                                         \
-                                                                        \
-	for (int i = 0; i < l.size(); ++i) {                                \
-		if (!p_compare_func((lr[i]), (rr[i])))                          \
-			return false;                                               \
-	}                                                                   \
-                                                                        \
+\
+	if (l.size() != r.size()) \
+		return false; \
+\
+	const p_type *lr = l.ptr(); \
+	const p_type *rr = r.ptr(); \
+\
+	for (int i = 0; i < l.size(); ++i) { \
+		if (!p_compare_func((lr[i]), (rr[i]))) \
+			return false; \
+	} \
+\
 	return true
 
 bool Variant::hash_compare(const Variant &p_variant, int recursion_count, bool semantic_comparison) const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -369,84 +369,84 @@ static _FORCE_INLINE_ Variant::Type vc_get_base_type(void (T::*method)(P...) con
 	return GetTypeInfo<T>::VARIANT_TYPE;
 }
 
-#define METHOD_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr)                                                                                        \
-	struct Method_##m_class##_##m_method_name {                                                                                                                   \
+#define METHOD_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr) \
+	struct Method_##m_class##_##m_method_name { \
 		static void call(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
-			vc_method_call(m_method_ptr, base, p_args, p_argcount, r_ret, p_defvals, r_error);                                                                    \
-		}                                                                                                                                                         \
-		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) {                                                       \
-			vc_validated_call(m_method_ptr, base, p_args, r_ret);                                                                                                 \
-		}                                                                                                                                                         \
-		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) {                                                                     \
-			vc_ptrcall(m_method_ptr, p_base, p_args, r_ret);                                                                                                      \
-		}                                                                                                                                                         \
-		static int get_argument_count() {                                                                                                                         \
-			return vc_get_argument_count(m_method_ptr);                                                                                                           \
-		}                                                                                                                                                         \
-		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
-			return vc_get_argument_type(m_method_ptr, p_arg);                                                                                                     \
-		}                                                                                                                                                         \
-		static Variant::Type get_return_type() {                                                                                                                  \
-			return vc_get_return_type(m_method_ptr);                                                                                                              \
-		}                                                                                                                                                         \
-		static bool has_return_type() {                                                                                                                           \
-			return vc_has_return_type(m_method_ptr);                                                                                                              \
-		}                                                                                                                                                         \
-		static bool is_const() {                                                                                                                                  \
-			return vc_is_const(m_method_ptr);                                                                                                                     \
-		}                                                                                                                                                         \
-		static bool is_static() {                                                                                                                                 \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static bool is_vararg() {                                                                                                                                 \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static Variant::Type get_base_type() {                                                                                                                    \
-			return vc_get_base_type(m_method_ptr);                                                                                                                \
-		}                                                                                                                                                         \
-		static StringName get_name() {                                                                                                                            \
-			return #m_exposed_name;                                                                                                                               \
-		}                                                                                                                                                         \
+			vc_method_call(m_method_ptr, base, p_args, p_argcount, r_ret, p_defvals, r_error); \
+		} \
+		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) { \
+			vc_validated_call(m_method_ptr, base, p_args, r_ret); \
+		} \
+		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) { \
+			vc_ptrcall(m_method_ptr, p_base, p_args, r_ret); \
+		} \
+		static int get_argument_count() { \
+			return vc_get_argument_count(m_method_ptr); \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return vc_get_argument_type(m_method_ptr, p_arg); \
+		} \
+		static Variant::Type get_return_type() { \
+			return vc_get_return_type(m_method_ptr); \
+		} \
+		static bool has_return_type() { \
+			return vc_has_return_type(m_method_ptr); \
+		} \
+		static bool is_const() { \
+			return vc_is_const(m_method_ptr); \
+		} \
+		static bool is_static() { \
+			return false; \
+		} \
+		static bool is_vararg() { \
+			return false; \
+		} \
+		static Variant::Type get_base_type() { \
+			return vc_get_base_type(m_method_ptr); \
+		} \
+		static StringName get_name() { \
+			return #m_exposed_name; \
+		} \
 	};
 
-#define CONVERT_METHOD_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr)                                                                                \
-	struct Method_##m_class##_##m_method_name {                                                                                                                   \
+#define CONVERT_METHOD_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr) \
+	struct Method_##m_class##_##m_method_name { \
 		static void call(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
-			vc_convert_method_call<m_class>(m_method_ptr, base, p_args, p_argcount, r_ret, p_defvals, r_error);                                                   \
-		}                                                                                                                                                         \
-		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) {                                                       \
-			vc_convert_validated_call<m_class>(m_method_ptr, base, p_args, r_ret);                                                                                \
-		}                                                                                                                                                         \
-		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) {                                                                     \
-			vc_convert_ptrcall<m_class>(m_method_ptr, p_base, p_args, r_ret);                                                                                     \
-		}                                                                                                                                                         \
-		static int get_argument_count() {                                                                                                                         \
-			return vc_get_argument_count(m_method_ptr);                                                                                                           \
-		}                                                                                                                                                         \
-		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
-			return vc_get_argument_type(m_method_ptr, p_arg);                                                                                                     \
-		}                                                                                                                                                         \
-		static Variant::Type get_return_type() {                                                                                                                  \
-			return vc_get_return_type(m_method_ptr);                                                                                                              \
-		}                                                                                                                                                         \
-		static bool has_return_type() {                                                                                                                           \
-			return vc_has_return_type(m_method_ptr);                                                                                                              \
-		}                                                                                                                                                         \
-		static bool is_const() {                                                                                                                                  \
-			return vc_is_const(m_method_ptr);                                                                                                                     \
-		}                                                                                                                                                         \
-		static bool is_static() {                                                                                                                                 \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static bool is_vararg() {                                                                                                                                 \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static Variant::Type get_base_type() {                                                                                                                    \
-			return GetTypeInfo<m_class>::VARIANT_TYPE;                                                                                                            \
-		}                                                                                                                                                         \
-		static StringName get_name() {                                                                                                                            \
-			return #m_exposed_name;                                                                                                                               \
-		}                                                                                                                                                         \
+			vc_convert_method_call<m_class>(m_method_ptr, base, p_args, p_argcount, r_ret, p_defvals, r_error); \
+		} \
+		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) { \
+			vc_convert_validated_call<m_class>(m_method_ptr, base, p_args, r_ret); \
+		} \
+		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) { \
+			vc_convert_ptrcall<m_class>(m_method_ptr, p_base, p_args, r_ret); \
+		} \
+		static int get_argument_count() { \
+			return vc_get_argument_count(m_method_ptr); \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return vc_get_argument_type(m_method_ptr, p_arg); \
+		} \
+		static Variant::Type get_return_type() { \
+			return vc_get_return_type(m_method_ptr); \
+		} \
+		static bool has_return_type() { \
+			return vc_has_return_type(m_method_ptr); \
+		} \
+		static bool is_const() { \
+			return vc_is_const(m_method_ptr); \
+		} \
+		static bool is_static() { \
+			return false; \
+		} \
+		static bool is_vararg() { \
+			return false; \
+		} \
+		static Variant::Type get_base_type() { \
+			return GetTypeInfo<m_class>::VARIANT_TYPE; \
+		} \
+		static StringName get_name() { \
+			return #m_exposed_name; \
+		} \
 	};
 
 template <typename R, typename... P>
@@ -459,44 +459,44 @@ static _FORCE_INLINE_ void vc_static_ptrcall(void (*method)(P...), const void **
 	call_with_ptr_args_static_method<P...>(method, p_args);
 }
 
-#define STATIC_METHOD_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr)                                                                                 \
-	struct Method_##m_class##_##m_method_name {                                                                                                                   \
+#define STATIC_METHOD_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr) \
+	struct Method_##m_class##_##m_method_name { \
 		static void call(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
-			vc_static_method_call(m_method_ptr, p_args, p_argcount, r_ret, p_defvals, r_error);                                                                   \
-		}                                                                                                                                                         \
-		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) {                                                       \
-			vc_validated_static_call(m_method_ptr, p_args, r_ret);                                                                                                \
-		}                                                                                                                                                         \
-		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) {                                                                     \
-			vc_static_ptrcall(m_method_ptr, p_args, r_ret);                                                                                                       \
-		}                                                                                                                                                         \
-		static int get_argument_count() {                                                                                                                         \
-			return vc_get_argument_count_static(m_method_ptr);                                                                                                    \
-		}                                                                                                                                                         \
-		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
-			return vc_get_argument_type_static(m_method_ptr, p_arg);                                                                                              \
-		}                                                                                                                                                         \
-		static Variant::Type get_return_type() {                                                                                                                  \
-			return vc_get_return_type(m_method_ptr);                                                                                                              \
-		}                                                                                                                                                         \
-		static bool has_return_type() {                                                                                                                           \
-			return vc_has_return_type_static(m_method_ptr);                                                                                                       \
-		}                                                                                                                                                         \
-		static bool is_const() {                                                                                                                                  \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static bool is_static() {                                                                                                                                 \
-			return true;                                                                                                                                          \
-		}                                                                                                                                                         \
-		static bool is_vararg() {                                                                                                                                 \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static Variant::Type get_base_type() {                                                                                                                    \
-			return GetTypeInfo<m_class>::VARIANT_TYPE;                                                                                                            \
-		}                                                                                                                                                         \
-		static StringName get_name() {                                                                                                                            \
-			return #m_exposed_name;                                                                                                                               \
-		}                                                                                                                                                         \
+			vc_static_method_call(m_method_ptr, p_args, p_argcount, r_ret, p_defvals, r_error); \
+		} \
+		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) { \
+			vc_validated_static_call(m_method_ptr, p_args, r_ret); \
+		} \
+		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) { \
+			vc_static_ptrcall(m_method_ptr, p_args, r_ret); \
+		} \
+		static int get_argument_count() { \
+			return vc_get_argument_count_static(m_method_ptr); \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return vc_get_argument_type_static(m_method_ptr, p_arg); \
+		} \
+		static Variant::Type get_return_type() { \
+			return vc_get_return_type(m_method_ptr); \
+		} \
+		static bool has_return_type() { \
+			return vc_has_return_type_static(m_method_ptr); \
+		} \
+		static bool is_const() { \
+			return false; \
+		} \
+		static bool is_static() { \
+			return true; \
+		} \
+		static bool is_vararg() { \
+			return false; \
+		} \
+		static Variant::Type get_base_type() { \
+			return GetTypeInfo<m_class>::VARIANT_TYPE; \
+		} \
+		static StringName get_name() { \
+			return #m_exposed_name; \
+		} \
 	};
 
 template <typename R, typename T, typename... P>
@@ -509,162 +509,162 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 	call_with_ptr_args_static<T, P...>(reinterpret_cast<T *>(p_base), method, p_args);
 }
 
-#define FUNCTION_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr, m_const)                                                                             \
-	struct Method_##m_class##_##m_method_name {                                                                                                                   \
+#define FUNCTION_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr, m_const) \
+	struct Method_##m_class##_##m_method_name { \
 		static void call(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
-			vc_method_call_static(m_method_ptr, base, p_args, p_argcount, r_ret, p_defvals, r_error);                                                             \
-		}                                                                                                                                                         \
-		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) {                                                       \
-			vc_validated_call_static(m_method_ptr, base, p_args, r_ret);                                                                                          \
-		}                                                                                                                                                         \
-		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) {                                                                     \
-			vc_ptrcall(m_method_ptr, p_base, p_args, r_ret);                                                                                                      \
-		}                                                                                                                                                         \
-		static int get_argument_count() {                                                                                                                         \
-			return vc_get_argument_count(m_method_ptr);                                                                                                           \
-		}                                                                                                                                                         \
-		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
-			return vc_get_argument_type(m_method_ptr, p_arg);                                                                                                     \
-		}                                                                                                                                                         \
-		static Variant::Type get_return_type() {                                                                                                                  \
-			return vc_get_return_type(m_method_ptr);                                                                                                              \
-		}                                                                                                                                                         \
-		static bool has_return_type() {                                                                                                                           \
-			return vc_has_return_type_static(m_method_ptr);                                                                                                       \
-		}                                                                                                                                                         \
-		static bool is_const() {                                                                                                                                  \
-			return m_const;                                                                                                                                       \
-		}                                                                                                                                                         \
-		static bool is_static() {                                                                                                                                 \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static bool is_vararg() {                                                                                                                                 \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static Variant::Type get_base_type() {                                                                                                                    \
-			return GetTypeInfo<m_class>::VARIANT_TYPE;                                                                                                            \
-		}                                                                                                                                                         \
-		static StringName get_name() {                                                                                                                            \
-			return #m_exposed_name;                                                                                                                               \
-		}                                                                                                                                                         \
+			vc_method_call_static(m_method_ptr, base, p_args, p_argcount, r_ret, p_defvals, r_error); \
+		} \
+		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) { \
+			vc_validated_call_static(m_method_ptr, base, p_args, r_ret); \
+		} \
+		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) { \
+			vc_ptrcall(m_method_ptr, p_base, p_args, r_ret); \
+		} \
+		static int get_argument_count() { \
+			return vc_get_argument_count(m_method_ptr); \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return vc_get_argument_type(m_method_ptr, p_arg); \
+		} \
+		static Variant::Type get_return_type() { \
+			return vc_get_return_type(m_method_ptr); \
+		} \
+		static bool has_return_type() { \
+			return vc_has_return_type_static(m_method_ptr); \
+		} \
+		static bool is_const() { \
+			return m_const; \
+		} \
+		static bool is_static() { \
+			return false; \
+		} \
+		static bool is_vararg() { \
+			return false; \
+		} \
+		static Variant::Type get_base_type() { \
+			return GetTypeInfo<m_class>::VARIANT_TYPE; \
+		} \
+		static StringName get_name() { \
+			return #m_exposed_name; \
+		} \
 	};
 
-#define VARARG_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr, m_has_return, m_return_type)                                                           \
-	struct Method_##m_class##_##m_method_name {                                                                                                                   \
+#define VARARG_CLASS(m_class, m_exposed_name, m_method_name, m_method_ptr, m_has_return, m_return_type) \
+	struct Method_##m_class##_##m_method_name { \
 		static void call(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
-			m_method_ptr(base, p_args, p_argcount, r_ret, r_error);                                                                                               \
-		}                                                                                                                                                         \
-		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) {                                                       \
-			Callable::CallError ce;                                                                                                                               \
-			m_method_ptr(base, p_args, p_argcount, *r_ret, ce);                                                                                                   \
-		}                                                                                                                                                         \
-		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) {                                                                     \
-			LocalVector<Variant> vars;                                                                                                                            \
-			LocalVector<const Variant *> vars_ptrs;                                                                                                               \
-			vars.resize(p_argcount);                                                                                                                              \
-			vars_ptrs.resize(p_argcount);                                                                                                                         \
-			for (int i = 0; i < p_argcount; i++) {                                                                                                                \
-				vars[i] = PtrToArg<Variant>::convert(p_args[i]);                                                                                                  \
-				vars_ptrs[i] = &vars[i];                                                                                                                          \
-			}                                                                                                                                                     \
-			Variant base = PtrToArg<m_class>::convert(p_base);                                                                                                    \
-			Variant ret;                                                                                                                                          \
-			Callable::CallError ce;                                                                                                                               \
-			m_method_ptr(&base, vars_ptrs.ptr(), p_argcount, ret, ce);                                                                                            \
-			if (m_has_return) {                                                                                                                                   \
-				m_return_type r = ret;                                                                                                                            \
-				PtrToArg<m_return_type>::encode(ret, r_ret);                                                                                                      \
-			}                                                                                                                                                     \
-		}                                                                                                                                                         \
-		static int get_argument_count() {                                                                                                                         \
-			return 0;                                                                                                                                             \
-		}                                                                                                                                                         \
-		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
-			return Variant::NIL;                                                                                                                                  \
-		}                                                                                                                                                         \
-		static Variant::Type get_return_type() {                                                                                                                  \
-			return GetTypeInfo<m_return_type>::VARIANT_TYPE;                                                                                                      \
-		}                                                                                                                                                         \
-		static bool has_return_type() {                                                                                                                           \
-			return m_has_return;                                                                                                                                  \
-		}                                                                                                                                                         \
-		static bool is_const() {                                                                                                                                  \
-			return true;                                                                                                                                          \
-		}                                                                                                                                                         \
-		static bool is_static() {                                                                                                                                 \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static bool is_vararg() {                                                                                                                                 \
-			return true;                                                                                                                                          \
-		}                                                                                                                                                         \
-		static Variant::Type get_base_type() {                                                                                                                    \
-			return GetTypeInfo<m_class>::VARIANT_TYPE;                                                                                                            \
-		}                                                                                                                                                         \
-		static StringName get_name() {                                                                                                                            \
-			return #m_exposed_name;                                                                                                                               \
-		}                                                                                                                                                         \
+			m_method_ptr(base, p_args, p_argcount, r_ret, r_error); \
+		} \
+		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) { \
+			Callable::CallError ce; \
+			m_method_ptr(base, p_args, p_argcount, *r_ret, ce); \
+		} \
+		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) { \
+			LocalVector<Variant> vars; \
+			LocalVector<const Variant *> vars_ptrs; \
+			vars.resize(p_argcount); \
+			vars_ptrs.resize(p_argcount); \
+			for (int i = 0; i < p_argcount; i++) { \
+				vars[i] = PtrToArg<Variant>::convert(p_args[i]); \
+				vars_ptrs[i] = &vars[i]; \
+			} \
+			Variant base = PtrToArg<m_class>::convert(p_base); \
+			Variant ret; \
+			Callable::CallError ce; \
+			m_method_ptr(&base, vars_ptrs.ptr(), p_argcount, ret, ce); \
+			if (m_has_return) { \
+				m_return_type r = ret; \
+				PtrToArg<m_return_type>::encode(ret, r_ret); \
+			} \
+		} \
+		static int get_argument_count() { \
+			return 0; \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return Variant::NIL; \
+		} \
+		static Variant::Type get_return_type() { \
+			return GetTypeInfo<m_return_type>::VARIANT_TYPE; \
+		} \
+		static bool has_return_type() { \
+			return m_has_return; \
+		} \
+		static bool is_const() { \
+			return true; \
+		} \
+		static bool is_static() { \
+			return false; \
+		} \
+		static bool is_vararg() { \
+			return true; \
+		} \
+		static Variant::Type get_base_type() { \
+			return GetTypeInfo<m_class>::VARIANT_TYPE; \
+		} \
+		static StringName get_name() { \
+			return #m_exposed_name; \
+		} \
 	};
 
-#define VARARG_CLASS1(m_class, m_exposed_name, m_method_name, m_method_ptr, m_arg_type)                                                                           \
-	struct Method_##m_class##_##m_method_name {                                                                                                                   \
+#define VARARG_CLASS1(m_class, m_exposed_name, m_method_name, m_method_ptr, m_arg_type) \
+	struct Method_##m_class##_##m_method_name { \
 		static void call(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
-			m_method_ptr(base, p_args, p_argcount, r_ret, r_error);                                                                                               \
-		}                                                                                                                                                         \
-		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) {                                                       \
-			Callable::CallError ce;                                                                                                                               \
-			m_method_ptr(base, p_args, p_argcount, *r_ret, ce);                                                                                                   \
-		}                                                                                                                                                         \
-		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) {                                                                     \
-			LocalVector<Variant> vars;                                                                                                                            \
-			LocalVector<const Variant *> vars_ptrs;                                                                                                               \
-			vars.resize(p_argcount);                                                                                                                              \
-			vars_ptrs.resize(p_argcount);                                                                                                                         \
-			for (int i = 0; i < p_argcount; i++) {                                                                                                                \
-				vars[i] = PtrToArg<Variant>::convert(p_args[i]);                                                                                                  \
-				vars_ptrs[i] = &vars[i];                                                                                                                          \
-			}                                                                                                                                                     \
-			Variant base = PtrToArg<m_class>::convert(p_base);                                                                                                    \
-			Variant ret;                                                                                                                                          \
-			Callable::CallError ce;                                                                                                                               \
-			m_method_ptr(&base, vars_ptrs.ptr(), p_argcount, ret, ce);                                                                                            \
-		}                                                                                                                                                         \
-		static int get_argument_count() {                                                                                                                         \
-			return 1;                                                                                                                                             \
-		}                                                                                                                                                         \
-		static Variant::Type get_argument_type(int p_arg) {                                                                                                       \
-			return m_arg_type;                                                                                                                                    \
-		}                                                                                                                                                         \
-		static Variant::Type get_return_type() {                                                                                                                  \
-			return Variant::NIL;                                                                                                                                  \
-		}                                                                                                                                                         \
-		static bool has_return_type() {                                                                                                                           \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static bool is_const() {                                                                                                                                  \
-			return true;                                                                                                                                          \
-		}                                                                                                                                                         \
-		static bool is_static() {                                                                                                                                 \
-			return false;                                                                                                                                         \
-		}                                                                                                                                                         \
-		static bool is_vararg() {                                                                                                                                 \
-			return true;                                                                                                                                          \
-		}                                                                                                                                                         \
-		static Variant::Type get_base_type() {                                                                                                                    \
-			return GetTypeInfo<m_class>::VARIANT_TYPE;                                                                                                            \
-		}                                                                                                                                                         \
-		static StringName get_name() {                                                                                                                            \
-			return #m_exposed_name;                                                                                                                               \
-		}                                                                                                                                                         \
+			m_method_ptr(base, p_args, p_argcount, r_ret, r_error); \
+		} \
+		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) { \
+			Callable::CallError ce; \
+			m_method_ptr(base, p_args, p_argcount, *r_ret, ce); \
+		} \
+		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) { \
+			LocalVector<Variant> vars; \
+			LocalVector<const Variant *> vars_ptrs; \
+			vars.resize(p_argcount); \
+			vars_ptrs.resize(p_argcount); \
+			for (int i = 0; i < p_argcount; i++) { \
+				vars[i] = PtrToArg<Variant>::convert(p_args[i]); \
+				vars_ptrs[i] = &vars[i]; \
+			} \
+			Variant base = PtrToArg<m_class>::convert(p_base); \
+			Variant ret; \
+			Callable::CallError ce; \
+			m_method_ptr(&base, vars_ptrs.ptr(), p_argcount, ret, ce); \
+		} \
+		static int get_argument_count() { \
+			return 1; \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return m_arg_type; \
+		} \
+		static Variant::Type get_return_type() { \
+			return Variant::NIL; \
+		} \
+		static bool has_return_type() { \
+			return false; \
+		} \
+		static bool is_const() { \
+			return true; \
+		} \
+		static bool is_static() { \
+			return false; \
+		} \
+		static bool is_vararg() { \
+			return true; \
+		} \
+		static Variant::Type get_base_type() { \
+			return GetTypeInfo<m_class>::VARIANT_TYPE; \
+		} \
+		static StringName get_name() { \
+			return #m_exposed_name; \
+		} \
 	};
 
-#define VARCALL_ARRAY_GETTER_SETTER(m_packed_type, m_type)                                                      \
-	static m_type func_##m_packed_type##_get(m_packed_type *p_instance, int64_t p_index) {                      \
-		ERR_FAIL_INDEX_V(p_index, p_instance->size(), m_type());                                                \
-		return p_instance->get(p_index);                                                                        \
-	}                                                                                                           \
+#define VARCALL_ARRAY_GETTER_SETTER(m_packed_type, m_type) \
+	static m_type func_##m_packed_type##_get(m_packed_type *p_instance, int64_t p_index) { \
+		ERR_FAIL_INDEX_V(p_index, p_instance->size(), m_type()); \
+		return p_instance->get(p_index); \
+	} \
 	static void func_##m_packed_type##_set(m_packed_type *p_instance, int64_t p_index, const m_type &p_value) { \
-		ERR_FAIL_INDEX(p_index, p_instance->size());                                                            \
-		p_instance->set(p_index, p_value);                                                                      \
+		ERR_FAIL_INDEX(p_index, p_instance->size()); \
+		p_instance->set(p_index, p_value); \
 	}
 
 struct _VariantCall {
@@ -1808,194 +1808,194 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 
 #ifdef DEBUG_ENABLED
 #define bind_method(m_type, m_method, m_arg_names, m_default_args) \
-	METHOD_CLASS(m_type, m_method, m_method, &m_type::m_method);   \
+	METHOD_CLASS(m_type, m_method, m_method, &m_type::m_method); \
 	register_builtin_method<Method_##m_type##_##m_method>(m_arg_names, m_default_args);
 #else
 #define bind_method(m_type, m_method, m_arg_names, m_default_args) \
-	METHOD_CLASS(m_type, m_method, m_method, &m_type ::m_method);  \
+	METHOD_CLASS(m_type, m_method, m_method, &m_type ::m_method); \
 	register_builtin_method<Method_##m_type##_##m_method>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_compat_method(m_type, m_exposed_method, m_method, m_arg_names, m_default_args) \
-	METHOD_CLASS(m_type, m_exposed_method, m_method, &m_type::m_method);                    \
+	METHOD_CLASS(m_type, m_exposed_method, m_method, &m_type::m_method); \
 	register_builtin_compat_method<Method_##m_type##_##m_method>(m_arg_names, m_default_args);
 #else
 #define bind_compat_method(m_type, m_exposed_method, m_method, m_arg_names, m_default_args) \
-	METHOD_CLASS(m_type, m_exposed_method, m_method, &m_type ::m_method);                   \
+	METHOD_CLASS(m_type, m_exposed_method, m_method, &m_type ::m_method); \
 	register_builtin_compat_method<Method_##m_type##_##m_method>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_convert_method(m_type_from, m_type_to, m_method, m_arg_names, m_default_args) \
-	CONVERT_METHOD_CLASS(m_type_from, m_method, m_method, &m_type_to::m_method);           \
+	CONVERT_METHOD_CLASS(m_type_from, m_method, m_method, &m_type_to::m_method); \
 	register_builtin_method<Method_##m_type_from##_##m_method>(m_arg_names, m_default_args);
 #else
 #define bind_convert_method(m_type_from, m_type_to, m_method, m_arg_names, m_default_args) \
-	CONVERT_METHOD_CLASS(m_type_from, m_method, m_method, &m_type_to ::m_method);          \
+	CONVERT_METHOD_CLASS(m_type_from, m_method, m_method, &m_type_to ::m_method); \
 	register_builtin_method<Method_##m_type_from##_##m_method>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_convert_compat_method(m_type_from, m_type_to, m_exposed_method, m_method, m_arg_names, m_default_args) \
-	CONVERT_METHOD_CLASS(m_type_from, m_exposed_method, m_method, &m_type_to::m_method);                            \
+	CONVERT_METHOD_CLASS(m_type_from, m_exposed_method, m_method, &m_type_to::m_method); \
 	register_builtin_compat_method<Method_##m_type_from##_##m_method>(m_arg_names, m_default_args);
 #else
 #define bind_convert_compat_method(m_type_from, m_type_to, m_exposed_method, m_method, m_arg_names, m_default_args) \
-	CONVERT_METHOD_CLASS(m_type_from, m_exposed_method, m_method, &m_type_to ::m_method);                           \
+	CONVERT_METHOD_CLASS(m_type_from, m_exposed_method, m_method, &m_type_to ::m_method); \
 	register_builtin_compat_method<Method_##m_type_from##_##m_method>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_static_method(m_type, m_method, m_arg_names, m_default_args) \
-	STATIC_METHOD_CLASS(m_type, m_method, m_method, m_type::m_method);    \
+	STATIC_METHOD_CLASS(m_type, m_method, m_method, m_type::m_method); \
 	register_builtin_method<Method_##m_type##_##m_method>(m_arg_names, m_default_args);
 #else
 #define bind_static_method(m_type, m_method, m_arg_names, m_default_args) \
-	STATIC_METHOD_CLASS(m_type, m_method, m_method, m_type ::m_method);   \
+	STATIC_METHOD_CLASS(m_type, m_method, m_method, m_type ::m_method); \
 	register_builtin_method<Method_##m_type##_##m_method>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_static_compat_method(m_type, m_exposed_method, m_method, m_arg_names, m_default_args) \
-	STATIC_METHOD_CLASS(m_type, m_exposed_method, m_method, m_type::m_method);                     \
+	STATIC_METHOD_CLASS(m_type, m_exposed_method, m_method, m_type::m_method); \
 	register_builtin_compat_method<Method_##m_type##_##m_method>(m_arg_names, m_default_args);
 #else
 #define bind_static_compat_method(m_type, m_exposed_method, m_method, m_arg_names, m_default_args) \
-	STATIC_METHOD_CLASS(m_type, m_exposed_method, m_method, m_type ::m_method);                    \
+	STATIC_METHOD_CLASS(m_type, m_exposed_method, m_method, m_type ::m_method); \
 	register_builtin_compat_method<Method_##m_type##_##m_method>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_static_methodv(m_type, m_name, m_method, m_arg_names, m_default_args) \
-	STATIC_METHOD_CLASS(m_type, m_name, m_name, m_method);                         \
+	STATIC_METHOD_CLASS(m_type, m_name, m_name, m_method); \
 	register_builtin_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_static_methodv(m_type, m_name, m_method, m_arg_names, m_default_args) \
-	STATIC_METHOD_CLASS(m_type, m_name, m_name, m_method);                         \
+	STATIC_METHOD_CLASS(m_type, m_name, m_name, m_method); \
 	register_builtin_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
 #endif
 
 #ifdef DEBUG_ENABLED
 #define bind_static_compat_methodv(m_type, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	STATIC_METHOD_CLASS(m_type, m_exposed_name, m_name, m_method);                                        \
+	STATIC_METHOD_CLASS(m_type, m_exposed_name, m_name, m_method); \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_static_compat_methodv(m_type, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	STATIC_METHOD_CLASS(m_type, m_exposed_name, m_name, m_method);                                        \
+	STATIC_METHOD_CLASS(m_type, m_exposed_name, m_name, m_method); \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
 #endif
 
 #ifdef DEBUG_ENABLED
 #define bind_methodv(m_type, m_name, m_method, m_arg_names, m_default_args) \
-	METHOD_CLASS(m_type, m_name, m_name, m_method);                         \
+	METHOD_CLASS(m_type, m_name, m_name, m_method); \
 	register_builtin_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_methodv(m_type, m_name, m_method, m_arg_names, m_default_args) \
-	METHOD_CLASS(m_type, m_name, m_name, m_method);                         \
+	METHOD_CLASS(m_type, m_name, m_name, m_method); \
 	register_builtin_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_compat_methodv(m_type, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	METHOD_CLASS(m_type, m_exposed_name, m_name, m_method);                                        \
+	METHOD_CLASS(m_type, m_exposed_name, m_name, m_method); \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_compat_methodv(m_type, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	METHOD_CLASS(m_type, m_exposed_name, m_name, m_method);                                        \
+	METHOD_CLASS(m_type, m_exposed_name, m_name, m_method); \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_convert_methodv(m_type_from, m_type_to, m_name, m_method, m_arg_names, m_default_args) \
-	CONVERT_METHOD_CLASS(m_type_from, m_name, m_name, m_method);                                    \
+	CONVERT_METHOD_CLASS(m_type_from, m_name, m_name, m_method); \
 	register_builtin_method<Method_##m_type_from##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_convert_methodv(m_type_from, m_type_to, m_name, m_method, m_arg_names, m_default_args) \
-	CONVERT_METHOD_CLASS(m_type_from, m_name, m_name, m_method);                                    \
+	CONVERT_METHOD_CLASS(m_type_from, m_name, m_name, m_method); \
 	register_builtin_method<Method_##m_type_from##_##m_name>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_convert_compat_methodv(m_type_from, m_type_to, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	CONVERT_METHOD_CLASS(m_type_from, m_exposed_name, m_name, m_method);                                                   \
+	CONVERT_METHOD_CLASS(m_type_from, m_exposed_name, m_name, m_method); \
 	register_builtin_compat_method<Method_##m_type_from##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_convert_compat_methodv(m_type_from, m_type_to, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	CONVERT_METHOD_CLASS(m_type_from, m_exposed_name, m_name, m_method);                                                   \
+	CONVERT_METHOD_CLASS(m_type_from, m_exposed_name, m_name, m_method); \
 	register_builtin_compat_method<Method_##m_type_from##_##m_name>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_function(m_type, m_name, m_method, m_arg_names, m_default_args) \
-	FUNCTION_CLASS(m_type, m_name, m_name, m_method, true);                  \
+	FUNCTION_CLASS(m_type, m_name, m_name, m_method, true); \
 	register_builtin_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_function(m_type, m_name, m_method, m_arg_names, m_default_args) \
-	FUNCTION_CLASS(m_type, m_name, m_name, m_method, true);                  \
+	FUNCTION_CLASS(m_type, m_name, m_name, m_method, true); \
 	register_builtin_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_compat_function(m_type, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	FUNCTION_CLASS(m_type, m_exposed_name, m_name, m_method, true);                                 \
+	FUNCTION_CLASS(m_type, m_exposed_name, m_name, m_method, true); \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_compat_function(m_type, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	FUNCTION_CLASS(m_type, m_exposed_name, m_name, m_method, true);                                 \
+	FUNCTION_CLASS(m_type, m_exposed_name, m_name, m_method, true); \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_functionnc(m_type, m_name, m_method, m_arg_names, m_default_args) \
-	FUNCTION_CLASS(m_type, m_name, m_name, m_method, false);                   \
+	FUNCTION_CLASS(m_type, m_name, m_name, m_method, false); \
 	register_builtin_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_functionnc(m_type, m_name, m_method, m_arg_names, m_default_args) \
-	FUNCTION_CLASS(m_type, m_name, m_name, m_method, false);                   \
+	FUNCTION_CLASS(m_type, m_name, m_name, m_method, false); \
 	register_builtin_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 #define bind_compat_functionnc(m_type, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	FUNCTION_CLASS(m_type, m_exposed_name, m_name, m_method, false);                                  \
+	FUNCTION_CLASS(m_type, m_exposed_name, m_name, m_method, false); \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(m_arg_names, m_default_args);
 #else
 #define bind_compat_functionnc(m_type, m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	FUNCTION_CLASS(m_type, m_exposed_name, m_name, m_method, false);                                  \
+	FUNCTION_CLASS(m_type, m_exposed_name, m_name, m_method, false); \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(sarray(), m_default_args);
 #endif // DEBUG_ENABLED
 
 #define bind_string_method(m_method, m_arg_names, m_default_args) \
-	bind_method(String, m_method, m_arg_names, m_default_args);   \
+	bind_method(String, m_method, m_arg_names, m_default_args); \
 	bind_convert_method(StringName, String, m_method, m_arg_names, m_default_args);
 
 #define bind_string_methodv(m_name, m_method, m_arg_names, m_default_args) \
-	bind_methodv(String, m_name, m_method, m_arg_names, m_default_args);   \
+	bind_methodv(String, m_name, m_method, m_arg_names, m_default_args); \
 	bind_convert_methodv(StringName, String, m_name, m_method, m_arg_names, m_default_args);
 
 #define bind_string_compat_method(m_exposed_name, m_method, m_arg_names, m_default_args) \
-	bind_compat_method(String, m_exposed_name, m_method, m_arg_names, m_default_args);   \
+	bind_compat_method(String, m_exposed_name, m_method, m_arg_names, m_default_args); \
 	bind_convert_compat_method(StringName, String, m_exposed_name, m_method, m_arg_names, m_default_args);
 
 #define bind_string_compat_methodv(m_exposed_name, m_name, m_method, m_arg_names, m_default_args) \
-	bind_compat_methodv(String, m_exposed_name, m_name, m_method, m_arg_names, m_default_args);   \
+	bind_compat_methodv(String, m_exposed_name, m_name, m_method, m_arg_names, m_default_args); \
 	bind_convert_compat_methodv(StringName, String, m_exposed_name, m_name, m_method, m_arg_names, m_default_args);
 
-#define bind_custom(m_type, m_name, m_method, m_has_return, m_ret_type)      \
+#define bind_custom(m_type, m_name, m_method, m_has_return, m_ret_type) \
 	VARARG_CLASS(m_type, m_name, m_name, m_method, m_has_return, m_ret_type) \
 	register_builtin_method<Method_##m_type##_##m_name>(sarray(), Vector<Variant>());
 
 #define bind_custom1(m_type, m_name, m_method, m_arg_type, m_arg_name) \
-	VARARG_CLASS1(m_type, m_name, m_name, m_method, m_arg_type)        \
+	VARARG_CLASS1(m_type, m_name, m_name, m_method, m_arg_type) \
 	register_builtin_method<Method_##m_type##_##m_name>(sarray(m_arg_name), Vector<Variant>());
 
 #define bind_compat_custom(m_type, m_exposed_name, m_name, m_method, m_has_return, m_ret_type) \
-	VARARG_CLASS(m_type, m_exposed_name, m_name, m_method, m_has_return, m_ret_type)           \
+	VARARG_CLASS(m_type, m_exposed_name, m_name, m_method, m_has_return, m_ret_type) \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(sarray(), Vector<Variant>());
 
 #define bind_compat_custom1(m_type, m_exposed_name, m_name, m_method, m_arg_type, m_arg_name) \
-	VARARG_CLASS1(m_type, m_exposed_name, m_name, m_method, m_arg_type)                       \
+	VARARG_CLASS1(m_type, m_exposed_name, m_name, m_method, m_arg_type) \
 	register_builtin_compat_method<Method_##m_type##_##m_name>(sarray(m_arg_name), Vector<Variant>());
 
 static void _register_variant_builtin_methods_string() {

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -43,12 +43,12 @@
 template <typename T>
 struct PtrConstruct {};
 
-#define MAKE_PTRCONSTRUCT(m_type)                                                  \
-	template <>                                                                    \
-	struct PtrConstruct<m_type> {                                                  \
+#define MAKE_PTRCONSTRUCT(m_type) \
+	template <> \
+	struct PtrConstruct<m_type> { \
 		_FORCE_INLINE_ static void construct(const m_type &p_value, void *p_ptr) { \
-			memnew_placement(p_ptr, m_type(p_value));                              \
-		}                                                                          \
+			memnew_placement(p_ptr, m_type(p_value)); \
+		} \
 	};
 
 MAKE_PTRCONSTRUCT(bool);

--- a/core/variant/variant_destruct.h
+++ b/core/variant/variant_destruct.h
@@ -37,15 +37,15 @@
 template <typename T>
 struct VariantDestruct {};
 
-#define MAKE_PTRDESTRUCT(m_type)                               \
-	template <>                                                \
-	struct VariantDestruct<m_type> {                           \
+#define MAKE_PTRDESTRUCT(m_type) \
+	template <> \
+	struct VariantDestruct<m_type> { \
 		_FORCE_INLINE_ static void ptr_destruct(void *p_ptr) { \
-			reinterpret_cast<m_type *>(p_ptr)->~m_type();      \
-		}                                                      \
-		_FORCE_INLINE_ static Variant::Type get_base_type() {  \
-			return GetTypeInfo<m_type>::VARIANT_TYPE;          \
-		}                                                      \
+			reinterpret_cast<m_type *>(p_ptr)->~m_type(); \
+		} \
+		_FORCE_INLINE_ static Variant::Type get_base_type() { \
+			return GetTypeInfo<m_type>::VARIANT_TYPE; \
+		} \
 	}
 
 MAKE_PTRDESTRUCT(String);

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -193,20 +193,20 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<Vector4>::VARIANT_TYPE; }
 };
 
-#define register_string_op(m_op_type, m_op_code)                                                               \
-	if constexpr (true) {                                                                                      \
-		register_op<m_op_type<String, String>>(m_op_code, Variant::STRING, Variant::STRING);                   \
-		register_op<m_op_type<String, StringName>>(m_op_code, Variant::STRING, Variant::STRING_NAME);          \
-		register_op<m_op_type<StringName, String>>(m_op_code, Variant::STRING_NAME, Variant::STRING);          \
+#define register_string_op(m_op_type, m_op_code) \
+	if constexpr (true) { \
+		register_op<m_op_type<String, String>>(m_op_code, Variant::STRING, Variant::STRING); \
+		register_op<m_op_type<String, StringName>>(m_op_code, Variant::STRING, Variant::STRING_NAME); \
+		register_op<m_op_type<StringName, String>>(m_op_code, Variant::STRING_NAME, Variant::STRING); \
 		register_op<m_op_type<StringName, StringName>>(m_op_code, Variant::STRING_NAME, Variant::STRING_NAME); \
-	} else                                                                                                     \
+	} else \
 		((void)0)
 
-#define register_string_modulo_op(m_class, m_type)                                                                         \
-	if constexpr (true) {                                                                                                  \
-		register_op<OperatorEvaluatorStringFormat<String, m_class>>(Variant::OP_MODULE, Variant::STRING, m_type);          \
+#define register_string_modulo_op(m_class, m_type) \
+	if constexpr (true) { \
+		register_op<OperatorEvaluatorStringFormat<String, m_class>>(Variant::OP_MODULE, Variant::STRING, m_type); \
 		register_op<OperatorEvaluatorStringFormat<StringName, m_class>>(Variant::OP_MODULE, Variant::STRING_NAME, m_type); \
-	} else                                                                                                                 \
+	} else \
 		((void)0)
 
 void Variant::_register_variant_operators() {

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -912,18 +912,18 @@ _FORCE_INLINE_ static bool _operate_get_ptr_object(const void *p_ptr) {
 	return PtrToArg<Object *>::convert(p_ptr) != nullptr;
 }
 
-#define OP_EVALUATOR(m_class_name, m_left, m_right, m_op)                                                                 \
-	class m_class_name : public CommonEvaluate<m_class_name> {                                                            \
-	public:                                                                                                               \
-		static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {                \
+#define OP_EVALUATOR(m_class_name, m_left, m_right, m_op) \
+	class m_class_name : public CommonEvaluate<m_class_name> { \
+	public: \
+		static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) { \
 			VariantInternalAccessor<bool>::get(r_ret) = m_op(_operate_get_##m_left(left), _operate_get_##m_right(right)); \
-		}                                                                                                                 \
-                                                                                                                          \
-		static void ptr_evaluate(const void *left, const void *right, void *r_ret) {                                      \
-			PtrToArg<bool>::encode(m_op(_operate_get_ptr_##m_left(left), _operate_get_ptr_##m_right(right)), r_ret);      \
-		}                                                                                                                 \
-                                                                                                                          \
-		using ReturnType = bool;                                                                                          \
+		} \
+\
+		static void ptr_evaluate(const void *left, const void *right, void *r_ret) { \
+			PtrToArg<bool>::encode(m_op(_operate_get_ptr_##m_left(left), _operate_get_ptr_##m_right(right)), r_ret); \
+		} \
+\
+		using ReturnType = bool; \
 	};
 
 // OR

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -329,329 +329,329 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 
 #endif
 
-#define INDEXED_SETGET_STRUCT_TYPED(m_base_type, m_elem_type)                                                                  \
-	struct VariantIndexedSetGet_##m_base_type {                                                                                \
-		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                       \
-			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size();                                             \
-			if (index < 0) {                                                                                                   \
-				index += size;                                                                                                 \
-			}                                                                                                                  \
-			if (index < 0 || index >= size) {                                                                                  \
-				*oob = true;                                                                                                   \
-				return;                                                                                                        \
-			}                                                                                                                  \
-			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                     \
-			VariantInternalAccessor<m_elem_type>::get(value) = (VariantInternalAccessor<m_base_type>::get(base))[index];       \
-			*oob = false;                                                                                                      \
-		}                                                                                                                      \
-		static void ptr_get(const void *base, int64_t index, void *member) {                                                   \
-			/* avoid ptrconvert for performance*/                                                                              \
-			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base);                                               \
-			if (index < 0)                                                                                                     \
-				index += v.size();                                                                                             \
-			OOB_TEST(index, v.size());                                                                                         \
-			PtrToArg<m_elem_type>::encode(v[index], member);                                                                   \
-		}                                                                                                                      \
-		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                          \
-			if (value->get_type() != GetTypeInfo<m_elem_type>::VARIANT_TYPE) {                                                 \
-				*oob = false;                                                                                                  \
-				*valid = false;                                                                                                \
-				return;                                                                                                        \
-			}                                                                                                                  \
-			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size();                                             \
-			if (index < 0) {                                                                                                   \
-				index += size;                                                                                                 \
-			}                                                                                                                  \
-			if (index < 0 || index >= size) {                                                                                  \
-				*oob = true;                                                                                                   \
-				*valid = false;                                                                                                \
-				return;                                                                                                        \
-			}                                                                                                                  \
-			(VariantInternalAccessor<m_base_type>::get(base)).write[index] = VariantInternalAccessor<m_elem_type>::get(value); \
-			*oob = false;                                                                                                      \
-			*valid = true;                                                                                                     \
-		}                                                                                                                      \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                             \
-			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size();                                             \
-			if (index < 0) {                                                                                                   \
-				index += size;                                                                                                 \
-			}                                                                                                                  \
-			if (index < 0 || index >= size) {                                                                                  \
-				*oob = true;                                                                                                   \
-				return;                                                                                                        \
-			}                                                                                                                  \
-			(VariantInternalAccessor<m_base_type>::get(base)).write[index] = VariantInternalAccessor<m_elem_type>::get(value); \
-			*oob = false;                                                                                                      \
-		}                                                                                                                      \
-		static void ptr_set(void *base, int64_t index, const void *member) {                                                   \
-			/* avoid ptrconvert for performance*/                                                                              \
-			m_base_type &v = *reinterpret_cast<m_base_type *>(base);                                                           \
-			if (index < 0)                                                                                                     \
-				index += v.size();                                                                                             \
-			OOB_TEST(index, v.size());                                                                                         \
-			v.write[index] = PtrToArg<m_elem_type>::convert(member);                                                           \
-		}                                                                                                                      \
-		static Variant::Type get_index_type() {                                                                                \
-			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                                     \
-		}                                                                                                                      \
-		static uint32_t get_index_usage() {                                                                                    \
-			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                           \
-		}                                                                                                                      \
-		static uint64_t get_indexed_size(const Variant *base) {                                                                \
-			return VariantInternalAccessor<m_base_type>::get(base).size();                                                     \
-		}                                                                                                                      \
-	};
-
-#define INDEXED_SETGET_STRUCT_TYPED_NUMERIC(m_base_type, m_elem_type, m_assign_type)                                           \
-	struct VariantIndexedSetGet_##m_base_type {                                                                                \
-		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                       \
-			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size();                                             \
-			if (index < 0) {                                                                                                   \
-				index += size;                                                                                                 \
-			}                                                                                                                  \
-			if (index < 0 || index >= size) {                                                                                  \
-				*oob = true;                                                                                                   \
-				return;                                                                                                        \
-			}                                                                                                                  \
-			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                     \
-			VariantInternalAccessor<m_elem_type>::get(value) = (VariantInternalAccessor<m_base_type>::get(base))[index];       \
-			*oob = false;                                                                                                      \
-		}                                                                                                                      \
-		static void ptr_get(const void *base, int64_t index, void *member) {                                                   \
-			/* avoid ptrconvert for performance*/                                                                              \
-			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base);                                               \
-			if (index < 0)                                                                                                     \
-				index += v.size();                                                                                             \
-			OOB_TEST(index, v.size());                                                                                         \
-			PtrToArg<m_elem_type>::encode(v[index], member);                                                                   \
-		}                                                                                                                      \
-		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                          \
-			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size();                                             \
-			if (index < 0) {                                                                                                   \
-				index += size;                                                                                                 \
-			}                                                                                                                  \
-			if (index < 0 || index >= size) {                                                                                  \
-				*oob = true;                                                                                                   \
-				*valid = false;                                                                                                \
-				return;                                                                                                        \
-			}                                                                                                                  \
-			m_assign_type num;                                                                                                 \
-			if (value->get_type() == Variant::INT) {                                                                           \
-				num = (m_assign_type) * &VariantInternalAccessor<int64_t>::get(value);                                         \
-			} else if (value->get_type() == Variant::FLOAT) {                                                                  \
-				num = (m_assign_type) * &VariantInternalAccessor<double>::get(value);                                          \
-			} else {                                                                                                           \
-				*oob = false;                                                                                                  \
-				*valid = false;                                                                                                \
-				return;                                                                                                        \
-			}                                                                                                                  \
-			(VariantInternalAccessor<m_base_type>::get(base)).write[index] = num;                                              \
-			*oob = false;                                                                                                      \
-			*valid = true;                                                                                                     \
-		}                                                                                                                      \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                             \
-			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size();                                             \
-			if (index < 0) {                                                                                                   \
-				index += size;                                                                                                 \
-			}                                                                                                                  \
-			if (index < 0 || index >= size) {                                                                                  \
-				*oob = true;                                                                                                   \
-				return;                                                                                                        \
-			}                                                                                                                  \
-			(VariantInternalAccessor<m_base_type>::get(base)).write[index] = VariantInternalAccessor<m_elem_type>::get(value); \
-			*oob = false;                                                                                                      \
-		}                                                                                                                      \
-		static void ptr_set(void *base, int64_t index, const void *member) {                                                   \
-			/* avoid ptrconvert for performance*/                                                                              \
-			m_base_type &v = *reinterpret_cast<m_base_type *>(base);                                                           \
-			if (index < 0)                                                                                                     \
-				index += v.size();                                                                                             \
-			OOB_TEST(index, v.size());                                                                                         \
-			v.write[index] = PtrToArg<m_elem_type>::convert(member);                                                           \
-		}                                                                                                                      \
-		static Variant::Type get_index_type() {                                                                                \
-			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                                     \
-		}                                                                                                                      \
-		static uint32_t get_index_usage() {                                                                                    \
-			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                           \
-		}                                                                                                                      \
-		static uint64_t get_indexed_size(const Variant *base) {                                                                \
-			return VariantInternalAccessor<m_base_type>::get(base).size();                                                     \
-		}                                                                                                                      \
-	};
-
-#define INDEXED_SETGET_STRUCT_BUILTIN_NUMERIC(m_base_type, m_elem_type, m_assign_type, m_max)                            \
-	struct VariantIndexedSetGet_##m_base_type {                                                                          \
-		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                 \
-			if (index < 0 || index >= m_max) {                                                                           \
-				*oob = true;                                                                                             \
-				return;                                                                                                  \
-			}                                                                                                            \
-			VariantTypeAdjust<m_elem_type>::adjust(value);                                                               \
+#define INDEXED_SETGET_STRUCT_TYPED(m_base_type, m_elem_type) \
+	struct VariantIndexedSetGet_##m_base_type { \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) { \
+			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size(); \
+			if (index < 0) { \
+				index += size; \
+			} \
+			if (index < 0 || index >= size) { \
+				*oob = true; \
+				return; \
+			} \
+			VariantTypeAdjust<m_elem_type>::adjust(value); \
 			VariantInternalAccessor<m_elem_type>::get(value) = (VariantInternalAccessor<m_base_type>::get(base))[index]; \
-			*oob = false;                                                                                                \
-		}                                                                                                                \
-		static void ptr_get(const void *base, int64_t index, void *member) {                                             \
-			/* avoid ptrconvert for performance*/                                                                        \
-			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base);                                         \
-			OOB_TEST(index, m_max);                                                                                      \
-			PtrToArg<m_elem_type>::encode(v[index], member);                                                             \
-		}                                                                                                                \
-		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                    \
-			if (index < 0 || index >= m_max) {                                                                           \
-				*oob = true;                                                                                             \
-				*valid = false;                                                                                          \
-				return;                                                                                                  \
-			}                                                                                                            \
-			m_assign_type num;                                                                                           \
-			if (value->get_type() == Variant::INT) {                                                                     \
-				num = (m_assign_type) * &VariantInternalAccessor<int64_t>::get(value);                                   \
-			} else if (value->get_type() == Variant::FLOAT) {                                                            \
-				num = (m_assign_type) * &VariantInternalAccessor<double>::get(value);                                    \
-			} else {                                                                                                     \
-				*oob = false;                                                                                            \
-				*valid = false;                                                                                          \
-				return;                                                                                                  \
-			}                                                                                                            \
-			(VariantInternalAccessor<m_base_type>::get(base))[index] = num;                                              \
-			*oob = false;                                                                                                \
-			*valid = true;                                                                                               \
-		}                                                                                                                \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                       \
-			if (index < 0 || index >= m_max) {                                                                           \
-				*oob = true;                                                                                             \
-				return;                                                                                                  \
-			}                                                                                                            \
+			*oob = false; \
+		} \
+		static void ptr_get(const void *base, int64_t index, void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base); \
+			if (index < 0) \
+				index += v.size(); \
+			OOB_TEST(index, v.size()); \
+			PtrToArg<m_elem_type>::encode(v[index], member); \
+		} \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) { \
+			if (value->get_type() != GetTypeInfo<m_elem_type>::VARIANT_TYPE) { \
+				*oob = false; \
+				*valid = false; \
+				return; \
+			} \
+			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size(); \
+			if (index < 0) { \
+				index += size; \
+			} \
+			if (index < 0 || index >= size) { \
+				*oob = true; \
+				*valid = false; \
+				return; \
+			} \
+			(VariantInternalAccessor<m_base_type>::get(base)).write[index] = VariantInternalAccessor<m_elem_type>::get(value); \
+			*oob = false; \
+			*valid = true; \
+		} \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) { \
+			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size(); \
+			if (index < 0) { \
+				index += size; \
+			} \
+			if (index < 0 || index >= size) { \
+				*oob = true; \
+				return; \
+			} \
+			(VariantInternalAccessor<m_base_type>::get(base)).write[index] = VariantInternalAccessor<m_elem_type>::get(value); \
+			*oob = false; \
+		} \
+		static void ptr_set(void *base, int64_t index, const void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			m_base_type &v = *reinterpret_cast<m_base_type *>(base); \
+			if (index < 0) \
+				index += v.size(); \
+			OOB_TEST(index, v.size()); \
+			v.write[index] = PtrToArg<m_elem_type>::convert(member); \
+		} \
+		static Variant::Type get_index_type() { \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE; \
+		} \
+		static uint32_t get_index_usage() { \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage; \
+		} \
+		static uint64_t get_indexed_size(const Variant *base) { \
+			return VariantInternalAccessor<m_base_type>::get(base).size(); \
+		} \
+	};
+
+#define INDEXED_SETGET_STRUCT_TYPED_NUMERIC(m_base_type, m_elem_type, m_assign_type) \
+	struct VariantIndexedSetGet_##m_base_type { \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) { \
+			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size(); \
+			if (index < 0) { \
+				index += size; \
+			} \
+			if (index < 0 || index >= size) { \
+				*oob = true; \
+				return; \
+			} \
+			VariantTypeAdjust<m_elem_type>::adjust(value); \
+			VariantInternalAccessor<m_elem_type>::get(value) = (VariantInternalAccessor<m_base_type>::get(base))[index]; \
+			*oob = false; \
+		} \
+		static void ptr_get(const void *base, int64_t index, void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base); \
+			if (index < 0) \
+				index += v.size(); \
+			OOB_TEST(index, v.size()); \
+			PtrToArg<m_elem_type>::encode(v[index], member); \
+		} \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) { \
+			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size(); \
+			if (index < 0) { \
+				index += size; \
+			} \
+			if (index < 0 || index >= size) { \
+				*oob = true; \
+				*valid = false; \
+				return; \
+			} \
+			m_assign_type num; \
+			if (value->get_type() == Variant::INT) { \
+				num = (m_assign_type) * &VariantInternalAccessor<int64_t>::get(value); \
+			} else if (value->get_type() == Variant::FLOAT) { \
+				num = (m_assign_type) * &VariantInternalAccessor<double>::get(value); \
+			} else { \
+				*oob = false; \
+				*valid = false; \
+				return; \
+			} \
+			(VariantInternalAccessor<m_base_type>::get(base)).write[index] = num; \
+			*oob = false; \
+			*valid = true; \
+		} \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) { \
+			int64_t size = VariantInternalAccessor<m_base_type>::get(base).size(); \
+			if (index < 0) { \
+				index += size; \
+			} \
+			if (index < 0 || index >= size) { \
+				*oob = true; \
+				return; \
+			} \
+			(VariantInternalAccessor<m_base_type>::get(base)).write[index] = VariantInternalAccessor<m_elem_type>::get(value); \
+			*oob = false; \
+		} \
+		static void ptr_set(void *base, int64_t index, const void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			m_base_type &v = *reinterpret_cast<m_base_type *>(base); \
+			if (index < 0) \
+				index += v.size(); \
+			OOB_TEST(index, v.size()); \
+			v.write[index] = PtrToArg<m_elem_type>::convert(member); \
+		} \
+		static Variant::Type get_index_type() { \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE; \
+		} \
+		static uint32_t get_index_usage() { \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage; \
+		} \
+		static uint64_t get_indexed_size(const Variant *base) { \
+			return VariantInternalAccessor<m_base_type>::get(base).size(); \
+		} \
+	};
+
+#define INDEXED_SETGET_STRUCT_BUILTIN_NUMERIC(m_base_type, m_elem_type, m_assign_type, m_max) \
+	struct VariantIndexedSetGet_##m_base_type { \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) { \
+			if (index < 0 || index >= m_max) { \
+				*oob = true; \
+				return; \
+			} \
+			VariantTypeAdjust<m_elem_type>::adjust(value); \
+			VariantInternalAccessor<m_elem_type>::get(value) = (VariantInternalAccessor<m_base_type>::get(base))[index]; \
+			*oob = false; \
+		} \
+		static void ptr_get(const void *base, int64_t index, void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base); \
+			OOB_TEST(index, m_max); \
+			PtrToArg<m_elem_type>::encode(v[index], member); \
+		} \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) { \
+			if (index < 0 || index >= m_max) { \
+				*oob = true; \
+				*valid = false; \
+				return; \
+			} \
+			m_assign_type num; \
+			if (value->get_type() == Variant::INT) { \
+				num = (m_assign_type) * &VariantInternalAccessor<int64_t>::get(value); \
+			} else if (value->get_type() == Variant::FLOAT) { \
+				num = (m_assign_type) * &VariantInternalAccessor<double>::get(value); \
+			} else { \
+				*oob = false; \
+				*valid = false; \
+				return; \
+			} \
+			(VariantInternalAccessor<m_base_type>::get(base))[index] = num; \
+			*oob = false; \
+			*valid = true; \
+		} \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) { \
+			if (index < 0 || index >= m_max) { \
+				*oob = true; \
+				return; \
+			} \
 			(VariantInternalAccessor<m_base_type>::get(base))[index] = VariantInternalAccessor<m_elem_type>::get(value); \
-			*oob = false;                                                                                                \
-		}                                                                                                                \
-		static void ptr_set(void *base, int64_t index, const void *member) {                                             \
-			/* avoid ptrconvert for performance*/                                                                        \
-			m_base_type &v = *reinterpret_cast<m_base_type *>(base);                                                     \
-			OOB_TEST(index, m_max);                                                                                      \
-			v[index] = PtrToArg<m_elem_type>::convert(member);                                                           \
-		}                                                                                                                \
-		static Variant::Type get_index_type() {                                                                          \
-			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                               \
-		}                                                                                                                \
-		static uint32_t get_index_usage() {                                                                              \
-			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                     \
-		}                                                                                                                \
-		static uint64_t get_indexed_size(const Variant *base) {                                                          \
-			return m_max;                                                                                                \
-		}                                                                                                                \
+			*oob = false; \
+		} \
+		static void ptr_set(void *base, int64_t index, const void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			m_base_type &v = *reinterpret_cast<m_base_type *>(base); \
+			OOB_TEST(index, m_max); \
+			v[index] = PtrToArg<m_elem_type>::convert(member); \
+		} \
+		static Variant::Type get_index_type() { \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE; \
+		} \
+		static uint32_t get_index_usage() { \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage; \
+		} \
+		static uint64_t get_indexed_size(const Variant *base) { \
+			return m_max; \
+		} \
 	};
 
-#define INDEXED_SETGET_STRUCT_BUILTIN_ACCESSOR(m_base_type, m_elem_type, m_accessor, m_max)                                         \
-	struct VariantIndexedSetGet_##m_base_type {                                                                                     \
-		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                            \
-			if (index < 0 || index >= m_max) {                                                                                      \
-				*oob = true;                                                                                                        \
-				return;                                                                                                             \
-			}                                                                                                                       \
-			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                          \
-			VariantInternalAccessor<m_elem_type>::get(value) = (VariantInternalAccessor<m_base_type>::get(base))m_accessor[index];  \
-			*oob = false;                                                                                                           \
-		}                                                                                                                           \
-		static void ptr_get(const void *base, int64_t index, void *member) {                                                        \
-			/* avoid ptrconvert for performance*/                                                                                   \
-			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base);                                                    \
-			OOB_TEST(index, m_max);                                                                                                 \
-			PtrToArg<m_elem_type>::encode(v m_accessor[index], member);                                                             \
-		}                                                                                                                           \
-		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                               \
-			if (value->get_type() != GetTypeInfo<m_elem_type>::VARIANT_TYPE) {                                                      \
-				*oob = false;                                                                                                       \
-				*valid = false;                                                                                                     \
-			}                                                                                                                       \
-			if (index < 0 || index >= m_max) {                                                                                      \
-				*oob = true;                                                                                                        \
-				*valid = false;                                                                                                     \
-				return;                                                                                                             \
-			}                                                                                                                       \
+#define INDEXED_SETGET_STRUCT_BUILTIN_ACCESSOR(m_base_type, m_elem_type, m_accessor, m_max) \
+	struct VariantIndexedSetGet_##m_base_type { \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) { \
+			if (index < 0 || index >= m_max) { \
+				*oob = true; \
+				return; \
+			} \
+			VariantTypeAdjust<m_elem_type>::adjust(value); \
+			VariantInternalAccessor<m_elem_type>::get(value) = (VariantInternalAccessor<m_base_type>::get(base))m_accessor[index]; \
+			*oob = false; \
+		} \
+		static void ptr_get(const void *base, int64_t index, void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base); \
+			OOB_TEST(index, m_max); \
+			PtrToArg<m_elem_type>::encode(v m_accessor[index], member); \
+		} \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) { \
+			if (value->get_type() != GetTypeInfo<m_elem_type>::VARIANT_TYPE) { \
+				*oob = false; \
+				*valid = false; \
+			} \
+			if (index < 0 || index >= m_max) { \
+				*oob = true; \
+				*valid = false; \
+				return; \
+			} \
 			(VariantInternalAccessor<m_base_type>::get(base)) m_accessor[index] = VariantInternalAccessor<m_elem_type>::get(value); \
-			*oob = false;                                                                                                           \
-			*valid = true;                                                                                                          \
-		}                                                                                                                           \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                                  \
-			if (index < 0 || index >= m_max) {                                                                                      \
-				*oob = true;                                                                                                        \
-				return;                                                                                                             \
-			}                                                                                                                       \
+			*oob = false; \
+			*valid = true; \
+		} \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) { \
+			if (index < 0 || index >= m_max) { \
+				*oob = true; \
+				return; \
+			} \
 			(VariantInternalAccessor<m_base_type>::get(base)) m_accessor[index] = VariantInternalAccessor<m_elem_type>::get(value); \
-			*oob = false;                                                                                                           \
-		}                                                                                                                           \
-		static void ptr_set(void *base, int64_t index, const void *member) {                                                        \
-			/* avoid ptrconvert for performance*/                                                                                   \
-			m_base_type &v = *reinterpret_cast<m_base_type *>(base);                                                                \
-			OOB_TEST(index, m_max);                                                                                                 \
-			v m_accessor[index] = PtrToArg<m_elem_type>::convert(member);                                                           \
-		}                                                                                                                           \
-		static Variant::Type get_index_type() {                                                                                     \
-			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                                          \
-		}                                                                                                                           \
-		static uint32_t get_index_usage() {                                                                                         \
-			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                                \
-		}                                                                                                                           \
-		static uint64_t get_indexed_size(const Variant *base) {                                                                     \
-			return m_max;                                                                                                           \
-		}                                                                                                                           \
+			*oob = false; \
+		} \
+		static void ptr_set(void *base, int64_t index, const void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			m_base_type &v = *reinterpret_cast<m_base_type *>(base); \
+			OOB_TEST(index, m_max); \
+			v m_accessor[index] = PtrToArg<m_elem_type>::convert(member); \
+		} \
+		static Variant::Type get_index_type() { \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE; \
+		} \
+		static uint32_t get_index_usage() { \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage; \
+		} \
+		static uint64_t get_indexed_size(const Variant *base) { \
+			return m_max; \
+		} \
 	};
 
-#define INDEXED_SETGET_STRUCT_BUILTIN_FUNC(m_base_type, m_elem_type, m_set, m_get, m_max)                                    \
-	struct VariantIndexedSetGet_##m_base_type {                                                                              \
-		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {                                     \
-			if (index < 0 || index >= m_max) {                                                                               \
-				*oob = true;                                                                                                 \
-				return;                                                                                                      \
-			}                                                                                                                \
-			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                   \
+#define INDEXED_SETGET_STRUCT_BUILTIN_FUNC(m_base_type, m_elem_type, m_set, m_get, m_max) \
+	struct VariantIndexedSetGet_##m_base_type { \
+		static void get(const Variant *base, int64_t index, Variant *value, bool *oob) { \
+			if (index < 0 || index >= m_max) { \
+				*oob = true; \
+				return; \
+			} \
+			VariantTypeAdjust<m_elem_type>::adjust(value); \
 			VariantInternalAccessor<m_elem_type>::get(value) = VariantInternalAccessor<m_base_type>::get(base).m_get(index); \
-			*oob = false;                                                                                                    \
-		}                                                                                                                    \
-		static void ptr_get(const void *base, int64_t index, void *member) {                                                 \
-			/* avoid ptrconvert for performance*/                                                                            \
-			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base);                                             \
-			OOB_TEST(index, m_max);                                                                                          \
-			PtrToArg<m_elem_type>::encode(v.m_get(index), member);                                                           \
-		}                                                                                                                    \
-		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {                        \
-			if (value->get_type() != GetTypeInfo<m_elem_type>::VARIANT_TYPE) {                                               \
-				*oob = false;                                                                                                \
-				*valid = false;                                                                                              \
-			}                                                                                                                \
-			if (index < 0 || index >= m_max) {                                                                               \
-				*oob = true;                                                                                                 \
-				*valid = false;                                                                                              \
-				return;                                                                                                      \
-			}                                                                                                                \
-			VariantInternalAccessor<m_base_type>::get(base).m_set(index, VariantInternalAccessor<m_elem_type>::get(value));  \
-			*oob = false;                                                                                                    \
-			*valid = true;                                                                                                   \
-		}                                                                                                                    \
-		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {                           \
-			if (index < 0 || index >= m_max) {                                                                               \
-				*oob = true;                                                                                                 \
-				return;                                                                                                      \
-			}                                                                                                                \
-			VariantInternalAccessor<m_base_type>::get(base).m_set(index, VariantInternalAccessor<m_elem_type>::get(value));  \
-			*oob = false;                                                                                                    \
-		}                                                                                                                    \
-		static void ptr_set(void *base, int64_t index, const void *member) {                                                 \
-			/* avoid ptrconvert for performance*/                                                                            \
-			m_base_type &v = *reinterpret_cast<m_base_type *>(base);                                                         \
-			OOB_TEST(index, m_max);                                                                                          \
-			v.m_set(index, PtrToArg<m_elem_type>::convert(member));                                                          \
-		}                                                                                                                    \
-		static Variant::Type get_index_type() {                                                                              \
-			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                                   \
-		}                                                                                                                    \
-		static uint32_t get_index_usage() {                                                                                  \
-			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                         \
-		}                                                                                                                    \
-		static uint64_t get_indexed_size(const Variant *base) {                                                              \
-			return m_max;                                                                                                    \
-		}                                                                                                                    \
+			*oob = false; \
+		} \
+		static void ptr_get(const void *base, int64_t index, void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base); \
+			OOB_TEST(index, m_max); \
+			PtrToArg<m_elem_type>::encode(v.m_get(index), member); \
+		} \
+		static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) { \
+			if (value->get_type() != GetTypeInfo<m_elem_type>::VARIANT_TYPE) { \
+				*oob = false; \
+				*valid = false; \
+			} \
+			if (index < 0 || index >= m_max) { \
+				*oob = true; \
+				*valid = false; \
+				return; \
+			} \
+			VariantInternalAccessor<m_base_type>::get(base).m_set(index, VariantInternalAccessor<m_elem_type>::get(value)); \
+			*oob = false; \
+			*valid = true; \
+		} \
+		static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) { \
+			if (index < 0 || index >= m_max) { \
+				*oob = true; \
+				return; \
+			} \
+			VariantInternalAccessor<m_base_type>::get(base).m_set(index, VariantInternalAccessor<m_elem_type>::get(value)); \
+			*oob = false; \
+		} \
+		static void ptr_set(void *base, int64_t index, const void *member) { \
+			/* avoid ptrconvert for performance*/ \
+			m_base_type &v = *reinterpret_cast<m_base_type *>(base); \
+			OOB_TEST(index, m_max); \
+			v.m_set(index, PtrToArg<m_elem_type>::convert(member)); \
+		} \
+		static Variant::Type get_index_type() { \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE; \
+		} \
+		static uint32_t get_index_usage() { \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage; \
+		} \
+		static uint64_t get_indexed_size(const Variant *base) { \
+			return m_max; \
+		} \
 	};
 
 struct VariantIndexedSetGet_Array {

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -38,244 +38,244 @@
 
 /**** NAMED SETTERS AND GETTERS ****/
 
-#define SETGET_STRUCT(m_base_type, m_member_type, m_member)                                                                    \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                          \
-		static void get(const Variant *base, Variant *member) {                                                                \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                  \
-			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member;    \
-		}                                                                                                                      \
-		static inline void validated_get(const Variant *base, Variant *member) {                                               \
-			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member;    \
-		}                                                                                                                      \
-		static void ptr_get(const void *base, void *member) {                                                                  \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_member, member);                            \
-		}                                                                                                                      \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                    \
-			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                               \
+#define SETGET_STRUCT(m_base_type, m_member_type, m_member) \
+	struct VariantSetGet_##m_base_type##_##m_member { \
+		static void get(const Variant *base, Variant *member) { \
+			VariantTypeAdjust<m_member_type>::adjust(member); \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member; \
+		} \
+		static inline void validated_get(const Variant *base, Variant *member) { \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member; \
+		} \
+		static void ptr_get(const void *base, void *member) { \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_member, member); \
+		} \
+		static void set(Variant *base, const Variant *value, bool &valid) { \
+			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) { \
 				VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<m_member_type>::get(value); \
-				valid = true;                                                                                                  \
-			} else {                                                                                                           \
-				valid = false;                                                                                                 \
-			}                                                                                                                  \
-		}                                                                                                                      \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                \
-			VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<m_member_type>::get(value);     \
-		}                                                                                                                      \
-		static void ptr_set(void *base, const void *member) {                                                                  \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                              \
-			b.m_member = PtrToArg<m_member_type>::convert(member);                                                             \
-			PtrToArg<m_base_type>::encode(b, base);                                                                            \
-		}                                                                                                                      \
-		static Variant::Type get_type() {                                                                                      \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                   \
-		}                                                                                                                      \
+				valid = true; \
+			} else { \
+				valid = false; \
+			} \
+		} \
+		static inline void validated_set(Variant *base, const Variant *value) { \
+			VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<m_member_type>::get(value); \
+		} \
+		static void ptr_set(void *base, const void *member) { \
+			m_base_type b = PtrToArg<m_base_type>::convert(base); \
+			b.m_member = PtrToArg<m_member_type>::convert(member); \
+			PtrToArg<m_base_type>::encode(b, base); \
+		} \
+		static Variant::Type get_type() { \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE; \
+		} \
 	};
 
-#define SETGET_NUMBER_STRUCT(m_base_type, m_member_type, m_member)                                                          \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                       \
-		static void get(const Variant *base, Variant *member) {                                                             \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                               \
+#define SETGET_NUMBER_STRUCT(m_base_type, m_member_type, m_member) \
+	struct VariantSetGet_##m_base_type##_##m_member { \
+		static void get(const Variant *base, Variant *member) { \
+			VariantTypeAdjust<m_member_type>::adjust(member); \
 			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member; \
-		}                                                                                                                   \
-		static inline void validated_get(const Variant *base, Variant *member) {                                            \
+		} \
+		static inline void validated_get(const Variant *base, Variant *member) { \
 			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_member; \
-		}                                                                                                                   \
-		static void ptr_get(const void *base, void *member) {                                                               \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_member, member);                         \
-		}                                                                                                                   \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                 \
-			if (value->get_type() == Variant::FLOAT) {                                                                      \
-				VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<double>::get(value);     \
-				valid = true;                                                                                               \
-			} else if (value->get_type() == Variant::INT) {                                                                 \
-				VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<int64_t>::get(value);    \
-				valid = true;                                                                                               \
-			} else {                                                                                                        \
-				valid = false;                                                                                              \
-			}                                                                                                               \
-		}                                                                                                                   \
-		static inline void validated_set(Variant *base, const Variant *value) {                                             \
-			VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<m_member_type>::get(value);  \
-		}                                                                                                                   \
-		static void ptr_set(void *base, const void *member) {                                                               \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                           \
-			b.m_member = PtrToArg<m_member_type>::convert(member);                                                          \
-			PtrToArg<m_base_type>::encode(b, base);                                                                         \
-		}                                                                                                                   \
-		static Variant::Type get_type() {                                                                                   \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                \
-		}                                                                                                                   \
+		} \
+		static void ptr_get(const void *base, void *member) { \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_member, member); \
+		} \
+		static void set(Variant *base, const Variant *value, bool &valid) { \
+			if (value->get_type() == Variant::FLOAT) { \
+				VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<double>::get(value); \
+				valid = true; \
+			} else if (value->get_type() == Variant::INT) { \
+				VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<int64_t>::get(value); \
+				valid = true; \
+			} else { \
+				valid = false; \
+			} \
+		} \
+		static inline void validated_set(Variant *base, const Variant *value) { \
+			VariantInternalAccessor<m_base_type>::get(base).m_member = VariantInternalAccessor<m_member_type>::get(value); \
+		} \
+		static void ptr_set(void *base, const void *member) { \
+			m_base_type b = PtrToArg<m_base_type>::convert(base); \
+			b.m_member = PtrToArg<m_member_type>::convert(member); \
+			PtrToArg<m_base_type>::encode(b, base); \
+		} \
+		static Variant::Type get_type() { \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE; \
+		} \
 	};
 
-#define SETGET_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                                   \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                          \
-		static void get(const Variant *base, Variant *member) {                                                                \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                  \
-			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom;    \
-		}                                                                                                                      \
-		static inline void validated_get(const Variant *base, Variant *member) {                                               \
-			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom;    \
-		}                                                                                                                      \
-		static void ptr_get(const void *base, void *member) {                                                                  \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_custom, member);                            \
-		}                                                                                                                      \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                    \
-			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                               \
+#define SETGET_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom) \
+	struct VariantSetGet_##m_base_type##_##m_member { \
+		static void get(const Variant *base, Variant *member) { \
+			VariantTypeAdjust<m_member_type>::adjust(member); \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom; \
+		} \
+		static inline void validated_get(const Variant *base, Variant *member) { \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom; \
+		} \
+		static void ptr_get(const void *base, void *member) { \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_custom, member); \
+		} \
+		static void set(Variant *base, const Variant *value, bool &valid) { \
+			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) { \
 				VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<m_member_type>::get(value); \
-				valid = true;                                                                                                  \
-			} else {                                                                                                           \
-				valid = false;                                                                                                 \
-			}                                                                                                                  \
-		}                                                                                                                      \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                \
-			VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<m_member_type>::get(value);     \
-		}                                                                                                                      \
-		static void ptr_set(void *base, const void *member) {                                                                  \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                              \
-			b.m_custom = PtrToArg<m_member_type>::convert(member);                                                             \
-			PtrToArg<m_base_type>::encode(b, base);                                                                            \
-		}                                                                                                                      \
-		static Variant::Type get_type() {                                                                                      \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                   \
-		}                                                                                                                      \
+				valid = true; \
+			} else { \
+				valid = false; \
+			} \
+		} \
+		static inline void validated_set(Variant *base, const Variant *value) { \
+			VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<m_member_type>::get(value); \
+		} \
+		static void ptr_set(void *base, const void *member) { \
+			m_base_type b = PtrToArg<m_base_type>::convert(base); \
+			b.m_custom = PtrToArg<m_member_type>::convert(member); \
+			PtrToArg<m_base_type>::encode(b, base); \
+		} \
+		static Variant::Type get_type() { \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE; \
+		} \
 	};
 
-#define SETGET_NUMBER_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                         \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                       \
-		static void get(const Variant *base, Variant *member) {                                                             \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                               \
+#define SETGET_NUMBER_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom) \
+	struct VariantSetGet_##m_base_type##_##m_member { \
+		static void get(const Variant *base, Variant *member) { \
+			VariantTypeAdjust<m_member_type>::adjust(member); \
 			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom; \
-		}                                                                                                                   \
-		static inline void validated_get(const Variant *base, Variant *member) {                                            \
+		} \
+		static inline void validated_get(const Variant *base, Variant *member) { \
 			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_custom; \
-		}                                                                                                                   \
-		static void ptr_get(const void *base, void *member) {                                                               \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_custom, member);                         \
-		}                                                                                                                   \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                 \
-			if (value->get_type() == Variant::FLOAT) {                                                                      \
-				VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<double>::get(value);     \
-				valid = true;                                                                                               \
-			} else if (value->get_type() == Variant::INT) {                                                                 \
-				VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<int64_t>::get(value);    \
-				valid = true;                                                                                               \
-			} else {                                                                                                        \
-				valid = false;                                                                                              \
-			}                                                                                                               \
-		}                                                                                                                   \
-		static inline void validated_set(Variant *base, const Variant *value) {                                             \
-			VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<m_member_type>::get(value);  \
-		}                                                                                                                   \
-		static void ptr_set(void *base, const void *member) {                                                               \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                           \
-			b.m_custom = PtrToArg<m_member_type>::convert(member);                                                          \
-			PtrToArg<m_base_type>::encode(b, base);                                                                         \
-		}                                                                                                                   \
-		static Variant::Type get_type() {                                                                                   \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                \
-		}                                                                                                                   \
+		} \
+		static void ptr_get(const void *base, void *member) { \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_custom, member); \
+		} \
+		static void set(Variant *base, const Variant *value, bool &valid) { \
+			if (value->get_type() == Variant::FLOAT) { \
+				VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<double>::get(value); \
+				valid = true; \
+			} else if (value->get_type() == Variant::INT) { \
+				VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<int64_t>::get(value); \
+				valid = true; \
+			} else { \
+				valid = false; \
+			} \
+		} \
+		static inline void validated_set(Variant *base, const Variant *value) { \
+			VariantInternalAccessor<m_base_type>::get(base).m_custom = VariantInternalAccessor<m_member_type>::get(value); \
+		} \
+		static void ptr_set(void *base, const void *member) { \
+			m_base_type b = PtrToArg<m_base_type>::convert(base); \
+			b.m_custom = PtrToArg<m_member_type>::convert(member); \
+			PtrToArg<m_base_type>::encode(b, base); \
+		} \
+		static Variant::Type get_type() { \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE; \
+		} \
 	};
 
-#define SETGET_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                          \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                         \
-		static void get(const Variant *base, Variant *member) {                                                               \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                 \
+#define SETGET_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter) \
+	struct VariantSetGet_##m_base_type##_##m_member { \
+		static void get(const Variant *base, Variant *member) { \
+			VariantTypeAdjust<m_member_type>::adjust(member); \
 			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(); \
-		}                                                                                                                     \
-		static inline void validated_get(const Variant *base, Variant *member) {                                              \
+		} \
+		static inline void validated_get(const Variant *base, Variant *member) { \
 			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(); \
-		}                                                                                                                     \
-		static void ptr_get(const void *base, void *member) {                                                                 \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(), member);                         \
-		}                                                                                                                     \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                   \
-			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                              \
+		} \
+		static void ptr_get(const void *base, void *member) { \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(), member); \
+		} \
+		static void set(Variant *base, const Variant *value, bool &valid) { \
+			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) { \
 				VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<m_member_type>::get(value)); \
-				valid = true;                                                                                                 \
-			} else {                                                                                                          \
-				valid = false;                                                                                                \
-			}                                                                                                                 \
-		}                                                                                                                     \
-		static inline void validated_set(Variant *base, const Variant *value) {                                               \
-			VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<m_member_type>::get(value));     \
-		}                                                                                                                     \
-		static void ptr_set(void *base, const void *member) {                                                                 \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                             \
-			b.m_setter(PtrToArg<m_member_type>::convert(member));                                                             \
-			PtrToArg<m_base_type>::encode(b, base);                                                                           \
-		}                                                                                                                     \
-		static Variant::Type get_type() {                                                                                     \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                  \
-		}                                                                                                                     \
+				valid = true; \
+			} else { \
+				valid = false; \
+			} \
+		} \
+		static inline void validated_set(Variant *base, const Variant *value) { \
+			VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<m_member_type>::get(value)); \
+		} \
+		static void ptr_set(void *base, const void *member) { \
+			m_base_type b = PtrToArg<m_base_type>::convert(base); \
+			b.m_setter(PtrToArg<m_member_type>::convert(member)); \
+			PtrToArg<m_base_type>::encode(b, base); \
+		} \
+		static Variant::Type get_type() { \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE; \
+		} \
 	};
 
-#define SETGET_NUMBER_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                   \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                         \
-		static void get(const Variant *base, Variant *member) {                                                               \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                 \
+#define SETGET_NUMBER_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter) \
+	struct VariantSetGet_##m_base_type##_##m_member { \
+		static void get(const Variant *base, Variant *member) { \
+			VariantTypeAdjust<m_member_type>::adjust(member); \
 			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(); \
-		}                                                                                                                     \
-		static inline void validated_get(const Variant *base, Variant *member) {                                              \
+		} \
+		static inline void validated_get(const Variant *base, Variant *member) { \
 			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(); \
-		}                                                                                                                     \
-		static void ptr_get(const void *base, void *member) {                                                                 \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(), member);                         \
-		}                                                                                                                     \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                   \
-			if (value->get_type() == Variant::FLOAT) {                                                                        \
-				VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<double>::get(value));        \
-				valid = true;                                                                                                 \
-			} else if (value->get_type() == Variant::INT) {                                                                   \
-				VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<int64_t>::get(value));       \
-				valid = true;                                                                                                 \
-			} else {                                                                                                          \
-				valid = false;                                                                                                \
-			}                                                                                                                 \
-		}                                                                                                                     \
-		static inline void validated_set(Variant *base, const Variant *value) {                                               \
-			VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<m_member_type>::get(value));     \
-		}                                                                                                                     \
-		static void ptr_set(void *base, const void *member) {                                                                 \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                             \
-			b.m_setter(PtrToArg<m_member_type>::convert(member));                                                             \
-			PtrToArg<m_base_type>::encode(b, base);                                                                           \
-		}                                                                                                                     \
-		static Variant::Type get_type() {                                                                                     \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                  \
-		}                                                                                                                     \
+		} \
+		static void ptr_get(const void *base, void *member) { \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(), member); \
+		} \
+		static void set(Variant *base, const Variant *value, bool &valid) { \
+			if (value->get_type() == Variant::FLOAT) { \
+				VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<double>::get(value)); \
+				valid = true; \
+			} else if (value->get_type() == Variant::INT) { \
+				VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<int64_t>::get(value)); \
+				valid = true; \
+			} else { \
+				valid = false; \
+			} \
+		} \
+		static inline void validated_set(Variant *base, const Variant *value) { \
+			VariantInternalAccessor<m_base_type>::get(base).m_setter(VariantInternalAccessor<m_member_type>::get(value)); \
+		} \
+		static void ptr_set(void *base, const void *member) { \
+			m_base_type b = PtrToArg<m_base_type>::convert(base); \
+			b.m_setter(PtrToArg<m_member_type>::convert(member)); \
+			PtrToArg<m_base_type>::encode(b, base); \
+		} \
+		static Variant::Type get_type() { \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE; \
+		} \
 	};
 
-#define SETGET_STRUCT_FUNC_INDEX(m_base_type, m_member_type, m_member, m_setter, m_getter, m_index)                                    \
-	struct VariantSetGet_##m_base_type##_##m_member {                                                                                  \
-		static void get(const Variant *base, Variant *member) {                                                                        \
-			VariantTypeAdjust<m_member_type>::adjust(member);                                                                          \
-			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(m_index);   \
-		}                                                                                                                              \
-		static inline void validated_get(const Variant *base, Variant *member) {                                                       \
-			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(m_index);   \
-		}                                                                                                                              \
-		static void ptr_get(const void *base, void *member) {                                                                          \
-			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(m_index), member);                           \
-		}                                                                                                                              \
-		static void set(Variant *base, const Variant *value, bool &valid) {                                                            \
-			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) {                                                       \
+#define SETGET_STRUCT_FUNC_INDEX(m_base_type, m_member_type, m_member, m_setter, m_getter, m_index) \
+	struct VariantSetGet_##m_base_type##_##m_member { \
+		static void get(const Variant *base, Variant *member) { \
+			VariantTypeAdjust<m_member_type>::adjust(member); \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(m_index); \
+		} \
+		static inline void validated_get(const Variant *base, Variant *member) { \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(m_index); \
+		} \
+		static void ptr_get(const void *base, void *member) { \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(m_index), member); \
+		} \
+		static void set(Variant *base, const Variant *value, bool &valid) { \
+			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) { \
 				VariantInternalAccessor<m_base_type>::get(base).m_setter(m_index, VariantInternalAccessor<m_member_type>::get(value)); \
-				valid = true;                                                                                                          \
-			} else {                                                                                                                   \
-				valid = false;                                                                                                         \
-			}                                                                                                                          \
-		}                                                                                                                              \
-		static inline void validated_set(Variant *base, const Variant *value) {                                                        \
-			VariantInternalAccessor<m_base_type>::get(base).m_setter(m_index, VariantInternalAccessor<m_member_type>::get(value));     \
-		}                                                                                                                              \
-		static void ptr_set(void *base, const void *member) {                                                                          \
-			m_base_type b = PtrToArg<m_base_type>::convert(base);                                                                      \
-			b.m_setter(m_index, PtrToArg<m_member_type>::convert(member));                                                             \
-			PtrToArg<m_base_type>::encode(b, base);                                                                                    \
-		}                                                                                                                              \
-		static Variant::Type get_type() {                                                                                              \
-			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                           \
-		}                                                                                                                              \
+				valid = true; \
+			} else { \
+				valid = false; \
+			} \
+		} \
+		static inline void validated_set(Variant *base, const Variant *value) { \
+			VariantInternalAccessor<m_base_type>::get(base).m_setter(m_index, VariantInternalAccessor<m_member_type>::get(value)); \
+		} \
+		static void ptr_set(void *base, const void *member) { \
+			m_base_type b = PtrToArg<m_base_type>::convert(base); \
+			b.m_setter(m_index, PtrToArg<m_member_type>::convert(member)); \
+			PtrToArg<m_base_type>::encode(b, base); \
+		} \
+		static Variant::Type get_type() { \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE; \
+		} \
 	};
 
 SETGET_NUMBER_STRUCT(Vector2, double, x)

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1269,318 +1269,318 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 	return Variant::NIL;
 }
 
-#define FUNCBINDR(m_func, m_args, m_category)                                                                    \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
+#define FUNCBINDR(m_func, m_args, m_category) \
+	class Func_##m_func { \
+	public: \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args);                              \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args);                                      \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return get_arg_count_helperr(VariantUtilityFunctions::m_func);                                       \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg);                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return get_ret_type_helperr(VariantUtilityFunctions::m_func);                                        \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
+			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, r_error); \
+		} \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) { \
+			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args); \
+		} \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) { \
+			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args); \
+		} \
+		static int get_argument_count() { \
+			return get_arg_count_helperr(VariantUtilityFunctions::m_func); \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg); \
+		} \
+		static Variant::Type get_return_type() { \
+			return get_ret_type_helperr(VariantUtilityFunctions::m_func); \
+		} \
+		static bool has_return_type() { \
+			return true; \
+		} \
+		static bool is_vararg() { \
+			return false; \
+		} \
+		static Variant::UtilityFunctionType get_type() { \
+			return m_category; \
+		} \
+	}; \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
-#define FUNCBINDVR(m_func, m_args, m_category)                                                                          \
-	class Func_##m_func {                                                                                               \
-	public:                                                                                                             \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {        \
-			r_error.error = Callable::CallError::CALL_OK;                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], r_error);                                              \
-		}                                                                                                               \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                            \
-			Callable::CallError ce;                                                                                     \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], ce);                                                   \
-		}                                                                                                               \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                           \
-			Callable::CallError ce;                                                                                     \
+#define FUNCBINDVR(m_func, m_args, m_category) \
+	class Func_##m_func { \
+	public: \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK; \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], r_error); \
+		} \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) { \
+			Callable::CallError ce; \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], ce); \
+		} \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) { \
+			Callable::CallError ce; \
 			PtrToArg<Variant>::encode(VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), ce), ret); \
-		}                                                                                                               \
-		static int get_argument_count() {                                                                               \
-			return 1;                                                                                                   \
-		}                                                                                                               \
-		static Variant::Type get_argument_type(int p_arg) {                                                             \
-			return Variant::NIL;                                                                                        \
-		}                                                                                                               \
-		static Variant::Type get_return_type() {                                                                        \
-			return Variant::NIL;                                                                                        \
-		}                                                                                                               \
-		static bool has_return_type() {                                                                                 \
-			return true;                                                                                                \
-		}                                                                                                               \
-		static bool is_vararg() {                                                                                       \
-			return false;                                                                                               \
-		}                                                                                                               \
-		static Variant::UtilityFunctionType get_type() {                                                                \
-			return m_category;                                                                                          \
-		}                                                                                                               \
-	};                                                                                                                  \
+		} \
+		static int get_argument_count() { \
+			return 1; \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return Variant::NIL; \
+		} \
+		static Variant::Type get_return_type() { \
+			return Variant::NIL; \
+		} \
+		static bool has_return_type() { \
+			return true; \
+		} \
+		static bool is_vararg() { \
+			return false; \
+		} \
+		static Variant::UtilityFunctionType get_type() { \
+			return m_category; \
+		} \
+	}; \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
-#define FUNCBINDVR2(m_func, m_args, m_category)                                                                                    \
-	class Func_##m_func {                                                                                                          \
-	public:                                                                                                                        \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {                   \
-			r_error.error = Callable::CallError::CALL_OK;                                                                          \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], r_error);                                             \
-		}                                                                                                                          \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                       \
-			Callable::CallError ce;                                                                                                \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], ce);                                                  \
-		}                                                                                                                          \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                      \
-			Callable::CallError ce;                                                                                                \
-			Variant r;                                                                                                             \
+#define FUNCBINDVR2(m_func, m_args, m_category) \
+	class Func_##m_func { \
+	public: \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK; \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], r_error); \
+		} \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) { \
+			Callable::CallError ce; \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], ce); \
+		} \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) { \
+			Callable::CallError ce; \
+			Variant r; \
 			r = VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), PtrToArg<Variant>::convert(p_args[1]), ce); \
-			PtrToArg<Variant>::encode(r, ret);                                                                                     \
-		}                                                                                                                          \
-		static int get_argument_count() {                                                                                          \
-			return 2;                                                                                                              \
-		}                                                                                                                          \
-		static Variant::Type get_argument_type(int p_arg) {                                                                        \
-			return Variant::NIL;                                                                                                   \
-		}                                                                                                                          \
-		static Variant::Type get_return_type() {                                                                                   \
-			return Variant::NIL;                                                                                                   \
-		}                                                                                                                          \
-		static bool has_return_type() {                                                                                            \
-			return true;                                                                                                           \
-		}                                                                                                                          \
-		static bool is_vararg() {                                                                                                  \
-			return false;                                                                                                          \
-		}                                                                                                                          \
-		static Variant::UtilityFunctionType get_type() {                                                                           \
-			return m_category;                                                                                                     \
-		}                                                                                                                          \
-	};                                                                                                                             \
+			PtrToArg<Variant>::encode(r, ret); \
+		} \
+		static int get_argument_count() { \
+			return 2; \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return Variant::NIL; \
+		} \
+		static Variant::Type get_return_type() { \
+			return Variant::NIL; \
+		} \
+		static bool has_return_type() { \
+			return true; \
+		} \
+		static bool is_vararg() { \
+			return false; \
+		} \
+		static Variant::UtilityFunctionType get_type() { \
+			return m_category; \
+		} \
+	}; \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
-#define FUNCBINDVR3(m_func, m_args, m_category)                                                                                                                           \
-	class Func_##m_func {                                                                                                                                                 \
-	public:                                                                                                                                                               \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {                                                          \
-			r_error.error = Callable::CallError::CALL_OK;                                                                                                                 \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], *p_args[2], r_error);                                                                        \
-		}                                                                                                                                                                 \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                                              \
-			Callable::CallError ce;                                                                                                                                       \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], *p_args[2], ce);                                                                             \
-		}                                                                                                                                                                 \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                                             \
-			Callable::CallError ce;                                                                                                                                       \
-			Variant r;                                                                                                                                                    \
+#define FUNCBINDVR3(m_func, m_args, m_category) \
+	class Func_##m_func { \
+	public: \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK; \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], *p_args[2], r_error); \
+		} \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) { \
+			Callable::CallError ce; \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], *p_args[2], ce); \
+		} \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) { \
+			Callable::CallError ce; \
+			Variant r; \
 			r = VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), PtrToArg<Variant>::convert(p_args[1]), PtrToArg<Variant>::convert(p_args[2]), ce); \
-			PtrToArg<Variant>::encode(r, ret);                                                                                                                            \
-		}                                                                                                                                                                 \
-		static int get_argument_count() {                                                                                                                                 \
-			return 3;                                                                                                                                                     \
-		}                                                                                                                                                                 \
-		static Variant::Type get_argument_type(int p_arg) {                                                                                                               \
-			return Variant::NIL;                                                                                                                                          \
-		}                                                                                                                                                                 \
-		static Variant::Type get_return_type() {                                                                                                                          \
-			return Variant::NIL;                                                                                                                                          \
-		}                                                                                                                                                                 \
-		static bool has_return_type() {                                                                                                                                   \
-			return true;                                                                                                                                                  \
-		}                                                                                                                                                                 \
-		static bool is_vararg() {                                                                                                                                         \
-			return false;                                                                                                                                                 \
-		}                                                                                                                                                                 \
-		static Variant::UtilityFunctionType get_type() {                                                                                                                  \
-			return m_category;                                                                                                                                            \
-		}                                                                                                                                                                 \
-	};                                                                                                                                                                    \
+			PtrToArg<Variant>::encode(r, ret); \
+		} \
+		static int get_argument_count() { \
+			return 3; \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return Variant::NIL; \
+		} \
+		static Variant::Type get_return_type() { \
+			return Variant::NIL; \
+		} \
+		static bool has_return_type() { \
+			return true; \
+		} \
+		static bool is_vararg() { \
+			return false; \
+		} \
+		static Variant::UtilityFunctionType get_type() { \
+			return m_category; \
+		} \
+	}; \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
-#define FUNCBINDVARARG(m_func, m_args, m_category)                                                               \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
+#define FUNCBINDVARARG(m_func, m_args, m_category) \
+	class Func_##m_func { \
+	public: \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                     \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-			PtrToArg<Variant>::encode(r, ret);                                                                   \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 2;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
+			r_error.error = Callable::CallError::CALL_OK; \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error); \
+		} \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) { \
+			Callable::CallError c; \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c); \
+		} \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) { \
+			Vector<Variant> args; \
+			for (int i = 0; i < p_argcount; i++) { \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i])); \
+			} \
+			Vector<const Variant *> argsp; \
+			for (int i = 0; i < p_argcount; i++) { \
+				argsp.push_back(&args[i]); \
+			} \
+			Variant r; \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount); \
+			PtrToArg<Variant>::encode(r, ret); \
+		} \
+		static int get_argument_count() { \
+			return 2; \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return Variant::NIL; \
+		} \
+		static Variant::Type get_return_type() { \
+			return Variant::NIL; \
+		} \
+		static bool has_return_type() { \
+			return true; \
+		} \
+		static bool is_vararg() { \
+			return true; \
+		} \
+		static Variant::UtilityFunctionType get_type() { \
+			return m_category; \
+		} \
+	}; \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
-#define FUNCBINDVARARGS(m_func, m_args, m_category)                                                              \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
+#define FUNCBINDVARARGS(m_func, m_args, m_category) \
+	class Func_##m_func { \
+	public: \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                     \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-			PtrToArg<String>::encode(r.operator String(), ret);                                                  \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 1;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::STRING;                                                                              \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
+			r_error.error = Callable::CallError::CALL_OK; \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error); \
+		} \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) { \
+			Callable::CallError c; \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c); \
+		} \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) { \
+			Vector<Variant> args; \
+			for (int i = 0; i < p_argcount; i++) { \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i])); \
+			} \
+			Vector<const Variant *> argsp; \
+			for (int i = 0; i < p_argcount; i++) { \
+				argsp.push_back(&args[i]); \
+			} \
+			Variant r; \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount); \
+			PtrToArg<String>::encode(r.operator String(), ret); \
+		} \
+		static int get_argument_count() { \
+			return 1; \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return Variant::NIL; \
+		} \
+		static Variant::Type get_return_type() { \
+			return Variant::STRING; \
+		} \
+		static bool has_return_type() { \
+			return true; \
+		} \
+		static bool is_vararg() { \
+			return true; \
+		} \
+		static Variant::UtilityFunctionType get_type() { \
+			return m_category; \
+		} \
+	}; \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
-#define FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category)                                          \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
+#define FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category) \
+	class Func_##m_func { \
+	public: \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, r_error);                                  \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, c);                                        \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 1;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
+			r_error.error = Callable::CallError::CALL_OK; \
+			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, r_error); \
+		} \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) { \
+			Callable::CallError c; \
+			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, c); \
+		} \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) { \
+			Vector<Variant> args; \
+			for (int i = 0; i < p_argcount; i++) { \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i])); \
+			} \
+			Vector<const Variant *> argsp; \
+			for (int i = 0; i < p_argcount; i++) { \
+				argsp.push_back(&args[i]); \
+			} \
+			Variant r; \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount); \
+		} \
+		static int get_argument_count() { \
+			return 1; \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return Variant::NIL; \
+		} \
+		static Variant::Type get_return_type() { \
+			return Variant::NIL; \
+		} \
+		static bool has_return_type() { \
+			return false; \
+		} \
+		static bool is_vararg() { \
+			return true; \
+		} \
+		static Variant::UtilityFunctionType get_type() { \
+			return m_category; \
+		} \
+	}; \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
 #define FUNCBINDVARARGV(m_func, m_args, m_category) FUNCBINDVARARGV_CNAME(m_func, m_func, m_args, m_category)
 
-#define FUNCBIND(m_func, m_args, m_category)                                                                     \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
+#define FUNCBIND(m_func, m_args, m_category) \
+	class Func_##m_func { \
+	public: \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			call_helper(VariantUtilityFunctions::m_func, p_args, r_error);                                       \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			validated_call_helper(VariantUtilityFunctions::m_func, p_args);                                      \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			ptr_call_helper(VariantUtilityFunctions::m_func, p_args);                                            \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return get_arg_count_helper(VariantUtilityFunctions::m_func);                                        \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return get_arg_type_helper(VariantUtilityFunctions::m_func, p_arg);                                  \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return get_ret_type_helper(VariantUtilityFunctions::m_func);                                         \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
+			call_helper(VariantUtilityFunctions::m_func, p_args, r_error); \
+		} \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) { \
+			validated_call_helper(VariantUtilityFunctions::m_func, p_args); \
+		} \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) { \
+			ptr_call_helper(VariantUtilityFunctions::m_func, p_args); \
+		} \
+		static int get_argument_count() { \
+			return get_arg_count_helper(VariantUtilityFunctions::m_func); \
+		} \
+		static Variant::Type get_argument_type(int p_arg) { \
+			return get_arg_type_helper(VariantUtilityFunctions::m_func, p_arg); \
+		} \
+		static Variant::Type get_return_type() { \
+			return get_ret_type_helper(VariantUtilityFunctions::m_func); \
+		} \
+		static bool has_return_type() { \
+			return false; \
+		} \
+		static bool is_vararg() { \
+			return false; \
+		} \
+		static Variant::UtilityFunctionType get_type() { \
+			return m_category; \
+		} \
+	}; \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
 struct VariantUtilityFunctionInfo {

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -62,14 +62,14 @@ Error AudioDriverALSA::init_output_device() {
 	snd_pcm_hw_params_t *hwparams;
 	snd_pcm_sw_params_t *swparams;
 
-#define CHECK_FAIL(m_cond)                                       \
-	if (m_cond) {                                                \
+#define CHECK_FAIL(m_cond) \
+	if (m_cond) { \
 		fprintf(stderr, "ALSA ERR: %s\n", snd_strerror(status)); \
-		if (pcm_handle) {                                        \
-			snd_pcm_close(pcm_handle);                           \
-			pcm_handle = nullptr;                                \
-		}                                                        \
-		ERR_FAIL_COND_V(m_cond, ERR_CANT_OPEN);                  \
+		if (pcm_handle) { \
+			snd_pcm_close(pcm_handle); \
+			pcm_handle = nullptr; \
+		} \
+		ERR_FAIL_COND_V(m_cond, ERR_CANT_OPEN); \
 	}
 
 	//todo, add

--- a/drivers/apple_embedded/platform_config.h
+++ b/drivers/apple_embedded/platform_config.h
@@ -37,8 +37,8 @@
 #define PTHREAD_RENAME_SELF
 
 #define _weakify(var) __weak typeof(var) GDWeak_##var = var;
-#define _strongify(var)                                      \
-	_Pragma("clang diagnostic push")                         \
+#define _strongify(var) \
+	_Pragma("clang diagnostic push") \
 			_Pragma("clang diagnostic ignored \"-Wshadow\"") \
 					__strong typeof(var) var = GDWeak_##var; \
 	_Pragma("clang diagnostic pop")

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -1075,9 +1075,9 @@ public:
 };
 
 namespace rid {
-#define MAKE_ID(FROM, TO)                \
+#define MAKE_ID(FROM, TO) \
 	_FORCE_INLINE_ TO make(FROM p_obj) { \
-		return TO(owned(p_obj));         \
+		return TO(owned(p_obj)); \
 	}
 
 MAKE_ID(id<MTLCommandQueue>, RDD::CommandPoolID)

--- a/drivers/metal/metal_objects_shared.h
+++ b/drivers/metal/metal_objects_shared.h
@@ -38,14 +38,14 @@ using RDC = RenderingDeviceCommons;
 // These types can be used in Vector and other containers that use
 // pointer operations not supported by ARC.
 namespace MTL {
-#define MTL_CLASS(name)                               \
-	class name {                                      \
-	public:                                           \
+#define MTL_CLASS(name) \
+	class name { \
+	public: \
 		name(id<MTL##name> obj = nil) : m_obj(obj) {} \
-		operator id<MTL##name>() const {              \
-			return m_obj;                             \
-		}                                             \
-		id<MTL##name> m_obj;                          \
+		operator id<MTL##name>() const { \
+			return m_obj; \
+		} \
+		id<MTL##name> m_obj; \
 	};
 
 MTL_CLASS(Texture)
@@ -169,9 +169,9 @@ _FORCE_INLINE_ void *owned(id p_id) {
 	return (__bridge_retained void *)p_id;
 }
 
-#define MAKE_ID(FROM, TO)                \
+#define MAKE_ID(FROM, TO) \
 	_FORCE_INLINE_ TO make(FROM p_obj) { \
-		return TO(owned(p_obj));         \
+		return TO(owned(p_obj)); \
 	}
 
 // These are shared for Metal and Metal 4 drivers

--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -279,10 +279,10 @@ PixelFormats::PixelFormats(id<MTLDevice> p_device, const MetalFeatures &p_feat) 
 }
 
 #define addDataFormatDescFull(DATA_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, CSPC, CSCB, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE, SWIZ_R, SWIZ_G, SWIZ_B, SWIZ_A) \
-	dfFmt = RD::DATA_FORMAT_##DATA_FMT;                                                                                                                                           \
-	_data_format_descs[dfFmt] = { dfFmt, MTLPixelFormat##MTL_FMT, MTLPixelFormat##MTL_FMT_ALT, MTLVertexFormat##MTL_VTX_FMT, MTLVertexFormat##MTL_VTX_FMT_ALT,                    \
-		CSPC, CSCB, { BLK_W, BLK_H }, BLK_BYTE_CNT, MTLFormatType::MVK_FMT_TYPE,                                                                                                  \
-		{ RD::TEXTURE_SWIZZLE_##SWIZ_R, RD::TEXTURE_SWIZZLE_##SWIZ_G, RD::TEXTURE_SWIZZLE_##SWIZ_B, RD::TEXTURE_SWIZZLE_##SWIZ_A },                                               \
+	dfFmt = RD::DATA_FORMAT_##DATA_FMT; \
+	_data_format_descs[dfFmt] = { dfFmt, MTLPixelFormat##MTL_FMT, MTLPixelFormat##MTL_FMT_ALT, MTLVertexFormat##MTL_VTX_FMT, MTLVertexFormat##MTL_VTX_FMT_ALT, \
+		CSPC, CSCB, { BLK_W, BLK_H }, BLK_BYTE_CNT, MTLFormatType::MVK_FMT_TYPE, \
+		{ RD::TEXTURE_SWIZZLE_##SWIZ_R, RD::TEXTURE_SWIZZLE_##SWIZ_G, RD::TEXTURE_SWIZZLE_##SWIZ_B, RD::TEXTURE_SWIZZLE_##SWIZ_A }, \
 		"DATA_FORMAT_" #DATA_FMT, false }
 
 #define addDataFormatDesc(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE) \
@@ -582,20 +582,20 @@ void PixelFormats::addMTLPixelFormatDescImpl(MTLPixelFormat p_pix_fmt, MTLPixelF
 	_mtl_pixel_format_descs[p_pix_fmt] = { .mtlPixelFormat = p_pix_fmt, DataFormat::DATA_FORMAT_MAX, p_fmt_caps, p_view_class, p_pix_fmt_linear, p_name };
 }
 
-#define addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleGPUCaps)                             \
+#define addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleGPUCaps) \
 	addMTLPixelFormatDescImpl(MTLPixelFormat##mtlFmt, MTLPixelFormat##mtlFmtLinear, MTLViewClass::viewClass, \
 			appleGPUCaps, "MTLPixelFormat" #mtlFmt)
 
 #define addMTLPixelFormatDesc(mtlFmt, viewClass, appleGPUCaps) \
 	addMTLPixelFormatDescFull(mtlFmt, mtlFmt, viewClass, kMTLFmtCaps##appleGPUCaps)
 
-#define addMTLPixelFormatDescSRGB(mtlFmt, viewClass, appleGPUCaps, mtlFmtLinear)               \
-	/* Cannot write to sRGB textures in the simulator */                                       \
-	if (TARGET_OS_SIMULATOR) {                                                                 \
-		MTLFmtCaps appleFmtCaps = kMTLFmtCaps##appleGPUCaps;                                   \
-		flags::clear(appleFmtCaps, kMTLFmtCapsWrite);                                          \
-		addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleFmtCaps);              \
-	} else {                                                                                   \
+#define addMTLPixelFormatDescSRGB(mtlFmt, viewClass, appleGPUCaps, mtlFmtLinear) \
+	/* Cannot write to sRGB textures in the simulator */ \
+	if (TARGET_OS_SIMULATOR) { \
+		MTLFmtCaps appleFmtCaps = kMTLFmtCaps##appleGPUCaps; \
+		flags::clear(appleFmtCaps, kMTLFmtCapsWrite); \
+		addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleFmtCaps); \
+	} else { \
 		addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, kMTLFmtCaps##appleGPUCaps); \
 	}
 
@@ -787,8 +787,8 @@ void PixelFormats::addMTLVertexFormatDescImpl(MTLVertexFormat mtlVtxFmt, MTLFmtC
 }
 
 // Check mtlVtx exists on platform, to avoid overwriting the MTLVertexFormatInvalid entry.
-#define addMTLVertexFormatDesc(mtlVtx)                                                                     \
-	if (MTLVertexFormat##mtlVtx) {                                                                         \
+#define addMTLVertexFormatDesc(mtlVtx) \
+	if (MTLVertexFormat##mtlVtx) { \
 		addMTLVertexFormatDescImpl(MTLVertexFormat##mtlVtx, kMTLFmtCapsVertex, "MTLVertexFormat" #mtlVtx); \
 	}
 

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -2485,13 +2485,13 @@ uint64_t RenderingDeviceDriverMetal::limit_get(Limit p_limit) {
 	MetalLimits const &limits = props.limits;
 	uint64_t safe_unbounded = ((uint64_t)1 << 30);
 #if defined(DEV_ENABLED)
-#define UNKNOWN(NAME)                                                            \
-	case NAME:                                                                   \
+#define UNKNOWN(NAME) \
+	case NAME: \
 		WARN_PRINT_ONCE("Returning maximum value for unknown limit " #NAME "."); \
 		return safe_unbounded;
 #else
 #define UNKNOWN(NAME) \
-	case NAME:        \
+	case NAME: \
 		return safe_unbounded
 #endif
 

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -47,9 +47,9 @@ JoypadSDL *JoypadSDL::singleton = nullptr;
 
 // Macro to skip the SDL joystick event handling if the device is an SDL gamepad, because
 // there are separate events for SDL gamepads
-#define SKIP_EVENT_FOR_GAMEPAD                    \
+#define SKIP_EVENT_FOR_GAMEPAD \
 	if (SDL_IsGamepad(sdl_event.jdevice.which)) { \
-		continue;                                 \
+		continue; \
 	}
 
 JoypadSDL::JoypadSDL() {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -711,23 +711,23 @@ PackedByteArray OS_Unix::string_to_multibyte(const String &p_encoding, const Str
 }
 
 Dictionary OS_Unix::execute_with_pipe(const String &p_path, const List<String> &p_arguments, bool p_blocking) {
-#define CLEAN_PIPES           \
-	if (pipe_in[0] >= 0) {    \
-		::close(pipe_in[0]);  \
-	}                         \
-	if (pipe_in[1] >= 0) {    \
-		::close(pipe_in[1]);  \
-	}                         \
-	if (pipe_out[0] >= 0) {   \
+#define CLEAN_PIPES \
+	if (pipe_in[0] >= 0) { \
+		::close(pipe_in[0]); \
+	} \
+	if (pipe_in[1] >= 0) { \
+		::close(pipe_in[1]); \
+	} \
+	if (pipe_out[0] >= 0) { \
 		::close(pipe_out[0]); \
-	}                         \
-	if (pipe_out[1] >= 0) {   \
+	} \
+	if (pipe_out[1] >= 0) { \
 		::close(pipe_out[1]); \
-	}                         \
-	if (pipe_err[0] >= 0) {   \
+	} \
+	if (pipe_err[0] >= 0) { \
 		::close(pipe_err[0]); \
-	}                         \
-	if (pipe_err[1] >= 0) {   \
+	} \
+	if (pipe_err[1] >= 0) { \
 		::close(pipe_err[1]); \
 	}
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -738,10 +738,10 @@ Error RenderingDeviceDriverVulkan::_check_device_features() {
 	// - sparseResidencyAliased
 	// - inheritedQueries
 
-#define VK_DEVICEFEATURE_ENABLE_IF(x)                             \
-	if (physical_device_features.x) {                             \
+#define VK_DEVICEFEATURE_ENABLE_IF(x) \
+	if (physical_device_features.x) { \
 		requested_device_features.x = physical_device_features.x; \
-	} else                                                        \
+	} else \
 		((void)0)
 
 	requested_device_features = {};

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -110,10 +110,10 @@ const IID IID_IAudioClient3 = __uuidof(IAudioClient3);
 const IID IID_IAudioRenderClient = __uuidof(IAudioRenderClient);
 const IID IID_IAudioCaptureClient = __uuidof(IAudioCaptureClient);
 
-#define SAFE_RELEASE(memory)   \
+#define SAFE_RELEASE(memory) \
 	if ((memory) != nullptr) { \
-		(memory)->Release();   \
-		(memory) = nullptr;    \
+		(memory)->Release(); \
+		(memory) = nullptr; \
 	}
 
 #define REFTIMES_PER_SEC 10000000

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -488,56 +488,56 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &
 
 // Macros for assigning the deprecated/experimental marks to class members in overview.
 
-#define DEPRECATED_DOC_TAG                                                                   \
-	class_desc->push_font(theme_cache.doc_bold_font);                                        \
+#define DEPRECATED_DOC_TAG \
+	class_desc->push_font(theme_cache.doc_bold_font); \
 	class_desc->push_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor))); \
-	Ref<Texture2D> error_icon = get_editor_theme_icon(SNAME("StatusError"));                 \
-	class_desc->add_image(error_icon, error_icon->get_width(), error_icon->get_height());    \
-	class_desc->add_text(String::chr(160) + TTR("Deprecated"));                              \
-	class_desc->pop();                                                                       \
+	Ref<Texture2D> error_icon = get_editor_theme_icon(SNAME("StatusError")); \
+	class_desc->add_image(error_icon, error_icon->get_width(), error_icon->get_height()); \
+	class_desc->add_text(String::chr(160) + TTR("Deprecated")); \
+	class_desc->pop(); \
 	class_desc->pop();
 
-#define EXPERIMENTAL_DOC_TAG                                                                    \
-	class_desc->push_font(theme_cache.doc_bold_font);                                           \
-	class_desc->push_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));  \
-	Ref<Texture2D> warning_icon = get_editor_theme_icon(SNAME("NodeWarning"));                  \
+#define EXPERIMENTAL_DOC_TAG \
+	class_desc->push_font(theme_cache.doc_bold_font); \
+	class_desc->push_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor))); \
+	Ref<Texture2D> warning_icon = get_editor_theme_icon(SNAME("NodeWarning")); \
 	class_desc->add_image(warning_icon, warning_icon->get_width(), warning_icon->get_height()); \
-	class_desc->add_text(String::chr(160) + TTR("Experimental"));                               \
-	class_desc->pop();                                                                          \
+	class_desc->add_text(String::chr(160) + TTR("Experimental")); \
+	class_desc->pop(); \
 	class_desc->pop();
 
 // Macros for displaying the deprecated/experimental info in class member descriptions.
 
-#define DEPRECATED_DOC_MSG(m_message, m_default_message)                                     \
-	Ref<Texture2D> error_icon = get_editor_theme_icon(SNAME("StatusError"));                 \
-	class_desc->add_image(error_icon, error_icon->get_width(), error_icon->get_height());    \
-	class_desc->add_text(nbsp);                                                              \
+#define DEPRECATED_DOC_MSG(m_message, m_default_message) \
+	Ref<Texture2D> error_icon = get_editor_theme_icon(SNAME("StatusError")); \
+	class_desc->add_image(error_icon, error_icon->get_width(), error_icon->get_height()); \
+	class_desc->add_text(nbsp); \
 	class_desc->push_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor))); \
-	class_desc->push_font(theme_cache.doc_bold_font);                                        \
-	class_desc->add_text(TTR("Deprecated:"));                                                \
-	class_desc->pop();                                                                       \
-	class_desc->pop();                                                                       \
-	class_desc->add_text(" ");                                                               \
-	if ((m_message).is_empty()) {                                                            \
-		class_desc->add_text(m_default_message);                                             \
-	} else {                                                                                 \
-		_add_text(m_message);                                                                \
+	class_desc->push_font(theme_cache.doc_bold_font); \
+	class_desc->add_text(TTR("Deprecated:")); \
+	class_desc->pop(); \
+	class_desc->pop(); \
+	class_desc->add_text(" "); \
+	if ((m_message).is_empty()) { \
+		class_desc->add_text(m_default_message); \
+	} else { \
+		_add_text(m_message); \
 	}
 
-#define EXPERIMENTAL_DOC_MSG(m_message, m_default_message)                                      \
-	Ref<Texture2D> warning_icon = get_editor_theme_icon(SNAME("NodeWarning"));                  \
+#define EXPERIMENTAL_DOC_MSG(m_message, m_default_message) \
+	Ref<Texture2D> warning_icon = get_editor_theme_icon(SNAME("NodeWarning")); \
 	class_desc->add_image(warning_icon, warning_icon->get_width(), warning_icon->get_height()); \
-	class_desc->add_text(nbsp);                                                                 \
-	class_desc->push_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));  \
-	class_desc->push_font(theme_cache.doc_bold_font);                                           \
-	class_desc->add_text(TTR("Experimental:"));                                                 \
-	class_desc->pop();                                                                          \
-	class_desc->pop();                                                                          \
-	class_desc->add_text(" ");                                                                  \
-	if ((m_message).is_empty()) {                                                               \
-		class_desc->add_text(m_default_message);                                                \
-	} else {                                                                                    \
-		_add_text(m_message);                                                                   \
+	class_desc->add_text(nbsp); \
+	class_desc->push_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor))); \
+	class_desc->push_font(theme_cache.doc_bold_font); \
+	class_desc->add_text(TTR("Experimental:")); \
+	class_desc->pop(); \
+	class_desc->pop(); \
+	class_desc->add_text(" "); \
+	if ((m_message).is_empty()) { \
+		class_desc->add_text(m_default_message); \
+	} else { \
+		_add_text(m_message); \
 	}
 
 void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview, bool p_override) {

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -3845,21 +3845,21 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	bool section_ended = false;
 
 // Marks beginning of a new separated section. When used multiple times in a row, only first use has effect.
-#define BEGIN_SECTION()            \
-	{                              \
-		if (section_ended) {       \
+#define BEGIN_SECTION() \
+	{ \
+		if (section_ended) { \
 			section_ended = false; \
 			menu->add_separator(); \
-		}                          \
-		section_started = true;    \
+		} \
+		section_started = true; \
 	}
 // Marks end of a section.
-#define END_SECTION()                \
-	{                                \
-		if (section_started) {       \
-			section_ended = true;    \
+#define END_SECTION() \
+	{ \
+		if (section_started) { \
+			section_ended = true; \
 			section_started = false; \
-		}                            \
+		} \
 	}
 
 	Ref<Script> existing_script;

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -199,11 +199,11 @@ bool CodeSignCodeResources::add_file2(const String &p_root, const String &p_path
 }
 
 bool CodeSignCodeResources::add_nested_file(const String &p_root, const String &p_path, const String &p_exepath) {
-#define CLEANUP()                                       \
-	if (files_to_add.size() > 1) {                      \
+#define CLEANUP() \
+	if (files_to_add.size() > 1) { \
 		for (int j = 0; j < files_to_add.size(); j++) { \
-			da->remove(files_to_add[j]);                \
-		}                                               \
+			da->remove(files_to_add[j]); \
+		} \
 	}
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
@@ -1181,11 +1181,11 @@ PackedByteArray CodeSign::file_hash_sha256(const String &p_path) {
 }
 
 Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const String &p_info, const String &p_exe_path, const String &p_bundle_path, const String &p_ent_path, bool p_ios_bundle, String &r_error_msg) {
-#define CLEANUP()                                        \
-	if (files_to_sign.size() > 1) {                      \
+#define CLEANUP() \
+	if (files_to_sign.size() > 1) { \
 		for (int j = 0; j < files_to_sign.size(); j++) { \
-			da->remove(files_to_sign[j]);                \
-		}                                                \
+			da->remove(files_to_sign[j]); \
+		} \
 	}
 
 	print_verbose(vformat("CodeSign: Signing executable: %s, bundle: %s with entitlements %s", p_exe_path, p_bundle_path, p_ent_path));

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2618,15 +2618,15 @@ Error EditorExportPlatformAppleEmbedded::run(const Ref<EditorExportPreset> &p_pr
 	filesystem_da->make_dir_recursive(EditorPaths::get_singleton()->get_temp_dir().path_join(id));
 	String tmp_export_path = EditorPaths::get_singleton()->get_temp_dir().path_join(id).path_join("export.ipa");
 
-#define CLEANUP_AND_RETURN(m_err)                                                                          \
-	{                                                                                                      \
+#define CLEANUP_AND_RETURN(m_err) \
+	{ \
 		if (filesystem_da->change_dir(EditorPaths::get_singleton()->get_temp_dir().path_join(id)) == OK) { \
-			filesystem_da->erase_contents_recursive();                                                     \
-			filesystem_da->change_dir("..");                                                               \
-			filesystem_da->remove(id);                                                                     \
-		}                                                                                                  \
-		return m_err;                                                                                      \
-	}                                                                                                      \
+			filesystem_da->erase_contents_recursive(); \
+			filesystem_da->change_dir(".."); \
+			filesystem_da->remove(id); \
+		} \
+		return m_err; \
+	} \
 	((void)0)
 
 	Device dev = devices[p_device];

--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -431,27 +431,27 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 				Vector3(x0 * zr0, z0, y0 * zr0)
 			};
 
-#define ADD_POINT(m_idx)                                                                               \
-	normals.push_back(v[m_idx]);                                                                       \
-	vertices.push_back(v[m_idx] * radius);                                                             \
-	{                                                                                                  \
-		Vector2 uv;                                                                                    \
-		if (j >= lons / 2) {                                                                           \
+#define ADD_POINT(m_idx) \
+	normals.push_back(v[m_idx]); \
+	vertices.push_back(v[m_idx] * radius); \
+	{ \
+		Vector2 uv; \
+		if (j >= lons / 2) { \
 			uv = Vector2(Math::atan2(-v[m_idx].x, -v[m_idx].z), Math::atan2(v[m_idx].y, -v[m_idx].z)); \
-		} else {                                                                                       \
-			uv = Vector2(Math::atan2(v[m_idx].x, v[m_idx].z), Math::atan2(-v[m_idx].y, v[m_idx].z));   \
-		}                                                                                              \
-		uv /= Math::PI;                                                                                \
-		uv *= 4.0;                                                                                     \
-		uv = uv * 0.5 + Vector2(0.5, 0.5);                                                             \
-		uvs.push_back(uv);                                                                             \
-	}                                                                                                  \
-	{                                                                                                  \
-		Vector3 t = tt.xform(v[m_idx]);                                                                \
-		tangents.push_back(t.x);                                                                       \
-		tangents.push_back(t.y);                                                                       \
-		tangents.push_back(t.z);                                                                       \
-		tangents.push_back(1.0);                                                                       \
+		} else { \
+			uv = Vector2(Math::atan2(v[m_idx].x, v[m_idx].z), Math::atan2(-v[m_idx].y, v[m_idx].z)); \
+		} \
+		uv /= Math::PI; \
+		uv *= 4.0; \
+		uv = uv * 0.5 + Vector2(0.5, 0.5); \
+		uvs.push_back(uv); \
+	} \
+	{ \
+		Vector3 t = tt.xform(v[m_idx]); \
+		tangents.push_back(t.x); \
+		tangents.push_back(t.y); \
+		tangents.push_back(t.z); \
+		tangents.push_back(1.0); \
 	}
 
 			ADD_POINT(0);

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -627,20 +627,20 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	TreeItem *root = tile_data_editors_tree->create_item();
 
 	TreeItem *group;
-#define ADD_TILE_DATA_EDITOR_GROUP(text)               \
+#define ADD_TILE_DATA_EDITOR_GROUP(text) \
 	group = tile_data_editors_tree->create_item(root); \
-	group->set_custom_bg_color(0, group_color);        \
-	group->set_selectable(0, false);                   \
-	group->set_disable_folding(true);                  \
+	group->set_custom_bg_color(0, group_color); \
+	group->set_selectable(0, false); \
+	group->set_disable_folding(true); \
 	group->set_text(0, text);
 
 	TreeItem *item;
-#define ADD_TILE_DATA_EDITOR(parent, text, property)    \
+#define ADD_TILE_DATA_EDITOR(parent, text, property) \
 	item = tile_data_editors_tree->create_item(parent); \
-	item->set_text(0, text);                            \
-	item->set_metadata(0, property);                    \
-	if (property == previously_selected) {              \
-		item->select(0);                                \
+	item->set_text(0, text); \
+	item->set_metadata(0, property); \
+	if (property == previously_selected) { \
+		item->select(0); \
 	}
 
 	// Theming.

--- a/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
@@ -164,14 +164,14 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 				radius = MIN(radius, player->get_max_distance());
 			}
 
-#define PUSH_QUARTER_XY(m_from_x, m_from_y, m_to_x, m_to_y, m_y)   \
-	points_ptrw[index++] = Vector3(m_from_x, -m_from_y - m_y, 0);  \
-	points_ptrw[index++] = Vector3(m_to_x, -m_to_y - m_y, 0);      \
-	points_ptrw[index++] = Vector3(m_from_x, m_from_y + m_y, 0);   \
-	points_ptrw[index++] = Vector3(m_to_x, m_to_y + m_y, 0);       \
+#define PUSH_QUARTER_XY(m_from_x, m_from_y, m_to_x, m_to_y, m_y) \
+	points_ptrw[index++] = Vector3(m_from_x, -m_from_y - m_y, 0); \
+	points_ptrw[index++] = Vector3(m_to_x, -m_to_y - m_y, 0); \
+	points_ptrw[index++] = Vector3(m_from_x, m_from_y + m_y, 0); \
+	points_ptrw[index++] = Vector3(m_to_x, m_to_y + m_y, 0); \
 	points_ptrw[index++] = Vector3(-m_from_x, -m_from_y - m_y, 0); \
-	points_ptrw[index++] = Vector3(-m_to_x, -m_to_y - m_y, 0);     \
-	points_ptrw[index++] = Vector3(-m_from_x, m_from_y + m_y, 0);  \
+	points_ptrw[index++] = Vector3(-m_to_x, -m_to_y - m_y, 0); \
+	points_ptrw[index++] = Vector3(-m_from_x, m_from_y + m_y, 0); \
 	points_ptrw[index++] = Vector3(-m_to_x, m_to_y + m_y, 0);
 
 			// Number of points in an octant. So there will be 8 * points_in_octant points in total.
@@ -252,14 +252,14 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			uint32_t index = 0;
 			float previous_x = radius;
 			float previous_y = 0.f;
-#define PUSH_QUARTER(m_from_x, m_from_y, m_to_x, m_to_y, m_y)  \
-	points_ptrw[index++] = Vector3(m_from_x, -m_from_y, m_y);  \
-	points_ptrw[index++] = Vector3(m_to_x, -m_to_y, m_y);      \
-	points_ptrw[index++] = Vector3(m_from_x, m_from_y, m_y);   \
-	points_ptrw[index++] = Vector3(m_to_x, m_to_y, m_y);       \
+#define PUSH_QUARTER(m_from_x, m_from_y, m_to_x, m_to_y, m_y) \
+	points_ptrw[index++] = Vector3(m_from_x, -m_from_y, m_y); \
+	points_ptrw[index++] = Vector3(m_to_x, -m_to_y, m_y); \
+	points_ptrw[index++] = Vector3(m_from_x, m_from_y, m_y); \
+	points_ptrw[index++] = Vector3(m_to_x, m_to_y, m_y); \
 	points_ptrw[index++] = Vector3(-m_from_x, -m_from_y, m_y); \
-	points_ptrw[index++] = Vector3(-m_to_x, -m_to_y, m_y);     \
-	points_ptrw[index++] = Vector3(-m_from_x, m_from_y, m_y);  \
+	points_ptrw[index++] = Vector3(-m_to_x, -m_to_y, m_y); \
+	points_ptrw[index++] = Vector3(-m_from_x, m_from_y, m_y); \
 	points_ptrw[index++] = Vector3(-m_to_x, m_to_y, m_y);
 
 			for (uint32_t i = 0; i < points_in_octant; i++) {

--- a/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
@@ -153,25 +153,25 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	const Size2 size_factor = viewport_aspect > 1.0 ? Size2(1.0, 1.0 / viewport_aspect) : Size2(viewport_aspect, 1.0);
 
 #define ADD_TRIANGLE(m_a, m_b, m_c) \
-	{                               \
-		lines.push_back(m_a);       \
-		lines.push_back(m_b);       \
-		lines.push_back(m_b);       \
-		lines.push_back(m_c);       \
-		lines.push_back(m_c);       \
-		lines.push_back(m_a);       \
+	{ \
+		lines.push_back(m_a); \
+		lines.push_back(m_b); \
+		lines.push_back(m_b); \
+		lines.push_back(m_c); \
+		lines.push_back(m_c); \
+		lines.push_back(m_a); \
 	}
 
 #define ADD_QUAD(m_a, m_b, m_c, m_d) \
-	{                                \
-		lines.push_back(m_a);        \
-		lines.push_back(m_b);        \
-		lines.push_back(m_b);        \
-		lines.push_back(m_c);        \
-		lines.push_back(m_c);        \
-		lines.push_back(m_d);        \
-		lines.push_back(m_d);        \
-		lines.push_back(m_a);        \
+	{ \
+		lines.push_back(m_a); \
+		lines.push_back(m_b); \
+		lines.push_back(m_b); \
+		lines.push_back(m_c); \
+		lines.push_back(m_c); \
+		lines.push_back(m_d); \
+		lines.push_back(m_d); \
+		lines.push_back(m_a); \
 	}
 
 	switch (camera->get_projection()) {

--- a/editor/scene/3d/gizmos/gpu_particles_collision_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/gpu_particles_collision_3d_gizmo_plugin.cpp
@@ -168,34 +168,34 @@ void GPUParticlesCollision3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	if (Object::cast_to<GPUParticlesCollisionSphere3D>(cs) || Object::cast_to<GPUParticlesAttractorSphere3D>(cs)) {
 		float radius = cs->call("get_radius");
 
-#define PUSH_QUARTER(m_from_x, m_from_y, m_to_x, m_to_y, m_y)  \
-	points_ptrw[index++] = Vector3(m_from_x, m_y, m_from_y);   \
-	points_ptrw[index++] = Vector3(m_to_x, m_y, m_to_y);       \
-	points_ptrw[index++] = Vector3(m_from_x, m_y, -m_from_y);  \
-	points_ptrw[index++] = Vector3(m_to_x, m_y, -m_to_y);      \
-	points_ptrw[index++] = Vector3(-m_from_x, m_y, m_from_y);  \
-	points_ptrw[index++] = Vector3(-m_to_x, m_y, m_to_y);      \
+#define PUSH_QUARTER(m_from_x, m_from_y, m_to_x, m_to_y, m_y) \
+	points_ptrw[index++] = Vector3(m_from_x, m_y, m_from_y); \
+	points_ptrw[index++] = Vector3(m_to_x, m_y, m_to_y); \
+	points_ptrw[index++] = Vector3(m_from_x, m_y, -m_from_y); \
+	points_ptrw[index++] = Vector3(m_to_x, m_y, -m_to_y); \
+	points_ptrw[index++] = Vector3(-m_from_x, m_y, m_from_y); \
+	points_ptrw[index++] = Vector3(-m_to_x, m_y, m_to_y); \
 	points_ptrw[index++] = Vector3(-m_from_x, m_y, -m_from_y); \
 	points_ptrw[index++] = Vector3(-m_to_x, m_y, -m_to_y);
 
-#define PUSH_QUARTER_XY(m_from_x, m_from_y, m_to_x, m_to_y)  \
-	points_ptrw[index++] = Vector3(m_from_x, -m_from_y, 0);  \
-	points_ptrw[index++] = Vector3(m_to_x, -m_to_y, 0);      \
-	points_ptrw[index++] = Vector3(m_from_x, m_from_y, 0);   \
-	points_ptrw[index++] = Vector3(m_to_x, m_to_y, 0);       \
+#define PUSH_QUARTER_XY(m_from_x, m_from_y, m_to_x, m_to_y) \
+	points_ptrw[index++] = Vector3(m_from_x, -m_from_y, 0); \
+	points_ptrw[index++] = Vector3(m_to_x, -m_to_y, 0); \
+	points_ptrw[index++] = Vector3(m_from_x, m_from_y, 0); \
+	points_ptrw[index++] = Vector3(m_to_x, m_to_y, 0); \
 	points_ptrw[index++] = Vector3(-m_from_x, -m_from_y, 0); \
-	points_ptrw[index++] = Vector3(-m_to_x, -m_to_y, 0);     \
-	points_ptrw[index++] = Vector3(-m_from_x, m_from_y, 0);  \
+	points_ptrw[index++] = Vector3(-m_to_x, -m_to_y, 0); \
+	points_ptrw[index++] = Vector3(-m_from_x, m_from_y, 0); \
 	points_ptrw[index++] = Vector3(-m_to_x, m_to_y, 0);
 
-#define PUSH_QUARTER_YZ(m_from_x, m_from_y, m_to_x, m_to_y)  \
-	points_ptrw[index++] = Vector3(0, -m_from_y, m_from_x);  \
-	points_ptrw[index++] = Vector3(0, -m_to_y, m_to_x);      \
-	points_ptrw[index++] = Vector3(0, m_from_y, m_from_x);   \
-	points_ptrw[index++] = Vector3(0, m_to_y, m_to_x);       \
+#define PUSH_QUARTER_YZ(m_from_x, m_from_y, m_to_x, m_to_y) \
+	points_ptrw[index++] = Vector3(0, -m_from_y, m_from_x); \
+	points_ptrw[index++] = Vector3(0, -m_to_y, m_to_x); \
+	points_ptrw[index++] = Vector3(0, m_from_y, m_from_x); \
+	points_ptrw[index++] = Vector3(0, m_to_y, m_to_x); \
 	points_ptrw[index++] = Vector3(0, -m_from_y, -m_from_x); \
-	points_ptrw[index++] = Vector3(0, -m_to_y, -m_to_x);     \
-	points_ptrw[index++] = Vector3(0, m_from_y, -m_from_x);  \
+	points_ptrw[index++] = Vector3(0, -m_to_y, -m_to_x); \
+	points_ptrw[index++] = Vector3(0, m_from_y, -m_from_x); \
 	points_ptrw[index++] = Vector3(0, m_to_y, -m_to_x);
 
 		// Number of points in an octant. So there will be 8 * points_in_octant points in total.

--- a/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
@@ -333,34 +333,34 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Ref<SphereShape3D> sp = s;
 		float radius = sp->get_radius();
 
-#define PUSH_QUARTER(from_x, from_y, to_x, to_y, y)      \
-	points_ptrw[index++] = Vector3(from_x, y, from_y);   \
-	points_ptrw[index++] = Vector3(to_x, y, to_y);       \
-	points_ptrw[index++] = Vector3(from_x, y, -from_y);  \
-	points_ptrw[index++] = Vector3(to_x, y, -to_y);      \
-	points_ptrw[index++] = Vector3(-from_x, y, from_y);  \
-	points_ptrw[index++] = Vector3(-to_x, y, to_y);      \
+#define PUSH_QUARTER(from_x, from_y, to_x, to_y, y) \
+	points_ptrw[index++] = Vector3(from_x, y, from_y); \
+	points_ptrw[index++] = Vector3(to_x, y, to_y); \
+	points_ptrw[index++] = Vector3(from_x, y, -from_y); \
+	points_ptrw[index++] = Vector3(to_x, y, -to_y); \
+	points_ptrw[index++] = Vector3(-from_x, y, from_y); \
+	points_ptrw[index++] = Vector3(-to_x, y, to_y); \
 	points_ptrw[index++] = Vector3(-from_x, y, -from_y); \
 	points_ptrw[index++] = Vector3(-to_x, y, -to_y);
 
-#define PUSH_QUARTER_XY(from_x, from_y, to_x, to_y, y)       \
-	points_ptrw[index++] = Vector3(from_x, -from_y - y, 0);  \
-	points_ptrw[index++] = Vector3(to_x, -to_y - y, 0);      \
-	points_ptrw[index++] = Vector3(from_x, from_y + y, 0);   \
-	points_ptrw[index++] = Vector3(to_x, to_y + y, 0);       \
+#define PUSH_QUARTER_XY(from_x, from_y, to_x, to_y, y) \
+	points_ptrw[index++] = Vector3(from_x, -from_y - y, 0); \
+	points_ptrw[index++] = Vector3(to_x, -to_y - y, 0); \
+	points_ptrw[index++] = Vector3(from_x, from_y + y, 0); \
+	points_ptrw[index++] = Vector3(to_x, to_y + y, 0); \
 	points_ptrw[index++] = Vector3(-from_x, -from_y - y, 0); \
-	points_ptrw[index++] = Vector3(-to_x, -to_y - y, 0);     \
-	points_ptrw[index++] = Vector3(-from_x, from_y + y, 0);  \
+	points_ptrw[index++] = Vector3(-to_x, -to_y - y, 0); \
+	points_ptrw[index++] = Vector3(-from_x, from_y + y, 0); \
 	points_ptrw[index++] = Vector3(-to_x, to_y + y, 0);
 
-#define PUSH_QUARTER_YZ(from_x, from_y, to_x, to_y, y)       \
-	points_ptrw[index++] = Vector3(0, -from_y - y, from_x);  \
-	points_ptrw[index++] = Vector3(0, -to_y - y, to_x);      \
-	points_ptrw[index++] = Vector3(0, from_y + y, from_x);   \
-	points_ptrw[index++] = Vector3(0, to_y + y, to_x);       \
+#define PUSH_QUARTER_YZ(from_x, from_y, to_x, to_y, y) \
+	points_ptrw[index++] = Vector3(0, -from_y - y, from_x); \
+	points_ptrw[index++] = Vector3(0, -to_y - y, to_x); \
+	points_ptrw[index++] = Vector3(0, from_y + y, from_x); \
+	points_ptrw[index++] = Vector3(0, to_y + y, to_x); \
 	points_ptrw[index++] = Vector3(0, -from_y - y, -from_x); \
-	points_ptrw[index++] = Vector3(0, -to_y - y, -to_x);     \
-	points_ptrw[index++] = Vector3(0, from_y + y, -from_x);  \
+	points_ptrw[index++] = Vector3(0, -to_y - y, -to_x); \
+	points_ptrw[index++] = Vector3(0, from_y + y, -from_x); \
 	points_ptrw[index++] = Vector3(0, to_y + y, -to_x);
 
 		// Number of points in an octant. So there will be 8 * points_in_octant * 2 points in total for one circle.
@@ -459,34 +459,34 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		points_ptrw[index++] = Vector3(-radius, y_value, 0.f);
 		points_ptrw[index++] = Vector3(-radius, -y_value, 0.f);
 
-#define PUSH_QUARTER(from_x, from_y, to_x, to_y, y)      \
-	points_ptrw[index++] = Vector3(from_x, y, from_y);   \
-	points_ptrw[index++] = Vector3(to_x, y, to_y);       \
-	points_ptrw[index++] = Vector3(from_x, y, -from_y);  \
-	points_ptrw[index++] = Vector3(to_x, y, -to_y);      \
-	points_ptrw[index++] = Vector3(-from_x, y, from_y);  \
-	points_ptrw[index++] = Vector3(-to_x, y, to_y);      \
+#define PUSH_QUARTER(from_x, from_y, to_x, to_y, y) \
+	points_ptrw[index++] = Vector3(from_x, y, from_y); \
+	points_ptrw[index++] = Vector3(to_x, y, to_y); \
+	points_ptrw[index++] = Vector3(from_x, y, -from_y); \
+	points_ptrw[index++] = Vector3(to_x, y, -to_y); \
+	points_ptrw[index++] = Vector3(-from_x, y, from_y); \
+	points_ptrw[index++] = Vector3(-to_x, y, to_y); \
 	points_ptrw[index++] = Vector3(-from_x, y, -from_y); \
 	points_ptrw[index++] = Vector3(-to_x, y, -to_y);
 
-#define PUSH_QUARTER_XY(from_x, from_y, to_x, to_y, y)       \
-	points_ptrw[index++] = Vector3(from_x, -from_y - y, 0);  \
-	points_ptrw[index++] = Vector3(to_x, -to_y - y, 0);      \
-	points_ptrw[index++] = Vector3(from_x, from_y + y, 0);   \
-	points_ptrw[index++] = Vector3(to_x, to_y + y, 0);       \
+#define PUSH_QUARTER_XY(from_x, from_y, to_x, to_y, y) \
+	points_ptrw[index++] = Vector3(from_x, -from_y - y, 0); \
+	points_ptrw[index++] = Vector3(to_x, -to_y - y, 0); \
+	points_ptrw[index++] = Vector3(from_x, from_y + y, 0); \
+	points_ptrw[index++] = Vector3(to_x, to_y + y, 0); \
 	points_ptrw[index++] = Vector3(-from_x, -from_y - y, 0); \
-	points_ptrw[index++] = Vector3(-to_x, -to_y - y, 0);     \
-	points_ptrw[index++] = Vector3(-from_x, from_y + y, 0);  \
+	points_ptrw[index++] = Vector3(-to_x, -to_y - y, 0); \
+	points_ptrw[index++] = Vector3(-from_x, from_y + y, 0); \
 	points_ptrw[index++] = Vector3(-to_x, to_y + y, 0);
 
-#define PUSH_QUARTER_YZ(from_x, from_y, to_x, to_y, y)       \
-	points_ptrw[index++] = Vector3(0, -from_y - y, from_x);  \
-	points_ptrw[index++] = Vector3(0, -to_y - y, to_x);      \
-	points_ptrw[index++] = Vector3(0, from_y + y, from_x);   \
-	points_ptrw[index++] = Vector3(0, to_y + y, to_x);       \
+#define PUSH_QUARTER_YZ(from_x, from_y, to_x, to_y, y) \
+	points_ptrw[index++] = Vector3(0, -from_y - y, from_x); \
+	points_ptrw[index++] = Vector3(0, -to_y - y, to_x); \
+	points_ptrw[index++] = Vector3(0, from_y + y, from_x); \
+	points_ptrw[index++] = Vector3(0, to_y + y, to_x); \
 	points_ptrw[index++] = Vector3(0, -from_y - y, -from_x); \
-	points_ptrw[index++] = Vector3(0, -to_y - y, -to_x);     \
-	points_ptrw[index++] = Vector3(0, from_y + y, -from_x);  \
+	points_ptrw[index++] = Vector3(0, -to_y - y, -to_x); \
+	points_ptrw[index++] = Vector3(0, from_y + y, -from_x); \
 	points_ptrw[index++] = Vector3(0, to_y + y, -to_x);
 
 		float previous_x = radius;
@@ -533,13 +533,13 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		float radius = cs2->get_radius();
 		float height = cs2->get_height();
 
-#define PUSH_QUARTER(from_x, from_y, to_x, to_y, y)      \
-	points_ptrw[index++] = Vector3(from_x, y, from_y);   \
-	points_ptrw[index++] = Vector3(to_x, y, to_y);       \
-	points_ptrw[index++] = Vector3(from_x, y, -from_y);  \
-	points_ptrw[index++] = Vector3(to_x, y, -to_y);      \
-	points_ptrw[index++] = Vector3(-from_x, y, from_y);  \
-	points_ptrw[index++] = Vector3(-to_x, y, to_y);      \
+#define PUSH_QUARTER(from_x, from_y, to_x, to_y, y) \
+	points_ptrw[index++] = Vector3(from_x, y, from_y); \
+	points_ptrw[index++] = Vector3(to_x, y, to_y); \
+	points_ptrw[index++] = Vector3(from_x, y, -from_y); \
+	points_ptrw[index++] = Vector3(to_x, y, -to_y); \
+	points_ptrw[index++] = Vector3(-from_x, y, from_y); \
+	points_ptrw[index++] = Vector3(-to_x, y, to_y); \
 	points_ptrw[index++] = Vector3(-from_x, y, -from_y); \
 	points_ptrw[index++] = Vector3(-to_x, y, -to_y);
 

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
@@ -655,12 +655,12 @@ void Joint3DGizmoPlugin::CreateGeneric6DOFJointGizmo(
 				break;
 		}
 
-#define ADD_VTX(x, y, z)                                         \
-	{                                                            \
-		Vector3 v;                                               \
-		v[a1] = (x);                                             \
-		v[a2] = (y);                                             \
-		v[a3] = (z);                                             \
+#define ADD_VTX(x, y, z) \
+	{ \
+		Vector3 v; \
+		v[a1] = (x); \
+		v[a2] = (y); \
+		v[a3] = (z); \
 		r_points.push_back(p_offset.translated_local(v).origin); \
 	}
 

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -166,8 +166,8 @@ void EditorSceneTabs::_reposition_active_tab(int p_to_index) {
 }
 
 void EditorSceneTabs::_update_context_menu() {
-#define DISABLE_LAST_OPTION_IF(m_condition)                   \
-	if (m_condition) {                                        \
+#define DISABLE_LAST_OPTION_IF(m_condition) \
+	if (m_condition) { \
 		scene_tabs_context_menu->set_item_disabled(-1, true); \
 	}
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -390,15 +390,15 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_THREAD_SAFE_METHOD_
 // Sets up the editor setting with a default value and hint PropertyInfo.
 #define EDITOR_SETTING(m_type, m_property_hint, m_name, m_default_value, m_hint_string) \
-	_initial_set(m_name, m_default_value);                                              \
+	_initial_set(m_name, m_default_value); \
 	hints[m_name] = PropertyInfo(m_type, m_name, m_property_hint, m_hint_string);
 
 #define EDITOR_SETTING_BASIC(m_type, m_property_hint, m_name, m_default_value, m_hint_string) \
-	_initial_set(m_name, m_default_value, true);                                              \
+	_initial_set(m_name, m_default_value, true); \
 	hints[m_name] = PropertyInfo(m_type, m_name, m_property_hint, m_hint_string);
 
 #define EDITOR_SETTING_USAGE(m_type, m_property_hint, m_name, m_default_value, m_hint_string, m_usage) \
-	_initial_set(m_name, m_default_value);                                                             \
+	_initial_set(m_name, m_default_value); \
 	hints[m_name] = PropertyInfo(m_type, m_name, m_property_hint, m_hint_string, m_usage);
 
 	/* Languages */

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2339,11 +2339,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		Array force_angle_list;
 
-#define FORCE_ANGLE(m_vendor, m_name)       \
-	{                                       \
-		Dictionary device;                  \
-		device["vendor"] = m_vendor;        \
-		device["name"] = m_name;            \
+#define FORCE_ANGLE(m_vendor, m_name) \
+	{ \
+		Dictionary device; \
+		device["vendor"] = m_vendor; \
+		device["name"] = m_name; \
 		force_angle_list.push_back(device); \
 	}
 

--- a/main/main.h
+++ b/main/main.h
@@ -88,18 +88,18 @@ public:
 };
 
 // Test main override is for the testing behavior.
-#define TEST_MAIN_OVERRIDE                                         \
-	bool run_test = false;                                         \
+#define TEST_MAIN_OVERRIDE \
+	bool run_test = false; \
 	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
-		godot_cleanup_profiler();                                  \
-		return return_code;                                        \
+	if (run_test) { \
+		godot_cleanup_profiler(); \
+		return return_code; \
 	}
 
-#define TEST_MAIN_PARAM_OVERRIDE(argc, argv)                       \
-	bool run_test = false;                                         \
+#define TEST_MAIN_PARAM_OVERRIDE(argc, argv) \
+	bool run_test = false; \
 	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
-		godot_cleanup_profiler();                                  \
-		return return_code;                                        \
+	if (run_test) { \
+		godot_cleanup_profiler(); \
+		return return_code; \
 	}

--- a/modules/camera/camera_android.cpp
+++ b/modules/camera/camera_android.cpp
@@ -72,7 +72,7 @@ public:
 
 #ifndef IF_EQUAL_RETURN
 #define MAKE_FORMAT_CONST(suffix) AIMAGE_FORMAT_##suffix
-#define IF_EQUAL_RETURN(param, val)      \
+#define IF_EQUAL_RETURN(param, val) \
 	if (MAKE_FORMAT_CONST(val) == param) \
 	return #val
 #endif

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -55,8 +55,8 @@ static void _editor_init() {
 #endif // TOOLS_ENABLED
 
 #define FBX_REGISTER_DOCUMENT_EXTENSION(m_doc_ext_class) \
-	Ref<m_doc_ext_class> extension_##m_doc_ext_class;    \
-	extension_##m_doc_ext_class.instantiate();           \
+	Ref<m_doc_ext_class> extension_##m_doc_ext_class; \
+	extension_##m_doc_ext_class.instantiate(); \
 	FBXDocument::register_gltf_document_extension(extension_##m_doc_ext_class);
 
 void initialize_fbx_module(ModuleInitializationLevel p_level) {

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -1116,56 +1116,56 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				incr += 3;
 			} break;
 
-#define DISASSEMBLE_ITERATE(m_type)      \
-	case OPCODE_ITERATE_##m_type: {      \
-		text += "for-loop (typed ";      \
-		text += #m_type;                 \
-		text += ") ";                    \
-		text += DADDR(3);                \
-		text += " in ";                  \
-		text += DADDR(2);                \
-		text += " counter ";             \
-		text += DADDR(1);                \
-		text += " end ";                 \
+#define DISASSEMBLE_ITERATE(m_type) \
+	case OPCODE_ITERATE_##m_type: { \
+		text += "for-loop (typed "; \
+		text += #m_type; \
+		text += ") "; \
+		text += DADDR(3); \
+		text += " in "; \
+		text += DADDR(2); \
+		text += " counter "; \
+		text += DADDR(1); \
+		text += " end "; \
 		text += itos(_code_ptr[ip + 4]); \
-		incr += 5;                       \
+		incr += 5; \
 	} break
 
 #define DISASSEMBLE_ITERATE_BEGIN(m_type) \
 	case OPCODE_ITERATE_BEGIN_##m_type: { \
-		text += "for-init (typed ";       \
-		text += #m_type;                  \
-		text += ") ";                     \
-		text += DADDR(3);                 \
-		text += " in ";                   \
-		text += DADDR(2);                 \
-		text += " counter ";              \
-		text += DADDR(1);                 \
-		text += " end ";                  \
-		text += itos(_code_ptr[ip + 4]);  \
-		incr += 5;                        \
+		text += "for-init (typed "; \
+		text += #m_type; \
+		text += ") "; \
+		text += DADDR(3); \
+		text += " in "; \
+		text += DADDR(2); \
+		text += " counter "; \
+		text += DADDR(1); \
+		text += " end "; \
+		text += itos(_code_ptr[ip + 4]); \
+		incr += 5; \
 	} break
 
 #define DISASSEMBLE_ITERATE_TYPES(m_macro) \
-	m_macro(INT);                          \
-	m_macro(FLOAT);                        \
-	m_macro(VECTOR2);                      \
-	m_macro(VECTOR2I);                     \
-	m_macro(VECTOR3);                      \
-	m_macro(VECTOR3I);                     \
-	m_macro(STRING);                       \
-	m_macro(DICTIONARY);                   \
-	m_macro(ARRAY);                        \
-	m_macro(PACKED_BYTE_ARRAY);            \
-	m_macro(PACKED_INT32_ARRAY);           \
-	m_macro(PACKED_INT64_ARRAY);           \
-	m_macro(PACKED_FLOAT32_ARRAY);         \
-	m_macro(PACKED_FLOAT64_ARRAY);         \
-	m_macro(PACKED_STRING_ARRAY);          \
-	m_macro(PACKED_VECTOR2_ARRAY);         \
-	m_macro(PACKED_VECTOR3_ARRAY);         \
-	m_macro(PACKED_COLOR_ARRAY);           \
-	m_macro(PACKED_VECTOR4_ARRAY);         \
+	m_macro(INT); \
+	m_macro(FLOAT); \
+	m_macro(VECTOR2); \
+	m_macro(VECTOR2I); \
+	m_macro(VECTOR3); \
+	m_macro(VECTOR3I); \
+	m_macro(STRING); \
+	m_macro(DICTIONARY); \
+	m_macro(ARRAY); \
+	m_macro(PACKED_BYTE_ARRAY); \
+	m_macro(PACKED_INT32_ARRAY); \
+	m_macro(PACKED_INT64_ARRAY); \
+	m_macro(PACKED_FLOAT32_ARRAY); \
+	m_macro(PACKED_FLOAT64_ARRAY); \
+	m_macro(PACKED_STRING_ARRAY); \
+	m_macro(PACKED_VECTOR2_ARRAY); \
+	m_macro(PACKED_VECTOR3_ARRAY); \
+	m_macro(PACKED_COLOR_ARRAY); \
+	m_macro(PACKED_VECTOR4_ARRAY); \
 	m_macro(OBJECT)
 
 			case OPCODE_ITERATE_BEGIN: {
@@ -1256,11 +1256,11 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 #define DISASSEMBLE_TYPE_ADJUST(m_v_type) \
 	case OPCODE_TYPE_ADJUST_##m_v_type: { \
-		text += "type adjust (";          \
-		text += #m_v_type;                \
-		text += ") ";                     \
-		text += DADDR(1);                 \
-		incr += 2;                        \
+		text += "type adjust ("; \
+		text += #m_v_type; \
+		text += ") "; \
+		text += DADDR(1); \
+		incr += 2; \
 	} break
 
 				DISASSEMBLE_TYPE_ADJUST(BOOL);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -703,12 +703,12 @@ void GDScriptParser::parse_program() {
 	current_class = head;
 	bool can_have_class_or_extends = true;
 
-#define PUSH_PENDING_ANNOTATIONS_TO_HEAD                 \
-	if (!annotation_stack.is_empty()) {                  \
+#define PUSH_PENDING_ANNOTATIONS_TO_HEAD \
+	if (!annotation_stack.is_empty()) { \
 		for (AnnotationNode *annot : annotation_stack) { \
-			head->annotations.push_back(annot);          \
-		}                                                \
-		annotation_stack.clear();                        \
+			head->annotations.push_back(annot); \
+		} \
+		annotation_stack.clear(); \
 	}
 
 	while (!check(GDScriptTokenizer::Token::TK_EOF)) {
@@ -5104,14 +5104,14 @@ bool GDScriptParser::warning_ignore_annotation(AnnotationNode *p_annotation, Nod
 			int end_line = p_target->end_line;
 
 			switch (p_target->type) {
-#define SIMPLE_CASE(m_type, m_class, m_property)          \
-	case m_type: {                                        \
+#define SIMPLE_CASE(m_type, m_class, m_property) \
+	case m_type: { \
 		m_class *node = static_cast<m_class *>(p_target); \
-		if (node->m_property == nullptr) {                \
-			end_line = node->start_line;                  \
-		} else {                                          \
-			end_line = node->m_property->end_line;        \
-		}                                                 \
+		if (node->m_property == nullptr) { \
+			end_line = node->start_line; \
+		} else { \
+			end_line = node->m_property->end_line; \
+		} \
 	} break;
 
 				// Can contain properties (set/get).

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -483,66 +483,66 @@ GDScriptTokenizer::Token GDScriptTokenizerText::annotation() {
 	return annotation;
 }
 
-#define KEYWORDS(KEYWORD_GROUP, KEYWORD)     \
-	KEYWORD_GROUP('a')                       \
-	KEYWORD("as", Token::AS)                 \
-	KEYWORD("and", Token::AND)               \
-	KEYWORD("assert", Token::ASSERT)         \
-	KEYWORD("await", Token::AWAIT)           \
-	KEYWORD_GROUP('b')                       \
-	KEYWORD("break", Token::BREAK)           \
+#define KEYWORDS(KEYWORD_GROUP, KEYWORD) \
+	KEYWORD_GROUP('a') \
+	KEYWORD("as", Token::AS) \
+	KEYWORD("and", Token::AND) \
+	KEYWORD("assert", Token::ASSERT) \
+	KEYWORD("await", Token::AWAIT) \
+	KEYWORD_GROUP('b') \
+	KEYWORD("break", Token::BREAK) \
 	KEYWORD("breakpoint", Token::BREAKPOINT) \
-	KEYWORD_GROUP('c')                       \
-	KEYWORD("class", Token::CLASS)           \
+	KEYWORD_GROUP('c') \
+	KEYWORD("class", Token::CLASS) \
 	KEYWORD("class_name", Token::CLASS_NAME) \
-	KEYWORD("const", Token::TK_CONST)        \
-	KEYWORD("continue", Token::CONTINUE)     \
-	KEYWORD_GROUP('e')                       \
-	KEYWORD("elif", Token::ELIF)             \
-	KEYWORD("else", Token::ELSE)             \
-	KEYWORD("enum", Token::ENUM)             \
-	KEYWORD("extends", Token::EXTENDS)       \
-	KEYWORD_GROUP('f')                       \
-	KEYWORD("for", Token::FOR)               \
-	KEYWORD("func", Token::FUNC)             \
-	KEYWORD_GROUP('i')                       \
-	KEYWORD("if", Token::IF)                 \
-	KEYWORD("in", Token::TK_IN)              \
-	KEYWORD("is", Token::IS)                 \
-	KEYWORD_GROUP('m')                       \
-	KEYWORD("match", Token::MATCH)           \
-	KEYWORD_GROUP('n')                       \
-	KEYWORD("namespace", Token::NAMESPACE)   \
-	KEYWORD("not", Token::NOT)               \
-	KEYWORD_GROUP('o')                       \
-	KEYWORD("or", Token::OR)                 \
-	KEYWORD_GROUP('p')                       \
-	KEYWORD("pass", Token::PASS)             \
-	KEYWORD("preload", Token::PRELOAD)       \
-	KEYWORD_GROUP('r')                       \
-	KEYWORD("return", Token::RETURN)         \
-	KEYWORD_GROUP('s')                       \
-	KEYWORD("self", Token::SELF)             \
-	KEYWORD("signal", Token::SIGNAL)         \
-	KEYWORD("static", Token::STATIC)         \
-	KEYWORD("super", Token::SUPER)           \
-	KEYWORD_GROUP('t')                       \
-	KEYWORD("trait", Token::TRAIT)           \
-	KEYWORD_GROUP('v')                       \
-	KEYWORD("var", Token::VAR)               \
-	KEYWORD("void", Token::TK_VOID)          \
-	KEYWORD_GROUP('w')                       \
-	KEYWORD("while", Token::WHILE)           \
-	KEYWORD("when", Token::WHEN)             \
-	KEYWORD_GROUP('y')                       \
-	KEYWORD("yield", Token::YIELD)           \
-	KEYWORD_GROUP('I')                       \
-	KEYWORD("INF", Token::CONST_INF)         \
-	KEYWORD_GROUP('N')                       \
-	KEYWORD("NAN", Token::CONST_NAN)         \
-	KEYWORD_GROUP('P')                       \
-	KEYWORD("PI", Token::CONST_PI)           \
-	KEYWORD_GROUP('T')                       \
+	KEYWORD("const", Token::TK_CONST) \
+	KEYWORD("continue", Token::CONTINUE) \
+	KEYWORD_GROUP('e') \
+	KEYWORD("elif", Token::ELIF) \
+	KEYWORD("else", Token::ELSE) \
+	KEYWORD("enum", Token::ENUM) \
+	KEYWORD("extends", Token::EXTENDS) \
+	KEYWORD_GROUP('f') \
+	KEYWORD("for", Token::FOR) \
+	KEYWORD("func", Token::FUNC) \
+	KEYWORD_GROUP('i') \
+	KEYWORD("if", Token::IF) \
+	KEYWORD("in", Token::TK_IN) \
+	KEYWORD("is", Token::IS) \
+	KEYWORD_GROUP('m') \
+	KEYWORD("match", Token::MATCH) \
+	KEYWORD_GROUP('n') \
+	KEYWORD("namespace", Token::NAMESPACE) \
+	KEYWORD("not", Token::NOT) \
+	KEYWORD_GROUP('o') \
+	KEYWORD("or", Token::OR) \
+	KEYWORD_GROUP('p') \
+	KEYWORD("pass", Token::PASS) \
+	KEYWORD("preload", Token::PRELOAD) \
+	KEYWORD_GROUP('r') \
+	KEYWORD("return", Token::RETURN) \
+	KEYWORD_GROUP('s') \
+	KEYWORD("self", Token::SELF) \
+	KEYWORD("signal", Token::SIGNAL) \
+	KEYWORD("static", Token::STATIC) \
+	KEYWORD("super", Token::SUPER) \
+	KEYWORD_GROUP('t') \
+	KEYWORD("trait", Token::TRAIT) \
+	KEYWORD_GROUP('v') \
+	KEYWORD("var", Token::VAR) \
+	KEYWORD("void", Token::TK_VOID) \
+	KEYWORD_GROUP('w') \
+	KEYWORD("while", Token::WHILE) \
+	KEYWORD("when", Token::WHEN) \
+	KEYWORD_GROUP('y') \
+	KEYWORD("yield", Token::YIELD) \
+	KEYWORD_GROUP('I') \
+	KEYWORD("INF", Token::CONST_INF) \
+	KEYWORD_GROUP('N') \
+	KEYWORD("NAN", Token::CONST_NAN) \
+	KEYWORD_GROUP('P') \
+	KEYWORD("PI", Token::CONST_PI) \
+	KEYWORD_GROUP('T') \
 	KEYWORD("TAU", Token::CONST_TAU)
 
 #define MIN_KEYWORD_LENGTH 2
@@ -604,18 +604,18 @@ GDScriptTokenizer::Token GDScriptTokenizerText::potential_identifier() {
 
 	// Define some helper macros for the switch case.
 #define KEYWORD_GROUP_CASE(char) \
-	break;                       \
+	break; \
 	case char:
-#define KEYWORD(keyword, token_type)                                                                                      \
-	{                                                                                                                     \
-		const int keyword_length = sizeof(keyword) - 1;                                                                   \
-		static_assert(keyword_length <= MAX_KEYWORD_LENGTH, "There's a keyword longer than the defined maximum length");  \
+#define KEYWORD(keyword, token_type) \
+	{ \
+		const int keyword_length = sizeof(keyword) - 1; \
+		static_assert(keyword_length <= MAX_KEYWORD_LENGTH, "There's a keyword longer than the defined maximum length"); \
 		static_assert(keyword_length >= MIN_KEYWORD_LENGTH, "There's a keyword shorter than the defined minimum length"); \
-		if (keyword_length == len && name == keyword) {                                                                   \
-			Token kw = make_token(token_type);                                                                            \
-			kw.literal = name;                                                                                            \
-			return kw;                                                                                                    \
-		}                                                                                                                 \
+		if (keyword_length == len && name == keyword) { \
+			Token kw = make_token(token_type); \
+			kw.literal = name; \
+			return kw; \
+		} \
 	}
 
 	// Find if it's a keyword.

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -41,36 +41,36 @@
 
 #ifdef DEBUG_ENABLED
 
-#define DEBUG_VALIDATE_ARG_COUNT(m_min_count, m_max_count)                  \
-	if (unlikely(p_arg_count < m_min_count)) {                              \
-		*r_ret = Variant();                                                 \
-		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;  \
-		r_error.expected = m_min_count;                                     \
-		return;                                                             \
-	}                                                                       \
-	if (unlikely(p_arg_count > m_max_count)) {                              \
-		*r_ret = Variant();                                                 \
+#define DEBUG_VALIDATE_ARG_COUNT(m_min_count, m_max_count) \
+	if (unlikely(p_arg_count < m_min_count)) { \
+		*r_ret = Variant(); \
+		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS; \
+		r_error.expected = m_min_count; \
+		return; \
+	} \
+	if (unlikely(p_arg_count > m_max_count)) { \
+		*r_ret = Variant(); \
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS; \
-		r_error.expected = m_max_count;                                     \
-		return;                                                             \
+		r_error.expected = m_max_count; \
+		return; \
 	}
 
-#define DEBUG_VALIDATE_ARG_TYPE(m_arg, m_type)                                       \
+#define DEBUG_VALIDATE_ARG_TYPE(m_arg, m_type) \
 	if (unlikely(!Variant::can_convert_strict(p_args[m_arg]->get_type(), m_type))) { \
-		*r_ret = Variant();                                                          \
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;            \
-		r_error.argument = m_arg;                                                    \
-		r_error.expected = m_type;                                                   \
-		return;                                                                      \
+		*r_ret = Variant(); \
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT; \
+		r_error.argument = m_arg; \
+		r_error.expected = m_type; \
+		return; \
 	}
 
-#define DEBUG_VALIDATE_ARG_CUSTOM(m_arg, m_type, m_cond, m_msg)           \
-	if (unlikely(m_cond)) {                                               \
-		*r_ret = m_msg;                                                   \
+#define DEBUG_VALIDATE_ARG_CUSTOM(m_arg, m_type, m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
+		*r_ret = m_msg; \
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT; \
-		r_error.argument = m_arg;                                         \
-		r_error.expected = m_type;                                        \
-		return;                                                           \
+		r_error.argument = m_arg; \
+		r_error.expected = m_type; \
+		return; \
 	}
 
 #else // !DEBUG_ENABLED
@@ -81,20 +81,20 @@
 
 #endif // DEBUG_ENABLED
 
-#define VALIDATE_ARG_CUSTOM(m_arg, m_type, m_cond, m_msg)                 \
-	if (unlikely(m_cond)) {                                               \
-		*r_ret = m_msg;                                                   \
+#define VALIDATE_ARG_CUSTOM(m_arg, m_type, m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
+		*r_ret = m_msg; \
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT; \
-		r_error.argument = m_arg;                                         \
-		r_error.expected = m_type;                                        \
-		return;                                                           \
+		r_error.argument = m_arg; \
+		r_error.expected = m_type; \
+		return; \
 	}
 
-#define GDFUNC_FAIL_COND_MSG(m_cond, m_msg)                             \
-	if (unlikely(m_cond)) {                                             \
-		*r_ret = m_msg;                                                 \
+#define GDFUNC_FAIL_COND_MSG(m_cond, m_msg) \
+	if (unlikely(m_cond)) { \
+		*r_ret = m_msg; \
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD; \
-		return;                                                         \
+		return; \
 	}
 
 struct GDScriptUtilityFunctionsDefinitions {
@@ -527,19 +527,19 @@ static void _register_function(const StringName &p_name, const MethodInfo &p_met
 	utility_function_name_table.push_back(p_name);
 }
 
-#define REGISTER_FUNC(m_func, m_is_const, m_return, m_args, m_is_vararg, m_default_args)         \
-	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1);                                                               \
-		}                                                                                        \
-		MethodInfo info = m_args;                                                                \
-		info.name = name;                                                                        \
-		info.return_val = m_return;                                                              \
-		info.default_arguments = m_default_args;                                                 \
-		if (m_is_vararg) {                                                                       \
-			info.flags |= METHOD_FLAG_VARARG;                                                    \
-		}                                                                                        \
+#define REGISTER_FUNC(m_func, m_is_const, m_return, m_args, m_is_vararg, m_default_args) \
+	{ \
+		String name(#m_func); \
+		if (name.begins_with("_")) { \
+			name = name.substr(1); \
+		} \
+		MethodInfo info = m_args; \
+		info.name = name; \
+		info.return_val = m_return; \
+		info.default_arguments = m_default_args; \
+		if (m_is_vararg) { \
+			info.flags |= METHOD_FLAG_VARARG; \
+		} \
 		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
 	}
 

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -251,167 +251,167 @@ void (*type_init_function_table[])(Variant *) = {
 };
 
 #if defined(__GNUC__) || defined(__clang__)
-#define OPCODES_TABLE                                    \
-	static const void *switch_table_ops[] = {            \
-		&&OPCODE_OPERATOR,                               \
-		&&OPCODE_OPERATOR_VALIDATED,                     \
-		&&OPCODE_TYPE_TEST_BUILTIN,                      \
-		&&OPCODE_TYPE_TEST_ARRAY,                        \
-		&&OPCODE_TYPE_TEST_DICTIONARY,                   \
-		&&OPCODE_TYPE_TEST_NATIVE,                       \
-		&&OPCODE_TYPE_TEST_SCRIPT,                       \
-		&&OPCODE_SET_KEYED,                              \
-		&&OPCODE_SET_KEYED_VALIDATED,                    \
-		&&OPCODE_SET_INDEXED_VALIDATED,                  \
-		&&OPCODE_GET_KEYED,                              \
-		&&OPCODE_GET_KEYED_VALIDATED,                    \
-		&&OPCODE_GET_INDEXED_VALIDATED,                  \
-		&&OPCODE_SET_NAMED,                              \
-		&&OPCODE_SET_NAMED_VALIDATED,                    \
-		&&OPCODE_GET_NAMED,                              \
-		&&OPCODE_GET_NAMED_VALIDATED,                    \
-		&&OPCODE_SET_MEMBER,                             \
-		&&OPCODE_GET_MEMBER,                             \
-		&&OPCODE_SET_STATIC_VARIABLE,                    \
-		&&OPCODE_GET_STATIC_VARIABLE,                    \
-		&&OPCODE_ASSIGN,                                 \
-		&&OPCODE_ASSIGN_NULL,                            \
-		&&OPCODE_ASSIGN_TRUE,                            \
-		&&OPCODE_ASSIGN_FALSE,                           \
-		&&OPCODE_ASSIGN_TYPED_BUILTIN,                   \
-		&&OPCODE_ASSIGN_TYPED_ARRAY,                     \
-		&&OPCODE_ASSIGN_TYPED_DICTIONARY,                \
-		&&OPCODE_ASSIGN_TYPED_NATIVE,                    \
-		&&OPCODE_ASSIGN_TYPED_SCRIPT,                    \
-		&&OPCODE_CAST_TO_BUILTIN,                        \
-		&&OPCODE_CAST_TO_NATIVE,                         \
-		&&OPCODE_CAST_TO_SCRIPT,                         \
-		&&OPCODE_CONSTRUCT,                              \
-		&&OPCODE_CONSTRUCT_VALIDATED,                    \
-		&&OPCODE_CONSTRUCT_ARRAY,                        \
-		&&OPCODE_CONSTRUCT_TYPED_ARRAY,                  \
-		&&OPCODE_CONSTRUCT_DICTIONARY,                   \
-		&&OPCODE_CONSTRUCT_TYPED_DICTIONARY,             \
-		&&OPCODE_CALL,                                   \
-		&&OPCODE_CALL_RETURN,                            \
-		&&OPCODE_CALL_ASYNC,                             \
-		&&OPCODE_CALL_UTILITY,                           \
-		&&OPCODE_CALL_UTILITY_VALIDATED,                 \
-		&&OPCODE_CALL_GDSCRIPT_UTILITY,                  \
-		&&OPCODE_CALL_BUILTIN_TYPE_VALIDATED,            \
-		&&OPCODE_CALL_SELF_BASE,                         \
-		&&OPCODE_CALL_METHOD_BIND,                       \
-		&&OPCODE_CALL_METHOD_BIND_RET,                   \
-		&&OPCODE_CALL_BUILTIN_STATIC,                    \
-		&&OPCODE_CALL_NATIVE_STATIC,                     \
-		&&OPCODE_CALL_NATIVE_STATIC_VALIDATED_RETURN,    \
+#define OPCODES_TABLE \
+	static const void *switch_table_ops[] = { \
+		&&OPCODE_OPERATOR, \
+		&&OPCODE_OPERATOR_VALIDATED, \
+		&&OPCODE_TYPE_TEST_BUILTIN, \
+		&&OPCODE_TYPE_TEST_ARRAY, \
+		&&OPCODE_TYPE_TEST_DICTIONARY, \
+		&&OPCODE_TYPE_TEST_NATIVE, \
+		&&OPCODE_TYPE_TEST_SCRIPT, \
+		&&OPCODE_SET_KEYED, \
+		&&OPCODE_SET_KEYED_VALIDATED, \
+		&&OPCODE_SET_INDEXED_VALIDATED, \
+		&&OPCODE_GET_KEYED, \
+		&&OPCODE_GET_KEYED_VALIDATED, \
+		&&OPCODE_GET_INDEXED_VALIDATED, \
+		&&OPCODE_SET_NAMED, \
+		&&OPCODE_SET_NAMED_VALIDATED, \
+		&&OPCODE_GET_NAMED, \
+		&&OPCODE_GET_NAMED_VALIDATED, \
+		&&OPCODE_SET_MEMBER, \
+		&&OPCODE_GET_MEMBER, \
+		&&OPCODE_SET_STATIC_VARIABLE, \
+		&&OPCODE_GET_STATIC_VARIABLE, \
+		&&OPCODE_ASSIGN, \
+		&&OPCODE_ASSIGN_NULL, \
+		&&OPCODE_ASSIGN_TRUE, \
+		&&OPCODE_ASSIGN_FALSE, \
+		&&OPCODE_ASSIGN_TYPED_BUILTIN, \
+		&&OPCODE_ASSIGN_TYPED_ARRAY, \
+		&&OPCODE_ASSIGN_TYPED_DICTIONARY, \
+		&&OPCODE_ASSIGN_TYPED_NATIVE, \
+		&&OPCODE_ASSIGN_TYPED_SCRIPT, \
+		&&OPCODE_CAST_TO_BUILTIN, \
+		&&OPCODE_CAST_TO_NATIVE, \
+		&&OPCODE_CAST_TO_SCRIPT, \
+		&&OPCODE_CONSTRUCT, \
+		&&OPCODE_CONSTRUCT_VALIDATED, \
+		&&OPCODE_CONSTRUCT_ARRAY, \
+		&&OPCODE_CONSTRUCT_TYPED_ARRAY, \
+		&&OPCODE_CONSTRUCT_DICTIONARY, \
+		&&OPCODE_CONSTRUCT_TYPED_DICTIONARY, \
+		&&OPCODE_CALL, \
+		&&OPCODE_CALL_RETURN, \
+		&&OPCODE_CALL_ASYNC, \
+		&&OPCODE_CALL_UTILITY, \
+		&&OPCODE_CALL_UTILITY_VALIDATED, \
+		&&OPCODE_CALL_GDSCRIPT_UTILITY, \
+		&&OPCODE_CALL_BUILTIN_TYPE_VALIDATED, \
+		&&OPCODE_CALL_SELF_BASE, \
+		&&OPCODE_CALL_METHOD_BIND, \
+		&&OPCODE_CALL_METHOD_BIND_RET, \
+		&&OPCODE_CALL_BUILTIN_STATIC, \
+		&&OPCODE_CALL_NATIVE_STATIC, \
+		&&OPCODE_CALL_NATIVE_STATIC_VALIDATED_RETURN, \
 		&&OPCODE_CALL_NATIVE_STATIC_VALIDATED_NO_RETURN, \
-		&&OPCODE_CALL_METHOD_BIND_VALIDATED_RETURN,      \
-		&&OPCODE_CALL_METHOD_BIND_VALIDATED_NO_RETURN,   \
-		&&OPCODE_AWAIT,                                  \
-		&&OPCODE_AWAIT_RESUME,                           \
-		&&OPCODE_CREATE_LAMBDA,                          \
-		&&OPCODE_CREATE_SELF_LAMBDA,                     \
-		&&OPCODE_JUMP,                                   \
-		&&OPCODE_JUMP_IF,                                \
-		&&OPCODE_JUMP_IF_NOT,                            \
-		&&OPCODE_JUMP_TO_DEF_ARGUMENT,                   \
-		&&OPCODE_JUMP_IF_SHARED,                         \
-		&&OPCODE_RETURN,                                 \
-		&&OPCODE_RETURN_TYPED_BUILTIN,                   \
-		&&OPCODE_RETURN_TYPED_ARRAY,                     \
-		&&OPCODE_RETURN_TYPED_DICTIONARY,                \
-		&&OPCODE_RETURN_TYPED_NATIVE,                    \
-		&&OPCODE_RETURN_TYPED_SCRIPT,                    \
-		&&OPCODE_ITERATE_BEGIN,                          \
-		&&OPCODE_ITERATE_BEGIN_INT,                      \
-		&&OPCODE_ITERATE_BEGIN_FLOAT,                    \
-		&&OPCODE_ITERATE_BEGIN_VECTOR2,                  \
-		&&OPCODE_ITERATE_BEGIN_VECTOR2I,                 \
-		&&OPCODE_ITERATE_BEGIN_VECTOR3,                  \
-		&&OPCODE_ITERATE_BEGIN_VECTOR3I,                 \
-		&&OPCODE_ITERATE_BEGIN_STRING,                   \
-		&&OPCODE_ITERATE_BEGIN_DICTIONARY,               \
-		&&OPCODE_ITERATE_BEGIN_ARRAY,                    \
-		&&OPCODE_ITERATE_BEGIN_PACKED_BYTE_ARRAY,        \
-		&&OPCODE_ITERATE_BEGIN_PACKED_INT32_ARRAY,       \
-		&&OPCODE_ITERATE_BEGIN_PACKED_INT64_ARRAY,       \
-		&&OPCODE_ITERATE_BEGIN_PACKED_FLOAT32_ARRAY,     \
-		&&OPCODE_ITERATE_BEGIN_PACKED_FLOAT64_ARRAY,     \
-		&&OPCODE_ITERATE_BEGIN_PACKED_STRING_ARRAY,      \
-		&&OPCODE_ITERATE_BEGIN_PACKED_VECTOR2_ARRAY,     \
-		&&OPCODE_ITERATE_BEGIN_PACKED_VECTOR3_ARRAY,     \
-		&&OPCODE_ITERATE_BEGIN_PACKED_COLOR_ARRAY,       \
-		&&OPCODE_ITERATE_BEGIN_PACKED_VECTOR4_ARRAY,     \
-		&&OPCODE_ITERATE_BEGIN_OBJECT,                   \
-		&&OPCODE_ITERATE_BEGIN_RANGE,                    \
-		&&OPCODE_ITERATE,                                \
-		&&OPCODE_ITERATE_INT,                            \
-		&&OPCODE_ITERATE_FLOAT,                          \
-		&&OPCODE_ITERATE_VECTOR2,                        \
-		&&OPCODE_ITERATE_VECTOR2I,                       \
-		&&OPCODE_ITERATE_VECTOR3,                        \
-		&&OPCODE_ITERATE_VECTOR3I,                       \
-		&&OPCODE_ITERATE_STRING,                         \
-		&&OPCODE_ITERATE_DICTIONARY,                     \
-		&&OPCODE_ITERATE_ARRAY,                          \
-		&&OPCODE_ITERATE_PACKED_BYTE_ARRAY,              \
-		&&OPCODE_ITERATE_PACKED_INT32_ARRAY,             \
-		&&OPCODE_ITERATE_PACKED_INT64_ARRAY,             \
-		&&OPCODE_ITERATE_PACKED_FLOAT32_ARRAY,           \
-		&&OPCODE_ITERATE_PACKED_FLOAT64_ARRAY,           \
-		&&OPCODE_ITERATE_PACKED_STRING_ARRAY,            \
-		&&OPCODE_ITERATE_PACKED_VECTOR2_ARRAY,           \
-		&&OPCODE_ITERATE_PACKED_VECTOR3_ARRAY,           \
-		&&OPCODE_ITERATE_PACKED_COLOR_ARRAY,             \
-		&&OPCODE_ITERATE_PACKED_VECTOR4_ARRAY,           \
-		&&OPCODE_ITERATE_OBJECT,                         \
-		&&OPCODE_ITERATE_RANGE,                          \
-		&&OPCODE_STORE_GLOBAL,                           \
-		&&OPCODE_STORE_NAMED_GLOBAL,                     \
-		&&OPCODE_TYPE_ADJUST_BOOL,                       \
-		&&OPCODE_TYPE_ADJUST_INT,                        \
-		&&OPCODE_TYPE_ADJUST_FLOAT,                      \
-		&&OPCODE_TYPE_ADJUST_STRING,                     \
-		&&OPCODE_TYPE_ADJUST_VECTOR2,                    \
-		&&OPCODE_TYPE_ADJUST_VECTOR2I,                   \
-		&&OPCODE_TYPE_ADJUST_RECT2,                      \
-		&&OPCODE_TYPE_ADJUST_RECT2I,                     \
-		&&OPCODE_TYPE_ADJUST_VECTOR3,                    \
-		&&OPCODE_TYPE_ADJUST_VECTOR3I,                   \
-		&&OPCODE_TYPE_ADJUST_TRANSFORM2D,                \
-		&&OPCODE_TYPE_ADJUST_VECTOR4,                    \
-		&&OPCODE_TYPE_ADJUST_VECTOR4I,                   \
-		&&OPCODE_TYPE_ADJUST_PLANE,                      \
-		&&OPCODE_TYPE_ADJUST_QUATERNION,                 \
-		&&OPCODE_TYPE_ADJUST_AABB,                       \
-		&&OPCODE_TYPE_ADJUST_BASIS,                      \
-		&&OPCODE_TYPE_ADJUST_TRANSFORM3D,                \
-		&&OPCODE_TYPE_ADJUST_PROJECTION,                 \
-		&&OPCODE_TYPE_ADJUST_COLOR,                      \
-		&&OPCODE_TYPE_ADJUST_STRING_NAME,                \
-		&&OPCODE_TYPE_ADJUST_NODE_PATH,                  \
-		&&OPCODE_TYPE_ADJUST_RID,                        \
-		&&OPCODE_TYPE_ADJUST_OBJECT,                     \
-		&&OPCODE_TYPE_ADJUST_CALLABLE,                   \
-		&&OPCODE_TYPE_ADJUST_SIGNAL,                     \
-		&&OPCODE_TYPE_ADJUST_DICTIONARY,                 \
-		&&OPCODE_TYPE_ADJUST_ARRAY,                      \
-		&&OPCODE_TYPE_ADJUST_PACKED_BYTE_ARRAY,          \
-		&&OPCODE_TYPE_ADJUST_PACKED_INT32_ARRAY,         \
-		&&OPCODE_TYPE_ADJUST_PACKED_INT64_ARRAY,         \
-		&&OPCODE_TYPE_ADJUST_PACKED_FLOAT32_ARRAY,       \
-		&&OPCODE_TYPE_ADJUST_PACKED_FLOAT64_ARRAY,       \
-		&&OPCODE_TYPE_ADJUST_PACKED_STRING_ARRAY,        \
-		&&OPCODE_TYPE_ADJUST_PACKED_VECTOR2_ARRAY,       \
-		&&OPCODE_TYPE_ADJUST_PACKED_VECTOR3_ARRAY,       \
-		&&OPCODE_TYPE_ADJUST_PACKED_COLOR_ARRAY,         \
-		&&OPCODE_TYPE_ADJUST_PACKED_VECTOR4_ARRAY,       \
-		&&OPCODE_ASSERT,                                 \
-		&&OPCODE_BREAKPOINT,                             \
-		&&OPCODE_LINE,                                   \
-		&&OPCODE_END                                     \
-	};                                                   \
+		&&OPCODE_CALL_METHOD_BIND_VALIDATED_RETURN, \
+		&&OPCODE_CALL_METHOD_BIND_VALIDATED_NO_RETURN, \
+		&&OPCODE_AWAIT, \
+		&&OPCODE_AWAIT_RESUME, \
+		&&OPCODE_CREATE_LAMBDA, \
+		&&OPCODE_CREATE_SELF_LAMBDA, \
+		&&OPCODE_JUMP, \
+		&&OPCODE_JUMP_IF, \
+		&&OPCODE_JUMP_IF_NOT, \
+		&&OPCODE_JUMP_TO_DEF_ARGUMENT, \
+		&&OPCODE_JUMP_IF_SHARED, \
+		&&OPCODE_RETURN, \
+		&&OPCODE_RETURN_TYPED_BUILTIN, \
+		&&OPCODE_RETURN_TYPED_ARRAY, \
+		&&OPCODE_RETURN_TYPED_DICTIONARY, \
+		&&OPCODE_RETURN_TYPED_NATIVE, \
+		&&OPCODE_RETURN_TYPED_SCRIPT, \
+		&&OPCODE_ITERATE_BEGIN, \
+		&&OPCODE_ITERATE_BEGIN_INT, \
+		&&OPCODE_ITERATE_BEGIN_FLOAT, \
+		&&OPCODE_ITERATE_BEGIN_VECTOR2, \
+		&&OPCODE_ITERATE_BEGIN_VECTOR2I, \
+		&&OPCODE_ITERATE_BEGIN_VECTOR3, \
+		&&OPCODE_ITERATE_BEGIN_VECTOR3I, \
+		&&OPCODE_ITERATE_BEGIN_STRING, \
+		&&OPCODE_ITERATE_BEGIN_DICTIONARY, \
+		&&OPCODE_ITERATE_BEGIN_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_BYTE_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_INT32_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_INT64_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_FLOAT32_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_FLOAT64_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_STRING_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_VECTOR2_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_VECTOR3_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_COLOR_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_PACKED_VECTOR4_ARRAY, \
+		&&OPCODE_ITERATE_BEGIN_OBJECT, \
+		&&OPCODE_ITERATE_BEGIN_RANGE, \
+		&&OPCODE_ITERATE, \
+		&&OPCODE_ITERATE_INT, \
+		&&OPCODE_ITERATE_FLOAT, \
+		&&OPCODE_ITERATE_VECTOR2, \
+		&&OPCODE_ITERATE_VECTOR2I, \
+		&&OPCODE_ITERATE_VECTOR3, \
+		&&OPCODE_ITERATE_VECTOR3I, \
+		&&OPCODE_ITERATE_STRING, \
+		&&OPCODE_ITERATE_DICTIONARY, \
+		&&OPCODE_ITERATE_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_BYTE_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_INT32_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_INT64_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_FLOAT32_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_FLOAT64_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_STRING_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_VECTOR2_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_VECTOR3_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_COLOR_ARRAY, \
+		&&OPCODE_ITERATE_PACKED_VECTOR4_ARRAY, \
+		&&OPCODE_ITERATE_OBJECT, \
+		&&OPCODE_ITERATE_RANGE, \
+		&&OPCODE_STORE_GLOBAL, \
+		&&OPCODE_STORE_NAMED_GLOBAL, \
+		&&OPCODE_TYPE_ADJUST_BOOL, \
+		&&OPCODE_TYPE_ADJUST_INT, \
+		&&OPCODE_TYPE_ADJUST_FLOAT, \
+		&&OPCODE_TYPE_ADJUST_STRING, \
+		&&OPCODE_TYPE_ADJUST_VECTOR2, \
+		&&OPCODE_TYPE_ADJUST_VECTOR2I, \
+		&&OPCODE_TYPE_ADJUST_RECT2, \
+		&&OPCODE_TYPE_ADJUST_RECT2I, \
+		&&OPCODE_TYPE_ADJUST_VECTOR3, \
+		&&OPCODE_TYPE_ADJUST_VECTOR3I, \
+		&&OPCODE_TYPE_ADJUST_TRANSFORM2D, \
+		&&OPCODE_TYPE_ADJUST_VECTOR4, \
+		&&OPCODE_TYPE_ADJUST_VECTOR4I, \
+		&&OPCODE_TYPE_ADJUST_PLANE, \
+		&&OPCODE_TYPE_ADJUST_QUATERNION, \
+		&&OPCODE_TYPE_ADJUST_AABB, \
+		&&OPCODE_TYPE_ADJUST_BASIS, \
+		&&OPCODE_TYPE_ADJUST_TRANSFORM3D, \
+		&&OPCODE_TYPE_ADJUST_PROJECTION, \
+		&&OPCODE_TYPE_ADJUST_COLOR, \
+		&&OPCODE_TYPE_ADJUST_STRING_NAME, \
+		&&OPCODE_TYPE_ADJUST_NODE_PATH, \
+		&&OPCODE_TYPE_ADJUST_RID, \
+		&&OPCODE_TYPE_ADJUST_OBJECT, \
+		&&OPCODE_TYPE_ADJUST_CALLABLE, \
+		&&OPCODE_TYPE_ADJUST_SIGNAL, \
+		&&OPCODE_TYPE_ADJUST_DICTIONARY, \
+		&&OPCODE_TYPE_ADJUST_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_BYTE_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_INT32_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_INT64_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_FLOAT32_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_FLOAT64_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_STRING_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_VECTOR2_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_VECTOR3_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_COLOR_ARRAY, \
+		&&OPCODE_TYPE_ADJUST_PACKED_VECTOR4_ARRAY, \
+		&&OPCODE_ASSERT, \
+		&&OPCODE_BREAKPOINT, \
+		&&OPCODE_LINE, \
+		&&OPCODE_END \
+	}; \
 	static_assert(std_size(switch_table_ops) == (OPCODE_END + 1), "Opcodes in jump table aren't the same as opcodes in enum.");
 
 #define OPCODE(m_op) \
@@ -424,7 +424,7 @@ void (*type_init_function_table[])(Variant *) = {
 #define OPCODE_SWITCH(m_test) goto *switch_table_ops[m_test];
 
 #ifdef DEBUG_ENABLED
-#define DISPATCH_OPCODE          \
+#define DISPATCH_OPCODE \
 	last_opcode = _code_ptr[ip]; \
 	goto *switch_table_ops[last_opcode]
 #else // !DEBUG_ENABLED
@@ -442,7 +442,7 @@ void (*type_init_function_table[])(Variant *) = {
 #define DISPATCH_OPCODE continue
 
 #ifdef _MSC_VER
-#define OPCODE_SWITCH(m_test)       \
+#define OPCODE_SWITCH(m_test) \
 	__assume(m_test <= OPCODE_END); \
 	switch (m_test)
 #else // !_MSC_VER
@@ -663,61 +663,61 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	GDScriptLanguage::get_singleton()->enter_function(&call_level, p_instance, this, stack, &ip, &line);
 
 #ifdef DEBUG_ENABLED
-#define GD_ERR_BREAK(m_cond)                                                                                           \
-	{                                                                                                                  \
-		if (unlikely(m_cond)) {                                                                                        \
+#define GD_ERR_BREAK(m_cond) \
+	{ \
+		if (unlikely(m_cond)) { \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:"); \
-			OPCODE_BREAK;                                                                                              \
-		}                                                                                                              \
+			OPCODE_BREAK; \
+		} \
 	}
 
 #define CHECK_SPACE(m_space) \
 	GD_ERR_BREAK((ip + m_space) > _code_size)
 
-#define GET_VARIANT_PTR(m_v, m_code_ofs)                                                            \
-	Variant *m_v;                                                                                   \
-	{                                                                                               \
-		int address = _code_ptr[ip + 1 + (m_code_ofs)];                                             \
-		int address_type = (address & ADDR_TYPE_MASK) >> ADDR_BITS;                                 \
-		if (unlikely(address_type < 0 || address_type >= ADDR_TYPE_MAX)) {                          \
-			err_text = "Bad address type.";                                                         \
-			OPCODE_BREAK;                                                                           \
-		}                                                                                           \
-		int address_index = address & ADDR_MASK;                                                    \
+#define GET_VARIANT_PTR(m_v, m_code_ofs) \
+	Variant *m_v; \
+	{ \
+		int address = _code_ptr[ip + 1 + (m_code_ofs)]; \
+		int address_type = (address & ADDR_TYPE_MASK) >> ADDR_BITS; \
+		if (unlikely(address_type < 0 || address_type >= ADDR_TYPE_MAX)) { \
+			err_text = "Bad address type."; \
+			OPCODE_BREAK; \
+		} \
+		int address_index = address & ADDR_MASK; \
 		if (unlikely(address_index < 0 || address_index >= variant_address_limits[address_type])) { \
-			if (address_type == ADDR_TYPE_MEMBER && !p_instance) {                                  \
-				err_text = "Cannot access member without instance.";                                \
-			} else {                                                                                \
-				err_text = "Bad address index.";                                                    \
-			}                                                                                       \
-			OPCODE_BREAK;                                                                           \
-		}                                                                                           \
-		m_v = &variant_addresses[address_type][address_index];                                      \
-		if (unlikely(!m_v))                                                                         \
-			OPCODE_BREAK;                                                                           \
+			if (address_type == ADDR_TYPE_MEMBER && !p_instance) { \
+				err_text = "Cannot access member without instance."; \
+			} else { \
+				err_text = "Bad address index."; \
+			} \
+			OPCODE_BREAK; \
+		} \
+		m_v = &variant_addresses[address_type][address_index]; \
+		if (unlikely(!m_v)) \
+			OPCODE_BREAK; \
 	}
 
 #else // !DEBUG_ENABLED
 #define GD_ERR_BREAK(m_cond)
 #define CHECK_SPACE(m_space)
 
-#define GET_VARIANT_PTR(m_v, m_code_ofs)                                                        \
-	Variant *m_v;                                                                               \
-	{                                                                                           \
-		int address = _code_ptr[ip + 1 + (m_code_ofs)];                                         \
+#define GET_VARIANT_PTR(m_v, m_code_ofs) \
+	Variant *m_v; \
+	{ \
+		int address = _code_ptr[ip + 1 + (m_code_ofs)]; \
 		m_v = &variant_addresses[(address & ADDR_TYPE_MASK) >> ADDR_BITS][address & ADDR_MASK]; \
-		if (unlikely(!m_v))                                                                     \
-			OPCODE_BREAK;                                                                       \
+		if (unlikely(!m_v)) \
+			OPCODE_BREAK; \
 	}
 
 #endif // DEBUG_ENABLED
 
-#define LOAD_INSTRUCTION_ARGS                   \
-	int instr_arg_count = _code_ptr[ip + 1];    \
+#define LOAD_INSTRUCTION_ARGS \
+	int instr_arg_count = _code_ptr[ip + 1]; \
 	for (int i = 0; i < instr_arg_count; i++) { \
-		GET_VARIANT_PTR(v, i + 1);              \
-		instruction_args[i] = v;                \
-	}                                           \
+		GET_VARIANT_PTR(v, i + 1); \
+		instruction_args[i] = v; \
+	} \
 	ip += 1; // Offset to skip instruction argcount.
 
 #define GET_INSTRUCTION_ARG(m_v, m_idx) \
@@ -3301,25 +3301,25 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 #define OPCODE_ITERATE_BEGIN_PACKED_ARRAY(m_var_type, m_elem_type, m_get_func, m_var_ret_type, m_ret_type, m_ret_get_func) \
-	OPCODE(OPCODE_ITERATE_BEGIN_PACKED_##m_var_type##_ARRAY) {                                                             \
-		CHECK_SPACE(8);                                                                                                    \
-		GET_VARIANT_PTR(counter, 0);                                                                                       \
-		GET_VARIANT_PTR(container, 1);                                                                                     \
-		Vector<m_elem_type> *array = VariantInternal::m_get_func(container);                                               \
-		VariantInternal::initialize(counter, Variant::INT);                                                                \
-		*VariantInternal::get_int(counter) = 0;                                                                            \
-		if (!array->is_empty()) {                                                                                          \
-			GET_VARIANT_PTR(iterator, 2);                                                                                  \
-			VariantInternal::initialize(iterator, Variant::m_var_ret_type);                                                \
-			m_ret_type *it = VariantInternal::m_ret_get_func(iterator);                                                    \
-			*it = array->get(0);                                                                                           \
-			ip += 5;                                                                                                       \
-		} else {                                                                                                           \
-			int jumpto = _code_ptr[ip + 4];                                                                                \
-			GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);                                                               \
-			ip = jumpto;                                                                                                   \
-		}                                                                                                                  \
-	}                                                                                                                      \
+	OPCODE(OPCODE_ITERATE_BEGIN_PACKED_##m_var_type##_ARRAY) { \
+		CHECK_SPACE(8); \
+		GET_VARIANT_PTR(counter, 0); \
+		GET_VARIANT_PTR(container, 1); \
+		Vector<m_elem_type> *array = VariantInternal::m_get_func(container); \
+		VariantInternal::initialize(counter, Variant::INT); \
+		*VariantInternal::get_int(counter) = 0; \
+		if (!array->is_empty()) { \
+			GET_VARIANT_PTR(iterator, 2); \
+			VariantInternal::initialize(iterator, Variant::m_var_ret_type); \
+			m_ret_type *it = VariantInternal::m_ret_get_func(iterator); \
+			*it = array->get(0); \
+			ip += 5; \
+		} else { \
+			int jumpto = _code_ptr[ip + 4]; \
+			GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size); \
+			ip = jumpto; \
+		} \
+	} \
 	DISPATCH_OPCODE
 
 			OPCODE_ITERATE_BEGIN_PACKED_ARRAY(BYTE, uint8_t, get_byte_array, INT, int64_t, get_int);
@@ -3669,24 +3669,24 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			}
 			DISPATCH_OPCODE;
 
-#define OPCODE_ITERATE_PACKED_ARRAY(m_var_type, m_elem_type, m_get_func, m_ret_get_func)            \
-	OPCODE(OPCODE_ITERATE_PACKED_##m_var_type##_ARRAY) {                                            \
-		CHECK_SPACE(4);                                                                             \
-		GET_VARIANT_PTR(counter, 0);                                                                \
-		GET_VARIANT_PTR(container, 1);                                                              \
+#define OPCODE_ITERATE_PACKED_ARRAY(m_var_type, m_elem_type, m_get_func, m_ret_get_func) \
+	OPCODE(OPCODE_ITERATE_PACKED_##m_var_type##_ARRAY) { \
+		CHECK_SPACE(4); \
+		GET_VARIANT_PTR(counter, 0); \
+		GET_VARIANT_PTR(container, 1); \
 		const Vector<m_elem_type> *array = VariantInternal::m_get_func((const Variant *)container); \
-		int64_t *idx = VariantInternal::get_int(counter);                                           \
-		(*idx)++;                                                                                   \
-		if (*idx >= array->size()) {                                                                \
-			int jumpto = _code_ptr[ip + 4];                                                         \
-			GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);                                        \
-			ip = jumpto;                                                                            \
-		} else {                                                                                    \
-			GET_VARIANT_PTR(iterator, 2);                                                           \
-			*VariantInternal::m_ret_get_func(iterator) = array->get(*idx);                          \
-			ip += 5;                                                                                \
-		}                                                                                           \
-	}                                                                                               \
+		int64_t *idx = VariantInternal::get_int(counter); \
+		(*idx)++; \
+		if (*idx >= array->size()) { \
+			int jumpto = _code_ptr[ip + 4]; \
+			GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size); \
+			ip = jumpto; \
+		} else { \
+			GET_VARIANT_PTR(iterator, 2); \
+			*VariantInternal::m_ret_get_func(iterator) = array->get(*idx); \
+			ip += 5; \
+		} \
+	} \
 	DISPATCH_OPCODE
 
 			OPCODE_ITERATE_PACKED_ARRAY(BYTE, uint8_t, get_byte_array, get_int);
@@ -3810,13 +3810,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			}
 			DISPATCH_OPCODE;
 
-#define OPCODE_TYPE_ADJUST(m_v_type, m_c_type)    \
-	OPCODE(OPCODE_TYPE_ADJUST_##m_v_type) {       \
-		CHECK_SPACE(2);                           \
-		GET_VARIANT_PTR(arg, 0);                  \
+#define OPCODE_TYPE_ADJUST(m_v_type, m_c_type) \
+	OPCODE(OPCODE_TYPE_ADJUST_##m_v_type) { \
+		CHECK_SPACE(2); \
+		GET_VARIANT_PTR(arg, 0); \
 		VariantTypeAdjust<m_c_type>::adjust(arg); \
-		ip += 2;                                  \
-	}                                             \
+		ip += 2; \
+	} \
 	DISPATCH_OPCODE
 
 			OPCODE_TYPE_ADJUST(BOOL, bool);

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -38,15 +38,15 @@
 #include "editor/settings/editor_settings.h"
 #include "modules/gdscript/language_server/godot_lsp.h"
 
-#define LSP_CLIENT_V(m_ret_val)                                    \
+#define LSP_CLIENT_V(m_ret_val) \
 	ERR_FAIL_COND_V(latest_client_id == LSP_NO_CLIENT, m_ret_val); \
-	ERR_FAIL_COND_V(!clients.has(latest_client_id), m_ret_val);    \
-	Ref<LSPeer> client = clients.get(latest_client_id);            \
+	ERR_FAIL_COND_V(!clients.has(latest_client_id), m_ret_val); \
+	Ref<LSPeer> client = clients.get(latest_client_id); \
 	ERR_FAIL_COND_V(!client.is_valid(), m_ret_val);
 
-#define LSP_CLIENT                                      \
-	ERR_FAIL_COND(latest_client_id == LSP_NO_CLIENT);   \
-	ERR_FAIL_COND(!clients.has(latest_client_id));      \
+#define LSP_CLIENT \
+	ERR_FAIL_COND(latest_client_id == LSP_NO_CLIENT); \
+	ERR_FAIL_COND(!clients.has(latest_client_id)); \
 	Ref<LSPeer> client = clients.get(latest_client_id); \
 	ERR_FAIL_COND(!client.is_valid());
 

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -99,8 +99,8 @@ static void _editor_init() {
 #endif // TOOLS_ENABLED
 
 #define GLTF_REGISTER_DOCUMENT_EXTENSION(m_doc_ext_class) \
-	Ref<m_doc_ext_class> extension_##m_doc_ext_class;     \
-	extension_##m_doc_ext_class.instantiate();            \
+	Ref<m_doc_ext_class> extension_##m_doc_ext_class; \
+	extension_##m_doc_ext_class.instantiate(); \
 	GLTFDocument::register_gltf_document_extension(extension_##m_doc_ext_class);
 
 void initialize_gltf_module(ModuleInitializationLevel p_level) {

--- a/modules/godot_physics_2d/godot_collision_solver_2d_sat.cpp
+++ b/modules/godot_physics_2d/godot_collision_solver_2d_sat.cpp
@@ -374,9 +374,9 @@ public:
 
 /****** SAT TESTS *******/
 
-#define TEST_POINT(m_a, m_b)                                                                \
-	((!separator.test_axis(((m_a) - (m_b)).normalized())) ||                                \
-			(castA && !separator.test_axis(((m_a) + p_motion_a - (m_b)).normalized())) ||   \
+#define TEST_POINT(m_a, m_b) \
+	((!separator.test_axis(((m_a) - (m_b)).normalized())) || \
+			(castA && !separator.test_axis(((m_a) + p_motion_a - (m_b)).normalized())) || \
 			(castB && !separator.test_axis(((m_a) - ((m_b) + p_motion_b)).normalized())) || \
 			(castA && castB && !separator.test_axis(((m_a) + p_motion_a - ((m_b) + p_motion_b)).normalized())))
 

--- a/modules/godot_physics_2d/godot_shape_2d.h
+++ b/modules/godot_physics_2d/godot_shape_2d.h
@@ -128,19 +128,19 @@ public:
 };
 
 //let the optimizer do the magic
-#define DEFAULT_PROJECT_RANGE_CAST                                                                                                                                  \
+#define DEFAULT_PROJECT_RANGE_CAST \
 	virtual void project_range_castv(const Vector2 &p_cast, const Vector2 &p_normal, const Transform2D &p_transform, real_t &r_min, real_t &r_max) const override { \
-		project_range_cast(p_cast, p_normal, p_transform, r_min, r_max);                                                                                            \
-	}                                                                                                                                                               \
-	_FORCE_INLINE_ void project_range_cast(const Vector2 &p_cast, const Vector2 &p_normal, const Transform2D &p_transform, real_t &r_min, real_t &r_max) const {    \
-		real_t mina, maxa;                                                                                                                                          \
-		real_t minb, maxb;                                                                                                                                          \
-		Transform2D ofsb = p_transform;                                                                                                                             \
-		ofsb.columns[2] += p_cast;                                                                                                                                  \
-		project_range(p_normal, p_transform, mina, maxa);                                                                                                           \
-		project_range(p_normal, ofsb, minb, maxb);                                                                                                                  \
-		r_min = MIN(mina, minb);                                                                                                                                    \
-		r_max = MAX(maxa, maxb);                                                                                                                                    \
+		project_range_cast(p_cast, p_normal, p_transform, r_min, r_max); \
+	} \
+	_FORCE_INLINE_ void project_range_cast(const Vector2 &p_cast, const Vector2 &p_normal, const Transform2D &p_transform, real_t &r_min, real_t &r_max) const { \
+		real_t mina, maxa; \
+		real_t minb, maxb; \
+		Transform2D ofsb = p_transform; \
+		ofsb.columns[2] += p_cast; \
+		project_range(p_normal, p_transform, mina, maxa); \
+		project_range(p_normal, ofsb, minb, maxb); \
+		r_min = MIN(mina, minb); \
+		r_max = MAX(maxa, maxb); \
 	}
 
 class GodotWorldBoundaryShape2D : public GodotShape2D {

--- a/modules/jolt_physics/shapes/jolt_shape_3d.h
+++ b/modules/jolt_physics/shapes/jolt_shape_3d.h
@@ -95,25 +95,25 @@ public:
 
 #ifdef DEBUG_ENABLED
 
-#define JOLT_ENSURE_SCALE_NOT_ZERO(m_transform, m_msg)                                                         \
-	if (unlikely((m_transform).basis.determinant() == 0.0f)) {                                                 \
-		WARN_PRINT(vformat("%s "                                                                               \
+#define JOLT_ENSURE_SCALE_NOT_ZERO(m_transform, m_msg) \
+	if (unlikely((m_transform).basis.determinant() == 0.0f)) { \
+		WARN_PRINT(vformat("%s " \
 						   "The basis of the transform was singular, which is not supported by Jolt Physics. " \
-						   "This is likely caused by one or more axes having a scale of zero. "                \
-						   "The basis (and thus its scale) will be treated as identity.",                      \
-				m_msg));                                                                                       \
-                                                                                                               \
-		(m_transform).basis = Basis();                                                                         \
-	} else                                                                                                     \
+						   "This is likely caused by one or more axes having a scale of zero. " \
+						   "The basis (and thus its scale) will be treated as identity.", \
+				m_msg)); \
+\
+		(m_transform).basis = Basis(); \
+	} else \
 		((void)0)
 
-#define ERR_PRINT_INVALID_SCALE_MSG(m_scale, m_valid_scale, m_msg)                               \
-	if (unlikely(!JoltShape3D::is_scale_valid(m_scale, valid_scale))) {                          \
-		ERR_PRINT(vformat("%s "                                                                  \
+#define ERR_PRINT_INVALID_SCALE_MSG(m_scale, m_valid_scale, m_msg) \
+	if (unlikely(!JoltShape3D::is_scale_valid(m_scale, valid_scale))) { \
+		ERR_PRINT(vformat("%s " \
 						  "A scale of %v is not supported by Jolt Physics for this shape/body. " \
-						  "The scale will instead be treated as %v.",                            \
-				m_msg, m_scale, valid_scale));                                                   \
-	} else                                                                                       \
+						  "The scale will instead be treated as %v.", \
+				m_msg, m_scale, valid_scale)); \
+	} else \
 		((void)0)
 
 #else
@@ -124,10 +124,10 @@ public:
 
 #endif
 
-#define JOLT_ENSURE_SCALE_VALID(m_shape, m_scale, m_msg)                             \
-	if (true) {                                                                      \
+#define JOLT_ENSURE_SCALE_VALID(m_shape, m_scale, m_msg) \
+	if (true) { \
 		const Vector3 valid_scale = JoltShape3D::make_scale_valid(m_shape, m_scale); \
-		ERR_PRINT_INVALID_SCALE_MSG(m_scale, valid_scale, m_msg);                    \
-		(m_scale) = valid_scale;                                                     \
-	} else                                                                           \
+		ERR_PRINT_INVALID_SCALE_MSG(m_scale, valid_scale, m_msg); \
+		(m_scale) = valid_scale; \
+	} else \
 		((void)0)

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -1169,19 +1169,19 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	RID shadowmask_tex;
 	RID shadowmask_tex2;
 
-#define FREE_TEXTURES                    \
-	rd->free_rid(albedo_array_tex);      \
-	rd->free_rid(emission_array_tex);    \
-	rd->free_rid(normal_tex);            \
-	rd->free_rid(position_tex);          \
-	rd->free_rid(unocclude_tex);         \
-	rd->free_rid(light_source_tex);      \
-	rd->free_rid(light_accum_tex2);      \
-	rd->free_rid(light_accum_tex);       \
+#define FREE_TEXTURES \
+	rd->free_rid(albedo_array_tex); \
+	rd->free_rid(emission_array_tex); \
+	rd->free_rid(normal_tex); \
+	rd->free_rid(position_tex); \
+	rd->free_rid(unocclude_tex); \
+	rd->free_rid(light_source_tex); \
+	rd->free_rid(light_accum_tex2); \
+	rd->free_rid(light_accum_tex); \
 	rd->free_rid(light_environment_tex); \
-	if (p_bake_shadowmask) {             \
-		rd->free_rid(shadowmask_tex);    \
-		rd->free_rid(shadowmask_tex2);   \
+	if (p_bake_shadowmask) { \
+		rd->free_rid(shadowmask_tex); \
+		rd->free_rid(shadowmask_tex2); \
 	}
 
 	{ // create all textures
@@ -1286,16 +1286,16 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	Vector<int> slice_seam_count;
 
-#define FREE_BUFFERS                       \
-	rd->free_rid(bake_parameters_buffer);  \
-	rd->free_rid(vertex_buffer);           \
-	rd->free_rid(triangle_buffer);         \
-	rd->free_rid(lights_buffer);           \
+#define FREE_BUFFERS \
+	rd->free_rid(bake_parameters_buffer); \
+	rd->free_rid(vertex_buffer); \
+	rd->free_rid(triangle_buffer); \
+	rd->free_rid(lights_buffer); \
 	rd->free_rid(triangle_indices_buffer); \
-	rd->free_rid(cluster_indices_buffer);  \
-	rd->free_rid(cluster_aabbs_buffer);    \
-	rd->free_rid(grid_texture);            \
-	rd->free_rid(seams_buffer);            \
+	rd->free_rid(cluster_indices_buffer); \
+	rd->free_rid(cluster_aabbs_buffer); \
+	rd->free_rid(grid_texture); \
+	rd->free_rid(seams_buffer); \
 	rd->free_rid(probe_positions_buffer);
 
 	const uint32_t cluster_size = 16;
@@ -1537,9 +1537,9 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	}
 #endif
 
-#define FREE_RASTER_RESOURCES       \
+#define FREE_RASTER_RESOURCES \
 	rd->free_rid(rasterize_shader); \
-	rd->free_rid(sampler);          \
+	rd->free_rid(sampler); \
 	rd->free_rid(raster_depth_buffer);
 
 	/* Plot direct light */
@@ -1598,9 +1598,9 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	RID compute_base_uniform_set = rd->uniform_set_create(base_uniforms, compute_shader_primary, 0);
 
-#define FREE_COMPUTE_RESOURCES              \
+#define FREE_COMPUTE_RESOURCES \
 	rd->free_rid(compute_shader_unocclude); \
-	rd->free_rid(compute_shader_primary);   \
+	rd->free_rid(compute_shader_primary); \
 	rd->free_rid(compute_shader_secondary); \
 	rd->free_rid(compute_shader_light_probes);
 
@@ -2179,7 +2179,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	ERR_FAIL_COND_V(blendseams_triangle_raster_shader.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 
-#define FREE_BLENDSEAMS_RESOURCES                \
+#define FREE_BLENDSEAMS_RESOURCES \
 	rd->free_rid(blendseams_line_raster_shader); \
 	rd->free_rid(blendseams_triangle_raster_shader);
 

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1575,43 +1575,43 @@ void BindingsGenerator::_generate_array_extensions(StringBuilder &p_output) {
 	// The class where we put the extensions doesn't matter, so just use "GD".
 	p_output.append("public static partial class " BINDINGS_GLOBAL_SCOPE_CLASS "\n{");
 
-#define ARRAY_IS_EMPTY(m_type)                                                                          \
-	p_output.append("\n" INDENT1 "/// <summary>\n");                                                    \
+#define ARRAY_IS_EMPTY(m_type) \
+	p_output.append("\n" INDENT1 "/// <summary>\n"); \
 	p_output.append(INDENT1 "/// Returns true if this " #m_type " array is empty or doesn't exist.\n"); \
-	p_output.append(INDENT1 "/// </summary>\n");                                                        \
-	p_output.append(INDENT1 "/// <param name=\"instance\">The " #m_type " array check.</param>\n");     \
-	p_output.append(INDENT1 "/// <returns>Whether or not the array is empty.</returns>\n");             \
-	p_output.append(INDENT1 "public static bool IsEmpty(this " #m_type "[] instance)\n");               \
-	p_output.append(OPEN_BLOCK_L1);                                                                     \
-	p_output.append(INDENT2 "return instance == null || instance.Length == 0;\n");                      \
+	p_output.append(INDENT1 "/// </summary>\n"); \
+	p_output.append(INDENT1 "/// <param name=\"instance\">The " #m_type " array check.</param>\n"); \
+	p_output.append(INDENT1 "/// <returns>Whether or not the array is empty.</returns>\n"); \
+	p_output.append(INDENT1 "public static bool IsEmpty(this " #m_type "[] instance)\n"); \
+	p_output.append(OPEN_BLOCK_L1); \
+	p_output.append(INDENT2 "return instance == null || instance.Length == 0;\n"); \
 	p_output.append(INDENT1 CLOSE_BLOCK);
 
-#define ARRAY_JOIN(m_type)                                                                                          \
-	p_output.append("\n" INDENT1 "/// <summary>\n");                                                                \
-	p_output.append(INDENT1 "/// Converts this " #m_type " array to a string delimited by the given string.\n");    \
-	p_output.append(INDENT1 "/// </summary>\n");                                                                    \
-	p_output.append(INDENT1 "/// <param name=\"instance\">The " #m_type " array to convert.</param>\n");            \
-	p_output.append(INDENT1 "/// <param name=\"delimiter\">The delimiter to use between items.</param>\n");         \
-	p_output.append(INDENT1 "/// <returns>A single string with all items.</returns>\n");                            \
-	p_output.append(INDENT1 "public static string Join(this " #m_type "[] instance, string delimiter = \", \")\n"); \
-	p_output.append(OPEN_BLOCK_L1);                                                                                 \
-	p_output.append(INDENT2 "return String.Join(delimiter, instance);\n");                                          \
-	p_output.append(INDENT1 CLOSE_BLOCK);
-
-#define ARRAY_STRINGIFY(m_type)                                                                          \
-	p_output.append("\n" INDENT1 "/// <summary>\n");                                                     \
-	p_output.append(INDENT1 "/// Converts this " #m_type " array to a string with brackets.\n");         \
-	p_output.append(INDENT1 "/// </summary>\n");                                                         \
+#define ARRAY_JOIN(m_type) \
+	p_output.append("\n" INDENT1 "/// <summary>\n"); \
+	p_output.append(INDENT1 "/// Converts this " #m_type " array to a string delimited by the given string.\n"); \
+	p_output.append(INDENT1 "/// </summary>\n"); \
 	p_output.append(INDENT1 "/// <param name=\"instance\">The " #m_type " array to convert.</param>\n"); \
-	p_output.append(INDENT1 "/// <returns>A single string with all items.</returns>\n");                 \
-	p_output.append(INDENT1 "public static string Stringify(this " #m_type "[] instance)\n");            \
-	p_output.append(OPEN_BLOCK_L1);                                                                      \
-	p_output.append(INDENT2 "return \"[\" + instance.Join() + \"]\";\n");                                \
+	p_output.append(INDENT1 "/// <param name=\"delimiter\">The delimiter to use between items.</param>\n"); \
+	p_output.append(INDENT1 "/// <returns>A single string with all items.</returns>\n"); \
+	p_output.append(INDENT1 "public static string Join(this " #m_type "[] instance, string delimiter = \", \")\n"); \
+	p_output.append(OPEN_BLOCK_L1); \
+	p_output.append(INDENT2 "return String.Join(delimiter, instance);\n"); \
 	p_output.append(INDENT1 CLOSE_BLOCK);
 
-#define ARRAY_ALL(m_type)  \
+#define ARRAY_STRINGIFY(m_type) \
+	p_output.append("\n" INDENT1 "/// <summary>\n"); \
+	p_output.append(INDENT1 "/// Converts this " #m_type " array to a string with brackets.\n"); \
+	p_output.append(INDENT1 "/// </summary>\n"); \
+	p_output.append(INDENT1 "/// <param name=\"instance\">The " #m_type " array to convert.</param>\n"); \
+	p_output.append(INDENT1 "/// <returns>A single string with all items.</returns>\n"); \
+	p_output.append(INDENT1 "public static string Stringify(this " #m_type "[] instance)\n"); \
+	p_output.append(OPEN_BLOCK_L1); \
+	p_output.append(INDENT2 "return \"[\" + instance.Join() + \"]\";\n"); \
+	p_output.append(INDENT1 CLOSE_BLOCK);
+
+#define ARRAY_ALL(m_type) \
 	ARRAY_IS_EMPTY(m_type) \
-	ARRAY_JOIN(m_type)     \
+	ARRAY_JOIN(m_type) \
 	ARRAY_STRINGIFY(m_type)
 
 	ARRAY_ALL(byte);
@@ -4739,12 +4739,12 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 
 	TypeInterface itype;
 
-#define INSERT_STRUCT_TYPE(m_type, m_proxy_name)                                          \
-	{                                                                                     \
+#define INSERT_STRUCT_TYPE(m_type, m_proxy_name) \
+	{ \
 		itype = TypeInterface::create_value_type(String(#m_type), String(#m_proxy_name)); \
-		itype.cs_in_expr = "&%0";                                                         \
-		itype.cs_in_expr_is_unsafe = true;                                                \
-		builtin_types.insert(itype.cname, itype);                                         \
+		itype.cs_in_expr = "&%0"; \
+		itype.cs_in_expr_is_unsafe = true; \
+		builtin_types.insert(itype.cname, itype); \
 	}
 
 	INSERT_STRUCT_TYPE(Vector2, Vector2)
@@ -4781,21 +4781,21 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	{
 		// C interface for 'uint32_t' is the same as that of enums. Remember to apply
 		// any of the changes done here to 'TypeInterface::postsetup_enum_type' as well.
-#define INSERT_INT_TYPE(m_name, m_int_struct_name)                                             \
-	{                                                                                          \
-		itype = TypeInterface::create_value_type(String(m_name));                              \
-		if (itype.name != "long" && itype.name != "ulong") {                                   \
-			itype.c_in = "%5%0 %1_in = %1;\n";                                                 \
-			itype.c_out = "%5return (%0)(%1);\n";                                              \
-			itype.c_type = "long";                                                             \
-			itype.c_arg_in = "&%s_in";                                                         \
-		} else {                                                                               \
-			itype.c_arg_in = "&%s";                                                            \
-		}                                                                                      \
-		itype.c_type_in = itype.name;                                                          \
-		itype.c_type_out = itype.name;                                                         \
+#define INSERT_INT_TYPE(m_name, m_int_struct_name) \
+	{ \
+		itype = TypeInterface::create_value_type(String(m_name)); \
+		if (itype.name != "long" && itype.name != "ulong") { \
+			itype.c_in = "%5%0 %1_in = %1;\n"; \
+			itype.c_out = "%5return (%0)(%1);\n"; \
+			itype.c_type = "long"; \
+			itype.c_arg_in = "&%s_in"; \
+		} else { \
+			itype.c_arg_in = "&%s"; \
+		} \
+		itype.c_type_in = itype.name; \
+		itype.c_type_out = itype.name; \
 		itype.c_in_vararg = "%5using godot_variant %1_in = VariantUtils.CreateFromInt(%1);\n"; \
-		builtin_types.insert(itype.cname, itype);                                              \
+		builtin_types.insert(itype.cname, itype); \
 	}
 
 		// The expected type for all integers in ptrcall is 'int64_t', so that's what we use for 'c_type'
@@ -4967,22 +4967,22 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.is_span_compatible = true;
 	builtin_types.insert(itype.cname, itype);
 
-#define INSERT_ARRAY_FULL(m_name, m_type, m_managed_type, m_proxy_t)                \
-	{                                                                               \
-		itype = TypeInterface();                                                    \
-		itype.name = #m_name;                                                       \
-		itype.cname = itype.name;                                                   \
-		itype.proxy_name = #m_proxy_t "[]";                                         \
-		itype.cs_type = itype.proxy_name;                                           \
+#define INSERT_ARRAY_FULL(m_name, m_type, m_managed_type, m_proxy_t) \
+	{ \
+		itype = TypeInterface(); \
+		itype.name = #m_name; \
+		itype.cname = itype.name; \
+		itype.proxy_name = #m_proxy_t "[]"; \
+		itype.cs_type = itype.proxy_name; \
 		itype.c_in = "%5using %0 %1_in = " C_METHOD_MONOARRAY_TO(m_type) "(%1);\n"; \
-		itype.c_out = "%5return " C_METHOD_MONOARRAY_FROM(m_type) "(%1);\n";        \
-		itype.c_arg_in = "&%s_in";                                                  \
-		itype.c_type = #m_managed_type;                                             \
-		itype.c_type_in = "ReadOnlySpan<" #m_proxy_t ">";                           \
-		itype.c_type_out = itype.proxy_name;                                        \
-		itype.c_type_is_disposable_struct = true;                                   \
-		itype.is_span_compatible = true;                                            \
-		builtin_types.insert(itype.name, itype);                                    \
+		itype.c_out = "%5return " C_METHOD_MONOARRAY_FROM(m_type) "(%1);\n"; \
+		itype.c_arg_in = "&%s_in"; \
+		itype.c_type = #m_managed_type; \
+		itype.c_type_in = "ReadOnlySpan<" #m_proxy_t ">"; \
+		itype.c_type_out = itype.proxy_name; \
+		itype.c_type_is_disposable_struct = true; \
+		itype.is_span_compatible = true; \
+		builtin_types.insert(itype.name, itype); \
 	}
 
 #define INSERT_ARRAY(m_type, m_managed_type, m_proxy_t) INSERT_ARRAY_FULL(m_type, m_type, m_managed_type, m_proxy_t)

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -40,11 +40,11 @@ bool godot_api_cache_updated = false;
 void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	int checked_count = 0;
 
-#define CHECK_CALLBACK_NOT_NULL_IMPL(m_var, m_class, m_method)                             \
-	{                                                                                      \
-		ERR_FAIL_NULL_MSG(m_var,                                                           \
+#define CHECK_CALLBACK_NOT_NULL_IMPL(m_var, m_class, m_method) \
+	{ \
+		ERR_FAIL_NULL_MSG(m_var, \
 				"Mono Cache: Managed callback for '" #m_class "_" #m_method "' is null."); \
-		checked_count += 1;                                                                \
+		checked_count += 1; \
 	}
 
 #define CHECK_CALLBACK_NOT_NULL(m_class, m_method) CHECK_CALLBACK_NOT_NULL_IMPL(p_managed_callbacks.m_class##_##m_method, m_class, m_method)

--- a/modules/mono/utils/macros.h
+++ b/modules/mono/utils/macros.h
@@ -40,8 +40,8 @@
 #define GD_UNREACHABLE() __builtin_unreachable()
 #else
 #define GD_UNREACHABLE() \
-	CRASH_NOW();         \
-	do {                 \
+	CRASH_NOW(); \
+	do { \
 	} while (true)
 #endif
 

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -37,7 +37,7 @@
 #include "core/os/os.h"
 #include "scene/main/node.h"
 
-#define MAKE_ROOM(m_amount)             \
+#define MAKE_ROOM(m_amount) \
 	if (packet_cache.size() < m_amount) \
 		packet_cache.resize(m_amount);
 

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -346,7 +346,7 @@ void SceneRPCInterface::_send_rpc(Node *p_node, int p_to, uint16_t p_rpc_id, con
 	// Create base packet, lots of hardcode because it must be tight.
 	int ofs = 0;
 
-#define MAKE_ROOM(m_amount)             \
+#define MAKE_ROOM(m_amount) \
 	if (packet_cache.size() < m_amount) \
 		packet_cache.resize(m_amount);
 

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
@@ -38,43 +38,43 @@
 #include "nav_mesh_generator_2d.h"
 #endif // CLIPPER2_ENABLED
 
-#define COMMAND_1(F_NAME, T_0, D_0)                                     \
-	struct MERGE(F_NAME, _command_2d) : public SetCommand2D {           \
-		T_0 d_0;                                                        \
-		MERGE(F_NAME, _command_2d)                                      \
-		(T_0 p_d_0) :                                                   \
-				d_0(p_d_0) {}                                           \
+#define COMMAND_1(F_NAME, T_0, D_0) \
+	struct MERGE(F_NAME, _command_2d) : public SetCommand2D { \
+		T_0 d_0; \
+		MERGE(F_NAME, _command_2d) \
+		(T_0 p_d_0) : \
+				d_0(p_d_0) {} \
 		virtual void exec(GodotNavigationServer2D *p_server) override { \
-			p_server->MERGE(_cmd_, F_NAME)(d_0);                        \
-		}                                                               \
-	};                                                                  \
-	void GodotNavigationServer2D::F_NAME(T_0 D_0) {                     \
-		auto cmd = memnew(MERGE(F_NAME, _command_2d)(                   \
-				D_0));                                                  \
-		add_command(cmd);                                               \
-	}                                                                   \
+			p_server->MERGE(_cmd_, F_NAME)(d_0); \
+		} \
+	}; \
+	void GodotNavigationServer2D::F_NAME(T_0 D_0) { \
+		auto cmd = memnew(MERGE(F_NAME, _command_2d)( \
+				D_0)); \
+		add_command(cmd); \
+	} \
 	void GodotNavigationServer2D::MERGE(_cmd_, F_NAME)(T_0 D_0)
 
-#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1)                           \
-	struct MERGE(F_NAME, _command_2d) : public SetCommand2D {           \
-		T_0 d_0;                                                        \
-		T_1 d_1;                                                        \
-		MERGE(F_NAME, _command_2d)                                      \
-		(                                                               \
-				T_0 p_d_0,                                              \
-				T_1 p_d_1) :                                            \
-				d_0(p_d_0),                                             \
-				d_1(p_d_1) {}                                           \
+#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1) \
+	struct MERGE(F_NAME, _command_2d) : public SetCommand2D { \
+		T_0 d_0; \
+		T_1 d_1; \
+		MERGE(F_NAME, _command_2d) \
+		( \
+				T_0 p_d_0, \
+				T_1 p_d_1) : \
+				d_0(p_d_0), \
+				d_1(p_d_1) {} \
 		virtual void exec(GodotNavigationServer2D *p_server) override { \
-			p_server->MERGE(_cmd_, F_NAME)(d_0, d_1);                   \
-		}                                                               \
-	};                                                                  \
-	void GodotNavigationServer2D::F_NAME(T_0 D_0, T_1 D_1) {            \
-		auto cmd = memnew(MERGE(F_NAME, _command_2d)(                   \
-				D_0,                                                    \
-				D_1));                                                  \
-		add_command(cmd);                                               \
-	}                                                                   \
+			p_server->MERGE(_cmd_, F_NAME)(d_0, d_1); \
+		} \
+	}; \
+	void GodotNavigationServer2D::F_NAME(T_0 D_0, T_1 D_1) { \
+		auto cmd = memnew(MERGE(F_NAME, _command_2d)( \
+				D_0, \
+				D_1)); \
+		add_command(cmd); \
+	} \
 	void GodotNavigationServer2D::MERGE(_cmd_, F_NAME)(T_0 D_0, T_1 D_1)
 
 void GodotNavigationServer2D::init() {

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.h
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.h
@@ -48,11 +48,11 @@
 #define MERGE_INTERNAL(A, B) A##B
 #define MERGE(A, B) MERGE_INTERNAL(A, B)
 
-#define COMMAND_1(F_NAME, T_0, D_0)        \
+#define COMMAND_1(F_NAME, T_0, D_0) \
 	virtual void F_NAME(T_0 D_0) override; \
 	void MERGE(_cmd_, F_NAME)(T_0 D_0)
 
-#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1)       \
+#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1) \
 	virtual void F_NAME(T_0 D_0, T_1 D_1) override; \
 	void MERGE(_cmd_, F_NAME)(T_0 D_0, T_1 D_1)
 

--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -55,16 +55,16 @@ using namespace Nav2D;
 #define NAVMAP_ITERATION_ZERO_ERROR_MSG()
 #endif // DEBUG_ENABLED
 
-#define GET_MAP_ITERATION()                                                   \
-	iteration_slot_rwlock.read_lock();                                        \
+#define GET_MAP_ITERATION() \
+	iteration_slot_rwlock.read_lock(); \
 	NavMapIteration2D &map_iteration = iteration_slots[iteration_slot_index]; \
-	NavMapIterationRead2D iteration_read_lock(map_iteration);                 \
+	NavMapIterationRead2D iteration_read_lock(map_iteration); \
 	iteration_slot_rwlock.read_unlock();
 
-#define GET_MAP_ITERATION_CONST()                                                   \
-	iteration_slot_rwlock.read_lock();                                              \
+#define GET_MAP_ITERATION_CONST() \
+	iteration_slot_rwlock.read_lock(); \
 	const NavMapIteration2D &map_iteration = iteration_slots[iteration_slot_index]; \
-	NavMapIterationRead2D iteration_read_lock(map_iteration);                       \
+	NavMapIterationRead2D iteration_read_lock(map_iteration); \
 	iteration_slot_rwlock.read_unlock();
 
 void NavMap2D::set_cell_size(real_t p_cell_size) {

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -41,43 +41,43 @@ using namespace NavigationDefaults3D;
 /// an instance of that struct with the submitted parameters.
 /// Then, that struct is stored in an array; the `sync` function consume that array.
 
-#define COMMAND_1(F_NAME, T_0, D_0)                                   \
-	struct MERGE(F_NAME, _command_3d) : public SetCommand3D {         \
-		T_0 d_0;                                                      \
-		MERGE(F_NAME, _command_3d)                                    \
-		(T_0 p_d_0) :                                                 \
-				d_0(p_d_0) {}                                         \
+#define COMMAND_1(F_NAME, T_0, D_0) \
+	struct MERGE(F_NAME, _command_3d) : public SetCommand3D { \
+		T_0 d_0; \
+		MERGE(F_NAME, _command_3d) \
+		(T_0 p_d_0) : \
+				d_0(p_d_0) {} \
 		virtual void exec(GodotNavigationServer3D *server) override { \
-			server->MERGE(_cmd_, F_NAME)(d_0);                        \
-		}                                                             \
-	};                                                                \
-	void GodotNavigationServer3D::F_NAME(T_0 D_0) {                   \
-		auto cmd = memnew(MERGE(F_NAME, _command_3d)(                 \
-				D_0));                                                \
-		add_command(cmd);                                             \
-	}                                                                 \
+			server->MERGE(_cmd_, F_NAME)(d_0); \
+		} \
+	}; \
+	void GodotNavigationServer3D::F_NAME(T_0 D_0) { \
+		auto cmd = memnew(MERGE(F_NAME, _command_3d)( \
+				D_0)); \
+		add_command(cmd); \
+	} \
 	void GodotNavigationServer3D::MERGE(_cmd_, F_NAME)(T_0 D_0)
 
-#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1)                         \
-	struct MERGE(F_NAME, _command_3d) : public SetCommand3D {         \
-		T_0 d_0;                                                      \
-		T_1 d_1;                                                      \
-		MERGE(F_NAME, _command_3d)                                    \
-		(                                                             \
-				T_0 p_d_0,                                            \
-				T_1 p_d_1) :                                          \
-				d_0(p_d_0),                                           \
-				d_1(p_d_1) {}                                         \
+#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1) \
+	struct MERGE(F_NAME, _command_3d) : public SetCommand3D { \
+		T_0 d_0; \
+		T_1 d_1; \
+		MERGE(F_NAME, _command_3d) \
+		( \
+				T_0 p_d_0, \
+				T_1 p_d_1) : \
+				d_0(p_d_0), \
+				d_1(p_d_1) {} \
 		virtual void exec(GodotNavigationServer3D *server) override { \
-			server->MERGE(_cmd_, F_NAME)(d_0, d_1);                   \
-		}                                                             \
-	};                                                                \
-	void GodotNavigationServer3D::F_NAME(T_0 D_0, T_1 D_1) {          \
-		auto cmd = memnew(MERGE(F_NAME, _command_3d)(                 \
-				D_0,                                                  \
-				D_1));                                                \
-		add_command(cmd);                                             \
-	}                                                                 \
+			server->MERGE(_cmd_, F_NAME)(d_0, d_1); \
+		} \
+	}; \
+	void GodotNavigationServer3D::F_NAME(T_0 D_0, T_1 D_1) { \
+		auto cmd = memnew(MERGE(F_NAME, _command_3d)( \
+				D_0, \
+				D_1)); \
+		add_command(cmd); \
+	} \
 	void GodotNavigationServer3D::MERGE(_cmd_, F_NAME)(T_0 D_0, T_1 D_1)
 
 GodotNavigationServer3D::GodotNavigationServer3D() {}

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.h
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.h
@@ -48,11 +48,11 @@
 #define MERGE_INTERNAL(A, B) A##B
 #define MERGE(A, B) MERGE_INTERNAL(A, B)
 
-#define COMMAND_1(F_NAME, T_0, D_0)        \
+#define COMMAND_1(F_NAME, T_0, D_0) \
 	virtual void F_NAME(T_0 D_0) override; \
 	void MERGE(_cmd_, F_NAME)(T_0 D_0)
 
-#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1)       \
+#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1) \
 	virtual void F_NAME(T_0 D_0, T_1 D_1) override; \
 	void MERGE(_cmd_, F_NAME)(T_0 D_0, T_1 D_1)
 

--- a/modules/navigation_3d/editor/navigation_link_3d_gizmo_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_link_3d_gizmo_plugin.cpp
@@ -96,21 +96,21 @@ void NavigationLink3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		// Draw axis-aligned circle.
 		switch (up_axis) {
 			case Vector3::AXIS_X:
-#define PUSH_OCTANT(_position, a, b)                          \
-	lines_ptrw[index++] = _position + Vector3(0, a.x, a.y);   \
-	lines_ptrw[index++] = _position + Vector3(0, x, y);       \
-	lines_ptrw[index++] = _position + Vector3(0, -a.x, a.y);  \
-	lines_ptrw[index++] = _position + Vector3(0, x, y);       \
-	lines_ptrw[index++] = _position + Vector3(0, a.x, -a.y);  \
-	lines_ptrw[index++] = _position + Vector3(0, x, -y);      \
+#define PUSH_OCTANT(_position, a, b) \
+	lines_ptrw[index++] = _position + Vector3(0, a.x, a.y); \
+	lines_ptrw[index++] = _position + Vector3(0, x, y); \
+	lines_ptrw[index++] = _position + Vector3(0, -a.x, a.y); \
+	lines_ptrw[index++] = _position + Vector3(0, x, y); \
+	lines_ptrw[index++] = _position + Vector3(0, a.x, -a.y); \
+	lines_ptrw[index++] = _position + Vector3(0, x, -y); \
 	lines_ptrw[index++] = _position + Vector3(0, -a.x, -a.y); \
-	lines_ptrw[index++] = _position + Vector3(0, x, y);       \
-	lines_ptrw[index++] = _position + Vector3(0, a.y, a.x);   \
-	lines_ptrw[index++] = _position + Vector3(0, y, x);       \
-	lines_ptrw[index++] = _position + Vector3(0, -a.y, a.x);  \
-	lines_ptrw[index++] = _position + Vector3(0, -y, x);      \
-	lines_ptrw[index++] = _position + Vector3(0, a.y, -a.x);  \
-	lines_ptrw[index++] = _position + Vector3(0, y, -x);      \
+	lines_ptrw[index++] = _position + Vector3(0, x, y); \
+	lines_ptrw[index++] = _position + Vector3(0, a.y, a.x); \
+	lines_ptrw[index++] = _position + Vector3(0, y, x); \
+	lines_ptrw[index++] = _position + Vector3(0, -a.y, a.x); \
+	lines_ptrw[index++] = _position + Vector3(0, -y, x); \
+	lines_ptrw[index++] = _position + Vector3(0, a.y, -a.x); \
+	lines_ptrw[index++] = _position + Vector3(0, y, -x); \
 	lines_ptrw[index++] = _position + Vector3(0, -a.y, -a.x); \
 	lines_ptrw[index++] = _position + Vector3(0, -y, -x);
 
@@ -119,21 +119,21 @@ void NavigationLink3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 #undef PUSH_OCTANT
 				break;
 			case Vector3::AXIS_Y:
-#define PUSH_OCTANT(_position, a, b)                          \
-	lines_ptrw[index++] = _position + Vector3(a.x, 0, a.y);   \
-	lines_ptrw[index++] = _position + Vector3(x, 0, y);       \
-	lines_ptrw[index++] = _position + Vector3(-a.x, 0, a.y);  \
-	lines_ptrw[index++] = _position + Vector3(-x, 0, y);      \
-	lines_ptrw[index++] = _position + Vector3(a.x, 0, -a.y);  \
-	lines_ptrw[index++] = _position + Vector3(x, 0, -y);      \
+#define PUSH_OCTANT(_position, a, b) \
+	lines_ptrw[index++] = _position + Vector3(a.x, 0, a.y); \
+	lines_ptrw[index++] = _position + Vector3(x, 0, y); \
+	lines_ptrw[index++] = _position + Vector3(-a.x, 0, a.y); \
+	lines_ptrw[index++] = _position + Vector3(-x, 0, y); \
+	lines_ptrw[index++] = _position + Vector3(a.x, 0, -a.y); \
+	lines_ptrw[index++] = _position + Vector3(x, 0, -y); \
 	lines_ptrw[index++] = _position + Vector3(-a.x, 0, -a.y); \
-	lines_ptrw[index++] = _position + Vector3(-x, 0, -y);     \
-	lines_ptrw[index++] = _position + Vector3(a.y, 0, a.x);   \
-	lines_ptrw[index++] = _position + Vector3(y, 0, x);       \
-	lines_ptrw[index++] = _position + Vector3(-a.y, 0, a.x);  \
-	lines_ptrw[index++] = _position + Vector3(-y, 0, x);      \
-	lines_ptrw[index++] = _position + Vector3(a.y, 0, -a.x);  \
-	lines_ptrw[index++] = _position + Vector3(y, 0, -x);      \
+	lines_ptrw[index++] = _position + Vector3(-x, 0, -y); \
+	lines_ptrw[index++] = _position + Vector3(a.y, 0, a.x); \
+	lines_ptrw[index++] = _position + Vector3(y, 0, x); \
+	lines_ptrw[index++] = _position + Vector3(-a.y, 0, a.x); \
+	lines_ptrw[index++] = _position + Vector3(-y, 0, x); \
+	lines_ptrw[index++] = _position + Vector3(a.y, 0, -a.x); \
+	lines_ptrw[index++] = _position + Vector3(y, 0, -x); \
 	lines_ptrw[index++] = _position + Vector3(-a.y, 0, -a.x); \
 	lines_ptrw[index++] = _position + Vector3(-y, 0, -x);
 
@@ -142,21 +142,21 @@ void NavigationLink3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 #undef PUSH_OCTANT
 				break;
 			case Vector3::AXIS_Z:
-#define PUSH_OCTANT(_position, a, b)                          \
-	lines_ptrw[index++] = _position + Vector3(a.x, a.y, 0);   \
-	lines_ptrw[index++] = _position + Vector3(x, y, 0);       \
-	lines_ptrw[index++] = _position + Vector3(-a.x, a.y, 0);  \
-	lines_ptrw[index++] = _position + Vector3(-x, y, 0);      \
-	lines_ptrw[index++] = _position + Vector3(a.x, -a.y, 0);  \
-	lines_ptrw[index++] = _position + Vector3(x, -y, 0);      \
+#define PUSH_OCTANT(_position, a, b) \
+	lines_ptrw[index++] = _position + Vector3(a.x, a.y, 0); \
+	lines_ptrw[index++] = _position + Vector3(x, y, 0); \
+	lines_ptrw[index++] = _position + Vector3(-a.x, a.y, 0); \
+	lines_ptrw[index++] = _position + Vector3(-x, y, 0); \
+	lines_ptrw[index++] = _position + Vector3(a.x, -a.y, 0); \
+	lines_ptrw[index++] = _position + Vector3(x, -y, 0); \
 	lines_ptrw[index++] = _position + Vector3(-a.x, -a.y, 0); \
-	lines_ptrw[index++] = _position + Vector3(-x, -y, 0);     \
-	lines_ptrw[index++] = _position + Vector3(a.y, a.x, 0);   \
-	lines_ptrw[index++] = _position + Vector3(y, x, 0);       \
-	lines_ptrw[index++] = _position + Vector3(-a.y, a.x, 0);  \
-	lines_ptrw[index++] = _position + Vector3(-y, x, 0);      \
-	lines_ptrw[index++] = _position + Vector3(a.y, -a.x, 0);  \
-	lines_ptrw[index++] = _position + Vector3(y, -x, 0);      \
+	lines_ptrw[index++] = _position + Vector3(-x, -y, 0); \
+	lines_ptrw[index++] = _position + Vector3(a.y, a.x, 0); \
+	lines_ptrw[index++] = _position + Vector3(y, x, 0); \
+	lines_ptrw[index++] = _position + Vector3(-a.y, a.x, 0); \
+	lines_ptrw[index++] = _position + Vector3(-y, x, 0); \
+	lines_ptrw[index++] = _position + Vector3(a.y, -a.x, 0); \
+	lines_ptrw[index++] = _position + Vector3(y, -x, 0); \
 	lines_ptrw[index++] = _position + Vector3(-a.y, -a.x, 0); \
 	lines_ptrw[index++] = _position + Vector3(-y, -x, 0);
 

--- a/modules/navigation_3d/nav_map_3d.cpp
+++ b/modules/navigation_3d/nav_map_3d.cpp
@@ -55,16 +55,16 @@ using namespace Nav3D;
 #define NAVMAP_ITERATION_ZERO_ERROR_MSG()
 #endif // DEBUG_ENABLED
 
-#define GET_MAP_ITERATION()                                                   \
-	iteration_slot_rwlock.read_lock();                                        \
+#define GET_MAP_ITERATION() \
+	iteration_slot_rwlock.read_lock(); \
 	NavMapIteration3D &map_iteration = iteration_slots[iteration_slot_index]; \
-	NavMapIterationRead3D iteration_read_lock(map_iteration);                 \
+	NavMapIterationRead3D iteration_read_lock(map_iteration); \
 	iteration_slot_rwlock.read_unlock();
 
-#define GET_MAP_ITERATION_CONST()                                                   \
-	iteration_slot_rwlock.read_lock();                                              \
+#define GET_MAP_ITERATION_CONST() \
+	iteration_slot_rwlock.read_lock(); \
 	const NavMapIteration3D &map_iteration = iteration_slots[iteration_slot_index]; \
-	NavMapIterationRead3D iteration_read_lock(map_iteration);                       \
+	NavMapIterationRead3D iteration_read_lock(map_iteration); \
 	iteration_slot_rwlock.read_unlock();
 
 void NavMap3D::set_up(Vector3 p_up) {

--- a/modules/noise/tests/test_fastnoise_lite.h
+++ b/modules/noise/tests/test_fastnoise_lite.h
@@ -63,13 +63,13 @@ Vector<Pair<size_t, size_t>> find_approx_equal_vec_pairs(std::initializer_list<V
 	return result;
 }
 
-#define CHECK_ARGS_APPROX_PAIRWISE_DISTINCT_VECS(...)                                                              \
-	{                                                                                                              \
-		Vector<Pair<size_t, size_t>> equal_pairs = find_approx_equal_vec_pairs({ __VA_ARGS__ });                   \
-		for (Pair<size_t, size_t> p : equal_pairs) {                                                               \
+#define CHECK_ARGS_APPROX_PAIRWISE_DISTINCT_VECS(...) \
+	{ \
+		Vector<Pair<size_t, size_t>> equal_pairs = find_approx_equal_vec_pairs({ __VA_ARGS__ }); \
+		for (Pair<size_t, size_t> p : equal_pairs) { \
 			MESSAGE("Argument with index ", p.first, " is approximately equal to argument with index ", p.second); \
-		}                                                                                                          \
-		CHECK_MESSAGE(equal_pairs.size() == 0, "All arguments should be pairwise distinct.");                      \
+		} \
+		CHECK_MESSAGE(equal_pairs.size() == 0, "All arguments should be pairwise distinct."); \
 	}
 
 Vector<real_t> get_noise_samples_1d(const FastNoiseLite &p_noise, size_t p_count = 32) {

--- a/modules/openxr/extensions/openxr_composition_layer_extension.h
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.h
@@ -46,23 +46,23 @@ class JavaObject;
 
 // This extension provides access to composition layers for displaying 2D content through the XR compositor.
 
-#define OPENXR_LAYER_FUNC1(m_name, m_arg1)                                                                                                                                \
-	void _composition_layer_##m_name##_rt(RID p_layer, m_arg1 p1) {                                                                                                       \
-		CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer);                                                                                           \
-		ERR_FAIL_NULL(layer);                                                                                                                                             \
-		layer->m_name(p1);                                                                                                                                                \
-	}                                                                                                                                                                     \
-	void composition_layer_##m_name(RID p_layer, m_arg1 p1) {                                                                                                             \
+#define OPENXR_LAYER_FUNC1(m_name, m_arg1) \
+	void _composition_layer_##m_name##_rt(RID p_layer, m_arg1 p1) { \
+		CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer); \
+		ERR_FAIL_NULL(layer); \
+		layer->m_name(p1); \
+	} \
+	void composition_layer_##m_name(RID p_layer, m_arg1 p1) { \
 		RenderingServer::get_singleton()->call_on_render_thread(callable_mp(this, &OpenXRCompositionLayerExtension::_composition_layer_##m_name##_rt).bind(p_layer, p1)); \
 	}
 
-#define OPENXR_LAYER_FUNC2(m_name, m_arg1, m_arg2)                                                                                                                            \
-	void _composition_layer_##m_name##_rt(RID p_layer, m_arg1 p1, m_arg2 p2) {                                                                                                \
-		CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer);                                                                                               \
-		ERR_FAIL_NULL(layer);                                                                                                                                                 \
-		layer->m_name(p1, p2);                                                                                                                                                \
-	}                                                                                                                                                                         \
-	void composition_layer_##m_name(RID p_layer, m_arg1 p1, m_arg2 p2) {                                                                                                      \
+#define OPENXR_LAYER_FUNC2(m_name, m_arg1, m_arg2) \
+	void _composition_layer_##m_name##_rt(RID p_layer, m_arg1 p1, m_arg2 p2) { \
+		CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer); \
+		ERR_FAIL_NULL(layer); \
+		layer->m_name(p1, p2); \
+	} \
+	void composition_layer_##m_name(RID p_layer, m_arg1 p1, m_arg2 p2) { \
 		RenderingServer::get_singleton()->call_on_render_thread(callable_mp(this, &OpenXRCompositionLayerExtension::_composition_layer_##m_name##_rt).bind(p_layer, p1, p2)); \
 	}
 

--- a/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
@@ -315,8 +315,8 @@ void OpenXRD3D12Extension::cleanup_swapchain_graphics_data(void **p_swapchain_gr
 }
 
 #define ENUM_TO_STRING_CASE(e) \
-	case e: {                  \
-		return String(#e);     \
+	case e: { \
+		return String(#e); \
 	} break;
 
 String OpenXRD3D12Extension::get_swapchain_format_name(int64_t p_swapchain_format) const {

--- a/modules/openxr/extensions/platform/openxr_metal_extension.mm
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.mm
@@ -122,8 +122,8 @@ void OpenXRMetalExtension::get_usable_depth_formats(Vector<int64_t> &p_usable_sw
 }
 
 #define ENUM_TO_STRING_CASE(m_e) \
-	case m_e: {                  \
-		return String(#m_e);     \
+	case m_e: { \
+		return String(#m_e); \
 	} break;
 
 String OpenXRMetalExtension::get_swapchain_format_name(int64_t p_swapchain_format) const {

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -327,8 +327,8 @@ void OpenXROpenGLExtension::cleanup_swapchain_graphics_data(void **p_swapchain_g
 }
 
 #define ENUM_TO_STRING_CASE(e) \
-	case e: {                  \
-		return String(#e);     \
+	case e: { \
+		return String(#e); \
 	} break;
 
 String OpenXROpenGLExtension::get_swapchain_format_name(int64_t p_swapchain_format) const {

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
@@ -501,8 +501,8 @@ void OpenXRVulkanExtension::cleanup_swapchain_graphics_data(void **p_swapchain_g
 }
 
 #define ENUM_TO_STRING_CASE(e) \
-	case e: {                  \
-		return String(#e);     \
+	case e: { \
+		return String(#e); \
 	} break;
 
 String OpenXRVulkanExtension::get_swapchain_format_name(int64_t p_swapchain_format) const {

--- a/modules/openxr/openxr_util.h
+++ b/modules/openxr/openxr_util.h
@@ -36,10 +36,10 @@
 #include <openxr/openxr_reflection.h>
 
 #define XR_ENUM_CASE_STR(name, val) \
-	case name:                      \
+	case name: \
 		return #name;
-#define XR_ENUM_SWITCH(enumType, var)                                                                                           \
-	switch (var) {                                                                                                              \
+#define XR_ENUM_SWITCH(enumType, var) \
+	switch (var) { \
 		XR_LIST_ENUM_##enumType(XR_ENUM_CASE_STR) default : return "Unknown " #enumType ": " + String::num_int64(int64_t(var)); \
 	}
 

--- a/modules/openxr/util.h
+++ b/modules/openxr/util.h
@@ -32,23 +32,23 @@
 
 #define UNPACK(...) __VA_ARGS__
 
-#define INIT_XR_FUNC_V(openxr_api, name)                                                                              \
-	if constexpr (true) {                                                                                             \
-		XrResult get_instance_proc_addr_result;                                                                       \
+#define INIT_XR_FUNC_V(openxr_api, name) \
+	if constexpr (true) { \
+		XrResult get_instance_proc_addr_result; \
 		get_instance_proc_addr_result = openxr_api->get_instance_proc_addr(#name, (PFN_xrVoidFunction *)&name##_ptr); \
-		ERR_FAIL_COND_V(XR_FAILED(get_instance_proc_addr_result), false);                                             \
-	} else                                                                                                            \
+		ERR_FAIL_COND_V(XR_FAILED(get_instance_proc_addr_result), false); \
+	} else \
 		((void)0)
 
 #define EXT_INIT_XR_FUNC_V(name) INIT_XR_FUNC_V(OpenXRAPI::get_singleton(), name)
 #define OPENXR_API_INIT_XR_FUNC_V(name) INIT_XR_FUNC_V(this, name)
 
-#define INIT_XR_FUNC(openxr_api, name)                                                                                \
-	if constexpr (true) {                                                                                             \
-		XrResult get_instance_proc_addr_result;                                                                       \
+#define INIT_XR_FUNC(openxr_api, name) \
+	if constexpr (true) { \
+		XrResult get_instance_proc_addr_result; \
 		get_instance_proc_addr_result = openxr_api->get_instance_proc_addr(#name, (PFN_xrVoidFunction *)&name##_ptr); \
-		ERR_FAIL_COND(XR_FAILED(get_instance_proc_addr_result));                                                      \
-	} else                                                                                                            \
+		ERR_FAIL_COND(XR_FAILED(get_instance_proc_addr_result)); \
+	} else \
 		((void)0)
 
 #define EXT_INIT_XR_FUNC(name) INIT_XR_FUNC(OpenXRAPI::get_singleton(), name)
@@ -59,70 +59,70 @@
 
 #define EXT_TRY_INIT_XR_FUNC(name) TRY_INIT_XR_FUNC(OpenXRAPI::get_singleton(), name)
 #define OPENXR_TRY_API_INIT_XR_FUNC(name) TRY_INIT_XR_FUNC(this, name)
-#define GDEXTENSION_INIT_XR_FUNC(name)                                                              \
-	if constexpr (true) {                                                                           \
+#define GDEXTENSION_INIT_XR_FUNC(name) \
+	if constexpr (true) { \
 		name##_ptr = reinterpret_cast<PFN_##name>(get_openxr_api()->get_instance_proc_addr(#name)); \
-		ERR_FAIL_NULL(name##_ptr);                                                                  \
-	} else                                                                                          \
+		ERR_FAIL_NULL(name##_ptr); \
+	} else \
 		((void)0)
 
-#define GDEXTENSION_INIT_XR_FUNC_V(name)                                                            \
-	if constexpr (true) {                                                                           \
+#define GDEXTENSION_INIT_XR_FUNC_V(name) \
+	if constexpr (true) { \
 		name##_ptr = reinterpret_cast<PFN_##name>(get_openxr_api()->get_instance_proc_addr(#name)); \
-		ERR_FAIL_NULL_V(name##_ptr, false);                                                         \
-	} else                                                                                          \
+		ERR_FAIL_NULL_V(name##_ptr, false); \
+	} else \
 		((void)0)
 
-#define EXT_PROTO_XRRESULT_FUNC1(func_name, arg1_type, arg1)                    \
-	PFN_##func_name func_name##_ptr = nullptr;                                  \
+#define EXT_PROTO_XRRESULT_FUNC1(func_name, arg1_type, arg1) \
+	PFN_##func_name func_name##_ptr = nullptr; \
 	XRAPI_ATTR XrResult XRAPI_CALL func_name(UNPACK arg1_type p_##arg1) const { \
-		if (!func_name##_ptr) {                                                 \
-			return XR_ERROR_HANDLE_INVALID;                                     \
-		}                                                                       \
-		return (*func_name##_ptr)(p_##arg1);                                    \
+		if (!func_name##_ptr) { \
+			return XR_ERROR_HANDLE_INVALID; \
+		} \
+		return (*func_name##_ptr)(p_##arg1); \
 	}
 
-#define EXT_PROTO_XRRESULT_FUNC2(func_name, arg1_type, arg1, arg2_type, arg2)                              \
-	PFN_##func_name func_name##_ptr = nullptr;                                                             \
+#define EXT_PROTO_XRRESULT_FUNC2(func_name, arg1_type, arg1, arg2_type, arg2) \
+	PFN_##func_name func_name##_ptr = nullptr; \
 	XRAPI_ATTR XrResult XRAPI_CALL func_name(UNPACK arg1_type p_##arg1, UNPACK arg2_type p_##arg2) const { \
-		if (!func_name##_ptr) {                                                                            \
-			return XR_ERROR_HANDLE_INVALID;                                                                \
-		}                                                                                                  \
-		return (*func_name##_ptr)(p_##arg1, p_##arg2);                                                     \
+		if (!func_name##_ptr) { \
+			return XR_ERROR_HANDLE_INVALID; \
+		} \
+		return (*func_name##_ptr)(p_##arg1, p_##arg2); \
 	}
 
-#define EXT_PROTO_XRRESULT_FUNC3(func_name, arg1_type, arg1, arg2_type, arg2, arg3_type, arg3)                                        \
-	PFN_##func_name func_name##_ptr = nullptr;                                                                                        \
+#define EXT_PROTO_XRRESULT_FUNC3(func_name, arg1_type, arg1, arg2_type, arg2, arg3_type, arg3) \
+	PFN_##func_name func_name##_ptr = nullptr; \
 	XRAPI_ATTR XrResult XRAPI_CALL func_name(UNPACK arg1_type p_##arg1, UNPACK arg2_type p_##arg2, UNPACK arg3_type p_##arg3) const { \
-		if (!func_name##_ptr) {                                                                                                       \
-			return XR_ERROR_HANDLE_INVALID;                                                                                           \
-		}                                                                                                                             \
-		return (*func_name##_ptr)(p_##arg1, p_##arg2, p_##arg3);                                                                      \
+		if (!func_name##_ptr) { \
+			return XR_ERROR_HANDLE_INVALID; \
+		} \
+		return (*func_name##_ptr)(p_##arg1, p_##arg2, p_##arg3); \
 	}
 
-#define EXT_PROTO_XRRESULT_FUNC4(func_name, arg1_type, arg1, arg2_type, arg2, arg3_type, arg3, arg4_type, arg4)                                                  \
-	PFN_##func_name func_name##_ptr = nullptr;                                                                                                                   \
+#define EXT_PROTO_XRRESULT_FUNC4(func_name, arg1_type, arg1, arg2_type, arg2, arg3_type, arg3, arg4_type, arg4) \
+	PFN_##func_name func_name##_ptr = nullptr; \
 	XRAPI_ATTR XrResult XRAPI_CALL func_name(UNPACK arg1_type p_##arg1, UNPACK arg2_type p_##arg2, UNPACK arg3_type p_##arg3, UNPACK arg4_type p_##arg4) const { \
-		if (!func_name##_ptr) {                                                                                                                                  \
-			return XR_ERROR_HANDLE_INVALID;                                                                                                                      \
-		}                                                                                                                                                        \
-		return (*func_name##_ptr)(p_##arg1, p_##arg2, p_##arg3, p_##arg4);                                                                                       \
+		if (!func_name##_ptr) { \
+			return XR_ERROR_HANDLE_INVALID; \
+		} \
+		return (*func_name##_ptr)(p_##arg1, p_##arg2, p_##arg3, p_##arg4); \
 	}
 
-#define EXT_PROTO_XRRESULT_FUNC5(func_name, arg1_type, arg1, arg2_type, arg2, arg3_type, arg3, arg4_type, arg4, arg5_type, arg5)                                                            \
-	PFN_##func_name func_name##_ptr = nullptr;                                                                                                                                              \
+#define EXT_PROTO_XRRESULT_FUNC5(func_name, arg1_type, arg1, arg2_type, arg2, arg3_type, arg3, arg4_type, arg4, arg5_type, arg5) \
+	PFN_##func_name func_name##_ptr = nullptr; \
 	XRAPI_ATTR XrResult XRAPI_CALL func_name(UNPACK arg1_type p_##arg1, UNPACK arg2_type p_##arg2, UNPACK arg3_type p_##arg3, UNPACK arg4_type p_##arg4, UNPACK arg5_type p_##arg5) const { \
-		if (!func_name##_ptr) {                                                                                                                                                             \
-			return XR_ERROR_HANDLE_INVALID;                                                                                                                                                 \
-		}                                                                                                                                                                                   \
-		return (*func_name##_ptr)(p_##arg1, p_##arg2, p_##arg3, p_##arg4, p_##arg5);                                                                                                        \
+		if (!func_name##_ptr) { \
+			return XR_ERROR_HANDLE_INVALID; \
+		} \
+		return (*func_name##_ptr)(p_##arg1, p_##arg2, p_##arg3, p_##arg4, p_##arg5); \
 	}
 
-#define EXT_PROTO_XRRESULT_FUNC6(func_name, arg1_type, arg1, arg2_type, arg2, arg3_type, arg3, arg4_type, arg4, arg5_type, arg5, arg6_type, arg6)                                                                      \
-	PFN_##func_name func_name##_ptr = nullptr;                                                                                                                                                                         \
+#define EXT_PROTO_XRRESULT_FUNC6(func_name, arg1_type, arg1, arg2_type, arg2, arg3_type, arg3, arg4_type, arg4, arg5_type, arg5, arg6_type, arg6) \
+	PFN_##func_name func_name##_ptr = nullptr; \
 	XRAPI_ATTR XrResult XRAPI_CALL func_name(UNPACK arg1_type p_##arg1, UNPACK arg2_type p_##arg2, UNPACK arg3_type p_##arg3, UNPACK arg4_type p_##arg4, UNPACK arg5_type p_##arg5, UNPACK arg6_type p_##arg6) const { \
-		if (!func_name##_ptr) {                                                                                                                                                                                        \
-			return XR_ERROR_HANDLE_INVALID;                                                                                                                                                                            \
-		}                                                                                                                                                                                                              \
-		return (*func_name##_ptr)(p_##arg1, p_##arg2, p_##arg3, p_##arg4, p_##arg5, p_##arg6);                                                                                                                         \
+		if (!func_name##_ptr) { \
+			return XR_ERROR_HANDLE_INVALID; \
+		} \
+		return (*func_name##_ptr)(p_##arg1, p_##arg2, p_##arg3, p_##arg4, p_##arg5, p_##arg6); \
 	}

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -89,8 +89,8 @@ Error ImageLoaderTGA::decode_tga_rle(const uint8_t *p_compressed_buffer, size_t 
 }
 
 Error ImageLoaderTGA::convert_to_image(Ref<Image> p_image, const uint8_t *p_buffer, const tga_header_s &p_header, const uint8_t *p_palette, const bool p_is_monochrome, size_t p_input_size) {
-#define TGA_PUT_PIXEL(r, g, b, a)             \
-	int image_data_ofs = ((y * width) + x);   \
+#define TGA_PUT_PIXEL(r, g, b, a) \
+	int image_data_ofs = ((y * width) + x); \
 	image_data_w[image_data_ofs * 4 + 0] = r; \
 	image_data_w[image_data_ofs * 4 + 1] = g; \
 	image_data_w[image_data_ofs * 4 + 2] = b; \

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -175,7 +175,7 @@ bool WSLPeer::_parse_client_request() {
 	}
 	requested_host = headers.has("host") ? headers.get("host") : "";
 	requested_url = (use_tls ? "wss://" : "ws://") + requested_host + req[1];
-#define WSL_CHECK(NAME, VALUE)                                                          \
+#define WSL_CHECK(NAME, VALUE) \
 	ERR_FAIL_COND_V_MSG(!headers.has(NAME) || headers[NAME].to_lower() != VALUE, false, \
 			"Missing or invalid header '" + String(NAME) + "'. Expected value '" + VALUE + "'.");
 #define WSL_CHECK_EX(NAME) \
@@ -440,10 +440,10 @@ bool WSLPeer::_verify_server_response() {
 		}
 	}
 
-#define WSL_CHECK(NAME, VALUE)                                                          \
+#define WSL_CHECK(NAME, VALUE) \
 	ERR_FAIL_COND_V_MSG(!headers.has(NAME) || headers[NAME].to_lower() != VALUE, false, \
 			"Missing or invalid header '" + String(NAME) + "'. Expected value '" + VALUE + "'.");
-#define WSL_CHECK_NC(NAME, VALUE)                                            \
+#define WSL_CHECK_NC(NAME, VALUE) \
 	ERR_FAIL_COND_V_MSG(!headers.has(NAME) || headers[NAME] != VALUE, false, \
 			"Missing or invalid header '" + String(NAME) + "'. Expected value '" + VALUE + "'.");
 	WSL_CHECK("connection", "upgrade");

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2363,14 +2363,14 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 	String tmp_export_path = EditorPaths::get_singleton()->get_temp_dir().path_join("tmpexport." + uitos(OS::get_singleton()->get_unix_time()) + ".apk");
 
-#define CLEANUP_AND_RETURN(m_err)                                        \
-	{                                                                    \
-		DirAccess::remove_file_or_error(tmp_export_path);                \
-		if (FileAccess::exists(tmp_export_path + ".idsig")) {            \
+#define CLEANUP_AND_RETURN(m_err) \
+	{ \
+		DirAccess::remove_file_or_error(tmp_export_path); \
+		if (FileAccess::exists(tmp_export_path + ".idsig")) { \
 			DirAccess::remove_file_or_error(tmp_export_path + ".idsig"); \
-		}                                                                \
-		return m_err;                                                    \
-	}                                                                    \
+		} \
+		return m_err; \
+	} \
 	((void)0)
 
 	// Export to temporary APK before sending to device.
@@ -4034,11 +4034,11 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 
 	String tmp_unaligned_path = EditorPaths::get_singleton()->get_temp_dir().path_join("tmpexport-unaligned." + uitos(OS::get_singleton()->get_unix_time()) + ".apk");
 
-#define CLEANUP_AND_RETURN(m_err)                            \
-	{                                                        \
+#define CLEANUP_AND_RETURN(m_err) \
+	{ \
 		DirAccess::remove_file_or_error(tmp_unaligned_path); \
-		return m_err;                                        \
-	}                                                        \
+		return m_err; \
+	} \
 	((void)0)
 
 	zipFile unaligned_apk = zipOpen2(tmp_unaligned_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io2);

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -487,19 +487,19 @@ Error EditorExportPlatformLinuxBSD::run(const Ref<EditorExportPreset> &p_preset,
 
 	const String basepath = dest.path_join("tmp_linuxbsd_export");
 
-#define CLEANUP_AND_RETURN(m_err)                      \
-	{                                                  \
-		if (da->file_exists(basepath + ".zip")) {      \
-			da->remove(basepath + ".zip");             \
-		}                                              \
+#define CLEANUP_AND_RETURN(m_err) \
+	{ \
+		if (da->file_exists(basepath + ".zip")) { \
+			da->remove(basepath + ".zip"); \
+		} \
 		if (da->file_exists(basepath + "_start.sh")) { \
-			da->remove(basepath + "_start.sh");        \
-		}                                              \
+			da->remove(basepath + "_start.sh"); \
+		} \
 		if (da->file_exists(basepath + "_clean.sh")) { \
-			da->remove(basepath + "_clean.sh");        \
-		}                                              \
-		return m_err;                                  \
-	}                                                  \
+			da->remove(basepath + "_clean.sh"); \
+		} \
+		return m_err; \
+	} \
 	((void)0)
 
 	if (ep.step(TTR("Exporting project..."), 1)) {

--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -57,11 +57,11 @@
 // Gotta flush as we're doing this mess from a thread without any
 // synchronization. It's awful, I know, but the `print_*` utilities hang for
 // some reason during editor startup and I need some quick and dirty debugging.
-#define DEBUG_LOG_WAYLAND_EMBED(...)                               \
-	if (1) {                                                       \
+#define DEBUG_LOG_WAYLAND_EMBED(...) \
+	if (1) { \
 		printf("[PROXY] %s\n", vformat(__VA_ARGS__).utf8().ptr()); \
-		fflush(stdout);                                            \
-	} else                                                         \
+		fflush(stdout); \
+	} else \
 		((void)0)
 
 #else

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3098,9 +3098,9 @@ void DisplayServerMacOS::enable_for_stealing_focus(OS::ProcessID pid) {
 }
 
 #define GET_OR_FAIL_V(m_val, m_map, m_key, m_retval) \
-	m_val = m_map.getptr(m_key);                     \
-	if (m_val == nullptr) {                          \
-		ERR_FAIL_V(m_retval);                        \
+	m_val = m_map.getptr(m_key); \
+	if (m_val == nullptr) { \
+		ERR_FAIL_V(m_retval); \
 	}
 
 uint32_t DisplayServerMacOS::window_get_display_id(WindowID p_window) const {

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -2701,19 +2701,19 @@ Error EditorExportPlatformMacOS::run(const Ref<EditorExportPreset> &p_preset, in
 
 	const String basepath = dest.path_join("tmp_macos_export");
 
-#define CLEANUP_AND_RETURN(m_err)                      \
-	{                                                  \
-		if (da->file_exists(basepath + ".zip")) {      \
-			da->remove(basepath + ".zip");             \
-		}                                              \
+#define CLEANUP_AND_RETURN(m_err) \
+	{ \
+		if (da->file_exists(basepath + ".zip")) { \
+			da->remove(basepath + ".zip"); \
+		} \
 		if (da->file_exists(basepath + "_start.sh")) { \
-			da->remove(basepath + "_start.sh");        \
-		}                                              \
+			da->remove(basepath + "_start.sh"); \
+		} \
 		if (da->file_exists(basepath + "_clean.sh")) { \
-			da->remove(basepath + "_clean.sh");        \
-		}                                              \
-		return m_err;                                  \
-	}                                                  \
+			da->remove(basepath + "_clean.sh"); \
+		} \
+		return m_err; \
+	} \
 	((void)0)
 
 	if (ep.step(TTR("Exporting project..."), 1)) {

--- a/platform/macos/platform_config.h
+++ b/platform/macos/platform_config.h
@@ -37,8 +37,8 @@
 #define PTHREAD_RENAME_SELF
 
 #define _weakify(var) __weak typeof(var) GDWeak_##var = var;
-#define _strongify(var)                                      \
-	_Pragma("clang diagnostic push")                         \
+#define _strongify(var) \
+	_Pragma("clang diagnostic push") \
 			_Pragma("clang diagnostic ignored \"-Wshadow\"") \
 					__strong typeof(var) var = GDWeak_##var; \
 	_Pragma("clang diagnostic pop")

--- a/platform/web/dom_keys.inc
+++ b/platform/web/dom_keys.inc
@@ -32,9 +32,9 @@
 
 // See https://w3c.github.io/uievents-code/#code-value-tables
 Key dom_code2godot_scancode(EM_UTF8 const p_code[32], EM_UTF8 const p_key[32], bool p_physical) {
-#define DOM2GODOT(p_str, p_godot_code)                                                                \
+#define DOM2GODOT(p_str, p_godot_code) \
 	if (memcmp((const void *)p_str, (void *)(p_physical ? p_code : p_key), strlen(p_str) + 1) == 0) { \
-		return Key::p_godot_code;                                                                     \
+		return Key::p_godot_code; \
 	}
 
 	// Numpad section.
@@ -225,9 +225,9 @@ Key dom_code2godot_scancode(EM_UTF8 const p_code[32], EM_UTF8 const p_key[32], b
 }
 
 KeyLocation dom_code2godot_key_location(EM_UTF8 const p_code[32]) {
-#define DOM2GODOT(m_str, m_godot_code)                                         \
+#define DOM2GODOT(m_str, m_godot_code) \
 	if (memcmp((const void *)m_str, (void *)p_code, strlen(m_str) + 1) == 0) { \
-		return KeyLocation::m_godot_code;                                      \
+		return KeyLocation::m_godot_code; \
 	}
 
 	DOM2GODOT("AltLeft", LEFT);

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -1004,19 +1004,19 @@ Error EditorExportPlatformWindows::run(const Ref<EditorExportPreset> &p_preset, 
 
 	const String basepath = dest.path_join("tmp_windows_export");
 
-#define CLEANUP_AND_RETURN(m_err)                       \
-	{                                                   \
-		if (da->file_exists(basepath + ".zip")) {       \
-			da->remove(basepath + ".zip");              \
-		}                                               \
+#define CLEANUP_AND_RETURN(m_err) \
+	{ \
+		if (da->file_exists(basepath + ".zip")) { \
+			da->remove(basepath + ".zip"); \
+		} \
 		if (da->file_exists(basepath + "_start.ps1")) { \
-			da->remove(basepath + "_start.ps1");        \
-		}                                               \
+			da->remove(basepath + "_start.ps1"); \
+		} \
 		if (da->file_exists(basepath + "_clean.ps1")) { \
-			da->remove(basepath + "_clean.ps1");        \
-		}                                               \
-		return m_err;                                   \
-	}                                                   \
+			da->remove(basepath + "_clean.ps1"); \
+		} \
+		return m_err; \
+	} \
 	((void)0)
 
 	if (ep.step(TTR("Exporting project..."), 1)) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1285,23 +1285,23 @@ Dictionary OS_Windows::get_memory_info() const {
 }
 
 Dictionary OS_Windows::execute_with_pipe(const String &p_path, const List<String> &p_arguments, bool p_blocking) {
-#define CLEAN_PIPES               \
-	if (pipe_in[0] != 0) {        \
-		CloseHandle(pipe_in[0]);  \
-	}                             \
-	if (pipe_in[1] != 0) {        \
-		CloseHandle(pipe_in[1]);  \
-	}                             \
-	if (pipe_out[0] != 0) {       \
+#define CLEAN_PIPES \
+	if (pipe_in[0] != 0) { \
+		CloseHandle(pipe_in[0]); \
+	} \
+	if (pipe_in[1] != 0) { \
+		CloseHandle(pipe_in[1]); \
+	} \
+	if (pipe_out[0] != 0) { \
 		CloseHandle(pipe_out[0]); \
-	}                             \
-	if (pipe_out[1] != 0) {       \
+	} \
+	if (pipe_out[1] != 0) { \
 		CloseHandle(pipe_out[1]); \
-	}                             \
-	if (pipe_err[0] != 0) {       \
+	} \
+	if (pipe_err[0] != 0) { \
 		CloseHandle(pipe_err[0]); \
-	}                             \
-	if (pipe_err[1] != 0) {       \
+	} \
+	if (pipe_err[1] != 0) { \
 		CloseHandle(pipe_err[1]); \
 	}
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -71,8 +71,8 @@
 #ifndef SAFE_RELEASE // when Windows Media Device M? is not present
 #define SAFE_RELEASE(x) \
 	if (x != nullptr) { \
-		x->Release();   \
-		x = nullptr;    \
+		x->Release(); \
+		x = nullptr; \
 	}
 #endif
 

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1404,13 +1404,13 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 	set_gravity(Vector2(proc_mat->get_gravity().x, proc_mat->get_gravity().y));
 	set_lifetime_randomness(proc_mat->get_lifetime_randomness());
 
-#define CONVERT_PARAM(m_param)                                                                  \
-	set_param_min(m_param, proc_mat->get_param_min(ParticleProcessMaterial::m_param));          \
-	{                                                                                           \
+#define CONVERT_PARAM(m_param) \
+	set_param_min(m_param, proc_mat->get_param_min(ParticleProcessMaterial::m_param)); \
+	{ \
 		Ref<CurveTexture> ctex = proc_mat->get_param_texture(ParticleProcessMaterial::m_param); \
-		if (ctex.is_valid())                                                                    \
-			set_param_curve(m_param, ctex->get_curve());                                        \
-	}                                                                                           \
+		if (ctex.is_valid()) \
+			set_param_curve(m_param, ctex->get_curve()); \
+	} \
 	set_param_max(m_param, proc_mat->get_param_max(ParticleProcessMaterial::m_param));
 
 	CONVERT_PARAM(PARAM_INITIAL_LINEAR_VELOCITY);

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -574,16 +574,16 @@ void GPUParticles2D::convert_from_particles(Node *p_particles) {
 	proc_mat->set_gravity(Vector3(gravity.x, gravity.y, 0));
 	proc_mat->set_lifetime_randomness(cpu_particles->get_lifetime_randomness());
 
-#define CONVERT_PARAM(m_param)                                                                                        \
+#define CONVERT_PARAM(m_param) \
 	proc_mat->set_param_min(ParticleProcessMaterial::m_param, cpu_particles->get_param_min(CPUParticles2D::m_param)); \
-	{                                                                                                                 \
-		Ref<Curve> curve = cpu_particles->get_param_curve(CPUParticles2D::m_param);                                   \
-		if (curve.is_valid()) {                                                                                       \
-			Ref<CurveTexture> tex = memnew(CurveTexture);                                                             \
-			tex->set_curve(curve);                                                                                    \
-			proc_mat->set_param_texture(ParticleProcessMaterial::m_param, tex);                                       \
-		}                                                                                                             \
-	}                                                                                                                 \
+	{ \
+		Ref<Curve> curve = cpu_particles->get_param_curve(CPUParticles2D::m_param); \
+		if (curve.is_valid()) { \
+			Ref<CurveTexture> tex = memnew(CurveTexture); \
+			tex->set_curve(curve); \
+			proc_mat->set_param_texture(ParticleProcessMaterial::m_param, tex); \
+		} \
+	} \
 	proc_mat->set_param_max(ParticleProcessMaterial::m_param, cpu_particles->get_param_max(CPUParticles2D::m_param));
 
 	CONVERT_PARAM(PARAM_INITIAL_LINEAR_VELOCITY);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -38,17 +38,17 @@
 #endif // NAVIGATION_2D_DISABLED
 
 #define TILEMAP_CALL_FOR_LAYER(layer, function, ...) \
-	if (layer < 0) {                                 \
-		layer = layers.size() + layer;               \
-	};                                               \
-	ERR_FAIL_INDEX(layer, (int)layers.size());       \
+	if (layer < 0) { \
+		layer = layers.size() + layer; \
+	}; \
+	ERR_FAIL_INDEX(layer, (int)layers.size()); \
 	layers[layer]->function(__VA_ARGS__);
 
 #define TILEMAP_CALL_FOR_LAYER_V(layer, err_value, function, ...) \
-	if (layer < 0) {                                              \
-		layer = layers.size() + layer;                            \
-	};                                                            \
-	ERR_FAIL_INDEX_V(layer, (int)layers.size(), err_value);       \
+	if (layer < 0) { \
+		layer = layers.size() + layer; \
+	}; \
+	ERR_FAIL_INDEX_V(layer, (int)layers.size(), err_value); \
 	return layers[layer]->function(__VA_ARGS__);
 
 #ifndef NAVIGATION_2D_DISABLED

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1460,13 +1460,13 @@ void CPUParticles3D::convert_from_particles(Node *p_particles) {
 	set_gravity(material->get_gravity());
 	set_lifetime_randomness(material->get_lifetime_randomness());
 
-#define CONVERT_PARAM(m_param)                                                                  \
-	set_param_min(m_param, material->get_param_min(ParticleProcessMaterial::m_param));          \
-	{                                                                                           \
+#define CONVERT_PARAM(m_param) \
+	set_param_min(m_param, material->get_param_min(ParticleProcessMaterial::m_param)); \
+	{ \
 		Ref<CurveTexture> ctex = material->get_param_texture(ParticleProcessMaterial::m_param); \
-		if (ctex.is_valid())                                                                    \
-			set_param_curve(m_param, ctex->get_curve());                                        \
-	}                                                                                           \
+		if (ctex.is_valid()) \
+			set_param_curve(m_param, ctex->get_curve()); \
+	} \
 	set_param_max(m_param, material->get_param_max(ParticleProcessMaterial::m_param));
 
 	CONVERT_PARAM(PARAM_INITIAL_LINEAR_VELOCITY);

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -699,16 +699,16 @@ void GPUParticles3D::convert_from_particles(Node *p_particles) {
 	proc_mat->set_gravity(cpu_particles->get_gravity());
 	proc_mat->set_lifetime_randomness(cpu_particles->get_lifetime_randomness());
 
-#define CONVERT_PARAM(m_param)                                                                                        \
+#define CONVERT_PARAM(m_param) \
 	proc_mat->set_param_min(ParticleProcessMaterial::m_param, cpu_particles->get_param_min(CPUParticles3D::m_param)); \
-	{                                                                                                                 \
-		Ref<Curve> curve = cpu_particles->get_param_curve(CPUParticles3D::m_param);                                   \
-		if (curve.is_valid()) {                                                                                       \
-			Ref<CurveTexture> tex = memnew(CurveTexture);                                                             \
-			tex->set_curve(curve);                                                                                    \
-			proc_mat->set_param_texture(ParticleProcessMaterial::m_param, tex);                                       \
-		}                                                                                                             \
-	}                                                                                                                 \
+	{ \
+		Ref<Curve> curve = cpu_particles->get_param_curve(CPUParticles3D::m_param); \
+		if (curve.is_valid()) { \
+			Ref<CurveTexture> tex = memnew(CurveTexture); \
+			tex->set_curve(curve); \
+			proc_mat->set_param_texture(ParticleProcessMaterial::m_param, tex); \
+		} \
+	} \
 	proc_mat->set_param_max(ParticleProcessMaterial::m_param, cpu_particles->get_param_max(CPUParticles3D::m_param));
 
 	CONVERT_PARAM(PARAM_INITIAL_LINEAR_VELOCITY);

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -1014,7 +1014,7 @@ Ref<MultiMesh> Voxelizer::create_debug_multimesh() {
 
 		Vector<Vector3> vertices;
 		Vector<Color> colors;
-#define ADD_VTX(m_idx)                      \
+#define ADD_VTX(m_idx) \
 	vertices.push_back(face_points[m_idx]); \
 	colors.push_back(Color(1, 1, 1, 1));
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -34,7 +34,7 @@
 #include "scene/main/node.h"
 #include "scene/resources/animation.h"
 
-#define CHECK_VALID()                                                                                      \
+#define CHECK_VALID() \
 	ERR_FAIL_COND_V_MSG(!valid, nullptr, "Tween invalid. Either finished or created outside scene tree."); \
 	ERR_FAIL_COND_V_MSG(started, nullptr, "Can't append to a Tween that has started. Use stop() first.");
 

--- a/scene/gui/graph_edit_arranger.cpp
+++ b/scene/gui/graph_edit_arranger.cpp
@@ -426,14 +426,14 @@ void GraphEditArranger::_calculate_inner_shifts(Dictionary &r_inner_shifts, cons
 
 float GraphEditArranger::_calculate_threshold(const StringName &p_v, const StringName &p_w, const Dictionary &r_node_names, const HashMap<int, Vector<StringName>> &r_layers, const Dictionary &r_root, const Dictionary &r_align, const Dictionary &r_inner_shift, real_t p_current_threshold, const HashMap<StringName, Vector2> &r_node_positions) {
 #define MAX_ORDER 2147483647
-#define ORDER(node, layers)                            \
+#define ORDER(node, layers) \
 	for (unsigned int i = 0; i < layers.size(); i++) { \
-		int index = layers[i].find(node);              \
-		if (index > 0) {                               \
-			order = index;                             \
-			break;                                     \
-		}                                              \
-		order = MAX_ORDER;                             \
+		int index = layers[i].find(node); \
+		if (index > 0) { \
+			order = index; \
+			break; \
+		} \
+		order = MAX_ORDER; \
 	}
 
 	int order = MAX_ORDER;
@@ -505,14 +505,14 @@ float GraphEditArranger::_calculate_threshold(const StringName &p_v, const Strin
 }
 
 void GraphEditArranger::_place_block(const StringName &p_v, float p_delta, const HashMap<int, Vector<StringName>> &r_layers, const Dictionary &r_root, const Dictionary &r_align, const Dictionary &r_node_name, const Dictionary &r_inner_shift, Dictionary &r_sink, Dictionary &r_shift, HashMap<StringName, Vector2> &r_node_positions) {
-#define PRED(node, layers)                             \
+#define PRED(node, layers) \
 	for (unsigned int i = 0; i < layers.size(); i++) { \
-		int index = layers[i].find(node);              \
-		if (index > 0) {                               \
-			predecessor = layers[i][index - 1];        \
-			break;                                     \
-		}                                              \
-		predecessor = StringName();                    \
+		int index = layers[i].find(node); \
+		if (index > 0) { \
+			predecessor = layers[i][index - 1]; \
+			break; \
+		} \
+		predecessor = StringName(); \
 	}
 
 	StringName predecessor;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -3263,29 +3263,29 @@ void LineEdit::_update_context_menu() {
 
 	int idx = -1;
 
-#define MENU_ITEM_ACTION_DISABLED(m_menu, m_id, m_action, m_disabled)                                                  \
-	idx = m_menu->get_item_index(m_id);                                                                                \
-	if (idx >= 0) {                                                                                                    \
+#define MENU_ITEM_ACTION_DISABLED(m_menu, m_id, m_action, m_disabled) \
+	idx = m_menu->get_item_index(m_id); \
+	if (idx >= 0) { \
 		m_menu->set_item_accelerator(idx, shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
-		m_menu->set_item_disabled(idx, m_disabled);                                                                    \
+		m_menu->set_item_disabled(idx, m_disabled); \
 	}
 
-#define MENU_ITEM_ACTION(m_menu, m_id, m_action)                                                                       \
-	idx = m_menu->get_item_index(m_id);                                                                                \
-	if (idx >= 0) {                                                                                                    \
+#define MENU_ITEM_ACTION(m_menu, m_id, m_action) \
+	idx = m_menu->get_item_index(m_id); \
+	if (idx >= 0) { \
 		m_menu->set_item_accelerator(idx, shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
 	}
 
 #define MENU_ITEM_DISABLED(m_menu, m_id, m_disabled) \
-	idx = m_menu->get_item_index(m_id);              \
-	if (idx >= 0) {                                  \
-		m_menu->set_item_disabled(idx, m_disabled);  \
+	idx = m_menu->get_item_index(m_id); \
+	if (idx >= 0) { \
+		m_menu->set_item_disabled(idx, m_disabled); \
 	}
 
 #define MENU_ITEM_CHECKED(m_menu, m_id, m_checked) \
-	idx = m_menu->get_item_index(m_id);            \
-	if (idx >= 0) {                                \
-		m_menu->set_item_checked(idx, m_checked);  \
+	idx = m_menu->get_item_index(m_id); \
+	if (idx >= 0) { \
+		m_menu->set_item_checked(idx, m_checked); \
 	}
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_EMOJI_AND_SYMBOL_PICKER)) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1531,9 +1531,9 @@ void PopupMenu::_notification(int p_what) {
  */
 
 #define ITEM_SETUP_WITH_ACCEL(p_label, p_id, p_accel) \
-	item.text = p_label;                              \
-	item.xl_text = atr(p_label);                      \
-	item.id = p_id == -1 ? items.size() : p_id;       \
+	item.text = p_label; \
+	item.xl_text = atr(p_label); \
+	item.id = p_id == -1 ? items.size() : p_id; \
 	item.accel = p_accel;
 
 void PopupMenu::add_item(const String &p_label, int p_id, Key p_accel) {
@@ -1708,14 +1708,14 @@ void PopupMenu::add_multistate_item(const String &p_label, int p_max_states, int
 	notify_property_list_changed();
 }
 
-#define ITEM_SETUP_WITH_SHORTCUT(p_shortcut, p_id, p_global, p_allow_echo)             \
+#define ITEM_SETUP_WITH_SHORTCUT(p_shortcut, p_id, p_global, p_allow_echo) \
 	ERR_FAIL_COND_MSG(p_shortcut.is_null(), "Cannot add item with invalid Shortcut."); \
-	_ref_shortcut(p_shortcut);                                                         \
-	item.text = p_shortcut->get_name();                                                \
-	item.xl_text = atr(item.text);                                                     \
-	item.id = p_id == -1 ? items.size() : p_id;                                        \
-	item.shortcut = p_shortcut;                                                        \
-	item.shortcut_is_global = p_global;                                                \
+	_ref_shortcut(p_shortcut); \
+	item.text = p_shortcut->get_name(); \
+	item.xl_text = atr(item.text); \
+	item.id = p_id == -1 ? items.size() : p_id; \
+	item.shortcut = p_shortcut; \
+	item.shortcut_is_global = p_global; \
 	item.allow_echo = p_allow_echo;
 
 void PopupMenu::add_shortcut(const Ref<Shortcut> &p_shortcut, int p_id, bool p_global, bool p_allow_echo) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -8050,11 +8050,11 @@ void RichTextLabel::_update_context_menu() {
 
 	int idx = -1;
 
-#define MENU_ITEM_ACTION_DISABLED(m_menu, m_id, m_action, m_disabled)                                                  \
-	idx = m_menu->get_item_index(m_id);                                                                                \
-	if (idx >= 0) {                                                                                                    \
+#define MENU_ITEM_ACTION_DISABLED(m_menu, m_id, m_action, m_disabled) \
+	idx = m_menu->get_item_index(m_id); \
+	if (idx >= 0) { \
 		m_menu->set_item_accelerator(idx, shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
-		m_menu->set_item_disabled(idx, m_disabled);                                                                    \
+		m_menu->set_item_disabled(idx, m_disabled); \
 	}
 
 	MENU_ITEM_ACTION_DISABLED(menu, MENU_COPY, "ui_copy", !selection.enabled)

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -8060,29 +8060,29 @@ void TextEdit::_update_context_menu() {
 
 	int idx = -1;
 
-#define MENU_ITEM_ACTION_DISABLED(m_menu, m_id, m_action, m_disabled)                                                  \
-	idx = m_menu->get_item_index(m_id);                                                                                \
-	if (idx >= 0) {                                                                                                    \
+#define MENU_ITEM_ACTION_DISABLED(m_menu, m_id, m_action, m_disabled) \
+	idx = m_menu->get_item_index(m_id); \
+	if (idx >= 0) { \
 		m_menu->set_item_accelerator(idx, shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
-		m_menu->set_item_disabled(idx, m_disabled);                                                                    \
+		m_menu->set_item_disabled(idx, m_disabled); \
 	}
 
-#define MENU_ITEM_ACTION(m_menu, m_id, m_action)                                                                       \
-	idx = m_menu->get_item_index(m_id);                                                                                \
-	if (idx >= 0) {                                                                                                    \
+#define MENU_ITEM_ACTION(m_menu, m_id, m_action) \
+	idx = m_menu->get_item_index(m_id); \
+	if (idx >= 0) { \
 		m_menu->set_item_accelerator(idx, shortcut_keys_enabled ? _get_menu_action_accelerator(m_action) : Key::NONE); \
 	}
 
 #define MENU_ITEM_DISABLED(m_menu, m_id, m_disabled) \
-	idx = m_menu->get_item_index(m_id);              \
-	if (idx >= 0) {                                  \
-		m_menu->set_item_disabled(idx, m_disabled);  \
+	idx = m_menu->get_item_index(m_id); \
+	if (idx >= 0) { \
+		m_menu->set_item_disabled(idx, m_disabled); \
 	}
 
 #define MENU_ITEM_CHECKED(m_menu, m_id, m_checked) \
-	idx = m_menu->get_item_index(m_id);            \
-	if (idx >= 0) {                                \
-		m_menu->set_item_checked(idx, m_checked);  \
+	idx = m_menu->get_item_index(m_id); \
+	if (idx >= 0) { \
+		m_menu->set_item_checked(idx, m_checked); \
 	}
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_EMOJI_AND_SYMBOL_PICKER)) {

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -2201,11 +2201,11 @@ void TileSet::draw_cells_outline(CanvasItem *p_canvas_item, const RBSet<Vector2i
 	for (const Vector2i &E : p_cells) {
 		Vector2 center = map_to_local(E);
 
-#define DRAW_SIDE_IF_NEEDED(side, polygon_index_from, polygon_index_to)                     \
-	if (!p_cells.has(get_neighbor_cell(E, side))) {                                         \
+#define DRAW_SIDE_IF_NEEDED(side, polygon_index_from, polygon_index_to) \
+	if (!p_cells.has(get_neighbor_cell(E, side))) { \
 		Vector2 from = p_transform.xform(center + polygon[polygon_index_from] * tile_size); \
-		Vector2 to = p_transform.xform(center + polygon[polygon_index_to] * tile_size);     \
-		p_canvas_item->draw_line(from, to, p_color);                                        \
+		Vector2 to = p_transform.xform(center + polygon[polygon_index_to] * tile_size); \
+		p_canvas_item->draw_line(from, to, p_color); \
 	}
 
 		if (tile_shape == TileSet::TILE_SHAPE_SQUARE) {

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -274,16 +274,16 @@ void ImporterMesh::optimize_indices() {
 }
 
 #define VERTEX_SKIN_FUNC(bone_count, vert_idx, read_array, write_array, transform_array, bone_array, weight_array) \
-	Vector3 transformed_vert;                                                                                      \
-	for (unsigned int weight_idx = 0; weight_idx < bone_count; weight_idx++) {                                     \
-		int bone_idx = bone_array[vert_idx * bone_count + weight_idx];                                             \
-		float w = weight_array[vert_idx * bone_count + weight_idx];                                                \
-		if (w < FLT_EPSILON) {                                                                                     \
-			continue;                                                                                              \
-		}                                                                                                          \
-		ERR_FAIL_INDEX(bone_idx, static_cast<int>(transform_array.size()));                                        \
-		transformed_vert += transform_array[bone_idx].xform(read_array[vert_idx]) * w;                             \
-	}                                                                                                              \
+	Vector3 transformed_vert; \
+	for (unsigned int weight_idx = 0; weight_idx < bone_count; weight_idx++) { \
+		int bone_idx = bone_array[vert_idx * bone_count + weight_idx]; \
+		float w = weight_array[vert_idx * bone_count + weight_idx]; \
+		if (w < FLT_EPSILON) { \
+			continue; \
+		} \
+		ERR_FAIL_INDEX(bone_idx, static_cast<int>(transform_array.size())); \
+		transformed_vert += transform_array[bone_idx].xform(read_array[vert_idx]) * w; \
+	} \
 	write_array[vert_idx] = transformed_vert;
 
 void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transform_array) {

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -441,9 +441,9 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 	point = 0;
 
 #define ADD_TANGENT(m_x, m_y, m_z, m_d) \
-	tangents.push_back(m_x);            \
-	tangents.push_back(m_y);            \
-	tangents.push_back(m_z);            \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
 	tangents.push_back(m_d);
 
 	// Note, this has been aligned with our collision shape but I've left the descriptions as top/middle/bottom.
@@ -761,9 +761,9 @@ void BoxMesh::create_mesh_array(Array &p_arr, Vector3 size, int subdivide_w, int
 	point = 0;
 
 #define ADD_TANGENT(m_x, m_y, m_z, m_d) \
-	tangents.push_back(m_x);            \
-	tangents.push_back(m_y);            \
-	tangents.push_back(m_z);            \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
 	tangents.push_back(m_d);
 
 	// front + back
@@ -1104,9 +1104,9 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 	point = 0;
 
 #define ADD_TANGENT(m_x, m_y, m_z, m_d) \
-	tangents.push_back(m_x);            \
-	tangents.push_back(m_y);            \
-	tangents.push_back(m_z);            \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
 	tangents.push_back(m_d);
 
 	thisrow = 0;
@@ -1440,9 +1440,9 @@ void PlaneMesh::_create_mesh_array(Array &p_arr) const {
 	point = 0;
 
 #define ADD_TANGENT(m_x, m_y, m_z, m_d) \
-	tangents.push_back(m_x);            \
-	tangents.push_back(m_y);            \
-	tangents.push_back(m_z);            \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
 	tangents.push_back(m_d);
 
 	/* top + bottom */
@@ -1655,9 +1655,9 @@ void PrismMesh::_create_mesh_array(Array &p_arr) const {
 	point = 0;
 
 #define ADD_TANGENT(m_x, m_y, m_z, m_d) \
-	tangents.push_back(m_x);            \
-	tangents.push_back(m_y);            \
-	tangents.push_back(m_z);            \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
 	tangents.push_back(m_d);
 
 	/* front + back */
@@ -2013,9 +2013,9 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 	point = 0;
 
 #define ADD_TANGENT(m_x, m_y, m_z, m_d) \
-	tangents.push_back(m_x);            \
-	tangents.push_back(m_y);            \
-	tangents.push_back(m_z);            \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
 	tangents.push_back(m_d);
 
 	thisrow = 0;
@@ -2224,9 +2224,9 @@ void TorusMesh::_create_mesh_array(Array &p_arr) const {
 	indices.reserve(rings * ring_segments * 6);
 
 #define ADD_TANGENT(m_x, m_y, m_z, m_d) \
-	tangents.push_back(m_x);            \
-	tangents.push_back(m_y);            \
-	tangents.push_back(m_z);            \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
 	tangents.push_back(m_d);
 
 	ERR_FAIL_COND_MSG(inner_radius == outer_radius, "Inner radius and outer radius cannot be the same.");
@@ -2527,9 +2527,9 @@ void TubeTrailMesh::_create_mesh_array(Array &p_arr) const {
 	int point = 0;
 
 #define ADD_TANGENT(m_x, m_y, m_z, m_d) \
-	tangents.push_back(m_x);            \
-	tangents.push_back(m_y);            \
-	tangents.push_back(m_z);            \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
 	tangents.push_back(m_d);
 
 	int thisrow = 0;
@@ -2902,9 +2902,9 @@ void RibbonTrailMesh::_create_mesh_array(Array &p_arr) const {
 	indices.reserve(total_segments * 6 * (shape == SHAPE_CROSS ? 2 : 1));
 
 #define ADD_TANGENT(m_x, m_y, m_z, m_d) \
-	tangents.push_back(m_x);            \
-	tangents.push_back(m_y);            \
-	tangents.push_back(m_z);            \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
 	tangents.push_back(m_d);
 
 	for (int j = 0; j <= total_segments; j++) {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -154,17 +154,17 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	// Nodes where instantiation failed (because something is missing.)
 	List<Node *> stray_instances;
 
-#define NODE_FROM_ID(p_name, p_id)                                             \
-	Node *p_name;                                                              \
-	if (p_id & FLAG_ID_IS_PATH) {                                              \
-		NodePath np = node_paths[p_id & FLAG_MASK];                            \
-		p_name = ret_nodes[0]->get_node_or_null(np);                           \
-		if (!p_name) {                                                         \
+#define NODE_FROM_ID(p_name, p_id) \
+	Node *p_name; \
+	if (p_id & FLAG_ID_IS_PATH) { \
+		NodePath np = node_paths[p_id & FLAG_MASK]; \
+		p_name = ret_nodes[0]->get_node_or_null(np); \
+		if (!p_name) { \
 			p_name = _recover_node_path_index(ret_nodes[0], p_id & FLAG_MASK); \
-		}                                                                      \
-	} else {                                                                   \
-		ERR_FAIL_INDEX_V(p_id & FLAG_MASK, nc, nullptr);                       \
-		p_name = ret_nodes[p_id & FLAG_MASK];                                  \
+		} \
+	} else { \
+		ERR_FAIL_INDEX_V(p_id & FLAG_MASK, nc, nullptr); \
+		p_name = ret_nodes[p_id & FLAG_MASK]; \
 	}
 
 	int nc = nodes.size();

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -2196,10 +2196,10 @@ void ParticleProcessMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_bounce", "bounce"), &ParticleProcessMaterial::set_collision_bounce);
 	ClassDB::bind_method(D_METHOD("get_collision_bounce"), &ParticleProcessMaterial::get_collision_bounce);
 
-#define ADD_MIN_MAX_PROPERTY(m_property, m_range, m_parameter_name)                                                                                                                       \
+#define ADD_MIN_MAX_PROPERTY(m_property, m_range, m_parameter_name) \
 	ADD_PROPERTYI(PropertyInfo(Variant::VECTOR2, m_property, PROPERTY_HINT_RANGE, m_range, PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_INTERNAL), "set_param", "get_param", m_parameter_name); \
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, m_property "_min", PROPERTY_HINT_RANGE, m_range), "set_param_min", "get_param_min", m_parameter_name);                                     \
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, m_property "_max", PROPERTY_HINT_RANGE, m_range), "set_param_max", "get_param_max", m_parameter_name);                                     \
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, m_property "_min", PROPERTY_HINT_RANGE, m_range), "set_param_min", "get_param_min", m_parameter_name); \
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, m_property "_max", PROPERTY_HINT_RANGE, m_range), "set_param_max", "get_param_max", m_parameter_name); \
 	min_max_properties.insert(m_property);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lifetime_randomness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_lifetime_randomness", "get_lifetime_randomness");

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -383,19 +383,19 @@ void SurfaceTool::add_triangle_fan(const Vector<Vector3> &p_vertices, const Vect
 	ERR_FAIL_COND(primitive != Mesh::PRIMITIVE_TRIANGLES);
 	ERR_FAIL_COND(p_vertices.size() < 3);
 
-#define ADD_POINT(n)                    \
-	{                                   \
-		if (p_colors.size() > n)        \
-			set_color(p_colors[n]);     \
-		if (p_uvs.size() > n)           \
-			set_uv(p_uvs[n]);           \
-		if (p_uv2s.size() > n)          \
-			set_uv2(p_uv2s[n]);         \
-		if (p_normals.size() > n)       \
-			set_normal(p_normals[n]);   \
-		if (p_tangents.size() > n)      \
+#define ADD_POINT(n) \
+	{ \
+		if (p_colors.size() > n) \
+			set_color(p_colors[n]); \
+		if (p_uvs.size() > n) \
+			set_uv(p_uvs[n]); \
+		if (p_uv2s.size() > n) \
+			set_uv2(p_uv2s[n]); \
+		if (p_normals.size() > n) \
+			set_normal(p_normals[n]); \
+		if (p_tangents.size() > n) \
 			set_tangent(p_tangents[n]); \
-		add_vertex(p_vertices[n]);      \
+		add_vertex(p_vertices[n]); \
 	}
 
 	for (int i = 0; i < p_vertices.size() - 2; i++) {

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -44,28 +44,28 @@ class ThemeContext;
 // Macros for binding theme items of this class. This information is used for the documentation, theme
 // overrides, etc. This is also the basis for theme cache.
 
-#define BIND_THEME_ITEM(m_data_type, m_class, m_prop)                                                       \
-	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, #m_prop,            \
-			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {            \
-				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                     \
+#define BIND_THEME_ITEM(m_data_type, m_class, m_prop) \
+	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, #m_prop, \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) { \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance); \
 				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name); \
 			})
 
-#define BIND_THEME_ITEM_CUSTOM(m_data_type, m_class, m_prop, m_item_name)                                   \
-	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, m_item_name,        \
-			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {            \
-				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                     \
+#define BIND_THEME_ITEM_CUSTOM(m_data_type, m_class, m_prop, m_item_name) \
+	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, m_item_name, \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) { \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance); \
 				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name); \
 			})
 
 // Macro for binding theme items used by this class, but defined/binded by other classes. This is primarily used for
 // the theme cache. Can also be used to list such items in documentation.
 
-#define BIND_THEME_ITEM_EXT(m_data_type, m_class, m_prop, m_item_name, m_type_name)                                        \
+#define BIND_THEME_ITEM_EXT(m_data_type, m_class, m_prop, m_item_name, m_type_name) \
 	ThemeDB::get_singleton()->bind_class_external_item(m_data_type, get_class_static(), #m_prop, m_item_name, m_type_name, \
-			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {                           \
-				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                                    \
-				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name);                \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) { \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance); \
+				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name); \
 			})
 
 class ThemeDB : public Object {

--- a/servers/audio/effects/eq_filter.cpp
+++ b/servers/audio/effects/eq_filter.cpp
@@ -115,12 +115,12 @@ void EQ::recalculate_band_coefficients() {
 void EQ::set_preset_band_mode(Preset p_preset) {
 	band.clear();
 
-#define PUSH_BANDS(m_bands)             \
+#define PUSH_BANDS(m_bands) \
 	for (int i = 0; i < m_bands; i++) { \
-		Band b;                         \
-		b.freq = bands[i];              \
-		b.c1 = b.c2 = b.c3 = 0;         \
-		band.push_back(b);              \
+		Band b; \
+		b.freq = bands[i]; \
+		b.c1 = b.c2 = b.c3 = 0; \
+		band.push_back(b); \
 	}
 
 	switch (p_preset) {

--- a/servers/navigation_3d/navigation_server_3d.cpp
+++ b/servers/navigation_3d/navigation_server_3d.cpp
@@ -253,23 +253,23 @@ NavigationServer3D::NavigationServer3D() {
 
 #ifdef DEBUG_ENABLED
 #ifndef DISABLE_DEPRECATED
-#define MOVE_PROJECT_SETTING_1(m_old_setting, m_new_setting)                                                                             \
+#define MOVE_PROJECT_SETTING_1(m_old_setting, m_new_setting) \
 	if (!ProjectSettings::get_singleton()->has_setting(m_new_setting) && ProjectSettings::get_singleton()->has_setting(m_old_setting)) { \
-		Variant value = GLOBAL_GET(m_old_setting);                                                                                       \
-		ProjectSettings::get_singleton()->set_setting(m_new_setting, value);                                                             \
-		ProjectSettings::get_singleton()->clear(m_old_setting);                                                                          \
+		Variant value = GLOBAL_GET(m_old_setting); \
+		ProjectSettings::get_singleton()->set_setting(m_new_setting, value); \
+		ProjectSettings::get_singleton()->clear(m_old_setting); \
 	}
-#define MOVE_PROJECT_SETTING_2(m_old_setting, m_new_setting_1, m_new_setting_2)                                                                 \
+#define MOVE_PROJECT_SETTING_2(m_old_setting, m_new_setting_1, m_new_setting_2) \
 	if ((!ProjectSettings::get_singleton()->has_setting(m_new_setting_1) || !ProjectSettings::get_singleton()->has_setting(m_new_setting_2)) && \
-			ProjectSettings::get_singleton()->has_setting(m_old_setting)) {                                                                     \
-		Variant value = GLOBAL_GET(m_old_setting);                                                                                              \
-		if (!ProjectSettings::get_singleton()->has_setting(m_new_setting_1)) {                                                                  \
-			ProjectSettings::get_singleton()->set_setting(m_new_setting_1, value);                                                              \
-		}                                                                                                                                       \
-		if (!ProjectSettings::get_singleton()->has_setting(m_new_setting_2)) {                                                                  \
-			ProjectSettings::get_singleton()->set_setting(m_new_setting_2, value);                                                              \
-		}                                                                                                                                       \
-		ProjectSettings::get_singleton()->clear(m_old_setting);                                                                                 \
+			ProjectSettings::get_singleton()->has_setting(m_old_setting)) { \
+		Variant value = GLOBAL_GET(m_old_setting); \
+		if (!ProjectSettings::get_singleton()->has_setting(m_new_setting_1)) { \
+			ProjectSettings::get_singleton()->set_setting(m_new_setting_1, value); \
+		} \
+		if (!ProjectSettings::get_singleton()->has_setting(m_new_setting_2)) { \
+			ProjectSettings::get_singleton()->set_setting(m_new_setting_2, value); \
+		} \
+		ProjectSettings::get_singleton()->clear(m_old_setting); \
 	}
 	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/edge_connection_color", "debug/shapes/navigation/2d/edge_connection_color", "debug/shapes/navigation/3d/edge_connection_color");
 	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/geometry_edge_color", "debug/shapes/navigation/2d/geometry_edge_color", "debug/shapes/navigation/3d/geometry_edge_color");

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -2712,29 +2712,29 @@ void RendererCanvasCull::tick() {
 }
 
 void RendererCanvasCull::update_interpolation_tick(bool p_process) {
-#define GODOT_UPDATE_INTERPOLATION_TICK(m_list_prev, m_list_curr, m_type, m_owner_list)      \
-	/* Detect any that were on the previous transform list that are no longer active. */     \
-	for (unsigned int n = 0; n < _interpolation_data.m_list_prev->size(); n++) {             \
-		const RID &rid = (*_interpolation_data.m_list_prev)[n];                              \
-		m_type *item = m_owner_list.get_or_null(rid);                                        \
+#define GODOT_UPDATE_INTERPOLATION_TICK(m_list_prev, m_list_curr, m_type, m_owner_list) \
+	/* Detect any that were on the previous transform list that are no longer active. */ \
+	for (unsigned int n = 0; n < _interpolation_data.m_list_prev->size(); n++) { \
+		const RID &rid = (*_interpolation_data.m_list_prev)[n]; \
+		m_type *item = m_owner_list.get_or_null(rid); \
 		/* no longer active? (either the instance deleted or no longer being transformed) */ \
-		if (item && !item->on_interpolate_transform_list) {                                  \
-			item->xform_prev = item->xform_curr;                                             \
-		}                                                                                    \
-	}                                                                                        \
-	/* and now for any in the transform list (being actively interpolated), */               \
-	/* keep the previous transform value up to date and ready for next tick */               \
-	if (p_process) {                                                                         \
-		for (unsigned int n = 0; n < _interpolation_data.m_list_curr->size(); n++) {         \
-			const RID &rid = (*_interpolation_data.m_list_curr)[n];                          \
-			m_type *item = m_owner_list.get_or_null(rid);                                    \
-			if (item) {                                                                      \
-				item->xform_prev = item->xform_curr;                                         \
-				item->on_interpolate_transform_list = false;                                 \
-			}                                                                                \
-		}                                                                                    \
-	}                                                                                        \
-	SWAP(_interpolation_data.m_list_curr, _interpolation_data.m_list_prev);                  \
+		if (item && !item->on_interpolate_transform_list) { \
+			item->xform_prev = item->xform_curr; \
+		} \
+	} \
+	/* and now for any in the transform list (being actively interpolated), */ \
+	/* keep the previous transform value up to date and ready for next tick */ \
+	if (p_process) { \
+		for (unsigned int n = 0; n < _interpolation_data.m_list_curr->size(); n++) { \
+			const RID &rid = (*_interpolation_data.m_list_curr)[n]; \
+			m_type *item = m_owner_list.get_or_null(rid); \
+			if (item) { \
+				item->xform_prev = item->xform_curr; \
+				item->on_interpolate_transform_list = false; \
+			} \
+		} \
+	} \
+	SWAP(_interpolation_data.m_list_curr, _interpolation_data.m_list_prev); \
 	_interpolation_data.m_list_curr->clear();
 
 	GODOT_UPDATE_INTERPOLATION_TICK(canvas_item_transform_update_list_prev, canvas_item_transform_update_list_curr, Item, canvas_item_owner);

--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -301,11 +301,11 @@ public:
 			// Approximate, probably better to use a cone support function.
 			float max_d = -1e20;
 			float min_d = 1e20;
-#define CONE_MINMAX(m_x, m_y)                                             \
-	{                                                                     \
+#define CONE_MINMAX(m_x, m_y) \
+	{ \
 		float d = -xform.xform(Vector3(len * m_x, len * m_y, -radius)).z; \
-		min_d = MIN(d, min_d);                                            \
-		max_d = MAX(d, max_d);                                            \
+		min_d = MIN(d, min_d); \
+		max_d = MAX(d, max_d); \
 	}
 
 			CONE_MINMAX(1, 1);

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -625,8 +625,8 @@ void RenderForwardClustered::_render_list(RenderingDevice::DrawListID p_draw_lis
 	//use template for faster performance (pass mode comparisons are inlined)
 
 	switch (p_params->pass_mode) {
-#define VALID_FLAG_COMBINATION(f)                                                                                             \
-	case f: {                                                                                                                 \
+#define VALID_FLAG_COMBINATION(f) \
+	case f: { \
 		_render_list_template<PASS_MODE_COLOR, f>(p_draw_list, p_framebuffer_Format, p_params, p_from_element, p_to_element); \
 	} break;
 

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -32,30 +32,30 @@
 
 #include "servers/rendering/rendering_device.h"
 
-#define RD_SETGET(m_type, m_member)            \
+#define RD_SETGET(m_type, m_member) \
 	void set_##m_member(m_type p_##m_member) { \
-		base.m_member = p_##m_member;          \
-	}                                          \
-	m_type get_##m_member() const {            \
-		return base.m_member;                  \
+		base.m_member = p_##m_member; \
+	} \
+	m_type get_##m_member() const { \
+		return base.m_member; \
 	}
 
-#define RD_BIND(m_variant_type, m_class, m_member)                                                          \
+#define RD_BIND(m_variant_type, m_class, m_member) \
 	ClassDB::bind_method(D_METHOD("set_" _MKSTR(m_member), "p_" _MKSTR(member)), &m_class::set_##m_member); \
-	ClassDB::bind_method(D_METHOD("get_" _MKSTR(m_member)), &m_class::get_##m_member);                      \
+	ClassDB::bind_method(D_METHOD("get_" _MKSTR(m_member)), &m_class::get_##m_member); \
 	ADD_PROPERTY(PropertyInfo(m_variant_type, #m_member), "set_" _MKSTR(m_member), "get_" _MKSTR(m_member))
 
-#define RD_SETGET_SUB(m_type, m_sub, m_member)           \
+#define RD_SETGET_SUB(m_type, m_sub, m_member) \
 	void set_##m_sub##_##m_member(m_type p_##m_member) { \
-		base.m_sub.m_member = p_##m_member;              \
-	}                                                    \
-	m_type get_##m_sub##_##m_member() const {            \
-		return base.m_sub.m_member;                      \
+		base.m_sub.m_member = p_##m_member; \
+	} \
+	m_type get_##m_sub##_##m_member() const { \
+		return base.m_sub.m_member; \
 	}
 
-#define RD_BIND_SUB(m_variant_type, m_class, m_sub, m_member)                                                                           \
+#define RD_BIND_SUB(m_variant_type, m_class, m_sub, m_member) \
 	ClassDB::bind_method(D_METHOD("set_" _MKSTR(m_sub) "_" _MKSTR(m_member), "p_" _MKSTR(member)), &m_class::set_##m_sub##_##m_member); \
-	ClassDB::bind_method(D_METHOD("get_" _MKSTR(m_sub) "_" _MKSTR(m_member)), &m_class::get_##m_sub##_##m_member);                      \
+	ClassDB::bind_method(D_METHOD("get_" _MKSTR(m_sub) "_" _MKSTR(m_member)), &m_class::get_##m_sub##_##m_member); \
 	ADD_PROPERTY(PropertyInfo(m_variant_type, _MKSTR(m_sub) "_" _MKSTR(m_member)), "set_" _MKSTR(m_sub) "_" _MKSTR(m_member), "get_" _MKSTR(m_sub) "_" _MKSTR(m_member))
 
 class RDTextureFormat : public RefCounted {

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -98,28 +98,28 @@ public:
 				id(p_id) {}
 	};
 
-#define DEFINE_ID(m_name)                                                         \
-	struct m_name##ID : public ID {                                               \
-		_ALWAYS_INLINE_ explicit operator bool() const {                          \
-			return id != 0;                                                       \
-		}                                                                         \
-		_ALWAYS_INLINE_ m_name##ID &operator=(m_name##ID p_other) {               \
-			id = p_other.id;                                                      \
-			return *this;                                                         \
-		}                                                                         \
-		_ALWAYS_INLINE_ bool operator<(const m_name##ID &p_other) const {         \
-			return id < p_other.id;                                               \
-		}                                                                         \
-		_ALWAYS_INLINE_ bool operator==(const m_name##ID &p_other) const {        \
-			return id == p_other.id;                                              \
-		}                                                                         \
-		_ALWAYS_INLINE_ bool operator!=(const m_name##ID &p_other) const {        \
-			return id != p_other.id;                                              \
-		}                                                                         \
+#define DEFINE_ID(m_name) \
+	struct m_name##ID : public ID { \
+		_ALWAYS_INLINE_ explicit operator bool() const { \
+			return id != 0; \
+		} \
+		_ALWAYS_INLINE_ m_name##ID &operator=(m_name##ID p_other) { \
+			id = p_other.id; \
+			return *this; \
+		} \
+		_ALWAYS_INLINE_ bool operator<(const m_name##ID &p_other) const { \
+			return id < p_other.id; \
+		} \
+		_ALWAYS_INLINE_ bool operator==(const m_name##ID &p_other) const { \
+			return id == p_other.id; \
+		} \
+		_ALWAYS_INLINE_ bool operator!=(const m_name##ID &p_other) const { \
+			return id != p_other.id; \
+		} \
 		_ALWAYS_INLINE_ m_name##ID(const m_name##ID &p_other) : ID(p_other.id) {} \
-		_ALWAYS_INLINE_ explicit m_name##ID(uint64_t p_int) : ID(p_int) {}        \
+		_ALWAYS_INLINE_ explicit m_name##ID(uint64_t p_int) : ID(p_int) {} \
 		_ALWAYS_INLINE_ explicit m_name##ID(void *p_ptr) : ID((uint64_t)p_ptr) {} \
-		_ALWAYS_INLINE_ m_name##ID() = default;                                   \
+		_ALWAYS_INLINE_ m_name##ID() = default; \
 	};
 
 	// Id types declared before anything else to prevent cyclic dependencies between the different concerns.

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -164,13 +164,13 @@ RID RenderingServer::_make_test_cube() {
 	Vector<float> tangents;
 	Vector<Vector3> uvs;
 
-#define ADD_VTX(m_idx)                           \
-	vertices.push_back(face_points[m_idx]);      \
-	normals.push_back(normal_points[m_idx]);     \
+#define ADD_VTX(m_idx) \
+	vertices.push_back(face_points[m_idx]); \
+	normals.push_back(normal_points[m_idx]); \
 	tangents.push_back(normal_points[m_idx][1]); \
 	tangents.push_back(normal_points[m_idx][2]); \
 	tangents.push_back(normal_points[m_idx][0]); \
-	tangents.push_back(1.0);                     \
+	tangents.push_back(1.0); \
 	uvs.push_back(Vector3(uv_points[m_idx * 2 + 0], uv_points[m_idx * 2 + 1], 0));
 
 	for (int i = 0; i < 6; i++) {
@@ -269,7 +269,7 @@ RID RenderingServer::make_sphere_mesh(int p_lats, int p_lons, real_t p_radius) {
 				Vector3(x0 * zr0, z0, y0 * zr0)
 			};
 
-#define ADD_POINT(m_idx)         \
+#define ADD_POINT(m_idx) \
 	normals.push_back(v[m_idx]); \
 	vertices.push_back(v[m_idx] * p_radius);
 

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -45,13 +45,13 @@ struct MeshData;
 // Helper macros for code outside of the rendering server, but that is
 // called by the rendering server.
 #ifdef DEBUG_ENABLED
-#define ERR_NOT_ON_RENDER_THREAD                                          \
+#define ERR_NOT_ON_RENDER_THREAD \
 	RenderingServer *rendering_server = RenderingServer::get_singleton(); \
-	ERR_FAIL_NULL(rendering_server);                                      \
+	ERR_FAIL_NULL(rendering_server); \
 	ERR_FAIL_COND(!rendering_server->is_on_render_thread());
-#define ERR_NOT_ON_RENDER_THREAD_V(m_ret)                                 \
+#define ERR_NOT_ON_RENDER_THREAD_V(m_ret) \
 	RenderingServer *rendering_server = RenderingServer::get_singleton(); \
-	ERR_FAIL_NULL_V(rendering_server, m_ret);                             \
+	ERR_FAIL_NULL_V(rendering_server, m_ret); \
 	ERR_FAIL_COND_V(!rendering_server->is_on_render_thread(), m_ret);
 #else
 #define ERR_NOT_ON_RENDER_THREAD

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -130,81 +130,81 @@ public:
 #define ServerName RendererTextureStorage
 #define server_name RSG::texture_storage
 
-#define FUNCRIDTEX0(m_type)                                                                              \
-	virtual RID m_type##_create() override {                                                             \
-		RID ret = RSG::texture_storage->texture_allocate();                                              \
+#define FUNCRIDTEX0(m_type) \
+	virtual RID m_type##_create() override { \
+		RID ret = RSG::texture_storage->texture_allocate(); \
 		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) { \
-			RSG::texture_storage->m_type##_initialize(ret);                                              \
-		} else {                                                                                         \
+			RSG::texture_storage->m_type##_initialize(ret); \
+		} else { \
 			command_queue.push(RSG::texture_storage, &RendererTextureStorage::m_type##_initialize, ret); \
-		}                                                                                                \
-		return ret;                                                                                      \
+		} \
+		return ret; \
 	}
 
-#define FUNCRIDTEX1(m_type, m_type1)                                                                         \
-	virtual RID m_type##_create(m_type1 p1) override {                                                       \
-		RID ret = RSG::texture_storage->texture_allocate();                                                  \
-		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) {     \
-			RSG::texture_storage->m_type##_initialize(ret, p1);                                              \
-		} else {                                                                                             \
+#define FUNCRIDTEX1(m_type, m_type1) \
+	virtual RID m_type##_create(m_type1 p1) override { \
+		RID ret = RSG::texture_storage->texture_allocate(); \
+		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) { \
+			RSG::texture_storage->m_type##_initialize(ret, p1); \
+		} else { \
 			command_queue.push(RSG::texture_storage, &RendererTextureStorage::m_type##_initialize, ret, p1); \
-		}                                                                                                    \
-		return ret;                                                                                          \
+		} \
+		return ret; \
 	}
 
-#define FUNCRIDTEX2(m_type, m_type1, m_type2)                                                                    \
-	virtual RID m_type##_create(m_type1 p1, m_type2 p2) override {                                               \
-		RID ret = RSG::texture_storage->texture_allocate();                                                      \
-		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) {         \
-			RSG::texture_storage->m_type##_initialize(ret, p1, p2);                                              \
-		} else {                                                                                                 \
+#define FUNCRIDTEX2(m_type, m_type1, m_type2) \
+	virtual RID m_type##_create(m_type1 p1, m_type2 p2) override { \
+		RID ret = RSG::texture_storage->texture_allocate(); \
+		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) { \
+			RSG::texture_storage->m_type##_initialize(ret, p1, p2); \
+		} else { \
 			command_queue.push(RSG::texture_storage, &RendererTextureStorage::m_type##_initialize, ret, p1, p2); \
-		}                                                                                                        \
-		return ret;                                                                                              \
+		} \
+		return ret; \
 	}
 
-#define FUNCRIDTEX3(m_type, m_type1, m_type2, m_type3)                                                               \
-	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3) override {                                       \
-		RID ret = RSG::texture_storage->texture_allocate();                                                          \
-		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) {             \
-			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3);                                              \
-		} else {                                                                                                     \
+#define FUNCRIDTEX3(m_type, m_type1, m_type2, m_type3) \
+	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3) override { \
+		RID ret = RSG::texture_storage->texture_allocate(); \
+		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) { \
+			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3); \
+		} else { \
 			command_queue.push(RSG::texture_storage, &RendererTextureStorage::m_type##_initialize, ret, p1, p2, p3); \
-		}                                                                                                            \
-		return ret;                                                                                                  \
+		} \
+		return ret; \
 	}
 
-#define FUNCRIDTEX4(m_type, m_type1, m_type2, m_type3, m_type4)                                                          \
-	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3, m_type4 p4) override {                               \
-		RID ret = RSG::texture_storage->texture_allocate();                                                              \
-		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) {                 \
-			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3, p4);                                              \
-		} else {                                                                                                         \
+#define FUNCRIDTEX4(m_type, m_type1, m_type2, m_type3, m_type4) \
+	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3, m_type4 p4) override { \
+		RID ret = RSG::texture_storage->texture_allocate(); \
+		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) { \
+			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3, p4); \
+		} else { \
 			command_queue.push(RSG::texture_storage, &RendererTextureStorage::m_type##_initialize, ret, p1, p2, p3, p4); \
-		}                                                                                                                \
-		return ret;                                                                                                      \
+		} \
+		return ret; \
 	}
 
-#define FUNCRIDTEX5(m_type, m_type1, m_type2, m_type3, m_type4, m_type5)                                                     \
-	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3, m_type4 p4, m_type5 p5) override {                       \
-		RID ret = RSG::texture_storage->texture_allocate();                                                                  \
-		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) {                     \
-			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3, p4, p5);                                              \
-		} else {                                                                                                             \
+#define FUNCRIDTEX5(m_type, m_type1, m_type2, m_type3, m_type4, m_type5) \
+	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3, m_type4 p4, m_type5 p5) override { \
+		RID ret = RSG::texture_storage->texture_allocate(); \
+		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) { \
+			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3, p4, p5); \
+		} else { \
 			command_queue.push(RSG::texture_storage, &RendererTextureStorage::m_type##_initialize, ret, p1, p2, p3, p4, p5); \
-		}                                                                                                                    \
-		return ret;                                                                                                          \
+		} \
+		return ret; \
 	}
 
-#define FUNCRIDTEX6(m_type, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6)                                                \
-	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3, m_type4 p4, m_type5 p5, m_type6 p6) override {               \
-		RID ret = RSG::texture_storage->texture_allocate();                                                                      \
-		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) {                         \
-			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3, p4, p5, p6);                                              \
-		} else {                                                                                                                 \
+#define FUNCRIDTEX6(m_type, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6) \
+	virtual RID m_type##_create(m_type1 p1, m_type2 p2, m_type3 p3, m_type4 p4, m_type5 p5, m_type6 p6) override { \
+		RID ret = RSG::texture_storage->texture_allocate(); \
+		if (Thread::get_caller_id() == server_thread || RSG::rasterizer->can_create_resources_async()) { \
+			RSG::texture_storage->m_type##_initialize(ret, p1, p2, p3, p4, p5, p6); \
+		} else { \
 			command_queue.push(RSG::texture_storage, &RendererTextureStorage::m_type##_initialize, ret, p1, p2, p3, p4, p5, p6); \
-		}                                                                                                                        \
-		return ret;                                                                                                              \
+		} \
+		return ret; \
 	}
 
 	//these go pass-through, as they can be called from any thread

--- a/servers/rendering/storage/utilities.h
+++ b/servers/rendering/storage/utilities.h
@@ -148,15 +148,15 @@ public:
 
 	bool capturing_timestamps = false;
 
-#define TIMESTAMP_BEGIN()                               \
-	{                                                   \
-		if (RSG::utilities->capturing_timestamps)       \
+#define TIMESTAMP_BEGIN() \
+	{ \
+		if (RSG::utilities->capturing_timestamps) \
 			RSG::utilities->capture_timestamps_begin(); \
 	}
 
-#define RENDER_TIMESTAMP(m_text)                       \
-	{                                                  \
-		if (RSG::utilities->capturing_timestamps)      \
+#define RENDER_TIMESTAMP(m_text) \
+	{ \
+		if (RSG::utilities->capturing_timestamps) \
 			RSG::utilities->capture_timestamp(m_text); \
 	}
 

--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -31,781 +31,781 @@
 #pragma once
 
 #ifdef DEBUG_ENABLED
-#define MAIN_THREAD_SYNC_CHECK                                                                         \
+#define MAIN_THREAD_SYNC_CHECK \
 	if (unlikely(Thread::is_main_thread() && Engine::get_singleton()->notify_frame_server_synced())) { \
-		MAIN_THREAD_SYNC_WARN                                                                          \
+		MAIN_THREAD_SYNC_WARN \
 	}
 #else
 #define MAIN_THREAD_SYNC_CHECK
 #endif
 
-#define FUNC0R(m_r, m_type)                                                     \
-	virtual m_r m_type() override {                                             \
-		if (ASYNC_COND_PUSH_AND_RET) {                                          \
-			m_r ret;                                                            \
+#define FUNC0R(m_r, m_type) \
+	virtual m_r m_type() override { \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret); \
-			SYNC_DEBUG                                                          \
-			MAIN_THREAD_SYNC_CHECK                                              \
-			return ret;                                                         \
-		} else {                                                                \
-			command_queue.flush_if_pending();                                   \
-			return server_name->m_type();                                       \
-		}                                                                       \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(); \
+		} \
 	}
 
-#define FUNCRIDSPLIT(m_type)                                                        \
-	virtual RID m_type##_create() override {                                        \
-		RID ret = server_name->m_type##_allocate();                                 \
-		if (ASYNC_COND_PUSH) {                                                      \
+#define FUNCRIDSPLIT(m_type) \
+	virtual RID m_type##_create() override { \
+		RID ret = server_name->m_type##_allocate(); \
+		if (ASYNC_COND_PUSH) { \
 			command_queue.push(server_name, &ServerName::m_type##_initialize, ret); \
-		} else {                                                                    \
-			server_name->m_type##_initialize(ret);                                  \
-		}                                                                           \
-		return ret;                                                                 \
+		} else { \
+			server_name->m_type##_initialize(ret); \
+		} \
+		return ret; \
 	}
 
 //RID now returns directly, ensure thread safety yourself
-#define FUNCRID(m_type)                        \
-	virtual RID m_type##_create() override {   \
+#define FUNCRID(m_type) \
+	virtual RID m_type##_create() override { \
 		return server_name->m_type##_create(); \
 	}
 
-#define FUNC0RC(m_r, m_type)                                                    \
-	virtual m_r m_type() const override {                                       \
-		WRITE_ACTION                                                            \
-		if (ASYNC_COND_PUSH_AND_RET) {                                          \
-			m_r ret;                                                            \
+#define FUNC0RC(m_r, m_type) \
+	virtual m_r m_type() const override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret); \
-			SYNC_DEBUG                                                          \
-			MAIN_THREAD_SYNC_CHECK                                              \
-			return ret;                                                         \
-		} else {                                                                \
-			command_queue.flush_if_pending();                                   \
-			return server_name->m_type();                                       \
-		}                                                                       \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(); \
+		} \
 	}
 
-#define FUNC0(m_type)                                             \
-	virtual void m_type() override {                              \
-		WRITE_ACTION                                              \
-		if (ASYNC_COND_PUSH) {                                    \
+#define FUNC0(m_type) \
+	virtual void m_type() override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
 			command_queue.push(server_name, &ServerName::m_type); \
-		} else {                                                  \
-			command_queue.flush_if_pending();                     \
-			server_name->m_type();                                \
-		}                                                         \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(); \
+		} \
 	}
 
-#define FUNC0C(m_type)                                            \
-	virtual void m_type() const override {                        \
-		if (ASYNC_COND_PUSH) {                                    \
+#define FUNC0C(m_type) \
+	virtual void m_type() const override { \
+		if (ASYNC_COND_PUSH) { \
 			command_queue.push(server_name, &ServerName::m_type); \
-		} else {                                                  \
-			command_queue.flush_if_pending();                     \
-			server_name->m_type();                                \
-		}                                                         \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(); \
+		} \
 	}
 
-#define FUNC0S(m_type)                                                     \
-	virtual void m_type() override {                                       \
-		WRITE_ACTION                                                       \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                    \
+#define FUNC0S(m_type) \
+	virtual void m_type() override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
 			command_queue.push_and_sync(server_name, &ServerName::m_type); \
-			SYNC_DEBUG                                                     \
-			MAIN_THREAD_SYNC_CHECK                                         \
-		} else {                                                           \
-			command_queue.flush_if_pending();                              \
-			server_name->m_type();                                         \
-		}                                                                  \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(); \
+		} \
 	}
 
-#define FUNC0SC(m_type)                                                    \
-	virtual void m_type() const override {                                 \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                    \
+#define FUNC0SC(m_type) \
+	virtual void m_type() const override { \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
 			command_queue.push_and_sync(server_name, &ServerName::m_type); \
-			SYNC_DEBUG                                                     \
-			MAIN_THREAD_SYNC_CHECK                                         \
-		} else {                                                           \
-			command_queue.flush_if_pending();                              \
-			server_name->m_type();                                         \
-		}                                                                  \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(); \
+		} \
 	}
 
 ///////////////////////////////////////////////
 
-#define FUNC1R(m_r, m_type, m_arg1)                                                 \
-	virtual m_r m_type(m_arg1 p1) override {                                        \
-		WRITE_ACTION                                                                \
-		if (ASYNC_COND_PUSH_AND_RET) {                                              \
-			m_r ret;                                                                \
+#define FUNC1R(m_r, m_type, m_arg1) \
+	virtual m_r m_type(m_arg1 p1) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1); \
-			SYNC_DEBUG                                                              \
-			MAIN_THREAD_SYNC_CHECK                                                  \
-			return ret;                                                             \
-		} else {                                                                    \
-			command_queue.flush_if_pending();                                       \
-			return server_name->m_type(p1);                                         \
-		}                                                                           \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1); \
+		} \
 	}
 
-#define FUNC1RC(m_r, m_type, m_arg1)                                                \
-	virtual m_r m_type(m_arg1 p1) const override {                                  \
-		if (ASYNC_COND_PUSH_AND_RET) {                                              \
-			m_r ret;                                                                \
+#define FUNC1RC(m_r, m_type, m_arg1) \
+	virtual m_r m_type(m_arg1 p1) const override { \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1); \
-			SYNC_DEBUG                                                              \
-			MAIN_THREAD_SYNC_CHECK                                                  \
-			return ret;                                                             \
-		} else {                                                                    \
-			command_queue.flush_if_pending();                                       \
-			return server_name->m_type(p1);                                         \
-		}                                                                           \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1); \
+		} \
 	}
 
-#define FUNC1S(m_type, m_arg1)                                                 \
-	virtual void m_type(m_arg1 p1) override {                                  \
-		WRITE_ACTION                                                           \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                        \
+#define FUNC1S(m_type, m_arg1) \
+	virtual void m_type(m_arg1 p1) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1); \
-			SYNC_DEBUG                                                         \
-			MAIN_THREAD_SYNC_CHECK                                             \
-		} else {                                                               \
-			command_queue.flush_if_pending();                                  \
-			server_name->m_type(p1);                                           \
-		}                                                                      \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1); \
+		} \
 	}
 
-#define FUNC1SC(m_type, m_arg1)                                                \
-	virtual void m_type(m_arg1 p1) const override {                            \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                        \
+#define FUNC1SC(m_type, m_arg1) \
+	virtual void m_type(m_arg1 p1) const override { \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1); \
-			SYNC_DEBUG                                                         \
-			MAIN_THREAD_SYNC_CHECK                                             \
-		} else {                                                               \
-			command_queue.flush_if_pending();                                  \
-			server_name->m_type(p1);                                           \
-		}                                                                      \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1); \
+		} \
 	}
 
-#define FUNC1(m_type, m_arg1)                                         \
-	virtual void m_type(m_arg1 p1) override {                         \
-		WRITE_ACTION                                                  \
-		if (ASYNC_COND_PUSH) {                                        \
+#define FUNC1(m_type, m_arg1) \
+	virtual void m_type(m_arg1 p1) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
 			command_queue.push(server_name, &ServerName::m_type, p1); \
-		} else {                                                      \
-			command_queue.flush_if_pending();                         \
-			server_name->m_type(p1);                                  \
-		}                                                             \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1); \
+		} \
 	}
 
-#define FUNC1C(m_type, m_arg1)                                        \
-	virtual void m_type(m_arg1 p1) const override {                   \
-		if (ASYNC_COND_PUSH) {                                        \
+#define FUNC1C(m_type, m_arg1) \
+	virtual void m_type(m_arg1 p1) const override { \
+		if (ASYNC_COND_PUSH) { \
 			command_queue.push(server_name, &ServerName::m_type, p1); \
-		} else {                                                      \
-			command_queue.flush_if_pending();                         \
-			server_name->m_type(p1);                                  \
-		}                                                             \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1); \
+		} \
 	}
 
-#define FUNC2R(m_r, m_type, m_arg1, m_arg2)                                             \
-	virtual m_r m_type(m_arg1 p1, m_arg2 p2) override {                                 \
-		WRITE_ACTION                                                                    \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                  \
-			m_r ret;                                                                    \
+#define FUNC2R(m_r, m_type, m_arg1, m_arg2) \
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2); \
-			SYNC_DEBUG                                                                  \
-			MAIN_THREAD_SYNC_CHECK                                                      \
-			return ret;                                                                 \
-		} else {                                                                        \
-			command_queue.flush_if_pending();                                           \
-			return server_name->m_type(p1, p2);                                         \
-		}                                                                               \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2); \
+		} \
 	}
 
-#define FUNC2RC(m_r, m_type, m_arg1, m_arg2)                                            \
-	virtual m_r m_type(m_arg1 p1, m_arg2 p2) const override {                           \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                  \
-			m_r ret;                                                                    \
+#define FUNC2RC(m_r, m_type, m_arg1, m_arg2) \
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2) const override { \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2); \
-			SYNC_DEBUG                                                                  \
-			MAIN_THREAD_SYNC_CHECK                                                      \
-			return ret;                                                                 \
-		} else {                                                                        \
-			command_queue.flush_if_pending();                                           \
-			return server_name->m_type(p1, p2);                                         \
-		}                                                                               \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2); \
+		} \
 	}
 
-#define FUNC2S(m_type, m_arg1, m_arg2)                                             \
-	virtual void m_type(m_arg1 p1, m_arg2 p2) override {                           \
-		WRITE_ACTION                                                               \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                            \
+#define FUNC2S(m_type, m_arg1, m_arg2) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2); \
-			SYNC_DEBUG                                                             \
-			MAIN_THREAD_SYNC_CHECK                                                 \
-		} else {                                                                   \
-			command_queue.flush_if_pending();                                      \
-			server_name->m_type(p1, p2);                                           \
-		}                                                                          \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2); \
+		} \
 	}
 
-#define FUNC2SC(m_type, m_arg1, m_arg2)                                            \
-	virtual void m_type(m_arg1 p1, m_arg2 p2) const override {                     \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                            \
+#define FUNC2SC(m_type, m_arg1, m_arg2) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2) const override { \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2); \
-			SYNC_DEBUG                                                             \
-			MAIN_THREAD_SYNC_CHECK                                                 \
-		} else {                                                                   \
-			command_queue.flush_if_pending();                                      \
-			server_name->m_type(p1, p2);                                           \
-		}                                                                          \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2); \
+		} \
 	}
 
-#define FUNC2(m_type, m_arg1, m_arg2)                                     \
-	virtual void m_type(m_arg1 p1, m_arg2 p2) override {                  \
-		WRITE_ACTION                                                      \
-		if (ASYNC_COND_PUSH) {                                            \
+#define FUNC2(m_type, m_arg1, m_arg2) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2); \
-		} else {                                                          \
-			command_queue.flush_if_pending();                             \
-			server_name->m_type(p1, p2);                                  \
-		}                                                                 \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2); \
+		} \
 	}
 
-#define FUNC2C(m_type, m_arg1, m_arg2)                                    \
-	virtual void m_type(m_arg1 p1, m_arg2 p2) const override {            \
-		if (ASYNC_COND_PUSH) {                                            \
+#define FUNC2C(m_type, m_arg1, m_arg2) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2) const override { \
+		if (ASYNC_COND_PUSH) { \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2); \
-		} else {                                                          \
-			command_queue.flush_if_pending();                             \
-			server_name->m_type(p1, p2);                                  \
-		}                                                                 \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2); \
+		} \
 	}
 
-#define FUNC3R(m_r, m_type, m_arg1, m_arg2, m_arg3)                                         \
-	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) override {                          \
-		WRITE_ACTION                                                                        \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                      \
-			m_r ret;                                                                        \
+#define FUNC3R(m_r, m_type, m_arg1, m_arg2, m_arg3) \
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3); \
-			SYNC_DEBUG                                                                      \
-			MAIN_THREAD_SYNC_CHECK                                                          \
-			return ret;                                                                     \
-		} else {                                                                            \
-			command_queue.flush_if_pending();                                               \
-			return server_name->m_type(p1, p2, p3);                                         \
-		}                                                                                   \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3); \
+		} \
 	}
 
-#define FUNC3RC(m_r, m_type, m_arg1, m_arg2, m_arg3)                                        \
-	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const override {                    \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                      \
-			m_r ret;                                                                        \
+#define FUNC3RC(m_r, m_type, m_arg1, m_arg2, m_arg3) \
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const override { \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3); \
-			SYNC_DEBUG                                                                      \
-			MAIN_THREAD_SYNC_CHECK                                                          \
-			return ret;                                                                     \
-		} else {                                                                            \
-			command_queue.flush_if_pending();                                               \
-			return server_name->m_type(p1, p2, p3);                                         \
-		}                                                                                   \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3); \
+		} \
 	}
 
-#define FUNC3S(m_type, m_arg1, m_arg2, m_arg3)                                         \
-	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) override {                    \
-		WRITE_ACTION                                                                   \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                \
+#define FUNC3S(m_type, m_arg1, m_arg2, m_arg3) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3); \
-			SYNC_DEBUG                                                                 \
-			MAIN_THREAD_SYNC_CHECK                                                     \
-		} else {                                                                       \
-			command_queue.flush_if_pending();                                          \
-			server_name->m_type(p1, p2, p3);                                           \
-		}                                                                              \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3); \
+		} \
 	}
 
-#define FUNC3SC(m_type, m_arg1, m_arg2, m_arg3)                                        \
-	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const override {              \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                \
+#define FUNC3SC(m_type, m_arg1, m_arg2, m_arg3) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const override { \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3); \
-			SYNC_DEBUG                                                                 \
-			MAIN_THREAD_SYNC_CHECK                                                     \
-		} else {                                                                       \
-			command_queue.flush_if_pending();                                          \
-			server_name->m_type(p1, p2, p3);                                           \
-		}                                                                              \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3); \
+		} \
 	}
 
-#define FUNC3(m_type, m_arg1, m_arg2, m_arg3)                                 \
-	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) override {           \
-		WRITE_ACTION                                                          \
-		if (ASYNC_COND_PUSH) {                                                \
+#define FUNC3(m_type, m_arg1, m_arg2, m_arg3) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3); \
-		} else {                                                              \
-			command_queue.flush_if_pending();                                 \
-			server_name->m_type(p1, p2, p3);                                  \
-		}                                                                     \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3); \
+		} \
 	}
 
-#define FUNC3C(m_type, m_arg1, m_arg2, m_arg3)                                \
-	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const override {     \
-		if (ASYNC_COND_PUSH) {                                                \
+#define FUNC3C(m_type, m_arg1, m_arg2, m_arg3) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const override { \
+		if (ASYNC_COND_PUSH) { \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3); \
-		} else {                                                              \
-			command_queue.flush_if_pending();                                 \
-			server_name->m_type(p1, p2, p3);                                  \
-		}                                                                     \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3); \
+		} \
 	}
 
-#define FUNC4R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                     \
-	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) override {                   \
-		WRITE_ACTION                                                                            \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                          \
-			m_r ret;                                                                            \
+#define FUNC4R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4) \
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4); \
-			SYNC_DEBUG                                                                          \
-			MAIN_THREAD_SYNC_CHECK                                                              \
-			return ret;                                                                         \
-		} else {                                                                                \
-			command_queue.flush_if_pending();                                                   \
-			return server_name->m_type(p1, p2, p3, p4);                                         \
-		}                                                                                       \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4); \
+		} \
 	}
 
-#define FUNC4RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                    \
-	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const override {             \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                          \
-			m_r ret;                                                                            \
+#define FUNC4RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4) \
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const override { \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4); \
-			SYNC_DEBUG                                                                          \
-			MAIN_THREAD_SYNC_CHECK                                                              \
-			return ret;                                                                         \
-		} else {                                                                                \
-			command_queue.flush_if_pending();                                                   \
-			return server_name->m_type(p1, p2, p3, p4);                                         \
-		}                                                                                       \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4); \
+		} \
 	}
 
-#define FUNC4S(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                     \
-	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) override {             \
-		WRITE_ACTION                                                                       \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                    \
+#define FUNC4S(m_type, m_arg1, m_arg2, m_arg3, m_arg4) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4); \
-			SYNC_DEBUG                                                                     \
-			MAIN_THREAD_SYNC_CHECK                                                         \
-		} else {                                                                           \
-			command_queue.flush_if_pending();                                              \
-			server_name->m_type(p1, p2, p3, p4);                                           \
-		}                                                                                  \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4); \
+		} \
 	}
 
-#define FUNC4SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                    \
-	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const override {       \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                    \
-			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4); \
-			SYNC_DEBUG                                                                     \
-			MAIN_THREAD_SYNC_CHECK                                                         \
-		} else {                                                                           \
-			command_queue.flush_if_pending();                                              \
-			server_name->m_type(p1, p2, p3, p4);                                           \
-		}                                                                                  \
-	}
-
-#define FUNC4(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                             \
-	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) override {    \
-		WRITE_ACTION                                                              \
-		if (ASYNC_COND_PUSH) {                                                    \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4); \
-		} else {                                                                  \
-			command_queue.flush_if_pending();                                     \
-			server_name->m_type(p1, p2, p3, p4);                                  \
-		}                                                                         \
-	}
-
-#define FUNC4C(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                               \
+#define FUNC4SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const override { \
-		if (ASYNC_COND_PUSH) {                                                       \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4);    \
-		} else {                                                                     \
-			command_queue.flush_if_pending();                                        \
-			server_name->m_type(p1, p2, p3, p4);                                     \
-		}                                                                            \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
+			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4); \
+		} \
 	}
 
-#define FUNC5R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                 \
-	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) {                     \
-		WRITE_ACTION                                                                                \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                              \
-			m_r ret;                                                                                \
+#define FUNC4(m_type, m_arg1, m_arg2, m_arg3, m_arg4) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4); \
+		} \
+	}
+
+#define FUNC4C(m_type, m_arg1, m_arg2, m_arg3, m_arg4) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const override { \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4); \
+		} \
+	}
+
+#define FUNC5R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5) \
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5); \
-			SYNC_DEBUG                                                                              \
-			MAIN_THREAD_SYNC_CHECK                                                                  \
-			return ret;                                                                             \
-		} else {                                                                                    \
-			command_queue.flush_if_pending();                                                       \
-			return server_name->m_type(p1, p2, p3, p4, p5);                                         \
-		}                                                                                           \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4, p5); \
+		} \
 	}
 
-#define FUNC5RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                \
-	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const override {      \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                              \
-			m_r ret;                                                                                \
+#define FUNC5RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5) \
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const override { \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5); \
-			SYNC_DEBUG                                                                              \
-			MAIN_THREAD_SYNC_CHECK                                                                  \
-			return ret;                                                                             \
-		} else {                                                                                    \
-			command_queue.flush_if_pending();                                                       \
-			return server_name->m_type(p1, p2, p3, p4, p5);                                         \
-		}                                                                                           \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4, p5); \
+		} \
 	}
 
-#define FUNC5S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                 \
-	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) override {      \
-		WRITE_ACTION                                                                           \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                        \
-			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
-			SYNC_DEBUG                                                                         \
-			MAIN_THREAD_SYNC_CHECK                                                             \
-		} else {                                                                               \
-			command_queue.flush_if_pending();                                                  \
-			server_name->m_type(p1, p2, p3, p4, p5);                                           \
-		}                                                                                      \
-	}
-
-#define FUNC5SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                 \
-	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const override { \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                         \
-			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5);  \
-			SYNC_DEBUG                                                                          \
-			MAIN_THREAD_SYNC_CHECK                                                              \
-		} else {                                                                                \
-			command_queue.flush_if_pending();                                                   \
-			server_name->m_type(p1, p2, p3, p4, p5);                                            \
-		}                                                                                       \
-	}
-
-#define FUNC5(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                             \
+#define FUNC5S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) override { \
-		WRITE_ACTION                                                                      \
-		if (ASYNC_COND_PUSH) {                                                            \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5);     \
-		} else {                                                                          \
-			command_queue.flush_if_pending();                                             \
-			server_name->m_type(p1, p2, p3, p4, p5);                                      \
-		}                                                                                 \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
+			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5); \
+		} \
 	}
 
-#define FUNC5C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                  \
+#define FUNC5SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const override { \
-		if (ASYNC_COND_PUSH) {                                                                  \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5);           \
-		} else {                                                                                \
-			command_queue.flush_if_pending();                                                   \
-			server_name->m_type(p1, p2, p3, p4, p5);                                            \
-		}                                                                                       \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
+			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5); \
+		} \
 	}
 
-#define FUNC6R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                             \
-	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) {              \
-		WRITE_ACTION                                                                                    \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                                  \
-			m_r ret;                                                                                    \
+#define FUNC5(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) override { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5); \
+		} \
+	}
+
+#define FUNC5C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5) \
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const override { \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5); \
+		} \
+	}
+
+#define FUNC6R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6) \
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) { \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6); \
-			SYNC_DEBUG                                                                                  \
-			MAIN_THREAD_SYNC_CHECK                                                                      \
-			return ret;                                                                                 \
-		} else {                                                                                        \
-			command_queue.flush_if_pending();                                                           \
-			return server_name->m_type(p1, p2, p3, p4, p5, p6);                                         \
-		}                                                                                               \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4, p5, p6); \
+		} \
 	}
 
-#define FUNC6RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                              \
+#define FUNC6RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6) \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) const override { \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                                    \
-			m_r ret;                                                                                      \
-			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6);   \
-			SYNC_DEBUG                                                                                    \
-			MAIN_THREAD_SYNC_CHECK                                                                        \
-			return ret;                                                                                   \
-		} else {                                                                                          \
-			command_queue.flush_if_pending();                                                             \
-			return server_name->m_type(p1, p2, p3, p4, p5, p6);                                           \
-		}                                                                                                 \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
+			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4, p5, p6); \
+		} \
 	}
 
-#define FUNC6S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                               \
+#define FUNC6S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) override { \
-		WRITE_ACTION                                                                                 \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                              \
-			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);   \
-			SYNC_DEBUG                                                                               \
-			MAIN_THREAD_SYNC_CHECK                                                                   \
-		} else {                                                                                     \
-			command_queue.flush_if_pending();                                                        \
-			server_name->m_type(p1, p2, p3, p4, p5, p6);                                             \
-		}                                                                                            \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
+			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6); \
+		} \
 	}
 
-#define FUNC6SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                                    \
+#define FUNC6SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) const override { \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                    \
-			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);         \
-			SYNC_DEBUG                                                                                     \
-			MAIN_THREAD_SYNC_CHECK                                                                         \
-		} else {                                                                                           \
-			command_queue.flush_if_pending();                                                              \
-			server_name->m_type(p1, p2, p3, p4, p5, p6);                                                   \
-		}                                                                                                  \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
+			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6); \
+		} \
 	}
 
-#define FUNC6(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                                \
+#define FUNC6(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) override { \
-		WRITE_ACTION                                                                                 \
-		if (ASYNC_COND_PUSH) {                                                                       \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);            \
-		} else {                                                                                     \
-			command_queue.flush_if_pending();                                                        \
-			server_name->m_type(p1, p2, p3, p4, p5, p6);                                             \
-		}                                                                                            \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6); \
+		} \
 	}
 
-#define FUNC6C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                                     \
+#define FUNC6C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) const override { \
-		if (ASYNC_COND_PUSH) {                                                                             \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);                  \
-		} else {                                                                                           \
-			command_queue.flush_if_pending();                                                              \
-			server_name->m_type(p1, p2, p3, p4, p5, p6);                                                   \
-		}                                                                                                  \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6); \
+		} \
 	}
 
-#define FUNC7R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                            \
+#define FUNC7R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7) \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) override { \
-		WRITE_ACTION                                                                                           \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                                         \
-			m_r ret;                                                                                           \
-			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7);    \
-			SYNC_DEBUG                                                                                         \
-			MAIN_THREAD_SYNC_CHECK                                                                             \
-			return ret;                                                                                        \
-		} else {                                                                                               \
-			command_queue.flush_if_pending();                                                                  \
-			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                            \
-		}                                                                                                      \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
+			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7); \
+		} \
 	}
 
-#define FUNC7RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                 \
+#define FUNC7RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7) \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) const override { \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                                               \
-			m_r ret;                                                                                                 \
-			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7);          \
-			SYNC_DEBUG                                                                                               \
-			MAIN_THREAD_SYNC_CHECK                                                                                   \
-			return ret;                                                                                              \
-		} else {                                                                                                     \
-			command_queue.flush_if_pending();                                                                        \
-			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                                  \
-		}                                                                                                            \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
+			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7); \
+		} \
 	}
 
-#define FUNC7S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                  \
+#define FUNC7S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) override { \
-		WRITE_ACTION                                                                                            \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                         \
-			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);          \
-			SYNC_DEBUG                                                                                          \
-			MAIN_THREAD_SYNC_CHECK                                                                              \
-		} else {                                                                                                \
-			command_queue.flush_if_pending();                                                                   \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                                    \
-		}                                                                                                       \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
+			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7); \
+		} \
 	}
 
-#define FUNC7SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                       \
+#define FUNC7SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) const override { \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                               \
-			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);                \
-			SYNC_DEBUG                                                                                                \
-			MAIN_THREAD_SYNC_CHECK                                                                                    \
-		} else {                                                                                                      \
-			command_queue.flush_if_pending();                                                                         \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                                          \
-		}                                                                                                             \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
+			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7); \
+		} \
 	}
 
-#define FUNC7(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                   \
+#define FUNC7(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) override { \
-		WRITE_ACTION                                                                                            \
-		if (ASYNC_COND_PUSH) {                                                                                  \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);                   \
-		} else {                                                                                                \
-			command_queue.flush_if_pending();                                                                   \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                                    \
-		}                                                                                                       \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7); \
+		} \
 	}
 
-#define FUNC7C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                        \
+#define FUNC7C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) const override { \
-		if (ASYNC_COND_PUSH) {                                                                                        \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);                         \
-		} else {                                                                                                      \
-			command_queue.flush_if_pending();                                                                         \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                                          \
-		}                                                                                                             \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7); \
+		} \
 	}
 
-#define FUNC8R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                               \
+#define FUNC8R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8) \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) override { \
-		WRITE_ACTION                                                                                                      \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                                                    \
-			m_r ret;                                                                                                      \
-			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7, p8);           \
-			SYNC_DEBUG                                                                                                    \
-			MAIN_THREAD_SYNC_CHECK                                                                                        \
-			return ret;                                                                                                   \
-		} else {                                                                                                          \
-			command_queue.flush_if_pending();                                                                             \
-			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                   \
-		}                                                                                                                 \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
+			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7, p8); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8); \
+		} \
 	}
 
-#define FUNC8RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                    \
+#define FUNC8RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8) \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const override { \
-		if (ASYNC_COND_PUSH_AND_RET) {                                                                                          \
-			m_r ret;                                                                                                            \
-			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7, p8);                 \
-			SYNC_DEBUG                                                                                                          \
-			MAIN_THREAD_SYNC_CHECK                                                                                              \
-			return ret;                                                                                                         \
-		} else {                                                                                                                \
-			command_queue.flush_if_pending();                                                                                   \
-			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                         \
-		}                                                                                                                       \
+		if (ASYNC_COND_PUSH_AND_RET) { \
+			m_r ret; \
+			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7, p8); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+			return ret; \
+		} else { \
+			command_queue.flush_if_pending(); \
+			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8); \
+		} \
 	}
 
-#define FUNC8S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                     \
+#define FUNC8S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) override { \
-		WRITE_ACTION                                                                                                       \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                                    \
-			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                 \
-			SYNC_DEBUG                                                                                                     \
-			MAIN_THREAD_SYNC_CHECK                                                                                         \
-		} else {                                                                                                           \
-			command_queue.flush_if_pending();                                                                              \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                           \
-		}                                                                                                                  \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
+			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8); \
+		} \
 	}
 
-#define FUNC8SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                          \
+#define FUNC8SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const override { \
-		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                                          \
-			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                       \
-			SYNC_DEBUG                                                                                                           \
-			MAIN_THREAD_SYNC_CHECK                                                                                               \
-		} else {                                                                                                                 \
-			command_queue.flush_if_pending();                                                                                    \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                                 \
-		}                                                                                                                        \
+		if (ASYNC_COND_PUSH_AND_SYNC) { \
+			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8); \
+			SYNC_DEBUG \
+			MAIN_THREAD_SYNC_CHECK \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8); \
+		} \
 	}
 
-#define FUNC8(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                      \
+#define FUNC8(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) override { \
-		WRITE_ACTION                                                                                                       \
-		if (ASYNC_COND_PUSH) {                                                                                             \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                          \
-		} else {                                                                                                           \
-			command_queue.flush_if_pending();                                                                              \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                           \
-		}                                                                                                                  \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8); \
+		} \
 	}
 
-#define FUNC8C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                           \
+#define FUNC8C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const override { \
-		if (ASYNC_COND_PUSH) {                                                                                                   \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                                \
-		} else {                                                                                                                 \
-			command_queue.flush_if_pending();                                                                                    \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                                 \
-		}                                                                                                                        \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8); \
+		} \
 	}
 
-#define FUNC9(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9)                                         \
+#define FUNC9(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9) override { \
-		WRITE_ACTION                                                                                                                  \
-		if (ASYNC_COND_PUSH) {                                                                                                        \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9);                                 \
-		} else {                                                                                                                      \
-			command_queue.flush_if_pending();                                                                                         \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9);                                                                  \
-		}                                                                                                                             \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9); \
+		} \
 	}
 
-#define FUNC10(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10)                                            \
+#define FUNC10(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10) override { \
-		WRITE_ACTION                                                                                                                               \
-		if (ASYNC_COND_PUSH) {                                                                                                                     \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);                                         \
-		} else {                                                                                                                                   \
-			command_queue.flush_if_pending();                                                                                                      \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);                                                                          \
-		}                                                                                                                                          \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10); \
+		} \
 	}
 
-#define FUNC11(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11)                                                \
+#define FUNC11(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11) override { \
-		WRITE_ACTION                                                                                                                                            \
-		if (ASYNC_COND_PUSH) {                                                                                                                                  \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);                                                 \
-		} else {                                                                                                                                                \
-			command_queue.flush_if_pending();                                                                                                                   \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);                                                                                  \
-		}                                                                                                                                                       \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11); \
+		} \
 	}
 
-#define FUNC12(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12)                                                    \
+#define FUNC12(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12) override { \
-		WRITE_ACTION                                                                                                                                                         \
-		if (ASYNC_COND_PUSH) {                                                                                                                                               \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);                                                         \
-		} else {                                                                                                                                                             \
-			command_queue.flush_if_pending();                                                                                                                                \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);                                                                                          \
-		}                                                                                                                                                                    \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12); \
+		} \
 	}
 
-#define FUNC13(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13)                                                        \
+#define FUNC13(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12, m_arg13 p13) override { \
-		WRITE_ACTION                                                                                                                                                                      \
-		if (ASYNC_COND_PUSH) {                                                                                                                                                            \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);                                                                 \
-		} else {                                                                                                                                                                          \
-			command_queue.flush_if_pending();                                                                                                                                             \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);                                                                                                  \
-		}                                                                                                                                                                                 \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13); \
+		} \
 	}
 
-#define FUNC14(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13, m_arg14)                                                            \
+#define FUNC14(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13, m_arg14) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12, m_arg13 p13, m_arg14 p14) override { \
-		WRITE_ACTION                                                                                                                                                                                   \
-		if (ASYNC_COND_PUSH) {                                                                                                                                                                         \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);                                                                         \
-		} else {                                                                                                                                                                                       \
-			command_queue.flush_if_pending();                                                                                                                                                          \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);                                                                                                          \
-		}                                                                                                                                                                                              \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14); \
+		} \
 	}
 
-#define FUNC15(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13, m_arg14, m_arg15)                                                                \
+#define FUNC15(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13, m_arg14, m_arg15) \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12, m_arg13 p13, m_arg14 p14, m_arg15 p15) override { \
-		WRITE_ACTION                                                                                                                                                                                                \
-		if (ASYNC_COND_PUSH) {                                                                                                                                                                                      \
-			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);                                                                                 \
-		} else {                                                                                                                                                                                                    \
-			command_queue.flush_if_pending();                                                                                                                                                                       \
-			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);                                                                                                                  \
-		}                                                                                                                                                                                                           \
+		WRITE_ACTION \
+		if (ASYNC_COND_PUSH) { \
+			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15); \
+		} else { \
+			command_queue.flush_if_pending(); \
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15); \
+		} \
 	}

--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -255,109 +255,109 @@ public:
 	}
 };
 
-#define DEFINE_DUPLICATE_GUINEA_PIG(m_class_name, m_property_usage)                                                                                 \
-	class m_class_name : public Resource {                                                                                                          \
-		GDCLASS(m_class_name, Resource)                                                                                                             \
-                                                                                                                                                    \
-		DuplicateGuineaPigData data;                                                                                                                \
-                                                                                                                                                    \
-	public:                                                                                                                                         \
-		void set_obj(Object *p_obj) {                                                                                                               \
-			data.obj = p_obj;                                                                                                                       \
-		}                                                                                                                                           \
-		Object *get_obj() const {                                                                                                                   \
-			return data.obj;                                                                                                                        \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-		void set_arr(const Array &p_arr) {                                                                                                          \
-			data.arr = p_arr;                                                                                                                       \
-		}                                                                                                                                           \
-		Array get_arr() const {                                                                                                                     \
-			return data.arr;                                                                                                                        \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-		void set_dict(const Dictionary &p_dict) {                                                                                                   \
-			data.dict = p_dict;                                                                                                                     \
-		}                                                                                                                                           \
-		Dictionary get_dict() const {                                                                                                               \
-			return data.dict;                                                                                                                       \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-		void set_packed(const Variant &p_packed) {                                                                                                  \
-			data.packed = p_packed;                                                                                                                 \
-		}                                                                                                                                           \
-		Variant get_packed() const {                                                                                                                \
-			return data.packed;                                                                                                                     \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-		void set_subres(const Ref<Resource> &p_subres) {                                                                                            \
-			data.subres = p_subres;                                                                                                                 \
-		}                                                                                                                                           \
-		Ref<Resource> get_subres() const {                                                                                                          \
-			return data.subres;                                                                                                                     \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-		void set_subres_sl(const Ref<Resource> &p_subres) {                                                                                         \
-			data.subres_sl = p_subres;                                                                                                              \
-		}                                                                                                                                           \
-		Ref<Resource> get_subres_sl() const {                                                                                                       \
-			return data.subres_sl;                                                                                                                  \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-		void set_defaults() {                                                                                                                       \
-			data.set_defaults();                                                                                                                    \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-		Object *get_data() {                                                                                                                        \
-			return &data;                                                                                                                           \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-		void verify_duplication(const Ref<Resource> &p_orig, int p_test_mode, int p_deep_mode) const {                                              \
-			const DuplicateGuineaPigData *orig_data = Object::cast_to<DuplicateGuineaPigData>(p_orig->call("get_data"));                            \
-			data.verify_duplication(orig_data, m_property_usage, (TestDuplicateMode)p_test_mode, (ResourceDeepDuplicateMode)p_deep_mode);           \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-	protected:                                                                                                                                      \
-		static void _bind_methods() {                                                                                                               \
-			ClassDB::bind_method(D_METHOD("set_obj", "obj"), &m_class_name::set_obj);                                                               \
-			ClassDB::bind_method(D_METHOD("get_obj"), &m_class_name::get_obj);                                                                      \
-                                                                                                                                                    \
-			ClassDB::bind_method(D_METHOD("set_arr", "arr"), &m_class_name::set_arr);                                                               \
-			ClassDB::bind_method(D_METHOD("get_arr"), &m_class_name::get_arr);                                                                      \
-                                                                                                                                                    \
-			ClassDB::bind_method(D_METHOD("set_dict", "dict"), &m_class_name::set_dict);                                                            \
-			ClassDB::bind_method(D_METHOD("get_dict"), &m_class_name::get_dict);                                                                    \
-                                                                                                                                                    \
-			ClassDB::bind_method(D_METHOD("set_packed", "packed"), &m_class_name::set_packed);                                                      \
-			ClassDB::bind_method(D_METHOD("get_packed"), &m_class_name::get_packed);                                                                \
-                                                                                                                                                    \
-			ClassDB::bind_method(D_METHOD("set_subres", "subres"), &m_class_name::set_subres);                                                      \
-			ClassDB::bind_method(D_METHOD("get_subres"), &m_class_name::get_subres);                                                                \
-                                                                                                                                                    \
-			ClassDB::bind_method(D_METHOD("set_subres_sl", "subres"), &m_class_name::set_subres_sl);                                                \
-			ClassDB::bind_method(D_METHOD("get_subres_sl"), &m_class_name::get_subres_sl);                                                          \
-                                                                                                                                                    \
-			ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "obj", PROPERTY_HINT_NONE, "", m_property_usage), "set_obj", "get_obj");                     \
-			ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "arr", PROPERTY_HINT_NONE, "", m_property_usage), "set_arr", "get_arr");                      \
-			ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "dict", PROPERTY_HINT_NONE, "", m_property_usage), "set_dict", "get_dict");              \
+#define DEFINE_DUPLICATE_GUINEA_PIG(m_class_name, m_property_usage) \
+	class m_class_name : public Resource { \
+		GDCLASS(m_class_name, Resource) \
+\
+		DuplicateGuineaPigData data; \
+\
+	public: \
+		void set_obj(Object *p_obj) { \
+			data.obj = p_obj; \
+		} \
+		Object *get_obj() const { \
+			return data.obj; \
+		} \
+\
+		void set_arr(const Array &p_arr) { \
+			data.arr = p_arr; \
+		} \
+		Array get_arr() const { \
+			return data.arr; \
+		} \
+\
+		void set_dict(const Dictionary &p_dict) { \
+			data.dict = p_dict; \
+		} \
+		Dictionary get_dict() const { \
+			return data.dict; \
+		} \
+\
+		void set_packed(const Variant &p_packed) { \
+			data.packed = p_packed; \
+		} \
+		Variant get_packed() const { \
+			return data.packed; \
+		} \
+\
+		void set_subres(const Ref<Resource> &p_subres) { \
+			data.subres = p_subres; \
+		} \
+		Ref<Resource> get_subres() const { \
+			return data.subres; \
+		} \
+\
+		void set_subres_sl(const Ref<Resource> &p_subres) { \
+			data.subres_sl = p_subres; \
+		} \
+		Ref<Resource> get_subres_sl() const { \
+			return data.subres_sl; \
+		} \
+\
+		void set_defaults() { \
+			data.set_defaults(); \
+		} \
+\
+		Object *get_data() { \
+			return &data; \
+		} \
+\
+		void verify_duplication(const Ref<Resource> &p_orig, int p_test_mode, int p_deep_mode) const { \
+			const DuplicateGuineaPigData *orig_data = Object::cast_to<DuplicateGuineaPigData>(p_orig->call("get_data")); \
+			data.verify_duplication(orig_data, m_property_usage, (TestDuplicateMode)p_test_mode, (ResourceDeepDuplicateMode)p_deep_mode); \
+		} \
+\
+	protected: \
+		static void _bind_methods() { \
+			ClassDB::bind_method(D_METHOD("set_obj", "obj"), &m_class_name::set_obj); \
+			ClassDB::bind_method(D_METHOD("get_obj"), &m_class_name::get_obj); \
+\
+			ClassDB::bind_method(D_METHOD("set_arr", "arr"), &m_class_name::set_arr); \
+			ClassDB::bind_method(D_METHOD("get_arr"), &m_class_name::get_arr); \
+\
+			ClassDB::bind_method(D_METHOD("set_dict", "dict"), &m_class_name::set_dict); \
+			ClassDB::bind_method(D_METHOD("get_dict"), &m_class_name::get_dict); \
+\
+			ClassDB::bind_method(D_METHOD("set_packed", "packed"), &m_class_name::set_packed); \
+			ClassDB::bind_method(D_METHOD("get_packed"), &m_class_name::get_packed); \
+\
+			ClassDB::bind_method(D_METHOD("set_subres", "subres"), &m_class_name::set_subres); \
+			ClassDB::bind_method(D_METHOD("get_subres"), &m_class_name::get_subres); \
+\
+			ClassDB::bind_method(D_METHOD("set_subres_sl", "subres"), &m_class_name::set_subres_sl); \
+			ClassDB::bind_method(D_METHOD("get_subres_sl"), &m_class_name::get_subres_sl); \
+\
+			ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "obj", PROPERTY_HINT_NONE, "", m_property_usage), "set_obj", "get_obj"); \
+			ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "arr", PROPERTY_HINT_NONE, "", m_property_usage), "set_arr", "get_arr"); \
+			ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "dict", PROPERTY_HINT_NONE, "", m_property_usage), "set_dict", "get_dict"); \
 			ADD_PROPERTY(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "packed", PROPERTY_HINT_NONE, "", m_property_usage), "set_packed", "get_packed"); \
-			ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "subres", PROPERTY_HINT_NONE, "", m_property_usage), "set_subres", "get_subres");            \
-			ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "subres_sl", PROPERTY_HINT_NONE, "", m_property_usage), "set_subres_sl", "get_subres_sl");   \
-                                                                                                                                                    \
-			ClassDB::bind_method(D_METHOD("set_defaults"), &m_class_name::set_defaults);                                                            \
-			ClassDB::bind_method(D_METHOD("get_data"), &m_class_name::get_data);                                                                    \
-			ClassDB::bind_method(D_METHOD("verify_duplication", "orig", "test_mode", "deep_mode"), &m_class_name::verify_duplication);              \
-		}                                                                                                                                           \
-                                                                                                                                                    \
-	public:                                                                                                                                         \
-		static m_class_name *register_and_instantiate() {                                                                                           \
-			static bool registered = false;                                                                                                         \
-			if (!registered) {                                                                                                                      \
-				GDREGISTER_CLASS(m_class_name);                                                                                                     \
-				registered = true;                                                                                                                  \
-			}                                                                                                                                       \
-			return memnew(m_class_name);                                                                                                            \
-		}                                                                                                                                           \
+			ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "subres", PROPERTY_HINT_NONE, "", m_property_usage), "set_subres", "get_subres"); \
+			ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "subres_sl", PROPERTY_HINT_NONE, "", m_property_usage), "set_subres_sl", "get_subres_sl"); \
+\
+			ClassDB::bind_method(D_METHOD("set_defaults"), &m_class_name::set_defaults); \
+			ClassDB::bind_method(D_METHOD("get_data"), &m_class_name::get_data); \
+			ClassDB::bind_method(D_METHOD("verify_duplication", "orig", "test_mode", "deep_mode"), &m_class_name::verify_duplication); \
+		} \
+\
+	public: \
+		static m_class_name *register_and_instantiate() { \
+			static bool registered = false; \
+			if (!registered) { \
+				GDREGISTER_CLASS(m_class_name); \
+				registered = true; \
+			} \
+			return memnew(m_class_name); \
+		} \
 	};
 
 DEFINE_DUPLICATE_GUINEA_PIG(DuplicateGuineaPig_None, PROPERTY_USAGE_NONE)

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1622,9 +1622,9 @@ TEST_CASE("[String] Checking string is empty when it should be") {
 }
 
 TEST_CASE("[String] lstrip and rstrip") {
-#define STRIP_TEST(x)             \
-	{                             \
-		bool success = x;         \
+#define STRIP_TEST(x) \
+	{ \
+		bool success = x; \
 		state = state && success; \
 	}
 
@@ -2183,17 +2183,17 @@ TEST_CASE("[String] Variant ptr indexed set") {
 
 TEST_CASE("[String][URL] Parse URL") {
 #define CHECK_URL(m_url_to_parse, m_expected_schema, m_expected_host, m_expected_port, m_expected_path, m_expected_fragment, m_expected_error) \
-	if (true) {                                                                                                                                \
-		int port;                                                                                                                              \
-		String url(m_url_to_parse), schema, host, path, fragment;                                                                              \
-                                                                                                                                               \
-		CHECK_EQ(url.parse_url(schema, host, port, path, fragment), m_expected_error);                                                         \
-		CHECK_EQ(schema, m_expected_schema);                                                                                                   \
-		CHECK_EQ(host, m_expected_host);                                                                                                       \
-		CHECK_EQ(path, m_expected_path);                                                                                                       \
-		CHECK_EQ(fragment, m_expected_fragment);                                                                                               \
-		CHECK_EQ(port, m_expected_port);                                                                                                       \
-	} else                                                                                                                                     \
+	if (true) { \
+		int port; \
+		String url(m_url_to_parse), schema, host, path, fragment; \
+\
+		CHECK_EQ(url.parse_url(schema, host, port, path, fragment), m_expected_error); \
+		CHECK_EQ(schema, m_expected_schema); \
+		CHECK_EQ(host, m_expected_host); \
+		CHECK_EQ(path, m_expected_path); \
+		CHECK_EQ(fragment, m_expected_fragment); \
+		CHECK_EQ(port, m_expected_port); \
+	} else \
 		((void)0)
 
 	// All elements.

--- a/tests/scene/test_split_container.h
+++ b/tests/scene/test_split_container.h
@@ -37,9 +37,9 @@
 
 namespace TestSplitContainer {
 
-#define CHECK_RECTS(m_rects, m_child_rects)                                                                                                                   \
-	CHECK(m_rects.size() == m_child_rects.size());                                                                                                            \
-	for (int i = 0; i < (int)m_child_rects.size(); i++) {                                                                                                     \
+#define CHECK_RECTS(m_rects, m_child_rects) \
+	CHECK(m_rects.size() == m_child_rects.size()); \
+	for (int i = 0; i < (int)m_child_rects.size(); i++) { \
 		CHECK_MESSAGE(m_child_rects[i] == m_rects[i], vformat("Child %s is the wrong size. Child rect: %s, expected: %s.", i, m_child_rects[i], m_rects[i])); \
 	}
 

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -65,22 +65,22 @@
 // Stringify all `Variant` compatible types for doctest output by default.
 // https://github.com/onqtam/doctest/blob/master/doc/markdown/stringification.md
 
-#define DOCTEST_STRINGIFY_VARIANT(m_type)                     \
-	template <>                                               \
-	struct doctest::StringMaker<m_type> {                     \
+#define DOCTEST_STRINGIFY_VARIANT(m_type) \
+	template <> \
+	struct doctest::StringMaker<m_type> { \
 		static doctest::String convert(const m_type &p_val) { \
-			const Variant val = p_val;                        \
+			const Variant val = p_val; \
 			return val.operator ::String().utf8().get_data(); \
-		}                                                     \
+		} \
 	};
 
-#define DOCTEST_STRINGIFY_VARIANT_POINTER(m_type)             \
-	template <>                                               \
-	struct doctest::StringMaker<m_type> {                     \
+#define DOCTEST_STRINGIFY_VARIANT_POINTER(m_type) \
+	template <> \
+	struct doctest::StringMaker<m_type> { \
 		static doctest::String convert(const m_type *p_val) { \
-			const Variant val = p_val;                        \
+			const Variant val = p_val; \
 			return val.operator ::String().utf8().get_data(); \
-		}                                                     \
+		} \
 	};
 
 DOCTEST_STRINGIFY_VARIANT(Variant);
@@ -131,7 +131,7 @@ typedef void (*TestFunc)();
 extern HashMap<String, TestFunc> *test_commands;
 int register_test_command(String p_command, TestFunc p_function);
 
-#define REGISTER_TEST_COMMAND(m_command, m_function)                 \
+#define REGISTER_TEST_COMMAND(m_command, m_function) \
 	DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), \
 			register_test_command(m_command, m_function))
 
@@ -147,98 +147,98 @@ int register_test_command(String p_command, TestFunc p_function);
 
 #define _SEND_DISPLAYSERVER_EVENT(m_event) ((DisplayServerMock *)(DisplayServer::get_singleton()))->simulate_event(m_event);
 
-#define SEND_GUI_ACTION(m_action)                                                                     \
-	{                                                                                                 \
+#define SEND_GUI_ACTION(m_action) \
+	{ \
 		const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(m_action); \
-		const List<Ref<InputEvent>>::Element *first_event = events->front();                          \
-		Ref<InputEventKey> event = first_event->get()->duplicate();                                   \
-		event->set_pressed(true);                                                                     \
-		_SEND_DISPLAYSERVER_EVENT(event);                                                             \
-		MessageQueue::get_singleton()->flush();                                                       \
+		const List<Ref<InputEvent>>::Element *first_event = events->front(); \
+		Ref<InputEventKey> event = first_event->get()->duplicate(); \
+		event->set_pressed(true); \
+		_SEND_DISPLAYSERVER_EVENT(event); \
+		MessageQueue::get_singleton()->flush(); \
 	}
 
-#define SEND_GUI_KEY_EVENT(m_input)                                          \
-	{                                                                        \
+#define SEND_GUI_KEY_EVENT(m_input) \
+	{ \
 		Ref<InputEventKey> event = InputEventKey::create_reference(m_input); \
-		event->set_pressed(true);                                            \
-		_SEND_DISPLAYSERVER_EVENT(event);                                    \
-		MessageQueue::get_singleton()->flush();                              \
+		event->set_pressed(true); \
+		_SEND_DISPLAYSERVER_EVENT(event); \
+		MessageQueue::get_singleton()->flush(); \
 	}
 
-#define SEND_GUI_KEY_UP_EVENT(m_input)                                       \
-	{                                                                        \
+#define SEND_GUI_KEY_UP_EVENT(m_input) \
+	{ \
 		Ref<InputEventKey> event = InputEventKey::create_reference(m_input); \
-		event->set_pressed(false);                                           \
-		_SEND_DISPLAYSERVER_EVENT(event);                                    \
-		MessageQueue::get_singleton()->flush();                              \
+		event->set_pressed(false); \
+		_SEND_DISPLAYSERVER_EVENT(event); \
+		MessageQueue::get_singleton()->flush(); \
 	}
 
-#define _UPDATE_EVENT_MODIFIERS(m_event, m_modifiers)                                  \
+#define _UPDATE_EVENT_MODIFIERS(m_event, m_modifiers) \
 	m_event->set_shift_pressed(((m_modifiers) & KeyModifierMask::SHIFT) != Key::NONE); \
-	m_event->set_alt_pressed(((m_modifiers) & KeyModifierMask::ALT) != Key::NONE);     \
-	m_event->set_ctrl_pressed(((m_modifiers) & KeyModifierMask::CTRL) != Key::NONE);   \
+	m_event->set_alt_pressed(((m_modifiers) & KeyModifierMask::ALT) != Key::NONE); \
+	m_event->set_ctrl_pressed(((m_modifiers) & KeyModifierMask::CTRL) != Key::NONE); \
 	m_event->set_meta_pressed(((m_modifiers) & KeyModifierMask::META) != Key::NONE);
 
 #define _CREATE_GUI_MOUSE_EVENT(m_screen_pos, m_input, m_mask, m_modifiers) \
-	Ref<InputEventMouseButton> event;                                       \
-	event.instantiate();                                                    \
-	event->set_position(m_screen_pos);                                      \
-	event->set_button_index(m_input);                                       \
-	event->set_button_mask(m_mask);                                         \
-	event->set_factor(1);                                                   \
-	_UPDATE_EVENT_MODIFIERS(event, m_modifiers);                            \
+	Ref<InputEventMouseButton> event; \
+	event.instantiate(); \
+	event->set_position(m_screen_pos); \
+	event->set_button_index(m_input); \
+	event->set_button_mask(m_mask); \
+	event->set_factor(1); \
+	_UPDATE_EVENT_MODIFIERS(event, m_modifiers); \
 	event->set_pressed(true);
 
 #define _CREATE_GUI_TOUCH_EVENT(m_screen_pos, m_pressed, m_double) \
-	Ref<InputEventScreenTouch> event;                              \
-	event.instantiate();                                           \
-	event->set_position(m_screen_pos);                             \
-	event->set_pressed(m_pressed);                                 \
+	Ref<InputEventScreenTouch> event; \
+	event.instantiate(); \
+	event->set_position(m_screen_pos); \
+	event->set_pressed(m_pressed); \
 	event->set_double_tap(m_double);
 
 #define SEND_GUI_MOUSE_BUTTON_EVENT(m_screen_pos, m_input, m_mask, m_modifiers) \
-	{                                                                           \
-		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, m_input, m_mask, m_modifiers);    \
-		_SEND_DISPLAYSERVER_EVENT(event);                                       \
-		MessageQueue::get_singleton()->flush();                                 \
+	{ \
+		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, m_input, m_mask, m_modifiers); \
+		_SEND_DISPLAYSERVER_EVENT(event); \
+		MessageQueue::get_singleton()->flush(); \
 	}
 
 #define SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(m_screen_pos, m_input, m_mask, m_modifiers) \
-	{                                                                                    \
-		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, m_input, m_mask, m_modifiers);             \
-		event->set_pressed(false);                                                       \
-		_SEND_DISPLAYSERVER_EVENT(event);                                                \
-		MessageQueue::get_singleton()->flush();                                          \
+	{ \
+		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, m_input, m_mask, m_modifiers); \
+		event->set_pressed(false); \
+		_SEND_DISPLAYSERVER_EVENT(event); \
+		MessageQueue::get_singleton()->flush(); \
 	}
 
-#define SEND_GUI_DOUBLE_CLICK(m_screen_pos, m_modifiers)                                              \
-	{                                                                                                 \
+#define SEND_GUI_DOUBLE_CLICK(m_screen_pos, m_modifiers) \
+	{ \
 		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, MouseButton::LEFT, MouseButtonMask::NONE, m_modifiers); \
-		event->set_double_click(true);                                                                \
-		_SEND_DISPLAYSERVER_EVENT(event);                                                             \
-		MessageQueue::get_singleton()->flush();                                                       \
+		event->set_double_click(true); \
+		_SEND_DISPLAYSERVER_EVENT(event); \
+		MessageQueue::get_singleton()->flush(); \
 	}
 
 // We toggle _print_error_enabled to prevent display server not supported warnings.
 #define SEND_GUI_MOUSE_MOTION_EVENT(m_screen_pos, m_mask, m_modifiers) \
-	{                                                                  \
-		bool errors_enabled = CoreGlobals::print_error_enabled;        \
-		CoreGlobals::print_error_enabled = false;                      \
-		Ref<InputEventMouseMotion> event;                              \
-		event.instantiate();                                           \
-		event->set_position(m_screen_pos);                             \
-		event->set_button_mask(m_mask);                                \
-		_UPDATE_EVENT_MODIFIERS(event, m_modifiers);                   \
-		_SEND_DISPLAYSERVER_EVENT(event);                              \
-		MessageQueue::get_singleton()->flush();                        \
-		CoreGlobals::print_error_enabled = errors_enabled;             \
+	{ \
+		bool errors_enabled = CoreGlobals::print_error_enabled; \
+		CoreGlobals::print_error_enabled = false; \
+		Ref<InputEventMouseMotion> event; \
+		event.instantiate(); \
+		event->set_position(m_screen_pos); \
+		event->set_button_mask(m_mask); \
+		_UPDATE_EVENT_MODIFIERS(event, m_modifiers); \
+		_SEND_DISPLAYSERVER_EVENT(event); \
+		MessageQueue::get_singleton()->flush(); \
+		CoreGlobals::print_error_enabled = errors_enabled; \
 	}
 
-#define SEND_GUI_TOUCH_EVENT(m_screen_pos, m_pressed, m_double)    \
-	{                                                              \
+#define SEND_GUI_TOUCH_EVENT(m_screen_pos, m_pressed, m_double) \
+	{ \
 		_CREATE_GUI_TOUCH_EVENT(m_screen_pos, m_pressed, m_double) \
-		_SEND_DISPLAYSERVER_EVENT(event);                          \
-		MessageQueue::get_singleton()->flush();                    \
+		_SEND_DISPLAYSERVER_EVENT(event); \
+		MessageQueue::get_singleton()->flush(); \
 	}
 
 // Utility class / macros for testing signals
@@ -406,68 +406,68 @@ public:
 #define SIGNAL_DISCARD(m_signal) SignalWatcher::get_singleton()->discard_signal(m_signal);
 
 #define MULTICHECK_STRING_EQ(m_obj, m_func, m_param1, m_eq) \
-	CHECK(m_obj.m_func(m_param1) == m_eq);                  \
-	CHECK(m_obj.m_func(U##m_param1) == m_eq);               \
-	CHECK(m_obj.m_func(L##m_param1) == m_eq);               \
+	CHECK(m_obj.m_func(m_param1) == m_eq); \
+	CHECK(m_obj.m_func(U##m_param1) == m_eq); \
+	CHECK(m_obj.m_func(L##m_param1) == m_eq); \
 	CHECK(m_obj.m_func(String(m_param1)) == m_eq);
 
 #define MULTICHECK_STRING_INT_EQ(m_obj, m_func, m_param1, m_param2, m_eq) \
-	CHECK(m_obj.m_func(m_param1, m_param2) == m_eq);                      \
-	CHECK(m_obj.m_func(U##m_param1, m_param2) == m_eq);                   \
-	CHECK(m_obj.m_func(L##m_param1, m_param2) == m_eq);                   \
+	CHECK(m_obj.m_func(m_param1, m_param2) == m_eq); \
+	CHECK(m_obj.m_func(U##m_param1, m_param2) == m_eq); \
+	CHECK(m_obj.m_func(L##m_param1, m_param2) == m_eq); \
 	CHECK(m_obj.m_func(String(m_param1), m_param2) == m_eq);
 
 #define MULTICHECK_STRING_INT_INT_EQ(m_obj, m_func, m_param1, m_param2, m_param3, m_eq) \
-	CHECK(m_obj.m_func(m_param1, m_param2, m_param3) == m_eq);                          \
-	CHECK(m_obj.m_func(U##m_param1, m_param2, m_param3) == m_eq);                       \
-	CHECK(m_obj.m_func(L##m_param1, m_param2, m_param3) == m_eq);                       \
+	CHECK(m_obj.m_func(m_param1, m_param2, m_param3) == m_eq); \
+	CHECK(m_obj.m_func(U##m_param1, m_param2, m_param3) == m_eq); \
+	CHECK(m_obj.m_func(L##m_param1, m_param2, m_param3) == m_eq); \
 	CHECK(m_obj.m_func(String(m_param1), m_param2, m_param3) == m_eq);
 
 #define MULTICHECK_STRING_STRING_EQ(m_obj, m_func, m_param1, m_param2, m_eq) \
-	CHECK(m_obj.m_func(m_param1, m_param2) == m_eq);                         \
-	CHECK(m_obj.m_func(U##m_param1, U##m_param2) == m_eq);                   \
-	CHECK(m_obj.m_func(L##m_param1, L##m_param2) == m_eq);                   \
+	CHECK(m_obj.m_func(m_param1, m_param2) == m_eq); \
+	CHECK(m_obj.m_func(U##m_param1, U##m_param2) == m_eq); \
+	CHECK(m_obj.m_func(L##m_param1, L##m_param2) == m_eq); \
 	CHECK(m_obj.m_func(String(m_param1), String(m_param2)) == m_eq);
 
-#define MULTICHECK_GET_SLICE(m_obj, m_param1, m_slices)                 \
-	for (int i = 0; i < m_obj.get_slice_count(m_param1); ++i) {         \
-		CHECK(m_obj.get_slice(m_param1, i) == m_slices[i]);             \
-	}                                                                   \
-	for (int i = 0; i < m_obj.get_slice_count(U##m_param1); ++i) {      \
-		CHECK(m_obj.get_slice(U##m_param1, i) == m_slices[i]);          \
-	}                                                                   \
-	for (int i = 0; i < m_obj.get_slice_count(L##m_param1); ++i) {      \
-		CHECK(m_obj.get_slice(L##m_param1, i) == m_slices[i]);          \
-	}                                                                   \
+#define MULTICHECK_GET_SLICE(m_obj, m_param1, m_slices) \
+	for (int i = 0; i < m_obj.get_slice_count(m_param1); ++i) { \
+		CHECK(m_obj.get_slice(m_param1, i) == m_slices[i]); \
+	} \
+	for (int i = 0; i < m_obj.get_slice_count(U##m_param1); ++i) { \
+		CHECK(m_obj.get_slice(U##m_param1, i) == m_slices[i]); \
+	} \
+	for (int i = 0; i < m_obj.get_slice_count(L##m_param1); ++i) { \
+		CHECK(m_obj.get_slice(L##m_param1, i) == m_slices[i]); \
+	} \
 	for (int i = 0; i < m_obj.get_slice_count(String(m_param1)); ++i) { \
-		CHECK(m_obj.get_slice(String(m_param1), i) == m_slices[i]);     \
+		CHECK(m_obj.get_slice(String(m_param1), i) == m_slices[i]); \
 	}
 
 #define MULTICHECK_SPLIT(m_obj, m_func, m_param1, m_param2, m_param3, m_slices, m_expected_size) \
-	do {                                                                                         \
-		Vector<String> string_list;                                                              \
-                                                                                                 \
-		string_list = m_obj.m_func(m_param1, m_param2, m_param3);                                \
-		CHECK(m_expected_size == string_list.size());                                            \
-		for (int i = 0; i < string_list.size(); ++i) {                                           \
-			CHECK(string_list[i] == m_slices[i]);                                                \
-		}                                                                                        \
-                                                                                                 \
-		string_list = m_obj.m_func(U##m_param1, m_param2, m_param3);                             \
-		CHECK(m_expected_size == string_list.size());                                            \
-		for (int i = 0; i < string_list.size(); ++i) {                                           \
-			CHECK(string_list[i] == m_slices[i]);                                                \
-		}                                                                                        \
-                                                                                                 \
-		string_list = m_obj.m_func(L##m_param1, m_param2, m_param3);                             \
-		CHECK(m_expected_size == string_list.size());                                            \
-		for (int i = 0; i < string_list.size(); ++i) {                                           \
-			CHECK(string_list[i] == m_slices[i]);                                                \
-		}                                                                                        \
-                                                                                                 \
-		string_list = m_obj.m_func(String(m_param1), m_param2, m_param3);                        \
-		CHECK(m_expected_size == string_list.size());                                            \
-		for (int i = 0; i < string_list.size(); ++i) {                                           \
-			CHECK(string_list[i] == m_slices[i]);                                                \
-		}                                                                                        \
+	do { \
+		Vector<String> string_list; \
+\
+		string_list = m_obj.m_func(m_param1, m_param2, m_param3); \
+		CHECK(m_expected_size == string_list.size()); \
+		for (int i = 0; i < string_list.size(); ++i) { \
+			CHECK(string_list[i] == m_slices[i]); \
+		} \
+\
+		string_list = m_obj.m_func(U##m_param1, m_param2, m_param3); \
+		CHECK(m_expected_size == string_list.size()); \
+		for (int i = 0; i < string_list.size(); ++i) { \
+			CHECK(string_list[i] == m_slices[i]); \
+		} \
+\
+		string_list = m_obj.m_func(L##m_param1, m_param2, m_param3); \
+		CHECK(m_expected_size == string_list.size()); \
+		for (int i = 0; i < string_list.size(); ++i) { \
+			CHECK(string_list[i] == m_slices[i]); \
+		} \
+\
+		string_list = m_obj.m_func(String(m_param1), m_param2, m_param3); \
+		CHECK(m_expected_size == string_list.size()); \
+		for (int i = 0; i < string_list.size(); ++i) { \
+			CHECK(string_list[i] == m_slices[i]); \
+		} \
 	} while (false)


### PR DESCRIPTION
Removes whitespace indentation for escaped newlines.

### Motivation

This decouples the lines from one another for git diff purposes: When the backslashes are right-aligned, a change to the max size of the block changes all lines in it. 
This leads to unnecessarily long change lists, increasing the chance and difficulty of merge conflicts, and makes it harder to view changes to these blocks in GitHub (e.g. https://github.com/godotengine/godot/pull/78971/files, though notably, the "hide whitespace" option helps, if you know it exists). In addition, the `git blame` is unnecessarily modified, and line history browsers are harder to use.

It also makes it hard to hand-align these blocks, which means you need to run `pre-commit` while working on the code, or risk `pre-commit` changing it later. For me, this has led to unnecessary local recompilations.

### Downsides

The main downside to this is that the code is arguably harder to read. 
Given that C macros lead to difficult to read and error-prone code (for example, they are not [hygienic](https://en.wikipedia.org/wiki/Macro_(computer_science)#Hygienic_macros)), we should be limiting their use anyway (and we do, for the most part). So I think this is an acceptable caveat.