### PR TITLE
Add option to scale images in RichTextLabel relative to font size

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -34,16 +34,16 @@
 		<method name="add_image">
 			<return type="void" />
 			<param index="0" name="image" type="Texture2D" />
-			<param index="1" name="width" type="int" default="0" />
-			<param index="2" name="height" type="int" default="0" />
+			<param index="1" name="width" type="float" default="0" />
+			<param index="2" name="height" type="float" default="0" />
 			<param index="3" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="4" name="inline_align" type="int" enum="InlineAlignment" default="5" />
 			<param index="5" name="region" type="Rect2" default="Rect2(0, 0, 0, 0)" />
 			<param index="6" name="key" type="Variant" default="null" />
 			<param index="7" name="pad" type="bool" default="false" />
 			<param index="8" name="tooltip" type="String" default="&quot;&quot;" />
-			<param index="9" name="width_in_percent" type="bool" default="false" />
-			<param index="10" name="height_in_percent" type="bool" default="false" />
+			<param index="9" name="width_unit" type="int" enum="RichTextLabel.ImageUnit" default="0" />
+			<param index="10" name="height_unit" type="int" enum="RichTextLabel.ImageUnit" default="0" />
 			<param index="11" name="alt_text" type="String" default="&quot;&quot;" />
 			<description>
 				Adds an image's opening and closing tags to the tag stack, optionally providing a [param width] and [param height] to resize the image, a [param color] to tint the image and a [param region] to only use parts of the image.
@@ -51,8 +51,7 @@
 				If [param width] and [param height] are not set, but [param region] is, the region's rect will be used.
 				[param key] is an optional identifier, that can be used to modify the image via [method update_image].
 				If [param pad] is set, and the image is smaller than the size specified by [param width] and [param height], the image padding is added to match the size instead of upscaling.
-				If [param width_in_percent] is set, [param width] values are percentages of the control width instead of pixels.
-				If [param height_in_percent] is set, [param height] values are percentages of the control width instead of pixels.
+				Parameters [param width_unit] and [param height_unit] determine the units used to calculate the image width and height, respectively.
 				[param alt_text] is used as the image description for assistive apps.
 			</description>
 		</method>
@@ -698,15 +697,15 @@
 			<param index="0" name="key" type="Variant" />
 			<param index="1" name="mask" type="int" enum="RichTextLabel.ImageUpdateMask" is_bitfield="true" />
 			<param index="2" name="image" type="Texture2D" />
-			<param index="3" name="width" type="int" default="0" />
-			<param index="4" name="height" type="int" default="0" />
+			<param index="3" name="width" type="float" default="0" />
+			<param index="4" name="height" type="float" default="0" />
 			<param index="5" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="6" name="inline_align" type="int" enum="InlineAlignment" default="5" />
 			<param index="7" name="region" type="Rect2" default="Rect2(0, 0, 0, 0)" />
 			<param index="8" name="pad" type="bool" default="false" />
 			<param index="9" name="tooltip" type="String" default="&quot;&quot;" />
-			<param index="10" name="width_in_percent" type="bool" default="false" />
-			<param index="11" name="height_in_percent" type="bool" default="false" />
+			<param index="10" name="width_unit" type="int" enum="RichTextLabel.ImageUnit" default="0" />
+			<param index="11" name="height_unit" type="int" enum="RichTextLabel.ImageUnit" default="0" />
 			<description>
 				Updates the existing images with the key [param key]. Only properties specified by [param mask] bits are updated. See [method add_image].
 			</description>
@@ -903,8 +902,17 @@
 		<constant name="UPDATE_TOOLTIP" value="64" enum="ImageUpdateMask" is_bitfield="true">
 			If this bit is set, [method update_image] changes image tooltip.
 		</constant>
-		<constant name="UPDATE_WIDTH_IN_PERCENT" value="128" enum="ImageUpdateMask" is_bitfield="true">
-			If this bit is set, [method update_image] changes image width from/to percents.
+		<constant name="UPDATE_WIDTH_UNIT" value="128" enum="ImageUpdateMask" is_bitfield="true">
+			If this bit is set, [method update_image] changes the units used to calculate image size.
+		</constant>
+		<constant name="IMAGE_UNIT_PIXEL" value="0" enum="ImageUnit">
+			Images drawn with this unit will be in pixels.
+		</constant>
+		<constant name="IMAGE_UNIT_PERCENT" value="1" enum="ImageUnit">
+			Images drawn with this unit will be in percentages of the control width.
+		</constant>
+		<constant name="IMAGE_UNIT_EM" value="2" enum="ImageUnit">
+			Images drawn with this unit will be in percentages of the surrounding font size.
 		</constant>
 	</constants>
 	<theme_items>

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -2903,7 +2903,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			}
 
 			String image_path = bbcode.substr(brk_end + 1, end - brk_end - 1);
