### PR TITLE
Add cubic root function

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -155,6 +155,13 @@ _ALWAYS_INLINE_ float sqrt(float p_x) {
 	return std::sqrt(p_x);
 }
 
+_ALWAYS_INLINE_ double cbrt(double p_x) {
+	return std::cbrt(p_x);
+}
+_ALWAYS_INLINE_ float cbrt(float p_x) {
+	return std::cbrt(p_x);
+}
+
 _ALWAYS_INLINE_ double fmod(double p_x, double p_y) {
 	return std::fmod(p_x, p_y);
 }

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -97,6 +97,10 @@ double VariantUtilityFunctions::sqrt(double x) {
 	return Math::sqrt(x);
 }
 
+double VariantUtilityFunctions::cbrt(double x) {
+	return Math::cbrt(x);
+}
+
 double VariantUtilityFunctions::fmod(double b, double r) {
 	return Math::fmod(b, r);
 }
@@ -1649,6 +1653,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(atanh, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(sqrt, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(cbrt, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(fmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(fposmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(posmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -48,6 +48,7 @@ struct VariantUtilityFunctions {
 	static double acosh(double arg);
 	static double atanh(double arg);
 	static double sqrt(double x);
+	static double cbrt(double x);
 	static double fmod(double b, double r);
 	static double fposmod(double b, double r);
 	static int64_t posmod(int64_t b, int64_t r);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -192,6 +192,19 @@
 				[b]Warning:[/b] Deserialized object can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats (remote code execution).
 			</description>
 		</method>
+		<method name="cbrt">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<description>
+				Returns the cubic root of [param x].
+				[codeblock]
+				cbrt(9)     # Returns 2.0800838230519
+				cbrt(3.5)   # Returns 1.51829448593783
+				cbrt(-1)    # Returns -1.0
+				[/codeblock]
+				See also [method sqrt].
+			</description>
+		</method>
 		<method name="ceil">
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
@@ -1322,6 +1335,7 @@
 				sqrt(10.24) # Returns 3.2
 				sqrt(-1)    # Returns NaN
 				[/codeblock]
+				See also [method cbrt].
 				[b]Note:[/b] Negative values of [param x] return NaN ("Not a Number"). In C#, if you need negative inputs, use [code]System.Numerics.Complex[/code].
 			</description>
 		</method>

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -404,12 +404,12 @@ float EditorAudioBus::_scaled_db_to_normalized_volume(float db) {
 			/* To accommodate for NaN on negative numbers for root, we will mirror the
 			 * results of the positive db range in order to get the desired numerical
 			 * value on the negative side. */
-			float positive_x = Math::pow(Math::abs(db) / 45.0f, 1.0f / 3.0f) + 1.0f;
-			Vector2 translation = Vector2(1.0f, 0.0f) - Vector2(positive_x, Math::abs(db));
+			float positive_x = Math::cbrt(-db / 45.0f) + 1.0f;
+			Vector2 translation = Vector2(1.0f, 0.0f) - Vector2(positive_x, -db);
 			Vector2 reflected_position = Vector2(1.0, 0.0f) + translation;
 			return reflected_position.x;
 		} else {
-			return Math::pow(db / 45.0f, 1.0f / 3.0f) + 1.0f;
+			return Math::cbrt(db / 45.0f) + 1.0f;
 		}
 	}
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -1657,6 +1657,26 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the cubic root of <paramref name="s"/>.
+        /// </summary>
+        /// <param name="s">The input number.</param>
+        /// <returns>The cubic root of <paramref name="s"/>.</returns>
+        public static float Cbrt(float s)
+        {
+            return MathF.Cbrt(s);
+        }
+
+        /// <summary>
+        /// Returns the cubic root of <paramref name="s"/>.
+        /// </summary>
+        /// <param name="s">The input number.</param>
+        /// <returns>The cubic root of <paramref name="s"/>.</returns>
+        public static double Cbrt(double s)
+        {
+            return Math.Cbrt(s);
+        }
+
+        /// <summary>
         /// Returns the position of the first non-zero digit, after the
         /// decimal point. Note that the maximum return value is 10,
         /// which is a design decision in the implementation.


### PR DESCRIPTION
I think this function is a useful addition. Previously, user may use: `pow(number, 1.0 / 3.0)` - compared to it, according to C++ documentation (https://en.cppreference.com/w/cpp/numeric/math/cbrt) this function should work faster and more precise.