### PR TITLE
Fully hide preset settings when no preset is found in the export dialog

### DIFF
--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -78,11 +78,14 @@ class ProjectExportDialog : public ConfirmationDialog {
 	Button *delete_preset = nullptr;
 	ItemList *presets = nullptr;
 
+	VBoxContainer *settings_vb = nullptr;
 	LineEdit *name = nullptr;
 	EditorPropertyPath *export_path = nullptr;
 	EditorInspector *parameters = nullptr;
 	CheckButton *runnable = nullptr;
 	CheckButton *advanced_options = nullptr;
+
+	Label *empty_label = nullptr;
 
 	Button *button_export = nullptr;
 	bool updating = false;


### PR DESCRIPTION
This PR does a few things:
- Makes so that all preset settings are hidden if none are selected.
- Auto-selects one if any is available.
- Fixes a bug that made a specific error message not hide when it should.

|Before|After|
|-|-|
|<img width="1044" height="771" alt="Screenshot_20251121_182602" src="https://github.com/user-attachments/assets/9d64cb1a-a197-4632-aed5-0044d94349a2" />|<img width="1044" height="771" alt="Screenshot_20251121_182231" src="https://github.com/user-attachments/assets/b4db3bea-127f-4edd-82ca-b7d6a937108e" />|