### PR TITLE
Add extra panels to some areas of the editor

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1527,8 +1527,16 @@ ProjectExportDialog::ProjectExportDialog() {
 	settings_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbox->add_child(settings_vb);
 
+	PanelContainer *panel = memnew(PanelContainer);
+	panel->set_theme_type_variation(SNAME("PanelForeground"));
+	settings_vb->add_child(panel);
+
+	VBoxContainer *top_settings = memnew(VBoxContainer);
+	top_settings->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	panel->add_child(top_settings);
+
 	name = memnew(LineEdit);
-	settings_vb->add_margin_child(TTR("Name:"), name);
+	top_settings->add_margin_child(TTR("Name:"), name);
 	name->connect(SceneStringName(text_submitted), callable_mp(this, &ProjectExportDialog::_name_changed));
 	name->connect(SceneStringName(focus_exited), callable_mp(this, &ProjectExportDialog::_name_editing_finished));
 
@@ -1547,10 +1555,10 @@ ProjectExportDialog::ProjectExportDialog() {
 	preset_configs_container->add_spacer(true);
 	preset_configs_container->add_child(advanced_options);
 	preset_configs_container->add_child(runnable);
-	settings_vb->add_child(preset_configs_container);
+	top_settings->add_child(preset_configs_container);
 
 	export_path = memnew(EditorPropertyPath);
-	settings_vb->add_child(export_path);
+	top_settings->add_child(export_path);
 	export_path->set_label(TTR("Export Path"));
 	export_path->set_object_and_property(this, "export_path");
 	export_path->set_save_mode();

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1935,6 +1935,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	// Display the same tooltips as in the Import dock.
 	inspector->set_object_class(ResourceImporterScene::get_class_static());
 	inspector->set_use_doc_hints(true);
+	inspector->set_theme_type_variation(SNAME("EditorInspectorForeground"));
 
 	property_split->add_child(inspector);
 

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -186,6 +186,8 @@ public:
 		Ref<StyleBoxFlat> panel_container_style;
 		Ref<StyleBoxFlat> content_panel_style;
 		Ref<StyleBoxFlat> tree_panel_style;
+		Ref<StyleBoxFlat> tab_container_style;
+		Ref<StyleBoxFlat> foreground_panel;
 
 		Vector2 widget_margin;
 

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -337,6 +337,8 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_config.content_panel_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
 			p_config.content_panel_style->set_content_margin_individual(content_panel_margin, 2 * EDSCALE + content_panel_margin, content_panel_margin, content_panel_margin);
 
+			p_config.tab_container_style = p_config.content_panel_style;
+
 			// Trees and similarly inset panels.
 
 			p_config.tree_panel_style = p_config.base_style->duplicate();
@@ -816,7 +818,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
 		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 		p_theme->set_stylebox("tabbar_background", "TabContainer", style_tabbar_background);
-		p_theme->set_stylebox(SceneStringName(panel), "TabContainer", p_config.content_panel_style);
+		p_theme->set_stylebox(SceneStringName(panel), "TabContainer", p_config.tab_container_style);
 
 		p_theme->set_stylebox("tab_selected", "TabContainer", style_tab_selected);
 		p_theme->set_stylebox("tab_hovered", "TabContainer", style_tab_hovered);
@@ -1971,6 +1973,10 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		// Secondary trees and item lists.
 		p_theme->set_type_variation("TreeSecondary", "Tree");
 		p_theme->set_type_variation("ItemListSecondary", "ItemList");
+
+		// ForegroundPanel.
+		p_theme->set_type_variation("PanelForeground", "Panel");
+		p_theme->set_stylebox(SceneStringName(panel), "PanelForeground", p_config.base_empty_style);
 	}
 
 	// Editor inspector.
@@ -2088,7 +2094,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
 			p_theme->set_stylebox("DictionaryAddItem" + itos(i + 1), EditorStringName(EditorStyles), style_dictionary_add_item);
 
-			// Object selector;
+			// Object selector.
 			p_theme->set_type_variation("ObjectSelectorMargin", "MarginContainer");
 			p_theme->set_constant("margin_left", "ObjectSelectorMargin", 4 * EDSCALE);
 			p_theme->set_constant("margin_right", "ObjectSelectorMargin", 6 * EDSCALE);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -384,6 +384,14 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_config.content_panel_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
 			p_config.content_panel_style->set_content_margin_individual(content_panel_margin, 2 * EDSCALE + content_panel_margin, content_panel_margin, content_panel_margin);
 
+			p_config.tab_container_style = p_config.base_style->duplicate();
+			p_config.tab_container_style->set_content_margin_all(p_config.increased_margin * 1.5 * EDSCALE);
+			p_config.tab_container_style->set_corner_radius_individual(0, 0, p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE);
+
+			p_config.foreground_panel = p_config.tab_container_style->duplicate();
+			p_config.foreground_panel->set_corner_radius(CORNER_TOP_LEFT, p_config.tab_container_style->get_corner_radius(CORNER_BOTTOM_LEFT));
+			p_config.foreground_panel->set_corner_radius(CORNER_TOP_RIGHT, p_config.tab_container_style->get_corner_radius(CORNER_BOTTOM_RIGHT));
+
 			// Trees and similarly inset panels.
 
 			p_config.tree_panel_style = p_config.base_style->duplicate();
@@ -755,12 +763,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 		style_tabbar_background->set_content_margin_individual(0, 0, p_config.base_margin * 0.25 * EDSCALE, 0);
 
-		Ref<StyleBoxFlat> style_panel = p_config.base_style->duplicate();
-		style_panel->set_content_margin_all(p_config.increased_margin * 1.5 * EDSCALE);
-		style_panel->set_corner_radius_individual(0, 0, p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE);
-
 		p_theme->set_stylebox("tabbar_background", "TabContainer", style_tabbar_background);
-		p_theme->set_stylebox(SceneStringName(panel), "TabContainer", style_panel);
+		p_theme->set_stylebox(SceneStringName(panel), "TabContainer", p_config.tab_container_style);
 
 		p_theme->set_stylebox("tab_selected", "TabContainer", style_tab_selected);
 		p_theme->set_stylebox("tab_hovered", "TabContainer", style_tab_hovered);
@@ -1500,14 +1504,10 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, EditorThemeManager::ThemeConfiguration &p_config) {
 	// Project manager.
 	{
-		Ref<StyleBoxFlat> style_panel_container = p_theme->get_stylebox(SceneStringName(panel), SNAME("TabContainer"))->duplicate();
-		style_panel_container->set_corner_radius(CORNER_TOP_LEFT, style_panel_container->get_corner_radius(CORNER_BOTTOM_LEFT));
-		style_panel_container->set_corner_radius(CORNER_TOP_RIGHT, style_panel_container->get_corner_radius(CORNER_BOTTOM_RIGHT));
-
 		Ref<StyleBoxFlat> style_project_list = p_config.base_style->duplicate();
 		style_project_list->set_bg_color(p_config.surface_low_color);
 
-		p_theme->set_stylebox("panel_container", "ProjectManager", style_panel_container);
+		p_theme->set_stylebox("panel_container", "ProjectManager", p_config.foreground_panel);
 		p_theme->set_stylebox("project_list", "ProjectManager", style_project_list);
 		p_theme->set_stylebox("quick_settings_panel", "ProjectManager", style_project_list);
 		p_theme->set_constant("sidebar_button_icon_separation", "ProjectManager", int(6 * EDSCALE));
@@ -1927,6 +1927,15 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			// as the debugger inspector is too small to be considered a main area.
 			p_theme->set_stylebox(SceneStringName(panel), "EditorDebuggerInspector", style_sidebar);
 		}
+
+		// ForegroundPanel.
+		{
+			p_theme->set_type_variation("PanelForeground", "Panel");
+			p_theme->set_type_variation("EditorInspectorForeground", "EditorInspector");
+
+			p_theme->set_stylebox(SceneStringName(panel), "PanelForeground", p_config.foreground_panel);
+			p_theme->set_stylebox(SceneStringName(panel), "EditorInspectorForeground", p_config.foreground_panel);
+		}
 	}
 
 	// Editor inspector.
@@ -2092,7 +2101,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		Ref<StyleBoxEmpty> style_dictionary_add_item = EditorThemeManager::make_empty_stylebox(0, 4, 0, 4);
 		p_theme->set_stylebox("DictionaryAddItem0", EditorStringName(EditorStyles), style_dictionary_add_item);
 
-		// Object selector;
+		// Object selector.
 		p_theme->set_type_variation("ObjectSelectorMargin", "MarginContainer");
 		p_theme->set_constant("margin_left", "ObjectSelectorMargin", p_config.base_margin * 2 * EDSCALE);
 		p_theme->set_constant("margin_right", "ObjectSelectorMargin", p_config.base_margin * 2.5 * EDSCALE);


### PR DESCRIPTION
As per @passivestar's recommendation, this adds panels to some areas of the editor in the modern theme:
<img width="1666" height="1118" alt="Screenshot_20251105_004958" src="https://github.com/user-attachments/assets/124739aa-4b8d-4b3c-8509-86a844ebbd20" />
<img width="1030" height="847" alt="Screenshot_20251105_022911" src="https://github.com/user-attachments/assets/681f30b5-f8f2-4a83-9b5b-4a6a208f0398" />