### PR TITLE
Fix StringExtensions.SplitFloats incorrect float parsing

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1539,7 +1539,7 @@ namespace Godot
                 if (end < 0)
                     end = len;
                 if (allowEmpty || end > from)
-                    ret.Add(float.Parse(instance.AsSpan(from), CultureInfo.InvariantCulture));
+                    ret.Add(float.Parse(instance.AsSpan(from, end - from), CultureInfo.InvariantCulture));
                 if (end == len)
                     break;
 


### PR DESCRIPTION
the current code assumes that float.Parse behaves the same as the internal C++ code, however without using "end" as part of the span, it will parse from index 0 to the end of the string, ignoring commas. for example, this causes it to parse "0,5,0" with divisor "," as [50, 50, 0], as the float.Parse method ignores commas in floats.

if another divisor is used, it throws a System.FormatException due to containing invalid characters, as it fails to account for the position of the divisor for the span.