### PR TITLE
SCons: Isolate `compile_db` generation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -236,6 +236,7 @@ opts.Add(BoolVariable("ninja", "Use the ninja backend for faster rebuilds", Fals
 opts.Add(BoolVariable("ninja_auto_run", "Run ninja automatically after generating the ninja file", True))
 opts.Add("ninja_file", "Path to the generated ninja file", "build.ninja")
 opts.Add(BoolVariable("compiledb", "Generate compilation DB (`compile_commands.json`) for external tools", False))
+opts.Add(BoolVariable("compiledb_gen_only", "Exit after building the compilation database", False))
 opts.Add(
     "num_jobs",
     "Use up to N jobs when compiling (equivalent to `-j N`). Defaults to max jobs - 1. Ignored if -j is used.",
@@ -1172,7 +1173,6 @@ env.Append(BUILDERS=GLSL_BUILDERS)
 
 if env["compiledb"]:
     env.Tool("compilation_db")
-    env.Alias("compiledb", env.CompilationDatabase())
     env.NoCache(env.CompilationDatabase())
     if not env["verbose"]:
         env["COMPILATIONDB_COMSTR"] = "$GENCOMSTR"
@@ -1232,6 +1232,12 @@ if env["vsproj"]:
 
 # Miscellaneous & post-build methods.
 if not env.GetOption("clean") and not env.GetOption("help"):
+    if env["compiledb"] and env["compiledb_gen_only"]:
+        from SCons.Tool.compilation_db import write_compilation_db
+
+        write_compilation_db([env.File("compile_commands.json")], [], env)
+        env.Exit()
+
     methods.dump(env)
     methods.show_progress(env)
     methods.prepare_purge(env)


### PR DESCRIPTION
This re-implements the native SCons `compile_commands.json` generation, with two primary benefits:
1. Simplified logic, which slightly speeds up construction
2. Handled entirely via emitter, meaning that everything can be executed ahead of time

The latter in particular enables us to do something previously impossible: generating `compile_commands.json` *exclusively*. This eliminates a long-standing roadblock to integrating CI features which relied on this file (e.g. `clang-tidy`), while keeping style/build actions properly separated