### PR TITLE
Fix CylinderShape3D property order to match other shapes.

### DIFF
--- a/scene/resources/3d/cylinder_shape_3d.cpp
+++ b/scene/resources/3d/cylinder_shape_3d.cpp
@@ -119,8 +119,8 @@ void CylinderShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_height", "height"), &CylinderShape3D::set_height);
 	ClassDB::bind_method(D_METHOD("get_height"), &CylinderShape3D::get_height);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_height", "get_height");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_height", "get_height");
 }
 
 CylinderShape3D::CylinderShape3D() :


### PR DESCRIPTION
Fixes #112550

Swapped the property registration order in `CylinderShape3D` so that `radius` appears before `height` in the Inspector.

---

### Why this approach?

After analyzing all cylinder-like components in the codebase (CSGCylinder3D, CapsuleShape3D, CapsuleMesh, and CylinderMesh), the standard convention is **radius before height**. CylinderShape3D was the only class breaking this pattern.

This ensures consistent ordering across all cylinder/capsule shapes, improving the user experience when prototyping.
