### PR TITLE
Add microshadows support

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -291,6 +291,14 @@
 		<member name="metallic_texture_channel" type="int" setter="set_metallic_texture_channel" getter="get_metallic_texture_channel" enum="BaseMaterial3D.TextureChannel" default="0">
 			Specifies the channel of the [member metallic_texture] in which the metallic information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
+		<member name="micro_shadows_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
+			If [code]true[/code] and [member ProjectSettings.rendering/lights_and_shadows/micro_shadows/enabled] is [code]true[/code], micro-shadows are enabled. Micro-shadows can help improve the appearance of ambient occlusion by simulating small details embedded in the materials. This property serves as a physically-based alternative to [member ao_light_affect].
+		</member>
+		<member name="micro_shadows_strength" type="float" setter="set_micro_shadows_strength" getter="get_micro_shadows_strength" default="0.85">
+			Amount of micro shadowing applied to ambient occlusion. Higher values result in more shadowing in crevices and corners, while lower values result in less shadowing.
+			[b]Note:[/b] This setting only has an effect if directional lights are present in the scene. It does not affect light rendering with [OmniLight3D] and [SpotLight3D].
+			[b]Note:[/b] For best results, this setting requires an [member ao_texture] and a [member normal_texture] generated with the same pipeline.
+		</member>
 		<member name="msdf_outline_size" type="float" setter="set_msdf_outline_size" getter="get_msdf_outline_size" default="0.0">
 			The width of the shape outline.
 		</member>
@@ -647,7 +655,10 @@
 		<constant name="FEATURE_BENT_NORMAL_MAPPING" value="12" enum="Feature">
 			Constant for setting [member bent_normal_enabled].
 		</constant>
-		<constant name="FEATURE_MAX" value="13" enum="Feature">
+		<constant name="FEATURE_MICRO_SHADOWS" value="13" enum="Feature">
+			Constant for setting [member micro_shadows_enabled].
+		</constant>
+		<constant name="FEATURE_MAX" value="14" enum="Feature">
 			Represents the size of the [enum Feature] enum.
 		</constant>
 		<constant name="BLEND_MODE_MIX" value="0" enum="BlendMode">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3138,6 +3138,9 @@
 		<member name="rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality] on mobile devices, due to performance concerns or driver support.
 		</member>
+		<member name="rendering/lights_and_shadows/micro_shadows/enabled" type="bool" setter="" getter="" default="true">
+			If [code]false[/code], disable micro-shadowing globally for all [BaseMaterial3D] and [ShaderMaterial] instances.
+		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/atlas_16_bits" type="bool" setter="" getter="" default="true">
 			Use 16 bits for the omni/spot shadow depth map. Enabling this results in shadows having less precision and may result in shadow acne, but can lead to performance improvements on some devices.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3172,6 +3172,9 @@
 		<member name="rendering/lights_and_shadows/multi_bounce_occlusion/enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], approximates local multi-bounce global illumination in ambient occlusion by integrating albedo information.
 		</member>
+		<member name="rendering/lights_and_shadows/micro_shadows/enabled" type="bool" setter="" getter="" default="true">
+			If [code]false[/code], disable micro-shadowing globally for all [BaseMaterial3D] and [ShaderMaterial] instances.
+		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/atlas_16_bits" type="bool" setter="" getter="" default="true">
 			Use 16 bits for the omni/spot shadow depth map. Enabling this results in shadows having less precision and may result in shadow acne, but can lead to performance improvements on some devices.
 		</member>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4429,6 +4429,9 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 		if (!config->specular_occlusion) {
 			global_defines += "\n#define SPECULAR_OCCLUSION_DISABLED\n";
 		}
+		if (!config->micro_shadows) {
+			global_defines += "\n#define MICRO_SHADOWS_DISABLED\n";
+		}
 		material_storage->shaders.scene_shader.initialize(global_defines);
 		scene_globals.shader_default_version = material_storage->shaders.scene_shader.version_create();
 		material_storage->shaders.scene_shader.version_bind_shader(scene_globals.shader_default_version, SceneShaderGLES3::MODE_COLOR);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4691,6 +4691,9 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 		if (!config->specular_occlusion) {
 			global_defines += "\n#define SPECULAR_OCCLUSION_DISABLED\n";
 		}
+		if (!config->micro_shadows) {
+			global_defines += "\n#define MICRO_SHADOWS_DISABLED\n";
+		}
 		material_storage->shaders.scene_shader.initialize(global_defines);
 		scene_globals.shader_default_version = material_storage->shaders.scene_shader.version_create();
 		material_storage->shaders.scene_shader.version_bind_shader(scene_globals.shader_default_version, SceneShaderGLES3::MODE_COLOR);

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1522,6 +1522,13 @@ float V_Kelemen(float LdotH) {
 	return 0.25 / (LdotH * LdotH + 1e-4);
 }
 
+// Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
+float compute_micro_shadowing(float NoL, float ao, float opacity) {
+	float aperture = 2.0 * ao * ao;
+	float microshadow = clamp(NoL + aperture - 1.0, 0.0, 1.0);
+	return mix(1.0, microshadow, opacity);
+}
+
 void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_directional, float attenuation, vec3 f0, float roughness, float metallic, float specular_amount, vec3 albedo, inout float alpha, vec2 screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
