### PR TITLE
[DRAFT] Expose native struct for ray cast through `PhysicsDirectSpaceState3D`

### DIFF
--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -150,7 +150,7 @@ struct PtrToArg<GDExtensionConstPtr<T>> {
 template <typename T>
 struct PtrToArg<GDExtensionPtr<T>> {
 	_FORCE_INLINE_ static GDExtensionPtr<T> convert(const void *p_ptr) {
-		return GDExtensionPtr<T>(reinterpret_cast<const T *>(p_ptr));
+		return GDExtensionPtr<T>(reinterpret_cast<T *>(const_cast<void *>(p_ptr)));
 	}
 	typedef T *EncodeT;
 	_FORCE_INLINE_ static void encode(GDExtensionPtr<T> p_val, void *p_ptr) {

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -382,6 +382,13 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(const Ref<PhysicsRayQueryPa
 	return d;
 }
 
+bool PhysicsDirectSpaceState3D::_intersect_ray_extension(const Ref<PhysicsRayQueryParameters3D> &p_ray_query, GDExtensionPtr<PhysicsServer3DExtensionRayResult> r_result) {
+	ERR_FAIL_COND_V(p_ray_query.is_null(), false);
+	ERR_FAIL_NULL_V(r_result, false);
+
+	return intersect_ray(p_ray_query->get_parameters(), *r_result.operator PhysicsServer3DExtensionRayResult *());
+}
+
 TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results) {
 	ERR_FAIL_COND_V(p_point_query.is_null(), TypedArray<Dictionary>());
 
@@ -487,6 +494,7 @@ PhysicsDirectSpaceState3D::PhysicsDirectSpaceState3D() {
 void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_point, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
+	ClassDB::bind_method(D_METHOD("intersect_ray_extension", "parameters", "result"), &PhysicsDirectSpaceState3D::_intersect_ray_extension);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);
 	ClassDB::bind_method(D_METHOD("collide_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_collide_shape, DEFVAL(32));

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -32,6 +32,7 @@
 
 #include "core/io/resource.h"
 #include "core/object/gdvirtual.gen.inc"
+#include "core/variant/native_ptr.h"
 
 constexpr int MAX_CONTACTS_REPORTED_3D_MAX = 4096;
 
@@ -122,11 +123,24 @@ class PhysicsRayQueryParameters3D;
 class PhysicsPointQueryParameters3D;
 class PhysicsShapeQueryParameters3D;
 
+struct PhysicsServer3DExtensionRayResult {
+	Vector3 position;
+	Vector3 normal;
+	RID rid;
+	ObjectID collider_id;
+	Object *collider = nullptr;
+	int shape = 0;
+	int face_index = -1;
+};
+
+GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionRayResult)
+
 class PhysicsDirectSpaceState3D : public Object {
 	GDCLASS(PhysicsDirectSpaceState3D, Object);
 
 private:
 	Dictionary _intersect_ray(const Ref<PhysicsRayQueryParameters3D> &p_ray_query);
+	bool _intersect_ray_extension(const Ref<PhysicsRayQueryParameters3D> &p_ray_query, GDExtensionPtr<PhysicsServer3DExtensionRayResult> r_result);
 	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
 	Vector<real_t> _cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
@@ -152,15 +166,7 @@ public:
 		bool pick_ray = false;
 	};
 
-	struct RayResult {
-		Vector3 position;
-		Vector3 normal;
-		RID rid;
-		ObjectID collider_id;
-		Object *collider = nullptr;
-		int shape = 0;
-		int face_index = -1;
-	};
+	typedef PhysicsServer3DExtensionRayResult RayResult;
 
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -116,11 +116,9 @@ public:
 	PhysicsDirectBodyState3DExtension();
 };
 
-typedef PhysicsDirectSpaceState3D::RayResult PhysicsServer3DExtensionRayResult;
 typedef PhysicsDirectSpaceState3D::ShapeResult PhysicsServer3DExtensionShapeResult;
 typedef PhysicsDirectSpaceState3D::ShapeRestInfo PhysicsServer3DExtensionShapeRestInfo;
 
-GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionRayResult)
 GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionShapeResult)
 GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionShapeRestInfo)
 


### PR DESCRIPTION
In the past, folks have complained about `PhysicsDirectSpaceState3D::interset_ray()` returning a `Dictionary`

This PR demonstrates how we could instead have it fill a native struct when using the API via GDExtension.

It reuses an existing native struct (`PhysicsServer3DExtensionRayResult`) we already had registered to allow GDExtensions to define their own physics servers, and just moves it over to `physics_server_3d.h`. I think the name still works because "Extension" could refer to it being usable via GDExtension.

This is marked as a DRAFT because I haven't actually tested it yet, and we'd probably want to expose a few more things with native structs too (perhaps `RayParameters`, `ShapeResult`, `ShapeParameters` and `ShapeRestInfo`?)