### PR TITLE
Make theme constants Variants

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -155,7 +155,7 @@
 		<theme_item name="focused_not_editing_cursor_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.275)">
 			Color of rectangle or circle drawn when a picker shape part is focused but not editable via keyboard or joypad. Displayed [i]over[/i] the picker shape, so a partially transparent color should be used to ensure the picker shape remains visible.
 		</theme_item>
-		<theme_item name="center_slider_grabbers" data_type="constant" type="int" default="1">
+		<theme_item name="center_slider_grabbers" data_type="constant" type="bool" default="true">
 			Overrides the [theme_item Slider.center_grabber] theme property of the sliders.
 		</theme_item>
 		<theme_item name="h_width" data_type="constant" type="int" default="30">

--- a/editor/scene/gui/theme_editor_plugin.h
+++ b/editor/scene/gui/theme_editor_plugin.h
@@ -403,6 +403,7 @@ class ThemeTypeEditor : public MarginContainer {
 
 	void _color_item_changed(Color p_value, String p_item_name);
 	void _constant_item_changed(float p_value, String p_item_name);
+	void _constant_item_changed_bool(bool p_value, String p_item_name);
 	void _font_size_item_changed(float p_value, String p_item_name);
 	void _edit_resource_item(Ref<Resource> p_resource, bool p_edit);
 	void _font_item_changed(Ref<Font> p_value, String p_item_name);

--- a/editor/themes/editor_theme.cpp
+++ b/editor/themes/editor_theme.cpp
@@ -50,7 +50,7 @@ Color EditorTheme::get_color(const StringName &p_name, const StringName &p_theme
 }
 
 // Keep in sync with Theme::get_constant.
-int EditorTheme::get_constant(const StringName &p_name, const StringName &p_theme_type) const {
+Variant EditorTheme::get_constant(const StringName &p_name, const StringName &p_theme_type) const {
 	if (constant_map.has(p_theme_type) && constant_map[p_theme_type].has(p_name)) {
 		return constant_map[p_theme_type][p_name];
 	} else {

--- a/editor/themes/editor_theme.h
+++ b/editor/themes/editor_theme.h
@@ -43,7 +43,7 @@ class EditorTheme : public Theme {
 
 public:
 	virtual Color get_color(const StringName &p_name, const StringName &p_theme_type) const override;
-	virtual int get_constant(const StringName &p_name, const StringName &p_theme_type) const override;
+	virtual Variant get_constant(const StringName &p_name, const StringName &p_theme_type) const override;
 	virtual Ref<Font> get_font(const StringName &p_name, const StringName &p_theme_type) const override;
 	virtual int get_font_size(const StringName &p_name, const StringName &p_theme_type) const override;
 	virtual Ref<Texture2D> get_icon(const StringName &p_name, const StringName &p_theme_type) const override;

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1458,7 +1458,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_constant("sv_height", "ColorPicker", 256 * EDSCALE);
 		p_theme->set_constant("h_width", "ColorPicker", 30 * EDSCALE);
 		p_theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
-		p_theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
+		p_theme->set_constant("center_slider_grabbers", "ColorPicker", true);
 
 		p_theme->set_stylebox("sample_focus", "ColorPicker", p_config.button_style_focus);
 		p_theme->set_stylebox("picker_focus_rectangle", "ColorPicker", p_config.button_style_focus);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1443,7 +1443,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_constant("sv_height", "ColorPicker", 256 * EDSCALE);
 		p_theme->set_constant("h_width", "ColorPicker", 30 * EDSCALE);
 		p_theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
-		p_theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
+		p_theme->set_constant("center_slider_grabbers", "ColorPicker", true);
 
 		p_theme->set_stylebox("sample_focus", "ColorPicker", p_config.focus_style);
 		p_theme->set_stylebox("picker_focus_rectangle", "ColorPicker", p_config.focus_style);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2019,7 +2019,7 @@ void ColorPicker::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ColorPicker, sv_height);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ColorPicker, h_width);
 
-	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ColorPicker, center_slider_grabbers);
+	BIND_THEME_ITEM_TYPED(Theme::DATA_TYPE_CONSTANT, ColorPicker, center_slider_grabbers, Variant::BOOL);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, ColorPicker, sample_focus);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, ColorPicker, picker_focus_rectangle);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, ColorPicker, picker_focus_circle);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -421,7 +421,21 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 				if (data.theme_constant_override.has(E.item_name)) {
 					usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
 				}
