### PR TITLE
Fix incorrect equivalent method reference in screen-space transform methods doc

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -520,7 +520,7 @@
 			<return type="Transform2D" />
 			<description>
 				Returns the transform of this [CanvasItem] in global screen coordinates (i.e. taking window position into account). Mostly useful for editor plugins.
-				Equals to [method get_global_transform] if the window is embedded (see [member Viewport.gui_embed_subwindows]).
+				Equivalent to [method get_global_transform_with_canvas] if the window is embedded (see [member Viewport.gui_embed_subwindows]).
 			</description>
 		</method>
 		<method name="get_transform" qualifiers="const">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -493,10 +493,14 @@
 			<return type="Vector2" />
 			<description>
 				Returns the position of this [Control] in global screen coordinates (i.e. taking window position into account). Mostly useful for editor plugins.
-				Equals to [member global_position] if the window is embedded (see [member Viewport.gui_embed_subwindows]).
+				Equivalent to [code]get_screen_transform().origin[/code] (see [method CanvasItem.get_screen_transform]).
 				[b]Example:[/b] Show a popup at the mouse position:
 				[codeblock]
-				popup_menu.position = get_screen_position() + get_local_mouse_position()
+				popup_menu.position = get_screen_position() + get_screen_transform().basis_xform(get_local_mouse_position())
+
+				# The above code is equivalent to:
+				popup_menu.position = get_screen_transform() * get_local_mouse_position()
+
 				popup_menu.reset_size()
 				popup_menu.popup()
 				[/codeblock]


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/112950.

The `get_global_transform` method of CanvasItem doesn't consider the canvas_transform, so when any camera is enabled, its return value may differ from `get_screen_transform`. Thus, we should change the equivalent method reference to `get_global_transform_with_canvas` instead, which provides consistent results with or without cameras enabled.


https://github.com/godotengine/godot/blob/b15a13eed39d902fafb14ca0637c5827c80b2bc9/doc/classes/CanvasItem.xml#L519-L525


#### Edit History:
- **Add:** With kleonc's help and inspiration, also fix incorrect method reference in Control.get_screen_position doc.
- **Modify:** Follow Mickeon's advice, replace `equal` with more accurate word `equivalent`, and simplify code example.
- **Remove:** Follow Kleonc's advice, remove redundant equivalent method reference in Control doc.
- After unremitting efforts, the format and commit records have finally been cleaned up!
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
