### PR TITLE
Add GDScript warnings for implicit bool <-> number conversions

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -535,6 +535,9 @@
 		<member name="debug/gdscript/warnings/assert_always_true" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an [code]assert[/code] call always evaluates to [code]true[/code].
 		</member>
+		<member name="debug/gdscript/warnings/bool_to_number_implicit_cast" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an implicit cast from [bool] to [int] or [float] occurs. Explicit casts can be performed using [code]int(...)[/code] and [code]float(...)[/code], and won't produce a warning.
+		</member>
 		<member name="debug/gdscript/warnings/confusable_capture_reassignment" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a local variable captured by a lambda is reassigned, since this does not modify the outer local variable.
 		</member>
@@ -596,6 +599,9 @@
 		</member>
 		<member name="debug/gdscript/warnings/native_method_override" type="int" setter="" getter="" default="2">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a method in the script overrides a native method, because it may not behave as expected.
+		</member>
+		<member name="debug/gdscript/warnings/number_to_bool_implicit_cast" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an implicit cast from [int] or [float] to [bool] occurs. Explicit casts can be performed using [code]bool(...)[/code] and won't produce a warning.
 		</member>
 		<member name="debug/gdscript/warnings/onready_with_export" type="int" setter="" getter="" default="2">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when the [code]@onready[/code] annotation is used together with the [code]@export[/code] annotation, since it may not behave as expected.

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1476,6 +1476,10 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 #ifdef DEBUG_ENABLED
 							if (member.variable->datatype.builtin_type == Variant::INT && return_datatype.builtin_type == Variant::FLOAT) {
 								parser->push_warning(member.variable, GDScriptWarning::NARROWING_CONVERSION);
+							} else if ((member.variable->datatype.builtin_type == Variant::INT || member.variable->datatype.builtin_type == Variant::FLOAT) && return_datatype.builtin_type == Variant::BOOL) {
+								parser->push_warning(member.variable, GDScriptWarning::BOOL_TO_NUMBER_IMPLICIT_CONVERSION);
+							} else if (member.variable->datatype.builtin_type == Variant::BOOL && (return_datatype.builtin_type == Variant::INT || return_datatype.builtin_type == Variant::FLOAT)) {
+								parser->push_warning(member.variable, GDScriptWarning::NUMBER_TO_BOOL_IMPLICIT_CONVERSION);
 							}
 #endif // DEBUG_ENABLED
 						}
@@ -1502,6 +1506,10 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 #ifdef DEBUG_ENABLED
 						if (member.variable->datatype.builtin_type == Variant::FLOAT && setter_function->parameters[0]->datatype.builtin_type == Variant::INT) {
 							parser->push_warning(member.variable, GDScriptWarning::NARROWING_CONVERSION);
+						} else if ((member.variable->datatype.builtin_type == Variant::INT || member.variable->datatype.builtin_type == Variant::FLOAT) && setter_function->parameters[0]->datatype.builtin_type == Variant::BOOL) {
+							parser->push_warning(member.variable, GDScriptWarning::BOOL_TO_NUMBER_IMPLICIT_CONVERSION);
+						} else if (member.variable->datatype.builtin_type == Variant::BOOL && (setter_function->parameters[0]->datatype.builtin_type == Variant::INT || setter_function->parameters[0]->datatype.builtin_type == Variant::FLOAT)) {
+							parser->push_warning(member.variable, GDScriptWarning::NUMBER_TO_BOOL_IMPLICIT_CONVERSION);
 						}
 #endif // DEBUG_ENABLED
 					}
