### PR TITLE
Autoload: Save path together with the UID

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -65,7 +65,6 @@ public:
 #endif // TOOLS_ENABLED
 
 	struct AutoloadInfo {
-		StringName name;
 		String path;
 		bool is_singleton = false;
 	};
@@ -108,9 +107,13 @@ protected:
 	HashMap<StringName, LocalVector<Pair<StringName, StringName>>> feature_overrides;
 
 	LocalVector<String> hidden_prefixes;
-	HashMap<StringName, AutoloadInfo> autoloads;
 	HashMap<StringName, String> global_groups;
 	HashMap<StringName, HashSet<StringName>> scene_groups_cache;
+
+	// UIDs can't be used until ProjectSettings is set up.
+	// Store the raw values temporarily and parse them on-demand.
+	mutable HashMap<StringName, String> pending_autoloads;
+	mutable HashMap<StringName, AutoloadInfo> autoloads;
 
 	Array global_class_list;
 	bool is_global_class_list_loaded = false;
@@ -219,10 +222,12 @@ public:
 	bool check_changed_settings_in_group(const String &p_setting_prefix) const;
 
 	const HashMap<StringName, AutoloadInfo> &get_autoload_list() const;
-	void add_autoload(const AutoloadInfo &p_autoload);
-	void remove_autoload(const StringName &p_autoload);
 	bool has_autoload(const StringName &p_autoload) const;
 	AutoloadInfo get_autoload(const StringName &p_name) const;
+
+	// These two methods are public for the autoload editor.
+	static void parse_autoload_value(const String &p_value, String &r_path, bool &r_is_singleton);
+	static String stringify_autoload_value(const String &p_path, bool p_is_singleton);
 
 	const HashMap<StringName, String> &get_global_groups_list() const;
 	void add_global_group(const StringName &p_name, const String &p_description);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -145,7 +145,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
 		const ProjectSettings::AutoloadInfo &info = E.value;
 		if (info.is_singleton) {
-			highlighter->add_keyword_color(info.name, usertype_color);
+			highlighter->add_keyword_color(E.key, usertype_color);
 		}
 	}
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4335,7 +4335,7 @@ int Main::start() {
 
 					if (info.is_singleton) {
 						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-							ScriptServer::get_language(i)->add_global_constant(info.name, Variant());
+							ScriptServer::get_language(i)->add_global_constant(E.key, Variant());
 						}
 					}
 				}
