### PR TITLE
Add `workflow_dispatch` triggers to platform CI.

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,6 +1,7 @@
 name: 🤖 Android Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -1,6 +1,7 @@
 name: 🍏 iOS Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,6 +1,7 @@
 name: 🐧 Linux Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -1,6 +1,7 @@
 name: 🍎 macOS Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,5 +1,5 @@
 name: 🔗 GHA
-on: [push, pull_request, merge_group]
+on: [push, pull_request, merge_group, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}|${{ github.ref_name }}
@@ -9,7 +9,7 @@ jobs:
   # First stage: Only static checks, fast and prevent expensive builds from running.
 
   static-checks:
-    if: ${{ !vars.DISABLE_GODOT_CI || github.run_attempt > 1 }}
+    if: ${{ !vars.DISABLE_GODOT_CI || github.run_attempt > 1 || github.event_name == 'workflow_dispatch' }}
     name: 📊 Static checks
     uses: ./.github/workflows/static_checks.yml
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,6 +1,7 @@
 name: 📊 Static Checks
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   static-checks:

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -1,6 +1,7 @@
 name: 🌐 Web Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,6 +1,7 @@
 name: 🏁 Windows Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:


### PR DESCRIPTION
This allows users to dispatch these GitHub actions from their own repositories.

Given that most users have automatic CI disabled, most probably won't make use of this. Still, it may occasionally be useful:

- When the user has `DISABLE_GODOT_CI` enabled in their repository, and wants to trigger a build
    - (Notably, the 'retry' button is also possible, but it doesn't support triggering just one of the actions)
- When the user has pushed with `[ci skip]` in the commit message (for example, to skip CI on the Godot repo, but trigger it on their own)
- When the CI doesn't get past the `Static assertions` stage, but the user still wants to test CI (from their own repository)
- When the user wants to dispatch a CI run again, for example to test race conditions, or because the previous CI run was already deleted by GitHub

The dispatch looks as such, in the `Actions` tab:

<img width="1171" height="289" alt="SCR-20251109-swfp" src="https://github.com/user-attachments/assets/7c821437-13c6-4ea7-a39a-ee865c51c4cb" />
