### PR TITLE
Fix GDScript code sample for `@GlobalScope.instance_from_id()`

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -500,7 +500,7 @@
 				func _ready():
 					var id = get_instance_id()
 					var instance = instance_from_id(id)
-					print(instance.foo) # Prints "water"
+					print(instance.drink) # Prints "water"
 				[/gdscript]
 				[csharp]
 				public partial class MyNode : Node


### PR DESCRIPTION
The C# version is already correct.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/81#discussioncomment-13381214.
