### PR TITLE
[3.x] `BlobShadows` - Ensure blob shadow is hidden when light exits tree

### DIFF
--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -293,6 +293,11 @@ void Light::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_update_visibility();
 		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			if (blob_light.is_valid()) {
+				VS::get_singleton()->blob_light_set_visible(blob_light, false);
+			}
+		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (blob_light.is_valid() && is_visible_in_tree() && !is_physics_interpolated_and_enabled()) {


### PR DESCRIPTION
Fixes bug reported on discord:
When you delete a light with a blob shadow in the editor, the blob shadow remains even after the light is "deleted".
The reason is that light is not truly deleted, it is kept in the undo-redo queue, so the blob shadow never gets deleted (until the scene is closed).

## Solution
The obvious solution is to either delete or hide the blob shadow on exiting the tree, and indeed this is in retrospect better than relying on the light lifetime, as users can detach lights without deleting them.

Here I've chosen the simple solution, to always hide the blob shadow on tree exit. It should be more performant for cases of detaching then reattaching lights, and it makes handling the blob shadow lifetime easier (as it is tied to the light).

## Notes
* I'm not quite sure offhand how the light itself gets hidden on exiting the tree, but no matter, the method in this PR should work well.
* This is quite a nasty bug for real world cases so worth solving. Currently, in games, users would have to ensure lights they are removing from the tree are also deleted.
* I hadn't seen this during development probably because of lack of environmental lighting in test cases, and it doesn't crop up much outside the editor.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
