### PR TITLE
Remove undefined method `Skeleton3D::remove_bone`

### DIFF
--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -224,7 +224,6 @@ public:
 	// Skeleton creation API
 	uint64_t get_version() const;
 	int add_bone(const String &p_name);
-	void remove_bone(int p_bone);
 	int find_bone(const String &p_name) const;
 	String get_bone_name(int p_bone) const;
 	void set_bone_name(int p_bone, const String &p_name);


### PR DESCRIPTION
Closes #112376

The method declaration was added in https://github.com/godotengine/godot/pull/97824.
As there is no implementation nor official documentation for the method, I agree that it should be removed from the class definition.