### PR TITLE
Android Editor: Adjust script editor size for virtual keyboard

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -58,6 +58,7 @@
 #include "editor/gui/window_wrapper.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/run/editor_run_bar.h"
+#include "editor/scene/editor_scene_tabs.h"
 #include "editor/script/editor_script.h"
 #include "editor/script/find_in_files.h"
 #include "editor/settings/editor_command_palette.h"
@@ -1883,8 +1884,9 @@ void ScriptEditor::_notification(int p_what) {
 			last_kb_height = kb_height;
 			float spacer_height = 0.0f;
 			const float status_bar_height = 28 * EDSCALE; // Magic number
+			const bool kb_visible = kb_height > 0;
 
-			if (kb_height > 0) {
+			if (kb_visible) {
 				if (ScriptEditorBase *editor = _get_current_editor()) {
 					if (CodeTextEditor *code_editor = editor->get_code_editor()) {
 						if (CodeEdit *text_editor = code_editor->get_text_editor()) {
@@ -1906,6 +1908,8 @@ void ScriptEditor::_notification(int p_what) {
 			}
 
 			virtual_keyboard_spacer->set_custom_minimum_size(Size2(0, spacer_height));
+			EditorSceneTabs::get_singleton()->set_visible(!kb_height);
+			menu_hb->set_visible(!kb_visible);
 		} break;
 #endif
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1864,7 +1864,50 @@ void ScriptEditor::_notification(int p_what) {
 
 			EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &ScriptEditor::_editor_settings_changed));
 			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &ScriptEditor::_filesystem_changed));
+#ifdef ANDROID_ENABLED
+			set_process(true);
+#endif
 		} break;
+
+#ifdef ANDROID_ENABLED
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			set_process(is_visible_in_tree());
+		} break;
+
+		case NOTIFICATION_PROCESS: {
+			const int kb_height = DisplayServer::get_singleton()->virtual_keyboard_get_height();
+			if (kb_height == last_kb_height) {
+				break;
+			}
+
+			last_kb_height = kb_height;
+			float spacer_height = 0.0f;
+			const float status_bar_height = 28 * EDSCALE; // Magic number
+
+			if (kb_height > 0) {
+				if (ScriptEditorBase *editor = _get_current_editor()) {
+					if (CodeTextEditor *code_editor = editor->get_code_editor()) {
+						if (CodeEdit *text_editor = code_editor->get_text_editor()) {
+							if (!text_editor->has_focus()) {
+								break;
+							}
+							text_editor->adjust_viewport_to_caret();
+						}
+					}
+				}
+
+				const float control_bottom = get_global_position().y + get_size().y;
+				const float extra_bottom = get_viewport_rect().size.y - control_bottom;
+				spacer_height = float(kb_height) - extra_bottom - status_bar_height;
+
+				if (spacer_height < 0.0f) {
+					spacer_height = 0.0f;
+				}
+			}
+
+			virtual_keyboard_spacer->set_custom_minimum_size(Size2(0, spacer_height));
+		} break;
+#endif
 
 		case NOTIFICATION_EXIT_TREE: {
 			EditorRunBar::get_singleton()->disconnect("stop_pressed", callable_mp(this, &ScriptEditor::_editor_stop));
@@ -4186,6 +4229,12 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	script_split = memnew(HSplitContainer);
 	main_container->add_child(script_split);
 	script_split->set_v_size_flags(SIZE_EXPAND_FILL);
+
+#ifdef ANDROID_ENABLED
+	virtual_keyboard_spacer = memnew(Control);
+	virtual_keyboard_spacer->set_h_size_flags(SIZE_EXPAND_FILL);
+	main_container->add_child(virtual_keyboard_spacer);
+#endif
 
 	list_split = memnew(VSplitContainer);
 	script_split->add_child(list_split);

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -372,6 +372,11 @@ class ScriptEditor : public PanelContainer {
 
 	WindowWrapper *window_wrapper = nullptr;
 
+#ifdef ANDROID_ENABLED
+	Control *virtual_keyboard_spacer = nullptr;
+	int last_kb_height = -1;
+#endif
+
 	enum {
 		SCRIPT_EDITOR_FUNC_MAX = 32,
 	};


### PR DESCRIPTION
This PR improves the script editor experience on the Android Editor by automatically adjusting the script editor's height when the virtual keyboard appears. It also ensures that the line currently being edited remains visible.

While it's not much improvement on phones due to the limited vertical space, it would provide a significantly better editing experience on tablets

### Mobile
https://github.com/user-attachments/assets/d9b49921-4e17-496b-b1c5-537a752a71ec

### Tablet
[untitled.webm](https://github.com/user-attachments/assets/2ac7a7d0-db68-4e8a-9b5f-b1f6a015c7e0)

