### PR TITLE
Editor: Add indication to properties that have invalid values

### DIFF
--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -78,6 +78,8 @@ public:
 
 private:
 	ControlState control_state = CONTROL_STATE_DEFAULT;
+	double unbounded_value = 0.0;
+	bool valid = true;
 	bool flat = false;
 	bool editing_integer = false;
 
@@ -104,15 +106,22 @@ private:
 protected:
 	void _notification(int p_what);
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual void _value_changed(double p_value) override;
 	static void _bind_methods();
 	void _grabber_mouse_entered();
 	void _grabber_mouse_exited();
 	void _focus_entered(bool p_hide_focus = false);
 
 public:
+	void set_unbounded_value_no_signal(double p_val);
+	_FORCE_INLINE_ double get_unbounded_value() const { return unbounded_value; }
+
+	void set_valid(bool p_valid);
+	_FORCE_INLINE_ bool is_valid() const { return valid; }
+
 	String get_tooltip(const Point2 &p_pos) const override;
 
-	String get_text_value() const;
+	String get_text_value(bool p_unbounded = false) const;
 	void set_label(const String &p_label);
 	String get_label() const;
 

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -60,6 +60,54 @@
 #include "scene/resources/mesh.h"
 #include "scene/resources/visual_shader_nodes.h"
 
+static void _mark_invalid_value(Button *p_button) {
+	ERR_FAIL_NULL(p_button);
+
+	const Color error_color = p_button->get_theme_color("error_color", EditorStringName(Editor));
+	p_button->add_theme_color_override(SceneStringName(font_color), error_color);
+	p_button->add_theme_color_override("font_hover_color", error_color);
+	p_button->add_theme_color_override("font_hover_pressed_color", error_color);
+	p_button->add_theme_color_override("font_focus_color", error_color);
+	p_button->add_theme_color_override("font_pressed_color", error_color);
+	p_button->add_theme_color_override("font_disabled_color", error_color);
+}
+
+static void _unmark_invalid_value(Button *p_button) {
+	ERR_FAIL_NULL(p_button);
+
+	p_button->remove_theme_color_override(SceneStringName(font_color));
+	p_button->remove_theme_color_override("font_hover_color");
+	p_button->remove_theme_color_override("font_hover_pressed_color");
+	p_button->remove_theme_color_override("font_focus_color");
+	p_button->remove_theme_color_override("font_pressed_color");
+	p_button->remove_theme_color_override("font_disabled_color");
+}
+
+static void _validate_spin_slider_value(EditorSpinSlider *p_spin) {
+	ERR_FAIL_NULL(p_spin);
+
+	const double value = p_spin->get_unbounded_value();
+
+	if (Math::is_nan(value)) {
+		p_spin->set_valid(false);
+		return;
+	}
+
+	if (!p_spin->is_lesser_allowed() && value < p_spin->get_min()) {
+		p_spin->set_valid(false);
+		return;
+	}
+
+	if (!p_spin->is_greater_allowed() && value > p_spin->get_max()) {
+		p_spin->set_valid(false);
+		return;
+	}
+
+	// TODO: Check step?
+
+	p_spin->set_valid(true);
+}
+
 ///////////////////// NIL /////////////////////////
 
 void EditorPropertyNil::update_property() {
@@ -835,6 +883,8 @@ void EditorPropertyEnum::update_property() {
 	if (current.get_type() == Variant::NIL) {
 		options->select(-1);
 		options->set_text("<null>");
+		options->set_tooltip_text(TTR("The property value is not one of the enumerated values."));
+		_mark_invalid_value(options);
 		return;
 	}
 
@@ -842,11 +892,15 @@ void EditorPropertyEnum::update_property() {
 	for (int i = 0; i < options->get_item_count(); i++) {
 		if (which == (int64_t)options->get_item_metadata(i)) {
 			options->select(i);
+			options->set_tooltip_text(vformat("%s (%d)", options->get_item_text(i), which));
+			_unmark_invalid_value(options);
 			return;
 		}
 	}
 	options->select(-1);
 	options->set_text(itos(which));
+	options->set_tooltip_text(TTR("The property value is not one of the enumerated values."));
+	_mark_invalid_value(options);
 }
 
 void EditorPropertyEnum::setup(const Vector<String> &p_options) {
@@ -1462,13 +1516,14 @@ void EditorPropertyInteger::_value_changed(int64_t val) {
 
 void EditorPropertyInteger::update_property() {
 	int64_t val = get_edited_property_display_value();
-	spin->set_value_no_signal(val);
+	spin->set_unbounded_value_no_signal(val);
 #ifdef DEBUG_ENABLED
 	// If spin (currently EditorSplinSlider : Range) is changed so that it can use int64_t, then the below warning wouldn't be a problem.
 	if (val != (int64_t)(double)(val)) {
 		WARN_PRINT("Cannot reliably represent '" + itos(val) + "' in the inspector, value is too large.");
 	}
 #endif
+	_validate_spin_slider_value(spin);
 }
 
 void EditorPropertyInteger::setup(const EditorPropertyRangeHint &p_range_hint) {
@@ -1599,7 +1654,8 @@ void EditorPropertyFloat::update_property() {
 	if (radians_as_degrees) {
 		val = Math::rad_to_deg(val);
 	}
-	spin->set_value_no_signal(val);
+	spin->set_unbounded_value_no_signal(val);
+	_validate_spin_slider_value(spin);
 }
 
 void EditorPropertyFloat::setup(const EditorPropertyRangeHint &p_range_hint) {


### PR DESCRIPTION
* Fixes #75555.

Export annotations/hints allow you to impose restrictions on Inspector fields, making manual setting of certain values ​​impossible. However, you can still accidentally have invalid property values ​​(for example, if you forgot to initialize an `int` or `float` variable, and its range doesn't include `0` or `0.0`). The current behavior of the Inspector can be misleading, as it displays incorrect values.

```gdscript
@export_enum("A", "B", "C") var enum_1
@export_enum("A", "B", "C") var enum_2: int = 42

@export_range(10, 20, 1) var range_int_1: int = -100
@export_range(10, 20, 1) var range_int_2: int = +100

@export_range(1.0, 2.0, 0.1) var range_float_1: float = NAN
@export_range(1.0, 2.0, 0.1) var range_float_2: float = -INF
@export_range(1.0, 2.0, 0.1) var range_float_3: float = +INF
@export_range(1.0, 2.0, 0.1) var range_float_4: float = -10.0
@export_range(1.0, 2.0, 0.1) var range_float_5: float = +10.0
```

<img width="554" height="304" alt="" src="https://github.com/user-attachments/assets/0b5bc9de-b2ce-4407-b85b-2a9abe5d9a6b" />

See also:

* https://github.com/godotengine/godot-proposals/issues/10068
* https://github.com/godotengine/godot/pull/88354
* https://github.com/godotengine/godot/pull/105911
* https://github.com/godotengine/godot/pull/106019
