### PR TITLE
Add GodotProfileSetThreadName with tracy implementation

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -34,6 +34,8 @@
 
 #include "thread.h"
 
+#include "core/profiling/profiling.h"
+
 #ifdef THREADS_ENABLED
 #include "core/object/script_language.h"
 
@@ -89,6 +91,7 @@ void Thread::wait_to_finish() {
 }
 
 Error Thread::set_name(const String &p_name) {
+	GodotProfileSetThreadName(p_name);
 	if (platform_functions.set_name) {
 		return platform_functions.set_name(p_name);
 	}

--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -99,6 +99,10 @@ const char *intern_string(const CharString &p_name);
 #define GodotProfileAlloc(m_ptr, m_size) TracyAlloc(m_ptr, m_size)
 #define GodotProfileFree(m_ptr) TracyFree(m_ptr)
 
+// Threading
+#define GodotProfileSetThreadName(m_name) \
+	tracy::SetThreadName(intern_string(m_name));
+
 void godot_init_profiler();
 
 #elif defined(GODOT_USE_PERFETTO)
@@ -135,7 +139,8 @@ struct PerfettoGroupedEventEnder {
 
 #define GodotProfileAlloc(m_ptr, m_size)
 #define GodotProfileFree(m_ptr)
-#define GodotProfileZoneScript(m_varname, m_zone_name, m_function, m_file, m_line, m_color) \\ TODO
+#define GodotProfileZoneScript(m_varname, m_zone_name, m_function, m_file, m_line, m_color) // TODO
+#define GodotProfileSetThreadName(m_name) // TODO
 
 void godot_init_profiler();
 
@@ -170,5 +175,8 @@ void godot_init_profiler();
 // Define a zone with custom source information, for scripting, unique utf8
 // strings will be copied and stored for the duration of the program.
 #define GodotProfileZoneScript(m_varname, m_zone_name, m_function, m_file, m_line, m_color)
+
+// Set the thread name
+#define GodotProfileSetThreadName(m_name)
 
 #endif

--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/typedefs.h"
 #include "profiling.gen.h"
 
 // This header provides profiling primitives (implemented as macros) for various backends.
@@ -46,12 +45,25 @@
 #if defined(GODOT_USE_TRACY)
 // Use the tracy profiler.
 
+#include "core/string/ustring.h"
+
 #define TRACY_ENABLE
+
 #include <tracy/Tracy.hpp>
+
+inline const char *intern_string(const char *p_name) {
+	return p_name;
+}
+const char *intern_string(const String &p_name);
+const char *intern_string(const CharString &p_name);
+
+// Helper Macro
+#define GodotProfileVarname(m_varname) __godot_tracy_##m_varname
 
 // Define tracing macros.
 #define GodotProfileFrameMark FrameMark
 #define GodotProfileZone(m_zone_name) ZoneNamedN(GD_UNIQUE_NAME(__godot_tracy_szone_), m_zone_name, true)
+#define GodotProfileZoneV(m_varname, m_zone_name) ZoneNamedN(GodotProfileVarname(zone_##m_varname), m_zone_name, true)
 #define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name) ZoneNamedN(__godot_tracy_zone_##m_group_name, m_zone_name, true)
 #define GodotProfileZoneGroupedEndEarly(m_group_name, m_zone_name) __godot_tracy_zone_##m_group_name.~ScopedZone();
 #ifndef TRACY_CALLSTACK
@@ -65,6 +77,23 @@
 	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location, TracyLine){ m_zone_name, TracyFunction, TracyFile, (uint32_t)TracyLine, 0 }; \
 	new (&__godot_tracy_zone_##m_group_name) tracy::ScopedZone(&TracyConcat(__tracy_source_location, TracyLine), TRACY_CALLSTACK, true)
 #endif
+
+// Fully Dynamic Custom source location, and naming.
+#define GodotProfileZoneScript(m_varname, m_zone_name, m_function, m_file, m_line, m_color)       \
+	const char *GodotProfileVarname(m_varname##_name) = intern_string(m_zone_name);               \
+	const char *GodotProfileVarname(m_varname##_func) = intern_string(m_function);                \
+	const char *GodotProfileVarname(m_varname##_file) = intern_string(m_file);                    \
+	auto GodotProfileVarname(m_varname) = tracy::ScopedZone(                                      \
+			static_cast<uint32_t>(m_line),                                                        \
+			GodotProfileVarname(m_varname##_file), strlen(GodotProfileVarname(m_varname##_file)), \
+			GodotProfileVarname(m_varname##_func), strlen(GodotProfileVarname(m_varname##_func)), \
+			GodotProfileVarname(m_varname##_name), strlen(GodotProfileVarname(m_varname##_name)), \
+			m_color.to_rgba32(),                                                                  \
+			-1, true);
+
+#define GodotProfileZoneRename(m_varname, m_zone_name)                              \
+	const char *GodotProfileVarname(m_varname##_name) = intern_string(m_zone_name); \
+	ZoneNameV(GodotProfileVarname(zone_##m_varname), GodotProfileVarname(m_varname##_name), strlen(GodotProfileVarname(m_varname##_name)))
 
 // Memory allocation
 #define GodotProfileAlloc(m_ptr, m_size) TracyAlloc(m_ptr, m_size)
@@ -94,6 +123,8 @@ struct PerfettoGroupedEventEnder {
 
 #define GodotProfileFrameMark // TODO
 #define GodotProfileZone(m_zone_name) TRACE_EVENT("godot", m_zone_name);
+#define GodotProfileZoneV(m_varname, m_zone_name) // TODO
+#define GodotProfileZoneRename(m_varname, m_zone_name) // TODO
 #define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name) \
 	TRACE_EVENT_BEGIN("godot", m_zone_name);                    \
 	PerfettoGroupedEventEnder __godot_perfetto_zone_##m_group_name
@@ -104,6 +135,8 @@ struct PerfettoGroupedEventEnder {
 
 #define GodotProfileAlloc(m_ptr, m_size)
 #define GodotProfileFree(m_ptr)
+#define GodotProfileZoneScript(m_varname, m_zone_name, m_function, m_file, m_line, m_color) \\ TODO
+
 void godot_init_profiler();
 
 #else
@@ -115,6 +148,11 @@ void godot_init_profiler();
 #define GodotProfileFrameMark
 // Defines a profile zone from here to the end of the scope.
 #define GodotProfileZone(m_zone_name)
+// Defines a profile zone from here to the end of the scope, with a variable
+// name specified.
+#define GodotProfileZoneV(m_varname, m_zone_name)
+// Rename an existing zone
+#define GodotProfileZoneRename(m_varname, m_zone_name)
 // Defines a profile zone group. The first profile zone starts immediately,
 // and ends either when the next zone starts, or when the scope ends.
 #define GodotProfileZoneGroupedFirst(m_group_name, m_zone_name)
@@ -128,4 +166,9 @@ void godot_init_profiler();
 // Tell the profiling backend that an allocation was freed.
 // There must be a one to one correspondence of GodotProfileAlloc and GodotProfileFree calls.
 #define GodotProfileFree(m_ptr)
+
+// Define a zone with custom source information, for scripting, unique utf8
+// strings will be copied and stored for the duration of the program.
+#define GodotProfileZoneScript(m_varname, m_zone_name, m_function, m_file, m_line, m_color)
+
 #endif

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -28,11 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include "core/math/color_names.inc"
 #include "gdscript.h"
 #include "gdscript_function.h"
 #include "gdscript_lambda_callable.h"
 
 #include "core/os/os.h"
+#include "core/profiling/profiling.h"
 
 #ifdef DEBUG_ENABLED
 
@@ -495,6 +497,11 @@ void (*type_init_function_table[])(Variant *) = {
 #define METHOD_CALL_ON_FREED_INSTANCE_ERROR(method_pointer) "Cannot call method '" + (method_pointer)->get_name() + "' on a previously freed instance."
 
 Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err, CallState *p_state) {
+	//It would be nice to use something like "ObjectName::function_name"
+	// But it would be much more expensive
+	// eg _script->get_fully_qualified_name() + "::" + name
+	GodotProfileZoneScript(zone, _func_cname, name, source, _initial_line, Color::named("dodger_blue"));
+
 	OPCODES_TABLE;
 
 	if (!_code_ptr) {
@@ -2097,6 +2104,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_CALL_BUILTIN_STATIC) {
+				GodotProfileZoneGroupedFirst(_static, "OPCODE_CALL_BUILTIN_STATIC");
 				LOAD_INSTRUCTION_ARGS
 				CHECK_SPACE(4 + instr_arg_count);
 
@@ -2108,6 +2116,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				int methodname_idx = _code_ptr[ip + 2];
 				GD_ERR_BREAK(methodname_idx < 0 || methodname_idx >= _global_names_count);
 				const StringName *methodname = &_global_names_ptr[methodname_idx];
+
+				GodotProfileZoneRename(_static, *methodname);
 
 				int argc = _code_ptr[ip + 3];
 				GD_ERR_BREAK(argc < 0);
@@ -2131,6 +2141,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_CALL_NATIVE_STATIC) {
+				GodotProfileZoneV(_native_static, "OPCODE_CALL_NATIVE_STATIC");
+
 				LOAD_INSTRUCTION_ARGS
 				CHECK_SPACE(3 + instr_arg_count);
 
@@ -2138,6 +2150,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				GD_ERR_BREAK(_code_ptr[ip + 1] < 0 || _code_ptr[ip + 1] >= _methods_count);
 				MethodBind *method = _methods_ptr[_code_ptr[ip + 1]];
+
+				GodotProfileZoneRename(_native_static, method->get_name());
 
 				int argc = _code_ptr[ip + 2];
 				GD_ERR_BREAK(argc < 0);
@@ -2174,6 +2188,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_CALL_NATIVE_STATIC_VALIDATED_RETURN) {
+				GodotProfileZoneV(_nsvr, "OPCODE_CALL_NATIVE_STATIC_VALIDATED_RETURN");
+
 				LOAD_INSTRUCTION_ARGS
 				CHECK_SPACE(3 + instr_arg_count);
 
@@ -2184,6 +2200,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
 				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
+
+				GodotProfileZoneRename(_nsvr, method->get_name());
 
 				Variant **argptrs = instruction_args;
 
@@ -2210,6 +2228,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_CALL_NATIVE_STATIC_VALIDATED_NO_RETURN) {
+				GodotProfileZoneV(_nsvnr, "OPCODE_CALL_NATIVE_STATIC_VALIDATED_NO_RETURN");
+
 				LOAD_INSTRUCTION_ARGS
 				CHECK_SPACE(3 + instr_arg_count);
 
@@ -2220,6 +2240,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
 				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
+
+				GodotProfileZoneRename(_nsvnr, method->get_name());
 
 				Variant **argptrs = instruction_args;
 #ifdef DEBUG_ENABLED
@@ -2371,6 +2393,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			DISPATCH_OPCODE;
 
 			OPCODE(OPCODE_CALL_UTILITY) {
+				GodotProfileZoneV(_utility, "OPCODE_CALL_UTILITY");
+
 				LOAD_INSTRUCTION_ARGS
 				CHECK_SPACE(3 + instr_arg_count);
 
@@ -2381,6 +2405,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _global_names_count);
 				StringName function = _global_names_ptr[_code_ptr[ip + 2]];
+
+				GodotProfileZoneRename(_utility, function);
 
 				Variant **argptrs = instruction_args;
 


### PR DESCRIPTION
This PR builds upon #112707 as it also requires utf8 strings interned for the duration of the process.

Adding the macro GodotProfileSetThreadName called from `Thread::set_name()` function.
This will give us all the "WorkerThread %d" names.
I have experimented with adding names to any thread function I could find, but found once the initial name is set, it will not adopt a new one, so in most cases where thread workers are used it is pointless.

I did not submit names for threads that don't use the threadworker pool as I didnt want to increase the surface area of this PR.