### PR TITLE
Add scene import and export methods to GLTFDocumentExtension

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocumentExtension.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtension.xml
@@ -29,7 +29,7 @@
 			<param index="2" name="json" type="Dictionary" />
 			<param index="3" name="node" type="Node" />
 			<description>
-				Part of the export process. This method is run after [method _get_saveable_image_formats] and before [method _export_post]. If this [GLTFDocumentExtension] is used for exporting images, this runs after [method _serialize_texture_json].
+				Part of the export process. This method is run after [method _get_saveable_image_formats] and before [method _export_scene]. If this [GLTFDocumentExtension] is used for exporting images, this runs after [method _serialize_texture_json].
 				This method can be used to modify the final JSON of each node. Data should be primarily stored in [param gltf_node] prior to serializing the JSON, but the original Godot [Node] is also provided if available. [param node] may be [code]null[/code] if not available, such as when exporting glTF data not generated from a Godot scene.
 			</description>
 		</method>
@@ -79,6 +79,15 @@
 			<description>
 				Part of the export process. This method is run after [method _export_post_convert] and before [method _get_saveable_image_formats].
 				This method can be used to alter the state before performing serialization. It runs every time when generating a buffer with [method GLTFDocument.generate_buffer] or writing to the file system with [method GLTFDocument.write_to_filesystem].
+			</description>
+		</method>
+		<method name="_export_scene" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="state" type="GLTFState" />
+			<param index="1" name="json" type="Dictionary" />
+			<description>
+				Part of the export process. This method is run after [method _export_node] and before [method _export_post].
+				This method can be used to modify the final JSON of the scene, such as adding extensions to the scene. Data should be primarily stored in [param state] prior to serializing the JSON.
 			</description>
 		</method>
 		<method name="_generate_scene_node" qualifiers="virtual">
@@ -185,8 +194,17 @@
 			<param index="1" name="gltf_node" type="GLTFNode" />
 			<param index="2" name="extensions" type="Dictionary" />
 			<description>
-				Part of the import process. This method is run after [method _get_supported_extensions] and before [method _import_post_parse].
+				Part of the import process. This method is run after [method _parse_scene_extensions] and before [method _import_post_parse].
 				Runs when parsing the node extensions of a GLTFNode. This method can be used to process the extension JSON data into a format that can be used by [method _generate_scene_node]. The return value should be a member of the [enum Error] enum.
+			</description>
+		</method>
+		<method name="_parse_scene_extensions" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="state" type="GLTFState" />
+			<param index="1" name="extensions" type="Dictionary" />
+			<description>
+				Part of the import process. This method is run after [method _get_supported_extensions] and before [method _parse_node_extensions].
+				Runs when parsing the scene extensions of the GLTFState. This method can be used to process the extension JSON data into a format that can be used by later stages in the import process. The return value should be a member of the [enum Error] enum.
 			</description>
 		</method>
 		<method name="_parse_texture_json" qualifiers="virtual">

--- a/modules/gltf/extensions/gltf_document_extension.cpp
+++ b/modules/gltf/extensions/gltf_document_extension.cpp
@@ -34,6 +34,7 @@ void GLTFDocumentExtension::_bind_methods() {
 	// Import process.
 	GDVIRTUAL_BIND(_import_preflight, "state", "extensions");
 	GDVIRTUAL_BIND(_get_supported_extensions);
+	GDVIRTUAL_BIND(_parse_scene_extensions, "state", "extensions");
 	GDVIRTUAL_BIND(_parse_node_extensions, "state", "gltf_node", "extensions");
 	GDVIRTUAL_BIND(_parse_image_data, "state", "image_data", "mime_type", "ret_image");
 	GDVIRTUAL_BIND(_get_image_file_extension);
@@ -55,6 +56,7 @@ void GLTFDocumentExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_save_image_at_path, "state", "image", "file_path", "image_format", "lossy_quality");
 	GDVIRTUAL_BIND(_serialize_texture_json, "state", "texture_json", "gltf_texture", "image_format");
 	GDVIRTUAL_BIND(_export_node, "state", "gltf_node", "json", "node");
+	GDVIRTUAL_BIND(_export_scene, "state", "json");
 	GDVIRTUAL_BIND(_export_post, "state");
 }
 
@@ -70,6 +72,13 @@ Vector<String> GLTFDocumentExtension::get_supported_extensions() {
 	Vector<String> ret;
 	GDVIRTUAL_CALL(_get_supported_extensions, ret);
 	return ret;
+}
+
+Error GLTFDocumentExtension::parse_scene_extensions(Ref<GLTFState> p_state, const Dictionary &p_extensions) {
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	Error err = OK;
+	GDVIRTUAL_CALL(_parse_scene_extensions, p_state, Dictionary(p_extensions), err);
+	return err;
 }
 
 Error GLTFDocumentExtension::parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions) {
@@ -222,6 +231,13 @@ Error GLTFDocumentExtension::export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p
 	ERR_FAIL_COND_V(p_gltf_node.is_null(), ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_export_node, p_state, p_gltf_node, Dictionary(r_dict), p_node, err);
+	return err;
+}
+
+Error GLTFDocumentExtension::export_scene(Ref<GLTFState> p_state, Dictionary &r_json) {
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	Error err = OK;
+	GDVIRTUAL_CALL(_export_scene, p_state, Dictionary(r_json), err);
 	return err;
 }
 

