### PR TITLE
[2.1] More build fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -65,11 +65,15 @@ elif (os.name == "nt"):
     if (os.getenv("VCINSTALLDIR") == None or platform_arg == "android" or platform_arg == "javascript"):
         custom_tools = ['mingw']
 
+# We let SCons build its default ENV as it includes OS-specific things which we don't
+# want to have to pull in manually.
+# Then we prepend PATH to make it take precedence, while preserving SCons' own entries.
 env_base = Environment(tools=custom_tools)
-if 'TERM' in os.environ:
-    env_base['ENV']['TERM'] = os.environ['TERM']
-env_base.AppendENVPath('PATH', os.getenv('PATH'))
-env_base.AppendENVPath('PKG_CONFIG_PATH', os.getenv('PKG_CONFIG_PATH'))
+env_base.PrependENVPath("PATH", os.getenv("PATH"))
+env_base.PrependENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
+if "TERM" in os.environ:  # Used for colored output.
+    env_base["ENV"]["TERM"] = os.environ["TERM"]
+
 env_base.global_defaults = global_defaults
 env_base.android_maven_repos = []
 env_base.android_flat_dirs = []

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -15,7 +15,7 @@ if (env["platform"] in ["haiku", "osx", "windows", "x11"]):
         env.Append(CPPFLAGS=['-DGLEW_STATIC'])
         env.Append(CPPPATH=[thirdparty_dir])
 
-    env.Append(CPPFLAGS=['-DGLEW_ENABLED'])
+    env.Append(CPPFLAGS=['-DGLEW_ENABLED', '-DGLEW_NO_GLU'])
 
 # Godot source files
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -33,5 +33,7 @@ obj = env_ios.Object('godot_iphone.cpp')
 
 prog = None
 prog = env_ios.add_program('#bin/godot', [obj] + iphone_lib)
-action = "$IPHONEPATH/usr/bin/dsymutil " + File(prog)[0].path + " -o " + File(prog)[0].path + ".dSYM"
-env.AddPostAction(prog, action)
+
+if env['separate_debug_symbols']:
+    action = "$IPHONEPATH/usr/bin/dsymutil " + File(prog)[0].path + " -o " + File(prog)[0].path + ".dSYM"
+    env.AddPostAction(prog, action)

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -32,7 +32,8 @@ def get_opts():
         ('ios_exceptions', 'Enable exceptions', 'no'),
         ('ios_triple', 'Triple for ios toolchain', ''),
         ('ios_sim', 'Build simulator binary', 'no'),
-        ('use_lto', 'Use link time optimization', 'no')
+        ('use_lto', 'Use link time optimization', 'no'),
+        ('separate_debug_symbols', 'Extract debug symbols in .dSYM archive', False),
     ]
 
 

--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -15,7 +15,7 @@ files = [
 
 prog = env.add_program('#bin/godot', files)
 
-if (env['target'] == "debug" or env['target'] == "release_debug"):
+if env['separate_debug_symbols'] and (env['target'] == "debug" or env['target'] == "release_debug"):
     # Build the .dSYM file for atos
     action = "dsymutil " + File(prog)[0].path + " -o " + File(prog)[0].path + ".dSYM"
     env.AddPostAction(prog, action)

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -23,7 +23,7 @@ def get_opts():
 
     return [
         ('osxcross_sdk', 'OSXCross SDK version', 'darwin14'),
-
+        ('separate_debug_symbols', 'Extract debug symbols in .dSYM archive', False),
     ]
 
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -239,10 +239,10 @@ def configure(env):
 
     if (is64 and env["bits"] == "32"):
         env.Append(CPPFLAGS=['-m32'])
-        env.Append(LINKFLAGS=['-m32', '-L/usr/lib/i386-linux-gnu'])
+        env.Append(LINKFLAGS=['-m32'])
     elif (not is64 and env["bits"] == "64"):
         env.Append(CPPFLAGS=['-m64'])
-        env.Append(LINKFLAGS=['-m64', '-L/usr/lib/i686-linux-gnu'])
+        env.Append(LINKFLAGS=['-m64'])
 
     import methods
 


### PR DESCRIPTION
I'm tentatively checking if I could build new 2.1.x binaries with our current build containers.

The main reason is that a bunch of work was committed to `2.1` for a 2.1.7 release, and we even had some release candidate builds in #41300, but since TuxFamily went down we lost those builds.
So if it doesn't require too much work, I may tag a 2.1.7.stable to fully close that long-EOL branch.

So far I've built Windows and Linux binaries successfully with this.

*Edit:* Got all binaries built with:
- https://github.com/godotengine/build-containers/tree/2.1
- https://github.com/godotengine/godot-build-scripts/tree/2.1