### PR TITLE
Add scale 3D and rotation 3D in particle process

### DIFF
--- a/doc/classes/ParticleProcessMaterial.xml
+++ b/doc/classes/ParticleProcessMaterial.xml
@@ -315,6 +315,20 @@
 			Minimum radial velocity applied to each particle. Makes particles move away from the [member velocity_pivot], or toward it if negative.
 			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
 		</member>
+		<member name="rotation_3d_max" type="Vector3" setter="set_rotation_3d_max" getter="get_rotation_3d_max">
+			The maximum 3D orientation, in degrees. Works only in 3D and if [member use_rotation_3d] is enabled.
+		</member>
+		<member name="rotation_3d_min" type="Vector3" setter="set_rotation_3d_min" getter="get_rotation_3d_min">
+			The minimum 3D orientation, in degrees. Works only in 3D and if [member use_rotation_3d] is enabled.
+		</member>
+		<member name="scale_3d_max" type="Vector3" setter="set_scale_3d_max" getter="get_scale_3d_max">
+			The maximum value of the random scale vector for each particle.
+			Works only if [member use_scale_3d] is enabled.
+		</member>
+		<member name="scale_3d_min" type="Vector3" setter="set_scale_3d_min" getter="get_scale_3d_min">
+			The minimum value of the random scale vector for each particle.
+			Works only if [member use_scale_3d] is enabled.
+		</member>
 		<member name="scale_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's scale will vary along this [CurveTexture] over its lifetime. If a [CurveXYZTexture] is supplied instead, the scale will be separated per-axis.
 		</member>
@@ -406,6 +420,12 @@
 		</member>
 		<member name="turbulence_noise_strength" type="float" setter="set_turbulence_noise_strength" getter="get_turbulence_noise_strength" default="1.0">
 			The turbulence noise strength. Increasing this will result in a stronger, more contrasting, flow pattern.
