### PR TITLE
Fix control toolbar button sizing for different Base Spacing values

### DIFF
--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -498,14 +498,14 @@ bool EditorInspectorPluginControl::parse_property(Object *p_object, const Varian
 // Toolbars controls.
 
 Size2 ControlEditorPopupButton::get_minimum_size() const {
-	Vector2 base_size = Vector2(26, 26) * EDSCALE;
+	Size2 base_size = Button::get_minimum_size();
 
 	if (arrow_icon.is_null()) {
 		return base_size;
 	}
 
-	Vector2 final_size;
-	final_size.x = base_size.x + arrow_icon->get_width();
+	Size2 final_size;
+	final_size.x = base_size.x + arrow_icon->get_width() - (2 * EDSCALE);
 	final_size.y = MAX(base_size.y, arrow_icon->get_height());
 
 	return final_size;
@@ -541,7 +541,7 @@ void ControlEditorPopupButton::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 			if (arrow_icon.is_valid()) {
-				Vector2 arrow_pos = Point2(26, 0) * EDSCALE;
+				Vector2 arrow_pos = Point2(get_size().x - arrow_icon->get_width() - (get_theme_stylebox(CoreStringName(normal))->get_margin(SIDE_RIGHT) * 0.5) + (2 * EDSCALE), 0);
 				if (is_layout_rtl()) {
 					arrow_pos.x = get_size().x - arrow_pos.x - arrow_icon->get_width();
 				}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/112735

Before/After

Default:

<img width="163" height="99" alt="Screenshot_20251113_222700" src="https://github.com/user-attachments/assets/1cd0a037-172c-488e-bf1e-74429a848805" />

<img width="163" height="99" alt="Screenshot_20251113_222740" src="https://github.com/user-attachments/assets/3acf9e60-48b4-4a88-966c-eb7e77d5ee7d" />

Base Spacing 0:

<img width="163" height="99" alt="Screenshot_20251113_222854" src="https://github.com/user-attachments/assets/736b7109-77b9-489d-ae95-03c63be6a4ef" />

<img width="163" height="99" alt="Screenshot_20251113_222907" src="https://github.com/user-attachments/assets/0475c61a-d502-42f9-ae68-fb9a689f435b" />


Classic, Base Spacing 0:

<img width="163" height="99" alt="Screenshot_20251113_223025" src="https://github.com/user-attachments/assets/f745932b-7603-48bf-940f-726f4fc4d94b" />

<img width="163" height="99" alt="Screenshot_20251113_223055" src="https://github.com/user-attachments/assets/ff09e681-cc57-4cfc-9fa2-87014846f59a" />

Default 200% scale

<img width="163" height="99" alt="Screenshot_20251113_223445" src="https://github.com/user-attachments/assets/cc87e916-ce2a-4d8f-98e5-856c1c2fd1e1" />

<img width="163" height="99" alt="Screenshot_20251113_223501" src="https://github.com/user-attachments/assets/ba9c8a1f-ecc1-4fe1-a55c-68df751f911e" />

