### PR TITLE
GPUParticles2D: Don't reset trail bind poses (fixes instant disappearance of trails)

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -667,7 +667,7 @@ void GPUParticles2D::_notification(int p_what) {
 				arr[RS::ARRAY_INDEX] = indices;
 
 				RS::get_singleton()->mesh_add_surface_from_arrays(mesh, RS::PRIMITIVE_TRIANGLES, arr, Array(), Dictionary(), RS::ARRAY_FLAG_USE_2D_VERTICES);
-				RS::get_singleton()->particles_set_trail_bind_poses(particles, Vector<Transform3D>());
+				//RS::get_singleton()->particles_set_trail_bind_poses(particles, Vector<Transform3D>());
 			}
 			RS::get_singleton()->canvas_item_add_particles(get_canvas_item(), particles, texture_rid);
 


### PR DESCRIPTION
Removes stray line resetting trail bind poses to empty vector, causing trails to disappear instantly and ignore color/scale curves. Opening as draft for testing.

Closes #112438