### PR TITLE
Remove unused `Shape2D`/`3D::get_enclosing_radius` method

### DIFF
--- a/scene/resources/2d/capsule_shape_2d.cpp
+++ b/scene/resources/2d/capsule_shape_2d.cpp
@@ -117,10 +117,6 @@ Rect2 CapsuleShape2D::get_rect() const {
 	return Rect2(-half_size, half_size * 2.0f);
 }
 
-real_t CapsuleShape2D::get_enclosing_radius() const {
-	return height * 0.5f;
-}
-
 void CapsuleShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &CapsuleShape2D::set_radius);
 	ClassDB::bind_method(D_METHOD("get_radius"), &CapsuleShape2D::get_radius);

--- a/scene/resources/2d/capsule_shape_2d.h
+++ b/scene/resources/2d/capsule_shape_2d.h
@@ -58,7 +58,6 @@ public:
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	CapsuleShape2D();
 };

--- a/scene/resources/2d/circle_shape_2d.cpp
+++ b/scene/resources/2d/circle_shape_2d.cpp
@@ -69,10 +69,6 @@ Rect2 CircleShape2D::get_rect() const {
 	return rect;
 }
 
-real_t CircleShape2D::get_enclosing_radius() const {
-	return radius;
-}
-
 void CircleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Vector2> points;
 	points.resize(24);

--- a/scene/resources/2d/circle_shape_2d.h
+++ b/scene/resources/2d/circle_shape_2d.h
@@ -49,7 +49,6 @@ public:
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	CircleShape2D();
 };

--- a/scene/resources/2d/concave_polygon_shape_2d.cpp
+++ b/scene/resources/2d/concave_polygon_shape_2d.cpp
@@ -95,16 +95,6 @@ Rect2 ConcavePolygonShape2D::get_rect() const {
 	return rect;
 }
 
-real_t ConcavePolygonShape2D::get_enclosing_radius() const {
-	Vector<Vector2> data = get_segments();
-	const Vector2 *read = data.ptr();
-	real_t r = 0.0;
-	for (int i(0); i < data.size(); i++) {
-		r = MAX(read[i].length_squared(), r);
-	}
-	return Math::sqrt(r);
-}
-
 void ConcavePolygonShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_segments", "segments"), &ConcavePolygonShape2D::set_segments);
 	ClassDB::bind_method(D_METHOD("get_segments"), &ConcavePolygonShape2D::get_segments);

--- a/scene/resources/2d/concave_polygon_shape_2d.h
+++ b/scene/resources/2d/concave_polygon_shape_2d.h
@@ -46,7 +46,6 @@ public:
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	ConcavePolygonShape2D();
 };

--- a/scene/resources/2d/convex_polygon_shape_2d.cpp
+++ b/scene/resources/2d/convex_polygon_shape_2d.cpp
@@ -130,14 +130,6 @@ Rect2 ConvexPolygonShape2D::get_rect() const {
 	return rect;
 }
 
-real_t ConvexPolygonShape2D::get_enclosing_radius() const {
-	real_t r = 0.0;
-	for (int i(0); i < get_points().size(); i++) {
-		r = MAX(get_points()[i].length_squared(), r);
-	}
-	return Math::sqrt(r);
-}
-
 ConvexPolygonShape2D::ConvexPolygonShape2D() :
 		Shape2D(PhysicsServer2D::get_singleton()->convex_polygon_shape_create()) {
 }

--- a/scene/resources/2d/convex_polygon_shape_2d.h
+++ b/scene/resources/2d/convex_polygon_shape_2d.h
@@ -50,7 +50,6 @@ public:
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	ConvexPolygonShape2D();
 };

--- a/scene/resources/2d/rectangle_shape_2d.cpp
+++ b/scene/resources/2d/rectangle_shape_2d.cpp
@@ -92,10 +92,6 @@ Rect2 RectangleShape2D::get_rect() const {
 	return Rect2(-size * 0.5, size);
 }
 
-real_t RectangleShape2D::get_enclosing_radius() const {
-	return size.length() / 2;
-}
-
 void RectangleShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &RectangleShape2D::set_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &RectangleShape2D::get_size);

--- a/scene/resources/2d/rectangle_shape_2d.h
+++ b/scene/resources/2d/rectangle_shape_2d.h
@@ -51,7 +51,6 @@ public:
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	RectangleShape2D();
 };

--- a/scene/resources/2d/segment_shape_2d.cpp
+++ b/scene/resources/2d/segment_shape_2d.cpp
@@ -82,10 +82,6 @@ Rect2 SegmentShape2D::get_rect() const {
 	return rect;
 }
 
-real_t SegmentShape2D::get_enclosing_radius() const {
-	return (a + b).length();
-}
-
 void SegmentShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_a", "a"), &SegmentShape2D::set_a);
 	ClassDB::bind_method(D_METHOD("get_a"), &SegmentShape2D::get_a);

--- a/scene/resources/2d/segment_shape_2d.h
+++ b/scene/resources/2d/segment_shape_2d.h
@@ -54,7 +54,6 @@ public:
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	SegmentShape2D();
 };

