### PR TITLE
Avoid extra copy in `Vector`/`CowData` `push_back`/`insert`

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -206,8 +206,8 @@ public:
 
 	_FORCE_INLINE_ void remove_at(Size p_index);
 
-	Error insert(Size p_pos, const T &p_val);
-	Error push_back(const T &p_val);
+	Error insert(Size p_pos, T &&p_val);
+	Error push_back(T &&p_val);
 
 	_FORCE_INLINE_ operator Span<T>() const { return Span<T>(ptr(), size()); }
 	_FORCE_INLINE_ Span<T> span() const { return operator Span<T>(); }
@@ -296,7 +296,7 @@ void CowData<T>::remove_at(Size p_index) {
 }
 
 template <typename T>
-Error CowData<T>::insert(Size p_pos, const T &p_val) {
+Error CowData<T>::insert(Size p_pos, T &&p_val) {
 	const Size new_size = size() + 1;
 	ERR_FAIL_INDEX_V(p_pos, new_size, ERR_INVALID_PARAMETER);
 
@@ -326,13 +326,13 @@ Error CowData<T>::insert(Size p_pos, const T &p_val) {
 	}
 
 	// Create the new element at the given index.
-	memnew_placement(_ptr + p_pos, T(p_val));
+	memnew_placement(_ptr + p_pos, T(std::move(p_val)));
 
 	return OK;
 }
 
 template <typename T>
-Error CowData<T>::push_back(const T &p_val) {
+Error CowData<T>::push_back(T &&p_val) {
 	const Size new_size = size() + 1;
 
 	if (!_ptr) {
@@ -361,7 +361,7 @@ Error CowData<T>::push_back(const T &p_val) {
 	}
 
 	// Create the new element at the given index.
-	memnew_placement(_ptr + new_size - 1, T(p_val));
+	memnew_placement(_ptr + new_size - 1, T(std::move(p_val)));
 
 	return OK;
 }

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -71,8 +71,8 @@ private:
 
 public:
 	// Must take a copy instead of a reference (see GH-31736).
-	_FORCE_INLINE_ bool push_back(T p_elem) { return _cowdata.push_back(p_elem); }
-	_FORCE_INLINE_ bool append(const T &p_elem) { return push_back(p_elem); } //alias
+	_FORCE_INLINE_ bool push_back(T p_elem) { return _cowdata.push_back(std::move(p_elem)); }
+	_FORCE_INLINE_ bool append(T p_elem) { return _cowdata.push_back(std::move(p_elem)); } //alias
 	void fill(T p_elem);
 
 	void remove_at(Size p_index) { _cowdata.remove_at(p_index); }
@@ -133,7 +133,7 @@ public:
 
 	_FORCE_INLINE_ const T &operator[](Size p_index) const { return _cowdata.get(p_index); }
 	// Must take a copy instead of a reference (see GH-31736).
-	Error insert(Size p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }
+	Error insert(Size p_pos, T p_val) { return _cowdata.insert(p_pos, std::move(p_val)); }
 	Size find(const T &p_val, Size p_from = 0) const {
 		if (p_from < 0) {
 			p_from = size() + p_from;


### PR DESCRIPTION
Update `push_back`/`insert` methods to move new item into `CowData` instead of copying.

This mainly helps with `String`/`RefCounted` types, making `Array.push_back` around 20% faster for these types, and similar improvement for `String.split`, compared with gdscript below:

```gdscript
func _ready():
	run_test("array_push_back_int")
	run_test("array_push_back_str")
	run_test("array_push_back_refcounted")
	run_test("string_split")
	run_test("array_insert_str")

func run_test(test_name: String):
	var start := Time.get_ticks_msec()
	call(test_name)
	var end := Time.get_ticks_msec()
	print("%s: %dms" % [test_name.rpad(27), end - start])

func array_push_back_int():
	var a := []
	for i in 3000000:
		a.push_back(i)
		
func array_push_back_str():
	var a := []
	for i in 3000000:
		a.push_back("test")
		
func array_push_back_refcounted():
	var a := []
	var regex := RegEx.new()
	for i in 3000000:
		a.push_back(regex)

func string_split():
	var s := "1,2,3,4,5,6,7,8,9"
	for i in 500000:
		s.split()

func array_insert_str():
	var a := []
	for i in 3000000:
		a.insert(a.size(), "test")
```
old:
```
array_push_back_int        : 119ms
array_push_back_str        : 218ms
array_push_back_refcounted : 198ms
string_split               : 555ms
array_insert_str           : 218ms
```
new:
```
array_push_back_int        : 104ms
array_push_back_str        : 163ms
array_push_back_refcounted : 160ms
string_split               : 460ms
array_insert_str           : 181ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
