### PR TITLE
Fix crash after clearing `SpriteFrames`

### DIFF
--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -83,6 +83,7 @@ public:
 	const StringName bind = "bind";
 	const StringName notification = "notification";
 	const StringName property_list_changed = "property_list_changed";
+	const StringName _property_value_changed = "_property_value_changed";
 };
 
 #define CoreStringName(m_name) CoreStringNames::get_singleton()->m_name

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1943,6 +1943,7 @@ void Object::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("script_changed"));
 	ADD_SIGNAL(MethodInfo("property_list_changed"));
+	ADD_SIGNAL(MethodInfo("_property_value_changed"));
 
 #define BIND_OBJ_CORE_METHOD(m_method) \
 	::ClassDB::add_virtual_method(get_class_static(), m_method, true, Vector<String>(), true);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1188,6 +1188,21 @@ void EditorNode::_plugin_over_edit(EditorPlugin *p_plugin, Object *p_object) {
 	}
 }
 
+void EditorNode::refresh_plugins() {
+	ObjectID current_id = get_editor_selection_history()->get_current();
+	Object *current_obj = current_id.is_valid() ? ObjectDB::get_instance(current_id) : nullptr;
+	if (!current_obj) {
+		return;
+	}
+	bool is_resource = Object::cast_to<Resource>(current_obj);
+	bool is_node = Object::cast_to<Node>(current_obj);
+
+	Object *editor_owner = (is_node || Object::cast_to<MultiNodeEdit>(current_obj)) ? SceneTreeDock::get_singleton() : is_resource ? (Object *)InspectorDock::get_inspector_singleton()
+																																   : (Object *)this;
+
+	edit_item(current_obj, editor_owner);
+}
+
 void EditorNode::_plugin_over_self_own(EditorPlugin *p_plugin) {
 	active_plugins[p_plugin->get_instance_id()].insert(p_plugin);
 }
@@ -2875,6 +2890,10 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 
 	for (EditorPlugin *plugin : to_over_edit) {
 		_plugin_over_edit(plugin, p_object);
+	}
+
+	if (p_object && !p_object->is_connected(CoreStringName(_property_value_changed), callable_mp(this, &EditorNode::refresh_plugins))) {
+		p_object->connect(CoreStringName(_property_value_changed), callable_mp(this, &EditorNode::refresh_plugins));
 	}
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -731,6 +731,7 @@ public:
 	// Public for use with callable_mp.
 	void init_plugins();
 	void _on_plugin_ready(Object *p_script, const String &p_activate_name);
+	void refresh_plugins();
 
 	bool call_build();
 	void call_run_scene(const String &p_scene, Vector<String> &r_args);

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -334,6 +334,9 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 	queue_redraw();
 	update_configuration_warnings();
 	emit_signal("sprite_frames_changed");
+#ifdef TOOLS_ENABLED
+	emit_signal(CoreStringName(_property_value_changed));
+#endif
 }
 
 Ref<SpriteFrames> AnimatedSprite2D::get_sprite_frames() const {

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1225,6 +1225,9 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 	_queue_redraw();
 	update_configuration_warnings();
 	emit_signal("sprite_frames_changed");
+#ifdef TOOLS_ENABLED
+	emit_signal(CoreStringName(_property_value_changed));
+#endif
 }
 
 Ref<SpriteFrames> AnimatedSprite3D::get_sprite_frames() const {


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/112576*

## Issue Description

When clearing `SpriteFrames` for `AnimatedSprite2D`, the relevant `EditorPlugin` did not hide immediately. When clicking anywhere of `EditorPlugin`, the editor will crash.

## Explaination

The `SpriteFramesEditor` observes the `sprite_frames_changed` signal of `AnimatedSprite2D`. But it didn't hide `EditorPlugin` in `_edit()` when clearing.

https://github.com/godotengine/godot/blob/e6aa06d3de372513bedb036d2adb1052a9b4b87f/editor/scene/sprite_frames_editor_plugin.cpp#L1962

 As described in https://github.com/godotengine/godot/pull/110280 , the bottom panel first `edit()`, then `make_visible(false)`, to hide the bottom panel plugin.

But in this scenario, `EditorInspector` called `SpriteFramesEditor::_edit()` directly, it didnot call `make_visible(false)`, so `EditorPlugin` is still there. But relevant `SpriteFrames` had been freed, so redraw caused crash.

## Solution

We should hide `EditorPlugin` when clearing `SpriteFrames` of `AnimatedSprite2D`, then editor won't crash.

[spriteframes.webm](https://github.com/user-attachments/assets/6a72aaac-0a3a-45e7-bcdc-a8c718fd57b8)

## MRP

[test-112576.zip](https://github.com/user-attachments/files/23523160/test-112576.zip)



