### PR TITLE
Add hints for `Translation`

### DIFF
--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -50,18 +50,14 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 
 	List<StringName> keys;
 	{
-		List<StringName> raw_keys;
+		List<MessageKey> raw_keys;
 		p_from->get_message_list(&raw_keys);
 
-		for (const StringName &key : raw_keys) {
-			const String key_str = key.operator String();
-			int p = key_str.find_char(0x04);
-			if (p == -1) {
-				keys.push_back(key);
+		for (const MessageKey &key : raw_keys) {
+			if (key.msgctxt.is_empty()) {
+				keys.push_back(key.msgid);
 			} else {
-				const String &msgctxt = key_str.substr(0, p);
-				const String &msgid = key_str.substr(p + 1);
-				WARN_PRINT(vformat("OptimizedTranslation does not support context, ignoring message '%s' with context '%s'.", msgid, msgctxt));
+				WARN_PRINT(vformat("OptimizedTranslation does not support context, ignoring message '%s' with context '%s'.", key.msgid, key.msgctxt));
 			}
 		}
 	}
@@ -319,7 +315,7 @@ Vector<String> OptimizedTranslation::_get_message_list() const {
 	return {};
 }
 
-void OptimizedTranslation::get_message_list(List<StringName> *r_messages) const {
+void OptimizedTranslation::get_message_list(List<MessageKey> *r_messages) const {
 	WARN_PRINT_ONCE("OptimizedTranslation does not store the message texts to be translated.");
 }
 

--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -97,7 +97,7 @@ public:
 	virtual Vector<String> get_translated_message_list() const override;
 	void generate(const Ref<Translation> &p_from);
 
-	virtual void get_message_list(List<StringName> *r_messages) const override;
+	virtual void get_message_list(List<MessageKey> *r_messages) const override;
 	virtual int get_message_count() const override;
 
 	OptimizedTranslation() {}

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -34,7 +34,9 @@
 #include "core/string/plural_rules.h"
 #include "core/string/translation_server.h"
 
-void _check_for_incompatibility(const String &p_msgctxt, const String &p_msgid) {
+#define HINTS_STORAGE_KEY 0
+
+static void _check_for_incompatibility(const String &p_msgctxt, const String &p_msgid) {
 	// Gettext PO and MO files use an empty untranslated string without context
 	// to store metadata.
 	if (p_msgctxt.is_empty() && p_msgid.is_empty()) {
@@ -56,55 +58,170 @@ void _check_for_incompatibility(const String &p_msgctxt, const String &p_msgid) 
 	}
 }
 
+static Variant _write_message_key(const Translation::MessageKey &p_key) {
+	if (p_key.msgctxt.is_empty()) {
+		return p_key.msgid;
+	}
+	const Array &arr = { p_key.msgctxt, p_key.msgid };
+	return arr;
+}
+
+static bool _read_message_key(const Variant &p_raw, Translation::MessageKey &r_key) {
+	switch (p_raw.get_type()) {
+		case Variant::STRING_NAME: {
+			r_key.msgctxt = StringName();
+			r_key.msgid = p_raw;
+			return true;
+		} break;
+
+		case Variant::ARRAY: {
+			const Array &arr = p_raw;
+			r_key.msgctxt = arr[0];
+			r_key.msgid = arr[1];
+			return true;
+		} break;
+
+		default: {
+			WARN_PRINT(vformat("Unknown message key type: %s.", Variant::get_type_name(p_raw.get_type())));
+		} break;
+	}
+	return false;
+}
+
+static Vector<StringName> _read_message_value(const Variant &p_raw) {
+	switch (p_raw.get_type()) {
+		case Variant::STRING_NAME: {
+			return { p_raw };
+		} break;
+
+		case Variant::ARRAY: {
+			const Array &arr = p_raw;
+
+			Vector<StringName> msgstrs;
+			msgstrs.resize(arr.size());
+			for (int i = 0; i < arr.size(); i++) {
+				msgstrs.write[i] = arr[i];
+			}
+			return msgstrs;
+		} break;
+
+		default: {
+			WARN_PRINT(vformat("Unknown message value type: %s.", Variant::get_type_name(p_raw.get_type())));
+		} break;
+	}
+	return {};
+}
+
 Dictionary Translation::_get_messages() const {
 	Dictionary d;
-	for (const KeyValue<MessageKey, Vector<StringName>> &E : translation_map) {
-		const Array &storage_key = { E.key.msgctxt, E.key.msgid };
 
-		Array storage_value;
-		storage_value.resize(E.value.size());
-		for (int i = 0; i < E.value.size(); i++) {
-			storage_value[i] = E.value[i];
+	// Messages.
+	for (const KeyValue<MessageKey, Vector<StringName>> &E : translation_map) {
+		const Variant message_key = _write_message_key(E.key);
+
+		Variant message_value;
+		switch (E.value.size()) {
+			// Should not happen, but just in case.
+			case 0: {
+				continue;
+			} break;
+
+			// Compact and compatible with older versions.
+			case 1: {
+				message_value = E.value[0];
+			} break;
+
+			default: {
+				Array arr;
+				arr.resize(E.value.size());
+				for (int i = 0; i < E.value.size(); i++) {
+					arr[i] = E.value[i];
+				}
+				message_value = arr;
+			} break;
 		}
-		d[storage_key] = storage_value;
+
+		d[message_key] = message_value;
 	}
+
+	// Optional hints.
+	Dictionary hints_dict;
+	for (int type = 0; type < HINT_MAX; type++) {
+		const HashMap<MessageKey, String, MessageKey> *map = hint_maps[type];
+		if (map == nullptr || map->is_empty()) {
+			continue;
+		}
+
+		for (const KeyValue<MessageKey, String> &E : *map) {
+			if (E.value.is_empty()) {
+				continue; // Should not happen, but just in case.
+			}
+
+			const Variant message_key = _write_message_key(E.key);
+			Dictionary hints = hints_dict.get_or_add(message_key, Dictionary());
+			hints[type] = E.value;
+			hints_dict[message_key] = hints;
+		}
+	}
+	d[HINTS_STORAGE_KEY] = hints_dict;
+
 	return d;
 }
 
 void Translation::_set_messages(const Dictionary &p_messages) {
 	translation_map.clear();
+	for (int type = 0; type < HINT_MAX; type++) {
+		HashMap<MessageKey, String, MessageKey> *map = hint_maps[type];
+		if (map) {
+			map->clear();
+		}
+	}
 
+	Dictionary hints_dict;
 	for (const KeyValue<Variant, Variant> &kv : p_messages) {
-		switch (kv.key.get_type()) {
-			// Old version, no context or plural support.
-			case Variant::STRING_NAME: {
-				const MessageKey msg_key = { StringName(), kv.key };
-				_check_for_incompatibility(msg_key.msgctxt, msg_key.msgid);
-				translation_map[msg_key] = { kv.value };
-			} break;
+		// Hints are added after all messages are loaded.
+		if (kv.key.get_type() == Variant::INT && kv.key.operator int() == HINTS_STORAGE_KEY) {
+			hints_dict = kv.value;
+			continue;
+		}
 
-			// Current version.
-			case Variant::ARRAY: {
-				const Array &storage_key = kv.key;
-				const MessageKey msg_key = { storage_key[0], storage_key[1] };
+		MessageKey key;
+		if (!_read_message_key(kv.key, key)) {
+			continue;
+		}
+		_check_for_incompatibility(key.msgctxt, key.msgid);
 
-				const Array &storage_value = kv.value;
-				ERR_CONTINUE_MSG(storage_value.is_empty(), vformat("No translated strings for untranslated string '%s' with context '%s'.", msg_key.msgid, msg_key.msgctxt));
+		const Vector<StringName> msgstrs = _read_message_value(kv.value);
+		ERR_CONTINUE_MSG(msgstrs.is_empty(), vformat("No translated strings for untranslated string '%s' with context '%s'.", key.msgid, key.msgctxt));
 
-				Vector<StringName> msgstrs;
-				msgstrs.resize(storage_value.size());
-				for (int i = 0; i < storage_value.size(); i++) {
-					msgstrs.write[i] = storage_value[i];
-				}
+		translation_map[key] = msgstrs;
+	}
 
-				_check_for_incompatibility(msg_key.msgctxt, msg_key.msgid);
-				translation_map[msg_key] = msgstrs;
-			} break;
+	for (const KeyValue<Variant, Variant> &kv : hints_dict) {
+		MessageKey key;
+		if (!_read_message_key(kv.key, key)) {
+			continue;
+		}
+		if (!translation_map.has(key)) {
+			continue;
+		}
 
-			default: {
-				WARN_PRINT(vformat("Invalid key type in messages dictionary: %s.", Variant::get_type_name(kv.key.get_type())));
+		const Dictionary hints = kv.value;
+		for (int i = 0; i < HINT_MAX; i++) {
+			const Variant *v = hints.getptr(i);
+			if (v == nullptr || v->get_type() != Variant::STRING) {
 				continue;
 			}
+			const String hint_value = *v;
+			if (hint_value.is_empty()) {
+				continue;
+			}
+
+			if (hint_maps[i] == nullptr) {
+				hint_maps[i] = memnew((HashMap<MessageKey, String, MessageKey>));
+			}
+			HashMap<MessageKey, String, MessageKey> &map = *hint_maps[i];
+			map[key] = hint_value;
 		}
 	}
 }
@@ -193,7 +310,15 @@ StringName Translation::get_plural_message(const StringName &p_src_text, const S
 }
 
 void Translation::erase_message(const StringName &p_src_text, const StringName &p_context) {
-	translation_map.erase({ p_context, p_src_text });
+	const MessageKey key = { p_context, p_src_text };
+	translation_map.erase(key);
+
+	for (int type = 0; type < HINT_MAX; type++) {
+		HashMap<MessageKey, String, MessageKey> *map = hint_maps[type];
+		if (map) {
+			map->erase(key);
+		}
+	}
 }
 
 void Translation::get_message_list(List<StringName> *r_messages) const {
@@ -253,6 +378,42 @@ int Translation::get_nplurals() const {
 	return _get_plural_rules()->get_nplurals();
 }
 
+String Translation::get_hint(const StringName &p_src_text, const StringName &p_context, HintType p_type) const {
+	ERR_FAIL_INDEX_V(p_type, HINT_MAX, String());
+	const HashMap<MessageKey, String, MessageKey> *map = hint_maps[p_type];
+	if (map == nullptr) {
+		return String();
+	}
+	const String *value = map->getptr({ p_context, p_src_text });
+	if (value == nullptr) {
+		return String();
+	}
+	return *value; // This should be non-empty technically.
+}
+
+void Translation::set_hint(const StringName &p_src_text, const StringName &p_context, HintType p_type, const String &p_value) {
+	ERR_FAIL_INDEX(p_type, HINT_MAX);
+	const MessageKey key = { p_context, p_src_text };
+
+	// Empty value removes the hint entry.
+	if (p_value.is_empty()) {
+		HashMap<MessageKey, String, MessageKey> *map = hint_maps[p_type];
+		if (map) {
+			map->erase(key);
+		}
+		return;
+	}
+
+	// There should always be a corresponding translation for the hint.
+	ERR_FAIL_COND_MSG(!translation_map.has(key), vformat("Can't set hint for '%s' with context '%s' as such a message does not exist.", p_src_text, p_context));
+
+	if (hint_maps[p_type] == nullptr) {
+		hint_maps[p_type] = memnew((HashMap<MessageKey, String, MessageKey>));
+	}
+	HashMap<MessageKey, String, MessageKey> &map = *hint_maps[p_type];
+	map[key] = p_value;
+}
+
 void Translation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_locale", "locale"), &Translation::set_locale);
 	ClassDB::bind_method(D_METHOD("get_locale"), &Translation::get_locale);
@@ -269,17 +430,31 @@ void Translation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_plural_rules_override", "rules"), &Translation::set_plural_rules_override);
 	ClassDB::bind_method(D_METHOD("get_plural_rules_override"), &Translation::get_plural_rules_override);
 
+	ClassDB::bind_method(D_METHOD("get_hint", "src_message", "context", "type"), &Translation::get_hint);
+	ClassDB::bind_method(D_METHOD("set_hint", "src_message", "context", "type", "value"), &Translation::set_hint);
+
 	GDVIRTUAL_BIND(_get_plural_message, "src_message", "src_plural_message", "n", "context");
 	GDVIRTUAL_BIND(_get_message, "src_message", "context");
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "messages", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_messages", "_get_messages");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "locale", PROPERTY_HINT_LOCALE_ID), "set_locale", "get_locale");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "plural_rules_override"), "set_plural_rules_override", "get_plural_rules_override");
+
+	BIND_ENUM_CONSTANT(HINT_PLURAL);
+	BIND_ENUM_CONSTANT(HINT_COMMENTS);
+	BIND_ENUM_CONSTANT(HINT_LOCATIONS);
+	BIND_ENUM_CONSTANT(HINT_MAX);
 }
 
 Translation::~Translation() {
 	if (plural_rules_cache) {
 		memdelete(plural_rules_cache);
 		plural_rules_cache = nullptr;
+	}
+	for (int i = 0; i < HINT_MAX; i++) {
+		if (hint_maps[i]) {
+			memdelete(hint_maps[i]);
+			hint_maps[i] = nullptr;
+		}
 	}
 }

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -253,6 +253,18 @@ Vector<String> Translation::get_translated_message_list() const {
 	return msgstrs;
 }
 
+Vector<String> Translation::get_plural_forms(const StringName &p_src_text, const StringName &p_context) const {
+	Vector<String> plural_forms;
+	const Vector<StringName> *msgstrs = translation_map.getptr({ p_context, p_src_text });
+	if (msgstrs) {
+		plural_forms.reserve_exact(msgstrs->size());
+		for (const StringName &msgstr : *msgstrs) {
+			plural_forms.push_back(msgstr);
+		}
+	}
+	return plural_forms;
+}
+
 void Translation::set_locale(const String &p_locale) {
 	locale = TranslationServer::get_singleton()->standardize_locale(p_locale);
 
@@ -428,6 +440,7 @@ void Translation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_message", "src_message", "context"), &Translation::has_message);
 	ClassDB::bind_method(D_METHOD("get_message_list"), &Translation::_get_message_list);
 	ClassDB::bind_method(D_METHOD("get_translated_message_list"), &Translation::get_translated_message_list);
+	ClassDB::bind_method(D_METHOD("get_plural_forms", "src_message", "context"), &Translation::get_plural_forms);
 	ClassDB::bind_method(D_METHOD("get_message_count"), &Translation::get_message_count);
 	ClassDB::bind_method(D_METHOD("_set_messages", "messages"), &Translation::_set_messages);
 	ClassDB::bind_method(D_METHOD("_get_messages"), &Translation::_get_messages);

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -41,6 +41,13 @@ class Translation : public Resource {
 	RES_BASE_EXTENSION("translation");
 
 public:
+	enum HintType {
+		HINT_PLURAL,
+		HINT_COMMENTS,
+		HINT_LOCATIONS,
+		HINT_MAX
+	};
+
 	struct MessageKey {
 		StringName msgctxt;
 		StringName msgid;
@@ -59,6 +66,9 @@ private:
 	String locale = "en";
 
 	HashMap<MessageKey, Vector<StringName>, MessageKey> translation_map;
+
+	// These are not mandatory for i18n, but essential for tools.
+	HashMap<MessageKey, String, MessageKey> *hint_maps[HINT_MAX] = {};
 
 	mutable PluralRules *plural_rules_cache = nullptr;
 	String plural_rules_override;
@@ -93,8 +103,13 @@ public:
 	void set_plural_rules_override(const String &p_rules);
 	String get_plural_rules_override() const;
 
+	String get_hint(const StringName &p_src_text, const StringName &p_context, HintType p_type) const;
+	void set_hint(const StringName &p_src_text, const StringName &p_context, HintType p_type, const String &p_value);
+
 	// This method is not exposed to scripting intentionally. It is only used by TranslationLoaderPO and tests.
 	int get_nplurals() const;
 
 	~Translation();
 };
+
+VARIANT_ENUM_CAST(Translation::HintType);

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -100,6 +100,7 @@ public:
 	virtual void get_message_list(List<MessageKey> *r_messages) const;
 	virtual int get_message_count() const;
 	virtual Vector<String> get_translated_message_list() const;
+	virtual Vector<String> get_plural_forms(const StringName &p_src_text, const StringName &p_context) const;
 
 	void set_plural_rules_override(const String &p_rules);
 	String get_plural_rules_override() const;

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -96,7 +96,8 @@ public:
 	virtual StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const; //overridable for other implementations
 	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const;
 	virtual void erase_message(const StringName &p_src_text, const StringName &p_context = "");
-	virtual void get_message_list(List<StringName> *r_messages) const;
+	virtual bool has_message(const StringName &p_src_text, const StringName &p_context) const;
+	virtual void get_message_list(List<MessageKey> *r_messages) const;
 	virtual int get_message_count() const;
 	virtual Vector<String> get_translated_message_list() const;
 

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -59,6 +59,15 @@
 				Erases a message.
 			</description>
 		</method>
+		<method name="get_hint" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="src_message" type="StringName" />
+			<param index="1" name="context" type="StringName" />
+			<param index="2" name="type" type="int" enum="Translation.HintType" />
+			<description>
+				Returns the hint of type [param type] for the given message. Hints default to an empty string.
+			</description>
+		</method>
 		<method name="get_message" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="src_message" type="StringName" />
@@ -100,13 +109,22 @@
 			<description>
 				Returns a message's translation involving plurals.
 				The number [param n] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
-				[b]Note:[/b] Plurals are only supported in [url=$DOCS_URL/tutorials/i18n/localization_using_gettext.html]gettext-based translations (PO)[/url], not CSV.
 			</description>
 		</method>
 		<method name="get_translated_message_list" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>
 				Returns all the translated strings.
+			</description>
+		</method>
+		<method name="set_hint">
+			<return type="void" />
+			<param index="0" name="src_message" type="StringName" />
+			<param index="1" name="context" type="StringName" />
+			<param index="2" name="type" type="int" enum="Translation.HintType" />
+			<param index="3" name="value" type="String" />
+			<description>
+				Sets the hint of type [param type] for the given message to [param value].
 			</description>
 		</method>
 	</methods>
@@ -119,4 +137,19 @@
 			If empty or invalid, default plural rules from [method TranslationServer.get_plural_rules] are used. The English plural rules are used as a fallback.
 		</member>
 	</members>
+	<constants>
+		<constant name="HINT_PLURAL" value="0" enum="HintType">
+			Hint type for the untranslated string's plural form. If non-empty, hints that the message is intended to be translated by [method get_plural_message].
+			[b]Note:[/b] Hints don't affect how translation works. Whether a message should be translated by [method get_message] or [method get_plural_message] still depends on whether it was added by [method add_message] or [method add_plural_message].
+		</constant>
+		<constant name="HINT_COMMENTS" value="1" enum="HintType">
+			Hint type for the message's comments.
+		</constant>
+		<constant name="HINT_LOCATIONS" value="2" enum="HintType">
+			Hint type for the message's references to the program's source code. Each line should be of the form [code]file_name:line_number[/code] or just [code]file_name[/code].
+		</constant>
+		<constant name="HINT_MAX" value="3" enum="HintType">
+			Represents the size of the [enum HintType] enum.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -117,6 +117,14 @@
 				Returns all the translated strings.
 			</description>
 		</method>
+		<method name="has_message" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="src_message" type="StringName" />
+			<param index="1" name="context" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the given message exists.
+			</description>
+		</method>
 		<method name="set_hint">
 			<return type="void" />
 			<param index="0" name="src_message" type="StringName" />

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -100,6 +100,15 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="get_plural_forms" qualifiers="const">
+			<return type="PackedStringArray" />
+			<param index="0" name="src_message" type="StringName" />
+			<param index="1" name="context" type="StringName" />
+			<description>
+				Returns the array of plural translations for a given message. The array is empty on failure.
+				[b]Note:[/b] The message should be added by [method add_plural_message], otherwise the behavior is undefined.
+			</description>
+		</method>
 		<method name="get_plural_message" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="src_message" type="StringName" />

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -136,6 +136,7 @@ Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const 
 
 		bool reading_plural_rows = false;
 		String plural_msgid;
+		String plural_msgid_plural;
 		String plural_msgctxt;
 		HashMap<int, Vector<String>> plural_msgstrs;
 
@@ -183,6 +184,7 @@ Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const 
 					const Vector<String> &msgstrs = plural_msgstrs[E.key];
 					if (!msgstrs.is_empty()) {
 						translation->add_plural_message(plural_msgid, msgstrs, plural_msgctxt);
+						translation->set_hint(plural_msgid, plural_msgctxt, Translation::HINT_PLURAL, plural_msgid_plural);
 					}
 				}
 				plural_msgstrs.clear();
@@ -192,6 +194,7 @@ Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const 
 			if (!reading_plural_rows && !msgid_plural.is_empty()) {
 				reading_plural_rows = true;
 				plural_msgid = msgid;
+				plural_msgid_plural = msgid_plural;
 				plural_msgctxt = msgctxt;
 			}
 
@@ -217,6 +220,7 @@ Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const 
 				const Vector<String> &msgstrs = plural_msgstrs[E.key];
 				if (!msgstrs.is_empty()) {
 					translation->add_plural_message(plural_msgid, msgstrs, plural_msgctxt);
+					translation->set_hint(plural_msgid, plural_msgctxt, Translation::HINT_PLURAL, plural_msgid_plural);
 				}
 			}
 		}

--- a/editor/inspector/translation_viewer_plugin.cpp
+++ b/editor/inspector/translation_viewer_plugin.cpp
@@ -1,0 +1,354 @@
+/**************************************************************************/
+/*  translation_viewer_plugin.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "translation_viewer_plugin.h"
+
+#include "core/string/optimized_translation.h"
+#include "core/string/translation.h"
+#include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/foldable_container.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/margin_container.h"
+#include "scene/gui/text_edit.h"
+#include "scene/gui/tree.h"
+
+static TextEdit *_create_text_view() {
+	TextEdit *text_edit = memnew(TextEdit);
+	text_edit->set_editable(false);
+	text_edit->set_line_wrapping_mode(TextEdit::LINE_WRAPPING_BOUNDARY);
+	text_edit->set_fit_content_height_enabled(true);
+	return text_edit;
+}
+
+static Control *_add_details_section(Control *p_parent, const String &p_title, Control *p_content) {
+	FoldableContainer *fc = memnew(FoldableContainer);
+	fc->set_title(p_title);
+	fc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	fc->add_child(p_content);
+	p_parent->add_child(fc);
+	return fc;
+}
+
+static void _set_label_autowrap(Label *p_label) {
+	// Workaround a known bug that causes autowrap labels to be extremely tall.
+	p_label->set_custom_minimum_size(Vector2(100 * EDSCALE, 0));
+	p_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+}
+
+static String _get_first_line(const String &p_text) {
+	int newline_index = p_text.find_char('\n');
+	if (newline_index == -1) {
+		return p_text;
+	}
+	return p_text.left(newline_index);
+}
+
+void TranslationViewerDialog::_on_translation_changed() {
+	Ref<OptimizedTranslation> ot = translation;
+	if (ot.is_valid()) {
+		info_label->set_text(TTR("OptimizedTranslation does not support viewing messages."));
+	} else {
+		int message_count = translation.is_valid() ? translation->get_message_count() : 0;
+		info_label->set_text(vformat(TTRN("%d message found.", "%d messages found.", message_count), message_count));
+	}
+
+	keys.clear();
+
+	if (translation.is_valid() && ot.is_null()) {
+		List<Translation::MessageKey> raw_keys;
+		translation->get_message_list(&raw_keys);
+
+		keys.reserve(raw_keys.size());
+		for (const Translation::MessageKey &key : raw_keys) {
+			keys.push_back({ key.msgctxt, key.msgid });
+		}
+	}
+
+	_update_messages_list(false);
+}
+
+void TranslationViewerDialog::_update_messages_list(bool p_keep_selection) {
+	int prev_selected_index = -1;
+	if (p_keep_selection) {
+		TreeItem *selected = messages_list->get_selected();
+		if (selected) {
+			prev_selected_index = selected->get_metadata(0);
+		}
+	}
+
+	// Filter first to determine whether to show the context column.
+	const String &filter_text = filter_edit->get_text();
+	bool context_column_needed = false;
+	LocalVector<unsigned int> indices;
+	indices.reserve(keys.size());
+	for (unsigned int i = 0; i < keys.size(); i++) {
+		const KeyEntry &key = keys[i];
+		if (!filter_text.is_empty() && !key.msgid.containsn(filter_text) && !key.msgctxt.containsn(filter_text)) {
+			continue;
+		}
+		if (!key.msgctxt.is_empty()) {
+			context_column_needed = true;
+		}
+		indices.push_back(i);
+	}
+
+	TreeItem *root = messages_list->get_root();
+	root->clear_children();
+
+	if (context_column_needed) {
+		messages_list->set_columns(2);
+		messages_list->set_column_expand(1, false);
+	} else {
+		messages_list->set_columns(1);
+	}
+
+	TreeItem *selected_item = nullptr;
+	for (unsigned int i : indices) {
+		const KeyEntry &key = keys[i];
+
+		TreeItem *item = root->create_child();
+		item->set_text(0, _get_first_line(key.msgid));
+		item->set_metadata(0, i);
+		if (!key.msgctxt.is_empty()) {
+			item->set_text_alignment(1, HORIZONTAL_ALIGNMENT_RIGHT);
+			item->set_text_overrun_behavior(1, TextServer::OVERRUN_NO_TRIMMING);
+			item->set_text(1, _get_first_line(key.msgctxt));
+			item->set_tooltip_text(1, TTRC("Context"));
+		}
+
+		if (prev_selected_index != -1 && (unsigned int)prev_selected_index == i) {
+			selected_item = item;
+		}
+	}
+
+	if (selected_item == nullptr && root->get_child_count() > 0) {
+		selected_item = root->get_child(0);
+	}
+	if (selected_item) {
+		messages_list->set_selected(selected_item, 0);
+		messages_list->scroll_to_item(selected_item);
+	}
+
+	_update_details_view();
+}
+
+void TranslationViewerDialog::_update_details_view() {
+	TreeItem *selected = messages_list->get_selected();
+	if (!selected) {
+		details_info_label->show();
+		details_scroll->hide();
+		return;
+	}
+
+	unsigned int key_index = selected->get_metadata(0);
+	ERR_FAIL_UNSIGNED_INDEX(key_index, keys.size());
+	const KeyEntry &key = keys[key_index];
+
+	msgid_view->set_text(key.msgid);
+
+	msgctxt_section->set_visible(!key.msgctxt.is_empty());
+	msgctxt_view->set_text(key.msgctxt);
+
+	const String &msgid_plural = translation->get_hint(key.msgid, key.msgctxt, Translation::HINT_PLURAL);
+	msgid_plural_section->set_visible(!msgid_plural.is_empty());
+	msgid_plural_view->set_text(msgid_plural);
+
+	if (msgid_plural.is_empty()) {
+		_set_msgstrs({ translation->get_message(key.msgid, key.msgctxt) });
+	} else {
+		_set_msgstrs(translation->get_plural_forms(key.msgid, key.msgctxt));
+	}
+
+	const String &comments = translation->get_hint(key.msgid, key.msgctxt, Translation::HINT_COMMENTS);
+	comments_section->set_visible(!comments.is_empty());
+	comments_view->set_text(comments);
+
+	const String &locations = translation->get_hint(key.msgid, key.msgctxt, Translation::HINT_LOCATIONS);
+	locations_section->set_visible(!locations.is_empty());
+	locations_view->set_text(locations);
+
+	details_info_label->hide();
+	details_scroll->show();
+}
+
+void TranslationViewerDialog::_set_msgstrs(const Vector<String> &p_msgstrs) {
+	for (int i = msgstrs_view->get_child_count(); i < p_msgstrs.size(); i++) {
+		msgstrs_view->add_child(_create_text_view());
+	}
+	for (int i = 0; i < msgstrs_view->get_child_count(); i++) {
+		TextEdit *text_edit = Object::cast_to<TextEdit>(msgstrs_view->get_child(i));
+		ERR_CONTINUE(text_edit == nullptr); // Should not happen, but just in case.
+
+		if (i < p_msgstrs.size()) {
+			text_edit->set_text(p_msgstrs[i]);
+			text_edit->show();
+		} else {
+			text_edit->hide();
+		}
+	}
+}
+
+void TranslationViewerDialog::edit(Ref<Translation> p_translation) {
+	if (translation == p_translation) {
+		return;
+	}
+	if (translation.is_valid()) {
+		translation->disconnect_changed(callable_mp(this, &TranslationViewerDialog::_on_translation_changed));
+	}
+	translation = p_translation;
+	if (translation.is_valid()) {
+		translation->connect_changed(callable_mp(this, &TranslationViewerDialog::_on_translation_changed));
+	}
+
+	filter_edit->set_text(String());
+	_on_translation_changed();
+}
+
+void TranslationViewerDialog::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			filter_edit->set_right_icon(get_theme_icon(SNAME("Search"), EditorStringName(EditorIcons)));
+		} break;
+	}
+}
+
+TranslationViewerDialog::TranslationViewerDialog() {
+	set_title(TTRC("Translation Viewer"));
+
+	VBoxContainer *main_vb = memnew(VBoxContainer);
+	add_child(main_vb);
+
+	info_label = memnew(Label);
+	info_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	_set_label_autowrap(info_label);
+	main_vb->add_child(info_label);
+
+	HSplitContainer *split = memnew(HSplitContainer);
+	split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_vb->add_child(split);
+
+	VBoxContainer *list_vb = memnew(VBoxContainer);
+	list_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	list_vb->set_stretch_ratio(3);
+	split->add_child(list_vb);
+
+	messages_list = memnew(Tree);
+	messages_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	messages_list->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
+	messages_list->set_auto_tooltip(false);
+	messages_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	messages_list->set_select_mode(Tree::SELECT_ROW);
+	messages_list->set_hide_root(true);
+	messages_list->create_item();
+	messages_list->connect(SceneStringName(item_selected), callable_mp(this, &TranslationViewerDialog::_update_details_view));
+	list_vb->add_child(messages_list);
+
+	filter_edit = memnew(LineEdit);
+	filter_edit->set_clear_button_enabled(true);
+	filter_edit->set_placeholder(TTRC("Filter Messages"));
+	filter_edit->connect(SceneStringName(text_changed), callable_mp(this, &TranslationViewerDialog::_update_messages_list).bind(true).unbind(1));
+	list_vb->add_child(filter_edit);
+
+	MarginContainer *details_view = memnew(MarginContainer);
+	details_view->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	details_view->set_stretch_ratio(2);
+	split->add_child(details_view);
+
+	details_info_label = memnew(Label);
+	details_info_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	details_info_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	details_info_label->set_text(TTRC("Select a message to see details."));
+	_set_label_autowrap(details_info_label);
+	details_view->add_child(details_info_label);
+
+	details_scroll = memnew(ScrollContainer);
+	details_scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	details_view->add_child(details_scroll);
+
+	VBoxContainer *details_vb = memnew(VBoxContainer);
+	details_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	details_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	details_scroll->add_child(details_vb);
+
+	msgctxt_view = _create_text_view();
+	msgctxt_section = _add_details_section(details_vb, TTRC("Context"), msgctxt_view);
+
+	msgid_view = _create_text_view();
+	_add_details_section(details_vb, TTRC("Source Text"), msgid_view);
+
+	msgid_plural_view = _create_text_view();
+	msgid_plural_section = _add_details_section(details_vb, TTRC("Source Text Plural"), msgid_plural_view);
+
+	msgstrs_view = memnew(VBoxContainer);
+	_add_details_section(details_vb, TTRC("Translated Text"), msgstrs_view);
+
+	comments_view = _create_text_view();
+	comments_section = _add_details_section(details_vb, TTRC("Comments"), comments_view);
+
+	locations_view = _create_text_view();
+	locations_section = _add_details_section(details_vb, TTRC("Locations"), locations_view);
+}
+
+////////////////////////
+
+void EditorInspectorPluginTranslation::_on_view_messages_pressed(Object *p_object) {
+	Ref<Translation> translation = Object::cast_to<Translation>(p_object);
+	if (translation.is_null()) {
+		return;
+	}
+
+	if (!dialog) {
+		dialog = memnew(TranslationViewerDialog);
+		EditorNode::get_singleton()->get_gui_base()->add_child(dialog);
+	}
+	dialog->edit(translation);
+	dialog->popup_centered_clamped(Size2(800, 600) * EDSCALE);
+}
+
+bool EditorInspectorPluginTranslation::can_handle(Object *p_object) {
+	return Object::cast_to<Translation>(p_object) != nullptr;
+}
+
+void EditorInspectorPluginTranslation::parse_end(Object *p_object) {
+	Button *button = memnew(EditorInspectorActionButton(TTRC("View Messages"), SNAME("FileList")));
+	button->connect(SceneStringName(pressed), callable_mp(this, &EditorInspectorPluginTranslation::_on_view_messages_pressed).bind(p_object));
+	add_custom_control(button);
+}
+
+////////////////////////
+
+TranslationViewerPlugin::TranslationViewerPlugin() {
+	Ref<EditorInspectorPluginTranslation> inspector_plugin;
+	inspector_plugin.instantiate();
+	add_inspector_plugin(inspector_plugin);
+}

--- a/editor/inspector/translation_viewer_plugin.h
+++ b/editor/inspector/translation_viewer_plugin.h
@@ -1,0 +1,111 @@
+/**************************************************************************/
+/*  translation_viewer_plugin.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/inspector/editor_inspector.h"
+#include "editor/plugins/editor_plugin.h"
+#include "scene/gui/dialogs.h"
+
+class Label;
+class ScrollContainer;
+class TextEdit;
+class Translation;
+class Tree;
+class VBoxContainer;
+
+class TranslationViewerDialog : public AcceptDialog {
+	GDCLASS(TranslationViewerDialog, AcceptDialog);
+
+	Ref<Translation> translation;
+
+	// Filtering needs String operations. Avoid converting from StringName every time.
+	struct KeyEntry {
+		String msgctxt;
+		String msgid;
+	};
+	LocalVector<KeyEntry> keys;
+
+	Label *info_label = nullptr;
+
+	Tree *messages_list = nullptr;
+	LineEdit *filter_edit = nullptr;
+
+	Label *details_info_label = nullptr;
+	ScrollContainer *details_scroll = nullptr;
+
+	TextEdit *msgctxt_view = nullptr;
+	TextEdit *msgid_view = nullptr;
+	TextEdit *msgid_plural_view = nullptr;
+	VBoxContainer *msgstrs_view = nullptr;
+	TextEdit *comments_view = nullptr;
+	TextEdit *locations_view = nullptr;
+
+	Control *msgctxt_section = nullptr;
+	Control *msgid_plural_section = nullptr;
+	Control *comments_section = nullptr;
+	Control *locations_section = nullptr;
+
+	void _on_translation_changed();
+
+	void _update_messages_list(bool p_keep_selection);
+	void _update_details_view();
+
+	void _set_msgstrs(const Vector<String> &p_msgstrs);
+
+protected:
+	void _notification(int p_what);
+
+public:
+	void edit(Ref<Translation> p_translation);
+
+	TranslationViewerDialog();
+};
+
+class EditorInspectorPluginTranslation : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginTranslation, EditorInspectorPlugin);
+
+	TranslationViewerDialog *dialog = nullptr;
+
+	void _on_view_messages_pressed(Object *p_object);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual void parse_end(Object *p_object) override;
+};
+
+class TranslationViewerPlugin : public EditorPlugin {
+	GDCLASS(TranslationViewerPlugin, EditorPlugin);
+
+public:
+	virtual String get_plugin_name() const override { return "TranslationViewer"; }
+
+	TranslationViewerPlugin();
+};

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -74,6 +74,7 @@
 #include "editor/inspector/input_event_editor_plugin.h"
 #include "editor/inspector/sub_viewport_preview_editor_plugin.h"
 #include "editor/inspector/tool_button_editor_plugin.h"
+#include "editor/inspector/translation_viewer_plugin.h"
 #include "editor/scene/2d/camera_2d_editor_plugin.h"
 #include "editor/scene/2d/light_occluder_2d_editor_plugin.h"
 #include "editor/scene/2d/line_2d_editor_plugin.h"
@@ -256,6 +257,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<TextureRegionEditorPlugin>();
 	EditorPlugins::add_by_type<ThemeEditorPlugin>();
 	EditorPlugins::add_by_type<ToolButtonEditorPlugin>();
+	EditorPlugins::add_by_type<TranslationViewerPlugin>();
 	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
 #ifndef DISABLE_DEPRECATED
 	EditorPlugins::add_by_type<SkeletonIK3DEditorPlugin>();

--- a/editor/translations/template_generator.h
+++ b/editor/translations/template_generator.h
@@ -36,18 +36,10 @@
 class TranslationTemplateGenerator {
 	static inline TranslationTemplateGenerator *singleton = nullptr;
 
-	struct MessageData {
-		String plural;
-		HashSet<String> locations;
-		HashSet<String> comments;
-	};
+	Ref<Translation> parse(const Vector<String> &p_sources, bool p_add_builtin) const;
 
-	using MessageMap = HashMap<Translation::MessageKey, MessageData, Translation::MessageKey>;
-
-	MessageMap parse(const Vector<String> &p_sources, bool p_add_builtin) const;
-
-	void _write_to_pot(Ref<FileAccess> p_file, const MessageMap &p_map) const;
-	void _write_to_csv(Ref<FileAccess> p_file, const MessageMap &p_map) const;
+	void _write_to_pot(Ref<FileAccess> p_file, const Ref<Translation> &p_template) const;
+	void _write_to_csv(Ref<FileAccess> p_file, const Ref<Translation> &p_template) const;
 
 public:
 	static TranslationTemplateGenerator *get_singleton();

--- a/tests/core/string/test_translation.h
+++ b/tests/core/string/test_translation.h
@@ -55,7 +55,7 @@ TEST_CASE("[Translation] Messages") {
 	// The message no longer exists, so it returns an empty string instead.
 	CHECK(translation->get_message("Hello") == "");
 
-	List<StringName> messages;
+	List<Translation::MessageKey> messages;
 	translation->get_message_list(&messages);
 	CHECK(translation->get_message_count() == 0);
 	CHECK(messages.size() == 0);
@@ -67,8 +67,8 @@ TEST_CASE("[Translation] Messages") {
 	CHECK(translation->get_message_count() == 2);
 	CHECK(messages.size() == 2);
 	// Messages are stored in a Map, don't assume ordering.
-	CHECK(messages.find("Hello2"));
-	CHECK(messages.find("Hello3"));
+	CHECK(messages.find(Translation::MessageKey{ StringName(), "Hello2" }));
+	CHECK(messages.find(Translation::MessageKey{ StringName(), "Hello3" }));
 }
 
 TEST_CASE("[Translation] Messages with context") {
@@ -88,7 +88,7 @@ TEST_CASE("[Translation] Messages with context") {
 	CHECK(translation->get_message("Hello", "friendly") == "Salut");
 	CHECK(translation->get_message("Hello", "nonexistent_context") == "");
 
-	List<StringName> messages;
+	List<Translation::MessageKey> messages;
 	translation->get_message_list(&messages);
 
 	CHECK(translation->get_message_count() == 1);
@@ -103,10 +103,9 @@ TEST_CASE("[Translation] Messages with context") {
 	CHECK(translation->get_message_count() == 4);
 	CHECK(messages.size() == 4);
 	// Messages are stored in a Map, don't assume ordering.
-	CHECK(messages.find("Hello2"));
-	CHECK(messages.find("Hello3"));
-	// Context and untranslated string are separated by EOT.
-	CHECK(messages.find("friendly\x04Hello2"));
+	CHECK(messages.find(Translation::MessageKey{ StringName(), "Hello2" }));
+	CHECK(messages.find(Translation::MessageKey{ "friendly", "Hello2" }));
+	CHECK(messages.find(Translation::MessageKey{ StringName(), "Hello3" }));
 }
 
 TEST_CASE("[Translation] Plural messages") {
@@ -207,10 +206,12 @@ TEST_CASE("[OptimizedTranslation] Generate from Translation and read messages") 
 	CHECK(optimized_translation->get_message("Hello3") == "Bonjour3");
 	CHECK(optimized_translation->get_message("DoesNotExist") == "");
 
-	List<StringName> messages;
+	List<Translation::MessageKey> messages;
 	// `get_message_list()` can't return the list of messages stored in an OptimizedTranslation.
+	ERR_PRINT_OFF;
 	optimized_translation->get_message_list(&messages);
 	CHECK(optimized_translation->get_message_count() == 0);
+	ERR_PRINT_ON;
 	CHECK(messages.size() == 0);
 }
 


### PR DESCRIPTION
This PR is separated into 3 commits for easier review.

## 1. Add hints for `Translation`

There are two problems.

First, whether a message in `Translation` should be translated using `get_message()` or `get_plural_message()` depends on whether it was added using `add_message()` or `add_plural_message()`. But there is currently no way to know that information in code.

Second, even if we record the source of the message when adding it, we still cannot properly call `get_plural_message()`: The plural form of the source text remains unknown. This also means that we can't reliably restore a `Translation` loaded from PO files back to a PO file. For example, #106573 attempts to convert PO files to MO files on export, but it has to write `?` for the `msgid_plural` field, which is technically wrong.

Considering https://github.com/godotengine/godot-proposals/issues/7334, it'll also be better if metadata like comments and locations can be stored along with the message. The long-term goal is to make PO, CSV, and `Translation` interchangeable.

This PR added `{get,set}_hint()` for storing hints like untranslated plural, comments, and locations (references to the program's source code).

How a `Translation` is serialized to a dictionary (`_{get,set}_messages()`) is also updated:

For messages, keys can be either:

- `&"msgid"`
- `[&"&msgctxt", &"msgid"]`

Their values can be either:

- `&"msgstr[0]"`
- `[&"msgstr[0], &"msgstr[1]", ...]`

The optional hints are stored using an integer key. The value is another dictionary, mapping message keys to a hints dictionary which maps `HINT_*` to the hint value. Empty values are not stored for hints.

This makes the format compact. And it's still compatible with older versions as long as new features (context, plural forms, and hints) are not used.

## 2. Use plural hint when importing/exporting `Translation`s

When importing CSV files and loading PO files, `HINT_PLURAL` is now set. For exisitng projects, `.csv` files have to be reimported to get this hint.

When generating the translation template, the parse result is now a `Translation` instead of a vector of custom structs. This lays the foundation to adding template generation related APIs in the future (for problems like #111074).

When implementing, I also fixed some problems about the `Translation` APIs:

- Added missing `has_message()`
- Changed internal version of `get_message_list()` to yield `MessageKey`s instead of `StringName`s. The scripting API version concats `msgid` and `msgctxt` for compatibility.

Usages of other hints (comments and locations) are not added in this PR. I think that should be done in separate ones.

- They are information for the translators, so not as important as the plural hint.
- The PO parsing code is a complex state machine, hard to change.
- The CSV importer does not have the concept of comments and locations yet. CSV template generation produces these two metadata as ignored columns.

## 3. Add translation viewer

Currently, the inspector only shows `Locale` and `Plural Rules Override` for `Translation`s. This commit adds a View Messages button for inspecting contents in the resource.

This makes it easier to debug translation related problems and dogfoods the new API.

https://github.com/user-attachments/assets/a4e1d4c2-9c3d-4a38-81c2-019e9a780b0e

*The screencast is using the Classic style theme. `Tree`s don't have frames when using the modern style theme, which makes many editor UI look broken :(

When implementing, I also added `get_plural_forms()` to `Translation` for getting all possible plural forms for a given message.

Test project: [translation-hints.zip](https://github.com/user-attachments/files/23522279/translation-hints.zip)
