### PR TITLE
Modern style: Use stylebox setter for Action Map `TreeItem`s

### DIFF
--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -418,18 +418,6 @@ bool ActionMapEditor::_should_display_action(const String &p_name, const Array &
 	return event_match && action_list_search_bar->get_name().is_subsequence_ofn(p_name);
 }
 
-void ActionMapEditor::_highlight_subsection_action(Object *p_item, const Rect2 p_rect) {
-	TreeItem *item = Object::cast_to<TreeItem>(p_item);
-	ERR_FAIL_NULL(item);
-
-	if (item->is_selected(0)) {
-		return;
-	}
-
-	const Ref<StyleBox> &stylebox = get_theme_stylebox(SNAME("style_highlight_subsection"), EditorStringName(Editor));
-	stylebox->draw(action_tree->get_canvas_item(), p_rect);
-}
-
 void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_infos) {
 	if (!p_action_infos.is_empty()) {
 		actions_cache = p_action_infos;
@@ -478,7 +466,6 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 		// First Column - Action Name
 		action_item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 		action_item->set_cell_mode(0, TreeItem::CELL_MODE_CUSTOM);
-		action_item->set_custom_draw_callback(0, callable_mp(this, &ActionMapEditor::_highlight_subsection_action));
 		action_item->set_text(0, action_info.name);
 		action_item->set_editable(0, action_info.editable);
 		action_item->set_icon(0, action_info.icon);
@@ -502,6 +489,8 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 
 		action_item->set_custom_bg_color(0, get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor)));
 		action_item->set_custom_bg_color(1, get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor)));
+		action_item->set_custom_stylebox(0, get_theme_stylebox(SNAME("prop_subsection_stylebox_left"), EditorStringName(Editor)));
+		action_item->set_custom_stylebox(1, get_theme_stylebox(SNAME("prop_subsection_stylebox_right"), EditorStringName(Editor)));
 
 		if (selected_item.first == action_info.name) {
 			action_item->select(selected_item.second);

--- a/editor/settings/action_map_editor.h
+++ b/editor/settings/action_map_editor.h
@@ -108,7 +108,6 @@ private:
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 	void _set_show_builtin_actions(bool p_show);
-	void _highlight_subsection_action(Object *p_item, const Rect2 p_rect);
 
 protected:
 	void _notification(int p_what);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1964,11 +1964,12 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_constant("h_separation", "EditorInspectorSection", 2.0 * EDSCALE);
 
 		Color prop_subsection_stylebox_color = Color(1, 1, 1, 0);
-		p_theme->set_color("prop_subsection_stylebox", EditorStringName(Editor), prop_subsection_stylebox_color);
-
-		Ref<StyleBoxFlat> style_highlight_subsection = p_config.base_style->duplicate();
-		style_highlight_subsection->set_bg_color(prop_subsection_stylebox_color);
-		p_theme->set_stylebox("style_highlight_subsection", EditorStringName(Editor), style_highlight_subsection);
+		p_theme->set_color("prop_subsection_stylebox_color", EditorStringName(Editor), prop_subsection_stylebox_color);
+		Ref<StyleBoxFlat> prop_subsection_stylebox = p_config.base_style->duplicate();
+		prop_subsection_stylebox->set_bg_color(p_theme->get_color("prop_subsection_stylebox_color", EditorStringName(Editor)));
+		p_theme->set_stylebox("prop_subsection_stylebox", EditorStringName(Editor), prop_subsection_stylebox);
+		p_theme->set_stylebox("prop_subsection_stylebox_left", EditorStringName(Editor), prop_subsection_stylebox);
+		p_theme->set_stylebox("prop_subsection_stylebox_right", EditorStringName(Editor), prop_subsection_stylebox);
 
 		Color prop_category_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.12);
 		Color prop_subsection_color = p_config.dark_color_1.lerp(p_config.mono_color, 0.06);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1924,12 +1924,22 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_constant("h_separation", "EditorInspectorSection", p_config.base_margin * EDSCALE);
 
 		Color prop_subsection_stylebox_color = p_config.button_disabled_color.lerp(p_config.base_color, 0.48);
-		p_theme->set_color("prop_subsection_stylebox", EditorStringName(Editor), prop_subsection_stylebox_color);
+		p_theme->set_color("prop_subsection_stylebox_color", EditorStringName(Editor), prop_subsection_stylebox_color);
 
-		Ref<StyleBoxFlat> style_highlight_subsection = p_config.base_style->duplicate();
-		style_highlight_subsection->set_bg_color(prop_subsection_stylebox_color);
-		style_highlight_subsection->set_corner_radius_all(p_config.corner_radius * EDSCALE);
-		p_theme->set_stylebox("style_highlight_subsection", EditorStringName(Editor), style_highlight_subsection);
+		Ref<StyleBoxFlat> prop_subsection_stylebox = p_config.base_style->duplicate();
+		prop_subsection_stylebox->set_bg_color(p_theme->get_color("prop_subsection_stylebox_color", EditorStringName(Editor)));
+		prop_subsection_stylebox->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		p_theme->set_stylebox("prop_subsection_stylebox", EditorStringName(Editor), prop_subsection_stylebox);
+
+		Ref<StyleBoxFlat> prop_subsection_stylebox_left = prop_subsection_stylebox->duplicate();
+		prop_subsection_stylebox_left->set_corner_radius(CORNER_TOP_RIGHT, 0);
+		prop_subsection_stylebox_left->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+		p_theme->set_stylebox("prop_subsection_stylebox_left", EditorStringName(Editor), prop_subsection_stylebox_left);
+
+		Ref<StyleBoxFlat> prop_subsection_stylebox_right = prop_subsection_stylebox->duplicate();
+		prop_subsection_stylebox_right->set_corner_radius(CORNER_TOP_LEFT, 0);
+		prop_subsection_stylebox_right->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		p_theme->set_stylebox("prop_subsection_stylebox_right", EditorStringName(Editor), prop_subsection_stylebox_right);
 
 		p_theme->set_color("prop_subsection", EditorStringName(Editor), Color(1, 1, 1, 0));
 #ifndef DISABLE_DEPRECATED // Used before 4.3.


### PR DESCRIPTION
~~Requires #112371 and #112443.~~ Both are merged.

Undoes the workaround from #112233 in favor of the new custom stylebox implementation in `TreeItem` (#112371), bringing the highlight closer to how it was in the Classic style but with rounded corners:
| Before | After |
|-|-|
|![before](https://github.com/user-attachments/assets/b136b67b-a37e-477a-8858-c2bed2e35e7f) | ![new](https://github.com/user-attachments/assets/aed1e742-78a3-4f51-817c-d1f12fc2d28c)|

The theme now exposes the "prop_subsection_stylebox_color" and the "prop_subsection_stylebox(_left/right)" stylebox, both of which are used for this. Any changes to the classic theme are just precautions.