### PR TITLE
Windows: Fix `window_get_size_with_decorations` returning an invalid size when restoring from minimize

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2300,6 +2300,11 @@ Size2i DisplayServerWindows::window_get_size_with_decorations(WindowID p_window)
 	ERR_FAIL_COND_V(!windows.has(p_window), Size2i());
 	const WindowData &wd = windows[p_window];
 
+	// GetWindowRect() returns a zero rect for a minimized window, so we need to get the size in another way.
+	if (wd.minimized) {
+		return Size2(wd.width_with_decorations, wd.height_with_decorations);
+	}
+
 	RECT r;
 	if (GetWindowRect(wd.hWnd, &r)) { // Retrieves area inside of window border, including decoration.
 		int off_x = (wd.multiwindow_fs || (!wd.fullscreen && wd.borderless && wd.maximized)) ? FS_TRANSP_BORDER : 0;
@@ -5803,6 +5808,8 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				if (!window.minimized) {
 					window.width = window_client_rect.size.width;
 					window.height = window_client_rect.size.height;
+					window.width_with_decorations = window_rect.size.width;
+					window.height_with_decorations = window_rect.size.height;
 
 					rect_changed = true;
 				}

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -341,6 +341,7 @@ class DisplayServerWindows : public DisplayServer {
 		Size2 min_size;
 		Size2 max_size;
 		int width = 0, height = 0;
+		int width_with_decorations = 0, height_with_decorations = 0;
 
 		Size2 window_rect;
 		Point2 last_pos;


### PR DESCRIPTION
Fixes #79754.

In Windows (replicated in Windows 10 & 11), minimizing then restoring a window that has both a `size` and a `max_size` set will cause the window to shrink to the smallest size window possible.

This PR fixes it by storing the width and height from `GetWindowRect()` and reading from that if the window is minimized. This is the exact same way we already solve the issue when reading from `GetClientRect()` in `window_get_size`.

**Before**

https://github.com/user-attachments/assets/4c311a54-4379-4388-91c5-00ae9c0a9083

**After**

https://github.com/user-attachments/assets/d6f693ac-7ab3-48a1-8cd1-e530447bc3e8

**Minimum reproduction**

[min-rep-resize_2025-11-08_20-39-42.zip](https://github.com/user-attachments/files/23430597/min-rep-resize_2025-11-08_20-39-42.zip)
