### PR TITLE
OpenXR: Fix PICO Ultra controller support

### DIFF
--- a/modules/openxr/extensions/openxr_pico_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_pico_controller_extension.cpp
@@ -36,21 +36,18 @@
 HashMap<String, bool *> OpenXRPicoControllerExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
-	// Note, this used to be XR_PICO_controller_interaction but that has since been retired
-	// and was never part of the OpenXX specification.
-	// All PICO devices should be updated to an OS supporting the official extension.
-
-	if (true || p_version < XR_API_VERSION_1_1_0) {
-		// Extension was promoted in OpenXR 1.1, only include it in OpenXR 1.0.
-		// Note, we still need it for pico4_interaction, hence the temporary `if (true || ...`
-		request_extensions[XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
+	if (p_version < XR_API_VERSION_1_1_0) {
+		request_extensions[XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available[BD_CONTROLLERS];
 	}
+	request_extensions[XR_BD_ULTRA_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available[BD_CONTROLLERS];
 
 	return request_extensions;
 }
 
-bool OpenXRPicoControllerExtension::is_available() {
-	return available;
+bool OpenXRPicoControllerExtension::is_available(PICOControllers p_type) {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_type, BD_MAX_CONTROLLERS, false);
+
+	return available[p_type];
 }
 
 void OpenXRPicoControllerExtension::on_register_metadata() {
@@ -59,6 +56,7 @@ void OpenXRPicoControllerExtension::on_register_metadata() {
 
 	// Make sure we switch to our new name.
 	openxr_metadata->register_profile_rename("/interaction_profiles/pico/neo3_controller", "/interaction_profiles/bytedance/pico_neo3_controller");
+	openxr_metadata->register_profile_rename("/interaction_profiles/bytedance/pico4s_controller", "/interaction_profiles/bytedance/pico_ultra_controller_bd");
 
 	{ // Pico neo 3 controller.
 		const String profile_path = "/interaction_profiles/bytedance/pico_neo3_controller";
@@ -136,9 +134,9 @@ void OpenXRPicoControllerExtension::on_register_metadata() {
 		openxr_metadata->register_io_path(profile_path, "B touch", "/user/hand/right", "/user/hand/right/input/b/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
 	}
 
-	{ // Pico 4 Ultra controller, note: not provided by OpenXR 1.1
-		const String profile_path = "/interaction_profiles/bytedance/pico4s_controller";
-		openxr_metadata->register_interaction_profile("Pico 4 Ultra controller", profile_path, XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME);
+	{ // Pico Ultra controller.
+		const String profile_path = "/interaction_profiles/bytedance/pico_ultra_controller_bd";
+		openxr_metadata->register_interaction_profile("Pico Ultra controller", profile_path, XR_BD_ULTRA_CONTROLLER_INTERACTION_EXTENSION_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);

--- a/modules/openxr/extensions/openxr_pico_controller_extension.h
+++ b/modules/openxr/extensions/openxr_pico_controller_extension.h
@@ -39,12 +39,18 @@ protected:
 	static void _bind_methods() {}
 
 public:
+	enum PICOControllers {
+		BD_CONTROLLERS, // Neo3 and PICO 4 controller support
+		BD_ULTRA_CONTROLLER, // PICO Ultra controller support
+		BD_MAX_CONTROLLERS
+	};
+
 	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
-	bool is_available();
+	bool is_available(PICOControllers p_type = BD_CONTROLLERS);
 
 	virtual void on_register_metadata() override;
 
 private:
-	bool available = false;
+	bool available[BD_MAX_CONTROLLERS] = { false, false };
 };


### PR DESCRIPTION
PICO introduced their new ultra controllers with the PICO 4s however the initial interaction profile was rolled into the existing BD extension which was later corrected.

With the release of OpenXR 1.1.53 we can now properly address this and use the correct extension and naming conventions.

This PR includes #112421, which should be merged prior to this PR.