### PR TITLE
Fix get_base() returning RID(0) for Light3D nodes

### DIFF
--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -41,7 +41,7 @@ void Light3D::set_param(Param p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 	param[p_param] = p_value;
 
-	RS::get_singleton()->light_set_param(light, RSE::LightParam(p_param), p_value);
+	RS::get_singleton()->light_set_param(get_base(), RSE::LightParam(p_param), p_value);
 
 	if (p_param == PARAM_SPOT_ANGLE || p_param == PARAM_RANGE) {
 		update_gizmos();
@@ -59,7 +59,7 @@ real_t Light3D::get_param(Param p_param) const {
 
 void Light3D::set_shadow(bool p_enable) {
 	shadow = p_enable;
-	RS::get_singleton()->light_set_shadow(light, p_enable);
+	RS::get_singleton()->light_set_shadow(get_base(), p_enable);
 
 	update_configuration_warnings();
 }
@@ -70,7 +70,7 @@ bool Light3D::has_shadow() const {
 
 void Light3D::set_negative(bool p_enable) {
 	negative = p_enable;
-	RS::get_singleton()->light_set_negative(light, p_enable);
+	RS::get_singleton()->light_set_negative(get_base(), p_enable);
 }
 
 bool Light3D::is_negative() const {
@@ -79,7 +79,7 @@ bool Light3D::is_negative() const {
 
 void Light3D::set_enable_distance_fade(bool p_enable) {
 	distance_fade_enabled = p_enable;
-	RS::get_singleton()->light_set_distance_fade(light, distance_fade_enabled, distance_fade_begin, distance_fade_shadow, distance_fade_length);
+	RS::get_singleton()->light_set_distance_fade(get_base(), distance_fade_enabled, distance_fade_begin, distance_fade_shadow, distance_fade_length);
 	notify_property_list_changed();
 }
 
@@ -89,7 +89,7 @@ bool Light3D::is_distance_fade_enabled() const {
 
 void Light3D::set_distance_fade_begin(real_t p_distance) {
 	distance_fade_begin = p_distance;
-	RS::get_singleton()->light_set_distance_fade(light, distance_fade_enabled, distance_fade_begin, distance_fade_shadow, distance_fade_length);
+	RS::get_singleton()->light_set_distance_fade(get_base(), distance_fade_enabled, distance_fade_begin, distance_fade_shadow, distance_fade_length);
 }
 
 real_t Light3D::get_distance_fade_begin() const {
@@ -98,7 +98,7 @@ real_t Light3D::get_distance_fade_begin() const {
 
 void Light3D::set_distance_fade_shadow(real_t p_distance) {
 	distance_fade_shadow = p_distance;
-	RS::get_singleton()->light_set_distance_fade(light, distance_fade_enabled, distance_fade_begin, distance_fade_shadow, distance_fade_length);
+	RS::get_singleton()->light_set_distance_fade(get_base(), distance_fade_enabled, distance_fade_begin, distance_fade_shadow, distance_fade_length);
 }
 
 real_t Light3D::get_distance_fade_shadow() const {
@@ -107,7 +107,7 @@ real_t Light3D::get_distance_fade_shadow() const {
 
 void Light3D::set_distance_fade_length(real_t p_length) {
 	distance_fade_length = p_length;
-	RS::get_singleton()->light_set_distance_fade(light, distance_fade_enabled, distance_fade_begin, distance_fade_shadow, distance_fade_length);
+	RS::get_singleton()->light_set_distance_fade(get_base(), distance_fade_enabled, distance_fade_begin, distance_fade_shadow, distance_fade_length);
 }
 
 real_t Light3D::get_distance_fade_length() const {
@@ -116,7 +116,7 @@ real_t Light3D::get_distance_fade_length() const {
 
 void Light3D::set_cull_mask(uint32_t p_cull_mask) {
 	cull_mask = p_cull_mask;
-	RS::get_singleton()->light_set_cull_mask(light, p_cull_mask);
+	RS::get_singleton()->light_set_cull_mask(get_base(), p_cull_mask);
 }
 
 uint32_t Light3D::get_cull_mask() const {
@@ -129,9 +129,9 @@ void Light3D::set_color(const Color &p_color) {
 	if (GLOBAL_GET_CACHED(bool, "rendering/lights_and_shadows/use_physical_light_units")) {
 		Color combined = color.srgb_to_linear();
 		combined *= correlated_color.srgb_to_linear();
-		RS::get_singleton()->light_set_color(light, combined.linear_to_srgb());
+		RS::get_singleton()->light_set_color(get_base(), combined.linear_to_srgb());
 	} else {
-		RS::get_singleton()->light_set_color(light, color);
+		RS::get_singleton()->light_set_color(get_base(), color);
 	}
 	// The gizmo color depends on the light color, so update it.
 	update_gizmos();
@@ -143,7 +143,7 @@ Color Light3D::get_color() const {
 
 void Light3D::set_shadow_reverse_cull_face(bool p_enable) {
 	reverse_cull = p_enable;
-	RS::get_singleton()->light_set_reverse_cull_face_mode(light, reverse_cull);
+	RS::get_singleton()->light_set_reverse_cull_face_mode(get_base(), reverse_cull);
 }
 
 bool Light3D::get_shadow_reverse_cull_face() const {
@@ -152,7 +152,7 @@ bool Light3D::get_shadow_reverse_cull_face() const {
 
 void Light3D::set_shadow_caster_mask(uint32_t p_caster_mask) {
 	shadow_caster_mask = p_caster_mask;
-	RS::get_singleton()->light_set_shadow_caster_mask(light, shadow_caster_mask);
+	RS::get_singleton()->light_set_shadow_caster_mask(get_base(), shadow_caster_mask);
 }
 
 uint32_t Light3D::get_shadow_caster_mask() const {
@@ -202,7 +202,7 @@ PackedStringArray Light3D::get_configuration_warnings() const {
 
 void Light3D::set_bake_mode(BakeMode p_mode) {
 	bake_mode = p_mode;
-	RS::get_singleton()->light_set_bake_mode(light, RSE::LightBakeMode(p_mode));
+	RS::get_singleton()->light_set_bake_mode(get_base(), RSE::LightBakeMode(p_mode));
 }
 
 Light3D::BakeMode Light3D::get_bake_mode() const {
@@ -226,7 +226,7 @@ void Light3D::set_projector(const Ref<Texture2D> &p_texture) {
 	}
 #endif
 
-	RS::get_singleton()->light_set_projector(light, tex_id);
+	RS::get_singleton()->light_set_projector(get_base(), tex_id);
 	update_configuration_warnings();
 }
 
@@ -276,7 +276,7 @@ void Light3D::set_temperature(const float p_temperature) {
 
 	Color combined = color.srgb_to_linear() * correlated_color.srgb_to_linear();
 
-	RS::get_singleton()->light_set_color(light, combined.linear_to_srgb());
+	RS::get_singleton()->light_set_color(get_base(), combined.linear_to_srgb());
 	// The gizmo color depends on the light color, so update it.
 	update_gizmos();
 }
@@ -462,6 +462,7 @@ void Light3D::_bind_methods() {
 
 Light3D::Light3D(RSE::LightType p_type) {
 	type = p_type;
+	RID light;
 	switch (p_type) {
 		case RSE::LIGHT_DIRECTIONAL:
 			light = RenderingServer::get_singleton()->directional_light_create();
@@ -479,7 +480,7 @@ Light3D::Light3D(RSE::LightType p_type) {
 		};
 	}
 
-	RS::get_singleton()->instance_set_base(get_instance(), light);
+	set_base(light);
 
 	set_color(Color(1, 1, 1, 1));
 	set_shadow(false);
@@ -521,8 +522,8 @@ Light3D::~Light3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->instance_set_base(get_instance(), RID());
 
-	if (light.is_valid()) {
-		RenderingServer::get_singleton()->free_rid(light);
+	if (get_base().is_valid()) {
+		RenderingServer::get_singleton()->free_rid(get_base());
 	}
 }
 
@@ -530,7 +531,7 @@ Light3D::~Light3D() {
 
 void DirectionalLight3D::set_shadow_mode(ShadowMode p_mode) {
 	shadow_mode = p_mode;
-	RS::get_singleton()->light_directional_set_shadow_mode(light, RSE::LightDirectionalShadowMode(p_mode));
+	RS::get_singleton()->light_directional_set_shadow_mode(get_base(), RSE::LightDirectionalShadowMode(p_mode));
 	notify_property_list_changed();
 }
 
@@ -540,7 +541,7 @@ DirectionalLight3D::ShadowMode DirectionalLight3D::get_shadow_mode() const {
 
 void DirectionalLight3D::set_blend_splits(bool p_enable) {
 	blend_splits = p_enable;
-	RS::get_singleton()->light_directional_set_blend_splits(light, p_enable);
+	RS::get_singleton()->light_directional_set_blend_splits(get_base(), p_enable);
 }
 
 bool DirectionalLight3D::is_blend_splits_enabled() const {
@@ -549,7 +550,7 @@ bool DirectionalLight3D::is_blend_splits_enabled() const {
 
 void DirectionalLight3D::set_sky_mode(SkyMode p_mode) {
 	sky_mode = p_mode;
-	RS::get_singleton()->light_directional_set_sky_mode(light, RSE::LightDirectionalSkyMode(p_mode));
+	RS::get_singleton()->light_directional_set_sky_mode(get_base(), RSE::LightDirectionalSkyMode(p_mode));
 }
 
 DirectionalLight3D::SkyMode DirectionalLight3D::get_sky_mode() const {
@@ -624,7 +625,7 @@ DirectionalLight3D::DirectionalLight3D() :
 
 void OmniLight3D::set_shadow_mode(ShadowMode p_mode) {
 	shadow_mode = p_mode;
-	RS::get_singleton()->light_omni_set_shadow_mode(light, RSE::LightOmniShadowMode(p_mode));
+	RS::get_singleton()->light_omni_set_shadow_mode(get_base(), RSE::LightOmniShadowMode(p_mode));
 }
 
 OmniLight3D::ShadowMode OmniLight3D::get_shadow_mode() const {
@@ -712,7 +713,7 @@ void AreaLight3D::set_area_texture(const Ref<Texture2D> &p_texture) {
 	}
 #endif
 
-	RS::get_singleton()->light_area_set_texture(light, tex_id);
+	RS::get_singleton()->light_area_set_texture(get_base(), tex_id);
 	update_configuration_warnings();
 }
 
@@ -722,7 +723,7 @@ Ref<Texture2D> AreaLight3D::get_area_texture() const {
 
 void AreaLight3D::set_area_size(const Vector2 &p_size) {
 	area_size = p_size.maxf(0.0f);
-	RS::get_singleton()->light_area_set_size(light, area_size);
+	RS::get_singleton()->light_area_set_size(get_base(), area_size);
 
 	update_gizmos();
 }
@@ -733,7 +734,7 @@ Vector2 AreaLight3D::get_area_size() const {
 
 void AreaLight3D::set_area_normalize_energy(bool p_enabled) {
 	area_normalize_energy = p_enabled;
-	RS::get_singleton()->light_area_set_normalize_energy(light, p_enabled);
+	RS::get_singleton()->light_area_set_normalize_energy(get_base(), p_enabled);
 }
 
 bool AreaLight3D::is_area_normalizing_energy() const {
@@ -789,7 +790,7 @@ AreaLight3D::~AreaLight3D() {
 	// has to run, because light RID needs to be freed before area_texture RID.
 	// Since area_texture is a member of AreaLight3D, it would be destructed before the deconstructor of Light3D would be called, leading to errors.
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	if (light.is_valid()) {
-		RenderingServer::get_singleton()->free_rid(light);
+	if (get_base().is_valid()) {
+		RenderingServer::get_singleton()->free_rid(get_base());
 	}
 }

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -91,8 +91,6 @@ private:
 	virtual void owner_changed_notify() override;
 
 protected:
-	RID light;
-
 	static void _bind_methods();
 	void _notification(int p_what);
 	void _validate_property(PropertyInfo &p_property) const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112601
`RenderingServer.light_set_param(light, param, value)` expects a RID associated with the Light3D resource,  
but `Light3D.get_base()` returns an empty RID.