### PR TITLE
Sync editor audio bus changes and effects to a running game

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -247,6 +247,13 @@
 				Moves the bus from index [param index] to index [param to_index].
 			</description>
 		</method>
+		<method name="refresh_bus_effects">
+			<return type="void" />
+			<param index="0" name="bus_idx" type="int" />
+			<description>
+				Recreates effect instances for the bus at [param bus_idx]. Call this after changing effect parameters so that the updated values take effect immediately (e.g. when syncing bus state from the editor to a running project).
+			</description>
+		</method>
 		<method name="register_stream_as_sample" experimental="">
 			<return type="void" />
 			<param index="0" name="stream" type="AudioStream" />

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -36,6 +36,8 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
+#include "editor/debugger/editor_debugger_node.h"
+#include "editor/debugger/script_editor_debugger.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/editor_node.h"
@@ -161,10 +163,34 @@ void EditorAudioBus::_notification(int p_what) {
 				float real_peak[2] = { -100, -100 };
 				bool activity_found = false;
 
-				if (AudioServer::get_singleton()->is_bus_channel_active(get_index(), i)) {
-					activity_found = true;
-					real_peak[0] = MAX(real_peak[0], AudioServer::get_singleton()->get_bus_peak_volume_left_db(get_index(), i));
-					real_peak[1] = MAX(real_peak[1], AudioServer::get_singleton()->get_bus_peak_volume_right_db(get_index(), i));
+				bool used_remote = false;
+				if (EditorDebuggerNode::get_singleton() != nullptr) {
+					if (ScriptEditorDebugger *dbg = EditorDebuggerNode::get_singleton()->get_current_debugger()) {
+						if (dbg->is_session_active()) {
+							Vector<float> lvals;
+							Vector<float> rvals;
+							Vector<bool> actives;
+							if (dbg->get_remote_audio_bus_peaks(get_index(), lvals, rvals, actives) && i < lvals.size()) {
+								used_remote = true;
+								real_peak[0] = MAX(lvals[i], -80.0f);
+								real_peak[1] = MAX(rvals[i], -80.0f);
+								// Derive activity from current levels to avoid sticky state.
+								activity_found = (real_peak[0] > -75.0f) || (real_peak[1] > -75.0f);
+							}
+						}
+					}
+				}
+
+				if (!used_remote) {
+					if (AudioServer::get_singleton()->is_bus_channel_active(get_index(), i)) {
+						activity_found = true;
+						real_peak[0] = MAX(real_peak[0], AudioServer::get_singleton()->get_bus_peak_volume_left_db(get_index(), i));
+						real_peak[1] = MAX(real_peak[1], AudioServer::get_singleton()->get_bus_peak_volume_right_db(get_index(), i));
+					}
+					// Also derive activity from levels to turn off reliably when near silence.
+					if (!activity_found) {
+						activity_found = (real_peak[0] > -75.0f) || (real_peak[1] > -75.0f);
+					}
 				}
 
 				if (real_peak[0] > channel[i].peak_l) {
@@ -339,6 +365,11 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 
 	ur->commit_action();
 
+	// Sync audio bus changes to running game
+	if (EditorDebuggerNode::get_singleton() != nullptr) {
+		EditorDebuggerNode::get_singleton()->sync_audio_buses();
+	}
+
 	updating_bus = false;
 }
 
@@ -364,6 +395,11 @@ void EditorAudioBus::_volume_changed(float p_normalized) {
 	ur->add_do_method(buses, "_update_bus", get_index());
 	ur->add_undo_method(buses, "_update_bus", get_index());
 	ur->commit_action();
+
+	// Sync audio bus changes to running game
+	if (EditorDebuggerNode::get_singleton() != nullptr) {
+		EditorDebuggerNode::get_singleton()->sync_audio_buses();
+	}
 
 	updating_bus = false;
 }
@@ -459,6 +495,11 @@ void EditorAudioBus::_solo_toggled() {
 	ur->add_undo_method(buses, "_update_bus", get_index());
 	ur->commit_action();
 
+	// Sync audio bus changes to running game
+	if (EditorDebuggerNode::get_singleton() != nullptr) {
+		EditorDebuggerNode::get_singleton()->sync_audio_buses();
+	}
+
 	updating_bus = false;
 }
 
@@ -472,6 +513,11 @@ void EditorAudioBus::_mute_toggled() {
 	ur->add_do_method(buses, "_update_bus", get_index());
 	ur->add_undo_method(buses, "_update_bus", get_index());
 	ur->commit_action();
+
+	// Sync audio bus changes to running game
+	if (EditorDebuggerNode::get_singleton() != nullptr) {
+		EditorDebuggerNode::get_singleton()->sync_audio_buses();
+	}
 
 	updating_bus = false;
 }
@@ -487,6 +533,11 @@ void EditorAudioBus::_bypass_toggled() {
 	ur->add_undo_method(buses, "_update_bus", get_index());
 	ur->commit_action();
 
+	// Sync audio bus changes to running game
+	if (EditorDebuggerNode::get_singleton() != nullptr) {
+		EditorDebuggerNode::get_singleton()->sync_audio_buses();
+	}
+
 	updating_bus = false;
 }
 
@@ -500,6 +551,11 @@ void EditorAudioBus::_send_selected(int p_which) {
 	ur->add_do_method(buses, "_update_bus", get_index());
 	ur->add_undo_method(buses, "_update_bus", get_index());
 	ur->commit_action();
+
+	// Sync audio bus changes to running game
+	if (EditorDebuggerNode::get_singleton() != nullptr) {
+		EditorDebuggerNode::get_singleton()->sync_audio_buses();
+	}
 
 	updating_bus = false;
 }
@@ -551,6 +607,11 @@ void EditorAudioBus::_effect_edited() {
 		ur->add_undo_method(buses, "_update_bus", get_index());
 		ur->commit_action();
 
+		// Sync audio bus changes to running game
+		if (EditorDebuggerNode::get_singleton() != nullptr) {
+			EditorDebuggerNode::get_singleton()->sync_audio_buses();
+		}
+
 		updating_bus = false;
 	}
 }
@@ -577,6 +638,11 @@ void EditorAudioBus::_effect_add(int p_which) {
 	ur->add_do_method(buses, "_update_bus", get_index());
 	ur->add_undo_method(buses, "_update_bus", get_index());
 	ur->commit_action();
+
+	// Sync audio bus changes to running game
+	if (EditorDebuggerNode::get_singleton() != nullptr) {
+		EditorDebuggerNode::get_singleton()->sync_audio_buses();
+	}
 }
 
 void EditorAudioBus::gui_input(const Ref<InputEvent> &p_event) {
@@ -785,6 +851,11 @@ void EditorAudioBus::_delete_effect_pressed(int p_option) {
 	ur->add_do_method(buses, "_update_bus", get_index());
 	ur->add_undo_method(buses, "_update_bus", get_index());
 	ur->commit_action();
+
+	// Sync audio bus changes to running game
+	if (EditorDebuggerNode::get_singleton() != nullptr) {
+		EditorDebuggerNode::get_singleton()->sync_audio_buses();
+	}
 }
 
 void EditorAudioBus::_effect_rmb(const Vector2 &p_pos, MouseButton p_button) {

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -684,6 +684,12 @@ void EditorDebuggerNode::reload_scripts(const Vector<String> &p_script_paths) {
 	});
 }
 
+void EditorDebuggerNode::sync_audio_buses() {
+	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
+		dbg->sync_audio_buses();
+	});
+}
+
 void EditorDebuggerNode::debug_next() {
 	get_current_debugger()->debug_next();
 }

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -191,6 +191,7 @@ public:
 	void set_breakpoints(const String &p_path, const Array &p_lines);
 	void reload_all_scripts();
 	void reload_scripts(const Vector<String> &p_script_paths);
