### PR TITLE
Add MeshInstance3D upgrade code

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -988,6 +988,21 @@ Error ProjectSettings::_load_settings_text_or_binary(const String &p_text_path, 
 	// Fallback to text-based project.godot file if binary was not found.
 	err = _load_settings_text(p_text_path);
 	if (err == OK) {
+#ifndef DISABLE_DEPRECATED
+		const PackedStringArray features = get_setting("application/config/features");
+		for (const String &feat : features) {
+			if (feat.contains_char('.') && feat.get_slice_count(".") == 2) {
+				int major_version = feat.get_slicec('.', 0).to_int();
+				int minor_version = feat.get_slicec('.', 1).to_int();
+				// Major version is irrelevant, but the extra check ensures that the feature is in fact a version string.
+				if (major_version == 4 && minor_version < 6) {
+					// Enable MeshInstance3D compat for projects created before 4.6.
+					set_setting("animation/compatibility/default_parent_skeleton_in_mesh_instance_3d", true);
+				}
+				break;
+			}
+		}
+#endif
 		return OK;
 	} else if (err != ERR_FILE_NOT_FOUND) {
 		ERR_PRINT(vformat("Couldn't load file '%s', error code %d.", p_text_path, err));

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -284,6 +284,7 @@
 		</member>
 		<member name="animation/compatibility/default_parent_skeleton_in_mesh_instance_3d" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], [member MeshInstance3D.skeleton] will point to the parent node ([code]..[/code]) by default, which was the behavior before Godot 4.6. It's recommended to keep this setting disabled unless the old behavior is needed for compatibility.
+			[b]Note:[/b] If you disable this option in an existing project, it's strongly recommended to use the [code]Project &gt; Tools &gt; Upgrade Project Files...[/code] option to ensure existing scenes do not break.
 		</member>
 		<member name="animation/warnings/check_angle_interpolation_type_conflicting" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], [AnimationMixer] prints the warning of interpolation being forced to choose the shortest rotation path due to multiple angle interpolation types being mixed in the [AnimationMixer] cache.

--- a/editor/project_upgrade/project_upgrade_tool.cpp
+++ b/editor/project_upgrade/project_upgrade_tool.cpp
@@ -30,12 +30,14 @@
 
 #include "project_upgrade_tool.h"
 
+#include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "editor/editor_node.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/scene/editor_scene_tabs.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/dialogs.h"
 
 void ProjectUpgradeTool::_add_files(EditorFileSystemDirectory *p_dir, Vector<String> &r_reimport_paths, Vector<String> &r_resave_scenes, Vector<String> &r_resave_resources) {
@@ -77,6 +79,9 @@ void ProjectUpgradeTool::popup_dialog() {
 void ProjectUpgradeTool::prepare_upgrade() {
 	EditorSettings::get_singleton()->set_project_metadata(META_PROJECT_UPGRADE_TOOL, META_RUN_ON_RESTART, true);
 
+	ProjectSettings::get_singleton()->set_setting("animation/compatibility/default_parent_skeleton_in_mesh_instance_3d", false);
+	ProjectSettings::get_singleton()->save();
+
 	Vector<String> reimport_paths;
 	Vector<String> resave_scenes;
 	Vector<String> resave_resources;
@@ -102,6 +107,7 @@ void ProjectUpgradeTool::finish_upgrade() {
 	EditorFileSystem::get_singleton()->reimport_files(paths);
 	EditorSettings::get_singleton()->set_project_metadata(META_PROJECT_UPGRADE_TOOL, META_REIMPORT_PATHS, Variant());
 
+	MeshInstance3D::upgrading_skeleton_compat = true;
 	{
 		paths = EditorSettings::get_singleton()->get_project_metadata(META_PROJECT_UPGRADE_TOOL, META_RESAVE_SCENES, Vector<String>());
 		EditorProgress ep("uid_upgrade_resave", TTR("Updating Project Scenes"), paths.size());
@@ -115,6 +121,7 @@ void ProjectUpgradeTool::finish_upgrade() {
 		}
 		EditorSettings::get_singleton()->set_project_metadata(META_PROJECT_UPGRADE_TOOL, META_RESAVE_SCENES, Variant());
 	}
+	MeshInstance3D::upgrading_skeleton_compat = false;
 
 	{
 		paths = EditorSettings::get_singleton()->get_project_metadata(META_PROJECT_UPGRADE_TOOL, META_RESAVE_RESOURCES, Vector<String>());

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -342,6 +342,13 @@ void MeshInstance3D::create_multiple_convex_collisions(const Ref<MeshConvexDecom
 void MeshInstance3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+#ifndef DISABLE_DEPRECATED
+			if (upgrading_skeleton_compat) {
+				if (skeleton_path.is_empty() && Object::cast_to<Skeleton3D>(get_parent())) {
+					skeleton_path = NodePath("..");
+				}
+			}
+#endif
 			_resolve_skeleton_path();
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -75,6 +75,7 @@ public:
 
 #ifndef DISABLE_DEPRECATED
 	static inline bool use_parent_skeleton_compat = false;
+	static inline bool upgrading_skeleton_compat = false;
 #endif
 
 	void set_mesh(const Ref<Mesh> &p_mesh);


### PR DESCRIPTION
Follow-up to #112267
Supersedes #112605

*Bugsquad edit:*
- Fixes #112655
- Fixes #112863

Forcing no skeleton path has caused problems as expected, so this PR takes a bit different approach.
- When opening a project created before 4.6 (based on `features` setting), `default_parent_skeleton_in_mesh_instance_3d` is set to true
- Running the project upgrade tool will set the setting to false and fix the scenes

This takes away some advantages of #112267, as users need to be aware of the compat option to make use of it (unless they create a new project). I added a note in the docs and we should probably make a prominent note in the update blog post for next version.

Please test and provide a reproduction project if there are still problems. I got some weird results when testing this (although it seems to fix the problem).