### PR TITLE
Clarify that `Node.duplicate()` duplicates entire subtree recursively

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -280,7 +280,7 @@
 			<return type="Node" />
 			<param index="0" name="flags" type="int" default="15" />
 			<description>
-				Duplicates the node, returning a new node with all of its properties, signals, groups, and children copied from the original. The behavior can be tweaked through the [param flags] (see [enum DuplicateFlags]). Internal nodes are not duplicated.
+				Duplicates the node, returning a new node with all of its properties, signals, groups, and children copied from the original, recursively. The behavior can be tweaked through the [param flags] (see [enum DuplicateFlags]). Internal nodes are not duplicated.
 				[b]Note:[/b] For nodes with a [Script] attached, if [method Object._init] has been defined with required parameters, the duplicated node will not have a [Script].
 				[b]Note:[/b] By default, this method will duplicate only properties marked for serialization (i.e. using [constant @GlobalScope.PROPERTY_USAGE_STORAGE], or in GDScript, [annotation @GDScript.@export]). If you want to duplicate all properties, use [constant DUPLICATE_INTERNAL_STATE].
 			</description>


### PR DESCRIPTION
Fixes #95895

The documentation for `Node.duplicate()` mentioned that it copies "children" but didn't explicitly state that it duplicates the **entire node subtree recursively** (all descendants, not just direct children).

This caused confusion for users who didn't expect the method to duplicate child nodes and their children as well. Added a note to clarify this behavior.