### PR TITLE
Fix crash during POT generation due to scene dependency issues

### DIFF
--- a/editor/translations/packed_scene_translation_parser_plugin.cpp
+++ b/editor/translations/packed_scene_translation_parser_plugin.cpp
@@ -170,7 +170,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 			if (property_name == "script" && property_value.get_type() == Variant::OBJECT && !property_value.is_null()) {
 				// Parse built-in script.
 				Ref<Script> s = Object::cast_to<Script>(property_value);
-				if (!s->is_built_in()) {
+				if (s.is_null() || !s->is_built_in()) {
 					continue;
 				}
 


### PR DESCRIPTION
Fixes #112578

The direct cause is that the value of the `script` property is not a valid `Script`, so it's a null pointer access calling `s->is_built_in()` after `Object::cast_to<Script>(property_value)`. This access was added in #86479.

But it's strange because there was actually a `property_value.is_null()` check above. When the script is not found, what could the value be if not null?

It turns out that it's a vanilla `Resource` instance for storing the original path:

https://github.com/godotengine/godot/blob/6fd949a6dcbda94140200633394f2b4b99de8f6f/scene/resources/resource_format_text.cpp#L165-L171

This behavior was introduced in #86781.

I wonder if there are other potential hidden crashes caused by this change of behavior. It seems that similar issues are likey to only occur when accessing property values through the `PackedScene` API, so it might not be a major concern.

CC @KoBeWi