### PR TITLE
Fix incorrect alignment padding calculation for PCK header in embedded export

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -2048,7 +2048,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 		}
 
 		// Ensure embedded PCK starts at a 64-bit multiple
-		int pad = f->get_position() % 8;
+		int pad = _get_pad(8, f->get_position());
 		for (int i = 0; i < pad; i++) {
 			f->store_8(0);
 		}
@@ -2142,7 +2142,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 	if (p_embed) {
 		// Ensure embedded data ends at a 64-bit multiple.
 		uint64_t embed_end = f->get_position() - embed_pos + 12;
-		uint64_t pad = embed_end % 8;
+		uint64_t pad = _get_pad(8, embed_end);
 		for (uint64_t i = 0; i < pad; i++) {
 			f->store_8(0);
 		}


### PR DESCRIPTION
Fixed #112812

The PCK header alignment padding calculation in EditorExportPlatform::save_pack() is incorrect.

The current code calculates the padding as position % 8, which is wrong. For example:

If position = 10, then 10 % 8 = 2
The code fills 2 bytes, making position = 12
But 12 is not aligned to 8 bytes)
The correct padding should be (8 - (position % 8)) % 8, which would fill 6 bytes to reach position 16.

This bug causes embedded PCK header to potentially start at misaligned positions.

In fact, we should use the _get_pad function to calculate the alignment bytes.
`
int pad = _get_pad(8, f->get_position());
for (int i = 0; i < pad; i++) {
	f->store_8(0);
}
`
