### PR TITLE
Add missing warning about copying packed arrays to `EditorHelpBit`

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -87,6 +87,7 @@ BASE_STRINGS = [
     "This method may be changed or removed in future versions.",
     "This operator may be changed or removed in future versions.",
     "This theme property may be changed or removed in future versions.",
+    # See also `make_rst_class()` and `editor/doc/editor_help.cpp`.
     "[b]Note:[/b] The returned array is [i]copied[/i] and any changes to it will not update the original property value. See [%s] for more details.",
 ]
 strings_l10n: Dict[str, str] = {}
@@ -1303,6 +1304,7 @@ def make_rst_class(class_def: ClassDef, state: State, dry_run: bool, output_dir:
 
                 # Add copy note to built-in properties returning `Packed*Array`.
                 if property_def.type_name.type_name in PACKED_ARRAY_TYPES:
+                    # See also `BASE_STRINGS` and `editor/doc/editor_help.cpp`.
                     copy_note = f"[b]Note:[/b] The returned array is [i]copied[/i] and any changes to it will not update the original property value. See [{property_def.type_name.type_name}] for more details."
                     f.write(f"{format_text_block(copy_note, property_def, state)}\n\n")
 

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -2325,6 +2325,7 @@ void EditorHelp::_update_doc() {
 			if (!cd.is_script_doc && packed_array_types.has(prop.type)) {
 				class_desc->add_newline();
 				class_desc->add_newline();
+				// See also `EditorHelpBit::parse_symbol()` and `doc/tools/make_rst.py`.
 				_add_text(vformat(TTR("[b]Note:[/b] The returned array is [i]copied[/i] and any changes to it will not update the original property value. See [%s] for more details."), prop.type));
 			}
 
@@ -4368,6 +4369,16 @@ void EditorHelpBit::parse_symbol(const String &p_symbol, const String &p_prologu
 			symbol_hint = SYMBOL_HINT_ASSIGNABLE;
 		}
 		help_data = _get_property_help_data(class_name, item_name);
+
+		// Add copy note to built-in properties returning `Packed*Array`.
+		const DocData::ClassDoc *cd = EditorHelp::get_doc(class_name);
+		if (cd && !cd->is_script_doc && packed_array_types.has(help_data.doc_type.type)) {
+			if (!help_data.description.is_empty()) {
+				help_data.description += "\n";
+			}
+			// See also `EditorHelp::_update_doc()` and `doc/tools/make_rst.py`.
+			help_data.description += vformat(TTR("[b]Note:[/b] The returned array is [i]copied[/i] and any changes to it will not update the original property value. See [%s] for more details."), help_data.doc_type.type);
+		}
 	} else if (item_type == "internal_property") {
 		symbol_type = TTR("Internal Property");
 		help_data.description = "[color=<EditorHelpBitCommentColor>][i]" + TTR("This property can only be set in the Inspector.") + "[/i][/color]";


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot-docs/issues/11454#issuecomment-3514362581.

<img width="640" height="106" alt="" src="https://github.com/user-attachments/assets/28253c88-6285-4f01-b173-dad214fe9947" />