### PR TITLE
Revert "Add "Show in File Manager" button to sidebar of Project Manager"

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -265,7 +265,6 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			rename_btn->set_button_icon(get_editor_theme_icon("Rename"));
 			duplicate_btn->set_button_icon(get_editor_theme_icon("Duplicate"));
 			manage_tags_btn->set_button_icon(get_editor_theme_icon("Script"));
-			show_in_fm_btn->set_button_icon(get_editor_theme_icon("Load"));
 			erase_btn->set_button_icon(get_editor_theme_icon("Remove"));
 			erase_missing_btn->set_button_icon(get_editor_theme_icon("Clear"));
 			create_tag_btn->set_button_icon(get_editor_theme_icon("Add"));
@@ -283,7 +282,6 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			rename_btn->add_theme_constant_override("h_separation", h_separation);
 			duplicate_btn->add_theme_constant_override("h_separation", h_separation);
 			manage_tags_btn->add_theme_constant_override("h_separation", h_separation);
-			show_in_fm_btn->add_theme_constant_override("h_separation", h_separation);
 			erase_btn->add_theme_constant_override("h_separation", h_separation);
 			erase_missing_btn->add_theme_constant_override("h_separation", h_separation);
 
@@ -742,17 +740,6 @@ void ProjectManager::_duplicate_project_with_action(PostDuplicateAction p_post_a
 	project_dialog->show_dialog(false);
 }
 
-void ProjectManager::_show_project_in_file_manager() {
-	const Vector<ProjectList::Item> &selected_list = project_list->get_selected_projects();
-	if (selected_list.is_empty()) {
-		return;
-	}
-
-	for (const ProjectList::Item &E : selected_list) {
-		OS::get_singleton()->shell_show_in_file_manager(E.path, true);
-	}
-}
-
 void ProjectManager::_erase_project() {
 	const HashSet<String> &selected_list = project_list->get_selected_project_keys();
 
@@ -807,7 +794,6 @@ void ProjectManager::_update_project_buttons() {
 	rename_btn->set_disabled(empty_selection || is_missing_project_selected);
 	duplicate_btn->set_disabled(empty_selection || is_missing_project_selected);
 	manage_tags_btn->set_disabled(empty_selection || is_missing_project_selected || selected_projects.size() > 1);
-	show_in_fm_btn->set_disabled(empty_selection || is_missing_project_selected);
 	run_btn->set_disabled(empty_selection || is_missing_project_selected);
 
 	erase_missing_btn->set_disabled(!project_list->is_any_project_missing());
@@ -1651,11 +1637,6 @@ ProjectManager::ProjectManager() {
 			manage_tags_btn->set_text(TTRC("Manage Tags"));
 			manage_tags_btn->set_shortcut(ED_SHORTCUT("project_manager/project_tags", TTRC("Manage Tags"), KeyModifierMask::CMD_OR_CTRL | Key::T));
 			project_list_sidebar->add_child(manage_tags_btn);
-
-			show_in_fm_btn = memnew(Button);
-			show_in_fm_btn->set_text(TTRC("Show in File Manager"));
-			show_in_fm_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_show_project_in_file_manager));
-			project_list_sidebar->add_child(show_in_fm_btn);
 
 			erase_btn = memnew(Button);
 			erase_btn->set_text(TTRC("Remove"));

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -160,7 +160,6 @@ class ProjectManager : public Control {
 	Button *rename_btn = nullptr;
 	Button *duplicate_btn = nullptr;
 	Button *manage_tags_btn = nullptr;
-	Button *show_in_fm_btn = nullptr;
 	Button *erase_btn = nullptr;
 	Button *erase_missing_btn = nullptr;
 	Button *donate_btn = nullptr;
@@ -196,7 +195,6 @@ class ProjectManager : public Control {
 	void _rename_project();
 	void _duplicate_project();
 	void _duplicate_project_with_action(PostDuplicateAction p_action);
-	void _show_project_in_file_manager();
 	void _erase_project();
 	void _erase_missing_projects();
 	void _erase_project_confirm();


### PR DESCRIPTION
This reverts commit 769007c707ff96f889ec63af732ebefdc1e49841 (#111624).

It was noted that the new button is larger than the others, [creating a UX issue](https://github.com/godotengine/godot/pull/111624#issuecomment-3404515340) in some languages, especially those where the translated button title is long.

[My proposal](https://github.com/godotengine/godot/pull/111624#issuecomment-3405486525) to revert this PR was mostly well received. 

I recommend [adding a right-click menu](https://github.com/godotengine/godot-proposals/issues/13389) to the project manager, and adding this item there instead.

~Merging this may supersede https://github.com/godotengine/godot/pull/112717.~ (see arkology's comment below)