### PR TITLE
Fix CowData reader thread-safety / crash — assignment now "observably atomic"

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -56,6 +56,18 @@ GODOT_GCC_PRAGMA(GCC diagnostic warning "-Wstringop-overflow=0") // Can't "ignor
 GODOT_GCC_PRAGMA(GCC diagnostic warning "-Wdangling-pointer=0") // Can't "ignore" this for some reason.
 #endif
 
+namespace CowDataThreading {
+static constexpr size_t READER_BUCKET_COUNT = 128; // Must be a power of 2 to facilitate fast modulo
+
+// We provide thread-safe assignment operations (internally ref/unref) supporting one writer and multiple readers.
+// To facilitate read operations in a lock-free fashion (with fixed memory cost), we maintain reader count "buckets".
+// Each bucket contains the sum of multiple individual CowData's "reader count". The reader count being the number of
+// threads that are actively in the process of trying to obtain a reference to the underlying buffer of a particular
+// CowData. Although reader counts are incredibly unlikely to exceed even the size of uint8_t, uint64_t was chosen
+// as mitigation for "false sharing".
+inline SafeNumeric<uint64_t> reader_counts[READER_BUCKET_COUNT];
+}; //namespace CowDataThreading
+
 template <typename T>
 class CowData {
 public:
@@ -75,6 +87,13 @@ private:
 	static constexpr size_t CAPACITY_OFFSET = Memory::get_aligned_address(REF_COUNT_OFFSET + sizeof(SafeNumeric<USize>), alignof(USize));
 	static constexpr size_t SIZE_OFFSET = Memory::get_aligned_address(CAPACITY_OFFSET + sizeof(USize), alignof(USize));
 	static constexpr size_t DATA_OFFSET = Memory::get_aligned_address(SIZE_OFFSET + sizeof(USize), Memory::MAX_ALIGN);
+
+	static SafeNumeric<uint64_t> &get_reader_count(const CowData *instance) {
+		uint64_t hash = reinterpret_cast<uint64_t>(instance);
+		hash ^= hash >> 7;
+		hash ^= hash >> 13;
+		return CowDataThreading::reader_counts[hash & (CowDataThreading::READER_BUCKET_COUNT - 1)];
+	}
 
 	mutable T *_ptr = nullptr;
 
@@ -105,14 +124,25 @@ private:
 		return (T *)(p_ptr + DATA_OFFSET);
 	}
 
+	static _FORCE_INLINE_ USize *_get_size(uint8_t *p_ptr) {
+		return (USize *)(p_ptr - DATA_OFFSET + SIZE_OFFSET);
+	}
+
+	static _FORCE_INLINE_ SafeNumeric<USize> *_get_refcount(uint8_t *p_ptr) {
+		return (SafeNumeric<USize> *)(p_ptr - DATA_OFFSET + REF_COUNT_OFFSET);
+	}
+
+	// Decrements the reference count of p_ptr (must not be nullptr). Deallocates the backing buffer if needed.
+	static void _unref(uint8_t *p_ptr);
+
 	/// Note: Assumes _ptr != nullptr.
 	_FORCE_INLINE_ SafeNumeric<USize> *_get_refcount() const {
-		return (SafeNumeric<USize> *)((uint8_t *)_ptr - DATA_OFFSET + REF_COUNT_OFFSET);
+		return _get_refcount((uint8_t *)_ptr);
 	}
 
 	/// Note: Assumes _ptr != nullptr.
 	_FORCE_INLINE_ USize *_get_size() const {
-		return (USize *)((uint8_t *)_ptr - DATA_OFFSET + SIZE_OFFSET);
+		return _get_size((uint8_t *)_ptr);
 	}
 
 	/// Note: Assumes _ptr != nullptr.
@@ -120,9 +150,40 @@ private:
 		return (USize *)((uint8_t *)_ptr - DATA_OFFSET + CAPACITY_OFFSET);
 	}
 
-	// Decrements the reference count. Deallocates the backing buffer if needed.
 	// After this function, _ptr is guaranteed to be NULL.
-	void _unref();
+	// Decrements the reference count. Deallocates the backing buffer if needed.
+	_FORCE_INLINE_ void _unref() const {
+		if (!_ptr) {
+			return;
+		}
+
+		// First, invalidate our own reference.
+		// NOTE: It is required to do so immediately because it must not be observable outside of this
+		//       function after refcount has already been reduced to 0.
+		// WARNING: It must be done before calling the destructors, because one of them may otherwise
+		//          observe it through a reference to us. In this case, it may try to access the buffer,
+		//          which is illegal after some of the elements in it have already been destructed, and
+		//          may lead to a segmentation fault.
+		T *prev_ptr = _ptr;
+		_ptr = nullptr;
+
+		if (prev_ptr) {
+			SafeNumeric<uint64_t> &reader_count = get_reader_count(this);
+
+			while (reader_count.get() > 0) {
+				// spin lock prevents prev_ptr being freed as a reader is obtaining a reference to it
+			}
+
+			_unref((uint8_t *)prev_ptr);
+		}
+
+#if defined(DEBUG_ENABLED) && !defined(ASAN_ENABLED)
+		// If any destructors access us through pointers, it is a bug.
+		// We can't really test for that, but we can at least check no items have been added.
+		ERR_FAIL_COND_MSG(_ptr != nullptr, "Internal bug, please report: CowData was modified during destruction.");
+#endif
+	}
+
 	void _ref(const CowData *p_from);
 	void _ref(const CowData &p_from);
 
