### PR TITLE
Allow to add padding to `ScrollBar`s

### DIFF
--- a/doc/classes/HScrollBar.xml
+++ b/doc/classes/HScrollBar.xml
@@ -8,4 +8,14 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<theme_items>
+		<theme_item name="padding_bottom" data_type="constant" type="int" default="0">
+			Padding between the bottom of the [theme_item ScrollBar.scroll] element and the [theme_item ScrollBar.grabber].
+			[b]Note:[/b] To apply horizontal padding, modify the left/right content margins of [theme_item ScrollBar.scroll] instead.
+		</theme_item>
+		<theme_item name="padding_top" data_type="constant" type="int" default="0">
+			Padding between the top of the [theme_item ScrollBar.scroll] element and the [theme_item ScrollBar.grabber].
+			[b]Note:[/b] To apply horizontal padding, modify the left/right content margins of [theme_item ScrollBar.scroll] instead.
+		</theme_item>
+	</theme_items>
 </class>

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -12,4 +12,14 @@
 		<member name="size_flags_horizontal" type="int" setter="set_h_size_flags" getter="get_h_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="0" />
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="1" />
 	</members>
+	<theme_items>
+		<theme_item name="padding_left" data_type="constant" type="int" default="0">
+			Padding between the left of the [theme_item ScrollBar.scroll] element and the [theme_item ScrollBar.grabber].
+			[b]Note:[/b] To apply vertical padding, modify the top/bottom content margins of [theme_item ScrollBar.scroll] instead.
+		</theme_item>
+		<theme_item name="padding_right" data_type="constant" type="int" default="0">
+			Padding between the right of the [theme_item ScrollBar.scroll] element and the [theme_item ScrollBar.grabber].
+			[b]Note:[/b] To apply vertical padding, modify the top/bottom content margins of [theme_item ScrollBar.scroll] instead.
+		</theme_item>
+	</theme_items>
 </class>

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -295,15 +295,19 @@ void ScrollBar::_notification(int p_what) {
 			Rect2 grabber_rect;
 
 			if (orientation == HORIZONTAL) {
+				int padding_top = MAX(theme_cache.padding_top, 0);
+				int padding_bottom = MAX(theme_cache.padding_bottom, 0);
 				grabber_rect.size.width = get_grabber_size();
-				grabber_rect.size.height = get_size().height;
-				grabber_rect.position.y = 0;
+				grabber_rect.size.height = get_size().height - padding_top - padding_bottom;
+				grabber_rect.position.y = padding_top;
 				grabber_rect.position.x = get_grabber_offset() + decr->get_width() + theme_cache.scroll_style->get_margin(SIDE_LEFT);
 			} else {
-				grabber_rect.size.width = get_size().width;
+				int padding_left = MAX(theme_cache.padding_left, 0);
+				int padding_right = MAX(theme_cache.padding_right, 0);
+				grabber_rect.size.width = get_size().width - padding_left - padding_right;
 				grabber_rect.size.height = get_grabber_size();
 				grabber_rect.position.y = get_grabber_offset() + decr->get_height() + theme_cache.scroll_style->get_margin(SIDE_TOP);
-				grabber_rect.position.x = 0;
+				grabber_rect.position.x = padding_left;
 			}
 
 			grabber->draw(ci, grabber_rect);
@@ -488,7 +492,10 @@ Size2 ScrollBar::get_minimum_size() const {
 	Size2 minsize;
 
 	if (orientation == VERTICAL) {
+		int padding_left = MAX(theme_cache.padding_left, 0);
+		int padding_right = MAX(theme_cache.padding_right, 0);
 		minsize.width = MAX(incr->get_size().width, bg->get_minimum_size().width);
+		minsize.width += padding_left + padding_right;
 		minsize.height += incr->get_size().height;
 		minsize.height += decr->get_size().height;
 		minsize.height += bg->get_minimum_size().height;
@@ -496,7 +503,10 @@ Size2 ScrollBar::get_minimum_size() const {
 	}
 
 	if (orientation == HORIZONTAL) {
+		int padding_top = MAX(theme_cache.padding_top, 0);
+		int padding_bottom = MAX(theme_cache.padding_bottom, 0);
 		minsize.height = MAX(incr->get_size().height, bg->get_minimum_size().height);
+		minsize.height += padding_top + padding_bottom;
 		minsize.width += incr->get_size().width;
 		minsize.width += decr->get_size().width;
 		minsize.width += bg->get_minimum_size().width;
@@ -668,4 +678,14 @@ ScrollBar::ScrollBar(Orientation p_orientation) {
 }
 
 ScrollBar::~ScrollBar() {
+}
+
+void VScrollBar::_bind_methods() {
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, VScrollBar, padding_left);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, VScrollBar, padding_right);
+}
+
+void HScrollBar::_bind_methods() {
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, HScrollBar, padding_top);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, HScrollBar, padding_bottom);
 }

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -84,6 +84,12 @@ class ScrollBar : public Range {
 	double target_scroll = 0.0;
 	bool smooth_scroll_enabled = false;
 
+	void _drag_node_exit();
+	void _drag_node_input(const Ref<InputEvent> &p_input);
+
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
+protected:
 	struct ThemeCache {
 		Ref<StyleBox> scroll_style;
 		Ref<StyleBox> scroll_focus_style;
@@ -98,14 +104,13 @@ class ScrollBar : public Range {
 		Ref<Texture2D> decrement_icon;
 		Ref<Texture2D> decrement_hl_icon;
 		Ref<Texture2D> decrement_pressed_icon;
+
+		int padding_left = 0;
+		int padding_top = 0;
+		int padding_right = 0;
+		int padding_bottom = 0;
 	} theme_cache;
 
-	void _drag_node_exit();
-	void _drag_node_input(const Ref<InputEvent> &p_input);
-
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
-
-protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
@@ -133,6 +138,9 @@ public:
 class HScrollBar : public ScrollBar {
 	GDCLASS(HScrollBar, ScrollBar);
 
+protected:
+	static void _bind_methods();
+
 public:
 	HScrollBar() :
 			ScrollBar(HORIZONTAL) { set_v_size_flags(0); }
@@ -140,6 +148,9 @@ public:
 
 class VScrollBar : public ScrollBar {
 	GDCLASS(VScrollBar, ScrollBar);
+
+protected:
+	static void _bind_methods();
 
 public:
 	VScrollBar() :


### PR DESCRIPTION
<img width="1124" height="531" alt="Screenshot_20251105_111758" src="https://github.com/user-attachments/assets/d9162513-b76e-4ab9-9015-1e0378985dea" />

_(A comparison between the default scrollbar and one with left/right padding plus top/bottom content margins in the `scroll` theme element)_

This PR adds a set of `padding_*` theme constants with all four directions, with the horizontal ones being used for `VScrollBar`, and the vertical ones for `HScrollBar`.
This inversely mirrors the behavior of the content margins in the `scroll` theme element, where the horizontal margins are present in `HScrollBar`, and the vertical ones in are in `VScrollBar`.

Helps address https://github.com/godotengine/godot/pull/112296#issuecomment-3476933619.

> But why not just change it so that all content margins add padding?

Because that would result in a compatibility break, as some users make use of them to increase the minimum size. Even the Godot editor and the default project theme make use of them for that.