### PR TITLE
Add `CONNECT_UNIQUE` flag to connect the same callable multiple times with different bind arguments

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -106,6 +106,40 @@ struct ObjectSignalLock {
 	}
 };
 
+uint32_t Object::SignalCallableHasher::hash(const Callable &p_callable) {
+	uint32_t hash = p_callable.hash();
+	if (p_callable.get_bound_arguments_count() > 0) {
+		Vector<Variant> bound_args;
+		p_callable.get_bound_arguments_ref(bound_args);
+		for (const Variant &arg : bound_args) {
+			hash = hash_murmur3_one_32(arg.hash(), hash);
+		}
+		hash = hash_fmix32(hash);
+	}
+	if (p_callable.get_unbound_arguments_count() > 0) {
+		hash = hash_murmur3_one_32(p_callable.get_unbound_arguments_count(), hash);
+		hash = hash_fmix32(hash);
+	}
+	return hash;
+}
+
+bool Object::SignalCallableComparator::compare(const Callable &p_lhs, const Callable &p_rhs) {
+	if (p_lhs != p_rhs) {
+		return false;
+	}
+
+	if (p_lhs.get_unbound_arguments_count() != p_rhs.get_unbound_arguments_count()) {
+		return false;
+	}
+
+	Vector<Variant> lhs_bound_args;
+	Vector<Variant> rhs_bound_args;
+	p_lhs.get_bound_arguments_ref(lhs_bound_args);
+	p_rhs.get_bound_arguments_ref(rhs_bound_args);
+
+	return lhs_bound_args == rhs_bound_args;
+}
+
 Object::Connection::operator Variant() const {
 	Dictionary d;
 	d["signal"] = signal;
@@ -1125,7 +1159,7 @@ bool Object::_has_user_signal(const StringName &p_name) const {
 }
 
 void Object::_remove_user_signal(const StringName &p_name) {
-	HashMap<Callable, Object::SignalData::Slot> slots_to_disconnect;
+	HashMap<Callable, Object::SignalData::Slot, Object::SignalCallableHasher, Object::SignalCallableComparator> slots_to_disconnect;
 
 	{
 		ObjectSignalLock signal_lock(this);
@@ -1552,10 +1586,11 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 		s = &signal_map[p_signal];
 	}
 
-	//compare with the base callable, so binds can be ignored
-	if (s->slot_map.has(*p_callable.get_base_comparator())) {
+	// Unless CONNECT_UNIQUE, compare with the base callable, so binds can be ignored.
+	const Callable *comparator = (p_flags & CONNECT_UNIQUE) ? &p_callable : p_callable.get_base_comparator();
+	if (s->slot_map.has(*comparator)) {
 		if (p_flags & CONNECT_REFERENCE_COUNTED) {
-			s->slot_map[*p_callable.get_base_comparator()].reference_count++;
+			s->slot_map[*comparator].reference_count++;
 			return OK;
 		} else {
 			ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER, vformat("Signal '%s' is already connected to given callable '%s' in that object.", p_signal, p_callable));
@@ -1576,8 +1611,7 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 		slot.reference_count = 1;
 	}
 
-	//use callable version as key, so binds can be ignored
-	s->slot_map[*p_callable.get_base_comparator()] = slot;
+	s->slot_map[*comparator] = slot;
 
 	return OK;
 }
@@ -1598,6 +1632,10 @@ bool Object::is_connected(const StringName &p_signal, const Callable &p_callable
 		}
 
 		ERR_FAIL_V_MSG(false, vformat("Nonexistent signal: '%s'.", p_signal));
+	}
+
+	if (s->slot_map.has(p_callable)) {
+		return true;
 	}
 
 	return s->slot_map.has(*p_callable.get_base_comparator());
@@ -1640,9 +1678,15 @@ bool Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 	}
 	ERR_FAIL_NULL_V_MSG(s, false, vformat("Disconnecting nonexistent signal '%s' in '%s'.", p_signal, to_string()));
 