@@ -2040,7 +2047,9 @@ void main() {
 #endif
 
 	float ao = 1.0;
+	float direct_ao = 0.0;
 	float ao_light_affect = 0.0;
+	float micro_shadows = 0.0;
 
 	float alpha = 1.0;
 
@@ -2396,7 +2405,7 @@ void main() {
 #endif // !AMBIENT_LIGHT_DISABLED
 
 	// convert ao to direct light ao
-	ao = mix(1.0, ao, ao_light_affect);
+	direct_ao = mix(1.0, ao, ao_light_affect);
 #ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
@@ -2550,7 +2559,7 @@ void main() {
 	normal_output_buffer.rgb = normal * 0.5 + 0.5;
 	normal_output_buffer.a = 0.0;
 
-	orm_output_buffer.r = ao;
+	orm_output_buffer.r = direct_ao;
 	orm_output_buffer.g = roughness;
 	orm_output_buffer.b = metallic;
 	orm_output_buffer.a = 1.0;
@@ -2747,6 +2756,16 @@ void main() {
 #else
 	float directional_shadow = 1.0f;
 #endif // SHADOWS_DISABLED
+
+#ifndef MICRO_SHADOWS_DISABLED
+#ifdef BENT_NORMAL_MAP_USED
+	float NdotL = dot(bent_normal_vector, directional_lights[directional_shadow_index].direction);
+#else
+	float NdotL = dot(normal, directional_lights[directional_shadow_index].direction);
+#endif // BENT_NORMAL_MAP_USED
+	// Disable microshadowing when facing away from light.
+	directional_shadow *= NdotL >= 0.0 ? compute_micro_shadowing(NdotL, ao, micro_shadows) : 1.0;
+#endif // MICRO_SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
 	if (bool(directional_lights[directional_shadow_index].mask & layer_mask)) {

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1598,6 +1598,13 @@ float V_Kelemen(float LdotH) {
 	return 0.25 / (LdotH * LdotH + 1e-4);
 }
 
+// Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
+float compute_micro_shadowing(float NoL, float ao, float opacity) {
+	float aperture = 2.0 * ao * ao;
+	float microshadow = clamp(NoL + aperture - 1.0, 0.0, 1.0);
+	return mix(1.0, microshadow, opacity);
+}
+
 void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_directional, float attenuation, vec3 f0, float roughness, float metallic, float specular_amount, vec3 albedo, inout float alpha, vec2 screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
@@ -2267,7 +2274,9 @@ void main() {
 #endif
 
 	float ao = 1.0;
+	float direct_ao = 0.0;
 	float ao_light_affect = 0.0;
+	float micro_shadows = 0.0;
 
 	float alpha = 1.0;
 
@@ -2756,7 +2765,7 @@ void main() {
 #endif // !AMBIENT_LIGHT_DISABLED
 
 	// convert ao to direct light ao
-	ao = mix(1.0, ao, ao_light_affect);
+	direct_ao = mix(1.0, ao, ao_light_affect);
 #ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
@@ -2936,7 +2945,7 @@ void main() {
 	normal_output_buffer.rgb = normal * 0.5 + 0.5;
 	normal_output_buffer.a = 0.0;
 
-	orm_output_buffer.r = ao;
+	orm_output_buffer.r = direct_ao;
 	orm_output_buffer.g = roughness;
 	orm_output_buffer.b = metallic;
 	orm_output_buffer.a = 1.0;
@@ -3137,6 +3146,16 @@ void main() {
 #else
 	float directional_shadow = 1.0f;
 #endif // SHADOWS_DISABLED
+
+#ifndef MICRO_SHADOWS_DISABLED
+#ifdef BENT_NORMAL_MAP_USED
+	float NdotL = dot(bent_normal_vector, directional_lights[directional_shadow_index].direction);
+#else
+	float NdotL = dot(normal, directional_lights[directional_shadow_index].direction);
+#endif // BENT_NORMAL_MAP_USED
+	// Disable microshadowing when facing away from light.
+	directional_shadow *= NdotL >= 0.0 ? compute_micro_shadowing(NdotL, ao, micro_shadows) : 1.0;
+#endif // MICRO_SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
 	if (bool(directional_lights[directional_shadow_index].mask & layer_mask)) {

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -193,6 +193,7 @@ Config::Config() {
 
 	force_vertex_shading = GLOBAL_GET("rendering/shading/overrides/force_vertex_shading");
 	specular_occlusion = GLOBAL_GET("rendering/reflections/specular_occlusion/enabled");
+	micro_shadows = GLOBAL_GET("rendering/lights_and_shadows/micro_shadows/enabled");
 	use_nearest_mip_filter = GLOBAL_GET("rendering/textures/default_filters/use_nearest_mipmap_filter");
 
 	use_depth_prepass = bool(GLOBAL_GET("rendering/driver/depth_prepass/enable"));

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -197,6 +197,7 @@ Config::Config() {
 
 	force_vertex_shading = GLOBAL_GET("rendering/shading/overrides/force_vertex_shading");
 	specular_occlusion = GLOBAL_GET("rendering/reflections/specular_occlusion/enabled");
+	micro_shadows = GLOBAL_GET("rendering/lights_and_shadows/micro_shadows/enabled");
 	use_nearest_mip_filter = GLOBAL_GET("rendering/textures/default_filters/use_nearest_mipmap_filter");
 
 	use_depth_prepass = bool(GLOBAL_GET("rendering/driver/depth_prepass/enable"));

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -91,6 +91,7 @@ public:
 
 	bool force_vertex_shading = false;
 	bool specular_occlusion = false;
+	bool micro_shadows = false;
 
 	bool support_anisotropic_filter = false;
 	float anisotropic_level = 0.0f;

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -89,6 +89,7 @@ public:
 
 	bool force_vertex_shading = false;
 	bool specular_occlusion = false;
+	bool micro_shadows = false;
 
 	bool support_anisotropic_filter = false;
 	float anisotropic_level = 0.0f;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1309,6 +1309,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["BACKLIGHT"] = "backlight";
 		actions.renames["AO"] = "ao";
 		actions.renames["AO_LIGHT_AFFECT"] = "ao_light_affect";
+		actions.renames["MICRO_SHADOWS"] = "micro_shadows";
 		actions.renames["EMISSION"] = "emission";
 		actions.renames["POINT_COORD"] = "gl_PointCoord";
 		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
@@ -1423,6 +1424,8 @@ MaterialStorage::MaterialStorage() {
 		actions.render_mode_defines["fog_disabled"] = "#define FOG_DISABLED\n";
 
 		actions.render_mode_defines["specular_occlusion_disabled"] = "#define SPECULAR_OCCLUSION_DISABLED\n";
+
+		actions.render_mode_defines["micro_shadows_disabled"] = "#define MICRO_SHADOWS_DISABLED\n";
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1321,6 +1321,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["BACKLIGHT"] = "backlight";
 		actions.renames["AO"] = "ao";
 		actions.renames["AO_LIGHT_AFFECT"] = "ao_light_affect";
+		actions.renames["MICRO_SHADOWS"] = "micro_shadows";
 		actions.renames["EMISSION"] = "emission";
 		actions.renames["POINT_COORD"] = "gl_PointCoord";
 		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
@@ -1441,6 +1442,8 @@ MaterialStorage::MaterialStorage() {
 		actions.render_mode_defines["fog_disabled"] = "#define FOG_DISABLED\n";
 
 		actions.render_mode_defines["specular_occlusion_disabled"] = "#define SPECULAR_OCCLUSION_DISABLED\n";
+
+		actions.render_mode_defines["micro_shadows_disabled"] = "#define MICRO_SHADOWS_DISABLED\n";
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8247,6 +8247,7 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	HashMap<String, Variant> settings;
 	settings["physics/3d/physics_engine"] = "Jolt Physics";
 	settings["rendering/rendering_device/driver.windows"] = "d3d12";
+	settings["rendering/lights_and_shadows/micro_shadows/enabled"] = true;
 	return settings;
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8434,6 +8434,7 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	settings["physics/3d/physics_engine"] = "Jolt Physics";
 	settings["rendering/rendering_device/driver.windows"] = "d3d12";
 	settings["rendering/lights_and_shadows/multi_bounce_occlusion/enabled"] = true;
+	settings["rendering/lights_and_shadows/micro_shadows/enabled"] = true;
 	return settings;
 }
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -627,6 +627,7 @@ void BaseMaterial3D::init_shaders() {
 	shader_names->grow = "grow";
 
 	shader_names->ao_light_affect = "ao_light_affect";
+	shader_names->micro_shadows_strength = "micro_shadows_strength";
 
 	shader_names->proximity_fade_distance = "proximity_fade_distance";
 	shader_names->distance_fade_min = "distance_fade_min";
@@ -902,6 +903,9 @@ void BaseMaterial3D::_update_shader() {
 	if (transparency == TRANSPARENCY_ALPHA_DEPTH_PRE_PASS) {
 		code += ", depth_prepass_alpha";
 	}
+	if (flags[FLAG_DISABLE_MICRO_SHADOWS]) {
+		code += ", micro_shadows_disabled";
+	}
 
 	// Although it's technically possible to do alpha antialiasing without using alpha hash or alpha scissor,
 	// it is restricted in the base material because it has no use, and abusing it with regular Alpha blending can
@@ -1134,6 +1138,10 @@ uniform vec4 ao_texture_channel;
 uniform float ao_light_affect : hint_range(0.0, 1.0, 0.01);
 )",
 				texfilter_str);
+	}
+
+	if (!flags[FLAG_DISABLE_MICRO_SHADOWS]) {
+		code += "uniform float micro_shadows_strength : hint_range(0.0, 1.0, 0.01);";
 	}
 
 	if (features[FEATURE_DETAIL]) {
@@ -1963,6 +1971,13 @@ void fragment() {)";
 		code += "	AO_LIGHT_AFFECT = ao_light_affect;\n";
 	}
 
+	if (!flags[FLAG_DISABLE_MICRO_SHADOWS]) {
+		code += R"(
+	// Micro Shadows: Enabled
+)";
+		code += "	MICRO_SHADOWS = micro_shadows_strength;\n";
+	}
+
 	if (features[FEATURE_SUBSURFACE_SCATTERING]) {
 		code += R"(
 	// Subsurface Scattering: Enabled
@@ -2255,6 +2270,15 @@ void BaseMaterial3D::set_ao_light_affect(float p_ao_light_affect) {
 
 float BaseMaterial3D::get_ao_light_affect() const {
 	return ao_light_affect;
+}
+
+void BaseMaterial3D::set_micro_shadows_strength(float p_micro_shadows_strength) {
+	micro_shadows_strength = p_micro_shadows_strength;
+	_material_set_param(shader_names->micro_shadows_strength, p_micro_shadows_strength);
+}
+
+float BaseMaterial3D::get_micro_shadows_strength() const {
+	return micro_shadows_strength;
 }
 
 void BaseMaterial3D::set_clearcoat(float p_clearcoat) {
@@ -3522,6 +3546,9 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ao_light_affect", "amount"), &BaseMaterial3D::set_ao_light_affect);
 	ClassDB::bind_method(D_METHOD("get_ao_light_affect"), &BaseMaterial3D::get_ao_light_affect);
 
+	ClassDB::bind_method(D_METHOD("set_micro_shadows_strength", "amount"), &BaseMaterial3D::set_micro_shadows_strength);
+	ClassDB::bind_method(D_METHOD("get_micro_shadows_strength"), &BaseMaterial3D::get_micro_shadows_strength);
+
 	ClassDB::bind_method(D_METHOD("set_alpha_scissor_threshold", "threshold"), &BaseMaterial3D::set_alpha_scissor_threshold);
 	ClassDB::bind_method(D_METHOD("get_alpha_scissor_threshold"), &BaseMaterial3D::get_alpha_scissor_threshold);
 
@@ -3607,6 +3634,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "disable_ambient_light"), "set_flag", "get_flag", FLAG_DISABLE_AMBIENT_LIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "disable_fog"), "set_flag", "get_flag", FLAG_DISABLE_FOG);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "disable_specular_occlusion"), "set_flag", "get_flag", FLAG_DISABLE_SPECULAR_OCCLUSION);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "disable_micro_shadows"), "set_flag", "get_flag", FLAG_DISABLE_MICRO_SHADOWS);
 
 	ADD_GROUP("Vertex Color", "vertex_color");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "vertex_color_use_as_albedo"), "set_flag", "get_flag", FLAG_ALBEDO_FROM_VERTEX_COLOR);
@@ -3674,6 +3702,9 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "ao_texture", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), "set_texture", "get_texture", TEXTURE_AMBIENT_OCCLUSION);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "ao_on_uv2"), "set_flag", "get_flag", FLAG_AO_ON_UV2);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ao_texture_channel", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Gray"), "set_ao_texture_channel", "get_ao_texture_channel");
+
+	ADD_GROUP("Micro Shadows", "micro_shadows_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "micro_shadows_strength", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_micro_shadows_strength", "get_micro_shadows_strength");
 
 	ADD_GROUP("Height", "heightmap_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "heightmap_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_feature", "get_feature", FEATURE_HEIGHT_MAPPING);
@@ -3889,6 +3920,7 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_DISABLE_SPECULAR_OCCLUSION);
 	BIND_ENUM_CONSTANT(FLAG_USE_Z_CLIP_SCALE);
 	BIND_ENUM_CONSTANT(FLAG_USE_FOV_OVERRIDE);
