### PR TITLE
Fix project manager minimum size not being large enough

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -170,7 +170,7 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 // Main layout.
 
 void ProjectManager::_update_size_limits() {
-	const Size2 minimum_size = Size2(720, 450) * EDSCALE;
+	const Size2 minimum_size = Size2(770, 460) * EDSCALE;
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());


### PR DESCRIPTION
This caused UI elements to be cut off when the window was resized to its lowest allowed size.

- Related to https://github.com/godotengine/godot/issues/111735.

## Preview

Before | After
-|-
<img width="720" height="450" alt="Before" src="https://github.com/user-attachments/assets/e028f9cd-6f5f-4526-8a2d-bf99a7729cfe" /> | <img width="770" height="460" alt="After" src="https://github.com/user-attachments/assets/3c578da5-f7ea-4c57-a548-148ce624e7e3" />