### PR TITLE
Image: Properly round floating point values to integers

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3402,10 +3402,10 @@ _FORCE_INLINE_ Color color_from_rgba4444(uint16_t p_col) {
 _FORCE_INLINE_ uint16_t color_to_rgba4444(Color p_col) {
 	uint16_t rgba = 0;
 
-	rgba = uint16_t(CLAMP(p_col.r * 15.0, 0, 15)) << 12;
-	rgba |= uint16_t(CLAMP(p_col.g * 15.0, 0, 15)) << 8;
-	rgba |= uint16_t(CLAMP(p_col.b * 15.0, 0, 15)) << 4;
-	rgba |= uint16_t(CLAMP(p_col.a * 15.0, 0, 15));
+	rgba = uint16_t(CLAMP(Math::round(p_col.r * 15.0), 0, 15)) << 12;
+	rgba |= uint16_t(CLAMP(Math::round(p_col.g * 15.0), 0, 15)) << 8;
+	rgba |= uint16_t(CLAMP(Math::round(p_col.b * 15.0), 0, 15)) << 4;
+	rgba |= uint16_t(CLAMP(Math::round(p_col.a * 15.0), 0, 15));
 
 	return rgba;
 }
@@ -3420,9 +3420,9 @@ _FORCE_INLINE_ Color color_from_rgb565(uint16_t p_col) {
 _FORCE_INLINE_ uint16_t color_to_rgb565(Color p_col) {
 	uint16_t rgba = 0;
 
-	rgba = uint16_t(CLAMP(p_col.r * 31.0, 0, 31)) << 11;
-	rgba |= uint16_t(CLAMP(p_col.g * 63.0, 0, 63)) << 5;
-	rgba |= uint16_t(CLAMP(p_col.b * 31.0, 0, 31));
+	rgba = uint16_t(CLAMP(Math::round(p_col.r * 31.0), 0, 31)) << 11;
+	rgba |= uint16_t(CLAMP(Math::round(p_col.g * 63.0), 0, 63)) << 5;
+	rgba |= uint16_t(CLAMP(Math::round(p_col.b * 31.0), 0, 31));
 
 	return rgba;
 }
@@ -3567,29 +3567,29 @@ Color Image::_get_color_at_ofs(const uint8_t *ptr, uint32_t ofs) const {
 void Image::_set_color_at_ofs(uint8_t *ptr, uint32_t ofs, const Color &p_color) {
 	switch (format) {
 		case FORMAT_L8: {
-			ptr[ofs] = uint8_t(CLAMP(p_color.get_v() * 255.0, 0, 255));
+			ptr[ofs] = uint8_t(CLAMP(Math::round(p_color.get_v() * 255.0), 0, 255));
 		} break;
 		case FORMAT_LA8: {
-			ptr[ofs * 2 + 0] = uint8_t(CLAMP(p_color.get_v() * 255.0, 0, 255));
-			ptr[ofs * 2 + 1] = uint8_t(CLAMP(p_color.a * 255.0, 0, 255));
+			ptr[ofs * 2 + 0] = uint8_t(CLAMP(Math::round(p_color.get_v() * 255.0), 0, 255));
+			ptr[ofs * 2 + 1] = uint8_t(CLAMP(Math::round(p_color.a * 255.0), 0, 255));
 		} break;
 		case FORMAT_R8: {
-			ptr[ofs] = uint8_t(CLAMP(p_color.r * 255.0, 0, 255));
+			ptr[ofs] = uint8_t(CLAMP(Math::round(p_color.r * 255.0), 0, 255));
 		} break;
 		case FORMAT_RG8: {
-			ptr[ofs * 2 + 0] = uint8_t(CLAMP(p_color.r * 255.0, 0, 255));
-			ptr[ofs * 2 + 1] = uint8_t(CLAMP(p_color.g * 255.0, 0, 255));
+			ptr[ofs * 2 + 0] = uint8_t(CLAMP(Math::round(p_color.r * 255.0), 0, 255));
+			ptr[ofs * 2 + 1] = uint8_t(CLAMP(Math::round(p_color.g * 255.0), 0, 255));
 		} break;
 		case FORMAT_RGB8: {
-			ptr[ofs * 3 + 0] = uint8_t(CLAMP(p_color.r * 255.0, 0, 255));
-			ptr[ofs * 3 + 1] = uint8_t(CLAMP(p_color.g * 255.0, 0, 255));
-			ptr[ofs * 3 + 2] = uint8_t(CLAMP(p_color.b * 255.0, 0, 255));
+			ptr[ofs * 3 + 0] = uint8_t(CLAMP(Math::round(p_color.r * 255.0), 0, 255));
+			ptr[ofs * 3 + 1] = uint8_t(CLAMP(Math::round(p_color.g * 255.0), 0, 255));
+			ptr[ofs * 3 + 2] = uint8_t(CLAMP(Math::round(p_color.b * 255.0), 0, 255));
 		} break;
 		case FORMAT_RGBA8: {
-			ptr[ofs * 4 + 0] = uint8_t(CLAMP(p_color.r * 255.0, 0, 255));
-			ptr[ofs * 4 + 1] = uint8_t(CLAMP(p_color.g * 255.0, 0, 255));
-			ptr[ofs * 4 + 2] = uint8_t(CLAMP(p_color.b * 255.0, 0, 255));
-			ptr[ofs * 4 + 3] = uint8_t(CLAMP(p_color.a * 255.0, 0, 255));
+			ptr[ofs * 4 + 0] = uint8_t(CLAMP(Math::round(p_color.r * 255.0), 0, 255));
+			ptr[ofs * 4 + 1] = uint8_t(CLAMP(Math::round(p_color.g * 255.0), 0, 255));
+			ptr[ofs * 4 + 2] = uint8_t(CLAMP(Math::round(p_color.b * 255.0), 0, 255));
+			ptr[ofs * 4 + 3] = uint8_t(CLAMP(Math::round(p_color.a * 255.0), 0, 255));
 		} break;
 		case FORMAT_RGBA4444: {
 			((uint16_t *)ptr)[ofs] = color_to_rgba4444(p_color);
@@ -3637,40 +3637,40 @@ void Image::_set_color_at_ofs(uint8_t *ptr, uint32_t ofs, const Color &p_color) 
 			((uint32_t *)ptr)[ofs] = p_color.to_rgbe9995();
 		} break;
 		case FORMAT_R16: {
-			((uint16_t *)ptr)[ofs] = uint16_t(CLAMP(p_color.r * 65535.0, 0, 65535));
+			((uint16_t *)ptr)[ofs] = uint16_t(CLAMP(Math::round(p_color.r * 65535.0), 0, 65535));
 		} break;
 		case FORMAT_RG16: {
-			((uint16_t *)ptr)[ofs * 2 + 0] = uint16_t(CLAMP(p_color.r * 65535.0, 0, 65535));
-			((uint16_t *)ptr)[ofs * 2 + 1] = uint16_t(CLAMP(p_color.g * 65535.0, 0, 65535));
+			((uint16_t *)ptr)[ofs * 2 + 0] = uint16_t(CLAMP(Math::round(p_color.r * 65535.0), 0, 65535));
+			((uint16_t *)ptr)[ofs * 2 + 1] = uint16_t(CLAMP(Math::round(p_color.g * 65535.0), 0, 65535));
 		} break;
 		case FORMAT_RGB16: {
-			((uint16_t *)ptr)[ofs * 3 + 0] = uint16_t(CLAMP(p_color.r * 65535.0, 0, 65535));
-			((uint16_t *)ptr)[ofs * 3 + 1] = uint16_t(CLAMP(p_color.g * 65535.0, 0, 65535));
-			((uint16_t *)ptr)[ofs * 3 + 2] = uint16_t(CLAMP(p_color.b * 65535.0, 0, 65535));
+			((uint16_t *)ptr)[ofs * 3 + 0] = uint16_t(CLAMP(Math::round(p_color.r * 65535.0), 0, 65535));
+			((uint16_t *)ptr)[ofs * 3 + 1] = uint16_t(CLAMP(Math::round(p_color.g * 65535.0), 0, 65535));
+			((uint16_t *)ptr)[ofs * 3 + 2] = uint16_t(CLAMP(Math::round(p_color.b * 65535.0), 0, 65535));
 		} break;
 		case FORMAT_RGBA16: {
-			((uint16_t *)ptr)[ofs * 4 + 0] = uint16_t(CLAMP(p_color.r * 65535.0, 0, 65535));
-			((uint16_t *)ptr)[ofs * 4 + 1] = uint16_t(CLAMP(p_color.g * 65535.0, 0, 65535));
-			((uint16_t *)ptr)[ofs * 4 + 2] = uint16_t(CLAMP(p_color.b * 65535.0, 0, 65535));
-			((uint16_t *)ptr)[ofs * 4 + 3] = uint16_t(CLAMP(p_color.a * 65535.0, 0, 65535));
+			((uint16_t *)ptr)[ofs * 4 + 0] = uint16_t(CLAMP(Math::round(p_color.r * 65535.0), 0, 65535));
+			((uint16_t *)ptr)[ofs * 4 + 1] = uint16_t(CLAMP(Math::round(p_color.g * 65535.0), 0, 65535));
+			((uint16_t *)ptr)[ofs * 4 + 2] = uint16_t(CLAMP(Math::round(p_color.b * 65535.0), 0, 65535));
+			((uint16_t *)ptr)[ofs * 4 + 3] = uint16_t(CLAMP(Math::round(p_color.a * 65535.0), 0, 65535));
 		} break;
 		case FORMAT_R16I: {
-			((uint16_t *)ptr)[ofs] = uint16_t(CLAMP(p_color.r, 0, 65535));
+			((uint16_t *)ptr)[ofs] = uint16_t(CLAMP(Math::round(p_color.r), 0, 65535));
 		} break;
 		case FORMAT_RG16I: {
-			((uint16_t *)ptr)[ofs * 2 + 0] = uint16_t(CLAMP(p_color.r, 0, 65535));
-			((uint16_t *)ptr)[ofs * 2 + 1] = uint16_t(CLAMP(p_color.g, 0, 65535));
+			((uint16_t *)ptr)[ofs * 2 + 0] = uint16_t(CLAMP(Math::round(p_color.r), 0, 65535));
+			((uint16_t *)ptr)[ofs * 2 + 1] = uint16_t(CLAMP(Math::round(p_color.g), 0, 65535));
 		} break;
 		case FORMAT_RGB16I: {
-			((uint16_t *)ptr)[ofs * 3 + 0] = uint16_t(CLAMP(p_color.r, 0, 65535));
-			((uint16_t *)ptr)[ofs * 3 + 1] = uint16_t(CLAMP(p_color.g, 0, 65535));
-			((uint16_t *)ptr)[ofs * 3 + 2] = uint16_t(CLAMP(p_color.b, 0, 65535));
+			((uint16_t *)ptr)[ofs * 3 + 0] = uint16_t(CLAMP(Math::round(p_color.r), 0, 65535));
+			((uint16_t *)ptr)[ofs * 3 + 1] = uint16_t(CLAMP(Math::round(p_color.g), 0, 65535));
+			((uint16_t *)ptr)[ofs * 3 + 2] = uint16_t(CLAMP(Math::round(p_color.b), 0, 65535));
 		} break;
 		case FORMAT_RGBA16I: {
-			((uint16_t *)ptr)[ofs * 4 + 0] = uint16_t(CLAMP(p_color.r, 0, 65535));
-			((uint16_t *)ptr)[ofs * 4 + 1] = uint16_t(CLAMP(p_color.g, 0, 65535));
-			((uint16_t *)ptr)[ofs * 4 + 2] = uint16_t(CLAMP(p_color.b, 0, 65535));
-			((uint16_t *)ptr)[ofs * 4 + 3] = uint16_t(CLAMP(p_color.a, 0, 65535));
+			((uint16_t *)ptr)[ofs * 4 + 0] = uint16_t(CLAMP(Math::round(p_color.r), 0, 65535));
+			((uint16_t *)ptr)[ofs * 4 + 1] = uint16_t(CLAMP(Math::round(p_color.g), 0, 65535));
+			((uint16_t *)ptr)[ofs * 4 + 2] = uint16_t(CLAMP(Math::round(p_color.b), 0, 65535));
+			((uint16_t *)ptr)[ofs * 4 + 3] = uint16_t(CLAMP(Math::round(p_color.a), 0, 65535));
 		} break;
 
 		default: {

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3510,6 +3510,11 @@ void Image::_copy_internals_from(const Image &p_image) {
 	data = p_image.data;
 }
 
+template <typename T>
+_FORCE_INLINE_ T _quantize_unorm_fast(float p_value, float p_max) {
+	return static_cast<T>(CLAMP(p_value * p_max + 0.5f, 0.0f, p_max));
+}
+
 _FORCE_INLINE_ Color color_from_rgba4444(uint16_t p_col) {
 	float r = ((p_col >> 12) & 0xF) / 15.0;
 	float g = ((p_col >> 8) & 0xF) / 15.0;
@@ -3521,10 +3526,10 @@ _FORCE_INLINE_ Color color_from_rgba4444(uint16_t p_col) {
 _FORCE_INLINE_ uint16_t color_to_rgba4444(Color p_col) {
 	uint16_t rgba = 0;
 
-	rgba = uint16_t(CLAMP(p_col.r * 15.0, 0, 15)) << 12;
-	rgba |= uint16_t(CLAMP(p_col.g * 15.0, 0, 15)) << 8;
-	rgba |= uint16_t(CLAMP(p_col.b * 15.0, 0, 15)) << 4;
-	rgba |= uint16_t(CLAMP(p_col.a * 15.0, 0, 15));
+	rgba = _quantize_unorm_fast<uint16_t>(p_col.r, 15.0f) << 12;
+	rgba |= _quantize_unorm_fast<uint16_t>(p_col.g, 15.0f) << 8;
+	rgba |= _quantize_unorm_fast<uint16_t>(p_col.b, 15.0f) << 4;
+	rgba |= _quantize_unorm_fast<uint16_t>(p_col.a, 15.0f);
 
 	return rgba;
 }
@@ -3539,9 +3544,9 @@ _FORCE_INLINE_ Color color_from_rgb565(uint16_t p_col) {
 _FORCE_INLINE_ uint16_t color_to_rgb565(Color p_col) {
 	uint16_t rgba = 0;
 
-	rgba = uint16_t(CLAMP(p_col.r * 31.0, 0, 31)) << 11;
-	rgba |= uint16_t(CLAMP(p_col.g * 63.0, 0, 63)) << 5;
-	rgba |= uint16_t(CLAMP(p_col.b * 31.0, 0, 31));
+	rgba = _quantize_unorm_fast<uint16_t>(p_col.r, 31.0f) << 11;
+	rgba |= _quantize_unorm_fast<uint16_t>(p_col.g, 63.0f) << 5;
+	rgba |= _quantize_unorm_fast<uint16_t>(p_col.b, 31.0f);
 
 	return rgba;
 }
@@ -3686,29 +3691,29 @@ Color Image::_get_color_at_ofs(const uint8_t *p_ptr, uint32_t p_ofs) const {
 void Image::_set_color_at_ofs(uint8_t *r_ptr, uint32_t p_ofs, const Color &p_color) {
 	switch (format) {
 		case FORMAT_L8: {
-			r_ptr[p_ofs] = uint8_t(CLAMP(p_color.get_v() * 255.0, 0, 255));
+			r_ptr[p_ofs] = _quantize_unorm_fast<uint8_t>(p_color.get_v(), 255.0f);
 		} break;
 		case FORMAT_LA8: {
-			r_ptr[p_ofs * 2 + 0] = uint8_t(CLAMP(p_color.get_v() * 255.0, 0, 255));
-			r_ptr[p_ofs * 2 + 1] = uint8_t(CLAMP(p_color.a * 255.0, 0, 255));
+			r_ptr[p_ofs * 2 + 0] = _quantize_unorm_fast<uint8_t>(p_color.get_v(), 255.0f);
+			r_ptr[p_ofs * 2 + 1] = _quantize_unorm_fast<uint8_t>(p_color.a, 255.0f);
 		} break;
 		case FORMAT_R8: {
-			r_ptr[p_ofs] = uint8_t(CLAMP(p_color.r * 255.0, 0, 255));
+			r_ptr[p_ofs] = _quantize_unorm_fast<uint8_t>(p_color.r, 255.0f);
 		} break;
 		case FORMAT_RG8: {
-			r_ptr[p_ofs * 2 + 0] = uint8_t(CLAMP(p_color.r * 255.0, 0, 255));
-			r_ptr[p_ofs * 2 + 1] = uint8_t(CLAMP(p_color.g * 255.0, 0, 255));
+			r_ptr[p_ofs * 2 + 0] = _quantize_unorm_fast<uint8_t>(p_color.r, 255.0f);
+			r_ptr[p_ofs * 2 + 1] = _quantize_unorm_fast<uint8_t>(p_color.g, 255.0f);
 		} break;
 		case FORMAT_RGB8: {
-			r_ptr[p_ofs * 3 + 0] = uint8_t(CLAMP(p_color.r * 255.0, 0, 255));
-			r_ptr[p_ofs * 3 + 1] = uint8_t(CLAMP(p_color.g * 255.0, 0, 255));
-			r_ptr[p_ofs * 3 + 2] = uint8_t(CLAMP(p_color.b * 255.0, 0, 255));
+			r_ptr[p_ofs * 3 + 0] = _quantize_unorm_fast<uint8_t>(p_color.r, 255.0f);
+			r_ptr[p_ofs * 3 + 1] = _quantize_unorm_fast<uint8_t>(p_color.g, 255.0f);
+			r_ptr[p_ofs * 3 + 2] = _quantize_unorm_fast<uint8_t>(p_color.b, 255.0f);
 		} break;
 		case FORMAT_RGBA8: {
-			r_ptr[p_ofs * 4 + 0] = uint8_t(CLAMP(p_color.r * 255.0, 0, 255));
-			r_ptr[p_ofs * 4 + 1] = uint8_t(CLAMP(p_color.g * 255.0, 0, 255));
-			r_ptr[p_ofs * 4 + 2] = uint8_t(CLAMP(p_color.b * 255.0, 0, 255));
-			r_ptr[p_ofs * 4 + 3] = uint8_t(CLAMP(p_color.a * 255.0, 0, 255));
+			r_ptr[p_ofs * 4 + 0] = _quantize_unorm_fast<uint8_t>(p_color.r, 255.0f);
+			r_ptr[p_ofs * 4 + 1] = _quantize_unorm_fast<uint8_t>(p_color.g, 255.0f);
+			r_ptr[p_ofs * 4 + 2] = _quantize_unorm_fast<uint8_t>(p_color.b, 255.0f);
+			r_ptr[p_ofs * 4 + 3] = _quantize_unorm_fast<uint8_t>(p_color.a, 255.0f);
 		} break;
 		case FORMAT_RGBA4444: {
 			((uint16_t *)r_ptr)[p_ofs] = color_to_rgba4444(p_color);
@@ -3756,40 +3761,40 @@ void Image::_set_color_at_ofs(uint8_t *r_ptr, uint32_t p_ofs, const Color &p_col
 			((uint32_t *)r_ptr)[p_ofs] = p_color.to_rgbe9995();
 		} break;
 		case FORMAT_R16: {
-			((uint16_t *)r_ptr)[p_ofs] = uint16_t(CLAMP(p_color.r * 65535.0, 0, 65535));
+			((uint16_t *)r_ptr)[p_ofs] = _quantize_unorm_fast<uint16_t>(p_color.r, 65535.0f);
 		} break;
 		case FORMAT_RG16: {
-			((uint16_t *)r_ptr)[p_ofs * 2 + 0] = uint16_t(CLAMP(p_color.r * 65535.0, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 2 + 1] = uint16_t(CLAMP(p_color.g * 65535.0, 0, 65535));
+			((uint16_t *)r_ptr)[p_ofs * 2 + 0] = _quantize_unorm_fast<uint16_t>(p_color.r, 65535.0f);
+			((uint16_t *)r_ptr)[p_ofs * 2 + 1] = _quantize_unorm_fast<uint16_t>(p_color.g, 65535.0f);
 		} break;
 		case FORMAT_RGB16: {
-			((uint16_t *)r_ptr)[p_ofs * 3 + 0] = uint16_t(CLAMP(p_color.r * 65535.0, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 3 + 1] = uint16_t(CLAMP(p_color.g * 65535.0, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 3 + 2] = uint16_t(CLAMP(p_color.b * 65535.0, 0, 65535));
+			((uint16_t *)r_ptr)[p_ofs * 3 + 0] = _quantize_unorm_fast<uint16_t>(p_color.r, 65535.0f);
+			((uint16_t *)r_ptr)[p_ofs * 3 + 1] = _quantize_unorm_fast<uint16_t>(p_color.g, 65535.0f);
+			((uint16_t *)r_ptr)[p_ofs * 3 + 2] = _quantize_unorm_fast<uint16_t>(p_color.b, 65535.0f);
 		} break;
 		case FORMAT_RGBA16: {
-			((uint16_t *)r_ptr)[p_ofs * 4 + 0] = uint16_t(CLAMP(p_color.r * 65535.0, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 4 + 1] = uint16_t(CLAMP(p_color.g * 65535.0, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 4 + 2] = uint16_t(CLAMP(p_color.b * 65535.0, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 4 + 3] = uint16_t(CLAMP(p_color.a * 65535.0, 0, 65535));
+			((uint16_t *)r_ptr)[p_ofs * 4 + 0] = _quantize_unorm_fast<uint16_t>(p_color.r, 65535.0f);
+			((uint16_t *)r_ptr)[p_ofs * 4 + 1] = _quantize_unorm_fast<uint16_t>(p_color.g, 65535.0f);
+			((uint16_t *)r_ptr)[p_ofs * 4 + 2] = _quantize_unorm_fast<uint16_t>(p_color.b, 65535.0f);
+			((uint16_t *)r_ptr)[p_ofs * 4 + 3] = _quantize_unorm_fast<uint16_t>(p_color.a, 65535.0f);
 		} break;
 		case FORMAT_R16I: {
-			((uint16_t *)r_ptr)[p_ofs] = uint16_t(CLAMP(p_color.r, 0, 65535));
+			((uint16_t *)r_ptr)[p_ofs] = uint16_t(CLAMP(p_color.r, 0.0f, 65535));
 		} break;
 		case FORMAT_RG16I: {
-			((uint16_t *)r_ptr)[p_ofs * 2 + 0] = uint16_t(CLAMP(p_color.r, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 2 + 1] = uint16_t(CLAMP(p_color.g, 0, 65535));
+			((uint16_t *)r_ptr)[p_ofs * 2 + 0] = uint16_t(CLAMP(p_color.r, 0.0f, 65535.0f));
+			((uint16_t *)r_ptr)[p_ofs * 2 + 1] = uint16_t(CLAMP(p_color.g, 0.0f, 65535.0f));
 		} break;
 		case FORMAT_RGB16I: {
-			((uint16_t *)r_ptr)[p_ofs * 3 + 0] = uint16_t(CLAMP(p_color.r, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 3 + 1] = uint16_t(CLAMP(p_color.g, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 3 + 2] = uint16_t(CLAMP(p_color.b, 0, 65535));
+			((uint16_t *)r_ptr)[p_ofs * 3 + 0] = uint16_t(CLAMP(p_color.r, 0.0f, 65535.0f));
+			((uint16_t *)r_ptr)[p_ofs * 3 + 1] = uint16_t(CLAMP(p_color.g, 0.0f, 65535.0f));
+			((uint16_t *)r_ptr)[p_ofs * 3 + 2] = uint16_t(CLAMP(p_color.b, 0.0f, 65535.0f));
 		} break;
 		case FORMAT_RGBA16I: {
-			((uint16_t *)r_ptr)[p_ofs * 4 + 0] = uint16_t(CLAMP(p_color.r, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 4 + 1] = uint16_t(CLAMP(p_color.g, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 4 + 2] = uint16_t(CLAMP(p_color.b, 0, 65535));
-			((uint16_t *)r_ptr)[p_ofs * 4 + 3] = uint16_t(CLAMP(p_color.a, 0, 65535));
+			((uint16_t *)r_ptr)[p_ofs * 4 + 0] = uint16_t(CLAMP(p_color.r, 0.0f, 65535.0f));
+			((uint16_t *)r_ptr)[p_ofs * 4 + 1] = uint16_t(CLAMP(p_color.g, 0.0f, 65535.0f));
+			((uint16_t *)r_ptr)[p_ofs * 4 + 2] = uint16_t(CLAMP(p_color.b, 0.0f, 65535.0f));
+			((uint16_t *)r_ptr)[p_ofs * 4 + 3] = uint16_t(CLAMP(p_color.a, 0.0f, 65535.0f));
 		} break;
 
 		default: {

--- a/tests/core/io/test_image.cpp
+++ b/tests/core/io/test_image.cpp
@@ -379,8 +379,19 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 		CHECK_MESSAGE(gray_image->get_pixel(1, 1).is_equal_approx(Color(1, 1, 1, 1)), "convert() RGBA to L8 should be white.");
 		CHECK_MESSAGE(gray_image->get_pixel(1, 2).is_equal_approx(Color(0.250980407, 0.250980407, 0.250980407, 1)), "convert() RGBA to L8 should be around 0.250980407 (64).");
 		CHECK_MESSAGE(gray_image->get_pixel(2, 0).is_equal_approx(Color(0, 0, 0, 1)), "convert() RGBA to L8 should be black.");
-		CHECK_MESSAGE(gray_image->get_pixel(2, 1).is_equal_approx(Color(0.121568628, 0.121568628, 0.121568628, 1)), "convert() RGBA to L8 should be around 0.121568628 (31).");
+		CHECK_MESSAGE(gray_image->get_pixel(2, 1).is_equal_approx(Color(0.125490203, 0.125490203, 0.125490203, 1)), "convert() RGBA to L8 should be around 0.125490203 (32).");
 		CHECK_MESSAGE(gray_image->get_pixel(2, 2).is_equal_approx(Color(0.266666681, 0.266666681, 0.266666681, 1)), "convert() RGBA to L8 should be around 0.266666681 (68).");
+	}
+}
+
+TEST_CASE("[Image] Color rounding") {
+	Ref<Image> image = memnew(Image(1, 1, false, Image::FORMAT_R8));
+	for (int i = 0; i < 1024; i++) {
+		float expected_value = i / 1023.0f;
+		image->set_pixel(0, 0, Color(expected_value, 0.0f, 0.0f));
+
+		uint8_t expected_value_int = CLAMP(Math::round(expected_value * 255.0f), 0, 255);
+		CHECK_MESSAGE(image->get_data()[0] == expected_value_int, vformat("Pixel's r channel should be around %d", expected_value_int));
 	}
 }
 

--- a/tests/scene/test_image_texture.cpp
+++ b/tests/scene/test_image_texture.cpp
@@ -85,7 +85,7 @@ TEST_CASE("[SceneTree][ImageTexture] set_size_override") {
 TEST_CASE("[SceneTree][ImageTexture] is_pixel_opaque") {
 	Ref<Image> image = memnew(Image(8, 8, false, Image::FORMAT_RGBA8));
 	image->set_pixel(0, 0, Color(0.0, 0.0, 0.0, 0.0)); // not opaque
-	image->set_pixel(0, 1, Color(0.0, 0.0, 0.0, 0.1)); // not opaque
+	image->set_pixel(0, 1, Color(0.0, 0.0, 0.0, 0.09)); // not opaque
 	image->set_pixel(0, 2, Color(0.0, 0.0, 0.0, 0.5)); // opaque
 	image->set_pixel(0, 3, Color(0.0, 0.0, 0.0, 0.9)); // opaque
 	image->set_pixel(0, 4, Color(0.0, 0.0, 0.0, 1.0)); // opaque


### PR DESCRIPTION
# What problem(s) does this PR solve?

Supersedes #60135
Fixes #59983
Fixes #105868

Uses a custom unorm quantization method (value * max + 0.5f) instead of directly casting float to int to improve the precision of color conversion in the Image class.

# Additional information

## Errors (smaller = better)
Before:
| Format | Max absolute error | RMSE |
|---------|----------------------|--------|
| R8 | 0.00391963989081 | 0.00226272790201 |
| R16 | 0.00001525884727 | 0.00000880332326 |

After:
| Format | Max absolute error | RMSE |
|---------|----------------------|--------|
| R8 | 0.00195983484657 | 0.00113178288994 |
| R16 | 0.00000766293182 | 0.00000440495429 |

The precision errors have become 2x smaller.

## Performance
The performance of conversion between formats is a good indicator of any potential regressions (`set_pixel` called for every pixel).

AMD Ryzen 9 5900X 12-Core Processor (24 threads)
63.91 GiB memory (DDR4)

4096x4096 RGB565 -> RGBA8:
| Before | After |
|--------|-------|
| 86 ms | 84 ms |

1024x1024 RGB565 -> RGBA8:
| Before | After |
|--------|-------|
| 5 ms | 5 ms |

The performance is mostly the same, I've actually gotten better performance here than in the master branch in some cases, though that may very well have been by accident.

## AI disclosure
[In this comment](https://github.com/godotengine/godot/pull/112541#discussion_r3950057092) Claude was used to create an implementation of the helper function as well as to show the performance benefits from using it over `Math::round`. 
I used it as a reference for the one I made in this PR, then ran my own performance tests to ensure the measurements are correct. I fully understand the code.

TODO:
- [x] Measure the performance difference,
- [x] Add unit tests,
- [x] Compare the error