### PR TITLE
Fix error in `BlendSpace2D` when selecting blend position tool

### DIFF
--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -421,7 +421,7 @@ void AnimationNodeBlendSpace2DEditor::_update_tool_erase() {
 void AnimationNodeBlendSpace2DEditor::_tool_switch(int p_tool) {
 	making_triangle.clear();
 
-	if (p_tool == 2) {
+	if (p_tool == 3) {
 		Vector<Vector2> bl_points;
 		for (int i = 0; i < blend_space->get_blend_point_count(); i++) {
 			bl_points.push_back(blend_space->get_blend_point_position(i));


### PR DESCRIPTION
Fixes #112596.

I failed to change the if statement inside of tool_switch to p_tool == 3 when I [reordered and rebound the tools](109792) for BlendSpaces, so auto-triangulation was happening when selecting the blend position tool, not the triangle tool.