### PR TITLE
Support reading available OpenXR runtimes from Windows registry

### DIFF
--- a/modules/openxr/editor/openxr_select_runtime.h
+++ b/modules/openxr/editor/openxr_select_runtime.h
@@ -44,4 +44,8 @@ protected:
 private:
 	void _update_items();
 	void _on_item_selected(int p_which);
+
+	Dictionary _enumerate_runtimes();
+	String _try_and_get_runtime_name(const String &p_config_file);
+	void _add_runtime(Dictionary &r_runtimes, const String &p_config_file);
 };


### PR DESCRIPTION
Follows spec as described in https://registry.khronos.org/OpenXR/specs/1.0/loader.html#runtime-enumeration