### PR TITLE
Fix partially received packets in web build

### DIFF
--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -141,6 +141,13 @@ Error EMWSPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 
 	int read = 0;
 	Error err = in_buffer.read_packet(packet_buffer.ptrw(), packet_buffer.size(), &was_string, read);
+
+#ifdef WEB_ENABLED
+	if (err == ERR_UNAVAILABLE) {
+		return ERR_UNAVAILABLE;
+	}
+#endif
+
 	ERR_FAIL_COND_V(err != OK, err);
 
 	*r_buffer = packet_buffer.ptr();

--- a/modules/websocket/packet_buffer.h
+++ b/modules/websocket/packet_buffer.h
@@ -82,7 +82,18 @@ public:
 		}
 		_queued -= 1;
 
+#ifdef WEB_ENABLED
+		if (_payload.data_left() < (int)p.size) {
+			_queued += 1;
+			_read_pos -= 1;
+			if (_read_pos < 0) {
+				_read_pos = _packets.size() - 1;
+			}
+			return OK;
+		}
+#else
 		ERR_FAIL_COND_V(_payload.data_left() < (int)p.size, ERR_BUG);
+#endif
 		ERR_FAIL_COND_V(p_bytes < (int)p.size, ERR_OUT_OF_MEMORY);
 
 		r_read = p.size;


### PR DESCRIPTION
On play in browser, web build sometimes receive partial packets although the _get_available_packet_count() counts that partially received packet as ready for reading. Waiting for some time solves the issue but this commit fix it without blocking. This avoids ERR_FAIL_COND_V(_payload.data_left() < (int)p.size, ERR_BUG); when the real problem is packet which is on it's way.
