### PR TITLE
Ensure order is consistent when using both bind and unbind to connect signals

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -866,25 +866,21 @@ ConnectDialog::ConnectDialog() {
 	type_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	type_list->populate({ Variant::NIL, Variant::OBJECT });
 	add_bind_hb->add_child(type_list);
-	bind_controls.push_back(type_list);
 
 	Button *add_bind = memnew(Button);
 	add_bind->set_text(TTR("Add"));
 	add_bind_hb->add_child(add_bind);
 	add_bind->connect(SceneStringName(pressed), callable_mp(this, &ConnectDialog::_add_bind));
-	bind_controls.push_back(add_bind);
 
 	Button *del_bind = memnew(Button);
 	del_bind->set_text(TTR("Remove"));
 	add_bind_hb->add_child(del_bind);
 	del_bind->connect(SceneStringName(pressed), callable_mp(this, &ConnectDialog::_remove_bind));
-	bind_controls.push_back(del_bind);
 
 	vbc_right->add_margin_child(TTR("Add Extra Call Argument:"), add_bind_hb);
 
 	bind_editor = memnew(EditorInspector);
 	bind_editor->set_accessibility_name(TTRC("Extra Call Arguments:"));
-	bind_controls.push_back(bind_editor);
 
 	vbc_right->add_margin_child(TTR("Extra Call Arguments:"), bind_editor, true);
 
@@ -1663,9 +1659,6 @@ void ConnectionsDock::update_tree() {
 				if (cd.flags & CONNECT_APPEND_SOURCE_OBJECT) {
 					path += " (source)";
 				}
-				if (cd.unbinds > 0) {
-					path += " unbinds(" + itos(cd.unbinds) + ")";
-				}
 				if (!cd.binds.is_empty()) {
 					path += " binds(";
 					for (int i = 0; i < cd.binds.size(); i++) {
@@ -1675,6 +1668,9 @@ void ConnectionsDock::update_tree() {
 						path += cd.binds[i].operator String();
 					}
 					path += ")";
+				}
+				if (cd.unbinds > 0) {
+					path += " unbinds(" + itos(cd.unbinds) + ")";
 				}
 
 				TreeItem *connection_item = tree->create_item(signal_item);

--- a/editor/scene/connections_dialog.h
+++ b/editor/scene/connections_dialog.h
@@ -70,24 +70,27 @@ public:
 
 			Callable base_callable;
 			if (p_connection.callable.is_custom()) {
-				CallableCustomBind *ccb = dynamic_cast<CallableCustomBind *>(p_connection.callable.get_custom());
-				if (ccb) {
-					binds = ccb->get_binds();
-					unbinds = ccb->get_unbound_arguments_count();
+				CallableCustom *next_callable = p_connection.callable.get_custom();
 
-					base_callable = ccb->get_callable();
-				}
-
-				CallableCustomUnbind *ccu = dynamic_cast<CallableCustomUnbind *>(p_connection.callable.get_custom());
+				CallableCustomUnbind *ccu = dynamic_cast<CallableCustomUnbind *>(next_callable);
 				if (ccu) {
-					ccu->get_bound_arguments(binds);
 					unbinds = ccu->get_unbinds();
 					base_callable = ccu->get_callable();
+
+					if (base_callable.is_custom()) {
+						next_callable = base_callable.get_custom();
+					}
 				}
 
-				// The source object may already be bound, ignore it to prevent display of the source object.
-				if ((flags & CONNECT_APPEND_SOURCE_OBJECT) && (source == binds[0])) {
-					binds.remove_at(0);
+				CallableCustomBind *ccb = dynamic_cast<CallableCustomBind *>(next_callable);
+				if (ccb) {
+					binds = ccb->get_binds();
+					base_callable = ccb->get_callable();
+
+					// The source object may already be bound, ignore it to prevent display of the source object.
+					if ((flags & CONNECT_APPEND_SOURCE_OBJECT) && (source == binds[0])) {
+						binds.remove_at(0);
+					}
 				}
 			} else {
 				base_callable = p_connection.callable;
@@ -146,7 +149,6 @@ private:
 	CheckBox *one_shot = nullptr;
 	CheckBox *append_source = nullptr;
 	CheckButton *advanced = nullptr;
-	Vector<Control *> bind_controls;
 
 	Label *warning_label = nullptr;
 	Label *error_label = nullptr;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -663,8 +663,8 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 		}
 
 		Callable callable(cto, snames[c.method]);
-
 		Array binds;
+
 		if (c.flags & CONNECT_APPEND_SOURCE_OBJECT) {
 			binds.push_back(cfrom);
 		}
@@ -1175,24 +1175,27 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 			Callable base_callable;
 
 			if (c.callable.is_custom()) {
-				CallableCustomBind *ccb = dynamic_cast<CallableCustomBind *>(c.callable.get_custom());
-				if (ccb) {
-					binds = ccb->get_binds();
-					unbinds = ccb->get_unbound_arguments_count();
+				CallableCustom *next_callable = c.callable.get_custom();
 
-					base_callable = ccb->get_callable();
-				}
-
-				CallableCustomUnbind *ccu = dynamic_cast<CallableCustomUnbind *>(c.callable.get_custom());
+				CallableCustomUnbind *ccu = dynamic_cast<CallableCustomUnbind *>(next_callable);
 				if (ccu) {
-					ccu->get_bound_arguments(binds);
 					unbinds = ccu->get_unbinds();
 					base_callable = ccu->get_callable();
+
+					if (base_callable.is_custom()) {
+						next_callable = base_callable.get_custom();
+					}
 				}
 
-				// The source object may already be bound, ignore it to avoid saving the source object.
-				if ((c.flags & CONNECT_APPEND_SOURCE_OBJECT) && (p_node == binds[0])) {
-					binds.remove_at(0);
+				CallableCustomBind *ccb = dynamic_cast<CallableCustomBind *>(next_callable);
+				if (ccb) {
+					binds = ccb->get_binds();
+					base_callable = ccb->get_callable();
+
+					// The source object may already be bound, ignore it to avoid saving the source object.
+					if ((c.flags & CONNECT_APPEND_SOURCE_OBJECT) && (p_node == binds[0])) {
+						binds.remove_at(0);
+					}
 				}
 			} else {
 				base_callable = c.callable;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -2108,7 +2108,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			if (binds.size()) {
 				String vars;
 				VariantWriter::write_to_string(binds, vars, _write_resources, this, use_compat);
-				f->store_string(" binds= " + vars);
+				f->store_string(" binds=" + vars);
 			}
 
 			f->store_line("]");


### PR DESCRIPTION
This PR resolves the differences between #108741 and #100554. I have been using #100554 for about a year with no issues, let's hope the merge went ok here so that there's interesting comparison to be made.

Care was taken to ensure self-consistency in the ordering of arguments, please see this wonderful [comment](https://github.com/godotengine/godot/pull/98713#issuecomment-2451567279) for details.

@dalexeev: I have not looked at this code in some time, `get_bound_arguments` looks to do a lot now, can any of this traversal be simplified and compacted now? That aside, there are still some differences remaining worth examining.

I've quickly tested this with:
[unbind bind signal.zip](https://github.com/user-attachments/files/23553160/unbind.bind.signal.zip)
```
a 1 source=SourceNode arg=true
b 1 source=SourceNode arg=true

a 2 node=ChildNode source=SourceNode
b 2 node=ChildNode source=SourceNode

a 3
b 3

b 4 source=SourceNode arg=123
a 4 source=SourceNode arg=123

b 5 source=SourceNode
a 5 source=SourceNode
```
<sub>(a's and b's arguments/parameters should match)</sub>