### PR TITLE
[4.5] [Android editor] Add support for Android XR devices to the Godot XR Editor

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -15,7 +15,7 @@ ext.versions = [
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
     ndkVersion         : '28.1.13356709',
     splashscreenVersion: '1.0.1',
-    openxrVendorsVersion: '4.1.1-stable'
+    openxrVendorsVersion: '4.2.0-stable',
 
 ]
 

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -192,6 +192,8 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation "org.bouncycastle:bcprov-jdk15to18:1.78"
 
+    // Android XR dependencies
+    androidImplementation "org.godotengine:godot-openxr-vendors-androidxr:$versions.openxrVendorsVersion"
     // Meta dependencies
     horizonosImplementation "org.godotengine:godot-openxr-vendors-meta:$versions.openxrVendorsVersion"
     // Pico dependencies

--- a/platform/android/java/editor/src/android/AndroidManifest.xml
+++ b/platform/android/java/editor/src/android/AndroidManifest.xml
@@ -1,0 +1,42 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-feature
+        android:name="android.software.xr.api.openxr"
+        android:required="false" />
+
+    <!-- 6dof motion controllers -->
+    <uses-feature android:name="android.hardware.xr.input.controller" android:required="false" />
+
+    <!-- Eye tracking -->
+    <uses-feature android:name="android.hardware.xr.input.eye_tracking" android:required="false" />
+    <uses-permission android:name="android.permission.EYE_TRACKING_FINE" />
+
+    <!-- Hand tracking -->
+    <uses-feature android:name="android.hardware.xr.input.hand_tracking" android:required="false" />
+    <uses-permission android:name="android.permission.HAND_TRACKING" />
+
+    <application>
+        <uses-native-library android:name="libopenxr.google.so" android:required="false" />
+
+        <property
+            android:name="android.window.PROPERTY_XR_BOUNDARY_TYPE_RECOMMENDED"
+            android:value="XR_BOUNDARY_TYPE_NO_RECOMMENDATION" />
+
+        <activity
+            android:name=".GodotXRGame"
+            android:exported="false"
+            tools:node="merge">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+            </intent-filter>
+            <property
+                android:name="android.window.PROPERTY_XR_ACTIVITY_START_MODE"
+                android:value="XR_ACTIVITY_START_MODE_FULL_SPACE_UNMANAGED" />
+        </activity>
+    </application>
+
+</manifest>

--- a/platform/android/java/editor/src/android/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/android/java/org/godotengine/editor/GodotEditor.kt
@@ -33,6 +33,16 @@ package org.godotengine.editor
 /**
  * Primary window of the Godot Editor.
  *
- * This is the implementation of the editor used when running on regular Android devices.
+ * This is the implementation of the editor used when running on Android devices.
  */
-open class GodotEditor : BaseGodotEditor()
+open class GodotEditor : BaseGodotEditor() {
+
+	override fun getXRRuntimePermissions(): MutableSet<String> {
+		val xrRuntimePermissions = super.getXRRuntimePermissions()
+
+		xrRuntimePermissions.add("android.permission.EYE_TRACKING_FINE")
+		xrRuntimePermissions.add("android.permission.HAND_TRACKING")
+
+		return xrRuntimePermissions
+	}
+}

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -110,6 +110,7 @@
             android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:process=":GodotXRGame"
             android:launchMode="singleTask"
+            android:taskAffinity=":xr"
             android:icon="@mipmap/ic_play_window"
             android:label="@string/godot_game_activity_name"
             android:exported="false"

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -68,11 +68,7 @@ import org.godotengine.godot.error.Error
 import org.godotengine.godot.utils.DialogUtils
 import org.godotengine.godot.utils.PermissionsUtil
 import org.godotengine.godot.utils.ProcessPhoenix
-import org.godotengine.godot.utils.isNativeXRDevice
-import org.godotengine.godot.xr.HybridMode
-import org.godotengine.godot.xr.getHybridAppLaunchMode
-import org.godotengine.godot.xr.HYBRID_APP_PANEL_CATEGORY
-import org.godotengine.godot.xr.HYBRID_APP_IMMERSIVE_CATEGORY
+import org.godotengine.openxr.vendors.utils.*
 import kotlin.math.min
 
 /**
@@ -712,12 +708,8 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 			return isNativeXRDevice(applicationContext)
 		}
 
-		if (featureTag == "horizonos") {
-			return BuildConfig.FLAVOR == "horizonos"
-		}
-
-		if (featureTag == "picoos") {
-			return BuildConfig.FLAVOR == "picoos"
+		if (featureTag == BuildConfig.FLAVOR) {
+			return true
 		}
 
         return super.supportsFeature(featureTag)

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
@@ -38,8 +38,7 @@ import org.godotengine.godot.GodotLib
 import org.godotengine.godot.editor.utils.GameMenuUtils
 import org.godotengine.godot.utils.PermissionsUtil
 import org.godotengine.godot.utils.ProcessPhoenix
-import org.godotengine.godot.xr.HYBRID_APP_FEATURE
-import org.godotengine.godot.xr.isHybridAppEnabled
+import org.godotengine.openxr.vendors.utils.*
 
 /**
  * Base class for the Godot play windows.

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
@@ -43,11 +43,8 @@ import org.godotengine.editor.embed.GameMenuFragment
 import org.godotengine.godot.GodotLib
 import org.godotengine.godot.editor.utils.GameMenuUtils
 import org.godotengine.godot.utils.ProcessPhoenix
-import org.godotengine.godot.utils.isHorizonOSDevice
-import org.godotengine.godot.utils.isNativeXRDevice
-import org.godotengine.godot.xr.HYBRID_APP_PANEL_FEATURE
 import org.godotengine.godot.xr.XRMode
-import org.godotengine.godot.xr.isHybridAppEnabled
+import org.godotengine.openxr.vendors.utils.*
 
 /**
  * Drives the 'run project' window of the Godot Editor.


### PR DESCRIPTION
In [collaboration with W4 Games and Google](https://www.w4games.com/blog/w4-games-news-1/w4-games-works-with-the-androidxr-team-and-the-godot-foundation-to-improve-godots-android-xr-support-123), this PR adds Android XR support to the [Godot XR editor](https://play.google.com/store/apps/details?id=org.godotengine.editor.v4).

This is the 4.5 backport of https://github.com/godotengine/godot/pull/112777

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
