### PR TITLE
[TextServer] Fix some emoji sequences and add missing ICU emoji property data.

### DIFF
--- a/modules/text_server_adv/script_iterator.cpp
+++ b/modules/text_server_adv/script_iterator.cpp
@@ -32,17 +32,21 @@
 
 // This implementation is derived from ICU: icu4c/source/extra/scrptrun/scrptrun.cpp
 
+inline constexpr UChar32 ZERO_WIDTH_JOINER = 0x200d;
+inline constexpr UChar32 VARIATION_SELECTOR_15 = 0xfe0e;
+inline constexpr UChar32 VARIATION_SELECTOR_16 = 0xfe0f;
+
 inline bool ScriptIterator::same_script(int32_t p_script_one, int32_t p_script_two) {
 	return p_script_one <= USCRIPT_INHERITED || p_script_two <= USCRIPT_INHERITED || p_script_one == p_script_two;
 }
 
 inline bool ScriptIterator::is_emoji(UChar32 p_c, UChar32 p_next) {
-	if (p_next == 0xFE0E) { // Variation Selector-15
+	if (p_next == VARIATION_SELECTOR_15 && (u_hasBinaryProperty(p_c, UCHAR_EMOJI) || u_hasBinaryProperty(p_c, UCHAR_EXTENDED_PICTOGRAPHIC))) {
 		return false;
-	} else if (p_next == 0xFE0F) { // Variation Selector-16
+	} else if (p_next == VARIATION_SELECTOR_16 && (u_hasBinaryProperty(p_c, UCHAR_EMOJI) || u_hasBinaryProperty(p_c, UCHAR_EXTENDED_PICTOGRAPHIC))) {
 		return true;
 	} else {
-		return u_hasBinaryProperty(p_c, UCHAR_EMOJI) || u_hasBinaryProperty(p_c, UCHAR_EMOJI_PRESENTATION) || u_hasBinaryProperty(p_c, UCHAR_EMOJI_MODIFIER) || u_hasBinaryProperty(p_c, UCHAR_REGIONAL_INDICATOR) || u_hasBinaryProperty(p_c, UCHAR_EXTENDED_PICTOGRAPHIC);
+		return u_hasBinaryProperty(p_c, UCHAR_EMOJI_PRESENTATION) || u_hasBinaryProperty(p_c, UCHAR_EMOJI_MODIFIER) || u_hasBinaryProperty(p_c, UCHAR_REGIONAL_INDICATOR);
 	}
 }
 
@@ -119,8 +123,7 @@ ScriptIterator::ScriptIterator(const String &p_string, int p_start, int p_length
 			}
 
 			if (script_code == USCRIPT_SYMBOLS_EMOJI && script_code != sc) {
-				UCharCategory cat = (UCharCategory)u_charType(ch);
-				if ((cat >= U_SPACE_SEPARATOR && cat <= U_CONTROL_CHAR) || (cat >= U_DASH_PUNCTUATION && cat <= U_OTHER_PUNCTUATION) || (cat >= U_INITIAL_PUNCTUATION && cat <= U_FINAL_PUNCTUATION)) {
+				if (ch == VARIATION_SELECTOR_15 || n == VARIATION_SELECTOR_15 || !(is_emoji(ch, n) || ch == ZERO_WIDTH_JOINER || ch == VARIATION_SELECTOR_16 || u_hasBinaryProperty(ch, UCHAR_EXTENDED_PICTOGRAPHIC))) {
 					break;
 				}
 			} else if (same_script(script_code, sc)) {

--- a/thirdparty/icu4c/godot_data.json
+++ b/thirdparty/icu4c/godot_data.json
@@ -7,5 +7,7 @@
         misc: include
         normalization: include
         confusables: include
+        uemoji: include
+        uprops: include
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/110194
Fixes https://github.com/godotengine/godot/issues/112510

| Version | Screenshot 
|--|--|
| 4.5.1 | <img width="688" height="464" alt="Screenshot 2025-11-11 at 12 04 21" src="https://github.com/user-attachments/assets/1a1672f0-e3a6-47b4-a61d-dd3d563c5619" /> |
| 4.6.dev3 | <img width="688" height="468" alt="Screenshot 2025-11-11 at 12 03 38" src="https://github.com/user-attachments/assets/50902307-3183-4214-9919-e76c81758da1" /> |
| this PR | <img width="688" height="468" alt="Screenshot 2025-11-11 at 12 03 24" src="https://github.com/user-attachments/assets/7728408c-b3ec-4b0c-a9f6-ce7baa1f8dce" /> |
