### PR TITLE
Fix crash when using ANGLE OpenGL on Windows.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -5814,16 +5814,16 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					rect_changed = true;
 				}
 #if defined(RD_ENABLED)
-				if (window.create_completed && rendering_context && window.context_created) {
+				if (window.create_completed && rendering_context && window.rendering_context_window_created) {
 					// Note: Trigger resize event to update swapchains when window is minimized/restored, even if size is not changed.
 					rendering_context->window_set_size(window_id, window.width, window.height);
 				}
 #endif
 #if defined(GLES3_ENABLED)
-				if (window.create_completed && gl_manager_native) {
+				if (window.create_completed && gl_manager_native && window.gl_native_window_created) {
 					gl_manager_native->window_resize(window_id, window.width, window.height);
 				}
-				if (window.create_completed && gl_manager_angle) {
+				if (window.create_completed && gl_manager_angle && window.gl_angle_window_created) {
 					gl_manager_angle->window_resize(window_id, window.width, window.height);
 				}
 #endif
@@ -6632,7 +6632,7 @@ Error DisplayServerWindows::_create_rendering_context_window(WindowID p_window_i
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to create %s window.", rendering_driver));
 
 	rendering_context->window_set_size(p_window_id, wd.width, wd.height);
-	wd.context_created = true;
+	wd.rendering_context_window_created = true;
 
 	return OK;
 }
@@ -6641,10 +6641,10 @@ void DisplayServerWindows::_destroy_rendering_context_window(WindowID p_window_i
 	DEV_ASSERT(rendering_context != nullptr);
 
 	WindowData &wd = windows[p_window_id];
-	DEV_ASSERT(wd.context_created);
+	DEV_ASSERT(wd.rendering_context_window_created);
 
 	rendering_context->window_destroy(p_window_id);
-	wd.context_created = false;
+	wd.rendering_context_window_created = false;
 }
 #endif
 
@@ -6652,12 +6652,20 @@ void DisplayServerWindows::_destroy_rendering_context_window(WindowID p_window_i
 Error DisplayServerWindows::_create_gl_window(WindowID p_window_id) {
 	if (gl_manager_native) {
 		WindowData &wd = windows[p_window_id];
-		return gl_manager_native->window_create(p_window_id, wd.hWnd, hInstance, wd.width, wd.height);
+
+		Error err = gl_manager_native->window_create(p_window_id, wd.hWnd, hInstance, wd.width, wd.height);
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Failed to create native OpenGL window.");
+
+		wd.gl_native_window_created = true;
 	}
 
 	if (gl_manager_angle) {
 		WindowData &wd = windows[p_window_id];
-		return gl_manager_angle->window_create(p_window_id, nullptr, wd.hWnd, wd.width, wd.height);
+
+		Error err = gl_manager_angle->window_create(p_window_id, nullptr, wd.hWnd, wd.width, wd.height);
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Failed to create ANGLE OpenGL window.");
+
+		wd.gl_angle_window_created = true;
 	}
 
 	return OK;
@@ -7408,7 +7416,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 			gl_manager_native = nullptr;
 			windows.erase(MAIN_WINDOW_ID);
 			r_error = ERR_UNAVAILABLE;
-			ERR_FAIL_MSG("Failed to create an OpenGL window.");
+			return;
 		}
 		RasterizerGLES3::make_current(true);
 	}
@@ -7418,7 +7426,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 			gl_manager_angle = nullptr;
 			windows.erase(MAIN_WINDOW_ID);
 			r_error = ERR_UNAVAILABLE;
-			ERR_FAIL_MSG("Failed to create an OpenGL window.");
+			return;
 		}
 		RasterizerGLES3::make_current(false);
 	}

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -312,7 +312,9 @@ class DisplayServerWindows : public DisplayServer {
 		bool always_on_top = false;
 		bool no_focus = false;
 		bool exclusive = false;
-		bool context_created = false;
+		bool rendering_context_window_created = false;
+		bool gl_native_window_created = false;
+		bool gl_angle_window_created = false;
 		bool mpass = false;
 		bool sharp_corners = false;
 		bool hide_from_capture = false;


### PR DESCRIPTION
Fixes regression introduced in #112384.

Apparently, `SetWindowRgn` calls `WndProc` on the spot instead of queueing the messages. Godot's `WndProc` assumes the window for OpenGL had already been created, which is not true anymore as of #112384. A safety check for its existence can be added like the rendering context.