### PR TITLE
Add box scaling to value tracks

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -2334,12 +2334,19 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				// Pre-calculate the actual order of the keys. This is needed as a move might be happening
 				// which might cause the keys to be in a different order than their current indices.
-				Vector<Pair<float, int>> sorted_keys;
+				LocalVector<Pair<float, int>> sorted_keys;
 
 				for (int i = 0; i < animation->track_get_key_count(track); i++) {
 					float time_offset = animation->track_get_key_time(track, i) - timeline->get_value();
+
 					if (editor->is_key_selected(track, i) && editor->is_moving_selection()) {
 						time_offset += editor->get_moving_selection_offset();
+					}
+
+					if (editor->is_key_selected(track, i) && editor->is_scaling_selection()) {
+						float dynamic_scaling = editor->get_scaling_selection_drag() - editor->get_scaling_selection_pivot();
+						dynamic_scaling /= editor->get_scaling_selection_drag_start() - editor->get_scaling_selection_pivot();
+						time_offset = (time_offset - editor->get_scaling_selection_pivot()) * dynamic_scaling + editor->get_scaling_selection_pivot();
 					}
 
 					float screen_pos = time_offset * scale + limit;
@@ -2348,7 +2355,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				sorted_keys.sort();
 
-				for (int i = 0; i < sorted_keys.size(); i++) {
+				for (size_t i = 0; i < sorted_keys.size(); i++) {
 					float offset = sorted_keys[i].first;
 					int original_index = sorted_keys[i].second;
 					bool selected = editor->is_key_selected(track, original_index);
@@ -2879,6 +2886,11 @@ Control::CursorShape AnimationTrackEdit::get_cursor_shape(const Point2 &p_pos) c
 	if (command_or_control_pressed && animation->track_get_type(track) == Animation::TYPE_METHOD && hovering_key_idx != -1) {
 		return Control::CURSOR_POINTING_HAND;
 	}
+
+	if (editor->is_position_over_scale_handle(get_global_position() + p_pos) != AnimationTrackEditor::SCALE_HANDLE_NONE || editor->is_scaling_selection()) {
+		return Control::CURSOR_HSIZE;
+	}
+
 	return get_default_cursor_shape();
 }
 
@@ -3242,7 +3254,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 	}
 
-	if (!moving_selection && mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+	if (!moving_selection && !editor->is_scaling_selection() && mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
 		Point2 pos = mb->get_position();
 		if (pos.x >= timeline->get_name_limit() && pos.x <= get_size().width - timeline->get_buttons_width()) {
 			// Can do something with menu too! show insert key.
@@ -3382,7 +3394,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 bool AnimationTrackEdit::_try_select_at_ui_pos(const Point2 &p_pos, bool p_aggregate, bool p_deselectable) {
-	if (!animation->track_is_compressed(track)) { // Selecting compressed keyframes for editing is not possible.
+	if (!animation->track_is_compressed(track) && editor->is_position_over_scale_handle(get_global_position() + p_pos) == AnimationTrackEditor::SCALE_HANDLE_NONE) { // Selecting compressed keyframes for editing is not possible.
 		float scale = timeline->get_zoom_scale();
 		int limit = timeline->get_name_limit();
 		int limit_end = get_size().width - timeline->get_buttons_width();
@@ -4061,7 +4073,13 @@ AnimationTrackEditGroup::AnimationTrackEditGroup() {
 	set_mouse_filter(MOUSE_FILTER_PASS);
 }
 
-//////////////////////////////////////
+Control::CursorShape AnimationTrackEditGroup::get_cursor_shape(const Point2 &p_pos) const {
+	if (editor->is_position_over_scale_handle(get_global_position() + p_pos) != AnimationTrackEditor::SCALE_HANDLE_NONE || editor->is_scaling_selection()) {
+		return Control::CURSOR_HSIZE;
+	}
+
+	return get_default_cursor_shape();
+}
 
 void AnimationTrackEditor::add_track_edit_plugin(const Ref<AnimationTrackEditPlugin> &p_plugin) {
 	if (track_edit_plugins.has(p_plugin)) {
@@ -4173,6 +4191,10 @@ Ref<Animation> AnimationTrackEditor::get_current_animation() const {
 	return animation;
 }
 
+Control *AnimationTrackEditor::get_scale_control() const {
+	return scale_control;
+}
+
 void AnimationTrackEditor::_root_removed() {
 	root = nullptr;
 }
@@ -4270,10 +4292,21 @@ void AnimationTrackEditor::cleanup() {
 
 void AnimationTrackEditor::_name_limit_changed() {
 	_redraw_tracks();
+	if (selection.size() > 1) {
+		_update_scale_control();
+		scale_control->queue_redraw();
+	}
 }
 
 void AnimationTrackEditor::_timeline_changed(float p_new_pos, bool p_timeline_only) {
 	emit_signal(SNAME("timeline_changed"), p_new_pos, p_timeline_only, false);
+}
+
+void AnimationTrackEditor::_zoom_changed() {
+	if (selection.size() > 1) {
+		_update_scale_control();
+		scale_control->queue_redraw();
+	}
 }
 
 void AnimationTrackEditor::_track_remove_request(int p_track) {
@@ -5417,6 +5450,8 @@ void AnimationTrackEditor::_update_tracks() {
 		}
 
 	} else {
+		// Sort a copy so track_edits still contains the correct track order.
+		Vector<AnimationTrackEdit *> sorted_track_edits = track_edits;
 		if (use_alphabetic_sorting) {
 			struct TrackAlphaCompare {
 				bool operator()(const AnimationTrackEdit *p_lhs, const AnimationTrackEdit *p_rhs) const {
@@ -5426,10 +5461,10 @@ void AnimationTrackEditor::_update_tracks() {
 				}
 			};
 
-			track_edits.sort_custom<TrackAlphaCompare>();
+			sorted_track_edits.sort_custom<TrackAlphaCompare>();
 		}
 
-		for (AnimationTrackEdit *track_edit : track_edits) {
+		for (AnimationTrackEdit *track_edit : sorted_track_edits) {
 			track_vbox->add_child(track_edit);
 		}
 	}
@@ -5671,6 +5706,11 @@ void AnimationTrackEditor::_notification(int p_what) {
 
 			_update_nearest_fps_label();
 		} break;
+
+		case NOTIFICATION_RESIZED: {
+			_update_scale_control();
+			scale_control->queue_redraw();
+		}
 	}
 }
 
@@ -6206,6 +6246,26 @@ void AnimationTrackEditor::_move_selection_begin() {
 
 void AnimationTrackEditor::_move_selection(float p_offset) {
 	moving_selection_offset = p_offset;
+	scale_control->queue_redraw();
+	_redraw_tracks();
+}
+
+void AnimationTrackEditor::_scale_selection_begin(float p_pivot, float p_drag_start) {
+	scaling_selection_pivot = p_pivot;
+	scaling_selection_drag = p_drag_start;
+	scaling_selection_drag_start = p_drag_start;
+	scaling_selection = true;
+}
+
+void AnimationTrackEditor::_scale_selection(float p_drag_time) {
+	scaling_selection_drag = p_drag_time;
+	_redraw_tracks();
+}
+
+void AnimationTrackEditor::_scale_selection_cancel() {
+	scaling_selection = false;
+	scaling_selection_drag = scaling_selection_drag_start;
+	_update_scale_control();
 	_redraw_tracks();
 }
 
@@ -6241,6 +6301,7 @@ void AnimationTrackEditor::_clear_key_edit() {
 
 void AnimationTrackEditor::_clear_selection(bool p_update) {
 	selection.clear();
+	scale_control->hide();
 
 	if (p_update) {
 		_redraw_tracks();
@@ -6251,6 +6312,7 @@ void AnimationTrackEditor::_clear_selection(bool p_update) {
 
 void AnimationTrackEditor::_update_key_edit() {
 	_clear_key_edit();
+	scale_control->hide();
 	if (animation.is_null()) {
 		return;
 	}
@@ -6310,8 +6372,53 @@ void AnimationTrackEditor::_update_key_edit() {
 		multi_key_edit->use_fps = timeline->is_using_fps();
 		multi_key_edit->root_path = root;
 
+		if (!scale_control_update_pending) {
+			scale_control_update_pending = true;
+			callable_mp(this, &AnimationTrackEditor::_queue_update_scale_control).call_deferred();
+		}
+
 		EditorNode::get_singleton()->push_item(multi_key_edit);
 	}
+}
+
+void AnimationTrackEditor::_queue_update_scale_control() {
+	scale_control_update_pending = false;
+	if (selection.size() > 1) {
+		scale_control->set_visible(_update_scale_control());
+	} else {
+		scale_control->hide();
+	}
+}
+
+bool AnimationTrackEditor::_update_scale_control() {
+	if (read_only) {
+		return false;
+	}
+	const float timeline_margin_left = timeline_mc->get_theme_constant(SNAME("margin_left"), SNAME("AnimationTrackMargins"));
+	Rect2 bounds = Rect2();
+	bool first_key = true;
+
+	for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
+		int track = E.key.track;
+		int key_id = E.key.key;
+		Rect2 key_rect = Rect2();
+		key_rect.size.height = track_edits[track]->get_size().height;
+		float offset = animation->track_get_key_time(track, key_id) - timeline->get_value();
+		offset = offset * timeline->get_zoom_scale() + timeline->get_name_limit();
+		key_rect.position.x = offset + timeline_margin_left;
+		key_rect.position.y = track_edits[track]->get_global_position().y - scroll->get_global_position().y;
+
+		if (first_key) {
+			bounds = key_rect;
+			first_key = false;
+		} else {
+			bounds = bounds.merge(key_rect);
+		}
+	}
+
+	scale_control->set_rect(bounds);
+
+	return !Math::is_zero_approx(bounds.size.x);
 }
 
 void AnimationTrackEditor::_clear_selection_for_anim(const Ref<Animation> &p_anim) {
@@ -6346,7 +6453,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Animation Move Keys"));
 
-	List<_AnimMoveRestore> to_restore;
+	LocalVector<_AnimMoveRestore> to_restore;
 
 	float motion = moving_selection_offset;
 	// 1 - remove the keys.
@@ -6428,6 +6535,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 
 void AnimationTrackEditor::_move_selection_cancel() {
 	moving_selection = false;
+	scale_control->queue_redraw();
 	_redraw_tracks();
 }
 
@@ -6439,14 +6547,100 @@ float AnimationTrackEditor::get_moving_selection_offset() const {
 	return moving_selection_offset;
 }
 
+bool AnimationTrackEditor::is_scaling_selection() const {
+	return scaling_selection;
+}
+
+AnimationTrackEditor::ScaleHandle AnimationTrackEditor::is_position_over_scale_handle(const Point2 &p_global_pos) const {
+	if (!get_scale_control()->is_visible()) {
+		return ScaleHandle::SCALE_HANDLE_NONE;
+	}
+	static const int SCALE_HANDLE_WIDTH = 24;
+	static const int KEY_ICON_HALF_WIDTH = 5;
+
+	Vector2 local_pos = box_selection_container->get_global_transform().xform_inv(p_global_pos);
+	Rect2 scale_rect = scale_control->get_rect();
+
+	Rect2 left_edge = Rect2(
+			scale_rect.position - Vector2(Math::round(SCALE_HANDLE_WIDTH * EDSCALE), 0),
+			Vector2(Math::round((SCALE_HANDLE_WIDTH - KEY_ICON_HALF_WIDTH) * EDSCALE), scale_rect.size.y));
+	Rect2 right_edge = Rect2(
+			scale_rect.position + Vector2(scale_rect.size.x + Math::round(KEY_ICON_HALF_WIDTH * EDSCALE), 0),
+			Vector2(Math::round((SCALE_HANDLE_WIDTH - KEY_ICON_HALF_WIDTH) * EDSCALE), scale_rect.size.y));
+
+	if (left_edge.has_point(local_pos)) {
+		return ScaleHandle::SCALE_HANDLE_LEFT;
+	} else if (right_edge.has_point(local_pos)) {
+		return ScaleHandle::SCALE_HANDLE_RIGHT;
+	}
+
+	return ScaleHandle::SCALE_HANDLE_NONE;
+}
+
+float AnimationTrackEditor::get_scaling_selection_pivot() const {
+	return scaling_selection_pivot;
+}
+
+float AnimationTrackEditor::get_scaling_selection_drag_start() const {
+	return scaling_selection_drag_start;
+}
+
+float AnimationTrackEditor::get_scaling_selection_drag() const {
+	return scaling_selection_drag;
+}
+
 void AnimationTrackEditor::_box_selection_draw() {
 	const Rect2 selection_rect = Rect2(Point2(), box_selection->get_size());
 	box_selection->draw_rect(selection_rect, get_theme_color(SNAME("box_selection_fill_color"), EditorStringName(Editor)));
 	box_selection->draw_rect(selection_rect, get_theme_color(SNAME("box_selection_stroke_color"), EditorStringName(Editor)), false, Math::round(EDSCALE));
 }
 
+void AnimationTrackEditor::_scale_control_draw() {
+	static const int HALF_SCALE_HANDLE_WIDTH = 12;
+	static const int SCALE_HANDLE_LINE_WIDTH = 3;
+
+	const float timeline_margin_left = timeline_mc->get_theme_constant(SNAME("margin_left"), SNAME("AnimationTrackMargins"));
+
+	Rect2 scale_rect = Rect2(Point2(), scale_control->get_size());
+	scale_rect = scale_rect.grow_individual(HALF_SCALE_HANDLE_WIDTH * EDSCALE, 0, HALF_SCALE_HANDLE_WIDTH * EDSCALE, 0);
+
+	Point2 move_offset = moving_selection ? Point2(moving_selection_offset * timeline->get_zoom_scale(), 0) : Point2();
+
+	int left_limit = timeline->get_name_limit() + timeline_margin_left;
+	int right_limit = timeline->get_size().width - timeline->get_buttons_width() + timeline_margin_left;
+
+	float left_line_x = scale_control->get_position().x + move_offset.x;
+	float right_line_x = left_line_x + scale_control->get_size().x;
+
+	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+	float line_width = Math::round(SCALE_HANDLE_LINE_WIDTH * EDSCALE);
+
+	if (left_line_x >= left_limit && left_line_x <= right_limit) {
+		Point2 line_start = scale_rect.position + move_offset;
+		Point2 line_end = line_start + Point2(0, scale_rect.size.y);
+		scale_control->draw_line(line_start, line_end, accent_color, line_width);
+	}
+
+	if (right_line_x >= left_limit && right_line_x <= right_limit) {
+		Point2 line_start = scale_rect.position + move_offset + Point2(scale_rect.size.x, 0);
+		Point2 line_end = line_start + Point2(0, scale_rect.size.y);
+		scale_control->draw_line(line_start, line_end, accent_color, line_width);
+	}
+
+	Rect2 overlay_rect = Rect2(scale_control->get_position() + move_offset, scale_control->get_size());
+	Rect2 visible_region = Rect2(left_limit, overlay_rect.position.y, right_limit - left_limit, overlay_rect.size.y);
+	overlay_rect = overlay_rect.intersection(visible_region);
+
+	if (overlay_rect.has_area()) {
+		Rect2 local_clipped_rect = Rect2(overlay_rect.position - scale_control->get_position(), overlay_rect.size);
+		Color overlay_color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
+		overlay_color.a = 0.1;
+		scale_control->draw_rect(local_clipped_rect, overlay_color);
+	}
+}
+
 void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
-	if (!box_selecting) {
+	if (!box_selecting && !scaling_selection) {
 		if (panner->gui_input(p_event, scroll->get_global_rect())) {
 			scroll->accept_event();
 			return;
@@ -6455,8 +6649,36 @@ void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 
+	if (mb.is_valid() && scaling_selection) {
+		if (!mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+			_scale_selection_commit();
+			return;
+		}
+
+		if (mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+			_scale_selection_cancel();
+			return;
+		}
+	}
+
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
 		if (mb->is_pressed()) {
+			if (scale_control->is_visible_in_tree()) {
+				const float timeline_margin_left = timeline_mc->get_theme_constant(SNAME("margin_left"), SNAME("AnimationTrackMargins"));
+				float right_edge_time = (scale_control->get_end().x - timeline->get_name_limit() - timeline_margin_left) / timeline->get_zoom_scale();
+				float left_edge_time = (scale_control->get_begin().x - timeline->get_name_limit() - timeline_margin_left) / timeline->get_zoom_scale();
+
+				Point2 global_pos = scroll->get_global_transform().xform(mb->get_position());
+				ScaleHandle sh = is_position_over_scale_handle(global_pos);
+				if (sh == SCALE_HANDLE_LEFT) {
+					_scale_selection_begin(right_edge_time, left_edge_time);
+					return;
+				} else if (sh == SCALE_HANDLE_RIGHT) {
+					_scale_selection_begin(left_edge_time, right_edge_time);
+					return;
+				}
+			}
+
 			box_selecting = true;
 			box_selecting_from = scroll->get_global_transform().xform(mb->get_position());
 			box_select_rect = Rect2();
@@ -6485,6 +6707,26 @@ void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
+
+	if (mm.is_valid() && scaling_selection) {
+		static const int HALF_SCALE_HANDLE_WIDTH = Math::round(12 * EDSCALE);
+		const float timeline_margin_left = timeline_mc->get_theme_constant(SNAME("margin_left"), SNAME("AnimationTrackMargins"));
+
+		float raw_drag_time = (mm->get_position().x - timeline->get_name_limit() - timeline_margin_left) / timeline->get_zoom_scale();
+		float scale_dir_offset = CLAMP((raw_drag_time - scaling_selection_pivot) * timeline->get_zoom_scale(), -HALF_SCALE_HANDLE_WIDTH, HALF_SCALE_HANDLE_WIDTH);
+		float new_time = (mm->get_position().x - timeline->get_name_limit() - timeline_margin_left - scale_dir_offset) / timeline->get_zoom_scale();
+		new_time = MAX(-timeline->get_value(), new_time); // Don't allow scaling into negative time
+		float delta = new_time - scaling_selection_drag_start;
+		float snapped_time = snap_time(new_time + timeline->get_value()) - timeline->get_value();
+		if ((delta > CMP_EPSILON && snapped_time > scaling_selection_drag_start) || (delta < CMP_EPSILON && snapped_time < scaling_selection_drag_start)) {
+			_scale_selection(snapped_time);
+			Rect2 new_control = Rect2(scaling_selection_pivot * timeline->get_zoom_scale() + timeline->get_name_limit() + timeline_margin_left, scale_control->get_begin().y, 0.0, scale_control->get_size().y);
+			float snapped_pixel_x = snapped_time * timeline->get_zoom_scale() + timeline->get_name_limit() + timeline_margin_left;
+			new_control = new_control.expand(Point2(snapped_pixel_x, scale_control->get_begin().y));
+			scale_control->set_rect(new_control);
+		}
+		return;
+	}
 
 	if (mm.is_valid() && box_selecting) {
 		if (!mm->get_button_mask().has_flag(MouseButtonMask::LEFT)) {
@@ -6535,9 +6777,8 @@ void AnimationTrackEditor::_toggle_bezier_edit() {
 }
 
 void AnimationTrackEditor::_scroll_changed(const Vector2 &p_val) {
+	const Vector2 scroll_difference = p_val - prev_scroll_position;
 	if (box_selecting) {
-		const Vector2 scroll_difference = p_val - prev_scroll_position;
-
 		Vector2 from = box_selecting_from - scroll_difference;
 		Vector2 to = box_selecting_to;
 
@@ -6556,6 +6797,12 @@ void AnimationTrackEditor::_scroll_changed(const Vector2 &p_val) {
 		box_select_rect = rect;
 	}
 
+	if (scale_control->is_visible()) {
+		Rect2 offset_scale_rect = Rect2(scale_control->get_rect().position - scroll_difference, scale_control->get_rect().size);
+		scale_control->set_rect(offset_scale_rect);
+		scale_control->queue_redraw();
+	}
+
 	prev_scroll_position = p_val;
 }
 
@@ -6564,7 +6811,7 @@ void AnimationTrackEditor::_v_scroll_changed(float p_val) {
 }
 
 void AnimationTrackEditor::_h_scroll_changed(float p_val) {
-	_scroll_changed(Vector2(p_val, prev_scroll_position.y));
+	_scroll_changed(Vector2(p_val * timeline->get_zoom_scale(), prev_scroll_position.y));
 }
 
 void AnimationTrackEditor::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event) {
@@ -7168,106 +7415,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			if (selection.is_empty()) {
 				return;
 			}
-
-			float from_t = 1e20;
-			float to_t = -1e20;
-			float len = -1e20;
-			float pivot = 0;
-
-			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
-				float t = animation->track_get_key_time(E.key.track, E.key.key);
-				if (t < from_t) {
-					from_t = t;
-				}
-				if (t > to_t) {
-					to_t = t;
-				}
-			}
-
-			len = to_t - from_t;
-			if (scale_from_cursor) {
-				pivot = timeline->get_play_position();
-			} else {
-				pivot = from_t;
-			}
-
-			float s = scale->get_value();
-			ERR_FAIL_COND_MSG(s == 0, "Can't scale to 0.");
-
-			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-			undo_redo->create_action(TTR("Animation Scale Keys"));
-
-			List<_AnimMoveRestore> to_restore;
-
-			// 1 - Remove the keys.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
-			}
-			// 2 - Remove overlapped keys.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				float newtime = (E->get().pos - from_t) * s + from_t;
-				int idx = animation->track_find_key(E->key().track, newtime, Animation::FIND_MODE_APPROX);
-				if (idx == -1) {
-					continue;
-				}
-				SelectedKey sk;
-				sk.key = idx;
-				sk.track = E->key().track;
-				if (selection.has(sk)) {
-					continue; // Already in selection, don't save.
-				}
-
-				undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newtime);
-				_AnimMoveRestore amr;
-
-				amr.key = animation->track_get_key_value(E->key().track, idx);
-				amr.track = E->key().track;
-				amr.time = newtime;
-				amr.transition = animation->track_get_key_transition(E->key().track, idx);
-
-				to_restore.push_back(amr);
-			}
-
-#define NEW_POS(m_ofs) (((s > 0) ? m_ofs : from_t + (len - (m_ofs - from_t))) - pivot) * Math::abs(s) + pivot
-			// 3 - Move the keys (re insert them).
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				float newpos = NEW_POS(E->get().pos);
-				undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
-			}
-
-			// 4 - (Undo) Remove inserted keys.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				float newpos = NEW_POS(E->get().pos);
-				undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newpos);
-			}
-
-			// 5 - (Undo) Reinsert keys.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
-			}
-
-			// 6 - (Undo) Reinsert overlapped keys.
-			for (_AnimMoveRestore &amr : to_restore) {
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
-			}
-
-			undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
-			undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
-
-			// 7 - Reselect.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				float oldpos = E->get().pos;
-				float newpos = NEW_POS(oldpos);
-				if (newpos >= 0) {
-					undo_redo->add_do_method(this, "_select_at_anim", animation, E->key().track, newpos);
-				}
-				undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, oldpos);
-			}
-#undef NEW_POS
-
-			undo_redo->add_do_method(this, "_redraw_tracks");
-			undo_redo->add_undo_method(this, "_redraw_tracks");
-			undo_redo->commit_action();
+			_scale_selection_commit(false);
 		} break;
 
 		case EDIT_SET_START_OFFSET: {
@@ -7866,6 +8014,16 @@ void AnimationTrackEditor::_view_group_toggle() {
 	_update_tracks();
 	view_group->set_button_icon(get_editor_theme_icon(view_group->is_pressed() ? SNAME("AnimationTrackList") : SNAME("AnimationTrackGroup")));
 	bezier_edit->set_filtered(selected_filter->is_pressed());
+	if (selection.size() > 1) {
+		callable_mp(this, &AnimationTrackEditor::_update_scale_control).call_deferred();
+	}
+}
+
+void AnimationTrackEditor::_alphabetical_sorting_toggle() {
+	_update_tracks();
+	if (selection.size() > 1) {
+		callable_mp(this, &AnimationTrackEditor::_update_scale_control).call_deferred();
+	}
 }
 
 bool AnimationTrackEditor::is_grouping_tracks() {
@@ -8061,6 +8219,125 @@ void AnimationTrackEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("animation_step_changed", PropertyInfo(Variant::FLOAT, "step")));
 }
 
+void AnimationTrackEditor::_scale_selection_commit(bool p_dynamic) {
+	scaling_selection = false;
+	if (selection.is_empty()) {
+		return;
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Animation Scale Keys"));
+
+	LocalVector<_AnimMoveRestore> to_restore;
+
+	float from_t = scaling_selection_pivot;
+	float to_t = scaling_selection_drag_start;
+	float len = to_t - from_t;
+	if (Math::is_zero_approx(len)) {
+		return;
+	}
+	float scale_len = scaling_selection_drag - scaling_selection_pivot;
+	float scale_factor = scale_len / len;
+	float pivot = scaling_selection_pivot + timeline->get_value();
+
+	if (!p_dynamic) {
+		from_t = 1e20;
+		to_t = -1e20;
+		for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
+			float t = animation->track_get_key_time(E.key.track, E.key.key);
+			from_t = MIN(from_t, t);
+			to_t = MAX(to_t, t);
+		}
+		scale_factor = scale->get_value();
+		if (scale_from_cursor) {
+			pivot = timeline->get_play_position();
+		} else {
+			pivot = from_t;
+		}
+	}
+
+	// 1 - Remove the keys
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
+	}
+
+	// 2 - Remove overlapped keys
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		float newtime = (E->get().pos - from_t) * scale_factor + from_t;
+		newtime = MAX(0.0, newtime); // Don't allow scaling into negative space.
+		int idx = animation->track_find_key(E->key().track, newtime, Animation::FIND_MODE_APPROX);
+		if (idx == -1) {
+			continue;
+		}
+		SelectedKey sk;
+		sk.key = idx;
+		sk.track = E->key().track;
+		if (selection.has(sk)) {
+			continue;
+		}
+
+		undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newtime);
+		_AnimMoveRestore amr;
+		amr.key = animation->track_get_key_value(E->key().track, idx);
+		amr.track = E->key().track;
+		amr.time = newtime;
+		amr.transition = animation->track_get_key_transition(E->key().track, idx);
+		to_restore.push_back(amr);
+	}
+
+	// 3 - Move the keys (reinsert them)
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		float newpos = ((E->get().pos - pivot) * scale_factor) + pivot;
+		if (!p_dynamic && scale_factor < 0 && !scale_from_cursor) {
+			newpos = newpos + (to_t - from_t) * Math::abs(scale_factor);
+		}
+		undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos,
+				animation->track_get_key_value(E->key().track, E->key().key),
+				animation->track_get_key_transition(E->key().track, E->key().key));
+	}
+
+	// 4 - (Undo) Remove inserted keys
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		float newpos = ((E->get().pos - pivot) * scale_factor) + pivot;
+		if (!p_dynamic && scale_factor < 0 && !scale_from_cursor) {
+			newpos = newpos + (to_t - from_t) * Math::abs(scale_factor);
+		}
+		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newpos);
+	}
+
+	// 5 - (Undo) Reinsert keys
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos,
+				animation->track_get_key_value(E->key().track, E->key().key),
+				animation->track_get_key_transition(E->key().track, E->key().key));
+	}
+
+	// 6 - (Undo) Reinsert overlapped keys
+	for (_AnimMoveRestore &amr : to_restore) {
+		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
+	}
+
+	undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
+	undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
+
+	// 7 - Reselect
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		float oldpos = E->get().pos;
+		float newpos = ((E->get().pos - pivot) * scale_factor) + pivot;
+		if (!p_dynamic && scale_factor < 0 && !scale_from_cursor) {
+			newpos = newpos + (to_t - from_t) * Math::abs(scale_factor);
+		}
+		if (newpos >= 0) {
+			undo_redo->add_do_method(this, "_select_at_anim", animation, E->key().track, newpos);
+		}
+		undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, oldpos);
+	}
+
+	undo_redo->add_do_method(this, "_redraw_tracks");
+	undo_redo->add_undo_method(this, "_redraw_tracks");
+	undo_redo->commit_action();
+}
+
 void AnimationTrackEditor::_pick_track_filter_text_changed(const String &p_newtext) {
 	TreeItem *root_item = pick_track->get_scene_tree()->get_scene_tree()->get_root();
 
@@ -8166,6 +8443,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline->connect("track_added", callable_mp(this, &AnimationTrackEditor::_add_track));
 	timeline->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_timeline_value_changed));
 	timeline->connect("length_changed", callable_mp(this, &AnimationTrackEditor::_update_length));
