### PR TITLE
Don't save editor settings on startup

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1437,10 +1437,12 @@ void ProjectList::add_search_tag(const String &p_tag) {
 	sort_projects();
 }
 
-void ProjectList::set_order_option(int p_option) {
+void ProjectList::set_order_option(int p_option, bool p_save) {
 	FilterOption selected = (FilterOption)p_option;
-	EditorSettings::get_singleton()->set("project_manager/sorting_order", p_option);
-	EditorSettings::get_singleton()->save();
+	if (p_save) {
+		EditorSettings::get_singleton()->set("project_manager/sorting_order", p_option);
+		EditorSettings::get_singleton()->save();
+	}
 	_order_option = selected;
 
 	sort_projects();

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -323,7 +323,7 @@ public:
 
 	void set_search_term(String p_search_term);
 	void add_search_tag(const String &p_tag);
-	void set_order_option(int p_option);
+	void set_order_option(int p_option, bool p_save);
 
 	// Global menu integration.
 

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -98,7 +98,7 @@ void ProjectManager::_notification(int p_what) {
 			DisplayServer::get_singleton()->screen_set_keep_on(EDITOR_GET("interface/editor/keep_screen_on"));
 			const int default_sorting = (int)EDITOR_GET("project_manager/sorting_order");
 			filter_option->select(default_sorting);
-			project_list->set_order_option(default_sorting);
+			project_list->set_order_option(default_sorting, false);
 
 			_select_main_view(MAIN_VIEW_PROJECTS);
 			_update_list_placeholder();
@@ -964,7 +964,7 @@ void ProjectManager::_on_project_duplicated(const String &p_original_path, const
 
 void ProjectManager::_on_order_option_changed(int p_idx) {
 	if (is_inside_tree()) {
-		project_list->set_order_option(p_idx);
+		project_list->set_order_option(p_idx, true);
 	}
 }
 


### PR DESCRIPTION
Fix: Project Manager loads project sorting and sets it in a way that saves settings for no reason.