### PR TITLE
LSP: Add stdio mode

### DIFF
--- a/core/io/stream_peer_stdio.cpp
+++ b/core/io/stream_peer_stdio.cpp
@@ -1,0 +1,132 @@
+/**************************************************************************/
+/*  stream_peer_stdio.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "stream_peer_stdio.h"
+
+#include <fcntl.h>
+
+#include <cerrno>
+#include <cstdio>
+
+#ifdef WINDOWS_ENABLED
+#include <windows.h>
+
+#include <io.h>
+#define READ_FUNCTION _read
+#define WRITE_FUNCTION _write
+#else
+#include <sys/ioctl.h>
+#include <unistd.h>
+#define READ_FUNCTION read
+#define WRITE_FUNCTION write
+#endif
+
+StreamPeerStdio::StreamPeerStdio() {
+	// Set stdin to non-blocking mode and binary mode
+#ifdef WINDOWS_ENABLED
+	stdin_fileno = _fileno(stdin);
+	stdout_fileno = _fileno(stdout);
+
+	invalid_handles = _setmode(stdin_fileno, _O_BINARY) == -1;
+	invalid_handles = invalid_handles || (_setmode(stdout_fileno, _O_BINARY) == -1);
+#else
+	stdin_fileno = STDIN_FILENO;
+	stdout_fileno = STDOUT_FILENO;
+
+	int flags = fcntl(stdin_fileno, F_GETFL, 0);
+	invalid_handles = fcntl(stdin_fileno, F_SETFL, flags | O_NONBLOCK) == -1;
+#endif
+}
+
+Error StreamPeerStdio::put_data(const uint8_t *p_data, int p_bytes) {
+	int sent;
+	return put_partial_data(p_data, p_bytes, sent);
+}
+
+Error StreamPeerStdio::put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) {
+	if (invalid_handles) {
+		ERR_PRINT_ONCE("Can't write to stdout, invalid handle.");
+		return FAILED;
+	}
+
+	int sent = WRITE_FUNCTION(stdout_fileno, p_data, p_bytes);
+	if (sent < 0) {
+		r_sent = 0;
+		return FAILED;
+	}
+
+	r_sent = sent;
+
+	return OK;
+}
+
+Error StreamPeerStdio::get_data(uint8_t *p_buffer, int p_bytes) {
+	int received;
+	return get_partial_data(p_buffer, p_bytes, received);
+}
+
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wlogical-op") // Silence a false positive. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69602
+
+Error StreamPeerStdio::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) {
+	if (invalid_handles) {
+		ERR_PRINT_ONCE("Can't read from stdin, invalid handle.");
+		return FAILED;
+	}
+
+	int received = READ_FUNCTION(stdin_fileno, p_buffer, p_bytes);
+	if (received < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			r_received = 0;
+			return ERR_BUSY;
+		}
+		r_received = 0;
+		return FAILED;
+	} else if (received == 0) { // EOF
+		r_received = 0;
+		return FAILED;
+	}
+
+	r_received = received;
+	return OK;
+}
+
+GODOT_GCC_WARNING_POP
+
+int StreamPeerStdio::get_available_bytes() const {
+#ifdef WINDOWS_ENABLED
+	DWORD buf_rem = 0;
+	PeekNamedPipe((HANDLE)_get_osfhandle(stdin_fileno), nullptr, 0, nullptr, &buf_rem, nullptr);
+	return (int)buf_rem;
+#else
+	int buf_rem = 0;
+	ioctl(stdin_fileno, FIONREAD, &buf_rem);
+	return buf_rem;
+#endif
+}

--- a/core/io/stream_peer_stdio.h
+++ b/core/io/stream_peer_stdio.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gdscript_language_server.h                                            */
+/*  stream_peer_stdio.h                                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,34 +30,22 @@
 
 #pragma once
 
-#include "editor/plugins/editor_plugin.h"
+#include "core/io/stream_peer.h"
 
-class GDScriptLanguageServer : public EditorPlugin {
-	GDSOFTCLASS(GDScriptLanguageServer, EditorPlugin);
-
-	Thread thread;
-	bool thread_running = false;
-	// There is no notification when the editor is initialized. We need to poll till we attempted to start the server.
-	bool start_attempted = false;
-	bool started = false;
-
-	// Defaults located in editor_settings.cpp
-	bool use_thread = false;
-	String host;
-	int port = 0;
-	int poll_limit_usec = 0;
-
-	static void thread_main(void *p_userdata);
+class StreamPeerStdio : public StreamPeer {
+	GDCLASS(StreamPeerStdio, StreamPeer);
 
 private:
-	void _notification(int p_what);
+	int stdin_fileno = 0;
+	int stdout_fileno = 1;
+	bool invalid_handles = false;
 
 public:
-	static int port_override;
-	static bool use_stdio;
-	GDScriptLanguageServer();
-	void start();
-	void stop();
-};
+	virtual Error put_data(const uint8_t *p_data, int p_bytes) override;
+	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) override;
+	virtual Error get_data(uint8_t *p_buffer, int p_bytes) override;
+	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
+	virtual int get_available_bytes() const override;
 
-void register_lsp_types();
+	StreamPeerStdio();
+};

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -46,6 +46,7 @@
 #include "core/io/file_access_zip.h"
 #include "core/io/image.h"
 #include "core/io/image_loader.h"
+#include "core/io/logger.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"
@@ -153,6 +154,7 @@
 #include "modules/gdscript/gdscript.h"
 #if defined(TOOLS_ENABLED) && !defined(GDSCRIPT_NO_LSP)
 #include "modules/gdscript/language_server/gdscript_language_server.h"
+#include "modules/gdscript/language_server/lsp_logger.h"
 #endif // TOOLS_ENABLED && !GDSCRIPT_NO_LSP
 #endif // MODULE_GDSCRIPT_ENABLED
 
@@ -567,6 +569,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--dap-port <port>", "Use the specified port for the GDScript Debug Adapter Protocol. Recommended port range [1024, 49151].\n", CLI_OPTION_AVAILABILITY_EDITOR);
 #if defined(MODULE_GDSCRIPT_ENABLED) && !defined(GDSCRIPT_NO_LSP)
 	print_help_option("--lsp-port <port>", "Use the specified port for the GDScript Language Server Protocol. Recommended port range [1024, 49151].\n", CLI_OPTION_AVAILABILITY_EDITOR);
+	print_help_option("--lsp", "(experimental) Start the GDScript Language Server in headless mode (stdio). Useful for integration with external editors.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 #endif // MODULE_GDSCRIPT_ENABLED && !GDSCRIPT_NO_LSP
 #endif
 	print_help_option("--quit", "Quit after the first iteration.\n");
@@ -2028,6 +2031,19 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing <port> argument for --lsp-port <port>.\n");
 				goto error;
 			}
+		} else if (arg == "--lsp") {
+			editor = true;
+			GDScriptLanguageServer::use_stdio = true;
+
+			// This logger is used to prevent any kind of log go into stdout, which is used as transport by LSP protocol.
+			// It could cause LSP clients to fail parsing our LSP server messages.
+			Vector<Logger *> loggers;
+			loggers.push_back(memnew(LspLogger));
+			OS::get_singleton()->_set_logger(memnew(CompositeLogger(loggers)));
+
+			// `--lsp` implies `--headless` to avoid spawning an unnecessary window.
+			audio_driver = NULL_AUDIO_DRIVER;
+			display_driver = NULL_DISPLAY_DRIVER;
 #endif // TOOLS_ENABLED && MODULE_GDSCRIPT_ENABLED && !GDSCRIPT_NO_LSP
 #if defined(TOOLS_ENABLED)
 		} else if (arg == "--dap-port") {

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -30,9 +30,12 @@
 
 #include "gdscript_language_protocol.h"
 
+#include "gdscript_language_server.h"
 #include "godot_lsp.h"
 
 #include "core/config/project_settings.h"
+#include "core/error/error_list.h"
+#include "core/io/stream_peer_stdio.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -41,6 +44,7 @@
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/settings/editor_settings.h"
+#include "scene/main/scene_tree.h"
 
 #define LSP_CLIENT_V(m_ret_val) \
 	ERR_FAIL_COND_V(latest_client_id == LSP_NO_CLIENT, m_ret_val); \
@@ -67,10 +71,11 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 			}
 			Error err = connection->get_partial_data(&req_buf[req_pos], 1, read);
 			if (err != OK) {
-				return FAILED;
+				return (err == ERR_BUSY) ? ERR_BUSY : FAILED;
 			} else if (read != 1) { // Busy, wait until next poll
 				return ERR_BUSY;
 			}
+
 			char *r = (char *)req_buf;
 			int l = req_pos;
 
@@ -94,10 +99,10 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 				ERR_FAIL_COND_V_MSG(req_pos >= LSP_MAX_BUFFER_SIZE, ERR_OUT_OF_MEMORY, "Response content too big");
 			}
 			Error err = connection->get_partial_data(&req_buf[req_pos], 1, read);
-			if (err != OK) {
+			if (err == ERR_BUSY || read != 1) {
+				return ERR_BUSY; // Busy, wait until next poll
+			} else if (err != OK) {
 				return FAILED;
-			} else if (read != 1) {
-				return ERR_BUSY;
 			}
 			req_pos++;
 		}
@@ -260,6 +265,26 @@ Variant GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 	return ret.to_json();
 }
 
+Variant GDScriptLanguageProtocol::reject_message(const Variant &p_params) {
+	return make_response_error(JSONRPC::INVALID_REQUEST, "Server is shutting down.");
+}
+
+Variant GDScriptLanguageProtocol::shutdown() {
+	_shutdown = true;
+	Callable reject = callable_mp(this, &GDScriptLanguageProtocol::reject_message);
+	for (KeyValue<String, Callable> &E : methods) {
+		if (E.key != "exit") {
+			E.value = reject;
+		}
+	}
+	return Variant();
+}
+
+void GDScriptLanguageProtocol::exit() {
+	int exit_code = _shutdown ? EXIT_SUCCESS : EXIT_FAILURE;
+	EditorNode::get_singleton()->get_tree()->quit(exit_code);
+}
+
 void GDScriptLanguageProtocol::initialized(const Variant &p_params) {
 	LSP::GodotCapabilities capabilities;
 
@@ -289,34 +314,37 @@ void GDScriptLanguageProtocol::poll(int p_limit_usec) {
 	HashMap<int, Ref<LSPeer>>::Iterator E = clients.begin();
 	while (E != clients.end()) {
 		Ref<LSPeer> peer = E->value;
-		peer->connection->poll();
-		StreamPeerTCP::Status status = peer->connection->get_status();
-		if (status == StreamPeerTCP::STATUS_NONE || status == StreamPeerTCP::STATUS_ERROR) {
+		Ref<StreamPeerTCP> tcp_peer = peer->connection;
+		if (tcp_peer.is_valid()) {
+			tcp_peer->poll();
+			StreamPeerTCP::Status status = tcp_peer->get_status();
+			if (status == StreamPeerTCP::STATUS_NONE || status == StreamPeerTCP::STATUS_ERROR) {
+				on_client_disconnected(E->key);
+				E = clients.begin();
+				continue;
+			}
+		}
+
+		Error err = OK;
+		while (peer->connection->get_available_bytes() > 0) {
+			latest_client_id = E->key;
+			err = peer->handle_data();
+			if (err != OK || OS::get_singleton()->get_ticks_usec() >= target_ticks) {
+				break;
+			}
+		}
+
+		if (err != OK && err != ERR_BUSY) {
 			on_client_disconnected(E->key);
 			E = clients.begin();
 			continue;
-		} else {
-			Error err = OK;
-			while (peer->connection->get_available_bytes() > 0) {
-				latest_client_id = E->key;
-				err = peer->handle_data();
-				if (err != OK || OS::get_singleton()->get_ticks_usec() >= target_ticks) {
-					break;
-				}
-			}
+		}
 
-			if (err != OK && err != ERR_BUSY) {
-				on_client_disconnected(E->key);
-				E = clients.begin();
-				continue;
-			}
-
-			err = peer->send_data();
-			if (err != OK && err != ERR_BUSY) {
-				on_client_disconnected(E->key);
-				E = clients.begin();
-				continue;
-			}
+		err = peer->send_data();
+		if (err != OK && err != ERR_BUSY) {
+			on_client_disconnected(E->key);
+			E = clients.begin();
+			continue;
 		}
 		++E;
 	}
@@ -326,10 +354,27 @@ Error GDScriptLanguageProtocol::start(int p_port, const IPAddress &p_bind_ip) {
 	return server->listen(p_port, p_bind_ip);
 }
 
+Error GDScriptLanguageProtocol::start_stdio() {
+	Ref<LSPeer> peer;
+	peer.instantiate();
+	Ref<StreamPeerStdio> stdio_stream;
+	stdio_stream.instantiate();
+	peer->connection = stdio_stream;
+
+	clients.insert(next_client_id, peer);
+	next_client_id++;
+
+	print_line("[LSP] Started in stdio mode");
+	return OK;
+}
+
 void GDScriptLanguageProtocol::stop() {
 	for (const KeyValue<int, Ref<LSPeer>> &E : clients) {
 		Ref<LSPeer> peer = clients.get(E.key);
-		peer->connection->disconnect_from_host();
+		Ref<StreamPeerTCP> tcp_peer = peer->connection;
+		if (tcp_peer.is_valid()) {
+			tcp_peer->disconnect_from_host();
+		}
 	}
 
 	scene_cache.clear();
@@ -383,7 +428,7 @@ bool GDScriptLanguageProtocol::is_smart_resolve_enabled() const {
 }
 
 bool GDScriptLanguageProtocol::is_goto_native_symbols_enabled() const {
-	return bool(_EDITOR_GET("network/language_server/show_native_symbols_in_editor"));
+	return !GDScriptLanguageServer::use_stdio && bool(_EDITOR_GET("network/language_server/show_native_symbols_in_editor"));
 }
 
 ExtendGDScriptParser *GDScriptLanguageProtocol::LSPeer::parse_script(const String &p_path) {
@@ -687,6 +732,10 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 
 	set_method("initialize", callable_mp(this, &GDScriptLanguageProtocol::initialize));
 	set_method("initialized", callable_mp(this, &GDScriptLanguageProtocol::initialized));
+	if (GDScriptLanguageServer::use_stdio) {
+		set_method("shutdown", callable_mp(this, &GDScriptLanguageProtocol::shutdown));
+		set_method("exit", callable_mp(this, &GDScriptLanguageProtocol::exit));
+	}
 }
 
 #undef SET_DOCUMENT_METHOD

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -34,7 +34,7 @@
 #include "gdscript_workspace.h"
 #include "scene_cache.h"
 
-#include "core/io/stream_peer_tcp.h"
+#include "core/io/stream_peer.h"
 #include "core/io/tcp_server.h"
 
 #include "modules/jsonrpc/jsonrpc.h"
@@ -59,12 +59,11 @@ public:
 
 private:
 	struct LSPeer : RefCounted {
-		Ref<StreamPeerTCP> connection;
+		Ref<StreamPeer> connection;
 
 		uint8_t req_buf[LSP_MAX_BUFFER_SIZE];
 		int req_pos = 0;
 		bool has_header = false;
-		bool has_content = false;
 		int content_length = 0;
 		Vector<CharString> res_queue;
 		int res_sent = 0;
@@ -121,13 +120,18 @@ private:
 	String process_message(const String &p_text);
 	String format_output(const String &p_text);
 
+	Variant reject_message(const Variant &p_params);
+
 	bool _initialized = false;
+	bool _shutdown = false;
 
 protected:
 	static void _bind_methods();
 
 	Variant initialize(const Dictionary &p_params);
 	void initialized(const Variant &p_params);
+	Variant shutdown();
+	void exit();
 
 public:
 	_FORCE_INLINE_ static GDScriptLanguageProtocol *get_singleton() { return singleton; }
@@ -139,6 +143,7 @@ public:
 
 	void poll(int p_limit_usec);
 	Error start(int p_port, const IPAddress &p_bind_ip);
+	Error start_stdio();
 	void stop();
 
 	void notify_client(const String &p_method, const Variant &p_params = Variant(), int p_client_id = -1);

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -33,11 +33,13 @@
 #include "gdscript_language_protocol.h"
 
 #include "core/os/os.h"
+#include "core/string/print_string.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/settings/editor_settings.h"
 
 int GDScriptLanguageServer::port_override = -1;
+bool GDScriptLanguageServer::use_stdio = false;
 
 GDScriptLanguageServer::GDScriptLanguageServer() {
 	set_process_internal(true);
@@ -67,7 +69,7 @@ void GDScriptLanguageServer::_notification(int p_what) {
 
 			String remote_host = String(_EDITOR_GET("network/language_server/remote_host"));
 			int remote_port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
-			bool remote_use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
+			bool remote_use_thread = !GDScriptLanguageServer::use_stdio && (bool)_EDITOR_GET("network/language_server/use_thread");
 			int remote_poll_limit = (int)_EDITOR_GET("network/language_server/poll_limit_usec");
 			if (remote_host != host || remote_port != port || remote_use_thread != use_thread || remote_poll_limit != poll_limit_usec) {
 				stop();
@@ -88,22 +90,36 @@ void GDScriptLanguageServer::thread_main(void *p_userdata) {
 }
 
 void GDScriptLanguageServer::start() {
-	host = String(_EDITOR_GET("network/language_server/remote_host"));
-	port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
-	use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
+	use_thread = !GDScriptLanguageServer::use_stdio && (bool)_EDITOR_GET("network/language_server/use_thread");
 	poll_limit_usec = (int)_EDITOR_GET("network/language_server/poll_limit_usec");
-	const Error status = GDScriptLanguageProtocol::get_singleton()->start(port, IPAddress(host));
-	if (status != OK) {
-		EditorNode::get_log()->add_message("--- Failed to start GDScript language server on port " + itos(port) + ": " + error_names[status] + " ---", EditorLog::MSG_TYPE_EDITOR);
-		return;
+
+	Error status;
+	if (GDScriptLanguageServer::use_stdio) {
+		status = GDScriptLanguageProtocol::get_singleton()->start_stdio();
+		if (status != OK) {
+			print_line("--- Failed to start GDScript language server in stdio mode: %s ---", error_names[status]);
+			return;
+		}
+		print_line("--- GDScript language server started in stdio mode ---");
+	} else {
+		host = String(_EDITOR_GET("network/language_server/remote_host"));
+		port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
+		status = GDScriptLanguageProtocol::get_singleton()->start(port, IPAddress(host));
+		if (status != OK) {
+			EditorNode::get_log()->add_message("--- Failed to start GDScript language server on port " + itos(port) + ": " + error_names[status] + " ---", EditorLog::MSG_TYPE_EDITOR);
+			return;
+		}
+		EditorNode::get_log()->add_message("--- GDScript language server started on port " + itos(port) + " ---", EditorLog::MSG_TYPE_EDITOR);
 	}
-	EditorNode::get_log()->add_message("--- GDScript language server started on port " + itos(port) + " ---", EditorLog::MSG_TYPE_EDITOR);
-	if (use_thread) {
-		thread_running = true;
-		thread.start(GDScriptLanguageServer::thread_main, this);
+
+	if (status == OK) {
+		if (use_thread) {
+			thread_running = true;
+			thread.start(GDScriptLanguageServer::thread_main, this);
+		}
+		set_process_internal(!use_thread);
+		started = true;
 	}
-	set_process_internal(!use_thread);
-	started = true;
 }
 
 void GDScriptLanguageServer::stop() {
@@ -114,7 +130,11 @@ void GDScriptLanguageServer::stop() {
 	}
 	GDScriptLanguageProtocol::get_singleton()->stop();
 	started = false;
-	EditorNode::get_log()->add_message("--- GDScript language server stopped ---", EditorLog::MSG_TYPE_EDITOR);
+	if (GDScriptLanguageServer::use_stdio) {
+		OS::get_singleton()->print("--- GDScript language server stopped ---\n");
+	} else {
+		EditorNode::get_log()->add_message("--- GDScript language server stopped ---", EditorLog::MSG_TYPE_EDITOR);
+	}
 }
 
 void register_lsp_types() {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -233,10 +233,6 @@ void GDScriptWorkspace::list_script_files(const String &p_root_dir, List<String>
 #define HANDLE_DOC(m_string) ((is_native ? DTR(m_string) : (m_string)).strip_edges())
 
 Error GDScriptWorkspace::initialize() {
-	if (initialized) {
-		return OK;
-	}
-
 	DocTools *doc = EditorHelp::get_doc_data();
 	for (const KeyValue<String, DocData::ClassDoc> &E : doc->class_list) {
 		const DocData::ClassDoc &class_data = E.value;

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -54,7 +54,6 @@ private:
 
 protected:
 	static void _bind_methods();
-	bool initialized = false;
 	HashMap<StringName, LSP::DocumentSymbol> native_symbols;
 
 	// Absolute paths that are known to point to res://

--- a/modules/gdscript/language_server/lsp_logger.cpp
+++ b/modules/gdscript/language_server/lsp_logger.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gdscript_language_server.h                                            */
+/*  lsp_logger.cpp                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,36 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#include "lsp_logger.h"
 
-#include "editor/plugins/editor_plugin.h"
+#include <cstdio>
 
-class GDScriptLanguageServer : public EditorPlugin {
-	GDSOFTCLASS(GDScriptLanguageServer, EditorPlugin);
+void LspLogger::logv(const char *p_format, va_list p_list, bool p_err) {
+	if (!should_log(p_err)) {
+		return;
+	}
 
-	Thread thread;
-	bool thread_running = false;
-	// There is no notification when the editor is initialized. We need to poll till we attempted to start the server.
-	bool start_attempted = false;
-	bool started = false;
-
-	// Defaults located in editor_settings.cpp
-	bool use_thread = false;
-	String host;
-	int port = 0;
-	int poll_limit_usec = 0;
-
-	static void thread_main(void *p_userdata);
-
-private:
-	void _notification(int p_what);
-
-public:
-	static int port_override;
-	static bool use_stdio;
-	GDScriptLanguageServer();
-	void start();
-	void stop();
-};
-
-void register_lsp_types();
+	vfprintf(stderr, p_format, p_list);
+}

--- a/modules/gdscript/language_server/lsp_logger.h
+++ b/modules/gdscript/language_server/lsp_logger.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gdscript_language_server.h                                            */
+/*  lsp_logger.h                                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,34 +30,13 @@
 
 #pragma once
 
-#include "editor/plugins/editor_plugin.h"
+#include "core/io/logger.h"
 
-class GDScriptLanguageServer : public EditorPlugin {
-	GDSOFTCLASS(GDScriptLanguageServer, EditorPlugin);
-
-	Thread thread;
-	bool thread_running = false;
-	// There is no notification when the editor is initialized. We need to poll till we attempted to start the server.
-	bool start_attempted = false;
-	bool started = false;
-
-	// Defaults located in editor_settings.cpp
-	bool use_thread = false;
-	String host;
-	int port = 0;
-	int poll_limit_usec = 0;
-
-	static void thread_main(void *p_userdata);
-
-private:
-	void _notification(int p_what);
-
+// Logger for LSP stdio mode. Stdout is reserved for the LSP transport,
+// so all output goes to stderr. A future iteration could route messages
+// through the LSP window/logMessage notification instead.
+class LspLogger : public Logger {
 public:
-	static int port_override;
-	static bool use_stdio;
-	GDScriptLanguageServer();
-	void start();
-	void stop();
+	virtual void logv(const char *p_format, va_list p_list, bool p_err) override _PRINTF_FORMAT_ATTRIBUTE_2_0;
+	virtual ~LspLogger() {}
 };
-
-void register_lsp_types();

--- a/modules/jsonrpc/jsonrpc.h
+++ b/modules/jsonrpc/jsonrpc.h
@@ -37,10 +37,10 @@
 class JSONRPC : public Object {
 	GDCLASS(JSONRPC, Object)
 
+protected:
 	HashMap<String, Callable> methods;
 	HashMap<int, Callable> response_handlers;
 
-protected:
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -82,6 +82,7 @@ protected:
 public:
 	static inline const char *headless_args[] = {
 		"--headless",
+		"--lsp",
 		"-h",
 		"--help",
 		"/?",

--- a/tests/core/io/test_stream_peer_stdio.cpp
+++ b/tests/core/io/test_stream_peer_stdio.cpp
@@ -1,0 +1,137 @@
+/**************************************************************************/
+/*  test_stream_peer_stdio.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_stream_peer_stdio)
+
+#include "core/io/stream_peer_stdio.h"
+
+#include <fcntl.h>
+
+#include <cerrno>
+
+#ifdef WINDOWS_ENABLED
+#include <io.h>
+
+#include <cstdio>
+#define READ_FUNCTION _read
+#define WRITE_FUNCTION _write
+#define PIPE_FUNCTION _pipe
+#define DUP_FUNCTION _dup
+#define DUP2_FUNCTION _dup2
+#define CLOSE_FUNCTION _close
+#else
+#include <unistd.h>
+#define READ_FUNCTION read
+#define WRITE_FUNCTION write
+#define PIPE_FUNCTION pipe
+#define DUP_FUNCTION dup
+#define DUP2_FUNCTION dup2
+#define CLOSE_FUNCTION close
+#endif
+
+namespace TestStreamPeerStdio {
+
+TEST_CASE("[StreamPeerStdio] Write and read through pipes") {
+	int stdin_pipe[2]; // stdin_pipe[0] = read, stdin_pipe[1] = write
+	int stdout_pipe[2]; // stdout_pipe[0] = read, stdout_pipe[1] = write
+
+#ifdef WINDOWS_ENABLED
+	int stdin_fileno = _fileno(stdin);
+	int stdout_fileno = _fileno(stdout);
+
+	CHECK(_pipe(stdin_pipe, 4096, _O_BINARY) == 0);
+	CHECK(_pipe(stdout_pipe, 4096, _O_BINARY) == 0);
+#else
+	int stdin_fileno = STDIN_FILENO;
+	int stdout_fileno = STDOUT_FILENO;
+
+	CHECK(pipe(stdin_pipe) == 0);
+	CHECK(pipe(stdout_pipe) == 0);
+#endif
+
+	int original_stdin = DUP_FUNCTION(stdin_fileno);
+	int original_stdout = DUP_FUNCTION(stdout_fileno);
+
+	// This will duplicate our "stdin" read pipe into stdin
+	DUP2_FUNCTION(stdin_pipe[0], stdin_fileno);
+	CLOSE_FUNCTION(stdin_pipe[0]);
+
+	// This will duplicate our "stdout" write pipe into stdout
+	DUP2_FUNCTION(stdout_pipe[1], stdout_fileno);
+	CLOSE_FUNCTION(stdout_pipe[1]);
+
+	Ref<StreamPeerStdio> stdio;
+	stdio.instantiate();
+
+	SUBCASE("Read from stdin using StreamPeerStdio") {
+		const char *test_input = "Hello from stdin!";
+		int input_len = strlen(test_input);
+
+		size_t written = WRITE_FUNCTION(stdin_pipe[1], test_input, input_len);
+		CHECK_EQ(written, input_len);
+
+		uint8_t read_buffer[256];
+		memset(read_buffer, 0, sizeof(read_buffer));
+		int received = 0;
+
+		Error read_err = stdio->get_partial_data(read_buffer, input_len, received);
+		CHECK(read_err == OK);
+		CHECK_EQ(received, input_len);
+		CHECK_EQ(memcmp(read_buffer, test_input, input_len), 0);
+	}
+
+	SUBCASE("Write to stdout using StreamPeerStdio") {
+		const char *test_output = "Hello to stdout!";
+		int output_len = strlen(test_output);
+		int sent = 0;
+
+		Error write_err = stdio->put_partial_data((const uint8_t *)test_output, output_len, sent);
+		CHECK(write_err == OK);
+		CHECK_EQ(sent, output_len);
+
+		uint8_t read_buffer[256];
+		memset(read_buffer, 0, sizeof(read_buffer));
+		size_t read_bytes = READ_FUNCTION(stdout_pipe[0], read_buffer, output_len);
+		CHECK_EQ(read_bytes, output_len);
+		CHECK_EQ(memcmp(read_buffer, test_output, output_len), 0);
+	}
+
+	CLOSE_FUNCTION(stdin_pipe[1]);
+	CLOSE_FUNCTION(stdout_pipe[0]);
+
+	// Restore original stdin/stdout
+	DUP2_FUNCTION(original_stdin, stdin_fileno);
+	DUP2_FUNCTION(original_stdout, stdout_fileno);
+	CLOSE_FUNCTION(original_stdin);
+	CLOSE_FUNCTION(original_stdout);
+}
+} // namespace TestStreamPeerStdio


### PR DESCRIPTION
Closes godotengine/godot-proposals#464

Now Godot can be started as a headless LSP server that reads from stdin and writes to stdout with the `--lsp` CLI parameter.

Bellow is an example of [`helix`](https://helix-editor.com/) using the stdio LSP

![Helix_Godot_LSP_stdio](https://github.com/user-attachments/assets/bcd7dac7-eb3b-4b2b-847c-bbf226d0ea41)

## Helix configuration example

`helix` configuration to get it working.
Linux and Mac: `~/.config/helix/languages.toml`
Windows: `%AppData%\helix\languages.toml`
```toml
[language-server.godot]
command = "<YOUR GODOT BINARY FULL PATH>"
args = [ "--lsp" ]

[[language]]
name = "gdscript"
language-servers = [ "godot" ]
```

## Testing tool

In order to make testing this easier and be sure that having multiple instances of Godot running doesn't broke the project and the LSP works I created a stress testing and validation tool.
It's spawns multiple concurrent LSP servers and continuously performs various checks to ensure they correctly handles file changes, symbol tracking, and diagnostics.
The tool does for each LSP server that spawns runs some tests in a forever loop. To prevent issues and because a regular Godot user won't edit code in two different editors at the same time,
the checks are executed for only one LSP server at a time.
Currently the checks are (open to write more if makes sense):
- Symbol tracking validation: Adds random functions to GDScript files and verifies the LSP recognizes them
- Diagnostics validation: Creates parent-child class relationships, removes the parent class, and confirms the LSP reports the expected diagnostic error ("Could not find base class")
I'm uploading binaries of the tool for Windows, Linux and Mac (I only tested it on Mac, so let me know if you are facing some issue)

Before start testing I encourage you to open Godot with the project that you want to test and if it's possible also have open an external editor that connects to Godot LSP Server through TCP (e.g. VSCode)
To verify that the use of a lot of LSP Servers didn't broke the project you could do a git diff on it or even export it an run it.

### Usage Example
We will use Godot 2D platformer demo:
```bash
# Clone the demo project
git clone https://github.com/godotengine/godot-demo-projects
cd godot-demo-projects/2d/platformer

# Run the test with 3 clients (default)
godot-lsp-test-os-arch -godot /path/to/godot -project .

# Run shutdown tests with 3 clients (default)
godot-lsp-test-os-arch -godot /path/to/godot -project . -test-shutdown

# Run with 5 clients, checking every 10 seconds, with verbose logging
godot-lsp-test-os-arch -godot /path/to/godot -project . -clients 5 -interval 10 -verbose
```

### Binaries (Windows, Linux and Mac)
[godot-lsp-test.zip](https://github.com/user-attachments/files/26649820/godot-lsp-test.zip)


