### PR TITLE
Fix VoxelGI rendering outside of non-uniform bounds

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3720,30 +3720,38 @@ void GI::setup_voxel_gi_instances(RenderDataRD *p_render_data, Ref<RenderSceneBu
 
 				RID base_probe = gipi->probe;
 
-				Transform3D to_cell = voxel_gi_get_to_cell_xform(gipi->probe) * gipi->transform.affine_inverse() * to_camera;
+				Transform3D to_cell = voxel_gi_get_to_cell_xform(base_probe);
+				Transform3D to_world_cell = to_cell * gipi->transform.affine_inverse() * to_camera;
 
-				gipd.xform[0] = to_cell.basis.rows[0][0];
-				gipd.xform[1] = to_cell.basis.rows[1][0];
-				gipd.xform[2] = to_cell.basis.rows[2][0];
+				gipd.xform[0] = to_world_cell.basis.rows[0][0];
+				gipd.xform[1] = to_world_cell.basis.rows[1][0];
+				gipd.xform[2] = to_world_cell.basis.rows[2][0];
 				gipd.xform[3] = 0;
-				gipd.xform[4] = to_cell.basis.rows[0][1];
-				gipd.xform[5] = to_cell.basis.rows[1][1];
-				gipd.xform[6] = to_cell.basis.rows[2][1];
+				gipd.xform[4] = to_world_cell.basis.rows[0][1];
+				gipd.xform[5] = to_world_cell.basis.rows[1][1];
+				gipd.xform[6] = to_world_cell.basis.rows[2][1];
 				gipd.xform[7] = 0;
-				gipd.xform[8] = to_cell.basis.rows[0][2];
-				gipd.xform[9] = to_cell.basis.rows[1][2];
-				gipd.xform[10] = to_cell.basis.rows[2][2];
+				gipd.xform[8] = to_world_cell.basis.rows[0][2];
+				gipd.xform[9] = to_world_cell.basis.rows[1][2];
+				gipd.xform[10] = to_world_cell.basis.rows[2][2];
 				gipd.xform[11] = 0;
-				gipd.xform[12] = to_cell.origin.x;
-				gipd.xform[13] = to_cell.origin.y;
-				gipd.xform[14] = to_cell.origin.z;
+				gipd.xform[12] = to_world_cell.origin.x;
+				gipd.xform[13] = to_world_cell.origin.y;
+				gipd.xform[14] = to_world_cell.origin.z;
 				gipd.xform[15] = 1;
 
-				Vector3 bounds = voxel_gi_get_octree_size(base_probe);
+				Vector3 bounds = voxel_gi_get_bounds(base_probe).size;
+				Vector3 cell_bounds = to_cell.basis.xform(bounds);
 
-				gipd.bounds[0] = bounds.x;
-				gipd.bounds[1] = bounds.y;
-				gipd.bounds[2] = bounds.z;
+				gipd.bounds[0] = cell_bounds.x;
+				gipd.bounds[1] = cell_bounds.y;
+				gipd.bounds[2] = cell_bounds.z;
+
+				Vector3 octree_size = voxel_gi_get_octree_size(base_probe);
+
+				gipd.octree_size[0] = octree_size.x;
+				gipd.octree_size[1] = octree_size.y;
+				gipd.octree_size[2] = octree_size.z;
 
 				gipd.dynamic_range = voxel_gi_get_dynamic_range(base_probe) * voxel_gi_get_energy(base_probe);
 				gipd.bias = voxel_gi_get_bias(base_probe);

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -760,7 +760,7 @@ public:
 		uint32_t blend_ambient; // 4 - 92
 		uint32_t mipmaps; // 4 - 96
 
-		float pad[3]; // 12 - 108
+		float octree_size[3]; // 12 - 108
 		float exposure_normalization; // 4 - 112
 	};
 

--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -90,7 +90,7 @@ struct VoxelGIData {
 	bool blend_ambient; // 4 - 92
 	uint mipmaps; // 4 - 96
 
-	vec3 pad; // 12 - 108
+	vec3 octree_size; // 12 - 108
 	float exposure_normalization; // 4 - 112
 };
 
@@ -547,7 +547,7 @@ void voxel_gi_compute(uint index, vec3 position, vec3 normal, vec3 ref_vec, mat3
 	//float blend=1.0;
 
 	float max_distance = length(voxel_gi_instances.data[index].bounds);
-	vec3 cell_size = 1.0 / voxel_gi_instances.data[index].bounds;
+	vec3 cell_size = 1.0 / voxel_gi_instances.data[index].octree_size;
 
 	//irradiance
 

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -80,7 +80,7 @@ struct VoxelGIData {
 	bool blend_ambient; // 4 - 92
 	uint mipmaps; // 4 - 96
 
-	vec3 pad; // 12 - 108
+	vec3 octree_size; // 12 - 108
 	float exposure_normalization; // 4 - 112
 };
 

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -426,7 +426,7 @@ struct VoxelGIData {
 	bool blend_ambient; // 4 - 92
 	uint mipmaps; // 4 - 96
 
-	vec3 pad; // 12 - 108
+	vec3 octree_size; // 12 - 108
 	float exposure_normalization; // 4 - 112
 };
 


### PR DESCRIPTION
Closes #62930 

### Before:
<img width="1920" height="1009" alt="editor_screenshot_2025-11-07T192310" src="https://github.com/user-attachments/assets/78d4130a-a4b5-44be-bc53-ac4efd79e8b2" />

### After:
<img width="1920" height="1009" alt="editor_screenshot_2025-11-07T222631" src="https://github.com/user-attachments/assets/359e1634-8056-4d27-b018-3268dff85e37" />

#### What was the problem?

The GPU receives the VoxelGI transform in cell space for quicker tracing.
The bounds need to be in cell space, too, so the octree_size was passed.
That's incorrect, since for non-uniform bounds, it doesn't match the actual bounds in cell space.

Instead, we scale the bounds using the basis of the to_cell transform and pass that.
We still have to map back to world units, hence we need to pass the octree_size as well (one could also pass the cell size (1.0/octree_size) instead for further optimization)...
Conveniently, a vec3 already existed as padding in the VoxelGIData struct passed to the GPU, so I just turned that into the octree_size.