### PR TITLE
Strip VoxelGIData and LightmapGIData using placeholders for dedicated server exports

### DIFF
--- a/doc/classes/LightmapGIData.xml
+++ b/doc/classes/LightmapGIData.xml
@@ -25,6 +25,12 @@
 				Clear all objects that are considered baked within this [LightmapGIData].
 			</description>
 		</method>
+		<method name="create_placeholder" qualifiers="const">
+			<return type="Resource" />
+			<description>
+				Creates a placeholder version of this resource ([PlaceholderLightmapGIData]).
+			</description>
+		</method>
 		<method name="get_user_count" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/PlaceholderLightmapGIData.xml
+++ b/doc/classes/PlaceholderLightmapGIData.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PlaceholderLightmapGIData" inherits="LightmapGIData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Placeholder class for [LightmapGIData].
+	</brief_description>
+	<description>
+		This class is used when loading a project that uses a [LightmapGIData] subclass, if the project was exported in dedicated server mode. In this mode, only the resource reference is kept, with no actual light probe data. This allows reducing the exported PCK's size significantly.
+		[b]Note:[/b] This is not intended to be used as an actual resource for rendering.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/PlaceholderVoxelGIData.xml
+++ b/doc/classes/PlaceholderVoxelGIData.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PlaceholderVoxelGIData" inherits="VoxelGIData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Placeholder class for [VoxelGIData].
+	</brief_description>
+	<description>
+		This class is used when loading a project that uses a [VoxelGIData] subclass, if the project was exported in dedicated server mode. In this mode, only the resource reference is kept, with no actual voxel data. This allows reducing the exported PCK's size significantly.
+		[b]Note:[/b] This is not intended to be used as an actual resource for rendering.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/VoxelGIData.xml
+++ b/doc/classes/VoxelGIData.xml
@@ -23,6 +23,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="create_placeholder" qualifiers="const">
+			<return type="Resource" />
+			<description>
+				Creates a placeholder version of this resource ([PlaceholderVoxelGIData]).
+			</description>
+		</method>
 		<method name="get_bounds" qualifiers="const">
 			<return type="AABB" />
 			<description>

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -323,6 +323,12 @@ Array LightmapGIData::_get_light_textures_data() const {
 }
 #endif
 
+Ref<Resource> LightmapGIData::create_placeholder() const {
+	Ref<PlaceholderLightmapGIData> data;
+	data.instantiate();
+	return data;
+}
+
 void LightmapGIData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_user_data", "data"), &LightmapGIData::_set_user_data);
 	ClassDB::bind_method(D_METHOD("_get_user_data"), &LightmapGIData::_get_user_data);
@@ -346,6 +352,8 @@ void LightmapGIData::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_probe_data", "data"), &LightmapGIData::_set_probe_data);
 	ClassDB::bind_method(D_METHOD("_get_probe_data"), &LightmapGIData::_get_probe_data);
+
+	ClassDB::bind_method(D_METHOD("create_placeholder"), &LightmapGIData::create_placeholder);
 
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "lightmap_textures", PROPERTY_HINT_ARRAY_TYPE, "TextureLayered", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "set_lightmap_textures", "get_lightmap_textures");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "shadowmask_textures", PROPERTY_HINT_ARRAY_TYPE, "TextureLayered", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "set_shadowmask_textures", "get_shadowmask_textures");
@@ -375,6 +383,21 @@ LightmapGIData::LightmapGIData() {
 }
 
 LightmapGIData::~LightmapGIData() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	RS::get_singleton()->free_rid(lightmap);
+}
+
+///////////////////////////
+
+RID PlaceholderLightmapGIData::get_rid() const {
+	return lightmap;
+}
+
+PlaceholderLightmapGIData::PlaceholderLightmapGIData() {
+	lightmap = RS::get_singleton()->lightmap_create();
+}
+
+PlaceholderLightmapGIData::~PlaceholderLightmapGIData() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free_rid(lightmap);
 }

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -37,6 +37,7 @@
 
 class Sky;
 class CameraAttributes;
+class PlaceholderLightmapGIData;
 
 class LightmapGIData : public Resource {
 	GDCLASS(LightmapGIData, Resource);
@@ -138,9 +139,22 @@ public:
 	void clear_shadowmask_textures();
 	bool has_shadowmask_textures();
 
+	Ref<Resource> create_placeholder() const;
+
 	virtual RID get_rid() const override;
 	LightmapGIData();
 	~LightmapGIData();
+};
+
+class PlaceholderLightmapGIData : public LightmapGIData {
+	GDCLASS(PlaceholderLightmapGIData, LightmapGIData);
+
+	RID lightmap;
+
+public:
+	virtual RID get_rid() const override;
+	PlaceholderLightmapGIData();
+	~PlaceholderLightmapGIData();
 };
 
 class LightmapGI : public VisualInstance3D {

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -225,6 +225,8 @@ void VoxelGIData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &VoxelGIData::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &VoxelGIData::_get_data);
 
