### PR TITLE
Fix: Allow conversion of uninitialized SkyMaterials

### DIFF
--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -55,9 +55,13 @@ Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_
 
 	// Some materials (like SkyMaterials) are not initialized in the inspector,
 	// so we should allow conversion for them without blocking on _is_initialized().
-	if (!p_from->_is_initialized() && !p_from->is_class("SkyMaterial")) {
-		ERR_FAIL_V_MSG(Ref<ShaderMaterial>(), "Failed to convert material: the source material is not initialized and is not a SkyMaterial.");
-	}
+	if (!p_from->_is_initialized() &&
+    !p_from->is_class("ProceduralSkyMaterial") &&
+    !p_from->is_class("PhysicalSkyMaterial") &&
+    !p_from->is_class("PanoramaSkyMaterial")) {
+	ERR_FAIL_V_MSG(Ref<ShaderMaterial>(),
+		"Failed to convert material: the source material is not initialized and is not a supported SkyMaterial type.");
+}
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -56,11 +56,11 @@ Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_
 	// Some materials (like SkyMaterials) are not initialized in the inspector,
 	// so we should allow conversion for them without blocking on _is_initialized().
 	if (!p_from->_is_initialized() &&
-    	!p_from->is_class("ProceduralSkyMaterial") &&
-    	!p_from->is_class("PhysicalSkyMaterial") &&
-    	!p_from->is_class("PanoramaSkyMaterial")) {
+			!p_from->is_class("ProceduralSkyMaterial") &&
+			!p_from->is_class("PhysicalSkyMaterial") &&
+			!p_from->is_class("PanoramaSkyMaterial")) {
 		ERR_FAIL_V_MSG(Ref<ShaderMaterial>(),
-			"Failed to convert material: the source material is not initialized and is not a supported SkyMaterial type.");
+				"Failed to convert material: the source material is not initialized and is not a supported SkyMaterial type.");
 	}
 
 	Ref<ShaderMaterial> smat;

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -56,12 +56,12 @@ Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_
 	// Some materials (like SkyMaterials) are not initialized in the inspector,
 	// so we should allow conversion for them without blocking on _is_initialized().
 	if (!p_from->_is_initialized() &&
-    !p_from->is_class("ProceduralSkyMaterial") &&
-    !p_from->is_class("PhysicalSkyMaterial") &&
-    !p_from->is_class("PanoramaSkyMaterial")) {
-	ERR_FAIL_V_MSG(Ref<ShaderMaterial>(),
-		"Failed to convert material: the source material is not initialized and is not a supported SkyMaterial type.");
-}
+    		!p_from->is_class("ProceduralSkyMaterial") &&
+    		!p_from->is_class("PhysicalSkyMaterial") &&
+    		!p_from->is_class("PanoramaSkyMaterial")) {
+		ERR_FAIL_V_MSG(Ref<ShaderMaterial>(),
+				"Failed to convert material: the source material is not initialized and is not a supported SkyMaterial type.");
+	}
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -52,13 +52,11 @@
 
 Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_from, bool p_copy_params) {
 	ERR_FAIL_COND_V(p_from.is_null(), Ref<ShaderMaterial>());
+	
 	// Some materials (like SkyMaterials) are not initialized in the inspector,
 	// so we should allow conversion for them without blocking on _is_initialized().
 	if (!p_from->_is_initialized()) {
-		if (p_from->is_class("SkyMaterial") ||
-			p_from->is_class("ProceduralSkyMaterial") ||
-			p_from->is_class("PhysicalSkyMaterial") ||
-			p_from->is_class("PanoramaSkyMaterial")) {
+		if (p_from->is_class("SkyMaterial")) {
 			// Allow conversion to continue.
 		} else {
 			ERR_FAIL_V_MSG(Ref<ShaderMaterial>(), "Failed to convert material: the source material is not initialized and is not a SkyMaterial.");

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -61,8 +61,7 @@ Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_
 			p_from->is_class("PanoramaSkyMaterial")) {
 			// Allow conversion to continue.
 		} else {
-			ERR_PRINT("Condition \"!p_from->_is_initialized()\" is true. Returning: Ref<ShaderMaterial>()");
-			return Ref<ShaderMaterial>();
+			ERR_FAIL_V_MSG(Ref<ShaderMaterial>(), "Failed to convert material: the source material is not initialized and is not a SkyMaterial.");
 		}
 	}
 	

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -52,7 +52,7 @@
 
 Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_from, bool p_copy_params) {
 	ERR_FAIL_COND_V(p_from.is_null(), Ref<ShaderMaterial>());
-	
+
 	// Some materials (like SkyMaterials) are not initialized in the inspector,
 	// so we should allow conversion for them without blocking on _is_initialized().
 	if (!p_from->_is_initialized()) {
@@ -62,7 +62,7 @@ Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_
 			ERR_FAIL_V_MSG(Ref<ShaderMaterial>(), "Failed to convert material: the source material is not initialized and is not a SkyMaterial.");
 		}
 	}
-	
+
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
 

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -56,11 +56,11 @@ Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_
 	// Some materials (like SkyMaterials) are not initialized in the inspector,
 	// so we should allow conversion for them without blocking on _is_initialized().
 	if (!p_from->_is_initialized() &&
-    		!p_from->is_class("ProceduralSkyMaterial") &&
-    		!p_from->is_class("PhysicalSkyMaterial") &&
-    		!p_from->is_class("PanoramaSkyMaterial")) {
+    	!p_from->is_class("ProceduralSkyMaterial") &&
+    	!p_from->is_class("PhysicalSkyMaterial") &&
+    	!p_from->is_class("PanoramaSkyMaterial")) {
 		ERR_FAIL_V_MSG(Ref<ShaderMaterial>(),
-				"Failed to convert material: the source material is not initialized and is not a supported SkyMaterial type.");
+			"Failed to convert material: the source material is not initialized and is not a supported SkyMaterial type.");
 	}
 
 	Ref<ShaderMaterial> smat;

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -52,8 +52,20 @@
 
 Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_from, bool p_copy_params) {
 	ERR_FAIL_COND_V(p_from.is_null(), Ref<ShaderMaterial>());
-	ERR_FAIL_COND_V(!p_from->_is_initialized(), Ref<ShaderMaterial>());
-
+	// Some materials (like SkyMaterials) are not initialized in the inspector,
+	// so we should allow conversion for them without blocking on _is_initialized().
+	if (!p_from->_is_initialized()) {
+		if (p_from->is_class("SkyMaterial") ||
+			p_from->is_class("ProceduralSkyMaterial") ||
+			p_from->is_class("PhysicalSkyMaterial") ||
+			p_from->is_class("PanoramaSkyMaterial")) {
+			// Allow conversion to continue.
+		} else {
+			ERR_PRINT("Condition \"!p_from->_is_initialized()\" is true. Returning: Ref<ShaderMaterial>()");
+			return Ref<ShaderMaterial>();
+		}
+	}
+	
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
 

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -55,12 +55,8 @@ Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_
 
 	// Some materials (like SkyMaterials) are not initialized in the inspector,
 	// so we should allow conversion for them without blocking on _is_initialized().
-	if (!p_from->_is_initialized()) {
-		if (p_from->is_class("SkyMaterial")) {
-			// Allow conversion to continue.
-		} else {
-			ERR_FAIL_V_MSG(Ref<ShaderMaterial>(), "Failed to convert material: the source material is not initialized and is not a SkyMaterial.");
-		}
+	if (!p_from->_is_initialized() && !p_from->is_class("SkyMaterial")) {
+		ERR_FAIL_V_MSG(Ref<ShaderMaterial>(), "Failed to convert material: the source material is not initialized and is not a SkyMaterial.");
 	}
 
 	Ref<ShaderMaterial> smat;


### PR DESCRIPTION
Some SkyMaterials like ProceduralSky, PhysicalSky, and PanoramaSky aren’t initialized in the inspector, which caused make_shader_material() to fail when converting them to ShaderMaterial.

This change skips the initialization check for those materials.

Fixes #112331
