### PR TITLE
Clarify notification call order

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -753,6 +753,7 @@
 		</constant>
 		<constant name="NOTIFICATION_EXIT_CANVAS" value="33">
 			The [CanvasItem] has exited the canvas.
+			This notification is sent in reversed order.
 		</constant>
 		<constant name="NOTIFICATION_WORLD_2D_CHANGED" value="36">
 			Notification received when this [CanvasItem] is registered to a new [World2D] (see [method get_world_2d]).

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1287,6 +1287,7 @@
 		</constant>
 		<constant name="NOTIFICATION_FOCUS_EXIT" value="44">
 			Sent when the node loses focus.
+			This notification is sent in reversed order.
 		</constant>
 		<constant name="NOTIFICATION_THEME_CHANGED" value="45">
 			Sent when the node needs to refresh its theme items. This happens in one of the following cases:

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1165,6 +1165,7 @@
 		<constant name="NOTIFICATION_EXIT_TREE" value="11">
 			Notification received when the node is about to exit a [SceneTree]. See [method _exit_tree].
 			This notification is received [i]after[/i] the related [signal tree_exiting] signal.
+			This notification is sent in reversed order.
 		</constant>
 		<constant name="NOTIFICATION_MOVED_IN_PARENT" value="12" deprecated="This notification is no longer sent by the engine. Use [constant NOTIFICATION_CHILD_ORDER_CHANGED] instead.">
 		</constant>

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -380,6 +380,7 @@
 		</constant>
 		<constant name="NOTIFICATION_EXIT_WORLD" value="42">
 			Notification received when this node is unregistered from the current [World3D] (see [method get_world_3d]).
+			This notification is sent in reversed order.
 		</constant>
 		<constant name="NOTIFICATION_VISIBILITY_CHANGED" value="43">
 			Notification received when this node's visibility changes (see [member visible] and [method is_visible_in_tree]).

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -267,7 +267,7 @@
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] The base [Object] defines a few notifications ([constant NOTIFICATION_POSTINITIALIZE] and [constant NOTIFICATION_PREDELETE]). Inheriting classes such as [Node] define a lot more notifications, which are also received by this method.
-				[b]Note:[/b] Unlike other virtual methods, this method is called automatically for every script that overrides it. This means that the base implementation should not be called via [code]super[/code] in GDScript or its equivalents in other languages. The bottom-most sub-class will be called first, with subsequent calls ascending the class hierarchy.
+				[b]Note:[/b] Unlike other virtual methods, this method is called automatically for every script that overrides it. This means that the base implementation should not be called via [code]super[/code] in GDScript or its equivalents in other languages. Call order depends on the [code]reversed[/code] argument of [method notification] and varies between different notifications. Most notifications are sent in the forward order (i.e. Object class first, most derived class last).
 			</description>
 		</method>
 		<method name="_property_can_revert" qualifiers="virtual">
@@ -1031,6 +1031,7 @@
 		</constant>
 		<constant name="NOTIFICATION_PREDELETE" value="1">
 			Notification received when the object is about to be deleted. Can be used like destructors in object-oriented programming languages.
+			This notification is sent in reversed order.
 		</constant>
 		<constant name="NOTIFICATION_EXTENSION_RELOADED" value="2">
 			Notification received when the object finishes hot reloading. This notification is only sent for extensions classes and derived.


### PR DESCRIPTION
The note added to `_notification()` in #111830 was wrong 🙃
The method is called in reverse order compared to other multilevel methods, and it also depends on the `reversed` argument (which makes it called like other methods, but not many notifications use it).

This PR fixes that mistake and adds notes to notifications sent in reversed order.