### PR TITLE
[Android] Make use of `activity-alias` as the primary launcher mechanism

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2561,7 +2561,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 		print_verbose(output);
 		if (err || rv != 0 || output.contains("Error: Activity not started")) {
 			// The implicit launch failed, let's try an explicit launch by specifying the component name before giving up.
-			const String component_name = get_package_name(p_preset, package_name) + "/com.godot.game.GodotApp";
+			const String component_name = get_package_name(p_preset, package_name) + "/com.godot.game.GodotAppLauncher";
 			print_line("Implicit launch failed... Trying explicit launch using", component_name);
 			args.erase(get_package_name(p_preset, package_name));
 			args.push_back("-n");

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -35,9 +35,11 @@ configurations {
 
 dependencies {
     // Android instrumented test dependencies
-    androidTestImplementation "androidx.test.ext:junit:1.3.0"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.7.0"
-    androidTestImplementation "org.jetbrains.kotlin:kotlin-test:1.3.11"
+    androidTestImplementation "androidx.test.ext:junit:$versions.junitVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$versions.espressoCoreVersion"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-test:$versions.kotlinTestVersion"
+    androidTestImplementation "androidx.test:runner:$versions.testRunnerVersion"
+    androidTestUtil "androidx.test:orchestrator:$versions.testOrchestratorVersion"
 
     implementation "androidx.fragment:fragment:$versions.fragmentVersion"
     implementation "androidx.core:core-splashscreen:$versions.splashscreenVersion"
@@ -121,6 +123,15 @@ android {
         missingDimensionStrategy 'products', 'template'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        // The following argument makes the Android Test Orchestrator run its
+        // "pm clear" command after each test invocation. This command ensures
+        // that the app's state is completely cleared between tests.
+        testInstrumentationRunnerArguments clearPackageData: 'true'
+    }
+
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 
     lintOptions {

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -15,8 +15,12 @@ ext.versions = [
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
     ndkVersion         : '28.1.13356709',
     splashscreenVersion: '1.0.1',
-    openxrVendorsVersion: '4.1.1-stable'
-
+    openxrVendorsVersion: '4.1.1-stable',
+    junitVersion       : '1.3.0',
+    espressoCoreVersion: '3.7.0',
+    kotlinTestVersion  : '1.3.11',
+    testRunnerVersion  : '1.7.0',
+    testOrchestratorVersion: '1.6.1',
 ]
 
 ext.getExportPackageName = { ->

--- a/platform/android/java/app/src/main/AndroidManifest.xml
+++ b/platform/android/java/app/src/main/AndroidManifest.xml
@@ -31,23 +31,25 @@
 
         <activity
             android:name=".GodotApp"
-            android:label="@string/godot_project_name_string"
             android:theme="@style/GodotAppSplashTheme"
             android:launchMode="singleInstancePerTask"
             android:excludeFromRecents="false"
-            android:exported="true"
+            android:exported="false"
             android:screenOrientation="landscape"
             android:windowSoftInputMode="adjustResize"
             android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:resizeableActivity="false"
-            tools:ignore="UnusedAttribute" >
-
+            tools:ignore="UnusedAttribute" />
+        <activity-alias
+            android:name=".GodotAppLauncher"
+            android:targetActivity=".GodotApp"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
     </application>
 

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -91,6 +91,17 @@ android {
         ]
 
         ndk { debugSymbolLevel 'NONE' }
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        // The following argument makes the Android Test Orchestrator run its
+        // "pm clear" command after each test invocation. This command ensures
+        // that the app's state is completely cleared between tests.
+        testInstrumentationRunnerArguments clearPackageData: 'true'
+    }
+
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 
     base {
@@ -196,4 +207,11 @@ dependencies {
     horizonosImplementation "org.godotengine:godot-openxr-vendors-meta:$versions.openxrVendorsVersion"
     // Pico dependencies
     picoosImplementation "org.godotengine:godot-openxr-vendors-pico:$versions.openxrVendorsVersion"
+
+    // Android instrumented test dependencies
+    androidTestImplementation "androidx.test.ext:junit:$versions.junitVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$versions.espressoCoreVersion"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-test:$versions.kotlinTestVersion"
+    androidTestImplementation "androidx.test:runner:$versions.testRunnerVersion"
+    androidTestUtil "androidx.test:orchestrator:$versions.testOrchestratorVersion"
 }

--- a/platform/android/java/editor/src/androidTest/java/org/godotengine/editor/GodotEditorTest.kt
+++ b/platform/android/java/editor/src/androidTest/java/org/godotengine/editor/GodotEditorTest.kt
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  GodotAppTest.kt                                                       */
+/*  GodotEditorTest.kt                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,16 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-package com.godot.game
+package org.godotengine.editor
 
 import android.content.ComponentName
 import android.content.Intent
-import android.util.Log
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.godot.game.test.GodotAppInstrumentedTestPlugin
 import org.godotengine.godot.GodotActivity.Companion.EXTRA_COMMAND_LINE_PARAMS
-import org.godotengine.godot.plugin.GodotPluginRegistry
 import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.test.assertEquals
@@ -46,58 +43,32 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * This instrumented test will launch the `instrumented` version of GodotApp and run a set of tests against it.
+ * Instrumented test for the Godot editor.
  */
 @RunWith(AndroidJUnit4::class)
-class GodotAppTest {
-
+class GodotEditorTest {
 	companion object {
-		private val TAG = GodotAppTest::class.java.simpleName
-
-		private const val GODOT_APP_LAUNCHER_CLASS_NAME = "com.godot.game.GodotAppLauncher"
-		private const val GODOT_APP_CLASS_NAME = "com.godot.game.GodotApp"
+		private val TAG = GodotEditorTest::class.simpleName
 
 		private val TEST_COMMAND_LINE_PARAMS = arrayOf("This is a test")
+		private const val PROJECT_MANAGER_CLASS_NAME = "org.godotengine.editor.ProjectManager"
+		private const val GODOT_EDITOR_CLASS_NAME = "org.godotengine.editor.GodotEditor"
 	}
 
 	/**
-	 * Runs the JavaClassWrapper tests via the GodotAppInstrumentedTestPlugin.
+	 * Implicitly launch the project manager.
 	 */
 	@Test
-	fun runJavaClassWrapperTests() {
-		ActivityScenario.launch(GodotApp::class.java).use { scenario ->
-			scenario.onActivity { activity ->
-				val testPlugin = GodotPluginRegistry.getPluginRegistry()
-					.getPlugin("GodotAppInstrumentedTestPlugin") as GodotAppInstrumentedTestPlugin?
-				assertNotNull(testPlugin)
-
-				Log.d(TAG, "Waiting for the Godot main loop to start...")
-				testPlugin.waitForGodotMainLoopStarted()
-
-				Log.d(TAG, "Running JavaClassWrapper tests...")
-				val result = testPlugin.runJavaClassWrapperTests()
-				assertNotNull(result)
-				result.exceptionOrNull()?.let { throw it }
-				assertTrue(result.isSuccess)
-				Log.d(TAG, "Passed ${result.getOrNull()} tests")
-			}
-		}
-	}
-
-	/**
-	 * Test implicit launch of the Godot app, and validates this resolves to the `GodotAppLauncher` activity alias.
-	 */
-	@Test
-	fun testImplicitGodotAppLauncherLaunch() {
+	fun testImplicitProjectManagerLaunch() {
 		val implicitLaunchIntent = Intent().apply {
 			setPackage(BuildConfig.APPLICATION_ID)
 			action = Intent.ACTION_MAIN
 			addCategory(Intent.CATEGORY_LAUNCHER)
 			putExtra(EXTRA_COMMAND_LINE_PARAMS, TEST_COMMAND_LINE_PARAMS)
 		}
-		ActivityScenario.launch<GodotApp>(implicitLaunchIntent).use { scenario ->
+		ActivityScenario.launch<GodotEditor>(implicitLaunchIntent).use { scenario ->
 			scenario.onActivity { activity ->
-				assertEquals(activity.intent.component?.className, GODOT_APP_LAUNCHER_CLASS_NAME)
+				assertEquals(activity.intent.component?.className, PROJECT_MANAGER_CLASS_NAME)
 
 				val commandLineParams = activity.intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
 				assertNull(commandLineParams)
@@ -106,17 +77,17 @@ class GodotAppTest {
 	}
 
 	/**
-	 * Test explicit launch of the Godot app via its activity-alias launcher, and validates it resolves properly.
+	 * Explicitly launch the project manager.
 	 */
 	@Test
-	fun testExplicitGodotAppLauncherLaunch() {
-		val explicitIntent = Intent().apply {
-			component = ComponentName(BuildConfig.APPLICATION_ID, GODOT_APP_LAUNCHER_CLASS_NAME)
+	fun testExplicitProjectManagerLaunch() {
+		val explicitProjectManagerIntent = Intent().apply {
+			component = ComponentName(BuildConfig.APPLICATION_ID, PROJECT_MANAGER_CLASS_NAME)
 			putExtra(EXTRA_COMMAND_LINE_PARAMS, TEST_COMMAND_LINE_PARAMS)
 		}
-		ActivityScenario.launch<GodotApp>(explicitIntent).use { scenario ->
+		ActivityScenario.launch<GodotEditor>(explicitProjectManagerIntent).use { scenario ->
 			scenario.onActivity { activity ->
-				assertEquals(activity.intent.component?.className, GODOT_APP_LAUNCHER_CLASS_NAME)
+				assertEquals(activity.intent.component?.className, PROJECT_MANAGER_CLASS_NAME)
 
 				val commandLineParams = activity.intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
 				assertNull(commandLineParams)
@@ -125,17 +96,17 @@ class GodotAppTest {
 	}
 
 	/**
-	 * Test explicit launch of the `GodotApp` activity.
+	 * Explicitly launch the `GodotEditor` activity.
 	 */
 	@Test
-	fun testExplicitGodotAppLaunch() {
-		val explicitIntent = Intent().apply {
-			component = ComponentName(BuildConfig.APPLICATION_ID, GODOT_APP_CLASS_NAME)
+	fun testExplicitGodotEditorLaunch() {
+		val godotEditorIntent = Intent().apply {
+			component = ComponentName(BuildConfig.APPLICATION_ID, GODOT_EDITOR_CLASS_NAME)
 			putExtra(EXTRA_COMMAND_LINE_PARAMS, TEST_COMMAND_LINE_PARAMS)
 		}
-		ActivityScenario.launch<GodotApp>(explicitIntent).use { scenario ->
+		ActivityScenario.launch<GodotEditor>(godotEditorIntent).use { scenario ->
 			scenario.onActivity { activity ->
-				assertEquals(activity.intent.component?.className, GODOT_APP_CLASS_NAME)
+				assertEquals(activity.intent.component?.className, GODOT_EDITOR_CLASS_NAME)
 
 				val commandLineParams = activity.intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
 				assertNotNull(commandLineParams)

--- a/platform/android/java/editor/src/horizonos/AndroidManifest.xml
+++ b/platform/android/java/editor/src/horizonos/AndroidManifest.xml
@@ -47,20 +47,31 @@
 
         <activity
             android:name=".GodotEditor"
-            android:exported="true"
+            android:exported="false"
             android:screenOrientation="landscape"
             tools:node="merge"
             tools:replace="android:screenOrientation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="com.oculus.intent.category.2D" />
             </intent-filter>
 
             <meta-data android:name="com.oculus.vrshell.free_resizing_lock_aspect_ratio" android:value="true"/>
         </activity>
+        <activity-alias
+            android:name=".ProjectManager"
+            android:exported="true"
+            tools:node="merge"
+            android:targetActivity=".GodotEditor">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="com.oculus.intent.category.2D" />
+            </intent-filter>
+        </activity-alias>
         <activity
             android:name=".GodotXRGame"
             android:exported="false"

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -46,20 +46,13 @@
         <activity
             android:name=".GodotEditor"
             android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
-            android:exported="true"
+            android:exported="false"
             android:icon="@mipmap/themed_icon"
             android:launchMode="singleTask"
             android:screenOrientation="userLandscape">
             <layout
                 android:defaultWidth="@dimen/editor_default_window_width"
                 android:defaultHeight="@dimen/editor_default_window_height" />
-
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
 
             <!-- Intent filter used to intercept hybrid PANEL launch for the current editor project, and route it
             properly through the editor 'run' logic (e.g: debugger setup) -->
@@ -77,6 +70,18 @@
                 <category android:name="org.godotengine.xr.hybrid.IMMERSIVE" />
             </intent-filter>
         </activity>
+        <activity-alias
+            android:name=".ProjectManager"
+            android:exported="true"
+            android:icon="@mipmap/themed_icon"
+            android:targetActivity=".GodotEditor">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
         <activity
             android:name=".GodotGame"
             android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -58,6 +58,7 @@ import org.godotengine.editor.embed.GameMenuFragment
 import org.godotengine.editor.utils.signApk
 import org.godotengine.editor.utils.verifyApk
 import org.godotengine.godot.BuildConfig
+import org.godotengine.godot.Godot
 import org.godotengine.godot.GodotActivity
 import org.godotengine.godot.GodotLib
 import org.godotengine.godot.editor.utils.EditorUtils
@@ -158,6 +159,20 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		internal const val SNACKBAR_SHOW_DURATION_MS = 5000L
 
 		private const val PREF_KEY_DONT_SHOW_GAME_RESUME_HINT = "pref_key_dont_show_game_resume_hint"
+
+		@JvmStatic
+		fun isRunningInInstrumentation(): Boolean {
+			if (BuildConfig.BUILD_TYPE == "release") {
+				return false
+			}
+
+			return try {
+				Class.forName("org.godotengine.editor.GodotEditorTest")
+				true
+			} catch (_: ClassNotFoundException) {
+				false
+			}
+		}
 	}
 
 	internal val editorMessageDispatcher = EditorMessageDispatcher(this)
@@ -229,9 +244,15 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 			enableEdgeToEdge()
 		}
 
-		// We exclude certain permissions from the set we request at startup, as they'll be
-		// requested on demand based on use cases.
-		PermissionsUtil.requestManifestPermissions(this, getExcludedPermissions())
+		// Skip permissions request if running in a device farm (e.g. firebase test lab) or if requested via the launch
+		// intent (e.g. instrumentation tests).
+		val skipPermissionsRequest = isRunningInInstrumentation() ||
+			Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && ActivityManager.isRunningInUserTestHarness()
+		if (!skipPermissionsRequest) {
+			// We exclude certain permissions from the set we request at startup, as they'll be
+			// requested on demand based on use cases.
+			PermissionsUtil.requestManifestPermissions(this, getExcludedPermissions())
+		}
 
 		editorMessageDispatcher.parseStartIntent(packageManager, intent)
 
@@ -247,7 +268,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 	override fun onNewIntent(newIntent: Intent) {
 		if (newIntent.hasCategory(HYBRID_APP_PANEL_CATEGORY) || newIntent.hasCategory(HYBRID_APP_IMMERSIVE_CATEGORY)) {
-			val params = newIntent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
+			val params = retrieveCommandLineParamsFromLaunchIntent(newIntent)
 			Log.d(TAG, "Received hybrid transition intent $newIntent with parameters ${params.contentToString()}")
 			// Override EXTRA_NEW_LAUNCH so the editor is not restarted
 			newIntent.putExtra(EXTRA_NEW_LAUNCH, false)
@@ -257,7 +278,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 				var scene = ""
 				var xrMode = XR_MODE_DEFAULT
 				var path = ""
-				if (params != null) {
+				if (params.isNotEmpty()) {
 					val sceneIndex = params.indexOf(SCENE_ARG)
 					if (sceneIndex != -1 && sceneIndex + 1 < params.size) {
 						scene = params[sceneIndex +1]
@@ -509,6 +530,14 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 			startActivity(newInstance, activityOptions?.toBundle())
 		}
 		return editorWindowInfo.windowId
+	}
+
+	override fun onGodotForceQuit(instance: Godot) {
+		if (!isRunningInInstrumentation()) {
+			// For instrumented tests, we disable force-quitting to allow the tests to complete successfully, otherwise
+			// they fail when the process crashes.
+			super.onGodotForceQuit(instance)
+		}
 	}
 
 	final override fun onGodotForceQuit(godotInstanceId: Int): Boolean {

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
@@ -63,20 +63,18 @@ abstract class BaseGodotGame: GodotEditor() {
 
 		// Check if we should be running in XR instead (if available) as it's possible we were
 		// launched from the project manager which doesn't have that information.
-		val launchingArgs = intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
-		if (launchingArgs != null) {
-			val editorWindowInfo = retrieveEditorWindowInfo(launchingArgs, getEditorGameEmbedMode())
-			if (editorWindowInfo != getEditorWindowInfo()) {
-				val relaunchIntent = getNewGodotInstanceIntent(editorWindowInfo, launchingArgs)
-				relaunchIntent.putExtra(EXTRA_NEW_LAUNCH, true)
-					.putExtra(EditorMessageDispatcher.EXTRA_MSG_DISPATCHER_PAYLOAD, intent.getBundleExtra(EditorMessageDispatcher.EXTRA_MSG_DISPATCHER_PAYLOAD))
+		val launchingArgs = retrieveCommandLineParamsFromLaunchIntent()
+		val editorWindowInfo = retrieveEditorWindowInfo(launchingArgs, getEditorGameEmbedMode())
+		if (editorWindowInfo != getEditorWindowInfo()) {
+			val relaunchIntent = getNewGodotInstanceIntent(editorWindowInfo, launchingArgs)
+			relaunchIntent.putExtra(EXTRA_NEW_LAUNCH, true)
+				.putExtra(EditorMessageDispatcher.EXTRA_MSG_DISPATCHER_PAYLOAD, intent.getBundleExtra(EditorMessageDispatcher.EXTRA_MSG_DISPATCHER_PAYLOAD))
 
-				Log.d(TAG, "Relaunching XR project using ${editorWindowInfo.windowClassName} with parameters ${launchingArgs.contentToString()}")
-				Godot.getInstance(applicationContext).destroyAndKillProcess {
-					ProcessPhoenix.triggerRebirth(this, relaunchIntent)
-				}
-				return
+			Log.d(TAG, "Relaunching XR project using ${editorWindowInfo.windowClassName} with parameters ${launchingArgs.contentToString()}")
+			Godot.getInstance(applicationContext).destroyAndKillProcess {
+				ProcessPhoenix.triggerRebirth(this, relaunchIntent)
 			}
+			return
 		}
 
 		// Request project runtime permissions if necessary.

--- a/platform/android/java/editor/src/picoos/AndroidManifest.xml
+++ b/platform/android/java/editor/src/picoos/AndroidManifest.xml
@@ -16,16 +16,10 @@
 
         <activity
             android:name=".GodotEditor"
-            android:exported="true"
+            android:exported="false"
             android:screenOrientation="landscape"
             tools:node="merge"
-            tools:replace="android:screenOrientation">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            tools:replace="android:screenOrientation"/>
 
         <activity
             android:name=".GodotXRGame"

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotActivity.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotActivity.kt
@@ -72,18 +72,48 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 	protected var godotFragment: GodotFragment? = null
 		private set
 
+	/**
+	 * Strip out the command line parameters from intent targeting exported activities.
+	 */
+	protected fun sanitizeLaunchIntent(launchIntent: Intent = intent): Intent {
+		val targetComponent = launchIntent.component ?: componentName
+		val activityInfo = packageManager.getActivityInfo(targetComponent, 0)
+		if (activityInfo.exported) {
+			launchIntent.removeExtra(EXTRA_COMMAND_LINE_PARAMS)
+		}
+
+		return launchIntent
+	}
+
+	/**
+	 * Only retrieve the command line parameters from the intent from non-exported activities.
+	 * This ensures only internal components can configure how the engine is run.
+	 */
+	protected fun retrieveCommandLineParamsFromLaunchIntent(launchIntent: Intent = intent): Array<String> {
+		val targetComponent = launchIntent.component ?: componentName
+		val activityInfo = packageManager.getActivityInfo(targetComponent, 0)
+		if (!activityInfo.exported) {
+			val params = launchIntent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
+			return params ?: emptyArray()
+		}
+		return emptyArray()
+	}
+
 	@CallSuper
 	override fun onCreate(savedInstanceState: Bundle?) {
+		intent = sanitizeLaunchIntent(intent)
+
 		val assetsCommandLine = try {
 			CommandLineFileParser.parseCommandLine(assets.open("_cl_"))
-		} catch (ignored: Exception) {
+		} catch (_: Exception) {
 			mutableListOf()
 		}
+		Log.d(TAG, "Project command line parameters: $assetsCommandLine")
 		commandLineParams.addAll(assetsCommandLine)
 
-		val params = intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
-		Log.d(TAG, "Starting intent $intent with parameters ${params.contentToString()}")
-		commandLineParams.addAll(params ?: emptyArray())
+		val intentCommandLine = retrieveCommandLineParamsFromLaunchIntent()
+		Log.d(TAG, "Launch intent $intent with parameters ${intentCommandLine.contentToString()}")
+		commandLineParams.addAll(intentCommandLine)
 
 		super.onCreate(savedInstanceState)
 
@@ -167,10 +197,9 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 	}
 
 	override fun onNewIntent(newIntent: Intent) {
-		super.onNewIntent(newIntent)
-		intent = newIntent
-
-		handleStartIntent(newIntent, false)
+		intent = sanitizeLaunchIntent(newIntent)
+		super.onNewIntent(intent)
+		handleStartIntent(intent, false)
 	}
 
 	private fun handleStartIntent(intent: Intent, newLaunch: Boolean) {


### PR DESCRIPTION
This update improves the launch flow for the Godot Android editor and the Godot Android app template by leveraging [`activity-alias`](https://developer.android.com/guide/topics/manifest/activity-alias-element) to act as the app's entry point.

This provides several benefits, most importantly, the ability to limit the app's public surface area, and the flexibility to change the internal app launch logic without changing its manifest declaration.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
