### PR TITLE
Fix input map editor (action map editor) items unable to be renamed

### DIFF
--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -465,7 +465,7 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 
 		// First Column - Action Name
 		action_item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
-		action_item->set_cell_mode(0, TreeItem::CELL_MODE_CUSTOM);
+		action_item->set_cell_mode(0, TreeItem::CELL_MODE_STRING);
 		action_item->set_text(0, action_info.name);
 		action_item->set_editable(0, action_info.editable);
 		action_item->set_icon(0, action_info.icon);


### PR DESCRIPTION
This regression was introduced by #112233 ("Modern Style: Use a style box for Input Map actions"). The highlight seems to work fine with a cell mode of `CELL_MODE_STRING`, and `CELL_MODE_CUSTOM` makes the renaming functionality stop working. It now works as expected and still retains the highlight:

<img width="1464" height="990" alt="Screenshot_20251117_213648" src="https://github.com/user-attachments/assets/a273bacf-2030-41e7-b47d-fa85e7e3e54b" />

Implements godotengine/godot-proposals#13648

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/113093*