### PR TITLE
Allow Tile Baking Chunks Setting for NavigationRegion3D 

### DIFF
--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -101,6 +101,7 @@
 			The size of the non-navigable border around the bake bounding area.
 			In conjunction with the [member filter_baking_aabb] and a [member edge_max_error] value at [code]1.0[/code] or below the border size can be used to bake tile aligned navigation meshes without the tile edges being shrunk by [member agent_radius].
 			[b]Note:[/b] If this value is not [code]0.0[/code], it will be rounded up to the nearest multiple of [member cell_size] during baking.
+			[b]Note:[/b] When [member tile_baking_enabled] is [code]true[/code], the effective border is clamped to at least [code]ceil([member agent_radius] / [member cell_size]) * [member cell_size] + 3 * [member cell_size][/code] (and at least 1 meter) so adjacent tiles keep enough overlap after erosion.
 		</member>
 		<member name="cell_height" type="float" setter="set_cell_height" getter="get_cell_height" default="0.25">
 			The cell height used to rasterize the navigation mesh vertices on the Y axis. Must match with the cell height on the navigation map.

--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -127,6 +127,12 @@
 		<member name="filter_baking_aabb_offset" type="Vector3" setter="set_filter_baking_aabb_offset" getter="get_filter_baking_aabb_offset" default="Vector3(0, 0, 0)">
 			The position offset applied to the [member filter_baking_aabb] [AABB].
 		</member>
+		<member name="tile_baking_enabled" type="bool" setter="set_tile_baking_enabled" getter="is_tile_baking_enabled" default="false">
+			If [code]true[/code], navmesh baking is executed in fixed-size tiles instead of the entire bounds at once. This makes it possible to bake very large areas without running out of memory at the cost of longer bake times.
+		</member>
+		<member name="tile_baking_size" type="float" setter="set_tile_baking_size" getter="get_tile_baking_size" default="30.0">
+			The core size in meters used for each tile when [member tile_baking_enabled] is [code]true[/code]. Values are clamped between 5 and 200 meters to prevent extremely small or extremely large tiles that could cause crashes or long bake times.
+		</member>
 		<member name="filter_ledge_spans" type="bool" setter="set_filter_ledge_spans" getter="get_filter_ledge_spans" default="false">
 			If [code]true[/code], marks spans that are ledges as non-walkable.
 		</member>

--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -127,12 +127,6 @@
 		<member name="filter_baking_aabb_offset" type="Vector3" setter="set_filter_baking_aabb_offset" getter="get_filter_baking_aabb_offset" default="Vector3(0, 0, 0)">
 			The position offset applied to the [member filter_baking_aabb] [AABB].
 		</member>
-		<member name="tile_baking_enabled" type="bool" setter="set_tile_baking_enabled" getter="is_tile_baking_enabled" default="false">
-			If [code]true[/code], navmesh baking is executed in fixed-size tiles instead of the entire bounds at once. This makes it possible to bake very large areas without running out of memory at the cost of longer bake times.
-		</member>
-		<member name="tile_baking_size" type="float" setter="set_tile_baking_size" getter="get_tile_baking_size" default="30.0">
-			The core size in meters used for each tile when [member tile_baking_enabled] is [code]true[/code]. Values are clamped between 5 and 200 meters to prevent extremely small or extremely large tiles that could cause crashes or long bake times.
-		</member>
 		<member name="filter_ledge_spans" type="bool" setter="set_filter_ledge_spans" getter="get_filter_ledge_spans" default="false">
 			If [code]true[/code], marks spans that are ledges as non-walkable.
 		</member>
@@ -166,6 +160,12 @@
 		</member>
 		<member name="sample_partition_type" type="int" setter="set_sample_partition_type" getter="get_sample_partition_type" enum="NavigationMesh.SamplePartitionType" default="0">
 			Partitioning algorithm for creating the navigation mesh polys.
