### PR TITLE
Prevent C# source generators from fully qualifying members assigned to within an object initializer

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
@@ -221,6 +221,10 @@ partial class ExportedFields
         /// </summary>
         public new static readonly global::Godot.StringName @_fieldGodotResourceTexture = "_fieldGodotResourceTexture";
         /// <summary>
+        /// Cached name for the '_fieldGodotResourceTextureWithInitializer' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName @_fieldGodotResourceTextureWithInitializer = "_fieldGodotResourceTextureWithInitializer";
+        /// <summary>
         /// Cached name for the '_fieldStringName' field.
         /// </summary>
         public new static readonly global::Godot.StringName @_fieldStringName = "_fieldStringName";
@@ -467,6 +471,10 @@ partial class ExportedFields
         }
         if (name == PropertyName.@_fieldGodotResourceTexture) {
             this.@_fieldGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            return true;
+        }
+        if (name == PropertyName.@_fieldGodotResourceTextureWithInitializer) {
+            this.@_fieldGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
             return true;
         }
         if (name == PropertyName.@_fieldStringName) {
@@ -719,6 +727,10 @@ partial class ExportedFields
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@_fieldGodotResourceTexture);
             return true;
         }
+        if (name == PropertyName.@_fieldGodotResourceTextureWithInitializer) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@_fieldGodotResourceTextureWithInitializer);
+            return true;
+        }
         if (name == PropertyName.@_fieldStringName) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this.@_fieldStringName);
             return true;
@@ -815,6 +827,7 @@ partial class ExportedFields
         properties.Add(new(type: (global::Godot.Variant.Type)0, name: PropertyName.@_fieldVariant, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)135174, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.@_fieldGodotObjectOrDerived, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.@_fieldGodotResourceTexture, hint: (global::Godot.PropertyHint)17, hintString: "Texture", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.@_fieldGodotResourceTextureWithInitializer, hint: (global::Godot.PropertyHint)17, hintString: "Texture", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)21, name: PropertyName.@_fieldStringName, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)22, name: PropertyName.@_fieldNodePath, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)23, name: PropertyName.@_fieldRid, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptPropertyDefVal.generated.cs
@@ -11,7 +11,7 @@ partial class ExportedFields
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal new static global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant> GetGodotPropertyDefaultValues()
     {
-        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(61);
+        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(62);
         bool ___fieldBoolean_default_value = true;
         values.Add(PropertyName.@_fieldBoolean, global::Godot.Variant.From<bool>(___fieldBoolean_default_value));
         char ___fieldChar_default_value = 'f';
@@ -118,6 +118,8 @@ partial class ExportedFields
         values.Add(PropertyName.@_fieldGodotObjectOrDerived, global::Godot.Variant.From<global::Godot.GodotObject>(___fieldGodotObjectOrDerived_default_value));
         global::Godot.Texture ___fieldGodotResourceTexture_default_value = default;
         values.Add(PropertyName.@_fieldGodotResourceTexture, global::Godot.Variant.From<global::Godot.Texture>(___fieldGodotResourceTexture_default_value));
+        global::Godot.Texture ___fieldGodotResourceTextureWithInitializer_default_value = new()  { ResourceName  = ""   };
+        values.Add(PropertyName.@_fieldGodotResourceTextureWithInitializer, global::Godot.Variant.From<global::Godot.Texture>(___fieldGodotResourceTextureWithInitializer_default_value));
         global::Godot.StringName ___fieldStringName_default_value = new global::Godot.StringName("foo");
         values.Add(PropertyName.@_fieldStringName, global::Godot.Variant.From<global::Godot.StringName>(___fieldStringName_default_value));
         global::Godot.NodePath ___fieldNodePath_default_value = new global::Godot.NodePath("foo");

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
@@ -261,6 +261,10 @@ partial class ExportedProperties
         /// </summary>
         public new static readonly global::Godot.StringName @PropertyGodotResourceTexture = "PropertyGodotResourceTexture";
         /// <summary>
+        /// Cached name for the 'PropertyGodotResourceTextureWithInitializer' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName @PropertyGodotResourceTextureWithInitializer = "PropertyGodotResourceTextureWithInitializer";
+        /// <summary>
         /// Cached name for the 'PropertyStringName' property.
         /// </summary>
         public new static readonly global::Godot.StringName @PropertyStringName = "PropertyStringName";
@@ -571,6 +575,10 @@ partial class ExportedProperties
         }
         if (name == PropertyName.@PropertyGodotResourceTexture) {
             this.@PropertyGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            return true;
+        }
+        if (name == PropertyName.@PropertyGodotResourceTextureWithInitializer) {
+            this.@PropertyGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
             return true;
         }
         if (name == PropertyName.@PropertyStringName) {
@@ -887,6 +895,10 @@ partial class ExportedProperties
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@PropertyGodotResourceTexture);
             return true;
         }
+        if (name == PropertyName.@PropertyGodotResourceTextureWithInitializer) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@PropertyGodotResourceTextureWithInitializer);
+            return true;
+        }
         if (name == PropertyName.@PropertyStringName) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this.@PropertyStringName);
             return true;