-			p_rt->add_image(ResourceLoader::load(image_path, "Texture2D"), width, height, Color(1, 1, 1), INLINE_ALIGNMENT_CENTER, Rect2(), Variant(), false, String(), size_in_percent);
+			p_rt->add_image(ResourceLoader::load(image_path, "Texture2D"), width, height, Color(1, 1, 1), INLINE_ALIGNMENT_CENTER, Rect2(), Variant(), false, String(), size_in_percent ? RichTextLabel::IMAGE_UNIT_PERCENT : RichTextLabel::IMAGE_UNIT_PIXEL);
 
 			pos = end;
 			tag_stack.push_front("img");

--- a/misc/extension_api_validation/4.6-stable/GH-112617.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-112617.txt
@@ -1,0 +1,21 @@
+GH-112617
+---------
+Validate extension JSON: API was removed: classes/RichTextLabel/enums/ImageUpdateMask/values/UPDATE_WIDTH_IN_PERCENT
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/10': default_value changed value in new API, from "false" to "0".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/10': type changed value in new API, from "bool" to "enum::RichTextLabel.ImageUnit".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/9': default_value changed value in new API, from "false" to "0".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/9': type changed value in new API, from "bool" to "enum::RichTextLabel.ImageUnit".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments/10': default_value changed value in new API, from "false" to "0".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments/10': type changed value in new API, from "bool" to "enum::RichTextLabel.ImageUnit".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments/11': default_value changed value in new API, from "false" to "0".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments/11': type changed value in new API, from "bool" to "enum::RichTextLabel.ImageUnit".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/1': meta changed value in new API, from "int32" to "float".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/1': type changed value in new API, from "int" to "float".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/2': meta changed value in new API, from "int32" to "float".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/2': type changed value in new API, from "int" to "float".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments/3': meta changed value in new API, from "int32" to "float".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments/3': type changed value in new API, from "int" to "float".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments/4': meta changed value in new API, from "int32" to "float".
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments/4': type changed value in new API, from "int" to "float".
+
+Arguments changed from bools to enums for a few methods. Compatibility methods registered.

