### PR TITLE
Add emoji style menu to `LineEdit` and `TextEdit`.

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -511,7 +511,19 @@
 		<constant name="MENU_EMOJI_AND_SYMBOL" value="30" enum="MenuItems">
 			Opens system emoji and symbol picker.
 		</constant>
-		<constant name="MENU_MAX" value="31" enum="MenuItems">
+		<constant name="MENU_SUBMENU_VARIATION" value="31" enum="MenuItems">
+			ID of "Emoji Style" submenu.
+		</constant>
+		<constant name="MENU_VARIATION_CLEAR" value="32" enum="MenuItems">
+			Removes all emoji related variation selectors (VS-15 and VS-16) from select text.
+		</constant>
+		<constant name="MENU_VARIATION_COLOR" value="33" enum="MenuItems">
+			Adds color emoji variation selectors (VS-16) to the select text.
+		</constant>
+		<constant name="MENU_VARIATION_TEXT" value="34" enum="MenuItems">
+			Adds text symbols variation selectors (VS-15) to the select text.
+		</constant>
+		<constant name="MENU_MAX" value="35" enum="MenuItems">
 			Represents the size of the [enum MenuItems] enum.
 		</constant>
 		<constant name="KEYBOARD_TYPE_DEFAULT" value="0" enum="VirtualKeyboardType">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1565,7 +1565,19 @@
 		<constant name="MENU_EMOJI_AND_SYMBOL" value="30" enum="MenuItems">
 			Opens system emoji and symbol picker.
 		</constant>
-		<constant name="MENU_MAX" value="31" enum="MenuItems">
+		<constant name="MENU_SUBMENU_VARIATION" value="31" enum="MenuItems">
+			ID of "Emoji Style" submenu.
+		</constant>
+		<constant name="MENU_VARIATION_CLEAR" value="32" enum="MenuItems">
+			Removes all emoji related variation selectors (VS-15 and VS-16) from select text.
+		</constant>
+		<constant name="MENU_VARIATION_COLOR" value="33" enum="MenuItems">
+			Adds color emoji variation selectors (VS-16) to the select text.
+		</constant>
+		<constant name="MENU_VARIATION_TEXT" value="34" enum="MenuItems">
+			Adds text symbols variation selectors (VS-15) to the select text.
+		</constant>
+		<constant name="MENU_MAX" value="35" enum="MenuItems">
 			Represents the size of the [enum MenuItems] enum.
 		</constant>
 		<constant name="ACTION_NONE" value="0" enum="EditAction">

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1713,14 +1713,16 @@ void LineEdit::paste_text() {
 	}
 
 	// Strip escape characters like \n and \t as they can't be displayed on LineEdit.
-	String paste_buffer = DisplayServer::get_singleton()->clipboard_get().strip_escapes();
+	_replace_text_internal(DisplayServer::get_singleton()->clipboard_get().strip_escapes());
+}
 
