### PR TITLE
[Label] Account for max visible lines when trimming text.

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -982,7 +982,13 @@ Size2 Label::get_minimum_size() const {
 
 	Size2 min_style = theme_cache.normal_style->get_minimum_size();
 	if (autowrap_mode != TextServer::AUTOWRAP_OFF) {
-		return Size2(1, (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? 1 : min_size.height) + min_style;
+		if (!clip && overrun_behavior != TextServer::OVERRUN_NO_TRIMMING && max_lines_visible > 0) {
+			int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
+			min_size.height = MIN(min_size.height, (font->get_height(font_size) + line_spacing) * max_lines_visible);
+		} else if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
+			min_size.height = 1;
+		}
+		return Size2(1, min_size.height) + min_style;
 	} else {
 		if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 			min_size.width = 1;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112413
