### PR TITLE
Explain how `@export_group` can be nested just like subgroups

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -605,7 +605,6 @@
 			<description>
 				Define a new group for the following exported properties. This helps to organize properties in the Inspector dock. Groups can be added with an optional [param prefix], which would make group to only consider properties that have this prefix. The grouping will break on the first property that doesn't have a prefix. The prefix is also removed from the property's name in the Inspector dock.
 				If no [param prefix] is provided, then every following property will be added to the group. The group ends when then next group or category is defined. You can also force end a group by using this annotation with empty strings for parameters, [code]@export_group("", "")[/code].
-				Groups cannot be nested, use [annotation @export_subgroup] to add subgroups within groups.
 				See also [constant PROPERTY_USAGE_GROUP].
 				[codeblock]
 				@export_group("Racer Properties")
@@ -619,6 +618,20 @@
 				@export_group("", "")
 				@export var ungrouped_number = 3
 				[/codeblock]
+				[b]Note:[/b] Groups cannot be nested, but you can use the slash separator ([code]/[/code]) to achieve the desired effect:
+				[codeblock]
+				@export_group("Car Properties")
+				@export_group("Car Properties/Wheels", "wheel_")
+				@export_group("Car Properties/Wheels/Front", "front_wheel_")
+				@export var front_wheel_strength = 10
+				@export var front_wheel_mobility = 5
+				@export_group("Car Properties/Wheels/Rear", "rear_wheel_")
+				@export var rear_wheel_strength = 8
+				@export var rear_wheel_mobility = 3
+				@export_group("Car Properties/Wheels", "wheel_")
+				@export var wheel_material: PhysicsMaterial
+				[/codeblock]
+				Alternatively, you can use [annotation @export_subgroup] to add subgroups within groups.
 			</description>
 		</annotation>
 		<annotation name="@export_multiline">


### PR DESCRIPTION
The GdScript docs say that @export_groups cannot be nested, but `@export_subgroups` can be nested with /

https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html#class-gdscript-annotation-export-group
https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html#class-gdscript-annotation-export-subgroup

That's, like, not true. You can nest using / with both groups and subgroups.

Here is an example using the code from the docs, but I swapped "subgroup" with "group" :

<img width="1379" height="326" alt="image" src="https://github.com/user-attachments/assets/28abfc30-5207-4267-b72f-e2baeff6ad99" />

So I fixed the docs to reflect this.

However, this does put into question why we even have both `@export_group` and `@export_subgroup` if they do the same thing.

------------------------------------------

Also, I don't get why we are told to go on the godot-docs repo for issues, only to then be sent back here 
<img width="879" height="251" alt="image" src="https://github.com/user-attachments/assets/a2297fc3-3fa9-4115-a3c0-7fba0f1e0ef1" />
