### PR TITLE
iOS: Fix loading of xcframework dynamic libraries.

### DIFF
--- a/core/extension/gdextension_library_loader.h
+++ b/core/extension/gdextension_library_loader.h
@@ -49,8 +49,6 @@ private:
 	String library_path;
 	String entry_symbol;
 
-	bool is_static_library = false;
-
 #ifdef TOOLS_ENABLED
 	bool is_reloadable = false;
 #endif


### PR DESCRIPTION
The logic used to determine whether to invoke the in-memory registration or to
delegate the loading of a library is incorrect for xcframework packages - as
these can contain either static or dynamic libraries.  

This change instead lets the operating system handle the library request, and if
it fails, it attempts to load from the internal registry.

With this change, xcframeworks containing dynamic libraries work without
workarounds on iOS.

This fixes https://github.com/godotengine/godot/issues/112783
