### PR TITLE
Fix PackedScene instantiate losing collection types if property default is NIL

### DIFF
--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -317,3 +317,65 @@ Ref<Script> PropertyUtils::get_custom_type_script(const Object *p_object) {
 	}
 	return ResourceLoader::load(custom_script);
 }
+
+void PropertyUtils::parse_array_hint_string(const String &p_hint_string, Variant::Type &r_subtype, PropertyHint &r_subtype_hint, String *r_subtype_hint_string) {
+	r_subtype = Variant::NIL;
+	r_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+	if (r_subtype_hint_string) {
+		*r_subtype_hint_string = String();
+	}
+
+	if (p_hint_string.is_empty()) {
+		return;
+	}
+
+	int hint_subtype_separator = p_hint_string.find_char(':');
+	if (hint_subtype_separator >= 0) {
+		String subtype_string = p_hint_string.substr(0, hint_subtype_separator);
+		int slash_pos = subtype_string.find_char('/');
+		if (slash_pos >= 0) {
+			r_subtype_hint = PropertyHint(subtype_string.substr(slash_pos + 1).to_int());
+			subtype_string = subtype_string.substr(0, slash_pos);
+		}
+
+		if (r_subtype_hint_string) {
+			*r_subtype_hint_string = p_hint_string.substr(hint_subtype_separator + 1);
+		}
+		r_subtype = Variant::Type(subtype_string.to_int());
+	} else {
+		r_subtype = Variant::get_type_by_name(p_hint_string);
+
+		if (r_subtype == Variant::VARIANT_MAX) {
+			r_subtype = Variant::OBJECT;
+			r_subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
+			if (r_subtype_hint_string) {
+				*r_subtype_hint_string = p_hint_string;
+			}
+		}
+	}
+}
+
+void PropertyUtils::parse_dictionary_hint_string(const String &p_hint_string, Variant::Type &r_key_subtype, PropertyHint &r_key_subtype_hint, Variant::Type &r_value_subtype, PropertyHint &r_value_subtype_hint, String *r_key_subtype_hint_string, String *r_value_subtype_hint_string) {
+	r_key_subtype = Variant::NIL;
+	r_key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+	if (r_key_subtype_hint_string) {
+		*r_key_subtype_hint_string = String();
+	}
+	r_value_subtype = Variant::NIL;
+	r_value_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+	if (r_value_subtype_hint_string) {
+		*r_value_subtype_hint_string = String();
+	}
+	if (p_hint_string.is_empty()) {
+		return;
+	}
+
+	// Missing ; separator is treated as key only.
+	int key_value_separator = p_hint_string.find_char(';');
+	String key_hint_string = p_hint_string.substr(0, key_value_separator);
+	parse_array_hint_string(key_hint_string, r_key_subtype, r_key_subtype_hint, r_key_subtype_hint_string);
+	if (key_value_separator >= 0) {
+		String value_hint_string = p_hint_string.substr(key_value_separator + 1);
+		parse_array_hint_string(value_hint_string, r_value_subtype, r_value_subtype_hint, r_value_subtype_hint_string);
+	}
+}

--- a/scene/property_utils.h
+++ b/scene/property_utils.h
@@ -48,4 +48,7 @@ public:
 
 	static void assign_custom_type_script(Object *p_object, const Ref<Script> &p_script);
 	static Ref<Script> get_custom_type_script(const Object *p_object);
+
+	static void parse_array_hint_string(const String &p_hint_string, Variant::Type &r_subtype, PropertyHint &r_subtype_hint, String *r_subtype_hint_string = nullptr);
+	static void parse_dictionary_hint_string(const String &p_hint_string, Variant::Type &r_key_subtype, PropertyHint &r_key_subtype_hint, Variant::Type &r_value_subtype, PropertyHint &r_value_subtype_hint, String *r_key_subtype_hint_string = nullptr, String *r_value_subtype_hint_string = nullptr);
 };

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -441,6 +441,9 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 				Dictionary missing_resource_properties;
 
