### PR TITLE
Android: Fix loading sparse `.pck` from `assets://`

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/io/file/AssetData.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/io/file/AssetData.kt
@@ -106,6 +106,7 @@ internal class AssetData(context: Context, private val filePath: String, accessF
 
 	override fun seek(position: Long) {
 		try {
+			inputStream.reset();
 			inputStream.skip(position)
 
 			this.position = position


### PR DESCRIPTION
Quite surprised this one managed to go unnoticed for quite some time. The implementation of `AssetData`'s `seek` was simply performing `skip(position)`, however that's relative to the stream's current position. So it is only accurate if you seek immediately upon opening a file, and you can never seek backwards.

This manifests in some pretty nasty bugs. I ran into this when attempting to load a sparse .pck (the default) from `assets://`. The C++ implementation naturally needs to seek toward the end of the file to obtain the directory mapping. However, this fails and we overshoot the intended location and the file count read is then incorrect, as is everything else that follows.