### PR TITLE
Build: Add `Mutex` to hardcoded_classes for build profile detection

### DIFF
--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -889,7 +889,7 @@ void EditorBuildProfileManager::_detect_from_project() {
 
 	// Add classes that are either necessary for the engine to work properly, or there isn't a way to infer their use.
 
-	const LocalVector<String> hardcoded_classes = { "InputEvent", "MainLoop", "StyleBox" };
+	const LocalVector<String> hardcoded_classes = { "InputEvent", "MainLoop", "StyleBox", "Mutex" };
 	for (const String &hc_class : hardcoded_classes) {
 		used_classes.insert(hc_class);
 


### PR DESCRIPTION
While using Godot's build profile system to create a minimal custom build, discovered that adding `Mutex` to the list of disabled classes causes compilation errors as this:
<img width="692" height="237" alt="图片" src="https://github.com/user-attachments/assets/32895540-cecd-42ba-bf05-dcfe4eb8cb8b" />

Considering that the `Mutex` class may be added by the `detect from project` behavior to the `disabled_classes` list of the ` build_profile`, which could potentially lead to the aforementioned issues when using this feature, adding it to the `hardcoded_classes` collection should be the correct solution

- *Bugsquad edit: This partially addresses https://github.com/godotengine/godot/issues/115232.*