### PR TITLE
Fix inconsistent color clamping between Mobile and Forward+.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -862,17 +862,14 @@ void main() {
 	}
 
 	if (bool(params.flags & FLAG_USE_GLOW) && params.glow_mode != GLOW_MODE_SOFTLIGHT) {
-		vec3 glow = gather_glow(source_glow, uv_interp);
+		vec3 glow = gather_glow(source_glow, uv_interp) * params.glow_intensity;
+		if (params.glow_map_strength > 0.001) {
+			glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
+		}
+
 		if (params.glow_mode == GLOW_MODE_MIX) {
-			if (params.glow_map_strength > 0.001) {
-				glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
-			}
-			color.rgb = mix(color.rgb, glow, params.glow_intensity);
+			color.rgb = color.rgb * (1.0 - params.glow_intensity) + glow;
 		} else {
-			glow = glow * params.glow_intensity;
-			if (params.glow_map_strength > 0.001) {
-				glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
-			}
 			color.rgb = apply_glow(color.rgb, glow, params.white);
 		}
 	}
@@ -887,8 +884,7 @@ void main() {
 		// Apply soft light after tonemapping to mitigate the issue of discontinuity
 		// at 1.0 and higher. This makes the issue only appear with HDR output that
 		// can exceed a 1.0 output value.
-		vec3 glow = gather_glow(source_glow, uv_interp);
-		glow = glow * params.glow_intensity;
+		vec3 glow = gather_glow(source_glow, uv_interp) * params.glow_intensity;
 		if (params.glow_map_strength > 0.001) {
 			glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
 		}


### PR DESCRIPTION
Also remove inconsistencies with glow blending code and comments between the two shader files to allow for easier comparison of the two tonemap files.

## PR details

These inconsistencies come from the final rebase of #110077 where some differences slipped into `tonemap.glsl` without making their way into `tonemap_mobile.glsl`.

It may appear that the code for glow blending with the mix blend mode when using a glow map texture has changed in the Forward+ renderer, but this should be mathematically equivalent to the existing code: clayjohn introduced a nice code simplification to this blending in `tonemap_mobile.glsl`, so it makes sense to carry this simplification over to `tonemap.glsl`.

## Bug details
The inconsistency of colour clamping can be seen when HDR 2D is disabled and the contrast colour adjustment is used:

| | Mobile | Forward+
|--|--|--
| Before #110077 | <img width="1152" height="648" alt="image" src="https://github.com/user-attachments/assets/aab44434-2a9f-455e-8a2a-9b0c6e9acebd" /> | <img width="1152" height="648" alt="image" src="https://github.com/user-attachments/assets/ce691f30-0509-4105-b0ac-acb2561de254" />
| `master` (9c56102) | <img width="1152" height="648" alt="image" src="https://github.com/user-attachments/assets/8b94ab14-3b93-408a-b041-14336288fb6d" /> | <img width="1152" height="648" alt="image" src="https://github.com/user-attachments/assets/0632238e-1632-43e3-8976-f3dd99514f5e" />

MRP: [mobile-colour-clamping.zip](https://github.com/user-attachments/files/23611736/mobile-colour-clamping.zip)
