### PR TITLE
Bind `EditorFileSystem::is_importing()`

### DIFF
--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -36,6 +36,12 @@
 				Returns the scan progress for 0 to 1 if the FS is being scanned.
 			</description>
 		</method>
+		<method name="is_importing" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if resources are currently being imported.
+			</description>
+		</method>
 		<method name="is_scanning" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3676,6 +3676,7 @@ bool EditorFileSystem::_scan_extensions() {
 void EditorFileSystem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_filesystem"), &EditorFileSystem::get_filesystem);
 	ClassDB::bind_method(D_METHOD("is_scanning"), &EditorFileSystem::is_scanning);
+	ClassDB::bind_method(D_METHOD("is_importing"), &EditorFileSystem::is_importing);
 	ClassDB::bind_method(D_METHOD("get_scanning_progress"), &EditorFileSystem::get_scanning_progress);
 	ClassDB::bind_method(D_METHOD("scan"), &EditorFileSystem::scan);
 	ClassDB::bind_method(D_METHOD("scan_sources"), &EditorFileSystem::scan_changes);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
We're currently working on a version control plugin. When we are about to perform any sort of VCS operation (pull, checkout, etc.), we have to make sure that the editor is not currently in a state in which it may make changes to the project files. This would include whenever EditorFileSystem is scanning or is importing. While `EditorFileSystem::is_scanning()` is bound, `EditorFileSystem::is_importing()` is not. This PR fixes that.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/13669*