### PR TITLE
Fix crash in `EditorFileDialog` by checking for null pointer

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -543,7 +543,7 @@ void EditorFileDialog::_thumbnail_done(const String &p_path, const Ref<Texture2D
 }
 
 void EditorFileDialog::_request_single_thumbnail(const String &p_path) {
-	if (!FileAccess::exists(p_path) || !previews_enabled) {
+	if (!FileAccess::exists(p_path) || !previews_enabled || !EditorResourcePreview::get_singleton()) {
 		return;
 	}
 
@@ -1162,7 +1162,7 @@ void EditorFileDialog::update_file_list() {
 			d["path"] = file_info.path;
 			item_list->set_item_metadata(-1, d);
 
-			if (display_mode == DISPLAY_THUMBNAILS && previews_enabled) {
+			if (display_mode == DISPLAY_THUMBNAILS && previews_enabled && EditorResourcePreview::get_singleton()) {
 				EditorResourcePreview::get_singleton()->queue_resource_preview(file_info.path, callable_mp(this, &EditorFileDialog::_thumbnail_result));
 			}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes bug report #112855, in which opening the following nested windows caused a crash:

1. Project Manager
2. Editor Settings
3. Any file selector therein (e.g. `General` -> `FileSystem` -> `Directories` -> `Default Project Path`)

This is caused by the return value of `EditorResourcePreview::get_singleton()` being a null pointer for a short period after attempting to open the file selector, as above.

The fix was tested on:

- Apple Silicone M1 Pro
- MacOS `15.6.1 (24G90)`