### PR TITLE
[.NET] Allow for read-only properties and fields to be exported

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -47,3 +47,11 @@ GD0108  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https
 GD0109  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0109.html)
 GD0110  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0110.html)
 GD0111  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0111.html)
+
+## Release 4.6
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+GD0103  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0103.html)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -57,16 +57,6 @@ namespace Godot.SourceGenerators
                 "The type of the exported member is not supported. Use a supported type, or remove the '[Export]' attribute.",
                 helpLinkUri: string.Format(_helpLinkFormat, "GD0102"));
 
-        public static readonly DiagnosticDescriptor ExportedMemberIsReadOnlyRule =
-            new DiagnosticDescriptor(id: "GD0103",
-                title: "The exported member is read-only",
-                messageFormat: "The exported member '{0}' is read-only",
-                category: "Usage",
-                DiagnosticSeverity.Error,
-                isEnabledByDefault: true,
-                "The exported member is read-only. Exported member must be writable.",
-                helpLinkUri: string.Format(_helpLinkFormat, "GD0103"));
-
         public static readonly DiagnosticDescriptor ExportedPropertyIsWriteOnlyRule =
             new DiagnosticDescriptor(id: "GD0104",
                 title: "The exported property is write-only",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -163,16 +163,6 @@ namespace Godot.SourceGenerators
                     continue;
                 }
 
-                if (property.IsReadOnly || property.SetMethod!.IsInitOnly)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        Common.ExportedMemberIsReadOnlyRule,
-                        property.Locations.FirstLocationWithSourceTreeOrDefault(),
-                        property.ToDisplayString()
-                    ));
-                    continue;
-                }
-
                 if (property.ExplicitInterfaceImplementations.Length > 0)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
@@ -285,18 +275,6 @@ namespace Godot.SourceGenerators
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         Common.ExportedMemberIsStaticRule,
-                        field.Locations.FirstLocationWithSourceTreeOrDefault(),
-                        field.ToDisplayString()
-                    ));
-                    continue;
-                }
-
-                // TODO: We should still restore read-only fields after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
-                // Ignore properties without a getter or without a setter. Godot properties must be both readable and writable.
-                if (field.IsReadOnly)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        Common.ExportedMemberIsReadOnlyRule,
                         field.Locations.FirstLocationWithSourceTreeOrDefault(),
                         field.ToDisplayString()
                     ));


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8502

This PR allows read only properties and fields to be exported.

Example:
```cs
// All of these used to cause GD103, but now they work.
[Export] public readonly uint ReadonlyField = 999;
[Export] public Resource GetterOnlyProperty { get; } = new();
[Export] public Node ExpressionBody => GetNode("Node"); 
```

It works by adding `PropertyUsage.ReadOnly` and removing `PropertyUsage.Storage` to properties and fields that are marked as read only; `PropertyUsage.Storage` is removed because read-only properties and fields can only be declared in code, which makes storing them useless. The GD103 diagnostic has also been removed as it's no longer needed, documentation should also be updated to reflect this.

AFAIK exporting a read-only variable to godot should not cause any problems, and my testing has also proven this so far. [This](https://github.com/user-attachments/files/23564228/C.Readonly.Export.Testing.zip) is the test project I've been using.