+	timeline->connect("zoom_changed", callable_mp(this, &AnimationTrackEditor::_zoom_changed));
 	timeline->connect("filter_changed", callable_mp(this, &AnimationTrackEditor::_update_tracks));
 
 	panner.instantiate();
@@ -8214,7 +8492,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	scroll->connect(SceneStringName(theme_changed), callable_mp(this, &AnimationTrackEditor::_update_timeline_margins), CONNECT_DEFERRED);
 	scroll->get_v_scroll_bar()->connect(SceneStringName(visibility_changed), callable_mp(this, &AnimationTrackEditor::_update_timeline_margins));
 	scroll->get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_v_scroll_changed));
-	scroll->get_h_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_h_scroll_changed));
 
 	timeline_vbox->set_custom_minimum_size(Size2(0, 150) * EDSCALE);
 
@@ -8222,6 +8499,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	hscroll->share(timeline);
 	hscroll->hide();
 	hscroll->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_update_scroll));
+	hscroll->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_h_scroll_changed));
 	timeline_vbox->add_child(hscroll);
 	timeline->set_hscroll(hscroll);
 
@@ -8304,7 +8582,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	alphabetic_sorting = memnew(Button);
 	alphabetic_sorting->set_flat(true);
-	alphabetic_sorting->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_update_tracks));
+	alphabetic_sorting->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_alphabetical_sorting_toggle));
 	alphabetic_sorting->set_toggle_mode(true);
 	alphabetic_sorting->set_tooltip_text(TTRC("Sort tracks/groups alphabetically.\nIf disabled, tracks are shown in the order they are added and can be reordered using drag-and-drop."));
 
