### PR TITLE
Clean up argument passing for export callbacks

### DIFF
--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -72,7 +72,7 @@
 			<param index="3" name="shared_cb" type="Callable" default="Callable()" />
 			<description>
 				Exports project files for the specified preset. This method can be used to implement custom export format, other than PCK and ZIP. One of the callbacks is called for each exported file.
-				[param save_cb] is called for all exported files and have the following arguments: [code]file_path: String[/code], [code]file_data: PackedByteArray[/code], [code]file_index: int[/code], [code]file_count: int[/code], [code]encryption_include_filters: PackedStringArray[/code], [code]encryption_exclude_filters: PackedStringArray[/code], [code]encryption_key: PackedByteArray[/code].
+				[param save_cb] is called for all exported files and have the following arguments: [code]info: Dictionary[/code], [code]file_data: PackedByteArray[/code]. The [code]info[/code] dictionary contains the following values: [code]path: String[/code], [code]source_path: String[/code], [code]file_index: int[/code], [code]file_count: int[/code].
 				[param shared_cb] is called for exported native shared/static libraries and have the following arguments: [code]file_path: String[/code], [code]tags: PackedStringArray[/code], [code]target_folder: String[/code].
 				[b]Note:[/b] [code]file_index[/code] and [code]file_count[/code] are intended for progress tracking only and aren't necessarily unique and precise.
 			</description>

--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -72,9 +72,10 @@
 			<param index="3" name="shared_cb" type="Callable" default="Callable()" />
 			<description>
 				Exports project files for the specified preset. This method can be used to implement custom export format, other than PCK and ZIP. One of the callbacks is called for each exported file.
-				[param save_cb] is called for all exported files and have the following arguments: [code]file_path: String[/code], [code]file_data: PackedByteArray[/code], [code]file_index: int[/code], [code]file_count: int[/code], [code]encryption_include_filters: PackedStringArray[/code], [code]encryption_exclude_filters: PackedStringArray[/code], [code]encryption_key: PackedByteArray[/code].
+				[param save_cb] is called for all exported files and have the following arguments: [code]info: Dictionary[/code], [code]file_data: PackedByteArray[/code]. The [code]info[/code] dictionary contains the following values: [code]path: String[/code], [code]source_path: String[/code], [code]file_index: int[/code], [code]file_count: int[/code].
 				[param shared_cb] is called for exported native shared/static libraries and have the following arguments: [code]file_path: String[/code], [code]tags: PackedStringArray[/code], [code]target_folder: String[/code].
 				[b]Note:[/b] [code]file_index[/code] and [code]file_count[/code] are intended for progress tracking only and aren't necessarily unique and precise.
