### PR TITLE
Fix control `set_position` modifying anchor rect size as a side effect

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -948,7 +948,7 @@ Control::GrowDirection Control::get_v_grow_direction() const {
 	return data.v_grow;
 }
 
-void Control::_compute_layout_rect(Rect2 p_rect, bool p_keep_offsets) {
+void Control::_compute_layout_rect(Rect2 p_rect, bool p_keep_offsets, bool p_grow_rect) {
 	Size2 parent_rect_size = get_parent_anchorable_rect().size;
 
 	if (p_keep_offsets) {
@@ -960,7 +960,7 @@ void Control::_compute_layout_rect(Rect2 p_rect, bool p_keep_offsets) {
 	real_t x = p_rect.position.x;
 	real_t y = p_rect.position.y;
 
-	if (_get_layout_mode() != LayoutMode::LAYOUT_MODE_CONTAINER) {
+	if (p_grow_rect && _get_layout_mode() != LayoutMode::LAYOUT_MODE_CONTAINER) {
 		float left_grow_factor =
 				(data.h_grow == GROW_DIRECTION_BEGIN) ? 1.0f
 				: (data.h_grow == GROW_DIRECTION_END) ? 0.0f
@@ -990,6 +990,68 @@ void Control::_compute_layout_rect(Rect2 p_rect, bool p_keep_offsets) {
 		data.offset[1] = y - (data.anchor[1] * parent_rect_size.y);
 		data.offset[2] = x + p_rect.size.x - (data.anchor[2] * parent_rect_size.x);
 		data.offset[3] = y + p_rect.size.y - (data.anchor[3] * parent_rect_size.y);
+	}
+}
+
+void Control::_compute_layout_position(const Rect2 &p_parent_rect, const Size2 &p_size, Point2 &r_position) const {
+	if (is_layout_rtl()) {
+		r_position.x = p_parent_rect.size.x + 2 * p_parent_rect.position.x - r_position.x - p_size.x;
+	}
+}
+
+void Control::_compute_edge_positions(const Rect2 &p_parent_rect, real_t (&r_edge_positions)[4]) const {
+	for (int i = 0; i < 4; i++) {
+		real_t area = p_parent_rect.size[i & 1];
+		r_edge_positions[i] = data.offset[i] + (data.anchor[i] * area);
+	}
+}
+
+void Control::_compute_position_and_size_with_grow(const Rect2 &p_parent_rect, Point2 &r_position, Size2 &r_size) const {
+	Size2 maximum_size = get_combined_maximum_size();
+	Size2 minimum_size = get_combined_minimum_size();
+
+	if (minimum_size.width > r_size.width) {
+		if (data.h_grow == GROW_DIRECTION_BEGIN) {
+			r_position.x += r_size.width - minimum_size.width;
+		} else if (data.h_grow == GROW_DIRECTION_BOTH) {
+			r_position.x += 0.5 * (r_size.width - minimum_size.width);
+		}
+
+		r_size.width = minimum_size.width;
+	}
+
+	if (maximum_size.width >= 0 && maximum_size.width < r_size.width) {
+		if (data.h_grow == GROW_DIRECTION_BEGIN) {
+			r_position.x += r_size.width - maximum_size.width;
+		} else if (data.h_grow == GROW_DIRECTION_BOTH) {
+			r_position.x += 0.5 * (r_size.width - maximum_size.width);
+		}
+
+		r_size.width = maximum_size.width;
+	}
+
+	if (is_layout_rtl()) {
+		r_position.x = p_parent_rect.size.x + 2 * p_parent_rect.position.x - r_position.x - r_size.x;
+	}
+
+	if (minimum_size.height > r_size.height) {
+		if (data.v_grow == GROW_DIRECTION_BEGIN) {
+			r_position.y += r_size.height - minimum_size.height;
+		} else if (data.v_grow == GROW_DIRECTION_BOTH) {
+			r_position.y += 0.5 * (r_size.height - minimum_size.height);
+		}
+
+		r_size.height = minimum_size.height;
+	}
+
+	if (maximum_size.height >= 0 && maximum_size.height < r_size.height) {
+		if (data.v_grow == GROW_DIRECTION_BEGIN) {
+			r_position.y += r_size.height - maximum_size.height;
+		} else if (data.v_grow == GROW_DIRECTION_BOTH) {
+			r_position.y += 0.5 * (r_size.height - maximum_size.height);
+		}
+
+		r_size.height = maximum_size.height;
 	}
 }
 
@@ -1523,7 +1585,23 @@ void Control::set_position(const Point2 &p_point, bool p_keep_offsets) {
 	}
 #endif // TOOLS_ENABLED
 
-	_compute_layout_rect(Rect2(p_point, data.size_cache), p_keep_offsets);
+	// Determine actual position of top-left corner based on anchors, offsets, grow direction, min size, and max size.
+	Rect2 parent_rect = get_parent_anchorable_rect();
+	real_t edge_pos[4];
+	_compute_edge_positions(parent_rect, edge_pos);
+
+	Point2 anchor_position = Point2(edge_pos[0], edge_pos[1]);
+	Size2 anchor_size = Point2(edge_pos[2], edge_pos[3]) - anchor_position;
+
+	Point2 position = anchor_position;
+	Size2 size = anchor_size;
+	_compute_position_and_size_with_grow(parent_rect, position, size);
+
+	// Only move anchor rect position by amount the top-left corner should change.
+	// Keep anchor rect size since that changes how overall sizing behaves.
+	_compute_layout_position(parent_rect, anchor_size, anchor_position);
+	anchor_position += p_point - position;
+	_compute_layout_rect(Rect2(anchor_position, anchor_size), p_keep_offsets, false);
 	_size_changed();
 }
 
@@ -2208,63 +2286,11 @@ Size2 Control::get_bound_minimum_size() const {
 
 void Control::_size_changed() {
 	Rect2 parent_rect = get_parent_anchorable_rect();
-
 	real_t edge_pos[4];
-
-	for (int i = 0; i < 4; i++) {
-		real_t area = parent_rect.size[i & 1];
-		edge_pos[i] = data.offset[i] + (data.anchor[i] * area);
-	}
-
+	_compute_edge_positions(parent_rect, edge_pos);
 	Point2 new_pos_cache = Point2(edge_pos[0], edge_pos[1]);
 	Size2 new_size_cache = Point2(edge_pos[2], edge_pos[3]) - new_pos_cache;
-
-	Size2 maximum_size = get_combined_maximum_size();
-	Size2 minimum_size = get_combined_minimum_size();
-
-	if (minimum_size.width > new_size_cache.width) {
-		if (data.h_grow == GROW_DIRECTION_BEGIN) {
-			new_pos_cache.x += new_size_cache.width - minimum_size.width;
-		} else if (data.h_grow == GROW_DIRECTION_BOTH) {
-			new_pos_cache.x += 0.5 * (new_size_cache.width - minimum_size.width);
-		}
-
-		new_size_cache.width = minimum_size.width;
-	}
-
-	if (maximum_size.width >= 0 && maximum_size.width < new_size_cache.width) {
-		if (data.h_grow == GROW_DIRECTION_BEGIN) {
-			new_pos_cache.x += new_size_cache.width - maximum_size.width;
-		} else if (data.h_grow == GROW_DIRECTION_BOTH) {
-			new_pos_cache.x += 0.5 * (new_size_cache.width - maximum_size.width);
-		}
-
-		new_size_cache.width = maximum_size.width;
-	}
-
-	if (is_layout_rtl()) {
-		new_pos_cache.x = parent_rect.size.x + 2 * parent_rect.position.x - new_pos_cache.x - new_size_cache.x;
-	}
-
-	if (minimum_size.height > new_size_cache.height) {
-		if (data.v_grow == GROW_DIRECTION_BEGIN) {
-			new_pos_cache.y += new_size_cache.height - minimum_size.height;
-		} else if (data.v_grow == GROW_DIRECTION_BOTH) {
-			new_pos_cache.y += 0.5 * (new_size_cache.height - minimum_size.height);
-		}
-
-		new_size_cache.height = minimum_size.height;
-	}
-
-	if (maximum_size.height >= 0 && maximum_size.height < new_size_cache.height) {
-		if (data.v_grow == GROW_DIRECTION_BEGIN) {
-			new_pos_cache.y += new_size_cache.height - maximum_size.height;
-		} else if (data.v_grow == GROW_DIRECTION_BOTH) {
-			new_pos_cache.y += 0.5 * (new_size_cache.height - maximum_size.height);
-		}
-
-		new_size_cache.height = maximum_size.height;
-	}
+	_compute_position_and_size_with_grow(parent_rect, new_pos_cache, new_size_cache);
 
 	bool pos_changed = new_pos_cache != data.pos_cache;
 	bool size_changed = new_size_cache != data.size_cache;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -365,7 +365,11 @@ private:
 	void _set_global_position(const Point2 &p_point);
 	void _set_size(const Size2 &p_size);
 
-	void _compute_layout_rect(Rect2 p_rect, bool p_keep_offsets = false);
+	void _compute_layout_rect(Rect2 p_rect, bool p_keep_offsets = false, bool p_grow_rect = true);
+
+	void _compute_layout_position(const Rect2 &p_parent_rect, const Size2 &p_size, Point2 &r_point) const;
+	void _compute_edge_positions(const Rect2 &p_parent_rect, real_t (&r_edge_positions)[4]) const;
+	void _compute_position_and_size_with_grow(const Rect2 &p_parent_rect, Point2 &r_position, Size2 &r_size) const;
 
 	void _set_layout_mode(LayoutMode p_mode);
 	void _update_layout_mode();

--- a/tests/scene/test_control.cpp
+++ b/tests/scene/test_control.cpp
@@ -1101,6 +1101,112 @@ TEST_CASE("[SceneTree][Control] Anchoring") {
 	memdelete(test_control);
 }
 
+TEST_CASE("[SceneTree][Control] Set position does not cause size side-effects") {
+	Control *test_control = memnew(Control);
+	test_control->set_size(Size2(2, 2));
+	test_control->set_custom_minimum_size(Size2(4, 4));
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(test_control);
+
+	SUBCASE("Shrinks after setting position and smaller custom minimum size. (Change offsets, Grow end)") {
+		test_control->set_h_grow_direction(Control::GrowDirection::GROW_DIRECTION_END);
+		test_control->set_v_grow_direction(Control::GrowDirection::GROW_DIRECTION_END);
+		test_control->set_position(Point2(10, 10), false);
+		SceneTree::get_singleton()->process(0);
+
+		test_control->set_custom_minimum_size(Size2(0, 0));
+		SceneTree::get_singleton()->process(0);
+		CHECK_MESSAGE(
+				test_control->get_size().is_equal_approx(Vector2(2, 2)),
+				"Should shrink to original size after setting a smaller custom minimum size.");
+		CHECK_MESSAGE(
+				test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Should keep position after shrink");
+	}
+
+	SUBCASE("Shrinks after setting position and smaller custom minimum size (Keep offsets, Grow end)") {
+		test_control->set_h_grow_direction(Control::GrowDirection::GROW_DIRECTION_END);
+		test_control->set_v_grow_direction(Control::GrowDirection::GROW_DIRECTION_END);
+		test_control->set_position(Point2(10, 10), true);
+		SceneTree::get_singleton()->process(0);
+
+		test_control->set_custom_minimum_size(Size2(0, 0));
+		SceneTree::get_singleton()->process(0);
+		CHECK_MESSAGE(
+				test_control->get_size().is_equal_approx(Vector2(2, 2)),
+				"Should shrink to original size after setting a smaller custom minimum size.");
+		CHECK_MESSAGE(
+				test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Should keep position after shrink");
+	}
+
+	SUBCASE("Shrinks after setting position and smaller custom minimum size (Keep offsets, Grow both)") {
+		test_control->set_h_grow_direction(Control::GrowDirection::GROW_DIRECTION_BOTH);
+		test_control->set_v_grow_direction(Control::GrowDirection::GROW_DIRECTION_BOTH);
+		test_control->set_position(Point2(10, 10), true);
+		SceneTree::get_singleton()->process(0);
+
+		test_control->set_custom_minimum_size(Size2(0, 0));
+		SceneTree::get_singleton()->process(0);
+		CHECK_MESSAGE(
+				test_control->get_size().is_equal_approx(Vector2(2, 2)),
+				"Should shrink to original size after setting a smaller custom minimum size.");
+		CHECK_MESSAGE(
+				test_control->get_position().is_equal_approx(Vector2(11, 11)),
+				"Should partially move down left after shrink");
+	}
+
+	SUBCASE("Shrinks after setting position and smaller custom minimum size (Change offsets, Grow both)") {
+		test_control->set_h_grow_direction(Control::GrowDirection::GROW_DIRECTION_BOTH);
+		test_control->set_v_grow_direction(Control::GrowDirection::GROW_DIRECTION_BOTH);
+		test_control->set_position(Point2(10, 10), false);
+		SceneTree::get_singleton()->process(0);
+
+		test_control->set_custom_minimum_size(Size2(0, 0));
+		SceneTree::get_singleton()->process(0);
+		CHECK_MESSAGE(
+				test_control->get_size().is_equal_approx(Vector2(2, 2)),
+				"Should shrink to original size after setting a smaller custom minimum size.");
+		CHECK_MESSAGE(
+				test_control->get_position().is_equal_approx(Vector2(11, 11)),
+				"Should partially move down left after shrink");
+	}
+
+	SUBCASE("Shrinks after setting position and smaller custom minimum size (Keep offsets, Grow begin)") {
+		test_control->set_h_grow_direction(Control::GrowDirection::GROW_DIRECTION_BEGIN);
+		test_control->set_v_grow_direction(Control::GrowDirection::GROW_DIRECTION_BEGIN);
+		test_control->set_position(Point2(10, 10), true);
+		SceneTree::get_singleton()->process(0);
+
+		test_control->set_custom_minimum_size(Size2(0, 0));
+		SceneTree::get_singleton()->process(0);
+		CHECK_MESSAGE(
+				test_control->get_size().is_equal_approx(Vector2(2, 2)),
+				"Should shrink to original size after setting a smaller custom minimum size.");
+		CHECK_MESSAGE(
+				test_control->get_position().is_equal_approx(Vector2(12, 12)),
+				"Should entirely move down left after shrink");
+	}
+
+	SUBCASE("Shrinks after setting position and smaller custom minimum size (Change offsets, Grow begin)") {
+		test_control->set_h_grow_direction(Control::GrowDirection::GROW_DIRECTION_BEGIN);
+		test_control->set_v_grow_direction(Control::GrowDirection::GROW_DIRECTION_BEGIN);
+		test_control->set_position(Point2(10, 10), false);
+		SceneTree::get_singleton()->process(0);
+
+		test_control->set_custom_minimum_size(Size2(0, 0));
+		SceneTree::get_singleton()->process(0);
+		CHECK_MESSAGE(
+				test_control->get_size().is_equal_approx(Vector2(2, 2)),
+				"Should shrink to original size after setting a smaller custom minimum size.");
+		CHECK_MESSAGE(
+				test_control->get_position().is_equal_approx(Vector2(12, 12)),
+				"Should entirely move down left after shrink");
+	}
+
+	memdelete(test_control);
+}
+
 TEST_CASE("[SceneTree][Control] Custom maximum size") {
 	Control *test_control = memnew(Control);
 	test_control->set_custom_maximum_size(Size2(4, 2));
@@ -1283,6 +1389,306 @@ TEST_CASE("[SceneTree][Control] Grow direction") {
 	}
 
 	memdelete(test_control);
+}
+
+TEST_CASE("[SceneTree][Control] Set global position") {
+	Control *test_parent = memnew(Control);
+
+	Control *test_child = memnew(Control);
+	test_parent->add_child(test_child);
+
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(test_parent);
+
+	SUBCASE("Parent at 0,0, unscaled, and no rotation") {
+		test_parent->set_global_position(Vector2(0, 0));
+		test_parent->set_scale(Vector2(1, 1));
+		test_parent->set_rotation(0);
+		test_child->set_global_position(Vector2(2, 2));
+		CHECK_MESSAGE(test_child->get_position().is_equal_approx(Vector2(2, 2)),
+				"Incorrect local position.");
+	}
+
+	SUBCASE("Parent translated") {
+		test_parent->set_global_position(Vector2(4, 4));
+		test_parent->set_scale(Vector2(1, 1));
+		test_parent->set_rotation_degrees(0);
+		test_child->set_global_position(Vector2(2, 2));
+		CHECK_MESSAGE(test_child->get_position().is_equal_approx(Vector2(-2, -2)),
+				"Incorrect local position.");
+	}
+
+	SUBCASE("Parent scaled") {
+		test_parent->set_global_position(Vector2(0, 0));
+		test_parent->set_scale(Vector2(2, 2));
+		test_parent->set_rotation_degrees(0);
+		test_child->set_global_position(Vector2(2, 2));
+		CHECK_MESSAGE(test_child->get_position().is_equal_approx(Vector2(1, 1)),
+				"Incorrect local position.");
+	}
+
+	SUBCASE("Parent rotated") {
+		test_parent->set_global_position(Vector2(0, 0));
+		test_parent->set_scale(Vector2(1, 1));
+		test_parent->set_rotation_degrees(90);
+		test_child->set_global_position(Vector2(2, 2));
+		CHECK_MESSAGE(test_child->get_position().is_equal_approx(Vector2(2, -2)),
+				"Incorrect local position.");
+	}
+
+	SUBCASE("Parent translated and scaled") {
+		test_parent->set_global_position(Vector2(4, 4));
+		test_parent->set_scale(Vector2(2, 2));
+		test_parent->set_rotation_degrees(0);
+		test_child->set_global_position(Vector2(2, 2));
+		CHECK_MESSAGE(test_child->get_position().is_equal_approx(Vector2(-1, -1)),
+				"Incorrect local position.");
+	}
+
+	SUBCASE("Parent translated and rotated") {
+		test_parent->set_global_position(Vector2(4, 4));
+		test_parent->set_scale(Vector2(1, 1));
+		test_parent->set_rotation_degrees(90);
+		test_child->set_global_position(Vector2(2, 2));
+		CHECK_MESSAGE(test_child->get_position().is_equal_approx(Vector2(-2, 2)),
+				"Incorrect local position.");
+	}
+
+	SUBCASE("Parent scaled and rotated") {
+		test_parent->set_global_position(Vector2(0, 0));
+		test_parent->set_scale(Vector2(2, 2));
+		test_parent->set_rotation_degrees(90);
+		test_child->set_global_position(Vector2(2, 2));
+		CHECK_MESSAGE(test_child->get_position().is_equal_approx(Vector2(1, -1)),
+				"Incorrect local position.");
+	}
+
+	SUBCASE("Parent translated, scaled, and rotated") {
+		test_parent->set_global_position(Vector2(4, 4));
+		test_parent->set_scale(Vector2(2, 2));
+		test_parent->set_rotation_degrees(90);
+		test_child->set_global_position(Vector2(2, 2));
+		CHECK_MESSAGE(test_child->get_position().is_equal_approx(Vector2(-1, 1)),
+				"Incorrect local position.");
+	}
+
+	memdelete(test_parent);
+}
+
+TEST_CASE("[SceneTree][Control] Set position with grow direction") {
+	Control *test_control = memnew(Control);
+	test_control->set_size(Size2(1, 1));
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(test_control);
+
+	SUBCASE("Horizontal grow direction begin without keep offsets") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction begin without keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BEGIN);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction end without keep offsets.") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_END);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction end without keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_END);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction both without keep offsets.") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BOTH);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction both without keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BOTH);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction begin with keep offsets") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction begin with keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BEGIN);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction end with keep offsets.") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_END);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction end with keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_END);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction both with keep offsets.") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BOTH);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction both with keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BOTH);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	memdelete(test_control);
+}
+
+TEST_CASE("[SceneTree][Control] Set position with grow direction in rtl") {
+	Control *rtl_control = memnew(Control);
+	rtl_control->set_layout_direction(Control::LAYOUT_DIRECTION_RTL);
+	rtl_control->set_size(Size2(100, 100));
+
+	Control *test_control = memnew(Control);
+	test_control->set_size(Size2(1, 1));
+	rtl_control->add_child(test_control);
+
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(rtl_control);
+
+	SUBCASE("Horizontal grow direction begin without keep offsets") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction begin without keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BEGIN);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction end without keep offsets.") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_END);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction end without keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_END);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction both without keep offsets.") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BOTH);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction both without keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BOTH);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), false);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position without keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction begin with keep offsets") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction begin with keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BEGIN);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction end with keep offsets.") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_END);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction end with keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_END);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Horizontal grow direction both with keep offsets.") {
+		test_control->set_h_grow_direction(Control::GROW_DIRECTION_BOTH);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	SUBCASE("Vertical grow direction both with keep offsets.") {
+		test_control->set_v_grow_direction(Control::GROW_DIRECTION_BOTH);
+		test_control->set_custom_minimum_size(Size2(2, 2));
+		test_control->set_position(Vector2(10, 10), true);
+		CHECK_MESSAGE(test_control->get_position().is_equal_approx(Vector2(10, 10)),
+				"Failed to set position with keep offsets.");
+	}
+
+	memdelete(rtl_control);
 }
 
 } // namespace TestControl