@@ -8501,6 +8779,12 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	box_selection->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	box_selection->hide();
 	box_selection->connect(SceneStringName(draw), callable_mp(this, &AnimationTrackEditor::_box_selection_draw));
+
+	scale_control = memnew(Control);
+	box_selection_container->add_child(scale_control);
+	scale_control->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	scale_control->hide();
+	scale_control->connect(SceneStringName(draw), callable_mp(this, &AnimationTrackEditor::_scale_control_draw));
 
 	// Default Plugins.
 

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -1890,7 +1890,7 @@ void AnimationTimelineEdit::_play_position_draw() {
 	int px = (-get_value() + play_position_pos) * scale + get_name_limit();
 
 	if (px >= get_name_limit() && px < (play_position->get_size().width - get_buttons_width())) {
-		int h = editor->box_selection_container->get_global_position().y - get_global_position().y;
+		int h = editor->overlay_container->get_global_position().y - get_global_position().y;
 		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
@@ -2332,12 +2332,19 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				// Pre-calculate the actual order of the keys. This is needed as a move might be happening
 				// which might cause the keys to be in a different order than their current indices.
-				Vector<Pair<float, int>> sorted_keys;
+				LocalVector<Pair<float, int>> sorted_keys;
 
 				for (int i = 0; i < animation->track_get_key_count(track); i++) {
 					float time_offset = animation->track_get_key_time(track, i) - timeline->get_value();
+
 					if (editor->is_key_selected(track, i) && editor->is_moving_selection()) {
 						time_offset += editor->get_moving_selection_offset();
+					}
+
+					if (editor->is_key_selected(track, i) && editor->is_scaling_selection()) {
+						float dynamic_scaling = editor->get_scaling_selection_drag() - editor->get_scaling_selection_pivot();
+						dynamic_scaling /= editor->get_scaling_selection_drag_start() - editor->get_scaling_selection_pivot();
+						time_offset = (time_offset - editor->get_scaling_selection_pivot()) * dynamic_scaling + editor->get_scaling_selection_pivot();
 					}
 
 					float screen_pos = time_offset * scale + limit;
@@ -2346,7 +2353,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				sorted_keys.sort();
 
-				for (int i = 0; i < sorted_keys.size(); i++) {
+				for (size_t i = 0; i < sorted_keys.size(); i++) {
 					float offset = sorted_keys[i].first;
 					int original_index = sorted_keys[i].second;
 					bool selected = editor->is_key_selected(track, original_index);
@@ -2877,6 +2884,11 @@ Control::CursorShape AnimationTrackEdit::get_cursor_shape(const Point2 &p_pos) c
 	if (command_or_control_pressed && animation->track_get_type(track) == Animation::TYPE_METHOD && hovering_key_idx != -1) {
 		return Control::CURSOR_POINTING_HAND;
 	}
+
+	if (editor->is_position_over_scale_handle(get_global_position() + p_pos) != AnimationTrackEditor::SCALE_HANDLE_NONE || editor->is_scaling_selection()) {
+		return Control::CURSOR_HSIZE;
+	}
+
 	return get_default_cursor_shape();
 }
 
@@ -3240,7 +3252,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 	}
 
-	if (!moving_selection && mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+	if (!moving_selection && !editor->is_scaling_selection() && mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
 		Point2 pos = mb->get_position();
 		if (pos.x >= timeline->get_name_limit() && pos.x <= get_size().width - timeline->get_buttons_width()) {
 			// Can do something with menu too! show insert key.
@@ -3380,7 +3392,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 bool AnimationTrackEdit::_try_select_at_ui_pos(const Point2 &p_pos, bool p_aggregate, bool p_deselectable) {
-	if (!animation->track_is_compressed(track)) { // Selecting compressed keyframes for editing is not possible.
+	if (!animation->track_is_compressed(track) && editor->is_position_over_scale_handle(get_global_position() + p_pos) == AnimationTrackEditor::SCALE_HANDLE_NONE) { // Selecting compressed keyframes for editing is not possible.
 		float scale = timeline->get_zoom_scale();
 		int limit = timeline->get_name_limit();
 		int limit_end = get_size().width - timeline->get_buttons_width();
@@ -4059,7 +4071,13 @@ AnimationTrackEditGroup::AnimationTrackEditGroup() {
 	set_mouse_filter(MOUSE_FILTER_PASS);
 }
 
-//////////////////////////////////////
+Control::CursorShape AnimationTrackEditGroup::get_cursor_shape(const Point2 &p_pos) const {
+	if (editor->is_position_over_scale_handle(get_global_position() + p_pos) != AnimationTrackEditor::SCALE_HANDLE_NONE || editor->is_scaling_selection()) {
+		return Control::CURSOR_HSIZE;
+	}
+
+	return get_default_cursor_shape();
+}
 
 void AnimationTrackEditor::add_track_edit_plugin(const Ref<AnimationTrackEditPlugin> &p_plugin) {
 	if (track_edit_plugins.has(p_plugin)) {
@@ -4171,6 +4189,10 @@ Ref<Animation> AnimationTrackEditor::get_current_animation() const {
 	return animation;
 }
 
+Control *AnimationTrackEditor::get_scale_control() const {
+	return scale_control;
+}
+
 void AnimationTrackEditor::_root_removed() {
 	root = nullptr;
 }
@@ -4268,10 +4290,21 @@ void AnimationTrackEditor::cleanup() {
 
 void AnimationTrackEditor::_name_limit_changed() {
 	_redraw_tracks();
+	if (selection.size() > 1) {
+		_update_scale_control();
+		scale_control->queue_redraw();
+	}
 }
 
 void AnimationTrackEditor::_timeline_changed(float p_new_pos, bool p_timeline_only) {
 	emit_signal(SNAME("timeline_changed"), p_new_pos, p_timeline_only, false);
+}
+
+void AnimationTrackEditor::_zoom_changed() {
+	if (selection.size() > 1) {
+		_update_scale_control();
+		scale_control->queue_redraw();
+	}
 }
 
 void AnimationTrackEditor::_track_remove_request(int p_track) {
@@ -5415,6 +5448,8 @@ void AnimationTrackEditor::_update_tracks() {
 		}
 
 	} else {
+		// Sort a copy so track_edits still contains the correct track order.
+		Vector<AnimationTrackEdit *> sorted_track_edits = track_edits;
 		if (use_alphabetic_sorting) {
 			struct TrackAlphaCompare {
 				bool operator()(const AnimationTrackEdit *p_lhs, const AnimationTrackEdit *p_rhs) const {
@@ -5424,10 +5459,10 @@ void AnimationTrackEditor::_update_tracks() {
 				}
 			};
 
-			track_edits.sort_custom<TrackAlphaCompare>();
+			sorted_track_edits.sort_custom<TrackAlphaCompare>();
 		}
 
-		for (AnimationTrackEdit *track_edit : track_edits) {
+		for (AnimationTrackEdit *track_edit : sorted_track_edits) {
 			track_vbox->add_child(track_edit);
 		}
 	}
@@ -5669,6 +5704,11 @@ void AnimationTrackEditor::_notification(int p_what) {
 
 			_update_nearest_fps_label();
 		} break;
+
+		case NOTIFICATION_RESIZED: {
+			_update_scale_control();
+			scale_control->queue_redraw();
+		}
 	}
 }
 
@@ -6204,6 +6244,26 @@ void AnimationTrackEditor::_move_selection_begin() {
 
 void AnimationTrackEditor::_move_selection(float p_offset) {
 	moving_selection_offset = p_offset;
+	scale_control->queue_redraw();
+	_redraw_tracks();
+}
+
+void AnimationTrackEditor::_scale_selection_begin(float p_pivot, float p_drag_start) {
+	scaling_selection_pivot = p_pivot;
+	scaling_selection_drag = p_drag_start;
+	scaling_selection_drag_start = p_drag_start;
+	scaling_selection = true;
+}
+
+void AnimationTrackEditor::_scale_selection(float p_drag_time) {
+	scaling_selection_drag = p_drag_time;
+	_redraw_tracks();
+}
+
+void AnimationTrackEditor::_scale_selection_cancel() {
+	scaling_selection = false;
+	scaling_selection_drag = scaling_selection_drag_start;
+	_update_scale_control();
 	_redraw_tracks();
 }
 
@@ -6240,6 +6300,7 @@ void AnimationTrackEditor::_clear_key_edit() {
 
 void AnimationTrackEditor::_clear_selection(bool p_update) {
 	selection.clear();
+	scale_control->hide();
 
 	if (p_update) {
 		_redraw_tracks();
@@ -6263,6 +6324,7 @@ void AnimationTrackEditor::_update_key_edit_callback() {
 	update_key_edit_pending = false;
 
 	_clear_key_edit();
+	scale_control->hide();
 	if (animation.is_null()) {
 		return;
 	}
@@ -6322,8 +6384,53 @@ void AnimationTrackEditor::_update_key_edit_callback() {
 		multi_key_edit->use_fps = timeline->is_using_fps();
 		multi_key_edit->root_path = root;
 
+		if (!scale_control_update_pending) {
+			scale_control_update_pending = true;
+			callable_mp(this, &AnimationTrackEditor::_queue_update_scale_control).call_deferred();
+		}
+
 		EditorNode::get_singleton()->push_item(multi_key_edit);
 	}
+}
+
+void AnimationTrackEditor::_queue_update_scale_control() {
+	scale_control_update_pending = false;
+	if (selection.size() > 1) {
+		scale_control->set_visible(_update_scale_control());
+	} else {
+		scale_control->hide();
+	}
+}
+
+bool AnimationTrackEditor::_update_scale_control() {
+	if (read_only) {
+		return false;
+	}
+	const float timeline_margin_left = timeline_mc->get_theme_constant(SNAME("margin_left"), SNAME("AnimationTrackMargins"));
+	Rect2 bounds = Rect2();
+	bool first_key = true;
+
+	for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
+		int track = E.key.track;
+		int key_id = E.key.key;
+		Rect2 key_rect = Rect2();
+		key_rect.size.height = track_edits[track]->get_size().height;
+		float offset = animation->track_get_key_time(track, key_id) - timeline->get_value();
+		offset = offset * timeline->get_zoom_scale() + timeline->get_name_limit();
+		key_rect.position.x = Math::round(offset + timeline_margin_left);
+		key_rect.position.y = track_edits[track]->get_global_position().y - scroll->get_global_position().y;
+
+		if (first_key) {
+			bounds = key_rect;
+			first_key = false;
+		} else {
+			bounds = bounds.merge(key_rect);
+		}
+	}
+
+	scale_control->set_rect(bounds);
+
+	return !Math::is_zero_approx(bounds.size.x);
 }
 
 void AnimationTrackEditor::_clear_selection_for_anim(const Ref<Animation> &p_anim) {
@@ -6358,7 +6465,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Animation Move Keys"));
 
-	List<_AnimMoveRestore> to_restore;
+	LocalVector<_AnimMoveRestore> to_restore;
 
 	float motion = moving_selection_offset;
 	// 1 - remove the keys.
@@ -6452,6 +6559,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 
 void AnimationTrackEditor::_move_selection_cancel() {
 	moving_selection = false;
+	scale_control->queue_redraw();
 	_redraw_tracks();
 }
 
@@ -6463,14 +6571,100 @@ float AnimationTrackEditor::get_moving_selection_offset() const {
 	return moving_selection_offset;
 }
 
+bool AnimationTrackEditor::is_scaling_selection() const {
+	return scaling_selection;
+}
+
+AnimationTrackEditor::ScaleHandle AnimationTrackEditor::is_position_over_scale_handle(const Point2 &p_global_pos) const {
+	if (!get_scale_control()->is_visible()) {
+		return ScaleHandle::SCALE_HANDLE_NONE;
+	}
+	static const int SCALE_HANDLE_WIDTH = 24;
+	static const int KEY_ICON_HALF_WIDTH = 5;
+
+	Vector2 local_pos = overlay_container->get_global_transform().xform_inv(p_global_pos);
+	Rect2 scale_rect = scale_control->get_rect();
+
+	Rect2 left_edge = Rect2(
+			scale_rect.position - Vector2(Math::round(SCALE_HANDLE_WIDTH * EDSCALE), 0),
+			Vector2(Math::round((SCALE_HANDLE_WIDTH - KEY_ICON_HALF_WIDTH) * EDSCALE), scale_rect.size.y));
+	Rect2 right_edge = Rect2(
+			scale_rect.position + Vector2(scale_rect.size.x + Math::round(KEY_ICON_HALF_WIDTH * EDSCALE), 0),
+			Vector2(Math::round((SCALE_HANDLE_WIDTH - KEY_ICON_HALF_WIDTH) * EDSCALE), scale_rect.size.y));
+
+	if (left_edge.has_point(local_pos)) {
+		return ScaleHandle::SCALE_HANDLE_LEFT;
+	} else if (right_edge.has_point(local_pos)) {
+		return ScaleHandle::SCALE_HANDLE_RIGHT;
+	}
+
+	return ScaleHandle::SCALE_HANDLE_NONE;
+}
+
+float AnimationTrackEditor::get_scaling_selection_pivot() const {
+	return scaling_selection_pivot;
+}
+
+float AnimationTrackEditor::get_scaling_selection_drag_start() const {
+	return scaling_selection_drag_start;
+}
+
+float AnimationTrackEditor::get_scaling_selection_drag() const {
+	return scaling_selection_drag;
+}
+
 void AnimationTrackEditor::_box_selection_draw() {
 	const Rect2 selection_rect = Rect2(Point2(), box_selection->get_size());
 	box_selection->draw_rect(selection_rect, get_theme_color(SNAME("box_selection_fill_color"), EditorStringName(Editor)));
 	box_selection->draw_rect(selection_rect, get_theme_color(SNAME("box_selection_stroke_color"), EditorStringName(Editor)), false, Math::round(EDSCALE));
 }
 
+void AnimationTrackEditor::_scale_control_draw() {
+	static const int HALF_SCALE_HANDLE_WIDTH = 12;
+	static const int SCALE_HANDLE_LINE_WIDTH = 3;
+
+	const float timeline_margin_left = timeline_mc->get_theme_constant(SNAME("margin_left"), SNAME("AnimationTrackMargins"));
+
+	Rect2 scale_rect = Rect2(Point2(), scale_control->get_size());
+	scale_rect = scale_rect.grow_individual(HALF_SCALE_HANDLE_WIDTH * EDSCALE, 0, HALF_SCALE_HANDLE_WIDTH * EDSCALE, 0);
+
+	Point2 move_offset = moving_selection ? Point2(moving_selection_offset * timeline->get_zoom_scale(), 0) : Point2();
+
+	int left_limit = timeline->get_name_limit() + timeline_margin_left;
+	int right_limit = timeline->get_size().width - timeline->get_buttons_width() + timeline_margin_left;
+
+	float left_line_x = scale_control->get_position().x + move_offset.x;
+	float right_line_x = left_line_x + scale_control->get_size().x;
+
+	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+	float line_width = Math::round(SCALE_HANDLE_LINE_WIDTH * EDSCALE);
+
+	if (left_line_x >= left_limit && left_line_x <= right_limit) {
+		Point2 line_start = scale_rect.position + move_offset;
+		Point2 line_end = line_start + Point2(0, scale_rect.size.y);
+		scale_control->draw_line(line_start, line_end, accent_color, line_width);
+	}
+
+	if (right_line_x >= left_limit && right_line_x <= right_limit) {
+		Point2 line_start = scale_rect.position + move_offset + Point2(scale_rect.size.x, 0);
+		Point2 line_end = line_start + Point2(0, scale_rect.size.y);
+		scale_control->draw_line(line_start, line_end, accent_color, line_width);
+	}
+
+	Rect2 overlay_rect = Rect2(scale_control->get_position() + move_offset, scale_control->get_size());
+	Rect2 visible_region = Rect2(left_limit, overlay_rect.position.y, right_limit - left_limit, overlay_rect.size.y);
+	overlay_rect = overlay_rect.intersection(visible_region);
+
+	if (overlay_rect.has_area()) {
+		Rect2 local_clipped_rect = Rect2(overlay_rect.position - scale_control->get_position(), overlay_rect.size);
+		Color overlay_color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
+		overlay_color.a = 0.1;
+		scale_control->draw_rect(local_clipped_rect, overlay_color);
+	}
+}
+
 void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
-	if (!box_selecting) {
+	if (!box_selecting && !scaling_selection) {
 		if (panner->gui_input(p_event, scroll->get_global_rect())) {
 			scroll->accept_event();
 			return;
@@ -6479,8 +6673,36 @@ void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 
+	if (mb.is_valid() && scaling_selection) {
+		if (!mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+			_scale_selection_commit();
+			return;
+		}
+
+		if (mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+			_scale_selection_cancel();
+			return;
+		}
+	}
+
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
 		if (mb->is_pressed()) {
+			if (scale_control->is_visible_in_tree()) {
+				const float timeline_margin_left = timeline_mc->get_theme_constant(SNAME("margin_left"), SNAME("AnimationTrackMargins"));
+				float right_edge_time = (scale_control->get_end().x - timeline->get_name_limit() - timeline_margin_left) / timeline->get_zoom_scale();
+				float left_edge_time = (scale_control->get_begin().x - timeline->get_name_limit() - timeline_margin_left) / timeline->get_zoom_scale();
+
+				Point2 global_pos = scroll->get_global_transform().xform(mb->get_position());
+				ScaleHandle sh = is_position_over_scale_handle(global_pos);
+				if (sh == SCALE_HANDLE_LEFT) {
+					_scale_selection_begin(right_edge_time, left_edge_time);
+					return;
+				} else if (sh == SCALE_HANDLE_RIGHT) {
+					_scale_selection_begin(left_edge_time, right_edge_time);
+					return;
+				}
+			}
+
 			box_selecting = true;
 			box_selecting_from = scroll->get_global_transform().xform(mb->get_position());
 			box_select_rect = Rect2();
@@ -6509,6 +6731,27 @@ void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
+
+	if (mm.is_valid() && scaling_selection) {
+		static const int HALF_SCALE_HANDLE_WIDTH = Math::round(12 * EDSCALE);
+		const float timeline_margin_left = timeline_mc->get_theme_constant(SNAME("margin_left"), SNAME("AnimationTrackMargins"));
+
+		float raw_drag_time = (mm->get_position().x - timeline->get_name_limit() - timeline_margin_left) / timeline->get_zoom_scale();
+		float scale_dir_offset = CLAMP((raw_drag_time - scaling_selection_pivot) * timeline->get_zoom_scale(), -HALF_SCALE_HANDLE_WIDTH, HALF_SCALE_HANDLE_WIDTH);
+		float new_time = (mm->get_position().x - timeline->get_name_limit() - timeline_margin_left - scale_dir_offset) / timeline->get_zoom_scale();
+		new_time = MAX(-timeline->get_value(), new_time); // Don't allow scaling into negative time
+		float delta = new_time - scaling_selection_drag_start;
+		float snapped_time = snap_time(new_time + timeline->get_value()) - timeline->get_value();
+		if ((delta > CMP_EPSILON && snapped_time > scaling_selection_drag_start) || (delta < CMP_EPSILON && snapped_time < scaling_selection_drag_start)) {
+			_scale_selection(snapped_time);
+			float pivot_x = Math::round(scaling_selection_pivot * timeline->get_zoom_scale() + timeline->get_name_limit() + timeline_margin_left);
+			Rect2 new_control = Rect2(pivot_x, scale_control->get_begin().y, 0.0, scale_control->get_size().y);
+			float snapped_pixel_x = Math::round(snapped_time * timeline->get_zoom_scale() + timeline->get_name_limit() + timeline_margin_left);
+			new_control = new_control.expand(Point2(snapped_pixel_x, scale_control->get_begin().y));
+			scale_control->set_rect(new_control);
+		}
+		return;
+	}
 
 	if (mm.is_valid() && box_selecting) {
 		if (!mm->get_button_mask().has_flag(MouseButtonMask::LEFT)) {
@@ -6559,9 +6802,8 @@ void AnimationTrackEditor::_toggle_bezier_edit() {
 }
 
 void AnimationTrackEditor::_scroll_changed(const Vector2 &p_val) {
+	const Vector2 scroll_difference = p_val - prev_scroll_position;
 	if (box_selecting) {
-		const Vector2 scroll_difference = p_val - prev_scroll_position;
-
 		Vector2 from = box_selecting_from - scroll_difference;
 		Vector2 to = box_selecting_to;
 
@@ -6580,6 +6822,12 @@ void AnimationTrackEditor::_scroll_changed(const Vector2 &p_val) {
 		box_select_rect = rect;
 	}
 
+	if (scale_control->is_visible()) {
+		Rect2 offset_scale_rect = Rect2(scale_control->get_rect().position - scroll_difference, scale_control->get_rect().size);
+		scale_control->set_rect(offset_scale_rect);
+		scale_control->queue_redraw();
+	}
+
 	prev_scroll_position = p_val;
 }
 
@@ -6588,7 +6836,7 @@ void AnimationTrackEditor::_v_scroll_changed(float p_val) {
 }
 
 void AnimationTrackEditor::_h_scroll_changed(float p_val) {
-	_scroll_changed(Vector2(p_val, prev_scroll_position.y));
+	_scroll_changed(Vector2(p_val * timeline->get_zoom_scale(), prev_scroll_position.y));
 }
 
 void AnimationTrackEditor::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event) {
@@ -6611,7 +6859,7 @@ void AnimationTrackEditor::_zoom_callback(float p_zoom_factor, Vector2 p_origin,
 
 void AnimationTrackEditor::_cancel_bezier_edit() {
 	bezier_mc->hide();
-	box_selection_container->show();
+	overlay_container->show();
 	bezier_edit_icon->set_pressed(false);
 	auto_fit->show();
 	auto_fit_bezier->hide();
@@ -6621,7 +6869,7 @@ void AnimationTrackEditor::_bezier_edit(int p_for_track) {
 	_clear_selection(); // Bezier probably wants to use a separate selection mode.
 	bezier_edit->set_root(root);
 	bezier_edit->set_animation_and_track(animation, p_for_track, read_only);
-	box_selection_container->hide();
+	overlay_container->hide();
 	bezier_mc->show();
 	auto_fit->hide();
 	auto_fit_bezier->show();
@@ -7204,118 +7452,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			if (selection.is_empty()) {
 				return;
 			}
-
-			float from_t = 1e20;
-			float to_t = -1e20;
-			float len = -1e20;
-			float pivot = 0;
-
-			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
-				float t = animation->track_get_key_time(E.key.track, E.key.key);
-				if (t < from_t) {
-					from_t = t;
-				}
-				if (t > to_t) {
-					to_t = t;
-				}
-			}
-
-			len = to_t - from_t;
-			if (scale_from_cursor) {
-				pivot = timeline->get_play_position();
-			} else {
-				pivot = from_t;
-			}
-
-			float s = scale->get_value();
-			ERR_FAIL_COND_MSG(s == 0, "Can't scale to 0.");
-
-			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-			undo_redo->create_action(TTR("Animation Scale Keys"));
-
-			List<_AnimMoveRestore> to_restore;
-
-			// 1 - Remove the keys.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
-			}
-			// 2 - Remove overlapped keys.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				float newtime = (E->get().pos - from_t) * s + from_t;
-				int idx = animation->track_find_key(E->key().track, newtime, Animation::FIND_MODE_APPROX);
-				if (idx == -1) {
-					continue;
-				}
-				SelectedKey sk;
-				sk.key = idx;
-				sk.track = E->key().track;
-				if (selection.has(sk)) {
-					continue; // Already in selection, don't save.
-				}
-
-				undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newtime);
-				_AnimMoveRestore amr;
-
-				amr.key = animation->track_get_key_value(E->key().track, idx);
-				amr.track = E->key().track;
-				amr.time = newtime;
-				amr.transition = animation->track_get_key_transition(E->key().track, idx);
-				if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
-					amr.handle_mode = animation->bezier_track_get_key_handle_mode(E->key().track, idx);
-				}
-
-				to_restore.push_back(amr);
-			}
-
-#define NEW_POS(m_ofs) (((s > 0) ? m_ofs : from_t + (len - (m_ofs - from_t))) - pivot) * Math::abs(s) + pivot
-			// 3 - Move the keys (re insert them).
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				float newpos = NEW_POS(E->get().pos);
-				undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
-				if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
-					undo_redo->add_do_method(this, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), E->key().track, newpos, animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key));
-				}
-			}
-
-			// 4 - (Undo) Remove inserted keys.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				float newpos = NEW_POS(E->get().pos);
-				undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newpos);
-			}
-
-			// 5 - (Undo) Reinsert keys.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
-				if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
-					undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode", animation.ptr(), E->key().track, E->key().key, animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key));
-				}
-			}
-
-			// 6 - (Undo) Reinsert overlapped keys.
-			for (_AnimMoveRestore &amr : to_restore) {
-				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
-				if (animation->track_get_type(amr.track) == Animation::TYPE_BEZIER) {
-					undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), amr.track, amr.time, amr.handle_mode);
-				}
-			}
-
-			undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
-			undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
-
-			// 7 - Reselect.
-			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-				float oldpos = E->get().pos;
-				float newpos = NEW_POS(oldpos);
-				if (newpos >= 0) {
-					undo_redo->add_do_method(this, "_select_at_anim", animation, E->key().track, newpos);
-				}
-				undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, oldpos);
-			}
-#undef NEW_POS
-
-			undo_redo->add_do_method(this, "_redraw_tracks");
-			undo_redo->add_undo_method(this, "_redraw_tracks");
-			undo_redo->commit_action();
+			_scale_selection_commit(false);
 		} break;
 
 		case EDIT_SET_START_OFFSET: {
@@ -7923,6 +8060,16 @@ void AnimationTrackEditor::_view_group_toggle() {
 	_update_tracks();
 	view_group->set_button_icon(get_editor_theme_icon(view_group->is_pressed() ? SNAME("AnimationTrackList") : SNAME("AnimationTrackGroup")));
 	bezier_edit->set_filtered(selected_filter->is_pressed());
+	if (selection.size() > 1) {
+		callable_mp(this, &AnimationTrackEditor::_update_scale_control).call_deferred();
+	}
+}
+
+void AnimationTrackEditor::_alphabetical_sorting_toggle() {
+	_update_tracks();
+	if (selection.size() > 1) {
+		callable_mp(this, &AnimationTrackEditor::_update_scale_control).call_deferred();
+	}
 }
 
 bool AnimationTrackEditor::is_grouping_tracks() {
@@ -8118,6 +8265,140 @@ void AnimationTrackEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("animation_step_changed", PropertyInfo(Variant::FLOAT, "step")));
 }
 
+void AnimationTrackEditor::_scale_selection_commit(bool p_dynamic) {
+	scaling_selection = false;
+	if (selection.is_empty()) {
+		return;
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Animation Scale Keys"));
+
+	LocalVector<_AnimMoveRestore> to_restore;
+
+	float from_t = scaling_selection_pivot;
+	float to_t = scaling_selection_drag_start;
+	float len = to_t - from_t;
+	if (Math::is_zero_approx(len)) {
+		return;
+	}
+	float scale_len = scaling_selection_drag - scaling_selection_pivot;
+	float scale_factor = scale_len / len;
+	float pivot = scaling_selection_pivot + timeline->get_value();
+
+	if (!p_dynamic) {
+		from_t = 1e20;
+		to_t = -1e20;
+		for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
+			float t = animation->track_get_key_time(E.key.track, E.key.key);
+			from_t = MIN(from_t, t);
+			to_t = MAX(to_t, t);
+		}
+		scale_factor = scale->get_value();
+		if (scale_from_cursor) {
+			pivot = timeline->get_play_position();
+		} else {
+			pivot = from_t;
+		}
+	}
+
+	// 1 - Remove the keys
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
+	}
+
+	// 2 - Remove overlapped keys
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		float newtime = (E->get().pos - from_t) * scale_factor + from_t;
+		newtime = MAX(0.0, newtime); // Don't allow scaling into negative space.
+		int idx = animation->track_find_key(E->key().track, newtime, Animation::FIND_MODE_APPROX);
+		if (idx == -1) {
+			continue;
+		}
+		SelectedKey sk;
+		sk.key = idx;
+		sk.track = E->key().track;
+		if (selection.has(sk)) {
+			continue;
+		}
+
+		undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newtime);
+		_AnimMoveRestore amr;
+		amr.key = animation->track_get_key_value(E->key().track, idx);
+		amr.track = E->key().track;
+		amr.time = newtime;
+		amr.transition = animation->track_get_key_transition(E->key().track, idx);
+		if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+			amr.handle_mode = animation->bezier_track_get_key_handle_mode(E->key().track, idx);
+		}
+		to_restore.push_back(amr);
+	}
+
+	// 3 - Move the keys (reinsert them)
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		float newpos = ((E->get().pos - pivot) * scale_factor) + pivot;
+		if (!p_dynamic && scale_factor < 0 && !scale_from_cursor) {
+			newpos = newpos + (to_t - from_t) * Math::abs(scale_factor);
+		}
+		undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos,
+				animation->track_get_key_value(E->key().track, E->key().key),
+				animation->track_get_key_transition(E->key().track, E->key().key));
+		if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+			undo_redo->add_do_method(this, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), E->key().track, newpos,
+					animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key));
+		}
+	}
+
+	// 4 - (Undo) Remove inserted keys
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		float newpos = ((E->get().pos - pivot) * scale_factor) + pivot;
+		if (!p_dynamic && scale_factor < 0 && !scale_from_cursor) {
+			newpos = newpos + (to_t - from_t) * Math::abs(scale_factor);
+		}
+		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newpos);
+	}
+
+	// 5 - (Undo) Reinsert keys
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos,
+				animation->track_get_key_value(E->key().track, E->key().key),
+				animation->track_get_key_transition(E->key().track, E->key().key));
+		if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+			undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode", animation.ptr(), E->key().track, E->key().key,
+					animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key));
+		}
+	}
+
+	// 6 - (Undo) Reinsert overlapped keys
+	for (_AnimMoveRestore &amr : to_restore) {
+		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
+		if (animation->track_get_type(amr.track) == Animation::TYPE_BEZIER) {
+			undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode_at_time",
+					animation.ptr(), amr.track, amr.time, amr.handle_mode);
+		}
+	}
+
+	undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
+	undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
+
+	// 7 - Reselect
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		float oldpos = E->get().pos;
+		float newpos = ((E->get().pos - pivot) * scale_factor) + pivot;
+		if (!p_dynamic && scale_factor < 0 && !scale_from_cursor) {
+			newpos = newpos + (to_t - from_t) * Math::abs(scale_factor);
+		}
+		if (newpos >= 0) {
+			undo_redo->add_do_method(this, "_select_at_anim", animation, E->key().track, newpos);
+		}
+		undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, oldpos);
+	}
+
+	undo_redo->add_do_method(this, "_redraw_tracks");
+	undo_redo->add_undo_method(this, "_redraw_tracks");
+	undo_redo->commit_action();
+}
+
 void AnimationTrackEditor::_pick_track_filter_text_changed(const String &p_newtext) {
 	TreeItem *root_item = pick_track->get_scene_tree()->get_scene_tree()->get_root();
 
@@ -8223,16 +8504,17 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline->connect("track_added", callable_mp(this, &AnimationTrackEditor::_add_track));
 	timeline->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_timeline_value_changed));
 	timeline->connect("length_changed", callable_mp(this, &AnimationTrackEditor::_update_length));
