### PR TITLE
Add a const version of `List::find`

### DIFF
--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -416,6 +416,19 @@ public:
 	 * find an element in the list,
 	 */
 	template <typename T_v>
+	const Element *find(const T_v &p_val) const {
+		const Element *it = front();
+		while (it) {
+			if (it->value == p_val) {
+				return it;
+			}
+			it = it->next();
+		}
+
+		return nullptr;
+	}
+
+	template <typename T_v>
 	Element *find(const T_v &p_val) {
 		Element *it = front();
 		while (it) {


### PR DESCRIPTION
This is the exact same as the existing `List::find`, but has `const` added to the iterator, return type, and function signature, allowing using `List::find` on `const` Lists. Previously, those lists would have to be non-const to use this function.

I previously had this slipped into other PRs because it's a minor addition, but @Ivorforce suggested it was out of scope elsewhere, so I am opening a dedicated PR for this (see https://github.com/godotengine/godot/pull/111372#discussion_r2507341300).