### PR TITLE
Fix animation playback single frame delay

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1834,6 +1834,13 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 								}
 							} else {
 								player2->play(anim_name);
+
+								// If the target animation player was not playing anything last frame,
+								// it will not be processed this frame. To avoid a full frame of delay,
+								// before first keyframes are applied, manually process the animation
+								// immediately.
+								player2->_process_animation(0);
+
 								t->playing = true;
 								playing_caches.insert(t);
 							}

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1833,13 +1833,16 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 									t->playing = false;
 								}
 							} else {
+								bool was_not_processing = !player2->processing;
 								player2->play(anim_name);
 
 								// If the target animation player was not playing anything last frame,
 								// it will not be processed this frame. To avoid a full frame of delay,
 								// before first keyframes are applied, manually process the animation
 								// immediately.
-								player2->_process_animation(0);
+								if (was_not_processing) {
+									player2->_process_animation(0);
+								}
 
 								t->playing = true;
 								playing_caches.insert(t);


### PR DESCRIPTION
Fixes #104046

**Disclaimer:** I'm not familiar enough with the engine internals to know if this has some sinister side effects. I'm opening a draft PR for discussing if this is a valid approach and if the infinite loop safeguards are necessary or not.

Fixes animation playback tracks waiting a full frame before applying the first keyframes of the animation clip being played. The issue occurs if animation player is not currently playing anything when a animation playback track starts playing a new animation on it.

Animation players do not receive `NOTIFICATION_INTERNAL_PROCESS` unless there is an animation actively being played. If there is no currently playing animation, and an animation playback track starts a new animation, the previously inactive animation player will not be receiving the process notification until the next frame. This causes an observable single frame delay before animation playback tracks apply their changes, in comparison to e.g. property tracks. If the animation player **is** currently playing another animation, the issue is dependent on the update order of the animation players.

To fix this, animation playback track needs to immediately instruct the target animation player to process its animation. This is effectively the same as calling `.advance(0)` on an animation player immediately after a `.play("foo")`.

To avoid/reduce possibilities for infinite loops of animation players' animation playback tracks updating each other in a cycle, the added animation processing is safeguarded with a check to see if the animation player was processing (before `play(..)` is internally called).

However, this safeguard has a major drawback: if there already was an animation playing on the targeted animation player, the animations are now dependent on the update order of the animation players. That is, the fix only works correctly with the safeguard **if and only if the targeted animation player is later in the update order** than the animation player with the animation playback track.

Alternative could be to just drop the safeguard, and naively always make the call to the `._process_animation(0)` immediately after the `player2->play(..)`. That would likely require some way of detecting infinite loops, but would not suffer from possibly confusing dependency on update order.