### PR TITLE
Correctly mark frame start for profilers (Tracy/Perfetto) on Linux

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -971,8 +971,6 @@ String OS_LinuxBSD::get_system_dir(SystemDir p_dir, bool p_shared_storage) const
 }
 
 void OS_LinuxBSD::run() {
-	GodotProfileFrameMark;
-	GodotProfileZone("OS_LinuxBSD::run");
 	if (!main_loop) {
 		return;
 	}
@@ -985,6 +983,8 @@ void OS_LinuxBSD::run() {
 	//uint64_t frame=0;
 
 	while (true) {
+		GodotProfileFrameMark;
+		GodotProfileZone("OS_LinuxBSD::run");
 		DisplayServer::get_singleton()->process_events(); // get rid of pending events
 #ifdef SDL_ENABLED
 		if (joypad_sdl) {


### PR DESCRIPTION
Currently, on Linux, profiling with Tracy will only ever have 4 frames, where the 4th frame has data for all the real frames:

<img width="1768" height="265" alt="Selection_402" src="https://github.com/user-attachments/assets/6dddec2a-b570-408b-bdd2-6ad8d3fa712e" />

This is because the `GodotProfileFrameMark` is at the start of `OS_LinuxBSD::run()` which only runs once and contains the main loop.

This PR moves it inside the `while (true) { ... }` loop which is just like how it's done in `OS_Windows::run()`