@@ -1024,6 +1036,7 @@ partial class ExportedProperties
         properties.Add(new(type: (global::Godot.Variant.Type)0, name: PropertyName.@PropertyVariant, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)135174, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.@PropertyGodotObjectOrDerived, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.@PropertyGodotResourceTexture, hint: (global::Godot.PropertyHint)17, hintString: "Texture", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)24, name: PropertyName.@PropertyGodotResourceTextureWithInitializer, hint: (global::Godot.PropertyHint)17, hintString: "Texture", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)21, name: PropertyName.@PropertyStringName, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)22, name: PropertyName.@PropertyNodePath, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)23, name: PropertyName.@PropertyRid, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
@@ -11,7 +11,7 @@ partial class ExportedProperties
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal new static global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant> GetGodotPropertyDefaultValues()
     {
-        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(70);
+        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(71);
         string __NotGenerateComplexLamdaProperty_default_value = default;
         values.Add(PropertyName.@NotGenerateComplexLamdaProperty, global::Godot.Variant.From<string>(__NotGenerateComplexLamdaProperty_default_value));
         string __NotGenerateLamdaNoFieldProperty_default_value = default;
@@ -138,6 +138,8 @@ partial class ExportedProperties
         values.Add(PropertyName.@PropertyGodotObjectOrDerived, global::Godot.Variant.From<global::Godot.GodotObject>(__PropertyGodotObjectOrDerived_default_value));
         global::Godot.Texture __PropertyGodotResourceTexture_default_value = default;
         values.Add(PropertyName.@PropertyGodotResourceTexture, global::Godot.Variant.From<global::Godot.Texture>(__PropertyGodotResourceTexture_default_value));
+        global::Godot.Texture __PropertyGodotResourceTextureWithInitializer_default_value = new()  { ResourceName  = ""   };
+        values.Add(PropertyName.@PropertyGodotResourceTextureWithInitializer, global::Godot.Variant.From<global::Godot.Texture>(__PropertyGodotResourceTextureWithInitializer_default_value));
         global::Godot.StringName __PropertyStringName_default_value = new global::Godot.StringName("foo");
         values.Add(PropertyName.@PropertyStringName, global::Godot.Variant.From<global::Godot.StringName>(__PropertyStringName_default_value));
         global::Godot.NodePath __PropertyNodePath_default_value = new global::Godot.NodePath("foo");

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedFields.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedFields.cs
@@ -88,6 +88,7 @@ public partial class ExportedFields : GodotObject
     // Classes
     [Export] private GodotObject _fieldGodotObjectOrDerived;
     [Export] private Godot.Texture _fieldGodotResourceTexture;
+    [Export] private Godot.Texture _fieldGodotResourceTextureWithInitializer = new() { ResourceName = "" };
     [Export] private StringName _fieldStringName = new StringName("foo");
     [Export] private NodePath _fieldNodePath = new NodePath("foo");
     [Export] private Rid _fieldRid;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
@@ -207,6 +207,7 @@ public partial class ExportedProperties(string primaryCtorParameter) : GodotObje
     // Classes
     [Export] private GodotObject PropertyGodotObjectOrDerived { get; set; }
     [Export] private Godot.Texture PropertyGodotResourceTexture { get; set; }
+    [Export] private Godot.Texture PropertyGodotResourceTextureWithInitializer { get; set; } = new() { ResourceName = "" };
     [Export] private StringName PropertyStringName { get; set; } = new StringName("foo");
     [Export] private NodePath PropertyNodePath { get; set; } = new NodePath("foo");
     [Export] private Rid PropertyRid { get; set; }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -212,11 +212,17 @@ namespace Godot.SourceGenerators
 
         private static void FullQualifiedSyntax(SyntaxNode node, SemanticModel sm, StringBuilder sb, bool isFirstNode)
         {
-            if (node is NameSyntax ns && (isFirstNode || node.Parent is not MemberAccessExpressionSyntax))
+            if (node is NameSyntax ns)
             {
-                SymbolInfo nameInfo = sm.GetSymbolInfo(ns);
-                sb.Append(nameInfo.Symbol?.ToDisplayString(FullyQualifiedFormatIncludeGlobal) ?? ns.ToString());
-                return;
+                bool isMemberAccess = !isFirstNode && node.Parent is MemberAccessExpressionSyntax;
+                bool isInitializer = isFirstNode && node.Parent is AssignmentExpressionSyntax { Parent: InitializerExpressionSyntax };
+
+                if (!isMemberAccess && !isInitializer)
+                {
+                    SymbolInfo nameInfo = sm.GetSymbolInfo(ns);
+                    sb.Append(nameInfo.Symbol?.ToDisplayString(FullyQualifiedFormatIncludeGlobal) ?? ns.ToString());
+                    return;
+                }
             }
 
             bool innerIsFirstNode = true;


### PR DESCRIPTION
Fixes #112869 

Prevents source generators from fully qualifying members being assigned to within an object initializer and adds source generator test cases for exported properties and fields with initializers.

Originally, the NameSyntax for the member was always written fully qualified, generating invalid code.
An example showing the fix applied to the minimum reproduction project for #112869:
Old generation:
`global::Godot.Resource __Resource_default_value = new()  { global::Godot.Resource.ResourceName = ""   };`
New generation:
`global::Godot.Resource __Resource_default_value = new()  { ResourceName = ""   };`