### PR TITLE
Add undo support to editor setting overrides

### DIFF
--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -48,6 +48,7 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/settings/event_listener_line_edit.h"
 #include "editor/settings/input_event_configuration_dialog.h"
+#include "editor/settings/project_settings_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/debugger/view_3d_controller.h"
@@ -255,6 +256,32 @@ void EditorSettingsDialog::_undo_redo_callback(void *p_self, const String &p_nam
 	EditorNode::get_log()->add_message(p_name, EditorLog::MSG_TYPE_EDITOR);
 }
 
+void EditorSettingsDialog::_create_setting_override(const String &p_setting, const Variant p_value) {
+	ProjectSettings::get_singleton()->set_editor_setting_override(p_setting, p_value);
+	ProjectSettings::get_singleton()->save();
+
+	if (is_visible() && p_setting.begins_with(inspector->get_current_section())) {
+		inspector->get_inspector()->update_tree();
+	}
+	if (ProjectSettingsEditor::get_singleton()->is_visible()) {
+		ProjectSettingsEditor::get_singleton()->get_inspector()->update_category_list();
+	}
+}
+
+void EditorSettingsDialog::_remove_setting_override(const String &p_setting) {
+	ProjectSettings::get_singleton()->set_editor_setting_override(p_setting, Variant());
+	ProjectSettings::get_singleton()->save();
+	EditorSettings::get_singleton()->mark_setting_changed(p_setting);
+	EditorNode::get_singleton()->notify_settings_overrides_changed();
+
+	if (is_visible() && p_setting.begins_with(inspector->get_current_section())) {
+		inspector->get_inspector()->update_tree();
+	}
+	if (ProjectSettingsEditor::get_singleton()->is_visible()) {
+		ProjectSettingsEditor::get_singleton()->get_inspector()->update_category_list();
+	}
+}
+
 void EditorSettingsDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -265,8 +292,6 @@ void EditorSettingsDialog::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			EditorSettingsPropertyWrapper::restart_request_callback = callable_mp(this, &EditorSettingsDialog::_editor_restart_request);
-
 			if (_is_in_project_manager()) {
 				return;
 			}
@@ -956,11 +981,15 @@ void EditorSettingsDialog::_editor_restart_close() {
 void EditorSettingsDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_shortcuts"), &EditorSettingsDialog::_update_shortcuts);
 	ClassDB::bind_method(D_METHOD("_settings_changed"), &EditorSettingsDialog::_settings_changed);
+	ClassDB::bind_method(D_METHOD("_create_setting_override"), &EditorSettingsDialog::_create_setting_override);
+	ClassDB::bind_method(D_METHOD("_remove_setting_override"), &EditorSettingsDialog::_remove_setting_override);
 
 	ADD_SIGNAL(MethodInfo("restart_requested"));
 }
 
 EditorSettingsDialog::EditorSettingsDialog() {
+	singleton = this;
+
 	set_title(TTRC("Editor Settings"));
 	set_flag(FLAG_MAXIMIZE_DISABLED, false);
 	set_clamp_to_embedder(true);
@@ -1089,6 +1118,10 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	EditorInspector::add_inspector_plugin(plugin);
 }
 
