### PR TITLE
Improve consistency of `Geometry2D` triangle area calculation

### DIFF
--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -363,19 +363,10 @@ public:
 	// Assumes cartesian coordinate system with +x to the right, +y up.
 	// If using screen coordinates (+x to the right, +y down) the result will need to be flipped.
 	static bool is_polygon_clockwise(const Vector<Vector2> &p_polygon) {
-		int c = p_polygon.size();
-		if (c < 3) {
+		if (p_polygon.size() < 3) {
 			return false;
 		}
-		const Vector2 *p = p_polygon.ptr();
-		real_t sum = 0;
-		for (int i = 0; i < c; i++) {
-			const Vector2 &v1 = p[i];
-			const Vector2 &v2 = p[(i + 1) % c];
-			sum += (v2.x - v1.x) * (v2.y + v1.y);
-		}
-
-		return sum > 0.0f;
+		return Triangulate::get_area(p_polygon) <= 0.0f;
 	}
 
 	// Alternate implementation that should be faster.

--- a/core/math/triangulate.cpp
+++ b/core/math/triangulate.cpp
@@ -36,8 +36,17 @@ real_t Triangulate::get_area(const Vector<Vector2> &contour) {
 
 	real_t A = 0.0;
 
+	Vector2 center;
+	for (int i = 0; i < n; i++) {
+		center += (c[i] - center) / (i + 1);
+	}
+
+	// Compute the area with vectors from the center of the polygon to
+	// reduce float precision errors with small and/or very offset polygons.
 	for (int p = n - 1, q = 0; q < n; p = q++) {
-		A += c[p].cross(c[q]);
+		Vector2 va = c[p] - center;
+		Vector2 vb = c[q] - center;
+		A += va.cross(vb);
 	}
 	return A * 0.5f;
 }


### PR DESCRIPTION
Fixes #112705 and #92537.
Calculating the area of triangles using the cross product of vectors from the (0,0) can result in loss of precision in the cross product operation. This causes small/nearly degenerate/far away triangles to have their areas calculated incorrectly and can make certain operations fail (`Geometry2D.triangulate` and `Geometry2D.is_polygon_clockwise`). This can be mitigated by calculating the cross product using vectors from the center of the polygon instead of (0,0).

Any feedback is welcome, I am not very familiar with C++.