### PR TITLE
Optimize ScriptManagerBridge::CreateManagedForGodotObjectBinding

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -94,11 +94,7 @@ namespace Godot.Bridge
         {
             try
             {
-                using var stringName = StringName.CreateTakingOwnershipOfDisposableValue(
-                    NativeFuncs.godotsharp_string_name_new_copy(CustomUnsafe.AsRef(nativeTypeName)));
-                string nativeTypeNameStr = stringName.ToString();
-
-                var instance = Constructors.Invoke(nativeTypeNameStr, godotObject);
+                var instance = Constructors.Invoke(CustomUnsafe.AsRef(nativeTypeName), godotObject);
 
                 return GCHandle.ToIntPtr(CustomGCHandle.AllocStrong(instance));
             }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Previously, `Constructors.Invoke` only had a `string` based overload, so  `ScriptManagerBridge.CreateManagedForGodotObjectBinding` had to do extra work and perform multiple allocations to convert the incoming `godot_string_name*` to a `string`.

This PR adds an overload of `Constructors.Invoke` that accepts a `godot_string_name` directly, removing the need for those conversions and allocations, which improves performance in hot paths.
