### PR TITLE
Fix custom audio track blend flag on reimport

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3951,6 +3951,9 @@ void Animation::copy_track(int p_track, Ref<Animation> p_to_animation) {
 	if (track_get_type(p_track) == TYPE_VALUE) {
 		p_to_animation->value_track_set_update_mode(dst_track, value_track_get_update_mode(p_track));
 	}
+	if (track_get_type(p_track) == TYPE_AUDIO) {
+		p_to_animation->audio_track_set_use_blend(dst_track, audio_track_is_use_blend(p_track));
+	}
 
 	for (int i = 0; i < track_get_key_count(p_track); i++) {
 		p_to_animation->track_insert_key(dst_track, track_get_key_time(p_track, i), track_get_key_value(p_track, i), track_get_key_transition(p_track, i));


### PR DESCRIPTION
Fixes #112552 

This commit fixes a bug where the "Use Blend" setting gets reset for Custom Audio Playback Tracks upon reimport.

The bug seems to be in `Animation::copy_track` where we never copy over the `use_blend` property to the destination track. This is used in `ResourceImporterScene::_save_animation_to_file` where we load the old animation and copy over tracks from it to our new animation. Since the `use_blend` property isn't copied it gets lost and we end up resetting it to the default value (`true`).