### PR TITLE
C#: Ensure .NET editor supports Visual Studio 2026

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
@@ -46,19 +46,13 @@ namespace GodotTools.OpenVisualStudio
 
             if (dte == null)
             {
-                // Open a new instance
-                dte = TryVisualStudioLaunch("VisualStudio.DTE.17.0");
+                dte = TryVisualStudioLaunch("VisualStudio.DTE.18.0")   // Visual Studio 18 (2026).
+                    ?? TryVisualStudioLaunch("VisualStudio.DTE.17.0"); // Visual Studio 17 (2022).
 
                 if (dte == null)
                 {
-                    // Launch of VS 2022 failed, fallback to 2019
-                    dte = TryVisualStudioLaunch("VisualStudio.DTE.16.0");
-
-                    if (dte == null)
-                    {
-                        Console.Error.WriteLine("Visual Studio not found");
-                        return 1;
-                    }
+                    Console.Error.WriteLine("Could not find a supported Visual Studio version (VS 2026 or VS 2022).");
+                    return 1;
                 }
 
                 dte.UserControl = true;
@@ -188,8 +182,8 @@ namespace GodotTools.OpenVisualStudio
                     if (ppszDisplayName == null)
                         continue;
 
-                    // The digits after the colon are the process ID
-                    if (!Regex.IsMatch(ppszDisplayName, "!VisualStudio.DTE.1[6-7].0:[0-9]"))
+                    // The digits after the colon are the process ID.
+                    if (!Regex.IsMatch(ppszDisplayName, "!VisualStudio.DTE.1[7-8].0:[0-9]"))
                         continue;
 
                     if (pprot.GetObject(moniker[0], out object ppunkObject) == 0)


### PR DESCRIPTION
- Fixes #112675
- Supersedes #110851
- Supersedes #112677

Considered writing up reviews for the above PRs, but this is functionally a release blocker and it's been straggling for a while now, so I'd prefer it dealt with expediently. This adds detection/launch support for Visual Studio 2026, and removes it for Visual Studio 2019.