### PR TITLE
Fix godot build errors with deprecated=no and production=yes

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -39,6 +39,7 @@
 #include "core/io/json.h"
 #include "core/io/marshalls.h"
 #include "core/version.h"
+#include "core/config/project_settings.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"


### PR DESCRIPTION
Fix the build errors caused by the lack of the project_settings.h import

close issue #112412