### PR TITLE
Update Android build tools to version 35.0.1

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -7,7 +7,7 @@ ext.versions = [
     minSdk             : 24,
     // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     targetSdk          : 35,
-    buildTools         : '35.0.0',
+    buildTools         : '35.0.1',
     kotlinVersion      : '2.1.20',
     fragmentVersion    : '1.8.6',
     nexusPublishVersion: '1.3.0',


### PR DESCRIPTION
Trying to build for Android fails for me on Windows 11.

Generating the templates works, `generate_apk=yes` fails pretty late in the gradle part with:
`\godot\platform\android\java\lib\build\generated\aidl_source_output_dir\templateDebug\out\com\android\vending\licensing\ILicenseResultListener.java:3: error: illegal unicode escape` a bunch of times.

According to [StackOverflow](https://stackoverflow.com/a/79767269), this is a bug in the Android `35.0.0` build tools (*maybe* specific to Windows on specific install paths) which apparently build tools version `35.0.1` fixed.

Bumping `buildTools` to `35.0.1` in `platform/android/java/app/config.gradle` fixes the issue for me. I found no other mention of `35.0.0` (outside the docs repo, which we need to update once this is merged; I can take care of that).