### PR TITLE
Apply `PREMUL_ALPHA_FACTOR` only in non-split-specular shader variants.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2909,6 +2909,10 @@ void fragment_shader(in SceneData scene_data) {
 	frag_color.rgb = frag_color.rgb * fog.a + fog.rgb;
 #endif //!FOG_DISABLED
 
+#if defined(PREMUL_ALPHA_USED) && !defined(MODE_RENDER_DEPTH)
+	frag_color.rgb *= premul_alpha;
+#endif //PREMUL_ALPHA_USED
+
 #endif //MODE_SEPARATE_SPECULAR
 
 #endif //MODE_RENDER_DEPTH
@@ -2921,10 +2925,6 @@ void fragment_shader(in SceneData scene_data) {
 
 	motion_vector = prev_position_uv - position_uv;
 #endif
-
-#if defined(PREMUL_ALPHA_USED) && !defined(MODE_RENDER_DEPTH)
-	frag_color.rgb *= premul_alpha;
-#endif //PREMUL_ALPHA_USED
 }
 
 void main() {


### PR DESCRIPTION
Fixes the shader compile error reported here: https://github.com/godotengine/godot/issues/112794#issuecomment-3536124981

This avoids a shader compile error when using SSS and PREMUL_ALPHA_FACTOR in the same shader.

This doesn't change any functionaility, since in practive, the split-specular shader variant is only ever used for opaque objects while using premul alpha makes the object non-opaque
