### PR TITLE
Fix modified editor shortcuts being erased

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -101,7 +101,7 @@ bool EditorSettings::_set_only(const StringName &p_name, const Variant &p_value)
 			Ref<Shortcut> sc;
 			sc.instantiate();
 			sc->set_events(shortcut_events);
-			add_shortcut(shortcut_name, sc);
+			_add_shortcut_default(shortcut_name, sc);
 		}
 
 		return false;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes: https://github.com/godotengine/godot/issues/112814

The bug was caused by using `add_shortcut()` when loading shortcuts from disk. The `add_shortcut()` function is designed for plugin registration and sets an "original" metadata tag to track what the default shortcut should be. When the Project Manager loaded customized shortcuts from disk, it incorrectly marked them as "original defaults", so when saving, the code compared the customization against itself, decided nothing changed, and skipped saving it which erases the customization.

The fix is to use `_add_shortcut_default()` instead, which simply loads the shortcut into memory without any metadata. 