+	void sync_audio_buses();
 
 	// Remote inspector/edit.
 	void request_remote_tree();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -70,6 +70,7 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/tree.h"
+#include "servers/audio/audio_stream.h"
 #include "servers/debugger/servers_debugger.h"
 #include "servers/display/display_server.h"
 
@@ -474,6 +475,57 @@ void ScriptEditorDebugger::_msg_scene_debug_mute_audio(uint64_t p_thread_id, con
 	// This is handled by SceneDebugger, we need to ignore here to not show a warning.
 }
 
+void ScriptEditorDebugger::_msg_scene_audio_peaks(uint64_t p_thread_id, const Array &p_data) {
+	if (p_data.is_empty()) {
+		return;
+	}
+	const Array &payload = p_data; // payload is the array of per-bus dictionaries.
+	remote_bus_peaks.clear();
+	for (int i = 0; i < payload.size(); i++) {
+		Array bus_arr = payload[i];
+		if (bus_arr.size() != 4) {
+			continue;
+		}
+		int bus_index = int(bus_arr[0]);
+		PackedFloat32Array lefts = bus_arr[1];
+		PackedFloat32Array rights = bus_arr[2];
+		PackedByteArray actives = bus_arr[3];
+		const int cc = MIN(lefts.size(), MIN(rights.size(), actives.size()));
+		Vector<ChannelPeak> v;
+		v.resize(cc);
+		for (int c = 0; c < cc; c++) {
+			ChannelPeak cp;
+			cp.l_db = lefts[c];
+			cp.r_db = rights[c];
+			cp.active = actives[c] != 0;
+			v.write[c] = cp;
+		}
+		remote_bus_peaks[bus_index] = v;
+	}
+	remote_bus_peaks_last_ms = OS::get_singleton()->get_ticks_msec();
+}
+
+bool ScriptEditorDebugger::get_remote_audio_bus_peaks(int p_bus_index, Vector<float> &r_left_db, Vector<float> &r_right_db, Vector<bool> &r_active) const {
+	// Require fresh data (avoid stale display when session stops).
+	const uint64_t now = OS::get_singleton()->get_ticks_msec();
+	if (now > remote_bus_peaks_last_ms + 500) {
+		return false;
+	}
+	const Vector<ChannelPeak> *peaks = remote_bus_peaks.getptr(p_bus_index);
+	if (!peaks) {
+		return false;
+	}
+	r_left_db.resize(peaks->size());
+	r_right_db.resize(peaks->size());
+	r_active.resize(peaks->size());
+	for (int i = 0; i < peaks->size(); i++) {
+		const ChannelPeak &cp = (*peaks)[i];
+		r_left_db.write[i] = cp.l_db;
+		r_right_db.write[i] = cp.r_db;
+		r_active.write[i] = cp.active;
+	}
+	return true;
+}
 void ScriptEditorDebugger::_msg_servers_memory_usage(uint64_t p_thread_id, const Array &p_data) {
 	vmem_tree->clear();
 	TreeItem *root = vmem_tree->create_item();
@@ -1009,6 +1061,7 @@ void ScriptEditorDebugger::_init_parse_message_handlers() {
 	parse_message_handlers["scene:inspect_object"] = &ScriptEditorDebugger::_msg_scene_inspect_object;
 #endif // DISABLE_DEPRECATED
 	parse_message_handlers["scene:debug_mute_audio"] = &ScriptEditorDebugger::_msg_scene_debug_mute_audio;
+	parse_message_handlers["scene:audio_peaks"] = &ScriptEditorDebugger::_msg_scene_audio_peaks;
 	parse_message_handlers["servers:memory_usage"] = &ScriptEditorDebugger::_msg_servers_memory_usage;
 	parse_message_handlers["servers:drawn"] = &ScriptEditorDebugger::_msg_servers_drawn;
 	parse_message_handlers["stack_dump"] = &ScriptEditorDebugger::_msg_stack_dump;
@@ -1776,6 +1829,75 @@ void ScriptEditorDebugger::reload_all_scripts() {
 
 void ScriptEditorDebugger::reload_scripts(const Vector<String> &p_script_paths) {
 	_put_msg("reload_scripts", Variant(p_script_paths).operator Array(), debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
+}
+
+void ScriptEditorDebugger::sync_audio_buses() {
+	// Send a minimal, serializable snapshot of audio buses to the running game.
+	if (!is_session_active()) {
+		return;
+	}
+
+	AudioServer *as = AudioServer::get_singleton();
+	if (!as) {
+		return;
+	}
+
+	Dictionary layout;
+	Array buses;
+	const int bus_count = as->get_bus_count();
+	for (int i = 0; i < bus_count; i++) {
+		Dictionary b;
+		b["name"] = as->get_bus_name(i);
+		b["send"] = String(as->get_bus_send(i));
+		b["volume_db"] = as->get_bus_volume_db(i);
+		b["solo"] = as->is_bus_solo(i);
+		b["mute"] = as->is_bus_mute(i);
+		b["bypass"] = as->is_bus_bypassing_effects(i);
+		// Effects
+		Array effects;
+		const int effect_count = as->get_bus_effect_count(i);
+		for (int j = 0; j < effect_count; j++) {
+			Dictionary fx;
+			Ref<AudioEffect> effect = as->get_bus_effect(i, j);
+			fx["class"] = effect.is_valid() ? effect->get_class() : String();
+			fx["enabled"] = as->is_bus_effect_enabled(i, j);
+			// Serialize simple parameters for the effect.
+			Dictionary params;
+			if (effect.is_valid()) {
+				List<PropertyInfo> plist;
+				effect->get_property_list(&plist, true);
+				for (const PropertyInfo &pi : plist) {
+					// Only serialize editor-exposed properties and skip non-data entries.
+					if (!(pi.usage & PROPERTY_USAGE_EDITOR)) {
+						continue;
+					}
+					// Skip categories and internal fields.
+					if (pi.type == Variant::NIL || pi.name.is_empty()) {
+						continue;
+					}
+					// Avoid complex/unsupported types across the debugger channel.
+					if (pi.type == Variant::OBJECT || pi.type == Variant::RID) {
+						continue;
+					}
+					params[pi.name] = effect->get(pi.name);
+				}
+			}
+			fx["params"] = params;
+			effects.push_back(fx);
+		}
+		b["effects"] = effects;
+		buses.push_back(b);
+	}
+	layout["buses"] = buses;
+
+	Array layout_data;
+	layout_data.push_back(layout);
+	// Skip sending if unchanged since last time.
+	if (last_sent_audio_layout == layout) {
+		return;
+	}
+	last_sent_audio_layout = layout;
+	_put_msg("scene:sync_audio_buses", layout_data);
 }
 
 bool ScriptEditorDebugger::is_skip_breakpoints() const {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -381,6 +381,8 @@ public:
 	void reload_all_scripts();
 	void reload_scripts(const Vector<String> &p_script_paths);
 
+	void sync_audio_buses();
+
 	bool is_skip_breakpoints() const;
 	bool is_ignore_error_breaks() const;
 
@@ -396,4 +398,19 @@ public:
 
 	ScriptEditorDebugger();
 	~ScriptEditorDebugger();
+
+private:
+	struct ChannelPeak {
+		float l_db = -100.f;
+		float r_db = -100.f;
+		bool active = false;
+	};
+	HashMap<int, Vector<ChannelPeak>> remote_bus_peaks; // bus_index -> channels
+	uint64_t remote_bus_peaks_last_ms = 0;
+	Dictionary last_sent_audio_layout; // cache to avoid redundant sends
+
+	void _msg_scene_audio_peaks(uint64_t p_thread_id, const Array &p_data);
+
+public:
+	bool get_remote_audio_bus_peaks(int p_bus_index, Vector<float> &r_left_db, Vector<float> &r_right_db, Vector<bool> &r_active) const;
 };

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -41,6 +41,7 @@
 #include "core/math/geometry_3d.h"
 #include "core/object/callable_mp.h"
 #include "scene/2d/camera_2d.h"
+#include "scene/debugger/scene_debugger.h"
 #include "scene/debugger/scene_debugger_object.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/main/canvas_layer.h"
@@ -310,6 +311,10 @@ void RuntimeNodeSelect::_update_input_state() {
 }
 
 void RuntimeNodeSelect::_process_frame() {
+#ifdef DEBUG_ENABLED
+	// Stream audio peaks to the editor UI at low frequency.
+	SceneDebugger::send_audio_peaks();
+#endif
 #ifndef _3D_DISABLED
 	if (camera_freelook) {
 		Transform3D transform = _get_cursor_transform();

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -218,6 +218,229 @@ Error SceneDebugger::_msg_debug_mute_audio(const Array &p_args) {
 	return OK;
 }
 
+Error SceneDebugger::_msg_sync_audio_buses(const Array &p_args) {
+	// Accept a serializable dictionary of bus data and apply it live.
+	if (p_args.size() != 1 || p_args[0].get_type() != Variant::DICTIONARY) {
+		return ERR_INVALID_DATA;
+	}
+
+	Dictionary layout = p_args[0];
+	if (!layout.has("buses")) {
+		return ERR_INVALID_DATA;
+	}
+
+	Array buses = layout["buses"];
+
+	AudioServer *as = AudioServer::get_singleton();
+	if (!as) {
+		return ERR_UNAVAILABLE;
+	}
+
+	// Ensure we can safely apply while a scene is running.
+	if (!SceneTree::get_singleton() || !SceneTree::get_singleton()->get_root()) {
+		return ERR_UNAVAILABLE;
+	}
+
+	// Resize bus count to match.
+	const int target_count = buses.size();
+	int current_count = as->get_bus_count();
+	// Add buses if needed.
+	while (current_count < target_count) {
+		as->add_bus(-1);
+		current_count++;
+	}
+	// Remove extra buses (but never remove Master at index 0).
+	while (current_count > target_count && current_count > 1) {
+		as->remove_bus(current_count - 1);
+		current_count--;
+	}
+
+	// Apply per-bus properties.
+	const int apply_count = MIN(current_count, target_count);
+	for (int i = 0; i < apply_count; i++) {
+		Dictionary b = buses[i];
+		if (b.has("name")) {
+			const String want = String(b["name"]);
+			if (as->get_bus_name(i) != want) {
+				as->set_bus_name(i, want);
+			}
+		}
+		if (b.has("send")) {
+			const StringName want = StringName(String(b["send"]));
+			if (as->get_bus_send(i) != want) {
+				as->set_bus_send(i, want);
+			}
+		}
+		if (b.has("volume_db")) {
+			const float want = (float)b["volume_db"];
+			if (!Math::is_equal_approx(as->get_bus_volume_db(i), want)) {
+				as->set_bus_volume_db(i, want);
+			}
+		}
+		if (b.has("solo")) {
+			const bool want = (bool)b["solo"];
+			if (as->is_bus_solo(i) != want) {
+				as->set_bus_solo(i, want);
+			}
+		}
+		if (b.has("mute")) {
+			const bool want = (bool)b["mute"];
+			if (as->is_bus_mute(i) != want) {
+				as->set_bus_mute(i, want);
+			}
+		}
+		if (b.has("bypass")) {
+			const bool want = (bool)b["bypass"];
+			if (as->is_bus_bypassing_effects(i) != want) {
+				as->set_bus_bypass_effects(i, want);
+			}
+		}
+
+		// Effects: update in place to minimize interruptions (minimal-diff using LCS).
+		if (b.has("effects") && b["effects"].get_type() == Variant::ARRAY) {
+			Array effects = b["effects"];
+			const int curr_count = as->get_bus_effect_count(i);
+			const int incoming_count = effects.size();
+
+			// Gather current and desired class sequences.
+			Vector<String> curr;
+			curr.resize(curr_count);
+			for (int e = 0; e < curr_count; e++) {
+				Ref<AudioEffect> ex = as->get_bus_effect(i, e);
+				curr.write[e] = ex.is_valid() ? ex->get_class() : String();
+			}
+			Vector<String> want;
+			want.resize(incoming_count);
+			for (int e = 0; e < incoming_count; e++) {
+				Dictionary fx = effects[e];
+				want.write[e] = fx.get("class", String());
+			}
+
+			// Compute LCS of class names.
+			const int n = curr.size();
+			const int m = want.size();
+			Vector<Vector<int>> dp;
+			dp.resize(n + 1);
+			for (int ii = 0; ii <= n; ii++) {
+				dp.write[ii].resize(m + 1);
+				for (int jj = 0; jj <= m; jj++) {
+					dp.write[ii].write[jj] = 0;
+				}
+			}
+			for (int ii = 1; ii <= n; ii++) {
+				for (int jj = 1; jj <= m; jj++) {
+					if (curr[ii - 1] == want[jj - 1]) {
+						dp.write[ii].write[jj] = dp[ii - 1][jj - 1] + 1;
+					} else {
+						dp.write[ii].write[jj] = MAX(dp[ii - 1][jj], dp[ii][jj - 1]);
+					}
+				}
+			}
+
+			// Build LCS sequence (class names) without push_front by filling backwards.
+			Vector<String> lcs;
+			{
+				const int lcs_len = dp[n][m];
+				lcs.resize(lcs_len);
+				int pos = lcs_len - 1;
+				int ii = n, jj = m;
+				while (ii > 0 && jj > 0) {
+					if (curr[ii - 1] == want[jj - 1]) {
+						if (pos >= 0) {
+							lcs.write[pos] = curr[ii - 1];
+							pos--;
+						}
+						ii--;
+						jj--;
+					} else if (dp[ii - 1][jj] >= dp[ii][jj - 1]) {
+						ii--;
+					} else {
+						jj--;
+					}
+				}
+			}
+
+			// Transform current chain into desired using LCS-guided edits.
+			int ci = 0, wi = 0, li = 0;
+			while (li < lcs.size()) {
+				// Remove non-LCS from current at position ci.
+				while (ci < as->get_bus_effect_count(i)) {
+					Ref<AudioEffect> ex = as->get_bus_effect(i, ci);
+					String ex_class = ex.is_valid() ? ex->get_class() : String();
+					if (ex_class == lcs[li]) {
+						break;
+					}
+					as->remove_bus_effect(i, ci); // removal shifts next into this index
+				}
+				// Insert missing desired until we reach LCS token.
+				while (wi < want.size() && want[wi] != lcs[li]) {
+					const String class_name = want[wi];
+					if (!class_name.is_empty()) {
+						Ref<AudioEffect> afxr = Object::cast_to<AudioEffect>(ClassDB::instantiate(class_name));
+						if (afxr.is_valid()) {
+							as->add_bus_effect(i, afxr, ci);
+							ci++; // advance past inserted
+						}
+					}
+					wi++;
+				}
+				// Skip the LCS token in both sequences.
+				if (ci < as->get_bus_effect_count(i)) {
+					ci++;
+				}
+				if (wi < want.size()) {
+					wi++;
+				}
+				li++;
+			}
+			// Remove any remaining extras from current.
+			while (ci < as->get_bus_effect_count(i)) {
+				as->remove_bus_effect(i, ci);
+			}
+			// Append any remaining desired.
+			while (wi < want.size()) {
+				const String class_name = want[wi];
+				if (!class_name.is_empty()) {
+					Ref<AudioEffect> afxr = Object::cast_to<AudioEffect>(ClassDB::instantiate(class_name));
+					if (afxr.is_valid()) {
+						as->add_bus_effect(i, afxr, -1);
+					}
+				}
+				wi++;
+			}
+
+			// Apply parameters and enabled flags for all incoming effects.
+			for (int e = 0; e < incoming_count; e++) {
+				Dictionary fx = effects[e];
+				const int final_count = as->get_bus_effect_count(i);
+				Ref<AudioEffect> eff = (e < final_count) ? as->get_bus_effect(i, e) : Ref<AudioEffect>();
+				if (eff.is_valid() && fx.has("params") && fx["params"].get_type() == Variant::DICTIONARY) {
+					Dictionary params = fx["params"];
+					LocalVector<Variant> keys = params.get_key_list();
+					for (const Variant &k : keys) {
+						const StringName prop = StringName(String(k));
+						const Variant &val = params[k];
+						Variant cur = eff->get(prop);
+						if (cur != val) {
+							eff->set(prop, val);
+						}
+					}
+				}
+				if (fx.has("enabled") && e < final_count) {
+					bool want_enabled = (bool)fx["enabled"];
+					if (as->is_bus_effect_enabled(i, e) != want_enabled) {
+						as->set_bus_effect_enabled(i, e, want_enabled);
+					}
+				}
+			}
+			// Recreate effect instances so updated parameters take effect immediately.
+			as->refresh_bus_effects(i);
+		}
+	}
+
+	return OK;
+}
+
 Error SceneDebugger::_msg_override_cameras(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
 	bool enable = p_args[0];
@@ -560,6 +783,7 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["next_frame"] = _msg_next_frame;
 	message_handlers["speed_changed"] = _msg_speed_changed;
 	message_handlers["debug_mute_audio"] = _msg_debug_mute_audio;
+	message_handlers["sync_audio_buses"] = _msg_sync_audio_buses;
 	message_handlers["override_cameras"] = _msg_override_cameras;
 	message_handlers["transform_camera_2d"] = _msg_transform_camera_2d;
 #ifndef _3D_DISABLED
@@ -1268,5 +1492,70 @@ void LiveEditor::_reparent_node_func(const NodePath &p_at, const NodePath &p_new
 			nto->move_child(nfrom, p_at_pos);
 		}
 	}
+}
+#endif // DEBUG_ENABLED
+
+#ifdef DEBUG_ENABLED
+void SceneDebugger::_send_audio_peaks() {
+	// Throttle to ~10 Hz using a frame counter
+	static int frame_counter = 0;
+	static int stride = 6;
+	// Adjust stride based on current FPS (~10 Hz target).
+	const double fps = MAX(1.0, Engine::get_singleton()->get_frames_per_second());
+	const int new_stride = CLAMP(int(Math::round(fps / 10.0)), 1, 30);
+	if (new_stride != stride) {
+		stride = new_stride;
+		frame_counter = 0; // resync
+	}
+	if ((++frame_counter % stride) != 0) {
+		return;
+	}
+
+	if (!EngineDebugger::is_active()) {
+		return;
+	}
+	// Skip while scene is suspended to avoid stale peak snapshots.
+	SceneTree *st = SceneTree::get_singleton();
+	if (st && st->is_suspended()) {
+		return;
+	}
+
+	AudioServer *as = AudioServer::get_singleton();
+	if (!as) {
+		return;
+	}
+	// No real audio with Dummy driver; skip sending peaks
+	if (as->get_driver_name() == "Dummy") {
+		return;
+	}
+
+	Array payload;
+	const int bus_count = as->get_bus_count();
+	for (int i = 0; i < bus_count; i++) {
+		const int cc = as->get_bus_channels(i);
+		PackedFloat32Array lefts;
+		PackedFloat32Array rights;
+		PackedByteArray actives;
+		lefts.resize(cc);
+		rights.resize(cc);
+		actives.resize(cc);
+		for (int c = 0; c < cc; c++) {
+			lefts.write[c] = as->get_bus_peak_volume_left_db(i, c);
+			rights.write[c] = as->get_bus_peak_volume_right_db(i, c);
+			actives.write[c] = as->is_bus_channel_active(i, c) ? uint8_t(1) : uint8_t(0);
+		}
+		Array bus_arr;
+		bus_arr.push_back(i);
+		bus_arr.push_back(lefts);
+		bus_arr.push_back(rights);
+		bus_arr.push_back(actives);
+		payload.push_back(bus_arr);
+	}
+
+	EngineDebugger::get_singleton()->send_message("scene:audio_peaks", payload);
+}
+
+void SceneDebugger::send_audio_peaks() {
+	_send_audio_peaks();
 }
 #endif // DEBUG_ENABLED

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -79,6 +79,7 @@ private:
 	static Error _msg_next_frame(const Array &p_args);
 	static Error _msg_speed_changed(const Array &p_args);
 	static Error _msg_debug_mute_audio(const Array &p_args);
+	static Error _msg_sync_audio_buses(const Array &p_args);
 	static Error _msg_override_cameras(const Array &p_args);
 	static Error _msg_set_object_property(const Array &p_args);
 	static Error _msg_set_object_property_field(const Array &p_args);
@@ -115,11 +116,16 @@ private:
 	static Error _msg_transform_camera_3d(const Array &p_args);
 #endif // _3D_DISABLED
 
+	// Periodic telemetry.
+	static void _send_audio_peaks();
+
 public:
 	static Error parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);
 	static void add_to_cache(const String &p_filename, Node *p_node);
 	static void remove_from_cache(const String &p_filename, Node *p_node);
 	static void reload_cached_files(const PackedStringArray &p_files);
+	// Public wrapper to allow external callers to trigger audio peak send.
+	static void send_audio_peaks();
 #endif
 };
 

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1205,6 +1205,13 @@ bool AudioServer::is_bus_effect_enabled(int p_bus, int p_effect) const {
 	return buses[p_bus]->effects[p_effect].enabled;
 }
 
+void AudioServer::refresh_bus_effects(int p_bus) {
+	ERR_FAIL_INDEX(p_bus, buses.size());
+	lock();
+	_update_bus_effects(p_bus);
+	unlock();
+}
+
 float AudioServer::get_bus_peak_volume_left_db(int p_bus, int p_channel) const {
 	ERR_FAIL_INDEX_V(p_bus, buses.size(), 0);
 	ERR_FAIL_INDEX_V(p_channel, buses[p_bus]->channels.size(), 0);
@@ -2073,6 +2080,7 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_bus_effect_enabled", "bus_idx", "effect_idx", "enabled"), &AudioServer::set_bus_effect_enabled);
 	ClassDB::bind_method(D_METHOD("is_bus_effect_enabled", "bus_idx", "effect_idx"), &AudioServer::is_bus_effect_enabled);
+	ClassDB::bind_method(D_METHOD("refresh_bus_effects", "bus_idx"), &AudioServer::refresh_bus_effects);
 
 	ClassDB::bind_method(D_METHOD("get_bus_peak_volume_left_db", "bus_idx", "channel"), &AudioServer::get_bus_peak_volume_left_db);
 	ClassDB::bind_method(D_METHOD("get_bus_peak_volume_right_db", "bus_idx", "channel"), &AudioServer::get_bus_peak_volume_right_db);

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -422,6 +422,9 @@ public:
 	void set_bus_effect_enabled(int p_bus, int p_effect, bool p_enabled);
 	bool is_bus_effect_enabled(int p_bus, int p_effect) const;
 
+	/// Recreate effect instances for a bus (e.g. after updating effect parameters from the editor).
+	void refresh_bus_effects(int p_bus);
+
 	float get_bus_peak_volume_left_db(int p_bus, int p_channel) const;
 	float get_bus_peak_volume_right_db(int p_bus, int p_channel) const;
 


### PR DESCRIPTION
TLDR: Implements real-time synchronization of audio bus changes from the editor to the running game during debug sessions. Sound designers can now iterate on mix balance, effects, and routing without restarting the game.
Closes #112980 
Closes https://github.com/godotengine/godot-proposals/issues/1186

Editor Side:

- Generates `AudioBusLayout` snapshot when bus properties change (volume, mute/solo/bypass, send, effects)
- Sends layout via `scene:sync_audio_buses` message through debugger protocol
- Triggers on all relevant editor actions: volume sliders, solo/mute/bypass toggles, send changes, effect add/remove/edit, parameter adjustments

Runtime Side:

- Registers `sync_audio_buses` message handler in SceneDebugger
- Applies received `AudioBusLayout` to `AudioServer` via `set_bus_layout`()
- Rebuilds all buses and effects from scratch on each sync

Changes in:

- `editor/audio/editor_audio_buses.cpp` - Trigger sync after bus modifications
- `editor/debugger/editor_debugger_node.cpp` - Route sync to active debuggers
- `editor/debugger/script_editor_debugger.cpp` - Serialize and send layout
- `scene/debugger/scene_debugger.cpp` - Receive and apply layout

How It Works
- Game is running from the godot editor
- User adjusts audio bus in editor (change volume, add effect or change its param, etc.)
- Editor generates complete AudioBusLayout via AudioServer::generate_bus_layout()
- Layout sent through debugger protocol as scene:sync_audio_buses message
- Running game receives message in SceneDebugger::_msg_sync_audio_buses()
- Game applies layout via AudioServer::set_bus_layout(), which rebuilds all buses and effects

Testing
1. Create multiple audio buses with various effects (reverb, delay, etc.)
2. Start the game (F5)
3. While game is running:
    - Adjust bus volumes -> hear immediate change
    - Toggle mute/solo/bypass -> effects apply instantly
    - Modify effect parameters (reverb size, delay time) -> updates in real-time
    - Add/remove effects -> rebuilds audio chain live
    - Change send routing -> audio flows to new buses

Limitations
- Debug-only feature (by design: no performance impact on release builds)
- Effects are fully rebuilt on each sync rather than patched incrementally
- Syncs all buses/effects, not individual properties (simple but effective approach)
- Requires "Sync Scene Changes" to be enabled (reuses existing sync infrastructure)

Notes
This implementation parallels Unity's audio mixer sync feature and follows the same pattern as other live-editing features in Godot (scene property sync, resource hot-reload). No changes to release builds or AudioServer runtime behavior.

This is just my second PR here, any suggestions for code style or anything, let me know :) 🎧 ❤️ 