### PR TITLE
Fix GodotTools.OpenVisualStudio to detect and open VS 2026

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
@@ -57,7 +57,6 @@ namespace GodotTools.OpenVisualStudio
                     return 1;
                 }
 
-
                 dte.UserControl = true;
 
                 try

--- a/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
@@ -46,20 +46,17 @@ namespace GodotTools.OpenVisualStudio
 
             if (dte == null)
             {
-                // Open a new instance
-                dte = TryVisualStudioLaunch("VisualStudio.DTE.17.0");
+                // Open a new instance, preferring the newest installed VS
+                dte = TryVisualStudioLaunch("VisualStudio.DTE.18.0")   // VS 2026
+                    ?? TryVisualStudioLaunch("VisualStudio.DTE.17.0")  // VS 2022
+                    ?? TryVisualStudioLaunch("VisualStudio.DTE.16.0"); // VS 2019
 
                 if (dte == null)
                 {
-                    // Launch of VS 2022 failed, fallback to 2019
-                    dte = TryVisualStudioLaunch("VisualStudio.DTE.16.0");
-
-                    if (dte == null)
-                    {
-                        Console.Error.WriteLine("Visual Studio not found");
-                        return 1;
-                    }
+                    Console.Error.WriteLine("Visual Studio not found");
+                    return 1;
                 }
+
 
                 dte.UserControl = true;
 
@@ -188,8 +185,10 @@ namespace GodotTools.OpenVisualStudio
                     if (ppszDisplayName == null)
                         continue;
 
-                    // The digits after the colon are the process ID
-                    if (!Regex.IsMatch(ppszDisplayName, "!VisualStudio.DTE.1[6-7].0:[0-9]"))
+                    // Match Visual Studio versions 16 (2019), 17 (2022), 18 (2026), or higher
+                    var match = Regex.Match(ppszDisplayName, @"!VisualStudio\.DTE\.(\d+)\.0:[0-9]+");
+
+                    if (!match.Success)
                         continue;
 
                     if (pprot.GetObject(moniker[0], out object ppunkObject) == 0)


### PR DESCRIPTION
Fixes #112675
Previously, the tool always launched Visual Studio 2022, ignoring VS 2026. This update allows detection of VS 2026 and makes it forward-compatible with future versions.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
