### PR TITLE
DAP: Enable showing errors to users 

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_types.h
+++ b/editor/debugger/debug_adapter/debug_adapter_types.h
@@ -176,7 +176,7 @@ struct Message {
 	int id = 0;
 	String format;
 	bool sendTelemetry = false; // Just in case :)
-	bool showUser = false;
+	bool showUser = true;
 	Dictionary variables;
 
 	_FORCE_INLINE_ Dictionary to_json() const {


### PR DESCRIPTION
Before the change, DAP errors were hardcoded to 'showUser = false', this sets it to 'true' so that users get useful feedback. fixes #112965

This implements the suggestion by user @rsubtil in #112965

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