+EditorSettingsDialog::~EditorSettingsDialog() {
+	singleton = nullptr;
+}
+
 void EditorSettingsPropertyWrapper::_setup_override_info() {
 	override_container = memnew(HBoxContainer);
 
@@ -1148,21 +1181,29 @@ void EditorSettingsPropertyWrapper::_update_override() {
 }
 
 void EditorSettingsPropertyWrapper::_create_override() {
-	ProjectSettings::get_singleton()->set_editor_setting_override(property, EDITOR_GET(property));
+	const Variant setting_value = EDITOR_GET(property);
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(vformat(TTR("Add project override for setting: %s"), property));
+	undo_redo->add_do_method(EditorSettingsDialog::get_singleton(), "_create_setting_override", property, setting_value);
+	undo_redo->add_undo_method(EditorSettingsDialog::get_singleton(), "_remove_setting_override", property);
+	undo_redo->commit_action(false);
+
+	ProjectSettings::get_singleton()->set_editor_setting_override(property, setting_value);
 	ProjectSettings::get_singleton()->save();
 	_update_override();
 }
 
 void EditorSettingsPropertyWrapper::_remove_override() {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(vformat(TTR("Remove project override for setting: %s"), property));
+	undo_redo->add_do_method(EditorSettingsDialog::get_singleton(), "_remove_setting_override", property);
+	undo_redo->add_undo_method(EditorSettingsDialog::get_singleton(), "_create_setting_override", property, ProjectSettings::get_singleton()->get_editor_setting_override(property));
+	undo_redo->commit_action(false);
+
 	ProjectSettings::get_singleton()->set_editor_setting_override(property, Variant());
 	ProjectSettings::get_singleton()->save();
-	EditorSettings::get_singleton()->mark_setting_changed(property);
-	EditorNode::get_singleton()->notify_settings_overrides_changed();
 	_update_override();
-
-	if (usage & PROPERTY_USAGE_RESTART_IF_CHANGED) {
-		restart_request_callback.call();
-	}
 }
 
 void EditorSettingsPropertyWrapper::_notification(int p_what) {

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -47,6 +47,8 @@ class TreeItem;
 class EditorSettingsDialog : public AcceptDialog {
 	GDCLASS(EditorSettingsDialog, AcceptDialog);
 
+	static inline EditorSettingsDialog *singleton = nullptr;
+
 	TabContainer *tabs = nullptr;
 	Control *tab_general = nullptr;
 	Control *tab_shortcuts = nullptr;
@@ -116,6 +118,9 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	static void _undo_redo_callback(void *p_self, const String &p_name);
 
+	void _create_setting_override(const String &p_setting, const Variant p_value);
+	void _remove_setting_override(const String &p_setting);
+
 	Label *restart_label = nullptr;
 	TextureRect *restart_icon = nullptr;
 	PanelContainer *restart_container = nullptr;
@@ -133,8 +138,10 @@ public:
 	static void update_3d_navigation_preset();
 	void set_current_section(const String &p_section);
 	void set_advanced_mode_enabled(bool p_enabled);
+	static EditorSettingsDialog *get_singleton() { return singleton; }
 
 	EditorSettingsDialog();
+	~EditorSettingsDialog();
 };
 
 class EditorSettingsPropertyWrapper : public EditorProperty {
@@ -162,8 +169,6 @@ protected:
 	void _notification(int p_what);
 
 public:
-	static inline Callable restart_request_callback;
-
 	virtual void update_property() override;
 	void setup(const String &p_property, EditorProperty *p_editor_property, PropertyHint p_hint, const String &p_hint_text, uint32_t p_usage);
 };

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -41,6 +41,7 @@
 #include "editor/gui/editor_variant_type_selectors.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/settings/editor_settings.h"
+#include "editor/settings/editor_settings_dialog.h"
 #include "editor/settings/gdextension/project_settings_gdextension.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_button.h"
@@ -138,14 +139,16 @@ void ProjectSettingsEditor::_on_category_changed(const String &p_new_category) {
 }
 
 void ProjectSettingsEditor::_on_editor_override_deleted(const String &p_setting) {
-	const String full_name = general_settings_inspector->get_full_item_path(p_setting);
-	ERR_FAIL_COND(!full_name.begins_with(ProjectSettings::EDITOR_SETTING_OVERRIDE_PREFIX));
+	String setting_name = general_settings_inspector->get_full_item_path(p_setting);
+	ERR_FAIL_COND(!setting_name.begins_with(ProjectSettings::EDITOR_SETTING_OVERRIDE_PREFIX));
 
-	ProjectSettings::get_singleton()->set_setting(full_name, Variant());
-	EditorSettings::get_singleton()->mark_setting_changed(full_name.trim_prefix(ProjectSettings::EDITOR_SETTING_OVERRIDE_PREFIX));
-	pending_override_notify = true;
-	_save();
-	general_settings_inspector->update_category_list();
+	setting_name = setting_name.trim_prefix(ProjectSettings::EDITOR_SETTING_OVERRIDE_PREFIX);
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(vformat(TTR("Remove project override for setting: %s"), setting_name));
+	undo_redo->add_do_method(EditorSettingsDialog::get_singleton(), "_remove_setting_override", setting_name);
+	undo_redo->add_undo_method(EditorSettingsDialog::get_singleton(), "_create_setting_override", setting_name, ProjectSettings::get_singleton()->get_editor_setting_override(setting_name));
+	undo_redo->commit_action();
 }
 
 void ProjectSettingsEditor::_advanced_toggled(bool p_button_pressed) {

--- a/editor/settings/project_settings_editor.h
+++ b/editor/settings/project_settings_editor.h
@@ -151,6 +151,7 @@ public:
 	EditorAutoloadSettings *get_autoload_settings() { return autoload_settings; }
 	GroupSettingsEditor *get_group_settings() { return group_settings; }
 	TabContainer *get_tabs() { return tab_container; }
+	SectionedInspector *get_inspector() { return general_settings_inspector; }
 
 	void queue_save();
 	void connect_filesystem_dock_signals(FileSystemDock *p_fs_dock);


### PR DESCRIPTION
Creating/deleting project overrides for editor settings did not create undo actions.