### PR TITLE
Hide TreeItem edit popup on scroll.

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5769,6 +5769,7 @@ int Tree::get_columns() const {
 void Tree::_scroll_moved(float) {
 	_determine_hovered_item();
 	queue_redraw();
+	popup_editor->hide();
 }
 
 Rect2 Tree::get_custom_popup_rect() const {


### PR DESCRIPTION
Before, you could scroll while editing an item on a Tree node.

Before:

https://github.com/user-attachments/assets/0e3355b9-eb68-4cc6-abd2-5979eb67543b

After:

https://github.com/user-attachments/assets/1cf9013e-bb1c-4c39-8a4a-9eee8360a903
