### PR TITLE
Core: Explicitly delete the `Variant` `initializer_list` constructor

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2521,11 +2521,6 @@ Variant::Variant(const Dictionary &p_dictionary) :
 	static_assert(sizeof(Dictionary) <= sizeof(_data._mem));
 }
 
-Variant::Variant(std::initializer_list<Variant> p_init) :
-		type(ARRAY) {
-	memnew_placement(_data._mem, Array(p_init));
-}
-
 Variant::Variant(const Array &p_array) :
 		type(ARRAY) {
 	memnew_placement(_data._mem, Array(p_array));

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -546,7 +546,8 @@ public:
 	Variant(const Signal &p_signal);
 	Variant(const Dictionary &p_dictionary);
 
-	Variant(std::initializer_list<Variant> p_init);
+	// Deleted to prevent ambiguous code. Explicitly convert Array to Variant instead.
+	Variant(std::initializer_list<Variant> p_init) = delete;
 	Variant(const Array &p_array);
 	Variant(const PackedByteArray &p_byte_array);
 	Variant(const PackedInt32Array &p_int32_array);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2644,7 +2644,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 					if (!fpath.ends_with("/")) {
 						fpath = fpath.get_base_dir();
 					}
-					EditorContextMenuPluginManager::get_singleton()->activate_custom_option(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE, p_option, { fpath });
+					EditorContextMenuPluginManager::get_singleton()->activate_custom_option(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE, p_option, PackedStringArray{ fpath });
 				}
 			} else if (p_option >= CONVERT_BASE_ID) {
 				selected_conversion_id = p_option - CONVERT_BASE_ID;

--- a/modules/multiplayer/tests/test_scene_multiplayer.h
+++ b/modules/multiplayer/tests/test_scene_multiplayer.h
@@ -164,7 +164,7 @@ TEST_CASE("[Multiplayer][SceneMultiplayer][SceneTree] Send Authentication") {
 		Ref<MultiplayerPeer> multiplayer_peer = scene_multiplayer->get_multiplayer_peer();
 		int peer_id = 42;
 		multiplayer_peer->emit_signal(SNAME("peer_connected"), peer_id);
-		SIGNAL_CHECK("peer_authenticating", { { peer_id } });
+		SIGNAL_CHECK("peer_authenticating", { Array{ peer_id } });
 
 		CHECK_EQ(scene_multiplayer->send_auth(peer_id, String("It's me").to_ascii_buffer()), Error::OK);
 
@@ -182,7 +182,7 @@ TEST_CASE("[Multiplayer][SceneMultiplayer][SceneTree] Send Authentication") {
 		int peer_id = 42;
 		multiplayer_peer->emit_signal(SNAME("peer_connected"), peer_id);
 		multiplayer_peer->emit_signal(SNAME("peer_disconnected"), peer_id);
-		SIGNAL_CHECK("peer_authentication_failed", { { peer_id } });
+		SIGNAL_CHECK("peer_authentication_failed", { Array{ peer_id } });
 
 		SIGNAL_UNWATCH(scene_multiplayer.ptr(), "peer_authentication_failed");
 	}
@@ -204,7 +204,7 @@ TEST_CASE("[Multiplayer][SceneMultiplayer][SceneTree] Send Authentication") {
 
 		CHECK_EQ(scene_multiplayer->poll(), Error::OK);
 
-		SIGNAL_CHECK("peer_authentication_failed", Array({ { first_peer_id }, { second_peer_id } }));
+		SIGNAL_CHECK("peer_authentication_failed", Array({ Array{ first_peer_id }, Array{ second_peer_id } }));
 
 		SIGNAL_UNWATCH(scene_multiplayer.ptr(), "peer_authentication_failed");
 	}

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -36,13 +36,13 @@
 
 namespace TestArray {
 TEST_CASE("[Array] initializer list") {
-	Array arr = { 0, 1, "test", true, { 0.0, 1.0 } };
+	Array arr = { 0, 1, "test", true, Array{ 0.0, 1.0 } };
 	CHECK(arr.size() == 5);
 	CHECK(arr[0] == Variant(0));
 	CHECK(arr[1] == Variant(1));
 	CHECK(arr[2] == Variant("test"));
 	CHECK(arr[3] == Variant(true));
-	CHECK(arr[4] == Variant({ 0.0, 1.0 }));
+	CHECK(arr[4] == Variant(Array{ 0.0, 1.0 }));
 
 	arr = { "reassign" };
 	CHECK(arr.size() == 1);
@@ -434,7 +434,7 @@ TEST_CASE("[Array] slice()") {
 
 TEST_CASE("[Array] Duplicate array") {
 	// a = [1, [2, 2], {3: 3}]
-	Array a = { 1, { 2, 2 }, Dictionary({ { 3, 3 } }) };
+	Array a = { 1, Array{ 2, 2 }, Dictionary({ { 3, 3 } }) };
 
 	// Deep copy
 	Array deep_a = a.duplicate(true);
@@ -497,7 +497,7 @@ TEST_CASE("[Array] Duplicate recursive array") {
 
 TEST_CASE("[Array] Hash array") {
 	// a = [1, [2, 2], {3: 3}]
-	Array a = { 1, { 2, 2 }, Dictionary({ { 3, 3 } }) };
+	Array a = { 1, Array{ 2, 2 }, Dictionary({ { 3, 3 } }) };
 	uint32_t original_hash = a.hash();
 
 	a.push_back(1);
@@ -562,12 +562,12 @@ TEST_CASE("[Array] Flat comparison") {
 
 TEST_CASE("[Array] Nested array comparison") {
 	// a1 = [[[1], 2], 3]
-	Array a1 = { { { 1 }, 2 }, 3 };
+	Array a1 = { Array{ Array{ 1 }, 2 }, 3 };
 
 	Array a2 = a1.duplicate(true);
 
 	// other_a = [[[1, 0], 2], 3]
-	Array other_a = { { { 1, 0 }, 2 }, 3 };
+	Array other_a = { Array{ Array{ 1, 0 }, 2 }, 3 };
 
 	// test both operator== and operator!=
 	CHECK_EQ(a1, a1); // compare self

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -474,12 +474,12 @@ TEST_CASE("[Dictionary] Nested dictionary comparison") {
 
 TEST_CASE("[Dictionary] Nested array comparison") {
 	// d1 = {1: [2, 3]}
-	Dictionary d1 = { { 1, { 2, 3 } } };
+	Dictionary d1 = { { 1, Array{ 2, 3 } } };
 
 	Dictionary d2 = d1.duplicate(true);
 
 	// other_d = {1: [2, 0]}
-	Dictionary other_d = { { 1, { 2, 0 } } };
+	Dictionary other_d = { { 1, Array{ 2, 0 } } };
 
 	// test both operator== and operator!=
 	CHECK_EQ(d1, d1); // compare self

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -1717,7 +1717,7 @@ TEST_CASE("[Variant] Assignment To Color from Bool,Int,Float,String,Vec2,Vec2i,V
 }
 
 TEST_CASE("[Variant] array initializer list") {
-	Variant arr_v = { 0, 1, "test", true, { 0.0, 1.0 } };
+	Variant arr_v = Array{ 0, 1, "test", true, Array{ 0.0, 1.0 } };
 	CHECK(arr_v.get_type() == Variant::ARRAY);
 	Array arr = (Array)arr_v;
 	CHECK(arr.size() == 5);
@@ -1725,7 +1725,7 @@ TEST_CASE("[Variant] array initializer list") {
 	CHECK(arr[1] == Variant(1));
 	CHECK(arr[2] == Variant("test"));
 	CHECK(arr[3] == Variant(true));
-	CHECK(arr[4] == Variant({ 0.0, 1.0 }));
+	CHECK(arr[4] == Variant(Array{ 0.0, 1.0 }));
 
 	PackedInt32Array packed_arr = { 2, 1, 0 };
 	CHECK(packed_arr.size() == 3);
@@ -2125,9 +2125,9 @@ TEST_CASE("[Variant] Identity comparison") {
 }
 
 TEST_CASE("[Variant] Nested array comparison") {
-	Array a1 = { 1, { 2, 3 } };
-	Array a2 = { 1, { 2, 3 } };
-	Array a_other = { 1, { 2, 4 } };
+	Array a1 = { 1, Array{ 2, 3 } };
+	Array a2 = { 1, Array{ 2, 3 } };
+	Array a_other = { 1, Array{ 2, 4 } };
 	Variant v_a1 = a1;
 	Variant v_a1_ref2 = a1;
 	Variant v_a2 = a2;

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -65,7 +65,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			ERR_PRINT_ON;
 
-			Array args = { { 0 } };
+			Array args = { Array{ 0 } };
 
 			code_edit->set_line_as_breakpoint(0, true);
 			CHECK(code_edit->is_line_breakpointed(0));
@@ -81,7 +81,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->clear_breakpointed_lines();
 			SIGNAL_CHECK_FALSE("breakpoint_toggled");
 
-			Array args = { { 0 } };
+			Array args = { Array{ 0 } };
 
 			code_edit->set_line_as_breakpoint(0, true);
 			CHECK(code_edit->is_line_breakpointed(0));
@@ -93,7 +93,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and set text") {
-			Array args = { { 0 } };
+			Array args = { Array{ 0 } };
 
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(0, true);
@@ -110,7 +110,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->clear_breakpointed_lines();
 			SIGNAL_DISCARD("breakpoint_toggled")
 
-			args = { { 1 } };
+			args = { Array{ 1 } };
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(1, true);
 			CHECK(code_edit->is_line_breakpointed(1));
@@ -126,7 +126,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and clear") {
-			Array args = { { 0 } };
+			Array args = { Array{ 0 } };
 
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(0, true);
@@ -143,7 +143,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->clear_breakpointed_lines();
 			SIGNAL_DISCARD("breakpoint_toggled")
 
-			args = { { 1 } };
+			args = { Array{ 1 } };
 			code_edit->set_text("test\nline");
 			code_edit->set_line_as_breakpoint(1, true);
 			CHECK(code_edit->is_line_breakpointed(1));
@@ -159,7 +159,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and new lines no text") {
-			Array args = { { 0 } };
+			Array args = { Array{ 0 } };
 
 			/* No text moves breakpoint. */
 			code_edit->set_line_as_breakpoint(0, true);
@@ -167,7 +167,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Normal.
-			args = { { 0 }, { 1 } };
+			args = { Array{ 0 }, Array{ 1 } };
 
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line_count() == 2);
@@ -176,7 +176,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Non-Breaking.
-			args = { { 1 }, { 2 } };
+			args = { Array{ 1 }, Array{ 2 } };
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line_count() == 3);
 			CHECK_FALSE(code_edit->is_line_breakpointed(1));
@@ -184,7 +184,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Above.
-			args = { { 2 }, { 3 } };
+			args = { Array{ 2 }, Array{ 3 } };
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line_count() == 4);
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
@@ -193,7 +193,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and new lines with text") {
-			Array args = { { 0 } };
+			Array args = { Array{ 0 } };
 
 			/* Having text does not move breakpoint. */
 			code_edit->insert_text_at_caret("text");
@@ -217,7 +217,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK_FALSE("breakpoint_toggled");
 
 			// Above does move.
-			args = { { 0 }, { 1 } };
+			args = { Array{ 0 }, Array{ 1 } };
 
 			code_edit->set_caret_line(0);
 			SEND_GUI_ACTION("ui_text_newline_above");
@@ -228,7 +228,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and backspace") {
-			Array args = { { 1 } };
+			Array args = { Array{ 1 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -251,7 +251,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Backspace above breakpointed line moves it.
-			args = { { 2 } };
+			args = { Array{ 2 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(2, true);
@@ -260,7 +260,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->set_caret_line(1);
 
-			args = { { 2 }, { 1 } };
+			args = { Array{ 2 }, Array{ 1 } };
 			SEND_GUI_ACTION("ui_text_backspace");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
@@ -270,7 +270,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and delete") {
-			Array args = { { 1 } };
+			Array args = { Array{ 1 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -294,7 +294,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Delete above breakpointed line moves it.
-			args = { { 2 } };
+			args = { Array{ 2 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(2, true);
@@ -303,7 +303,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->set_caret_line(0);
 
-			args = { { 2 }, { 1 } };
+			args = { Array{ 2 }, Array{ 1 } };
 			SEND_GUI_ACTION("ui_text_delete");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
@@ -313,7 +313,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and delete selection") {
-			Array args = { { 1 } };
+			Array args = { Array{ 1 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -327,7 +327,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Should handle breakpoint move when deleting selection by adding less text then removed.
-			args = { { 9 } };
+			args = { Array{ 9 } };
 
 			code_edit->set_text("\n\n\n\n\n\n\n\n\n");
 			code_edit->set_line_as_breakpoint(9, true);
@@ -336,7 +336,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->select(0, 0, 6, 0);
 
-			args = { { 9 }, { 4 } };
+			args = { Array{ 9 }, Array{ 4 } };
 			SEND_GUI_ACTION("ui_text_newline");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(9));
@@ -345,7 +345,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			// Should handle breakpoint move when deleting selection by adding more text then removed.
-			args = { { 9 }, { 14 } };
+			args = { Array{ 9 }, Array{ 14 } };
 
 			code_edit->insert_text_at_caret("\n\n\n\n\n");
 			MessageQueue::get_singleton()->flush();
@@ -360,7 +360,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 		}
 
 		SUBCASE("[CodeEdit] breakpoints and undo") {
-			Array args = { { 1 } };
+			Array args = { Array{ 1 } };
 
 			code_edit->set_text("\n\n");
 			code_edit->set_line_as_breakpoint(1, true);
@@ -4536,7 +4536,7 @@ TEST_CASE("[SceneTree][CodeEdit] symbol lookup") {
 		SEND_GUI_KEY_EVENT(Key::CTRL);
 #endif
 
-		Array signal_args = { { "some" } };
+		Array signal_args = { Array{ "some" } };
 		SIGNAL_CHECK("symbol_validate", signal_args);
 
 		SIGNAL_UNWATCH(code_edit, "symbol_validate");

--- a/tests/scene/test_split_container.h
+++ b/tests/scene/test_split_container.h
@@ -1169,7 +1169,7 @@ TEST_CASE("[SceneTree][SplitContainer] Two children") {
 	SUBCASE("[SplitContainer] Drag") {
 		SUBCASE("[SplitContainer] Vertical, no expand flags") {
 			SIGNAL_WATCH(split_container, "dragged");
-			Array signal_args = { { 0 } };
+			Array signal_args = { Array{ 0 } };
 
 			split_container->set_vertical(true);
 			Point2 mouse_offset = Point2(1, 1);

--- a/tests/scene/test_tab_bar.h
+++ b/tests/scene/test_tab_bar.h
@@ -57,8 +57,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->get_tab_count() == 1);
 		CHECK(tab_bar->get_current_tab() == 0);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 
 		tab_bar->add_tab("tab1");
 		CHECK(tab_bar->get_tab_count() == 2);
@@ -212,7 +212,7 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->get_current_tab() == -1);
 		CHECK(tab_bar->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK("tab_changed", { { -1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ -1 } });
 
 		// Remove current tab when there are other tabs.
 		tab_bar->add_tab("tab0");
@@ -231,7 +231,7 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 1);
 		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 	}
 
 	SUBCASE("[TabBar] move tabs") {
@@ -281,21 +281,21 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		tab_bar->add_tab("tab2");
 		CHECK(tab_bar->get_current_tab() == 0);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 
 		// Set the current tab.
 		tab_bar->set_current_tab(1);
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 
 		// Set to same tab.
 		tab_bar->set_current_tab(1);
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 
 		// Out of bounds.
@@ -335,8 +335,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		tab_bar->set_current_tab(-1);
 		CHECK(tab_bar->get_current_tab() == -1);
 		CHECK(tab_bar->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { -1 } });
-		SIGNAL_CHECK("tab_changed", { { -1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ -1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ -1 } });
 
 		// Adding first tab will NOT change the current tab. (stays deselected)
 		tab_bar->clear_tabs();
@@ -361,8 +361,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK_FALSE(tab_bar->get_deselect_enabled());
 		CHECK(tab_bar->get_current_tab() == 0);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 
 		// Cannot set to -1 if disabled.
 		ERR_PRINT_OFF;
@@ -383,8 +383,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		tab_bar->set_deselect_enabled(false);
 		CHECK(tab_bar->get_current_tab() == 2);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", { { 2 } });
-		SIGNAL_CHECK("tab_changed", { { 2 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 2 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 2 } });
 	}
 
 	SUBCASE("[TabBar] hidden tabs") {
@@ -480,15 +480,15 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->select_next_available());
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 
 		// Skips over disabled and hidden tabs.
 		CHECK(tab_bar->select_next_available());
 		CHECK(tab_bar->get_current_tab() == 4);
 		CHECK(tab_bar->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", { { 4 } });
-		SIGNAL_CHECK("tab_changed", { { 4 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 4 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 4 } });
 
 		// Does not wrap around.
 		CHECK_FALSE(tab_bar->select_next_available());
@@ -556,15 +556,15 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->select_previous_available());
 		CHECK(tab_bar->get_current_tab() == 3);
 		CHECK(tab_bar->get_previous_tab() == 4);
-		SIGNAL_CHECK("tab_selected", { { 3 } });
-		SIGNAL_CHECK("tab_changed", { { 3 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 3 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 3 } });
 
 		// Skips over disabled and hidden tabs.
 		CHECK(tab_bar->select_previous_available());
 		CHECK(tab_bar->get_current_tab() == 0);
 		CHECK(tab_bar->get_previous_tab() == 3);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 
 		// Does not wrap around.
 		CHECK_FALSE(tab_bar->select_previous_available());
@@ -638,8 +638,8 @@ TEST_CASE("[SceneTree][TabBar] initialization") {
 		CHECK(tab_bar->get_tab_count() == 2);
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 
 		// Does not work again.
 		ERR_PRINT_OFF;
@@ -895,7 +895,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 
 		// Hover over the first tab.
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position, MouseButtonMask::NONE, Key::NONE);
-		SIGNAL_CHECK("tab_hovered", { { 0 } });
+		SIGNAL_CHECK("tab_hovered", { Array{ 0 } });
 		CHECK(tab_bar->get_hovered_tab() == 0);
 
 		// Hover over same tab won't send signal again.
@@ -905,7 +905,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 
 		// Hover over different tab.
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[1].position, MouseButtonMask::NONE, Key::NONE);
-		SIGNAL_CHECK("tab_hovered", { { 1 } });
+		SIGNAL_CHECK("tab_hovered", { Array{ 1 } });
 		CHECK(tab_bar->get_hovered_tab() == 1);
 
 		// Exit area.
@@ -924,17 +924,17 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[1].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
-		SIGNAL_CHECK("tab_clicked", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
+		SIGNAL_CHECK("tab_clicked", { Array{ 1 } });
 
 		// Click on the same tab.
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[1].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(tab_bar->get_current_tab() == 1);
 		CHECK(tab_bar->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
-		SIGNAL_CHECK("tab_clicked", { { 1 } });
+		SIGNAL_CHECK("tab_clicked", { Array{ 1 } });
 	}
 
 	SUBCASE("[TabBar] Click on close button") {
@@ -950,7 +950,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		SEND_GUI_MOUSE_MOTION_EVENT(cb_pos, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_BUTTON_EVENT(cb_pos, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(cb_pos, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
-		SIGNAL_CHECK("tab_close_pressed", { { 0 } });
+		SIGNAL_CHECK("tab_close_pressed", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_clicked");
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
@@ -964,7 +964,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		CHECK_FALSE(tab_bar->get_drag_to_rearrange_enabled());
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[1].position, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(tab_rects[1].position, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -983,7 +983,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[1].position, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_bar->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -998,7 +998,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		// Move the first tab after the second.
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[1].position, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_bar->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(tab_rects[1].position + Point2(tab_rects[1].size.x / 2 + 1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -1007,8 +1007,8 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		CHECK(tab_bar->get_tab_title(1) == "tab0");
 		CHECK(tab_bar->get_tab_title(2) == "tab2    ");
 		CHECK(tab_bar->get_current_tab() == 1);
-		SIGNAL_CHECK("active_tab_rearranged", { { 1 } });
-		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("active_tab_rearranged", { Array{ 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 
 		tab_rects = { tab_bar->get_tab_rect(0), tab_bar->get_tab_rect(1), tab_bar->get_tab_rect(2) };
@@ -1016,8 +1016,8 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		// Move the last tab to be the first.
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[2].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 2 } });
-		SIGNAL_CHECK("tab_changed", { { 2 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 2 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 2 } });
 		CHECK(tab_bar->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 		CHECK_FALSE(tab_bar->get_viewport()->gui_is_dragging());
@@ -1025,8 +1025,8 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		CHECK(tab_bar->get_tab_title(1) == "tab1 ");
 		CHECK(tab_bar->get_tab_title(2) == "tab0");
 		CHECK(tab_bar->get_current_tab() == 0);
-		SIGNAL_CHECK("active_tab_rearranged", { { 0 } });
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("active_tab_rearranged", { Array{ 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 	}
 
@@ -1051,7 +1051,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_bar->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -1068,7 +1068,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_bar->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -1085,7 +1085,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_bar->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -1101,7 +1101,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_bar->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -1116,7 +1116,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		CHECK(target_tab_bar->get_current_tab() == 1);
 		SIGNAL_CHECK_FALSE("active_tab_rearranged");
 		SIGNAL_CHECK_FALSE("tab_selected"); // Does not send since tab was removed.
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 
 		Point2 target_tab = target_tab_bar->get_position();
 
@@ -1125,7 +1125,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_bar->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -1140,7 +1140,7 @@ TEST_CASE("[SceneTree][TabBar] Mouse interaction") {
 		CHECK(target_tab_bar->get_current_tab() == 0);
 		SIGNAL_CHECK_FALSE("active_tab_rearranged");
 		SIGNAL_CHECK_FALSE("tab_selected"); // Does not send since tab was removed.
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 
 		memdelete(target_tab_bar);
 	}

--- a/tests/scene/test_tab_container.h
+++ b/tests/scene/test_tab_container.h
@@ -60,8 +60,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		CHECK(tab_container->get_tab_count() == 1);
 		CHECK(tab_container->get_current_tab() == 0);
 		CHECK(tab_container->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 
 		// Add second tab child.
 		tab_container->add_child(tab1);
@@ -126,7 +126,7 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		CHECK(tab_container->get_current_tab() == -1);
 		CHECK(tab_container->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK("tab_changed", { { -1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ -1 } });
 
 		// Remove current tab when there are other tabs.
 		tab_container->add_child(tab0);
@@ -145,7 +145,7 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 1);
 		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 	}
 
 	SUBCASE("[TabContainer] move tabs by moving children") {
@@ -185,8 +185,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab_container->add_child(tab2);
 		CHECK(tab_container->get_current_tab() == 0);
 		CHECK(tab_container->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK(tab0->is_visible());
 		CHECK_FALSE(tab1->is_visible());
@@ -196,8 +196,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab_container->set_current_tab(1);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
@@ -207,7 +207,7 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab_container->set_current_tab(1);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
@@ -253,8 +253,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab1->show();
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
@@ -264,8 +264,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab1->hide();
 		CHECK(tab_container->get_current_tab() == 2);
 		CHECK(tab_container->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", { { 2 } });
-		SIGNAL_CHECK("tab_changed", { { 2 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 2 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 2 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 		CHECK_FALSE(tab1->is_visible());
@@ -275,8 +275,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab2->hide();
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 2);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
@@ -305,8 +305,8 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		tab0->hide();
 		CHECK(tab_container->get_current_tab() == -1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { -1 } });
-		SIGNAL_CHECK("tab_changed", { { -1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ -1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ -1 } });
 		MessageQueue::get_singleton()->flush();
 		CHECK_FALSE(tab0->is_visible());
 	}
@@ -390,8 +390,8 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		CHECK(tab_container->get_tab_count() == 3);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
 		CHECK_FALSE(tab2->is_visible());
@@ -469,8 +469,8 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		CHECK(tab_container->get_tab_count() == 2);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
 	}
@@ -505,8 +505,8 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		CHECK(tab_container->get_tab_count() == 3);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
 		CHECK_FALSE(tab0->is_visible());
 		CHECK(tab1->is_visible());
 		CHECK_FALSE(tab2->is_visible());
@@ -695,17 +695,17 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[1].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 0);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
-		SIGNAL_CHECK("tab_changed", { { 1 } });
-		SIGNAL_CHECK("tab_clicked", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 1 } });
+		SIGNAL_CHECK("tab_clicked", { Array{ 1 } });
 
 		// Click on the same tab.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[1].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 1);
-		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
-		SIGNAL_CHECK("tab_clicked", { { 1 } });
+		SIGNAL_CHECK("tab_clicked", { Array{ 1 } });
 
 		// Click outside of tabs.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(0, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
@@ -721,7 +721,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		CHECK_FALSE(tab_container->get_drag_to_rearrange_enabled());
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[1].position, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK_FALSE(tab_container->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2(side_margin, 0) + tab_rects[1].position, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -740,7 +740,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[1].position, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_container->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -755,7 +755,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		// Move the first tab after the second.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[1].position, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_container->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2(side_margin, 0) + tab_rects[1].position + Point2(tab_rects[1].size.x / 2 + 1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -763,8 +763,8 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		CHECK(tab_container->get_tab_idx_from_control(tab1) == 0);
 		CHECK(tab_container->get_tab_idx_from_control(tab0) == 1);
 		CHECK(tab_container->get_tab_idx_from_control(tab2) == 2);
-		SIGNAL_CHECK("active_tab_rearranged", { { 1 } });
-		SIGNAL_CHECK("tab_selected", { { 1 } });
+		SIGNAL_CHECK("active_tab_rearranged", { Array{ 1 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 1 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 
 		tab_rects = { tab_bar->get_tab_rect(0), tab_bar->get_tab_rect(1), tab_bar->get_tab_rect(2) };
@@ -772,16 +772,16 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		// Move the last tab to be the first.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[2].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 2 } });
-		SIGNAL_CHECK("tab_changed", { { 2 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 2 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 2 } });
 		CHECK(tab_container->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 		CHECK_FALSE(tab_container->get_viewport()->gui_is_dragging());
 		CHECK(tab_container->get_tab_idx_from_control(tab2) == 0);
 		CHECK(tab_container->get_tab_idx_from_control(tab1) == 1);
 		CHECK(tab_container->get_tab_idx_from_control(tab0) == 2);
-		SIGNAL_CHECK("active_tab_rearranged", { { 0 } });
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("active_tab_rearranged", { Array{ 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 	}
 
@@ -810,7 +810,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_container->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -827,7 +827,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_container->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -844,7 +844,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_container->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -860,7 +860,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab_after_first, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_container->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab_after_first, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -877,7 +877,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		CHECK(target_tab_container->get_current_tab() == 1);
 		SIGNAL_CHECK_FALSE("active_tab_rearranged");
 		SIGNAL_CHECK_FALSE("tab_selected"); // Does not send since tab was removed.
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 
 		Point2 target_tab = Point2(side_margin, 0) + target_tab_container->get_position();
 
@@ -886,7 +886,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(side_margin, 0) + tab_rects[0].position, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(side_margin, 0) + tab_rects[0].position + Point2(20, 0), MouseButtonMask::LEFT, Key::NONE);
 		SEND_GUI_MOUSE_MOTION_EVENT(target_tab, MouseButtonMask::LEFT, Key::NONE);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_selected", { Array{ 0 } });
 		SIGNAL_CHECK_FALSE("tab_changed");
 		CHECK(tab_container->get_viewport()->gui_is_dragging());
 		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_tab, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -901,7 +901,7 @@ TEST_CASE("[SceneTree][TabContainer] Mouse interaction") {
 		CHECK(target_tab_container->get_current_tab() == 0);
 		SIGNAL_CHECK_FALSE("active_tab_rearranged");
 		SIGNAL_CHECK_FALSE("tab_selected"); // Does not send since tab was removed.
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { Array{ 0 } });
 
 		memdelete(target_tab_container);
 	}

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -60,7 +60,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array lines_edited_args = { { 0, 0 }, { 0, 0 } };
+		Array lines_edited_args = { Array{ 0, 0 }, Array{ 0, 0 } };
 
 		SUBCASE("[TextEdit] clear and set text") {
 			// "text_changed" should not be emitted on clear / set.
@@ -125,7 +125,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Can clear even if not editable.
 			text_edit->set_editable(false);
 
-			Array lines_edited_clear_args = { { 1, 0 } };
+			Array lines_edited_clear_args = { Array{ 1, 0 } };
 
 			text_edit->clear();
 			MessageQueue::get_singleton()->flush();
@@ -223,7 +223,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Insert text when there is no text.
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			text_edit->insert_text("tes", 0, 0);
 			MessageQueue::get_singleton()->flush();
@@ -236,7 +236,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Insert multiple lines.
-			lines_edited_args = { { 0, 1 } };
+			lines_edited_args = { Array{ 0, 1 } };
 
 			text_edit->insert_text("t\ninserting text", 0, 3);
 			MessageQueue::get_singleton()->flush();
@@ -249,7 +249,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Can insert even if not editable.
-			lines_edited_args = { { 1, 1 } };
+			lines_edited_args = { Array{ 1, 1 } };
 
 			text_edit->set_editable(false);
 			text_edit->insert_text("mid", 1, 2);
@@ -291,7 +291,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(1, 4, 1, 6, 2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 2 } };
+			lines_edited_args = { Array{ 1, 2 } };
 
 			text_edit->insert_text("\n ", 1, 2);
 			MessageQueue::get_singleton()->flush();
@@ -325,7 +325,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			text_edit->insert_text("a", 0, 4, true, false);
 			MessageQueue::get_singleton()->flush();
@@ -352,7 +352,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			text_edit->insert_text("a", 0, 4, false, false);
 			MessageQueue::get_singleton()->flush();
@@ -379,7 +379,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			text_edit->insert_text("a", 0, 4, true, true);
 			MessageQueue::get_singleton()->flush();
@@ -406,7 +406,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			text_edit->insert_text("a", 0, 4, false, true);
 			MessageQueue::get_singleton()->flush();
@@ -420,7 +420,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] remove text") {
-			lines_edited_args = { { 0, 0 }, { 0, 2 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 2 } };
 
 			text_edit->set_text("test\nremoveing text\nthird line");
 			MessageQueue::get_singleton()->flush();
@@ -445,7 +445,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(10);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 2, 1 } };
+			lines_edited_args = { Array{ 2, 1 } };
 
 			text_edit->remove_text(1, 9, 2, 2);
 			MessageQueue::get_singleton()->flush();
@@ -458,7 +458,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Can remove even if not editable.
-			lines_edited_args = { { 1, 1 } };
+			lines_edited_args = { Array{ 1, 1 } };
 
 			text_edit->set_editable(false);
 			text_edit->remove_text(1, 5, 1, 6);
@@ -674,7 +674,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 }, { 0, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 1 } };
 
 			text_edit->set_line(0, "multiple\nlines");
 			MessageQueue::get_singleton()->flush();
@@ -693,7 +693,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] swap lines") {
-			lines_edited_args = { { 0, 0 }, { 0, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 1 } };
 
 			text_edit->set_text("testing\nswap");
 			MessageQueue::get_singleton()->flush();
@@ -707,7 +707,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			// Emitted twice for each line.
-			lines_edited_args = { { 0, 0 }, { 0, 0 }, { 1, 1 }, { 1, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 0 }, Array{ 1, 1 }, Array{ 1, 1 } };
 
 			// Order does not matter. Works when not editable.
 			text_edit->set_editable(false);
@@ -761,7 +761,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(1, 6);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 1 }, { 1, 1 }, { 0, 0 }, { 0, 0 } };
+			lines_edited_args = { Array{ 1, 1 }, Array{ 1, 1 }, Array{ 0, 0 }, Array{ 0, 0 } };
 
 			text_edit->swap_lines(0, 1);
 			MessageQueue::get_singleton()->flush();
@@ -790,7 +790,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("text_changed");
-			lines_edited_args = { { 2, 2 }, { 2, 2 }, { 0, 0 }, { 0, 0 } };
+			lines_edited_args = { Array{ 2, 2 }, Array{ 2, 2 }, Array{ 0, 0 }, Array{ 0, 0 } };
 
 			text_edit->swap_lines(0, 2);
 			MessageQueue::get_singleton()->flush();
@@ -804,7 +804,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] insert line at") {
-			lines_edited_args = { { 0, 0 }, { 0, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 1 } };
 
 			text_edit->set_text("testing\nswap");
 			MessageQueue::get_singleton()->flush();
@@ -823,7 +823,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Insert line at inserts a line before and moves caret and selection. Works when not editable.
 			text_edit->set_editable(false);
-			lines_edited_args = { { 0, 1 } };
+			lines_edited_args = { Array{ 0, 1 } };
 			text_edit->insert_line_at(0, "new");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "new\ntesting\nswap");
@@ -866,7 +866,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_from_line() == 0);
 			CHECK(text_edit->get_selection_to_line() == 2);
 			SIGNAL_CHECK_FALSE("caret_changed");
-			lines_edited_args = { { 2, 3 } };
+			lines_edited_args = { Array{ 2, 3 } };
 
 			text_edit->insert_line_at(2, "after");
 			MessageQueue::get_singleton()->flush();
@@ -898,7 +898,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(0, 1, 2, 2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 2, 4 } };
+			lines_edited_args = { Array{ 2, 4 } };
 
 			text_edit->insert_line_at(2, "multiple\nlines");
 			MessageQueue::get_singleton()->flush();
@@ -915,7 +915,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] remove line at") {
-			lines_edited_args = { { 0, 0 }, { 0, 5 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 5 } };
 			text_edit->set_text("testing\nremove line at\n\tremove\nlines\n\ntest");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "testing\nremove line at\n\tremove\nlines\n\ntest");
@@ -934,7 +934,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(1, 5);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 3, 2 } };
+			lines_edited_args = { Array{ 3, 2 } };
 
 			text_edit->remove_line_at(2, true);
 			MessageQueue::get_singleton()->flush();
@@ -969,7 +969,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(4, 4);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 } };
+			lines_edited_args = { Array{ 1, 0 } };
 
 			text_edit->remove_line_at(0, false);
 			MessageQueue::get_singleton()->flush();
@@ -990,7 +990,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(0);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 3, 2 } };
+			lines_edited_args = { Array{ 3, 2 } };
 
 			text_edit->remove_line_at(2, false);
 			MessageQueue::get_singleton()->flush();
@@ -1007,7 +1007,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 2, 1 } };
+			lines_edited_args = { Array{ 2, 1 } };
 
 			text_edit->remove_line_at(2, true);
 			MessageQueue::get_singleton()->flush();
@@ -1043,7 +1043,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 } };
+			lines_edited_args = { Array{ 1, 0 } };
 
 			text_edit->remove_line_at(1, false);
 			MessageQueue::get_singleton()->flush();
@@ -1083,7 +1083,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(10);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			text_edit->remove_line_at(0);
 			MessageQueue::get_singleton()->flush();
@@ -1098,7 +1098,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] insert text at caret") {
-			lines_edited_args = { { 0, 1 } };
+			lines_edited_args = { Array{ 0, 1 } };
 
 			// Insert text at caret can insert multiple lines.
 			text_edit->insert_text_at_caret("testing\nswap");
@@ -1117,7 +1117,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 			text_edit->insert_text_at_caret("mid");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "temidsting\nswap");
@@ -1131,7 +1131,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Selections are deleted then text is inserted. It also works even if not editable.
 			text_edit->select(0, 0, 0, text_edit->get_line(0).length());
 			CHECK(text_edit->has_selection());
-			lines_edited_args = { { 0, 0 }, { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 0 } };
 
 			text_edit->set_editable(false);
 			text_edit->insert_text_at_caret("new line");
@@ -1204,7 +1204,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array lines_edited_args = { { 0, 0 }, { 0, 0 } };
+		Array lines_edited_args = { Array{ 0, 0 }, Array{ 0, 0 } };
 
 		SUBCASE("[TextEdit] select all") {
 			// Select when there is no text does not select.
@@ -2813,7 +2813,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array lines_edited_args = { { 0, 0 } };
+		Array lines_edited_args = { Array{ 0, 0 } };
 
 		SUBCASE("[TextEdit] backspace") {
 			text_edit->set_text("this is\nsome\n");
@@ -2837,7 +2837,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(0);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 2, 1 } };
+			lines_edited_args = { Array{ 2, 1 } };
 
 			text_edit->backspace();
 			MessageQueue::get_singleton()->flush();
@@ -2849,7 +2849,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// Backspace removes a character.
-			lines_edited_args = { { 1, 1 } };
+			lines_edited_args = { Array{ 1, 1 } };
 			text_edit->backspace();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "this is\nsom");
@@ -2916,7 +2916,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 } };
+			lines_edited_args = { Array{ 1, 0 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -2958,7 +2958,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			SEND_GUI_ACTION("ui_cut");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3006,7 +3006,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 }, { 1, 0 } };
+			lines_edited_args = { Array{ 1, 0 }, Array{ 1, 0 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -3033,7 +3033,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -3069,7 +3069,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 }, { 3, 2 }, { 2, 1 } };
+			lines_edited_args = { Array{ 1, 0 }, Array{ 3, 2 }, Array{ 2, 1 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -3098,7 +3098,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 1 }, { 4, 3 }, { 0, 0 } };
+			lines_edited_args = { Array{ 1, 1 }, Array{ 4, 3 }, Array{ 0, 0 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();
@@ -3264,7 +3264,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 1 } };
+			lines_edited_args = { Array{ 1, 1 } };
 			DS->clipboard_set("paste");
 
 			text_edit->paste();
@@ -3309,7 +3309,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 2, 2 } };
+			lines_edited_args = { Array{ 2, 2 } };
 			DS->clipboard_set("paste2");
 
 			SEND_GUI_ACTION("ui_paste");
@@ -3330,7 +3330,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 }, { 0, 0 } };
+			lines_edited_args = { Array{ 1, 0 }, Array{ 0, 0 } };
 			DS->clipboard_set("paste");
 
 			text_edit->paste();
@@ -3353,7 +3353,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 3 } };
+			lines_edited_args = { Array{ 0, 3 } };
 			DS->clipboard_set("multi\n\nline\npaste");
 
 			text_edit->paste();
@@ -3375,7 +3375,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 2 } };
+			lines_edited_args = { Array{ 1, 2 } };
 			DS->clipboard_set("");
 			text_edit->copy();
 			text_edit->set_caret_column(3);
