### PR TITLE
LSP: Improve insertion algorithm for resolving completion options

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -667,6 +667,12 @@ String ExtendGDScriptParser::get_text_for_lookup_symbol(const LSP::Position &p_c
 	int len = lines.size();
 	for (int i = 0; i < len; i++) {
 		if (i == p_cursor.line) {
+			// This code tries to insert the symbol into the preexisting code. Due to using a simple
+			// algorithm, the results might not always match the option semantically (e.g. different
+			// identifier name). This is fine because symbol lookup will prioritize the provided
+			// symbol name over the actual code. Establishing a syntactic target (e.g. identifier)
+			// is usually sufficient.
+
 			String line = lines[i];
 			String first_part = line.substr(0, p_cursor.character);
 			String last_part = line.substr(p_cursor.character, lines[i].length());
@@ -678,6 +684,9 @@ String ExtendGDScriptParser::get_text_for_lookup_symbol(const LSP::Position &p_c
 						first_part = line.substr(0, c);
 						first_part += p_symbol;
 						break;
+					} else if (c == 0) {
+						// No preexisting code that matches the option. Insert option in place.
+						first_part += p_symbol;
 					}
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/891
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/842

(The fixes comments are a bit hard to say for sure, since there are also some very inconsistent cases with outdated content in the LSP which can result in the same symptoms. See https://github.com/godotengine/godot/pull/105236 for fixes to those cases. Anyway this PR should fix the most common origin of the symptoms.)

Supersedes https://github.com/godotengine/godot/pull/107865

The approach from this PR fixes an additional edge case which the PR mentioned above does not fix:

```gdscript
node. # with this PR completion options shown in this situation will correctly resolve their docs
```

The code is basically iterating increasingly big prefixes left of the cursor. And if those prefixes happen to be prefixes of the symbol the symbol gets insert-merged into the line.

The issue is, that if no prefix matches, the code would just continue without inserting the symbol at all. (This is a very simplified explanation! The original source right of the cursor always stays untouched so some very specific conditions are needed for an issue to occur.)

The older PR tried to solve this by starting iteration one character right of the cursor to ensure there would always be a matching prefix. This PR instead falls back to just inserting the symbol in place, if there was no match.

---

I also added a comment trying to add some context to what this code is trying to do and why correctness isn't the highest priority.
