### PR TITLE
Fix corruption of D3D12 CPU descriptor heap free blocks

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -489,13 +489,15 @@ Error RenderingDeviceDriverD3D12::CPUDescriptorsHeapPool::release(const CPUDescr
 	} else if (next != free_blocks_by_offset.end()) {
 		// Connects to the next block.
 		remove_from_size_map(next->value);
+
+		FreeBlockInfo merged_block = next->value;
+		merged_block.global_offset -= p_result.count;
+		merged_block.size += p_result.count;
+
+		// Replace with the merged block.
 		free_blocks_by_offset.erase(next->value.global_offset);
-
-		next->value.global_offset -= p_result.count;
-		next->value.size += p_result.count;
-
-		DEV_ASSERT(!free_blocks_by_offset.has(next->value.global_offset));
-		new_block = free_blocks_by_offset.insert(next->value.global_offset, next->value);
+		DEV_ASSERT(!free_blocks_by_offset.has(merged_block.global_offset));
+		new_block = free_blocks_by_offset.insert(merged_block.global_offset, merged_block);
 	} else {
 		// Connects to no block.
 		new_block = free_blocks_by_offset.insert(global_offset, FreeBlockInfo{ p_result.heap, global_offset, p_result.base_offset, p_result.count });


### PR DESCRIPTION
While running my own build of Godot 4.5.1 I was seeing heap corruption in D3D12 code. To investigate I made a dev build and found I was hitting a dev assert in the D3D12 CPU descriptor heap management logic:

<img width="1342" height="694" alt="image" src="https://github.com/user-attachments/assets/1c042ba2-15ca-4075-acbe-c967e350e522" />

I believe the problem due to the order of deletion and update, specifically:

```c++
free_blocks_by_offset.erase(next->value.global_offset);
```

`next->value.global_offset` always matches the key of the pair in this RBMap, so this is erasing "next" itself. So the `next` iterator now points to deleted memory, but then `next` is updated and put back into free_blocks_by_offset. Since `next` points to deleted memory, this is undefined behavior. In my debug builds, you can see in the screenshot that some kind of sentinel values get set to make this "use-after-free" issue more obvious.

To fix this I create a block separate from the one that `next` points to so I can mutate it before deleting the old block and inserting in the new merged block. I don't know if this fixes the original heap corruption but it does fix the DEV_ASSERT (on line 497 in my screenshot) and corrupted block data.