### PR TITLE
Android: Fix crash when gamepad connects immediately upon app startup

### DIFF
--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -436,7 +436,10 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyhat(JNIEnv *env, j
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyconnectionchanged(JNIEnv *env, jclass clazz, jint p_device, jboolean p_connected, jstring p_name) {
 	if (os_android) {
 		String name = jstring_to_string(p_name, env);
-		Input::get_singleton()->joy_connection_changed(p_device, p_connected, name);
+		Input *input = Input::get_singleton();
+		if (input) {
+			input->joy_connection_changed(p_device, p_connected, name);
+		}
 	}
 }
 


### PR DESCRIPTION
There are two different paths for handling controllers on Android:

1. Enumeration of connected gamepads on startup.
2. When a gamepad is connected.

On Android, gamepads are handled in Java via a `InputManager.InputDeviceListener`. Upon connection `onInputDeviceAdded` is fired on the apps main thread. _However_, Godot predominantly runs on a separate renderer thread, if a gamepad is connected when the Android app is launching, but before Godot has started up, you end up with a crash accessing a `nullptr` in C++:

<img width="5344" height="3054" alt="CleanShot 2025-11-09 at 18 04 22@2x" src="https://github.com/user-attachments/assets/2edabb0a-02ae-44e0-b44d-fcf5ff74c9cc" />

This PR introduces a simple check that ensures the `Input` singleton is available, before we try call methods on it. Otherwise the event is ignored. This is fine, the gamepad won't be ignored, when `Input` does startup, we'll enumerate existing connected gamepads. Granted, that's not to say I've specifically verified there's no race condition in that logic, but that's out of scope for this PR. We're just fixing a crash here.