### PR TITLE
Reduce outer inspector margins

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1870,9 +1870,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 	// Editor inspector.
 	{
 		// Panel.
-		Ref<StyleBoxEmpty> editor_inspector_panel = p_config.base_empty_style->duplicate();
-		editor_inspector_panel->set_content_margin_all(p_config.base_margin * 2 * EDSCALE);
-		p_theme->set_stylebox(SceneStringName(panel), "EditorInspector", editor_inspector_panel);
+		p_theme->set_stylebox(SceneStringName(panel), "EditorInspector", p_config.base_empty_style);
 
 		// Vertical separation between inspector categories and sections.
 		p_theme->set_constant("v_separation", "EditorInspector", Math::ceil(p_config.base_margin * 0.5 * EDSCALE));


### PR DESCRIPTION
Reduces inspector margins leaving the same outer gap in modern theme as it is in classic. Should fix https://github.com/godotengine/godot/issues/112284

| Master | PR |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/43c2e0a9-623d-496e-aae2-c5a7e853fe6b) | ![2](https://github.com/user-attachments/assets/cdc36a9f-0a3a-4606-9e89-ddb3b784f9e9) |

| Modern | Classic |
|--------|--------|
| ![3](https://github.com/user-attachments/assets/02ddc85a-18be-4ffb-8a32-b737115b6d1e) | ![4](https://github.com/user-attachments/assets/21b3cba9-3244-4dd0-9015-9c3756772bdc) |
