### PR TITLE
Fix `ShaderPreprocessor.consume_line_continuations()` skipping characters

### DIFF
--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -81,24 +81,23 @@ char32_t ShaderPreprocessor::Tokenizer::peek() {
 	return 0;
 }
 
-int ShaderPreprocessor::Tokenizer::consume_line_continuations(int p_offset) {
+int ShaderPreprocessor::Tokenizer::consume_line_continuations() {
 	int skips = 0;
 
-	for (int i = index + p_offset; i < size; i++) {
-		char32_t c = code[i];
-		if (c == '\\') {
-			if (i + 1 < size && code[i + 1] == '\n') {
-				// This line ends with "\" and "\n" continuation.
-				add_generated(Token('\n', line));
-				line++;
-				skips++;
-
-				i = i + 2;
-				index = i;
-			} else {
-				break;
+	for (; index < size; index++) {
+		char32_t c = code[index];
+		if (c != '\\') {
+			if (is_whitespace(c)) {
+				continue;
 			}
-		} else if (!is_whitespace(c)) {
+			break;
+		}
+		if (index + 1 < size && code[index + 1] == '\n') {
+			add_generated(Token('\n', line));
+			line++;
+			skips++;
+			index++;
+		} else {
 			break;
 		}
 	}
@@ -109,11 +108,11 @@ LocalVector<ShaderPreprocessor::Token> ShaderPreprocessor::Tokenizer::advance(ch
 	LocalVector<ShaderPreprocessor::Token> tokens;
 
 	while (index < size) {
-		char32_t c = code[index++];
-		if (c == '\\' && consume_line_continuations(-1) > 0) {
+		char32_t c = code[index];
+		if (c == '\\' && consume_line_continuations() > 0) {
 			continue;
 		}
-
+		index++;
 		if (c == '\n') {
 			add_generated(ShaderPreprocessor::Token('\n', line));
 			line++;
@@ -148,7 +147,7 @@ String ShaderPreprocessor::Tokenizer::get_identifier(bool *r_is_cursor, bool p_s
 
 	while (true) {
 		char32_t c = peek();
-		if (c == '\\' && consume_line_continuations(0) > 0) {
+		if (c == '\\' && consume_line_continuations() > 0) {
 			continue;
 		}
 

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -88,7 +88,7 @@ private:
 		int get_line() const;
 		int get_index() const;
 		char32_t peek();
-		int consume_line_continuations(int p_offset);
+		int consume_line_continuations();
 
 		void get_and_clear_generated(LocalVector<char32_t> *r_out);
 		void backtrack(char32_t p_what);


### PR DESCRIPTION
This function increments the code index by 2 when a line continuation is found, additional to the loop increment, so it skips over the next character following a line continuation.

In shader code like

```glsl
#define FUN_FUN(n)\
void fun1() { return;\
}\
void fun2() { return; }
FUN_FUN(1.0)
```

the first `}` will visibly get skipped, causing this error:

```
   10 | 
E  11->  void fun1() { return;void fun2() { return; } 
   12 |
```

The `v` in `void` will also get skipped over, but as the next `o` is enough to decide to end the loop, that is less obvious.

Simplify consume_line_continuations() to remove the unnecessary offset parameter and the extra loop index variable, and increment index the right amount.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