@@ -156,9 +217,19 @@ public:
 			return;
 		}
 
-		_unref();
+		T *prev_ptr = _ptr;
 		_ptr = p_from._ptr;
 		p_from._ptr = nullptr;
+
+		if (prev_ptr) {
+			SafeNumeric<uint64_t> &reader_count = get_reader_count(this);
+
+			while (reader_count.get() > 0) {
+				// spin lock prevents prev_ptr being freed as a reader is obtaining a reference to it
+			}
+
+			_unref((uint8_t *)prev_ptr);
+		}
 	}
 
 	_FORCE_INLINE_ T *ptrw() {
@@ -227,46 +298,18 @@ public:
 };
 
 template <typename T>
-void CowData<T>::_unref() {
-	if (!_ptr) {
-		return;
-	}
-
-	if (_get_refcount()->decrement() > 0) {
+void CowData<T>::_unref(uint8_t *p_ptr) {
+	if (_get_refcount(p_ptr)->decrement() > 0) {
 		// Data is still in use elsewhere.
-		_ptr = nullptr;
 		return;
 	}
-	// We had the only reference; destroy the data.
 
-	// First, invalidate our own reference.
-	// NOTE: It is required to do so immediately because it must not be observable outside of this
-	//       function after refcount has already been reduced to 0.
-	// WARNING: It must be done before calling the destructors, because one of them may otherwise
-	//          observe it through a reference to us. In this case, it may try to access the buffer,
-	//          which is illegal after some of the elements in it have already been destructed, and
-	//          may lead to a segmentation fault.
-	USize current_size = size();
-	T *prev_ptr = _ptr;
-	_ptr = nullptr;
+	USize current_size = *_get_size(p_ptr);
 
-#ifdef ASAN_ENABLED
-	// Access during destruction is illegal in C++, and results in undefined behavior.
-	// In address sanitizer builds, we can poison ourselves (_ptr) to catch this.
-	__asan_poison_memory_region(this, sizeof(CowData));
-#endif
-
-	destruct_arr_placement(prev_ptr, current_size);
+	destruct_arr_placement((T *)p_ptr, current_size);
 
 	// Free Memory.
-	Memory::free_static((uint8_t *)prev_ptr - DATA_OFFSET, false);
-
-#ifdef ASAN_ENABLED
-	__asan_unpoison_memory_region(this, sizeof(CowData));
-#elif defined(DEBUG_ENABLED)
-	// In a non-asan build, the best we can do is catch if elements were added during destruction.
-	ERR_FAIL_COND_MSG(_ptr != nullptr, "Internal bug, please report: CowData was modified during destruction.");
-#endif
+	Memory::free_static(p_ptr - DATA_OFFSET, false);
 }
 
 template <typename T>
@@ -558,14 +601,41 @@ void CowData<T>::_ref(const CowData &p_from) {
 		return; // self assign, do nothing.
 	}
 
-	_unref(); // Resets _ptr to nullptr.
+	T *prev_ptr = _ptr;
 
-	if (!p_from._ptr) {
-		return; //nothing to do
+	SafeNumeric<uint64_t> &from_reader_count = get_reader_count(&p_from);
+
+	from_reader_count.increment(); // prevents p_from._ptr being freed + acts as memory barrier for p_from._ptr
+	T *from_ptr = p_from._ptr; // memory barrier has ensured the value obtained has not been deallocated
+
+	if (from_ptr == nullptr) {
+		_ptr = nullptr;
+	} else {
+		SafeNumeric<USize> *from_refcount = _get_refcount((uint8_t *)from_ptr);
+#ifdef DEV_ENABLED
+		const USize new_refcount = from_refcount->increment();
+		DEV_ASSERT(new_refcount != 1 && "CowData::_ref observed 0->1 refcount resurrection; likely concurrent multi-thread writes to the same CowData.");
+#else
+		from_refcount->increment();
+#endif
+		_ptr = from_ptr;
 	}
 
-	if (p_from._get_refcount()->conditional_increment() > 0) { // could reference
-		_ptr = p_from._ptr;
+	// Reader bucket synchronization ensures that if from_ptr is non-null in single-writer mode,
+	// the backing buffer cannot reach refcount zero before we increment it.
+	// If there are multiple writers, all bets are off.
+	DEV_ASSERT(_ptr == from_ptr);
+
+	from_reader_count.decrement();
+
+	if (prev_ptr) {
+		SafeNumeric<uint64_t> &reader_count = get_reader_count(this);
+
+		while (reader_count.get() > 0) {
+			// spin lock prevents prev_ptr being freed as a reader is obtaining a reference to it
+		}
+
+		_unref((uint8_t *)prev_ptr);
 	}
 }
 


### PR DESCRIPTION
`CowData` is intended to be thread safe, but currently that is not the case. This PR fixes a thread-safety issue for reading whilst a write takes place and prevents real-world (sporadic) engine crashes.

**Note:** This PR only addresses thread-safety of readers (whilst one other thread writes). `CowData` is still _not thread-safe for multiple writers_ i.e. multiple concurrent assignments can still lead to a double free / crash.

# The problem

When assigning to `CowData` previously it would first `_unref` before taking on the new reference. `_unref` would leave the `CowData` ptr as `nullptr`. If another thread attempted to obtain their own reference to this `CowData`, they'd unexpectedly end up with a `nullptr`.

# Specific example: Android camera feed

Crash, accessing a `Vector`.

<img width="5344" height="3054" alt="CleanShot 2025-11-09 at 21 39 01@2x" src="https://github.com/user-attachments/assets/a9825787-399d-4559-a67e-90703bd6b499" />

_Sorry, the screenshot shows the stacktrace and a `SIGTRAP` but we're not we're not observing the top frame in the screenshot. Still, we can see a crash occurred accessing a (nullptr) vector._

Let's see what's going on...

## GLThread

<img width="5344" height="3054" alt="CleanShot 2025-11-09 at 21 45 58@2x" src="https://github.com/user-attachments/assets/33cbe9b8-c1e4-4317-a4b8-4033394ec89f" />

We're attempting to update an OpenGL texture, this update was stored in the command queue (inserted by the ImageReader thread). It's being processed on the GLThread.

Annotation (1) in the image we can see the assignment. Annotation (2) shows the value read. It was a `nullptr`. This should _never_ be the case. The image should always have a valid value.

If we look at Annotation (3), we can see the image _does_ actually have a valid value when we crash. Thus it must have previously been a `nullptr` but has changed since.

Why...?

## ImageReader

<img width="5344" height="3054" alt="CleanShot 2025-11-09 at 21 51 47@2x" src="https://github.com/user-attachments/assets/91c08bbd-3399-4556-a18a-bdece4cca614" />

This thread has just updated our image and is currently waiting for the command queue lock to push the new texture data. That means it has just recently called `initialize_data` on our `Image`. An operation that _should_ essentially be observed to outsiders like an atomic swap of the underlying image data. In practice, its implementation assigns the `p_data` (a `Vector`) to its own `data`. `Vector`'s assignment operator then assigns its underlying `_cowdata` and we end up in the troublesome `_ref` implementation that briefly points our `CowData` at a `nullptr` unnecessarily i.e. not an "atomic" swap.

# The Fix

We no longer call `_unref` on the `CowData` instance during assignment. We of course do still need to free our previously pointed to data, but this logic has been extracted out into a static `_unref`. We call this last though _after_ we've assigned the new pointer to the `CowData`. We no longer have an intermediary `nullptr` state.

**_Now_ there's actually a second related bug.**

What happens if another thread grabs our `_ptr` and is in the process of incrementing the reference count but our thread doing the assignment wins the race i.e. obtains a new value AND decrements the reference count before the other thread increments?

This was _partially_ handled before. The new assignment would have just silently never gone through, since we previously ran `_unref` though, you'd unexpectedly end up with `nullptr`. That's fine if the source `CowData` had actually been cleared (rather than reassigned), but we should NOT end up with a `nullptr` just because another thread happened to assign just as we read.

Fortunately, we can detect this situation. ~This PR introduces a loop in `_ref`. >99.99% of the time we won't ever loop. _But_ what the loop does is requery from the source `CowData` if a buffer is unexpectedly freed before we can obtain a reference to it. Now, that may genuinely happen if the source `CowData` is `clear()`d, and this is correctly handled by checking if the new value is a `nullptr` and bailing out. But otherwise, we try claim the latest value again.~ **EDIT:** Implementation has been updated to instead use a lock-free (for readers) cross-thread signaling implementation, paired with a memory barrier that guarantees the `_ref` we're trying to claim is valid (assuming no unsupported parallel writes took place).

Collectively this PR basically fixes swapping / double buffering in many places through-out the engine.

## Fix observed in practice

The Android camera crash is actually a bit easier to reproduce than I would have thought. So I was fortunately able to place a break point that shows where a crash would have _previously_ occurred, but is now being handled correctly.

<img width="5344" height="3054" alt="CleanShot 2025-11-10 at 01 48 52@2x" src="https://github.com/user-attachments/assets/715bda7e-cc52-443d-9a6b-9f1c634896d2" />

Here we can see we failed to increment the reference count of the buffer we're attempting to claim. We can see the cause of this, the `p_from._ptr` has changed out from under us. That's fine. We're stopped on a line of code that'll grab the new value and try again.

<img width="5344" height="3054" alt="CleanShot 2025-11-10 at 02 10 28@2x" src="https://github.com/user-attachments/assets/51723445-e410-4523-a74f-3a6009145032" />

The above shows the loop passing back through and claiming the newly updated buffer i.e. no unexpected `nullptr`s for us anymore. Yay!

This probably fixes quite a few sporadic crashes people have run into for otherwise unexplained reasons. One issue closely related and presumably fixed:
Fixes https://github.com/godotengine/godot/issues/93125
