### PR TITLE
Maximize window when changing size if screen is too small on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2273,6 +2273,15 @@ void DisplayServerWindows::window_set_size(const Size2i p_size, WindowID p_windo
 	}
 
 	MoveWindow(wd.hWnd, rect.left, rect.top, w, h, TRUE);
+
+	const int current_screen = window_get_current_screen(p_window);
+	const Size2i screen_size = screen_get_usable_rect(current_screen).size;
+	const Size2i decoration_size = window_get_size_with_decorations(p_window) - window_get_size(p_window);
+
+	if (p_size.width > (screen_size.width - decoration_size.width) || p_size.height > (screen_size.height - decoration_size.height)) {
+		// Maximize the window if it's too small to fit on the current screen.
+		window_set_mode(WINDOW_MODE_MAXIMIZED, p_window);
+	}
 }
 
 Size2i DisplayServerWindows::window_get_size(WindowID p_window) const {


### PR DESCRIPTION
This matches behavior found on Linux/X11. This fixes the project manager having its title or bottom cut off by the task bar on small displays.

The implementation could certainly be improved, but it's functional in my experience (tested on a 1024x768 display at 100% scaling).

* This closes https://github.com/godotengine/godot/issues/111735.

@lasseedsvik Could you [test this PR locally](https://contributing.godotengine.org/en/latest/organization/pull_requests/testing.html) to see if it resolves the issue on your end?

