### PR TITLE
Validate Resource type when pasting property

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -43,6 +43,7 @@
 #include "editor/inspector/add_metadata_dialog.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/inspector/editor_property_name_processor.h"
+#include "editor/inspector/editor_resource_picker.h"
 #include "editor/inspector/multi_node_edit.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_feature_profile.h"
@@ -1417,6 +1418,13 @@ void EditorProperty::menu_option(int p_option) {
 			EditorInspector::set_property_clipboard(object->get(property));
 		} break;
 		case MENU_PASTE_VALUE: {
+			EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(this);
+			if (epr) {
+				const Ref<Resource> res = InspectorDock::get_inspector_singleton()->get_property_clipboard();
+				if (res.is_valid() && !epr->get_resource_picker()->is_resource_allowed(res)) {
+					return;
+				}
+			}
 			emit_changed(property, EditorInspector::get_property_clipboard());
 		} break;
 		case MENU_COPY_PROPERTY_PATH: {

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -764,6 +764,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(Object *p_object, const String &p_path, const String &p_base_type);
+	EditorResourcePicker *get_resource_picker() const { return resource_picker; }
 
 	void collapse_all_folding() override;
 	void expand_all_folding() override;

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1156,11 +1156,9 @@ Vector<String> EditorResourcePicker::get_allowed_types() const {
 	return types;
 }
 
-void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
+bool EditorResourcePicker::is_resource_allowed(const Ref<Resource> &p_resource) {
 	if (p_resource.is_null()) {
-		edited_resource = Ref<Resource>();
-		_update_resource();
-		return;
+		return true;
 	}
 
 	if (!base_type.is_empty()) {
@@ -1175,9 +1173,20 @@ void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
 		}
 
 		if (!is_custom && !_is_type_valid(p_resource->get_class(), allowed_types)) {
-			String class_str = (custom_class == StringName() ? p_resource->get_class() : vformat("%s (%s)", custom_class, p_resource->get_class()));
-			ERR_FAIL_MSG(vformat("Failed to set a resource of the type '%s' because this EditorResourcePicker only accepts '%s' and its derivatives.", class_str, base_type));
+			return false;
 		}
+	}
+	return true;
+}
+
+void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
+	if (!is_resource_allowed(p_resource)) {
+		StringName custom_class;
+		if (p_resource->get_script()) {
+			custom_class = EditorNode::get_singleton()->get_object_custom_type_name(p_resource->get_script());
+		}
+		const String class_str = (custom_class.is_empty() ? p_resource->get_class() : vformat("%s (%s)", custom_class, p_resource->get_class()));
+		ERR_FAIL_MSG(vformat("Failed to set a resource of the type '%s' because this EditorResourcePicker only accepts '%s' and its derivatives.", class_str, base_type));
 	}
 	set_edited_resource_no_check(p_resource);
 }

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -140,6 +140,7 @@ public:
 	String get_base_type() const;
 	Vector<String> get_allowed_types() const;
 
+	bool is_resource_allowed(const Ref<Resource> &p_resource);
 	void set_edited_resource(Ref<Resource> p_resource);
 	void set_edited_resource_no_check(Ref<Resource> p_resource);
 	Ref<Resource> get_edited_resource();


### PR DESCRIPTION
Fixes #112347

When you paste a property value, the inspector will just emit that property has changed with the new value, without doing _any_ validation. It works with built-in properties, because when you try to e.g. assign Object to float or Texture2D to Image, the engine will cast it to the new value and assign whatever remains after casting (so e.g. you can paste Resource as bool and it will assign true).

It's a bit different for script properties. If the script isn't `@tool`, they are assigned to PlaceholderScriptInstance, which has no information about the properties. Whatever you set just goes in. After the value is pasted, the EditorProperty will update itself based on the value. In most cases the value will correct itself, e.g. you can't assign Node to EditorPropertyInt, because it just can't accept/display that value.

Then there is EditorPropertyResource. After #84446 the validation of the value assigned to the object does not happen, so as long as it's any Resource, the property will accept it. This, coupled with what I explained above, is the source of the bug. I opted to fix it at pasting operation.