### PR DESCRIPTION
Time for the 3rd attempt at this with great concern of another regression.

- Fixes #100536 
- Fixes #100626
- Fixes #102096

Does not recreate:
- #105771
- #106477

Different approach from:
- #112525

Just for clarity: I'm gonna call the rect formed by anchor points + anchor offsets as the "anchor rect".

These changes continue the work from #104357 and #106141 with the answer that if the cache isn't reliable, then just compute it. The only time the anchor rect's top left differs from the control position is if the control's min size is larger than the size of the anchor rect and grow directions aren't set to end, so just check for that the same way it's check in `_size_changed()`.

This solution just makes the workflow of setting up the anchor rect as a size constraint easier since something that sounds like it shouldn't have an effect on size, `set_position()`, will not impact size changes. It also makes moving a control after meticulously setting up offsets in custom anchor preset less annoying since a user no longer has to readjust offsets after moving. Ultimately, this helps min size, grow direction, and anchor rect be more independent settings for how a control is positioned and sized.

This doesn't provide a universal way of always keeping a control at its min size, which is more of the intent of the original bug reports, but does make it easier. A user would still need to have the anchor points and anchor offsets set so that the anchor rect is size 0,0 to always stay at min size. The main caveat to this is that using anchor presets via inspector sets different offsets based on the current min size. This means switching between the presets in inspector can change sizing behavior, but whether that's desirable whole different discussion and the user can just switch to the custom preset. 

Despite the indirect solution, the changes end up fixing the bugs because the containers in question have a 0,0 min size without children. It'd still be possible for containers to not always be their min size if it had children and then had it's presets changed as described above.

## Tests a plenty
Because of the history of regressions, I made a bunch of tests around positioning controls. I don't quite understand how right-to-left works, so I wouldn't be surprised if the rtl test case doesn't make sense. 

- `[SceneTree][Control] Set position with grow direction` tests cover #105771
- `[SceneTree][Control] Set position with grow direction in rtl` tries to cover #106477

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
