### PR TITLE
Document the conditions under which `setup_local_to_scene()` and `ViewportTexture` take effect

### DIFF
--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -36,7 +36,7 @@
 		<method name="_setup_local_to_scene" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				Override this method to customize the newly duplicated resource created from [method PackedScene.instantiate], if the original's [member resource_local_to_scene] is set to [code]true[/code].
+				Override this method to customize the newly duplicated resource created from [method PackedScene.instantiate]. This method is automatically called from [method PackedScene.instantiate] by the newly duplicated resource within the scene instance, only when the [member resource_local_to_scene] property is enabled for this resource and all its ancestor resources. If the [member resource_local_to_scene] property is not enabled for any of these resources, this method will not be called automatically.
 				[b]Example:[/b] Set a random [code]damage[/code] value to every local resource from an instantiated scene:
 				[codeblock]
 				extends Resource
@@ -101,6 +101,7 @@
 			<return type="Node" />
 			<description>
 				If [member resource_local_to_scene] is set to [code]true[/code] and the resource has been loaded from a [PackedScene] instantiation, returns the root [Node] of the scene where this resource is used. Otherwise, returns [code]null[/code].
+				[b]Note:[/b] The local scene is not directly assigned, but is passed on through the resource chain. Therefore, in order for the local scene to be passed to this resource instance, [member resource_local_to_scene] also needs to be enabled for all its ancestor resources. See also [method setup_local_to_scene].
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
@@ -140,7 +141,7 @@
 		<method name="setup_local_to_scene" deprecated="This method should only be called internally.">
 			<return type="void" />
 			<description>
-				Calls [method _setup_local_to_scene]. If [member resource_local_to_scene] is set to [code]true[/code], this method is automatically called from [method PackedScene.instantiate] by the newly duplicated resource within the scene instance.
+				Calls [method _setup_local_to_scene]. This method is automatically called from [method PackedScene.instantiate] by the newly duplicated resource within the scene instance, only when the [member resource_local_to_scene] property is enabled for this resource and all its ancestor resources. If the [member resource_local_to_scene] property is not enabled for any of these resources, this method will not be called automatically, and calling this method manually may not work. See also [method get_local_scene].
 			</description>
 		</method>
 		<method name="take_over_path">

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -7,6 +7,7 @@
 		A [ViewportTexture] provides the content of a [Viewport] as a dynamic [Texture2D]. This can be used to combine the rendering of [Control], [Node2D] and [Node3D] nodes. For example, you can use this texture to display a 3D scene inside a [TextureRect], or a 2D overlay in a [Sprite3D].
 		To get a [ViewportTexture] in code, use the [method Viewport.get_texture] method on the target viewport.
 		[b]Note:[/b] A [ViewportTexture] is always local to its scene (see [member Resource.resource_local_to_scene]). If the scene root is not ready, it may return incorrect data (see [signal Node.ready]).
+		[b]Note:[/b] For it to work correctly, its ancestor resources also need to have [member Resource.resource_local_to_scene] enabled. See also [method Resource.setup_local_to_scene].
 		[b]Note:[/b] Instantiating scenes containing a high-resolution [ViewportTexture] may cause noticeable stutter.
 		[b]Note:[/b] When using a [Viewport] with [member Viewport.use_hdr_2d] set to [code]true[/code], the returned texture will be an HDR image that uses linear encoding. This may look darker than normal when displayed directly on screen. To convert to nonlinear sRGB encoding, you can do the following:
 		[codeblock]


### PR DESCRIPTION
They are affected by how the **local scene** is delivered. If the **local scene** is not delivered correctly, they will not function properly.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
To avoid issues similar to https://github.com/godotengine/godot/issues/66247#issuecomment-3563244392.