### PR TITLE
Fix normals for particles with directed points emission shape

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -964,9 +964,20 @@ void CPUParticles3D::_particles_process(double p_delta) {
 							p.velocity.y = velocity_2d.y;
 						} else {
 							Vector3 normal = emission_normals.get(random_idx);
-							Vector3 v0 = Math::abs(normal.z) < 0.999 ? Vector3(0.0, 0.0, 1.0) : Vector3(0, 1.0, 0.0);
-							Vector3 tangent = v0.cross(normal).normalized();
-							Vector3 bitangent = tangent.cross(normal).normalized();
+							if (normal.length_squared() == 0) {
+								normal = Vector3(0, 0, 1);
+							} else {
+								normal.normalize();
+							}
+
+							Vector3 tangent = Vector3(0, 1, 0).cross(normal);
+							if (tangent.length_squared() < 0.00000001) {
+								tangent = Vector3(0, 0, 1);
+							} else {
+								tangent.normalize();
+							}
+
+							Vector3 bitangent = normal.cross(tangent).normalized();
 							Basis m3;
 							m3.set_column(0, tangent);
 							m3.set_column(1, bitangent);

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -995,9 +995,10 @@ void ParticleProcessMaterial::_update_shader() {
 		} else {
 			code += "		{\n";
 			code += "			vec3 normal = texelFetch(emission_texture_normal, emission_tex_ofs, 0).xyz;\n";
-			code += "			vec3 v0 = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(0.0, 1.0, 0.0);\n";
-			code += "			vec3 tangent = normalize(cross(v0, normal));\n";
-			code += "			vec3 bitangent = normalize(cross(tangent, normal));\n";
+			code += "			normal = normal == vec3(0) ? vec3(0, 0, 1) : normalize(normal);\n";
+			code += "			vec3 tangent = cross(vec3(0, 1, 0), normal);\n";
+			code += "			tangent = (pow(tangent.x, 2.0) + pow(tangent.y, 2.0) + pow(tangent.z, 2.0)) < 0.00000001 ? vec3(0, 0, 1) : normalize(tangent);\n";
+			code += "			vec3 bitangent = normalize(cross(normal, tangent));\n";
 			code += "			USERDATA1.xyz = mat3(tangent, bitangent, normal) * USERDATA1.xyz;\n";
 			code += "		}\n";
 		}


### PR DESCRIPTION
I was trying to achieve a particular effect using directed points but I realized that the current behaviour is completely broken, if not extremely unintuitive.

The videos show 8 points in a circle all pointing ourwards. The direction of the velocity relative to the point should be up + forward. In the before video you can see that this is not what happens. If you instead try to point the normal up instead of the velocity, the flatness is not relative to the normal direction.

Before:

https://github.com/user-attachments/assets/f48fa6f5-4f60-4b6c-8cdf-ad3532d0c24d

After:

https://github.com/user-attachments/assets/08b4482e-b3f4-4348-9a52-23e60bb441d3

The length of the normal also affects the velocity of the particles on master, which is probably unintended.

I was not able to test the changes to GPUParticles3D aside from making sure that the shader compiles properly because I could not figure out how to get the texture to work. If someone else knows how to do that it should be checked.