### PR TITLE
Fix error when double-clicking nothing on scene tree

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4164,7 +4164,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 					if (rtl) {
 						pressing_pos.x = get_size().width - pressing_pos.x;
 					}
-				} else if (mb->is_double_click()) {
+				} else if (mb->is_double_click() && get_item_at_position(mb->get_position()) != nullptr) {
 					emit_signal(SNAME("item_icon_double_clicked"));
 				}
 


### PR DESCRIPTION
Fixes an issue caused by #111780 where `item_icon_double_clicked` in `Tree` would get signalled when an empty space is double-clicked.

For example, when double-clicking an empty space in the scene tree dock, an error like this would be displayed:
`ERROR: editor\docks\scene_tree_dock.cpp:4150 - Parameter "node" is null.`