--- a/modules/gltf/extensions/gltf_document_extension.h
+++ b/modules/gltf/extensions/gltf_document_extension.h
@@ -44,6 +44,7 @@ public:
 	// Import process.
 	virtual Error import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions);
 	virtual Vector<String> get_supported_extensions();
+	virtual Error parse_scene_extensions(Ref<GLTFState> p_state, const Dictionary &p_extensions);
 	virtual Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions);
 	virtual Error parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image);
 	virtual String get_image_file_extension();
@@ -65,11 +66,13 @@ public:
 	virtual Error save_image_at_path(Ref<GLTFState> p_state, Ref<Image> p_image, const String &p_file_path, const String &p_image_format, float p_lossy_quality);
 	virtual Error serialize_texture_json(Ref<GLTFState> p_state, Dictionary &r_texture_json, Ref<GLTFTexture> p_gltf_texture, const String &p_image_format);
 	virtual Error export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node);
+	virtual Error export_scene(Ref<GLTFState> p_state, Dictionary &r_json);
 	virtual Error export_post(Ref<GLTFState> p_state);
 
 	// Import process.
 	GDVIRTUAL2R(Error, _import_preflight, Ref<GLTFState>, Vector<String>);
 	GDVIRTUAL0R(Vector<String>, _get_supported_extensions);
+	GDVIRTUAL2R(Error, _parse_scene_extensions, Ref<GLTFState>, Dictionary);
 	GDVIRTUAL3R(Error, _parse_node_extensions, Ref<GLTFState>, Ref<GLTFNode>, Dictionary);
 	GDVIRTUAL4R(Error, _parse_image_data, Ref<GLTFState>, PackedByteArray, String, Ref<Image>);
 	GDVIRTUAL0R(String, _get_image_file_extension);
@@ -91,5 +94,6 @@ public:
 	GDVIRTUAL5R(Error, _save_image_at_path, Ref<GLTFState>, Ref<Image>, String, String, float);
 	GDVIRTUAL4R(Error, _serialize_texture_json, Ref<GLTFState>, Dictionary, Ref<GLTFTexture>, String);
 	GDVIRTUAL4R(Error, _export_node, Ref<GLTFState>, Ref<GLTFNode>, Dictionary, Node *);
+	GDVIRTUAL2R(Error, _export_scene, Ref<GLTFState>, Dictionary);
 	GDVIRTUAL1R(Error, _export_post, Ref<GLTFState>);
 };

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -276,6 +276,11 @@ Error GLTFDocument::_serialize_scenes(Ref<GLTFState> p_state) {
 	// Godot only supports one scene per glTF file.
 	Array scenes;
 	Dictionary scene_dict;
+	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
+		ERR_CONTINUE(ext.is_null());
+		Error err = ext->export_scene(p_state, scene_dict);
+		ERR_CONTINUE(err != OK);
+	}
 	scenes.append(scene_dict);
 	p_state->json["scenes"] = scenes;
 	p_state->json["scene"] = 0;
@@ -597,6 +602,16 @@ Error GLTFDocument::_parse_scenes(Ref<GLTFState> p_state) {
 		}
 		if (_naming_version == 0) {
 			p_state->scene_name = _gen_unique_name(p_state, p_state->scene_name);
+		}
+
+		if (scene_dict.has("extensions")) {
+			Dictionary extensions = scene_dict["extensions"];
+
+			for (Ref<GLTFDocumentExtension> ext : document_extensions) {
+				ERR_CONTINUE(ext.is_null());
+				Error err = ext->parse_scene_extensions(p_state, extensions);
+				ERR_CONTINUE_MSG(err != OK, "glTF: Encountered error " + itos(err) + " when parsing scene extensions in file " + p_state->filename + ". Continuing.");
+			}
 		}
 	}
 


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/13643

This PR adds methods to GLTFDocumentExtension that enable the ability to use extensions stored in the scene component of a gltf document.

- `_parse_scene_extensions` runs after `_get_supported_extensions` and before `_parse_node_extensions`. This method provides the scene component's `extensions` JSON data as a parameter, now exposing the ability to parse said data in a GLTFDocumentExtension.
- `_export_scene` runs after `_export_node` and before `_export_post`. This method provides a dictionary that can be used to modify the scene JSON data prior to serialization, allowing scene extension data to be serialized.

I've also updated the documentation to reflect these new methods, and the new import/export ordering.

I've made this PR in response to my own needs, I've been developing an addon to be used with both Blender and Godot in an attempt to provide a workflow that feels more intuitive (subjective) to me. But I hit a snag, while embedding data in a custom extension stored in the scene component, I found that I had no way of parsing said data on Godot's side of the addon.