### PR TITLE
Use American spelling of "favorite" in Project Manager code for consistency

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -70,7 +70,7 @@ void ProjectListItemControl::_notification(int p_what) {
 
 			favorite_focus_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 			_update_favorite_button_focus_color();
-			if (is_favourite) {
+			if (is_favorite) {
 				favorite_button->set_texture_normal(get_editor_theme_icon(SNAME("Favorites")));
 			} else {
 				favorite_button->set_texture_normal(get_editor_theme_icon(SNAME("Unfavorite")));
@@ -303,7 +303,7 @@ void ProjectListItemControl::set_selected(bool p_selected) {
 }
 
 void ProjectListItemControl::set_is_favorite(bool p_favorite) {
-	is_favourite = p_favorite;
+	is_favorite = p_favorite;
 	if (p_favorite) {
 		favorite_button->set_texture_normal(get_editor_theme_icon(SNAME("Favorites")));
 	} else {
@@ -965,7 +965,7 @@ int ProjectList::refresh_project(const String &dir_path) {
 	// If it is in the list but doesn't exist anymore, it is marked as missing.
 
 	bool should_be_in_list = _config.has_section(dir_path);
-	bool is_favourite = _config.get_value(dir_path, "favorite", false);
+	bool is_favorite = _config.get_value(dir_path, "favorite", false);
 
 	bool was_selected = _selected_project_paths.has(dir_path);
 
@@ -982,7 +982,7 @@ int ProjectList::refresh_project(const String &dir_path) {
 	if (should_be_in_list) {
 		// Recreate it with updated info
 
-		Item item = load_project_data(dir_path, is_favourite);
+		Item item = load_project_data(dir_path, is_favorite);
 
 		_projects.push_back(item);
 		_create_project_item_control(_projects.size() - 1);

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -65,7 +65,7 @@ class ProjectListItemControl : public HBoxContainer {
 	bool icon_needs_reload = true;
 	bool is_selected = false;
 	bool is_hovering = false;
-	bool is_favourite = false;
+	bool is_favorite = false;
 
 	void _update_favorite_button_focus_color();
 	void _favorite_button_pressed();


### PR DESCRIPTION
A recent PR for improving the Project Manager introduced a variable `is_favourite`. This PR just changes the name of that variable to be consistent with the rest of the codebase, which uses the American spelling "favorite".