+	BIND_ENUM_CONSTANT(FLAG_DISABLE_MICRO_SHADOWS);
 	BIND_ENUM_CONSTANT(FLAG_MAX);
 
 	BIND_ENUM_CONSTANT(DIFFUSE_BURLEY);
@@ -3985,6 +4017,7 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	set_distance_fade_max_distance(10);
 
 	set_ao_light_affect(0.0);
+	set_micro_shadows_strength(0.85);
 
 	set_metallic_texture_channel(TEXTURE_CHANNEL_RED);
 	set_roughness_texture_channel(TEXTURE_CHANNEL_RED);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -594,6 +594,7 @@ void BaseMaterial3D::init_shaders() {
 	shader_names->grow = "grow";
 
 	shader_names->ao_light_affect = "ao_light_affect";
+	shader_names->micro_shadows_strength = "micro_shadows_strength";
 
 	shader_names->proximity_fade_distance = "proximity_fade_distance";
 	shader_names->distance_fade_min = "distance_fade_min";
@@ -869,6 +870,9 @@ void BaseMaterial3D::_update_shader() {
 	if (transparency == TRANSPARENCY_ALPHA_DEPTH_PRE_PASS) {
 		code += ", depth_prepass_alpha";
 	}
+	if (flags[FLAG_DISABLE_MICRO_SHADOWS]) {
+		code += ", micro_shadows_disabled";
+	}
 
 	// Although it's technically possible to do alpha antialiasing without using alpha hash or alpha scissor,
 	// it is restricted in the base material because it has no use, and abusing it with regular Alpha blending can
@@ -1101,6 +1105,10 @@ uniform vec4 ao_texture_channel;
 uniform float ao_light_affect : hint_range(0.0, 1.0, 0.01);
 )",
 				texfilter_str);
