### PR TITLE
Clean up Volumetric Fog blending behavior

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -281,7 +281,8 @@ void main() {
 
 	if (sky_scene_data.volumetric_fog_enabled) {
 		vec4 fog = volumetric_fog_process(uv);
-		frag_color.rgb = frag_color.rgb * (1.0 - fog.a * sky_scene_data.volumetric_fog_sky_affect) + fog.rgb * sky_scene_data.volumetric_fog_sky_affect;
+		fog.rgb = frag_color.rgb * fog.a + fog.rgb;
+		frag_color.rgb = mix(frag_color.rgb, fog.rgb, sky_scene_data.volumetric_fog_sky_affect);
 	}
 
 	if (custom_fog.a > 0.0) {

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -719,7 +719,7 @@ void main() {
 
 		prev_z = z;
 
-		imageStore(fog_map, fog_pos, vec4(fog_accum.rgb, 1.0 - fog_accum.a));
+		imageStore(fog_map, fog_pos, vec4(fog_accum.rgb, fog_accum.a));
 	}
 
 #endif


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/112468, but only if merged along with https://github.com/godotengine/tps-demo/pull/212

This PR finished the work that https://github.com/godotengine/godot/pull/111998 started. Prior to https://github.com/godotengine/godot/pull/111998 we were wrongly blending Volumetric Fog with the scene. In particular, by using the `mix()` function to blend Volumetric Fog, we were applying the fog's opacity twice. Effectively making thin fog much thinner. This had the effect of making fog much darker than it should be which is especially noticeable at the edge of Fog Volumes since it produces a dark outline (as reported in https://github.com/godotengine/godot/issues/101514)

This PR cleans up the Volumetric Fog code to be more consistent and use transmittance everywhere instead of opacity. transmittance makes the blending calculations a lot simpler, so this PR has the bonus effect of making our code slightly more efficient as well. 

**Warning:** This is technically a compatibility breaking change. Users who previously compensated for the fact that opacity was multiplied twice will experience visual changes especially if they are using extreme values like we do in the TPS demo. Users who have default settings or denser fog will not notice much or any change. 

At any rate, I think we need to go ahead with this and live with the small compatibility breakage as it will be much better in the long run to have the underlying bug fixed