--- a/scene/resources/2d/separation_ray_shape_2d.cpp
+++ b/scene/resources/2d/separation_ray_shape_2d.cpp
@@ -78,10 +78,6 @@ Rect2 SeparationRayShape2D::get_rect() const {
 	return rect;
 }
 
-real_t SeparationRayShape2D::get_enclosing_radius() const {
-	return length;
-}
-
 void SeparationRayShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_length", "length"), &SeparationRayShape2D::set_length);
 	ClassDB::bind_method(D_METHOD("get_length"), &SeparationRayShape2D::get_length);

--- a/scene/resources/2d/separation_ray_shape_2d.h
+++ b/scene/resources/2d/separation_ray_shape_2d.h
@@ -52,7 +52,6 @@ public:
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	SeparationRayShape2D();
 };

--- a/scene/resources/2d/shape_2d.h
+++ b/scene/resources/2d/shape_2d.h
@@ -57,8 +57,6 @@ public:
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) {}
 	virtual Rect2 get_rect() const { return Rect2(); }
-	/// Returns the radius of a circle that fully enclose this shape
-	virtual real_t get_enclosing_radius() const = 0;
 	virtual RID get_rid() const override;
 
 	static bool is_collision_outline_enabled();

--- a/scene/resources/2d/world_boundary_shape_2d.cpp
+++ b/scene/resources/2d/world_boundary_shape_2d.cpp
@@ -139,10 +139,6 @@ Rect2 WorldBoundaryShape2D::get_rect() const {
 	return rect;
 }
 
-real_t WorldBoundaryShape2D::get_enclosing_radius() const {
-	return distance;
-}
-
 void WorldBoundaryShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_normal", "normal"), &WorldBoundaryShape2D::set_normal);
 	ClassDB::bind_method(D_METHOD("get_normal"), &WorldBoundaryShape2D::get_normal);

--- a/scene/resources/2d/world_boundary_shape_2d.h
+++ b/scene/resources/2d/world_boundary_shape_2d.h
@@ -55,7 +55,6 @@ public:
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	WorldBoundaryShape2D();
 };

--- a/scene/resources/3d/box_shape_3d.cpp
+++ b/scene/resources/3d/box_shape_3d.cpp
@@ -67,10 +67,6 @@ Ref<ArrayMesh> BoxShape3D::get_debug_arraymesh_faces(const Color &p_modulate) co
 	return box_mesh;
 }
 
-real_t BoxShape3D::get_enclosing_radius() const {
-	return size.length() / 2;
-}
-
 void BoxShape3D::_update_shape() {
 	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), size / 2);
 	Shape3D::_update_shape();

--- a/scene/resources/3d/box_shape_3d.h
+++ b/scene/resources/3d/box_shape_3d.h
@@ -51,7 +51,6 @@ public:
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	BoxShape3D();
 };

--- a/scene/resources/3d/capsule_shape_3d.cpp
+++ b/scene/resources/3d/capsule_shape_3d.cpp
@@ -86,10 +86,6 @@ Ref<ArrayMesh> CapsuleShape3D::get_debug_arraymesh_faces(const Color &p_modulate
 	return capsule_mesh;
 }
 
-real_t CapsuleShape3D::get_enclosing_radius() const {
-	return height * 0.5f;
-}
-
 void CapsuleShape3D::_update_shape() {
 	Dictionary d;
 	d["radius"] = radius;

--- a/scene/resources/3d/capsule_shape_3d.h
+++ b/scene/resources/3d/capsule_shape_3d.h
@@ -54,7 +54,6 @@ public:
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	CapsuleShape3D();
 };

--- a/scene/resources/3d/concave_polygon_shape_3d.cpp
+++ b/scene/resources/3d/concave_polygon_shape_3d.cpp
@@ -77,16 +77,6 @@ Ref<ArrayMesh> ConcavePolygonShape3D::get_debug_arraymesh_faces(const Color &p_m
 	return mesh;
 }
 
-real_t ConcavePolygonShape3D::get_enclosing_radius() const {
-	Vector<Vector3> data = get_faces();
-	const Vector3 *read = data.ptr();
-	real_t r = 0.0;
-	for (int i(0); i < data.size(); i++) {
-		r = MAX(read[i].length_squared(), r);
-	}
-	return Math::sqrt(r);
-}
-
 void ConcavePolygonShape3D::_update_shape() {
 	Dictionary d;
 	d["faces"] = faces;

--- a/scene/resources/3d/concave_polygon_shape_3d.h
+++ b/scene/resources/3d/concave_polygon_shape_3d.h
@@ -74,7 +74,6 @@ public:
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	ConcavePolygonShape3D();
 };

--- a/scene/resources/3d/convex_polygon_shape_3d.cpp
+++ b/scene/resources/3d/convex_polygon_shape_3d.cpp
@@ -92,16 +92,6 @@ Ref<ArrayMesh> ConvexPolygonShape3D::get_debug_arraymesh_faces(const Color &p_mo
 	return mesh;
 }
 
