### PR TITLE
Change prev/next button theme variation to FlatButton for FileSystem and Inspector dock

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -4261,14 +4261,14 @@ FileSystemDock::FileSystemDock() {
 	toolbar_hbc->add_child(nav_hbc);
 
 	button_hist_prev = memnew(Button);
-	button_hist_prev->set_flat(true);
+	button_hist_prev->set_theme_type_variation(SceneStringName(FlatButton));
 	button_hist_prev->set_disabled(true);
 	button_hist_prev->set_focus_mode(FOCUS_ACCESSIBILITY);
 	button_hist_prev->set_tooltip_text(TTRC("Go to previous selected folder/file."));
 	nav_hbc->add_child(button_hist_prev);
 
 	button_hist_next = memnew(Button);
-	button_hist_next->set_flat(true);
+	button_hist_next->set_theme_type_variation(SceneStringName(FlatButton));
 	button_hist_next->set_disabled(true);
 	button_hist_next->set_focus_mode(FOCUS_ACCESSIBILITY);
 	button_hist_next->set_tooltip_text(TTRC("Go to next selected folder/file."));

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -764,14 +764,14 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	general_options_hb->add_spacer();
 
 	backward_button = memnew(Button);
-	backward_button->set_flat(true);
+	backward_button->set_theme_type_variation(SceneStringName(FlatButton));
 	general_options_hb->add_child(backward_button);
 	backward_button->set_tooltip_text(TTRC("Go to previous edited object in history."));
 	backward_button->set_disabled(true);
 	backward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_back));
 
 	forward_button = memnew(Button);
-	forward_button->set_flat(true);
+	forward_button->set_theme_type_variation(SceneStringName(FlatButton));
 	general_options_hb->add_child(forward_button);
 	forward_button->set_tooltip_text(TTRC("Go to next edited object in history."));
 	forward_button->set_disabled(true);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/112619

Before/After

<img width="282" height="305" alt="Screenshot_20251110_210717" src="https://github.com/user-attachments/assets/22ef3dcf-39ba-4727-9f8a-daafb165547b" />

<img width="282" height="305" alt="Screenshot_20251110_210854" src="https://github.com/user-attachments/assets/3d159cdd-d817-4661-8158-321bd820e70a" />

Width of the prev/next buttons is a bit less then before
This also adds a hover state.

For Classic theme the only change should be the hover state:

Before/After

<img width="287" height="159" alt="Screenshot_20251110_214709" src="https://github.com/user-attachments/assets/842f26ef-12b2-4ccf-b07a-8499a9522df2" />

<img width="287" height="159" alt="Screenshot_20251110_214814" src="https://github.com/user-attachments/assets/8669b8d5-0bc9-4b87-98a2-e02b57683f01" />

