### PR TITLE
Core: Add missing `String` operators

### DIFF
--- a/core/templates/rid.cpp
+++ b/core/templates/rid.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rid.h                                                                 */
+/*  rid.cpp                                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,53 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#include "rid.h"
 
-#include "core/templates/hashfuncs.h"
-#include "core/typedefs.h"
+#include "core/string/ustring.h"
 
-class RID_AllocBase;
-class String;
-
-class RID {
-	friend class RID_AllocBase;
-	uint64_t _id = 0;
-
-public:
-	_ALWAYS_INLINE_ bool operator==(const RID &p_rid) const {
-		return _id == p_rid._id;
-	}
-	_ALWAYS_INLINE_ bool operator<(const RID &p_rid) const {
-		return _id < p_rid._id;
-	}
-	_ALWAYS_INLINE_ bool operator<=(const RID &p_rid) const {
-		return _id <= p_rid._id;
-	}
-	_ALWAYS_INLINE_ bool operator>(const RID &p_rid) const {
-		return _id > p_rid._id;
-	}
-	_ALWAYS_INLINE_ bool operator>=(const RID &p_rid) const {
-		return _id >= p_rid._id;
-	}
-	_ALWAYS_INLINE_ bool operator!=(const RID &p_rid) const {
-		return _id != p_rid._id;
-	}
-	_ALWAYS_INLINE_ bool is_valid() const { return _id != 0; }
-	_ALWAYS_INLINE_ bool is_null() const { return _id == 0; }
-
-	_ALWAYS_INLINE_ uint32_t get_local_index() const { return _id & 0xFFFFFFFF; }
-
-	static _ALWAYS_INLINE_ RID from_uint64(uint64_t p_id) {
-		RID _rid;
-		_rid._id = p_id;
-		return _rid;
-	}
-	_ALWAYS_INLINE_ uint64_t get_id() const { return _id; }
-
-	uint32_t hash() const { return HashMapHasherDefault::hash(_id); }
-
-	explicit operator String() const;
-};
-
-template <>
-struct is_zero_constructible<RID> : std::true_type {};
+RID::operator String() const {
+	return "RID(" + uitos(_id) + ")";
+}

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -949,6 +949,10 @@ Span<Variant> Array::span() const {
 	return _p->array.span();
 }
 
+Array::operator String() const {
+	return Variant(*this).stringify();
+}
+
 Array::Array(const Array &p_from) {
 	_p = nullptr;
 	_ref(p_from);

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -195,6 +195,8 @@ public:
 		return this->span();
 	}
 
+	explicit operator String() const;
+
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);
 	Array(std::initializer_list<Variant> p_init);

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -754,6 +754,10 @@ const void *Dictionary::id() const {
 	return _p;
 }
 
+Dictionary::operator String() const {
+	return Variant(*this).stringify();
+}
+
 Dictionary::Dictionary(const Dictionary &p_base, uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script) {
 	_p = memnew(DictionaryPrivate);
 	_p->refcount.init();

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -129,6 +129,8 @@ public:
 
 	const void *id() const;
 
+	explicit operator String() const;
+
 	Dictionary(const Dictionary &p_base, uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script);
 	Dictionary(const Dictionary &p_from);
 	Dictionary(std::initializer_list<KeyValue<Variant, Variant>> p_init);

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1733,7 +1733,7 @@ String Variant::stringify(int recursion_count) const {
 		}
 		case RID: {
 			const ::RID &s = *reinterpret_cast<const ::RID *>(_data._mem);
-			return "RID(" + itos(s.get_id()) + ")";
+			return String(s);
 		}
 		default: {
 			return "<" + get_type_name(type) + ">";


### PR DESCRIPTION
Part of moving away from implicit `Variant` casts will rely on ensuring the relevant functionality can be achieved on the relevant types. One of the most obvious areas this needed to be implemented with was `String` operators, which lacked explicit operators for several types, instead opting for `Variant` to handle the details behind the scenes. Explicit operators were added to the types: `RID`, `Array`, and `Dictionary`. The latter two types still rely on `Variant::stringify` to handle recursion, but this could eventually be given a generic function decoupled from `Variant` entirely, similar to our current `hash` function setup