### PR TITLE
Add regex find and replace to find in files dialog

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -405,6 +405,13 @@
 				Returns the clipping behavior when the text exceeds the item's bounding rectangle in the given [param column]. By default it is [constant TextServer.OVERRUN_TRIM_ELLIPSIS].
 			</description>
 		</method>
+		<method name="get_text_paragraph" qualifiers="const">
+			<return type="TextParagraph" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns the [TextParagraph] used to draw the text of a cell internally. This can be used to measure the text layouts of a cell.
+			</description>
+		</method>
 		<method name="get_tooltip_text" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="column" type="int" />

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1402,6 +1402,18 @@ void CodeTextEditor::goto_line_centered(int p_line, int p_column) {
 	callable_mp((TextEdit *)text_editor, &TextEdit::center_viewport_to_caret).call_deferred(0);
 }
 
+void CodeTextEditor::select(int p_origin_line, int p_origin_column, int p_caret_line, int p_caret_column) {
+	text_editor->remove_secondary_carets();
+	text_editor->deselect();
+	for (int line = p_origin_line; line <= p_origin_line; line++) {
+		text_editor->unfold_line(CLAMP(line, 0, text_editor->get_line_count() - 1));
+	}
+	text_editor->select(p_origin_line, p_origin_column, p_caret_line, p_caret_column);
+	text_editor->set_code_hint("");
+	text_editor->cancel_code_completion();
+	callable_mp((TextEdit *)text_editor, &TextEdit::center_viewport_to_caret).call_deferred(0);
+}
+
 void CodeTextEditor::set_executing_line(int p_line) {
 	text_editor->set_line_as_executing(p_line, true);
 }

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -257,6 +257,7 @@ public:
 	void goto_line(int p_line, int p_column = 0);
 	void goto_line_selection(int p_line, int p_begin, int p_end);
 	void goto_line_centered(int p_line, int p_column = 0);
+	void select(int p_origin_line, int p_origin_column, int p_caret_line, int p_caret_column);
 	void set_executing_line(int p_line);
 	void clear_executing_line();
 

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -33,9 +33,12 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/os.h"
+#include "core/string/string_builder.h"
+#include "editor/docks/editor_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_validation_panel.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
@@ -48,6 +51,10 @@
 #include "scene/gui/progress_bar.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/tree.h"
+
+namespace {
+constexpr int FULL_LINE = -1;
+}
 
 const char *FindInFiles::SIGNAL_RESULT_FOUND = "result_found";
 
@@ -96,6 +103,10 @@ void FindInFiles::set_whole_words(bool p_whole_word) {
 
 void FindInFiles::set_match_case(bool p_match_case) {
 	_match_case = p_match_case;
+}
+
+void FindInFiles::set_regex(bool p_regex) {
+	_regex_active = p_regex;
 }
 
 void FindInFiles::set_folder(const String &folder) {
@@ -279,26 +290,94 @@ void FindInFiles::_scan_dir(const String &path, PackedStringArray &out_folders, 
 	}
 }
 
+static TypedDictionary<Variant, String> _get_regex_captures(const Ref<RegExMatch> p_match) {
+	TypedDictionary<Variant, String> dict;
+	for (const KeyValue<Variant, Variant> &name : p_match->get_names()) {
+		dict[name.key] = p_match->get_string(name.value);
+	}
+	const PackedStringArray &strings = p_match->get_strings();
+	for (int group_i = 0; group_i < strings.size(); group_i++) {
+		dict[group_i] = strings[group_i];
+	}
+	return dict;
+}
+
+static int _get_line_number(const int p_index, const String &p_text, const int p_starting_index = 0) {
+	int line_number = 1;
+	for (int i = p_starting_index; i < p_index; ++i) {
+		if (p_text[i] == '\n') {
+			line_number++;
+		}
+	}
+	return line_number;
+}
+
+static Vector2i _get_line_boundaries(const int p_start_index, const int p_end_index, const String &p_text) {
+	int start = p_start_index;
+	for (; start > 0; start--) {
+		if (p_text[start - 1] == '\n') {
+			break;
+		}
+	}
+	int end = p_end_index;
+	for (; end < p_text.length() - 1; end++) {
+		if (p_text[end] == '\n') {
+			break;
+		}
+	}
+	return Vector2i(start, end);
+}
+
 void FindInFiles::_scan_file(const String &fpath) {
-	Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ);
+	static Ref<RegEx> regex = memnew(RegEx);
+	const Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ);
 	if (f.is_null()) {
 		print_verbose(String("Cannot open file ") + fpath);
 		return;
 	}
 
