### PR TITLE
Add signal to Viewport for when the current Camera3D is changed

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -514,6 +514,13 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="camera_3d_changed">
+			<param index="0" name="old_camera" type="Camera3D" />
+			<param index="1" name="new_camera" type="Camera3D" />
+			<description>
+				Emitted when the active 3D camera is changed. If there are no active 3D cameras, the corresponding argument will be [code]null[/code].
+			</description>
+		</signal>
 		<signal name="gui_focus_changed">
 			<param index="0" name="node" type="Control" />
 			<description>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4763,6 +4763,7 @@ void Viewport::_camera_3d_set(Camera3D *p_camera) {
 		camera_3d->notification(Camera3D::NOTIFICATION_LOST_CURRENT);
 	}
 
+	Camera3D *old_camera_3d = camera_3d;
 	camera_3d = p_camera;
 
 	if (camera_3d) {
@@ -4775,6 +4776,7 @@ void Viewport::_camera_3d_set(Camera3D *p_camera) {
 		camera_3d->notification(Camera3D::NOTIFICATION_BECAME_CURRENT);
 	}
 
+	emit_signal(SNAME("camera_3d_changed"), old_camera_3d, camera_3d);
 	_update_audio_listener_3d();
 	_camera_3d_transform_changed_notify();
 }
@@ -5417,6 +5419,9 @@ void Viewport::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("size_changed"));
 	ADD_SIGNAL(MethodInfo("gui_focus_changed", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, Control::get_class_static())));
+#ifndef _3D_DISABLED
+	ADD_SIGNAL(MethodInfo("camera_3d_changed", PropertyInfo(Variant::OBJECT, "old_camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera3D"), PropertyInfo(Variant::OBJECT, "new_camera", PROPERTY_HINT_RESOURCE_TYPE, Camera3D::get_class_static())));
+#endif // _3D_DISABLED
 
 	BIND_ENUM_CONSTANT(SHADOW_ATLAS_QUADRANT_SUBDIV_DISABLED);
 	BIND_ENUM_CONSTANT(SHADOW_ATLAS_QUADRANT_SUBDIV_1);


### PR DESCRIPTION
This adds a signal to `Viewport` for when the current `Camera3D` is changed using the implementation suggested in https://github.com/godotengine/godot-proposals/discussions/9089#discussioncomment-8500502.

Closes https://github.com/godotengine/godot-proposals/issues/12425.