### PR TITLE
Add methods for querying loaded `Translation` instances

### DIFF
--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -32,6 +32,7 @@
 
 #include "core/string/translation.h"
 #include "core/string/translation_server.h"
+#include "core/variant/typed_array.h"
 
 struct _character_accent_pair {
 	const char32_t character;
@@ -252,27 +253,7 @@ PackedStringArray TranslationDomain::get_loaded_locales() const {
 	return locales;
 }
 
-bool TranslationDomain::has_translation_for_locale(const String &p_locale) const {
-	for (const Ref<Translation> &E : translations) {
-		if (E->get_locale() == p_locale) {
-			return true;
-		}
-	}
-	return false;
-}
-
-// Translation objects that could potentially be used for the given locale.
-HashSet<Ref<Translation>> TranslationDomain::get_potential_translations(const String &p_locale) const {
-	HashSet<Ref<Translation>> res;
-
-	for (const Ref<Translation> &E : translations) {
-		if (TranslationServer::get_singleton()->compare_locales(p_locale, E->get_locale()) > 0) {
-			res.insert(E);
-		}
-	}
-	return res;
-}
-
+#ifndef DISABLE_DEPRECATED
 Ref<Translation> TranslationDomain::get_translation_object(const String &p_locale) const {
 	Ref<Translation> res;
 	int best_score = 0;
@@ -289,6 +270,7 @@ Ref<Translation> TranslationDomain::get_translation_object(const String &p_local
 	}
 	return res;
 }
+#endif
 
 void TranslationDomain::add_translation(const Ref<Translation> &p_translation) {
 	ERR_FAIL_COND_MSG(p_translation.is_null(), "Invalid translation provided.");
@@ -301,6 +283,69 @@ void TranslationDomain::remove_translation(const Ref<Translation> &p_translation
 
 void TranslationDomain::clear() {
 	translations.clear();
+}
+
+const HashSet<Ref<Translation>> TranslationDomain::get_translations() const {
+	return translations;
+}
+
+HashSet<Ref<Translation>> TranslationDomain::find_translations(const String &p_locale, bool p_exact) const {
+	HashSet<Ref<Translation>> res;
+	if (p_exact) {
+		for (const Ref<Translation> &E : translations) {
+			if (E->get_locale() == p_locale) {
+				res.insert(E);
+			}
+		}
+	} else {
+		for (const Ref<Translation> &E : translations) {
+			if (TranslationServer::get_singleton()->compare_locales(p_locale, E->get_locale()) > 0) {
+				res.insert(E);
+			}
+		}
+	}
+	return res;
+}
+
+bool TranslationDomain::has_translation(const Ref<Translation> &p_translation) const {
+	return translations.has(p_translation);
+}
+
+bool TranslationDomain::has_translation_for_locale(const String &p_locale, bool p_exact) const {
+	if (p_exact) {
+		for (const Ref<Translation> &E : translations) {
+			if (E->get_locale() == p_locale) {
+				return true;
+			}
+		}
+	} else {
+		for (const Ref<Translation> &E : translations) {
+			if (TranslationServer::get_singleton()->compare_locales(p_locale, E->get_locale()) > 0) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+TypedArray<Translation> TranslationDomain::get_translations_bind() const {
+	TypedArray<Translation> res;
+	res.reserve(translations.size());
+	for (const Ref<Translation> &E : translations) {
+		res.push_back(E);
+	}
+	return res;
+}
+
+TypedArray<Translation> TranslationDomain::find_translations_bind(const String &p_locale, bool p_exact) const {
+	const HashSet<Ref<Translation>> &found = find_translations(p_locale, p_exact);
+
+	TypedArray<Translation> res;
+	res.reserve(found.size());
+	for (const Ref<Translation> &E : found) {
+		res.push_back(E);
+	}
+	return res;
 }
 
 StringName TranslationDomain::translate(const StringName &p_message, const StringName &p_context) const {
@@ -459,10 +504,17 @@ StringName TranslationDomain::pseudolocalize(const StringName &p_message) const 
 }
 
 void TranslationDomain::_bind_methods() {
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("get_translation_object", "locale"), &TranslationDomain::get_translation_object);
+#endif
+
 	ClassDB::bind_method(D_METHOD("add_translation", "translation"), &TranslationDomain::add_translation);
 	ClassDB::bind_method(D_METHOD("remove_translation", "translation"), &TranslationDomain::remove_translation);
 	ClassDB::bind_method(D_METHOD("clear"), &TranslationDomain::clear);
+	ClassDB::bind_method(D_METHOD("get_translations"), &TranslationDomain::get_translations_bind);
+	ClassDB::bind_method(D_METHOD("has_translation_for_locale", "locale", "exact"), &TranslationDomain::has_translation_for_locale);
+	ClassDB::bind_method(D_METHOD("has_translation", "translation"), &TranslationDomain::has_translation);
+	ClassDB::bind_method(D_METHOD("find_translations", "locale", "exact"), &TranslationDomain::find_translations_bind);
 	ClassDB::bind_method(D_METHOD("translate", "message", "context"), &TranslationDomain::translate, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("translate_plural", "message", "message_plural", "n", "context"), &TranslationDomain::translate_plural, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_locale_override"), &TranslationDomain::get_locale_override);

--- a/core/string/translation_domain.h
+++ b/core/string/translation_domain.h
@@ -71,15 +71,24 @@ public:
 	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_context) const;
 	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const;
 	PackedStringArray get_loaded_locales() const;
-	bool has_translation_for_locale(const String &p_locale) const;
-	HashSet<Ref<Translation>> get_potential_translations(const String &p_locale) const;
 
 public:
+	// These two methods are public for easier TranslationServer bindings.
+	TypedArray<Translation> get_translations_bind() const;
+	TypedArray<Translation> find_translations_bind(const String &p_locale, bool p_exact) const;
+
+#ifndef DISABLE_DEPRECATED
 	Ref<Translation> get_translation_object(const String &p_locale) const;
+#endif
 
 	void add_translation(const Ref<Translation> &p_translation);
 	void remove_translation(const Ref<Translation> &p_translation);
 	void clear();
+
+	bool has_translation(const Ref<Translation> &p_translation) const;
+	const HashSet<Ref<Translation>> get_translations() const;
+	HashSet<Ref<Translation>> find_translations(const String &p_locale, bool p_exact) const;
+	bool has_translation_for_locale(const String &p_locale, bool p_exact) const;
 
 	StringName translate(const StringName &p_message, const StringName &p_context) const;
 	StringName translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const;

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -110,7 +110,15 @@ public:
 	String get_locale() const;
 	void set_fallback_locale(const String &p_locale);
 	String get_fallback_locale() const;
+
+#ifndef DISABLE_DEPRECATED
 	Ref<Translation> get_translation_object(const String &p_locale);
+#endif
+
+	bool has_translation(const Ref<Translation> &p_translation) const;
+	TypedArray<Translation> get_translations() const;
+	TypedArray<Translation> find_translations(const String &p_locale, bool p_exact) const;
+	bool has_translation_for_locale(const String &p_locale, bool p_exact) const;
 
 	Vector<String> get_all_languages() const;
 	String get_language_name(const String &p_language) const;

--- a/doc/classes/TranslationDomain.xml
+++ b/doc/classes/TranslationDomain.xml
@@ -23,17 +23,46 @@
 				Removes all translations.
 			</description>
 		</method>
+		<method name="find_translations" qualifiers="const">
+			<return type="Translation[]" />
+			<param index="0" name="locale" type="String" />
+			<param index="1" name="exact" type="bool" />
+			<description>
+				Returns the [Translation] instances that match [param locale] (see [method TranslationServer.compare_locales]). If [param exact] is [code]true[/code], only instances whose locale exactly equals [param locale] will be returned.
+			</description>
+		</method>
 		<method name="get_locale_override" qualifiers="const">
 			<return type="String" />
 			<description>
 				Returns the locale override of the domain. Returns an empty string if locale override is disabled.
 			</description>
 		</method>
-		<method name="get_translation_object" qualifiers="const">
+		<method name="get_translation_object" qualifiers="const" deprecated="Use [method find_translations] instead.">
 			<return type="Translation" />
 			<param index="0" name="locale" type="String" />
 			<description>
 				Returns the [Translation] instance that best matches [param locale]. Returns [code]null[/code] if there are no matches.
+			</description>
+		</method>
+		<method name="get_translations" qualifiers="const">
+			<return type="Translation[]" />
+			<description>
+				Returns all available [Translation] instances as added by [method add_translation].
+			</description>
+		</method>
+		<method name="has_translation" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="translation" type="Translation" />
+			<description>
+				Returns [code]true[/code] if this translation domain contains the given [param translation].
+			</description>
+		</method>
+		<method name="has_translation_for_locale" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="locale" type="String" />
+			<param index="1" name="exact" type="bool" />
+			<description>
+				Returns [code]true[/code] if there are any [Translation] instances that match [param locale] (see [method TranslationServer.compare_locales]). If [param exact] is [code]true[/code], only instances whose locale exactly equals [param locale] are considered.
 			</description>
 		</method>
 		<method name="pseudolocalize" qualifiers="const">

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -33,6 +33,14 @@
 				Compares two locales and returns a similarity score between [code]0[/code] (no match) and [code]10[/code] (full match).
 			</description>
 		</method>
+		<method name="find_translations" qualifiers="const">
+			<return type="Translation[]" />
+			<param index="0" name="locale" type="String" />
+			<param index="1" name="exact" type="bool" />
+			<description>
+				Returns the [Translation] instances in the main translation domain that match [param locale] (see [method compare_locales]). If [param exact] is [code]true[/code], only instances whose locale exactly equals [param locale] will be returned.
+			</description>
+		</method>
 		<method name="format_number" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="number" type="String" />
@@ -128,11 +136,17 @@
 				[b]Note:[/b] When called from an exported project returns the same value as [method get_locale].
 			</description>
 		</method>
-		<method name="get_translation_object">
+		<method name="get_translation_object" deprecated="Use [method find_translations] instead.">
 			<return type="Translation" />
 			<param index="0" name="locale" type="String" />
 			<description>
 				Returns the [Translation] instance that best matches [param locale] in the main translation domain. Returns [code]null[/code] if there are no matches.
+			</description>
+		</method>
+		<method name="get_translations" qualifiers="const">
+			<return type="Translation[]" />
+			<description>
+				Returns all available [Translation] instances in the main translation domain as added by [method add_translation].
 			</description>
 		</method>
 		<method name="has_domain" qualifiers="const">
@@ -140,6 +154,21 @@
 			<param index="0" name="domain" type="StringName" />
 			<description>
 				Returns [code]true[/code] if a translation domain with the specified name exists.
+			</description>
+		</method>
+		<method name="has_translation" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="translation" type="Translation" />
+			<description>
+				Returns [code]true[/code] if the main translation domain contains the given [param translation].
+			</description>
+		</method>
+		<method name="has_translation_for_locale" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="locale" type="String" />
+			<param index="1" name="exact" type="bool" />
+			<description>
+				Returns [code]true[/code] if there are any [Translation] instances in the main translation domain that match [param locale] (see [method compare_locales]). If [param exact] is [code]true[/code], only instances whose locale exactly equals [param locale] are considered.
 			</description>
 		</method>
 		<method name="parse_number" qualifiers="const">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -585,10 +585,9 @@ void EditorNode::_update_translations() {
 
 	if (main->is_enabled()) {
 		// Check for the exact locale.
-		// `get_potential_translations("zh_CN")` could return translations for "zh".
-		if (main->has_translation_for_locale(main->get_locale_override())) {
+		if (main->has_translation_for_locale(main->get_locale_override(), true)) {
 			// The set of translation resources for the current locale changed.
-			const HashSet<Ref<Translation>> translations = main->get_potential_translations(main->get_locale_override());
+			const HashSet<Ref<Translation>> translations = main->find_translations(main->get_locale_override(), false);
 			if (translations != tracked_translations) {
 				_translation_resources_changed();
 			}
@@ -609,7 +608,7 @@ void EditorNode::_translation_resources_changed() {
 
 	const Ref<TranslationDomain> main = TranslationServer::get_singleton()->get_main_domain();
 	if (main->is_enabled()) {
-		const HashSet<Ref<Translation>> translations = main->get_potential_translations(main->get_locale_override());
+		const HashSet<Ref<Translation>> translations = main->find_translations(main->get_locale_override(), false);
 		tracked_translations.reserve(translations.size());
 		for (const Ref<Translation> &translation : translations) {
 			translation->connect_changed(callable_mp(this, &EditorNode::_queue_translation_notification));
@@ -957,7 +956,7 @@ void EditorNode::_notification(int p_what) {
 
 			// Remember the selected locale to preview node translations.
 			const String preview_locale = EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "preview_locale", String());
-			if (!preview_locale.is_empty() && TranslationServer::get_singleton()->get_loaded_locales().has(preview_locale)) {
+			if (!preview_locale.is_empty() && TranslationServer::get_singleton()->has_translation_for_locale(preview_locale, true)) {
 				set_preview_locale(preview_locale);
 			}
 

--- a/tests/core/string/test_translation.h
+++ b/tests/core/string/test_translation.h
@@ -228,37 +228,37 @@ TEST_CASE("[TranslationCSV] CSV import") {
 	CHECK(result == OK);
 	CHECK(gen_files.size() == 4);
 
-	TranslationServer *ts = TranslationServer::get_singleton();
-
+	Ref<TranslationDomain> td = TranslationServer::get_singleton()->get_or_add_domain("godot.test");
 	for (const String &file : gen_files) {
 		Ref<Translation> translation = ResourceLoader::load(file);
 		CHECK(translation.is_valid());
-		ts->add_translation(translation);
+		td->add_translation(translation);
 	}
 
-	ts->set_locale("en");
+	td->set_locale_override("en");
 
-	// `tr` can be called on any Object, we reuse TranslationServer for convenience.
-	CHECK(ts->tr("GOOD_MORNING") == "Good Morning");
-	CHECK(ts->tr("GOOD_EVENING") == "Good Evening");
+	CHECK(td->translate("GOOD_MORNING", StringName()) == "Good Morning");
+	CHECK(td->translate("GOOD_EVENING", StringName()) == "Good Evening");
 
-	ts->set_locale("de");
+	td->set_locale_override("de");
 
-	CHECK(ts->tr("GOOD_MORNING") == "Guten Morgen");
-	CHECK(ts->tr("GOOD_EVENING") == "Good Evening"); // Left blank in CSV, should source from 'en'.
+	CHECK(td->translate("GOOD_MORNING", StringName()) == "Guten Morgen");
+	CHECK(td->translate("GOOD_EVENING", StringName()) == "Good Evening"); // Left blank in CSV, should source from 'en'.
 
-	ts->set_locale("ja");
+	td->set_locale_override("ja");
 
-	CHECK(ts->tr("GOOD_MORNING") == String::utf8("おはよう"));
-	CHECK(ts->tr("GOOD_EVENING") == String::utf8("こんばんは"));
+	CHECK(td->translate("GOOD_MORNING", StringName()) == String::utf8("おはよう"));
+	CHECK(td->translate("GOOD_EVENING", StringName()) == String::utf8("こんばんは"));
 
 	/* FIXME: This passes, but triggers a chain reaction that makes test_viewport
 	 * and test_text_edit explode in a billion glittery Unicode particles.
-	ts->set_locale("fa");
+	td->set_locale_override("fa");
 
-	CHECK(ts->tr("GOOD_MORNING") == String::utf8("صبح بخیر"));
-	CHECK(ts->tr("GOOD_EVENING") == String::utf8("عصر بخیر"));
+	CHECK(td->translate("GOOD_MORNING", String()) == String::utf8("صبح بخیر"));
+	CHECK(td->translate("GOOD_EVENING", String()) == String::utf8("عصر بخیر"));
 	*/
+
+	TranslationServer::get_singleton()->remove_domain("godot.test");
 }
 #endif // TOOLS_ENABLED
 


### PR DESCRIPTION
Closes #99258

Currently, there are methods to add and remove `Translation`s, but there has been no way to query them. This PR added:

- `get_translations()` to get the list of `Translation`s in the domain.
- `find_translations(locale, exact)` to get the list of `Translation`s that match the given `locale`.
    - The reason for `exact` is that queries often need to consider whether, for example, translations with the locale set to `en` should be included when searching for `en_US`.
- `has_translation_for_locale(locale, exact)` is a more efficient version of `not find_translations(locale, exact).is_empty()`.
- `has_translation(translation)` for completeness.

This PR also deprecated two methods that were added along the history due to the lack of querying methods.

- `get_translation_object(locale)`
    - It has always been supported to add multiple `Translation`s for one locale. The flaw of this method is that it does not take this fact into account.
    -  This method was added in #40443 but it was not used in that PR at all. Later, some other parts of the engine used this method, propagating the erroneous assumption. I believe adding this API is a mistake from the beginning.
    - It's now recommended to use `find_translations(locale, exact)` instead.
- ~`get_loaded_locales()`~
    - Added in #28376 to allow building a language selection menu in their game.
    - ~Building a language selection menu is usually more complex than retrieving the loaded locales. For instance, you must consider which strategy to adopt for constructing a language menu when `en`, `en_US`, and `en_UK` are loaded at the same time (e.g., should `en` be listed as a separate language option?). Therefore, it is now recommended to use `get_translations()` and write the filtering logic yourself.~
    - Another common usage of `get_loaded_locales()` is to check whether a locale is loaded. This usage is now replaced by `has_translations(locale, exact)`.

Also fixed an issue where test cases interfered with each other in translation-related test code.