### PR TITLE
Fix wrong AABB when selecting Node3D gizmo in editor

### DIFF
--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -253,7 +253,7 @@ void EditorNode3DGizmo::_update_bvh() {
 
 	float effective_icon_size = selectable_icon_size > 0.0f ? selectable_icon_size : 0.0f;
 	Vector3 icon_size_vector3 = Vector3(effective_icon_size, effective_icon_size, effective_icon_size);
-	AABB aabb(spatial_node->get_position() - icon_size_vector3 * 100.0f, icon_size_vector3 * 200.0f);
+	AABB aabb(transform.origin - icon_size_vector3 * 100.0f, icon_size_vector3 * 200.0f);
 
 	for (const Vector3 &segment_end : collision_segments) {
 		aabb.expand_to(transform.xform(segment_end));


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112582
The `AABB` was incorrectly calculated and then passed to the BVH update function, which is used to select the gizmo.
This caused wrong selection bounds.

before:

https://github.com/user-attachments/assets/484212db-9bcd-475f-b5dc-1aaae505ec4c

after:

https://github.com/user-attachments/assets/67ac5831-02b1-43e6-b63c-d74ff0de1a87