@@ -3402,7 +3402,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 1 } };
+			lines_edited_args = { Array{ 0, 1 } };
 			DS->clipboard_set("paste\n");
 
 			text_edit->paste();
@@ -3426,7 +3426,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 1 }, { 2, 3 }, { 5, 6 } };
+			lines_edited_args = { Array{ 0, 1 }, Array{ 2, 3 }, Array{ 5, 6 } };
 			DS->clipboard_set("paste\ntest");
 
 			text_edit->paste();
@@ -3456,7 +3456,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 }, { 1, 1 }, { 3, 3 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 1, 1 }, Array{ 3, 3 } };
 			DS->clipboard_set("paste\ntest\n1");
 
 			text_edit->paste();
@@ -3537,7 +3537,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 3, 4 } };
+			lines_edited_args = { Array{ 3, 4 } };
 
 			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(3, 2).get_center() + Point2i(2, 0), MouseButton::MIDDLE, MouseButtonMask::MIDDLE, Key::NONE);
 			CHECK(DS->clipboard_get_primary() == "is is\nsom");
@@ -3558,7 +3558,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 			DS->clipboard_set_primary("paste");
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			text_edit->paste_primary_clipboard();
 			MessageQueue::get_singleton()->flush();
@@ -3583,7 +3583,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 			DS->clipboard_set_primary("paste");
-			lines_edited_args = { { 1, 1 }, { 2, 2 } };
+			lines_edited_args = { Array{ 1, 1 }, Array{ 2, 2 } };
 
 			text_edit->paste_primary_clipboard();
 			MessageQueue::get_singleton()->flush();
