### PR TITLE
Support for Wavefront OBJ Point and Line Element Primitives

### DIFF
--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -275,7 +275,6 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 	bool uses_uvs = false;
 
 	while (true) {
-		//print_verbose(String::num_int64(line++));
 		String l = f->get_line().strip_edges();
 		while (l.length() && l[l.length() - 1] == '\\') {
 			String add = f->get_line().strip_edges();
@@ -345,7 +344,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 			Vector<String> v = l.split(" ", false);
 			ERR_FAIL_COND_V(v.size() < 3, ERR_FILE_CORRUPT);
 			for (int i = 2; i < v.size(); i++) {
-				int vtx = v[i-1].to_int() - 1;
+				int vtx = v[i - 1].to_int() - 1;
 				if (vtx < 0) {
 					vtx += vertices.size() + 1;
 				}

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -254,6 +254,17 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 	Ref<SurfaceTool> surf_tool = memnew(SurfaceTool);
 	surf_tool->begin(Mesh::PRIMITIVE_TRIANGLES);
 
+	Ref<SurfaceTool> surf_tool_lines = memnew(SurfaceTool);
+	surf_tool_lines->begin(Mesh::PRIMITIVE_LINES);
+
+	Ref<SurfaceTool> surf_tool_points = memnew(SurfaceTool);
+	surf_tool_points->begin(Mesh::PRIMITIVE_POINTS);
+
+	int lines = 0;
+	int lines_total = 0;
+	int points = 0;
+	int points_total = 0;
+
 	String current_material_library;
 	String current_material;
 	String current_group;
@@ -264,6 +275,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 	bool uses_uvs = false;
 
 	while (true) {
+		//print_verbose(String::num_int64(line++));
 		String l = f->get_line().strip_edges();
 		while (l.length() && l[l.length() - 1] == '\\') {
 			String add = f->get_line().strip_edges();
@@ -312,6 +324,51 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 			nrm.y = v[2].to_float();
 			nrm.z = v[3].to_float();
 			normals.push_back(nrm);
+		} else if (l.begins_with("p ")) {
+			Vector<String> v = l.split(" ", false);
+			ERR_FAIL_COND_V(v.size() < 2, ERR_FILE_CORRUPT);
+			for (int i = 1; i < v.size(); i++) {
+				int vtx = v[i].to_int() - 1;
+				if (vtx < 0) {
+					vtx += vertices.size() + 1;
+				}
+				ERR_FAIL_INDEX_V(vtx, vertices.size(), ERR_FILE_CORRUPT);
+				Vector3 vertex = vertices[vtx];
+				if (!colors.is_empty()) {
+					surf_tool_points->set_color(colors[vtx]);
+				}
+				surf_tool_points->add_vertex(vertex);
+			}
+			points += 1;
+			points_total += 1;
+		} else if (l.begins_with("l ")) {
+			Vector<String> v = l.split(" ", false);
+			ERR_FAIL_COND_V(v.size() < 3, ERR_FILE_CORRUPT);
+			for (int i = 2; i < v.size(); i++) {
+				int vtx = v[i-1].to_int() - 1;
+				if (vtx < 0) {
+					vtx += vertices.size() + 1;
+				}
+				ERR_FAIL_INDEX_V(vtx, vertices.size(), ERR_FILE_CORRUPT);
+				Vector3 vertex = vertices[vtx];
+				if (!colors.is_empty()) {
+					surf_tool_lines->set_color(colors[vtx]);
+				}
+				surf_tool_lines->add_vertex(vertex);
+
+				vtx = v[i].to_int() - 1;
+				if (vtx < 0) {
+					vtx += vertices.size() + 1;
+				}
+				ERR_FAIL_INDEX_V(vtx, vertices.size(), ERR_FILE_CORRUPT);
+				vertex = vertices[vtx];
+				if (!colors.is_empty()) {
+					surf_tool_lines->set_color(colors[vtx]);
+				}
+				surf_tool_lines->add_vertex(vertex);
+			}
+			lines += 1;
+			lines_total += 1;
 		} else if (l.begins_with("f ")) {
 			//vertex
 
@@ -420,17 +477,23 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 			}
 
 			//groups are too annoying
-			if (surf_tool->get_vertex_array().size()) {
+			bool nonlines = false;
+			if (surf_tool->get_vertex_array().size() > 0) {
+				nonlines = true;
+			}
+			if (nonlines || lines > 0 || points > 0) {
 				//another group going on, commit it
-				if (normals.is_empty()) {
-					surf_tool->generate_normals();
-				}
+				if (nonlines) {
+					if (normals.is_empty()) {
+						surf_tool->generate_normals();
+					}
 
-				if (generate_tangents && uses_uvs) {
-					surf_tool->generate_tangents();
-				}
+					if (generate_tangents && uses_uvs) {
+						surf_tool->generate_tangents();
+					}
 
-				surf_tool->index();
+					surf_tool->index();
+				}
 
 				print_verbose("OBJ: Current material library " + current_material_library + " has " + itos(material_map.has(current_material_library)));
 				print_verbose("OBJ: Current material " + current_material + " has " + itos(material_map.has(current_material_library) && material_map[current_material_library].has(current_material)));
@@ -440,41 +503,100 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 					if (!colors.is_empty()) {
 						material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
 					}
-					surf_tool->set_material(material);
+					if (nonlines) {
+						surf_tool->set_material(material);
+					}
+					if (lines > 0) {
+						surf_tool_lines->set_material(material);
+					}
+					if (points > 0) {
+						surf_tool_points->set_material(material);
+					}
 				}
 
-				Array array = surf_tool->commit_to_arrays();
+				Array array;
 
-				if (mesh_flags & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES && generate_tangents && uses_uvs) {
-					// Compression is enabled, so let's validate that the normals and generated tangents are correct.
-					Vector<Vector3> norms = array[Mesh::ARRAY_NORMAL];
-					Vector<float> tangents = array[Mesh::ARRAY_TANGENT];
-					ERR_FAIL_COND_V(tangents.is_empty(), ERR_FILE_CORRUPT);
-					for (int vert = 0; vert < norms.size(); vert++) {
-						Vector3 tan = Vector3(tangents[vert * 4 + 0], tangents[vert * 4 + 1], tangents[vert * 4 + 2]);
-						if (std::abs(tan.dot(norms[vert])) > 0.0001) {
-							// Tangent is not perpendicular to the normal, so we can't use compression.
-							mesh_flags &= ~RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+				if (nonlines) {
+#ifdef DEBUG_ENABLED
+					mesh->set_meta(StringName("surface" + String::num_int64(mesh->get_surface_count()) + "_vertexCount"), String::num_int64(surf_tool->get_vertex_array().size()));
+					mesh->set_meta(StringName("surface" + String::num_int64(mesh->get_surface_count()) + "_aabb"), String(surf_tool->get_aabb()));
+#endif
+					array = surf_tool->commit_to_arrays();
+
+					if (mesh_flags & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES && generate_tangents && uses_uvs) {
+						// Compression is enabled, so let's validate that the normals and generated tangents are correct.
+						Vector<Vector3> norms = array[Mesh::ARRAY_NORMAL];
+						Vector<float> tangents = array[Mesh::ARRAY_TANGENT];
+						ERR_FAIL_COND_V(tangents.is_empty(), ERR_FILE_CORRUPT);
+						for (int vert = 0; vert < norms.size(); vert++) {
+							Vector3 tan = Vector3(tangents[vert * 4 + 0], tangents[vert * 4 + 1], tangents[vert * 4 + 2]);
+							if (std::abs(tan.dot(norms[vert])) > 0.0001) {
+								// Tangent is not perpendicular to the normal, so we can't use compression.
+								mesh_flags &= ~RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+							}
 						}
 					}
+
+					mesh->add_surface(Mesh::PRIMITIVE_TRIANGLES, array, TypedArray<Array>(), Dictionary(), material, name, mesh_flags);
+
+					print_verbose("OBJ: Added surface: " + mesh->get_surface_name(mesh->get_surface_count() - 1));
+
+					if (!current_material.is_empty()) {
+						if (mesh->get_surface_count() >= 1) {
+							mesh->set_surface_name(mesh->get_surface_count() - 1, current_material.get_basename());
+						}
+					} else if (!current_group.is_empty()) {
+						if (mesh->get_surface_count() >= 1) {
+							mesh->set_surface_name(mesh->get_surface_count() - 1, current_group);
+						}
+					}
+
+					surf_tool->clear();
+					surf_tool->begin(Mesh::PRIMITIVE_TRIANGLES);
 				}
 
-				mesh->add_surface(Mesh::PRIMITIVE_TRIANGLES, array, TypedArray<Array>(), Dictionary(), material, name, mesh_flags);
-
-				print_verbose("OBJ: Added surface :" + mesh->get_surface_name(mesh->get_surface_count() - 1));
-
-				if (!current_material.is_empty()) {
-					if (mesh->get_surface_count() >= 1) {
-						mesh->set_surface_name(mesh->get_surface_count() - 1, current_material.get_basename());
+				if (lines > 0) {
+#ifdef DEBUG_ENABLED
+					mesh->set_meta(StringName("surface" + String::num_int64(mesh->get_surface_count()) + "_vertexCount"), String::num_int64(surf_tool_lines->get_vertex_array().size()));
+					mesh->set_meta(StringName("surface" + String::num_int64(mesh->get_surface_count()) + "_aabb"), String(surf_tool_lines->get_aabb()));
+#endif
+					array = surf_tool_lines->commit_to_arrays();
+					mesh->add_surface(Mesh::PRIMITIVE_LINES, array, TypedArray<Array>(), Dictionary(), material, "__" + name + "_Line_" + String::num_int64(lines_total), 0);
+					if (!current_material.is_empty()) {
+						if (mesh->get_surface_count() >= 1) {
+							mesh->set_surface_name(mesh->get_surface_count() - 1, current_material.get_basename());
+						}
+					} else if (!current_group.is_empty()) {
+						if (mesh->get_surface_count() >= 1) {
+							mesh->set_surface_name(mesh->get_surface_count() - 1, current_group);
+						}
 					}
-				} else if (!current_group.is_empty()) {
-					if (mesh->get_surface_count() >= 1) {
-						mesh->set_surface_name(mesh->get_surface_count() - 1, current_group);
-					}
+					print_verbose("OBJ: Added surface: " + mesh->get_surface_name(mesh->get_surface_count() - 1));
+					surf_tool_lines->clear();
+					surf_tool_lines->begin(Mesh::PRIMITIVE_LINES);
+					lines = 0;
 				}
-
-				surf_tool->clear();
-				surf_tool->begin(Mesh::PRIMITIVE_TRIANGLES);
+				if (points > 0) {
+#ifdef DEBUG_ENABLED
+					mesh->set_meta(StringName("surface" + String::num_int64(mesh->get_surface_count()) + "_vertexCount"), String::num_int64(surf_tool_points->get_vertex_array().size()));
+					mesh->set_meta(StringName("surface" + String::num_int64(mesh->get_surface_count()) + "_aabb"), String(surf_tool_points->get_aabb()));
+#endif
+					array = surf_tool_points->commit_to_arrays();
+					mesh->add_surface(Mesh::PRIMITIVE_POINTS, array, TypedArray<Array>(), Dictionary(), material, "__" + name + "_Point_" + String::num_int64(points_total), 0);
+					if (!current_material.is_empty()) {
+						if (mesh->get_surface_count() >= 1) {
+							mesh->set_surface_name(mesh->get_surface_count() - 1, current_material.get_basename());
+						}
+					} else if (!current_group.is_empty()) {
+						if (mesh->get_surface_count() >= 1) {
+							mesh->set_surface_name(mesh->get_surface_count() - 1, current_group);
+						}
+					}
+					print_verbose("OBJ: Added surface: " + mesh->get_surface_name(mesh->get_surface_count() - 1));
+					surf_tool_points->clear();
+					surf_tool_points->begin(Mesh::PRIMITIVE_POINTS);
+					points = 0;
+				}
 				uses_uvs = false;
 			}
 
@@ -585,12 +707,25 @@ Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, co
 
 	Node3D *scene = memnew(Node3D);
 
+	int idx = 0;
 	for (Ref<ImporterMesh> m : meshes) {
 		ImporterMeshInstance3D *mi = memnew(ImporterMeshInstance3D);
+#ifdef DEBUG_ENABLED
+		List<StringName> meta_keys;
+		m->get_meta_list(&meta_keys);
+		for (const StringName &key : meta_keys) {
+			String meta = "obj_mesh" + String::num_int64(idx) + "_" + key;
+			mi->set_meta(StringName(meta), m->get_meta(key));
+		}
+#endif
 		mi->set_mesh(m);
 		mi->set_name(m->get_name());
 		scene->add_child(mi, true);
 		mi->set_owner(scene);
+#ifdef DEBUG_ENABLED
+		scene->merge_meta_from(mi);
+#endif
+		idx += 1;
 	}
 
 	if (r_err) {
@@ -691,7 +826,11 @@ Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_s
 
 	String save_path = p_save_path + ".mesh";
 
-	err = ResourceSaver::save(meshes.front()->get()->get_mesh(), save_path);
+	Ref<ArrayMesh> mesh = meshes.front()->get()->get_mesh();
+#ifdef DEBUG_ENABLED
+	mesh->merge_meta_from(*meshes.front()->get());
+#endif
+	err = ResourceSaver::save(mesh, save_path);
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save Mesh to file '" + save_path + "'.");
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4595,7 +4595,7 @@ void EditorInspector::update_tree() {
 					if (node != nullptr) {
 						_default = PropertyUtils::get_property_default_value(node, p.name, nullptr, &sstack, false, nullptr, nullptr);
 					}
-					ep->set_deletable(_default == Variant());
+					ep->set_deletable(_default == Variant() && !all_read_only);
 				} else {
 					ep->set_deletable(deletable_properties);
 				}

--- a/scene/resources/mesh_data_tool.h
+++ b/scene/resources/mesh_data_tool.h
@@ -36,6 +36,7 @@ class MeshDataTool : public RefCounted {
 	GDCLASS(MeshDataTool, RefCounted);
 
 	uint64_t format = 0;
+	Mesh::PrimitiveType primitive_type = Mesh::PRIMITIVE_TRIANGLES;
 	struct Vertex {
 		Vector3 vertex;
 		Color color;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -4118,6 +4118,7 @@ RID RenderingDevice::render_pipeline_create(RID p_shader, FramebufferFormatID p_
 		1,
 	};
 	pipeline.validation.primitive_minimum = primitive_minimum[p_render_primitive];
+	pipeline.validation.render_primitive = p_render_primitive;
 #endif
 
 	// Create ID to associate with this pipeline.
@@ -4593,6 +4594,7 @@ void RenderingDevice::draw_list_bind_render_pipeline(DrawListID p_list, RID p_re
 	draw_list.validation.pipeline_dynamic_state = pipeline->validation.dynamic_state;
 	draw_list.validation.pipeline_vertex_format = pipeline->validation.vertex_format;
 	draw_list.validation.pipeline_uses_restart_indices = pipeline->validation.uses_restart_indices;
+	draw_list.validation.pipeline_render_primitive = pipeline->validation.render_primitive;
 	draw_list.validation.pipeline_primitive_divisor = pipeline->validation.primitive_divisor;
 	draw_list.validation.pipeline_primitive_minimum = pipeline->validation.primitive_minimum;
 	draw_list.validation.pipeline_push_constant_size = pipeline->push_constant_size;
@@ -4847,7 +4849,7 @@ void RenderingDevice::draw_list_draw(DrawListID p_list, bool p_use_indices, uint
 				"Too few indices (" + itos(to_draw) + ") for the render primitive set in the render pipeline (" + itos(draw_list.validation.pipeline_primitive_minimum) + ").");
 
 		ERR_FAIL_COND_MSG((to_draw % draw_list.validation.pipeline_primitive_divisor) != 0,
-				"Index amount (" + itos(to_draw) + ") must be a multiple of the amount of indices required by the render primitive (" + itos(draw_list.validation.pipeline_primitive_divisor) + ").");
+				"Index amount (" + itos(to_draw) + ") must be a multiple of the amount of indices required by the render primitive " + itos(draw_list.validation.pipeline_render_primitive) + " (" + itos(draw_list.validation.pipeline_primitive_divisor) + ").");
 #endif
 
 		draw_graph.add_draw_list_draw_indexed(to_draw, p_instances, 0);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1185,6 +1185,7 @@ private:
 			uint32_t dynamic_state = 0;
 			VertexFormatID vertex_format;
 			bool uses_restart_indices = false;
+			RenderPrimitive render_primitive = RENDER_PRIMITIVE_MAX;
 			uint32_t primitive_minimum = 0;
 			uint32_t primitive_divisor = 0;
 		} validation;
@@ -1302,6 +1303,7 @@ private:
 			VertexFormatID pipeline_vertex_format = INVALID_ID;
 			RID pipeline_shader;
 			bool pipeline_uses_restart_indices = false;
+			RenderPrimitive pipeline_render_primitive = RENDER_PRIMITIVE_MAX;
 			uint32_t pipeline_primitive_divisor = 0;
 			uint32_t pipeline_primitive_minimum = 0;
 			uint32_t pipeline_push_constant_size = 0;


### PR DESCRIPTION
This pull request implements support for Wavefront OBJ mesh files which include line and point primitives in their element lists ( e.g. https://en.wikipedia.org/wiki/Wavefront_.obj_file#Line_elements & https://paulbourke.net/dataformats/obj/obj_spec.pdf ).

Additionally, I also provide several miscellaneous improvements such as making read-only metadata properties un-delete-able from the editor resource inspection tab UI. Also, the rendering server will now explicitly report associated primitive types when meshes are dispatched with misconfigured indexing information. GLTF line loop modes are preliminarily supported by leveraging existing line strip support. Finally, the `MeshDataTool` class offers some initial manipulation capacity for working with any non-triangle-primitive mesh data so that users can at last at least query vertex and edge data from the surface array within a GDScript context.

I used the following project to test these new features...
https://github.com/PierceLBrooks/godot-mahjong-test