+	timeline->connect("zoom_changed", callable_mp(this, &AnimationTrackEditor::_zoom_changed));
 	timeline->connect("filter_changed", callable_mp(this, &AnimationTrackEditor::_update_tracks));
 
 	panner.instantiate();
 	panner->set_scroll_zoom_factor(AnimationTimelineEdit::SCROLL_ZOOM_FACTOR_IN);
 	panner->set_callbacks(callable_mp(this, &AnimationTrackEditor::_pan_callback), callable_mp(this, &AnimationTrackEditor::_zoom_callback));
 
-	box_selection_container = memnew(Control);
-	box_selection_container->set_v_size_flags(SIZE_EXPAND_FILL);
-	box_selection_container->set_clip_contents(true);
-	timeline_vbox->add_child(box_selection_container);
+	overlay_container = memnew(Control);
+	overlay_container->set_v_size_flags(SIZE_EXPAND_FILL);
+	overlay_container->set_clip_contents(true);
+	timeline_vbox->add_child(overlay_container);
 
 	bezier_mc = memnew(MarginContainer);
 	bezier_mc->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -8260,7 +8542,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	scroll = memnew(ScrollContainer);
 	scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
-	box_selection_container->add_child(scroll);
+	overlay_container->add_child(scroll);
 	scroll->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
 
 	scroll->set_focus_mode(FOCUS_CLICK);
