### PR TITLE
Fix disabled tabs in TabBar are selectable

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -292,7 +292,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				}
 
 				// Selecting a tab.
-				if (selecting) {
+				if (selecting && !tabs[found].disabled) {
 					if (deselect_enabled && get_current_tab() == found) {
 						set_current_tab(-1);
 					} else {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/113056
- regression from https://github.com/godotengine/godot/pull/107440 (cc @lodetrick )

Disabled tabs should not be selectable with the mouse.

The tab right button still works when disabled as before, and the close button is still blocked when disabled as before. (I don't know why they are different though).

The right click signal works when disabled, but I can prevent it if wanted.