### PR TITLE
Add stepOut request support to Debug Adapter Protocol server

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -57,6 +57,7 @@ void DebugAdapterParser::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("req_variables", "params"), &DebugAdapterParser::req_variables);
 	ClassDB::bind_method(D_METHOD("req_next", "params"), &DebugAdapterParser::req_next);
 	ClassDB::bind_method(D_METHOD("req_stepIn", "params"), &DebugAdapterParser::req_stepIn);
+	ClassDB::bind_method(D_METHOD("req_stepOut", "params"), &DebugAdapterParser::req_stepOut);
 	ClassDB::bind_method(D_METHOD("req_evaluate", "params"), &DebugAdapterParser::req_evaluate);
 	ClassDB::bind_method(D_METHOD("req_godot/put_msg", "params"), &DebugAdapterParser::req_godot_put_msg);
 }
@@ -488,6 +489,13 @@ Dictionary DebugAdapterParser::req_next(const Dictionary &p_params) const {
 
 Dictionary DebugAdapterParser::req_stepIn(const Dictionary &p_params) const {
 	EditorDebuggerNode::get_singleton()->get_default_debugger()->debug_step();
+	DebugAdapterProtocol::get_singleton()->_stepping = true;
+
+	return prepare_success_response(p_params);
+}
+
+Dictionary DebugAdapterParser::req_stepOut(const Dictionary &p_params) const {
+	EditorDebuggerNode::get_singleton()->get_default_debugger()->debug_out();
 	DebugAdapterProtocol::get_singleton()->_stepping = true;
 
 	return prepare_success_response(p_params);

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -81,6 +81,7 @@ public:
 	Dictionary req_variables(const Dictionary &p_params) const;
 	Dictionary req_next(const Dictionary &p_params) const;
 	Dictionary req_stepIn(const Dictionary &p_params) const;
+	Dictionary req_stepOut(const Dictionary &p_params) const;
 	Dictionary req_evaluate(const Dictionary &p_params) const;
 	Dictionary req_godot_put_msg(const Dictionary &p_params) const;
 


### PR DESCRIPTION
## Summary

Adds `stepOut` request handler to the DAP server, enabling external clients to step out of functions during debugging.

## Motivation

PR #97758 added step-out functionality to the editor debugger in Godot 4.6, making it easy to extend the Debug Adapter Protocol (DAP) server with the step-out capability as well. This will allow users of external DAP clients (Neovim, Zed, etc.) to utilize step-out.

## Changes

  - Added `req_stepOut()` declaration to `debug_adapter_parser.h`
  - Added `req_stepOut()` implementation to `debug_adapter_parser.cpp`
  - Registered `stepOut` command handler in `debug_adapter_parser.cpp`

## Implementation

Follows the pattern used by `req_next()` (step over) and `req_stepIn()` (step into). The implementation bridges the step-out DAP request to the existing debug_out() method added in #97758. 

## Testing

Manually tested with custom scripts. I can provide more information if you like.

## Breaking changes

No breaking changes.

## References

  - Related feature request: godotengine/godot-proposals#2815 (closed by #97758, adding step-out to built-in debugger)
  - Editor implementation: #97758 (merged Nov 14, 2025)
  - DAP specification: https://microsoft.github.io/debug-adapter-protocol/specification#Requests_StepOut