@@ -8271,7 +8553,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	scroll->connect(SceneStringName(theme_changed), callable_mp(this, &AnimationTrackEditor::_update_timeline_margins), CONNECT_DEFERRED);
 	scroll->get_v_scroll_bar()->connect(SceneStringName(visibility_changed), callable_mp(this, &AnimationTrackEditor::_update_timeline_margins));
 	scroll->get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_v_scroll_changed));
-	scroll->get_h_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_h_scroll_changed));
 
 	timeline_vbox->set_custom_minimum_size(Size2(0, 150) * EDSCALE);
 
@@ -8279,6 +8560,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	hscroll->share(timeline);
 	hscroll->hide();
 	hscroll->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_update_scroll));
+	hscroll->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_h_scroll_changed));
 	timeline_vbox->add_child(hscroll);
 	timeline->set_hscroll(hscroll);
 
@@ -8361,7 +8643,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	alphabetic_sorting = memnew(Button);
 	alphabetic_sorting->set_flat(true);
-	alphabetic_sorting->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_update_tracks));
+	alphabetic_sorting->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_alphabetical_sorting_toggle));
 	alphabetic_sorting->set_toggle_mode(true);
 	alphabetic_sorting->set_tooltip_text(TTRC("Sort tracks/groups alphabetically.\nIf disabled, tracks are shown in the order they are added and can be reordered using drag-and-drop."));
 