--- a/scene/gui/rich_text_label.compat.inc
+++ b/scene/gui/rich_text_label.compat.inc
@@ -55,11 +55,11 @@ void RichTextLabel::_push_meta_bind_compat_89024(const Variant &p_meta) {
 }
 
 void RichTextLabel::_add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region) {
-	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, Variant(), false, String(), false, false, String());
+	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, Variant(), false, String(), IMAGE_UNIT_PIXEL, IMAGE_UNIT_PIXEL, String());
 }
 
 void RichTextLabel::_add_image_bind_compat_76829(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, const Variant &p_key, bool p_pad, const String &p_tooltip, bool p_size_in_percent) {
-	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, p_key, p_pad, p_tooltip, p_size_in_percent, p_size_in_percent, String());
+	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, p_key, p_pad, p_tooltip, p_size_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL, p_size_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL, String());
 }
 
 void RichTextLabel::_push_table_bind_compat_76829(int p_columns, InlineAlignment p_alignment, int p_align_to_row) {
@@ -79,11 +79,19 @@ void RichTextLabel::_push_strikethrough_bind_compat_106300() {
 }
 
 void RichTextLabel::_add_image_bind_compat_107347(const Ref<Texture2D> &p_image, int p_width, int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, const Variant &p_key, bool p_pad, const String &p_tooltip, bool p_size_in_percent, const String &p_alt_text) {
-	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, p_key, p_pad, p_tooltip, p_size_in_percent, p_size_in_percent, p_alt_text);
+	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, p_key, p_pad, p_tooltip, p_size_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL, p_size_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL, p_alt_text);
 }
 
 void RichTextLabel::_update_image_bind_compat_107347(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, int p_width, int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, bool p_pad, const String &p_tooltip, bool p_size_in_percent) {
-	update_image(p_key, p_mask, p_image, p_width, p_height, p_color, p_alignment, p_region, p_pad, p_tooltip, p_size_in_percent, p_size_in_percent);
+	update_image(p_key, p_mask, p_image, p_width, p_height, p_color, p_alignment, p_region, p_pad, p_tooltip, p_size_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL, p_size_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL);
+}
+
+void RichTextLabel::_add_image_bind_compat_112617(const Ref<Texture2D> &p_image, int p_width, int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, const Variant &p_key, bool p_pad, const String &p_tooltip, bool p_width_in_percent, bool p_height_in_percent, const String &p_alt_text) {
+	add_image(p_image, p_width, p_height, p_color, p_alignment, p_region, p_key, p_pad, p_tooltip, p_width_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL, p_height_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL, p_alt_text);
+}
+
+void RichTextLabel::_update_image_bind_compat_112617(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, int p_width, int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, bool p_pad, const String &p_tooltip, bool p_width_in_percent, bool p_height_in_percent) {
+	update_image(p_key, p_mask, p_image, p_width, p_height, p_color, p_alignment, p_region, p_pad, p_tooltip, p_width_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL, p_height_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL);
 }
 
 void RichTextLabel::_bind_compatibility_methods() {
@@ -100,6 +108,9 @@ void RichTextLabel::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("push_strikethrough"), &RichTextLabel::_push_strikethrough_bind_compat_106300);
 	ClassDB::bind_compatibility_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region", "key", "pad", "tooltip", "size_in_percent", "alt_text"), &RichTextLabel::_add_image_bind_compat_107347, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()), DEFVAL(Variant()), DEFVAL(false), DEFVAL(String()), DEFVAL(false), DEFVAL(String()));
 	ClassDB::bind_compatibility_method(D_METHOD("update_image", "key", "mask", "image", "width", "height", "color", "inline_align", "region", "pad", "tooltip", "size_in_percent"), &RichTextLabel::_update_image_bind_compat_107347, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()), DEFVAL(false), DEFVAL(String()), DEFVAL(false));
