### PR TITLE
Fix incorrect material and mesh thumbnails

### DIFF
--- a/editor/inspector/editor_resource_preview.h
+++ b/editor/inspector/editor_resource_preview.h
@@ -53,7 +53,8 @@ protected:
 	class DrawRequester : public Object {
 		Semaphore semaphore;
 
-		Variant _post_semaphore();
+		void _post_semaphore();
+		void _prepare_draw(RID p_viewport);
 
 	public:
 		void request_and_wait(RID p_viewport);


### PR DESCRIPTION
Fixes #112432

Defers the thumbnails' render callback registration to the Rendering Server's `frame_pre_draw` signal.