+	}
+
+	if (!flags[FLAG_DISABLE_MICRO_SHADOWS]) {
+		code += "uniform float micro_shadows_strength : hint_range(0.0, 1.0, 0.01);";
 	}
 
 	if (features[FEATURE_DETAIL]) {
@@ -1930,6 +1938,13 @@ void fragment() {)";
 		code += "	AO_LIGHT_AFFECT = ao_light_affect;\n";
 	}
 
+	if (!flags[FLAG_DISABLE_MICRO_SHADOWS]) {
+		code += R"(
+	// Micro Shadows: Enabled
+)";
+		code += "	MICRO_SHADOWS = micro_shadows_strength;\n";
+	}
+
 	if (features[FEATURE_SUBSURFACE_SCATTERING]) {
 		code += R"(
 	// Subsurface Scattering: Enabled
@@ -2224,6 +2239,15 @@ float BaseMaterial3D::get_ao_light_affect() const {
 	return ao_light_affect;
 }
 
+void BaseMaterial3D::set_micro_shadows_strength(float p_micro_shadows_strength) {
+	micro_shadows_strength = p_micro_shadows_strength;
+	_material_set_param(shader_names->micro_shadows_strength, p_micro_shadows_strength);
+}
+
+float BaseMaterial3D::get_micro_shadows_strength() const {
+	return micro_shadows_strength;
+}
+
 void BaseMaterial3D::set_clearcoat(float p_clearcoat) {
 	clearcoat = p_clearcoat;
 	_material_set_param(shader_names->clearcoat, p_clearcoat);
@@ -2474,7 +2498,8 @@ void BaseMaterial3D::set_flag(Flags p_flag, bool p_enabled) {
 			p_flag == FLAG_UV2_USE_TRIPLANAR ||
 			p_flag == FLAG_USE_Z_CLIP_SCALE ||
 			p_flag == FLAG_USE_FOV_OVERRIDE ||
-			p_flag == FLAG_DISABLE_DEPTH_TEST) {
+			p_flag == FLAG_DISABLE_DEPTH_TEST ||
+			p_flag == FLAG_DISABLE_MICRO_SHADOWS) {
 		notify_property_list_changed();
 	}
 
@@ -2720,6 +2745,12 @@ void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
 		}
 
 		if (p_property.name.begins_with("transmittance")) {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+	}
+
+	if (flags[FLAG_DISABLE_MICRO_SHADOWS] || !GLOBAL_GET_CACHED(bool, "rendering/lights_and_shadows/micro_shadows/enabled")) {
+		if (p_property.name == "micro_shadows_strength") {
 			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
@@ -3489,6 +3520,9 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ao_light_affect", "amount"), &BaseMaterial3D::set_ao_light_affect);
 	ClassDB::bind_method(D_METHOD("get_ao_light_affect"), &BaseMaterial3D::get_ao_light_affect);
 
+	ClassDB::bind_method(D_METHOD("set_micro_shadows_strength", "amount"), &BaseMaterial3D::set_micro_shadows_strength);
+	ClassDB::bind_method(D_METHOD("get_micro_shadows_strength"), &BaseMaterial3D::get_micro_shadows_strength);
+
 	ClassDB::bind_method(D_METHOD("set_alpha_scissor_threshold", "threshold"), &BaseMaterial3D::set_alpha_scissor_threshold);
 	ClassDB::bind_method(D_METHOD("get_alpha_scissor_threshold"), &BaseMaterial3D::get_alpha_scissor_threshold);
 
@@ -3574,6 +3608,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "disable_ambient_light"), "set_flag", "get_flag", FLAG_DISABLE_AMBIENT_LIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "disable_fog"), "set_flag", "get_flag", FLAG_DISABLE_FOG);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "disable_specular_occlusion"), "set_flag", "get_flag", FLAG_DISABLE_SPECULAR_OCCLUSION);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "disable_micro_shadows"), "set_flag", "get_flag", FLAG_DISABLE_MICRO_SHADOWS);
 
 	ADD_GROUP("Vertex Color", "vertex_color");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "vertex_color_use_as_albedo"), "set_flag", "get_flag", FLAG_ALBEDO_FROM_VERTEX_COLOR);
@@ -3641,6 +3676,9 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "ao_texture", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), "set_texture", "get_texture", TEXTURE_AMBIENT_OCCLUSION);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "ao_on_uv2"), "set_flag", "get_flag", FLAG_AO_ON_UV2);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ao_texture_channel", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Gray"), "set_ao_texture_channel", "get_ao_texture_channel");
+
+	ADD_GROUP("Micro Shadows", "micro_shadows_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "micro_shadows_strength", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_micro_shadows_strength", "get_micro_shadows_strength");
 
 	ADD_GROUP("Height", "heightmap_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "heightmap_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_feature", "get_feature", FEATURE_HEIGHT_MAPPING);
@@ -3857,6 +3895,7 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_DISABLE_SPECULAR_OCCLUSION);
 	BIND_ENUM_CONSTANT(FLAG_USE_Z_CLIP_SCALE);
 	BIND_ENUM_CONSTANT(FLAG_USE_FOV_OVERRIDE);
+	BIND_ENUM_CONSTANT(FLAG_DISABLE_MICRO_SHADOWS);
 	BIND_ENUM_CONSTANT(FLAG_MAX);
 
 	BIND_ENUM_CONSTANT(DIFFUSE_BURLEY);