+
+	ClassDB::bind_compatibility_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region", "key", "pad", "tooltip", "width_in_percent", "height_in_percent", "alt_text"), &RichTextLabel::_add_image_bind_compat_112617, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()), DEFVAL(Variant()), DEFVAL(false), DEFVAL(String()), DEFVAL(false), DEFVAL(false), DEFVAL(String()));
+	ClassDB::bind_compatibility_method(D_METHOD("update_image", "key", "mask", "image", "width", "height", "color", "inline_align", "region", "pad", "tooltip", "width_in_percent", "height_in_percent"), &RichTextLabel::_update_image_bind_compat_112617, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()), DEFVAL(false), DEFVAL(String()), DEFVAL(false), DEFVAL(false));
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -559,8 +559,9 @@ float RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font
 			case ITEM_IMAGE: {
 				ItemImage *img = static_cast<ItemImage *>(it);
 				Size2 img_size = img->size;
-				if (img->width_in_percent || img->height_in_percent) {
-					img_size = _get_image_size(img->image, img->width_in_percent ? (p_width * img->rq_size.width / 100.f) : img->rq_size.width, img->height_in_percent ? (p_width * img->rq_size.height / 100.f) : img->rq_size.height, img->region);
+				if (img->width_unit == IMAGE_UNIT_PERCENT || img->height_unit == IMAGE_UNIT_PERCENT || img->width_unit == IMAGE_UNIT_EM || img->height_unit == IMAGE_UNIT_EM) {
+					Size2 new_size = _get_item_image_final_size(img, p_width, p_base_font_size);
+					img_size = _get_image_size(img->image, new_size.width, new_size.height, img->region);
 					l.text_buf->resize_object(it->rid, img_size, img->inline_align);
 					if (l.text_buf_disp.is_valid() && l.text_buf_disp->has_object(it->rid)) {
 						l.text_buf_disp->resize_object(it->rid, img_size, img->inline_align);
@@ -783,8 +784,9 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 			case ITEM_IMAGE: {
 				ItemImage *img = static_cast<ItemImage *>(it);
 				Size2 img_size = img->size;
-				if (img->width_in_percent || img->height_in_percent) {
-					img_size = _get_image_size(img->image, img->width_in_percent ? (p_width * img->rq_size.width / 100.f) : img->rq_size.width, img->height_in_percent ? (p_width * img->rq_size.height / 100.f) : img->rq_size.height, img->region);
+				if (img->width_unit == IMAGE_UNIT_PERCENT || img->height_unit == IMAGE_UNIT_PERCENT || img->width_unit == IMAGE_UNIT_EM || img->height_unit == IMAGE_UNIT_EM) {
+					Size2 new_size = _get_item_image_final_size(img, p_width, p_base_font_size);
+					img_size = _get_image_size(img->image, new_size.width, new_size.height, img->region);
 				}
 				l.text_buf->add_object(it->rid, img_size, img->inline_align, 1);
 				txt += String::chr(0xfffc);
@@ -884,6 +886,24 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 
 	l.offset.y = p_h;
 	return _calculate_line_vertical_offset(l);
+}
+
+Size2 RichTextLabel::_get_item_image_final_size(ItemImage *p_img, float p_orig_width, float p_base_font_size) {
+	Size2 new_size(p_img->rq_size);
+	ItemFontSize *font_size_it = _find_font_size(p_img);
+
+	if (p_img->width_unit == IMAGE_UNIT_PERCENT) {
+		new_size.width = p_orig_width * p_img->rq_size.width / 100.f;
+	} else if (p_img->width_unit == IMAGE_UNIT_EM) {
+		new_size.width = (font_size_it ? font_size_it->font_size : p_base_font_size) * p_img->rq_size.width;
+	}
+
+	if (p_img->height_unit == IMAGE_UNIT_PERCENT) {
+		new_size.height = p_orig_width * p_img->rq_size.height / 100.f;
+	} else if (p_img->height_unit == IMAGE_UNIT_EM) {
+		new_size.height = (font_size_it ? font_size_it->font_size : p_base_font_size) * p_img->rq_size.height;
+	}
+	return new_size;
 }
 
 void RichTextLabel::_update_table_column_width(ItemTable *p_table, int p_available_width) {
@@ -4304,7 +4324,7 @@ void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline)
 	queue_redraw();
 }
 
-Size2 RichTextLabel::_get_image_size(const Ref<Texture2D> &p_image, int p_width, int p_height, const Rect2 &p_region) {
+Size2 RichTextLabel::_get_image_size(const Ref<Texture2D> &p_image, float p_width, float p_height, const Rect2 &p_region) {
 	Size2 ret;
 	if (p_width > 0) {
 		// custom width
@@ -4367,8 +4387,8 @@ void RichTextLabel::add_hr(int p_width, int p_height, const Color &p_color, Hori
 	item->inline_align = INLINE_ALIGNMENT_CENTER;
 	item->rq_size = Size2(p_width, p_height);
 	item->size = _get_image_size(theme_cache.horizontal_rule, p_width, p_height, Rect2());
-	item->width_in_percent = p_width_in_percent;
-	item->height_in_percent = p_height_in_percent;
+	item->width_unit = p_width_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL;
+	item->height_unit = p_height_in_percent ? IMAGE_UNIT_PERCENT : IMAGE_UNIT_PIXEL;
 
 	item->image->connect_changed(callable_mp(this, &RichTextLabel::_texture_changed).bind(item->rid), CONNECT_REFERENCE_COUNTED);
 
@@ -4384,7 +4404,7 @@ void RichTextLabel::add_hr(int p_width, int p_height, const Color &p_color, Hori
 	}
 }
 
-void RichTextLabel::add_image(const Ref<Texture2D> &p_image, int p_width, int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, const Variant &p_key, bool p_pad, const String &p_tooltip, bool p_width_in_percent, bool p_height_in_percent, const String &p_alt_text) {
+void RichTextLabel::add_image(const Ref<Texture2D> &p_image, float p_width, float p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, const Variant &p_key, bool p_pad, const String &p_tooltip, ImageUnit p_width_unit, ImageUnit p_height_unit, const String &p_alt_text) {
 	_stop_thread();
 	MutexLock data_lock(data_mutex);
 
@@ -4415,8 +4435,8 @@ void RichTextLabel::add_image(const Ref<Texture2D> &p_image, int p_width, int p_
 	item->rq_size = Size2(p_width, p_height);
 	item->region = p_region;
 	item->size = _get_image_size(p_image, p_width, p_height, p_region);
-	item->width_in_percent = p_width_in_percent;
-	item->height_in_percent = p_height_in_percent;
+	item->width_unit = p_width_unit;
+	item->height_unit = p_height_unit;
 	item->pad = p_pad;
 	item->key = p_key;
 	item->tooltip = p_tooltip;
@@ -4428,7 +4448,7 @@ void RichTextLabel::add_image(const Ref<Texture2D> &p_image, int p_width, int p_
 	update_configuration_warnings();
 }
 
-void RichTextLabel::update_image(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, int p_width, int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, bool p_pad, const String &p_tooltip, bool p_width_in_percent, bool p_height_in_percent) {
+void RichTextLabel::update_image(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, float p_width, float p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region, bool p_pad, const String &p_tooltip, ImageUnit p_width_unit, ImageUnit p_height_unit) {
 	_stop_thread();
 	MutexLock data_lock(data_mutex);
 
@@ -4488,11 +4508,11 @@ void RichTextLabel::update_image(const Variant &p_key, BitField<ImageUpdateMask>
 						item->inline_align = p_alignment;
 					}
 				}
-				if (p_mask & UPDATE_WIDTH_IN_PERCENT) {
-					if (item->width_in_percent != p_width_in_percent || item->height_in_percent != p_height_in_percent) {
+				if (p_mask & UPDATE_WIDTH_UNIT) {
+					if (item->width_unit != p_width_unit || item->height_unit != p_height_unit) {
 						reshape = true;
-						item->width_in_percent = p_width_in_percent;
-						item->height_in_percent = p_height_in_percent;
+						item->width_unit = p_width_unit;
+						item->height_unit = p_height_unit;
 					}
 				}
 				if (p_mask & UPDATE_SIZE) {
@@ -6188,28 +6208,28 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 					alt_text = alt_text_option->value;
 				}
 
-				int width = 0;
-				int height = 0;
+				float width = 0;
+				float height = 0;
 				bool pad = false;
 				String tooltip;
-				bool width_in_percent = false;
-				bool height_in_percent = false;
+				ImageUnit width_unit = IMAGE_UNIT_PIXEL;
+				ImageUnit height_unit = IMAGE_UNIT_PIXEL;
 				if (!bbcode_value.is_empty()) {
 					int sep = bbcode_value.find_char('x');
 					if (sep == -1) {
 						if (bbcode_value.ends_with("%")) {
-							width_in_percent = true;
+							width_unit = IMAGE_UNIT_PERCENT;
 						}
-						width = bbcode_value.to_int();
+						width = bbcode_value.to_float();
 					} else {
 						if (bbcode_value.substr(0, sep).ends_with("%")) {
-							width_in_percent = true;
+							width_unit = IMAGE_UNIT_PERCENT;
 						}
-						width = bbcode_value.substr(0, sep).to_int();
+						width = bbcode_value.substr(0, sep).to_float();
 						if (bbcode_value.substr(sep + 1).ends_with("%")) {
-							height_in_percent = true;
+							width_unit = IMAGE_UNIT_PERCENT;
 						}
-						height = bbcode_value.substr(sep + 1).to_int();
+						height = bbcode_value.substr(sep + 1).to_float();
 					}
 				} else {
 					OptionMap::Iterator align_option = bbcode_options.find("align");
@@ -6246,17 +6266,25 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 					}
 					OptionMap::Iterator width_option = bbcode_options.find("width");
 					if (width_option) {
-						width = width_option->value.to_int();
+						width = width_option->value.to_float();
 						if (width_option->value.ends_with("%")) {
-							width_in_percent = true;
+							width = width_option->value.trim_suffix("%").to_float();
+							width_unit = IMAGE_UNIT_PERCENT;
+						} else if (width_option->value.ends_with("em")) {
+							width = width_option->value.trim_suffix("em").to_float();
+							width_unit = IMAGE_UNIT_EM;
 						}
 					}
 
 					OptionMap::Iterator height_option = bbcode_options.find("height");
 					if (height_option) {
-						height = height_option->value.to_int();
+						height = height_option->value.to_float();
 						if (height_option->value.ends_with("%")) {
-							height_in_percent = true;
+							height = height_option->value.trim_suffix("%").to_float();
+							height_unit = IMAGE_UNIT_PERCENT;
+						} else if (height_option->value.ends_with("em")) {
+							height = height_option->value.trim_suffix("em").to_float();
+							height_unit = IMAGE_UNIT_EM;
 						}
 					}
 
@@ -6271,7 +6299,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 					}
 				}
 
-				add_image(texture, width, height, color, (InlineAlignment)alignment, region, Variant(), pad, tooltip, width_in_percent, height_in_percent, alt_text);
+				add_image(texture, width, height, color, (InlineAlignment)alignment, region, Variant(), pad, tooltip, width_unit, height_unit, alt_text);
 			}
 
 			pos = end;
@@ -7741,8 +7769,8 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_text", "text"), &RichTextLabel::add_text);
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &RichTextLabel::set_text);
 	ClassDB::bind_method(D_METHOD("add_hr", "width", "height", "color", "alignment", "width_in_percent", "height_in_percent"), &RichTextLabel::add_hr, DEFVAL(90), DEFVAL(2), DEFVAL(Color(1, 1, 1, 1)), DEFVAL(HORIZONTAL_ALIGNMENT_CENTER), DEFVAL(true), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region", "key", "pad", "tooltip", "width_in_percent", "height_in_percent", "alt_text"), &RichTextLabel::add_image, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()), DEFVAL(Variant()), DEFVAL(false), DEFVAL(String()), DEFVAL(false), DEFVAL(false), DEFVAL(String()));
-	ClassDB::bind_method(D_METHOD("update_image", "key", "mask", "image", "width", "height", "color", "inline_align", "region", "pad", "tooltip", "width_in_percent", "height_in_percent"), &RichTextLabel::update_image, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()), DEFVAL(false), DEFVAL(String()), DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region", "key", "pad", "tooltip", "width_unit", "height_unit", "alt_text"), &RichTextLabel::add_image, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()), DEFVAL(Variant()), DEFVAL(false), DEFVAL(String()), DEFVAL(IMAGE_UNIT_PIXEL), DEFVAL(IMAGE_UNIT_PIXEL), DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("update_image", "key", "mask", "image", "width", "height", "color", "inline_align", "region", "pad", "tooltip", "width_unit", "height_unit"), &RichTextLabel::update_image, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()), DEFVAL(false), DEFVAL(String()), DEFVAL(IMAGE_UNIT_PIXEL), DEFVAL(IMAGE_UNIT_PIXEL));
 	ClassDB::bind_method(D_METHOD("newline"), &RichTextLabel::add_newline);
 	ClassDB::bind_method(D_METHOD("remove_paragraph", "paragraph", "no_invalidate"), &RichTextLabel::remove_paragraph, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("invalidate_paragraph", "paragraph"), &RichTextLabel::invalidate_paragraph);
@@ -7989,7 +8017,11 @@ void RichTextLabel::_bind_methods() {
 	BIND_BITFIELD_FLAG(UPDATE_REGION);
 	BIND_BITFIELD_FLAG(UPDATE_PAD);
 	BIND_BITFIELD_FLAG(UPDATE_TOOLTIP);
-	BIND_BITFIELD_FLAG(UPDATE_WIDTH_IN_PERCENT);
+	BIND_BITFIELD_FLAG(UPDATE_WIDTH_UNIT);
+
+	BIND_ENUM_CONSTANT(IMAGE_UNIT_PIXEL);
+	BIND_ENUM_CONSTANT(IMAGE_UNIT_PERCENT);
+	BIND_ENUM_CONSTANT(IMAGE_UNIT_EM);
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, RichTextLabel, normal_style, "normal");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, RichTextLabel, focus_style, "focus");

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -130,7 +130,13 @@ public:
 		UPDATE_REGION = 1 << 4,
 		UPDATE_PAD = 1 << 5,
 		UPDATE_TOOLTIP = 1 << 6,
-		UPDATE_WIDTH_IN_PERCENT = 1 << 7,
+		UPDATE_WIDTH_UNIT = 1 << 7,
+	};
+
+	enum ImageUnit {
+		IMAGE_UNIT_PIXEL,
+		IMAGE_UNIT_PERCENT,
+		IMAGE_UNIT_EM,
 	};
 
 protected:
@@ -153,7 +159,8 @@ protected:
 	void _push_strikethrough_bind_compat_106300();
 	void _add_image_bind_compat_107347(const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), const Variant &p_key = Variant(), bool p_pad = false, const String &p_tooltip = String(), bool p_size_in_percent = false, const String &p_alt_text = String());
 	void _update_image_bind_compat_107347(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), bool p_pad = false, const String &p_tooltip = String(), bool p_size_in_percent = false);
-
+	void _add_image_bind_compat_112617(const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), const Variant &p_key = Variant(), bool p_pad = false, const String &p_tooltip = String(), bool p_width_in_percent = false, bool p_height_in_percent = false, const String &p_alt_text = String());
+	void _update_image_bind_compat_112617(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), bool p_pad = false, const String &p_tooltip = String(), bool p_width_in_percent = false, bool p_height_in_percent = false);
 	static void _bind_compatibility_methods();
 #endif
 
@@ -271,8 +278,8 @@ private:
 		String alt_text;
 		InlineAlignment inline_align = INLINE_ALIGNMENT_CENTER;
 		bool pad = false;
-		bool width_in_percent = false;
-		bool height_in_percent = false;
+		ImageUnit width_unit = IMAGE_UNIT_PIXEL;
+		ImageUnit height_unit = IMAGE_UNIT_PIXEL;
 		Rect2 region;
 		Size2 size;
 		Size2 rq_size;
@@ -728,7 +735,8 @@ private:
 
 	void _invalidate_fonts();
 
-	Size2 _get_image_size(const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Rect2 &p_region = Rect2());
+	Size2 _get_image_size(const Ref<Texture2D> &p_image, float p_width = 0, float p_height = 0, const Rect2 &p_region = Rect2());
+	Size2 _get_item_image_final_size(ItemImage *p_img, float p_orig_width, float p_base_font_size);
 
 	String _get_prefix(Item *p_item, const Vector<int> &p_list_index, const Vector<ItemList *> &p_list_items);
 	void _add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l);
@@ -815,8 +823,8 @@ public:
 	String get_parsed_text() const;
 	void add_text(const String &p_text);
 	void add_hr(int p_width = 90, int p_height = 2, const Color &p_color = Color(1.0, 1.0, 1.0), HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, bool p_width_in_percent = true, bool p_height_in_percent = false);
-	void add_image(const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), const Variant &p_key = Variant(), bool p_pad = false, const String &p_tooltip = String(), bool p_width_in_percent = false, bool p_height_in_percent = false, const String &p_alt_text = String());
-	void update_image(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), bool p_pad = false, const String &p_tooltip = String(), bool p_width_in_percent = false, bool p_height_in_percent = false);
+	void add_image(const Ref<Texture2D> &p_image, float p_width = 0, float p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), const Variant &p_key = Variant(), bool p_pad = false, const String &p_tooltip = String(), ImageUnit p_width_unit = IMAGE_UNIT_PIXEL, ImageUnit p_height_unit = IMAGE_UNIT_PIXEL, const String &p_alt_text = String());
+	void update_image(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, float p_width = 0, float p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), bool p_pad = false, const String &p_tooltip = String(), ImageUnit p_width_unit = IMAGE_UNIT_PIXEL, ImageUnit p_height_unit = IMAGE_UNIT_PIXEL);
 	void add_newline();
 	bool remove_paragraph(int p_paragraph, bool p_no_invalidate = false);
 	bool invalidate_paragraph(int p_paragraph);
@@ -1028,3 +1036,4 @@ VARIANT_ENUM_CAST(RichTextLabel::ListType);
 VARIANT_ENUM_CAST(RichTextLabel::MenuItems);
 VARIANT_ENUM_CAST(RichTextLabel::MetaUnderline);
 VARIANT_BITFIELD_CAST(RichTextLabel::ImageUpdateMask);
+VARIANT_ENUM_CAST(RichTextLabel::ImageUnit);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13609.

This PR allows `img` tags in RichTextLabels to specify `height` and `width` with the `em` suffix, which makes the values a percentage of the surrounding text's font size.

For example, the following text:
```
Do you have any [img height=1em]coin.png[/img] coins?
...I said, [font_size=50]DO YOU HAVE ANY [img height=1em]coin.png[/img] COINS??[/font_size]
```
Displays like this:
<img width="1384" height="178" alt="CleanShot 2025-11-10 at 10 07 05@2x" src="https://github.com/user-attachments/assets/35c124f7-512f-4f7a-9eff-8cc72e261804" />
