### PR TITLE
Add `float` overloads to `Randfn` and `RandRange` methods in C#

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -58,6 +58,10 @@ double Math::randfn(double p_mean, double p_deviation) {
 	return default_rand.randfn(p_mean, p_deviation);
 }
 
+float Math::randfn(float p_mean, float p_deviation) {
+	return default_rand.randfn(p_mean, p_deviation);
+}
+
 int Math::step_decimals(double p_step) {
 	static const int maxn = 10;
 	static const double sd[maxn] = {

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -690,6 +690,7 @@ _ALWAYS_INLINE_ float randf() {
 	return (float)rand() / (float)UINT32_MAX;
 }
 double randfn(double p_mean, double p_deviation);
+float randfn(float p_mean, float p_deviation);
 
 double random(double p_from, double p_to);
 float random(float p_from, float p_to);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using Godot.NativeInterop;
@@ -430,10 +431,22 @@ namespace Godot
         /// and a standard <paramref name="deviation"/>.
         /// This is also called Gaussian distribution.
         /// </summary>
-        /// <returns>A random normally-distributed <see langword="float"/> number.</returns>
+        /// <returns>A random normally-distributed <see langword="double"/> number.</returns>
         public static double Randfn(double mean, double deviation)
         {
             return NativeFuncs.godotsharp_randfn(mean, deviation);
+        }
+
+        /// <summary>
+        /// Returns a normally-distributed pseudo-random floating point value
+        /// using Box-Muller transform with the specified <pararmref name="mean"/>
+        /// and a standard <paramref name="deviation"/>.
+        /// This is also called Gaussian distribution.
+        /// </summary>
+        /// <returns>A random normally-distributed <see langword="float"/> number.</returns>
+        public static float Randfn(float mean, float deviation)
+        {
+            return NativeFuncs.godotsharp_randfn32(mean, deviation);
         }
 
         /// <summary>
@@ -485,6 +498,22 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns a random floating point value between <paramref name="from"/>
+        /// and <paramref name="to"/> (inclusive).
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GD.RandRange(0.0f, 20.5f);   // Returns e.g. 7.45315
+        /// GD.RandRange(-10.0f, 10.0f); // Returns e.g. -3.844535
+        /// </code>
+        /// </example>
+        /// <returns>A random <see langword="float"/> number inside the given range.</returns>
+        public static float RandRange(float from, float to)
+        {
+            return NativeFuncs.godotsharp_randf32_range(from, to);
+        }
+
+        /// <summary>
         /// Returns a random signed 32-bit integer between <paramref name="from"/>
         /// and <paramref name="to"/> (inclusive). If <paramref name="to"/> is lesser than
         /// <paramref name="from"/>, they are swapped.
@@ -507,11 +536,12 @@ namespace Godot
         /// Passing the same <paramref name="seed"/> consistently returns the same value.
         ///
         /// Note: "Seed" here refers to the internal state of the pseudo random number
-        /// generator, currently implemented as a 64 bit integer.
+        /// generator, currently implemented as a 64 bit unsigned integer.
         /// </summary>
         /// <example>
         /// <code>
-        /// var a = GD.RandFromSeed(4);
+        /// ulong seed = 4;
+        /// uint result = GD.RandFromSeed(ref seed);
         /// </code>
         /// </example>
         /// <param name="seed">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -584,7 +584,11 @@ namespace Godot.NativeInterop
 
         internal static partial double godotsharp_randf_range(double from, double to);
 
+        internal static partial float godotsharp_randf32_range(float from, float to);
+
         internal static partial double godotsharp_randfn(double mean, double deviation);
+
+        internal static partial float godotsharp_randfn32(float mean, float deviation);
 
         internal static partial int godotsharp_randi_range(int from, int to);
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1415,7 +1415,15 @@ double godotsharp_randf_range(double p_from, double p_to) {
 	return Math::random(p_from, p_to);
 }
 
+float godotsharp_randf32_range(float p_from, float p_to) {
+	return Math::random(p_from, p_to);
+}
+
 double godotsharp_randfn(double p_mean, double p_deviation) {
+	return Math::randfn(p_mean, p_deviation);
+}
+
+float godotsharp_randfn32(float p_mean, float p_deviation) {
 	return Math::randfn(p_mean, p_deviation);
 }
 
@@ -1834,7 +1842,9 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_randi,
 	(void *)godotsharp_randomize,
 	(void *)godotsharp_randf_range,
+	(void *)godotsharp_randf32_range,
 	(void *)godotsharp_randfn,
+	(void *)godotsharp_randfn32,
 	(void *)godotsharp_randi_range,
 	(void *)godotsharp_rand_from_seed,
 	(void *)godotsharp_seed,


### PR DESCRIPTION
This issue aims to implement a small part of https://github.com/godotengine/godot-proposals/issues/12356 in making random number generation more consistent/complete in C#.

Here are the main changes:
- Add `float GD.Randfn(float, float)` to match `double GD.Randfn(double, double)`
- Add `float GD.RandRange(float, float)` to match `double GD.RandRange(double, double)`
- Documentation comment fixes

Full list of changes:
- Add `float GD.Randfn(float, float)`:
  - Add `float Math::randfn(float, float)` to match `double Math::randfn(double, double)`
  - Add `float godotsharp_randfn32(float, float)` to match `double godotsharp_randfn(double, double)`
  - Fix a documentation comment error in `double Randfn(double, double)`
- Add `float GD.RandRange(float, float)`:
  - Add `float godotsharp_randf32_range(float, float)` to match `double godotsharp_randf_range(double, double)`
- Fix two documentation comment errors in `uint GD.RandFromSeed(ref ulong)`

Unfortunately, I wasn't able to implement most of what I suggested in the proposal because of the following issues:
- There is no way to generate a 64-bit integer in Godot core due to the use of `pcg32_random_t` rather than `pcg64_random_t`.
- There is no way to have multiple overloads in GDExtension, therefore I couldn't add `double RandomNumberGenerator.Randfn(double, double)`. I also couldn't add a method with a new name for this because the original uses `real_t` rather than `float`/`double`.
- I didn't want to change the return type of `long RandomNumberGenerator.RandWeighted(float[])` because it's a binary-breaking change, and also it's based on the C++ implementation which uses 64-bit indexes for vectors.

Nevertheless, I think this a good start, since `float` is widely used in Godot C#. In my own projects, I have to write code like `(float)GD.RandRange(0f, 1f)`.