### PR TITLE
Fix VehicleWheel3D sinking

### DIFF
--- a/scene/3d/physics/vehicle_body_3d.cpp
+++ b/scene/3d/physics/vehicle_body_3d.cpp
@@ -484,7 +484,7 @@ real_t VehicleBody3D::_ray_cast(int p_idx, PhysicsDirectBodyState3D *s) {
 	bool col = ss->intersect_ray(ray_params, rr);
 
 	if (col) {
-		param = source.distance_to(rr.position) / source.distance_to(target);
+		param = (source.distance_to(rr.position) - wheel.m_wheelRadius) / raylen;
 		depth = raylen * param;
 		wheel.m_raycastInfo.m_contactNormalWS = rr.normal;
 

--- a/scene/3d/physics/vehicle_body_3d.cpp
+++ b/scene/3d/physics/vehicle_body_3d.cpp
@@ -459,7 +459,7 @@ real_t VehicleBody3D::_ray_cast(int p_idx, PhysicsDirectBodyState3D *s) {
 
 	_update_wheel_transform(wheel, s);
 
-	real_t depth = -1;
+	real_t hit_depth = -1;
 
 	real_t raylen = wheel.m_suspensionRestLength + wheel.m_wheelRadius;
 
@@ -468,8 +468,6 @@ real_t VehicleBody3D::_ray_cast(int p_idx, PhysicsDirectBodyState3D *s) {
 	wheel.m_raycastInfo.m_contactPointWS = source + rayvector;
 	const Vector3 &target = wheel.m_raycastInfo.m_contactPointWS;
 	source -= wheel.m_wheelRadius * wheel.m_raycastInfo.m_wheelDirectionWS;
-
-	real_t param = real_t(0.);
 
 	PS3DT::RayResult rr;
 
@@ -485,8 +483,7 @@ real_t VehicleBody3D::_ray_cast(int p_idx, PhysicsDirectBodyState3D *s) {
 	bool col = ss->intersect_ray(ray_params, rr);
 
 	if (col) {
-		param = source.distance_to(rr.position) / source.distance_to(target);
-		depth = raylen * param;
+		hit_depth = (source.distance_to(rr.position) - wheel.m_wheelRadius);
 		wheel.m_raycastInfo.m_contactNormalWS = rr.normal;
 
 		wheel.m_raycastInfo.m_isInContact = true;
@@ -494,8 +491,7 @@ real_t VehicleBody3D::_ray_cast(int p_idx, PhysicsDirectBodyState3D *s) {
 			wheel.m_raycastInfo.m_groundObject = Object::cast_to<PhysicsBody3D>(rr.collider);
 		}
 
-		real_t hitDistance = param * raylen;
-		wheel.m_raycastInfo.m_suspensionLength = hitDistance - wheel.m_wheelRadius;
+		wheel.m_raycastInfo.m_suspensionLength = hit_depth - wheel.m_wheelRadius;
 		//clamp on max suspension travel
 
 		real_t minSuspensionLength = wheel.m_suspensionRestLength - wheel.m_maxSuspensionTravel;
@@ -539,7 +535,7 @@ real_t VehicleBody3D::_ray_cast(int p_idx, PhysicsDirectBodyState3D *s) {
 		wheel.m_clippedInvContactDotSuspension = real_t(1.0);
 	}
 
-	return depth;
+	return hit_depth;
 }
 
 void VehicleBody3D::_update_suspension(PhysicsDirectBodyState3D *s) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #45339 

## Additional information

The suspension length was incorrectly calculated before. In the scope of this some redundant variables (as in containing the same values) were also cut.

Before: 
<img width="843" height="440" alt="image" src="https://github.com/user-attachments/assets/4236868f-ecae-48fd-a629-368d2c134428" />
After: 
<img width="795" height="379" alt="image" src="https://github.com/user-attachments/assets/1c90ef42-ac79-4620-816a-7d86d1c73d29" />
