### PR TITLE
Fix fake UID cache entries

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -205,6 +205,9 @@ void ResourceUID::remove_id(ID p_id) {
 	MutexLock l(mutex);
 	ERR_FAIL_COND(!unique_ids.has(p_id));
 	unique_ids.erase(p_id);
+	// To prevent fake entries from being generated the next time the cache file is loaded.
+	changed = true;
+	cache_entries = 0;
 }
 
 String ResourceUID::uid_to_path(const String &p_uid) {
@@ -291,6 +294,11 @@ Error ResourceUID::load_from_cache(bool p_reset) {
 Error ResourceUID::update_cache() {
 	if (!changed) {
 		return OK;
+	}
+
+	// To prevent the number of cached file entries from increasing due to file movement.
+	if (cache_entries >= unique_ids.size()) {
+		cache_entries = 0;
 	}
 
 	if (cache_entries == 0) {


### PR DESCRIPTION
When `ResourceUID::remove_id()` is called, the UID cache is removed from memory, but not from the cache file. These entries will be loaded from the cache file into memory the next time the editor is launched, and cannot be removed.

When `ResourceUID::update_cache()` is called, if the file has only been moved previously, it appends the new entries to the end of the cache file. If the file has been moved repeatedly, this will result in a large number of duplicate entries.

Although we can rely on `ResourceUID::clear()` to clean up, but `ResourceUID::clear()` is only called when the editor is launched (during the first scan).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Upon closer examination, retaining these legacy UIDs seems to make sense. For example, if you need to switch between different Git branches. And `.godot` is generally not tracked by Git.

At its root, the problem is mainly due to insufficient precision in the timestamps of the file's modification time.
