### PR TITLE
Fix cannot remove scene root when reload scene

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -643,7 +643,7 @@ void EditorData::remove_scene(int p_idx) {
 			editor_plugins[i]->notify_scene_closed(edited_scene[p_idx].root->get_scene_file_path());
 		}
 
-		memdelete(edited_scene[p_idx].root);
+		edited_scene[p_idx].root->queue_free();
 		edited_scene.write[p_idx].root = nullptr;
 	}
 


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/112880*
- *Follow up: https://github.com/godotengine/godot/pull/112401*

## Issue Description

When we move a instanced scene file cross different folders in `FileSystemDock`, we will call `reload_scene()` to reload both `main.tscn` and `sub.tscn`.

Currently, we call `memdelete()` to delete root node of scene immediately. It will be considered as an accidental deletion.

Because `remove_scene()` not only delete root node, but also delete whole scene, so it won't crash before.

## Solution

We can change `memdelete()` to `queue_free()`, to free root node defer. In the current frame, we will delete relevant scene, then next frame won't consider root node cannot be deleted.

## MRP

[test-112880.zip](https://github.com/user-attachments/files/23596729/test-112880.zip)

[remove-root-node.webm](https://github.com/user-attachments/assets/f208af1c-1407-42de-9ad2-7d7ad6093dc1)