@@ -8554,10 +8836,16 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	ichb->add_child(insert_confirm_reset);
 
 	box_selection = memnew(Control);
-	box_selection_container->add_child(box_selection);
+	overlay_container->add_child(box_selection);
 	box_selection->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	box_selection->hide();
 	box_selection->connect(SceneStringName(draw), callable_mp(this, &AnimationTrackEditor::_box_selection_draw));
+
+	scale_control = memnew(Control);
+	overlay_container->add_child(scale_control);
+	scale_control->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	scale_control->hide();
+	scale_control->connect(SceneStringName(draw), callable_mp(this, &AnimationTrackEditor::_scale_control_draw));
 
 	// Default Plugins.
 

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -599,6 +599,7 @@ public:
 	void set_root(Node *p_root);
 	void set_editor(AnimationTrackEditor *p_editor);
 	String get_node_name() const;
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
 	AnimationTrackEditGroup();
 };
@@ -776,21 +777,36 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _move_selection_commit();
 	void _move_selection_cancel();
 
+	bool scaling_selection = false;
+	bool scale_control_update_pending = false;
+	float scaling_selection_pivot = 0.0f;
+	float scaling_selection_drag_start = 0.0f;
+	float scaling_selection_drag = 0.0f;
+	void _scale_selection_begin(float p_pivot, float p_drag_start);
+	void _scale_selection(float p_offset);
+	void _scale_selection_commit(bool p_dynamic = true);
+	void _scale_selection_cancel();
+
 	AnimationTrackKeyEdit *key_edit = nullptr;
 	AnimationMultiTrackKeyEdit *multi_key_edit = nullptr;
 	void _update_key_edit();