-	if (!paste_buffer.is_empty()) {
+void LineEdit::_replace_text_internal(const String &p_text) {
+	if (!p_text.is_empty()) {
 		int prev_len = text.length();
 		if (selection.enabled) {
 			selection_delete();
 		}
-		insert_text_at_caret(paste_buffer);
+		insert_text_at_caret(p_text);
 
 		if (!text_changed_dirty) {
 			if (is_inside_tree() && text.length() != prev_len) {
@@ -2746,6 +2748,60 @@ void LineEdit::menu_option(int p_option) {
 		case MENU_EMOJI_AND_SYMBOL: {
 			show_emoji_and_symbol_picker();
 		} break;
+		case MENU_VARIATION_CLEAR: {
+			if (!editable || !has_selection()) {
+				return;
+			}
+
+			String old_text = get_selected_text();
+			String new_text;
+			for (int i = 0; i < old_text.length(); i++) {
+				const char32_t &c = old_text[i];
+				if (c == 0xFE0F || c == 0xFE0E) {
+					continue;
+				}
+				new_text += c;
+			}
+			_replace_text_internal(new_text);
+		} break;
+		case MENU_VARIATION_COLOR: {
+			if (!editable || !has_selection()) {
+				return;
+			}
+
+			String old_text = get_selected_text();
+			String new_text;
+			for (int i = 0; i < old_text.length(); i++) {
+				const char32_t &c = old_text[i];
+				if (c == 0xFE0F || c == 0xFE0E) {
+					continue;
+				}
+				new_text += c;
+				if (!is_whitespace(c) && !is_linebreak(c) && !is_control(c)) {
+					new_text += (char32_t)0xFE0F;
+				}
+			}
+			_replace_text_internal(new_text);
+		} break;
+		case MENU_VARIATION_TEXT: {
+			if (!editable || !has_selection()) {
+				return;
+			}
+
+			String old_text = get_selected_text();
+			String new_text;
+			for (int i = 0; i < old_text.length(); i++) {
+				const char32_t &c = old_text[i];
+				if (c == 0xFE0F || c == 0xFE0E) {
+					continue;
+				}
+				new_text += c;
+				if (!is_whitespace(c) && !is_linebreak(c) && !is_control(c)) {
+					new_text += (char32_t)0xFE0E;
+				}
+			}
+			_replace_text_internal(new_text);
+		} break;
 	}
 
 	// Mirror paste/drag behavior, emit text_changed signal if a control character was inserted.
@@ -3112,6 +3168,11 @@ void LineEdit::_generate_context_menu() {
 	menu_dir->add_radio_check_item(ETR("Left-to-Right"), MENU_DIR_LTR);
 	menu_dir->add_radio_check_item(ETR("Right-to-Left"), MENU_DIR_RTL);
 
+	menu_var = memnew(PopupMenu);
+	menu_var->add_radio_check_item(ETR("Clear Style"), MENU_VARIATION_CLEAR);
+	menu_var->add_radio_check_item(ETR("Use Color Emoji"), MENU_VARIATION_COLOR);
+	menu_var->add_radio_check_item(ETR("Use Text Symbols"), MENU_VARIATION_TEXT);
+
 	menu_ctl = memnew(PopupMenu);
 	menu_ctl->add_item(ETR("Left-to-Right Mark (LRM)"), MENU_INSERT_LRM);
 	menu_ctl->add_item(ETR("Right-to-Left Mark (RLM)"), MENU_INSERT_RLM);
@@ -3151,9 +3212,11 @@ void LineEdit::_generate_context_menu() {
 	menu->add_separator();
 	menu->add_check_item(ETR("Display Control Characters"), MENU_DISPLAY_UCC);
 	menu->add_submenu_node_item(ETR("Insert Control Character"), menu_ctl, MENU_SUBMENU_INSERT_UCC);
+	menu->add_submenu_node_item(ETR("Emoji Style"), menu_var, MENU_SUBMENU_VARIATION);
 
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &LineEdit::menu_option));
 	menu_dir->connect(SceneStringName(id_pressed), callable_mp(this, &LineEdit::menu_option));
+	menu_var->connect(SceneStringName(id_pressed), callable_mp(this, &LineEdit::menu_option));
 	menu_ctl->connect(SceneStringName(id_pressed), callable_mp(this, &LineEdit::menu_option));
 
 	menu->connect(SceneStringName(focus_entered), callable_mp(this, &LineEdit::_validate_caret_can_draw));
@@ -3208,6 +3271,7 @@ void LineEdit::_update_context_menu() {
 	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_RTL, text_direction == TEXT_DIRECTION_RTL)
 	MENU_ITEM_CHECKED(menu, MENU_DISPLAY_UCC, draw_control_chars)
 	MENU_ITEM_DISABLED(menu, MENU_SUBMENU_INSERT_UCC, !editable)
+	MENU_ITEM_DISABLED(menu, MENU_SUBMENU_VARIATION, !editable || !has_selection() || !TS->has_feature(TextServer::FEATURE_SHAPING))
 
 #undef MENU_ITEM_ACTION_DISABLED
 #undef MENU_ITEM_ACTION
@@ -3360,6 +3424,10 @@ void LineEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(MENU_INSERT_WJ);
 	BIND_ENUM_CONSTANT(MENU_INSERT_SHY);
 	BIND_ENUM_CONSTANT(MENU_EMOJI_AND_SYMBOL);
+	BIND_ENUM_CONSTANT(MENU_SUBMENU_VARIATION);
+	BIND_ENUM_CONSTANT(MENU_VARIATION_CLEAR);
+	BIND_ENUM_CONSTANT(MENU_VARIATION_COLOR);
+	BIND_ENUM_CONSTANT(MENU_VARIATION_TEXT);
 	BIND_ENUM_CONSTANT(MENU_MAX);
 
 	BIND_ENUM_CONSTANT(KEYBOARD_TYPE_DEFAULT);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -69,6 +69,10 @@ public:
 		MENU_INSERT_WJ,
 		MENU_INSERT_SHY,
 		MENU_EMOJI_AND_SYMBOL,
+		MENU_SUBMENU_VARIATION,
+		MENU_VARIATION_CLEAR,
+		MENU_VARIATION_COLOR,
+		MENU_VARIATION_TEXT,
 		MENU_MAX
 	};
 
@@ -126,6 +130,7 @@ private:
 	PopupMenu *menu = nullptr;
 	PopupMenu *menu_dir = nullptr;
 	PopupMenu *menu_ctl = nullptr;
+	PopupMenu *menu_var = nullptr;
 
 	bool caret_mid_grapheme_enabled = false;
 
@@ -262,6 +267,7 @@ private:
 	void _backspace(bool p_word = false, bool p_all_to_left = false);
 	void _delete(bool p_word = false, bool p_all_to_right = false);
 	void _texture_changed();
+	void _replace_text_internal(const String &p_text);
 
 	void _edit(bool p_show_virtual_keyboard = true, bool p_hide_focus = false);
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4648,6 +4648,60 @@ void TextEdit::menu_option(int p_option) {
 		case MENU_EMOJI_AND_SYMBOL: {
 			show_emoji_and_symbol_picker();
 		} break;
+		case MENU_VARIATION_CLEAR: {
+			if (!editable || !has_selection()) {
+				return;
+			}
+
+			String old_text = get_selected_text();
+			String new_text;
+			for (int i = 0; i < old_text.length(); i++) {
+				const char32_t &c = old_text[i];
+				if (c == 0xFE0F || c == 0xFE0E) {
+					continue;
+				}
+				new_text += c;
+			}
+			_replace_text_internal(-1, new_text);
+		} break;
+		case MENU_VARIATION_COLOR: {
+			if (!editable || !has_selection()) {
+				return;
+			}
+
+			String old_text = get_selected_text();
+			String new_text;
+			for (int i = 0; i < old_text.length(); i++) {
+				const char32_t &c = old_text[i];
+				if (c == 0xFE0F || c == 0xFE0E) {
+					continue;
+				}
+				new_text += c;
+				if (!is_whitespace(c) && !is_linebreak(c) && !is_control(c)) {
+					new_text += (char32_t)0xFE0F;
+				}
+			}
+			_replace_text_internal(-1, new_text);
+		} break;
+		case MENU_VARIATION_TEXT: {
+			if (!editable || !has_selection()) {
+				return;
+			}
+
+			String old_text = get_selected_text();
+			String new_text;
+			for (int i = 0; i < old_text.length(); i++) {
+				const char32_t &c = old_text[i];
+				if (c == 0xFE0F || c == 0xFE0E) {
+					continue;
+				}
+				new_text += c;
+				if (!is_whitespace(c) && !is_linebreak(c) && !is_control(c)) {
+					new_text += (char32_t)0xFE0E;
+				}
+			}
+			_replace_text_internal(-1, new_text);
+		} break;
 	}
 }
 
@@ -7232,6 +7286,10 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(MENU_INSERT_WJ);
 	BIND_ENUM_CONSTANT(MENU_INSERT_SHY);
 	BIND_ENUM_CONSTANT(MENU_EMOJI_AND_SYMBOL);
+	BIND_ENUM_CONSTANT(MENU_SUBMENU_VARIATION);
+	BIND_ENUM_CONSTANT(MENU_VARIATION_CLEAR);
+	BIND_ENUM_CONSTANT(MENU_VARIATION_COLOR);
+	BIND_ENUM_CONSTANT(MENU_VARIATION_TEXT);
 	BIND_ENUM_CONSTANT(MENU_MAX);
 
 	/* Versioning */
@@ -7907,15 +7965,25 @@ void TextEdit::_paste_internal(int p_caret) {
 		// Nothing to paste.
 		return;
 	}
+	_replace_text_internal(p_caret, clipboard);
+}
+
+void TextEdit::_replace_text_internal(int p_caret, const String &p_text) {
+	ERR_FAIL_COND(p_caret >= get_caret_count() || p_caret < -1);
+	if (!editable) {
+		return;
+	}
+
+	String new_text = p_text;
 
 	// Paste a full line. Ignore '\r' characters that may have been added to the clipboard by the OS.
-	if (get_caret_count() == 1 && !has_selection(0) && !cut_copy_line.is_empty() && cut_copy_line == clipboard.remove_char('\r')) {
-		insert_text(clipboard, get_caret_line(), 0);
+	if (get_caret_count() == 1 && !has_selection(0) && !cut_copy_line.is_empty() && cut_copy_line == new_text.remove_char('\r')) {
+		insert_text(new_text, get_caret_line(), 0);
 		return;
 	}
 
 	// Paste text at each caret or one line per caret.
-	Vector<String> clipboard_lines = clipboard.split("\n");
+	Vector<String> clipboard_lines = new_text.split("\n");
 	bool insert_line_per_caret = p_caret == -1 && get_caret_count() > 1 && clipboard_lines.size() == get_caret_count();
 
 	begin_complex_operation();
@@ -7932,10 +8000,10 @@ void TextEdit::_paste_internal(int p_caret) {
 		}
 
 		if (insert_line_per_caret) {
-			clipboard = clipboard_lines[i];
+			new_text = clipboard_lines[i];
 		}
 
-		insert_text_at_caret(clipboard, caret_index);
+		insert_text_at_caret(new_text, caret_index);
 	}
 	end_multicaret_edit();
 	end_complex_operation();
@@ -8000,6 +8068,11 @@ void TextEdit::_generate_context_menu() {
 	menu_dir->add_radio_check_item(ETR("Left-to-Right"), MENU_DIR_LTR);
 	menu_dir->add_radio_check_item(ETR("Right-to-Left"), MENU_DIR_RTL);
 
+	menu_var = memnew(PopupMenu);
+	menu_var->add_radio_check_item(ETR("Clear Style"), MENU_VARIATION_CLEAR);
+	menu_var->add_radio_check_item(ETR("Use Color Emoji"), MENU_VARIATION_COLOR);
+	menu_var->add_radio_check_item(ETR("Use Text Symbols"), MENU_VARIATION_TEXT);
+
 	menu_ctl = memnew(PopupMenu);
 	menu_ctl->add_item(ETR("Left-to-Right Mark (LRM)"), MENU_INSERT_LRM);
 	menu_ctl->add_item(ETR("Right-to-Left Mark (RLM)"), MENU_INSERT_RLM);
@@ -8039,9 +8112,11 @@ void TextEdit::_generate_context_menu() {
 	menu->add_separator();
 	menu->add_check_item(ETR("Display Control Characters"), MENU_DISPLAY_UCC);
 	menu->add_submenu_node_item(ETR("Insert Control Character"), menu_ctl, MENU_SUBMENU_INSERT_UCC);
+	menu->add_submenu_node_item(ETR("Emoji Style"), menu_var, MENU_SUBMENU_VARIATION);
 
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &TextEdit::menu_option));
 	menu_dir->connect(SceneStringName(id_pressed), callable_mp(this, &TextEdit::menu_option));
+	menu_var->connect(SceneStringName(id_pressed), callable_mp(this, &TextEdit::menu_option));
 	menu_ctl->connect(SceneStringName(id_pressed), callable_mp(this, &TextEdit::menu_option));
 }
 
@@ -8093,6 +8168,7 @@ void TextEdit::_update_context_menu() {
 	MENU_ITEM_CHECKED(menu_dir, MENU_DIR_RTL, text_direction == TEXT_DIRECTION_RTL)
 	MENU_ITEM_CHECKED(menu, MENU_DISPLAY_UCC, draw_control_chars)
 	MENU_ITEM_DISABLED(menu, MENU_SUBMENU_INSERT_UCC, !editable)
+	MENU_ITEM_DISABLED(menu, MENU_SUBMENU_VARIATION, !editable || !has_selection() || !TS->has_feature(TextServer::FEATURE_SHAPING))
 
 #undef MENU_ITEM_ACTION_DISABLED
 #undef MENU_ITEM_ACTION

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -110,6 +110,10 @@ public:
 		MENU_INSERT_WJ,
 		MENU_INSERT_SHY,
 		MENU_EMOJI_AND_SYMBOL,
+		MENU_SUBMENU_VARIATION,
+		MENU_VARIATION_CLEAR,
+		MENU_VARIATION_COLOR,
+		MENU_VARIATION_TEXT,
 		MENU_MAX
 
 	};
@@ -356,6 +360,7 @@ private:
 	// Context menu.
 	PopupMenu *menu = nullptr;
 	PopupMenu *menu_dir = nullptr;
+	PopupMenu *menu_var = nullptr;
 	PopupMenu *menu_ctl = nullptr;
 
 	Callable inline_object_drawer;
@@ -757,6 +762,7 @@ protected:
 	virtual void _cut_internal(int p_caret);
 	virtual void _copy_internal(int p_caret);
 	virtual void _paste_internal(int p_caret);
+	virtual void _replace_text_internal(int p_caret, const String &p_text);
 	virtual void _paste_primary_clipboard_internal(int p_caret);
 
 	void _accessibility_action_set_selection(const Variant &p_data);


### PR DESCRIPTION
Note: requires https://github.com/godotengine/godot/pull/112940 to properly function.
Note: system fallback will have only color variants for most emojis, so adding monochrome emoji font to the project is necessary.

Adds a quick way to insert/removed emoji variation selectors.

Demo project: [emo_sty_dmo.zip](https://github.com/user-attachments/files/23624013/emo_sty_dmo.zip)

https://github.com/user-attachments/assets/a9a8a115-196c-4b05-95e2-28130939b679