@@ -1699,6 +1707,10 @@ void GDScriptAnalyzer::resolve_annotation(GDScriptParser::AnnotationNode *p_anno
 #ifdef DEBUG_ENABLED
 			if (argument_info.type == Variant::INT && value.get_type() == Variant::FLOAT) {
 				parser->push_warning(argument, GDScriptWarning::NARROWING_CONVERSION);
+			} else if ((argument_info.type == Variant::INT || argument_info.type == Variant::FLOAT) && value.get_type() == Variant::BOOL) {
+				parser->push_warning(argument, GDScriptWarning::BOOL_TO_NUMBER_IMPLICIT_CONVERSION);
+			} else if (argument_info.type == Variant::BOOL && (value.get_type() == Variant::INT || value.get_type() == Variant::FLOAT)) {
+				parser->push_warning(argument, GDScriptWarning::NUMBER_TO_BOOL_IMPLICIT_CONVERSION);
 			}
 #endif // DEBUG_ENABLED
 
@@ -2167,6 +2179,10 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 #ifdef DEBUG_ENABLED
 			} else if (specified_type.builtin_type == Variant::INT && initializer_type.builtin_type == Variant::FLOAT) {
 				parser->push_warning(p_assignable->initializer, GDScriptWarning::NARROWING_CONVERSION);
+			} else if ((specified_type.builtin_type == Variant::INT || specified_type.builtin_type == Variant::FLOAT) && initializer_type.builtin_type == Variant::BOOL) {
+				parser->push_warning(p_assignable->initializer, GDScriptWarning::BOOL_TO_NUMBER_IMPLICIT_CONVERSION);
+			} else if (specified_type.builtin_type == Variant::BOOL && (initializer_type.builtin_type == Variant::INT || initializer_type.builtin_type == Variant::FLOAT)) {
+				parser->push_warning(p_assignable->initializer, GDScriptWarning::NUMBER_TO_BOOL_IMPLICIT_CONVERSION);
 #endif // DEBUG_ENABLED
 			}
 		}
@@ -2580,6 +2596,10 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 #ifdef DEBUG_ENABLED
 		} else if (expected_type.builtin_type == Variant::INT && result.builtin_type == Variant::FLOAT) {
 			parser->push_warning(p_return, GDScriptWarning::NARROWING_CONVERSION);
+		} else if ((expected_type.builtin_type == Variant::INT || expected_type.builtin_type == Variant::FLOAT) && result.builtin_type == Variant::BOOL) {
+			parser->push_warning(p_return, GDScriptWarning::BOOL_TO_NUMBER_IMPLICIT_CONVERSION);
+		} else if (expected_type.builtin_type == Variant::BOOL && (result.builtin_type == Variant::INT || result.builtin_type == Variant::FLOAT)) {
+			parser->push_warning(p_return, GDScriptWarning::NUMBER_TO_BOOL_IMPLICIT_CONVERSION);
 #endif // DEBUG_ENABLED
 		}
 	}
