### PR TITLE
Duplicate Resources Separate from each other when using selecting multiple Nodes

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5164,12 +5164,47 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		} else {
 			_edit_request_change(object, p_name);
 		}
-
 		emit_signal(_prop_edited, p_name);
 	} else if (Object::cast_to<MultiNodeEdit>(object)) {
-		Object::cast_to<MultiNodeEdit>(object)->set_property_field(p_name, p_value, p_changed_field);
-		_edit_request_change(object, p_name);
-		emit_signal(_prop_edited, p_name);
+		if (!separate_resource_copy && p_value.get_type() == Variant::OBJECT && p_value.get_validated_object() != nullptr && EditorNode::get_singleton()->is_resource_internal_to_scene(p_value)) {
+			List<Ref<Resource>> internal_resources = { p_value };
+			EditorNode::get_singleton()->gather_resources(p_value, internal_resources, true);
+
+			for (Ref<Resource> R : internal_resources) {
+				if (Object::cast_to<MultiNodeEdit>(object)->get(p_name).get_validated_object() != nullptr && EditorNode::get_singleton()->get_resource_count(R) == 0) {
+					separate_resource_copy = true;
+					selected_nodes_for_duplication = EditorNode::get_singleton()->get_editor_selection()->get_full_selected_node_list();
+					undo_redo->create_action(vformat(TTR("Set %s on %d nodes"), p_name, selected_nodes_for_duplication.size()), UndoRedo::MERGE_ENDS);
+					break;
+				}
+			}
+		}
+		if (separate_resource_copy) {
+			Node *current = selected_nodes_for_duplication.front()->get();
+			Variant old_value = current->get(p_name);
+			Variant::Type type = old_value.get_type();
+
+			undo_redo->add_do_property(current, p_name, p_value);
+			undo_redo->add_undo_property(current, p_name, current->get(p_name));
+
+			if ((type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && old_value != p_value) {
+				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", old_value, current, true);
+				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", p_value, current, false);
+				// Perhaps an inefficient way of updating the resource count.
+				// We could go in depth and check which Resource values changed/got removed and which ones stayed the same, but this is more readable at the moment.
+				undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", p_value, current, true);
+				undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", old_value, current, false);
+			}
+			selected_nodes_for_duplication.pop_front();
+			if (selected_nodes_for_duplication.is_empty()) {
+				separate_resource_copy = false;
+				undo_redo->commit_action();
+			}
+		} else {
+			Object::cast_to<MultiNodeEdit>(object)->set_property_field(p_name, p_value, p_changed_field);
+			_edit_request_change(object, p_name);
+			emit_signal(_prop_edited, p_name);
+		}
 	} else if (Object::cast_to<EditorDebuggerRemoteObjects>(object)) {
 		Object::cast_to<EditorDebuggerRemoteObjects>(object)->set_property_field(p_name, p_value, p_changed_field);
 		_edit_request_change(object, p_name);

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -765,6 +765,9 @@ class EditorInspector : public ScrollContainer {
 
 	bool updating_theme = false;
 
+	List<Node *> selected_nodes_for_duplication;
+	bool separate_resource_copy = false; // Makes duplication of a Resource for each Node found in the 'MultiNodeEdit' possible.
+
 	struct DocCacheInfo {
 		String doc_path;
 		String theme_item_name;

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -459,11 +459,14 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			if (edited_resource.is_null()) {
 				return;
 			}
-			Ref<Resource> unique_resource = edited_resource->duplicate();
-			ERR_FAIL_COND(unique_resource.is_null()); // duplicate() may fail.
+			int selected_nodes_size = EditorNode::get_singleton()->get_editor_selection()->get_full_selected_node_list().size();
+			for (int i = 0; i < selected_nodes_size; i++) {
+				Ref<Resource> unique_resource = edited_resource->duplicate();
+				ERR_FAIL_COND(unique_resource.is_null()); // duplicate() may fail.
 
-			edited_resource = unique_resource;
-			_resource_changed();
+				edited_resource = unique_resource;
+				_resource_changed();
+			}
 		} break;
 
 		case OBJ_MENU_MAKE_UNIQUE_RECURSIVE: {
@@ -1294,75 +1297,81 @@ void EditorResourcePicker::_gather_resources_to_duplicate(const Ref<Resource> p_
 }
 
 void EditorResourcePicker::_duplicate_selected_resources() {
-	for (TreeItem *item = duplicate_resources_tree->get_root(); item; item = item->get_next_in_tree()) {
-		if (!item->is_checked(0)) {
-			continue;
-		}
+	int selected_nodes_size = EditorNode::get_singleton()->get_editor_selection()->get_full_selected_node_list().size();
 
-		Array meta = item->get_metadata(0);
-		Ref<Resource> res = meta[0];
-		Ref<Resource> unique_resource = res->duplicate();
-		ERR_FAIL_COND(unique_resource.is_null()); // duplicate() may fail.
-		meta[0] = unique_resource;
-
-		if (meta.size() == 1) { // Root.
-			edited_resource = unique_resource;
-			continue;
-		}
-		Array parent_meta = item->get_parent()->get_metadata(0);
-		Ref<Resource> parent = parent_meta[0];
-		Variant::Type property_type = parent->get(meta[1]).get_type();
-
-		if (property_type == Variant::OBJECT) {
-			parent->set(meta[1], unique_resource);
-			continue;
-		}
-
-		Variant property = parent->get(meta[1]);
-
-		if (!parent_meta.has(property)) {
-			property = property.duplicate();
-			parent->set(meta[1], property);
-			parent_meta.push_back(property); // Append Duplicated Type so we can check if it's already been duplicated.
-		}
-
-		if (property_type == Variant::ARRAY) {
-			Array arr = property;
-			arr[meta[2]] = unique_resource;
-			continue;
-		}
-
-		Dictionary dict = property;
-		LocalVector<Variant> keys = dict.get_key_list();
-
-		if (meta[2].get_type() == Variant::OBJECT) {
-			if (keys.has(meta[2])) {
-				//It's a key.
-				dict[unique_resource] = dict[meta[2]];
-				dict.erase(meta[2]);
-				parent_meta.push_back(unique_resource);
-			} else {
-				// If key has been erased, use last appended Resource key instead.
-				Variant key = keys.has(meta[3]) ? meta[3] : parent_meta.back();
-				dict[key] = unique_resource;
+	for (int i = 0; i < selected_nodes_size; i++) {
+		Dictionary parent_meta_table;
+		for (TreeItem *item = duplicate_resources_tree->get_root(); item; item = item->get_next_in_tree()) {
+			if (!item->is_checked(0)) {
+				continue;
 			}
-		} else {
-			dict[meta[2]] = unique_resource;
+			Array meta = item->get_metadata(0).duplicate();
+			Ref<Resource> res = meta[0];
+			Ref<Resource> unique_resource = res->duplicate();
+			ERR_FAIL_COND(unique_resource.is_null()); // duplicate() may fail.
+			meta[0] = unique_resource;
+
+			if (item->get_child_count() > 0) {
+				parent_meta_table[item] = meta;
+			}
+			if (meta.size() == 1) { // Root.
+				edited_resource = unique_resource;
+				continue;
+			}
+			Variant *parent_meta_ptr = parent_meta_table.getptr(item->get_parent());
+			if (parent_meta_ptr == nullptr) {
+				// If Parent Resource has not been duplicated, it makes SubResource duplication redundant. It also crashes if 'selected_nodes_size' > 1
+				ERR_FAIL_MSG(vformat("In order to make the Resource found in '%s' unique, mark its parent Resource '%s' for duplication as well.", item->get_text(1), item->get_parent()->get_text(0)));
+			}
+			Array parent_meta = *parent_meta_ptr;
+			Ref<Resource> parent = parent_meta[0];
+			Variant::Type property_type = parent->get(meta[1]).get_type();
+
+			if (property_type == Variant::OBJECT) {
+				parent->set(meta[1], unique_resource);
+				continue;
+			}
+
+			Variant property = parent->get(meta[1]);
+
+			if (!parent_meta.has(property)) {
+				property = property.duplicate();
+				parent->set(meta[1], property);
+				parent_meta.push_back(property); // Append Duplicated Type so we can check if it's already been duplicated.
+			}
+
+			if (property_type == Variant::ARRAY) {
+				Array arr = property;
+				arr[meta[2]] = unique_resource;
+				continue;
+			}
+
+			Dictionary dict = property;
+			LocalVector<Variant> keys = dict.get_key_list();
+
+			if (meta[2].get_type() == Variant::OBJECT) {
+				if (keys.has(meta[2])) {
+					//It's a key.
+					dict[unique_resource] = dict[meta[2]];
+					dict.erase(meta[2]);
+					parent_meta.push_back(unique_resource);
+				} else {
+					// If key has been erased, use last appended Resource key instead.
+					Variant key = keys.has(meta[3]) ? meta[3] : parent_meta.back();
+					dict[key] = unique_resource;
+				}
+			} else {
+				dict[meta[2]] = unique_resource;
+			}
 		}
+		_resource_changed();
 	}
-	_resource_changed();
 }
 
 bool EditorResourcePicker::_is_uniqueness_enabled(bool p_check_recursive) {
 	Ref<Resource> parent_resource = _has_parent_resource();
 	EditorNode *en = EditorNode::get_singleton();
 	bool internal_to_scene = en->is_resource_internal_to_scene(edited_resource);
-	List<Node *> node_list = en->get_editor_selection()->get_full_selected_node_list();
-
-	// Todo: Implement a more elegant solution for multiple selected Nodes. This should suffice for the time being.
-	if (node_list.size() > 1 && !p_check_recursive) {
-		return node_list.size() != EditorNode::get_singleton()->get_resource_count(edited_resource) || !internal_to_scene;
-	}
 
 	if (!internal_to_scene) {
 		if (parent_resource.is_valid() && (!EditorNode::get_singleton()->is_resource_internal_to_scene(parent_resource) || en->get_resource_count(parent_resource) > 1)) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13163

## Multi-Node Fixes

### Before
![MultiBefore](https://github.com/user-attachments/assets/a3a8f21d-f81f-47c5-bd1d-b97709e1aec8)

### After
![MultiAfter](https://github.com/user-attachments/assets/ae7c2ad0-1e43-48be-b3a4-ebef501a95ab)

- Every Resource from a selection will be duplicated and assigned to its respective node. This ensures the same behavior as selecting each Node one by one and making its Resource unique.
- For `Make_Unique (Recursive)`, it triggers an Error message if you uncheck a Parent Resource but tries to duplicate its Subresources. This is because duplication has no effect in these cases (i.e, SubResources are still linked).  This is fine when only one Node is selected, but it crashes for Dictionaries, so that's why it must be addressed in this PR.