@@ -3684,7 +3684,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array lines_edited_args = { { 0, 0 } };
+		Array lines_edited_args = { Array{ 0, 0 } };
 
 		SUBCASE("[TextEdit] ui_text_newline_above") {
 			text_edit->set_text("this is some test text.\nthis is some test text.");
@@ -3700,7 +3700,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 1 }, { 2, 3 } };
+			lines_edited_args = { Array{ 0, 1 }, Array{ 2, 3 } };
 
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3772,7 +3772,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(1, 10, 0, 0);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 1 }, { 4, 5 } };
+			lines_edited_args = { Array{ 0, 1 }, Array{ 4, 5 } };
 
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3797,7 +3797,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 1 }, { 1, 2 } };
+			lines_edited_args = { Array{ 0, 1 }, Array{ 1, 2 } };
 
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3826,7 +3826,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 1 }, { 2, 3 } };
+			lines_edited_args = { Array{ 0, 1 }, Array{ 2, 3 } };
 
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3897,7 +3897,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 1 }, { 0, 1 } };
+			lines_edited_args = { Array{ 0, 1 }, Array{ 0, 1 } };
 
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -3928,7 +3928,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 			// Lines edited: deletion, insert line, insert line.
-			lines_edited_args = { { 0, 0 }, { 0, 1 }, { 2, 3 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 1 }, Array{ 2, 3 } };
 
 			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4006,7 +4006,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(5);
 			text_edit->add_caret(1, 2);
 			text_edit->add_caret(1, 8);
