### PR TITLE
GLTF: Support MultiMesh objects using `EXT_mesh_gpu_instancing`

### DIFF
--- a/modules/gltf/extensions/gltf_document_extension_multi_mesh.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_multi_mesh.cpp
@@ -1,0 +1,404 @@
+/**************************************************************************/
+/*  gltf_document_extension_multi_mesh.cpp                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gltf_document_extension_multi_mesh.h"
+
+// Import process.
+Error GLTFDocumentExtensionMultiMesh::import_preflight(Ref<GLTFState> p_gltf_state, const Vector<String> &p_extensions) {
+	if (!p_extensions.has("EXT_mesh_gpu_instancing")) {
+		return ERR_SKIP;
+	}
+	return OK;
+}
+
+Vector<String> GLTFDocumentExtensionMultiMesh::get_supported_extensions() {
+	Vector<String> ret;
+	ret.push_back("EXT_mesh_gpu_instancing");
+	return ret;
+}
+
+Error GLTFDocumentExtensionMultiMesh::parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions) {
+	if (!p_extensions.has("EXT_mesh_gpu_instancing")) {
+		return OK;
+	}
+	const Dictionary ext_mesh_gpu = p_extensions["EXT_mesh_gpu_instancing"];
+	const Dictionary attributes = ext_mesh_gpu.get("attributes", Dictionary());
+	if (attributes.is_empty()) {
+		if (p_gltf_node->get_children().is_empty()) {
+			// This is a multi mesh with zero instances and no children, so it is a fallback mesh node.
+			// Since Godot supports EXT_mesh_gpu_instancing, we don't need the fallback nodes, and can skip them.
+			p_gltf_node->set_additional_data(StringName("SkipNodeGeneration"), true);
+		}
+		return OK;
+	}
+	const Vector<Ref<GLTFAccessor>> &accessors = p_state->get_accessors();
+	PackedVector3Array positions;
+	Vector<Quaternion> rotations;
+	PackedVector3Array scales;
+	PackedColorArray colors;
+	PackedColorArray custom_data;
+	const int64_t accessor_count = accessors.size();
+	if (attributes.has("TRANSLATION")) {
+		GLTFAccessorIndex position_accessor_index = attributes["TRANSLATION"];
+		ERR_FAIL_INDEX_V(position_accessor_index, accessor_count, ERR_INVALID_DATA);
+		Ref<GLTFAccessor> position_accessor = accessors[position_accessor_index];
+		positions = position_accessor->decode_as_vector3s(p_state);
+	}
+	if (attributes.has("ROTATION")) {
+		GLTFAccessorIndex rotation_accessor_index = attributes["ROTATION"];
+		ERR_FAIL_INDEX_V(rotation_accessor_index, accessor_count, ERR_INVALID_DATA);
+		Ref<GLTFAccessor> rotation_accessor = accessors[rotation_accessor_index];
+		rotations = rotation_accessor->decode_as_quaternions(p_state);
+	}
+	if (attributes.has("SCALE")) {
+		GLTFAccessorIndex scale_accessor_index = attributes["SCALE"];
+		ERR_FAIL_INDEX_V(scale_accessor_index, accessor_count, ERR_INVALID_DATA);
+		Ref<GLTFAccessor> scale_accessor = accessors[scale_accessor_index];
+		scales = scale_accessor->decode_as_vector3s(p_state);
+	}
+	if (attributes.has("_COLOR")) {
+		GLTFAccessorIndex color_accessor_index = attributes["_COLOR"];
+		ERR_FAIL_INDEX_V(color_accessor_index, accessor_count, ERR_INVALID_DATA);
+		Ref<GLTFAccessor> color_accessor = accessors[color_accessor_index];
+		colors = color_accessor->decode_as_colors(p_state);
+	}
+	if (attributes.has("_CUSTOM")) {
+		GLTFAccessorIndex custom_accessor_index = attributes["_CUSTOM"];
+		ERR_FAIL_INDEX_V(custom_accessor_index, accessor_count, ERR_INVALID_DATA);
+		Ref<GLTFAccessor> custom_accessor = accessors[custom_accessor_index];
+		custom_data = custom_accessor->decode_as_colors(p_state);
+	}
+	const int64_t instance_count = MAX(MAX(MAX(positions.size(), rotations.size()), scales.size()), MAX(colors.size(), custom_data.size()));
+	ERR_FAIL_COND_V(instance_count == 0, ERR_INVALID_DATA);
+	TypedArray<Transform3D> multi_mesh_transforms;
+	multi_mesh_transforms.resize(instance_count);
+	for (int64_t i = 0; i < instance_count; i++) {
+		Transform3D transform;
+		transform.basis.set_quaternion_scale(
+				i < rotations.size() ? rotations[i] : Quaternion(),
+				i < scales.size() ? scales[i] : Vector3(1, 1, 1));
+		transform.origin = i < positions.size() ? positions[i] : Vector3();
+		multi_mesh_transforms[i] = transform;
+	}
+	p_gltf_node->set_additional_data(StringName("MultiMeshTransforms"), multi_mesh_transforms);
+	if (!colors.is_empty()) {
+		p_gltf_node->set_additional_data(StringName("MultiMeshColors"), colors);
+	}
+	if (!custom_data.is_empty()) {
+		p_gltf_node->set_additional_data(StringName("MultiMeshCustomData"), custom_data);
+	}
+	return OK;
+}
+
+Ref<Mesh> GLTFDocumentExtensionMultiMesh::_generate_mesh(Ref<GLTFState> p_gltf_state, GLTFMeshIndex p_mesh_index) {
+	Ref<Mesh> ret;
+	const Vector<Ref<GLTFMesh>> &gltf_meshes = p_gltf_state->get_meshes();
+	ERR_FAIL_INDEX_V(p_mesh_index, gltf_meshes.size(), ret);
+	Ref<GLTFMesh> gltf_mesh = gltf_meshes[p_mesh_index];
+	ERR_FAIL_COND_V(gltf_mesh.is_null(), ret);
+	Ref<ImporterMesh> importer_mesh = gltf_mesh->get_mesh();
+	ERR_FAIL_COND_V(importer_mesh.is_null(), ret);
+	ret = importer_mesh->get_mesh();
+	return ret;
+}
+
+Node3D *GLTFDocumentExtensionMultiMesh::generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent) {
+	if (!p_gltf_node->has_additional_data(StringName("MultiMeshTransforms"))) {
+		return nullptr;
+	}
+	const TypedArray<Transform3D> multi_mesh_transforms = TypedArray<Transform3D>(p_gltf_node->get_additional_data(StringName("MultiMeshTransforms")));
+	const PackedColorArray multi_mesh_colors = p_gltf_node->has_additional_data(StringName("MultiMeshColors")) ? PackedColorArray(p_gltf_node->get_additional_data(StringName("MultiMeshColors"))) : PackedColorArray();
+	const PackedColorArray multi_mesh_custom_data = p_gltf_node->has_additional_data(StringName("MultiMeshCustomData")) ? PackedColorArray(p_gltf_node->get_additional_data(StringName("MultiMeshCustomData"))) : PackedColorArray();
+	Ref<MultiMesh> multi_mesh;
+	multi_mesh.instantiate();
+	multi_mesh->set_use_colors(!multi_mesh_colors.is_empty());
+	multi_mesh->set_use_custom_data(!multi_mesh_custom_data.is_empty());
+	multi_mesh->set_transform_format(MultiMesh::TRANSFORM_3D);
+	const GLTFMeshIndex mesh_index = p_gltf_node->get_mesh();
+	if (mesh_index >= 0) {
+		const Ref<Mesh> mesh = _generate_mesh(p_state, p_gltf_node->get_mesh());
+		if (mesh.is_valid()) {
+			multi_mesh->set_mesh(mesh);
+		}
+	}
+	const int64_t instance_count = MAX(multi_mesh_transforms.size(), MAX(multi_mesh_colors.size(), multi_mesh_custom_data.size()));
+	multi_mesh->set_instance_count(instance_count);
+	for (int64_t i = 0; i < multi_mesh_transforms.size(); i++) {
+		multi_mesh->set_instance_transform(i, multi_mesh_transforms[i]);
+	}
+	for (int64_t i = 0; i < multi_mesh_colors.size(); i++) {
+		multi_mesh->set_instance_color(i, multi_mesh_colors[i]);
+	}
+	for (int64_t i = 0; i < multi_mesh_custom_data.size(); i++) {
+		multi_mesh->set_instance_custom_data(i, multi_mesh_custom_data[i]);
+	}
+	MultiMeshInstance3D *multi_mesh_node = memnew(MultiMeshInstance3D);
+	multi_mesh_node->set_multimesh(multi_mesh);
+	return multi_mesh_node;
+}
+
+// Export process.
+bool GLTFDocumentExtensionMultiMesh::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == StringName("handling")) {
+		_handling = MultiMeshHandling(int(p_value));
+		return true;
+	}
+	return false;
+}
+
+bool GLTFDocumentExtensionMultiMesh::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == StringName("handling")) {
+		r_ret = int(_handling);
+		return true;
+	}
+	return false;
+}
+
+List<PropertyInfo> GLTFDocumentExtensionMultiMesh::export_get_property_list(Node *p_root_node) {
+	List<PropertyInfo> property_list;
+	if (p_root_node == nullptr) {
+		return property_list;
+	}
+	if (_any_multi_mesh_instance_exists_recursive(p_root_node)) {
+		property_list.push_back(PropertyInfo(Variant::INT, "handling", PROPERTY_HINT_ENUM, "Optional EXT_mesh_gpu_instancing,Required EXT_mesh_gpu_instancing,Multiple Nodes Only,Multiple Nodes Fallback", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE));
+	}
+	return property_list;
+}
+
+bool GLTFDocumentExtensionMultiMesh::_any_multi_mesh_instance_exists_recursive(Node *p_node) {
+	if (Object::cast_to<MultiMeshInstance3D>(p_node) != nullptr) {
+		return true;
+	}
+	for (int32_t i = 0; i < p_node->get_child_count(); i++) {
+		Node *child = p_node->get_child(i);
+		if (_any_multi_mesh_instance_exists_recursive(child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+GLTFMeshIndex GLTFDocumentExtensionMultiMesh::_convert_mesh_resource_into_state(Ref<GLTFState> p_gltf_state, const Ref<MultiMesh> &p_multi_mesh) {
+	const Ref<Mesh> mesh = p_multi_mesh->get_mesh();
+	if (mesh.is_null()) {
+		return -1;
+	}
+	Ref<GLTFMesh> gltf_mesh;
+	gltf_mesh.instantiate();
+	gltf_mesh->set_mesh(ImporterMesh::from_mesh(mesh));
+	const String multi_mesh_name = p_multi_mesh->get_name();
+	if (!multi_mesh_name.is_empty()) {
+		gltf_mesh->set_original_name(multi_mesh_name);
+		gltf_mesh->set_name(p_gltf_state->reserve_unique_name(multi_mesh_name));
+	}
+	Vector<Ref<GLTFMesh>> gltf_meshes = p_gltf_state->get_meshes();
+	GLTFMeshIndex mesh_index = gltf_meshes.size();
+	gltf_meshes.append(gltf_mesh);
+	p_gltf_state->set_meshes(gltf_meshes);
+	return mesh_index;
+}
+
+void GLTFDocumentExtensionMultiMesh::_convert_multi_mesh_to_extension(Ref<GLTFState> p_gltf_state, Ref<GLTFNode> p_gltf_node, const Ref<MultiMesh> &p_multi_mesh) {
+	TypedArray<Transform3D> multi_mesh_transforms;
+	const int64_t instance_count = p_multi_mesh->get_instance_count();
+	multi_mesh_transforms.resize(instance_count);
+	for (int64_t i = 0; i < instance_count; i++) {
+		multi_mesh_transforms[i] = get_multi_mesh_instance_transform(p_multi_mesh, i);
+	}
+	p_gltf_node->set_additional_data(StringName("MultiMeshTransforms"), multi_mesh_transforms);
+	if (p_multi_mesh->is_using_colors()) {
+		PackedColorArray multi_mesh_colors;
+		multi_mesh_colors.resize(instance_count);
+		for (int64_t i = 0; i < instance_count; i++) {
+			multi_mesh_colors.set(i, p_multi_mesh->get_instance_color(i));
+		}
+		p_gltf_node->set_additional_data(StringName("MultiMeshColors"), multi_mesh_colors);
+	}
+	if (p_multi_mesh->is_using_custom_data()) {
+		PackedColorArray multi_mesh_custom_data;
+		multi_mesh_custom_data.resize(instance_count);
+		for (int64_t i = 0; i < instance_count; i++) {
+			multi_mesh_custom_data.set(i, p_multi_mesh->get_instance_custom_data(i));
+		}
+		p_gltf_node->set_additional_data(StringName("MultiMeshCustomData"), multi_mesh_custom_data);
+	}
+}
+
+void GLTFDocumentExtensionMultiMesh::_convert_multi_mesh_to_gltf_nodes(Ref<GLTFState> p_gltf_state, Ref<GLTFNode> p_gltf_node, MultiMeshInstance3D *p_multi_mesh_node, GLTFMeshIndex p_mesh_index, bool p_for_fallback) {
+	// Ensure the base node is appended to the state before we append children after it.
+	const Vector<Ref<GLTFNode>> gltf_nodes = p_gltf_state->get_nodes();
+	GLTFNodeIndex self_index = gltf_nodes.find(p_gltf_node);
+	if (self_index == -1) {
+		Node *parent_godot_node = p_multi_mesh_node->get_parent();
+		const GLTFNodeIndex parent_index = p_gltf_state->get_node_index(parent_godot_node);
+		self_index = p_gltf_state->append_gltf_node(p_gltf_node, p_multi_mesh_node, parent_index);
+	}
+	// These are guaranteed by the only caller (`convert_scene_node`) to not be null.
+	const Ref<MultiMesh> &multi_mesh = p_multi_mesh_node->get_multimesh();
+	PackedInt32Array children = p_gltf_node->get_children();
+	for (int32_t instance_i = 0; instance_i < multi_mesh->get_instance_count(); instance_i++) {
+		const Transform3D instance_transform = get_multi_mesh_instance_transform(multi_mesh, instance_i);
+		if (p_for_fallback && instance_transform.is_equal_approx(Transform3D())) {
+			// If this is a glTF node intended as a fallback, and this instance has an identity transform,
+			// then the fallback is already represented by the base node, so skip generating a duplicate.
+			continue;
+		}
+		Ref<GLTFNode> new_gltf_node;
+		new_gltf_node.instantiate();
+		new_gltf_node->set_mesh(p_mesh_index);
+		new_gltf_node->set_xform(instance_transform);
+		new_gltf_node->set_original_name(p_multi_mesh_node->get_name());
+		new_gltf_node->set_name(p_gltf_state->reserve_unique_name(p_multi_mesh_node->get_name(), false));
+		if (p_for_fallback) {
+			// Mark this fallback node as a multimesh node with zero instances, effectively
+			// hiding it for implementations that support EXT_mesh_gpu_instancing.
+			TypedArray<Transform3D> transforms;
+			new_gltf_node->set_additional_data(StringName("MultiMeshTransforms"), transforms);
+		}
+		const GLTFNodeIndex new_index = p_gltf_state->append_gltf_node(new_gltf_node, p_multi_mesh_node, self_index);
+		children.append(new_index);
+	}
+	p_gltf_node->set_children(children);
+}
+
+Transform3D GLTFDocumentExtensionMultiMesh::get_multi_mesh_instance_transform(const Ref<MultiMesh> &p_multi_mesh, int p_instance) {
+	if (likely(p_multi_mesh->get_transform_format() == MultiMesh::TransformFormat::TRANSFORM_3D)) {
+		return p_multi_mesh->get_instance_transform(p_instance);
+	}
+	// Otherwise, convert 2D to 3D.
+	Transform3D ret;
+	const Transform2D transform_2d = p_multi_mesh->get_instance_transform_2d(p_instance);
+	ret.basis.rows[0][0] = transform_2d.columns[0][0];
+	ret.basis.rows[1][0] = transform_2d.columns[0][1];
+	ret.basis.rows[0][1] = transform_2d.columns[1][0];
+	ret.basis.rows[1][1] = transform_2d.columns[1][1];
+	ret.origin = Vector3(transform_2d.columns[2][0], transform_2d.columns[2][1], 0.0f);
+	return ret;
+}
+
+void GLTFDocumentExtensionMultiMesh::convert_scene_node(Ref<GLTFState> p_gltf_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node) {
+	MultiMeshInstance3D *multi_mesh_node = Object::cast_to<MultiMeshInstance3D>(p_scene_node);
+	if (multi_mesh_node == nullptr) {
+		return;
+	}
+	const Ref<MultiMesh> multi_mesh = multi_mesh_node->get_multimesh();
+	if (multi_mesh.is_null()) {
+		return;
+	}
+	const GLTFMeshIndex mesh_index = _convert_mesh_resource_into_state(p_gltf_state, multi_mesh);
+	switch (_handling) {
+		case MULTI_MESH_HANDLING_OPTIONAL_EXT_MESH_GPU_INSTANCING:
+		case MULTI_MESH_HANDLING_REQUIRED_EXT_MESH_GPU_INSTANCING: {
+			p_gltf_node->set_mesh(mesh_index);
+			_convert_multi_mesh_to_extension(p_gltf_state, p_gltf_node, multi_mesh);
+		} break;
+		case MULTI_MESH_HANDLING_MULTIPLE_NODES_ONLY: {
+			_convert_multi_mesh_to_gltf_nodes(p_gltf_state, p_gltf_node, multi_mesh_node, mesh_index, false);
+		} break;
+		case MULTI_MESH_HANDLING_MULTIPLE_NODES_FALLBACK: {
+			p_gltf_node->set_mesh(mesh_index);
+			_convert_multi_mesh_to_extension(p_gltf_state, p_gltf_node, multi_mesh);
+			_convert_multi_mesh_to_gltf_nodes(p_gltf_state, p_gltf_node, multi_mesh_node, mesh_index, true);
+		} break;
+	}
+}
+
+Error GLTFDocumentExtensionMultiMesh::export_node(Ref<GLTFState> p_gltf_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_node_json, Node *p_scene_node) {
+	if (!p_gltf_node->has_additional_data(StringName("MultiMeshTransforms"))) {
+		return OK;
+	}
+	const TypedArray<Transform3D> multi_mesh_transforms = TypedArray<Transform3D>(p_gltf_node->get_additional_data(StringName("MultiMeshTransforms")));
+	const PackedColorArray multi_mesh_colors = p_gltf_node->has_additional_data(StringName("MultiMeshColors")) ? PackedColorArray(p_gltf_node->get_additional_data(StringName("MultiMeshColors"))) : PackedColorArray();
+	const PackedColorArray multi_mesh_custom_data = p_gltf_node->has_additional_data(StringName("MultiMeshCustomData")) ? PackedColorArray(p_gltf_node->get_additional_data(StringName("MultiMeshCustomData"))) : PackedColorArray();
+	PackedVector3Array positions;
+	Vector<Quaternion> rotations;
+	PackedVector3Array scales;
+	const int64_t transform_count = multi_mesh_transforms.size();
+	for (int64_t i = 0; i < multi_mesh_transforms.size(); i++) {
+		const Transform3D transform = multi_mesh_transforms[i];
+		if (!transform.origin.is_zero_approx()) {
+			if (positions.size() < transform_count) {
+				positions.resize(transform_count);
+			}
+			positions.set(i, transform.origin);
+		}
+		const Quaternion rotation = transform.basis.get_rotation_quaternion();
+		if (!rotation.is_equal_approx(Quaternion())) {
+			if (rotations.size() < transform_count) {
+				rotations.resize(transform_count);
+			}
+			rotations.set(i, rotation);
+		}
+		const Vector3 scale = transform.basis.get_scale();
+		if (!scale.is_equal_approx(Vector3(1, 1, 1))) {
+			const int64_t old_scale_count = scales.size();
+			if (old_scale_count < transform_count) {
+				scales.resize(transform_count);
+				for (int64_t scale_i = old_scale_count; scale_i < transform_count; scale_i++) {
+					scales.set(scale_i, Vector3(1, 1, 1));
+				}
+			}
+			scales.set(i, scale);
+		}
+	}
+	Dictionary multi_mesh_attributes;
+	if (!positions.is_empty()) {
+		const GLTFAccessorIndex position_index = GLTFAccessor::encode_new_accessor_from_vector3s(p_gltf_state, positions);
+		multi_mesh_attributes["TRANSLATION"] = position_index;
+	}
+	if (!rotations.is_empty()) {
+		const GLTFAccessorIndex rotation_index = GLTFAccessor::encode_new_accessor_from_quaternions(p_gltf_state, rotations);
+		multi_mesh_attributes["ROTATION"] = rotation_index;
+	}
+	if (!scales.is_empty()) {
+		const GLTFAccessorIndex scale_index = GLTFAccessor::encode_new_accessor_from_vector3s(p_gltf_state, scales);
+		multi_mesh_attributes["SCALE"] = scale_index;
+	}
+	if (!multi_mesh_colors.is_empty()) {
+		const GLTFAccessorIndex color_index = GLTFAccessor::encode_new_accessor_from_colors(p_gltf_state, multi_mesh_colors);
+		multi_mesh_attributes["_COLOR"] = color_index;
+	}
+	if (!multi_mesh_custom_data.is_empty()) {
+		const GLTFAccessorIndex custom_index = GLTFAccessor::encode_new_accessor_from_colors(p_gltf_state, multi_mesh_custom_data);
+		multi_mesh_attributes["_CUSTOM"] = custom_index;
+	}
+	Dictionary ext_mesh_gpu;
+	if (!multi_mesh_attributes.is_empty()) {
+		ext_mesh_gpu["attributes"] = multi_mesh_attributes;
+	}
+	if (unlikely(!r_node_json.has("extensions"))) {
+		r_node_json["extensions"] = Dictionary();
+	}
+	Dictionary node_extensions = r_node_json["extensions"];
+	node_extensions["EXT_mesh_gpu_instancing"] = ext_mesh_gpu;
+	const bool is_required = _handling == MULTI_MESH_HANDLING_REQUIRED_EXT_MESH_GPU_INSTANCING;
+	p_gltf_state->add_used_extension("EXT_mesh_gpu_instancing", is_required);
+	return OK;
+}

--- a/modules/gltf/extensions/gltf_document_extension_multi_mesh.h
+++ b/modules/gltf/extensions/gltf_document_extension_multi_mesh.h
@@ -1,0 +1,71 @@
+/**************************************************************************/
+/*  gltf_document_extension_multi_mesh.h                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gltf_document_extension.h"
+
+#include "scene/3d/multimesh_instance_3d.h"
+
+class GLTFDocumentExtensionMultiMesh : public GLTFDocumentExtension {
+	GDCLASS(GLTFDocumentExtensionMultiMesh, GLTFDocumentExtension);
+
+	enum MultiMeshHandling {
+		MULTI_MESH_HANDLING_OPTIONAL_EXT_MESH_GPU_INSTANCING,
+		MULTI_MESH_HANDLING_REQUIRED_EXT_MESH_GPU_INSTANCING,
+		MULTI_MESH_HANDLING_MULTIPLE_NODES_ONLY,
+		MULTI_MESH_HANDLING_MULTIPLE_NODES_FALLBACK,
+	};
+	MultiMeshHandling _handling = MULTI_MESH_HANDLING_OPTIONAL_EXT_MESH_GPU_INSTANCING;
+
+	static bool _any_multi_mesh_instance_exists_recursive(Node *p_node);
+	static GLTFMeshIndex _convert_mesh_resource_into_state(Ref<GLTFState> p_gltf_state, const Ref<MultiMesh> &p_multi_mesh);
+	static void _convert_multi_mesh_to_extension(Ref<GLTFState> p_gltf_state, Ref<GLTFNode> p_gltf_node, const Ref<MultiMesh> &p_multi_mesh);
+	static void _convert_multi_mesh_to_gltf_nodes(Ref<GLTFState> p_gltf_state, Ref<GLTFNode> p_gltf_node, MultiMeshInstance3D *p_multi_mesh_node, GLTFMeshIndex p_mesh_index, bool p_for_fallback);
+	static Transform3D get_multi_mesh_instance_transform(const Ref<MultiMesh> &p_multi_mesh, int p_instance);
+	static Ref<Mesh> _generate_mesh(Ref<GLTFState> p_gltf_state, GLTFMeshIndex p_mesh_index);
+
+protected:
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+
+public:
+	// Import process.
+	virtual Error import_preflight(Ref<GLTFState> p_gltf_state, const Vector<String> &p_extensions) override;
+	virtual Vector<String> get_supported_extensions() override;
+	virtual Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions) override;
+	virtual Node3D *generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent) override;
+	// Export process.
+	virtual List<PropertyInfo> export_get_property_list(Node *p_root_node) override;
+	virtual void convert_scene_node(Ref<GLTFState> p_gltf_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node) override;
+	virtual Error export_node(Ref<GLTFState> p_gltf_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_node_json, Node *p_scene_node) override;
+};
+
+VARIANT_ENUM_CAST(GLTFDocumentExtensionMultiMesh::MultiMeshHandling);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -54,7 +54,6 @@
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/multimesh_instance_3d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/resources/3d/skin.h"
 #include "scene/resources/image_texture.h"
@@ -4240,9 +4239,6 @@ void GLTFDocument::_convert_scene_node(Ref<GLTFState> p_state, Node *p_current, 
 		_convert_skeleton_to_gltf(skel, p_state, p_gltf_parent, p_gltf_root, gltf_node);
 		// We ignore the Godot Engine node that is the skeleton.
 		return;
-	} else if (Object::cast_to<MultiMeshInstance3D>(p_current)) {
-		MultiMeshInstance3D *multi = Object::cast_to<MultiMeshInstance3D>(p_current);
-		_convert_multi_mesh_instance_to_gltf(multi, p_gltf_parent, p_gltf_root, gltf_node, p_state);
 #ifdef MODULE_CSG_ENABLED
 	} else if (Object::cast_to<CSGShape3D>(p_current)) {
 		CSGShape3D *shape = Object::cast_to<CSGShape3D>(p_current);
@@ -4401,55 +4397,6 @@ void GLTFDocument::_convert_grid_map_to_gltf(GridMap *p_grid_map, GLTFNodeIndex 
 #endif // MODULE_GRIDMAP_ENABLED
 }
 
-void GLTFDocument::_convert_multi_mesh_instance_to_gltf(
-		MultiMeshInstance3D *p_multi_mesh_instance,
-		GLTFNodeIndex p_parent_node_index,
-		GLTFNodeIndex p_root_node_index,
-		Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state) {
-	ERR_FAIL_NULL(p_multi_mesh_instance);
-	Ref<MultiMesh> multi_mesh = p_multi_mesh_instance->get_multimesh();
-	if (multi_mesh.is_null()) {
-		return;
-	}
-	Ref<GLTFMesh> gltf_mesh;
-	gltf_mesh.instantiate();
-	Ref<Mesh> mesh = multi_mesh->get_mesh();
-	if (mesh.is_null()) {
-		return;
-	}
-	gltf_mesh->set_original_name(multi_mesh->get_name());
-	gltf_mesh->set_name(multi_mesh->get_name());
-	gltf_mesh->set_mesh(ImporterMesh::from_mesh(mesh));
-	GLTFMeshIndex mesh_index = p_state->meshes.size();
-	p_state->meshes.push_back(gltf_mesh);
-	for (int32_t instance_i = 0; instance_i < multi_mesh->get_instance_count();
-			instance_i++) {
-		Transform3D transform;
-		if (multi_mesh->get_transform_format() == MultiMesh::TRANSFORM_2D) {
-			Transform2D xform_2d = multi_mesh->get_instance_transform_2d(instance_i);
-			transform.origin =
-					Vector3(xform_2d.get_origin().x, 0, xform_2d.get_origin().y);
-			real_t rotation = xform_2d.get_rotation();
-			Quaternion quaternion(Vector3(0, 1, 0), rotation);
-			Size2 scale = xform_2d.get_scale();
-			transform.basis.set_quaternion_scale(quaternion,
-					Vector3(scale.x, 0, scale.y));
-			transform = p_multi_mesh_instance->get_transform() * transform;
-		} else if (multi_mesh->get_transform_format() == MultiMesh::TRANSFORM_3D) {
-			transform = p_multi_mesh_instance->get_transform() *
-					multi_mesh->get_instance_transform(instance_i);
-		}
-		Ref<GLTFNode> new_gltf_node;
-		new_gltf_node.instantiate();
-		new_gltf_node->mesh = mesh_index;
-		new_gltf_node->transform = transform;
-		new_gltf_node->set_original_name(p_multi_mesh_instance->get_name());
-		new_gltf_node->set_name(_gen_unique_name(p_state, p_multi_mesh_instance->get_name()));
-		p_gltf_node->children.push_back(p_state->nodes.size());
-		p_state->nodes.push_back(new_gltf_node);
-	}
-}
-
 void GLTFDocument::_convert_skeleton_to_gltf(Skeleton3D *p_skeleton3d, Ref<GLTFState> p_state, GLTFNodeIndex p_parent_node_index, GLTFNodeIndex p_root_node_index, Ref<GLTFNode> p_gltf_node) {
 	Skeleton3D *skeleton = p_skeleton3d;
 	Ref<GLTFSkeleton> gltf_skeleton;
@@ -4590,6 +4537,9 @@ bool GLTFDocument::_does_skinned_mesh_require_placeholder_node(Ref<GLTFState> p_
 
 void GLTFDocument::_generate_scene_node(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index, Node *p_scene_parent, Node *p_scene_root) {
 	Ref<GLTFNode> gltf_node = p_state->nodes[p_node_index];
+	if (gltf_node->has_additional_data(StringName("SkipNodeGeneration"))) {
+		return;
+	}
 	Node3D *current_node = nullptr;
 	// Check if any GLTFDocumentExtension classes want to generate a node for us.
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -54,7 +54,6 @@
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/multimesh_instance_3d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/resources/3d/skin.h"
 #include "scene/resources/image_texture.h"
@@ -4267,9 +4266,6 @@ void GLTFDocument::_convert_scene_node(Ref<GLTFState> p_state, Node *p_current, 
 		_convert_skeleton_to_gltf(skel, p_state, p_gltf_parent, p_gltf_root, gltf_node);
 		// We ignore the Godot Engine node that is the skeleton.
 		return;
-	} else if (Object::cast_to<MultiMeshInstance3D>(p_current)) {
-		MultiMeshInstance3D *multi = Object::cast_to<MultiMeshInstance3D>(p_current);
-		_convert_multi_mesh_instance_to_gltf(multi, p_gltf_parent, p_gltf_root, gltf_node, p_state);
 #ifdef MODULE_CSG_ENABLED
 	} else if (Object::cast_to<CSGShape3D>(p_current)) {
 		CSGShape3D *shape = Object::cast_to<CSGShape3D>(p_current);
@@ -4428,55 +4424,6 @@ void GLTFDocument::_convert_grid_map_to_gltf(GridMap *p_grid_map, GLTFNodeIndex 
 #endif // MODULE_GRIDMAP_ENABLED
 }
 
-void GLTFDocument::_convert_multi_mesh_instance_to_gltf(
-		MultiMeshInstance3D *p_multi_mesh_instance,
-		GLTFNodeIndex p_parent_node_index,
-		GLTFNodeIndex p_root_node_index,
-		Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state) {
-	ERR_FAIL_NULL(p_multi_mesh_instance);
-	Ref<MultiMesh> multi_mesh = p_multi_mesh_instance->get_multimesh();
-	if (multi_mesh.is_null()) {
-		return;
-	}
-	Ref<GLTFMesh> gltf_mesh;
-	gltf_mesh.instantiate();
-	Ref<Mesh> mesh = multi_mesh->get_mesh();
-	if (mesh.is_null()) {
-		return;
-	}
-	gltf_mesh->set_original_name(multi_mesh->get_name());
-	gltf_mesh->set_name(multi_mesh->get_name());
-	gltf_mesh->set_mesh(ImporterMesh::from_mesh(mesh));
-	GLTFMeshIndex mesh_index = p_state->meshes.size();
-	p_state->meshes.push_back(gltf_mesh);
-	for (int32_t instance_i = 0; instance_i < multi_mesh->get_instance_count();
-			instance_i++) {
-		Transform3D transform;
-		if (multi_mesh->get_transform_format() == MultiMesh::TRANSFORM_2D) {
-			Transform2D xform_2d = multi_mesh->get_instance_transform_2d(instance_i);
-			transform.origin =
-					Vector3(xform_2d.get_origin().x, 0, xform_2d.get_origin().y);
-			real_t rotation = xform_2d.get_rotation();
-			Quaternion quaternion(Vector3(0, 1, 0), rotation);
-			Size2 scale = xform_2d.get_scale();
-			transform.basis.set_quaternion_scale(quaternion,
-					Vector3(scale.x, 0, scale.y));
-			transform = p_multi_mesh_instance->get_transform() * transform;
-		} else if (multi_mesh->get_transform_format() == MultiMesh::TRANSFORM_3D) {
-			transform = p_multi_mesh_instance->get_transform() *
-					multi_mesh->get_instance_transform(instance_i);
-		}
-		Ref<GLTFNode> new_gltf_node;
-		new_gltf_node.instantiate();
-		new_gltf_node->mesh = mesh_index;
-		new_gltf_node->transform = transform;
-		new_gltf_node->set_original_name(p_multi_mesh_instance->get_name());
-		new_gltf_node->set_name(_gen_unique_name(p_state, p_multi_mesh_instance->get_name()));
-		p_gltf_node->children.push_back(p_state->nodes.size());
-		p_state->nodes.push_back(new_gltf_node);
-	}
-}
-
 void GLTFDocument::_convert_skeleton_to_gltf(Skeleton3D *p_skeleton3d, Ref<GLTFState> p_state, GLTFNodeIndex p_parent_node_index, GLTFNodeIndex p_root_node_index, Ref<GLTFNode> p_gltf_node) {
 	Skeleton3D *skeleton = p_skeleton3d;
 	Ref<GLTFSkeleton> gltf_skeleton;
@@ -4617,6 +4564,9 @@ bool GLTFDocument::_does_skinned_mesh_require_placeholder_node(Ref<GLTFState> p_
 
 void GLTFDocument::_generate_scene_node(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index, Node *p_scene_parent, Node *p_scene_root) {
 	Ref<GLTFNode> gltf_node = p_state->nodes[p_node_index];
+	if (gltf_node->has_additional_data(StringName("SkipNodeGeneration"))) {
+		return;
+	}
 	Node3D *current_node = nullptr;
 	// Check if any GLTFDocumentExtension classes want to generate a node for us.
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -36,7 +36,6 @@
 #include "gltf_state.h"
 
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/multimesh_instance_3d.h"
 
 class CSGShape3D;
 class GridMap;
@@ -267,11 +266,6 @@ public:
 			Ref<GLTFNode> p_gltf_node);
 	void _convert_grid_map_to_gltf(
 			GridMap *p_grid_map,
-			GLTFNodeIndex p_parent_node_index,
-			GLTFNodeIndex p_root_node_index,
-			Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state);
-	void _convert_multi_mesh_instance_to_gltf(
-			MultiMeshInstance3D *p_multi_mesh_instance,
 			GLTFNodeIndex p_parent_node_index,
 			GLTFNodeIndex p_root_node_index,
 			Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state);

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -36,7 +36,6 @@
 #include "gltf_state.h"
 
 #include "scene/3d/mesh_instance_3d.h"
-#include "scene/3d/multimesh_instance_3d.h"
 
 class CSGShape3D;
 class GridMap;
@@ -269,11 +268,6 @@ public:
 			Ref<GLTFNode> p_gltf_node);
 	void _convert_grid_map_to_gltf(
 			GridMap *p_grid_map,
-			GLTFNodeIndex p_parent_node_index,
-			GLTFNodeIndex p_root_node_index,
-			Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state);
-	void _convert_multi_mesh_instance_to_gltf(
-			MultiMeshInstance3D *p_multi_mesh_instance,
 			GLTFNodeIndex p_parent_node_index,
 			GLTFNodeIndex p_root_node_index,
 			Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state);

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -491,3 +491,20 @@ GLTFNodeIndex GLTFState::append_gltf_node(Ref<GLTFNode> p_gltf_node, Node *p_god
 	}
 	return new_index;
 }
+
+String GLTFState::reserve_unique_name(const String &p_requested_name, bool p_show_warning) {
+	const String start_name = p_requested_name.validate_node_name();
+	String unique_name = start_name;
+	if (unique_names.has(unique_name)) {
+		uint64_t discriminator = 2;
+		while (unique_names.has(unique_name)) {
+			unique_name = p_requested_name + String::num_uint64(discriminator);
+			discriminator++;
+		}
+		if (p_show_warning) {
+			WARN_PRINT("GLTFState: The requested name " + p_requested_name + " is already in use. The name " + unique_name + " will be used instead.");
+		}
+	}
+	unique_names.insert(unique_name);
+	return unique_name;
+}

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -492,3 +492,20 @@ GLTFNodeIndex GLTFState::append_gltf_node(Ref<GLTFNode> p_gltf_node, Node *p_god
 	}
 	return new_index;
 }
+
+String GLTFState::reserve_unique_name(const String &p_requested_name, bool p_show_warning) {
+	const String start_name = p_requested_name.validate_node_name();
+	String unique_name = start_name;
+	if (unique_names.has(unique_name)) {
+		uint64_t discriminator = 2;
+		while (unique_names.has(unique_name)) {
+			unique_name = p_requested_name + String::num_uint64(discriminator);
+			discriminator++;
+		}
+		if (p_show_warning) {
+			WARN_PRINT("GLTFState: The requested name " + p_requested_name + " is already in use. The name " + unique_name + " will be used instead.");
+		}
+	}
+	unique_names.insert(unique_name);
+	return unique_name;
+}

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -173,6 +173,7 @@ public:
 	void add_used_extension(const String &p_extension, bool p_required = false);
 	GLTFBufferViewIndex append_data_to_buffers(const Vector<uint8_t> &p_data, const bool p_deduplication);
 	GLTFNodeIndex append_gltf_node(Ref<GLTFNode> p_gltf_node, Node *p_godot_scene_node, GLTFNodeIndex p_parent_node_index);
+	String reserve_unique_name(const String &p_requested_name, bool p_show_warning = true);
 
 	// Deprecated, use HandleBinaryImageMode instead.
 	enum GLTFHandleBinary {

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -31,6 +31,7 @@
 #include "register_types.h"
 
 #include "extensions/gltf_document_extension_convert_importer_mesh.h"
+#include "extensions/gltf_document_extension_multi_mesh.h"
 #include "extensions/gltf_document_extension_texture_ktx.h"
 #include "extensions/gltf_document_extension_texture_webp.h"
 #include "extensions/gltf_spec_gloss.h"
@@ -139,6 +140,7 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 #endif // PHYSICS_3D_DISABLED
 		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionTextureKTX);
 		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionTextureWebP);
+		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionMultiMesh);
 		bool is_editor = Engine::get_singleton()->is_editor_hint();
 		if (!is_editor) {
 			GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionConvertImporterMesh);


### PR DESCRIPTION
Fixes issue #109280, supersedes PR #107866.

This PR adds support for importing glTF `EXT_mesh_gpu_instancing` nodes as Godot MultiMesh nodes:

<img height="1380" alt="Screenshot 2025-11-16 at 1 30 54 PM" src="https://github.com/user-attachments/assets/2a167ad2-e7dd-4d31-bba3-554425320112" />

In master, this extension was not supported, which meant that such objects were not imported as multiple instances.

This PR also adds support for exporting MultiMesh nodes as glTF `EXT_mesh_gpu_instancing`, and configuring the export behavior. Users can choose to use the extension, use plain glTF nodes, or use both:

<img width="1040" height="920" alt="Screenshot 2025-11-16 at 12 42 04 PM" src="https://github.com/user-attachments/assets/2bc8c35b-8f34-4321-a455-69370ea758e9" />

Note that the dropdown only appears when the scene contains at least one MultiMeshInstance3D node, so it won't clutter the export settings UI in most cases where the user does not have any such nodes in their scene.

The options have the following behavior:
* Optional EXT_mesh_gpu_instancing: Convert MultiMesh nodes into the `EXT_mesh_gpu_instancing` extension. The extension is marked as not required, so implementations without support can still load the file, but they will see a single mesh instead of multiple instances of meshes.
* Required EXT_mesh_gpu_instancing: Convert MultiMesh nodes into the `EXT_mesh_gpu_instancing` extension. The extension is marked as required, so implementations without support cannot load the file.
* Multiple Nodes Only: Convert MultiMesh nodes into multiple glTF nodes. This is similar to the existing behavior in master, but there are multiple bugs with the current master, which have been fixed in this PR.
* Multiple Nodes Fallback: Convert MultiMesh nodes into both the `EXT_mesh_gpu_instancing` extension and multiple nodes, allowing it to be imported as a MultiMesh when supported, or imported as nodes when not supported.

Here's what it looks like when loading a glTF exported with "Multiple Nodes Fallback" into Godot 4.5-stable:

<img height="1740" alt="Screenshot 2025-11-16 at 12 36 37 PM" src="https://github.com/user-attachments/assets/6b46ee3e-e6bb-4904-8a5e-797cbb8e3873" />

This PR also makes several related changes:
* Add a function to GLTFState to reserve a unique name (previously was private to GLTFDocument).
* Fix a bug where MultiMesh's own transform was multiplied into each instance.
* Fix a bug where 2D MultiMesh transforms were swapping the Y coordinate into Z.
* Fix a bug where the material name was used as the surface name instead of the surface name.

Test files: [ext_mesh_gpu_instancing.zip](https://github.com/user-attachments/files/26908762/ext_mesh_gpu_instancing.zip)
