### PR TITLE
Default preset container to minimum size in Export dialog

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1463,6 +1463,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	VBoxContainer *preset_vb = memnew(VBoxContainer);
 	preset_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	preset_vb->set_stretch_ratio(0.35);
 	hbox->add_child(preset_vb);
 
 	Label *l = memnew(Label(TTR("Presets")));


### PR DESCRIPTION
This PR sets the preset container to its minimum size by default.
It improves usability, since it previously had to be manually resized each time; otherwise the Export dialog was hard to use in smaller window (Android Editor).

![Screenshot_2025-11-09-21-49-37-888_org godotengine editor v4 debug](https://github.com/user-attachments/assets/4532e185-2ecc-4553-b9ae-2ba724ba0c3e)
