### PR TITLE
Highlight current method in sidebar when moving caret in Script Editor

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -768,6 +768,14 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 	_update_online_doc();
 	_update_members_overview_visibility();
 	_update_help_overview_visibility();
+
+	if (seb) {
+		CodeTextEditor *cte = seb->get_code_editor();
+		if (cte) {
+			int current_line = cte->get_text_editor()->get_caret_line();
+			update_members_overview_current(current_line);
+		}
+	}
 }
 
 void ScriptEditor::_add_recent_script(const String &p_path) {
@@ -2107,6 +2115,7 @@ void ScriptEditor::_toggle_members_overview_alpha_sort(bool p_alphabetic_sort) {
 
 void ScriptEditor::_update_members_overview() {
 	members_overview->clear();
+	members_overview_selected_index = -1;
 
 	ScriptEditorBase *se = _get_current_editor();
 	if (!se) {
@@ -2143,6 +2152,44 @@ void ScriptEditor::_update_members_overview() {
 			members_overview->set_item_metadata(-1, line);
 		}
 	}
+
+	CodeTextEditor *cte = se->get_code_editor();
+	if (cte) {
+		int current_line = cte->get_text_editor()->get_caret_line();
+		update_members_overview_current(current_line);
+	}
+}
+
+void ScriptEditor::update_members_overview_current(int p_line) {
+	if (!members_overview->is_visible() || members_overview->get_item_count() == 0 || members_overview_selected_index == -2) {
+		return;
+	}
+
+	int best_match_idx = -1;
+	int best_match_line = -1;
+
+	for (int i = 0; i < members_overview->get_item_count(); i++) {
+		int function_line = members_overview->get_item_metadata(i);
+		if (function_line <= p_line && function_line > best_match_line) {
+			best_match_line = function_line;
+			best_match_idx = i;
+		}
+	}
+
+	if (best_match_idx != members_overview_selected_index) {
+		members_overview->deselect_all();
+
+		if (best_match_idx != -1) {
+			members_overview->select(best_match_idx, false);
+		}
+
+		members_overview_selected_index = best_match_idx;
+	}
+}
+
+void ScriptEditor::mark_members_overview_dirty() {
+	// Using -2 to indicate cache is dirty (metadata is possibly stale).
+	members_overview_selected_index = -2;
 }
 
 void ScriptEditor::_update_help_overview_visibility() {

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -341,6 +341,7 @@ class ScriptEditor : public PanelContainer {
 	ItemList *script_list = nullptr;
 	HSplitContainer *script_split = nullptr;
 	ItemList *members_overview = nullptr;
+	int members_overview_selected_index = -1;
 	LineEdit *filter_scripts = nullptr;
 	LineEdit *filter_methods = nullptr;
 	VBoxContainer *scripts_vbox = nullptr;
@@ -613,6 +614,9 @@ public:
 	void trigger_live_script_reload(const String &p_script_path);
 
 	VSplitContainer *get_left_list_split() { return list_split; }
+
+	void update_members_overview_current(int p_line);
+	void mark_members_overview_dirty();
 
 	void set_live_auto_reload_running_scripts(bool p_enabled);
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1272,6 +1272,8 @@ void ScriptTextEditor::_on_caret_moved() {
 		store_previous_state();
 	}
 	previous_line = current_line;
+
+	ScriptEditor::get_singleton()->update_members_overview_current(current_line);
 }
 
 void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_column) {
@@ -3017,6 +3019,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor->get_text_editor()->set_draw_executing_lines_gutter(true);
 	code_editor->get_text_editor()->connect("breakpoint_toggled", callable_mp(this, &ScriptTextEditor::_breakpoint_toggled));
 	code_editor->get_text_editor()->connect("caret_changed", callable_mp(this, &ScriptTextEditor::_on_caret_moved));
+	code_editor->get_text_editor()->connect("lines_edited_from", callable_mp(ScriptEditor::get_singleton(), &ScriptEditor::mark_members_overview_dirty).unbind(2));
 	code_editor->connect("navigation_preview_ended", callable_mp(this, &ScriptTextEditor::_on_caret_moved));
 
 	connection_gutter = 1;


### PR DESCRIPTION
Closes [#10336](https://github.com/godotengine/godot-proposals/issues/10336).

In the methods list in the sidebar of the script editor, clicking any method causes the editor to jump to that part of the script. This makes a highlight appear on that method. This highlight then remains on that method until another is clicked, or until the script is switched.

With this PR, moving the caret around a script causes the current method the caret resides to get highlighted, allowing the user to more easily get their bearings when deep inside a longer method.

https://github.com/user-attachments/assets/ec3f122a-5913-4c7f-b0d4-08ebb9659eea

This not only fixes the strange persistence of the highlight after selecting a method, but also makes the methods list more like the scripts list above it, which retains a highlight on the current script.

This PR does not at the moment scroll on the methods list to keep the current method within view, so that the user isn't too inconvenienced by their visible window of jumping around too much, in case they want to keep a specific set of functions in view. However, without that, this enhancement cannot reliably replace the role of other text editors' breadcrumbs. If the latter is more useful than the former, I'll implement it as well.