+				List<PropertyInfo> p_list;
+				node->get_property_list(&p_list);
+
 				for (int j = 0; j < nprop_count; j++) {
 					bool valid;
 
@@ -464,6 +467,12 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 						dnp.value = props[nprops[j].value];
 						dnp.base = node->get_instance_id();
 						dnp.property = snames[name_idx];
+						for (const PropertyInfo &E : p_list) {
+							if (E.name == snames[name_idx]) {
+								dnp.property_hint_string = E.hint_string;
+								break;
+							}
+						}
 						deferred_node_paths.push_back(dnp);
 						continue;
 					}
@@ -499,6 +508,10 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 						node->set_script(props[nprops[j].value]);
 #endif // TOOLS_ENABLED
 
+						// Script can modify property list, so get the updated list.
+						p_list.clear();
+						node->get_property_list(&p_list);
+
 						//restore old state for new script, if exists
 						for (const Pair<StringName, Variant> &E : old_state) {
 							node->set(E.first, E.second);
@@ -532,6 +545,26 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 								} else {
 									set_array = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
 								}
+							} else {
+								String hint_string;
+								for (const PropertyInfo &E : p_list) {
+									if (E.name == snames[nprops[j].name]) {
+										hint_string = E.hint_string;
+										break;
+									}
+								}
+
+								Variant::Type subtype;
+								PropertyHint subtype_hint;
+								String subtype_hint_string;
+								PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+								StringName subtype_class_name;
+								Ref<Script> subtype_script;
+								if (subtype == Variant::OBJECT) {
+									_get_class_from_hint_string(subtype_hint_string, subtype_class_name, subtype_script);
+								}
+								set_array = Array(set_array, subtype, subtype_class_name, subtype_script);
 							}
 
 							value = setup_resources_in_array(set_array, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
@@ -549,6 +582,36 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 								} else {
 									set_dict = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(), get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
 								}
