### PR TITLE
`FTI` - `Camera2D` accepts resets only after entering tree

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -307,10 +307,12 @@ void Camera2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			// Force the limits etc. to update.
-			_interpolation_data.xform_curr = get_camera_transform();
-			_interpolation_data.xform_prev = _interpolation_data.xform_curr;
-			_update_process_callback();
+			if (_interpolation_data.accepting_resets) {
+				// Force the limits etc. to update.
+				_interpolation_data.xform_curr = get_camera_transform();
+				_interpolation_data.xform_prev = _interpolation_data.xform_curr;
+				_update_process_callback();
+			}
 		} break;
 
 		case NOTIFICATION_SUSPENDED:
@@ -365,6 +367,8 @@ void Camera2D::_notification(int p_what) {
 				_interpolation_data.xform_curr = get_camera_transform();
 				_interpolation_data.xform_prev = _interpolation_data.xform_curr;
 			}
+
+			_interpolation_data.accepting_resets = true;
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -375,6 +379,7 @@ void Camera2D::_notification(int p_what) {
 			}
 			viewport = nullptr;
 			just_exited_tree = true;
+			_interpolation_data.accepting_resets = false;
 			callable_mp(this, &Camera2D::_reset_just_exited).call_deferred();
 		} break;
 

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -108,6 +108,10 @@ protected:
 		Transform2D xform_curr;
 		Transform2D xform_prev;
 		uint32_t last_update_physics_tick = UINT32_MAX; // Ensure tick 0 is detected as a change.
+
+		// Camera2D can only call get_camera_transform() without flagging warnings after setting up viewports
+		// during NOTIFICATION_ENTER_TREE, so we reject resets outside this lifetime.
+		bool accepting_resets = false;
 	} _interpolation_data;
 
 	void _ensure_update_interpolation_data();


### PR DESCRIPTION
Fixes #112689

#111384 introduced a warning when calling `Camera2D::get_camera_transform()` before the camera viewports had been set up in `NOTIFICATION_ENTER_TREE`.

This flagged a benign warning when using physics interpolation on `Camera2D`, because it inherits a standard reset from `CanvasItem` which is called before `Camera2D` `NOTIFICATION_ENTER_TREE`.

Here we use a simple approach to fix the warning, by adding a state flag of whether to accept resets, and set to true after setup, and set to false when exiting the tree.

## Notes
* There's a number of ways of fixing this - we could alternatively just not spam the warning introduced in #111384. Although it's fairly easy to workaround here, and it is possible the warning might catch bugs.
* The post-warning and the previous version both work fine, as there is a secondary manual reset performed in `Camera2D` at the end of `NOTIFICATION_ENTER_TREE` (and a comment to that effect), so this warning is purely cosmetic.
* Not necessary in 3.x as we don't have the warning.

## Discussion
As noted in the issue, this is caused by the `CanvasItem` `NOTIFICATION_ENTER_TREE` being called _before_ the `Camera2D`, so the resets can't depend on any state set up in derived classes, which isn't ideal, but thus far this hasn't been a significant problem - most classes xforms are up to date by this point.

An alternative we sometimes use is to _defer_ resets, but this has the potential to cause knock on bugs particularly with moving and standing starts with manual resets from script, so on balance it would be nice to avoid this bug potential and keep a local solution, at least for now. If we get any later similar issues we can re-evaluate this.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