-	ERR_FAIL_COND_V_MSG(!s->slot_map.has(*p_callable.get_base_comparator()), false, vformat("Attempt to disconnect a nonexistent connection from '%s'. Signal: '%s', callable: '%s'.", to_string(), p_signal, p_callable));
+	const Callable *comparator;
+	if (p_callable != *p_callable.get_base_comparator() && s->slot_map.has(p_callable)) {
+		comparator = &p_callable;
+	} else {
+		comparator = p_callable.get_base_comparator();
+		ERR_FAIL_COND_V_MSG(!s->slot_map.has(*comparator), false, vformat("Attempt to disconnect a nonexistent connection from '%s'. Signal: '%s', callable: '%s'.", to_string(), p_signal, p_callable));
+	}
 
-	SignalData::Slot *slot = &s->slot_map[*p_callable.get_base_comparator()];
+	SignalData::Slot *slot = &s->slot_map[*comparator];
 
 	if (!p_force) {
 		slot->reference_count--; // by default is zero, if it was not referenced it will go below it
@@ -1655,7 +1699,7 @@ bool Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 		target_object->connections.erase(slot->cE);
 	}
 
-	s->slot_map.erase(*p_callable.get_base_comparator());
+	s->slot_map.erase(*comparator);
 
 	if (s->slot_map.is_empty() && get_gdtype().get_signal_map(false).has(p_signal)) {
 		//not user signal, delete
@@ -1993,6 +2037,7 @@ void Object::_bind_methods() {
 	BIND_BITFIELD_FLAG(CONNECT_ONE_SHOT);
 	BIND_BITFIELD_FLAG(CONNECT_REFERENCE_COUNTED);
 	BIND_BITFIELD_FLAG(CONNECT_APPEND_SOURCE_OBJECT);
+	BIND_BITFIELD_FLAG(CONNECT_UNIQUE);
 }
 
 void Object::call_deferredp(const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -357,6 +357,7 @@ public:
 		CONNECT_REFERENCE_COUNTED = 8,
 		CONNECT_APPEND_SOURCE_OBJECT = 16,
 		CONNECT_INHERITED = 32, // Used in editor builds.
+		CONNECT_UNIQUE = 64,
 	};
 
 	// Store on each object a bitfield to quickly test whether it is derived from some "key" classes
@@ -408,6 +409,14 @@ private:
 	ObjectGDExtension *_extension = nullptr;
 	GDExtensionClassInstancePtr _extension_instance = nullptr;
 
+	struct SignalCallableHasher {
+		static uint32_t hash(const Callable &p_callable);
+	};
+
+	struct SignalCallableComparator {
+		static bool compare(const Callable &p_lhs, const Callable &p_rhs);
+	};
+
 	struct SignalData {
 		struct Slot {
 			int reference_count = 0;
@@ -416,7 +425,7 @@ private:
 		};
 
 		MethodInfo user;
-		HashMap<Callable, Slot> slot_map;
+		HashMap<Callable, Slot, SignalCallableHasher, SignalCallableComparator> slot_map;
 		bool removable = false;
 	};
 	mutable Mutex *signal_mutex = nullptr;

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -533,7 +533,8 @@
 			<param index="2" name="flags" type="int" default="0" />
 			<description>
 				Connects a [param signal] by name to a [param callable]. Optional [param flags] can be also added to configure the connection's behavior (see [enum ConnectFlags] constants).
-				A signal can only be connected once to the same [Callable]. If the signal is already connected, this method returns [constant ERR_INVALID_PARAMETER] and generates an error, unless the signal is connected with [constant CONNECT_REFERENCE_COUNTED]. To prevent this, use [method is_connected] first to check for existing connections.
+				A signal can only be connected once to the same [Callable]. A [Callable] is considered the same even if it has different arguments bound via [method Callable.bind], unless the [constant CONNECT_UNIQUE] flag is used.
+				If the signal is already connected to the [Callable], this method returns [constant ERR_INVALID_PARAMETER] and generates an error, unless the signal is connected with [constant CONNECT_REFERENCE_COUNTED]. To prevent this, use [method is_connected] first to check for existing connections.
 				[b]Note:[/b] If the [param callable]'s object is freed, the connection will be lost.
 				[b]Note:[/b] In GDScript, it is generally recommended to connect signals with [method Signal.connect] instead.
 				[b]Note:[/b] This method, and all other signal-related methods, are thread-safe.
@@ -791,7 +792,7 @@
 			<param index="0" name="signal" type="StringName" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
-				Returns [code]true[/code] if a connection exists between the given [param signal] name and [param callable].
+				Returns [code]true[/code] if a connection exists between the given [param signal] name and [param callable], even if the [Callable] has different arguments bound via [method Callable.bind].
 				[b]Note:[/b] In C#, [param signal] must be in snake_case when referring to built-in Godot signals. Prefer using the names exposed in the [code]SignalName[/code] class to avoid allocating a new [StringName] on each call.
 			</description>
 		</method>
@@ -1068,6 +1069,9 @@
 				test_signal.connect(prints.unbind(1), CONNECT_APPEND_SOURCE_OBJECT)
 				test_signal.emit("emit_arg_1", "emit_arg_2") # Prints emit_arg_1 &lt;Object#35332818393&gt;
 			[/codeblock]
+		</constant>
+		<constant name="CONNECT_UNIQUE" value="64" enum="ConnectFlags" is_bitfield="true">
+			Unique connections can use the same [Callable] as another connection on the same signal, but with different arguments bound via [method Callable.bind] or unbound via [method Callable.unbind].
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -182,7 +182,8 @@
 			<param index="1" name="flags" type="int" default="0" />
 			<description>
 				Connects this signal to the specified [param callable]. Optional [param flags] can be also added to configure the connection's behavior (see [enum Object.ConnectFlags] constants). You can provide additional arguments to the connected [param callable] by using [method Callable.bind].
-				A signal can only be connected once to the same [Callable]. If the signal is already connected, this method returns [constant ERR_INVALID_PARAMETER] and generates an error, unless the signal is connected with [constant Object.CONNECT_REFERENCE_COUNTED]. To prevent this, use [method is_connected] first to check for existing connections.
+				A signal can only be connected once to the same [Callable]. A [Callable] is considered the same even if it has different arguments bound via [method Callable.bind], unless the [constant Object.CONNECT_UNIQUE] flag is used.
+				If the signal is already connected to the [Callable], this method returns [constant ERR_INVALID_PARAMETER] and generates an error, unless the signal is connected with [constant Object.CONNECT_REFERENCE_COUNTED]. To prevent this, use [method is_connected] first to check for existing connections.
 				[codeblock]
 				for button in $Buttons.get_children():
 					button.pressed.connect(_on_pressed.bind(button))

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -672,6 +672,10 @@ bool ConnectDialog::get_append_source() const {
 	return !append_source->is_disabled() && append_source->is_pressed();
 }
 
+bool ConnectDialog::get_unique() const {
+	return unique->is_pressed();
+}
+
 /*
  * Returns true if ConnectDialog is being used to edit an existing connection.
  */
@@ -716,10 +720,12 @@ void ConnectDialog::init(const ConnectionData &p_cd, const PackedStringArray &p_
 	bool b_deferred = (p_cd.flags & CONNECT_DEFERRED);
 	bool b_oneshot = (p_cd.flags & CONNECT_ONE_SHOT);
 	bool b_append_source = (p_cd.flags & CONNECT_APPEND_SOURCE_OBJECT);
+	bool b_unique = (p_cd.flags & CONNECT_UNIQUE);
 
 	deferred->set_pressed(b_deferred);
 	one_shot->set_pressed(b_oneshot);
 	append_source->set_pressed(b_append_source);
+	unique->set_pressed(b_unique);
 
 	unbind_count->set_max(p_signal_args.size());
 	unbind_count->set_value(p_cd.unbinds);
@@ -946,6 +952,11 @@ ConnectDialog::ConnectDialog() {
 	append_source->set_tooltip_text(TTRC("The source object is automatically sent when the signal is emitted."));
 	fc_flags->add_child(append_source);
 
+	unique = memnew(CheckBox);
+	unique->set_text(TTRC("Unique"));
+	unique->set_tooltip_text(TTRC("Unique connections can use the same method, but with different arguments."));
+	fc_flags->add_child(unique);
+
 	cdbinds = memnew(ConnectDialogBinds);
 
 	error = memnew(AcceptDialog);
@@ -1002,7 +1013,8 @@ void ConnectionsDock::_make_or_edit_connection() {
 	bool b_deferred = connect_dialog->get_deferred();
 	bool b_oneshot = connect_dialog->get_one_shot();
 	bool b_append_source = connect_dialog->get_append_source();
-	cd.flags = CONNECT_PERSIST | (b_deferred ? CONNECT_DEFERRED : 0) | (b_oneshot ? CONNECT_ONE_SHOT : 0) | (b_append_source ? CONNECT_APPEND_SOURCE_OBJECT : 0);
+	bool b_unique = connect_dialog->get_unique();
+	cd.flags = CONNECT_PERSIST | (b_deferred ? CONNECT_DEFERRED : 0) | (b_oneshot ? CONNECT_ONE_SHOT : 0) | (b_append_source ? CONNECT_APPEND_SOURCE_OBJECT : 0) | (b_unique ? CONNECT_UNIQUE : 0);
 
 	// If the function is found in target's own script, check the editor setting
 	// to determine if the script should be opened.
@@ -1241,6 +1253,7 @@ void ConnectionsDock::_open_connection_dialog(TreeItem &p_item) {
 	cd.target = dst_node;
 	cd.signal = signal_name;
 	cd.method = ConnectDialog::generate_method_callback_name(cd.source, signal_name, cd.target);
+	cd.flags = CONNECT_UNIQUE;
 	connect_dialog->init(cd, signal_args);
 	connect_dialog->set_title(TTR("Connect a Signal to a Method"));
 	connect_dialog->popup_dialog(signal_name.string() + "(" + String(", ").join(signal_args) + ")");

--- a/editor/scene/connections_dialog.h
+++ b/editor/scene/connections_dialog.h
@@ -140,6 +140,7 @@ private:
 	CheckBox *deferred = nullptr;
 	CheckBox *one_shot = nullptr;
 	CheckBox *append_source = nullptr;
+	CheckBox *unique = nullptr;
 	CheckButton *advanced = nullptr;
 	Vector<Control *> bind_controls;
 
@@ -188,6 +189,7 @@ public:
 	bool get_deferred() const;
 	bool get_one_shot() const;
 	bool get_append_source() const;
+	bool get_unique() const;
 	bool is_editing() const;
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;


### PR DESCRIPTION
Presently, it you can't connect the same `Callable` with different binds to the same signal - you'll get the `Signal XXX is already connected to given callable` error.

This PR adds a new connection flag (`CONNECT_UNIQUE`) which will allow doing this!

For example:

```gdscript
signal test_signal()

func _ready():
	test_signal.connect(cb.bind(1), CONNECT_UNIQUE)
	test_signal.connect(cb.bind(2), CONNECT_UNIQUE)
	print(test_signal.get_connections())

	test_signal.emit()

	test_signal.disconnect(cb.bind(1))
	print(test_signal.get_connections())
	test_signal.disconnect(cb.bind(2))
	print(test_signal.get_connections())


func cb(value):
	print("Callback with ", value)
```

... which will print:

```
[{ "signal": Node2D(main.gd)::[signal]test_signal, "callable": Node2D(main.gd)::cb, "flags": 64 }, { "signal": Node2D(main.gd)::[signal]test_signal, "callable": Node2D(main.gd)::cb, "flags": 64 }]
Callback with 1
Callback with 2
[{ "signal": Node2D(main.gd)::[signal]test_signal, "callable": Node2D(main.gd)::cb, "flags": 64 }]
[]
```

~~Marking this as a DRAFT for now, because I've only barely tested it, I still need to add docs, and I'd like to expose this flag in the editor connection dialog as well.~~

This addresses a number of issues and proposal (although, not necessarily in the same way as suggested):

- Fixes https://github.com/godotengine/godot-proposals/issues/10035
- Fixes https://github.com/godotengine/godot-proposals/issues/8341
- Fixes https://github.com/godotengine/godot-proposals/issues/4922
- Fixes https://github.com/godotengine/godot/issues/63038