+							} else {
+								String hint_string;
+								for (const PropertyInfo &E : p_list) {
+									if (E.name == snames[nprops[j].name]) {
+										hint_string = E.hint_string;
+										break;
+									}
+								}
+
+								Variant::Type key_subtype;
+								PropertyHint key_subtype_hint;
+								String key_subtype_hint_string;
+								Variant::Type value_subtype;
+								PropertyHint value_subtype_hint;
+								String value_subtype_hint_string;
+								PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+								StringName key_subtype_class_name;
+								Ref<Script> key_subtype_script;
+								if (key_subtype == Variant::OBJECT) {
+									_get_class_from_hint_string(key_subtype_hint_string, key_subtype_class_name, key_subtype_script);
+								}
+
+								StringName value_subtype_class_name;
+								Ref<Script> value_subtype_script;
+								if (value_subtype == Variant::OBJECT) {
+									_get_class_from_hint_string(value_subtype_hint_string, value_subtype_class_name, value_subtype_script);
+								}
+
+								set_dict = Dictionary(set_dict, key_subtype, key_subtype_class_name, key_subtype_script, value_subtype, value_subtype_class_name, value_subtype_script);
 							}
 
 							value = setup_resources_in_dictionary(set_dict, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
@@ -675,9 +738,26 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			Array paths = dnp.value;
 
 			bool valid;
-			Array array = base->get(dnp.property, &valid);
+			Variant get_value = base->get(dnp.property, &valid);
+
 			ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
-			array = array.duplicate();
+			Array array;
+			if (get_value.get_type() == Variant::ARRAY) {
+				array = get_value;
+				array = array.duplicate();
+			} else {
+				Variant::Type subtype;
+				PropertyHint subtype_hint;
+				String subtype_hint_string;
+				PropertyUtils::parse_array_hint_string(dnp.property_hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+				StringName subtype_class_name;
+				Ref<Script> subtype_script;
+				if (subtype == Variant::OBJECT) {
+					_get_class_from_hint_string(subtype_hint_string, subtype_class_name, subtype_script);
+				}
+				array.set_typed(subtype, subtype_class_name, subtype_script);
+			}
 
 			array.resize(paths.size());
 			for (int i = 0; i < array.size(); i++) {
@@ -688,9 +768,36 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			Dictionary paths = dnp.value;
 
 			bool valid;
-			Dictionary dict = base->get(dnp.property, &valid);
+			Variant get_value = base->get(dnp.property, &valid);
 			ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
-			dict = dict.duplicate();
+			Dictionary dict;
+			if (get_value.get_type() == Variant::DICTIONARY) {
+				dict = get_value;
+				dict = dict.duplicate();
+			} else {
+				Variant::Type key_subtype;
+				PropertyHint key_subtype_hint;
+				String key_subtype_hint_string;
+				Variant::Type value_subtype;
+				PropertyHint value_subtype_hint;
+				String value_subtype_hint_string;
+				PropertyUtils::parse_dictionary_hint_string(dnp.property_hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+				StringName key_subtype_class_name;
+				Ref<Script> key_subtype_script;
+				if (key_subtype == Variant::OBJECT) {
+					_get_class_from_hint_string(key_subtype_hint_string, key_subtype_class_name, key_subtype_script);
+				}
+
+				StringName value_subtype_class_name;
+				Ref<Script> value_subtype_script;
+				if (value_subtype == Variant::OBJECT) {
+					_get_class_from_hint_string(value_subtype_hint_string, value_subtype_class_name, value_subtype_script);
+				}
+
+				dict.set_typed(key_subtype, key_subtype_class_name, key_subtype_script, value_subtype, value_subtype_class_name, value_subtype_script);
+			}
+
 			bool convert_key = dict.get_typed_key_builtin() == Variant::OBJECT &&
 					ClassDB::is_parent_class(dict.get_typed_key_class_name(), "Node");
 			bool convert_value = dict.get_typed_value_builtin() == Variant::OBJECT &&
@@ -973,80 +1080,54 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				value = missing_resource_properties[E.name];
 			}
 		} else if (E.type == Variant::ARRAY && E.hint == PROPERTY_HINT_TYPE_STRING) {
-			int hint_subtype_separator = E.hint_string.find_char(':');
-			if (hint_subtype_separator >= 0) {
-				String subtype_string = E.hint_string.substr(0, hint_subtype_separator);
-				int slash_pos = subtype_string.find_char('/');
-				PropertyHint subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
-				if (slash_pos >= 0) {
-					subtype_hint = PropertyHint(subtype_string.get_slicec('/', 1).to_int());
-					subtype_string = subtype_string.substr(0, slash_pos);
-				}
-				Variant::Type subtype = Variant::Type(subtype_string.to_int());
-
-				if (subtype == Variant::OBJECT && subtype_hint == PROPERTY_HINT_NODE_TYPE) {
-					use_deferred_node_path_bit = true;
-					Array array = value;
-					Array new_array;
-					for (int i = 0; i < array.size(); i++) {
-						Variant elem = array[i];
-						if (elem.get_type() == Variant::OBJECT) {
-							if (Node *n = Object::cast_to<Node>(elem)) {
-								new_array.push_back(p_node->get_path_to(n));
-								continue;
-							}
+			Variant::Type subtype;
+			PropertyHint subtype_hint;
+			PropertyUtils::parse_array_hint_string(E.hint_string, subtype, subtype_hint);
+			if (subtype == Variant::OBJECT && subtype_hint == PROPERTY_HINT_NODE_TYPE) {
+				use_deferred_node_path_bit = true;
+				Array array = value;
+				Array new_array;
+				for (int i = 0; i < array.size(); i++) {
+					Variant elem = array[i];
+					if (elem.get_type() == Variant::OBJECT) {
+						if (Node *n = Object::cast_to<Node>(elem)) {
+							new_array.push_back(p_node->get_path_to(n));
+							continue;
 						}
-						new_array.push_back(elem);
 					}
-					value = new_array;
+					new_array.push_back(elem);
 				}
+				value = new_array;
 			}
 		} else if (E.type == Variant::DICTIONARY && E.hint == PROPERTY_HINT_TYPE_STRING) {
-			int key_value_separator = E.hint_string.find_char(';');
-			if (key_value_separator >= 0) {
-				int key_subtype_separator = E.hint_string.find_char(':');
-				String key_subtype_string = E.hint_string.substr(0, key_subtype_separator);
-				int key_slash_pos = key_subtype_string.find_char('/');
-				PropertyHint key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
-				if (key_slash_pos >= 0) {
-					key_subtype_hint = PropertyHint(key_subtype_string.get_slicec('/', 1).to_int());
-					key_subtype_string = key_subtype_string.substr(0, key_slash_pos);
-				}
-				Variant::Type key_subtype = Variant::Type(key_subtype_string.to_int());
-				bool convert_key = key_subtype == Variant::OBJECT && key_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+			Variant::Type key_subtype;
+			PropertyHint key_subtype_hint;
+			Variant::Type value_subtype;
+			PropertyHint value_subtype_hint;
+			PropertyUtils::parse_dictionary_hint_string(E.hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint);
 
-				int value_subtype_separator = E.hint_string.find_char(':', key_value_separator) - (key_value_separator + 1);
-				String value_subtype_string = E.hint_string.substr(key_value_separator + 1, value_subtype_separator);
-				int value_slash_pos = value_subtype_string.find_char('/');
-				PropertyHint value_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
-				if (value_slash_pos >= 0) {
-					value_subtype_hint = PropertyHint(value_subtype_string.get_slicec('/', 1).to_int());
-					value_subtype_string = value_subtype_string.substr(0, value_slash_pos);
-				}
-				Variant::Type value_subtype = Variant::Type(value_subtype_string.to_int());
-				bool convert_value = value_subtype == Variant::OBJECT && value_subtype_hint == PROPERTY_HINT_NODE_TYPE;
-
-				if (convert_key || convert_value) {
-					use_deferred_node_path_bit = true;
-					Dictionary dict = value;
-					Dictionary new_dict;
-					for (const KeyValue<Variant, Variant> &kv : dict) {
-						Variant new_key = kv.key;
-						if (convert_key && new_key.get_type() == Variant::OBJECT) {
-							if (Node *n = Object::cast_to<Node>(new_key)) {
-								new_key = p_node->get_path_to(n);
-							}
+			bool convert_key = key_subtype == Variant::OBJECT && key_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+			bool convert_value = value_subtype == Variant::OBJECT && value_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+			if (convert_key || convert_value) {
+				use_deferred_node_path_bit = true;
+				Dictionary dict = value;
+				Dictionary new_dict;
+				for (const KeyValue<Variant, Variant> &kv : dict) {
+					Variant new_key = kv.key;
+					if (convert_key && new_key.get_type() == Variant::OBJECT) {
+						if (Node *n = Object::cast_to<Node>(new_key)) {
+							new_key = p_node->get_path_to(n);
 						}
-						Variant new_value = kv.value;
-						if (convert_value && new_value.get_type() == Variant::OBJECT) {
-							if (Node *n = Object::cast_to<Node>(new_value)) {
-								new_value = p_node->get_path_to(n);
-							}
-						}
-						new_dict[new_key] = new_value;
 					}
-					value = new_dict;
+					Variant new_value = kv.value;
+					if (convert_value && new_value.get_type() == Variant::OBJECT) {
+						if (Node *n = Object::cast_to<Node>(new_value)) {
+							new_value = p_node->get_path_to(n);
+						}
+					}
+					new_dict[new_key] = new_value;
 				}
+				value = new_dict;
 			}
 		}
 
@@ -2078,6 +2159,15 @@ Node *SceneState::_recover_node_path_index(Node *p_base, int p_idx) const {
 
 	NodePath recovered_path(full_path, false);
 	return p_base->get_node_or_null(recovered_path);
+}
+
+void SceneState::_get_class_from_hint_string(const String &p_hint_string, StringName &r_class_name, Ref<Script> &r_script) const {
+	if (ClassDB::class_exists(p_hint_string)) {
+		r_class_name = p_hint_string;
+	} else if (ScriptServer::is_global_class(p_hint_string)) {
+		r_class_name = ScriptServer::get_global_class_native_base(p_hint_string);
+		r_script = ResourceLoader::load(ScriptServer::get_global_class_path(p_hint_string), "Script");
+	}
 }
 
 int32_t SceneState::get_node_unique_id(int p_idx) const {

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -75,6 +75,7 @@ class SceneState : public RefCounted {
 	struct DeferredNodePathProperties {
 		ObjectID base;
 		StringName property;
+		String property_hint_string;
 		Variant value;
 	};
 
@@ -106,6 +107,8 @@ class SceneState : public RefCounted {
 	int _find_base_scene_node_remap_key(int p_idx) const;
 
 	Node *_recover_node_path_index(Node *p_base, int p_idx) const;
+
+	void _get_class_from_hint_string(const String &p_hint_string, StringName &r_class_name, Ref<Script> &r_script) const;
 
 	static Variant _duplicate_recursive(const Variant &p_variant, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_remap_cache, const Variant &p_fallback, Node *p_for_scene);
 

--- a/tests/scene/test_packed_scene.cpp
+++ b/tests/scene/test_packed_scene.cpp
@@ -33,9 +33,78 @@
 TEST_FORCE_LINK(test_packed_scene)
 
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "scene/resources/packed_scene.h"
 
 namespace TestPackedScene {
+
+class _TestIntArrayProperty : public Node {
+	GDCLASS(_TestIntArrayProperty, Node);
+
+	Variant property_value;
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("set_property", "property"), &_TestIntArrayProperty::set_property);
+		ClassDB::bind_method(D_METHOD("get_property"), &_TestIntArrayProperty::get_property);
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "property", PROPERTY_HINT_TYPE_STRING, vformat("%d:", Variant::INT)), "set_property", "get_property");
+	}
+
+public:
+	void set_property(Variant value) { property_value = value; }
+	Variant get_property() const { return property_value; }
+};
+
+class _TestNodeArrayProperty : public Node {
+	GDCLASS(_TestNodeArrayProperty, Node);
+
+	Variant property_value;
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("set_property", "property"), &_TestNodeArrayProperty::set_property);
+		ClassDB::bind_method(D_METHOD("get_property"), &_TestNodeArrayProperty::get_property);
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "property", PROPERTY_HINT_TYPE_STRING, vformat("%d/%d:%s", Variant::OBJECT, PROPERTY_HINT_NODE_TYPE, "Node")), "set_property", "get_property");
+	}
+
+public:
+	void set_property(Variant value) { property_value = value; }
+	Variant get_property() const { return property_value; }
+};
+
+class _TestDictionaryProperty : public Node {
+	GDCLASS(_TestDictionaryProperty, Node);
+
+	Variant property_value;
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("set_property", "property"), &_TestDictionaryProperty::set_property);
+		ClassDB::bind_method(D_METHOD("get_property"), &_TestDictionaryProperty::get_property);
+		ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "property", PROPERTY_HINT_TYPE_STRING, vformat("%d:;%d:", Variant::INT, Variant::INT)), "set_property", "get_property");
+	}
+
+public:
+	void set_property(Variant value) { property_value = value; }
+	Variant get_property() const { return property_value; }
+};
+
+class _TestNodeDictionaryProperty : public Node {
+	GDCLASS(_TestNodeDictionaryProperty, Node);
+
+	Variant property_value;
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("set_property", "property"), &_TestNodeDictionaryProperty::set_property);
+		ClassDB::bind_method(D_METHOD("get_property"), &_TestNodeDictionaryProperty::get_property);
+		ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "property", PROPERTY_HINT_TYPE_STRING, vformat("%d/%d:%s;%d/%d:%s", Variant::OBJECT, PROPERTY_HINT_NODE_TYPE, "Node", Variant::OBJECT, PROPERTY_HINT_NODE_TYPE, "Node")), "set_property", "get_property");
+	}
+
+public:
+	void set_property(Variant value) { property_value = value; }
+	Variant get_property() const { return property_value; }
+};
 
 TEST_CASE("[PackedScene] Pack Scene and Retrieve State") {
 	// Create a scene to pack.
@@ -280,6 +349,170 @@ TEST_CASE("[PackedScene] Recreate State") {
 	CHECK(state->get_node_count() == 0); // Since the state was recreated, it should be empty.
 
 	memdelete(scene);
+}
+
+TEST_CASE("[PackedScene] Preserve Array Types With Nil Default") {
+	GDREGISTER_CLASS(_TestIntArrayProperty);
+
+	// Create a scene to pack.
+	_TestIntArrayProperty *scene = memnew(_TestIntArrayProperty);
+	String property_name = "property";
+
+	// This test is pointless if default value can't be nil.
+	REQUIRE(scene->get(property_name).get_type() == Variant::NIL);
+
+	// Set property to a typed array.
+	Array array;
+	StringName class_name;
+	Ref<Script> script;
+	array.set_typed(Variant::INT, class_name, script);
+	array.push_back(0);
+	array.push_back(1);
+	array.push_back(2);
+	scene->set(property_name, array);
+
+	// Instantiate the scene.
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+	packed_scene->pack(scene);
+	Node *instantiated_scene = packed_scene->instantiate();
+
+	bool get_valid;
+	Array get_value = instantiated_scene->get(property_name, &get_valid);
+	CHECK(get_valid);
+	CHECK(get_value.get_typed_builtin() == Variant::INT);
+	CHECK(get_value.size() == 3);
+
+	memdelete(scene);
+	memdelete(instantiated_scene);
+}
+
+TEST_CASE("[PackedScene] Preserve Node Array Types With Nil Default") {
+	GDREGISTER_CLASS(_TestNodeArrayProperty);
+
+	// Create a scene to pack.
+	_TestNodeArrayProperty *scene = memnew(_TestNodeArrayProperty);
+	String property_name = "property";
+
+	// This test is pointless if default value can't be nil.
+	REQUIRE(scene->get(property_name).get_type() == Variant::NIL);
+
+	// Set property to a typed array.
+	Array array;
+	StringName class_name = "Node";
+	Ref<Script> script;
+	array.set_typed(Variant::OBJECT, class_name, script);
+	for (int i = 0; i < 3; i++) {
+		Node *child = memnew(Node);
+		scene->add_child(child);
+		child->set_owner(scene);
+		array.push_back(child);
+	}
+	scene->set(property_name, array);
+
+	// Instantiate the scene.
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+	packed_scene->pack(scene);
+	Node *instantiated_scene = packed_scene->instantiate();
+
+	bool get_valid;
+	Array get_value = instantiated_scene->get(property_name, &get_valid);
+	CHECK(get_valid);
+	CHECK(get_value.get_typed_builtin() == Variant::OBJECT);
+	CHECK(get_value.get_typed_class_name() == class_name);
+	for (int i = 0; i < 3; i++) {
+		CHECK(instantiated_scene->get_child(i) == get_value[i]);
+	}
+
+	memdelete(scene);
+	memdelete(instantiated_scene);
+}
+
+TEST_CASE("[PackedScene] Preserve Dictionary Types With Nil Default") {
+	GDREGISTER_CLASS(_TestDictionaryProperty);
+
+	// Create a scene to pack.
+	_TestDictionaryProperty *scene = memnew(_TestDictionaryProperty);
+	String property_name = "property";
+
+	// This test is pointless if default value can't be nil.
+	REQUIRE(scene->get(property_name).get_type() == Variant::NIL);
+
+	// Set property to a typed dictionary.
+	Dictionary dictionary;
+	StringName key_class_name;
+	Ref<Script> key_script;
+	StringName value_class_name;
+	Ref<Script> value_script;
+	dictionary.set_typed(Variant::INT, key_class_name, key_script, Variant::INT, value_class_name, value_script);
+	for (int i = 0; i < 3; i++) {
+		dictionary[i] = i;
+	}
+	scene->set(property_name, dictionary);
+
+	// Instantiate the scene.
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+	packed_scene->pack(scene);
+	Node *instantiated_scene = packed_scene->instantiate();
+
+	bool get_valid;
+	Dictionary get_value = instantiated_scene->get(property_name, &get_valid);
+	CHECK(get_valid);
+	CHECK(get_value.get_typed_key_builtin() == Variant::INT);
+	CHECK(get_value.get_typed_value_builtin() == Variant::INT);
+
+	memdelete(scene);
+	memdelete(instantiated_scene);
+}
+
+TEST_CASE("[PackedScene] Preserve Node Dictionary Types With Nil Default") {
+	GDREGISTER_CLASS(_TestNodeDictionaryProperty);
+
+	// Create a scene to pack.
+	_TestNodeDictionaryProperty *scene = memnew(_TestNodeDictionaryProperty);
+	String property_name = "property";
+
+	// This test is pointless if default value can't be nil.
+	REQUIRE(scene->get(property_name).get_type() == Variant::NIL);
+
+	// Set property to a typed dictionary.
+	Dictionary dictionary;
+	StringName key_class_name = "Node";
+	Ref<Script> key_script;
+	StringName value_class_name = "Node";
+	Ref<Script> value_script;
+	dictionary.set_typed(Variant::OBJECT, key_class_name, key_script, Variant::OBJECT, value_class_name, value_script);
+	for (int i = 0; i < 3; i++) {
+		Node *child = memnew(Node);
+		scene->add_child(child);
+		child->set_owner(scene);
+		dictionary[child] = child;
+	}
+	scene->set(property_name, dictionary);
+
+	// Instantiate the scene.
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+	packed_scene->pack(scene);
+	Node *instantiated_scene = packed_scene->instantiate();
+
+	bool get_valid;
+	Dictionary get_value = instantiated_scene->get(property_name, &get_valid);
+	CHECK(get_valid);
+	CHECK(get_value.get_typed_key_builtin() == Variant::OBJECT);
+	CHECK(get_value.get_typed_key_class_name() == key_class_name);
+	CHECK(get_value.get_typed_value_builtin() == Variant::OBJECT);
+	CHECK(get_value.get_typed_value_class_name() == value_class_name);
+	for (int i = 0; i < 3; i++) {
+		Node *child = instantiated_scene->get_child(i);
+		CHECK(get_value.has(child));
+		CHECK(get_value[child] == Variant(child));
+	}
+
+	memdelete(scene);
+	memdelete(instantiated_scene);
 }
 
 } // namespace TestPackedScene

