### PR TITLE
Fix CoreAudio driver crash when starting input with uninitialized device

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -520,6 +520,8 @@ void AudioDriverCoreAudio::finish_input_device() {
 }
 
 Error AudioDriverCoreAudio::input_start() {
+	ERR_FAIL_NULL_V(input_unit, FAILED);
+
 	input_buffer_init(capture_buffer_frames);
 
 	OSStatus result = AudioOutputUnitStart(input_unit);


### PR DESCRIPTION
Initialize input device if null before starting audio input to prevent crashes when input_unit is not yet initialized.

In the game we are building, we noticed a frequent crash caused with following stack trace:

```
Crashed: AURemotel0：：IOThread
EXC_BREAKPOINT 0x0000000105fd41ec

          Crashed: AURemoteIO::IOThread
0  [our game name]                        0x2fc6230 <deduplicated_symbol> + 227356
1  [our game name]                          0x2fc6230 <deduplicated_symbol> + 227356
2  [our game name]                          0x105e15c AudioDriverCoreAudio::init_input_device() + 4361625948
3  libEmbeddedSystemAUs.dylib      0xa8e8 ausdk::AUInputElement::PullInput(unsigned int&, AudioTimeStamp const&, unsigned int, unsigned int)
4  libEmbeddedSystemAUs.dylib      0xa7c8 AUInputFormatConverter2::InputProc(OpaqueAudioConverter*, unsigned int*, AudioBufferList*, AudioStreamPacketDescription**, void*)
5  AudioToolboxCore                0x1b7ba0 caulk::expected<unsigned int, int> caulk::function_ref<caulk::expected<unsigned int, int> (ACAudioSpan&)>::functor_invoker<acv2::AudioConverterV2::fillComplexBuffer(int (*)(OpaqueAudioConverter*, unsigned int*, AudioBufferList*, AudioStreamPacketDescription**, void*), void*, unsigned int*, AudioBufferList*, AudioStreamPacketDescription*, AudioStreamPacketDependencyDescription*, ConverterContext)::$_2>(caulk::details::erased_callable<caulk::expected<unsigned int, int> (ACAudioSpan&)> const&, ACAudioSpan&) + 152
6  AudioToolboxCore                0x18b28 acv2::AudioConverterChain::ObtainInput(acv2::AudioConverterBase&, unsigned int, ConverterContext) + 644
7  AudioToolboxCore                0x187a0 acv2::CBRConverter::ProduceOutput(ACAudioSpan&, ConverterContext) + 64
8  AudioToolboxCore                0x176e8 acv2::AudioConverterChain::ProduceOutput(caulk::function_ref<caulk::expected<unsigned int, int> (ACAudioSpan&)>, ACBaseAudioSpan&, ConverterContext) + 320
9  AudioToolboxCore                0x1b76f0 acv2::AudioConverterV2::fillComplexBuffer(int (*)(OpaqueAudioConverter*, unsigned int*, AudioBufferList*, AudioStreamPacketDescription**, void*), void*, unsigned int*, AudioBufferList*, AudioStreamPacketDescription*, AudioStreamPacketDependencyDescription*, ConverterContext) + 800
10 AudioToolboxCore                0x1b40c int caulk::rt_function_ref<int (AudioConverterAPI*)>::functor_invoker<AudioConverterFillComplexBufferRealtimeSafe::$_0>(caulk::details::erased_callable_rt<int (AudioConverterAPI*)> const&, AudioConverterAPI*) + 100
11 AudioToolboxCore                0x173c0 with_resolved_rt(OpaqueAudioConverter*, caulk::rt_function_ref<int (AudioConverterAPI*)>) + 60
12 AudioToolboxCore                0x1b39c AudioConverterFillComplexBufferRealtimeSafe + 88
13 libEmbeddedSystemAUs.dylib      0xa558 AUInputFormatConverter2::PullAndConvertInput(AudioTimeStamp const&, unsigned int&, AudioBufferList&, AudioStreamPacketDescription*, bool&)
14 libEmbeddedSystemAUs.dylib      0xa370 AUConverterBase::RenderBus(unsigned int&, AudioTimeStamp const&, unsigned int, unsigned int)
15 libEmbeddedSystemAUs.dylib      0x9d8c AURemoteIO::RenderBus(unsigned int&, AudioTimeStamp const&, unsigned int, unsigned int)
16 libEmbeddedSystemAUs.dylib      0x979c ausdk::AUBase::DoRender(unsigned int&, AudioTimeStamp const&, unsigned int, unsigned int, AudioBufferList&)
17 libEmbeddedSystemAUs.dylib      0x8e14 AURemoteIO::PerformIO(unsigned int, unsigned int, unsigned int, AudioTimeStamp const&, AudioTimeStamp const&, AudioBufferList const*, AudioBufferList*, int&)
18 libEmbeddedSystemAUs.dylib      0x855c _XPerformIO
19 libAudioToolboxUtility.dylib    0x2b04 mshMIGPerform + 284
20 libAudioToolboxUtility.dylib    0x2d04 MSHMIGDispatchMessage + 36
21 libEmbeddedSystemAUs.dylib      0x11b60 void* caulk::thread_proxy<std::__1::tuple<caulk::thread::attributes, AURemoteIO::IOThread::IOThread(AURemoteIO&, caulk::thread::attributes const&, caulk::mach::os_workgroup_managed const&)::'lambda'(), std::__1::tuple<>>>(void*)
22 libsystem_pthread.dylib         0x444c _pthread_start + 136
23 libsystem_pthread.dylib         0x8cc thread_start + 8
```

It's really strange since we already set the audio/driver/enable_input to false. After digging, we noticed some third-party sdk like Facebook, and firebase will try to start audio recording inside, which causes the crash.

And after read related source code across multiple platforms, I noticed iOS's audio driver doesn't check null in AudioDriverCoreAudio::input_start, by adding this fix, we can see it does the trick, no more crash.