### PR TITLE
Fix: ButtonGroup.pressed not emitted when calling set_pressed(false)

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -289,12 +289,13 @@ void BaseButton::set_pressed(bool p_pressed) {
 		return;
 	}
 
-	if (p_pressed) {
-		_unpress_group();
-		if (button_group.is_valid()) {
-			button_group->emit_signal(SceneStringName(pressed), this);
+	if (button_group.is_valid()) {
+		if (p_pressed) {
+			_unpress_group();
 		}
+		button_group->emit_signal(SceneStringName(pressed), this);
 	}
+	
 	_toggled(status.pressed);
 }
 

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -295,7 +295,6 @@ void BaseButton::set_pressed(bool p_pressed) {
 		}
 		button_group->emit_signal(SceneStringName(pressed), this);
 	}
-	
 	_toggled(status.pressed);
 }
 


### PR DESCRIPTION
Fixes #112634

This PR fixes issue where set_pressed(false) does not emit ButtonGroup.pressed, causing inconsistent behavior between user input and script-driven toggling.


