### PR TITLE
Fix editor preset names not being validated 

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -156,6 +156,19 @@ int EditorExport::get_export_platform_index_by_name(const String &p_name) {
 	return -1;
 }
 
+bool EditorExport::has_preset_with_name(const String &p_name, int p_exclude_index) const {
+	for (int i = 0; i < export_presets.size(); i++) {
+		if (i == p_exclude_index) {
+			continue;
+		}
+		if (export_presets[i]->get_name() == p_name) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 Ref<EditorExportPlatform> EditorExport::get_export_platform(int p_idx) {
 	ERR_FAIL_INDEX_V(p_idx, export_platforms.size(), Ref<EditorExportPlatform>());
 

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -88,6 +88,7 @@ public:
 	void load_config();
 	void update_export_presets();
 	bool poll_export_platforms();
+	bool has_preset_with_name(const String &p_name, int p_exclude_index = -1) const;
 	void connect_presets_runnable_updated(const Callable &p_target);
 
 	EditorExport();

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -133,6 +133,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _runnable_pressed();
 	void _update_parameters(const String &p_edited_property);
 	void _name_changed(const String &p_string);
+	void _name_editing_finished();
 	void _export_path_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);
 	void _add_preset(int p_platform);
 	void _edit_preset(int p_index);


### PR DESCRIPTION
Fixed: https://github.com/godotengine/godot/issues/112646

Sorry, im making this PR again because I merged coded that altered my fix and I didn't check if that code actually worked, (it didn't) so this PR addresses that.

When creating build profiles usally you were able to have profiles with blank names, and multiple profiles with the same name which made it difficult to export the project when using a CLI, so this fix adresses those issues by checking if the build profile name is left blank or matches the name of other build profiles. Then it resets the name and logs an error to the console that the preset name is invalid for any of those reasons.


https://github.com/user-attachments/assets/f040540e-d386-40bb-a0e0-b22adff1666d

