### PR TITLE
Fix typo in `Array` docs

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -498,7 +498,7 @@
 			<return type="int" />
 			<description>
 				Returns a hashed 32-bit integer value representing the array and its contents.
-				[b]Note:[/b] Arrays with equal hash values are [i]not[/i] guaranteed to be the same, as a result of hash collisions. On the countrary, arrays with different hash values are guaranteed to be different.
+				[b]Note:[/b] Arrays with equal hash values are [i]not[/i] guaranteed to be the same, as a result of hash collisions. On the contrary, arrays with different hash values are guaranteed to be different.
 			</description>
 		</method>
 		<method name="insert">


### PR DESCRIPTION
Fixed typo in array.xml Godot Engine Typo Tracker #91521 and Docs issue # 11452.
Changed: countrary -> contrary

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