@@ -3953,6 +3992,7 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	set_distance_fade_max_distance(10);
 
 	set_ao_light_affect(0.0);
+	set_micro_shadows_strength(0.85);
 
 	set_metallic_texture_channel(TEXTURE_CHANNEL_RED);
 	set_roughness_texture_channel(TEXTURE_CHANNEL_RED);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -278,6 +278,7 @@ public:
 		FLAG_DISABLE_SPECULAR_OCCLUSION,
 		FLAG_USE_Z_CLIP_SCALE,
 		FLAG_USE_FOV_OVERRIDE,
+		FLAG_DISABLE_MICRO_SHADOWS,
 		FLAG_MAX
 	};
 
@@ -501,6 +502,7 @@ private:
 		StringName distance_fade_min;
 		StringName distance_fade_max;
 		StringName ao_light_affect;
+		StringName micro_shadows_strength;
 
 		StringName metallic_texture_channel;
 		StringName ao_texture_channel;
@@ -562,6 +564,7 @@ private:
 	float alpha_antialiasing_edge = 0.0f;
 	bool grow_enabled = false;
 	float ao_light_affect = 0.0f;
+	float micro_shadows_strength = 0.0f;
 	float grow = 0.0f;
 	int particles_anim_h_frames = 0;
 	int particles_anim_v_frames = 0;
@@ -674,6 +677,9 @@ public:
 
 	void set_ao_light_affect(float p_ao_light_affect);
 	float get_ao_light_affect() const;
+
+	void set_micro_shadows_strength(float p_micro_shadows);
+	float get_micro_shadows_strength() const;
 
 	void set_clearcoat(float p_clearcoat);
 	float get_clearcoat() const;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -5019,6 +5019,11 @@ RenderForwardClustered::RenderForwardClustered() {
 			defines += "\n#define SPECULAR_OCCLUSION_DISABLED\n";
 		}
 
