### PR TITLE
[Wayland] Fix popups no showing if set to visible when added to the tree.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -638,7 +638,8 @@ bool Window::is_in_edited_scene_root() const {
 void Window::_make_window() {
 	ERR_FAIL_COND(window_id != DisplayServer::INVALID_WINDOW_ID);
 
-	if (transient && transient_to_focused) {
+	bool transient_upd = transient_to_focused || (transient_parent == nullptr && get_flag(FLAG_POPUP_WM_HINT) && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SELF_FITTING_WINDOWS));
+	if (transient && transient_upd) {
 		_make_transient();
 	}
 
@@ -1070,7 +1071,8 @@ void Window::set_transient(bool p_transient) {
 	}
 
 	if (transient) {
-		if (!transient_to_focused) {
+		bool transient_upd = transient_to_focused || (transient_parent != nullptr && get_flag(FLAG_POPUP_WM_HINT) && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SELF_FITTING_WINDOWS));
+		if (!transient_upd) {
 			_make_transient();
 		}
 	} else {
@@ -1551,7 +1553,8 @@ void Window::_notification(int p_what) {
 				}
 			}
 
-			if (transient && !transient_to_focused) {
+			bool transient_upd = transient_to_focused || (transient_parent != nullptr && get_flag(FLAG_POPUP_WM_HINT) && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SELF_FITTING_WINDOWS));
+			if (transient && !transient_upd) {
 				_make_transient();
 			}
 			if (visible) {
@@ -2002,6 +2005,12 @@ void Window::popup_centered_ratio(float p_ratio) {
 
 void Window::popup(const Rect2i &p_screen_rect) {
 	ERR_MAIN_THREAD_GUARD;
+
+	bool self_fit = DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SELF_FITTING_WINDOWS);
+	if (visible && self_fit) {
+		set_visible(false);
+	}
+
 	emit_signal(SNAME("about_to_popup"));
 
 	_pre_popup();
@@ -2017,7 +2026,7 @@ void Window::popup(const Rect2i &p_screen_rect) {
 	// Update window size to calculate the actual window size based on contents minimum size and minimum size.
 	_update_window_size();
 
-	bool should_fit = is_embedded() || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SELF_FITTING_WINDOWS);
+	bool should_fit = is_embedded() || !self_fit;
 
 	if (p_screen_rect != Rect2i()) {
 		set_position(p_screen_rect.position);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112589

- Wayland popups require parent top level window to work, which was not set when visible is already set when window is added to the tree.
- Also, hides popup first when `popup_*` is called and window is already visible, to allow autofitting it.