### PR TITLE
Fix `GodotProfileZone` with tracy backend failing with shadowed variable name warnings

### DIFF
--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -51,7 +51,7 @@
 
 // Define tracing macros.
 #define GodotProfileFrameMark FrameMark
-#define GodotProfileZone(m_zone_name) ZoneScopedN(m_zone_name)
+#define GodotProfileZone(m_zone_name) ZoneNamedN(GD_UNIQUE_NAME(__godot_tracy_szone_), m_zone_name, true)
 #define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name) ZoneNamedN(__godot_tracy_zone_##m_group_name, m_zone_name, true)
 #define GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name) __godot_tracy_zone_##m_group_name.~ScopedZone();
 #ifndef TRACY_CALLSTACK

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -465,3 +465,8 @@ constexpr bool is_fully_defined_v = is_fully_defined<T>::value;
 #else
 #define STATIC_ASSERT_INCOMPLETE_TYPE(m_keyword, m_type)
 #endif
+
+#define _GD_VARNAME_CONCAT_B_(m_ignore, m_name) m_name
+#define _GD_VARNAME_CONCAT_A_(m_a, m_b, m_c) _GD_VARNAME_CONCAT_B_(hello there, m_a##m_b##m_c)
+#define _GD_VARNAME_CONCAT_(m_a, m_b, m_c) _GD_VARNAME_CONCAT_A_(m_a, m_b, m_c)
+#define GD_UNIQUE_NAME(m_name) _GD_VARNAME_CONCAT_(m_name, _, __COUNTER__)

--- a/modules/mono/utils/macros.h
+++ b/modules/mono/utils/macros.h
@@ -30,10 +30,7 @@
 
 #pragma once
 
-#define _GD_VARNAME_CONCAT_B_(m_ignore, m_name) m_name
-#define _GD_VARNAME_CONCAT_A_(m_a, m_b, m_c) _GD_VARNAME_CONCAT_B_(hello there, m_a##m_b##m_c)
-#define _GD_VARNAME_CONCAT_(m_a, m_b, m_c) _GD_VARNAME_CONCAT_A_(m_a, m_b, m_c)
-#define GD_UNIQUE_NAME(m_name) _GD_VARNAME_CONCAT_(m_name, _, __COUNTER__)
+#include "core/typedefs.h"
 
 // unreachable
 


### PR DESCRIPTION
Reported by @deralmas on RocketChat

When building with `profiler_path` set to tracy, in some configurations, compilation may fail with variable name shadowing warnings.
This is technically a tracy problem, which isn't yet fixed.

The solution involves stealing `GD_UNIQUE_NAME` from the mono module, to give each zone its unique name automatically.
We have confirmed that this fixes the issue for @deralmas.