-				p_list->push_back(PropertyInfo(Variant::INT, PNAME("theme_override_constants") + String("/") + E.item_name, PROPERTY_HINT_RANGE, "-16384,16384", usage));
+				String name = PNAME("theme_override_constants") + String("/") + E.item_name;
+				switch (E.constant_type) {
+					case Variant::INT: {
+						p_list->push_back(PropertyInfo(Variant::INT, name, PROPERTY_HINT_RANGE, "-16384,16384", usage));
+					} break;
+					case Variant::FLOAT: {
+						p_list->push_back(PropertyInfo(Variant::FLOAT, name, PROPERTY_HINT_RANGE, "-16384,16384,0.001,or_greater,or_less", usage));
+					} break;
+					case Variant::BOOL: {
+						p_list->push_back(PropertyInfo(Variant::BOOL, name, PROPERTY_HINT_NONE, "", usage));
+					} break;
+					default: {
+						p_list->push_back(PropertyInfo(Variant::INT, name, PROPERTY_HINT_RANGE, "-16384,16384", usage));
+					} break;
+				}
 			} break;
 
 			case Theme::DATA_TYPE_FONT: {
@@ -3146,9 +3160,9 @@ int Control::get_theme_constant(const StringName &p_name, const StringName &p_th
 	}
 
 	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
-		const int *constant = data.theme_constant_override.getptr(p_name);
+		const Variant *constant = data.theme_constant_override.getptr(p_name);
 		if (constant) {
-			return *constant;
+			return (int)*constant;
 		}
 	}
 
@@ -3469,7 +3483,7 @@ bool Control::has_theme_color_override(const StringName &p_name) const {
 
 bool Control::has_theme_constant_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
-	const int *constant = data.theme_constant_override.getptr(p_name);
+	const Variant *constant = data.theme_constant_override.getptr(p_name);
 	return constant != nullptr;
 }
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2526,14 +2526,14 @@ Color Window::get_theme_color(const StringName &p_name, const StringName &p_them
 	return color;
 }
 
