### PR TITLE
Fix `Control::_update_minimum_size()` not updating offsets

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1659,6 +1659,12 @@ void Control::_update_minimum_size() {
 	data.updating_last_minimum_size = false;
 
 	if (minsize != data.last_minimum_size) {
+		Size2 old_minsize = data.last_minimum_size;
+
+		if ((data.size_cache.is_equal_approx(old_minsize)) && (minsize.width < old_minsize.width || minsize.height < old_minsize.height) && data.stored_layout_mode != LayoutMode::LAYOUT_MODE_ANCHORS) {
+			_compute_offsets(Rect2(data.pos_cache, minsize), data.anchor, data.offset);
+		}
+
 		data.last_minimum_size = minsize;
 		_size_changed();
 		emit_signal(SceneStringName(minimum_size_changed));


### PR DESCRIPTION
* Closes #100536 
* Does not reintroduce RTL bug as seen in #106477

Before this PR, whenever `Control::set_position` or `Control::set_size` was called, they would "freeze" the container's minimum size by fixing its offsets. If the Container was made smaller by resizing/deleting a child node (e.g., an `HBoxContainer` with a child deleted) after `set_position` or `set_size` had been called, it would not shrink to match the new expected size. 

This PR introduces an offset recalculation in `Control::_update_minimum_size` before `_size_changed()` is called, which fixes the issue. 

Before PR

https://github.com/user-attachments/assets/4f9bcaae-690a-46f9-94d9-a1a41a394654

After PR

https://github.com/user-attachments/assets/00f1d6f2-4fe8-4477-8faa-2a7bc006a813

*Note: I don't know why the recordings are so messed up but they show the behavior and fix, so good enough for me*