+		bool micro_shadows = GLOBAL_GET("rendering/lights_and_shadows/micro_shadows/enabled");
+		if (!micro_shadows) {
+			defines += "\n#define MICRO_SHADOWS_DISABLED\n";
+		}
+
 		{
 			//lightmaps
 			scene_state.max_lightmaps = MAX_LIGHTMAPS;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -5139,6 +5139,11 @@ RenderForwardClustered::RenderForwardClustered() {
 			defines += "\n#define SPECULAR_OCCLUSION_DISABLED\n";
 		}
 
+		bool micro_shadows = GLOBAL_GET("rendering/lights_and_shadows/micro_shadows/enabled");
+		if (!micro_shadows) {
+			defines += "\n#define MICRO_SHADOWS_DISABLED\n";
+		}
+
 		{
 			//lightmaps
 			scene_state.max_lightmaps = MAX_LIGHTMAPS;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -764,6 +764,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.renames["BACKLIGHT"] = "backlight";
 		actions.renames["AO"] = "ao";
 		actions.renames["AO_LIGHT_AFFECT"] = "ao_light_affect";
+		actions.renames["MICRO_SHADOWS"] = "micro_shadows";
 		actions.renames["EMISSION"] = "emission";
 		actions.renames["POINT_COORD"] = "point_coord";
 		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
@@ -888,6 +889,8 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.render_mode_defines["fog_disabled"] = "#define FOG_DISABLED\n";
 
 		actions.render_mode_defines["specular_occlusion_disabled"] = "#define SPECULAR_OCCLUSION_DISABLED\n";
+
+		actions.render_mode_defines["micro_shadows_disabled"] = "#define MICRO_SHADOWS_DISABLED\n";
 
 		actions.base_texture_binding_index = 1;
 		actions.texture_layout_set = RenderForwardClustered::MATERIAL_UNIFORM_SET;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -767,6 +767,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.renames["BACKLIGHT"] = "backlight";
 		actions.renames["AO"] = "ao";
 		actions.renames["AO_LIGHT_AFFECT"] = "ao_light_affect";
+		actions.renames["MICRO_SHADOWS"] = "micro_shadows";
 		actions.renames["EMISSION"] = "emission";
 		actions.renames["POINT_COORD"] = "point_coord";
 		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
@@ -897,6 +898,8 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.render_mode_defines["fog_disabled"] = "#define FOG_DISABLED\n";
 
 		actions.render_mode_defines["specular_occlusion_disabled"] = "#define SPECULAR_OCCLUSION_DISABLED\n";
+
+		actions.render_mode_defines["micro_shadows_disabled"] = "#define MICRO_SHADOWS_DISABLED\n";
 
 		actions.base_texture_binding_index = 1;
 		actions.texture_layout_set = RenderForwardClustered::MATERIAL_UNIFORM_SET;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -3454,6 +3454,11 @@ RenderForwardMobile::RenderForwardMobile() {
 		defines += "\n#define SPECULAR_OCCLUSION_DISABLED\n";
 	}
 
+	bool micro_shadows = GLOBAL_GET("rendering/lights_and_shadows/micro_shadows/enabled");
+	if (!micro_shadows) {
+		defines += "\n#define MICRO_SHADOWS_DISABLED\n";
+	}
+
 	{
 		//lightmaps
 		scene_state.max_lightmaps = MAX_LIGHTMAPS;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -3597,6 +3597,11 @@ RenderForwardMobile::RenderForwardMobile() {
 		defines += "\n#define SPECULAR_OCCLUSION_DISABLED\n";
 	}
 
+	bool micro_shadows = GLOBAL_GET("rendering/lights_and_shadows/micro_shadows/enabled");
+	if (!micro_shadows) {
+		defines += "\n#define MICRO_SHADOWS_DISABLED\n";
+	}
+
 	{
 		//lightmaps
 		scene_state.max_lightmaps = MAX_LIGHTMAPS;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -698,6 +698,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.renames["BACKLIGHT"] = "backlight_highp";
 		actions.renames["AO"] = "ao_highp";
 		actions.renames["AO_LIGHT_AFFECT"] = "ao_light_affect_highp";
+		actions.renames["MICRO_SHADOWS"] = "micro_shadows_highp";
 		actions.renames["EMISSION"] = "emission_highp";
 		actions.renames["POINT_COORD"] = "point_coord";
 		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
@@ -821,6 +822,8 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.render_mode_defines["fog_disabled"] = "#define FOG_DISABLED\n";
 
 		actions.render_mode_defines["specular_occlusion_disabled"] = "#define SPECULAR_OCCLUSION_DISABLED\n";
+
+		actions.render_mode_defines["micro_shadows_disabled"] = "#define MICRO_SHADOWS_DISABLED\n";
 
 		actions.base_texture_binding_index = 1;
 		actions.texture_layout_set = RenderForwardMobile::MATERIAL_UNIFORM_SET;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -707,6 +707,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.renames["BACKLIGHT"] = "backlight_highp";
 		actions.renames["AO"] = "ao_highp";
 		actions.renames["AO_LIGHT_AFFECT"] = "ao_light_affect_highp";
+		actions.renames["MICRO_SHADOWS"] = "micro_shadows_highp";
 		actions.renames["EMISSION"] = "emission_highp";
 		actions.renames["POINT_COORD"] = "point_coord";
 		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
@@ -836,6 +837,8 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.render_mode_defines["fog_disabled"] = "#define FOG_DISABLED\n";
 
 		actions.render_mode_defines["specular_occlusion_disabled"] = "#define SPECULAR_OCCLUSION_DISABLED\n";
+
+		actions.render_mode_defines["micro_shadows_disabled"] = "#define MICRO_SHADOWS_DISABLED\n";
 
 		actions.base_texture_binding_index = 1;
 		actions.texture_layout_set = RenderForwardMobile::MATERIAL_UNIFORM_SET;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1246,7 +1246,9 @@ void fragment_shader(in SceneData scene_data) {
 #endif
 
 	float ao = 1.0;
+	float direct_ao = 0.0;
 	float ao_light_affect = 0.0;
+	float micro_shadows = 0.0;
 
 	float alpha_highp = float(instances.data[instance_index].flags >> INSTANCE_FLAGS_FADE_SHIFT) / float(255.0);
 
@@ -2207,7 +2209,7 @@ void fragment_shader(in SceneData scene_data) {
 #endif // AMBIENT_LIGHT_DISABLED
 
 	// convert ao to direct light ao
-	ao = mix(1.0, ao, ao_light_affect);
+	direct_ao = mix(1.0, ao, ao_light_affect);
 
 	//this saves some VGPRs
 	vec3 f0 = F0(metallic, specular, albedo);
@@ -2637,6 +2639,15 @@ void fragment_shader(in SceneData scene_data) {
 			shadow = 1.0;
 #endif
 
+#ifndef MICRO_SHADOWS_DISABLED
+#ifdef BENT_NORMAL_MAP_USED
+			float NdotL = dot(bent_normal_vector, directional_lights.data[i].direction);
+#else
+			float NdotL = dot(normal, directional_lights.data[i].direction);
+#endif // BENT_NORMAL_MAP_USED
+			shadow *= compute_micro_shadowing(NdotL, ao, micro_shadows);
+#endif // MICRO_SHADOWS_DISABLED
+
 			float size_A = sc_use_directional_soft_shadows() ? directional_lights.data[i].size : 0.0;
 
 			light_compute(normal, directional_lights.data[i].direction, normalize(view), size_A,
@@ -2923,7 +2934,7 @@ void fragment_shader(in SceneData scene_data) {
 	normal_output_buffer.a = 0.0;
 	depth_output_buffer.r = -vertex.z;
 
-	orm_output_buffer.r = ao;
+	orm_output_buffer.r = direct_ao;
 	orm_output_buffer.g = roughness;
 	orm_output_buffer.b = metallic;
 	orm_output_buffer.a = sss_strength;
@@ -2964,8 +2975,8 @@ void fragment_shader(in SceneData scene_data) {
 	diffuse_light *= albedo; // ambient must be multiplied by albedo at the end
 
 	// apply direct light AO
-	diffuse_light *= ao;
-	direct_specular_light *= ao;
+	diffuse_light *= direct_ao;
+	direct_specular_light *= direct_ao;
 
 	// apply metallic
 	diffuse_light *= 1.0 - metallic;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1186,7 +1186,9 @@ void fragment_shader(in SceneData scene_data) {
 #endif
 
 	float ao = 1.0;
+	float direct_ao = 0.0;
 	float ao_light_affect = 0.0;
+	float micro_shadows = 0.0;
 
 	float alpha_highp = float(instances.data[instance_index].flags >> INSTANCE_FLAGS_FADE_SHIFT) / float(255.0);
 
@@ -2243,7 +2245,7 @@ void fragment_shader(in SceneData scene_data) {
 #endif // AMBIENT_LIGHT_DISABLED
 
 	// convert ao to direct light ao
-	ao = mix(1.0, ao, ao_light_affect);
+	direct_ao = mix(1.0, ao, ao_light_affect);
 
 	//this saves some VGPRs
 	vec3 f0 = F0(metallic, specular, albedo);
@@ -2673,6 +2675,15 @@ void fragment_shader(in SceneData scene_data) {
 			shadow = 1.0;
 #endif
 
+#ifndef MICRO_SHADOWS_DISABLED
+#ifdef BENT_NORMAL_MAP_USED
+			float NdotL = dot(bent_normal_vector, directional_lights.data[i].direction);
+#else
+			float NdotL = dot(normal, directional_lights.data[i].direction);
+#endif // BENT_NORMAL_MAP_USED
+			shadow *= compute_micro_shadowing(NdotL, ao, micro_shadows);
+#endif // MICRO_SHADOWS_DISABLED
+
 			float size_A = sc_use_directional_soft_shadows() ? directional_lights.data[i].size : 0.0;
 
 			light_compute(normal, directional_lights.data[i].direction, normalize(view), size_A,
@@ -3020,7 +3031,7 @@ void fragment_shader(in SceneData scene_data) {
 	normal_output_buffer.a = 0.0;
 	depth_output_buffer.r = -vertex.z;
 
-	orm_output_buffer.r = ao;
+	orm_output_buffer.r = direct_ao;
 	orm_output_buffer.g = roughness;
 	orm_output_buffer.b = metallic;
 	orm_output_buffer.a = sss_strength;
@@ -3061,8 +3072,8 @@ void fragment_shader(in SceneData scene_data) {
 	diffuse_light *= albedo; // ambient must be multiplied by albedo at the end
 
 	// apply direct light AO
-	diffuse_light *= ao;
-	direct_specular_light *= ao;
+	diffuse_light *= direct_ao;
+	direct_specular_light *= direct_ao;
 
 	// apply metallic
 	diffuse_light *= 1.0 - metallic;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -485,6 +485,17 @@ vec3 get_energy_compensation(vec3 f0, float env) {
 	return 1.0 + f0 * (1.0 / env - 1.0);
 }
 
+// Micro-Shadowing Analytical approach
+// see https://irradiance.ca/posts/microshadowing-part1/#micro-shadowing
+float compute_micro_shadowing(float NoL, float ao, float opacity) {
+	float xx = ao * ao;
+	float ao5 = xx * xx * ao;
+
+	float cosThetaPrime = inversesqrt(1.0 - ao5);
+	float micro_shadows = pow(clamp(NoL * cosThetaPrime, 0.0, 1.0), 0.75f / max(ao, 0.0001));
+	return mix(1.0, micro_shadows, opacity);
+}
+
 /* Set 2 Skeleton & Instancing (can change per item) */
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -507,6 +507,17 @@ vec3 get_energy_compensation(vec3 f0, float env) {
 	return 1.0 + f0 * (1.0 / env - 1.0);
 }
 
+// Micro-Shadowing Analytical approach
+// see https://irradiance.ca/posts/microshadowing-part1/#micro-shadowing
+float compute_micro_shadowing(float NoL, float ao, float opacity) {
+	float xx = ao * ao;
+	float ao5 = xx * xx * ao;
+
+	float cosThetaPrime = inversesqrt(1.0 - ao5);
+	float micro_shadows = pow(clamp(NoL * cosThetaPrime, 0.0, 1.0), 0.75f / max(ao, 0.0001));
+	return mix(1.0, micro_shadows, opacity);
+}
+
 /* Set 2 Skeleton & Instancing (can change per item) */
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1165,6 +1165,7 @@ void main() {
 
 	float ao_highp = 1.0;
 	float ao_light_affect_highp = 0.0;
+	float micro_shadows_highp = 0.0;
 
 	float alpha_highp = 1.0;
 
@@ -1288,6 +1289,8 @@ void main() {
 	hvec2 anisotropy_flow = hvec2(anisotropy_flow_highp);
 	half ao = half(ao_highp);
 	half ao_light_affect = half(ao_light_affect_highp);
+	half direct_ao = half(0.0);
+	half micro_shadows = half(micro_shadows_highp);
 	half alpha = half(alpha_highp);
 	half normal_map_depth = half(normal_map_depth_highp);
 	half sss_strength = half(sss_strength_highp);
@@ -1850,7 +1853,7 @@ void main() {
 #endif // !AMBIENT_LIGHT_DISABLED
 
 	// convert ao to direct light ao
-	ao = mix(half(1.0), ao, ao_light_affect);
+	direct_ao = mix(half(1.0), ao, ao_light_affect);
 
 	//this saves some VGPRs
 	hvec3 f0 = F0(metallic, specular, albedo);
@@ -2117,6 +2120,16 @@ void main() {
 			shadow = half(1.0);
 #endif
 
+#ifndef MICRO_SHADOWS_DISABLED
+#ifdef BENT_NORMAL_MAP_USED
+			half NdotL = dot(bent_normal_vector, hvec3(directional_lights.data[i].direction));
+#else
+			half NdotL = dot(normal, hvec3(directional_lights.data[i].direction));
+#endif // BENT_NORMAL_MAP_USED
+	   // Disable microshadowing when facing away from light.
+			shadow *= NdotL >= half(0.0) ? half(compute_micro_shadowing(NdotL, ao, micro_shadows)) : half(1.0);
+#endif // MICRO_SHADOWS_DISABLED
+
 			float size_A = sc_use_light_soft_shadows() ? directional_lights.data[i].size : 0.0;
 
 			light_compute(normal, hvec3(directional_lights.data[i].direction), view, saturateHalf(size_A),
@@ -2249,7 +2262,7 @@ void main() {
 	normal_output_buffer.a = 0.0;
 	depth_output_buffer.r = -vertex.z;
 
-	orm_output_buffer.r = ao;
+	orm_output_buffer.r = direct_ao;
 	orm_output_buffer.g = roughness;
 	orm_output_buffer.b = metallic;
 	orm_output_buffer.a = sss_strength;
@@ -2264,8 +2277,8 @@ void main() {
 	diffuse_light *= albedo; // ambient must be multiplied by albedo at the end
 
 	// apply direct light AO
-	diffuse_light *= ao;
-	direct_specular_light *= ao;
+	diffuse_light *= direct_ao;
+	direct_specular_light *= direct_ao;
 
 	// apply metallic
 	diffuse_light *= half(1.0) - metallic;

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1108,6 +1108,7 @@ void main() {
 
 	float ao_highp = 1.0;
 	float ao_light_affect_highp = 0.0;
+	float micro_shadows_highp = 0.0;
 
 	float alpha_highp = 1.0;
 
@@ -1231,6 +1232,8 @@ void main() {
 	hvec2 anisotropy_flow = hvec2(anisotropy_flow_highp);
 	half ao = half(ao_highp);
 	half ao_light_affect = half(ao_light_affect_highp);
+	half direct_ao = half(0.0);
+	half micro_shadows = half(micro_shadows_highp);
 	half alpha = half(alpha_highp);
 	half normal_map_depth = half(normal_map_depth_highp);
 	half sss_strength = half(sss_strength_highp);
@@ -1863,7 +1866,7 @@ void main() {
 #endif // !AMBIENT_LIGHT_DISABLED
 
 	// convert ao to direct light ao
-	ao = mix(half(1.0), ao, ao_light_affect);
+	direct_ao = mix(half(1.0), ao, ao_light_affect);
 
 	//this saves some VGPRs
 	hvec3 f0 = F0(metallic, specular, albedo);
@@ -2130,6 +2133,16 @@ void main() {
 			shadow = half(1.0);
 #endif
 
+#ifndef MICRO_SHADOWS_DISABLED
+#ifdef BENT_NORMAL_MAP_USED
+			half NdotL = dot(bent_normal_vector, hvec3(directional_lights.data[i].direction));
+#else
+			half NdotL = dot(normal, hvec3(directional_lights.data[i].direction));
+#endif // BENT_NORMAL_MAP_USED
+	   // Disable microshadowing when facing away from light.
+			shadow *= NdotL >= half(0.0) ? half(compute_micro_shadowing(NdotL, ao, micro_shadows)) : half(1.0);
+#endif // MICRO_SHADOWS_DISABLED
+
 			float size_A = sc_use_light_soft_shadows() ? directional_lights.data[i].size : 0.0;
 
 			light_compute(normal, hvec3(directional_lights.data[i].direction), view, saturateHalf(size_A),
@@ -2294,7 +2307,7 @@ void main() {
 	normal_output_buffer.a = 0.0;
 	depth_output_buffer.r = -vertex.z;
 
-	orm_output_buffer.r = ao;
+	orm_output_buffer.r = direct_ao;
 	orm_output_buffer.g = roughness;
 	orm_output_buffer.b = metallic;
 	orm_output_buffer.a = sss_strength;
@@ -2309,8 +2322,8 @@ void main() {
 	diffuse_light *= albedo; // ambient must be multiplied by albedo at the end
 
 	// apply direct light AO
-	diffuse_light *= ao;
-	direct_specular_light *= ao;
+	diffuse_light *= direct_ao;
+	direct_specular_light *= direct_ao;
 
 	// apply metallic
 	diffuse_light *= half(1.0) - metallic;

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -398,6 +398,13 @@ layout(set = 1, binding = 13 + 9) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_RE
 layout(set = 1, binding = 13 + 10) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
 layout(set = 1, binding = 13 + 11) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
 
+// Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
+float compute_micro_shadowing(float NoL, float ao, float opacity) {
+	float aperture = 2.0 * ao * ao;
+	float microshadow = clamp(NoL + aperture - 1.0, 0.0, 1.0);
+	return mix(1.0, microshadow, opacity);
+}
+
 /* Set 2 Skeleton & Instancing (can change per item) */
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -420,6 +420,13 @@ layout(set = 1, binding = 13 + 9) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_RE
 layout(set = 1, binding = 13 + 10) uniform sampler SAMPLER_NEAREST_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
 layout(set = 1, binding = 13 + 11) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_ANISOTROPIC_REPEAT;
 
+// Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
+float compute_micro_shadowing(float NoL, float ao, float opacity) {
+	float aperture = 2.0 * ao * ao;
+	float microshadow = clamp(NoL + aperture - 1.0, 0.0, 1.0);
+	return mix(1.0, microshadow, opacity);
+}
+
 /* Set 2 Skeleton & Instancing (can change per item) */
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3662,6 +3662,8 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality.mobile", 0);
 	GLOBAL_DEF("rendering/lights_and_shadows/positional_shadow/atlas_16_bits", true);
 
+	GLOBAL_DEF_RST("rendering/lights_and_shadows/micro_shadows/enabled", false);
+
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/2d/shadow_atlas/size", PROPERTY_HINT_RANGE, "128,16384"), 2048);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/2d/batching/item_buffer_size", PROPERTY_HINT_RANGE, "128,1048576,1"), 16384);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/2d/batching/uniform_set_cache_size", PROPERTY_HINT_RANGE, "256,1048576,1"), 4096);

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3690,6 +3690,8 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality.mobile", 0);
 	GLOBAL_DEF("rendering/lights_and_shadows/positional_shadow/atlas_16_bits", true);
 
+	GLOBAL_DEF_RST("rendering/lights_and_shadows/micro_shadows/enabled", false);
+
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/2d/shadow_atlas/size", PROPERTY_HINT_RANGE, "128,16384"), 2048);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/2d/batching/item_buffer_size", PROPERTY_HINT_RANGE, "128,1048576,1"), 16384);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/2d/batching/uniform_set_cache_size", PROPERTY_HINT_RANGE, "256,1048576,1"), 4096);

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -165,6 +165,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["BACKLIGHT"] = ShaderLanguage::TYPE_VEC3;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["AO"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["AO_LIGHT_AFFECT"] = ShaderLanguage::TYPE_FLOAT;
+	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["MICRO_SHADOWS"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["EMISSION"] = ShaderLanguage::TYPE_VEC3;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["DEPTH"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["SCREEN_UV"] = constt(ShaderLanguage::TYPE_VEC2);
@@ -253,6 +254,7 @@ ShaderTypes::ShaderTypes() {
 		shader_modes[RSE::SHADER_SPATIAL].modes.push_back({ PNAME("debug_shadow_splits") });
 		shader_modes[RSE::SHADER_SPATIAL].modes.push_back({ PNAME("fog_disabled") });
 		shader_modes[RSE::SHADER_SPATIAL].modes.push_back({ PNAME("specular_occlusion_disabled") });
+		shader_modes[RSE::SHADER_SPATIAL].modes.push_back({ PNAME("micro_shadows_disabled") });
 		shader_modes[RSE::SHADER_SPATIAL].stencil_modes.push_back({ PNAME("read") });
 		shader_modes[RSE::SHADER_SPATIAL].stencil_modes.push_back({ PNAME("write") });
 		shader_modes[RSE::SHADER_SPATIAL].stencil_modes.push_back({ PNAME("write_depth_fail") });

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -167,6 +167,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["BACKLIGHT"] = ShaderLanguage::TYPE_VEC3;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["AO"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["AO_LIGHT_AFFECT"] = ShaderLanguage::TYPE_FLOAT;
+	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["MICRO_SHADOWS"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["EMISSION"] = ShaderLanguage::TYPE_VEC3;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["DEPTH"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RSE::SHADER_SPATIAL].functions["fragment"].built_ins["SCREEN_UV"] = constt(ShaderLanguage::TYPE_VEC2);
@@ -258,6 +259,7 @@ ShaderTypes::ShaderTypes() {
 		shader_modes[RSE::SHADER_SPATIAL].modes.push_back({ PNAME("debug_shadow_splits") });
 		shader_modes[RSE::SHADER_SPATIAL].modes.push_back({ PNAME("fog_disabled") });
 		shader_modes[RSE::SHADER_SPATIAL].modes.push_back({ PNAME("specular_occlusion_disabled") });
+		shader_modes[RSE::SHADER_SPATIAL].modes.push_back({ PNAME("micro_shadows_disabled") });
 		shader_modes[RSE::SHADER_SPATIAL].stencil_modes.push_back({ PNAME("read") });
 		shader_modes[RSE::SHADER_SPATIAL].stencil_modes.push_back({ PNAME("write") });
 		shader_modes[RSE::SHADER_SPATIAL].stencil_modes.push_back({ PNAME("write_depth_fail") });


### PR DESCRIPTION
closes [#12671](https://github.com/godotengine/godot-proposals/issues/12671)

This PR adds support for microshadows, first described by Naughty Dog in [Uncharted 4](https://www.advances.realtimerendering.com/other/2016/naughty_dog/NaughtyDog_TechArt_Final.pdf), as a PBR alternative to Light Affect AO.

For more details, see... [#12671](https://github.com/godotengine/godot-proposals/issues/12671).