+				[b]Note:[/b] The signature of [param save_cb] changed in Godot 4.8. There is compatibility code to automatically handle the [url=https://docs.godotengine.org/en/4.7/classes/class_editorexportplatform.html#class-editorexportplatform-method-export-project-files]previous signature[/url] if the passed callable has 7 arguments.
 			</description>
 		</method>
 		<method name="export_zip">

--- a/doc/classes/EditorExportPreset.xml
+++ b/doc/classes/EditorExportPreset.xml
@@ -60,7 +60,7 @@
 		<method name="get_encryption_key" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns PCK encryption key.
+				Returns PCK encryption key. This will only return the value set in the export preset and not the value of the [code]GODOT_SCRIPT_ENCRYPTION_KEY[/code] environment variable. See also [method resolve_encryption_key].
 			</description>
 		</method>
 		<method name="get_exclude_filter" qualifiers="const">
@@ -167,6 +167,12 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the "Runnable" toggle is enabled in the export dialog.
+			</description>
+		</method>
+		<method name="resolve_encryption_key">
+			<return type="PackedByteArray" />
+			<description>
+				Returns PCK encryption key as a [PackedByteArray]. If the [code]GODOT_SCRIPT_ENCRYPTION_KEY[/code] environment variable is set, this will return that key instead of the key set in the export preset. See also [method get_encryption_key].
 			</description>
 		</method>
 	</methods>

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -95,8 +95,8 @@ void EditorExport::_save() {
 		config->set_value(section, "patch_delta_include_filters", preset->get_patch_delta_include_filter());
 		config->set_value(section, "patch_delta_exclude_filters", preset->get_patch_delta_exclude_filter());
 
-		config->set_value(section, "encryption_include_filters", preset->get_enc_in_filter());
-		config->set_value(section, "encryption_exclude_filters", preset->get_enc_ex_filter());
+		config->set_value(section, "encryption_include_filters", preset->get_enc_in_filters_str());
+		config->set_value(section, "encryption_exclude_filters", preset->get_enc_ex_filters_str());
 		config->set_value(section, "seed", preset->get_seed());
 
 		config->set_value(section, "encrypt_pck", preset->get_enc_pck());
@@ -407,10 +407,10 @@ void EditorExport::load_config() {
 			preset->set_enc_directory(config->get_value(section, "encrypt_directory"));
 		}
 		if (config->has_section_key(section, "encryption_include_filters")) {
-			preset->set_enc_in_filter(config->get_value(section, "encryption_include_filters"));
+			preset->set_enc_in_filters_str(config->get_value(section, "encryption_include_filters"));
 		}
 		if (config->has_section_key(section, "encryption_exclude_filters")) {
-			preset->set_enc_ex_filter(config->get_value(section, "encryption_exclude_filters"));
+			preset->set_enc_ex_filters_str(config->get_value(section, "encryption_exclude_filters"));
 		}
 		if (credentials->has_section_key(section, "script_encryption_key")) {
 			preset->set_script_encryption_key(credentials->get_value(section, "script_encryption_key"));

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -61,21 +61,21 @@
 
 class EditorExportSaveProxy {
 	HashSet<String> saved_paths;
-	EditorExportPlatform::EditorExportSaveFunction save_func;
+	EditorExportPlatform::SaveFileFunction save_func;
 	bool tracking_saves = false;
 
 public:
 	bool has_saved(const String &p_path) const { return saved_paths.has(p_path); }
 
-	Error save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+	Error save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const EditorExportPlatform::SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 		if (tracking_saves) {
-			saved_paths.insert(p_path.simplify_path().trim_prefix("res://"));
+			saved_paths.insert(p_info.path.simplify_path().trim_prefix("res://"));
 		}
 
-		return save_func(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta);
+		return save_func(p_preset, p_userdata, p_info, p_data);
 	}
 
-	EditorExportSaveProxy(EditorExportPlatform::EditorExportSaveFunction p_save_func, bool p_track_saves) :
+	EditorExportSaveProxy(EditorExportPlatform::SaveFileFunction p_save_func, bool p_track_saves) :
 			save_func(p_save_func), tracking_saves(p_track_saves) {}
 };
 
@@ -237,17 +237,18 @@ void EditorExportPlatform::_unload_patches() {
 	PackedData::get_singleton()->clear();
 }
 
-Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const String &p_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool &r_encrypt) {
+Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const Ref<EditorExportPreset> &p_preset, const String &p_path, const Vector<uint8_t> &p_data, bool &r_encrypt) {
 	r_encrypt = false;
-	for (int i = 0; i < p_enc_in_filters.size(); ++i) {
-		if (p_path.matchn(p_enc_in_filters[i]) || p_path.trim_prefix("res://").matchn(p_enc_in_filters[i])) {
+	for (const String &filter : p_preset->get_enc_in_filter().split(",", false)) {
+		String filter_stripped = filter.strip_edges();
+		if (p_path.matchn(filter_stripped) || p_path.trim_prefix("res://").matchn(filter_stripped)) {
 			r_encrypt = true;
-			break;
 		}
 	}
 
-	for (int i = 0; i < p_enc_ex_filters.size(); ++i) {
-		if (p_path.matchn(p_enc_ex_filters[i]) || p_path.trim_prefix("res://").matchn(p_enc_ex_filters[i])) {
+	for (const String &filter : p_preset->get_enc_ex_filter().split(",", false)) {
+		String filter_stripped = filter.strip_edges();
+		if (p_path.matchn(filter_stripped) || p_path.trim_prefix("res://").matchn(filter_stripped)) {
 			r_encrypt = false;
 			break;
 		}
@@ -256,10 +257,10 @@ Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const 
 	Ref<FileAccessEncrypted> fae;
 	Ref<FileAccess> ftmp = p_fd;
 	if (r_encrypt) {
+		Vector<uint8_t> key = _get_encryption_key(p_preset);
 		Vector<uint8_t> iv;
-		if (p_seed != 0) {
-			uint64_t seed = p_seed;
-
+		uint64_t seed = p_preset->get_seed();
+		if (seed != 0) {
 			const uint8_t *ptr = p_data.ptr();
 			int64_t len = p_data.size();
 			for (int64_t i = 0; i < len; i++) {
@@ -276,7 +277,7 @@ Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const 
 		fae.instantiate();
 		ERR_FAIL_COND_V(fae.is_null(), ERR_FILE_CANT_OPEN);
 
-		Error err = fae->open_and_parse(ftmp, p_key, FileAccessEncrypted::MODE_WRITE_AES256, false, iv);
+		Error err = fae->open_and_parse(ftmp, key, FileAccessEncrypted::MODE_WRITE_AES256, false, iv);
 		ERR_FAIL_COND_V(err != OK, ERR_FILE_CANT_OPEN);
 		ftmp = fae;
 	}
@@ -291,12 +292,12 @@ Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const 
 	return OK;
 }
 
-Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
-	ERR_FAIL_COND_V_MSG(p_total < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
+Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
+	ERR_FAIL_COND_V_MSG(p_info.file_count < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
 
 	PackData *pd = (PackData *)p_userdata;
 
-	const String simplified_path = simplify_path(p_path);
+	const String simplified_path = simplify_path(p_info.path);
 
 	Ref<FileAccess> ftmp;
 	if (pd->use_sparse_pck) {
@@ -309,8 +310,8 @@ Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_pre
 	sd.path_utf8 = simplified_path.trim_prefix("res://").utf8();
 	sd.ofs = (pd->use_sparse_pck) ? 0 : pd->f->get_position();
 	sd.size = p_data.size();
-	sd.delta = p_delta;
-	Error err = _encrypt_and_store_data(ftmp, simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, sd.encrypted);
+	sd.delta = p_info.delta;
+	Error err = _encrypt_and_store_data(ftmp, p_preset, simplified_path, p_data, sd.encrypted);
 	if (err != OK) {
 		return err;
 	}
@@ -338,17 +339,17 @@ Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_pre
 	pd->file_ofs.push_back(sd);
 
 	// TRANSLATORS: This is an editor progress label describing the storing of a file.
-	if (pd->ep->step(vformat(TTR("Storing File: %s"), p_path), 2 + p_file * 100 / p_total, false)) {
+	if (pd->ep->step(vformat(TTR("Storing File: %s"), p_info.path), 2 + p_info.file_index * 100 / p_info.file_count, false)) {
 		return ERR_SKIP;
 	}
 
 	return OK;
 }
 
-Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
-	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_path);
+Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
+	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_info.path);
 	if (old_file.is_null()) {
-		return _save_pack_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, false);
+		return _save_pack_file(p_preset, p_userdata, p_info, p_data);
 	}
 
 	Vector<uint8_t> old_data = old_file->get_buffer(old_file->get_length());
@@ -359,14 +360,14 @@ Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> 
 	}
 
 	if (!p_preset->is_patch_delta_encoding_enabled()) {
-		return _save_pack_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, false);
+		return _save_pack_file(p_preset, p_userdata, p_info, p_data);
 	}
 
 	bool delta = false;
 
 	for (const String &filter : p_preset->get_patch_delta_include_filter().split(",", false)) {
 		String filter_stripped = filter.strip_edges();
-		if (p_path.matchn(filter_stripped) || p_path.trim_prefix("res://").matchn(filter_stripped)) {
+		if (p_info.path.matchn(filter_stripped) || p_info.path.trim_prefix("res://").matchn(filter_stripped)) {
 			delta = true;
 			break;
 		}
@@ -374,7 +375,7 @@ Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> 
 
 	for (const String &filter : p_preset->get_patch_delta_exclude_filter().split(",", false)) {
 		String filter_stripped = filter.strip_edges();
-		if (p_path.matchn(filter_stripped) || p_path.trim_prefix("res://").matchn(filter_stripped)) {
+		if (p_info.path.matchn(filter_stripped) || p_info.path.trim_prefix("res://").matchn(filter_stripped)) {
 			delta = false;
 			break;
 		}
@@ -392,23 +393,26 @@ Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> 
 		double reduction_ratio = reduction_bytes / (double)p_data.size();
 
 		if (reduction_ratio >= p_preset->get_patch_delta_min_reduction()) {
-			print_verbose(vformat("Used delta encoding for patch of \"%s\", resulting in a patch of %d bytes, which reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+			print_verbose(vformat("Used delta encoding for patch of \"%s\", resulting in a patch of %d bytes, which reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_info.path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
 		} else {
-			print_verbose(vformat("Skipped delta encoding for patch of \"%s\", as it resulted in a patch of %d bytes, which only reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+			print_verbose(vformat("Skipped delta encoding for patch of \"%s\", as it resulted in a patch of %d bytes, which only reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_info.path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
 			patch_data = p_data;
 			delta = false;
 		}
 	} else {
-		print_verbose(vformat("Skipped delta encoding for patch of \"%s\", due to include/exclude filters.", p_path));
+		print_verbose(vformat("Skipped delta encoding for patch of \"%s\", due to include/exclude filters.", p_info.path));
 	}
 
-	return _save_pack_file(p_preset, p_userdata, p_path, patch_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, delta);
+	SaveFileInfo new_file_info = p_info;
+	new_file_info.delta = delta;
+
+	return _save_pack_file(p_preset, p_userdata, new_file_info, patch_data);
 }
 
-Error EditorExportPlatform::_save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
-	ERR_FAIL_COND_V_MSG(p_total < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
+Error EditorExportPlatform::_save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
+	ERR_FAIL_COND_V_MSG(p_info.file_count < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
 
-	const String path = simplify_path(p_path).replace_first("res://", "");
+	const String path = simplify_path(p_info.path).trim_prefix("res://");
 
 	ZipData *zd = (ZipData *)p_userdata;
 
@@ -430,15 +434,15 @@ Error EditorExportPlatform::_save_zip_file(const Ref<EditorExportPreset> &p_pres
 
 	zd->file_count += 1;
 
-	if (zd->ep->step(TTR("Storing File:") + " " + p_path, 2 + p_file * 100 / p_total, false)) {
+	if (zd->ep->step(TTR("Storing File:") + " " + p_info.path, 2 + p_info.file_index * 100 / p_info.file_count, false)) {
 		return ERR_SKIP;
 	}
 
 	return OK;
 }
 
-Error EditorExportPlatform::_save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
-	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_path);
+Error EditorExportPlatform::_save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
+	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_info.path);
 	if (old_file.is_valid()) {
 		Vector<uint8_t> old_data = old_file->get_buffer(old_file->get_length());
 
@@ -448,7 +452,7 @@ Error EditorExportPlatform::_save_zip_patch_file(const Ref<EditorExportPreset> &
 		}
 	}
 
-	return _save_zip_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta);
+	return _save_zip_file(p_preset, p_userdata, p_info, p_data);
 }
 
 Ref<Texture2D> EditorExportPlatform::get_option_icon(int p_index) const {
@@ -992,12 +996,46 @@ String EditorExportPlatform::_export_customize(const String &p_path, LocalVector
 	return save_path.is_empty() ? p_path : save_path;
 }
 
-String EditorExportPlatform::_get_script_encryption_key(const Ref<EditorExportPreset> &p_preset) const {
+String EditorExportPlatform::_get_script_encryption_key(const Ref<EditorExportPreset> &p_preset) {
 	const String from_env = OS::get_singleton()->get_environment(ENV_SCRIPT_ENCRYPTION_KEY);
 	if (!from_env.is_empty()) {
 		return from_env.to_lower();
 	}
 	return p_preset->get_script_encryption_key().to_lower();
+}
+
+Vector<uint8_t> EditorExportPlatform::_get_encryption_key(const Ref<EditorExportPreset> &p_preset) {
+	Vector<uint8_t> key;
+
+	String script_key = _get_script_encryption_key(p_preset);
+	if (script_key.length() == 64) {
+		key.resize(32);
+		for (int i = 0; i < 32; i++) {
+			int v = 0;
+			if (i * 2 < script_key.length()) {
+				char32_t ct = script_key[i * 2];
+				if (is_digit(ct)) {
+					ct = ct - '0';
+				} else if (ct >= 'a' && ct <= 'f') {
+					ct = 10 + ct - 'a';
+				}
+				v |= ct << 4;
+			}
+
+			if (i * 2 + 1 < script_key.length()) {
+				char32_t ct = script_key[i * 2 + 1];
+				if (is_digit(ct)) {
+					ct = ct - '0';
+				} else if (ct >= 'a' && ct <= 'f') {
+					ct = 10 + ct - 'a';
+				}
+				v |= ct;
+			}
+			key.write[i] = v;
+		}
+	}
+
+	return key;
 }
 
 Dictionary EditorExportPlatform::get_internal_export_files(const Ref<EditorExportPreset> &p_preset, bool p_debug) {
@@ -1076,26 +1114,43 @@ Vector<String> EditorExportPlatform::get_forced_export_files(const Ref<EditorExp
 	return files;
 }
 
-Error EditorExportPlatform::_script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+Error EditorExportPlatform::_script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 	Callable cb = ((ScriptCallbackData *)p_userdata)->file_cb;
 	ERR_FAIL_COND_V(!cb.is_valid(), FAILED);
 
-	const String simplified_path = simplify_path(p_path);
-
-	Variant path = simplified_path;
-	Variant data = p_data;
-	Variant file = p_file;
-	Variant total = p_total;
-	Variant enc_in = p_enc_in_filters;
-	Variant enc_ex = p_enc_ex_filters;
-	Variant enc_key = p_key;
-
 	Variant ret;
-	Callable::CallError ce;
-	const Variant *args[7] = { &path, &data, &file, &total, &enc_in, &enc_ex, &enc_key };
 
-	cb.callp(args, 7, ret, ce);
-	ERR_FAIL_COND_V_MSG(ce.error != Callable::CallError::CALL_OK, FAILED, vformat("Failed to execute file save callback: %s.", Variant::get_callable_error_text(cb, args, 7, ce)));
+#ifndef DISABLE_DEPRECATED
+	if (cb.get_argument_count() == 7) {
+		Variant v_path = simplify_path(p_info.path);
+		Variant v_data = p_data;
+		Variant v_file_index = p_info.file_index;
+		Variant v_file_count = p_info.file_count;
+		Variant v_enc_in_filter = p_preset->get_enc_in_filter();
+		Variant v_enc_ex_filter = p_preset->get_enc_ex_filter();
+		Variant v_enc_key = _get_encryption_key(p_preset);
+
+		Callable::CallError ce;
+		const Variant *args[7] = { &v_path, &v_data, &v_file_index, &v_file_count, &v_enc_in_filter, &v_enc_ex_filter, &v_enc_key };
+		cb.callp(args, 7, ret, ce);
+		ERR_FAIL_COND_V_MSG(ce.error != Callable::CallError::CALL_OK, FAILED, vformat("Failed to execute file save callback: %s.", Variant::get_callable_error_text(cb, args, 7, ce)));
+	} else
+#endif
+	{
+		Dictionary info;
+		info["path"] = simplify_path(p_info.path);
+		info["source_path"] = simplify_path(p_info.source_path);
+		info["file_index"] = p_info.file_index;
+		info["file_count"] = p_info.file_count;
+
+		Variant v_info = info;
+		Variant v_data = p_data;
+
+		Callable::CallError ce;
+		const Variant *args[2] = { &v_info, &v_data };
+		cb.callp(args, 2, ret, ce);
+		ERR_FAIL_COND_V_MSG(ce.error != Callable::CallError::CALL_OK, FAILED, vformat("Failed to execute file save callback: %s.", Variant::get_callable_error_text(cb, args, 2, ce)));
+	}
 
 	return (Error)ret.operator int();
 }
@@ -1127,7 +1182,7 @@ Error EditorExportPlatform::_export_project_files(const Ref<EditorExportPreset> 
 	return export_project_files(p_preset, p_debug, _script_save_file, nullptr, &data, _script_add_shared_object);
 }
 
-Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &p_preset, bool p_debug, EditorExportSaveFunction p_save_func, EditorExportRemoveFunction p_remove_func, void *p_udata, EditorExportSaveSharedObject p_so_func) {
+Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &p_preset, bool p_debug, SaveFileFunction p_save_func, RemoveFileFunction p_remove_func, void *p_udata, SaveSharedObjectFunction p_so_func) {
 	//figure out paths of files that will be exported
 	HashSet<String> paths;
 	Vector<String> path_remaps;
@@ -1184,63 +1239,6 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	// Ignore import files, since these are automatically added to the jar later with the resources
 	_edit_filter_list(paths, String("*.import"), true);
 
-	// Get encryption filters.
-	bool enc_pck = p_preset->get_enc_pck();
-	Vector<String> enc_in_filters;
-	Vector<String> enc_ex_filters;
-	Vector<uint8_t> key;
-	uint64_t seed = 0;
-
-	if (enc_pck) {
-		seed = p_preset->get_seed();
-		Vector<String> enc_in_split = p_preset->get_enc_in_filter().split(",");
-		for (int i = 0; i < enc_in_split.size(); i++) {
-			String f = enc_in_split[i].strip_edges();
-			if (f.is_empty()) {
-				continue;
-			}
-			enc_in_filters.push_back(f);
-		}
-
-		Vector<String> enc_ex_split = p_preset->get_enc_ex_filter().split(",");
-		for (int i = 0; i < enc_ex_split.size(); i++) {
-			String f = enc_ex_split[i].strip_edges();
-			if (f.is_empty()) {
-				continue;
-			}
-			enc_ex_filters.push_back(f);
-		}
-
-		// Get encryption key.
-		String script_key = _get_script_encryption_key(p_preset);
-		key.resize(32);
-		if (script_key.length() == 64) {
-			for (int i = 0; i < 32; i++) {
-				int v = 0;
-				if (i * 2 < script_key.length()) {
-					char32_t ct = script_key[i * 2];
-					if (is_digit(ct)) {
-						ct = ct - '0';
-					} else if (ct >= 'a' && ct <= 'f') {
-						ct = 10 + ct - 'a';
-					}
-					v |= ct << 4;
-				}
-
-				if (i * 2 + 1 < script_key.length()) {
-					char32_t ct = script_key[i * 2 + 1];
-					if (is_digit(ct)) {
-						ct = ct - '0';
-					} else if (ct >= 'a' && ct <= 'f') {
-						ct = 10 + ct - 'a';
-					}
-					v |= ct;
-				}
-				key.write[i] = v;
-			}
-		}
-	}
-
 	EditorExportSaveProxy save_proxy(p_save_func, p_remove_func != nullptr);
 
 	Error err = OK;
@@ -1263,7 +1261,12 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				}
 			}
 			for (int j = 0; j < export_plugins[i]->extra_files.size(); j++) {
-				err = save_proxy.save_file(p_preset, p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, 0, paths.size(), enc_in_filters, enc_ex_filters, key, seed, false);
+				EditorExportPlatform::SaveFileInfo save_info;
+				save_info.path = export_plugins[i]->extra_files[j].path;
+				save_info.source_path = save_info.path; // Not correct, but `ExtraFile` provides no source path.
+				save_info.file_index = 0;
+				save_info.file_count = paths.size();
+				err = save_proxy.save_file(p_preset, p_udata, save_info, export_plugins[i]->extra_files[j].data);
 				if (err != OK) {
 					return err;
 				}
@@ -1349,14 +1352,15 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		export_plugins.write[i]->set_export_base_path(export_base_path);
 	}
 
-	//store everything in the export medium
-	int total = paths.size();
-	// idx is incremented at the beginning of the paths loop to easily allow
-	// for continue statements without accidentally skipping an increment.
-	int idx = total > 0 ? -1 : 0;
+	EditorExportPlatform::SaveFileInfo save_info;
+	save_info.file_count = paths.size();
+	// We initialize index to -1 to allow us to increment the index at the beginning of the loop instead.
+	save_info.file_index = save_info.file_count > 0 ? -1 : 0;
 
 	for (const String &path : paths) {
-		idx++;
+		save_info.source_path = path;
+		save_info.file_index++;
+
 		String type = ResourceLoader::get_resource_type(path);
 
 		bool has_import_file = FileAccess::exists(path + ".import");
@@ -1393,15 +1397,16 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				}
 			}
 
-			for (int j = 0; j < export_plugins[i]->extra_files.size(); j++) {
-				err = save_proxy.save_file(p_preset, p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+			for (const EditorExportPlugin::ExtraFile &extra_file : export_plugins[i]->extra_files) {
+				save_info.path = extra_file.path;
+				err = save_proxy.save_file(p_preset, p_udata, save_info, extra_file.data);
 				if (err != OK) {
 					return err;
 				}
-				if (export_plugins[i]->extra_files[j].remap) {
+				if (extra_file.remap) {
 					do_export = false; // If remap, do not.
 					path_remaps.push_back(path);
-					path_remaps.push_back(export_plugins[i]->extra_files[j].path);
+					path_remaps.push_back(extra_file.path);
 				}
 			}
 
@@ -1422,10 +1427,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			String importer_type = config->get_value("remap", "importer");
 
 			if (importer_type == "keep") {
-				// Just keep file as-is.
-				Vector<uint8_t> array = FileAccess::get_file_as_bytes(path);
-				err = save_proxy.save_file(p_preset, p_udata, path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
-
+				save_info.path = path;
+				err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(path));
 				if (err != OK) {
 					return err;
 				}
@@ -1466,13 +1469,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				sarr.resize(cs.size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
-				err = save_proxy.save_file(p_preset, p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+				save_info.path = path + ".import";
+				err = save_proxy.save_file(p_preset, p_udata, save_info, sarr);
 				if (err != OK) {
 					return err;
 				}
 				// Now actual remapped file:
-				sarr = FileAccess::get_file_as_bytes(export_path);
-				err = save_proxy.save_file(p_preset, p_udata, export_path, sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+				save_info.path = export_path;
+				err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(export_path));
 				if (err != OK) {
 					return err;
 				}
@@ -1498,16 +1502,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				for (const String &F : remaps) {
 					String remap = F;
 					if (remap == "path") {
-						String remapped_path = config->get_value("remap", remap);
-						Vector<uint8_t> array = FileAccess::get_file_as_bytes(remapped_path);
-						err = save_proxy.save_file(p_preset, p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+						save_info.path = config->get_value("remap", remap);
+						err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(save_info.path));
 					} else if (remap.begins_with("path.")) {
 						String feature = remap.get_slicec('.', 1);
 
 						if (remap_features.has(feature)) {
-							String remapped_path = config->get_value("remap", remap);
-							Vector<uint8_t> array = FileAccess::get_file_as_bytes(remapped_path);
-							err = save_proxy.save_file(p_preset, p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+							save_info.path = config->get_value("remap", remap);
+							err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(save_info.path));
 						} else {
 							// Remove paths if feature not enabled.
 							config->erase_section_key("remap", remap);
@@ -1533,7 +1535,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				sarr.resize(cs.size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
-				err = save_proxy.save_file(p_preset, p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+				save_info.path = path + ".import";
+				err = save_proxy.save_file(p_preset, p_udata, save_info, sarr);
 
 				if (err != OK) {
 					return err;
@@ -1553,8 +1556,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				path_remaps.push_back(export_path);
 			}
 
-			Vector<uint8_t> array = FileAccess::get_file_as_bytes(export_path);
-			err = save_proxy.save_file(p_preset, p_udata, export_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+			save_info.path = export_path;
+			err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(export_path));
 			if (err != OK) {
 				return err;
 			}
@@ -1623,25 +1626,28 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				new_file.write[j] = utf8[j];
 			}
 
-			err = save_proxy.save_file(p_preset, p_udata, from + ".remap", new_file, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+			save_info.path = from + ".remap";
+			save_info.source_path = from;
+			err = save_proxy.save_file(p_preset, p_udata, save_info, new_file);
 			if (err != OK) {
 				return err;
 			}
 		}
 	}
 
-	Vector<String> forced_export = get_forced_export_files(p_preset);
-	for (int i = 0; i < forced_export.size(); i++) {
-		Vector<uint8_t> array;
-		if (GDExtension::get_extension_list_config_file() == forced_export[i]) {
-			array = _filter_extension_list_config_file(forced_export[i], paths);
-			if (array.is_empty()) {
+	for (const String &forced_export_file : get_forced_export_files(p_preset)) {
+		Vector<uint8_t> data;
+		if (GDExtension::get_extension_list_config_file() == forced_export_file) {
+			data = _filter_extension_list_config_file(forced_export_file, paths);
+			if (data.is_empty()) {
 				continue;
 			}
 		} else {
-			array = FileAccess::get_file_as_bytes(forced_export[i]);
+			data = FileAccess::get_file_as_bytes(forced_export_file);
 		}
-		err = save_proxy.save_file(p_preset, p_udata, forced_export[i], array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+		save_info.path = forced_export_file;
+		save_info.source_path = forced_export_file;
+		err = save_proxy.save_file(p_preset, p_udata, save_info, data);
 		if (err != OK) {
 			return err;
 		}
@@ -1649,8 +1655,9 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 	Dictionary int_export = get_internal_export_files(p_preset, p_debug);
 	for (const KeyValue<Variant, Variant> &int_export_kv : int_export) {
-		const PackedByteArray &array = int_export_kv.value;
-		err = save_proxy.save_file(p_preset, p_udata, int_export_kv.key, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+		save_info.path = int_export_kv.key;
+		save_info.source_path = save_info.path;
+		err = save_proxy.save_file(p_preset, p_udata, save_info, int_export_kv.value);
 		if (err != OK) {
 			return err;
 		}
@@ -1663,14 +1670,15 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	Vector<uint8_t> data = FileAccess::get_file_as_bytes(engine_cfb);
 	DirAccess::remove_file_or_error(engine_cfb);
 
-	err = save_proxy.save_file(p_preset, p_udata, "res://" + config_file, data, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+	save_info.path = config_file;
+	save_info.source_path = "res://project.godot";
+	err = save_proxy.save_file(p_preset, p_udata, save_info, data);
 	if (err != OK) {
 		return err;
 	}
 
 	if (p_remove_func) {
-		HashSet<String> currently_loaded_paths = PackedData::get_singleton()->get_file_paths();
-		for (const String &path : currently_loaded_paths) {
+		for (const String &path : PackedData::get_singleton()->get_file_paths()) {
 			if (!save_proxy.has_saved(path)) {
 				err = p_remove_func(p_preset, p_udata, path);
 				if (err != OK) {
@@ -2048,7 +2056,7 @@ bool EditorExportPlatform::_encrypt_and_store_directory(Ref<FileAccess> p_fd, Pa
 	return true;
 }
 
-Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files, EditorExportSaveFunction p_save_func, EditorExportRemoveFunction p_remove_func, bool p_embed, int64_t *r_embedded_start, int64_t *r_embedded_size) {
+Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files, SaveFileFunction p_save_func, RemoveFileFunction p_remove_func, bool p_embed, int64_t *r_embedded_start, int64_t *r_embedded_size) {
 	EditorProgress ep("savepack", TTR("Packing"), 102, true);
 
 	if (p_save_func == nullptr) {
@@ -2141,33 +2149,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 
 	Vector<uint8_t> key;
 	if (p_preset->get_enc_pck() && p_preset->get_enc_directory()) {
-		String script_key = _get_script_encryption_key(p_preset);
-		key.resize(32);
-		if (script_key.length() == 64) {
-			for (int i = 0; i < 32; i++) {
-				int v = 0;
-				if (i * 2 < script_key.length()) {
-					char32_t ct = script_key[i * 2];
-					if (is_digit(ct)) {
-						ct = ct - '0';
-					} else if (ct >= 'a' && ct <= 'f') {
-						ct = 10 + ct - 'a';
-					}
-					v |= ct << 4;
-				}
-
-				if (i * 2 + 1 < script_key.length()) {
-					char32_t ct = script_key[i * 2 + 1];
-					if (is_digit(ct)) {
-						ct = ct - '0';
-					} else if (ct >= 'a' && ct <= 'f') {
-						ct = 10 + ct - 'a';
-					}
-					v |= ct;
-				}
-				key.write[i] = v;
-			}
-		}
+		key = _get_encryption_key(p_preset);
 	}
 
 	if (!_encrypt_and_store_directory(f, pd, key, p_preset->get_seed(), file_base)) {
@@ -2200,7 +2182,7 @@ Error EditorExportPlatform::save_pack_patch(const Ref<EditorExportPreset> &p_pre
 	return save_pack(p_preset, p_debug, p_path, p_so_files, _save_pack_patch_file, _remove_pack_file, p_embed, r_embedded_start, r_embedded_size);
 }
 
-Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files, EditorExportSaveFunction p_save_func) {
+Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files, SaveFileFunction p_save_func) {
 	EditorProgress ep("savezip", TTR("Packing"), 102, true);
 
 	if (p_save_func == nullptr) {

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -66,21 +66,21 @@
 
 class EditorExportSaveProxy {
 	HashSet<String> saved_paths;
-	EditorExportPlatform::EditorExportSaveFunction save_func;
+	EditorExportPlatform::SaveFileFunction save_func;
 	bool tracking_saves = false;
 
 public:
 	bool has_saved(const String &p_path) const { return saved_paths.has(p_path); }
 
-	Error save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+	Error save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const EditorExportPlatform::SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 		if (tracking_saves) {
-			saved_paths.insert(p_path.simplify_path().trim_prefix("res://"));
+			saved_paths.insert(p_info.path.simplify_path().trim_prefix("res://"));
 		}
 
-		return save_func(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta);
+		return save_func(p_preset, p_userdata, p_info, p_data);
 	}
 
-	EditorExportSaveProxy(EditorExportPlatform::EditorExportSaveFunction p_save_func, bool p_track_saves) :
+	EditorExportSaveProxy(EditorExportPlatform::SaveFileFunction p_save_func, bool p_track_saves) :
 			save_func(p_save_func), tracking_saves(p_track_saves) {}
 };
 
@@ -348,7 +348,7 @@ Error EditorExportPlatform::_load_patches(const Ref<EditorExportPreset> &p_prese
 				patch_temp_dirs.push_back(temp_dir);
 			}
 
-			Error err = PackedData::get_singleton()->add_pack(pck_path, true, 0, _get_script_encryption_key_bytes(p_preset));
+			Error err = PackedData::get_singleton()->add_pack(pck_path, true, 0, p_preset->resolve_script_encryption_key());
 			if (err != OK) {
 				_unload_patches();
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Patch Creation"), vformat(TTR("Could not load patch pack with path \"%s\"."), pck_path));
@@ -374,29 +374,32 @@ void EditorExportPlatform::_unload_patches() {
 	patch_temp_dirs.clear();
 }
 
-Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const String &p_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool &r_encrypt) {
+Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const Ref<EditorExportPreset> &p_preset, const String &p_path, const Vector<uint8_t> &p_data, bool &r_encrypt) {
 	r_encrypt = false;
-	for (int i = 0; i < p_enc_in_filters.size(); ++i) {
-		if (p_path.matchn(p_enc_in_filters[i]) || p_path.trim_prefix("res://").matchn(p_enc_in_filters[i])) {
-			r_encrypt = true;
-			break;
-		}
-	}
 
-	for (int i = 0; i < p_enc_ex_filters.size(); ++i) {
-		if (p_path.matchn(p_enc_ex_filters[i]) || p_path.trim_prefix("res://").matchn(p_enc_ex_filters[i])) {
-			r_encrypt = false;
-			break;
+	if (p_preset->get_enc_pck()) {
+		for (const String &filter : p_preset->get_enc_in_filters()) {
+			if (p_path.matchn(filter) || p_path.trim_prefix("res://").matchn(filter)) {
+				r_encrypt = true;
+				break;
+			}
+		}
+
+		for (const String &filter : p_preset->get_enc_ex_filters()) {
+			if (p_path.matchn(filter) || p_path.trim_prefix("res://").matchn(filter)) {
+				r_encrypt = false;
+				break;
+			}
 		}
 	}
 
 	Ref<FileAccessEncrypted> fae;
 	Ref<FileAccess> ftmp = p_fd;
 	if (r_encrypt) {
+		Vector<uint8_t> key = p_preset->resolve_script_encryption_key();
 		Vector<uint8_t> iv;
-		if (p_seed != 0) {
-			uint64_t seed = p_seed;
-
+		uint64_t seed = p_preset->get_seed();
+		if (seed != 0) {
 			const uint8_t *ptr = p_data.ptr();
 			int64_t len = p_data.size();
 			for (int64_t i = 0; i < len; i++) {
@@ -413,7 +416,7 @@ Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const 
 		fae.instantiate();
 		ERR_FAIL_COND_V(fae.is_null(), ERR_FILE_CANT_OPEN);
 
-		Error err = fae->open_and_parse(ftmp, p_key, FileAccessEncrypted::MODE_WRITE_AES256, false, iv);
+		Error err = fae->open_and_parse(ftmp, key, FileAccessEncrypted::MODE_WRITE_AES256, false, iv);
 		ERR_FAIL_COND_V(err != OK, ERR_FILE_CANT_OPEN);
 		ftmp = fae;
 	}
@@ -428,12 +431,12 @@ Error EditorExportPlatform::_encrypt_and_store_data(Ref<FileAccess> p_fd, const 
 	return OK;
 }
 
-Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
-	ERR_FAIL_COND_V_MSG(p_total < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
+Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
+	ERR_FAIL_COND_V_MSG(p_info.file_count < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
 
 	PackData *pd = (PackData *)p_userdata;
 
-	const String simplified_path = simplify_path(p_path);
+	const String simplified_path = simplify_path(p_info.path);
 
 	Ref<FileAccess> ftmp;
 	if (pd->use_sparse_pck) {
@@ -446,8 +449,8 @@ Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_pre
 	sd.path_utf8 = simplified_path.trim_prefix("res://").utf8();
 	sd.ofs = (pd->use_sparse_pck) ? 0 : pd->f->get_position();
 	sd.size = p_data.size();
-	sd.delta = p_delta;
-	RETURN_IF_ERROR(_encrypt_and_store_data(ftmp, simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, sd.encrypted));
+	sd.delta = p_info.delta;
+	RETURN_IF_ERROR(_encrypt_and_store_data(ftmp, p_preset, simplified_path, p_data, sd.encrypted));
 	if (!pd->use_sparse_pck) {
 		ERR_FAIL_COND_V(pd->f->get_position() - sd.ofs < (uint64_t)p_data.size(), ERR_FILE_CANT_WRITE);
 	}
@@ -472,17 +475,17 @@ Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_pre
 	pd->file_ofs.push_back(sd);
 
 	// TRANSLATORS: This is an editor progress label describing the storing of a file.
-	if (pd->ep->step(vformat(TTR("Storing File: %s"), p_path), 2 + p_file * 100 / p_total, false)) {
+	if (pd->ep->step(vformat(TTR("Storing File: %s"), p_info.path), 2 + p_info.file_index * 100 / p_info.file_count, false)) {
 		return ERR_SKIP;
 	}
 
 	return OK;
 }
 
-Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
-	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_path, _get_script_encryption_key_bytes(p_preset));
+Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
+	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_info.path, p_preset->resolve_script_encryption_key());
 	if (old_file.is_null()) {
-		return _save_pack_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, false);
+		return _save_pack_file(p_preset, p_userdata, p_info, p_data);
 	}
 
 	Vector<uint8_t> old_data = old_file->get_buffer(old_file->get_length());
@@ -493,14 +496,14 @@ Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> 
 	}
 
 	if (!p_preset->is_patch_delta_encoding_enabled()) {
-		return _save_pack_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, false);
+		return _save_pack_file(p_preset, p_userdata, p_info, p_data);
 	}
 
 	bool delta = false;
 
 	for (const String &filter : p_preset->get_patch_delta_include_filter().split(",", false)) {
 		String filter_stripped = filter.strip_edges();
-		if (p_path.matchn(filter_stripped) || p_path.trim_prefix("res://").matchn(filter_stripped)) {
+		if (p_info.path.matchn(filter_stripped) || p_info.path.trim_prefix("res://").matchn(filter_stripped)) {
 			delta = true;
 			break;
 		}
@@ -508,7 +511,7 @@ Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> 
 
 	for (const String &filter : p_preset->get_patch_delta_exclude_filter().split(",", false)) {
 		String filter_stripped = filter.strip_edges();
-		if (p_path.matchn(filter_stripped) || p_path.trim_prefix("res://").matchn(filter_stripped)) {
+		if (p_info.path.matchn(filter_stripped) || p_info.path.trim_prefix("res://").matchn(filter_stripped)) {
 			delta = false;
 			break;
 		}
@@ -523,23 +526,26 @@ Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> 
 		double reduction_ratio = reduction_bytes / (double)p_data.size();
 
 		if (reduction_ratio >= p_preset->get_patch_delta_min_reduction()) {
-			print_verbose(vformat("Used delta encoding for patch of \"%s\", resulting in a patch of %d bytes, which reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+			print_verbose(vformat("Used delta encoding for patch of \"%s\", resulting in a patch of %d bytes, which reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_info.path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
 		} else {
-			print_verbose(vformat("Skipped delta encoding for patch of \"%s\", as it resulted in a patch of %d bytes, which only reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+			print_verbose(vformat("Skipped delta encoding for patch of \"%s\", as it resulted in a patch of %d bytes, which only reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_info.path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
 			patch_data = p_data;
 			delta = false;
 		}
 	} else {
-		print_verbose(vformat("Skipped delta encoding for patch of \"%s\", due to include/exclude filters.", p_path));
+		print_verbose(vformat("Skipped delta encoding for patch of \"%s\", due to include/exclude filters.", p_info.path));
 	}
 
-	return _save_pack_file(p_preset, p_userdata, p_path, patch_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, delta);
+	SaveFileInfo new_file_info = p_info;
+	new_file_info.delta = delta;
+
+	return _save_pack_file(p_preset, p_userdata, new_file_info, patch_data);
 }
 
-Error EditorExportPlatform::_save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
-	ERR_FAIL_COND_V_MSG(p_total < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
+Error EditorExportPlatform::_save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
+	ERR_FAIL_COND_V_MSG(p_info.file_count < 1, ERR_PARAMETER_RANGE_ERROR, "Must select at least one file to export.");
 
-	const String path = simplify_path(p_path).replace_first("res://", "");
+	const String path = simplify_path(p_info.path).trim_prefix("res://");
 
 	ZipData *zd = (ZipData *)p_userdata;
 
@@ -561,15 +567,15 @@ Error EditorExportPlatform::_save_zip_file(const Ref<EditorExportPreset> &p_pres
 
 	zd->file_count += 1;
 
-	if (zd->ep->step(TTR("Storing File:") + " " + p_path, 2 + p_file * 100 / p_total, false)) {
+	if (zd->ep->step(TTR("Storing File:") + " " + p_info.path, 2 + p_info.file_index * 100 / p_info.file_count, false)) {
 		return ERR_SKIP;
 	}
 
 	return OK;
 }
 
-Error EditorExportPlatform::_save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
-	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_path);
+Error EditorExportPlatform::_save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
+	Ref<FileAccess> old_file = PackedData::get_singleton()->try_open_path(p_info.path);
 	if (old_file.is_valid()) {
 		Vector<uint8_t> old_data = old_file->get_buffer(old_file->get_length());
 
@@ -579,7 +585,7 @@ Error EditorExportPlatform::_save_zip_patch_file(const Ref<EditorExportPreset> &
 		}
 	}
 
-	return _save_zip_file(p_preset, p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta);
+	return _save_zip_file(p_preset, p_userdata, p_info, p_data);
 }
 
 Ref<Texture2D> EditorExportPlatform::get_option_icon(int p_index) const {
@@ -1130,47 +1136,6 @@ String EditorExportPlatform::_export_customize(const String &p_path, LocalVector
 	return save_path.is_empty() ? p_path : save_path;
 }
 
-String EditorExportPlatform::_get_script_encryption_key(const Ref<EditorExportPreset> &p_preset) {
-	const String from_env = OS::get_singleton()->get_environment(ENV_SCRIPT_ENCRYPTION_KEY);
-	if (!from_env.is_empty()) {
-		return from_env.to_lower();
-	}
-	return p_preset->get_script_encryption_key().to_lower();
-}
-
-Vector<uint8_t> EditorExportPlatform::_get_script_encryption_key_bytes(const Ref<EditorExportPreset> &p_preset) {
-	Vector<uint8_t> key;
-	String script_key = _get_script_encryption_key(p_preset);
-	if (script_key.length() == 64) {
-		key.resize(32);
-		for (int i = 0; i < 32; i++) {
-			int v = 0;
-			if (i * 2 < script_key.length()) {
-				char32_t ct = script_key[i * 2];
-				if (is_digit(ct)) {
-					ct = ct - '0';
-				} else if (ct >= 'a' && ct <= 'f') {
-					ct = 10 + ct - 'a';
-				}
-				v |= ct << 4;
-			}
-
-			if (i * 2 + 1 < script_key.length()) {
-				char32_t ct = script_key[i * 2 + 1];
-				if (is_digit(ct)) {
-					ct = ct - '0';
-				} else if (ct >= 'a' && ct <= 'f') {
-					ct = 10 + ct - 'a';
-				}
-				v |= ct;
-			}
-			key.write[i] = v;
-		}
-	}
-
-	return key;
-}
-
 Dictionary EditorExportPlatform::get_internal_export_files(const Ref<EditorExportPreset> &p_preset, bool p_debug) {
 	Dictionary files;
 
@@ -1259,26 +1224,49 @@ Vector<String> EditorExportPlatform::get_forced_export_files(const Ref<EditorExp
 	return files;
 }
 
-Error EditorExportPlatform::_script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+Error EditorExportPlatform::_script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 	Callable cb = ((ScriptCallbackData *)p_userdata)->file_cb;
 	ERR_FAIL_COND_V(!cb.is_valid(), FAILED);
 
-	const String simplified_path = simplify_path(p_path);
-
-	Variant path = simplified_path;
-	Variant data = p_data;
-	Variant file = p_file;
-	Variant total = p_total;
-	Variant enc_in = p_enc_in_filters;
-	Variant enc_ex = p_enc_ex_filters;
-	Variant enc_key = p_key;
-
 	Variant ret;
-	Callable::CallError ce;
-	const Variant *args[7] = { &path, &data, &file, &total, &enc_in, &enc_ex, &enc_key };
 
-	cb.callp(args, 7, ret, ce);
-	ERR_FAIL_COND_V_MSG(ce.error != Callable::CallError::CALL_OK, FAILED, vformat("Failed to execute file save callback: %s.", Variant::get_callable_error_text(cb, args, 7, ce)));
+#ifndef DISABLE_DEPRECATED
+	if (cb.get_argument_count() == 7) {
+		Variant v_path = simplify_path(p_info.path);
+		Variant v_data = p_data;
+		Variant v_file_index = p_info.file_index;
+		Variant v_file_count = p_info.file_count;
+		Variant v_enc_in_filter = PackedStringArray();
+		Variant v_enc_ex_filter = PackedStringArray();
+		Variant v_enc_key = PackedByteArray();
+
+		if (p_preset->get_enc_pck()) {
+			v_enc_in_filter = p_preset->get_enc_in_filters();
+			v_enc_ex_filter = p_preset->get_enc_ex_filters();
+			v_enc_key = p_preset->resolve_script_encryption_key();
+		}
+
+		Callable::CallError ce;
+		const Variant *args[7] = { &v_path, &v_data, &v_file_index, &v_file_count, &v_enc_in_filter, &v_enc_ex_filter, &v_enc_key };
+		cb.callp(args, 7, ret, ce);
+		ERR_FAIL_COND_V_MSG(ce.error != Callable::CallError::CALL_OK, FAILED, vformat("Failed to execute file save callback: %s.", Variant::get_callable_error_text(cb, args, 7, ce)));
+	} else
+#endif
+	{
+		Dictionary info;
+		info["path"] = simplify_path(p_info.path);
+		info["source_path"] = simplify_path(p_info.source_path);
+		info["file_index"] = p_info.file_index;
+		info["file_count"] = p_info.file_count;
+
+		Variant v_info = info;
+		Variant v_data = p_data;
+
+		Callable::CallError ce;
+		const Variant *args[2] = { &v_info, &v_data };
+		cb.callp(args, 2, ret, ce);
+		ERR_FAIL_COND_V_MSG(ce.error != Callable::CallError::CALL_OK, FAILED, vformat("Failed to execute file save callback: %s.", Variant::get_callable_error_text(cb, args, 2, ce)));
+	}
 
 	return (Error)ret.operator int();
 }
@@ -1310,7 +1298,7 @@ Error EditorExportPlatform::_export_project_files(const Ref<EditorExportPreset> 
 	return export_project_files(p_preset, p_debug, _script_save_file, nullptr, &data, _script_add_shared_object);
 }
 
-Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &p_preset, bool p_debug, EditorExportSaveFunction p_save_func, EditorExportRemoveFunction p_remove_func, void *p_udata, EditorExportSaveSharedObject p_so_func) {
+Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &p_preset, bool p_debug, SaveFileFunction p_save_func, RemoveFileFunction p_remove_func, void *p_udata, SaveSharedObjectFunction p_so_func) {
 	//figure out paths of files that will be exported
 	HashSet<String> paths;
 	Vector<String> path_remaps;
@@ -1367,37 +1355,6 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	// Ignore import files, since these are automatically added to the jar later with the resources
 	_edit_filter_list(paths, String("*.import"), true);
 
-	// Get encryption filters.
-	bool enc_pck = p_preset->get_enc_pck();
-	Vector<String> enc_in_filters;
-	Vector<String> enc_ex_filters;
-	Vector<uint8_t> key;
-	uint64_t seed = 0;
-
-	if (enc_pck) {
-		seed = p_preset->get_seed();
-		Vector<String> enc_in_split = p_preset->get_enc_in_filter().split(",");
-		for (int i = 0; i < enc_in_split.size(); i++) {
-			String f = enc_in_split[i].strip_edges();
-			if (f.is_empty()) {
-				continue;
-			}
-			enc_in_filters.push_back(f);
-		}
-
-		Vector<String> enc_ex_split = p_preset->get_enc_ex_filter().split(",");
-		for (int i = 0; i < enc_ex_split.size(); i++) {
-			String f = enc_ex_split[i].strip_edges();
-			if (f.is_empty()) {
-				continue;
-			}
-			enc_ex_filters.push_back(f);
-		}
-
-		// Get encryption key.
-		key = _get_script_encryption_key_bytes(p_preset);
-	}
-
 	EditorExportSaveProxy save_proxy(p_save_func, p_remove_func != nullptr);
 
 	Error err = OK;
@@ -1420,7 +1377,12 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				}
 			}
 			for (int j = 0; j < export_plugins[i]->extra_files.size(); j++) {
-				err = save_proxy.save_file(p_preset, p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, 0, paths.size(), enc_in_filters, enc_ex_filters, key, seed, false);
+				EditorExportPlatform::SaveFileInfo save_info;
+				save_info.path = export_plugins[i]->extra_files[j].path;
+				save_info.source_path = save_info.path;
+				save_info.file_index = 0;
+				save_info.file_count = paths.size();
+				err = save_proxy.save_file(p_preset, p_udata, save_info, export_plugins[i]->extra_files[j].data);
 				if (err != OK) {
 					return err;
 				}
@@ -1506,14 +1468,15 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		export_plugins.write[i]->set_export_base_path(export_base_path);
 	}
 
-	//store everything in the export medium
-	int total = paths.size();
-	// idx is incremented at the beginning of the paths loop to easily allow
-	// for continue statements without accidentally skipping an increment.
-	int idx = total > 0 ? -1 : 0;
+	EditorExportPlatform::SaveFileInfo save_info;
+	save_info.file_count = paths.size();
+	// We initialize index to -1 to allow us to increment the index at the beginning of the loop instead.
+	save_info.file_index = save_info.file_count > 0 ? -1 : 0;
 
 	for (const String &path : paths) {
-		idx++;
+		save_info.source_path = path;
+		save_info.file_index++;
+
 		String type = ResourceLoader::get_resource_type(path);
 
 		bool has_import_file = FileAccess::exists(path + ".import");
@@ -1550,15 +1513,17 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				}
 			}
 
-			for (int j = 0; j < export_plugins[i]->extra_files.size(); j++) {
-				err = save_proxy.save_file(p_preset, p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+			for (const EditorExportPlugin::ExtraFile &extra_file : export_plugins[i]->extra_files) {
+				save_info.path = extra_file.path;
+				save_info.source_path = extra_file.remap ? path : save_info.path;
+				err = save_proxy.save_file(p_preset, p_udata, save_info, extra_file.data);
 				if (err != OK) {
 					return err;
 				}
-				if (export_plugins[i]->extra_files[j].remap) {
+				if (extra_file.remap) {
 					do_export = false; // If remap, do not.
 					path_remaps.push_back(path);
-					path_remaps.push_back(export_plugins[i]->extra_files[j].path);
+					path_remaps.push_back(extra_file.path);
 				}
 			}
 
@@ -1575,14 +1540,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			continue;
 		}
 
+		save_info.source_path = path; // Set it again, in case a plugin extra file changed it.
+
 		if (has_import_file) {
 			String importer_type = config->get_value("remap", "importer");
 
 			if (importer_type == "keep") {
-				// Just keep file as-is.
-				Vector<uint8_t> array = FileAccess::get_file_as_bytes(path);
-				err = save_proxy.save_file(p_preset, p_udata, path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
-
+				save_info.path = path;
+				err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(path));
 				if (err != OK) {
 					return err;
 				}
@@ -1623,13 +1588,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				sarr.resize(cs.size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
-				err = save_proxy.save_file(p_preset, p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+				save_info.path = path + ".import";
+				err = save_proxy.save_file(p_preset, p_udata, save_info, sarr);
 				if (err != OK) {
 					return err;
 				}
 				// Now actual remapped file:
-				sarr = FileAccess::get_file_as_bytes(export_path);
-				err = save_proxy.save_file(p_preset, p_udata, export_path, sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+				save_info.path = export_path;
+				err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(export_path));
 				if (err != OK) {
 					return err;
 				}
@@ -1655,16 +1621,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				for (const String &F : remaps) {
 					String remap = F;
 					if (remap == "path") {
-						String remapped_path = config->get_value("remap", remap);
-						Vector<uint8_t> array = FileAccess::get_file_as_bytes(remapped_path);
-						err = save_proxy.save_file(p_preset, p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+						save_info.path = config->get_value("remap", remap);
+						err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(save_info.path));
 					} else if (remap.begins_with("path.")) {
 						String feature = remap.get_slicec('.', 1);
 
 						if (remap_features.has(feature)) {
-							String remapped_path = config->get_value("remap", remap);
-							Vector<uint8_t> array = FileAccess::get_file_as_bytes(remapped_path);
-							err = save_proxy.save_file(p_preset, p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+							save_info.path = config->get_value("remap", remap);
+							err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(save_info.path));
 						} else {
 							// Remove paths if feature not enabled.
 							config->erase_section_key("remap", remap);
@@ -1690,7 +1654,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				sarr.resize(cs.size());
 				memcpy(sarr.ptrw(), cs.ptr(), sarr.size());
 
-				err = save_proxy.save_file(p_preset, p_udata, path + ".import", sarr, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+				save_info.path = path + ".import";
+				err = save_proxy.save_file(p_preset, p_udata, save_info, sarr);
 
 				if (err != OK) {
 					return err;
@@ -1715,8 +1680,8 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				}
 			}
 
-			Vector<uint8_t> array = FileAccess::get_file_as_bytes(export_path);
-			err = save_proxy.save_file(p_preset, p_udata, export_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+			save_info.path = export_path;
+			err = save_proxy.save_file(p_preset, p_udata, save_info, FileAccess::get_file_as_bytes(export_path));
 			if (err != OK) {
 				return err;
 			}
@@ -1785,7 +1750,9 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				new_file.write[j] = utf8[j];
 			}
 
-			err = save_proxy.save_file(p_preset, p_udata, from + ".remap", new_file, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+			save_info.path = from + ".remap";
+			save_info.source_path = from;
+			err = save_proxy.save_file(p_preset, p_udata, save_info, new_file);
 			if (err != OK) {
 				return err;
 			}
@@ -1810,22 +1777,27 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			continue;
 		}
 
-		err = save_proxy.save_file(p_preset, p_udata, file, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+		save_info.path = file;
+		save_info.source_path = file;
+		err = save_proxy.save_file(p_preset, p_udata, save_info, array);
 		if (err != OK) {
 			return err;
 		}
 	}
 
 	String uid_cache_file_path = ResourceUID::get_cache_file();
-	err = save_proxy.save_file(p_preset, p_udata, uid_cache_file_path, filtered_cache.uids, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+	save_info.path = uid_cache_file_path;
+	save_info.source_path = uid_cache_file_path;
+	err = save_proxy.save_file(p_preset, p_udata, save_info, filtered_cache.uids);
 	if (err != OK) {
 		return err;
 	}
 
 	Dictionary int_export = get_internal_export_files(p_preset, p_debug);
 	for (const KeyValue<Variant, Variant> &int_export_kv : int_export) {
-		const PackedByteArray &array = int_export_kv.value;
-		err = save_proxy.save_file(p_preset, p_udata, int_export_kv.key, array, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+		save_info.path = int_export_kv.key;
+		save_info.source_path = save_info.path;
+		err = save_proxy.save_file(p_preset, p_udata, save_info, int_export_kv.value);
 		if (err != OK) {
 			return err;
 		}
@@ -1838,14 +1810,15 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	Vector<uint8_t> data = FileAccess::get_file_as_bytes(engine_cfb);
 	DirAccess::remove_file_or_error(engine_cfb);
 
-	err = save_proxy.save_file(p_preset, p_udata, "res://" + config_file, data, idx, total, enc_in_filters, enc_ex_filters, key, seed, false);
+	save_info.path = "res://" + config_file;
+	save_info.source_path = "res://project.godot";
+	err = save_proxy.save_file(p_preset, p_udata, save_info, data);
 	if (err != OK) {
 		return err;
 	}
 
 	if (p_remove_func) {
-		HashSet<String> currently_loaded_paths = PackedData::get_singleton()->get_file_paths();
-		for (const String &path : currently_loaded_paths) {
+		for (const String &path : PackedData::get_singleton()->get_file_paths()) {
 			if (!save_proxy.has_saved(path)) {
 				err = p_remove_func(p_preset, p_udata, path);
 				if (err != OK) {
@@ -2280,7 +2253,7 @@ bool EditorExportPlatform::_encrypt_and_store_directory(Ref<FileAccess> p_fd, Pa
 	return true;
 }
 
-Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files, EditorExportSaveFunction p_save_func, EditorExportRemoveFunction p_remove_func, bool p_embed, int64_t *r_embedded_start, int64_t *r_embedded_size) {
+Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files, SaveFileFunction p_save_func, RemoveFileFunction p_remove_func, bool p_embed, int64_t *r_embedded_start, int64_t *r_embedded_size) {
 	EditorProgress ep("savepack", TTR("Packing"), 102, true);
 
 	if (p_save_func == nullptr) {
@@ -2373,7 +2346,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 
 	Vector<uint8_t> key;
 	if (p_preset->get_enc_pck() && p_preset->get_enc_directory()) {
-		key = _get_script_encryption_key_bytes(p_preset);
+		key = p_preset->resolve_script_encryption_key();
 	}
 
 	if (!_encrypt_and_store_directory(f, pd, key, p_preset->get_seed(), file_base)) {
@@ -2406,7 +2379,7 @@ Error EditorExportPlatform::save_pack_patch(const Ref<EditorExportPreset> &p_pre
 	return save_pack(p_preset, p_debug, p_path, p_so_files, _save_pack_patch_file, _remove_pack_file, p_embed, r_embedded_start, r_embedded_size);
 }
 
-Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files, EditorExportSaveFunction p_save_func) {
+Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files, SaveFileFunction p_save_func) {
 	EditorProgress ep("savezip", TTR("Packing"), 102, true);
 
 	if (p_save_func == nullptr) {

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -55,9 +55,17 @@ protected:
 	static void _bind_methods();
 
 public:
-	typedef Error (*EditorExportSaveFunction)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
-	typedef Error (*EditorExportRemoveFunction)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path);
-	typedef Error (*EditorExportSaveSharedObject)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
+	struct SaveFileInfo {
+		String path;
+		String source_path;
+		int file_index = 0;
+		int file_count = 0;
+		bool delta = false;
+	};
+
+	typedef Error (*SaveFileFunction)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
+	typedef Error (*RemoveFileFunction)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path);
+	typedef Error (*SaveSharedObjectFunction)(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	enum DebugFlags {
 		DEBUG_FLAG_DUMB_CLIENT = 1,
@@ -106,9 +114,7 @@ public:
 
 	static bool _store_header(Ref<FileAccess> p_fd, bool p_enc, bool p_sparse, uint64_t &r_file_base_ofs, uint64_t &r_dir_base_ofs, const String &p_salt);
 	static bool _encrypt_and_store_directory(Ref<FileAccess> p_fd, PackData &p_pack_data, const Vector<uint8_t> &p_key, uint64_t p_seed, uint64_t p_file_base);
-	static Error _encrypt_and_store_data(Ref<FileAccess> p_fd, const String &p_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool &r_encrypt);
-	static String _get_script_encryption_key(const Ref<EditorExportPreset> &p_preset);
-	static Vector<uint8_t> _get_script_encryption_key_bytes(const Ref<EditorExportPreset> &p_preset);
+	static Error _encrypt_and_store_data(Ref<FileAccess> p_fd, const Ref<EditorExportPreset> &p_preset, const String &p_path, const Vector<uint8_t> &p_data, bool &r_encrypt);
 
 private:
 	struct ZipData {
@@ -125,14 +131,14 @@ private:
 	void _export_find_customized_resources(const Ref<EditorExportPreset> &p_preset, EditorFileSystemDirectory *p_dir, EditorExportPreset::FileExportMode p_mode, HashSet<String> &p_paths);
 	void _export_find_dependencies(const String &p_path, HashSet<String> &p_paths);
 
-	static Error _save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
-	static Error _save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _save_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
+	static Error _save_pack_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
 	static Error _pack_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	static Error _remove_pack_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path);
 
-	static Error _save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
-	static Error _save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _save_zip_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
+	static Error _save_zip_patch_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
 	static Error _zip_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	struct ScriptCallbackData {
@@ -140,7 +146,7 @@ private:
 		Callable so_cb;
 	};
 
-	static Error _script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error _script_save_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
 	static Error _script_add_shared_object(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
 	void _edit_files_with_filter(Ref<DirAccess> &da, const Vector<String> &p_filters, HashSet<String> &r_list, bool exclude);
@@ -324,7 +330,7 @@ public:
 	Array get_current_presets() const;
 
 	Error _export_project_files(const Ref<EditorExportPreset> &p_preset, bool p_debug, const Callable &p_save_func, const Callable &p_so_func);
-	Error export_project_files(const Ref<EditorExportPreset> &p_preset, bool p_debug, EditorExportSaveFunction p_save_func, EditorExportRemoveFunction p_remove_func, void *p_udata, EditorExportSaveSharedObject p_so_func = nullptr);
+	Error export_project_files(const Ref<EditorExportPreset> &p_preset, bool p_debug, SaveFileFunction p_save_func, RemoveFileFunction p_remove_func, void *p_udata, SaveSharedObjectFunction p_so_func = nullptr);
 
 	Dictionary _save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, bool p_embed = false);
 	Dictionary _save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
@@ -332,8 +338,8 @@ public:
 	Dictionary _save_pack_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
 	Dictionary _save_zip_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
 
-	Error save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files = nullptr, EditorExportSaveFunction p_save_func = nullptr, EditorExportRemoveFunction p_remove_func = nullptr, bool p_embed = false, int64_t *r_embedded_start = nullptr, int64_t *r_embedded_size = nullptr);
-	Error save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files = nullptr, EditorExportSaveFunction p_save_func = nullptr);
+	Error save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files = nullptr, SaveFileFunction p_save_func = nullptr, RemoveFileFunction p_remove_func = nullptr, bool p_embed = false, int64_t *r_embedded_start = nullptr, int64_t *r_embedded_size = nullptr);
+	Error save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files = nullptr, SaveFileFunction p_save_func = nullptr);
 
 	Error save_pack_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files = nullptr, bool p_embed = false, int64_t *r_embedded_start = nullptr, int64_t *r_embedded_size = nullptr);
 	Error save_zip_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, Vector<SharedObject> *p_so_files = nullptr);

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -111,11 +111,12 @@ void EditorExportPreset::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_custom_features"), &EditorExportPreset::get_custom_features);
 	ClassDB::bind_method(D_METHOD("get_patches"), &EditorExportPreset::get_patches);
 	ClassDB::bind_method(D_METHOD("get_export_path"), &EditorExportPreset::get_export_path);
-	ClassDB::bind_method(D_METHOD("get_encryption_in_filter"), &EditorExportPreset::get_enc_in_filter);
-	ClassDB::bind_method(D_METHOD("get_encryption_ex_filter"), &EditorExportPreset::get_enc_ex_filter);
+	ClassDB::bind_method(D_METHOD("get_encryption_in_filter"), &EditorExportPreset::get_enc_in_filters_str);
+	ClassDB::bind_method(D_METHOD("get_encryption_ex_filter"), &EditorExportPreset::get_enc_ex_filters_str);
 	ClassDB::bind_method(D_METHOD("get_encrypt_pck"), &EditorExportPreset::get_enc_pck);
 	ClassDB::bind_method(D_METHOD("get_encrypt_directory"), &EditorExportPreset::get_enc_directory);
 	ClassDB::bind_method(D_METHOD("get_encryption_key"), &EditorExportPreset::get_script_encryption_key);
+	ClassDB::bind_method(D_METHOD("resolve_encryption_key"), &EditorExportPreset::resolve_script_encryption_key);
 	ClassDB::bind_method(D_METHOD("get_script_export_mode"), &EditorExportPreset::get_script_export_mode);
 
 	ClassDB::bind_method(D_METHOD("get_or_env", "name", "env_var"), &EditorExportPreset::_get_or_env);
@@ -517,21 +518,47 @@ String EditorExportPreset::get_custom_features() const {
 	return custom_features;
 }
 
-void EditorExportPreset::set_enc_in_filter(const String &p_filter) {
-	enc_in_filters = p_filter;
+void EditorExportPreset::set_enc_in_filters_str(const String &p_filter) {
+	enc_in_filters_str = p_filter;
+
+	enc_in_filters.clear();
+	for (const String &filter : enc_in_filters_str.split(",")) {
+		String stripped_filter = filter.strip_edges();
+		if (!stripped_filter.is_empty()) {
+			enc_in_filters.push_back(stripped_filter);
+		}
+	}
+
 	EditorExport::singleton->save_presets();
 }
 
-String EditorExportPreset::get_enc_in_filter() const {
+String EditorExportPreset::get_enc_in_filters_str() const {
+	return enc_in_filters_str;
+}
+
+Vector<String> EditorExportPreset::get_enc_in_filters() const {
 	return enc_in_filters;
 }
 
-void EditorExportPreset::set_enc_ex_filter(const String &p_filter) {
-	enc_ex_filters = p_filter;
+void EditorExportPreset::set_enc_ex_filters_str(const String &p_filter) {
+	enc_ex_filters_str = p_filter;
+
+	enc_ex_filters.clear();
+	for (const String &filter : enc_ex_filters_str.split(",")) {
+		String stripped_filter = filter.strip_edges();
+		if (!stripped_filter.is_empty()) {
+			enc_ex_filters.push_back(stripped_filter);
+		}
+	}
+
 	EditorExport::singleton->save_presets();
 }
 
-String EditorExportPreset::get_enc_ex_filter() const {
+String EditorExportPreset::get_enc_ex_filters_str() const {
+	return enc_ex_filters_str;
+}
+
+Vector<String> EditorExportPreset::get_enc_ex_filters() const {
 	return enc_ex_filters;
 }
 
@@ -564,11 +591,58 @@ bool EditorExportPreset::get_enc_directory() const {
 
 void EditorExportPreset::set_script_encryption_key(const String &p_key) {
 	script_key = p_key;
+	is_script_key_resolved = false;
 	EditorExport::singleton->save_presets();
 }
 
 String EditorExportPreset::get_script_encryption_key() const {
 	return script_key;
+}
+
+Vector<uint8_t> EditorExportPreset::resolve_script_encryption_key() {
+	if (is_script_key_resolved) {
+		return script_key_resolved;
+	}
+
+	String key;
+	const String from_env = OS::get_singleton()->get_environment(ENV_SCRIPT_ENCRYPTION_KEY);
+	if (!from_env.is_empty()) {
+		key = from_env.to_lower();
+	} else {
+		key = script_key.to_lower();
+	}
+
+	script_key_resolved.clear();
+	if (key.length() == 64) {
+		script_key_resolved.resize(32);
+		for (int i = 0; i < 32; i++) {
+			int v = 0;
+			if (i * 2 < key.length()) {
+				char32_t ct = key[i * 2];
+				if (is_digit(ct)) {
+					ct = ct - '0';
+				} else if (ct >= 'a' && ct <= 'f') {
+					ct = 10 + ct - 'a';
+				}
+				v |= ct << 4;
+			}
+
+			if (i * 2 + 1 < key.length()) {
+				char32_t ct = key[i * 2 + 1];
+				if (is_digit(ct)) {
+					ct = ct - '0';
+				} else if (ct >= 'a' && ct <= 'f') {
+					ct = 10 + ct - 'a';
+				}
+				v |= ct;
+			}
+			script_key_resolved.write[i] = v;
+		}
+	}
+
+	is_script_key_resolved = true;
+
+	return script_key_resolved;
 }
 
 void EditorExportPreset::set_script_export_mode(ScriptExportMode p_mode) {

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -92,13 +92,17 @@ private:
 
 	String custom_features;
 
-	String enc_in_filters;
-	String enc_ex_filters;
+	String enc_in_filters_str;
+	String enc_ex_filters_str;
+	Vector<String> enc_in_filters;
+	Vector<String> enc_ex_filters;
 	bool enc_pck = false;
 	bool enc_directory = false;
 	uint64_t seed = 0;
 
 	String script_key;
+	Vector<uint8_t> script_key_resolved;
+	bool is_script_key_resolved = false;
 	ScriptExportMode script_mode = MODE_SCRIPT_BINARY_TOKENS_COMPRESSED;
 
 protected:
@@ -190,11 +194,13 @@ public:
 	void set_export_path(const String &p_path);
 	String get_export_path() const;
 
-	void set_enc_in_filter(const String &p_filter);
-	String get_enc_in_filter() const;
+	void set_enc_in_filters_str(const String &p_filter);
+	String get_enc_in_filters_str() const;
+	Vector<String> get_enc_in_filters() const;
 
-	void set_enc_ex_filter(const String &p_filter);
-	String get_enc_ex_filter() const;
+	void set_enc_ex_filters_str(const String &p_filter);
+	String get_enc_ex_filters_str() const;
+	Vector<String> get_enc_ex_filters() const;
 
 	void set_seed(uint64_t p_seed);
 	uint64_t get_seed() const;
@@ -207,6 +213,7 @@ public:
 
 	void set_script_encryption_key(const String &p_key);
 	String get_script_encryption_key() const;
+	Vector<uint8_t> resolve_script_encryption_key();
 
 	void set_script_export_mode(ScriptExportMode p_mode);
 	ScriptExportMode get_script_export_mode() const;

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -421,8 +421,8 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		export_texture_format_error->hide();
 	}
 
-	String enc_in_filters_str = current->get_enc_in_filter();
-	String enc_ex_filters_str = current->get_enc_ex_filter();
+	String enc_in_filters_str = current->get_enc_in_filters_str();
+	String enc_ex_filters_str = current->get_enc_ex_filters_str();
 	if (!updating_enc_filters) {
 		enc_in_filters->set_text(enc_in_filters_str);
 		enc_ex_filters->set_text(enc_ex_filters_str);
@@ -658,8 +658,8 @@ void ProjectExportDialog::_enc_filters_changed(const String &p_filters) {
 	Ref<EditorExportPreset> current = get_current_preset();
 	ERR_FAIL_COND(current.is_null());
 
-	current->set_enc_in_filter(enc_in_filters->get_text());
-	current->set_enc_ex_filter(enc_ex_filters->get_text());
+	current->set_enc_in_filters_str(enc_in_filters->get_text());
+	current->set_enc_ex_filters_str(enc_ex_filters->get_text());
 
 	updating_enc_filters = true;
 	_update_current_preset();
@@ -807,8 +807,8 @@ void ProjectExportDialog::_duplicate_preset() {
 	preset->set_patch_delta_include_filter(current->get_patch_delta_include_filter());
 	preset->set_patch_delta_exclude_filter(current->get_patch_delta_exclude_filter());
 	preset->set_custom_features(current->get_custom_features());
-	preset->set_enc_in_filter(current->get_enc_in_filter());
-	preset->set_enc_ex_filter(current->get_enc_ex_filter());
+	preset->set_enc_in_filters_str(current->get_enc_in_filters_str());
+	preset->set_enc_ex_filters_str(current->get_enc_ex_filters_str());
 	preset->set_enc_pck(current->get_enc_pck());
 	preset->set_enc_directory(current->get_enc_directory());
 	preset->set_script_encryption_key(current->get_script_encryption_key());

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -801,14 +801,14 @@ Error EditorExportPlatformAndroid::save_apk_so(const Ref<EditorExportPreset> &p_
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 	APKExportData *ed = static_cast<APKExportData *>(p_userdata);
 
-	const String simplified_path = simplify_path(p_path);
+	const String simplified_path = EditorExportPlatform::simplify_path(p_info.path);
 
 	Vector<uint8_t> enc_data;
 	EditorExportPlatform::SavedData sd;
-	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd);
+	Error err = _store_temp_file(p_preset, simplified_path, p_data, enc_data, sd);
 	if (err != OK) {
 		return err;
 	}
@@ -822,7 +822,7 @@ Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+Error EditorExportPlatformAndroid::ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 	return OK;
 }
 
@@ -3536,33 +3536,7 @@ Error EditorExportPlatformAndroid::_generate_sparse_pck_metadata(const Ref<Edito
 
 	Vector<uint8_t> key;
 	if (p_preset->get_enc_pck() && p_preset->get_enc_directory()) {
-		String script_key = _get_script_encryption_key(p_preset);
-		key.resize(32);
-		if (script_key.length() == 64) {
-			for (int i = 0; i < 32; i++) {
-				int v = 0;
-				if (i * 2 < script_key.length()) {
-					char32_t ct = script_key[i * 2];
-					if (is_digit(ct)) {
-						ct = ct - '0';
-					} else if (ct >= 'a' && ct <= 'f') {
-						ct = 10 + ct - 'a';
-					}
-					v |= ct << 4;
-				}
-
-				if (i * 2 + 1 < script_key.length()) {
-					char32_t ct = script_key[i * 2 + 1];
-					if (is_digit(ct)) {
-						ct = ct - '0';
-					} else if (ct >= 'a' && ct <= 'f') {
-						ct = 10 + ct - 'a';
-					}
-					v |= ct;
-				}
-				key.write[i] = v;
-			}
-		}
+		key = _get_encryption_key(p_preset);
 	}
 
 	if (!EditorExportPlatform::_encrypt_and_store_directory(ftmp, p_pack_data, key, p_preset->get_seed(), 0)) {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -830,14 +830,14 @@ Error EditorExportPlatformAndroid::save_apk_so(const Ref<EditorExportPreset> &p_
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 	APKExportData *ed = static_cast<APKExportData *>(p_userdata);
 
-	const String simplified_path = simplify_path(p_path);
+	const String simplified_path = EditorExportPlatform::simplify_path(p_info.path);
 
 	Vector<uint8_t> enc_data;
 	EditorExportPlatform::SavedData sd;
-	RETURN_IF_ERROR(_store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd));
+	RETURN_IF_ERROR(_store_temp_file(p_preset, simplified_path, p_data, enc_data, sd));
 
 	String dst_path;
 	if (ed->pd.salt.length() == 32) {
@@ -853,7 +853,7 @@ Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &
 	return OK;
 }
 
-Error EditorExportPlatformAndroid::ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+Error EditorExportPlatformAndroid::ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 	return OK;
 }
 
@@ -3625,33 +3625,7 @@ Error EditorExportPlatformAndroid::_generate_sparse_pck_metadata(const Ref<Edito
 
 	Vector<uint8_t> key;
 	if (p_preset->get_enc_pck() && p_preset->get_enc_directory()) {
-		String script_key = _get_script_encryption_key(p_preset);
-		key.resize(32);
-		if (script_key.length() == 64) {
-			for (int i = 0; i < 32; i++) {
-				int v = 0;
-				if (i * 2 < script_key.length()) {
-					char32_t ct = script_key[i * 2];
-					if (is_digit(ct)) {
-						ct = ct - '0';
-					} else if (ct >= 'a' && ct <= 'f') {
-						ct = 10 + ct - 'a';
-					}
-					v |= ct << 4;
-				}
-
-				if (i * 2 + 1 < script_key.length()) {
-					char32_t ct = script_key[i * 2 + 1];
-					if (is_digit(ct)) {
-						ct = ct - '0';
-					} else if (ct >= 'a' && ct <= 'f') {
-						ct = 10 + ct - 'a';
-					}
-					v |= ct;
-				}
-				key.write[i] = v;
-			}
-		}
+		key = p_preset->resolve_script_encryption_key();
 	}
 
 	if (!EditorExportPlatform::_encrypt_and_store_directory(ftmp, p_pack_data, key, p_preset->get_seed(), 0)) {

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -153,9 +153,9 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	static Error save_apk_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
-	static Error save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
 
-	static Error ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
 
 	static Error copy_gradle_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
@@ -201,8 +201,6 @@ protected:
 	void _notification(int p_what);
 
 public:
-	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) const override;

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -159,9 +159,9 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	static Error save_apk_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
-	static Error save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error save_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
 
-	static Error ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+	static Error ignore_apk_file(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
 
 	static Error copy_gradle_so(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const SharedObject &p_so);
 
@@ -209,8 +209,6 @@ protected:
 	void _notification(int p_what);
 
 public:
-	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed);
-
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) const override;

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -165,19 +165,19 @@ Error store_string_at_path(const String &p_path, const String &p_data) {
 	return OK;
 }
 
-// Implementation of EditorExportSaveFunction.
+// Implementation of EditorExportPlatform::SaveFileFunction.
 // This method will only be called as an input to export_project_files.
 // It is used by the export_project_files method to save all the asset files into the gradle project.
 // It's functionality mirrors that of the method save_apk_file.
 // This method will be called ONLY when gradle build is enabled.
-Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const EditorExportPlatform::SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 	CustomExportData *export_data = static_cast<CustomExportData *>(p_userdata);
 
-	const String simplified_path = EditorExportPlatform::simplify_path(p_path);
+	const String simplified_path = EditorExportPlatform::simplify_path(p_info.path);
 
 	Vector<uint8_t> enc_data;
 	EditorExportPlatform::SavedData sd;
-	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd);
+	Error err = _store_temp_file(p_preset, simplified_path, p_data, enc_data, sd);
 	if (err != OK) {
 		return err;
 	}
@@ -398,7 +398,7 @@ String _get_application_tag(const Ref<EditorExportPlatform> &p_export_platform, 
 	return manifest_application_text;
 }
 
-Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd) {
+Error _store_temp_file(const Ref<EditorExportPreset> &p_preset, const String &p_simplified_path, const Vector<uint8_t> &p_data, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd) {
 	Error err = OK;
 	Ref<FileAccess> ftmp = FileAccess::create_temp(FileAccess::WRITE_READ, "export", "tmp", false, &err);
 	if (err != OK) {
@@ -407,8 +407,7 @@ Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p
 	r_sd.path_utf8 = p_simplified_path.trim_prefix("res://").utf8();
 	r_sd.ofs = 0;
 	r_sd.size = p_data.size();
-	r_sd.delta = p_delta;
-	err = EditorExportPlatform::_encrypt_and_store_data(ftmp, p_simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, r_sd.encrypted);
+	err = EditorExportPlatform::_encrypt_and_store_data(ftmp, p_preset, p_simplified_path, p_data, r_sd.encrypted);
 	if (err != OK) {
 		return err;
 	}

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -167,19 +167,19 @@ Error store_string_at_path(const String &p_path, const String &p_data) {
 	return OK;
 }
 
-// Implementation of EditorExportSaveFunction.
+// Implementation of EditorExportPlatform::SaveFileFunction.
 // This method will only be called as an input to export_project_files.
 // It is used by the export_project_files method to save all the asset files into the gradle project.
 // It's functionality mirrors that of the method save_apk_file.
 // This method will be called ONLY when gradle build is enabled.
-Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta) {
+Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const EditorExportPlatform::SaveFileInfo &p_info, const Vector<uint8_t> &p_data) {
 	CustomExportData *export_data = static_cast<CustomExportData *>(p_userdata);
 
-	const String simplified_path = EditorExportPlatform::simplify_path(p_path);
+	const String simplified_path = EditorExportPlatform::simplify_path(p_info.path);
 
 	Vector<uint8_t> enc_data;
 	EditorExportPlatform::SavedData sd;
-	RETURN_IF_ERROR(_store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd));
+	RETURN_IF_ERROR(_store_temp_file(p_preset, simplified_path, p_data, enc_data, sd));
 
 	String dst_path;
 	if (export_data->pd.salt.length() == 32) {
@@ -408,7 +408,7 @@ String _get_application_tag(const Ref<EditorExportPlatform> &p_export_platform, 
 	return manifest_application_text;
 }
 
-Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd) {
+Error _store_temp_file(const Ref<EditorExportPreset> &p_preset, const String &p_simplified_path, const Vector<uint8_t> &p_data, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd) {
 	Error err = OK;
 	Ref<FileAccess> ftmp = FileAccess::create_temp(FileAccess::WRITE_READ, "export", "tmp", false, &err);
 	if (err != OK) {
@@ -417,8 +417,7 @@ Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p
 	r_sd.path_utf8 = p_simplified_path.trim_prefix("res://").utf8();
 	r_sd.ofs = 0;
 	r_sd.size = p_data.size();
-	r_sd.delta = p_delta;
-	err = EditorExportPlatform::_encrypt_and_store_data(ftmp, p_simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, r_sd.encrypted);
+	err = EditorExportPlatform::_encrypt_and_store_data(ftmp, p_preset, p_simplified_path, p_data, r_sd.encrypted);
 	if (err != OK) {
 		return err;
 	}

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -85,7 +85,7 @@ int _get_app_category_value(int category_index);
 
 String _get_app_category_label(int category_index);
 
-Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd);
+Error _store_temp_file(const Ref<EditorExportPreset> &p_preset, const String &p_simplified_path, const Vector<uint8_t> &p_data, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd);
 
 // Utility method used to create a directory.
 Error create_directory(const String &p_dir);
@@ -98,12 +98,12 @@ Error store_file_at_path(const String &p_path, const Vector<uint8_t> &p_data);
 // Note: this will overwrite the file at p_path if it already exists.
 Error store_string_at_path(const String &p_path, const String &p_data);
 
-// Implementation of EditorExportSaveFunction.
+// Implementation of EditorExportPlatform::SaveFileFunction.
 // This method will only be called as an input to export_project_files.
 // It is used by the export_project_files method to save all the asset files into the gradle project.
 // It's functionality mirrors that of the method save_apk_file.
 // This method will be called ONLY when gradle build is enabled.
-Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const EditorExportPlatform::SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
 
 // Creates strings.xml files inside the gradle project for different locales.
 Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &p_project_name, const String &p_gradle_build_dir, const Dictionary &p_appnames);

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -80,7 +80,7 @@ int _get_app_category_value(int category_index);
 
 String _get_app_category_label(int category_index);
 
-Error _store_temp_file(const String &p_simplified_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd);
+Error _store_temp_file(const Ref<EditorExportPreset> &p_preset, const String &p_simplified_path, const Vector<uint8_t> &p_data, Vector<uint8_t> &r_enc_data, EditorExportPlatform::SavedData &r_sd);
 
 // Utility method used to create a directory.
 Error create_directory(const String &p_dir);
@@ -93,12 +93,12 @@ Error store_file_at_path(const String &p_path, const Vector<uint8_t> &p_data);
 // Note: this will overwrite the file at p_path if it already exists.
 Error store_string_at_path(const String &p_path, const String &p_data);
 
-// Implementation of EditorExportSaveFunction.
+// Implementation of EditorExportPlatform::SaveFileFunction.
 // This method will only be called as an input to export_project_files.
 // It is used by the export_project_files method to save all the asset files into the gradle project.
 // It's functionality mirrors that of the method save_apk_file.
 // This method will be called ONLY when gradle build is enabled.
-Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool p_delta);
+Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_preset, void *p_userdata, const EditorExportPlatform::SaveFileInfo &p_info, const Vector<uint8_t> &p_data);
 
 // Creates strings.xml files inside the gradle project for different locales.
 Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &p_project_name, const String &p_gradle_build_dir, const Dictionary &p_appnames);


### PR DESCRIPTION
`EditorExportSaveFunction`, as exposed by `EditorExportPlatform`, has slowly grown to accept more and more arguments, to the point of being unwieldy. Not only that, but since `EditorExportSaveFunction` is implemented all over the place you also end up with a lot of boilerplate whenever you do want to add anything new to `EditorExportSaveFunction`.

This pull request tries to resolve this by doing the following:

1. Introduce a new `EditorExportPlatform::SaveFileInfo` struct meant to hold anything that isn't the file data itself. This is similar to what's found in #87696.
2. Change the expected callback signature of `save_cb` in `EditorExportPlatform.export_project_files` to instead take the equivalent of `SaveFileInfo` as a `Dictionary`.
3. Stop passing encryption data through the export callbacks and instead fetch it through `EditorExportPreset`.
4. Added and bound a new `resolve_encryption_key` method to `EditorExportPreset`, which will convert either the preset key or the `GODOT_SCRIPT_ENCRYPTION_KEY` environment variable to a `PackedByteArray`. This is necessary since we no longer pass the binary encryption key to `save_cb`. I'm open to renaming this though.

I also took the liberty of including the following (mostly unrelated) changes:

1. Added a new `source_path` property to `EditorExportPlatform::SaveFileInfo`, to represent the source path, as opposed to the exported/remapped path. This will allow for things like #113240.
2. Renamed `EditorExportSaveFunction`, `EditorExportRemoveFunction` and `EditorExportSaveSharedObject` to `SaveFileFunction`, `RemoveFileFunction` and `SaveSharedObjectFunction` respectively, since the prefix seemed redundant given the type nesting.