### PR TITLE
Apply transparency when using `clip_children`

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2878,8 +2878,7 @@ render_mode unshaded;
 uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
 
 void fragment() {
-	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
-	COLOR.rgb = c.rgb;
+	COLOR = textureLod(screen_texture, SCREEN_UV, 0.0);
 }
 )");
 		default_clip_children_material = material_storage->material_allocate();

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2045,8 +2045,7 @@ render_mode unshaded;
 uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
 
 void fragment() {
-	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
-	COLOR.rgb = c.rgb;
+	COLOR = textureLod(screen_texture, SCREEN_UV, 0.0);
 }
 )");
 		default_clip_children_material = material_storage->material_allocate();


### PR DESCRIPTION
I couldn't figure out the reason for not copying alpha from the screen texture, but it seems to cause issues.

**Master:**
<img width="508" height="485" alt="image" src="https://github.com/user-attachments/assets/13798226-769a-41e8-a373-5a9856f30b25" />
**This pr:**
<img width="483" height="480" alt="image" src="https://github.com/user-attachments/assets/27bd4fc9-39d2-49ea-9eff-c4abe03ddb92" />
mrp from #94672.

Fixes #94672