### PR TITLE
Enhance contrast on Modern theme a bit more

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -356,7 +356,7 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 				preset_contrast = light_contrast;
 			} else { // Default
 				preset_accent_color = Color(0.337, 0.62, 1.0);
-				preset_base_color = Color(0.153, 0.153, 0.153);
+				preset_base_color = Color(0.161, 0.161, 0.161);
 			}
 
 			config.accent_color = preset_accent_color;

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -84,7 +84,7 @@ public:
 		// Make sure to keep those in sync with the definitions in the editor settings.
 		const float default_icon_saturation = 2.0;
 		const int default_relationship_lines = RELATIONSHIP_SELECTED_ONLY;
-		const float default_contrast = 0.35;
+		const float default_contrast = 0.37;
 		const int default_corner_radius = 4;
 
 		// Generated properties.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -110,7 +110,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Font colors.
 
-		p_config.font_color = p_config.mono_color_font * Color(1, 1, 1, 0.7);
+		p_config.font_color = p_config.mono_color_font * Color(1, 1, 1, 0.75);
 		p_config.font_secondary_color = p_config.mono_color_font * Color(1, 1, 1, 0.45);
 		p_config.font_focus_color = p_config.mono_color_font;
 		p_config.font_hover_color = p_config.mono_color_font;
@@ -139,7 +139,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Icon colors.
 
-		p_config.icon_normal_color = Color(1, 1, 1, p_config.dark_icon_and_font ? 0.7 : 0.95);
+		p_config.icon_normal_color = Color(1, 1, 1, p_config.dark_icon_and_font ? 0.75 : 0.95);
 		p_config.icon_secondary_color = Color(1, 1, 1, p_config.dark_icon_and_font ? 0.45 : 0.6);
 		p_config.icon_focus_color = Color(1, 1, 1);
 		p_config.icon_hover_color = Color(1, 1, 1);
@@ -160,15 +160,15 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_config.surface_low_color = _get_base_color(p_config, p_config.dark_theme ? -0.6 : -0.9);
 		p_config.surface_base_color = _get_base_color(p_config, -0.2);
 		p_config.surface_high_color = _get_base_color(p_config, 0.2, 0.8);
-		p_config.surface_higher_color = _get_base_color(p_config, 0.35, 0.8);
-		p_config.surface_highest_color = _get_base_color(p_config, 0.55, 0.6);
+		p_config.surface_higher_color = _get_base_color(p_config, 0.3, 0.8);
+		p_config.surface_highest_color = _get_base_color(p_config, 0.5, 0.6);
 
 		p_config.button_normal_color = _get_base_color(p_config, 0.35, 0.85);
-		p_config.button_hover_color = _get_base_color(p_config, 0.55, 0.75);
+		p_config.button_hover_color = _get_base_color(p_config, 0.5, 0.75);
 		p_config.button_pressed_color = _get_base_color(p_config, 0.75, 0.75);
 		p_config.button_disabled_color = _get_base_color(p_config, 0.2, 0.75);
 		p_config.button_border_normal_color = _get_base_color(p_config, 0.45, 0.75);
-		p_config.button_border_hover_color = _get_base_color(p_config, 0.65, 0.75);
+		p_config.button_border_hover_color = _get_base_color(p_config, 0.55, 0.75);
 		p_config.button_border_pressed_color = _get_base_color(p_config, 0.85, 0.75);
 
 		p_config.shadow_color = Color(0, 0, 0, p_config.dark_theme ? 0.3 : 0.1);


### PR DESCRIPTION
> This will likely be divisive, probably rejected, but I still think it's contrast improvement we should discuss regardless.

A 5% increase in contrast, bumping the main color from `#272727` to `#292929` and contrast from 0.35 to 0.37.

| Current | This PR |
|-|-|
| ![before](https://github.com/user-attachments/assets/818be21e-87e3-410f-823f-ce036c391ade) | ![after](https://github.com/user-attachments/assets/c3b5fbbc-84b8-4ed5-8631-a24f33f319b0) |

Also tweaks some elements to avoid contrast issues (see https://github.com/godotengine/godot/pull/112558#issuecomment-3507838253). There were some side effects, though, but I believe they were more positive than negative.

> What I would really suggest would be `#2d2d2d`, which matches the luminance of many popular dark themes, with a contrast of 0.4, but that would distance itself too much from the original proposal and would be even more divisive.

<details>
<summary>Exaggerated variant preview (isolated as it's not part of this PR)</summary>
<img alt="exaggerated" src="https://github.com/user-attachments/assets/faa28a58-0298-486d-9d4f-565ea3f3434f">
</details>

I made a little palette to compare colors:
![contrast](https://github.com/user-attachments/assets/f876729f-1dd8-4dd4-a9e1-6965be81a382)
For reference, from left to right:
- `#272727` (Current color)
- `#292929` (Proposed color)
- `#2d2d2d` (Exaggerated color)
- `#3f3f3f` (Halfway point between true black and true gray, slightly brighter than Godot's Gray theme)
- `#7f7f7f` (True gray)