### PR TITLE
Make AnimationLibrary use RBMap instead of HashMap

### DIFF
--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -49,13 +49,13 @@ Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animat
 	ERR_FAIL_COND_V(p_animation.is_null(), ERR_INVALID_PARAMETER);
 
 	if (animations.has(p_name)) {
-		animations.get(p_name)->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
+		animations[p_name]->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
 		animations.erase(p_name);
 		emit_signal(SNAME("animation_removed"), p_name);
 	}
 
 	animations.insert(p_name, p_animation);
-	animations.get(p_name)->connect_changed(callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_name));
+	animations[p_name]->connect_changed(callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_name));
 	emit_signal(SNAME("animation_added"), p_name);
 	notify_property_list_changed();
 	return OK;
@@ -64,7 +64,7 @@ Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animat
 void AnimationLibrary::remove_animation(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(!animations.has(p_name), vformat("Animation not found: %s.", p_name));
 
-	animations.get(p_name)->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
+	animations[p_name]->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
 	animations.erase(p_name);
 	emit_signal(SNAME("animation_removed"), p_name);
 	notify_property_list_changed();
@@ -75,8 +75,8 @@ void AnimationLibrary::rename_animation(const StringName &p_name, const StringNa
 	ERR_FAIL_COND_MSG(!is_valid_animation_name(p_new_name), "Invalid animation name: '" + String(p_new_name) + "'.");
 	ERR_FAIL_COND_MSG(animations.has(p_new_name), vformat("Animation name \"%s\" already exists in library.", p_new_name));
 
-	animations.get(p_name)->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
-	animations.get(p_name)->connect_changed(callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_new_name));
+	animations[p_name]->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
+	animations[p_name]->connect_changed(callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_new_name));
 	animations.insert(p_new_name, animations[p_name]);
 	animations.erase(p_name);
 	emit_signal(SNAME("animation_renamed"), p_name, p_new_name);

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rb_map.h"
 #include "core/variant/typed_array.h"
 #include "scene/resources/animation.h"
 
@@ -44,7 +45,7 @@ class AnimationLibrary : public Resource {
 	void _animation_changed(const StringName &p_name);
 
 	friend class AnimationMixer; // For faster access.
-	HashMap<StringName, Ref<Animation>> animations;
+	RBMap<StringName, Ref<Animation>, StringName::AlphCompare> animations;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/112340
- Supersedes/Closes https://github.com/godotengine/godot/pull/112374

Use RBMap with AlphCompare instead of HashMap to keep index as same way with https://github.com/godotengine/godot/pull/79595.

cc @KoBeWi @patwork 