### PR TITLE
Fix visual shader error when editing theme settings

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -730,7 +730,7 @@ void GraphEdit::add_child_notify(Node *p_child) {
 		}
 		graph_element->connect("raise_request", callable_mp(this, &GraphEdit::_ensure_node_order_from).bind(graph_element));
 		graph_element->connect("resize_request", callable_mp(this, &GraphEdit::_graph_element_resize_request).bind(graph_element));
-		if (connections_layer != nullptr && connections_layer->is_inside_tree()) {
+		if (connections_layer != nullptr) {
 			graph_element->connect(SceneStringName(item_rect_changed), callable_mp((CanvasItem *)connections_layer, &CanvasItem::queue_redraw));
 		}
 		graph_element->connect(SceneStringName(item_rect_changed), callable_mp((CanvasItem *)minimap, &GraphEditMinimap::queue_redraw));


### PR DESCRIPTION
This fixes an error that can happen when opening the editor with a node selected that has a visual shader, and then changing some theme setting:
```
ERROR: Attempt to disconnect a nonexistent connection from '0:<VSGraphNode#2176474766612>'. Signal: 'item_rect_changed', callable: 'CanvasItem::queue_redraw'.
```
This change shouldn't reintroduce #96289, since `connections_layer` is set to `nullptr` if removed anyways.