+	void _queue_update_scale_control();
+	bool _update_scale_control();
 	void _clear_key_edit();
 
 	Control *box_selection_container = nullptr;
 
 	Control *box_selection = nullptr;
 	void _box_selection_draw();
+	void _scale_control_draw();
 	bool box_selecting = false;
 	Vector2 box_selecting_from;
 	Vector2 box_selecting_to;
 	Rect2 box_select_rect;
 	Vector2 prev_scroll_position;
 	void _scroll_input(const Ref<InputEvent> &p_event);
+
+	Control *scale_control = nullptr;
 
 	Vector<Ref<AnimationTrackEditPlugin>> track_edit_plugins;
 
@@ -848,6 +864,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	Button *function_name_toggler = nullptr;
 
 	void _view_group_toggle();
+	void _alphabetical_sorting_toggle();
 
 	Button *view_group = nullptr;
 	Button *selected_filter = nullptr;
@@ -918,6 +935,7 @@ public:
 	void _clear_selection(bool p_update = false);
 	void _key_selected(int p_key, bool p_single, int p_track);
 	void _key_deselected(int p_key, int p_track);
+	void _zoom_changed();
 
 	enum {
 		EDIT_COPY_TRACKS,
@@ -954,11 +972,18 @@ public:
 		EDIT_GOTO_PREV_KEYFRAME,
 	};
 
