### PR TITLE
Improve scene tab right-click menu's Save All Scenes' disable condition

### DIFF
--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -188,15 +188,15 @@ void EditorSceneTabs::_update_context_menu() {
 		DISABLE_LAST_OPTION_IF(no_root_node);
 	}
 
-	bool can_save_all_scenes = false;
+	bool has_unsaved_scenes = false;
 	for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); i++) {
-		if (!EditorNode::get_editor_data().get_scene_path(i).is_empty() && EditorNode::get_editor_data().get_edited_scene_root(i)) {
-			can_save_all_scenes = true;
+		if (EditorNode::get_singleton()->is_scene_unsaved(i)) {
+			has_unsaved_scenes = true;
 			break;
 		}
 	}
 	scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/save_all_scenes"), EditorNode::SCENE_SAVE_ALL_SCENES);
-	DISABLE_LAST_OPTION_IF(!can_save_all_scenes);
+	DISABLE_LAST_OPTION_IF(!has_unsaved_scenes);
 
 	if (tab_id >= 0) {
 		const String scene_path = EditorNode::get_editor_data().get_scene_path(tab_id);


### PR DESCRIPTION
At the moment, the condition that enables the "Save All Scenes" option in scene tabs' right-click menu doesn't count freshly created scenes that do not already have a filesystem path. Even though the mechanism for saving scenes for the first time via `Save All Scenes` is fully functional, the option itself is disabled. This PR fixes that.

<img width="516" height="163" alt="image" src="https://github.com/user-attachments/assets/e29889ec-2f1a-4ad1-81ac-2127c56a11e6" />

