### PR TITLE
Core: Switch `RID_Alloc::owns` to lock-free (reverted)

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -310,16 +310,24 @@ public:
 	}
 
 	_FORCE_INLINE_ bool owns(const RID &p_rid) const {
+		if (p_rid == RID()) {
+			return false;
+		}
+
 		if constexpr (THREAD_SAFE) {
-			mutex.lock();
+			SYNC_ACQUIRE;
 		}
 
 		uint64_t id = p_rid.get_id();
 		uint32_t idx = uint32_t(id & 0xFFFFFFFF);
-		if (unlikely(idx >= max_alloc)) {
-			if constexpr (THREAD_SAFE) {
-				mutex.unlock();
-			}
+		uint32_t ma;
+		if constexpr (THREAD_SAFE) {
+			ma = ((std::atomic<uint32_t> *)&max_alloc)->load(std::memory_order_relaxed);
+		} else {
+			ma = max_alloc;
+		}
+
+		if (unlikely(idx >= ma)) {
 			return false;
 		}
 
@@ -328,10 +336,29 @@ public:
 
 		uint32_t validator = uint32_t(id >> 32);
 
-		bool owned = (chunks[idx_chunk][idx_element].validator & 0x7FFFFFFF) == validator;
+		if constexpr (THREAD_SAFE) {
+#ifdef TSAN_ENABLED
+			__tsan_acquire(&chunks[idx_chunk]); // We know not a race in practice.
+			__tsan_acquire(&chunks[idx_chunk][idx_element]); // We know not a race in practice.
+#endif
+		}
+
+		Chunk &c = chunks[idx_chunk][idx_element];
 
 		if constexpr (THREAD_SAFE) {
-			mutex.unlock();
+#ifdef TSAN_ENABLED
+			__tsan_release(&chunks[idx_chunk]);
+			__tsan_release(&chunks[idx_chunk][idx_element]);
+			__tsan_acquire(&c.validator); // We know not a race in practice.
+#endif
+		}
+
+		bool owned = (c.validator & 0x7FFFFFFF) == validator;
+
+		if constexpr (THREAD_SAFE) {
+#ifdef TSAN_ENABLED
+			__tsan_release(&c.validator);
+#endif
 		}
 
 		return owned;


### PR DESCRIPTION
# Summary

Whilst working on #112481 and running various benchmarks, including an MRP that @clayjohn created to test #104194, I observed 7% of the total CPU time was spent in `RenderingDevice::texture_is_valid`, which in turn calls `RID_Alloc::owns`. It is `owns` that spent most of its time acquiring and releasing a mutex. The `RID_Alloc::get_or_null` API uses atomics for a lock-free approach, which can also be applied to `owns`, given `get_or_null` also performs the validation. After the change, `texture_is_valid` drops from 7.3% to 1.3%:

<img width="2524" height="1832" alt="Clipboard - November 12, 2025 1_01 PM" src="https://github.com/user-attachments/assets/0336ae0f-8df2-4a9c-86ac-12e38e2f329d" />
