### PR TITLE
Fix CSG gizmo z-fighting in the editor.

### DIFF
--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -433,6 +433,18 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Ref<ArrayMesh> mesh = memnew(ArrayMesh);
 		Array array;
 		array.resize(Mesh::ARRAY_MAX);
+
+		// Move the faces a little to eliminate z fighting
+		for (int i = 0; i < faces.size(); i += 3) {
+			Vector3 a = faces[i + 0];
+			Vector3 b = faces[i + 1];
+			Vector3 c = faces[i + 2];
+			Vector3 n = (b - a).cross(c - a).normalized() * 0.0001f;
+			faces.write[i + 0] = a + n;
+			faces.write[i + 1] = b + n;
+			faces.write[i + 2] = c + n;
+		}
+
 		array[Mesh::ARRAY_VERTEX] = faces;
 		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, array);
 


### PR DESCRIPTION
Before, In the editor if you selected a CSG shape then it usually had a lot of z-fighting on the translucent orange/blue/white border. 

Before:

https://github.com/user-attachments/assets/9a5a91dd-d2a5-4184-b9ec-8f4ec93f92cb

After:

https://github.com/user-attachments/assets/bd41b04e-d3da-4bf5-a71f-4d417128c9a1
