### PR TITLE
Jolt: Don't try to wake up static bodies

### DIFF
--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -718,6 +718,10 @@ bool JoltBody3D::is_sleep_actually_allowed() const {
 }
 
 void JoltBody3D::set_is_sleeping(bool p_enabled) {
+	if (is_static()) {
+		return;
+	}
+
 	if (!in_space()) {
 		sleep_initially = p_enabled;
 	} else {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

This is unnecessary overhead because static bodies don't have motion properties. They only affect dynamic bodies through contact resolution. 

As an example of where this change benefits is a scene with several conveyors constantly and rapidly changing velocities. 