### PR TITLE
[3.x] `BlobShadows` - Fix `GLES3` shader builtin

### DIFF
--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -1233,6 +1233,7 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 	actions[VS::SHADER_SPATIAL].renames["CAMERA_POSITION_WORLD"] = "camera_matrix[3].xyz";
 	actions[VS::SHADER_SPATIAL].renames["CAMERA_DIRECTION_WORLD"] = "camera_inverse_matrix[3].xyz";
 	actions[VS::SHADER_SPATIAL].renames["NODE_POSITION_VIEW"] = "(camera_inverse_matrix * world_transform)[3].xyz";
+	actions[VS::SHADER_SPATIAL].renames["BLOB_SHADOW"] = "blob_shadow_total";
 
 	//for light
 	actions[VS::SHADER_SPATIAL].renames["VIEW"] = "view";


### PR DESCRIPTION
The `BLOB_SHADOW` builtin wasn't registered with the shader compiler for GLES3.

Although the fixed function spatial shader worked fine with blob shadoers in GLES3, you couldn't use `BLOB_SHADOW` built in in GLES3 shaders, as the shader wouldn't compile, as I forgot to add the rename.

Fixes issue mentioned in https://github.com/godotengine/godot/pull/84804#issuecomment-3529361911

## Notes
* Sorry, my bad, it was working in GLES2, I must have forgotten to copy this line across to GLES3.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
