### PR TITLE
Prevent infinite loop when duplicating a project into itself

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -272,6 +272,7 @@ void ProjectDialog::_validate_path() {
 
 		if (is_subdirectory_or_equal) {
 			_set_message(TTRC("Cannot duplicate a project into itself."), MESSAGE_ERROR, target_path_input_type);
+			return;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #112699

Added return statement after error message in ProjectDialog::_validate_path() to stop further validation when the duplicate target is the same as the original project path.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
