### PR TITLE
Add `T::make` style initialization, soon to replace `std::initializer_list`.

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -342,12 +342,25 @@ public:
 		return ret;
 	}
 
+	template <typename... Args>
+	static LocalVector make(Args &&...args) {
+		static_assert(sizeof...(Args) > 0);
+		RelocateInitData<T, sizeof...(Args)> data(std::forward<Args>(args)...);
+		return LocalVector(data);
+	}
+
 	_FORCE_INLINE_ LocalVector() {}
 	_FORCE_INLINE_ LocalVector(std::initializer_list<T> p_init) {
 		reserve(p_init.size());
 		for (const T &element : p_init) {
 			push_back(element);
 		}
+	}
+	_FORCE_INLINE_ explicit LocalVector(RelocateInitList<T> p_init) {
+		CRASH_COND(reserve(p_init.size));
+		// Relocate into data
+		memcpy((void *)data, p_init.ptr, p_init.size * sizeof(T));
+		count = p_init.size;
 	}
 	_FORCE_INLINE_ LocalVector(const LocalVector &p_from) {
 		resize(p_from.size());

--- a/core/templates/relocate_init_list.h
+++ b/core/templates/relocate_init_list.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  relocate_init_list.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/typedefs.h"
+
+// Kind of like std::initializer_list, but with required relocation semantics:
+// Whoever is passed the RelocateInitList is expected to relocate the data into itself.
+template <typename T>
+struct RelocateInitList {
+	T *ptr;
+	size_t size;
+};
+
+// If you want Container to support init list relocation, declare a relocation list constructor:
+// Constructor(RelocateInitList<T> p_init) {
+//     ptr = p_init.ptr;
+//     size = p_init.size;
+// }
+// A factory method is recommended for simpler use:
+// template<typename... Args> make(Args... args) {
+//     RelocateInitData<T, sizeof...(Args)> data(std::forward<Args>(args)...);
+//     return Container(data);
+// }
+// To use, simply call `Container<T>::make(a, b, c, ...)`.
+template <typename T, size_t CAPACITY>
+struct RelocateInitData {
+	alignas(T) uint8_t _data[CAPACITY * sizeof(T)];
+
+	_FORCE_INLINE_ T *ptr() { return reinterpret_cast<T *>(_data); }
+
+	template <typename... Args>
+	_FORCE_INLINE_ RelocateInitData(Args &&...args) {
+		static_assert(sizeof...(Args) == CAPACITY);
+		size_t i = -1;
+		(memnew_placement(ptr() + (++i), T(std::forward<Args>(args))), ...);
+	}
+
+	_FORCE_INLINE_ operator RelocateInitList<T>() { return RelocateInitList<T>{ ptr(), CAPACITY }; }
+};

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -315,9 +315,17 @@ public:
 		return ConstIterator(ptr() + size());
 	}
 
+	template <typename... Args>
+	static Vector make(Args &&...args) {
+		RelocateInitData<Args..., sizeof...(Args)> data(std::forward<Args>(args)...);
+		return Vector(data);
+	}
+
 	_FORCE_INLINE_ Vector() {}
 	_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) :
 			_cowdata(p_init) {}
+	_FORCE_INLINE_ explicit Vector(RelocateInitList<T> init) :
+			_cowdata(init) {}
 	_FORCE_INLINE_ Vector(const Vector &p_from) = default;
 	_FORCE_INLINE_ Vector(Vector &&p_from) = default;
 };

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -960,6 +960,12 @@ Array::Array(std::initializer_list<Variant> p_init) {
 	_p->array = Vector<Variant>(p_init);
 }
 
+Array::Array(RelocateInitList<Variant> p_init) {
+	_p = memnew(ArrayPrivate);
+	_p->refcount.init();
+	_p->array = Vector<Variant>(p_init);
+}
+
 Array::Array() {
 	_p = memnew(ArrayPrivate);
 	_p->refcount.init();

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/relocate_init_list.h"
 #include "core/templates/span.h"
 #include "core/typedefs.h"
 #include "core/variant/variant_deep_duplicate.h"
@@ -195,9 +196,17 @@ public:
 		return this->span();
 	}
 
+	template <typename... Args>
+	static Array make(Args &&...args) {
+		static_assert(sizeof...(Args) > 0);
+		RelocateInitData<Variant, sizeof...(Args)> data(std::forward<Args>(args)...);
+		return Array(data);
+	}
+
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);
-	Array(std::initializer_list<Variant> p_init);
+	Array(std::initializer_list<Variant> p_init); // Deprecated.
+	explicit Array(RelocateInitList<Variant> p_init);
 	Array();
 	~Array();
 };

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -3059,8 +3059,8 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 			}
 
 			RD::get_singleton()->draw_list_set_push_constant(p_draw_list, &push_constant, sizeof(push_constant));