-	int line_number = 0;
+	if (_regex_active) {
+		if (regex->get_pattern() != _pattern) {
+			regex->compile(_pattern, false);
+		}
 
-	while (!f->eof_reached()) {
-		// Line number starts at 1.
-		++line_number;
+		const String text = f->get_as_text();
+		int last_end = 0;
+		Ref<RegExMatch> match = regex->search(text);
+		while (match.is_valid()) {
+			const int abs_start = match->get_start(0);
+			const int abs_end = match->get_end(0);
+			const int start_line_number = _get_line_number(abs_start, text);
+			// Line numbers start at 1, so to get the proper offset, the 1 must be subtracted.
+			const int end_line_number = start_line_number + _get_line_number(abs_end, text, abs_start) - 1;
+			const Vector2i substring_bounds = _get_line_boundaries(abs_start, abs_end - 1, text);
 
-		int begin = 0;
-		int end = 0;
+			emit_signal(SNAME(SIGNAL_RESULT_FOUND), fpath, Vector2i(start_line_number, end_line_number), abs_start - substring_bounds.x, abs_end - substring_bounds.x, abs_start, abs_end, text.substr(substring_bounds.x, substring_bounds.y - substring_bounds.x), _get_regex_captures(match));
 
-		String line = f->get_line();
+			last_end = abs_end;
+			if (abs_start == last_end) {
+				last_end++;
+			}
 
-		while (find_next(line, _pattern, end, _match_case, _whole_words, begin, end)) {
-			emit_signal(SNAME(SIGNAL_RESULT_FOUND), fpath, line_number, begin, end, line);
+			match = regex->search(text, last_end);
+		}
+	} else {
+		int line_number = 0;
+		int absolute_position = 0;
+		while (!f->eof_reached()) {
+			// Line number starts at 1.
+			++line_number;
+
+			int begin = 0;
+			int end = 0;
+
+			String line = f->get_line();
+			while (find_next(line, _pattern, end, _match_case, _whole_words, begin, end)) {
+				emit_signal(SNAME(SIGNAL_RESULT_FOUND), fpath, Vector2i(line_number, line_number), begin, end, absolute_position + begin, absolute_position + end, line, TypedDictionary<Variant, String>());
+			}
+
+			// +1 for newlines.
+			absolute_position += line.size() + 1;
 		}
 	}
 }
@@ -382,8 +461,23 @@ FindInFilesDialog::FindInFilesDialog() {
 		_match_case_checkbox->set_text(TTRC("Match Case"));
 		hbc->add_child(_match_case_checkbox);
 
+		_regex_checkbox = memnew(CheckBox);
+		_regex_checkbox->set_text(TTRC("Use RegEx"));
+		_regex_checkbox->connect(SceneStringName(toggled), callable_mp(this, &FindInFilesDialog::_on_regex_checkbox_toggled));
+		hbc->add_child(_regex_checkbox);
+
 		gc->add_child(hbc);
 	}
+
+	_regex_status_label_filler = memnew(Control);
+	_regex_status_label_filler->hide();
+	gc->add_child(_regex_status_label_filler);
+
+	_regex_status_panel = memnew(EditorValidationPanel);
+	_regex_status_panel->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	_regex_status_panel->hide();
+	_regex_status_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT);
+	gc->add_child(_regex_status_panel);
 
 	Label *folder_label = memnew(Label);
 	folder_label->set_text(TTRC("Folder:"));
