### PR TITLE
Improve descriptions of locale name related methods

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -419,12 +419,11 @@ Vector<String> TranslationServer::get_all_languages() const {
 	return languages;
 }
 
-String TranslationServer::get_language_name(const String &p_language) const {
-	if (language_map.has(p_language)) {
-		return language_map[p_language];
-	} else {
-		return p_language;
+String TranslationServer::get_language_name(const String &p_code) const {
+	if (language_map.has(p_code)) {
+		return language_map[p_code];
 	}
+	return p_code;
 }
 
 Vector<String> TranslationServer::get_all_scripts() const {
@@ -437,12 +436,11 @@ Vector<String> TranslationServer::get_all_scripts() const {
 	return scripts;
 }
 
-String TranslationServer::get_script_name(const String &p_script) const {
-	if (script_map.has(p_script)) {
-		return script_map[p_script];
-	} else {
-		return p_script;
+String TranslationServer::get_script_name(const String &p_code) const {
+	if (script_map.has(p_code)) {
+		return script_map[p_code];
 	}
+	return p_code;
 }
 
 Vector<String> TranslationServer::get_all_countries() const {
@@ -455,12 +453,11 @@ Vector<String> TranslationServer::get_all_countries() const {
 	return countries;
 }
 
-String TranslationServer::get_country_name(const String &p_country) const {
-	if (country_name_map.has(p_country)) {
-		return country_name_map[p_country];
-	} else {
-		return p_country;
+String TranslationServer::get_country_name(const String &p_code) const {
+	if (country_name_map.has(p_code)) {
+		return country_name_map[p_code];
 	}
+	return p_code;
 }
 
 void TranslationServer::set_locale(const String &p_locale) {
@@ -658,13 +655,13 @@ void TranslationServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("standardize_locale", "locale", "add_defaults"), &TranslationServer::standardize_locale, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("get_all_languages"), &TranslationServer::get_all_languages);
-	ClassDB::bind_method(D_METHOD("get_language_name", "language"), &TranslationServer::get_language_name);
+	ClassDB::bind_method(D_METHOD("get_language_name", "code"), &TranslationServer::get_language_name);
 
 	ClassDB::bind_method(D_METHOD("get_all_scripts"), &TranslationServer::get_all_scripts);
-	ClassDB::bind_method(D_METHOD("get_script_name", "script"), &TranslationServer::get_script_name);
+	ClassDB::bind_method(D_METHOD("get_script_name", "code"), &TranslationServer::get_script_name);
 
 	ClassDB::bind_method(D_METHOD("get_all_countries"), &TranslationServer::get_all_countries);
-	ClassDB::bind_method(D_METHOD("get_country_name", "country"), &TranslationServer::get_country_name);
+	ClassDB::bind_method(D_METHOD("get_country_name", "code"), &TranslationServer::get_country_name);
 
 	ClassDB::bind_method(D_METHOD("get_locale_name", "locale"), &TranslationServer::get_locale_name);
 	ClassDB::bind_method(D_METHOD("get_plural_rules", "locale"), &TranslationServer::get_plural_rules);

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -113,13 +113,13 @@ public:
 	Ref<Translation> get_translation_object(const String &p_locale);
 
 	Vector<String> get_all_languages() const;
-	String get_language_name(const String &p_language) const;
+	String get_language_name(const String &p_code) const;
 
 	Vector<String> get_all_scripts() const;
-	String get_script_name(const String &p_script) const;
+	String get_script_name(const String &p_code) const;
 
 	Vector<String> get_all_countries() const;
-	String get_country_name(const String &p_country) const;
+	String get_country_name(const String &p_code) const;
 
 	String get_locale_name(const String &p_locale) const;
 	String get_plural_rules(const String &p_locale) const;

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -61,16 +61,18 @@
 		</method>
 		<method name="get_country_name" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="country" type="String" />
+			<param index="0" name="code" type="String" />
 			<description>
-				Returns a readable country name for the [param country] code.
+				Returns the English name for the given country code. Returns [param code] as-is if it is unrecognized.
+				[b]Note:[/b] The returned names are intended for editor scripts, plugins, or debugging purposes. The list of recognized codes may vary across different versions or builds.
 			</description>
 		</method>
 		<method name="get_language_name" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="language" type="String" />
+			<param index="0" name="code" type="String" />
 			<description>
-				Returns a readable language name for the [param language] code.
+				Returns the English name for the given language code. Returns [param code] as-is if it is unrecognized.
+				[b]Note:[/b] The returned names are intended for editor scripts, plugins, or debugging purposes. The list of recognized codes may vary across different versions or builds.
 			</description>
 		</method>
 		<method name="get_loaded_locales" qualifiers="const">
@@ -90,7 +92,8 @@
 			<return type="String" />
 			<param index="0" name="locale" type="String" />
 			<description>
-				Returns a locale's language and its variant (e.g. [code]"en_US"[/code] would return [code]"English (United States)"[/code]).
+				Returns a locale's language and its variant in English (e.g. [code]"en_US"[/code] would return [code]"English (United States)"[/code]).
+				[b]Note:[/b] The returned names are intended for editor scripts, plugins, or debugging purposes. The list of recognized codes may vary across different versions or builds.
 			</description>
 		</method>
 		<method name="get_or_add_domain">
@@ -116,9 +119,10 @@
 		</method>
 		<method name="get_script_name" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="script" type="String" />
+			<param index="0" name="code" type="String" />
 			<description>
-				Returns a readable script name for the [param script] code.
+				Returns the English name for the given script code. Returns [param code] as-is if it is unrecognized.
+				[b]Note:[/b] The returned names are intended for editor scripts, plugins, or debugging purposes. The list of recognized codes may vary across different versions or builds.
 			</description>
 		</method>
 		<method name="get_tool_locale">


### PR DESCRIPTION
```gdscript
func get_locale_name(locale) -> String
func get_language_name(code) -> String
func get_country_name(code) -> String
func get_script_name(code) -> String
```

Documents the fact that these methods either return names in English or return the input as-is.

These methods are very unlikely to get localization support. The number of languages supported by a game is typically quite limited. It is more practical and offers greater flexibility for the game to handle its own translations.

Further more, Godot does not guarantee recognition of all locale codes. Including numerous unused name strings in the game is also wasteful. Therefore, users should be advised to avoid using these methods to provide text for UI in production games.

In the future, I think we can consider shorten / strip the list of recognized code in release mode export templates.