### PR TITLE
Fix false positive `discard` and `frag_only` errors in gdshaderinc files

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -9220,8 +9220,8 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 	stages = &p_functions;
 
-	is_discard_supported = shader_type_identifier == "canvas_item" || shader_type_identifier == "spatial";
-	is_supported_frag_only_funcs = is_discard_supported || shader_type_identifier == "sky";
+	is_discard_supported = shader_type_identifier == "canvas_item" || shader_type_identifier == "spatial" || shader_type_identifier == StringName();
+	is_supported_frag_only_funcs = is_discard_supported || shader_type_identifier == "sky" || shader_type_identifier == StringName();
 
 	const FunctionInfo &constants = p_functions.has("constants") ? p_functions["constants"] : FunctionInfo();
 


### PR DESCRIPTION
In the same manner that #89752 fixed three of these false positive errors, I have added those same checks to is_discard_supported and is_supported_frag_only_funcs which contain several more functions that will error when used in a .gdshaderinc file (such as discard, dFdx, etc.) From what I can tell that should be all the false positives and .gdshaderinc files should no longer throw errors of the "not supported for the '' shader type" kind.

Fixes #108937 