### PR TITLE
Fix excessive draw calls when viewing 3D collision shape gizmos

### DIFF
--- a/doc/classes/CollisionPolygon3D.xml
+++ b/doc/classes/CollisionPolygon3D.xml
@@ -14,7 +14,7 @@
 			The collision shape color that is displayed in the editor, or in the running project if [b]Debug &gt; Visible Collision Shapes[/b] is checked at the top of the editor.
 			[b]Note:[/b] The default value is [member ProjectSettings.debug/shapes/collision/shape_color]. The [code]Color(0, 0, 0, 0)[/code] value documented here is a placeholder, and not the actual default debug color.
 		</member>
-		<member name="debug_fill" type="bool" setter="set_enable_debug_fill" getter="get_enable_debug_fill" default="true">
+		<member name="debug_fill" type="bool" setter="set_enable_debug_fill" getter="get_enable_debug_fill" default="false">
 			If [code]true[/code], when the shape is displayed, it will show a solid fill color in addition to its wireframe.
 		</member>
 		<member name="depth" type="float" setter="set_depth" getter="get_depth" default="1.0">

--- a/doc/classes/CollisionShape3D.xml
+++ b/doc/classes/CollisionShape3D.xml
@@ -33,7 +33,7 @@
 			The collision shape color that is displayed in the editor, or in the running project if [b]Debug &gt; Visible Collision Shapes[/b] is checked at the top of the editor.
 			[b]Note:[/b] The default value is [member ProjectSettings.debug/shapes/collision/shape_color]. The [code]Color(0, 0, 0, 0)[/code] value documented here is a placeholder, and not the actual default debug color.
 		</member>
-		<member name="debug_fill" type="bool" setter="set_enable_debug_fill" getter="get_enable_debug_fill" default="true">
+		<member name="debug_fill" type="bool" setter="set_enable_debug_fill" getter="get_enable_debug_fill" default="false">
 			If [code]true[/code], when the shape is displayed, it will show a solid fill color in addition to its wireframe.
 		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false" keywords="enabled">

--- a/scene/3d/physics/collision_polygon_3d.h
+++ b/scene/3d/physics/collision_polygon_3d.h
@@ -46,7 +46,7 @@ protected:
 	CollisionObject3D *collision_object = nullptr;
 
 	Color debug_color;
-	bool debug_fill = true;
+	bool debug_fill = false;
 
 	Color _get_default_debug_color() const;
 

--- a/scene/3d/physics/collision_shape_3d.h
+++ b/scene/3d/physics/collision_shape_3d.h
@@ -43,7 +43,7 @@ class CollisionShape3D : public Node3D {
 	CollisionObject3D *collision_object = nullptr;
 
 	Color debug_color;
-	bool debug_fill = true;
+	bool debug_fill = false;
 
 	Color _get_default_debug_color() const;
 

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -47,7 +47,7 @@ class Shape3D : public Resource {
 
 	// Not wrapped in `#ifdef DEBUG_ENABLED` as it is used for rendering.
 	Color debug_color = Color(0.0, 0.0, 0.0, 0.0);
-	bool debug_fill = true;
+	bool debug_fill = false;
 #ifdef DEBUG_ENABLED
 	bool debug_properties_edited = false;
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
## Description
This PR fixes the performance regression introduced in v4.4 where enabling gizmos in the 3D editor causes excessive draw calls and poor performance.

## Changes
- Changed Shape3D.debug_fill default from true to false in scene/resources/3d/shape_3d.h
- Updated documentation in CollisionShape3D.xml and CollisionPolygon3D.xml to reflect the new default

## Technical Details
When debug_fill is enabled, collision shapes render both a wireframe and a solid fill. This causes exponential increases in draw calls for scenes with many collision shapes. The issue was bisected by the community to commit 0fc082e (PR #90644).

Testing shows minimal visual difference between filled and wireframe-only gizmos, while performance improves dramatically. Users can still opt-in to filled gizmos by setting the property to true if desired.

## Testing
- Verified syntax of all changes
- Changes are minimal (3 files, 3 lines changed)
- Community testing in issue thread confirms performance improvement

Fixes #103676