### PR TITLE
[Import] Add import option to force monochrome font for emojis.

### DIFF
--- a/doc/classes/ResourceImporterDynamicFont.xml
+++ b/doc/classes/ResourceImporterDynamicFont.xml
@@ -85,5 +85,8 @@
 			[b]One Quarter of a Pixel:[/b] Always perform precise subpixel positioning regardless of font size. Highest quality, slowest rendering.
 			[b]Auto (Except Pixel Fonts):[/b] [b]Disabled[/b] for pixel style fonts (each glyph's contours contain only straight horizontal and vertical lines), [b]Auto[/b] for other fonts.
 		</member>
+		<member name="use_for_color_emojis" type="bool" setter="" getter="" default="false">
+			If set to [code]true[/code], the font will be used to render color emojis, even if it is not a color font.
+		</member>
 	</members>
 </class>

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -650,6 +650,7 @@ void DynamicFontImportSettingsDialog::_re_import() {
 	main_settings["msdf_pixel_range"] = import_settings_data->get("msdf_pixel_range");
 	main_settings["msdf_size"] = import_settings_data->get("msdf_size");
 	main_settings["allow_system_fallback"] = import_settings_data->get("allow_system_fallback");
+	main_settings["use_for_color_emojis"] = import_settings_data->get("use_for_color_emojis");
 	main_settings["force_autohinter"] = import_settings_data->get("force_autohinter");
 	main_settings["modulate_color_glyphs"] = import_settings_data->get("modulate_color_glyphs");
 	main_settings["hinting"] = import_settings_data->get("hinting");
@@ -1007,6 +1008,7 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "msdf_pixel_range", PROPERTY_HINT_RANGE, "1,100,1"), 8));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "msdf_size", PROPERTY_HINT_RANGE, "1,250,1"), 48));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "allow_system_fallback"), true));
+	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "use_for_color_emojis"), false));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "force_autohinter"), false));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "modulate_color_glyphs"), false));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal,Light (Except Pixel Fonts),Normal (Except Pixel Fonts)"), 3));

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -125,6 +125,7 @@ void ResourceImporterDynamicFont::get_import_options(const String &p_path, List<
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "force_autohinter"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "modulate_color_glyphs"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal,Light (Except Pixel Fonts),Normal (Except Pixel Fonts)"), 3));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "use_for_color_emojis"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "subpixel_positioning", PROPERTY_HINT_ENUM, "Disabled,Auto,One Half of a Pixel,One Quarter of a Pixel,Auto (Except Pixel Fonts)"), 4));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "keep_rounding_remainders"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_RANGE, "0,10,0.1"), 0.0));
@@ -163,6 +164,7 @@ Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const Str
 	bool autohinter = p_options["force_autohinter"];
 	bool modulate_color_glyphs = p_options["modulate_color_glyphs"];
 	bool allow_system_fallback = p_options["allow_system_fallback"];
+	bool use_for_color_emojis = p_options["use_for_color_emojis"];
 	int hinting = p_options["hinting"];
 	int subpixel_positioning = p_options["subpixel_positioning"];
 	bool keep_rounding_remainders = p_options["keep_rounding_remainders"];
@@ -189,6 +191,11 @@ Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const Str
 	font->set_allow_system_fallback(allow_system_fallback);
 	font->set_oversampling(oversampling);
 	font->set_fallbacks(fallbacks);
+	if (use_for_color_emojis) {
+		font->set_script_support_override("Zsye", true);
+	} else {
+		font->remove_script_support_override("Zsye");
+	}
 
 	if (subpixel_positioning == 4 || hinting == 3 || hinting == 4) /* Dected Pixel Fonts */ {
 		Array rids = font->get_rids();

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -6911,7 +6911,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_star
 	Vector2i fss = _get_size(fd, fs);
 	hb_font_t *hb_font = _font_get_hb_handle(f, fs, color);
 
-	if (p_script == HB_TAG('Z', 's', 'y', 'e') && !color && _font_is_allow_system_fallback(p_fonts[0])) {
+	if (p_script == HB_TAG('Z', 's', 'y', 'e') && !color && _font_is_allow_system_fallback(p_fonts[0]) && !_font_is_script_supported(f, "Zsye")) {
 		// Color emoji is requested, skip non-color font.
 		_shape_run(p_sd, p_start, p_end, p_language, p_script, p_direction, p_fonts, p_span, p_fb_index + 1, p_start, p_end, f);
 		return;


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/112436#issuecomment-3549238804

Normally a color font should be preferred for color emojis, but this is not always a desired behavior, it can be overridden by adding VS-15 variation selectors to the text, or disabling system fallback. This PR also adds import option to threat any font as if it was a color font for the purpose of emoji rendering, to quickly apply it to all text without disabling fallback or editing text.

https://github.com/user-attachments/assets/af037326-1464-4118-9a5f-c2431b9c6efd

(same font used for both labels, left one has VS-15 after each emoji)
