### PR TITLE
Fix gamepad detection being too picky on Linux

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -361,7 +361,7 @@ void JoypadLinux::open_joypad(const char *p_path) {
 		// Check if the device supports basic gamepad events
 		bool has_abs_left = (test_bit(ABS_X, absbit) && test_bit(ABS_Y, absbit));
 		bool has_abs_right = (test_bit(ABS_RX, absbit) && test_bit(ABS_RY, absbit));
-		if (!(test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) && (has_abs_left || has_abs_right))) {
+		if (!((test_bit(EV_KEY, evbit) || (test_bit(EV_ABS, evbit) && (has_abs_left || has_abs_right))) && test_bit(BTN_GAMEPAD, keybit))) {
 			close(fd);
 			return;
 		}


### PR DESCRIPTION
I am porting a Godot 4.4 game to two linux handhelds, all with face buttons, shoulder buttons, and a d-pad, but only one of those has analog sticks (axes). While one of the handhelds was detected fine, the (otherwise completely identical) one without sticks wasn't providing inputs or being returned by `get_connected_joypads().` I changed the line responsible to assume an input device is a gamepad if it has buttons OR sticks as opposed to both of those. At that point the volume buttons were also treated as a gamepad so I added the check from #94776. This may or may not make #93352 obsolete.

I made this PR to the best of my ability but I probably still made a mistake somewhere. Sorry.
