### PR TITLE
Core: Clean up `Variant` comparison operators

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -865,17 +865,6 @@ bool Variant::operator==(const Variant &p_variant) const {
 	return hash_compare(p_variant);
 }
 
-bool Variant::operator!=(const Variant &p_variant) const {
-	// Don't use `!hash_compare(p_variant)` given it makes use of OP_EQUAL
-	if (type != p_variant.type) { //evaluation of operator== needs to be more strict
-		return true;
-	}
-	bool v;
-	Variant r;
-	evaluate(OP_NOT_EQUAL, *this, p_variant, r, v);
-	return r;
-}
-
 bool Variant::operator<(const Variant &p_variant) const {
 	if (type != p_variant.type) { //if types differ, then order by type first
 		return type < p_variant.type;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -835,11 +835,13 @@ public:
 	static void get_utility_function_list(List<StringName> *r_functions);
 	static int get_utility_function_count();
 
-	//argsVariant call()
+	[[nodiscard]] bool operator==(const Variant &p_variant) const;
+	[[nodiscard]] bool operator<(const Variant &p_variant) const;
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator!=(const Variant &p_variant) const { return !(*this == p_variant); }
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator<=(const Variant &p_variant) const { return !(p_variant < *this); }
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator>(const Variant &p_variant) const { return p_variant < *this; }
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator>=(const Variant &p_variant) const { return !(*this < p_variant); }
 
-	bool operator==(const Variant &p_variant) const;
-	bool operator!=(const Variant &p_variant) const;
-	bool operator<(const Variant &p_variant) const;
 	uint32_t hash() const;
 	uint32_t recursive_hash(int recursion_count) const;
 


### PR DESCRIPTION
- Originally part of #112224 

Cleans up the `Variant` comparison operations in a few ways:
- Ensures all C++17 comparison operations exist, deriving from `==` and `<`
- Label return values as `[[nodiscard]]`
- Removed old `!=` operator entirely

The last one in particular should've never been separate logic to begin with. I've looked at the operation outputs, and I can't find a single scenario where `!=` and `!(==)` result in different outputs. I can only assume this was either once the case but has since been fixed, or the original comment was misinformed.