@@ -2760,6 +2780,10 @@ void GDScriptAnalyzer::update_const_expression_builtin_type(GDScriptParser::Expr
 #ifdef DEBUG_ENABLED
 	if (p_type.builtin_type == Variant::INT && value_type.builtin_type == Variant::FLOAT) {
 		parser->push_warning(p_expression, GDScriptWarning::NARROWING_CONVERSION);
+	} else if ((p_type.builtin_type == Variant::INT || p_type.builtin_type == Variant::FLOAT) && value_type.builtin_type == Variant::BOOL) {
+		parser->push_warning(p_expression, GDScriptWarning::BOOL_TO_NUMBER_IMPLICIT_CONVERSION);
+	} else if (p_type.builtin_type == Variant::BOOL && (value_type.builtin_type == Variant::INT || value_type.builtin_type == Variant::FLOAT)) {
+		parser->push_warning(p_expression, GDScriptWarning::NUMBER_TO_BOOL_IMPLICIT_CONVERSION);
 	}
 #endif // DEBUG_ENABLED
 
@@ -3038,6 +3062,10 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 #ifdef DEBUG_ENABLED
 	if (assignee_type.is_hard_type() && assignee_type.builtin_type == Variant::INT && assigned_value_type.builtin_type == Variant::FLOAT) {
 		parser->push_warning(p_assignment->assigned_value, GDScriptWarning::NARROWING_CONVERSION);
+	} else if (assignee_type.is_hard_type() && (assignee_type.builtin_type == Variant::INT || assignee_type.builtin_type == Variant::FLOAT) && assigned_value_type.builtin_type == Variant::BOOL) {
+		parser->push_warning(p_assignment->assigned_value, GDScriptWarning::BOOL_TO_NUMBER_IMPLICIT_CONVERSION);
+	} else if (assignee_type.is_hard_type() && assignee_type.builtin_type == Variant::BOOL && (assigned_value_type.builtin_type == Variant::INT || assigned_value_type.builtin_type == Variant::FLOAT)) {
+		parser->push_warning(p_assignment->assigned_value, GDScriptWarning::NUMBER_TO_BOOL_IMPLICIT_CONVERSION);
 	}
 	// Check for assignment with operation before assignment.
 	if (p_assignment->operation != GDScriptParser::AssignmentNode::OP_NONE && p_assignment->assignee->type == GDScriptParser::Node::IDENTIFIER) {
@@ -3382,6 +3410,10 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 						} else {
 							if (par_type.builtin_type == Variant::INT && arg_type.builtin_type == Variant::FLOAT && builtin_type != Variant::INT) {
 								parser->push_warning(p_call, GDScriptWarning::NARROWING_CONVERSION, function_name);
+							} else if ((par_type.builtin_type == Variant::INT || par_type.builtin_type == Variant::FLOAT) && arg_type.builtin_type == Variant::BOOL && (builtin_type != Variant::INT && builtin_type != Variant::FLOAT)) {
+								parser->push_warning(p_call, GDScriptWarning::BOOL_TO_NUMBER_IMPLICIT_CONVERSION, function_name);
+							} else if (par_type.builtin_type == Variant::BOOL && (arg_type.builtin_type == Variant::INT || arg_type.builtin_type == Variant::FLOAT) && builtin_type != Variant::BOOL) {
+								parser->push_warning(p_call, GDScriptWarning::NUMBER_TO_BOOL_IMPLICIT_CONVERSION, function_name);
 							}
 #endif // DEBUG_ENABLED
 						}
@@ -5985,6 +6017,10 @@ void GDScriptAnalyzer::validate_call_arg(const List<GDScriptParser::DataType> &p
 #ifdef DEBUG_ENABLED
 		} else if (par_type.kind == GDScriptParser::DataType::BUILTIN && par_type.builtin_type == Variant::INT && arg_type.kind == GDScriptParser::DataType::BUILTIN && arg_type.builtin_type == Variant::FLOAT) {
 			parser->push_warning(p_call->arguments[i], GDScriptWarning::NARROWING_CONVERSION, p_call->function_name);
+		} else if (par_type.kind == GDScriptParser::DataType::BUILTIN && (par_type.builtin_type == Variant::INT || par_type.builtin_type == Variant::FLOAT) && arg_type.kind == GDScriptParser::DataType::BUILTIN && arg_type.builtin_type == Variant::BOOL) {
+			parser->push_warning(p_call->arguments[i], GDScriptWarning::BOOL_TO_NUMBER_IMPLICIT_CONVERSION, p_call->function_name);
+		} else if (par_type.kind == GDScriptParser::DataType::BUILTIN && par_type.builtin_type == Variant::BOOL && arg_type.kind == GDScriptParser::DataType::BUILTIN && (arg_type.builtin_type == Variant::INT || arg_type.builtin_type == Variant::FLOAT)) {
+			parser->push_warning(p_call->arguments[i], GDScriptWarning::NUMBER_TO_BOOL_IMPLICIT_CONVERSION, p_call->function_name);
 #endif // DEBUG_ENABLED
 		}
 	}

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -128,6 +128,10 @@ String GDScriptWarning::get_message() const {
 			return "Integer division. Decimal part will be discarded.";
 		case NARROWING_CONVERSION:
 			return "Narrowing conversion (float is converted to int and loses precision).";
+		case BOOL_TO_NUMBER_IMPLICIT_CONVERSION:
+			return "Implicit cast from bool to number (int/float). If this is intended, cast the bool to the number type using \"int()\" or \"float()\".";
+		case NUMBER_TO_BOOL_IMPLICIT_CONVERSION:
+			return "Implicit cast from number (int/float) to bool. If this is intended, cast the number to the bool type using \"bool()\".";
 		case INT_AS_ENUM_WITHOUT_CAST:
 			return "Integer used when an enum value is expected. If this is intended, cast the integer to the enum type using the \"as\" keyword.";
 		case INT_AS_ENUM_WITHOUT_MATCH:
@@ -228,6 +232,8 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		PNAME("ASSERT_ALWAYS_FALSE"),
 		PNAME("INTEGER_DIVISION"),
 		PNAME("NARROWING_CONVERSION"),
+		PNAME("BOOL_TO_NUMBER_IMPLICIT_CONVERSION"),
+		PNAME("NUMBER_TO_BOOL_IMPLICIT_CONVERSION"),
 		PNAME("INT_AS_ENUM_WITHOUT_CAST"),
 		PNAME("INT_AS_ENUM_WITHOUT_MATCH"),
 		PNAME("ENUM_VARIABLE_WITHOUT_DEFAULT"),

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -77,6 +77,8 @@ public:
 		ASSERT_ALWAYS_FALSE, // Expression for assert argument is always false.
 		INTEGER_DIVISION, // Integer divide by integer, decimal part is discarded.
 		NARROWING_CONVERSION, // Float value into an integer slot, precision is lost.
+		BOOL_TO_NUMBER_IMPLICIT_CONVERSION, // Bool value into an integer/float slot.
+		NUMBER_TO_BOOL_IMPLICIT_CONVERSION, // Integer/float value into a bool slot.
 		INT_AS_ENUM_WITHOUT_CAST, // An integer value was used as an enum value without casting.
 		INT_AS_ENUM_WITHOUT_MATCH, // An integer value was used as an enum value without matching enum member.
 		ENUM_VARIABLE_WITHOUT_DEFAULT, // A variable with an enum type does not have a default value. The default will be set to `0` instead of the first enum value.
@@ -135,6 +137,8 @@ public:
 		WARN, // ASSERT_ALWAYS_FALSE
 		WARN, // INTEGER_DIVISION
 		WARN, // NARROWING_CONVERSION
+		WARN, // BOOL_TO_NUMBER_IMPLICIT_CONVERSION
+		WARN, // NUMBER_TO_BOOL_IMPLICIT_CONVERSION
 		WARN, // INT_AS_ENUM_WITHOUT_CAST
 		WARN, // INT_AS_ENUM_WITHOUT_MATCH
 		WARN, // ENUM_VARIABLE_WITHOUT_DEFAULT

--- a/modules/gdscript/tests/scripts/analyzer/features/as.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/as.out
@@ -1,4 +1,10 @@
 GDTEST_OK
+~~ WARNING at line 2: (NUMBER_TO_BOOL_IMPLICIT_CAST) Implicit cast from number (int/float) to bool. If this is intended, cast the number to the bool type using "bool()".
+~~ WARNING at line 3: (NUMBER_TO_BOOL_IMPLICIT_CAST) Implicit cast from number (int/float) to bool. If this is intended, cast the number to the bool type using "bool()".
+~~ WARNING at line 3: (UNUSED_VARIABLE) The local variable "some_bools" is declared but never used in the block. If this is intended, prefix it with an underscore: "_some_bools".
+~~ WARNING at line 4: (NARROWING_CONVERSION) Narrowing conversion (float is converted to int and loses precision).
+~~ WARNING at line 4: (UNUSED_VARIABLE) The local variable "some_boolss" is declared but never used in the block. If this is intended, prefix it with an underscore: "_some_boolss".
+~~ WARNING at line 13: (NUMBER_TO_BOOL_IMPLICIT_CAST) Implicit cast from number (int/float) to bool. If this is intended, cast the number to the bool type using "bool()".
 1
 2
 3

--- a/modules/gdscript/tests/scripts/parser/warnings/bool_to_number_implicit_cast.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/bool_to_number_implicit_cast.gd
@@ -1,0 +1,5 @@
+func i_accept_ints_only(_i: int):
+	pass
+
+func test():
+	i_accept_ints_only(true)

--- a/modules/gdscript/tests/scripts/parser/warnings/bool_to_number_implicit_cast.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/bool_to_number_implicit_cast.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+~~ WARNING at line 5: (BOOL_TO_NUMBER_IMPLICIT_CAST) Implicit cast from bool to number (int/float). If this is intended, cast the bool to the number type using "int()" or "float()".

--- a/modules/gdscript/tests/scripts/parser/warnings/number_to_bool_implicit_cast.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/number_to_bool_implicit_cast.gd
@@ -1,0 +1,5 @@
+func i_accept_bools_only(_i: bool):
+	pass
+
+func test():
+	i_accept_bools_only(12.345)

--- a/modules/gdscript/tests/scripts/parser/warnings/number_to_bool_implicit_cast.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/number_to_bool_implicit_cast.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+~~ WARNING at line 5: (NUMBER_TO_BOOL_IMPLICIT_CAST) Implicit cast from number (int/float) to bool. If this is intended, cast the number to the bool type using "bool()".


### PR DESCRIPTION
Implicit bool <-> number (int/float) conversions are the source of many bugs (not just in GDScript), so it's good to be able to catch them early on.

You can mark a conversion as intended using `bool()`, `int()` or `float()`.

Since this is a GDScript warning like any other, you can disable it in the project settings, or turn it into an error.

- This closes https://github.com/godotengine/godot/pull/40336 by superseding it.

**Testing project:** [test_bool_conversion_warnings.zip](https://github.com/user-attachments/files/23511816/test_bool_conversion_warnings.zip)

## Preview

<img width="1195" height="880" alt="Warnings" src="https://github.com/user-attachments/assets/c33af451-f76d-4147-aa0b-acf0c1f5f9f9" />

## TODO

- [ ] Should this apply to other primitive (non-Object) types like Vector2? If so, we should figure out a way to do so while reusing as much code as possible across checks.