--- a/tests/scene/test_property_utils.cpp
+++ b/tests/scene/test_property_utils.cpp
@@ -1,0 +1,399 @@
+/**************************************************************************/
+/*  test_property_utils.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_property_utils)
+
+#include "scene/property_utils.h"
+
+namespace TestPropertyUtils {
+
+TEST_CASE("[PropertyUtils] Empty Array Hint") {
+	String hint_string;
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::NIL);
+	CHECK(subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Type Only Array Hint") {
+	String hint_string = vformat("%d:", Variant::INT);
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::INT);
+	CHECK(subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Type String Array Hint") {
+	String hint_string = "int";
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::INT);
+	CHECK(subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Object Type Array Hint") {
+	String hint_string = "Texture";
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::OBJECT);
+	CHECK(subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(subtype_hint_string == "Texture");
+}
+
+TEST_CASE("[PropertyUtils] Type And Hint Array Hint") {
+	String hint_string = vformat("%d/%d:", Variant::INT, PROPERTY_HINT_ENUM);
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::INT);
+	CHECK(subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Complete Array Hint") {
+	String hint_string = vformat("%d/%d:%s", Variant::INT, PROPERTY_HINT_ENUM, "One,Two,Three");
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::INT);
+	CHECK(subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(subtype_hint_string == "One,Two,Three");
+}
+
+TEST_CASE("[PropertyUtils] Empty Dictionary Hint") {
+	String hint_string;
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key Type Only Dictionary Hint") {
+	String hint_string = vformat("%d:;", Variant::INT);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key Type String Dictionary Hint") {
+	String hint_string = "int";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key Object Type Dictionary Hint") {
+	String hint_string = "Texture";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::OBJECT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(key_subtype_hint_string == "Texture");
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key Type And Hint Dictionary Hint") {
+	String hint_string = vformat("%d/%d:;", Variant::INT, PROPERTY_HINT_ENUM);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Complete Key Dictionary Hint") {
+	String hint_string = vformat("%d/%d:%s;", Variant::INT, PROPERTY_HINT_ENUM, "One,Two,Three");
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(key_subtype_hint_string == "One,Two,Three");
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Value Type Only Dictionary Hint") {
+	String hint_string = vformat(";%d:", Variant::INT);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::INT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Value Type String Dictionary Hint") {
+	String hint_string = ";int";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::INT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Value Object Type Dictionary Hint") {
+	String hint_string = ";Texture";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::OBJECT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(value_subtype_hint_string == "Texture");
+}
+
+TEST_CASE("[PropertyUtils] Value Type And Hint Dictionary Hint") {
+	String hint_string = vformat(";%d/%d:", Variant::INT, PROPERTY_HINT_ENUM);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::INT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Complete Value Dictionary Hint") {
+	String hint_string = vformat(";%d/%d:%s", Variant::INT, PROPERTY_HINT_ENUM, "One,Two,Three");
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::INT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(value_subtype_hint_string == "One,Two,Three");
+}
+
+TEST_CASE("[PropertyUtils] Key And Value Type Only Dictionary Hint") {
+	String hint_string = vformat("%d:;%d:", Variant::INT, Variant::STRING);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::STRING);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key And Value Type Strings Dictionary Hint") {
+	String hint_string = "int;float";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::FLOAT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key And Value Object Type Dictionary Hint") {
+	String hint_string = "Texture;Texture2D";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::OBJECT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(key_subtype_hint_string == "Texture");
+	CHECK(value_subtype == Variant::OBJECT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(value_subtype_hint_string == "Texture2D");
+}
+
+TEST_CASE("[PropertyUtils] Key And Value Type And Hint Dictionary Hint") {
+	String hint_string = vformat("%d/%d:;%d/%d:", Variant::INT, PROPERTY_HINT_ENUM, Variant::STRING, PROPERTY_HINT_FILE);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::STRING);
+	CHECK(value_subtype_hint == PROPERTY_HINT_FILE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Complete Key And Value Dictionary Hint") {
+	String hint_string = vformat("%d/%d:%s;%d/%d:%s", Variant::INT, PROPERTY_HINT_ENUM, "One,Two,Three", Variant::STRING, PROPERTY_HINT_FILE, "*.png");
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(key_subtype_hint_string == "One,Two,Three");
+	CHECK(value_subtype == Variant::STRING);
+	CHECK(value_subtype_hint == PROPERTY_HINT_FILE);
+	CHECK(value_subtype_hint_string == "*.png");
+}
+
+} //namespace TestPropertyUtils


### PR DESCRIPTION
Fixes #97850
Fixes #91428
Fixes #101801
Fixes #117632
Supersedes #98546

These changes ensure both array and dictionary types are correctly set regardless of what `get` returns by setting types based on the property hint string. Technically these bugs were possible without C# scripts depending on property defaults, C# scripts are just the most user facing way to encounter this.

These changes fix duplication and instantiation bugs because the checks around correctly maintaining node references depend on having the correct collection types.

## Parsing behavior

The property hint string parsing behaves slightly differently for `PackedScene` since it now handles missing ":" or ";" cases to match `EditorPropertyArray` and `EditorPropertyDictionary` which can be updated to use `PropertyUtils::parse_*_hint_string` after this PR so everything is consistent.
<details>

<summary>Parsing behavior reference</summary>

https://github.com/godotengine/godot/blob/8327dfa215aa1758f2c3b99a52934172b94c134e/editor/inspector/editor_properties_array_dict.cpp#L854-L881

https://github.com/godotengine/godot/blob/8327dfa215aa1758f2c3b99a52934172b94c134e/editor/inspector/editor_properties_array_dict.cpp#L1157-L1214

</details>

## Loading and assigning the script type

Assigning the script resource was needed at least for dictionaries to property assign the native class type for these checks:

https://github.com/godotengine/godot/blob/8327dfa215aa1758f2c3b99a52934172b94c134e/scene/resources/packed_scene.cpp#L620-L623

But I'm not sure how important doing so for arrays since `EditorPropertyArray` does not, but I think the equivalent property in GDScript does set the script type.

https://github.com/godotengine/godot/blob/8327dfa215aa1758f2c3b99a52934172b94c134e/editor/inspector/editor_properties_array_dict.cpp#L236-L251

## Getting the property hint

I couldn't find a faster way to get the property hint for an individual property since there's only functions to grab the whole list, but at least the property list is only grabbed at most twice per node instead of once per node collection property.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