+		</member>
+		<member name="use_rotation_3d" type="bool" setter="set_use_rotation_3d" getter="is_using_rotation_3d" default="false">
+			Enable the usage of [member rotation_3d_min] and [member rotation_3d_max].
+		</member>
+		<member name="use_scale_3d" type="bool" setter="set_use_scale_3d" getter="is_using_scale_3d" default="false">
+			Enable the usage of [member scale_3d_min] and [member scale_3d_max].
 		</member>
 		<member name="velocity_limit_curve" type="Texture2D" setter="set_velocity_limit_curve" getter="get_velocity_limit_curve">
 			A [CurveTexture] that defines the maximum velocity of a particle during its lifetime.

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -63,6 +63,8 @@ void ParticleProcessMaterial::init_shaders() {
 	shader_names->anim_offset_min = "anim_offset_min";
 	shader_names->directional_velocity_min = "directional_velocity_min";
 	shader_names->scale_over_velocity_min = "scale_over_velocity_min";
+	shader_names->scale_3d_min = "scale_3d_min";
+	shader_names->rotation_3d_min = "rotation_3d_min";
 
 	shader_names->initial_linear_velocity_max = "initial_linear_velocity_max";
 	shader_names->initial_angle_max = "initial_angle_max";
@@ -79,6 +81,8 @@ void ParticleProcessMaterial::init_shaders() {
 	shader_names->anim_offset_max = "anim_offset_max";
 	shader_names->directional_velocity_max = "directional_velocity_max";
 	shader_names->scale_over_velocity_max = "scale_over_velocity_max";
+	shader_names->scale_3d_max = "scale_3d_max";
+	shader_names->rotation_3d_max = "rotation_3d_max";
 
 	shader_names->angle_texture = "angle_texture";
 	shader_names->angular_velocity_texture = "angular_velocity_texture";
@@ -234,8 +238,18 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "uniform float initial_angle_min;\n";
 	code += "uniform float initial_angle_max;\n";
 
-	code += "uniform float scale_min;\n";
-	code += "uniform float scale_max;\n";
+	if (use_scale_3d) {
+		code += "uniform vec3 scale_3d_min;\n";
+		code += "uniform vec3 scale_3d_max;\n";
+	} else {
+		code += "uniform float scale_min;\n";
+		code += "uniform float scale_max;\n";
+	}
+
+	if (!particle_flags[PARTICLE_FLAG_DISABLE_Z] && use_rotation_3d) {
+		code += "uniform vec3 rotation_3d_min;\n";
+		code += "uniform vec3 rotation_3d_max;\n";
+	}
 
 	code += "uniform float hue_variation_min;\n";
 	code += "uniform float hue_variation_max;\n";
@@ -559,6 +573,9 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "	float directional_velocity;\n";
 	code += "	float radial_velocity;\n";
 	code += "	float orbit_velocity;\n";
+	if (!particle_flags[PARTICLE_FLAG_DISABLE_Z] && use_rotation_3d) {
+		code += "	vec3 rotation_3d;\n";
+	}
 	if (turbulence_enabled) {
 		code += "	float turb_influence;\n";
 	}
@@ -590,13 +607,23 @@ void ParticleProcessMaterial::_update_shader() {
 	if (turbulence_enabled) {
 		code += "	params.turb_influence = mix(turbulence_influence_min, turbulence_influence_max, rand_from_seed(alt_seed));\n";
 	}
+	if (!particle_flags[PARTICLE_FLAG_DISABLE_Z] && use_rotation_3d) {
+		code += "	params.rotation_3d.x = mix(rotation_3d_min.x, rotation_3d_max.x, rand_from_seed(alt_seed));\n";
+		code += "	params.rotation_3d.y = mix(rotation_3d_min.y, rotation_3d_max.y, rand_from_seed(alt_seed));\n";
+		code += "	params.rotation_3d.z = mix(rotation_3d_min.z, rotation_3d_max.z, rand_from_seed(alt_seed));\n";
+		code += "	params.rotation_3d *= 3.14159 / 180.0;\n";
+	}
 	code += "}\n\n";
 
 	code += "void calculate_initial_display_params(inout DisplayParameters params, inout uint alt_seed) {\n";
 	code += "	// -------------------- DO NOT REORDER OPERATIONS, IT BREAKS VISUAL COMPATIBILITY\n";
 	code += "	// -------------------- ADD NEW OPERATIONS AT THE BOTTOM\n";
 	code += "	float pi = 3.14159;\n";
-	code += "	params.scale = vec3(mix(scale_min, scale_max, rand_from_seed(alt_seed)));\n";
+	if (use_scale_3d) {
+		code += "	params.scale = mix(scale_3d_min, scale_3d_max, rand_from_seed(alt_seed));\n";
+	} else {
+		code += "	params.scale = vec3(mix(scale_min, scale_max, rand_from_seed(alt_seed)));\n";
+	}
 	code += "	params.scale = sign(params.scale) * max(abs(params.scale), 0.001);\n";
 	code += "	params.hue_rotation = pi * 2.0 * mix(hue_variation_min, hue_variation_max, rand_from_seed(alt_seed));\n";
 	code += "	params.animation_speed = mix(anim_speed_min, anim_speed_max, rand_from_seed(alt_seed));\n";
@@ -616,6 +643,7 @@ void ParticleProcessMaterial::_update_shader() {
 			code += "	params.color *= texelFetch(emission_texture_color, emission_tex_ofs, 0);\n";
 		}
 	}
+	// New additions go at the bottom to preserve existing fixed-seed particles.
 	code += "}\n\n";
 
 	// Process display parameters that are bound solely by lifetime.
@@ -890,6 +918,34 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "		TRANSFORM[1].xyz = vec3(0.0, 1.0, 0.0);\n";
 	code += "		TRANSFORM[2].xyz = vec3(0.0, 0.0, 1.0);\n";
 	code += "	}\n";
+	code += "	process_display_param(params, 0.0);\n\n";
+	if (!particle_flags[PARTICLE_FLAG_DISABLE_Z] && use_rotation_3d) {
+		code += R"(
+	if (dot(dynamic_params.rotation_3d, dynamic_params.rotation_3d) > 0.0) {
+		mat4 rx = mat4(
+				vec4(1.0, 0.0, 0.0, 0.0),
+				vec4(0.0, cos(dynamic_params.rotation_3d.x), sin(dynamic_params.rotation_3d.x), 0.0),
+				vec4(0.0, -sin(dynamic_params.rotation_3d.x), cos(dynamic_params.rotation_3d.x), 0.0),
+				vec4(0.0, 0.0, 0.0, 1.0)
+			);
+		mat4 ry = mat4(
+				vec4(cos(dynamic_params.rotation_3d.y), 0.0, -sin(dynamic_params.rotation_3d.y), 0.0),
+				vec4(0.0, 1.0, 0.0, 0.0),
+				vec4(sin(dynamic_params.rotation_3d.y), 0.0, cos(dynamic_params.rotation_3d.y), 0.0),
+				vec4(0.0, 0.0, 0.0, 1.0)
+			);
+		mat4 rz = mat4(
+				vec4(cos(dynamic_params.rotation_3d.z), sin(dynamic_params.rotation_3d.z), 0.0, 0.0),
+				vec4(-sin(dynamic_params.rotation_3d.z), cos(dynamic_params.rotation_3d.z), 0.0, 0.0),
+				vec4(0.0, 0.0, 1.0, 0.0),
+				vec4(0.0, 0.0, 0.0, 1.0)
+			);
+		TRANSFORM[3].xyz = vec3(0.);
+		TRANSFORM = rz * ry * rx * TRANSFORM;
+	}
+)";
+	}
+
 	code += "	if (RESTART_POSITION) {\n";
 	code += "		TRANSFORM[3].xyz = calculate_initial_position(params, alt_seed);\n";
 	if (turbulence_enabled) {
@@ -954,7 +1010,7 @@ void ParticleProcessMaterial::_update_shader() {
 	if (sub_emitter_mode == SUB_EMITTER_AT_START && !RenderingServer::get_singleton()->is_low_end()) {
 		code += "	bool just_spawned = CUSTOM.y == 0.0;\n";
 	}
-
+	code += "	bool first_frame = CUSTOM.y == 0.0;\n";
 	code += "	CUSTOM.y += DELTA / LIFETIME;\n";
 	code += "	CUSTOM.y = mix(CUSTOM.y, 1.0, INTERPOLATE_TO_END);\n";
 	code += "	float lifetime_percent = CUSTOM.y / params.lifetime;\n";
@@ -1150,13 +1206,20 @@ void ParticleProcessMaterial::_update_shader() {
 	// A scale of 0 results in no emission at some emission amounts (including 3 and 6).
 	// `sign(scale)` is unsuitable, because sign(0) returns 0, nullifying the minimum value.
 	// The following evaluates to 1 when scale is 0, falling back to a positive minimum value.
-	code += "	float scale_sign_x = params.scale.x < 0.0 ? -1.0 : 1.0;\n";
-	code += "	float scale_sign_y = params.scale.y < 0.0 ? -1.0 : 1.0;\n";
-	code += "	float scale_sign_z = params.scale.z < 0.0 ? -1.0 : 1.0;\n";
-	code += "	float scale_minimum = 0.001;\n";
-	code += "	TRANSFORM[0].xyz *= scale_sign_x * max(abs(params.scale.x), scale_minimum);\n";
-	code += "	TRANSFORM[1].xyz *= scale_sign_y * max(abs(params.scale.y), scale_minimum);\n";
-	code += "	TRANSFORM[2].xyz *= scale_sign_z * max(abs(params.scale.z), scale_minimum);\n";
+	code += "	if (first_frame) {\n";
+	code += "		float scale_sign_x = params.scale.x < 0.0 ? -1.0 : 1.0;\n";
+	code += "		float scale_sign_y = params.scale.y < 0.0 ? -1.0 : 1.0;\n";
+	code += "		float scale_sign_z = params.scale.z < 0.0 ? -1.0 : 1.0;\n";
+	code += "		float scale_minimum = 0.001;\n";
+	code += "		TRANSFORM[0].xyz *= scale_sign_x * max(abs(params.scale.x), scale_minimum);\n";
+	code += "		TRANSFORM[1].xyz *= scale_sign_y * max(abs(params.scale.y), scale_minimum);\n";
+	code += "		TRANSFORM[2].xyz *= scale_sign_z * max(abs(params.scale.z), scale_minimum);\n";
+	code += "	} else {\n";
+	code += "		float scale_minimum = 0.001;\n";
+	code += "		TRANSFORM[0].xyz *= max(abs(params.scale.x), scale_minimum);\n";
+	code += "		TRANSFORM[1].xyz *= max(abs(params.scale.y), scale_minimum);\n";
+	code += "		TRANSFORM[2].xyz *= max(abs(params.scale.z), scale_minimum);\n";
+	code += "	}\n";
 	code += "\n";
 	code += "	CUSTOM.z = params.animation_offset + lifetime_percent * params.animation_speed;\n\n";
 
@@ -1803,6 +1866,76 @@ double ParticleProcessMaterial::get_inherit_velocity_ratio() {
 	return inherit_emitter_velocity_ratio;
 }
 
+void ParticleProcessMaterial::set_use_scale_3d(const bool p_use_scale_3d) {
+	if (p_use_scale_3d != use_scale_3d) {
+		_queue_shader_change();
+	}
+	use_scale_3d = p_use_scale_3d;
+	notify_property_list_changed();
+}
+bool ParticleProcessMaterial::is_using_scale_3d() const {
+	return use_scale_3d;
+}
+
+Vector3 ParticleProcessMaterial::get_scale_3d_min() const {
+	return scale_3d_min;
+}
+
+void ParticleProcessMaterial::set_scale_3d_min(const Vector3 &p_scale_3d_min) {
+	scale_3d_min = p_scale_3d_min;
+	if (scale_3d_min > scale_3d_max) {
+		set_scale_3d_max(scale_3d_min);
+	}
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->scale_3d_min, p_scale_3d_min);
+}
+
+Vector3 ParticleProcessMaterial::get_scale_3d_max() const {
+	return scale_3d_max;
+}
+
+void ParticleProcessMaterial::set_scale_3d_max(const Vector3 &p_scale_3d_max) {
+	scale_3d_max = p_scale_3d_max;
+	if (scale_3d_max < scale_3d_min) {
+		set_scale_3d_min(scale_3d_max);
+	}
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->scale_3d_max, p_scale_3d_max);
+}
+
+void ParticleProcessMaterial::set_use_rotation_3d(const bool p_use_rotation_3d) {
+	if (p_use_rotation_3d != use_rotation_3d) {
+		_queue_shader_change();
+	}
+	use_rotation_3d = p_use_rotation_3d;
+	notify_property_list_changed();
+}
+bool ParticleProcessMaterial::is_using_rotation_3d() const {
+	return use_rotation_3d;
+}
+
+Vector3 ParticleProcessMaterial::get_rotation_3d_min() const {
+	return rotation_3d_min;
+}
+
+void ParticleProcessMaterial::set_rotation_3d_min(const Vector3 &p_rotation_3d_min) {
+	rotation_3d_min = p_rotation_3d_min;
+	if (rotation_3d_min > rotation_3d_max) {
+		set_rotation_3d_max(rotation_3d_min);
+	}
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->rotation_3d_min, p_rotation_3d_min);
+}
+
+Vector3 ParticleProcessMaterial::get_rotation_3d_max() const {
+	return rotation_3d_max;
+}
+
+void ParticleProcessMaterial::set_rotation_3d_max(const Vector3 &p_rotation_3d_max) {
+	rotation_3d_max = p_rotation_3d_max;
+	if (rotation_3d_max < rotation_3d_min) {
+		set_rotation_3d_min(rotation_3d_max);
+	}
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->rotation_3d_max, p_rotation_3d_max);
+}
+
 void ParticleProcessMaterial::set_turbulence_enabled(const bool p_turbulence_enabled) {
 	turbulence_enabled = p_turbulence_enabled;
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->turbulence_enabled, turbulence_enabled);
@@ -1949,9 +2082,20 @@ void ParticleProcessMaterial::_validate_property(PropertyInfo &p_property) const
 			if (!tex_parameters[PARAM_ORBIT_VELOCITY].is_valid() && !particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 				p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 			}