+	enum ScaleHandle {
+		SCALE_HANDLE_NONE,
+		SCALE_HANDLE_LEFT,
+		SCALE_HANDLE_RIGHT
+	};
+
 	void add_track_edit_plugin(const Ref<AnimationTrackEditPlugin> &p_plugin);
 	void remove_track_edit_plugin(const Ref<AnimationTrackEditPlugin> &p_plugin);
 
 	void set_animation(const Ref<Animation> &p_anim, bool p_read_only);
 	Ref<Animation> get_current_animation() const;
+	Control *get_scale_control() const;
 	void set_root(Node *p_root);
 	Node *get_root() const;
 	void update_keying();
@@ -986,6 +1011,9 @@ public:
 	bool is_selection_active() const;
 	bool is_key_clipboard_active() const;
 	bool is_moving_selection() const;
+	bool is_scaling_selection() const;
+	ScaleHandle is_position_over_scale_handle(const Point2 &p_global_pos) const;
+
 	bool is_snap_timeline_enabled() const;
 	bool is_snap_keys_enabled() const;
 	bool is_insert_at_current_time_enabled() const;
@@ -994,6 +1022,9 @@ public:
 	bool can_add_reset_key() const;
 	void _on_filter_updated(const String &p_filter);
 	float get_moving_selection_offset() const;
+	float get_scaling_selection_pivot() const;
+	float get_scaling_selection_drag_start() const;
+	float get_scaling_selection_drag() const;
 	float snap_time(float p_value, bool p_relative = false);
 	float get_snap_unit();
 	bool is_grouping_tracks();

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -599,6 +599,7 @@ public:
 	void set_root(Node *p_root);
 	void set_editor(AnimationTrackEditor *p_editor);
 	String get_node_name() const;
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
 	AnimationTrackEditGroup();
 };
@@ -776,23 +777,38 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _move_selection_commit();
 	void _move_selection_cancel();
 
+	bool scaling_selection = false;
+	bool scale_control_update_pending = false;
+	float scaling_selection_pivot = 0.0f;
+	float scaling_selection_drag_start = 0.0f;
+	float scaling_selection_drag = 0.0f;
+	void _scale_selection_begin(float p_pivot, float p_drag_start);
+	void _scale_selection(float p_offset);
+	void _scale_selection_commit(bool p_dynamic = true);
+	void _scale_selection_cancel();
+
 	AnimationTrackKeyEdit *key_edit = nullptr;
 	AnimationMultiTrackKeyEdit *multi_key_edit = nullptr;
 	bool update_key_edit_pending = false;
 	void _update_key_edit();
+	void _queue_update_scale_control();
+	bool _update_scale_control();
 	void _update_key_edit_callback();
 	void _clear_key_edit();
 
-	Control *box_selection_container = nullptr;
+	Control *overlay_container = nullptr;
 
 	Control *box_selection = nullptr;
 	void _box_selection_draw();
+	void _scale_control_draw();
 	bool box_selecting = false;
 	Vector2 box_selecting_from;
 	Vector2 box_selecting_to;
 	Rect2 box_select_rect;
 	Vector2 prev_scroll_position;
 	void _scroll_input(const Ref<InputEvent> &p_event);
+
+	Control *scale_control = nullptr;
 
 	Vector<Ref<AnimationTrackEditPlugin>> track_edit_plugins;
 
@@ -850,6 +866,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	Button *function_name_toggler = nullptr;
 
 	void _view_group_toggle();
+	void _alphabetical_sorting_toggle();
 
 	Button *view_group = nullptr;
 	Button *selected_filter = nullptr;
@@ -921,6 +938,7 @@ public:
 	void _clear_selection(bool p_update = false);
 	void _key_selected(int p_key, bool p_single, int p_track);
 	void _key_deselected(int p_key, int p_track);
+	void _zoom_changed();
 
 	enum {
 		EDIT_COPY_TRACKS,
@@ -957,11 +975,18 @@ public:
 		EDIT_GOTO_PREV_KEYFRAME,
 	};
 
+	enum ScaleHandle {
+		SCALE_HANDLE_NONE,
+		SCALE_HANDLE_LEFT,
+		SCALE_HANDLE_RIGHT
+	};
+
 	void add_track_edit_plugin(const Ref<AnimationTrackEditPlugin> &p_plugin);
 	void remove_track_edit_plugin(const Ref<AnimationTrackEditPlugin> &p_plugin);
 
 	void set_animation(const Ref<Animation> &p_anim, bool p_read_only);
 	Ref<Animation> get_current_animation() const;
+	Control *get_scale_control() const;
 	void set_root(Node *p_root);
 	Node *get_root() const;
 	void update_keying();
@@ -989,6 +1014,9 @@ public:
 	bool is_selection_active() const;
 	bool is_key_clipboard_active() const;
 	bool is_moving_selection() const;
+	bool is_scaling_selection() const;
+	ScaleHandle is_position_over_scale_handle(const Point2 &p_global_pos) const;
+
 	bool is_snap_timeline_enabled() const;
 	bool is_snap_keys_enabled() const;
 	bool is_insert_at_current_time_enabled() const;
@@ -997,6 +1025,9 @@ public:
 	bool can_add_reset_key() const;
 	void _on_filter_updated(const String &p_filter);
 	float get_moving_selection_offset() const;
+	float get_scaling_selection_pivot() const;
+	float get_scaling_selection_drag_start() const;
+	float get_scaling_selection_drag() const;
 	float snap_time(float p_value, bool p_relative = false);
 	float get_snap_unit();
 	bool is_grouping_tracks();

--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -1175,10 +1175,10 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 Control::CursorShape AnimationTrackEditTypeAudio::get_cursor_shape(const Point2 &p_pos) const {
-	if (over_drag_position || len_resizing) {
+	if ((over_drag_position || len_resizing) && !get_editor()->get_scale_control()->is_visible()) {
 		return Control::CURSOR_HSIZE;
 	} else {
-		return get_default_cursor_shape();
+		return AnimationTrackEdit::get_cursor_shape(p_pos);
 	}
 }
 


### PR DESCRIPTION
This adds box scaling to the Value Tracks Editor, similar to what was added to the Bezier Track Editor
This would resolve https://github.com/godotengine/godot-proposals/issues/3532

https://github.com/user-attachments/assets/9f8b1089-41ac-47a2-9cf0-4a66c1331a23

 - [X] hide the lines if they are outside the range
 - [X] make the scale be offset by 12 pixels so it stays offset like the handle is
 - [X] make inverted scaling work
 - [X] make the handle offset correct when doing inverted scaling
 - [X] update the lines connecting identical keys when scaling
 - [X] adjust the rects so they are 5 pixels pushed away from the keys so it's easier to move the keys.
 - [X] key snapping
 - [X] fix scale and move cancelling
 - [X] make the edit -> scale options work again.
 - [X] fix inverted commit is broken
 - [X] hide and show handles correctly when scrolling sideways
 - [X] snap the handles
 - [X] fix zooming the timeline

This ended up being a bit of a bigger PR than I had hoped, so it needs a thorough review. I'll set it for draft now until I've had the chance to give it a thorough lookover myself.

---

Edit: OK this should be ready for a review. 