@@ -462,22 +556,25 @@ FindInFilesDialog::FindInFilesDialog() {
 	cancel_button->set_text(TTRC("Cancel"));
 
 	_mode = SEARCH_MODE;
+
+	_regex = memnew(RegEx);
 }
 
 void FindInFilesDialog::set_search_text(const String &text) {
+	const String &replaced_text = is_regex() ? RegEx::escape_literal(text) : text;
 	if (_mode == SEARCH_MODE) {
 		if (!text.is_empty()) {
-			_search_text_line_edit->set_text(text);
-			_on_search_text_modified(text);
+			_search_text_line_edit->set_text(replaced_text);
+			_on_search_text_modified(replaced_text);
 		}
 		callable_mp((Control *)_search_text_line_edit, &Control::grab_focus).call_deferred(false);
 		_search_text_line_edit->select_all();
 	} else if (_mode == REPLACE_MODE) {
-		if (!text.is_empty()) {
-			_search_text_line_edit->set_text(text);
+		if (!replaced_text.is_empty()) {
+			_search_text_line_edit->set_text(replaced_text);
 			callable_mp((Control *)_replace_text_line_edit, &Control::grab_focus).call_deferred(false);
 			_replace_text_line_edit->select_all();
-			_on_search_text_modified(text);
+			_on_search_text_modified(replaced_text);
 		} else {
 			callable_mp((Control *)_search_text_line_edit, &Control::grab_focus).call_deferred(false);
 			_search_text_line_edit->select_all();
@@ -524,6 +621,10 @@ bool FindInFilesDialog::is_match_case() const {
 
 bool FindInFilesDialog::is_whole_words() const {
 	return _whole_words_checkbox->is_pressed();
+}
+
+bool FindInFilesDialog::is_regex() const {
+	return _regex_checkbox->is_pressed();
 }
 
 String FindInFilesDialog::get_folder() const {
@@ -618,13 +719,12 @@ void FindInFilesDialog::custom_action(const String &p_action) {
 void FindInFilesDialog::_on_search_text_modified(const String &text) {
 	ERR_FAIL_NULL(_find_button);
 	ERR_FAIL_NULL(_replace_button);
-
-	_find_button->set_disabled(get_search_text().is_empty());
-	_replace_button->set_disabled(get_search_text().is_empty());
+	update_search_parameters();
 }
 
 void FindInFilesDialog::_on_search_text_submitted(const String &text) {
 	// This allows to trigger a global search without leaving the keyboard.
+	update_search_parameters();
 	if (!_find_button->is_disabled()) {
 		if (_mode == SEARCH_MODE) {
 			custom_action("find");
@@ -645,6 +745,23 @@ void FindInFilesDialog::_on_replace_text_submitted(const String &text) {
 			custom_action("replace");
 		}
 	}
+}
+
+void FindInFilesDialog::_on_regex_checkbox_toggled(bool p_toggled) {
+	update_search_parameters();
+}
+
+void FindInFilesDialog::update_search_parameters() {
+	const bool valid = validate_search_text(get_search_text());
+	const bool regex = is_regex();
+
+	_find_button->set_disabled(!valid);
+	_replace_button->set_disabled(!valid);
+
+	_regex_status_panel->set_visible(regex);
+	_regex_status_label_filler->set_visible(regex);
+	_whole_words_checkbox->set_disabled(regex);
+	_match_case_checkbox->set_disabled(regex);
 }
 
 void FindInFilesDialog::_on_folder_selected(String path) {
@@ -676,6 +793,23 @@ String FindInFilesDialog::validate_filter_wildcard(const String &p_expression) c
 	}
 
 	return ret;
+}
+
+bool FindInFilesDialog::validate_search_text(const String &p_text) const {
+	if (is_regex()) {
+		if (p_text.is_empty()) {
+			_regex_status_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Expression is empty"), EditorValidationPanel::MSG_ERROR);
+			return false;
+		}
+		if (_regex->compile(p_text, false) == OK) {
+			_regex_status_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Expression is valid"), EditorValidationPanel::MSG_OK);
+			return true;
+		}
+		_regex_status_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, _regex->get_compile_error(), EditorValidationPanel::MSG_ERROR);
+		return false;
+	} else {
+		return !p_text.is_empty();
+	}
 }
 
 void FindInFilesDialog::_bind_methods() {
@@ -918,10 +1052,38 @@ void FindInFilesPanel::_notification(int p_what) {
 	}
 }
 
-void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, int begin, int end, String text) {
+static String _process_tabs(const String &p_input, int &inout_start_index, int &inout_end_index) {
+	static constexpr int tab_width = 4;
+	static const String tab = String(" ").repeat(tab_width);
+	StringBuilder buffer;
+	int start_index = inout_start_index;
+	int end_index = inout_end_index;
+	for (int i = 0; i < p_input.length(); i++) {
+		if (const char32_t ch = p_input[i]; ch == '\t') {
+			buffer.append(tab);
+			if (inout_start_index > i) {
+				// 1 character gets replaced with tab_width.
+				start_index += tab_width - 1;
+			}
+			if (inout_end_index > i) {
+				// 1 character gets replaced with tab_width.
+				end_index += tab_width - 1;
+			}
+		} else {
+			buffer.append(String::chr(ch));
+		}
+	}
+	inout_start_index = start_index;
+	if (inout_end_index != FULL_LINE) {
+		inout_end_index = end_index;
+	}
+	return buffer;
+}
+
+void FindInFilesPanel::_on_result_found(const String &fpath, Vector2i line_range, int begin, int end, int absolute_begin, int absolute_end, const String &text, const TypedDictionary<Variant, String> &p_captures) {
 	TreeItem *file_item;
-	Ref<Texture2D> remove_texture = get_editor_theme_icon(SNAME("Close"));
-	Ref<Texture2D> replace_texture = get_editor_theme_icon(SNAME("ReplaceText"));
+	const Ref<Texture2D> remove_texture = get_editor_theme_icon(SNAME("Close"));
+	const Ref<Texture2D> replace_texture = get_editor_theme_icon(SNAME("ReplaceText"));
 
 	HashMap<String, TreeItem *>::Iterator E = _file_items.find(fpath);
 	if (!E) {
@@ -957,20 +1119,65 @@ void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, in
 	// Do this first because it resets properties of the cell...
 	item->set_cell_mode(text_index, TreeItem::CELL_MODE_CUSTOM);
 
-	// Trim result item line.
-	int old_text_size = text.size();
-	text = text.strip_edges(true, false);
-	int chars_removed = old_text_size - text.size();
-	String start = vformat("%3s: ", line_number);
+	Vector<HighlightRange> highlight_ranges;
+	String first_line_indent;
+	PackedStringArray lines = text.split("\n");
 
-	item->set_text(text_index, start + text);
+	// Handle mischievous users who try to match newlines.
+	// I am always two steps ahead.
+	const bool is_annoying_newline_match = line_range.y - line_range.x + 1 > lines.size();
+	if (is_annoying_newline_match) {
+		lines.append(" ");
+	}
+
+	PackedStringArray processed_lines;
+	processed_lines.reserve_exact(lines.size());
+	highlight_ranges.reserve_exact(lines.size());
+
+	// Only strip the leading whitespace from one line matches, and only if the start & end columns aren't inside the whitespace.
+	if (lines.size() == 1) {
+		const String stripped = lines[0].strip_edges(true, false);
+		const int stripped_chars = lines[0].length() - stripped.length();
+		if (begin >= stripped_chars && end >= stripped_chars) {
+			first_line_indent = lines[0].left(stripped_chars);
+		}
+	}
+
+	// `line_start_i` is the absolute index at which the current line began.
+	// `i` is the line number.
+	for (int i = 0, line_start_i = 0; i < lines.size(); line_start_i += lines[i].length() + 1, i++) {
+		const String &line = lines[i];
+		const String start = vformat("%03d: ", line_range.x + i);
+
+		String stripped_line = line.trim_prefix(first_line_indent);
+		int stripped_chars = line.length() - stripped_line.length();
+
+		Vector2i range{
+			i > 0 ? 0 : begin - stripped_chars,
+			i < lines.size() - 1 ? FULL_LINE : end - line_start_i - stripped_chars,
+		};
+
+		stripped_line = _process_tabs(stripped_line, range.x, range.y);
+
+		const String processed_line = start + stripped_line;
+		highlight_ranges.append({ start.length(), range, processed_line });
+		processed_lines.append(processed_line);
+	}
+
+	item->set_text(text_index, String("\n").join(processed_lines));
 	item->set_custom_draw_callback(text_index, callable_mp(this, &FindInFilesPanel::draw_result_text));
 
 	Result r;
-	r.line_number = line_number;
+	r.line_range = line_range;
 	r.begin = begin;
 	r.end = end;
-	r.begin_trimmed = begin - chars_removed + start.size() - 1;
+	r.absolute_begin = absolute_begin;
+	r.absolute_end = absolute_end;
+	r.captures = p_captures;
+	r.highlight_ranges = highlight_ranges;
+	r.was_annoying_newline_match = is_annoying_newline_match;
+
+	r.text = text;
 	_result_items[item] = r;
 
 	if (_with_replace) {
@@ -982,6 +1189,84 @@ void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, in
 	} else {
 		item->add_button(0, remove_texture, FIND_BUTTON_REMOVE, false, TTR("Remove result"));
 	}
+}
+
+void FindInFilesPanel::draw_result_text(Object *item_obj, Rect2 rect) {
+	TreeItem *item = Object::cast_to<TreeItem>(item_obj);
+	if (!item) {
+		return;
+	}
+
+	HashMap<TreeItem *, Result>::Iterator E = _result_items.find(item);
+	if (!E) {
+		return;
+	}
+	Result r = E->value;
+	const int column = _with_replace ? 1 : 0;
+	const Ref<TextParagraph> item_text_paragraph = item->get_text_paragraph(column);
+	const Ref<Font> font = _results_display->get_theme_font(SceneStringName(font));
+	Color outline_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.33);
+	Color background_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.17);
+	const int font_size = _results_display->get_theme_font_size(SceneStringName(font_size));
+	const real_t font_descent = font->get_descent(font_size);
+
+	int y_offset = 0;
+	int line = 0;
+	Vector<HighlightRange> ranges = r.highlight_ranges;
+	PackedVector2Array l_outline_points;
+	PackedVector2Array r_outline_points;
+	l_outline_points.reserve_exact(ranges.size());
+	r_outline_points.reserve_exact(ranges.size());
+
+	for (const HighlightRange &hl_range : ranges) {
+		const int prefix_text_width = hl_range.prefix_text_width;
+		const Vector2i range = hl_range.range;
+		const String &line_text = hl_range.text;
+
+		const bool is_first = line == 0;
+
+		const int start = range.x;
+		const int end = range.y == FULL_LINE ? line_text.size() - prefix_text_width : range.y;
+		const real_t height = item_text_paragraph->get_line_size(line).height;
+
+		const Size2 highlight_size = font->get_string_size(line_text.substr(start + prefix_text_width, end - start), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
+		Rect2 match_rect = rect;
+		match_rect.position.x += font->get_string_size(line_text.left(start + prefix_text_width), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x - 1;
+		match_rect.size.x = highlight_size.x + 1;
+		match_rect.size.y = height;
+		match_rect.position.y += y_offset;
+
+		if (is_first) {
+			match_rect = match_rect.grow_side(SIDE_BOTTOM, font_descent / 2);
+		} else {
+			match_rect.position.y += font_descent / 2;
+		}
+
+		Point2 tl = match_rect.position;
+		Point2 bl = match_rect.position + Vector2(0.0, match_rect.size.height);
+		Point2 tr = match_rect.position + Vector2(match_rect.size.width, 0.0);
+		Point2 br = match_rect.position + Vector2(match_rect.size.width, match_rect.size.height);
+
+		l_outline_points.append(tl);
+		l_outline_points.append(bl);
+		r_outline_points.append(tr);
+		r_outline_points.append(br);
+
+		_results_display->draw_rect(match_rect, background_color, true);
+
+		y_offset += height;
+		line++;
+	}
+
+	l_outline_points.reverse();
+	PackedVector2Array outline_points;
+	outline_points.reserve_exact(l_outline_points.size() + r_outline_points.size() + 1);
+	outline_points.append_array(l_outline_points);
+	outline_points.append_array(r_outline_points);
+	outline_points.append(outline_points[0]);
+	_results_display->draw_polyline(outline_points, outline_color, 1.0, true);
+
+	// Text is drawn by Tree already.
 }
 
 void FindInFilesPanel::_on_theme_changed() {
@@ -1014,33 +1299,6 @@ void FindInFilesPanel::_on_theme_changed() {
 
 		file_item = file_item->get_next();
 	}
-}
-
-void FindInFilesPanel::draw_result_text(Object *item_obj, Rect2 rect) {
-	TreeItem *item = Object::cast_to<TreeItem>(item_obj);
-	if (!item) {
-		return;
-	}
-
-	HashMap<TreeItem *, Result>::Iterator E = _result_items.find(item);
-	if (!E) {
-		return;
-	}
-	Result r = E->value;
-	String item_text = item->get_text(_with_replace ? 1 : 0);
-	Ref<Font> font = _results_display->get_theme_font(SceneStringName(font));
-	int font_size = _results_display->get_theme_font_size(SceneStringName(font_size));
-
-	Rect2 match_rect = rect;
-	match_rect.position.x += font->get_string_size(item_text.left(r.begin_trimmed), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x - 1;
-	match_rect.size.x = font->get_string_size(_search_text_label->get_text(), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + 1;
-	match_rect.position.y += 1 * EDSCALE;
-	match_rect.size.y -= 2 * EDSCALE;
-
-	_results_display->draw_rect(match_rect, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.33), false, 2.0);
-	_results_display->draw_rect(match_rect, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.17), true);
-
-	// Text is drawn by Tree already.
 }
 
 void FindInFilesPanel::_on_item_edited() {
@@ -1086,7 +1344,10 @@ void FindInFilesPanel::_on_result_selected() {
 	TreeItem *file_item = item->get_parent();
 	String fpath = file_item->get_metadata(0);
 
-	emit_signal(SNAME(SIGNAL_RESULT_SELECTED), fpath, r.line_number, r.begin, r.end);
+	// If yes, it matched a new line that doesn't show up in the text because it's at the very end.
+	const int end_col = r.was_annoying_newline_match ? 0 : (r.end - MAX(0, r.text.rfind("\n") + 1));
+	// Line numbers are one-based in the results list but the various text editors expect them to be zero-based.
+	emit_signal(SNAME(SIGNAL_RESULT_SELECTED), fpath, r.line_range - Vector2i(1, 1), r.begin, end_col);
 }
 
 void FindInFilesPanel::_on_replace_text_changed(const String &text) {
@@ -1211,13 +1472,92 @@ private:
 	Vector<char> _line_buffer;
 };
 
-void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<Result> &locations, const String &new_text) {
+// Reimplements a limited subset of the PCRE replacement syntax.
+static String _fake_regex_sub(const String &p_pattern, const TypedDictionary<Variant, String> &p_captures) {
+	StringBuilder sb;
+	for (int i = 0; i < p_pattern.length(); i++) {
+		char32_t ch = p_pattern[i];
+		if (ch != '$') {
+			sb.append(String::chr(ch));
+			continue;
+		}
+		if (i + 1 < p_pattern.length()) {
+			int peek = 1;
+			int start_i = i + peek;
+			ch = p_pattern[start_i];
+			if (ch == '$') {
+				// $$
+				sb.append("$");
+				i++;
+				continue;
+			} else if (ch >= '0' && ch <= '9') {
+				// $<number>
+				for (; i + peek < p_pattern.length(); peek++) {
+					ch = p_pattern[i + peek];
+					if (ch < '0' || ch > '9') {
+						break;
+					}
+				}
+				int num = p_pattern.substr(start_i, peek - 1).to_int();
+				Variant result = p_captures.get(num, Variant());
+				if (result.get_type() != Variant::NIL) {
+					// If the number is a valid capture group name, append it and consume the peeked digits.
+					sb.append(result);
+					i += peek - 1;
+					continue;
+				}
+			} else if (ch == '{') {
+				for (;; peek++) {
+					if (i + peek >= p_pattern.length()) {
+						goto not_matched;
+					}
+					ch = p_pattern[i + peek];
+					if (ch == '}') {
+						break;
+					}
+				}
+				// It needs to be `start_i + 1` because pattern[start_i] is '{'.
+				// peek needs two subtracted, because when the loop breaks it points at the curly brace and start_i has one added.
+				Variant result = p_captures.get(p_pattern.substr(start_i + 1, peek - 2), Variant());
+				if (result.get_type() != Variant::NIL) {
+					// If the number is a valid capture group name, append it and consume the peeked digits.
+					sb.append(result);
+					i += peek;
+					continue;
+				}
+			}
+		}
+	not_matched:
+		sb.append("$");
+	}
+	return sb.as_string();
+}
+
+void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<Result> &locations, const String &new_text) const {
 	// If the file is already open, I assume the editor will reload it.
 	// If there are unsaved changes, the user will be asked on focus,
 	// however that means either losing changes or losing replaces.
 
 	Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ);
 	ERR_FAIL_COND_MSG(f.is_null(), "Cannot open file from path '" + fpath + "'.");
+
+	if (_finder->is_regex()) {
+		int last_end = 0;
+		StringBuilder buffer;
+		const String full_text = f->get_as_text();
+		for (const Result &result : locations) {
+			buffer.append(full_text.substr(last_end, result.absolute_begin - last_end));
+			buffer.append(_fake_regex_sub(new_text, result.captures));
+			last_end = result.absolute_end;
+		}
+		buffer.append(full_text.substr(last_end));
+
+		const Error err = f->reopen(fpath, FileAccess::WRITE);
+		ERR_FAIL_COND_MSG(err != OK, "Cannot create file in path '" + fpath + "'.");
+
+		f->store_string(buffer);
+		return;
+	}
 
 	String buffer;
 	int current_line = 1;
@@ -1230,7 +1570,7 @@ void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<
 	int offset = 0;
 
 	for (int i = 0; i < locations.size(); ++i) {
-		int repl_line_number = locations[i].line_number;
+		int repl_line_number = locations[i].line_range.x;
 
 		while (current_line < repl_line_number) {
 			buffer += line;
@@ -1242,16 +1582,18 @@ void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<
 		int repl_begin = locations[i].begin + offset;
 		int repl_end = locations[i].end + offset;
 
+		String replacement_text = new_text;
 		int _;
 		if (!find_next(line, search_text, repl_begin, _finder->is_match_case(), _finder->is_whole_words(), _, _)) {
 			// Make sure the replace is still valid in case the file was tampered with.
-			print_verbose(String("Occurrence no longer matches, replace will be ignored in {0}: line {1}, col {2}").format(varray(fpath, repl_line_number, repl_begin)));
+			// RegEx matches are ignored in this case, since they have their own matching logic that doesn't work with find_next.
+			print_verbose(vformat("Occurrence no longer matches, replace will be ignored in %s: line %d, col %d", fpath, repl_line_number, repl_begin));
 			continue;
 		}
 
-		line = line.left(repl_begin) + new_text + line.substr(repl_end);
+		line = line.left(repl_begin) + replacement_text + line.substr(repl_end);
 		// Keep an offset in case there are successive replaces in the same line.
-		offset += new_text.length() - (repl_end - repl_begin);
+		offset += replacement_text.length() - (repl_end - repl_begin);
 	}
 
 	buffer += line;
@@ -1422,8 +1764,8 @@ void FindInFilesContainer::_on_theme_changed() {
 	}
 }
 
-void FindInFilesContainer::_on_find_in_files_result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end) {
-	emit_signal(SNAME("result_selected"), p_fpath, p_line_number, p_begin, p_end);
+void FindInFilesContainer::_on_find_in_files_result_selected(const String &p_fpath, Vector2i p_line_range, int p_begin, int p_end) {
+	emit_signal(SNAME("result_selected"), p_fpath, p_line_range, p_begin, p_end);
 }
 
 void FindInFilesContainer::_on_find_in_files_modified_files(const PackedStringArray &p_paths) {

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -31,7 +31,10 @@
 #pragma once
 
 #include "core/templates/hash_map.h"
+#include "core/variant/typed_dictionary.h"
 #include "editor/docks/editor_dock.h"
+#include "editor/gui/editor_validation_panel.h"
+#include "modules/regex/regex.h"
 #include "scene/gui/dialogs.h"
 
 // Performs the actual search
@@ -44,6 +47,7 @@ public:
 
 	void set_search_text(const String &p_pattern);
 	void set_whole_words(bool p_whole_word);
+	void set_regex(bool p_regex);
 	void set_match_case(bool p_match_case);
 	void set_folder(const String &folder);
 	void set_filter(const HashSet<String> &exts);
@@ -54,6 +58,7 @@ public:
 
 	bool is_whole_words() const { return _whole_words; }
 	bool is_match_case() const { return _match_case; }
+	bool is_regex() const { return _regex_active; }
 
 	void start();
 	void stop();
@@ -82,6 +87,7 @@ private:
 	String _root_dir;
 	bool _whole_words = true;
 	bool _match_case = true;
+	bool _regex_active = false;
 
 	// State
 	bool _searching = false;
@@ -120,6 +126,7 @@ public:
 	String get_replace_text() const;
 	bool is_match_case() const;
 	bool is_whole_words() const;
+	bool is_regex() const;
 	String get_folder() const;
 	HashSet<String> get_filter() const;
 	HashSet<String> get_includes() const;
@@ -138,8 +145,12 @@ private:
 	void _on_search_text_modified(const String &text);
 	void _on_search_text_submitted(const String &text);
 	void _on_replace_text_submitted(const String &text);
+	void _on_regex_checkbox_toggled(bool p_toggled);
+
+	void update_search_parameters();
 
 	String validate_filter_wildcard(const String &p_expression) const;
+	bool validate_search_text(const String &p_text) const;
 
 	FindInFilesMode _mode;
 	LineEdit *_search_text_line_edit = nullptr;
@@ -150,6 +161,10 @@ private:
 	LineEdit *_folder_line_edit = nullptr;
 	CheckBox *_match_case_checkbox = nullptr;
 	CheckBox *_whole_words_checkbox = nullptr;
+	Ref<RegEx> _regex;
+	CheckBox *_regex_checkbox = nullptr;
+	Control *_regex_status_label_filler = nullptr;
+	EditorValidationPanel *_regex_status_panel = nullptr;
 	Button *_find_button = nullptr;
 	Button *_replace_button = nullptr;
 	FileDialog *_folder_dialog = nullptr;
@@ -196,7 +211,7 @@ protected:
 
 private:
 	void _on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index);
-	void _on_result_found(const String &fpath, int line_number, int begin, int end, String text);
+	void _on_result_found(const String &fpath, Vector2i line_range, int begin, int end, int absolute_begin, int absolute_end, const String &text, const TypedDictionary<Variant, String> &p_captures);
 	void _on_theme_changed();
 	void _on_finished();
 	void _on_refresh_button_clicked();
@@ -212,14 +227,25 @@ private:
 		FIND_BUTTON_REMOVE,
 	};
 
-	struct Result {
-		int line_number = 0;
-		int begin = 0;
-		int end = 0;
-		int begin_trimmed = 0;
+	struct HighlightRange {
+		int prefix_text_width = 0;
+		Vector2i range;
+		String text;
 	};
 
-	void apply_replaces_in_file(const String &fpath, const Vector<Result> &locations, const String &new_text);
+	struct Result {
+		Vector2i line_range;
+		int begin = 0;
+		int end = 0;
+		int absolute_begin = 0;
+		int absolute_end = 0;
+		bool was_annoying_newline_match = false;
+		String text;
+		TypedDictionary<Variant, String> captures;
+		Vector<HighlightRange> highlight_ranges;
+	};
+
+	void apply_replaces_in_file(const String &fpath, const Vector<Result> &locations, const String &new_text) const;
 	void update_replace_buttons();
 	void update_matches_text();
 	String get_replace_text();
@@ -286,7 +312,7 @@ protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
-	void _on_find_in_files_result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end);
+	void _on_find_in_files_result_selected(const String &p_fpath, Vector2i p_line_range, int p_begin, int p_end);
 	void _on_find_in_files_modified_files(const PackedStringArray &p_paths);
 	void _on_find_in_files_close_button_clicked(FindInFilesPanel *p_panel);
 

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -209,6 +209,7 @@ public:
 	virtual void goto_line(int p_line, int p_column = 0) { code_editor->goto_line(p_line, p_column); }
 	virtual void goto_line_selection(int p_line, int p_begin, int p_end) { code_editor->goto_line_selection(p_line, p_begin, p_end); }
 	virtual void goto_line_centered(int p_line, int p_column = 0) { code_editor->goto_line_centered(p_line, p_column); }
+	virtual void select(int p_origin_line, int p_origin_column, int p_caret_line, int p_caret_column) { code_editor->select(p_origin_line, p_origin_column, p_caret_line, p_caret_column); }
 	virtual void set_executing_line(int p_line) { code_editor->set_executing_line(p_line); }
 	virtual void clear_executing_line() { code_editor->clear_executing_line(); }
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3613,7 +3613,7 @@ void ScriptEditor::_on_replace_in_files_requested(const String &text) {
 	find_in_files_dialog->popup_centered();
 }
 
-void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int line_number, int begin, int end) {
+void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, Vector2i p_line_range, int begin, int end) {
 	if (ResourceLoader::exists(fpath)) {
 		Ref<Resource> res = ResourceLoader::load(fpath);
 
@@ -3623,12 +3623,12 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 			shader_editor->make_visible(true);
 			TextShaderEditor *text_shader_editor = Object::cast_to<TextShaderEditor>(shader_editor->get_shader_editor(res));
 			if (text_shader_editor) {
-				text_shader_editor->goto_line_selection(line_number - 1, begin, end);
+				text_shader_editor->select(p_line_range.x, begin, p_line_range.y, end);
 			}
 			return;
 		} else if (fpath.get_extension() == "tscn") {
 			const PackedStringArray lines = FileAccess::get_file_as_string(fpath).split("\n");
-			if (line_number > lines.size()) {
+			if (p_line_range.x > lines.size() || p_line_range.y > lines.size()) {
 				return;
 			}
 
@@ -3637,12 +3637,13 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 			String script_id;
 
 			// Search the scene backwards from the found line.
-			int scan_line = line_number - 1;
+			int scan_line = p_line_range.x - 1;
 			while (scan_line >= 0) {
 				const String &line = lines[scan_line];
 				if (line.begins_with(source_header)) {
 					// Adjust line relative to the script beginning.
-					line_number -= scan_line + 1;
+					p_line_range.x -= scan_line + 1;
+					p_line_range.y -= scan_line + 1;
 				} else if (line.begins_with(scr_header)) {
 					script_id = line.trim_prefix(scr_header).get_slicec('"', 0);
 					break;
@@ -3659,12 +3660,10 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 
 					if (ste) {
 						callable_mp(EditorInterface::get_singleton(), &EditorInterface::set_main_screen_editor).call_deferred("Script");
-						if (line_number == 0) {
-							const int source_len = strlen(source_header);
-							ste->goto_line_selection(line_number, begin - source_len, end - source_len);
-						} else {
-							ste->goto_line_selection(line_number, begin, end);
-						}
+						const int source_len = strlen(source_header);
+						const int start_offset = p_line_range.x == 0 ? source_len : 0;
+						const int end_offset = p_line_range.y == 0 ? source_len : 0;
+						ste->select(p_line_range.x, begin - start_offset, p_line_range.y, end - end_offset);
 					}
 				}
 			}
@@ -3679,7 +3678,7 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 				ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
 				if (ste) {
 					EditorInterface::get_singleton()->set_main_screen_editor("Script");
-					ste->goto_line_selection(line_number - 1, begin, end);
+					ste->select(p_line_range.x, begin, p_line_range.y, end);
 				}
 				return;
 			}
@@ -3694,7 +3693,7 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 
 		TextEditor *te = Object::cast_to<TextEditor>(_get_current_editor());
 		if (te) {
-			te->goto_line_selection(line_number - 1, begin, end);
+			te->select(p_line_range.x, begin, p_line_range.y, end);
 		}
 	}
 }
@@ -3710,6 +3709,7 @@ void ScriptEditor::_start_find_in_files(bool with_replace) {
 	f->set_filter(find_in_files_dialog->get_filter());
 	f->set_includes(find_in_files_dialog->get_includes());
 	f->set_excludes(find_in_files_dialog->get_excludes());
+	f->set_regex(find_in_files_dialog->is_regex());
 
 	panel->set_with_replace(with_replace);
 	panel->set_replace_text(find_in_files_dialog->get_replace_text());

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -384,7 +384,7 @@ class ScriptEditor : public PanelContainer {
 	Error _save_text_file(Ref<TextFile> p_text_file, const String &p_path);
 
 	void _on_replace_in_files_requested(const String &text);
-	void _on_find_in_files_result_selected(const String &fpath, int line_number, int begin, int end);
+	void _on_find_in_files_result_selected(const String &fpath, Vector2i p_line_range, int begin, int end);
 	void _start_find_in_files(bool with_replace);
 	void _on_find_in_files_modified_files(const PackedStringArray &paths);
 

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -843,6 +843,10 @@ void TextShaderEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
 	code_editor->goto_line_selection(p_line, p_begin, p_end);
 }
 
+void TextShaderEditor::select(int p_origin_line, int p_origin_column, int p_caret_line, int p_caret_column) {
+	code_editor->select(p_origin_line, p_origin_column, p_caret_line, p_caret_column);
+}
+
 void TextShaderEditor::_project_settings_changed() {
 	_update_warnings(true);
 }

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -202,6 +202,7 @@ public:
 	bool get_trim_final_newlines_on_save() const { return trim_final_newlines_on_save; }
 	void ensure_select_current();
 	void goto_line_selection(int p_line, int p_begin, int p_end);
+	void select(int p_origin_line, int p_origin_column, int p_caret_line, int p_caret_column);
 	void trim_trailing_whitespace();
 	void trim_final_newlines();
 	void tag_saved_version();

--- a/modules/regex/doc_classes/RegEx.xml
+++ b/modules/regex/doc_classes/RegEx.xml
@@ -70,6 +70,19 @@
 				Creates and compiles a new [RegEx] object. See also [method compile].
 			</description>
 		</method>
+		<method name="escape_literal" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="literal" type="String" />
+			<description>
+				Escapes a string such that when used as a regular expression, the only text it will match is the textual content of the string. See also [method String.c_escape].
+			</description>
+		</method>
+		<method name="get_compile_error" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the last compilation error.
+			</description>
+		</method>
 		<method name="get_group_count" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -169,6 +169,30 @@ Ref<RegEx> RegEx::create_from_string(const String &p_pattern, bool p_show_error)
 	return ret;
 }
 
+String RegEx::escape_literal(const String &p_literal) {
+	String escaped = p_literal;
+	escaped = escaped.replace("\\", "\\\\");
+	escaped = escaped.replace("\n", "\\n");
+	escaped = escaped.replace("\r", "\\r");
+	escaped = escaped.replace("\t", "\\t");
+	escaped = escaped.replace("\f", "\\f");
+	escaped = escaped.replace(".", "\\.");
+	escaped = escaped.replace("^", "\\^");
+	escaped = escaped.replace("$", "\\$");
+	escaped = escaped.replace("|", "\\|");
+	escaped = escaped.replace("[", "\\[");
+	escaped = escaped.replace("]", "\\]");
+	escaped = escaped.replace("(", "\\(");
+	escaped = escaped.replace(")", "\\)");
+	escaped = escaped.replace("{", "\\{");
+	escaped = escaped.replace("}", "\\}");
+	escaped = escaped.replace("*", "\\*");
+	escaped = escaped.replace("+", "\\+");
+	escaped = escaped.replace("?", "\\?");
+
+	return escaped;
+}
+
 void RegEx::clear() {
 	if (code) {
 		pcre2_code_free_32((pcre2_code_32 *)code);
@@ -193,14 +217,16 @@ Error RegEx::compile(const String &p_pattern, bool p_show_error) {
 	pcre2_compile_context_free_32(cctx);
 
 	if (!code) {
+		PCRE2_UCHAR32 buf[256];
+		pcre2_get_error_message_32(err, buf, 256);
+		compile_error = String::num_int64(offset) + ": " + String((const char32_t *)buf);
 		if (p_show_error) {
-			PCRE2_UCHAR32 buf[256];
-			pcre2_get_error_message_32(err, buf, 256);
-			String message = String::num_int64(offset) + ": " + String((const char32_t *)buf);
-			ERR_PRINT(message);
+			ERR_PRINT(compile_error);
 		}
 		return FAILED;
 	}
+
+	compile_error = String();
 	return OK;
 }
 
@@ -400,6 +426,10 @@ PackedStringArray RegEx::get_names() const {
 	return result;
 }
 
+String RegEx::get_compile_error() const {
+	return compile_error;
+}
+
 RegEx::RegEx() {
 	general_ctx = pcre2_general_context_create_32(&_regex_malloc, &_regex_free, nullptr);
 }
@@ -418,6 +448,7 @@ RegEx::~RegEx() {
 
 void RegEx::_bind_methods() {
 	ClassDB::bind_static_method("RegEx", D_METHOD("create_from_string", "pattern", "show_error"), &RegEx::create_from_string, DEFVAL(true));
+	ClassDB::bind_static_method("RegEx", D_METHOD("escape_literal", "literal"), &RegEx::escape_literal);
 
 	ClassDB::bind_method(D_METHOD("clear"), &RegEx::clear);
 	ClassDB::bind_method(D_METHOD("compile", "pattern", "show_error"), &RegEx::compile, DEFVAL(true));
@@ -428,4 +459,5 @@ void RegEx::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pattern"), &RegEx::get_pattern);
 	ClassDB::bind_method(D_METHOD("get_group_count"), &RegEx::get_group_count);
 	ClassDB::bind_method(D_METHOD("get_names"), &RegEx::get_names);
+	ClassDB::bind_method(D_METHOD("get_compile_error"), &RegEx::get_compile_error);
 }

--- a/modules/regex/regex.h
+++ b/modules/regex/regex.h
@@ -74,6 +74,7 @@ class RegEx : public RefCounted {
 	void *general_ctx = nullptr;
 	void *code = nullptr;
 	String pattern;
+	String compile_error;
 
 	void _pattern_info(uint32_t what, void *where) const;
 
@@ -91,6 +92,8 @@ protected:
 public:
 	static Ref<RegEx> create_from_string(const String &p_pattern, bool p_show_error = true);
 
+	static String escape_literal(const String &p_literal);
+
 	void clear();
 	Error compile(const String &p_pattern, bool p_show_error = true);
 
@@ -102,6 +105,8 @@ public:
 	String get_pattern() const;
 	int get_group_count() const;
 	PackedStringArray get_names() const;
+
+	String get_compile_error() const;
 
 	RegEx();
 	RegEx(const String &p_pattern);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -569,6 +569,10 @@ String TreeItem::get_suffix(int p_column) const {
 	return cells[p_column].suffix;
 }
 
+Ref<TextParagraph> TreeItem::get_text_paragraph(const int p_column) const {
+	return cells[p_column].text_buf;
+}
+
 void TreeItem::set_icon(int p_column, const Ref<Texture2D> &p_icon) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 
@@ -1854,6 +1858,8 @@ void TreeItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_suffix", "column", "text"), &TreeItem::set_suffix);
 	ClassDB::bind_method(D_METHOD("get_suffix", "column"), &TreeItem::get_suffix);
+
+	ClassDB::bind_method(D_METHOD("get_text_paragraph", "column"), &TreeItem::get_text_paragraph);
 
 	ClassDB::bind_method(D_METHOD("set_icon", "column", "texture"), &TreeItem::set_icon);
 	ClassDB::bind_method(D_METHOD("get_icon", "column"), &TreeItem::get_icon);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -303,6 +303,8 @@ public:
 	void set_suffix(int p_column, String p_suffix);
 	String get_suffix(int p_column) const;
 
+	Ref<TextParagraph> get_text_paragraph(int p_column) const;
+
 	void set_icon(int p_column, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_icon(int p_column) const;
 


### PR DESCRIPTION
This adds a new match with regex toggle to the find in files dialog. It only works if the module is enabled. If it's disabled, all the regex functionality is removed and the checkbox disappears. The substitution syntax supports three replacement constructs: `$$` becomes `$`, `$<number>` (like `$1`) gets replaced with the capture group's contents by index (0 is whole match), and `${name}` gets replaced with the capture group's contents by name (e.g. for patterns like `(?<name>.*?)`).

Coincidentally, since the regex compilation error needs to be shown to the user, I also added a `RegEx::get_compilation_error` function, bound it, and documented it to close one of my really old proposals.

Closes godotengine/godot-proposals#8384
Closes godotengine/godot-proposals#10721
Closes godotengine/godot-proposals#7995
Partially closes godotengine/godot-proposals#9778 (not exposed as a theme item, but you can manipulate the text paragraph objects directly now)