-		} else if (p_property.usage & PROPERTY_USAGE_EDITOR && (p_property.name.ends_with("_min") || p_property.name.ends_with("_max"))) {
+		} else if (p_property.usage & PROPERTY_USAGE_EDITOR && (p_property.name.ends_with("_min") || p_property.name.ends_with("_max")) &&
+				!(p_property.name == "scale_3d_max" || p_property.name == "scale_3d_min") &&
+				!(p_property.name == "rotation_3d_max" || p_property.name == "rotation_3d_min")) {
 			p_property.usage &= ~PROPERTY_USAGE_EDITOR;
 		}
+	}
+	if ((p_property.name == "scale_3d_min" || p_property.name == "scale_3d_max") && !use_scale_3d) {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+	if (p_property.name == "scale" && use_scale_3d) {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+	if ((p_property.name == "rotation_3d_max" || p_property.name == "rotation_3d_min") && (particle_flags[PARTICLE_FLAG_DISABLE_Z] || !use_rotation_3d)) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
 
@@ -2089,6 +2233,24 @@ void ParticleProcessMaterial::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_color", "color"), &ParticleProcessMaterial::set_color);
 	ClassDB::bind_method(D_METHOD("get_color"), &ParticleProcessMaterial::get_color);
+
+	ClassDB::bind_method(D_METHOD("set_use_scale_3d", "using_scale_3d"), &ParticleProcessMaterial::set_use_scale_3d);
+	ClassDB::bind_method(D_METHOD("is_using_scale_3d"), &ParticleProcessMaterial::is_using_scale_3d);
+
+	ClassDB::bind_method(D_METHOD("set_scale_3d_min", "scale_3d_min"), &ParticleProcessMaterial::set_scale_3d_min);
+	ClassDB::bind_method(D_METHOD("get_scale_3d_min"), &ParticleProcessMaterial::get_scale_3d_min);
+
+	ClassDB::bind_method(D_METHOD("set_scale_3d_max", "scale_3d_max"), &ParticleProcessMaterial::set_scale_3d_max);
+	ClassDB::bind_method(D_METHOD("get_scale_3d_max"), &ParticleProcessMaterial::get_scale_3d_max);
+
+	ClassDB::bind_method(D_METHOD("set_use_rotation_3d", "using_rotation_3d"), &ParticleProcessMaterial::set_use_rotation_3d);
+	ClassDB::bind_method(D_METHOD("is_using_rotation_3d"), &ParticleProcessMaterial::is_using_rotation_3d);
+
+	ClassDB::bind_method(D_METHOD("set_rotation_3d_min", "rotation_3d_min"), &ParticleProcessMaterial::set_rotation_3d_min);
+	ClassDB::bind_method(D_METHOD("get_rotation_3d_min"), &ParticleProcessMaterial::get_rotation_3d_min);
+
+	ClassDB::bind_method(D_METHOD("set_rotation_3d_max", "rotation_3d_max"), &ParticleProcessMaterial::set_rotation_3d_max);
+	ClassDB::bind_method(D_METHOD("get_rotation_3d_max"), &ParticleProcessMaterial::get_rotation_3d_max);
 
 	ClassDB::bind_method(D_METHOD("set_color_ramp", "ramp"), &ParticleProcessMaterial::set_color_ramp);
 	ClassDB::bind_method(D_METHOD("get_color_ramp"), &ParticleProcessMaterial::get_color_ramp);
@@ -2237,6 +2399,10 @@ void ParticleProcessMaterial::_bind_methods() {
 	ADD_SUBGROUP("Angle", "");
 	ADD_MIN_MAX_PROPERTY("angle", "-720,720,0.1,or_less,or_greater,degrees", PARAM_ANGLE);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "angle_curve", PROPERTY_HINT_RESOURCE_TYPE, CurveTexture::get_class_static()), "set_param_texture", "get_param_texture", PARAM_ANGLE);
+	ADD_SUBGROUP("Rotation 3D", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_rotation_3d", PROPERTY_HINT_GROUP_ENABLE), "set_use_rotation_3d", "is_using_rotation_3d");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation_3d_min"), "set_rotation_3d_min", "get_rotation_3d_min");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation_3d_max"), "set_rotation_3d_max", "get_rotation_3d_max");
 	ADD_SUBGROUP("Velocity", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "inherit_velocity_ratio", PROPERTY_HINT_RANGE, "0.0,1.0,0.001,or_less,or_greater"), "set_inherit_velocity_ratio", "get_inherit_velocity_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "velocity_pivot"), "set_velocity_pivot", "get_velocity_pivot");
