### PR TITLE
Revert "Add warning when node name is invalid"

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1437,9 +1437,6 @@ void Node::set_name(const StringName &p_name) {
 			data.name = p_name;
 		} else {
 			data.name = StringName(validated_node_name_string);
-			WARN_PRINT(vformat(
-					R"(Node cannot be renamed to "%s" because it contains characters that are not allowed. The node was renamed to "%s" instead. The following characters are not allowed: %s)",
-					input_name_str, validated_node_name_string, String::get_invalid_node_name_characters()));
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 0d46d42f2ab3114ae291ea1a53d8cccebd39cff9.

As discussed in https://github.com/godotengine/godot/pull/112307, the warning is triggered frequently, often outside the user's control. Some users may also use the function expecting a rename, so in these cases a warning would not be appropriate.