### PR TITLE
Make ScrollContainer scrollbar margins affect minimum size

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -61,7 +61,7 @@ Size2 ScrollContainer::get_minimum_size() const {
 		min_size.x = largest_child_min_size.x;
 		bool v_scroll_show = vertical_scroll_mode == SCROLL_MODE_SHOW_ALWAYS || vertical_scroll_mode == SCROLL_MODE_RESERVE || (vertical_scroll_mode == SCROLL_MODE_AUTO && largest_child_min_size.y > size.y);
 		if (v_scroll_show && v_scroll->get_parent() == this) {
-			min_size.x += v_scroll->get_minimum_size().x;
+			min_size.x += v_scroll->get_minimum_size().x + theme_cache.scrollbar_h_separation;
 		}
 	}
 
@@ -69,7 +69,7 @@ Size2 ScrollContainer::get_minimum_size() const {
 		min_size.y = largest_child_min_size.y;
 		bool h_scroll_show = horizontal_scroll_mode == SCROLL_MODE_SHOW_ALWAYS || horizontal_scroll_mode == SCROLL_MODE_RESERVE || (horizontal_scroll_mode == SCROLL_MODE_AUTO && largest_child_min_size.x > size.x);
 		if (h_scroll_show && h_scroll->get_parent() == this) {
-			min_size.y += h_scroll->get_minimum_size().y;
+			min_size.y += h_scroll->get_minimum_size().y + theme_cache.scrollbar_v_separation;
 		}
 	}
 


### PR DESCRIPTION
I forgot to make the scrollbar separation values affect the minimum size of the ScrollContainer, making it so that if the ScrollContainer was set to shrink the margins would disappear. This PR fixes that oversight.

The examples below are similar to the original PR's (#111975) examples except the ScrollContainer's anchors are set to shrink left instead of setting its own size. The `scrollbar_h_separation` is set to 4.

4.6-dev3:
<img width="79" height="626" alt="image" src="https://github.com/user-attachments/assets/a3b47581-086f-4a95-9aeb-6acef4d1a71e" />

This PR:
<img width="81" height="625" alt="image" src="https://github.com/user-attachments/assets/29f52249-bb7b-4faa-8d29-c29b8eab8932" />