@@ -2280,6 +2446,9 @@ void ParticleProcessMaterial::_bind_methods() {
 
 	ADD_GROUP("Display", "");
 	ADD_SUBGROUP("Scale", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_scale_3d"), "set_use_scale_3d", "is_using_scale_3d");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale_3d_min", PROPERTY_HINT_LINK, ""), "set_scale_3d_min", "get_scale_3d_min");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale_3d_max", PROPERTY_HINT_LINK, ""), "set_scale_3d_max", "get_scale_3d_max");
 	ADD_MIN_MAX_PROPERTY("scale", "0,1000,0.01,or_greater", PARAM_SCALE);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "scale_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture,CurveXYZTexture"), "set_param_texture", "get_param_texture", PARAM_SCALE);
 	ADD_SUBGROUP("Scale Over Velocity", "");
@@ -2410,6 +2579,12 @@ ParticleProcessMaterial::ParticleProcessMaterial() :
 	set_param_max(PARAM_ANIM_OFFSET, 0);
 	set_param_min(PARAM_DIRECTIONAL_VELOCITY, 1.0);
 	set_param_max(PARAM_DIRECTIONAL_VELOCITY, 1.0);
+	set_use_scale_3d(false);
+	set_scale_3d_min(Vector3(1.0, 1.0, 1.0));
+	set_scale_3d_max(Vector3(1.0, 1.0, 1.0));
+	set_use_rotation_3d(false);
+	set_rotation_3d_min(Vector3(0.0, 0.0, 0.0));
+	set_rotation_3d_max(Vector3(0.0, 0.0, 0.0));
 	set_emission_shape(EMISSION_SHAPE_POINT);
 	set_emission_sphere_radius(1);
 	set_emission_box_extents(Vector3(1, 1, 1));

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -128,6 +128,8 @@ private:
 		uint64_t emission_curve : 1;
 		uint64_t has_initial_ramp : 1;
 		uint64_t orbit_uses_curve_xyz : 1;
