### PR TITLE
Make `Vector` `bsearch` method const.

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -175,24 +175,18 @@ public:
 		sorter.sort(data, len);
 	}
 
-	Size bsearch(const T &p_value, bool p_before) {
+	Size bsearch(const T &p_value, bool p_before) const {
 		return bsearch_custom<Comparator<T>>(p_value, p_before);
 	}
 
 	template <typename Comparator, typename Value, typename... Args>
-	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) {
+	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) const {
 		return span().bisect(p_value, p_before, Comparator{ args... });
 	}
 
 	Vector<T> duplicate() const {
 		return *this;
 	}
-
-#ifndef DISABLE_DEPRECATED
-	Vector<T> _duplicate_bind_compat_112290() {
-		return *this;
-	}
-#endif // DISABLE_DEPRECATED
 
 	void ordered_insert(const T &p_val) {
 		Size i;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1258,6 +1258,18 @@ struct _VariantCall {
 		enum_data[p_type].value[p_enum_type_name][p_enumeration_name] = p_enum_value;
 		enum_data[p_type].value_to_enum[p_enumeration_name] = p_enum_type_name;
 	}
+
+#ifndef DISABLE_DEPRECATED
+	template <typename T>
+	static Vector<T> _duplicate_bind_compat_112290(Vector<T> *p_vector) {
+		return *p_vector;
+	}
+
+	template <typename T>
+	static int64_t _bsearch_bind_compat_112539(Vector<T> *p_vector, const T &p_value, bool p_before) {
+		return p_vector->bsearch(p_value, p_before);
+	}
+#endif
 };
 
 _VariantCall::ConstantData *_VariantCall::constant_data = nullptr;
@@ -2754,7 +2766,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedByteArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedByteArray, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedByteArray, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedByteArray, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<uint8_t>, sarray(), varray());
+	bind_compat_functionnc(PackedByteArray, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<uint8_t>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedByteArray, find, sarray("value", "from"), varray(0));
 	bind_method(PackedByteArray, rfind, sarray("value", "from"), varray(-1));
@@ -2833,7 +2846,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedInt32Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedInt32Array, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedInt32Array, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedInt32Array, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<int32_t>, sarray(), varray());
+	bind_compat_functionnc(PackedInt32Array, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<int32_t>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedInt32Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedInt32Array, rfind, sarray("value", "from"), varray(-1));
@@ -2860,7 +2874,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedInt64Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedInt64Array, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedInt64Array, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedInt64Array, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<int64_t>, sarray(), varray());
+	bind_compat_functionnc(PackedInt64Array, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<int64_t>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedInt64Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedInt64Array, rfind, sarray("value", "from"), varray(-1));
@@ -2887,7 +2902,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedFloat32Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedFloat32Array, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedFloat32Array, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedFloat32Array, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<float>, sarray(), varray());
+	bind_compat_functionnc(PackedFloat32Array, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<float>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedFloat32Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedFloat32Array, rfind, sarray("value", "from"), varray(-1));
@@ -2914,7 +2930,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedFloat64Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedFloat64Array, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedFloat64Array, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedFloat64Array, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<double>, sarray(), varray());
+	bind_compat_functionnc(PackedFloat64Array, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<double>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedFloat64Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedFloat64Array, rfind, sarray("value", "from"), varray(-1));
@@ -2941,7 +2958,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedStringArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedStringArray, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedStringArray, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedStringArray, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<String>, sarray(), varray());
+	bind_compat_functionnc(PackedStringArray, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<String>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedStringArray, find, sarray("value", "from"), varray(0));
 	bind_method(PackedStringArray, rfind, sarray("value", "from"), varray(-1));
@@ -2968,7 +2986,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector2Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedVector2Array, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedVector2Array, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedVector2Array, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<Vector2>, sarray(), varray());
+	bind_compat_functionnc(PackedVector2Array, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<Vector2>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedVector2Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedVector2Array, rfind, sarray("value", "from"), varray(-1));
@@ -2995,7 +3014,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector3Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedVector3Array, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedVector3Array, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedVector3Array, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<Vector3>, sarray(), varray());
+	bind_compat_functionnc(PackedVector3Array, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<Vector3>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedVector3Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedVector3Array, rfind, sarray("value", "from"), varray(-1));
@@ -3022,7 +3042,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedColorArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedColorArray, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedColorArray, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedColorArray, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<Color>, sarray(), varray());
+	bind_compat_functionnc(PackedColorArray, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<Color>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedColorArray, find, sarray("value", "from"), varray(0));
 	bind_method(PackedColorArray, rfind, sarray("value", "from"), varray(-1));
