### PR TITLE
Move `WeakRef` to `CoreBind`, since it shouldn't be (and isn't) used internally

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2356,4 +2356,33 @@ void EngineDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_breakpoints"), &EngineDebugger::clear_breakpoints);
 }
 
+Variant WeakRef::get_ref() const {
+	if (ref.is_null()) {
+		return Variant();
+	}
+
+	Object *obj = ObjectDB::get_instance(ref);
+	if (!obj) {
+		return Variant();
+	}
+	RefCounted *r = cast_to<RefCounted>(obj);
+	if (r) {
+		return Ref<RefCounted>(r);
+	}
+
+	return obj;
+}
+
+void WeakRef::set_obj(Object *p_object) {
+	ref = p_object ? p_object->get_instance_id() : ObjectID();
+}
+
+void WeakRef::set_ref(const Ref<RefCounted> &p_ref) {
+	ref = p_ref.is_valid() ? p_ref->get_instance_id() : ObjectID();
+}
+
+void WeakRef::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_ref"), &WeakRef::get_ref);
+}
+
 } // namespace CoreBind

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -696,6 +696,20 @@ public:
 	~EngineDebugger();
 };
 
+class WeakRef : public RefCounted {
+	GDCLASS(WeakRef, RefCounted);
+
+	ObjectID ref;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Variant get_ref() const;
+	void set_obj(Object *p_object);
+	void set_ref(const Ref<RefCounted> &p_ref);
+};
+
 } // namespace CoreBind
 
 VARIANT_ENUM_CAST(CoreBind::Logger::ErrorType);

--- a/core/object/ref_counted.cpp
+++ b/core/object/ref_counted.cpp
@@ -133,32 +133,3 @@ RefCounted::RefCounted() :
 	refcount_init.init();
 	dereference_count.set(0);
 }
-
-Variant WeakRef::get_ref() const {
-	if (ref.is_null()) {
-		return Variant();
-	}
-
-	Object *obj = ObjectDB::get_instance(ref);
-	if (!obj) {
-		return Variant();
-	}
-	RefCounted *r = cast_to<RefCounted>(obj);
-	if (r) {
-		return Ref<RefCounted>(r);
-	}
-
-	return obj;
-}
-
-void WeakRef::set_obj(Object *p_object) {
-	ref = p_object ? p_object->get_instance_id() : ObjectID();
-}
-
-void WeakRef::set_ref(const Ref<RefCounted> &p_ref) {
-	ref = p_ref.is_valid() ? p_ref->get_instance_id() : ObjectID();
-}
-
-void WeakRef::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_ref"), &WeakRef::get_ref);
-}

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -238,20 +238,6 @@ void postinitialize_handler(Ref<T> &p_object) {
 	postinitialize_handler(p_object.ptr());
 }
 
