### PR TITLE
Add `@display_if` annotation to GDScript

### DIFF
--- a/editor/inspector/display_if_editor_plugin.cpp
+++ b/editor/inspector/display_if_editor_plugin.cpp
@@ -1,0 +1,74 @@
+/**************************************************************************/
+/*  display_if_editor_plugin.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "display_if_editor_plugin.h"
+
+#include "editor_properties.h"
+
+bool EditorInspectorDisplayIfPlugin::can_handle(Object *p_object) {
+	return true;
+}
+
+bool EditorInspectorDisplayIfPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
+	if (!p_hint_text.contains("condition:") || !p_usage.has_flag(PROPERTY_USAGE_EDITOR)) {
+		return false;
+	}
+
+	Vector<String> slices = p_hint_text.split(",");
+	String property_name;
+
+	for (String slice : slices) {
+		if (slice.contains("condition:")) {
+			property_name = slice.lstrip("condition:");
+		}
+	}
+
+	Variant value = p_object->get(property_name);
+
+	ERR_FAIL_COND_V_MSG(value.get_type() == Variant::NIL, false, vformat(R"(Unable to obtain property "%s" in "@display_if".)", property_name));
+	ERR_FAIL_COND_V_MSG(value.get_type() != Variant::BOOL, false, vformat(R"(The value of property "%s" in "@display_if" is %s, but bool was expected.)", p_hint_text, Variant::get_type_name(value.get_type())));
+
+	const bool condition = value;
+
+	if (!condition) {
+		EditorProperty *editor = EditorInspectorDefaultPlugin::get_editor_for_property(p_object, p_type, p_path, p_hint, p_hint_text, p_usage, p_wide);
+		editor->hide();
+		add_custom_control(editor);
+		return true;
+	}
+
+	return false;
+}
+
+DisplayIfEditorPlugin::DisplayIfEditorPlugin() {
+	Ref<EditorInspectorDisplayIfPlugin> plugin;
+	plugin.instantiate();
+	add_inspector_plugin(plugin);
+}

--- a/editor/inspector/display_if_editor_plugin.h
+++ b/editor/inspector/display_if_editor_plugin.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  display_if_editor_plugin.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/plugins/editor_plugin.h"
+#include "editor_inspector.h"
+
+class EditorInspectorDisplayIfPlugin : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorDisplayIfPlugin, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide = false) override;
+};
+
+class DisplayIfEditorPlugin : public EditorPlugin {
+	GDCLASS(DisplayIfEditorPlugin, EditorPlugin);
+
+public:
+	virtual String get_plugin_name() const override { return "ExportIfEditorPlugin"; }
+
+	DisplayIfEditorPlugin();
+};

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -67,6 +67,7 @@
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
 #include "editor/import/resource_importer_wav.h"
+#include "editor/inspector/display_if_editor_plugin.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/editor_resource_picker.h"
 #include "editor/inspector/editor_resource_preview.h"
@@ -225,6 +226,7 @@ void register_editor_types() {
 		EditorPlugins::add_by_type<DebugAdapterServer>();
 	}
 	EditorPlugins::add_by_type<EditorScriptPlugin>();
+	EditorPlugins::add_by_type<DisplayIfEditorPlugin>();
 	EditorPlugins::add_by_type<FontEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticles3DEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticlesCollisionSDF3DEditorPlugin>();

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -317,6 +317,17 @@
 				[/codeblock]
 			</description>
 		</annotation>
+		<annotation name="@display_if">
+			<return type="void" />
+			<param index="0" name="condition" type="String" />
+			<description>
+				Mark any property as exported if the [param condition] is true. [param condition] must be the name of a [bool] property.
+				[codeblock]
+				@export var is_alive = true
+				@export @display_if("is_alive") var health: int
+				[/codeblock]
+			</description>
+		</annotation>
 		<annotation name="@export">
 			<return type="void" />
 			<description>

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -981,6 +981,7 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 				}
 			}
 		}
+	} else if (p_annotation->name == SNAME("@display_if")) {
 	} else if (p_annotation->name == SNAME("@export_custom")) {
 		switch (p_argument) {
 			case 0: {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1530,6 +1530,7 @@ private:
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool abstract_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool display_if_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);


### PR DESCRIPTION
# Overview

This PR allows you to conditionally hide/show exported properties based on a bool with a new `@export_if` annotation:
```gdscript
# Before (needs @tool):
@export var is_alive : bool:
	set(value):
		is_alive = value
		notify_property_list_changed()
@export var health: int

func _validate_property(property: Dictionary):
	if property.name == "number" and not is_alive:
		property.usage |= ~PROPERTY_USAGE_EDITOR


# After (doesn't need @tool):
@export var is_alive := true
@export @display_if("is_alive") var health: int
```

It works by adding "condition: {argument}"  `hint_string`. Then in an `EditorInspectorPlugin` (alongside an `EditorPlugin`), we use `get()` on the object to obtain the condition, if it doesn't exist or isn't a `bool`, it fails and throws an error. Then, if the condition is true, we hide the property's associated `EditorProperty`.

The argument has to be the name of a boolean that's declared (either via static typing or by assigning a default value). Passing a `bool` instead of a `String` is not possible, more info on this in the [proposal (comment)](https://github.com/godotengine/godot-proposals/issues/9842#issuecomment-2136587725).

Closes godotengine/godot-proposals#9842

## Known issues

- Doing the equivalent of `@display_if` with `[Export(hintString : "condition: ConditionName")]` in C# does not properly hide certain data types (Node, Resource, typed Array, typed Dictionary and possibly more)

# TODO

- [ ] Find a way to automatically update the inspector instead of having to click away (need help on this one)
- [ ] Investigate possibility of adding a `[ExportIf(bool condition)]` attribute in C#, possibly in another PR
- [ ] Figure out if autocompletion is possible, and if so how (haven't looked into this yet)
- [ ] Add this to properties exported by the editor where it fits