### PR TITLE
[GDScript] Add language isolation to tests

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -159,7 +159,7 @@ void GDScriptCache::move_script(const String &p_from, const String &p_to) {
 
 	MutexLock lock(singleton->mutex);
 
-	if (singleton->cleared) {
+	if (singleton->clearing) {
 		return;
 	}
 
@@ -183,7 +183,7 @@ void GDScriptCache::remove_script(const String &p_path) {
 
 	MutexLock lock(singleton->mutex);
 
-	if (singleton->cleared) {
+	if (singleton->clearing) {
 		return;
 	}
 
@@ -451,10 +451,10 @@ void GDScriptCache::clear() {
 
 	MutexLock lock(singleton->mutex);
 
-	if (singleton->cleared) {
+	if (singleton->clearing) {
 		return;
 	}
-	singleton->cleared = true;
+	singleton->clearing = true;
 
 	singleton->parser_inverse_dependencies.clear();
 
@@ -486,6 +486,8 @@ void GDScriptCache::clear() {
 	singleton->shallow_gdscript_cache.clear();
 	singleton->full_gdscript_cache.clear();
 	singleton->static_gdscript_cache.clear();
+
+	singleton->clearing = false;
 }
 
 GDScriptCache::GDScriptCache() {
@@ -493,7 +495,7 @@ GDScriptCache::GDScriptCache() {
 }
 
 GDScriptCache::~GDScriptCache() {
-	if (!cleared) {
+	if (!clearing) {
 		clear();
 	}
 	singleton = nullptr;

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -94,7 +94,7 @@ class GDScriptCache {
 
 	static GDScriptCache *singleton;
 
-	bool cleared = false;
+	bool clearing = false;
 
 public:
 	static const int BINARY_MUTEX_TAG = 2;

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -44,7 +44,9 @@
 #include "core/string/string_builder.h"
 #include "scene/resources/packed_scene.h"
 
+#include "tests/core/config/test_project_settings.h"
 #include "tests/test_macros.h"
+#include "tests/test_utils.h"
 
 namespace GDScriptTests {
 
@@ -110,21 +112,88 @@ void init_autoloads() {
 	}
 }
 
-void init_language(const String &p_base_path) {
-	// Setup project settings since it's needed by the languages to get the global scripts.
-	// This also sets up the base resource path.
-	Error err = ProjectSettings::get_singleton()->setup(p_base_path, String(), true);
-	if (err) {
-		print_line("Could not load project settings.");
-		// Keep going since some scripts still work without this.
+void init_project_dir(const String &p_base_path, const String &p_test_name, const String &p_copy_target) {
+	Error err;
+
+	String base_path_godot_file = p_base_path.path_join("project.godot");
+
+	// Set up project settings since it's needed for the import process.
+	String project_folder = TestUtils::get_temp_path(vformat("gdscript_%s", p_test_name));
+	String project_godot_file = project_folder.path_join("project.godot");
+	String project_folder_dot_godot = project_folder.path_join(".godot");
+	String project_folder_imported = project_folder_dot_godot.path_join("imported");
+	String dot_godot_dir_backup = TestUtils::get_temp_path("gdscript_dot_godot_backup");
+
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	auto remove_dir = [&da, &err](const String &p_dir_to_remove) -> Error {
+		Ref<DirAccess> deletion_da = DirAccess::open(p_dir_to_remove);
+		if (deletion_da.is_null()) {
+			return FAILED;
+		}
+
+		err = deletion_da->erase_contents_recursive();
+		if (err != OK) {
+			return err;
+		}
+		return da->remove(p_dir_to_remove);
+	};
+
+	bool first_set_up = false;
+	if (!is_test_set_up.has(p_test_name) || !is_test_set_up[p_test_name]) {
+		// First set up.
+		is_test_set_up[p_test_name] = true;
+		first_set_up = true;
+		remove_dir(dot_godot_dir_backup);
+		remove_dir(project_folder);
+
+		err = da->make_dir_recursive(project_folder_imported);
+		CHECK_MESSAGE(err == OK, vformat(R"*(Couldn't create directory "%s".)*", project_folder_imported));
+
+		if (FileAccess::exists(base_path_godot_file)) {
+			err = da->copy(base_path_godot_file, project_godot_file);
+			CHECK_MESSAGE(err == OK, R"*(Couldn't copy "project.godot".)*");
+		}
 	}
 
+	// Initialize res:// to `project_folder`.
+	TestProjectSettingsInternalsAccessor::resource_path() = project_folder;
+	err = ProjectSettings::get_singleton()->setup(project_folder, String(), true);
+	CHECK_MESSAGE(err == OK, "Error while setting up the project.");
+
+#define CLEAN_UP_DOT_GODOT_DIR_BACKUP()                                                                    \
+	err = remove_dir(dot_godot_dir_backup);                                                                \
+	if (err != OK) {                                                                                       \
+		ERR_PRINT(vformat(R"*(Error while deleting "%s": %s.)*", dot_godot_dir_backup, error_names[err])); \
+	}                                                                                                      \
+	(void)0
+
+	if (!first_set_up || p_copy_target.is_empty()) {
+		CLEAN_UP_DOT_GODOT_DIR_BACKUP();
+		return;
+	}
+
+#define COPY_DIR(m_from, m_to)        \
+	err = da->copy_dir(m_from, m_to); \
+	CHECK_MESSAGE(err == OK, vformat(R"*(Error while copying directory "%s" to "%s".)*", m_from, m_to))
+
+	COPY_DIR(project_folder_dot_godot, dot_godot_dir_backup);
+	COPY_DIR(p_base_path, project_folder);
+	COPY_DIR(dot_godot_dir_backup, project_folder_dot_godot);
+
+#undef COPY_DIR
+
+	CLEAN_UP_DOT_GODOT_DIR_BACKUP();
+#undef CLEAN_UP_DOT_GODOT_DIR_BACKUP
+}
+
+void init_language() {
 	// Initialize the language for the test routine.
 	GDScriptLanguage::get_singleton()->init();
 	init_autoloads();
 }
 
 void finish_language() {
+	GDScriptCache::clear();
 	GDScriptLanguage::get_singleton()->finish();
 	ScriptServer::global_classes_clear();
 }
@@ -143,7 +212,8 @@ GDScriptTestRunner::GDScriptTestRunner(const String &p_source_dir, bool p_init_l
 	}
 
 	if (do_init_languages) {
-		init_language(p_source_dir);
+		init_project_dir(p_source_dir, "gdscript_test_runner");
+		init_language();
 	}
 #ifdef DEBUG_ENABLED
 	// Set all warning levels to "Warn" in order to test them properly, even the ones that default to error.
@@ -265,23 +335,28 @@ bool GDScriptTestRunner::make_tests_for_dir(const String &p_dir) {
 	dir->list_dir_begin();
 	String next = dir->get_next();
 
+#define CONTINUE()          \
+	next = dir->get_next(); \
+	continue
+
 	while (!next.is_empty()) {
 		if (dir->current_is_dir()) {
-			if (next == "." || next == ".." || next == "completion" || next == "lsp") {
-				next = dir->get_next();
-				continue;
+			if (next == "." || next == ".." || next == "completion" || next == "lsp" || next == "refactor") {
+				CONTINUE();
 			}
+			if (next == ".godot") {
+				CONTINUE();
+			}
+
 			if (!make_tests_for_dir(current_dir.path_join(next))) {
 				return false;
 			}
 		} else {
 			// `*.notest.gd` files are skipped.
 			if (next.ends_with(".notest.gd")) {
-				next = dir->get_next();
-				continue;
+				CONTINUE();
 			} else if (binary_tokens && next.ends_with(".textonly.gd")) {
-				next = dir->get_next();
-				continue;
+				CONTINUE();
 			} else if (next.has_extension("gd")) {
 #ifndef DEBUG_ENABLED
 				// On release builds, skip tests marked as debug only.
@@ -289,12 +364,10 @@ bool GDScriptTestRunner::make_tests_for_dir(const String &p_dir) {
 				Ref<FileAccess> script_file(FileAccess::open(current_dir.path_join(next), FileAccess::READ, &open_err));
 				if (open_err != OK) {
 					ERR_PRINT(vformat(R"(Couldn't open test file "%s".)", next));
-					next = dir->get_next();
-					continue;
+					CONTINUE();
 				} else {
 					if (script_file->get_line() == "#debug-only") {
-						next = dir->get_next();
-						continue;
+						CONTINUE();
 					}
 				}
 #endif
@@ -320,8 +393,9 @@ bool GDScriptTestRunner::make_tests_for_dir(const String &p_dir) {
 			}
 		}
 
-		next = dir->get_next();
+		CONTINUE();
 	}
+#undef CONTINUE
 
 	dir->list_dir_end();
 
@@ -354,17 +428,18 @@ static bool generate_class_index_recursive(const String &p_dir) {
 	StringName gdscript_name = GDScriptLanguage::get_singleton()->get_name();
 	while (!next.is_empty()) {
 		if (dir->current_is_dir()) {
-			if (next == "." || next == ".." || next == "completion" || next == "lsp") {
-				next = dir->get_next();
-				continue;
+			if (next == "." || next == ".." || next == "completion" || next == "lsp" || next == "refactor") {
+				goto next;
+			}
+			if (next == ".godot") {
+				goto next;
 			}
 			if (!generate_class_index_recursive(current_dir.path_join(next))) {
 				return false;
 			}
 		} else {
 			if (!next.ends_with(".gd")) {
-				next = dir->get_next();
-				continue;
+				goto next;
 			}
 			String base_type;
 			String source_file = current_dir.path_join(next);
@@ -372,8 +447,7 @@ static bool generate_class_index_recursive(const String &p_dir) {
 			bool is_tool = false;
 			String class_name = GDScriptLanguage::get_singleton()->get_global_class_name(source_file, &base_type, nullptr, &is_abstract, &is_tool);
 			if (class_name.is_empty()) {
-				next = dir->get_next();
-				continue;
+				goto next;
 			}
 			ERR_FAIL_COND_V_MSG(ScriptServer::is_global_class(class_name), false,
 					"Class name '" + class_name + "' from " + source_file + " is already used in " + ScriptServer::get_global_class_path(class_name));
@@ -381,6 +455,7 @@ static bool generate_class_index_recursive(const String &p_dir) {
 			ScriptServer::add_global_class(class_name, base_type, gdscript_name, source_file, is_abstract, is_tool);
 		}
 
+	next:
 		next = dir->get_next();
 	}
 
@@ -622,7 +697,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		ERR_FAIL_V_MSG(result, "\nCould not find test function on: '" + source_file + "'");
 	}
 
-	// Setup output handlers.
+	// Set up output handlers.
 	ErrorHandlerData error_data(&result, this);
 
 	_print_handler.userdata = &result;

--- a/modules/gdscript/tests/gdscript_test_runner.h
+++ b/modules/gdscript/tests/gdscript_test_runner.h
@@ -35,12 +35,16 @@
 #include "core/error/error_macros.h"
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
 #include "core/templates/vector.h"
 
 namespace GDScriptTests {
 
+static HashMap<String, bool> is_test_set_up;
+
 void init_autoloads();
-void init_language(const String &p_base_path);
+void init_project_dir(const String &p_base_path, const String &p_test_name, const String &p_copy_target = "res://");
+void init_language();
 void finish_language();
 
 // Single test instance in a suite.

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -35,11 +35,12 @@
 #include "tests/test_macros.h"
 
 namespace GDScriptTests {
+namespace TestRunnerSuite {
 
+TEST_SUITE("[Modules][GDScript][Suite]") {
 // TODO: Handle some cases failing on release builds. See: https://github.com/godotengine/godot/pull/88452
 #ifdef TOOLS_ENABLED
-TEST_SUITE("[Modules][GDScript]") {
-	TEST_CASE("Script compilation and runtime") {
+	TEST_CASE("[Compilation] Script compilation and runtime") {
 		bool print_filenames = OS::get_singleton()->get_cmdline_args().find("--print-filenames") != nullptr;
 		bool use_binary_tokens = OS::get_singleton()->get_cmdline_args().find("--use-binary-tokens") != nullptr;
 		GDScriptTestRunner runner("modules/gdscript/tests/scripts", true, print_filenames, use_binary_tokens);
@@ -47,59 +48,69 @@ TEST_SUITE("[Modules][GDScript]") {
 		INFO("Make sure `*.out` files have expected results.");
 		REQUIRE_MESSAGE(fail_count == 0, "All GDScript tests should pass.");
 	}
-}
 #endif // TOOLS_ENABLED
 
-TEST_CASE("[Modules][GDScript] Load source code dynamically and run it") {
-	GDScriptLanguage::get_singleton()->init();
-	Ref<GDScript> gdscript = memnew(GDScript);
-	gdscript->set_source_code(R"(
+	TEST_CASE("[Dynamic code] Load source code dynamically and run it") {
+		init_language();
+
+		Ref<GDScript> gdscript;
+		gdscript.instantiate();
+		gdscript->set_source_code(R"(
 extends RefCounted
 
 func _init():
 	set_meta("result", 42)
 )");
-	// A spurious `Condition "err" is true` message is printed (despite parsing being successful and returning `OK`).
-	// Silence it.
-	ERR_PRINT_OFF;
-	const Error error = gdscript->reload();
-	ERR_PRINT_ON;
-	CHECK_MESSAGE(error == OK, "The script should parse successfully.");
+		// A spurious `Condition "err" is true` message is printed (despite parsing being successful and returning `OK`).
+		// Silence it.
+		ERR_PRINT_OFF;
+		const Error error = gdscript->reload();
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(error == OK, "The script should parse successfully.");
 
-	// Run the script by assigning it to a reference-counted object.
-	Ref<RefCounted> ref_counted = memnew(RefCounted);
-	ref_counted->set_script(gdscript);
-	CHECK_MESSAGE(int(ref_counted->get_meta("result")) == 42, "The script should assign object metadata successfully.");
-}
+		// Run the script by assigning it to a reference-counted object.
+		Ref<RefCounted> ref_counted;
+		ref_counted.instantiate();
+		ref_counted->set_script(gdscript);
+		CHECK_MESSAGE(int(ref_counted->get_meta("result")) == 42, "The script should assign object metadata successfully.");
 
-TEST_CASE("[Modules][GDScript] Validate built-in API") {
-	GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
-
-	// Validate methods.
-	List<MethodInfo> builtin_methods;
-	lang->get_public_functions(&builtin_methods);
-
-	SUBCASE("[Modules][GDScript] Validate built-in methods") {
-		for (const MethodInfo &mi : builtin_methods) {
-			for (int64_t i = 0; i < mi.arguments.size(); ++i) {
-				TEST_COND((mi.arguments[i].name.is_empty() || mi.arguments[i].name.begins_with("_unnamed_arg")),
-						vformat("Unnamed argument in position %d of built-in method '%s'.", i, mi.name));
-			}
-		}
+		finish_language();
 	}
 
-	// Validate annotations.
-	List<MethodInfo> builtin_annotations;
-	lang->get_public_annotations(&builtin_annotations);
+	TEST_CASE("[API] Validate built-in API") {
+		init_language();
 
-	SUBCASE("[Modules][GDScript] Validate built-in annotations") {
-		for (const MethodInfo &ai : builtin_annotations) {
-			for (int64_t i = 0; i < ai.arguments.size(); ++i) {
-				TEST_COND((ai.arguments[i].name.is_empty() || ai.arguments[i].name.begins_with("_unnamed_arg")),
-						vformat("Unnamed argument in position %d of built-in annotation '%s'.", i, ai.name));
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+
+		// Validate methods.
+		List<MethodInfo> builtin_methods;
+		lang->get_public_functions(&builtin_methods);
+
+		SUBCASE("[Built-in][Methods] Validate built-in methods") {
+			for (const MethodInfo &mi : builtin_methods) {
+				for (int64_t i = 0; i < mi.arguments.size(); ++i) {
+					TEST_COND((mi.arguments[i].name.is_empty() || mi.arguments[i].name.begins_with("_unnamed_arg")),
+							vformat("Unnamed argument in position %d of built-in method '%s'.", i, mi.name));
+				}
 			}
 		}
+
+		// Validate annotations.
+		List<MethodInfo> builtin_annotations;
+		lang->get_public_annotations(&builtin_annotations);
+
+		SUBCASE("[Built-in][Annotations] Validate built-in annotations") {
+			for (const MethodInfo &ai : builtin_annotations) {
+				for (int64_t i = 0; i < ai.arguments.size(); ++i) {
+					TEST_COND((ai.arguments[i].name.is_empty() || ai.arguments[i].name.begins_with("_unnamed_arg")),
+							vformat("Unnamed argument in position %d of built-in annotation '%s'.", i, ai.name));
+				}
+			}
+		}
+
+		finish_language();
 	}
 }
 
+} // namespace TestRunnerSuite
 } // namespace GDScriptTests

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -51,6 +51,7 @@
 #include "modules/modules_enabled.gen.h" // For mono.
 
 namespace GDScriptTests {
+namespace TestCompletion {
 
 static bool match_option(const Dictionary p_expected, const ScriptLanguage::CodeCompletionOption p_got) {
 	if (p_expected.get("display", p_got.display) != p_got.display) {
@@ -93,19 +94,24 @@ static void test_directory(const String &p_dir) {
 	dir->list_dir_begin();
 	String next = dir->get_next();
 
+#define CONTINUE()          \
+	next = dir->get_next(); \
+	continue
+
 	while (!next.is_empty()) {
 		if (dir->current_is_dir()) {
 			if (next == "." || next == "..") {
-				next = dir->get_next();
-				continue;
+				CONTINUE();
+			}
+			if (next == ".godot") {
+				CONTINUE();
 			}
 			test_directory(path.path_join(next));
 		} else if (next.ends_with(".gd") && !next.ends_with(".notest.gd")) {
 			Ref<FileAccess> acc = FileAccess::open(path.path_join(next), FileAccess::READ, &err);
 
 			if (err != OK) {
-				next = dir->get_next();
-				continue;
+				CONTINUE();
 			}
 
 			String code = acc->get_as_utf8_string();
@@ -124,8 +130,7 @@ static void test_directory(const String &p_dir) {
 
 #ifndef MODULE_MONO_ENABLED
 			if (conf.get_value("input", "cs", false)) {
-				next = dir->get_next();
-				continue;
+				CONTINUE();
 			}
 #endif
 
@@ -219,8 +224,12 @@ static void test_directory(const String &p_dir) {
 				memdelete(scene);
 			}
 		}
-		next = dir->get_next();
+
+		CONTINUE();
 	}
+#undef CONTINUE
+
+	dir->list_dir_end();
 }
 
 static void setup_global_classes(const String &p_dir) {
@@ -237,8 +246,15 @@ static void setup_global_classes(const String &p_dir) {
 	dir->list_dir_begin();
 	String next = dir->get_next();
 
+#define CONTINUE()          \
+	next = dir->get_next(); \
+	continue
+
 	while (!next.is_empty()) {
 		if (dir->current_is_dir() && next != "." && next != "..") {
+			if (next == ".godot") {
+				CONTINUE();
+			}
 			setup_global_classes(path.path_join(next));
 		} else if (next.ends_with(".gd")) {
 			String base_type;
@@ -247,30 +263,39 @@ static void setup_global_classes(const String &p_dir) {
 			String source_file = path.path_join(next);
 			String class_name = GDScriptLanguage::get_singleton()->get_global_class_name(source_file, &base_type, nullptr, &is_abstract, &is_tool);
 			if (class_name.is_empty()) {
-				next = dir->get_next();
-				continue;
+				CONTINUE();
 			}
 			ERR_FAIL_COND_MSG(ScriptServer::is_global_class(class_name),
 					"Class name \"" + class_name + "\" from \"" + source_file + "\" is already used in \"" + ScriptServer::get_global_class_path(class_name) + "\".");
 
 			ScriptServer::add_global_class(class_name, base_type, GDScriptLanguage::get_singleton()->get_name(), source_file, is_abstract, is_tool);
 		}
-		next = dir->get_next();
+
+		CONTINUE();
 	}
+#undef CONTINUE
+
+	dir->list_dir_end();
 }
 
 TEST_SUITE("[Modules][GDScript][Completion]") {
 	TEST_CASE("[Editor] Check suggestion list") {
 		// Set all editor settings that code completion relies on.
 		EditorSettings::get_singleton()->set_setting("text_editor/completion/use_single_quotes", false);
-		init_language("modules/gdscript/tests/scripts");
+		init_project_dir("modules/gdscript/tests/scripts", "completion");
+		init_language();
 
-		setup_global_classes("modules/gdscript/tests/scripts/completion");
-		test_directory("modules/gdscript/tests/scripts/completion");
+		// Relative to "modules/gdscript/tests/scripts"
+		String completion_path = "res://completion";
+
+		setup_global_classes(completion_path);
+		test_directory(completion_path);
 
 		finish_language();
 	}
 }
+
+} // namespace TestCompletion
 } // namespace GDScriptTests
 
 #endif

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -311,7 +311,8 @@ void test(TestType p_type) {
 	ERR_FAIL_COND_MSG(fa.is_null(), "Could not open file: " + test);
 
 	// Initialize the language for the test routine.
-	init_language(fa->get_path_absolute().get_base_dir());
+	init_project_dir(fa->get_path_absolute().get_base_dir(), "gdscript");
+	init_language();
 
 	// Load global classes.
 	TypedArray<Dictionary> script_classes = ProjectSettings::get_singleton()->get_global_class_list();

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -76,6 +76,7 @@ struct doctest::StringMaker<GodotPosition> {
 };
 
 namespace GDScriptTests {
+namespace TestLSP {
 
 // LSP GDScript test scripts are located inside project of other GDScript tests:
 // Cannot reset `ProjectSettings` (singleton) -> Cannot load another workspace and resources in there.
@@ -93,7 +94,10 @@ GDScriptLanguageProtocol *initialize(const String &p_root) {
 	Ref<DirAccess> dir(DirAccess::open(p_root, &err));
 	REQUIRE_MESSAGE(err == OK, "Could not open specified root directory");
 	String absolute_root = dir->get_current_dir();
-	init_language(absolute_root);
+	init_project_dir(absolute_root, "lsp", "res://");
+	init_language();
+
+	absolute_root = ProjectSettings::get_singleton()->get_resource_path();
 
 	GDScriptLanguageProtocol *proto = memnew(GDScriptLanguageProtocol);
 
@@ -532,6 +536,7 @@ func f():
 	}
 }
 
+} // namespace TestLSP
 } // namespace GDScriptTests
 
 #endif // MODULE_JSONRPC_ENABLED


### PR DESCRIPTION
- This PR makes sure that languages are initialized and finished before each test.
- GDScript test files are now copied to temporary files before being tested on.
- Each GDScript test file now lives in its own namespace.
- GDScriptCache can now be cleaned and reinitialized (more than once).

This PR salvages mostly the updates done to the test engine made by #102380.