### PR TITLE
Fix glow visual compatibility regression

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -143,7 +143,7 @@
 		<member name="glow_hdr_scale" type="float" setter="set_glow_hdr_bleed_scale" getter="get_glow_hdr_bleed_scale" default="2.0">
 			The bleed scale of the HDR glow.
 		</member>
-		<member name="glow_hdr_threshold" type="float" setter="set_glow_hdr_bleed_threshold" getter="get_glow_hdr_bleed_threshold" default="0.0">
+		<member name="glow_hdr_threshold" type="float" setter="set_glow_hdr_bleed_threshold" getter="get_glow_hdr_bleed_threshold" default="1.0">
 			The lower threshold of the HDR glow. When using the Mobile rendering method (which only supports a lower dynamic range up to [code]2.0[/code]), this may need to be below [code]1.0[/code] for glow to be visible. A value of [code]0.9[/code] works well in this case. This value also needs to be decreased below [code]1.0[/code] when using glow in 2D, as 2D rendering is performed in SDR.
 		</member>
 		<member name="glow_intensity" type="float" setter="set_glow_intensity" getter="get_glow_intensity" default="0.3">

--- a/drivers/gles3/effects/glow.h
+++ b/drivers/gles3/effects/glow.h
@@ -49,7 +49,7 @@ private:
 
 	float glow_intensity = 1.0;
 	float glow_bloom = 0.0;
-	float glow_hdr_bleed_threshold = 0.0;
+	float glow_hdr_bleed_threshold = 1.0;
 	float glow_hdr_bleed_scale = 2.0;
 	float glow_hdr_luminance_cap = 12.0;
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2829,7 +2829,7 @@ void RasterizerSceneGLES3::_render_post_processing(const RenderDataGLES3 *p_rend
 	bool glow_enabled = false;
 	float glow_intensity = 1.0;
 	float glow_bloom = 0.0;
-	float glow_hdr_bleed_threshold = 0.0;
+	float glow_hdr_bleed_threshold = 1.0;
 	float glow_hdr_bleed_scale = 2.0;
 	float glow_hdr_luminance_cap = 12.0;
 	float srgb_white = 1.0;

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -168,7 +168,7 @@ private:
 	float glow_mix = 0.05;
 	float glow_bloom = 0.0;
 	GlowBlendMode glow_blend_mode = GLOW_BLEND_MODE_SCREEN;
-	float glow_hdr_bleed_threshold = 0.0;
+	float glow_hdr_bleed_threshold = 1.0;
 	float glow_hdr_bleed_scale = 2.0;
 	float glow_hdr_luminance_cap = 12.0;
 	float glow_map_strength = 0.8f;

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -103,7 +103,7 @@ private:
 		float glow_bloom = 0.0;
 		float glow_mix = 0.01;
 		RS::EnvironmentGlowBlendMode glow_blend_mode = RS::ENV_GLOW_BLEND_MODE_SCREEN;
-		float glow_hdr_bleed_threshold = 0.0;
+		float glow_hdr_bleed_threshold = 1.0;
 		float glow_hdr_luminance_cap = 12.0;
 		float glow_hdr_bleed_scale = 2.0;
 		float glow_map_strength = 0.0f; // 1.0f in GLES3 ??


### PR DESCRIPTION
Reverts the default value of Environment.glow_hdr_threshold from 0.0 back to 1.0 to restore the expected glow appearance in existing projects.

The default was inadvertently changed from 1.0 to 0.0 in PR #110077, which caused glow effects to render dramatically different across all rendering methods (Forward+, Mobile, and GL Compatibility). This broke backward compatibility with existing projects like the Kenney 3D Platformer starter kit.

Setting the value back to 1.0 aligns with documented recommendations and restores visual consistency.

Fixes #112469

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
