### PR TITLE
Modern style: Fix `prop_subsection_stylebox` color not scaling with luminance

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1923,7 +1923,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_constant("indent_size", "EditorInspectorSection", 6.0 * EDSCALE);
 		p_theme->set_constant("h_separation", "EditorInspectorSection", p_config.base_margin * EDSCALE);
 
-		Color prop_subsection_stylebox_color = p_config.dark_color_1.lerp(p_config.mono_color_font, p_config.dark_icon_and_font ? 0.09 : 0.16);
+		Color prop_subsection_stylebox_color = p_config.button_disabled_color.lerp(p_config.base_color, 0.48);
 		p_theme->set_color("prop_subsection_stylebox", EditorStringName(Editor), prop_subsection_stylebox_color);
 
 		Ref<StyleBoxFlat> style_highlight_subsection = p_config.base_style->duplicate();


### PR DESCRIPTION
The color was calculated wrongly due to being based on the Classic style.

It remains too dark if the editor main color is increased before this change, when it should be a highlight.

> `#7f7f7f` is the brightest color the editor can have before considering it as a Light theme.

| Color     | Before | After |
|-----------|--------|-------|
| `#252525` |![before_dark](https://github.com/user-attachments/assets/f85f3031-aeab-4e64-a036-96d9b30e5a69)|![after_dark](https://github.com/user-attachments/assets/b0b35d3e-5288-4cf2-8b58-4d40387b93b7)
| `#7f7f7f` |![before_7f7f7f](https://github.com/user-attachments/assets/014028af-5f2c-4099-b77e-b11ab5849669)|![after_7f7f7f](https://github.com/user-attachments/assets/57817451-4850-4ff3-914b-c60dc56dcc2d)