-int Window::get_theme_constant(const StringName &p_name, const StringName &p_theme_type) const {
+Variant Window::get_theme_constant(const StringName &p_name, const StringName &p_theme_type) const {
 	ERR_READ_THREAD_GUARD_V(0);
 	if (!initialized) {
 		WARN_PRINT_ONCE(vformat("Attempting to access theme items too early in %s; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED", get_description()));
 	}
 
 	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == theme_type_variation) {
-		const int *constant = theme_constant_override.getptr(p_name);
+		const Variant *constant = theme_constant_override.getptr(p_name);
 		if (constant) {
 			return *constant;
 		}
@@ -2830,7 +2830,7 @@ bool Window::has_theme_color_override(const StringName &p_name) const {
 
 bool Window::has_theme_constant_override(const StringName &p_name) const {
 	ERR_READ_THREAD_GUARD_V(false);
-	const int *constant = theme_constant_override.getptr(p_name);
+	const Variant *constant = theme_constant_override.getptr(p_name);
 	return constant != nullptr;
 }
 

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -492,7 +492,7 @@ public:
 	Ref<Font> get_theme_font(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	int get_theme_font_size(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Color get_theme_color(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
-	int get_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
+	Variant get_theme_constant(const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 	Variant get_theme_item(Theme::DataType p_data_type, const StringName &p_name, const StringName &p_theme_type = StringName()) const;
 #ifdef TOOLS_ENABLED
 	Ref<Texture2D> get_editor_theme_icon(const StringName &p_name) const;

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -51,7 +51,7 @@ public:
 	using ThemeFontMap = HashMap<StringName, Ref<Font>>;
 	using ThemeFontSizeMap = HashMap<StringName, int>;
 	using ThemeColorMap = HashMap<StringName, Color>;
-	using ThemeConstantMap = HashMap<StringName, int>;
+	using ThemeConstantMap = HashMap<StringName, Variant>;
 
 	enum DataType {
 		DATA_TYPE_COLOR,
@@ -192,8 +192,8 @@ public:
 	void rename_color_type(const StringName &p_old_theme_type, const StringName &p_theme_type);
 	void get_color_type_list(List<StringName> *p_list) const;
 
-	void set_constant(const StringName &p_name, const StringName &p_theme_type, int p_constant);
-	virtual int get_constant(const StringName &p_name, const StringName &p_theme_type) const;
+	void set_constant(const StringName &p_name, const StringName &p_theme_type, const Variant &p_constant);
+	virtual Variant get_constant(const StringName &p_name, const StringName &p_theme_type) const;
 	bool has_constant(const StringName &p_name, const StringName &p_theme_type) const;
 	bool has_constant_nocheck(const StringName &p_name, const StringName &p_theme_type) const;
 	void rename_constant(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1063,7 +1063,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("sv_height", "ColorPicker", Math::round(256 * scale));
 	theme->set_constant("h_width", "ColorPicker", Math::round(30 * scale));
 	theme->set_constant("label_width", "ColorPicker", Math::round(10 * scale));
-	theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
+	theme->set_constant("center_slider_grabbers", "ColorPicker", true);
 
 	theme->set_stylebox("sample_focus", "ColorPicker", focus);
 	theme->set_stylebox("picker_focus_rectangle", "ColorPicker", focus);

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -44,18 +44,32 @@ class ThemeContext;
 // Macros for binding theme items of this class. This information is used for the documentation, theme
 // overrides, etc. This is also the basis for theme cache.
 
-#define BIND_THEME_ITEM(m_data_type, m_class, m_prop)                                                       \
-	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, #m_prop,            \
-			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {            \
-				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                     \
-				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name); \
+#define BIND_THEME_ITEM(m_data_type, m_class, m_prop)                                                          \
+	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, #m_prop, Variant::INT, \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {               \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                        \
+				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name);    \
 			})
 
-#define BIND_THEME_ITEM_CUSTOM(m_data_type, m_class, m_prop, m_item_name)                                   \
-	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, m_item_name,        \
-			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {            \
-				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                     \
-				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name); \
+#define BIND_THEME_ITEM_CUSTOM(m_data_type, m_class, m_prop, m_item_name)                                          \
+	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, m_item_name, Variant::INT, \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {                   \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                            \
+				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name);        \
+			})
+
+#define BIND_THEME_ITEM_TYPED(m_data_type, m_class, m_prop, m_item_type)                                      \
+	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, #m_prop, m_item_type, \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {              \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                       \
+				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name);   \
+			})
+
+#define BIND_THEME_ITEM_TYPED_CUSTOM(m_data_type, m_class, m_prop, m_item_name, m_item_type)                      \
+	ThemeDB::get_singleton()->bind_class_item(m_data_type, get_class_static(), #m_prop, m_item_name, m_item_type, \
+			[](Node *p_instance, const StringName &p_item_name, const StringName &p_type_name) {                  \
+				m_class *p_cast = Object::cast_to<m_class>(p_instance);                                           \
+				p_cast->theme_cache.m_prop = p_cast->get_theme_item(m_data_type, p_item_name, p_type_name);       \
 			})
 
 // Macro for binding theme items used by this class, but defined/binded by other classes. This is primarily used for
@@ -106,6 +120,7 @@ public:
 		StringName item_name;
 		StringName type_name;
 		bool external = false;
+		Variant::Type constant_type = Variant::NIL;
 
 		ThemeItemSetter setter;
 
@@ -168,11 +183,13 @@ public:
 
 	// Theme item binding.
 
-	void bind_class_item(Theme::DataType p_data_type, const StringName &p_class_name, const StringName &p_prop_name, const StringName &p_item_name, ThemeItemSetter p_setter);
+	void bind_class_item(Theme::DataType p_data_type, const StringName &p_class_name, const StringName &p_prop_name, const StringName &p_item_name, Variant::Type p_constant_type, ThemeItemSetter p_setter);
 	void bind_class_external_item(Theme::DataType p_data_type, const StringName &p_class_name, const StringName &p_prop_name, const StringName &p_item_name, const StringName &p_type_name, ThemeItemSetter p_setter);
 	void update_class_instance_items(Node *p_instance);
 
 	void get_class_items(const StringName &p_class_name, List<ThemeItemBind> *r_list, bool p_include_inherited = false, Theme::DataType p_filter_type = Theme::DATA_TYPE_MAX);
+	void get_class_own_items(const StringName &p_class_name, List<ThemeItemBind> *r_list);
+	Variant::Type get_class_constant_type(const StringName &p_class_name, const StringName &p_item_name);
 
 	// Memory management, reference, and initialization.
 


### PR DESCRIPTION
Closes #36815
Heavily inspired on #87243

I decided to add `BIND_THEME_ITEM_TYPED` instead of changing `BIND_THEME_ITEM` to not change all the theme constant in the same PR that I'm adding this. That will make the PR smaller and easy to review, and also it will make it easier to merge because of less merge conflicts.
If this got merged I would make other PRs to start changing the rest of the theme constants.

As an example I changed `ColorPicker` `Center Slider Grabbers` to be an actual boolean theme constant.