### PR TITLE
Fix UID check for external resources when loading with no cache

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1085,7 +1085,7 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 				} else {
 #ifdef TOOLS_ENABLED
 					// Silence a warning that can happen during the initial filesystem scan due to cache being regenerated.
-					if (ResourceLoader::get_resource_uid(res_path) != er.uid) {
+					if (ResourceLoader::get_resource_uid(er.path) != er.uid) {
 						WARN_PRINT(vformat("'%s': In external resource #%d, invalid UID: '%s' - using text path instead: '%s'.", res_path, i, ResourceUID::get_singleton()->id_to_text(er.uid), er.path));
 					}
 #else


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fix to prevent this warning:

`WARNING: core\io\resource_format_binary.cpp:1089 - 'res://assets/resource.res': In external resource #0, invalid UID: 'uid://72b1k4c3va6s' - using text path instead: 'res://assets/er.tres'.`

Currently on initial file scan the loader is comparing a resource UID and the UID of external resources it is referencing.

The comparison should be between the external resource itself. 

The same pattern is used for text loader: https://github.com/godotengine/godot/blob/eb3d6d8cd35df40df0a7f12a33917b65a96a6518/scene/resources/resource_format_text.cpp#L452-L467