### PR TITLE
Fix assertions against buffer overruns in `input_event_codec.cpp`

### DIFF
--- a/core/input/input_event_codec.cpp
+++ b/core/input/input_event_codec.cpp
@@ -99,7 +99,7 @@ void encode_input_event_key(const Ref<InputEventKey> &p_event, PackedByteArray &
 	data++;
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+	DEV_ASSERT(r_data.size() >= (data - r_data.ptrw()));
 }
 
 Error decode_input_event_key(const PackedByteArray &p_data, Ref<InputEventKey> &r_event) {
@@ -156,7 +156,7 @@ void encode_input_event_mouse_button(const Ref<InputEventMouseButton> &p_event, 
 	data++;
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+	DEV_ASSERT(r_data.size() >= (data - r_data.ptrw()));
 }
 
 Error decode_input_event_mouse_button(const PackedByteArray &p_data, Ref<InputEventMouseButton> &r_event) {
@@ -206,7 +206,7 @@ void encode_input_event_mouse_motion(const Ref<InputEventMouseMotion> &p_event, 
 	data++;
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+	DEV_ASSERT(r_data.size() >= (data - r_data.ptrw()));
 }
 
 void decode_input_event_mouse_motion(const PackedByteArray &p_data, Ref<InputEventMouseMotion> &r_event) {
@@ -247,7 +247,7 @@ void decode_input_event_mouse_motion(const PackedByteArray &p_data, Ref<InputEve
 	data++;
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+	DEV_ASSERT(p_data.size() >= (data - p_data.ptr()));
 }
 
 void encode_input_event_joypad_button(const Ref<InputEventJoypadButton> &p_event, PackedByteArray &r_data) {
@@ -267,7 +267,7 @@ void encode_input_event_joypad_button(const Ref<InputEventJoypadButton> &p_event
 	data++;
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+	DEV_ASSERT(r_data.size() >= (data - r_data.ptrw()));
 }
 
 void decode_input_event_joypad_button(const PackedByteArray &p_data, Ref<InputEventJoypadButton> &r_event) {
@@ -284,7 +284,7 @@ void decode_input_event_joypad_button(const PackedByteArray &p_data, Ref<InputEv
 	data++;
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+	DEV_ASSERT(p_data.size() >= (data - p_data.ptr()));
 }
 
 void encode_input_event_joypad_motion(const Ref<InputEventJoypadMotion> &p_event, PackedByteArray &r_data) {
@@ -300,7 +300,7 @@ void encode_input_event_joypad_motion(const Ref<InputEventJoypadMotion> &p_event
 	data += encode_float(p_event->get_axis_value(), data);
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+	DEV_ASSERT(r_data.size() >= (data - r_data.ptrw()));
 }
 
 void decode_input_event_joypad_motion(const PackedByteArray &p_data, Ref<InputEventJoypadMotion> &r_event) {
@@ -316,7 +316,7 @@ void decode_input_event_joypad_motion(const PackedByteArray &p_data, Ref<InputEv
 	data += sizeof(float);
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+	DEV_ASSERT(p_data.size() >= (data - p_data.ptr()));
 }
 
 void encode_input_event_gesture_pan(const Ref<InputEventPanGesture> &p_event, PackedByteArray &r_data) {
@@ -333,7 +333,7 @@ void encode_input_event_gesture_pan(const Ref<InputEventPanGesture> &p_event, Pa
 	data += encode_vector2(p_event->get_delta(), data);
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+	DEV_ASSERT(r_data.size() >= (data - r_data.ptrw()));
 }
 
 void decode_input_event_gesture_pan(const PackedByteArray &p_data, Ref<InputEventPanGesture> &r_event) {
@@ -353,7 +353,7 @@ void decode_input_event_gesture_pan(const PackedByteArray &p_data, Ref<InputEven
 	r_event->set_delta(delta);
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+	DEV_ASSERT(p_data.size() >= (data - p_data.ptr()));
 }
 
 void encode_input_event_gesture_magnify(const Ref<InputEventMagnifyGesture> &p_event, PackedByteArray &r_data) {
@@ -370,7 +370,7 @@ void encode_input_event_gesture_magnify(const Ref<InputEventMagnifyGesture> &p_e
 	data += encode_float(p_event->get_factor(), data);
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - r_data.ptrw() >= r_data.size());
+	DEV_ASSERT(r_data.size() >= (data - r_data.ptrw()));
 }
 
 void decode_input_event_gesture_magnify(const PackedByteArray &p_data, Ref<InputEventMagnifyGesture> &r_event) {
@@ -389,7 +389,7 @@ void decode_input_event_gesture_magnify(const PackedByteArray &p_data, Ref<Input
 	data += sizeof(float);
 
 	// Assert we had enough space.
-	DEV_ASSERT(data - p_data.ptr() >= p_data.size());
+	DEV_ASSERT(p_data.size() >= (data - p_data.ptr()));
 }
 
 bool encode_input_event(const Ref<InputEvent> &p_event, PackedByteArray &r_data) {


### PR DESCRIPTION
I noticed `DisplayServerEmbeddedState::serialize` (in platform/macos/display_server_embedded.mm) had its assertion at the end fixed by @stuartcarnie from
`DEV_ASSERT((data - r_data.ptrw()) >= r_data.size());`
to
`DEV_ASSERT(r_data.size() >= (data - r_data.ptrw()));`
in commit c62ad8dc655c410b28bc80bce251d0e0f7e170ad

This makes sense, but I wanted to compare this change to similar asserts elsewhere.
Eventually this lead me to core/input/input_event_codec.cpp, which has a handful of equivalent assertions, also by @stuartcarnie.

It makes sense because we want to assert the buffer we are reading from / writing to is *at least as long* as the amount we have moved our `data`pointer while decoding/encoding.

This PR just follows his example and applies that fix to the `DEV_ASSERT`s in input_event_codec.cpp as well.