### PR TITLE
Remove padding columns from plugin settings

### DIFF
--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -260,24 +260,20 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list->set_column_title_alignment(COLUMN_VERSION, HORIZONTAL_ALIGNMENT_LEFT);
 	plugin_list->set_column_title_alignment(COLUMN_AUTHOR, HORIZONTAL_ALIGNMENT_LEFT);
 	plugin_list->set_column_title_alignment(COLUMN_EDIT, HORIZONTAL_ALIGNMENT_LEFT);
-	plugin_list->set_column_expand(COLUMN_PADDING_LEFT, false);
 	plugin_list->set_column_expand(COLUMN_STATUS, false);
 	plugin_list->set_column_expand(COLUMN_NAME, true);
 	plugin_list->set_column_expand(COLUMN_VERSION, false);
 	plugin_list->set_column_expand(COLUMN_AUTHOR, false);
 	plugin_list->set_column_expand(COLUMN_EDIT, false);
-	plugin_list->set_column_expand(COLUMN_PADDING_RIGHT, false);
 	plugin_list->set_column_clip_content(COLUMN_STATUS, true);
 	plugin_list->set_column_clip_content(COLUMN_NAME, true);
 	plugin_list->set_column_clip_content(COLUMN_VERSION, true);
 	plugin_list->set_column_clip_content(COLUMN_AUTHOR, true);
 	plugin_list->set_column_clip_content(COLUMN_EDIT, true);
-	plugin_list->set_column_custom_minimum_width(COLUMN_PADDING_LEFT, 10 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_STATUS, 80 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_VERSION, 100 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_AUTHOR, 250 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_EDIT, 40 * EDSCALE);
-	plugin_list->set_column_custom_minimum_width(COLUMN_PADDING_RIGHT, 10 * EDSCALE);
 	plugin_list->set_hide_root(true);
 	plugin_list->connect("item_edited", callable_mp(this, &EditorPluginSettings::_plugin_activity_changed), CONNECT_DEFERRED);
 

--- a/editor/plugins/editor_plugin_settings.h
+++ b/editor/plugins/editor_plugin_settings.h
@@ -43,13 +43,11 @@ class EditorPluginSettings : public VBoxContainer {
 	};
 
 	enum {
-		COLUMN_PADDING_LEFT,
 		COLUMN_STATUS,
 		COLUMN_NAME,
 		COLUMN_VERSION,
 		COLUMN_AUTHOR,
 		COLUMN_EDIT,
-		COLUMN_PADDING_RIGHT,
 		COLUMN_MAX,
 	};
 


### PR DESCRIPTION
The new theme made them especially bad.
Before:
<img width="1189" height="141" alt="image" src="https://github.com/user-attachments/assets/7bb677c4-2dcd-451c-992f-0b117aaabe2d" />
After:
<img width="1180" height="147" alt="image" src="https://github.com/user-attachments/assets/21fe1761-5b23-40a1-999c-1c53821d34c8" />
