### PR TITLE
Fix `TileMapLayer` transformations for `Node2D` scene tiles

### DIFF
--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -492,7 +492,7 @@ private:
 #ifdef DEBUG_ENABLED
 	void _scenes_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data);
 #endif // DEBUG_ENABLED
-	void _set_scene_transformed_alternative(const int p_alternative_id, Node2D *p_scene);
+	void _set_scene_transform_with_alternative(Node2D *p_scene, const Vector2 &p_cell_position, const int p_alternative_id);
 
 	// Terrains.
 	TileSet::TerrainsPattern _get_best_terrain_pattern_for_constraints(int p_terrain_set, const Vector2i &p_position, const RBSet<TerrainConstraint> &p_constraints, TileSet::TerrainsPattern p_current_pattern) const;


### PR DESCRIPTION
Noticed #108010 got merged, but it's completely broken as https://github.com/godotengine/godot/pull/108010#discussion_r2182325781 was never addressed, the scale is still being added. 🙃

While at it I've changed it to:
- Not rely on changing rotation, which is not precise (regardless whether using degrees/radians), contrary to directly applying flips/transpose to basis axes.
- Apply whole cell transform at once, including the cell position.

---

Note that currently placing a scene tile with non-default transform flags will throw an error, as tranforms flags are not ignored from the id here:
https://github.com/godotengine/godot/blob/ef34c3d534a16b140aef0643ed2fa36f8e9d1612/scene/resources/2d/tile_set.cpp#L5852-L5855

But seems it needs to be handled properly in few other places as well. Leaving it for another PR, should be probably resolved at once with #112175.