### PR TITLE
Update rect after `_pre_popup` in `popup_centered_*`.

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -71,7 +71,7 @@ void EditorFileDialog::_native_popup() {
 	DisplayServer::get_singleton()->file_dialog_with_options_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(dir->get_text()), root, file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &EditorFileDialog::_native_dialog_cb), wid);
 }
 
-void EditorFileDialog::popup(const Rect2i &p_rect) {
+void EditorFileDialog::_popup_base(const Rect2i &p_rect) {
 	_update_option_controls();
 
 	bool use_native = DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE) && (bool(EDITOR_GET("interface/editor/use_native_file_dialogs")) || OS::get_singleton()->is_sandboxed());
@@ -79,7 +79,7 @@ void EditorFileDialog::popup(const Rect2i &p_rect) {
 		_native_popup();
 	} else {
 		// Show custom file dialog.
-		ConfirmationDialog::popup(p_rect);
+		ConfirmationDialog::_popup_base(p_rect);
 	}
 }
 

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -290,6 +290,7 @@ private:
 protected:
 	virtual void _update_theme_item_cache() override;
 
+	virtual void _popup_base(const Rect2i &p_rect = Rect2i()) override;
 	void _notification(int p_what);
 	bool _set(const StringName &p_name, const Variant &p_value) { return property_helper.property_set_value(p_name, p_value); }
 	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }
@@ -300,7 +301,6 @@ protected:
 
 public:
 	virtual void set_visible(bool p_visible) override;
-	virtual void popup(const Rect2i &p_rect = Rect2i()) override;
 
 	// Public for use with callable_mp.
 	void _file_submitted(const String &p_file);

--- a/editor/gui/editor_variant_type_selectors.cpp
+++ b/editor/gui/editor_variant_type_selectors.cpp
@@ -166,12 +166,12 @@ void EditorVariantTypePopupMenu::_notification(int p_what) {
 	}
 }
 
