### PR TITLE
`ScriptEditor::reload_scripts`: Only call deferred if not main thread

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2821,7 +2821,11 @@ void ScriptEditor::apply_scripts() const {
 
 void ScriptEditor::reload_scripts(bool p_refresh_only) {
 	// Call deferred to make sure it runs on the main thread.
-	callable_mp(this, &ScriptEditor::_reload_scripts).call_deferred(p_refresh_only);
+	if (!Thread::is_main_thread()) {
+		callable_mp(this, &ScriptEditor::_reload_scripts).call_deferred(p_refresh_only);
+		return;
+	}
+	_reload_scripts(p_refresh_only);
 }
 
 void ScriptEditor::_reload_scripts(bool p_refresh_only) {


### PR DESCRIPTION
Sometimes we need to wait for the scripts to be fully reloaded before doing other stuff to update the editor state, and this becomes a problem because `reload_scripts` always ends up calling deferred, when it's not necessary.

According to @kitbdev , who made the original change to make `reload_scripts` call deferred:
> It doesn't need to be deferred, it just needs to be on the main thread. 
