### PR TITLE
Fix bottom panel not being able to resize on startup

### DIFF
--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -52,8 +52,8 @@ void EditorBottomPanel::_notification(int p_what) {
 }
 
 void EditorBottomPanel::_on_tab_changed(int p_idx) {
-	callable_mp(this, &EditorBottomPanel::_update_center_split_offset).call_deferred();
-	callable_mp(this, &EditorBottomPanel::_repaint).call_deferred();
+	_update_center_split_offset();
+	_repaint();
 }
 
 void EditorBottomPanel::_theme_changed() {
@@ -90,7 +90,7 @@ int EditorBottomPanel::get_bottom_panel_offset() {
 
 void EditorBottomPanel::_repaint() {
 	bool panel_collapsed = get_current_tab() == -1;
-	if (panel_collapsed == (get_previous_tab() == -1)) {
+	if (!panel_collapsed && (get_previous_tab() != -1)) {
 		return;
 	}
 


### PR DESCRIPTION
Closes #112780
Closes #112549 
Supersedes #112740

Fixes an issue with the repainting logic that caused it to not be updated on startup. Since the calls to repaint were deferred, they were called when the early exit logic skipped the execution, so when they were meant to update, they didn't.

The root cause of the issue was the `TileSet` and `TileMap` bottom panels being made visible in the same frame, so when the deferred call to `_repaint` got called a frame later, the early exit logic in `_repaint` thought that the bottom panel was up to date, so it didn't update it to the necessary values (ie the resizing bar).

This also means that anytime the editor started up with those two docks available, this issue would occur and not properly update the bottom panel.