### PR TITLE
Add error message to Quick Open dialog if callback is invalid

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -252,6 +252,15 @@ void EditorQuickOpenDialog::update_property() {
 			property_object->set(property_path, initial_property_value);
 		}
 	}
+
+	if (!item_selected_callback.is_valid()) {
+		String err_msg = "The callback provided to the Quick Open dialog was invalid.";
+		if (_is_instant_preview_active()) {
+			err_msg += " Try disabling \"Instant Preview\" as a workaround.";
+		}
+		ERR_FAIL_MSG(err_msg);
+	}
+
 	item_selected_callback.call(container->get_selected());
 }
 


### PR DESCRIPTION
Helps users diagnose and work around (but does not *fix*) issues like #112503.

Due to the way other parts of Godot are built, the Instant Preview function for the Quick Open dialog sometimes receives a callback that is invalid by the time it's ready to use it. This PR adds an error message explaining when this happens, and suggests to the user that they disable Instant Preview if it's currently enabled.

Following #112547, hopefully the conditions that cause this error shouldn't come up. But if they do, it will be very helpful to notify the users/developers rather than just silently failing.