### PR TITLE
Allow reflection probes to only recreate the atlas when switching to real time.

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -266,6 +266,8 @@ private:
 
 	mutable RID_Owner<ReflectionAtlas> reflection_atlas_owner;
 
+	void _reflection_atlas_clear(ReflectionAtlas *p_reflection_atlas);
+
 	/* REFLECTION PROBE INSTANCE */
 
 	struct ReflectionProbeInstance {


### PR DESCRIPTION
Should fix https://github.com/godotengine/godot/issues/112555.

Context behind this PR is provided on the issue.

https://github.com/godotengine/godot/issues/112555#issuecomment-3543032141

> Both the real time and not real time probes are pointing to use the same reflection atlas. The PR introduced a change where, if the use case by the probe changes, it'll recreate the textures with the correct size and configuration so the quality doesn't stay broken like the PR shows. This ends up causing an endless loop of recreating the texture if both a real time and not real time probe are present in the same scene.

> Solution: Permanently downgrade to real time resolution the first time any real time probe is detected during the rest of the runtime. This at least ensures the behavior remains consistent if the real time feature is used and will make it not depend on which probe ends up calling the function first.

While not the ideal solution, I've left a comment explaining that this behavior is intentional. I've also organized a bit the cleanup routine for the atlas to reuse code and free elements that were not being freed before, such as the depth buffer.