### PR TITLE
Persistently map staging buffers.

### DIFF
--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -151,6 +151,7 @@ private:
 		RDD::BufferID driver_id;
 		uint64_t frame_used = 0;
 		uint32_t fill_amount = 0;
+		uint8_t *data_ptr = nullptr;
 	};
 
 	struct StagingBuffers {


### PR DESCRIPTION
Low hanging fruit. Saved me about 0.2ms CPU time on average when rendering cube shadow maps for 85 omni lights every single frame. Probably won't make much difference in usual scenarios, if at all.