### PR TITLE
Make GDVIRTUAL Binding of _instantiate_playback non-const

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -64,7 +64,7 @@
 				Override this method to return [code]true[/code] if this stream has a loop.
 			</description>
 		</method>
-		<method name="_instantiate_playback" qualifiers="virtual required const">
+		<method name="_instantiate_playback" qualifiers="virtual required">
 			<return type="AudioStreamPlayback" />
 			<description>
 				Override this method to customize the returned value of [method instantiate_playback]. Should return a new [AudioStreamPlayback] created when the stream is played (such as by an [AudioStreamPlayer]).

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -170,7 +170,7 @@ class AudioStream : public Resource {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL0RC_REQUIRED(Ref<AudioStreamPlayback>, _instantiate_playback)
+	GDVIRTUAL0R_REQUIRED(Ref<AudioStreamPlayback>, _instantiate_playback)
 	GDVIRTUAL0RC(String, _get_stream_name)
 	GDVIRTUAL0RC(double, _get_length)
 	GDVIRTUAL0RC(bool, _is_monophonic)


### PR DESCRIPTION
# Fixes #112588 :

The GDVIRTUAL binding of the _instantiate_playback function of AudioStream marked it as const, when the actual function is non-const, making it impossible to override properly when using cpp bindings.

Binding (Incorrectly marked as const) : https://github.com/godotengine/godot/blob/6fd949a6dcbda94140200633394f2b4b99de8f6f/servers/audio/audio_stream.h#L173

Function(Non-const) : https://github.com/godotengine/godot/blob/6fd949a6dcbda94140200633394f2b4b99de8f6f/servers/audio/audio_stream.h#L185

**This PR fixes it (and the associated docs)**