### PR TITLE
Stop drawing of MarginContainer margins if not in tree

### DIFF
--- a/editor/scene/gui/margin_container_editor_plugin.cpp
+++ b/editor/scene/gui/margin_container_editor_plugin.cpp
@@ -51,7 +51,7 @@ bool MarginContainerEditorPlugin::handles(Object *p_object) const {
 }
 
 void MarginContainerEditorPlugin::forward_canvas_draw_over_viewport(Control *p_viewport_control) {
-	if (!margin_container) {
+	if (!margin_container || !margin_container->is_visible_in_tree()) {
 		return;
 	}
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/112684 .

The error itself didn't seem to cause any problems, but it cluttered the output and made it look like something had gone wrong. This PR just adds a check that stops unnecessary code from running, and that error from being emitted as a result.