### PR TITLE
[TextServer] Remove negative offset from the first char when shaping substrings.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5435,6 +5435,10 @@ bool TextServerAdvanced::_shape_substr(ShapedTextDataAdvanced *p_new_sd, const S
 							}
 							p_new_sd->width += gl.advance * gl.repeat;
 						}
+						if (p_new_sd->glyphs.is_empty() && gl.x_off < 0.0) {
+							gl.advance += -gl.x_off;
+							gl.x_off = 0.0;
+						}
 						p_new_sd->glyphs.push_back(gl);
 					}
 				}

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -4117,6 +4117,10 @@ RID TextServerFallback::_shaped_text_substr(const RID &p_shaped, int64_t p_start
 							new_sd->descent = MAX(new_sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5));
 						}
 					}
+					if (new_sd->glyphs.is_empty() && gl.x_off < 0.0) {
+						gl.advance += -gl.x_off;
+						gl.x_off = 0.0;
+					}
 					new_sd->width += gl.advance * gl.repeat;
 				}
 				new_sd->glyphs.push_back(gl);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112808