### PR TITLE
X11 Fix mouse motion

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5291,23 +5291,31 @@ void DisplayServerX11::process_events() {
 					focused_window_id = MAIN_WINDOW_ID;
 				}
 
-				while (true) {
-					if (mouse_mode == MOUSE_MODE_CAPTURED && event.xmotion.x == windows[focused_window_id].size.width / 2 && event.xmotion.y == windows[focused_window_id].size.height / 2) {
-						//this is likely the warp event since it was warped here
-						center = Vector2(event.xmotion.x, event.xmotion.y);
-						break;
-					}
+				// Check for warp event first
+				if (mouse_mode == MOUSE_MODE_CAPTURED && event.xmotion.x == windows[focused_window_id].size.width / 2 && event.xmotion.y == windows[focused_window_id].size.height / 2) {
+					center = Vector2(event.xmotion.x, event.xmotion.y);
+					break;
+				}
 
-					if (event_index + 1 < events.size()) {
+				// If not a warp, check for accumulation
+				if (Input::get_singleton()->is_using_accumulated_input()) {
+					// Accumulate all subsequent motion events,
+					// but stop if we see a warp event.
+					while (event_index + 1 < events.size()) {
 						const XEvent &next_event = events[event_index + 1];
 						if (next_event.type == MotionNotify) {
+							// Check if the *next* event is a warp. If so, stop accumulating.
+							if (mouse_mode == MOUSE_MODE_CAPTURED &&
+								next_event.xmotion.x == windows[focused_window_id].size.width / 2 &&
+								next_event.xmotion.y == windows[focused_window_id].size.height / 2) {
+								break;
+							}
+							
 							++event_index;
 							event = next_event;
 						} else {
 							break;
 						}
-					} else {
-						break;
 					}
 				}
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5292,8 +5292,8 @@ void DisplayServerX11::process_events() {
 				}
 
 				// Check for warp event first
-				if (mouse_mode == MOUSE_MODE_CAPTURED && 
-						event.xmotion.x == windows[focused_window_id].size.width / 2 && 
+				if (mouse_mode == MOUSE_MODE_CAPTURED &&
+						event.xmotion.x == windows[focused_window_id].size.width / 2 &&
 						event.xmotion.y == windows[focused_window_id].size.height / 2) {
 					center = Vector2(event.xmotion.x, event.xmotion.y);
 					break;
@@ -5308,11 +5308,11 @@ void DisplayServerX11::process_events() {
 						if (next_event.type == MotionNotify) {
 							// Check if the *next* event is a warp. If so, stop accumulating.
 							if (mouse_mode == MOUSE_MODE_CAPTURED &&
-								next_event.xmotion.x == windows[focused_window_id].size.width / 2 &&
-								next_event.xmotion.y == windows[focused_window_id].size.height / 2) {
+									next_event.xmotion.x == windows[focused_window_id].size.width / 2 &&
+									next_event.xmotion.y == windows[focused_window_id].size.height / 2) {
 								break;
 							}
-							
+
 							++event_index;
 							event = next_event;
 						} else {

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5292,7 +5292,9 @@ void DisplayServerX11::process_events() {
 				}
 
 				// Check for warp event first
-				if (mouse_mode == MOUSE_MODE_CAPTURED && event.xmotion.x == windows[focused_window_id].size.width / 2 && event.xmotion.y == windows[focused_window_id].size.height / 2) {
+				if (mouse_mode == MOUSE_MODE_CAPTURED && 
+						event.xmotion.x == windows[focused_window_id].size.width / 2 && 
+						event.xmotion.y == windows[focused_window_id].size.height / 2) {
 					center = Vector2(event.xmotion.x, event.xmotion.y);
 					break;
 				}


### PR DESCRIPTION
Closes #112505

Fix mouse motion logic for X11 display driver.
My guess is:  the bug is because a condition logic inside the `while(true)` loop. It executes and "eats" (drops) all intermediate mouse motion events even when Input.use_accumulated_input is set to false, which is precisely when you want to process every single event.