+	ClassDB::bind_method(D_METHOD("create_placeholder"), &VoxelGIData::create_placeholder);
+
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dynamic_range", PROPERTY_HINT_RANGE, "1,8,0.01"), "set_dynamic_range", "get_dynamic_range");
@@ -264,6 +266,16 @@ VoxelGIData::~VoxelGIData() {
 }
 
 //////////////////////
+
+PlaceholderVoxelGIData::PlaceholderVoxelGIData() {
+	probe = RS::get_singleton()->voxel_gi_create();
+}
+
+PlaceholderVoxelGIData::~PlaceholderVoxelGIData() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	RS::get_singleton()->free_rid(probe);
+}
+
 //////////////////////
 
 void VoxelGI::set_probe_data(const Ref<VoxelGIData> &p_data) {
@@ -535,6 +547,12 @@ float VoxelGI::_get_camera_exposure_normalization() {
 
 AABB VoxelGI::get_aabb() const {
 	return AABB(-size / 2, size);
+}
+
+Ref<Resource> VoxelGIData::create_placeholder() const {
+	Ref<PlaceholderVoxelGIData> data;
+	data.instantiate();
+	return data;
 }
 
 PackedStringArray VoxelGI::get_configuration_warnings() const {

--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -33,6 +33,7 @@
 #include "scene/3d/visual_instance_3d.h"
 
 class CameraAttributes;
+class PlaceholderVoxelGIData;
 
 class VoxelGIData : public Resource {
 	GDCLASS(VoxelGIData, Resource);
@@ -88,10 +89,22 @@ public:
 	void set_use_two_bounces(bool p_enable);
 	bool is_using_two_bounces() const;
 
+	Ref<Resource> create_placeholder() const;
+
 	virtual RID get_rid() const override;
 
 	VoxelGIData();
 	~VoxelGIData();
+};
+
+class PlaceholderVoxelGIData : public VoxelGIData {
+	GDCLASS(PlaceholderVoxelGIData, VoxelGIData);
+
+	RID probe;
+
+public:
+	PlaceholderVoxelGIData();
+	~PlaceholderVoxelGIData();
 };
 
 class VoxelGI : public VisualInstance3D {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -644,8 +644,10 @@ void register_scene_types() {
 	GDREGISTER_CLASS(Decal);
 	GDREGISTER_CLASS(VoxelGI);
 	GDREGISTER_CLASS(VoxelGIData);
+	GDREGISTER_CLASS(PlaceholderVoxelGIData);
 	GDREGISTER_CLASS(LightmapGI);
 	GDREGISTER_CLASS(LightmapGIData);
+	GDREGISTER_CLASS(PlaceholderLightmapGIData);
 	GDREGISTER_CLASS(LightmapProbe);
 	GDREGISTER_ABSTRACT_CLASS(Lightmapper);
 	GDREGISTER_CLASS(GPUParticles3D);


### PR DESCRIPTION
This greatly reduces PCK size for dedicated servers in projects that use either VoxelGI or LightmapGI for global illumination. Additionally, this prevents errors from being printed on export when using `--headless` to export a dedicated server PCK in a project that uses a VoxelGI node.

The same approach can be used to implement https://github.com/godotengine/godot-proposals/issues/12748 later on.
**Edit:** Done in https://github.com/godotengine/godot/pull/112773.

- This closes https://github.com/godotengine/godot/issues/109145.
- See https://github.com/godotengine/godot/pull/109146#issuecomment-3529921042
and https://github.com/godotengine/godot/pull/103284.

**Testing project:** [test_headless_voxelgi_export.zip](https://github.com/user-attachments/files/23535805/test_headless_voxelgi_export.zip)

## Preview

File sizes are in bytes. The test project includes a LightmapGI node with 16 probe subdivisions and a VoxelGI node with 128 subdivisions.

Before this PR, both PCK/ZIPs would be the same size as the project doesn't include any textures.

### PCK size

```
505140 /tmp/out.pck
 42852 /tmp/out_server.pck
```

### ZIP size

```
329870 /tmp/out.zip
 14608 /tmp/out_server.zip
```
