### PR TITLE
Change `TileSetScenesCollectionSource` raw pointers in the TileSet editor to ref

### DIFF
--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -76,7 +76,7 @@ bool TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::_s
 }
 
 bool TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::_get(const StringName &p_name, Variant &r_ret) const {
-	if (!tile_set_scenes_collection_source) {
+	if (tile_set_scenes_collection_source.is_null()) {
 		return false;
 	}
 	String name = p_name;
@@ -114,7 +114,7 @@ void TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::ed
 	}
 
 	// Disconnect to changes.
-	if (tile_set_scenes_collection_source) {
+	if (tile_set_scenes_collection_source.is_valid()) {
 		tile_set_scenes_collection_source->disconnect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 	}
 
@@ -123,7 +123,7 @@ void TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::ed
 	source_id = p_source_id;
 
 	// Connect to changes.
-	if (tile_set_scenes_collection_source) {
+	if (tile_set_scenes_collection_source.is_valid()) {
 		if (!tile_set_scenes_collection_source->is_connected(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed))) {
 			tile_set_scenes_collection_source->connect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 		}
@@ -134,7 +134,7 @@ void TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::ed
 
 // -- Proxy object used by the tile inspector --
 bool TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_set(const StringName &p_name, const Variant &p_value) {
-	if (!tile_set_scenes_collection_source) {
+	if (tile_set_scenes_collection_source.is_null()) {
 		return false;
 	}
 
@@ -166,7 +166,7 @@ bool TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_set(const Strin
 }
 
 bool TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_get(const StringName &p_name, Variant &r_ret) const {
-	if (!tile_set_scenes_collection_source) {
+	if (tile_set_scenes_collection_source.is_null()) {
 		return false;
 	}
 
@@ -185,7 +185,7 @@ bool TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_get(const Strin
 }
 
 void TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_get_property_list(List<PropertyInfo> *p_list) const {
-	if (!tile_set_scenes_collection_source) {
+	if (tile_set_scenes_collection_source.is_null()) {
 		return;
 	}
 
@@ -255,8 +255,8 @@ void TileSetScenesCollectionSourceEditor::_scene_file_selected(const String &p_p
 	int scene_id = tile_set_scenes_collection_source->get_next_scene_tile_id();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add a Scene Tile"));
-	undo_redo->add_do_method(tile_set_scenes_collection_source, "create_scene_tile", scene, scene_id);
-	undo_redo->add_undo_method(tile_set_scenes_collection_source, "remove_scene_tile", scene_id);
+	undo_redo->add_do_method(*tile_set_scenes_collection_source, "create_scene_tile", scene, scene_id);
+	undo_redo->add_undo_method(*tile_set_scenes_collection_source, "remove_scene_tile", scene_id);
 	undo_redo->commit_action();
 	_update_scenes_list();
 	_update_action_buttons();
@@ -270,8 +270,8 @@ void TileSetScenesCollectionSourceEditor::_source_delete_pressed() {
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Remove a Scene Tile"));
-	undo_redo->add_do_method(tile_set_scenes_collection_source, "remove_scene_tile", scene_id);
-	undo_redo->add_undo_method(tile_set_scenes_collection_source, "create_scene_tile", tile_set_scenes_collection_source->get_scene_tile_scene(scene_id), scene_id);
+	undo_redo->add_do_method(*tile_set_scenes_collection_source, "remove_scene_tile", scene_id);
+	undo_redo->add_undo_method(*tile_set_scenes_collection_source, "create_scene_tile", tile_set_scenes_collection_source->get_scene_tile_scene(scene_id), scene_id);
 	undo_redo->commit_action();
 	_update_scenes_list();
 	_update_action_buttons();
@@ -280,7 +280,7 @@ void TileSetScenesCollectionSourceEditor::_source_delete_pressed() {
 
 void TileSetScenesCollectionSourceEditor::_update_source_inspector() {
 	// Update the proxy object.
-	scenes_collection_source_proxy_object->edit(tile_set, tile_set_scenes_collection_source, tile_set_source_id);
+	scenes_collection_source_proxy_object->edit(tile_set, *tile_set_scenes_collection_source, tile_set_source_id);
 }
 
 void TileSetScenesCollectionSourceEditor::_update_tile_inspector() {
@@ -290,7 +290,7 @@ void TileSetScenesCollectionSourceEditor::_update_tile_inspector() {
 	// Update the proxy object.
 	if (has_atlas_tile_selected) {
 		int scene_id = scene_tiles_list->get_item_metadata(selected_indices[0]);
-		tile_proxy_object->edit(tile_set_scenes_collection_source, scene_id);
+		tile_proxy_object->edit(*tile_set_scenes_collection_source, scene_id);
 	}
 
 	// Update visibility.
@@ -304,7 +304,7 @@ void TileSetScenesCollectionSourceEditor::_update_action_buttons() {
 }
 
 void TileSetScenesCollectionSourceEditor::_update_scenes_list() {
-	if (!tile_set_scenes_collection_source) {
+	if (tile_set_scenes_collection_source.is_null()) {
 		return;
 	}
 
@@ -405,12 +405,12 @@ void TileSetScenesCollectionSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetS
 		new_read_only_state = EditorNode::get_singleton()->is_resource_read_only(p_tile_set);
 	}
 
-	if (p_tile_set == tile_set && p_tile_set_scenes_collection_source == tile_set_scenes_collection_source && p_source_id == tile_set_source_id && new_read_only_state == read_only) {
+	if (p_tile_set == tile_set && p_tile_set_scenes_collection_source == *tile_set_scenes_collection_source && p_source_id == tile_set_source_id && new_read_only_state == read_only) {
 		return;
 	}
 
 	// Remove listener for old objects.
-	if (tile_set_scenes_collection_source) {
+	if (tile_set_scenes_collection_source.is_valid()) {
 		tile_set_scenes_collection_source->disconnect_changed(callable_mp(this, &TileSetScenesCollectionSourceEditor::_tile_set_scenes_collection_source_changed));
 	}
 
@@ -430,7 +430,7 @@ void TileSetScenesCollectionSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetS
 	}
 
 	// Add the listener again.
-	if (tile_set_scenes_collection_source) {
+	if (tile_set_scenes_collection_source.is_valid()) {
 		tile_set_scenes_collection_source->connect_changed(callable_mp(this, &TileSetScenesCollectionSourceEditor::_tile_set_scenes_collection_source_changed));
 	}
 
@@ -456,8 +456,8 @@ void TileSetScenesCollectionSourceEditor::_drop_data_fw(const Point2 &p_point, c
 				int scene_id = tile_set_scenes_collection_source->get_next_scene_tile_id();
 				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 				undo_redo->create_action(TTR("Add a Scene Tile"));
-				undo_redo->add_do_method(tile_set_scenes_collection_source, "create_scene_tile", resource, scene_id);
-				undo_redo->add_undo_method(tile_set_scenes_collection_source, "remove_scene_tile", scene_id);
+				undo_redo->add_do_method(*tile_set_scenes_collection_source, "create_scene_tile", resource, scene_id);
+				undo_redo->add_undo_method(*tile_set_scenes_collection_source, "remove_scene_tile", scene_id);
 				undo_redo->commit_action();
 			}
 		}

--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.h
@@ -49,7 +49,7 @@ private:
 
 	private:
 		Ref<TileSet> tile_set;
-		TileSetScenesCollectionSource *tile_set_scenes_collection_source = nullptr;
+		Ref<TileSetScenesCollectionSource> tile_set_scenes_collection_source;
 		int source_id = -1;
 
 	protected:
@@ -72,7 +72,7 @@ private:
 	private:
 		TileSetScenesCollectionSourceEditor *tile_set_scenes_collection_source_editor = nullptr;
 
-		TileSetScenesCollectionSource *tile_set_scenes_collection_source = nullptr;
+		Ref<TileSetScenesCollectionSource> tile_set_scenes_collection_source;
 		int source_id;
 		int scene_id;
 
@@ -96,7 +96,7 @@ private:
 	bool read_only = false;
 
 	Ref<TileSet> tile_set;
-	TileSetScenesCollectionSource *tile_set_scenes_collection_source = nullptr;
+	Ref<TileSetScenesCollectionSource> tile_set_scenes_collection_source;
 	int tile_set_source_id = -1;
 
 	bool tile_set_scenes_collection_source_changed_needs_update = false;


### PR DESCRIPTION
…tor to Ref<TileSetScenesCollectionSource>

### Problem:
* Addresses Fixes #112643
* The Editor crashes due to a attempting to access a dangling pointer to a released TileSetScenesCollectionSource.
* The resource is released by the TileSetEditor either through Undo or by deleting it using the Editor UI.
* The pointers in tile_set_scenes_collection_source_editor are now dangling since they are not updated.
* Note - The pointers are only invalid after the redo stack is cleared and there aren't any other actions holding on to a reference of the source collection.

### Solution:
* Suggestion of @kleonc and @groud.
* Made tile_set_scenes_collection_source a Ref instead of a raw point, protecting against dangling pointers when the source is released.
   * Updated the relevant code to support usage of a Ref instead of a raw pointer.

### Testing:
* I verified that the repro steps provided in the issue no longer cause a crash.
* I verified that using the delete button in the UI still successfulyl deletes the source collection.
* I stress tested the undo redo stack by creating multiple sources and spamming undo\redo

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
