### PR TITLE
Fix find in files auto search when changing theme

### DIFF
--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -864,15 +864,7 @@ void FindInFilesPanel::stop_search() {
 void FindInFilesPanel::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			_search_text_label->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("source"), EditorStringName(EditorFonts)));
-			_search_text_label->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size(SNAME("source_size"), EditorStringName(EditorFonts)));
-			_results_display->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("source"), EditorStringName(EditorFonts)));
-			_results_display->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size(SNAME("source_size"), EditorStringName(EditorFonts)));
-
-			// Rebuild search tree.
-			if (!_finder->get_search_text().is_empty()) {
-				start_search();
-			}
+			_on_theme_changed();
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			update_matches_text();
@@ -961,6 +953,38 @@ void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, in
 		item->add_button(1, remove_texture, FIND_BUTTON_REMOVE, false, TTR("Remove result"));
 	} else {
 		item->add_button(0, remove_texture, FIND_BUTTON_REMOVE, false, TTR("Remove result"));
+	}
+}
+
+void FindInFilesPanel::_on_theme_changed() {
+	_results_display->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("source"), EditorStringName(EditorFonts)));
+	_results_display->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size(SNAME("source_size"), EditorStringName(EditorFonts)));
+
+	Color file_item_color = _results_display->get_theme_color(SceneStringName(font_color)) * Color(1, 1, 1, 0.67);
+	Ref<Texture2D> remove_texture = get_editor_theme_icon(SNAME("Close"));
+	Ref<Texture2D> replace_texture = get_editor_theme_icon(SNAME("ReplaceText"));
+
+	TreeItem *file_item = _results_display->get_root()->get_first_child();
+	while (file_item) {
+		file_item->set_custom_color(0, file_item_color);
+		if (_with_replace) {
+			file_item->set_button(0, file_item->get_button_by_id(0, FIND_BUTTON_REPLACE), replace_texture);
+		}
+		file_item->set_button(0, file_item->get_button_by_id(0, FIND_BUTTON_REMOVE), remove_texture);
+
+		TreeItem *result_item = file_item->get_first_child();
+		while (result_item) {
+			if (_with_replace) {
+				result_item->set_button(1, result_item->get_button_by_id(1, FIND_BUTTON_REPLACE), replace_texture);
+				result_item->set_button(1, result_item->get_button_by_id(1, FIND_BUTTON_REMOVE), remove_texture);
+			} else {
+				result_item->set_button(0, result_item->get_button_by_id(0, FIND_BUTTON_REMOVE), remove_texture);
+			}
+
+			result_item = result_item->get_next();
+		}
+
+		file_item = file_item->get_next();
 	}
 }
 

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -195,6 +195,7 @@ protected:
 private:
 	void _on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index);
 	void _on_result_found(const String &fpath, int line_number, int begin, int end, String text);
+	void _on_theme_changed();
 	void _on_finished();
 	void _on_refresh_button_clicked();
 	void _on_cancel_button_clicked();


### PR DESCRIPTION
Fix #112706.

When NOTIFICATION_THEME_CHANGED occurs, modify:
- Tree's font, 
- Tree's font_size
- TreeItem's text color
- TreeItem's button texture

These 4 'properties' are particularly set in `_on_result_found` to suit FindInFilesPanel, so we only modify them when theme changes.