-			FixedVector<RID, 1> vb = { p_batch->instance_buffer };
-			FixedVector<uint64_t, 1> vo = { uint64_t(p_batch->start) * sizeof(InstanceData) };
+			RID vb[1] = { p_batch->instance_buffer };
+			uint64_t vo[1] = { uint64_t(p_batch->start) * sizeof(InstanceData) };
 			RD::get_singleton()->draw_list_bind_vertex_buffers_format(p_draw_list, shader.quad_vertex_format_id, 1, vb, vo);
 			RD::get_singleton()->draw_list_bind_index_array(p_draw_list, shader.quad_index_array);
 			RD::get_singleton()->draw_list_draw(p_draw_list, true, p_batch->instance_count);
@@ -3110,8 +3110,8 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 			RD::get_singleton()->draw_list_bind_render_pipeline(p_draw_list, pipeline);
 
 			RD::get_singleton()->draw_list_set_push_constant(p_draw_list, &push_constant, sizeof(push_constant));
-			FixedVector<RID, 1> vb = { p_batch->instance_buffer };
-			FixedVector<uint64_t, 1> vo = { uint64_t(p_batch->start) * sizeof(InstanceData) };
+			RID vb[1] = { p_batch->instance_buffer };
+			uint64_t vo[1] = { uint64_t(p_batch->start) * sizeof(InstanceData) };
 			RD::get_singleton()->draw_list_bind_vertex_buffers_format(p_draw_list, shader.primitive_vertex_format_id, 1, vb, vo);
 			RD::get_singleton()->draw_list_bind_index_array(p_draw_list, primitive_arrays.index_array[MIN(3u, primitive->point_count) - 1]);
 			uint32_t instance_count = p_batch->instance_count;

--- a/tests/core/templates/test_fixed_vector.h
+++ b/tests/core/templates/test_fixed_vector.h
@@ -80,7 +80,7 @@ TEST_CASE("[FixedVector] Basic Checks") {
 	CHECK(vector.is_empty());
 	CHECK(!vector.is_full());
 
-	FixedVector<uint16_t, 2> vector1 = { 1, 2 };
+	FixedVector<uint16_t, 2> vector1 = FixedVector<uint16_t, 2>::make(1, 2);
 	CHECK_EQ(vector1.capacity(), 2);
 	CHECK_EQ(vector1.size(), 2);
 	CHECK_EQ(vector1[0], 1);


### PR DESCRIPTION
- Half resolves https://github.com/godotengine/godot-proposals/issues/12247
- Half supersedes https://github.com/godotengine/godot/pull/112664
- Works towards fixing https://github.com/godotengine/godot/issues/112662

With this PR, I propose an implementation to the `std::initializer_list` conundrum we've been facing. In short, the problems are:

- `std::initializer_list` [unexpectedly makes a copy](https://github.com/godotengine/godot-proposals/issues/12247) of the given data, which is inefficient.
- `std::initializer_list` [constructors are inherently ambiguous](https://github.com/godotengine/godot/issues/112662). This can create bugs that are hard to track down, and makes the code harder to reason about.

The proposed solution uses the following syntax:

```c++
// Equivalent to GDScript [1, 2, 3]
// Equivalent to current Array{1, 2, 3} (std::initializer_list)
Array array = Array::make(1, 2, 3);
```

## Proposed solution (implementation)

The `make` function is implemented by creating a `RelocateInitData`, which is essentially syntax sugar for `T[SIZE]`. Then, the data is passed as `RelocateInitList` (pointer and size, span-like) to a constructor of the type.

The constructor is expected to relocate the data into itself. We have decided in earlier core meetings that we should assume trivial relocatability in core containers (see https://github.com/godotengine/godot/issues/100509).

If the container can use `memcpy`, it should use `memcpy`. This is maximally efficient.
If it cannot use `memcpy` (which doesn't happen in our codebase right now), it can still use `std::move` (and call the destructor), which would still be way more efficient than the `std::initializer_list` version.

## Code safety note

Just like `std::initializer_list`, `RelocateInitData` and `RelocateInitList` are _very_ unsafe to use on their own, and should not be used outside their intended purpose.

However, their complexity is not very deep, so I expect people with good C++ understanding (specifically those who understand relocatability) to be able to review code that involves them.

## Follow-ups

This PR does not exchange any `std::initializer_list` calls yet. The reason is simply that there are a lot already (thousands).
This can be approached iteratively, until we can remove (or better, explicitly delete) all `std::initializer_list` constructors.