### PR TITLE
Optimize the bresenham algorithm to avoid an unneeded vector allocation

### DIFF
--- a/editor/import/editor_atlas_packer.cpp
+++ b/editor/import/editor_atlas_packer.cpp
@@ -79,8 +79,8 @@ void EditorAtlasPacker::chart_pack(Vector<Chart> &charts, int &r_width, int &r_h
 
 			for (int k = 0; k < 3; k++) {
 				int l = k == 0 ? 2 : k - 1;
-				Vector<Point2i> points = Geometry2D::bresenham_line(v[k], v[l]);
-				for (Point2i point : points) {
+				Iterable<Geometry2D::BresenhamIterator> bresenham = Geometry2D::bresenham_iter(v[k], v[l]);
+				for (const Point2i &point : bresenham) {
 					src_bitmap->set_bitv(point, true);
 				}
 			}

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -1114,9 +1114,9 @@ void TileDataDefaultEditor::forward_painting_atlas_gui_input(TileAtlasView *p_ti
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
 		if (drag_type == DRAG_TYPE_PAINT) {
-			Vector<Vector2i> line = Geometry2D::bresenham_line(p_tile_atlas_view->get_atlas_tile_coords_at_pos(drag_last_pos, true), p_tile_atlas_view->get_atlas_tile_coords_at_pos(mm->get_position(), true));
-			for (int i = 0; i < line.size(); i++) {
-				Vector2i coords = p_tile_set_atlas_source->get_tile_at_coords(line[i]);
+			Iterable<Geometry2D::BresenhamIterator> bresenham = Geometry2D::bresenham_iter(p_tile_atlas_view->get_atlas_tile_coords_at_pos(drag_last_pos, true), p_tile_atlas_view->get_atlas_tile_coords_at_pos(mm->get_position(), true));
+			for (const Vector2i &c : bresenham) {
+				Vector2i coords = p_tile_set_atlas_source->get_tile_at_coords(c);
 				if (coords != TileSetSource::INVALID_ATLAS_COORDS) {
 					TileMapCell cell;
 					cell.source_id = 0;
@@ -2202,9 +2202,9 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
 		if (drag_type == DRAG_TYPE_PAINT_TERRAIN_SET) {
-			Vector<Vector2i> line = Geometry2D::bresenham_line(p_tile_atlas_view->get_atlas_tile_coords_at_pos(drag_last_pos, true), p_tile_atlas_view->get_atlas_tile_coords_at_pos(mm->get_position(), true));
-			for (int i = 0; i < line.size(); i++) {
-				Vector2i coords = p_tile_set_atlas_source->get_tile_at_coords(line[i]);
+			Iterable<Geometry2D::BresenhamIterator> bresenham = Geometry2D::bresenham_iter(p_tile_atlas_view->get_atlas_tile_coords_at_pos(drag_last_pos, true), p_tile_atlas_view->get_atlas_tile_coords_at_pos(mm->get_position(), true));
+			for (const Vector2i &c : bresenham) {
+				Vector2i coords = p_tile_set_atlas_source->get_tile_at_coords(c);
 				if (coords != TileSetSource::INVALID_ATLAS_COORDS) {
 					int terrain_set = drag_painted_value;
 					TileMapCell cell;
@@ -2236,9 +2236,9 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 		} else if (drag_type == DRAG_TYPE_PAINT_TERRAIN_BITS) {
 			int terrain_set = Dictionary(drag_painted_value)["terrain_set"];
 			int terrain = Dictionary(drag_painted_value)["terrain"];
-			Vector<Vector2i> line = Geometry2D::bresenham_line(p_tile_atlas_view->get_atlas_tile_coords_at_pos(drag_last_pos, true), p_tile_atlas_view->get_atlas_tile_coords_at_pos(mm->get_position(), true));
-			for (int i = 0; i < line.size(); i++) {
-				Vector2i coords = p_tile_set_atlas_source->get_tile_at_coords(line[i]);
+			Iterable<Geometry2D::BresenhamIterator> bresenham = Geometry2D::bresenham_iter(p_tile_atlas_view->get_atlas_tile_coords_at_pos(drag_last_pos, true), p_tile_atlas_view->get_atlas_tile_coords_at_pos(mm->get_position(), true));
+			for (const Vector2i &c : bresenham) {
+				Vector2i coords = p_tile_set_atlas_source->get_tile_at_coords(c);
 				if (coords != TileSetSource::INVALID_ATLAS_COORDS) {
 					TileMapCell cell;
 					cell.source_id = 0;

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -1118,12 +1118,11 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 				// Create tiles.
 				last_base_tiles_coords = last_base_tiles_coords.maxi(0).min(grid_size - Vector2i(1, 1));
 				new_base_tiles_coords = new_base_tiles_coords.maxi(0).min(grid_size - Vector2i(1, 1));
-
-				Vector<Point2i> line = Geometry2D::bresenham_line(last_base_tiles_coords, new_base_tiles_coords);
-				for (int i = 0; i < line.size(); i++) {
-					if (tile_set_atlas_source->get_tile_at_coords(line[i]) == TileSetSource::INVALID_ATLAS_COORDS) {
-						tile_set_atlas_source->create_tile(line[i]);
-						drag_modified_tiles.insert(line[i]);
+				Iterable<Geometry2D::BresenhamIterator> bresenham = Geometry2D::bresenham_iter(last_base_tiles_coords, new_base_tiles_coords);
+				for (const Vector2i &c : bresenham) {
+					if (tile_set_atlas_source->get_tile_at_coords(c) == TileSetSource::INVALID_ATLAS_COORDS) {
+						tile_set_atlas_source->create_tile(c);
+						drag_modified_tiles.insert(c);
 					}
 				}
 
@@ -1133,10 +1132,9 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 				// Remove tiles.
 				last_base_tiles_coords = last_base_tiles_coords.maxi(0).min(grid_size - Vector2i(1, 1));
 				new_base_tiles_coords = new_base_tiles_coords.maxi(0).min(grid_size - Vector2i(1, 1));
-
-				Vector<Point2i> line = Geometry2D::bresenham_line(last_base_tiles_coords, new_base_tiles_coords);
-				for (int i = 0; i < line.size(); i++) {
-					Vector2i base_tile_coords = tile_set_atlas_source->get_tile_at_coords(line[i]);
+				Iterable<Geometry2D::BresenhamIterator> bresenham = Geometry2D::bresenham_iter(last_base_tiles_coords, new_base_tiles_coords);
+				for (const Vector2i &c : bresenham) {
+					Vector2i base_tile_coords = tile_set_atlas_source->get_tile_at_coords(c);
 					if (base_tile_coords != TileSetSource::INVALID_ATLAS_COORDS) {
 						drag_modified_tiles.insert(base_tile_coords);
 					}

--- a/editor/scene/curve_editor_plugin.cpp
+++ b/editor/scene/curve_editor_plugin.cpp
@@ -1087,8 +1087,8 @@ Ref<Texture2D> CurvePreviewGenerator::generate(const Ref<Resource> &p_from, cons
 		v = (curve->sample_baked(t) - curve->get_min_value()) / curve->get_value_range();
 		y = CLAMP(im.get_height() - v * im.get_height(), 0, im.get_height() - 1);
 
-		Vector<Point2i> points = Geometry2D::bresenham_line(Point2i(x - 1, prev_y), Point2i(x, y));
-		for (Point2i point : points) {
+		Iterable<Geometry2D::BresenhamIterator> bresenham = Geometry2D::bresenham_iter(Point2i(x - 1, prev_y), Point2i(x, y));
+		for (const Point2i &point : bresenham) {
 			im.set_pixelv(point, line_color);
 		}
 		prev_y = y;


### PR DESCRIPTION
When I implemented the bresenham algorithm 4 year ago, I didn't really put a lot of effort into optimizing it. This is now fixed for internal use, as this new implementation does not allocate a `Vector<Point2i>` anymore. I assume this should improve performance a bit in the TileMap editor when drawing lines.

Instead, this PR implements a C++ iterable that can be used that way:
```
for (Vector2i point : Geometry2D::Bresenham(from, to)) {
    ...
}
```

Note that we have tests for the algorithm that all passed correctly. So I think we can safely assume this new implementation is working fine.