+		uint64_t use_scale_3d : 1;
+		uint64_t use_rotation_3d : 1;
 
 		MaterialKey() {
 			memset(this, 0, sizeof(MaterialKey));
@@ -173,6 +175,8 @@ private:
 		mk.has_initial_ramp = color_initial_ramp.is_valid() ? 1 : 0;
 		CurveXYZTexture *texture = Object::cast_to<CurveXYZTexture>(tex_parameters[PARAM_ORBIT_VELOCITY].ptr());
 		mk.orbit_uses_curve_xyz = texture ? 1 : 0;
+		mk.use_scale_3d = use_scale_3d ? 1 : 0;
+		mk.use_rotation_3d = use_rotation_3d ? 1 : 0;
 
 		for (int i = 0; i < PARAM_MAX; i++) {
 			if (tex_parameters[i].is_valid()) {
@@ -210,6 +214,8 @@ private:
 		StringName anim_speed_min;
 		StringName anim_offset_min;
 		StringName directional_velocity_min;
+		StringName scale_3d_min;
+		StringName rotation_3d_min;
 
 		StringName initial_linear_velocity_max;
 		StringName initial_angle_max;
@@ -226,6 +232,8 @@ private:
 		StringName anim_speed_max;
 		StringName anim_offset_max;
 		StringName directional_velocity_max;
+		StringName scale_3d_max;
+		StringName rotation_3d_max;
 
 		StringName angle_texture;
 		StringName angular_velocity_texture;
@@ -347,6 +355,13 @@ private:
 	double lifetime_randomness = 0.0;
 	double inherit_emitter_velocity_ratio = 0.0;
 
+	bool use_rotation_3d = false;
+	bool use_scale_3d = false;
+	Vector3 scale_3d_min;
+	Vector3 scale_3d_max;
+	Vector3 rotation_3d_min;
+	Vector3 rotation_3d_max;
+
 	SubEmitterMode sub_emitter_mode;
 	double sub_emitter_frequency = 0.0;
 	int sub_emitter_amount_at_end = 0;
@@ -408,6 +423,24 @@ public:
 
 	void set_emission_curve(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_emission_curve() const;
+
+	void set_use_scale_3d(const bool p_use_scale_3d);
+	bool is_using_scale_3d() const;
+
+	void set_scale_3d_min(const Vector3 &p_scale_3d_min);
+	Vector3 get_scale_3d_min() const;
+
+	void set_scale_3d_max(const Vector3 &p_scale_3d_max);
+	Vector3 get_scale_3d_max() const;
+
+	void set_use_rotation_3d(const bool p_use_scale_3d);
+	bool is_using_rotation_3d() const;
+
+	void set_rotation_3d_min(const Vector3 &p_rotation_3d_min);
+	Vector3 get_rotation_3d_min() const;
+
+	void set_rotation_3d_max(const Vector3 &p_rotation_3d_max);
+	Vector3 get_rotation_3d_max() const;
 
 	void set_particle_flag(ParticleFlags p_particle_flag, bool p_enable);
 	bool get_particle_flag(ParticleFlags p_particle_flag) const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13020

EDIT: more details and test project.

- Added `scale_3d_max` and `scale_3d_min`. Works for both 2d and 3d.
- Added `angle_3d_max` and `angle_3d_min`. Works only in 3d.

Test project: 
[ange-3d-scale-3d.zip](https://github.com/user-attachments/files/23397389/ange-3d-scale-3d.zip)

screenshot:
<img width="1165" height="560" alt="image" src="https://github.com/user-attachments/assets/8b7cdb57-3440-4a42-b03b-8d6c33b1cf18" />
<img width="716" height="619" alt="image" src="https://github.com/user-attachments/assets/47e183fd-912f-415f-9b5b-39804e8255a7" />


video:

https://github.com/user-attachments/assets/a68b21c3-d5f9-40b6-a06e-22bebd4541e8

