### PR TITLE
[Android editor] Fix editor crash on exit

### DIFF
--- a/platform/android/editor/game_menu_utils_jni.cpp
+++ b/platform/android/editor/game_menu_utils_jni.cpp
@@ -35,7 +35,7 @@
 #include "editor/editor_node.h"
 #include "editor/run/game_view_plugin.h"
 
-static GameViewPlugin *_get_game_view_plugin() {
+_FORCE_INLINE_ static GameViewPlugin *_get_game_view_plugin() {
 	ERR_FAIL_NULL_V(EditorNode::get_singleton(), nullptr);
 	ERR_FAIL_NULL_V(EditorNode::get_singleton()->get_editor_main_screen(), nullptr);
 	return Object::cast_to<GameViewPlugin>(EditorNode::get_singleton()->get_editor_main_screen()->get_plugin_by_name("Game"));

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -74,6 +74,14 @@ String _remove_symlink(const String &dir) {
 	return dir_without_symlink;
 }
 
+#ifdef TOOLS_ENABLED
+_FORCE_INLINE_ static GameViewPlugin *_get_game_view_plugin() {
+	ERR_FAIL_NULL_V(EditorNode::get_singleton(), nullptr);
+	ERR_FAIL_NULL_V(EditorNode::get_singleton()->get_editor_main_screen(), nullptr);
+	return Object::cast_to<GameViewPlugin>(EditorNode::get_singleton()->get_editor_main_screen()->get_plugin_by_name("Game"));
+}
+#endif
+
 class AndroidLogger : public Logger {
 public:
 	virtual void logv(const char *p_format, va_list p_list, bool p_err) {
@@ -347,7 +355,7 @@ void OS_Android::main_loop_begin() {
 
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		GameViewPlugin *game_view_plugin = Object::cast_to<GameViewPlugin>(EditorNode::get_singleton()->get_editor_main_screen()->get_plugin_by_name("Game"));
+		GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 		if (game_view_plugin != nullptr) {
 			game_view_plugin->connect("main_screen_changed", callable_mp_static(&OS_Android::_on_main_screen_changed));
 		}
@@ -377,7 +385,7 @@ bool OS_Android::main_loop_iterate(bool *r_should_swap_buffers) {
 void OS_Android::main_loop_end() {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		GameViewPlugin *game_view_plugin = Object::cast_to<GameViewPlugin>(EditorNode::get_singleton()->get_editor_main_screen()->get_plugin_by_name("Game"));
+		GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 		if (game_view_plugin != nullptr) {
 			game_view_plugin->disconnect("main_screen_changed", callable_mp_static(&OS_Android::_on_main_screen_changed));
 		}


### PR DESCRIPTION
Fix the following crash:
```
/data/app/~~hvqlo1Av08miBF6mrw1QJw==/org.godotengine.editor.v4-uUxhtz8SY8YayZM2v6BJ_A==/split_config.arm64_v8a.apk!libgodot_android.so (OS_Android::main_loop_end()+746) (BuildId: c668ae16f5dbb4fa)
            EditorNode::get_editor_main_screen()
            /root/godot/./editor/editor_node.h:746:72
            OS_Android::main_loop_end()
            /root/godot/platform/android/os_android.cpp:379:70
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