-			lines_edited_args = { { 1, 1 } };
+			lines_edited_args = { Array{ 1, 1 } };
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
@@ -4057,7 +4057,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(3, 7, 3, 4, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 3, 3 }, { 1, 1 } };
+			lines_edited_args = { Array{ 3, 3 }, Array{ 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4078,7 +4078,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(0, false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 3, 2 }, { 1, 0 } };
+			lines_edited_args = { Array{ 3, 2 }, Array{ 1, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4117,7 +4117,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(true);
 
 			// Remove entire line content when at the end of the line.
-			lines_edited_args = { { 1, 1 }, { 0, 0 } };
+			lines_edited_args = { Array{ 1, 1 }, Array{ 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4180,7 +4180,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(3, 10, 3, 6, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 3, 3 }, { 1, 1 } };
+			lines_edited_args = { Array{ 3, 3 }, Array{ 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4197,7 +4197,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			text_edit->end_complex_operation();
 
-			lines_edited_args = { { 3, 2 }, { 1, 0 } };
+			lines_edited_args = { Array{ 3, 2 }, Array{ 1, 0 } };
 
 			// Start of line should also be a normal backspace.
 			text_edit->set_caret_column(0);
@@ -4244,7 +4244,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(12, false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 1 }, { 0, 0 } };
+			lines_edited_args = { Array{ 1, 1 }, Array{ 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4350,7 +4350,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
-			lines_edited_args = { { 0, 0 }, { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4414,7 +4414,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(3, 5, 3, 2, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 3, 3 }, { 1, 1 } };
+			lines_edited_args = { Array{ 3, 3 }, Array{ 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4469,7 +4469,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(0, false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 3, 2 }, { 1, 0 } };
+			lines_edited_args = { Array{ 3, 2 }, Array{ 1, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4541,7 +4541,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->start_action(TextEdit::ACTION_NONE);
 
 			// Backspace removes character to the left.
-			lines_edited_args = { { 1, 1 }, { 0, 0 } };
+			lines_edited_args = { Array{ 1, 1 }, Array{ 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4573,7 +4573,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// Undo both backspaces.
-			lines_edited_args = { { 1, 1 }, { 0, 0 }, { 1, 1 }, { 0, 0 } };
+			lines_edited_args = { Array{ 1, 1 }, Array{ 0, 0 }, Array{ 1, 1 }, Array{ 0, 0 } };
 
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
@@ -4612,7 +4612,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(0, 9);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 }, { 0, 0 }, { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 0 }, Array{ 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4631,7 +4631,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(1, text_edit->get_line(1).length(), 1, 0, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 1 }, { 0, 0 } };
+			lines_edited_args = { Array{ 1, 1 }, Array{ 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_text() == "\n");
@@ -4683,7 +4683,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(0, 20);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4697,7 +4697,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// Undo.
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
@@ -4734,7 +4734,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(1, 8, 1, 4, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 }, { 1, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4827,7 +4827,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(2, 10, 2, 6, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 }, { 2, 2 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 2, 2 } };
 
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4848,7 +4848,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(text_edit->get_line(2).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 }, { 2, 1 } };
+			lines_edited_args = { Array{ 1, 0 }, Array{ 2, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4890,7 +4890,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->start_action(TextEdit::ACTION_NONE);
 
 			// Delete to the end of the word right of the caret.
-			lines_edited_args = { { 0, 0 }, { 1, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -4943,7 +4943,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(6);
 			text_edit->add_caret(0, 9);
 			text_edit->add_caret(0, 3);
-			lines_edited_args = { { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 } };
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
@@ -5021,7 +5021,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
-			lines_edited_args = { { 0, 0 }, { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 0 } };
 
 			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -5037,7 +5037,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			lines_edited_args = { { 0, 0 }, { 0, 0 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 0 } };
 
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
@@ -5091,7 +5091,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(2, 5, 2, 2, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 0, 0 }, { 2, 2 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 2, 2 } };
 
 			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -5147,7 +5147,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(text_edit->get_line(2).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 }, { 2, 1 } };
+			lines_edited_args = { Array{ 1, 0 }, Array{ 2, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -5219,7 +5219,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->start_action(TextEdit::EditAction::ACTION_NONE);
 
 			// Delete removes character to the right.
-			lines_edited_args = { { 0, 0 }, { 1, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 1, 1 } };
 
 			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -5251,7 +5251,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// Undo both deletes.
-			lines_edited_args = { { 0, 0 }, { 1, 1 }, { 0, 0 }, { 1, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 1, 1 }, Array{ 0, 0 }, Array{ 1, 1 } };
 
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
@@ -6282,7 +6282,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			lines_edited_args = { { 0, 0 }, { 1, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 1, 1 } };
 
 			SEND_GUI_KEY_EVENT(Key::A);
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -6325,7 +6325,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			lines_edited_args = { { 0, 0 }, { 0, 0 }, { 1, 1 }, { 1, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 0, 0 }, Array{ 1, 1 }, Array{ 1, 1 } };
 
 			text_edit->select(0, 0, 0, 1);
 			text_edit->select(1, 0, 1, 1, 1);
@@ -6362,7 +6362,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_overtype_mode_enabled(false);
 			CHECK_FALSE(text_edit->is_overtype_mode_enabled());
 
-			lines_edited_args = { { 0, 0 }, { 1, 1 } };
+			lines_edited_args = { Array{ 0, 0 }, Array{ 1, 1 } };
 
 			SEND_GUI_KEY_EVENT(Key::TAB);
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -8243,12 +8243,12 @@ TEST_CASE("[SceneTree][TextEdit] gutters") {
 		// Click on gutter.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(5, line_height / 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(text_edit->get_hovered_gutter() == Vector2i(0, 0));
-		SIGNAL_CHECK("gutter_clicked", Array({ { 0, 0 } }));
+		SIGNAL_CHECK("gutter_clicked", Array({ Array{ 0, 0 } }));
 
 		// Click on gutter on another line.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(5, line_height * 3 + line_height / 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(text_edit->get_hovered_gutter() == Vector2i(0, 3));
-		SIGNAL_CHECK("gutter_clicked", Array({ { 3, 0 } }));
+		SIGNAL_CHECK("gutter_clicked", Array({ Array{ 3, 0 } }));
 
 		// Unclickable gutter can be hovered.
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2(15, line_height + line_height / 2), MouseButtonMask::NONE, Key::NONE);
@@ -8259,7 +8259,7 @@ TEST_CASE("[SceneTree][TextEdit] gutters") {
 		// Unclickable gutter can be clicked.
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2(15, line_height * 2 + line_height / 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 		CHECK(text_edit->get_hovered_gutter() == Vector2i(1, 2));
-		SIGNAL_CHECK("gutter_clicked", Array({ { 2, 1 } }));
+		SIGNAL_CHECK("gutter_clicked", Array({ Array{ 2, 1 } }));
 		CHECK(DS->get_cursor_shape() == DisplayServer::CURSOR_ARROW);
 
 		// Hover past last line.

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -413,7 +413,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 
 			SUBCASE("[Viewport][GuiInputEvent] Signal 'gui_focus_changed' is only emitted if a previously unfocused Control grabs focus.") {
 				SIGNAL_WATCH(root, SNAME("gui_focus_changed"));
-				Array signal_args = { { node_a } };
+				Array signal_args = { Array{ node_a } };
 
 				SEND_GUI_MOUSE_BUTTON_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);

--- a/tests/servers/test_navigation_server_2d.h
+++ b/tests/servers/test_navigation_server_2d.h
@@ -625,7 +625,7 @@ TEST_SUITE("[Navigation2D]") {
 			SIGNAL_WATCH(navigation_server, "map_changed");
 			SIGNAL_CHECK_FALSE("map_changed");
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
-			SIGNAL_CHECK("map_changed", { { map } });
+			SIGNAL_CHECK("map_changed", { Array{ map } });
 			SIGNAL_UNWATCH(navigation_server, "map_changed");
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector2(0, 0)), Vector2(0, 0));
 		}

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -556,7 +556,7 @@ TEST_SUITE("[Navigation3D]") {
 			SIGNAL_WATCH(navigation_server, "map_changed");
 			SIGNAL_CHECK_FALSE("map_changed");
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
-			SIGNAL_CHECK("map_changed", { { map } });
+			SIGNAL_CHECK("map_changed", { Array{ map } });
 			SIGNAL_UNWATCH(navigation_server, "map_changed");
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector3(0, 0, 0)), Vector3(0, 0, 0));
 		}
@@ -653,7 +653,7 @@ TEST_SUITE("[Navigation3D]") {
 			SIGNAL_WATCH(navigation_server, "map_changed");
 			SIGNAL_CHECK_FALSE("map_changed");
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
-			SIGNAL_CHECK("map_changed", { { map } });
+			SIGNAL_CHECK("map_changed", { Array{ map } });
 			SIGNAL_UNWATCH(navigation_server, "map_changed");
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector3(0, 0, 0)), Vector3(0, 0, 0));
 		}


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/112662

Fixes the ambiguity by explicitly disabling this syntax.
Simply removing the overload again could have caused regressions in the other direction (causing the syntax mentioned in https://github.com/godotengine/godot/issues/112662 to return a `String` variant again instead of an `Array` variant).

It is generally unexpected for `Variant` to "default" to any variant type. So I think it is appropriate to just delete it, and make callers use explicit interfaces.