### PR TITLE
Move History dock to the bottom left by default.

### DIFF
--- a/editor/docks/history_dock.cpp
+++ b/editor/docks/history_dock.cpp
@@ -239,7 +239,7 @@ HistoryDock::HistoryDock() {
 	set_name(TTRC("History"));
 	set_icon_name("History");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_history", TTRC("Open History Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_RIGHT_UL);
+	set_default_slot(DockConstants::DOCK_SLOT_LEFT_BR);
 
 	ur_manager = EditorUndoRedoManager::get_singleton();
 	ur_manager->connect("history_changed", callable_mp(this, &HistoryDock::on_history_changed));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8770,8 +8770,8 @@ EditorNode::EditorNode() {
 	default_layout.instantiate();
 	// Dock numbers are based on DockSlot enum value + 1.
 	default_layout->set_value(docks_section, "dock_3", "Scene,Import");
-	default_layout->set_value(docks_section, "dock_4", "FileSystem");
-	default_layout->set_value(docks_section, "dock_5", "Inspector,Signals,Groups,History");
+	default_layout->set_value(docks_section, "dock_4", "FileSystem,History");
+	default_layout->set_value(docks_section, "dock_5", "Inspector,Signals,Groups");
 
 	int hsplits[] = { 0, 270, -270, 0 };
 	DEV_ASSERT((int)std_size(hsplits) == editor_dock_manager->get_hsplit_count());


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/101787

This moves the "History" dock to the bottom left (next to `FileSystem`) by default, instead of the top right (next to `Inspector` and `Node`).
Originally suggested by @Mickeon in chat.

<img width="1392" height="834" alt="SCR-20251120-svci" src="https://github.com/user-attachments/assets/1ed5b361-8572-4b7f-af6a-205062d469f8" />

**My reasoning:** 
- The top right slot otherwise relates to the current edited `Node`/`Object`. `History` has no particular relation to the current edited `Node`.
- The top right slot is somewhat crowded, especially if https://github.com/godotengine/godot/pull/101787 is merged.
- The bottom left slot is pretty empty. Especially, `FileSystem` is often used, but `History` is probably rarely used. That makes it a good candidate to pair them.
- The dock fits in the bottom left thematically. While "Scene" does influence it (so it could arguably be in the top left slot), it is generally global, and makes the "Scene" relation clear with a checkbox.
