### PR TITLE
Add missing mipmaps to `RB_TEX_BACK_COLOR`

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -335,9 +335,13 @@ void RendererSceneRenderRD::_render_buffers_ensure_screen_texture(const RenderDa
 	if (reuse_blur_texture) {
 		rb->allocate_blur_textures();
 	} else {
-		uint32_t usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
-		usage_bits |= can_use_storage ? RD::TEXTURE_USAGE_STORAGE_BIT : RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
-		rb->create_texture(RB_SCOPE_BUFFERS, RB_TEX_BACK_COLOR, rb->get_base_data_format(), usage_bits);
+		if (!rb->has_texture(RB_SCOPE_BUFFERS, RB_TEX_BACK_COLOR)) {
+			uint32_t usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+			usage_bits |= can_use_storage ? RD::TEXTURE_USAGE_STORAGE_BIT : RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+			// This needs to have mipmaps if any shader needs textureLod to work on screen_texture
+			uint32_t mipmaps_required = Image::get_image_required_mipmaps(size.x, size.y, Image::FORMAT_RGBAH);
+			rb->create_texture(RB_SCOPE_BUFFERS, RB_TEX_BACK_COLOR, rb->get_base_data_format(), usage_bits, RenderingDeviceCommons::TEXTURE_SAMPLES_1, { 0, 0 }, 0U, mipmaps_required);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #112885

When FSR2 is enabled it hits the code path where the blur texture is not reused, and `RB_TEX_BACK_COLOR` is created and used instead. It was created without mipmaps causing `textureLod()` to not work as expected on `screen_texture`.

This has a small vram penalty. If the penalty for projects not using any blur is too big then introducing a flag like `scene_state.used_screen_texture_mipmapped` to decide whether mipmaps are needed might be worthwhile.