-class WeakRef : public RefCounted {
-	GDCLASS(WeakRef, RefCounted);
-
-	ObjectID ref;
-
-protected:
-	static void _bind_methods();
-
-public:
-	Variant get_ref() const;
-	void set_obj(Object *p_object);
-	void set_ref(const Ref<RefCounted> &p_ref);
-};
-
 // Zero-constructing Ref initializes reference to nullptr (and thus empty).
 template <typename T>
 struct is_zero_constructible<Ref<T>> : std::true_type {};

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -147,7 +147,7 @@ void register_core_types() {
 
 	GDREGISTER_CLASS(Object);
 	GDREGISTER_CLASS(RefCounted);
-	GDREGISTER_CLASS(WeakRef);
+	GDREGISTER_CLASS(CoreBind::WeakRef);
 	GDREGISTER_CLASS(Resource);
 
 	GDREGISTER_CLASS(Time);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -30,6 +30,7 @@
 
 #include "variant_utility.h"
 
+#include "core/core_bind.h"
 #include "core/io/marshalls.h"
 #include "core/object/ref_counted.h"
 #include "core/os/os.h"
@@ -816,14 +817,14 @@ Variant VariantUtilityFunctions::weakref(const Variant &p_obj, Callable::CallErr
 	if (p_obj.get_type() == Variant::OBJECT) {
 		r_error.error = Callable::CallError::CALL_OK;
 		if (p_obj.is_ref_counted()) {
-			Ref<WeakRef> wref = memnew(WeakRef);
+			Ref<CoreBind::WeakRef> wref = memnew(CoreBind::WeakRef);
 			Ref<RefCounted> r = p_obj;
 			if (r.is_valid()) {
 				wref->set_ref(r);
 			}
 			return wref;
 		} else {
-			Ref<WeakRef> wref = memnew(WeakRef);
+			Ref<CoreBind::WeakRef> wref = memnew(CoreBind::WeakRef);
 			Object *o = p_obj.get_validated_object();
 			if (o) {
 				wref->set_obj(o);
@@ -832,7 +833,7 @@ Variant VariantUtilityFunctions::weakref(const Variant &p_obj, Callable::CallErr
 		}
 	} else if (p_obj.get_type() == Variant::NIL) {
 		r_error.error = Callable::CallError::CALL_OK;
-		Ref<WeakRef> wref = memnew(WeakRef);
+		Ref<CoreBind::WeakRef> wref = memnew(CoreBind::WeakRef);
 		return wref;
 	} else {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -38,6 +38,7 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/core_bind.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "core/io/compression.h"
@@ -1430,7 +1431,7 @@ void godotsharp_weakref(Object *p_ptr, Ref<RefCounted> *r_weak_ref) {
 		return;
 	}
 
-	Ref<WeakRef> wref;
+	Ref<CoreBind::WeakRef> wref;
 	RefCounted *rc = Object::cast_to<RefCounted>(p_ptr);
 
 	if (rc) {

--- a/modules/objectdb_profiler/editor/snapshot_data.cpp
+++ b/modules/objectdb_profiler/editor/snapshot_data.cpp
@@ -276,7 +276,7 @@ void GameStateSnapshot::_get_rc_cycles(
 		}
 
 		SnapshotDataObject *next = objects[next_child.value];
-		if (next != nullptr && next->is_class(RefCounted::get_class_static()) && !next->is_class(WeakRef::get_class_static()) && !p_traversed_objs.has(next)) {
+		if (next != nullptr && next->is_class(RefCounted::get_class_static()) && !next->is_class("WeakRef") && !p_traversed_objs.has(next)) {
 			HashSet<SnapshotDataObject *> traversed_copy(p_traversed_objs);
 			if (p_obj != p_source_obj) {
 				traversed_copy.insert(p_obj);
@@ -309,7 +309,7 @@ void GameStateSnapshot::recompute_references() {
 	}
 
 	for (const KeyValue<ObjectID, SnapshotDataObject *> &obj : objects) {
-		if (!obj.value->is_class(RefCounted::get_class_static()) || obj.value->is_class(WeakRef::get_class_static())) {
+		if (!obj.value->is_class(RefCounted::get_class_static()) || obj.value->is_class("WeakRef")) {
 			continue;
 		}
 		LocalVector<String> cycles;


### PR DESCRIPTION
`WeakRef` is a way to store a weak reference to an `Object`. It's implemented as a `RefCounted` subtype, because it can be useful for `GDScript` users (and otherwise).

However, as an `Object` subtype, it's also unnecessarily slow and wasteful. We shouldn't use it internally — notably, we currently _don't_ use it internally at all.  If we need a weak `Object` reference, we should be using something more performant. This 'something' could be proposed in a future PR, if it is needed (it would probably be a templated `ObjectID` wrapper).

Since there is no user of this class in the engine, it's trivial to move it to `CoreBind`. It was especially wrong to have it in `ref_counted.h` since it is usable not just for `RefCounted`, but for any `Object` subclass.