### PR TITLE
Fix compile error with android export plugin

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -33,6 +33,7 @@
 #include "logo_svg.gen.h"
 #include "run_icon_svg.gen.h"
 
+#include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/image_loader.h"


### PR DESCRIPTION
Due to the absence of the necessary header files included, this compilation error occurs:
<img width="768" height="196" alt="{67FDE768-5B59-40E4-A034-997C3F61201A}" src="https://github.com/user-attachments/assets/9f1f9772-be9e-4766-9285-faf6e1961796" />

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/112412*