### PR TITLE
Reorganize canvas shader varyings in RD renderer

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1840,7 +1840,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		actions.base_uniform_string = "material.";
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR;
 		actions.default_repeat = ShaderLanguage::REPEAT_DISABLE;
-		actions.base_varying_index = 5;
+		actions.base_varying_index = 8;
 
 		actions.global_buffer_array_variable = "global_shader_uniforms.data";
 		actions.instance_uniform_index_variable = "read_draw_data_instance_offset";


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/112799

Regression from https://github.com/godotengine/godot/pull/112481

The simple fix was to increase the value of `actions.base_varying_index` to `1 + ` whatever the highest varying index is in the shader. However, in doing so, I set it to 10, which struck me as way too high. We should not be using up ten varying slots in our internal shader. Some hardware is limited to 16 total, so us reserving 10 for our own use is a bit extreme. 

I took a look at our current varying usage and was able to clean it up a bit and free up two extra slots. With more extreme optimizations, we could potentially free up 1-2 more as well. But I figured this was enough for now. 

In addition to freeing up more varying slots for our users, this PR also may improve performance on some Adreno devices