@@ -4350,7 +4350,7 @@ int Main::start() {
 						// Cache the scene reference before loading it (for cyclic references)
 						Ref<PackedScene> scn;
 						scn.instantiate();
-						scn->set_path(ResourceUID::ensure_path(info.path));
+						scn->set_path(info.path);
 						scn->reload_from_file();
 						ERR_CONTINUE_MSG(scn.is_null(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
 
@@ -4376,14 +4376,14 @@ int Main::start() {
 					}
 
 					ERR_CONTINUE_MSG(!n, vformat("Failed to instantiate an autoload, path is not pointing to a scene or a script: %s.", info.path));
-					n->set_name(info.name);
+					n->set_name(E.key);
 
 					//defer so references are all valid on _ready()
 					to_add.push_back(n);
 
 					if (info.is_singleton) {
 						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-							ScriptServer::get_language(i)->add_global_constant(info.name, n);
+							ScriptServer::get_language(i)->add_global_constant(E.key, n);
 						}
 					}
 				}

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -793,7 +793,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
 		const ProjectSettings::AutoloadInfo &info = E.value;
 		if (info.is_singleton) {
-			class_names[info.name] = usertype_color;
+			class_names[E.key] = usertype_color;
 		}
 	}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -493,7 +493,7 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 			} else if (ProjectSettings::get_singleton()->has_autoload(name) && ProjectSettings::get_singleton()->get_autoload(name).is_singleton) {
 				const ProjectSettings::AutoloadInfo &info = ProjectSettings::get_singleton()->get_autoload(name);
 				if (!info.path.has_extension(GDScriptLanguage::get_singleton()->get_extension())) {
-					push_error(vformat(R"(Singleton %s is not a GDScript.)", info.name), id);
+					push_error(vformat(R"(Singleton %s is not a GDScript.)", name), id);
 					return ERR_PARSE_ERROR;
 				}
 
@@ -806,8 +806,8 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 			String script_path;
 			if (ResourceLoader::get_resource_type(autoload.path) == "PackedScene") {
 				// Try to get script from scene if possible.
-				if (GDScriptLanguage::get_singleton()->has_any_global_constant(autoload.name)) {
-					Variant constant = GDScriptLanguage::get_singleton()->get_any_global_constant(autoload.name);
+				if (GDScriptLanguage::get_singleton()->has_any_global_constant(first)) {
+					Variant constant = GDScriptLanguage::get_singleton()->get_any_global_constant(first);
 					Node *node = Object::cast_to<Node>(constant);
 					if (node != nullptr) {
 						Ref<GDScript> scr = node->get_script();

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1126,7 +1126,7 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 		if (!info.is_singleton || !info.path.has_extension("gd")) {
 			continue;
 		}
-		ScriptLanguage::CodeCompletionOption option(info.name, ScriptLanguage::CODE_COMPLETION_KIND_CLASS, ScriptLanguage::LOCATION_OTHER_USER_CODE);
+		ScriptLanguage::CodeCompletionOption option(E.key, ScriptLanguage::CODE_COMPLETION_KIND_CLASS, ScriptLanguage::LOCATION_OTHER_USER_CODE);
 		r_result.insert(option.display, option);
 	}
 }

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -57,7 +57,7 @@ void init_autoloads() {
 
 		if (info.is_singleton) {
 			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-				ScriptServer::get_language(i)->add_global_constant(info.name, Variant());
+				ScriptServer::get_language(i)->add_global_constant(E.key, Variant());
 			}
 		}
 	}
@@ -76,7 +76,7 @@ void init_autoloads() {
 			// Cache the scene reference before loading it (for cyclic references)
 			Ref<PackedScene> scn;
 			scn.instantiate();
-			scn->set_path(ResourceUID::ensure_path(info.path));
+			scn->set_path(info.path);
 			scn->reload_from_file();
 			ERR_CONTINUE_MSG(scn.is_null(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
 
@@ -102,10 +102,10 @@ void init_autoloads() {
 		}
 
 		ERR_CONTINUE_MSG(!n, vformat("Failed to instantiate an autoload, path is not pointing to a scene or a script: %s.", info.path));
-		n->set_name(info.name);
+		n->set_name(E.key);
 
 		for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-			ScriptServer::get_language(i)->add_global_constant(info.name, n);
+			ScriptServer::get_language(i)->add_global_constant(E.key, n);
 		}
 	}
 }

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -126,8 +126,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
 
 				for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
-					const ProjectSettings::AutoloadInfo &info = E.value;
-					suggestions.push_back(quoted("/root/" + String(info.name)));
+					suggestions.push_back(quoted("/root/" + String(E.key)));
 				}
 			}
 


### PR DESCRIPTION
#112193 made UID being saved in `project.godot` instead of path.

The problem is, the fundamental truth is lost. When `.uid` files are lost (e.g., not being committed to the VCS), you have no idea what that UID is meant to be pointing at.

For example, in [are-you-sure.zip](https://github.com/user-attachments/files/23669489/are-you-sure.zip), we have no clue about which one of `res://foo.gd` and `res://bar.gd` should be `uid://h0mlkunk75qk`.

This PR solves this problem by saving the path together with UID.

```ini
# Before
[autoload]
Widget="*uid://h0mlkunk75qk"

# After
[autoload]
Widget="*res://foobar.gd::uid://h0mlkunk75qk"
```

`uid://h0mlkunk75qk` still takes precedence, `res://foobar.gd` is only used when the UID is invalid or unknown to the engine.

When making this PR, I also notices that:

- The `name` field in `ProjectSettings::AutoloadInfo` is redundant. So it's removed.
- `ResourceUID` can't be used until `ProjectSettings` is setup correctly. So the `AutoloadInfo` map is now parsed from strings on-demand.