@@ -3049,7 +3070,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(PackedVector4Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedVector4Array, duplicate, sarray(), varray());
 #ifndef DISABLE_DEPRECATED
-	bind_compat_method(PackedVector4Array, duplicate, _duplicate_bind_compat_112290, sarray(), varray());
+	bind_compat_functionnc(PackedVector4Array, duplicate, _duplicate_bind_compat_112290, _VariantCall::_duplicate_bind_compat_112290<Vector4>, sarray(), varray());
+	bind_compat_functionnc(PackedVector4Array, bsearch, _bsearch_bind_compat_112539, _VariantCall::_bsearch_bind_compat_112539<Vector4>, sarray("value", "before"), varray(true));
 #endif
 	bind_method(PackedVector4Array, find, sarray("value", "from"), varray(0));
 	bind_method(PackedVector4Array, rfind, sarray("value", "from"), varray(-1));

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -47,7 +47,7 @@
 				Appends a [PackedByteArray] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -51,7 +51,7 @@
 				Appends a [PackedColorArray] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Color" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -47,7 +47,7 @@
 				Appends a [PackedFloat32Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="float" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -48,7 +48,7 @@
 				Appends a [PackedFloat64Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="float" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -47,7 +47,7 @@
 				Appends a [PackedInt32Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -48,7 +48,7 @@
 				Appends a [PackedInt64Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -54,7 +54,7 @@
 				Appends a [PackedStringArray] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="String" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -52,7 +52,7 @@
 				Appends a [PackedVector2Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector2" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -51,7 +51,7 @@
 				Appends a [PackedVector3Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector3" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/doc/classes/PackedVector4Array.xml
+++ b/doc/classes/PackedVector4Array.xml
@@ -51,7 +51,7 @@
 				Appends a [PackedVector4Array] at the end of this array.
 			</description>
 		</method>
-		<method name="bsearch">
+		<method name="bsearch" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="value" type="Vector4" />
 			<param index="1" name="before" type="bool" default="true" />

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -86,7 +86,6 @@ Same enum is defined in SkeletonModifier3D which is a base class of SpringBoneSi
 
 GH-112290
 ---------
-
 Validate extension JSON: Error: Field 'builtin_classes/PackedByteArray/methods/duplicate': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'builtin_classes/PackedColorArray/methods/duplicate': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'builtin_classes/PackedFloat32Array/methods/duplicate': is_const changed value in new API, from false to true.
@@ -113,3 +112,19 @@ GH-90411
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/SplitContainer/methods/clamp_split_offset': arguments
 
 Optional argument added for index. Compatibility method registered.
+
+
+GH-112539
+---------
+Validate extension JSON: Error: Field 'builtin_classes/PackedByteArray/methods/bsearch': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'builtin_classes/PackedColorArray/methods/bsearch': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'builtin_classes/PackedFloat32Array/methods/bsearch': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'builtin_classes/PackedFloat64Array/methods/bsearch': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'builtin_classes/PackedInt32Array/methods/bsearch': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'builtin_classes/PackedInt64Array/methods/bsearch': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'builtin_classes/PackedStringArray/methods/bsearch': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'builtin_classes/PackedVector2Array/methods/bsearch': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'builtin_classes/PackedVector3Array/methods/bsearch': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'builtin_classes/PackedVector4Array/methods/bsearch': is_const changed value in new API, from false to true.
+
+bsearch method made const. Compatibility methods registered.


### PR DESCRIPTION
- Follow-up of #112290
- Supersedes https://github.com/godotengine/godot/pull/90341
- Enables https://github.com/godotengine/godot-cpp/pull/1711

`bsearch` not being const has plagued us for a while as well. Now that #112290 is merged, we can finally give it a compatibility method, and make it const.

I took this opportunity to move the compatibility method for `duplicate` to `variant_call.cpp`. It is not needed in `vector.h`, and moving it reduces confusion and build time.