### PR TITLE
Prevent going into freelook after right clicking to cancel a 3D Editor Gizmo action

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -1929,6 +1929,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, true);
 						_edit.gizmo = Ref<EditorNode3DGizmo>();
 						set_message("");
+						break;
 					}
 
 					if (_edit.mode == TRANSFORM_NONE) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Currently, manipulating a 3D editor gizmo, for example `Camera3D` or `CollisionShape3D`, and then pressing right click to cancel, the subsequent action will be to erroneously go into freelook (a busted version where the mouse doesn't work, but keyboard navigation does). 

The added break prevents this, similar to what already exists for the transform gizmo. 