### PR TITLE
Android: Fix root window shrinking when keyboard appears

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -382,7 +382,7 @@ class Godot private constructor(val context: Context) {
 			}
 		} else {
 			if (rootView.rootWindowInsets != null) {
-				if (!useImmersive.get() || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)) {
+				if (!useImmersive.get()) {
 					val windowInsets = WindowInsetsCompat.toWindowInsetsCompat(rootView.rootWindowInsets)
 					val insets = windowInsets.getInsets(getInsetType())
 					rootView.setPadding(insets.left, insets.top, insets.right, insets.bottom)
@@ -391,8 +391,7 @@ class Godot private constructor(val context: Context) {
 
 			ViewCompat.setOnApplyWindowInsetsListener(rootView) { v: View, insets: WindowInsetsCompat ->
 				v.post {
-					if (useImmersive.get() && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-						// Fixes issue where padding remained visible in immersive mode on some devices.
+					if (useImmersive.get()) {
 						v.setPadding(0, 0, 0, 0)
 					} else {
 						val windowInsets = insets.getInsets(getInsetType())


### PR DESCRIPTION
Fixes an issue where the root window shrinks when the keyboard appears. It happens in projects with immersive mode enabled and edge-to-edge disabled.

## Before

https://github.com/user-attachments/assets/1590bb46-eb47-4e47-a0db-2408af861439


## After

https://github.com/user-attachments/assets/7361a5ad-b977-4371-8e27-7dd875b67b1c