+		</member>
+		<member name="tile_baking_enabled" type="bool" setter="set_tile_baking_enabled" getter="is_tile_baking_enabled" default="false">
+			If [code]true[/code], navmesh baking is executed in fixed-size tiles instead of the entire bounds at once. This makes it possible to bake very large areas without running out of memory at the cost of longer bake times.
+		</member>
+		<member name="tile_baking_size" type="float" setter="set_tile_baking_size" getter="get_tile_baking_size" default="30.0">
+			The core size in meters used for each tile when [member tile_baking_enabled] is [code]true[/code]. Values are clamped between 5 and 200 meters to prevent extremely small or extremely large tiles that could cause crashes or long bake times.
 		</member>
 		<member name="vertices_per_polygon" type="float" setter="set_vertices_per_polygon" getter="get_vertices_per_polygon" default="6.0">
 			The maximum number of vertices allowed for polygons generated during the contour to polygon conversion process.

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
@@ -528,8 +528,6 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(NavMeshGenerat
 	float raw_bmin[3];
 	float raw_bmax[3];
 	rcCalcBounds(verts, nverts, raw_bmin, raw_bmax);
-	const Vector3 raw_bounds_min = Vector3(raw_bmin[0], raw_bmin[1], raw_bmin[2]);
-	const Vector3 raw_bounds_max = Vector3(raw_bmax[0], raw_bmax[1], raw_bmax[2]);
 	AABB baking_bounds(Vector3(raw_bmin[0], raw_bmin[1], raw_bmin[2]), Vector3(raw_bmax[0] - raw_bmin[0], raw_bmax[1] - raw_bmin[1], raw_bmax[2] - raw_bmin[2]));
 	AABB baking_aabb = p_navigation_mesh->get_filter_baking_aabb();
 	if (baking_aabb.has_volume()) {

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
@@ -31,12 +31,15 @@
 #include "nav_mesh_generator_3d.h"
 
 #include "core/config/project_settings.h"
+#include "core/math/math_defs.h"
 #include "core/os/thread.h"
+#include "core/string/print_string.h"
 #include "scene/3d/node_3d.h"
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
 #include "scene/resources/navigation_mesh.h"
 
 #include <Recast.h>
+#include <cfloat>
 
 NavMeshGenerator3D *NavMeshGenerator3D::singleton = nullptr;
 Mutex NavMeshGenerator3D::baking_navmesh_mutex;
@@ -64,6 +67,203 @@ static const char *_navmesh_bake_state_msgs[(size_t)NavMeshGenerator3D::NavMeshB
 	"Baking cleanup...",
 	"Baking finished.",
 };
+
+namespace {
+
+static constexpr float NAVMESH_TILE_SIZE_DEFAULT_METERS = 30.0f;
+static constexpr float NAVMESH_TILE_SIZE_MIN_METERS = 5.0f;
+static constexpr float NAVMESH_TILE_SIZE_MAX_METERS = 200.0f;
+static constexpr float NAVMESH_TILE_MIN_BORDER_METERS = 1.0f;
+
+struct TileCoreClip3D {
+	bool enabled = false;
+	Vector3 min;
+	Vector3 max;
+};
+
+struct TileDefinition3D {
+	AABB bake_bounds;
+	TileCoreClip3D clip;
+};
+
+struct NavMeshBuildAccumulator3D {
+	HashMap<Vector3, int> vertex_lookup;
+	Vector<Vector3> vertices;
+	Vector<Vector<int>> polygons;
+
+	int get_or_add_vertex(const Vector3 &p_vertex) {
+		int *existing_index = vertex_lookup.getptr(p_vertex);
+		if (existing_index) {
+			return *existing_index;
+		}
+		const int new_index = vertices.size();
+		vertex_lookup[p_vertex] = new_index;
+		vertices.push_back(p_vertex);
+		return new_index;
+	}
+};
+
+static bool navmesh_polygon_in_core(const Vector<Vector3> &p_tile_vertices, const Vector<int> &p_polygon, const TileCoreClip3D &p_clip) {
+	if (!p_clip.enabled) {
+		return true;
+	}
+	if (p_polygon.is_empty()) {
+		return false;
+	}
+
+	bool vertex_inside = false;
+	float poly_min_x = FLT_MAX;
+	float poly_max_x = -FLT_MAX;
+	float poly_min_z = FLT_MAX;
+	float poly_max_z = -FLT_MAX;
+
+	for (int i = 0; i < p_polygon.size(); i++) {
+		const int vertex_index = p_polygon[i];
+		if (vertex_index < 0 || vertex_index >= p_tile_vertices.size()) {
+			return false;
+		}
+		const Vector3 &vertex = p_tile_vertices[vertex_index];
+		if (vertex.x >= p_clip.min.x - CMP_EPSILON && vertex.x <= p_clip.max.x + CMP_EPSILON &&
+				vertex.z >= p_clip.min.z - CMP_EPSILON && vertex.z <= p_clip.max.z + CMP_EPSILON) {
+			vertex_inside = true;
+		}
+		poly_min_x = MIN(poly_min_x, vertex.x);
+		poly_max_x = MAX(poly_max_x, vertex.x);
+		poly_min_z = MIN(poly_min_z, vertex.z);
+		poly_max_z = MAX(poly_max_z, vertex.z);
+	}
+
+	if (vertex_inside) {
+		return true;
+	}
+
+	return poly_max_x >= p_clip.min.x - CMP_EPSILON && poly_min_x <= p_clip.max.x + CMP_EPSILON &&
+			poly_max_z >= p_clip.min.z - CMP_EPSILON && poly_min_z <= p_clip.max.z + CMP_EPSILON;
+}
+
+static void clamp_tile_vertices_to_clip(Vector<Vector3> &p_vertices, const TileCoreClip3D &p_clip, float p_cell_size) {
+	if (!p_clip.enabled || p_vertices.is_empty()) {
+		return;
+	}
+	const float tolerance = MAX(p_cell_size * 0.5f, 0.05f);
+	for (int i = 0; i < p_vertices.size(); i++) {
+		Vector3 vertex = p_vertices[i];
+		if (vertex.x < p_clip.min.x && vertex.x > p_clip.min.x - tolerance) {
+			vertex.x = p_clip.min.x;
+		} else if (vertex.x > p_clip.max.x && vertex.x < p_clip.max.x + tolerance) {
+			vertex.x = p_clip.max.x;
+		}
+
+		if (vertex.z < p_clip.min.z && vertex.z > p_clip.min.z - tolerance) {
+			vertex.z = p_clip.min.z;
+		} else if (vertex.z > p_clip.max.z && vertex.z < p_clip.max.z + tolerance) {
+			vertex.z = p_clip.max.z;
+		}
+		p_vertices.write[i] = vertex;
+	}
+}
+
+static void append_tile_to_accumulator(Vector<Vector3> &p_tile_vertices, const Vector<Vector<int>> &p_tile_polygons, const TileCoreClip3D &p_clip, float p_cell_size, NavMeshBuildAccumulator3D &r_accumulator) {
+	if (p_tile_vertices.is_empty()) {
+		return;
+	}
+
+	clamp_tile_vertices_to_clip(p_tile_vertices, p_clip, p_cell_size);
+
+	Vector<int> remap;
+	remap.resize(p_tile_vertices.size());
+	for (int i = 0; i < p_tile_vertices.size(); i++) {
+		remap.write[i] = r_accumulator.get_or_add_vertex(p_tile_vertices[i]);
+	}
+
+	for (int polygon_index = 0; polygon_index < p_tile_polygons.size(); polygon_index++) {
+		const Vector<int> &tile_polygon = p_tile_polygons[polygon_index];
+		if (tile_polygon.size() < 3) {
+			continue;
+		}
+		if (!navmesh_polygon_in_core(p_tile_vertices, tile_polygon, p_clip)) {
+			continue;
+		}
+
+		bool polygon_valid = true;
+		Vector<int> remapped_polygon = tile_polygon;
+		for (int corner = 0; corner < tile_polygon.size(); corner++) {
+			const int tile_vertex_index = tile_polygon[corner];
+			if (tile_vertex_index < 0 || tile_vertex_index >= remap.size()) {
+				polygon_valid = false;
+				break;
+			}
+			remapped_polygon.write[corner] = remap[tile_vertex_index];
+		}
+		if (!polygon_valid) {
+			continue;
+		}
+		r_accumulator.polygons.push_back(remapped_polygon);
+	}
+}
+
+static void compute_tile_definitions(const AABB &p_baking_bounds, float p_cell_size, int p_width_cells, int p_height_cells, int p_walkable_radius, bool p_enable_tiling, float p_tile_size_meters, LocalVector<TileDefinition3D> &r_tiles) {
+	r_tiles.clear();
+
+	if (!p_enable_tiling) {
+		TileDefinition3D tile;
+		tile.bake_bounds = p_baking_bounds;
+		tile.clip.enabled = false;
+		r_tiles.push_back(tile);
+		return;
+	}
+
+	const float tile_core_size = MAX(p_tile_size_meters, p_cell_size);
+	const int tile_core_span_x = MAX(1, (int)Math::ceil(tile_core_size / p_cell_size));
+	const int tile_core_span_z = MAX(1, (int)Math::ceil(tile_core_size / p_cell_size));
+
+	const int desired_overlap = MAX(p_walkable_radius + 2, 4);
+	const int overlap_x = MIN(desired_overlap, MAX(1, tile_core_span_x / 2));
+	const int overlap_z = MIN(desired_overlap, MAX(1, tile_core_span_z / 2));
+
+	const int tile_step_x = MAX(1, tile_core_span_x);
+	const int tile_step_z = MAX(1, tile_core_span_z);
+
+	for (int core_min_z = 0; core_min_z < p_height_cells; core_min_z += tile_step_z) {
+		const int core_max_z = MIN(p_height_cells, core_min_z + tile_core_span_z);
+		const int tile_min_z = MAX(0, core_min_z - overlap_z);
+		const int tile_max_z = MIN(p_height_cells, core_max_z + overlap_z);
+
+		for (int core_min_x = 0; core_min_x < p_width_cells; core_min_x += tile_step_x) {
+			const int core_max_x = MIN(p_width_cells, core_min_x + tile_core_span_x);
+			const int tile_min_x = MAX(0, core_min_x - overlap_x);
+			const int tile_max_x = MIN(p_width_cells, core_max_x + overlap_x);
+
+			if (tile_max_x <= tile_min_x || tile_max_z <= tile_min_z) {
+				continue;
+			}
+
+			TileDefinition3D tile;
+			tile.bake_bounds.position = Vector3(
+					p_baking_bounds.position.x + tile_min_x * p_cell_size,
+					p_baking_bounds.position.y,
+					p_baking_bounds.position.z + tile_min_z * p_cell_size);
+			tile.bake_bounds.size = Vector3(
+					(tile_max_x - tile_min_x) * p_cell_size,
+					p_baking_bounds.size.y,
+					(tile_max_z - tile_min_z) * p_cell_size);
+
+			tile.clip.enabled = true;
+			tile.clip.min = Vector3(
+					p_baking_bounds.position.x + core_min_x * p_cell_size,
+					p_baking_bounds.position.y,
+					p_baking_bounds.position.z + core_min_z * p_cell_size);
+			tile.clip.max = Vector3(
+					p_baking_bounds.position.x + core_max_x * p_cell_size,
+					p_baking_bounds.position.y + p_baking_bounds.size.y,
+					p_baking_bounds.position.z + core_max_z * p_cell_size);
+
+			r_tiles.push_back(tile);
+		}
+	}
+}
+
+} // namespace
 
 NavMeshGenerator3D *NavMeshGenerator3D::get_singleton() {
 	return singleton;
@@ -322,6 +522,92 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(NavMeshGenerat
 		return;
 	}
 
+	const float *verts = source_geometry_vertices.ptr();
+	const int nverts = source_geometry_vertices.size() / 3;
+
+	float raw_bmin[3];
+	float raw_bmax[3];
+	rcCalcBounds(verts, nverts, raw_bmin, raw_bmax);
+	const Vector3 raw_bounds_min = Vector3(raw_bmin[0], raw_bmin[1], raw_bmin[2]);
+	const Vector3 raw_bounds_max = Vector3(raw_bmax[0], raw_bmax[1], raw_bmax[2]);
+	AABB baking_bounds(Vector3(raw_bmin[0], raw_bmin[1], raw_bmin[2]), Vector3(raw_bmax[0] - raw_bmin[0], raw_bmax[1] - raw_bmin[1], raw_bmax[2] - raw_bmin[2]));
+	AABB baking_aabb = p_navigation_mesh->get_filter_baking_aabb();
+	if (baking_aabb.has_volume()) {
+		const Vector3 baking_aabb_offset = p_navigation_mesh->get_filter_baking_aabb_offset();
+		baking_bounds.position = baking_aabb.position + baking_aabb_offset;
+		baking_bounds.size = baking_aabb.size;
+	} else {
+	}
+
+	rcConfig bounds_cfg;
+	memset(&bounds_cfg, 0, sizeof(bounds_cfg));
+	bounds_cfg.cs = p_navigation_mesh->get_cell_size();
+	bounds_cfg.ch = p_navigation_mesh->get_cell_height();
+	bounds_cfg.bmin[0] = baking_bounds.position.x;
+	bounds_cfg.bmin[1] = baking_bounds.position.y;
+	bounds_cfg.bmin[2] = baking_bounds.position.z;
+	bounds_cfg.bmax[0] = baking_bounds.position.x + baking_bounds.size.x;
+	bounds_cfg.bmax[1] = baking_bounds.position.y + baking_bounds.size.y;
+	bounds_cfg.bmax[2] = baking_bounds.position.z + baking_bounds.size.z;
+
+	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_CALC_GRID_SIZE; // step #2
+	rcCalcGridSize(bounds_cfg.bmin, bounds_cfg.bmax, bounds_cfg.cs, &bounds_cfg.width, &bounds_cfg.height);
+
+	if (bounds_cfg.width <= 0 || bounds_cfg.height <= 0) {
+		ERR_FAIL_MSG("Baking interrupted.\nNavigationMesh baking bounds are too small for the current configuration.");
+	}
+
+	const int walkable_radius = (int)Math::ceil(p_navigation_mesh->get_agent_radius() / bounds_cfg.cs);
+	const bool use_tile_baking = p_navigation_mesh->is_tile_baking_enabled();
+	float requested_tile_size = p_navigation_mesh->get_tile_baking_size();
+	if (!use_tile_baking || requested_tile_size <= 0.0f) {
+		requested_tile_size = NAVMESH_TILE_SIZE_DEFAULT_METERS;
+	}
+	requested_tile_size = CLAMP(requested_tile_size, NAVMESH_TILE_SIZE_MIN_METERS, NAVMESH_TILE_SIZE_MAX_METERS);
+
+	LocalVector<TileDefinition3D> tiles;
+	compute_tile_definitions(baking_bounds, bounds_cfg.cs, bounds_cfg.width, bounds_cfg.height, walkable_radius, use_tile_baking, requested_tile_size, tiles);
+
+	const int tile_count = tiles.size();
+	if (tile_count == 0) {
+		WARN_PRINT("NavigationMesh baking aborted because no tiles were generated.");
+		return;
+	}
+
+	NavMeshBuildAccumulator3D build_accumulator;
+	for (int tile_index = 0; tile_index < tile_count; tile_index++) {
+		Vector<Vector3> tile_vertices;
+		Vector<Vector<int>> tile_polygons;
+		const Error tile_err = generator_bake_single_tile(
+				p_generator_task,
+				source_geometry_vertices,
+				source_geometry_indices,
+				projected_obstructions,
+				tiles[tile_index].bake_bounds,
+				tile_vertices,
+				tile_polygons,
+				tile_index,
+				tile_count);
+
+		if (tile_err != OK) {
+			return;
+		}
+
+		append_tile_to_accumulator(tile_vertices, tile_polygons, tiles[tile_index].clip, p_navigation_mesh->get_cell_size(), build_accumulator);
+	}
+
+	p_navigation_mesh->set_data(build_accumulator.vertices, build_accumulator.polygons);
+
+	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_BAKE_FINISHED; // step #12
+}
+
+Error NavMeshGenerator3D::generator_bake_single_tile(NavMeshGeneratorTask3D *p_generator_task, const Vector<float> &p_source_geometry_vertices, const Vector<int> &p_source_geometry_indices, const Vector<NavigationMeshSourceGeometryData3D::ProjectedObstruction> &p_projected_obstructions, const AABB &p_bake_bounds, Vector<Vector3> &r_nav_vertices, Vector<Vector<int>> &r_nav_polygons, int p_tile_index, int p_tile_count) {
+	ERR_FAIL_COND_V(p_generator_task == nullptr, ERR_INVALID_PARAMETER);
+	Ref<NavigationMesh> navigation_mesh = p_generator_task->navigation_mesh;
+	ERR_FAIL_COND_V(navigation_mesh.is_null(), ERR_INVALID_PARAMETER);
+
+	Error err = OK;
+
 	rcHeightfield *hf = nullptr;
 	rcCompactHeightfield *chf = nullptr;
 	rcContourSet *cset = nullptr;
@@ -329,138 +615,144 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(NavMeshGenerat
 	rcPolyMeshDetail *detail_mesh = nullptr;
 	rcContext ctx;
 
-	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_CONFIGURATION; // step #1
+	Vector<Vector3> nav_vertices;
+	Vector<Vector<int>> nav_polygons;
 
-	const float *verts = source_geometry_vertices.ptr();
-	const int nverts = source_geometry_vertices.size() / 3;
-	const int *tris = source_geometry_indices.ptr();
-	const int ntris = source_geometry_indices.size() / 3;
+	HashMap<Vector3, int> recast_vertex_to_native_index;
+	LocalVector<int> recast_index_to_native_index;
 
-	float bmin[3], bmax[3];
-	rcCalcBounds(verts, nverts, bmin, bmax);
+	const float *verts = p_source_geometry_vertices.ptr();
+	const int *tris = p_source_geometry_indices.ptr();
+	const int nverts = p_source_geometry_vertices.size() / 3;
+	const int ntris = p_source_geometry_indices.size() / 3;
 
 	rcConfig cfg;
 	memset(&cfg, 0, sizeof(cfg));
 
-	cfg.cs = p_navigation_mesh->get_cell_size();
-	cfg.ch = p_navigation_mesh->get_cell_height();
-	if (p_navigation_mesh->get_border_size() > 0.0) {
-		cfg.borderSize = (int)Math::ceil(p_navigation_mesh->get_border_size() / cfg.cs);
+	cfg.cs = navigation_mesh->get_cell_size();
+	cfg.ch = navigation_mesh->get_cell_height();
+	float effective_border_size = navigation_mesh->get_border_size();
+	if (navigation_mesh->is_tile_baking_enabled()) {
+		effective_border_size = MAX(effective_border_size, NAVMESH_TILE_MIN_BORDER_METERS);
 	}
-	cfg.walkableSlopeAngle = p_navigation_mesh->get_agent_max_slope();
-	cfg.walkableHeight = (int)Math::ceil(p_navigation_mesh->get_agent_height() / cfg.ch);
-	cfg.walkableClimb = (int)Math::floor(p_navigation_mesh->get_agent_max_climb() / cfg.ch);
-	cfg.walkableRadius = (int)Math::ceil(p_navigation_mesh->get_agent_radius() / cfg.cs);
-	cfg.maxEdgeLen = (int)(p_navigation_mesh->get_edge_max_length() / p_navigation_mesh->get_cell_size());
-	cfg.maxSimplificationError = p_navigation_mesh->get_edge_max_error();
-	cfg.minRegionArea = (int)(p_navigation_mesh->get_region_min_size() * p_navigation_mesh->get_region_min_size());
-	cfg.mergeRegionArea = (int)(p_navigation_mesh->get_region_merge_size() * p_navigation_mesh->get_region_merge_size());
-	cfg.maxVertsPerPoly = (int)p_navigation_mesh->get_vertices_per_polygon();
-	cfg.detailSampleDist = MAX(p_navigation_mesh->get_cell_size() * p_navigation_mesh->get_detail_sample_distance(), 0.1f);
-	cfg.detailSampleMaxError = p_navigation_mesh->get_cell_height() * p_navigation_mesh->get_detail_sample_max_error();
+	if (effective_border_size > 0.0f) {
+		cfg.borderSize = (int)Math::ceil(effective_border_size / cfg.cs);
+	}
+	cfg.walkableSlopeAngle = navigation_mesh->get_agent_max_slope();
+	cfg.walkableHeight = (int)Math::ceil(navigation_mesh->get_agent_height() / cfg.ch);
+	cfg.walkableClimb = (int)Math::floor(navigation_mesh->get_agent_max_climb() / cfg.ch);
+	cfg.walkableRadius = (int)Math::ceil(navigation_mesh->get_agent_radius() / cfg.cs);
+	cfg.maxEdgeLen = (int)(navigation_mesh->get_edge_max_length() / navigation_mesh->get_cell_size());
+	cfg.maxSimplificationError = navigation_mesh->get_edge_max_error();
+	cfg.minRegionArea = (int)(navigation_mesh->get_region_min_size() * navigation_mesh->get_region_min_size());
+	cfg.mergeRegionArea = (int)(navigation_mesh->get_region_merge_size() * navigation_mesh->get_region_merge_size());
+	cfg.maxVertsPerPoly = (int)navigation_mesh->get_vertices_per_polygon();
+	cfg.detailSampleDist = MAX(navigation_mesh->get_cell_size() * navigation_mesh->get_detail_sample_distance(), 0.1f);
+	cfg.detailSampleMaxError = navigation_mesh->get_cell_height() * navigation_mesh->get_detail_sample_max_error();
 
-	if (p_navigation_mesh->get_border_size() > 0.0 && !Math::is_zero_approx(Math::fmod(p_navigation_mesh->get_border_size(), p_navigation_mesh->get_cell_size()))) {
+	if (navigation_mesh->get_border_size() > 0.0 && !Math::is_zero_approx(Math::fmod(navigation_mesh->get_border_size(), navigation_mesh->get_cell_size()))) {
 		WARN_PRINT("Property border_size is ceiled to cell_size voxel units and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.walkableHeight * cfg.ch, p_navigation_mesh->get_agent_height())) {
+	if (!Math::is_equal_approx((float)cfg.walkableHeight * cfg.ch, navigation_mesh->get_agent_height())) {
 		WARN_PRINT("Property agent_height is ceiled to cell_height voxel units and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.walkableClimb * cfg.ch, p_navigation_mesh->get_agent_max_climb())) {
+	if (!Math::is_equal_approx((float)cfg.walkableClimb * cfg.ch, navigation_mesh->get_agent_max_climb())) {
 		WARN_PRINT("Property agent_max_climb is floored to cell_height voxel units and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.walkableRadius * cfg.cs, p_navigation_mesh->get_agent_radius())) {
+	if (!Math::is_equal_approx((float)cfg.walkableRadius * cfg.cs, navigation_mesh->get_agent_radius())) {
 		WARN_PRINT("Property agent_radius is ceiled to cell_size voxel units and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.maxEdgeLen * cfg.cs, p_navigation_mesh->get_edge_max_length())) {
+	if (!Math::is_equal_approx((float)cfg.maxEdgeLen * cfg.cs, navigation_mesh->get_edge_max_length())) {
 		WARN_PRINT("Property edge_max_length is rounded to cell_size voxel units and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.minRegionArea, p_navigation_mesh->get_region_min_size() * p_navigation_mesh->get_region_min_size())) {
+	if (!Math::is_equal_approx((float)cfg.minRegionArea, navigation_mesh->get_region_min_size() * navigation_mesh->get_region_min_size())) {
 		WARN_PRINT("Property region_min_size is converted to int and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.mergeRegionArea, p_navigation_mesh->get_region_merge_size() * p_navigation_mesh->get_region_merge_size())) {
+	if (!Math::is_equal_approx((float)cfg.mergeRegionArea, navigation_mesh->get_region_merge_size() * navigation_mesh->get_region_merge_size())) {
 		WARN_PRINT("Property region_merge_size is converted to int and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.maxVertsPerPoly, p_navigation_mesh->get_vertices_per_polygon())) {
+	if (!Math::is_equal_approx((float)cfg.maxVertsPerPoly, navigation_mesh->get_vertices_per_polygon())) {
 		WARN_PRINT("Property vertices_per_polygon is converted to int and loses precision.");
 	}
-	if (p_navigation_mesh->get_cell_size() * p_navigation_mesh->get_detail_sample_distance() < 0.1f) {
+	if (navigation_mesh->get_cell_size() * navigation_mesh->get_detail_sample_distance() < 0.1f) {
 		WARN_PRINT("Property detail_sample_distance is clamped to 0.1 world units as the resulting value from multiplying with cell_size is too low.");
 	}
 
-	cfg.bmin[0] = bmin[0];
-	cfg.bmin[1] = bmin[1];
-	cfg.bmin[2] = bmin[2];
-	cfg.bmax[0] = bmax[0];
-	cfg.bmax[1] = bmax[1];
-	cfg.bmax[2] = bmax[2];
+	cfg.bmin[0] = p_bake_bounds.position.x;
+	cfg.bmin[1] = p_bake_bounds.position.y;
+	cfg.bmin[2] = p_bake_bounds.position.z;
+	cfg.bmax[0] = p_bake_bounds.position.x + p_bake_bounds.size.x;
+	cfg.bmax[1] = p_bake_bounds.position.y + p_bake_bounds.size.y;
+	cfg.bmax[2] = p_bake_bounds.position.z + p_bake_bounds.size.z;
 
-	AABB baking_aabb = p_navigation_mesh->get_filter_baking_aabb();
-	if (baking_aabb.has_volume()) {
-		Vector3 baking_aabb_offset = p_navigation_mesh->get_filter_baking_aabb_offset();
-		cfg.bmin[0] = baking_aabb.position[0] + baking_aabb_offset.x;
-		cfg.bmin[1] = baking_aabb.position[1] + baking_aabb_offset.y;
-		cfg.bmin[2] = baking_aabb.position[2] + baking_aabb_offset.z;
-		cfg.bmax[0] = cfg.bmin[0] + baking_aabb.size[0];
-		cfg.bmax[1] = cfg.bmin[1] + baking_aabb.size[1];
-		cfg.bmax[2] = cfg.bmin[2] + baking_aabb.size[2];
-	}
+	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_CONFIGURATION; // step #1
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_CALC_GRID_SIZE; // step #2
 	rcCalcGridSize(cfg.bmin, cfg.bmax, cfg.cs, &cfg.width, &cfg.height);
 
-	// ~30000000 seems to be around sweetspot where Editor baking breaks
 	if ((cfg.width * cfg.height) > 30000000 && GLOBAL_GET("navigation/baking/use_crash_prevention_checks")) {
-		ERR_FAIL_MSG("Baking interrupted."
-					 "\nNavigationMesh baking process would likely crash the engine."
-					 "\nSource geometry is suspiciously big for the current Cell Size and Cell Height in the NavMesh Resource bake settings."
-					 "\nIf baking does not crash the engine or fail, the resulting NavigationMesh will create serious pathfinding performance issues."
-					 "\nIt is advised to increase Cell Size and/or Cell Height in the NavMesh Resource bake settings or reduce the size / scale of the source geometry."
-					 "\nIf you would like to try baking anyway, disable the 'navigation/baking/use_crash_prevention_checks' project setting.");
-		return;
+		ERR_PRINT("NavigationMesh baking tile exceeds safety threshold. Increase cell_size / cell_height or disable crash prevention checks to continue.");
+		err = ERR_CANT_CREATE;
+		goto tile_cleanup;
 	}
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_CREATE_HEIGHTFIELD; // step #3
 	hf = rcAllocHeightfield();
-
-	ERR_FAIL_NULL(hf);
-	ERR_FAIL_COND(!rcCreateHeightfield(&ctx, *hf, cfg.width, cfg.height, cfg.bmin, cfg.bmax, cfg.cs, cfg.ch));
+	if (!hf) {
+		err = ERR_OUT_OF_MEMORY;
+		goto tile_cleanup;
+	}
+	if (!rcCreateHeightfield(&ctx, *hf, cfg.width, cfg.height, cfg.bmin, cfg.bmax, cfg.cs, cfg.ch)) {
+		err = ERR_CANT_CREATE;
+		goto tile_cleanup;
+	}
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_MARK_WALKABLE_TRIANGLES; // step #4
 	{
 		Vector<unsigned char> tri_areas;
 		tri_areas.resize(ntris);
 
-		ERR_FAIL_COND(tri_areas.is_empty());
+		if (tri_areas.is_empty()) {
+			err = ERR_CANT_CREATE;
+			goto tile_cleanup;
+		}
 
 		memset(tri_areas.ptrw(), 0, ntris * sizeof(unsigned char));
 		rcMarkWalkableTriangles(&ctx, cfg.walkableSlopeAngle, verts, nverts, tris, ntris, tri_areas.ptrw());
 
-		ERR_FAIL_COND(!rcRasterizeTriangles(&ctx, verts, nverts, tris, tri_areas.ptr(), ntris, *hf, cfg.walkableClimb));
+		if (!rcRasterizeTriangles(&ctx, verts, nverts, tris, tri_areas.ptr(), ntris, *hf, cfg.walkableClimb)) {
+			err = ERR_CANT_CREATE;
+			goto tile_cleanup;
+		}
 	}
 
-	if (p_navigation_mesh->get_filter_low_hanging_obstacles()) {
+	if (navigation_mesh->get_filter_low_hanging_obstacles()) {
 		rcFilterLowHangingWalkableObstacles(&ctx, cfg.walkableClimb, *hf);
 	}
-	if (p_navigation_mesh->get_filter_ledge_spans()) {
+	if (navigation_mesh->get_filter_ledge_spans()) {
 		rcFilterLedgeSpans(&ctx, cfg.walkableHeight, cfg.walkableClimb, *hf);
 	}
-	if (p_navigation_mesh->get_filter_walkable_low_height_spans()) {
+	if (navigation_mesh->get_filter_walkable_low_height_spans()) {
 		rcFilterWalkableLowHeightSpans(&ctx, cfg.walkableHeight, *hf);
 	}
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_CONSTRUCT_COMPACT_HEIGHTFIELD; // step #5
 
 	chf = rcAllocCompactHeightfield();
-
-	ERR_FAIL_NULL(chf);
-	ERR_FAIL_COND(!rcBuildCompactHeightfield(&ctx, cfg.walkableHeight, cfg.walkableClimb, *hf, *chf));
+	if (!chf) {
+		err = ERR_OUT_OF_MEMORY;
+		goto tile_cleanup;
+	}
+	if (!rcBuildCompactHeightfield(&ctx, cfg.walkableHeight, cfg.walkableClimb, *hf, *chf)) {
+		err = ERR_CANT_CREATE;
+		goto tile_cleanup;
+	}
 
 	rcFreeHeightField(hf);
 	hf = nullptr;
 
-	// Add obstacles to the source geometry. Those will be affected by e.g. agent_radius.
-	if (!projected_obstructions.is_empty()) {
-		for (const NavigationMeshSourceGeometryData3D::ProjectedObstruction &projected_obstruction : projected_obstructions) {
+	if (!p_projected_obstructions.is_empty()) {
+		for (const NavigationMeshSourceGeometryData3D::ProjectedObstruction &projected_obstruction : p_projected_obstructions) {
 			if (projected_obstruction.carve) {
 				continue;
 			}
@@ -477,11 +769,13 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(NavMeshGenerat
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_ERODE_WALKABLE_AREA; // step #6
 
-	ERR_FAIL_COND(!rcErodeWalkableArea(&ctx, cfg.walkableRadius, *chf));
+	if (!rcErodeWalkableArea(&ctx, cfg.walkableRadius, *chf)) {
+		err = ERR_CANT_CREATE;
+		goto tile_cleanup;
+	}
 
-	// Carve obstacles to the eroded geometry. Those will NOT be affected by e.g. agent_radius because that step is already done.
-	if (!projected_obstructions.is_empty()) {
-		for (const NavigationMeshSourceGeometryData3D::ProjectedObstruction &projected_obstruction : projected_obstructions) {
+	if (!p_projected_obstructions.is_empty()) {
+		for (const NavigationMeshSourceGeometryData3D::ProjectedObstruction &projected_obstruction : p_projected_obstructions) {
 			if (!projected_obstruction.carve) {
 				continue;
 			}
@@ -498,31 +792,60 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(NavMeshGenerat
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_SAMPLE_PARTITIONING; // step #7
 
-	if (p_navigation_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_WATERSHED) {
-		ERR_FAIL_COND(!rcBuildDistanceField(&ctx, *chf));
-		ERR_FAIL_COND(!rcBuildRegions(&ctx, *chf, cfg.borderSize, cfg.minRegionArea, cfg.mergeRegionArea));
-	} else if (p_navigation_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_MONOTONE) {
-		ERR_FAIL_COND(!rcBuildRegionsMonotone(&ctx, *chf, cfg.borderSize, cfg.minRegionArea, cfg.mergeRegionArea));
+	if (navigation_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_WATERSHED) {
+		if (!rcBuildDistanceField(&ctx, *chf)) {
+			err = ERR_CANT_CREATE;
+			goto tile_cleanup;
+		}
+		if (!rcBuildRegions(&ctx, *chf, cfg.borderSize, cfg.minRegionArea, cfg.mergeRegionArea)) {
+			err = ERR_CANT_CREATE;
+			goto tile_cleanup;
+		}
+	} else if (navigation_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_MONOTONE) {
+		if (!rcBuildRegionsMonotone(&ctx, *chf, cfg.borderSize, cfg.minRegionArea, cfg.mergeRegionArea)) {
+			err = ERR_CANT_CREATE;
+			goto tile_cleanup;
+		}
 	} else {
-		ERR_FAIL_COND(!rcBuildLayerRegions(&ctx, *chf, cfg.borderSize, cfg.minRegionArea));
+		if (!rcBuildLayerRegions(&ctx, *chf, cfg.borderSize, cfg.minRegionArea)) {
+			err = ERR_CANT_CREATE;
+			goto tile_cleanup;
+		}
 	}
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_CREATING_CONTOURS; // step #8
 
 	cset = rcAllocContourSet();
-
-	ERR_FAIL_NULL(cset);
-	ERR_FAIL_COND(!rcBuildContours(&ctx, *chf, cfg.maxSimplificationError, cfg.maxEdgeLen, *cset));
+	if (!cset) {
+		err = ERR_OUT_OF_MEMORY;
+		goto tile_cleanup;
+	}
+	if (!rcBuildContours(&ctx, *chf, cfg.maxSimplificationError, cfg.maxEdgeLen, *cset)) {
+		err = ERR_CANT_CREATE;
+		goto tile_cleanup;
+	}
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_CREATING_POLYMESH; // step #9
 
 	poly_mesh = rcAllocPolyMesh();
-	ERR_FAIL_NULL(poly_mesh);
-	ERR_FAIL_COND(!rcBuildPolyMesh(&ctx, *cset, cfg.maxVertsPerPoly, *poly_mesh));
+	if (!poly_mesh) {
+		err = ERR_OUT_OF_MEMORY;
+		goto tile_cleanup;
+	}
+	if (!rcBuildPolyMesh(&ctx, *cset, cfg.maxVertsPerPoly, *poly_mesh)) {
+		err = ERR_CANT_CREATE;
+		goto tile_cleanup;
+	}
 
 	detail_mesh = rcAllocPolyMeshDetail();
-	ERR_FAIL_NULL(detail_mesh);
-	ERR_FAIL_COND(!rcBuildPolyMeshDetail(&ctx, *poly_mesh, *chf, cfg.detailSampleDist, cfg.detailSampleMaxError, *detail_mesh));
+	if (!detail_mesh) {
+		err = ERR_OUT_OF_MEMORY;
+		goto tile_cleanup;
+	}
+	if (!rcBuildPolyMeshDetail(&ctx, *poly_mesh, *chf, cfg.detailSampleDist, cfg.detailSampleMaxError, *detail_mesh)) {
+		err = ERR_CANT_CREATE;
+		goto tile_cleanup;
+	}
 
 	rcFreeCompactHeightfield(chf);
 	chf = nullptr;
@@ -531,11 +854,6 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(NavMeshGenerat
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_CONVERTING_NATIVE_NAVMESH; // step #10
 
-	Vector<Vector3> nav_vertices;
-	Vector<Vector<int>> nav_polygons;
-
-	HashMap<Vector3, int> recast_vertex_to_native_index;
-	LocalVector<int> recast_index_to_native_index;
 	recast_index_to_native_index.resize(detail_mesh->nverts);
 
 	for (int i = 0; i < detail_mesh->nverts; i++) {
@@ -561,10 +879,9 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(NavMeshGenerat
 		for (unsigned int j = 0; j < detail_mesh_ntris; j++) {
 			Vector<int> nav_indices;
 			nav_indices.resize(3);
-			// Polygon order in recast is opposite than godot's
-			int index1 = ((int)(detail_mesh_bverts + detail_mesh_tris[j * 4 + 0]));
-			int index2 = ((int)(detail_mesh_bverts + detail_mesh_tris[j * 4 + 2]));
-			int index3 = ((int)(detail_mesh_bverts + detail_mesh_tris[j * 4 + 1]));
+			const int index1 = ((int)(detail_mesh_bverts + detail_mesh_tris[j * 4 + 0]));
+			const int index2 = ((int)(detail_mesh_bverts + detail_mesh_tris[j * 4 + 2]));
+			const int index3 = ((int)(detail_mesh_bverts + detail_mesh_tris[j * 4 + 1]));
 
 			nav_indices.write[0] = recast_index_to_native_index[index1];
 			nav_indices.write[1] = recast_index_to_native_index[index2];
@@ -574,16 +891,34 @@ void NavMeshGenerator3D::generator_bake_from_source_geometry_data(NavMeshGenerat
 		}
 	}
 
-	p_navigation_mesh->set_data(nav_vertices, nav_polygons);
+	r_nav_vertices = nav_vertices;
+	r_nav_polygons = nav_polygons;
 
 	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_BAKE_CLEANUP; // step #11
 
-	rcFreePolyMesh(poly_mesh);
-	poly_mesh = nullptr;
-	rcFreePolyMeshDetail(detail_mesh);
-	detail_mesh = nullptr;
+tile_cleanup:
+	if (poly_mesh) {
+		rcFreePolyMesh(poly_mesh);
+		poly_mesh = nullptr;
+	}
+	if (detail_mesh) {
+		rcFreePolyMeshDetail(detail_mesh);
+		detail_mesh = nullptr;
+	}
+	if (chf) {
+		rcFreeCompactHeightfield(chf);
+		chf = nullptr;
+	}
+	if (cset) {
+		rcFreeContourSet(cset);
+		cset = nullptr;
+	}
+	if (hf) {
+		rcFreeHeightField(hf);
+		hf = nullptr;
+	}
 
-	p_generator_task->bake_state = NavMeshBakeState::BAKE_STATE_BAKE_FINISHED; // step #12
+	return err;
 }
 
 bool NavMeshGenerator3D::generator_emit_callback(const Callable &p_callback) {

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.h
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.h
@@ -33,6 +33,7 @@
 #include "core/object/class_db.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/templates/rid_owner.h"
+#include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 
 class Node;
@@ -100,6 +101,7 @@ private:
 	static void generator_parse_geometry_node(const Ref<NavigationMesh> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, Node *p_node, bool p_recurse_children);
 	static void generator_parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, Node *p_root_node);
 	static void generator_bake_from_source_geometry_data(NavMeshGeneratorTask3D *p_generator_task);
+	static Error generator_bake_single_tile(NavMeshGeneratorTask3D *p_generator_task, const Vector<float> &p_source_geometry_vertices, const Vector<int> &p_source_geometry_indices, const Vector<NavigationMeshSourceGeometryData3D::ProjectedObstruction> &p_projected_obstructions, const AABB &p_bake_bounds, Vector<Vector3> &r_nav_vertices, Vector<Vector<int>> &r_nav_polygons, int p_tile_index, int p_tile_count);
 
 	static bool generator_emit_callback(const Callable &p_callback);
 

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -303,6 +303,31 @@ Vector3 NavigationMesh::get_filter_baking_aabb_offset() const {
 	return filter_baking_aabb_offset;
 }
 
+void NavigationMesh::set_tile_baking_enabled(bool p_enabled) {
+	if (tile_baking_enabled == p_enabled) {
+		return;
+	}
+	tile_baking_enabled = p_enabled;
+	emit_changed();
+}
+
+bool NavigationMesh::is_tile_baking_enabled() const {
+	return tile_baking_enabled;
+}
+
+void NavigationMesh::set_tile_baking_size(float p_size) {
+	const float clamped = CLAMP(p_size, 5.0f, 200.0f);
+	if (Math::is_equal_approx(clamped, tile_baking_size)) {
+		return;
+	}
+	tile_baking_size = clamped;
+	emit_changed();
+}
+
+float NavigationMesh::get_tile_baking_size() const {
+	return tile_baking_size;
+}
+
 void NavigationMesh::set_vertices(const Vector<Vector3> &p_vertices) {
 	RWLockWrite write_lock(rwlock);
 	vertices = p_vertices;
@@ -553,6 +578,10 @@ void NavigationMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_filter_baking_aabb"), &NavigationMesh::get_filter_baking_aabb);
 	ClassDB::bind_method(D_METHOD("set_filter_baking_aabb_offset", "baking_aabb_offset"), &NavigationMesh::set_filter_baking_aabb_offset);
 	ClassDB::bind_method(D_METHOD("get_filter_baking_aabb_offset"), &NavigationMesh::get_filter_baking_aabb_offset);
+	ClassDB::bind_method(D_METHOD("set_tile_baking_enabled", "enabled"), &NavigationMesh::set_tile_baking_enabled);
+	ClassDB::bind_method(D_METHOD("is_tile_baking_enabled"), &NavigationMesh::is_tile_baking_enabled);
+	ClassDB::bind_method(D_METHOD("set_tile_baking_size", "size"), &NavigationMesh::set_tile_baking_size);
+	ClassDB::bind_method(D_METHOD("get_tile_baking_size"), &NavigationMesh::get_tile_baking_size);
 
 	ClassDB::bind_method(D_METHOD("set_vertices", "vertices"), &NavigationMesh::set_vertices);
 	ClassDB::bind_method(D_METHOD("get_vertices"), &NavigationMesh::get_vertices);
@@ -601,6 +630,9 @@ void NavigationMesh::_bind_methods() {
 	ADD_GROUP("Details", "detail_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail_sample_distance", PROPERTY_HINT_RANGE, "0.1,16.0,0.01,or_greater,suffix:m"), "set_detail_sample_distance", "get_detail_sample_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail_sample_max_error", PROPERTY_HINT_RANGE, "0.0,16.0,0.01,or_greater,suffix:m"), "set_detail_sample_max_error", "get_detail_sample_max_error");
+	ADD_GROUP("Tile Baking", "tile_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tile_baking_enabled"), "set_tile_baking_enabled", "is_tile_baking_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tile_baking_size", PROPERTY_HINT_RANGE, "5,200,0.1,or_greater,suffix:m"), "set_tile_baking_size", "get_tile_baking_size");
 	ADD_GROUP("Filters", "filter_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_low_hanging_obstacles"), "set_filter_low_hanging_obstacles", "get_filter_low_hanging_obstacles");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_ledge_spans"), "set_filter_ledge_spans", "get_filter_ledge_spans");

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -104,6 +104,8 @@ protected:
 	bool filter_walkable_low_height_spans = false;
 	AABB filter_baking_aabb;
 	Vector3 filter_baking_aabb_offset;
+	bool tile_baking_enabled = false;
+	float tile_baking_size = 30.0f;
 
 public:
 	// Recast settings
@@ -181,6 +183,11 @@ public:
 
 	void set_filter_baking_aabb_offset(const Vector3 &p_aabb_offset);
 	Vector3 get_filter_baking_aabb_offset() const;
+
+	void set_tile_baking_enabled(bool p_enabled);
+	bool is_tile_baking_enabled() const;
+	void set_tile_baking_size(float p_size);
+	float get_tile_baking_size() const;
 
 	void create_from_mesh(const Ref<Mesh> &p_mesh);
 


### PR DESCRIPTION
This is a non intrusive change to the current NavigationRegion3D baking system. 
It gives users the option to bake the NavigationMesh in chunks rather than all at once.
Additionally it allows user to change the chunk size.
It uses the exact same pipeline as the standard NavigationMesh baking, just breaking the geometry into chunks, processing them individually, and then stitching them back together.
I added this to allow users to bake accurate NavigationMeshes on large and detailed terrain. 
