### PR TITLE
Prevent the main locale from being set to an empty string

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -464,6 +464,8 @@ String TranslationServer::get_country_name(const String &p_country) const {
 }
 
 void TranslationServer::set_locale(const String &p_locale) {
+	ERR_FAIL_COND_MSG(p_locale.is_empty(), "Locale cannot be an empty string.");
+
 	String new_locale = standardize_locale(p_locale);
 	if (locale == new_locale) {
 		return;


### PR DESCRIPTION
It's assumed that `TranslationServer.get_locale()` always returns a non-empty string. But there is currently nothing to prevent it from being set to an empty string.

Note: Technically, being non-empty is not enough for a string to be a valid locale. However, this appears to be the only requirement for locales in the current codebase.

Another reason for this change was that Akien [encountered](https://chat.godotengine.org/channel/core?msg=WbN8BaZYhNSkhxk2t) a case where `interface/editor/editor_language` somehow carries an empty string, which caused an error spam when importing a 3D model. This issue cannot be reproduced consistently, but we should at least turn the error spam into only one error on startup.
