### PR TITLE
Add a project setting to break on any error or warning printed

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1729,6 +1729,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "display/window/stretch/scale", PROPERTY_HINT_RANGE, "0.5,8.0,0.01"), 1.0);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/window/stretch/scale_mode", PROPERTY_HINT_ENUM, "fractional,integer"), "fractional");
 
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "debug/settings/debugger/break_on_error", PROPERTY_HINT_ENUM, "Disabled,On Errors,On Errors and Warnings"), 0);
+
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "debug/settings/profiler/max_functions", PROPERTY_HINT_RANGE, "128,65535,1"), 16384);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "debug/settings/profiler/max_timestamp_query_elements", PROPERTY_HINT_RANGE, "256,65535,1"), 256);
 

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -46,6 +46,12 @@ public:
 		MESSAGE_TYPE_LOG_RICH,
 	};
 
+	enum BreakOnError {
+		BREAK_ON_ERROR_DISABLED = 0,
+		BREAK_ON_ERROR_ERRORS = 1,
+		BREAK_ON_ERROR_ERRORS_AND_WARNINGS = 2,
+	};
+
 private:
 	typedef DebuggerMarshalls::OutputError ErrorMessage;
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -682,6 +682,9 @@
 		<member name="debug/settings/crash_handler/message.editor" type="String" setter="" getter="" default="&quot;Please include this when reporting the bug on: https://github.com/godotengine/godot/issues&quot;">
 			Editor-only override for [member debug/settings/crash_handler/message]. Does not affect exported projects in debug or release mode.
 		</member>
+		<member name="debug/settings/debugger/break_on_error" type="int" setter="" getter="" default="0">
+			Controls whether the debugger should automatically break when an error or warning is printed. This can be used to find and resolve errors of any source as they occur. This includes errors from scripts ([method @GlobalScope.push_error] and [method @GlobalScope.push_warning]), as well as any error or warning prrinted by the engine itself.
+		</member>
 		<member name="debug/settings/gdscript/always_track_call_stacks" type="bool" setter="" getter="" default="false">
 			Whether GDScript call stacks will be tracked in release builds, thus allowing [method Engine.capture_script_backtraces] to function.
 			[b]Note:[/b] This setting has no effect on editor builds or debug builds, where GDScript call stacks are tracked regardless.


### PR DESCRIPTION
- Alternative implementation of https://github.com/godotengine/godot/pull/50955
that is more general-purpose.

This can be used to find and resolve errors/warnings as they occur during development, which makes them less likely to pop up at the last minute.

This affects any error/warning message regardless of its source (engine, `push_error()`/`push_warning()` in scripts, ...).

This is **disabled by default**, and must be enabled in the Project Settings to work:

<img width="853" height="200" alt="Screenshot_20251112_183329" src="https://github.com/user-attachments/assets/9f85061a-d4a0-4e2f-8d94-3071c67358e8" />

- This closes https://github.com/godotengine/godot-proposals/issues/1729.

**Testing project:** [test_error_break.zip](https://github.com/user-attachments/files/23506416/test_error_break.zip)

## Preview

https://github.com/user-attachments/assets/57102847-4163-4353-82ef-45431d4c64f9

## TODO

- [ ] Do not break for errors that already break without the setting, such as the method call on null instance error seen in the above video. (This is why it's breaking twice on that message.)
- [ ] Implement in LocalDebugger for command-line debugging. I've attempted this in the past, but it seemed to not work reliably (it would either not break or break twice in a row).
- [ ] Use an approach that's functional in C#/GDExtension as well, and works when the GDScript module is disabled at compile-time.
  - I could call `EngineDebugger::get_script_debugger()->debug(nullptr, true, false);`, but it doesn't seem to do anything in GDScript.
- [ ] Add a way to exclude certain error/warning messages, e.g. based on a regex. During engine development on `master`, you may run into unavoidable errors you don't want to silence using `Engine.print_error_enabled = false` as it's too general.