### PR TITLE
Don't redraw `Sprite3D`/`AnimatedSprite3D` outside the tree

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -68,17 +68,17 @@ void SpriteBase3D::_propagate_color_changed() {
 void SpriteBase3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			if (!pending_update) {
-				_im_update();
-			}
+			_im_update();
+		} break;
 
+		case NOTIFICATION_PARENTED: {
 			parent_sprite = Object::cast_to<SpriteBase3D>(get_parent());
 			if (parent_sprite) {
 				pI = parent_sprite->children.push_back(this);
 			}
 		} break;
 
-		case NOTIFICATION_EXIT_TREE: {
+		case NOTIFICATION_UNPARENTED: {
 			if (parent_sprite) {
 				parent_sprite->children.erase(pI);
 				pI = nullptr;
@@ -417,15 +417,21 @@ Vector3::Axis SpriteBase3D::get_axis() const {
 }
 
 void SpriteBase3D::_im_update() {
+	if (!redraw_needed) {
+		return;
+	}
 	_draw();
+	redraw_needed = false;
 
 	pending_update = false;
-
-	//texture->draw_rect_region(ci,dst_rect,src_rect,modulate);
 }
 
 void SpriteBase3D::_queue_redraw() {
 	// The 3D equivalent of CanvasItem.queue_redraw().
+	redraw_needed = true;
+	if (!is_inside_tree()) {
+		return;
+	}
 	if (pending_update) {
 		return;
 	}

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -92,6 +92,7 @@ private:
 	float alpha_antialiasing_edge = 0.0f;
 	StandardMaterial3D::BillboardMode billboard_mode = StandardMaterial3D::BILLBOARD_DISABLED;
 	StandardMaterial3D::TextureFilter texture_filter = StandardMaterial3D::TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
+	bool redraw_needed = false;
 	bool pending_update = false;
 	void _im_update();
 


### PR DESCRIPTION
Fixes #112566.

Ensures `SpriteBase3D::parent_sprite` is set on `NOTIFICATION_PARENTED`/`NOTIFICATION_UNPARENTED` instead of on `NOTIFICATION_ENTER_TREE`/`NOTIFICATION_EXIT_TREE`. This was already enough to fix #112566 as the bug happened because `SpriteBase3D::_draw()` was called before the sprites entered the tree:
- the redraw was queued when outside the tree, during scene instantiation when setting stored color/texture,
- the `MessageQueue` was flushed before entering the tree, during physics processing (it's irrelevant where exactly),
- the child sprite's dirty-marked color was updated as if it had no parent, and was marked as not dirty anymore with such incorrect cumulated-color,
- scene was changed "at the end of a frame" (scene changes are deferred on their own, independent of `MessageQueue`/`call_deffered` calls).

Moreover, after the above there was another redraw triggered, as on `NOTIFICATION_ENTER_TREE` it would update/redraw immediately in case no redraw is enqueued, which was the case when reloading the scene (the another redraw would use wrong cumulated-color for the child sprite).

Redrawing being triggered when outside the tree seems pointless to me. :thinking:
Hence I've made it not update when outside the tree, and update immediately on entering the tree. This makes e.g. on reloading the scene as in the MRP from #112566 the `SpriteBase3D::_draw()` be called only once per Sprite3D (instead of twice, including the first one outside the tree).