### PR TITLE
Optimize `Node.find_children` by 24%

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2005,24 +2005,40 @@ Node *Node::find_child(const String &p_pattern, bool p_recursive, bool p_owned) 
 // Can be recursive or not, and limited to owned nodes.
 TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_type, bool p_recursive, bool p_owned) const {
 	ERR_THREAD_GUARD_V(TypedArray<Node>());
+
 	TypedArray<Node> ret;
 	ERR_FAIL_COND_V(p_pattern.is_empty() && p_type.is_empty(), ret);
+
+	// Start at first child.
 	_update_children_cache();
-	Node *const *cptr = data.children_cache.ptr();
-	int ccount = data.children_cache.size();
-	for (int i = 0; i < ccount; i++) {
-		if (p_owned && !cptr[i]->data.owner) {
+	if (data.children_cache.is_empty()) {
+		return ret;
+	}
+	const Node *current_node = data.children_cache[0];
+
+	// Check current node repeatedly.
+	while (true) {
+		if (p_owned && !current_node->data.owner) {
+			const LocalVector<Node *> &siblings = current_node->data.parent->data.children_cache;
+
+			if (current_node->data.index + 1 >= (int)siblings.size()) {
+				// Finished iterating all children.
+				return ret;
+			}
+
+			// Go to next sibling.
+			current_node = siblings[current_node->data.index + 1];
 			continue;
 		}
 
-		if (p_pattern.is_empty() || cptr[i]->data.name.operator String().match(p_pattern)) {
-			if (p_type.is_empty() || cptr[i]->is_class(p_type)) {
-				ret.append(cptr[i]);
-			} else if (cptr[i]->get_script_instance()) {
-				Ref<Script> scr = cptr[i]->get_script_instance()->get_script();
+		if (p_pattern.is_empty() || current_node->data.name.operator String().match(p_pattern)) {
+			if (p_type.is_empty() || current_node->is_class(p_type)) {
+				ret.append(current_node);
+			} else if (current_node->get_script_instance()) {
+				Ref<Script> scr = current_node->get_script_instance()->get_script();
 				while (scr.is_valid()) {
 					if ((ScriptServer::is_global_class(p_type) && ScriptServer::get_global_class_path(p_type) == scr->get_path()) || p_type == scr->get_path()) {
-						ret.append(cptr[i]);
+						ret.append(current_node);
 						break;
 					}
 
@@ -2031,12 +2047,47 @@ TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_ty
 			}
 		}
 
-		if (p_recursive) {
-			ret.append_array(cptr[i]->find_children(p_pattern, p_type, true, p_owned));
+		// The following code performs a "tree walk" to avoid recursion and allocations.
+		current_node->_update_children_cache();
+
+		if (!p_recursive) {
+			const LocalVector<Node *> &siblings = current_node->data.parent->data.children_cache;
+
+			if (current_node->data.index + 1 >= (int)siblings.size()) {
+				// Finished iterating all children.
+				return ret;
+			}
+
+			// Go to next sibling.
+			current_node = siblings[current_node->data.index + 1];
+			continue;
+		}
+
+		if (!current_node->data.children_cache.is_empty()) {
+			// Go to first child.
+			current_node = current_node->data.children_cache[0];
+			continue;
+		}
+
+		// Find next sibling.
+		while (true) {
+			const LocalVector<Node *> &siblings = current_node->data.parent->data.children_cache;
+
+			if (current_node->data.index + 1 < (int)siblings.size()) {
+				// Go to next sibling.
+				current_node = siblings[current_node->data.index + 1];
+				break;
+			}
+
+			// Go back to parent.
+			current_node = current_node->data.parent;
+
+			if (current_node == this) {
+				// Finished iterating all descendants.
+				return ret;
+			}
 		}
 	}
-
-	return ret;
 }
 
 void Node::reparent(Node *p_parent, bool p_keep_global_transform) {


### PR DESCRIPTION
I optimized the performance of recursive `find_children` by 24%. Currently, it creates a new array for each descendant, only to append each descendant to the original array. This pull request makes it use the same array, using a lambda function.

Benchmark:
```gdscript
extends Node3D

func _ready()->void:
	while true:
		bench_old()
		bench_new()
		await get_tree().process_frame

func bench_old()->void:
	var start:float = Time.get_unix_time_from_system()
	var results:Array[Node]
	for i:int in 100_000:
		results = find_children_old("*")
	var end:float = Time.get_unix_time_from_system()
	print("old: ", (end - start) * 1000, "ms")
	results.clear()

func bench_new()->void:
	var start:float = Time.get_unix_time_from_system()
	var results:Array[Node]
	for i:int in 100_000:
		results = find_children("*")
	var end:float = Time.get_unix_time_from_system()
	print("new: ", (end - start) * 1000, "ms")
	results.clear()

```
Result:
```gdscript
old: 839.999914169312ms
new: 636.000156402588ms
old: 832.000017166138ms
new: 635.999917984009ms
old: 833.000183105469ms
new: 638.000011444092ms
```

This means each benchmark call used to take `0.0084ms` but now takes `0.00636ms`.

The benchmarks were run in-editor with 41 descendants that I created and scattered randomly to emulate a real scene tree.