### PR TITLE
Fix incorrect bottom panel theming

### DIFF
--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -56,7 +56,7 @@ void EditorBottomPanel::_on_tab_changed(int p_idx) {
 }
 
 void EditorBottomPanel::_theme_changed() {
-	Ref<StyleBox> bottom_tabbar_style = get_theme_stylebox("tabbar_background", "BottomPanel")->duplicate();
+	Ref<StyleBox> bottom_tabbar_style = EditorNode::get_singleton()->get_editor_theme()->get_stylebox("tabbar_background", "BottomPanel")->duplicate();
 	bottom_tabbar_style->set_content_margin(SIDE_RIGHT, bottom_hbox->get_minimum_size().x + bottom_tabbar_style->get_content_margin(SIDE_LEFT));
 	add_theme_style_override("tabbar_background", bottom_tabbar_style);
 


### PR DESCRIPTION
Closes #112611

Previously, if the editor theme was changed, the bottom panel's background would not be updated. This is because when the bottom panel retrieved the necessary stylebox it retrieved the overridden previous theme rather than the new theme. Removing the override is a simple method to force the retrieved stylebox to be correct.

I'm not too sure why it retrieved the override in the first place because overrides are specific to nodes but this method worked well.