### PR TITLE
[Android editor] Ensure that the Android editor properly passes hybrid data when switching mode

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -17,7 +17,7 @@ ext.versions = [
     splashscreenVersion: '1.0.1',
     // 'openxrLoaderVersion' should be set to XR_CURRENT_API_VERSION, see 'thirdparty/openxr'
     openxrLoaderVersion: '1.1.53',
-    openxrVendorsVersion: '4.2.0-stable',
+    openxrVendorsVersion: '4.2.1-stable',
     junitVersion       : '1.3.0',
     espressoCoreVersion: '3.7.0',
     kotlinTestVersion  : '1.3.11',

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -270,10 +270,11 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 			newIntent.putExtra(EXTRA_NEW_LAUNCH, false)
 
 			godot?.runOnRenderThread {
-				// Look for the scene and xr-mode arguments
+				// Look for the scene, XR-mode, and hybrid data arguments.
 				var scene = ""
 				var xrMode = XR_MODE_DEFAULT
 				var path = ""
+				var base64HybridData = ""
 				if (params.isNotEmpty()) {
 					val sceneIndex = params.indexOf(SCENE_ARG)
 					if (sceneIndex != -1 && sceneIndex + 1 < params.size) {
@@ -289,9 +290,14 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 					if (pathIndex != -1 && pathIndex + 1 < params.size) {
 						path = params[pathIndex + 1]
 					}
+
+					val hybridDataIndex = params.indexOf(HYBRID_DATA_ARG)
+					if (hybridDataIndex != -1 && hybridDataIndex + 1 < params.size) {
+						base64HybridData = params[hybridDataIndex + 1]
+					}
 				}
 
-				val sceneArgs = mutableSetOf(XR_MODE_ARG, xrMode).apply {
+				val sceneArgs = mutableSetOf(XR_MODE_ARG, xrMode, HYBRID_DATA_ARG, base64HybridData).apply {
 					if (path.isNotEmpty() && scene.isEmpty()) {
 						add(PATH_ARG)
 						add(path)


### PR DESCRIPTION
This fixes the previous logic which was not passing the hybrid data when transitioning between modes while developing in the Android editor.

Depends on https://github.com/GodotVR/godot_openxr_vendors/pull/394

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
