### PR TITLE
Don't expose underscored signals

### DIFF
--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -660,6 +660,10 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 
 			if (signal_list.size()) {
 				for (const MethodInfo &mi : signal_list) {
+					if (mi.name.is_empty() || mi.name[0] == '_') {
+						continue; // Hidden, don't count.
+					}
+
 					DocData::MethodDoc signal;
 					signal.name = mi.name;
 					for (const PropertyInfo &arginfo : mi.arguments) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1290,6 +1290,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 							List<MethodInfo> signals;
 							scr->get_script_signal_list(&signals);
 							for (const MethodInfo &E : signals) {
+								if (E.name.begins_with("_")) {
+									continue;
+								}
 								int location = p_recursion_depth + _get_signal_location(scr, E.name);
 								ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_SIGNAL, location);
 								r_result.insert(option.display, option);
@@ -1383,6 +1386,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						List<MethodInfo> signals;
 						ClassDB::get_signal_list(type, &signals);
 						for (const MethodInfo &E : signals) {
+							if (E.name.begins_with("_")) {
+								continue;
+							}
 							int location = p_recursion_depth + _get_signal_location(type, StringName(E.name));
 							ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_SIGNAL, location);
 							r_result.insert(option.display, option);


### PR DESCRIPTION
Inspired by https://github.com/godotengine/godot/actions/runs/19370312655/job/55424339576?pr=102963

This PR makes signals starting with underscore no longer appear in the documentation (including script documentation), nor autocompletion, making them consistent with methods. Interestingly, we don't have any such signal in core, but I know a few cases that were worked around with `add_user_signal()`.