### PR TITLE
Fix crash on queue free scene node in editor

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -279,7 +279,13 @@ void Node::_notification(int p_notification) {
 				ERR_PRINT("Attempted to free a node that is currently added to the SceneTree from a thread. This is not permitted, use queue_free() instead. Node has not been freed.");
 				return;
 			}
-
+#ifdef TOOLS_ENABLED
+			if (Engine::get_singleton()->is_editor_hint() && data.tree && this == data.tree->get_edited_scene_root()) {
+				cancel_free();
+				ERR_PRINT(vformat("Something attempted to free the root Node of a scene (\"%s\"). This is not supported inside the editor, so the Node was not freed.", get_name()));
+				return;
+			}
+#endif
 			if (data.owner) {
 				_clean_up_owner();
 			}


### PR DESCRIPTION
- *Fixes https://github.com/godotengine/godot/issues/112171*

## Issue Description

When we try to delete scene root node using `queue_free` in editor, we will meet a crash. The marked node will be freed defer. But the editor still want to redraw relevant plugins for scene root node, then crashed.

It is an abnormal behavior to **delete** a node in editor in `@tool` annotated gdscript. If we delete a child node, we will see the child node disappeared from left `EditorTreeDock` menu. If we delete the root node, the scene cannot display normally.

```
# First, enable gdscript running in editor
@tool
extends Node2D

func _ready() -> void:
	# Second, queue free scene root node 
	queue_free()
```

## MRP

[112171-1.zip](https://github.com/user-attachments/files/23349138/112171-1.zip)

## Solution

Prohibit  `queue_clear` to delete scene root node in editor.

[queue-free.webm](https://github.com/user-attachments/assets/d05e7ce0-37b9-486d-a867-ccc5c5456f64)