-real_t ConvexPolygonShape3D::get_enclosing_radius() const {
-	Vector<Vector3> data = get_points();
-	const Vector3 *read = data.ptr();
-	real_t r = 0.0;
-	for (int i(0); i < data.size(); i++) {
-		r = MAX(read[i].length_squared(), r);
-	}
-	return Math::sqrt(r);
-}
-
 void ConvexPolygonShape3D::_update_shape() {
 	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), points);
 	Shape3D::_update_shape();

--- a/scene/resources/3d/convex_polygon_shape_3d.h
+++ b/scene/resources/3d/convex_polygon_shape_3d.h
@@ -49,7 +49,6 @@ public:
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	ConvexPolygonShape3D();
 };

--- a/scene/resources/3d/cylinder_shape_3d.cpp
+++ b/scene/resources/3d/cylinder_shape_3d.cpp
@@ -79,10 +79,6 @@ Ref<ArrayMesh> CylinderShape3D::get_debug_arraymesh_faces(const Color &p_modulat
 	return cylinder_mesh;
 }
 
-real_t CylinderShape3D::get_enclosing_radius() const {
-	return Vector2(radius, height * 0.5).length();
-}
-
 void CylinderShape3D::_update_shape() {
 	Dictionary d;
 	d["radius"] = radius;

--- a/scene/resources/3d/cylinder_shape_3d.h
+++ b/scene/resources/3d/cylinder_shape_3d.h
@@ -51,7 +51,6 @@ public:
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	CylinderShape3D();
 };

--- a/scene/resources/3d/height_map_shape_3d.cpp
+++ b/scene/resources/3d/height_map_shape_3d.cpp
@@ -137,10 +137,6 @@ Ref<ArrayMesh> HeightMapShape3D::get_debug_arraymesh_faces(const Color &p_modula
 	return mesh;
 }
 
-real_t HeightMapShape3D::get_enclosing_radius() const {
-	return Vector3(real_t(map_width), max_height - min_height, real_t(map_depth)).length();
-}
-
 void HeightMapShape3D::_update_shape() {
 	Dictionary d;
 	d["width"] = map_width;

--- a/scene/resources/3d/height_map_shape_3d.h
+++ b/scene/resources/3d/height_map_shape_3d.h
@@ -63,7 +63,6 @@ public:
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	HeightMapShape3D();
 };

--- a/scene/resources/3d/separation_ray_shape_3d.cpp
+++ b/scene/resources/3d/separation_ray_shape_3d.cpp
@@ -46,10 +46,6 @@ Ref<ArrayMesh> SeparationRayShape3D::get_debug_arraymesh_faces(const Color &p_mo
 	return memnew(ArrayMesh);
 }
 
-real_t SeparationRayShape3D::get_enclosing_radius() const {
-	return length;
-}
-
 void SeparationRayShape3D::_update_shape() {
 	Dictionary d;
 	d["length"] = length;

--- a/scene/resources/3d/separation_ray_shape_3d.h
+++ b/scene/resources/3d/separation_ray_shape_3d.h
@@ -52,7 +52,6 @@ public:
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	SeparationRayShape3D();
 };

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -66,8 +66,6 @@ public:
 	Ref<ArrayMesh> get_debug_mesh();
 	virtual Vector<Vector3> get_debug_mesh_lines() const = 0; // { return Vector<Vector3>(); }
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const = 0;
-	/// Returns the radius of a sphere that fully enclose this shape
-	virtual real_t get_enclosing_radius() const = 0;
 
 	void add_vertices_to_array(Vector<Vector3> &array, const Transform3D &p_xform);
 

--- a/scene/resources/3d/sphere_shape_3d.cpp
+++ b/scene/resources/3d/sphere_shape_3d.cpp
@@ -73,10 +73,6 @@ Ref<ArrayMesh> SphereShape3D::get_debug_arraymesh_faces(const Color &p_modulate)
 	return sphere_mesh;
 }
 
-real_t SphereShape3D::get_enclosing_radius() const {
-	return radius;
-}
-
 void SphereShape3D::_update_shape() {
 	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), radius);
 	Shape3D::_update_shape();

--- a/scene/resources/3d/sphere_shape_3d.h
+++ b/scene/resources/3d/sphere_shape_3d.h
@@ -49,7 +49,6 @@ public:
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
-	virtual real_t get_enclosing_radius() const override;
 
 	SphereShape3D();
 };

--- a/scene/resources/3d/world_boundary_shape_3d.h
+++ b/scene/resources/3d/world_boundary_shape_3d.h
@@ -48,10 +48,6 @@ public:
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
-	virtual real_t get_enclosing_radius() const override {
-		// Should be infinite?
-		return 0;
-	}
 
 	WorldBoundaryShape3D();
 };


### PR DESCRIPTION
Removes dead code: `Shape2D::get_enclosing_radius` and `Shape3D::get_enclosing_radius` virtual methods, and all their overrides. These methods are non-exposed, and are unused internally.

(not sure about labels for this PR)