-void EditorVariantTypePopupMenu::popup(const Rect2i &p_bounds) {
+void EditorVariantTypePopupMenu::_popup_base(const Rect2i &p_bounds) {
 	if (icons_dirty) {
 		_update_menu_icons();
 		icons_dirty = false;
 	}
-	PopupMenu::popup(p_bounds);
+	PopupMenu::_popup_base(p_bounds);
 }
 
 EditorVariantTypePopupMenu::EditorVariantTypePopupMenu(bool p_remove_item) {

--- a/editor/gui/editor_variant_type_selectors.h
+++ b/editor/gui/editor_variant_type_selectors.h
@@ -59,9 +59,8 @@ class EditorVariantTypePopupMenu : public PopupMenu {
 
 protected:
 	void _notification(int p_what);
+	virtual void _popup_base(const Rect2i &p_bounds = Rect2i()) override;
 
 public:
-	virtual void popup(const Rect2i &p_bounds = Rect2i()) override;
-
 	EditorVariantTypePopupMenu(bool p_remove_item);
 };

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -95,12 +95,12 @@ bool FileDialog::_can_use_native_popup() {
 	return DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE);
 }
 
-void FileDialog::popup(const Rect2i &p_rect) {
+void FileDialog::_popup_base(const Rect2i &p_rect) {
 	_update_option_controls();
 
 #ifdef TOOLS_ENABLED
 	if (is_part_of_edited_scene()) {
-		ConfirmationDialog::popup(p_rect);
+		ConfirmationDialog::_popup_base(p_rect);
 		return;
 	}
 #endif
@@ -108,7 +108,7 @@ void FileDialog::popup(const Rect2i &p_rect) {
 	if (_can_use_native_popup() && (use_native_dialog || OS::get_singleton()->is_sandboxed())) {
 		_native_popup();
 	} else {
-		ConfirmationDialog::popup(p_rect);
+		ConfirmationDialog::_popup_base(p_rect);
 	}
 }
 

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -368,6 +368,7 @@ private:
 	virtual void _post_popup() override;
 
 protected:
+	virtual void _popup_base(const Rect2i &p_rect = Rect2i()) override;
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	bool _set(const StringName &p_name, const Variant &p_value) { return property_helper.property_set_value(p_name, p_value); }
@@ -385,7 +386,6 @@ protected:
 
 public:
 	virtual void set_visible(bool p_visible) override;
-	virtual void popup(const Rect2i &p_rect = Rect2i()) override;
 
 	void popup_file_dialog();
 	void clear_filters();

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3211,7 +3211,7 @@ String PopupMenu::_atr(int p_idx, const String &p_text) const {
 	ERR_FAIL_V_MSG(atr(p_text), "Unexpected auto translate mode: " + itos(items[p_idx].auto_translate_mode));
 }
 
-void PopupMenu::popup(const Rect2i &p_bounds) {
+void PopupMenu::_popup_base(const Rect2i &p_bounds) {
 	bool native = global_menu.is_valid();
 #ifdef TOOLS_ENABLED
 	if (is_part_of_edited_scene()) {
@@ -3230,7 +3230,7 @@ void PopupMenu::popup(const Rect2i &p_bounds) {
 		moved = Vector2();
 		popup_time_msec = OS::get_singleton()->get_ticks_msec();
 
-		Popup::popup(p_bounds);
+		Popup::_popup_base(p_bounds);
 	}
 }
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -237,6 +237,7 @@ protected:
 	virtual void remove_child_notify(Node *p_child) override;
 	virtual void _input_from_window(const Ref<InputEvent> &p_event) override;
 
+	virtual void _popup_base(const Rect2i &p_bounds = Rect2i()) override;
 	void _notification(int p_what);
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }
@@ -396,7 +397,6 @@ public:
 	void set_allow_search(bool p_allow);
 	bool get_allow_search() const;
 
-	virtual void popup(const Rect2i &p_bounds = Rect2i()) override;
 	virtual void set_visible(bool p_visible) override;
 
 	PopupMenu();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1941,7 +1941,17 @@ void Window::popup_centered_clamped(const Size2i &p_size, float p_fallback_ratio
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
 	}
 
-	popup(popup_rect);
+	emit_signal(SNAME("about_to_popup"));
+
+	if (popup_rect != Rect2()) {
+		set_size(popup_rect.size);
+	}
+	_pre_popup();
+	if (popup_rect != Rect2i()) {
+		popup_rect.size = get_size();
+		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
+	}
+	_popup_base(popup_rect);
 }
 
 void Window::popup_centered(const Size2i &p_minsize) {
@@ -1970,7 +1980,17 @@ void Window::popup_centered(const Size2i &p_minsize) {
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
 	}
 
-	popup(popup_rect);
+	emit_signal(SNAME("about_to_popup"));
+
+	if (popup_rect != Rect2()) {
+		set_size(popup_rect.size);
+	}
+	_pre_popup();
+	if (popup_rect != Rect2i()) {
+		popup_rect.size = get_size();
+		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
+	}
+	_popup_base(popup_rect);
 }
 
 void Window::popup_centered_ratio(float p_ratio) {
@@ -1997,14 +2017,36 @@ void Window::popup_centered_ratio(float p_ratio) {
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
 	}
 
-	popup(popup_rect);
+	emit_signal(SNAME("about_to_popup"));
+
+	if (popup_rect != Rect2()) {
+		set_size(popup_rect.size);
+	}
+	_pre_popup();
+	if (popup_rect != Rect2i()) {
+		popup_rect.size = get_size();
+		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
+	}
+	_popup_base(popup_rect);
 }
 
 void Window::popup(const Rect2i &p_screen_rect) {
 	ERR_MAIN_THREAD_GUARD;
 	emit_signal(SNAME("about_to_popup"));
 
+	Rect2i screen_rect = p_screen_rect;
+	if (screen_rect != Rect2i()) {
+		set_size(screen_rect.size);
+	}
 	_pre_popup();
+	if (screen_rect != Rect2i()) {
+		screen_rect.size = get_size();
+	}
+	_popup_base(screen_rect);
+}
+
+void Window::_popup_base(const Rect2i &p_screen_rect) {
+	ERR_MAIN_THREAD_GUARD;
 
 	if (!get_embedder() && get_flag(FLAG_POPUP)) {
 		// Send a focus-out notification when opening a Window Manager Popup.

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -261,6 +261,7 @@ private:
 	static int root_layout_direction;
 
 protected:
+	virtual void _popup_base(const Rect2i &p_screen_rect = Rect2i());
 	virtual void _pre_popup() {} // Called after "about_to_popup", but before window is shown.
 	virtual Rect2i _popup_adjust_rect() const { return Rect2i(); }
 	virtual void _post_popup() {}
@@ -409,7 +410,7 @@ public:
 	Window *get_non_popup_window() const;
 	Viewport *get_parent_viewport() const;
 
-	virtual void popup(const Rect2i &p_screen_rect = Rect2i());
+	void popup(const Rect2i &p_screen_rect = Rect2i());
 	void popup_on_parent(const Rect2i &p_parent_rect);
 	void popup_centered(const Size2i &p_minsize = Size2i());
 	void popup_centered_ratio(float p_ratio = 0.8);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112062

`_pre_popup` can change window size, and therefore, but `popup_centered` was overwriting it immediately after, now it's recalculating position instead.