### PR TITLE
Fix incorrectly range for expressions

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3279,6 +3279,11 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_grouping(ExpressionNode *p
 		push_error(R"(Expected grouping expression.)");
 	} else {
 		consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected closing ")" after grouping expression.)*");
+
+		grouped->start_line = previous.start_line;
+		grouped->start_column = previous.start_column;
+		grouped->end_line = previous.end_line;
+		grouped->end_column = previous.end_column;
 	}
 	return grouped;
 }


### PR DESCRIPTION
Fixes #80174

This PR fixes a bug where the parser would miscalculate the source code range (start and end lines) for multi-line expressions enclosed in parentheses.

I've tested this and couldn't find any issues or regressions. However, please let me know if you spot anything I might have missed.