### PR TITLE
Fix JacobianIK to apply gradient correctly

### DIFF
--- a/doc/classes/JacobianIK3D.xml
+++ b/doc/classes/JacobianIK3D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="JacobianIK3D" inherits="IterateIK3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Pseudo inverse Jacobian matrix based inverse kinematics solver.
+		Jacobian transpose based inverse kinematics solver.
 	</brief_description>
 	<description>
 		[JacobianIK3D] calculates rotations for all joints simultaneously, producing natural and smooth movement. It is particularly suited for biological animations.

--- a/scene/3d/jacobian_ik_3d.cpp
+++ b/scene/3d/jacobian_ik_3d.cpp
@@ -54,7 +54,7 @@ void JacobianIK3D::_solve_iteration(double p_delta, Skeleton3D *p_skeleton, Iter
 			continue;
 		}
 
-		Quaternion to_rot = Quaternion(axis.normalized(), axis.length() / MAX(CMP_EPSILON, head_to_effector.length()));
+		Quaternion to_rot = Quaternion(axis.normalized(), MIN(axis.length() / MAX(CMP_EPSILON, head_to_effector.length_squared()), angular_delta_limit)); // Clip by angular_delta_limit for stability.
 
 		for (int j = TAIL; j < chain_size; j++) {
 			Vector3 to_tail = p_setting->chain[j] - current_head;


### PR DESCRIPTION
The distance gradient ratio was not applied to angle correctly (it should be divided by powered 2 of the length), resulting in excessive rotation. And applying `angular_delta_limit` clipping at an earlier stage allows users to prevent excessive rotation at their discretion.

Also, the document incorrectly states “pseudo inverse matrix.” The correct method is the "Jacobian transpose" method. Fixed. cc @jitspoe

Before:

![jacobian_ik](https://github.com/user-attachments/assets/e9f93567-ea2a-4dae-a12b-d92b13b17ae7)

After:

https://github.com/user-attachments/assets/785a8bcf-d41d-4d23-a764-13f8cdea7d9b
