### PR TITLE
Make the EditorFileSystem cache more reliable

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1436,10 +1436,10 @@ void ProjectSettings::refresh_global_class_list() {
 	Array script_classes = get_global_class_list();
 	for (int i = 0; i < script_classes.size(); i++) {
 		Dictionary c = script_classes[i];
-		if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
+		if (!c.has("class") || !c.has("language") || (!c.has("uid") && !c.has("path")) || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
 			continue;
 		}
-		ScriptServer::add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"]);
+		ScriptServer::add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"], ResourceUID::get_singleton()->text_to_id(c["uid"]));
 	}
 }
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1980,6 +1980,21 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 	}
 }
 
+struct ScriptFirst {
+	int _priority(const PropertyInfo &p_a) const {
+		if (p_a.name == "metadata/_custom_type_script") {
+			return 0;
+		}
+		if (p_a.name == "script") {
+			return 1;
+		}
+		return 255;
+	}
+	bool operator()(const PropertyInfo &p_a, const PropertyInfo &p_b) const {
+		return _priority(p_a) < _priority(p_b);
+	}
+};
+
 void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant, bool p_main) {
 	switch (p_variant.get_type()) {
 		case Variant::OBJECT: {
@@ -2008,6 +2023,7 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 			List<PropertyInfo> property_list;
 
 			res->get_property_list(&property_list);
+			property_list.sort_custom<ScriptFirst>();
 
 			for (const PropertyInfo &E : property_list) {
 				if (E.usage & PROPERTY_USAGE_STORAGE) {

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -2344,7 +2344,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 	return OK;
 }
 
-Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+Error ResourceFormatSaverBinaryInstance::set_info(const String &p_path, ResourceUID::ID p_uid, const String &p_script_class) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, vformat("Cannot open file '%s'.", p_path));
 
@@ -2425,13 +2425,26 @@ Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceU
 
 	uint32_t flags = f->get_32();
 	flags |= ResourceFormatSaverBinaryInstance::FORMAT_FLAG_UIDS;
-	f->get_64(); // Skip previous UID
+
+	if (p_uid == ResourceUID::INVALID_ID) {
+		p_uid = ResourceUID::ID(f->get_64()); // Keep previous UID
+	} else {
+		f->get_64(); // Skip previous UID
+	}
+
+	if (!p_script_class.is_empty()) {
+		flags |= ResourceFormatSaverBinaryInstance::FORMAT_FLAG_HAS_SCRIPT_CLASS;
+	}
 
 	fw->store_32(flags);
 	fw->store_64(uint64_t(p_uid));
 
 	if (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_HAS_SCRIPT_CLASS) {
-		save_ustring(fw, get_ustring(f));
+		String script_class = get_ustring(f);
+		if (!p_script_class.is_empty()) {
+			script_class = p_script_class;
+		}
+		save_ustring(fw, script_class);
 	}
 
 	//rest of file
@@ -2466,7 +2479,13 @@ Error ResourceFormatSaverBinary::save(const Ref<Resource> &p_resource, const Str
 Error ResourceFormatSaverBinary::set_uid(const String &p_path, ResourceUID::ID p_uid) {
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	ResourceFormatSaverBinaryInstance saver;
-	return saver.set_uid(local_path, p_uid);
+	return saver.set_info(local_path, p_uid, String());
+}
+
+Error ResourceFormatSaverBinary::set_script_class(const String &p_path, const String &p_script_class) {
+	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
+	ResourceFormatSaverBinaryInstance saver;
+	return saver.set_info(p_path, ResourceUID::INVALID_ID, p_script_class);
 }
 
 bool ResourceFormatSaverBinary::recognize(const Ref<Resource> &p_resource) const {

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -175,7 +175,7 @@ public:
 		RESERVED_FIELDS = 11
 	};
 	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
-	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
+	Error set_info(const String &p_path, ResourceUID::ID p_uid, const String &p_script_class);
 	static void write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
 };
 
@@ -186,6 +186,7 @@ public:
 	static inline ResourceFormatSaverBinary *singleton = nullptr;
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
+	virtual Error set_script_class(const String &p_path, const String &p_script_class) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -501,14 +501,11 @@ void ResourceFormatImporter::add_importer(const Ref<ResourceImporter> &p_importe
 }
 
 void ResourceFormatImporter::get_importers_for_file(const String &p_file, List<Ref<ResourceImporter>> *r_importers) {
-	for (int i = 0; i < importers.size(); i++) {
+	for (const Ref<ResourceImporter> &I : importers) {
 		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
-		for (const String &F : local_exts) {
-			if (p_file.right(F.length()).nocasecmp_to(F) == 0) {
-				r_importers->push_back(importers[i]);
-				break;
-			}
+		I->get_recognized_extensions(&local_exts);
+		if (p_file.validate_extension(local_exts)) {
+			r_importers->push_back(I);
 		}
 	}
 }
@@ -522,16 +519,15 @@ void ResourceFormatImporter::get_importers(List<Ref<ResourceImporter>> *r_import
 Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_file(const String &p_file) const {
 	Ref<ResourceImporter> importer;
 	float priority = 0;
-
-	for (int i = 0; i < importers.size(); i++) {
+	for (const Ref<ResourceImporter> &I : importers) {
+		if (I->get_priority() <= priority) {
+			continue;
+		}
 		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
-		for (const String &F : local_exts) {
-			if (p_file.right(F.length()).nocasecmp_to(F) == 0 && importers[i]->get_priority() > priority) {
-				importer = importers[i];
-				priority = importers[i]->get_priority();
-				break;
-			}
+		I->get_recognized_extensions(&local_exts);
+		if (p_file.validate_extension(local_exts)) {
+			importer = I;
+			priority = I->get_priority();
 		}
 	}
 

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -71,15 +71,7 @@ bool ResourceFormatLoader::recognize_path(const String &p_path, const String &p_
 	} else {
 		get_recognized_extensions_for_type(p_for_type, &extensions);
 	}
-
-	for (const String &E : extensions) {
-		const String ext = !E.begins_with(".") ? "." + E : E;
-		if (p_path.right(ext.length()).nocasecmp_to(ext) == 0) {
-			return true;
-		}
-	}
-
-	return false;
+	return p_path.validate_extension(extensions);
 }
 
 bool ResourceFormatLoader::handles_type(const String &p_type) const {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1258,15 +1258,14 @@ ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {
 	return ResourceUID::INVALID_ID;
 }
 
-bool ResourceLoader::should_create_uid_file(const String &p_path) {
+bool ResourceLoader::has_custom_uid_support(const String &p_path) {
 	const String local_path = _validate_local_path(p_path);
-	if (FileAccess::exists(local_path + ".uid")) {
-		return false;
-	}
-
 	for (int i = 0; i < loader_count; i++) {
-		if (loader[i]->recognize_path(local_path)) {
-			return !loader[i]->has_custom_uid_support();
+		if (!loader[i]->recognize_path(local_path)) {
+			continue;
+		}
+		if (loader[i]->has_custom_uid_support()) {
+			return true;
 		}
 	}
 	return false;

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -261,7 +261,7 @@ public:
 	static String get_resource_type(const String &p_path);
 	static String get_resource_script_class(const String &p_path);
 	static ResourceUID::ID get_resource_uid(const String &p_path);
-	static bool should_create_uid_file(const String &p_path);
+	static bool has_custom_uid_support(const String &p_path);
 	static void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false);
 	static Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map);
 	static bool is_import_valid(const String &p_path);

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -55,6 +55,12 @@ Error ResourceFormatSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) 
 	return err;
 }
 
+Error ResourceFormatSaver::set_script_class(const String &p_path, const String &p_script_class) {
+	Error err = ERR_FILE_UNRECOGNIZED;
+	GDVIRTUAL_CALL(_set_script_class, p_path, p_script_class, err);
+	return err;
+}
+
 bool ResourceFormatSaver::recognize(const Ref<Resource> &p_resource) const {
 	bool success = false;
 	GDVIRTUAL_CALL(_recognize, p_resource, success);
@@ -85,6 +91,7 @@ bool ResourceFormatSaver::recognize_path(const Ref<Resource> &p_resource, const 
 void ResourceFormatSaver::_bind_methods() {
 	GDVIRTUAL_BIND(_save, "resource", "path", "flags");
 	GDVIRTUAL_BIND(_set_uid, "path", "uid");
+	GDVIRTUAL_BIND(_set_script_class, "path", "script_class");
 	GDVIRTUAL_BIND(_recognize, "resource");
 	GDVIRTUAL_BIND(_get_recognized_extensions, "resource");
 	GDVIRTUAL_BIND(_recognize_path, "resource", "path");
@@ -154,6 +161,21 @@ Error ResourceSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
 
 	for (int i = 0; i < saver_count; i++) {
 		err = saver[i]->set_uid(path, p_uid);
+		if (err == OK) {
+			break;
+		}
+	}
+
+	return err;
+}
+
+Error ResourceSaver::set_script_class(const String &p_path, const String &p_script_class) {
+	ERR_FAIL_COND_V_MSG(p_path.is_empty(), ERR_INVALID_PARAMETER, "Can't update UID to empty path. Provide non-empty path.");
+
+	Error err = ERR_FILE_UNRECOGNIZED;
+
+	for (int i = 0; i < saver_count; i++) {
+		err = saver[i]->set_script_class(p_path, p_script_class);
 		if (err == OK) {
 			break;
 		}

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -77,18 +77,9 @@ bool ResourceFormatSaver::recognize_path(const Ref<Resource> &p_resource, const 
 		return ret;
 	}
 
-	String extension = p_path.get_extension();
-
 	List<String> extensions;
 	get_recognized_extensions(p_resource, &extensions);
-
-	for (const String &E : extensions) {
-		if (E.nocasecmp_to(extension) == 0) {
-			return true;
-		}
-	}
-
-	return false;
+	return p_path.validate_extension(extensions);
 }
 
 void ResourceFormatSaver::_bind_methods() {

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -170,7 +170,7 @@ Error ResourceSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
 }
 
 Error ResourceSaver::set_script_class(const String &p_path, const String &p_script_class) {
-	ERR_FAIL_COND_V_MSG(p_path.is_empty(), ERR_INVALID_PARAMETER, "Can't update UID to empty path. Provide non-empty path.");
+	ERR_FAIL_COND_V_MSG(p_path.is_empty(), ERR_INVALID_PARAMETER, "Can't update the script class for an empty path. Provide a non-empty path.");
 
 	Error err = ERR_FILE_UNRECOGNIZED;
 

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -41,6 +41,7 @@ protected:
 
 	GDVIRTUAL3R(Error, _save, Ref<Resource>, String, uint32_t)
 	GDVIRTUAL2R(Error, _set_uid, String, ResourceUID::ID)
+	GDVIRTUAL2R(Error, _set_script_class, String, String)
 	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
 	GDVIRTUAL2RC(bool, _recognize_path, Ref<Resource>, String)
@@ -48,6 +49,7 @@ protected:
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid);
+	virtual Error set_script_class(const String &p_path, const String &p_script_class);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize_path(const Ref<Resource> &p_resource, const String &p_path) const;
@@ -89,6 +91,7 @@ public:
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);
 
 	static Error set_uid(const String &p_path, ResourceUID::ID p_uid);
+	static Error set_script_class(const String &p_path, const String &p_script_class);
 
 	static void set_timestamp_on_save(bool p_timestamp) { timestamp_on_save = p_timestamp; }
 	static bool get_timestamp_on_save() { return timestamp_on_save; }

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -39,6 +39,12 @@
 #include "core/math/random_pcg.h"
 #include "core/object/class_db.h"
 
+#ifdef TOOLS_ENABLED
+#define TOOLS_PRINT_VERBOSE(m_text) print_verbose(m_text)
+#else
+#define TOOLS_PRINT_VERBOSE(m_text)
+#endif
+
 // These constants are off by 1, causing the 'z' and '9' characters never to be used.
 // This cannot be fixed without breaking compatibility; see GH-83843.
 static constexpr uint32_t char_count = ('z' - 'a');
@@ -234,6 +240,8 @@ void ResourceUID::remove_id(ID p_id) {
 		reverse_cache.erase(unique_ids[p_id].cs);
 	}
 	unique_ids.erase(p_id);
+	changed = true;
+	cache_entries = 0;
 }
 
 String ResourceUID::uid_to_path(const String &p_uid) {
@@ -289,14 +297,19 @@ Error ResourceUID::save_to_cache() {
 	entries.reserve(unique_ids.size());
 	cache_entries = 0;
 
+	TOOLS_PRINT_VERBOSE("Saving UIDs to file...");
+
 	for (KeyValue<ID, Cache> &E : unique_ids) {
 		entries.push_back(Pair<ID, String>(E.key, String::utf8(E.value.cs.ptr(), E.value.cs.length())));
 		E.value.saved_to_cache = true;
 		cache_entries++;
+		TOOLS_PRINT_VERBOSE(vformat(R"(Saving UID: "%s" path: "%s".)", id_to_text(E.key), String::utf8(E.value.cs.ptr())));
 	}
 
 	Vector<uint8_t> data = encode_binary_cache(entries);
 	f->store_buffer(data.ptr(), data.size());
+
+	TOOLS_PRINT_VERBOSE("Appending UIDs done.");
 
 	changed = false;
 	return OK;
@@ -316,6 +329,8 @@ Error ResourceUID::load_from_cache(bool p_reset) {
 		unique_ids.clear();
 	}
 
+	TOOLS_PRINT_VERBOSE("Loading UIDs from cache...");
+
 	uint32_t entry_count = f->get_32();
 	for (uint32_t i = 0; i < entry_count; i++) {
 		int64_t id = f->get_64();
@@ -329,10 +344,15 @@ Error ResourceUID::load_from_cache(bool p_reset) {
 
 		c.saved_to_cache = true;
 		unique_ids[id] = c;
+
 		if (use_reverse_cache) {
 			reverse_cache[c.cs] = id;
 		}
+
+		TOOLS_PRINT_VERBOSE(vformat(R"(Loading UID: "%s" path: "%s".)", id_to_text(id), String::utf8(c.cs.ptr())));
 	}
+
+	TOOLS_PRINT_VERBOSE("Loading UIDs done.");
 
 	cache_entries = entry_count;
 	changed = false;
@@ -345,11 +365,15 @@ Error ResourceUID::update_cache() {
 		return OK;
 	}
 
+	if (cache_entries >= unique_ids.size()) {
+		cache_entries = 0;
+	}
+
 	if (cache_entries == 0) {
 		return save_to_cache();
 	}
 	MutexLock l(mutex);
-
+	TOOLS_PRINT_VERBOSE("Appending UIDs to file...");
 	Ref<FileAccess> f;
 	for (KeyValue<ID, Cache> &E : unique_ids) {
 		if (!E.value.saved_to_cache) {
@@ -366,9 +390,10 @@ Error ResourceUID::update_cache() {
 			f->store_buffer((const uint8_t *)E.value.cs.ptr(), s);
 			E.value.saved_to_cache = true;
 			cache_entries++;
+			TOOLS_PRINT_VERBOSE(vformat(R"(Appending UID: "%s" path: "%s".)", id_to_text(E.key), String::utf8(E.value.cs.ptr())));
 		}
 	}
-
+	TOOLS_PRINT_VERBOSE("Appending UIDs done.");
 	if (f.is_valid()) {
 		f->seek(0);
 		f->store_32(cache_entries); //update amount of entries
@@ -402,15 +427,6 @@ String ResourceUID::get_path_from_cache(Ref<FileAccess> &p_cache_file, const Str
 		}
 	}
 	return String();
-}
-
-void ResourceUID::clear() {
-	cache_entries = 0;
-	if (use_reverse_cache) {
-		reverse_cache.clear();
-	}
-	unique_ids.clear();
-	changed = false;
 }
 
 void ResourceUID::_bind_methods() {

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -92,7 +92,6 @@ public:
 	static Vector<uint8_t> encode_binary_cache(const Vector<Pair<ID, String>> &p_entries);
 
 	void enable_reverse_cache() { use_reverse_cache = true; }
-	void clear();
 
 	static ResourceUID *get_singleton() { return singleton; }
 

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -42,8 +42,4 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
-
-	// Treat translations as text/binary files, do not generate a `*.{po,mo}.uid` file.
-	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override { return ResourceUID::INVALID_ID; }
-	virtual bool has_custom_uid_support() const override { return true; }
 };

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -281,10 +281,10 @@ void ScriptServer::init_languages() {
 
 			for (const Variant &script_class : script_classes) {
 				Dictionary c = script_class;
-				if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
+				if (!c.has("class") || !c.has("language") || (!c.has("uid") && !c.has("path")) || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
 					continue;
 				}
-				add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"]);
+				add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"], ResourceUID::get_singleton()->text_to_id(c["uid"]));
 			}
 			ProjectSettings::get_singleton()->clear("_global_script_classes");
 		}
@@ -293,10 +293,10 @@ void ScriptServer::init_languages() {
 		Array script_classes = ProjectSettings::get_singleton()->get_global_class_list();
 		for (const Variant &script_class : script_classes) {
 			Dictionary c = script_class;
-			if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
+			if (!c.has("class") || !c.has("language") || (!c.has("uid") && !c.has("path")) || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
 				continue;
 			}
-			add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"]);
+			add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"], ResourceUID::get_singleton()->text_to_id(c["uid"]));
 		}
 	}
 
@@ -405,23 +405,25 @@ void ScriptServer::global_classes_clear() {
 	inheriters_cache.clear();
 }
 
-void ScriptServer::add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, bool p_is_abstract, bool p_is_tool) {
+void ScriptServer::add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, bool p_is_abstract, bool p_is_tool, const ResourceUID::ID &p_uid) {
 	ERR_FAIL_COND_MSG(p_class == p_base || (global_classes.has(p_base) && get_global_class_native_base(p_base) == p_class), "Cyclic inheritance in script class.");
 	GlobalScriptClass *existing = global_classes.getptr(p_class);
 	if (existing) {
 		// Update an existing class (only set dirty if something changed).
-		if (existing->base != p_base || existing->path != p_path || existing->language != p_language) {
+		if (existing->base != p_base || existing->path != p_path || existing->language != p_language || existing->uid != p_uid) {
 			existing->base = p_base;
+			existing->uid = p_uid;
 			existing->path = p_path;
 			existing->language = p_language;
-			existing->is_abstract = p_is_abstract;
-			existing->is_tool = p_is_tool;
 			inheriters_cache_dirty = true;
 		}
+		existing->is_abstract = p_is_abstract;
+		existing->is_tool = p_is_tool;
 	} else {
 		// Add new class.
 		GlobalScriptClass g;
 		g.language = p_language;
+		g.uid = p_uid;
 		g.path = p_path;
 		g.base = p_base;
 		g.is_abstract = p_is_abstract;
@@ -489,6 +491,11 @@ StringName ScriptServer::get_global_class_language(const StringName &p_class) {
 	return global_classes[p_class].language;
 }
 
+ResourceUID::ID ScriptServer::get_global_class_uid(const String &p_class) {
+	ERR_FAIL_COND_V(!global_classes.has(p_class), ResourceUID::INVALID_ID);
+	return global_classes[p_class].uid;
+}
+
 String ScriptServer::get_global_class_path(const String &p_class) {
 	ERR_FAIL_COND_V(!global_classes.has(p_class), String());
 	return global_classes[p_class].path;
@@ -532,16 +539,19 @@ void ScriptServer::get_global_class_list(LocalVector<StringName> &r_global_class
 	sorter.sort(&r_global_classes[r_global_classes.size() - global_classes.size()], global_classes.size());
 }
 
-void ScriptServer::save_global_classes() {
-	Dictionary class_icons;
-
-	Array script_classes = ProjectSettings::get_singleton()->get_global_class_list();
-	for (const Variant &script_class : script_classes) {
-		Dictionary d = script_class;
-		if (!d.has("name") || !d.has("icon")) {
-			continue;
+void ScriptServer::save_global_classes(const HashMap<StringName, String> &p_script_class_icon_paths) {
+	HashMap<StringName, String> script_class_icon_paths;
+	if (p_script_class_icon_paths.is_empty()) {
+		Array script_classes = ProjectSettings::get_singleton()->get_global_class_list();
+		for (const Variant &script_class : script_classes) {
+			Dictionary d = script_class;
+			if (!d.has("name") || !d.has("icon")) {
+				continue;
+			}
+			script_class_icon_paths[d["name"]] = d["icon"];
 		}
-		class_icons[d["name"]] = d["icon"];
+	} else {
+		script_class_icon_paths = p_script_class_icon_paths;
 	}
 
 	LocalVector<StringName> gc;
@@ -549,12 +559,14 @@ void ScriptServer::save_global_classes() {
 	Array gcarr;
 	for (const StringName &class_name : gc) {
 		const GlobalScriptClass &global_class = global_classes[class_name];
+		String *icon = script_class_icon_paths.getptr(class_name);
 		Dictionary d;
 		d["class"] = class_name;
 		d["language"] = global_class.language;
+		d["uid"] = ResourceUID::get_singleton()->id_to_text(global_class.uid);
 		d["path"] = global_class.path;
 		d["base"] = global_class.base;
-		d["icon"] = class_icons.get(class_name, "");
+		d["icon"] = icon ? *icon : String();
 		d["is_abstract"] = global_class.is_abstract;
 		d["is_tool"] = global_class.is_tool;
 		gcarr.push_back(d);

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -59,6 +59,7 @@ class ScriptServer {
 
 	struct GlobalScriptClass {
 		StringName language;
+		ResourceUID::ID uid = ResourceUID::INVALID_ID;
 		String path;
 		StringName base;
 		bool is_abstract = false;
@@ -85,11 +86,12 @@ public:
 	static void thread_exit();
 
 	static void global_classes_clear();
-	static void add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, bool p_is_abstract, bool p_is_tool);
+	static void add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, bool p_is_abstract, bool p_is_tool, const ResourceUID::ID &p_uid = ResourceUID::INVALID_ID);
 	static void remove_global_class(const StringName &p_class);
 	static void remove_global_class_by_path(const String &p_path);
 	static bool is_global_class(const StringName &p_class);
 	static StringName get_global_class_language(const StringName &p_class);
+	static ResourceUID::ID get_global_class_uid(const String &p_class);
 	static String get_global_class_path(const String &p_class);
 	static StringName get_global_class_base(const String &p_class);
 	static StringName get_global_class_native_base(const String &p_class);
@@ -98,7 +100,7 @@ public:
 	static void get_global_class_list(LocalVector<StringName> &r_global_classes);
 	static void get_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes);
 	static void get_indirect_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes);
-	static void save_global_classes();
+	static void save_global_classes(const HashMap<StringName, String> &p_script_class_icon_paths = {});
 
 	static Vector<Ref<ScriptBacktrace>> capture_script_backtraces(bool p_include_variables = false);
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5040,6 +5040,42 @@ String String::get_extension() const {
 	return substr(pos + 1, length());
 }
 
+String String::_get_longest_suffix_with_dot() const {
+	String file = get_file().trim_prefix(".");
+	int pos = file.find_char('.');
+	if (pos < 0) {
+		return "";
+	}
+
+	return file.substr(pos);
+}
+
+bool String::validate_extension(const HashSet<String> &p_extensions) const {
+	String longest_suffix_with_dot = _get_longest_suffix_with_dot();
+	if (longest_suffix_with_dot.is_empty()) {
+		return false;
+	}
+	for (const String &E : p_extensions) {
+		if (longest_suffix_with_dot.right(E.length() + 1).nocasecmp_to("." + E) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool String::validate_extension(const List<String> &p_extensions) const {
+	String longest_suffix_with_dot = _get_longest_suffix_with_dot();
+	if (longest_suffix_with_dot.is_empty()) {
+		return false;
+	}
+	for (const String &E : p_extensions) {
+		if (longest_suffix_with_dot.right(E.length() + 1).nocasecmp_to("." + E) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
 String String::path_join(const String &p_file) const {
 	if (is_empty()) {
 		return p_file;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -32,7 +32,9 @@
 
 #include "core/string/char_utils.h" // IWYU pragma: export
 #include "core/templates/cowdata.h"
+#include "core/templates/hash_set.h"
 #include "core/templates/hashfuncs.h"
+#include "core/templates/list.h"
 #include "core/templates/vector.h"
 #include "core/typedefs.h"
 
@@ -287,6 +289,7 @@ class [[nodiscard]] String {
 	int _count(const String &p_string, int p_from, int p_to, bool p_case_insensitive) const;
 	int _count(const char *p_string, int p_from, int p_to, bool p_case_insensitive) const;
 	String _separate_compound_words() const;
+	String _get_longest_suffix_with_dot() const;
 
 public:
 	enum {
@@ -514,6 +517,8 @@ public:
 	char32_t unicode_at(int p_idx) const;
 	bool has_extension(const char *p_ext) const { return get_extension().to_lower() == p_ext; }
 	bool has_extension(const String &p_ext) const { return get_extension().to_lower() == p_ext; }
+	bool validate_extension(const HashSet<String> &p_extensions) const;
+	bool validate_extension(const List<String> &p_extensions) const;
 
 	CharString ascii(bool p_allow_extended = false) const;
 	// Parse an ascii string.

--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -60,21 +60,20 @@
 		<method name="scan">
 			<return type="void" />
 			<description>
-				Scan the filesystem for changes.
+				Scans the filesystem for changes. During the scan, the timestamps of the folders will be ignored, and the scan will always try to detect new changes to the folders.
 			</description>
 		</method>
 		<method name="scan_sources">
 			<return type="void" />
 			<description>
-				Check if the source of any imported resource changed.
+				Scans the filesystem for changes. The behavior is affected by [member ProjectSettings.filesystem/on_scan/detect_mode].
 			</description>
 		</method>
 		<method name="update_file">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Add a file in an existing directory, or schedule file information to be updated on editor restart. Can be used to update text files saved by an external program.
-				This will not import the file. To reimport, call [method reimport_files] or [method scan] methods.
+				Immediately updates the file information from the file in the memory cache, which may trigger further actions at the end of the frame.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1230,6 +1230,11 @@
 		<member name="filesystem/import/fbx2gltf/enabled.web" type="bool" setter="" getter="" default="false">
 			Override for [member filesystem/import/fbx2gltf/enabled] on the Web where FBX2glTF can't easily be accessed from Godot.
 		</member>
+		<member name="filesystem/on_scan/detect_mode" type="int" setter="" getter="" default="0">
+			This will affect the behavior of [method EditorFileSystem.scan_sources].
+			If set to [code]Force[/code], force detection of new files in directories during scanning, ignoring whether the directory timestamps have been updated.
+			If set to [code]Auto[/code], on file systems such as FAT32 or exFAT, or in projects managed by Git, the behavior is the same as setting it to [code]Force[/code]; otherwise, the timestamp of the directory's modification time will be used to determine whether to check for directory changes.
+		</member>
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.
 		</member>

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -43,6 +43,14 @@
 				Returns [constant OK] on success, or an [enum Error] constant in case of failure.
 			</description>
 		</method>
+		<method name="_set_script_class" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="script_class" type="String" />
+			<description>
+				Sets a new script class for the resource at the given [param path]. Returns [constant OK] on success, or an [enum Error] constant in case of failure.
+			</description>
+		</method>
 		<method name="_set_uid" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -138,7 +138,9 @@ uint64_t DirAccessUnix::get_modified_time(String p_file) {
 	bool success = (stat(p_file.utf8().get_data(), &flags) == 0);
 
 	if (success) {
-		return flags.st_mtime;
+		// `mv` may only update the ctime, whereas `cp -p` preserves the mtime as well.
+		// The file operations in OS file managers (such as Nemo and Nautilus) also preserves the mtime.
+		return MAX(flags.st_mtime, flags.st_ctime);
 	} else {
 		ERR_FAIL_V(0);
 	}

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -373,15 +373,13 @@ uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 		if ((st.st_mode & S_IFMT) == S_IFLNK || (st.st_mode & S_IFMT) == S_IFREG || (st.st_mode & S_IFDIR) == S_IFDIR) {
 			modified_time = st.st_mtime;
 		}
-#ifdef ANDROID_ENABLED
 		// Workaround for GH-101007
-		//FIXME: After saving, all timestamps (st_mtime, st_ctime, st_atime) are set to the same value.
-		// After exporting or after some time, only 'modified_time' resets to a past timestamp.
+		// `mv` may only update the ctime, whereas `cp -p` preserves the mtime as well.
+		// The file operations in OS file managers (such as Nemo and Nautilus) also preserves the mtime.
 		uint64_t created_time = st.st_ctime;
 		if (modified_time < created_time) {
 			modified_time = created_time;
 		}
-#endif
 		return modified_time;
 	} else {
 		return 0;

--- a/editor/asset_library/editor_asset_installer.cpp
+++ b/editor/asset_library/editor_asset_installer.cpp
@@ -30,7 +30,6 @@
 
 #include "editor_asset_installer.h"
 
-#include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/zip_io.h"
 #include "core/object/callable_mp.h"
@@ -519,7 +518,6 @@ void EditorAssetInstaller::_install_asset() {
 
 	ProgressDialog::get_singleton()->add_task("uncompress", TTR("Uncompressing Assets"), file_item_map.size());
 
-	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	for (int idx = 0; ret == UNZ_OK; ret = unzGoToNextFile(pkg), idx++) {
 		unz_file_info info;
 		char fname[16384];
@@ -547,7 +545,7 @@ void EditorAssetInstaller::_install_asset() {
 				target_path = target_path.substr(0, target_path.length() - 1);
 			}
 
-			da->make_dir_recursive(target_path);
+			EditorFileSystem::get_singleton()->make_dir_recursive(E->value, target_dir_path);
 		} else {
 			Vector<uint8_t> uncomp_data;
 			uncomp_data.resize(info.uncompressed_size);
@@ -557,7 +555,7 @@ void EditorAssetInstaller::_install_asset() {
 			unzCloseCurrentFile(pkg);
 
 			// Ensure that the target folder exists.
-			da->make_dir_recursive(target_path.get_base_dir());
+			EditorFileSystem::get_singleton()->make_dir_recursive(E->value.get_base_dir(), target_dir_path);
 
 			Ref<FileAccess> f = FileAccess::open(target_path, FileAccess::WRITE);
 			if (f.is_valid()) {
@@ -591,7 +589,7 @@ void EditorAssetInstaller::_install_asset() {
 		}
 	}
 
-	EditorFileSystem::get_singleton()->scan_changes();
+	EditorFileSystem::get_singleton()->pending_scan_fs_changes(target_dir_path, true);
 }
 
 void EditorAssetInstaller::set_asset_name(const String &p_asset_name) {

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1332,19 +1332,9 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 
 		String resource_type = ResourceLoader::get_resource_type(fpath);
 		if (resource_type == "PackedScene" || resource_type == "AnimationLibrary") {
-			bool is_imported = false;
-			{
-				List<String> importer_exts;
-				ResourceImporterScene::get_scene_importer_extensions(&importer_exts);
-				String extension = fpath.get_extension();
-				for (const String &E : importer_exts) {
-					if (extension.nocasecmp_to(E) == 0) {
-						is_imported = true;
-						break;
-					}
-				}
-			}
-
+			List<String> importer_exts;
+			ResourceImporterScene::get_scene_importer_extensions(&importer_exts);
+			const bool is_imported = fpath.validate_extension(importer_exts);
 			if (is_imported) {
 				SceneImportSettingsDialog::get_singleton()->open_settings(p_path, resource_type);
 			} else {
@@ -1873,7 +1863,7 @@ void FileSystemDock::_rename_operation_confirm() {
 		EditorNode::get_singleton()->show_warning(TTRC("This filename begins with a dot rendering the file invisible to the editor.\nIf you want to rename it anyway, use your operating system's file manager."));
 		rename_error = true;
 	} else if (to_rename.is_file && to_rename.path.get_extension() != new_name.get_extension()) {
-		if (!EditorFileSystem::get_singleton()->get_valid_extensions().find(new_name.get_extension())) {
+		if (!new_name.validate_extension(EditorFileSystem::get_singleton()->get_valid_extensions())) {
 			unrecognized_ext_dialog->popup_centered_clamped();
 			rename_error = true;
 		}
@@ -3590,25 +3580,26 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 		{
 			List<String> resource_extensions;
 			ResourceFormatImporter::get_singleton()->get_recognized_extensions_for_type("Resource", &resource_extensions);
-			HashSet<String> extension_list;
-			for (const String &extension : resource_extensions) {
-				extension_list.insert(extension);
-			}
 
 			bool resource_valid = true;
 			String main_extension;
 
-			for (int i = 0; i != p_paths.size(); ++i) {
-				String extension = p_paths[i].get_extension();
-				if (extension_list.has(extension)) {
-					if (main_extension.is_empty()) {
-						main_extension = extension;
-					} else if (extension != main_extension) {
-						resource_valid = false;
-						break;
+			for (const String &file_path : p_paths) {
+				resource_valid = false;
+				const String file = file_path.get_file();
+				for (const String &ext : resource_extensions) {
+					if (file.right(ext.length() + 1).nocasecmp_to("." + ext) != 0) {
+						continue;
 					}
-				} else {
-					resource_valid = false;
+					if (main_extension.is_empty()) {
+						main_extension = ext;
+						resource_valid = true;
+					} else if (ext != main_extension) {
+						resource_valid = false;
+					}
+					break;
+				}
+				if (!resource_valid) {
 					break;
 				}
 			}

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1623,105 +1623,7 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 	}
 }
 
-void FileSystemDock::_update_resource_paths_after_move(const HashMap<String, String> &p_renames) const {
-	// Rename all resources loaded, be it subresources or actual resources.
-	List<Ref<Resource>> cached;
-	ResourceCache::get_cached_resources(&cached);
-
-	for (Ref<Resource> &r : cached) {
-		String base_path = r->get_path();
-		String extra_path;
-		int sep_pos = r->get_path().find("::");
-		if (sep_pos >= 0) {
-			extra_path = base_path.substr(sep_pos);
-			base_path = base_path.substr(0, sep_pos);
-		}
-
-		if (p_renames.has(base_path)) {
-			base_path = p_renames[base_path];
-			r->set_path(base_path + extra_path);
-		}
-	}
-
-	Vector<String> files_to_update;
-	for (const KeyValue<String, String> &E : p_renames) {
-		if (!files_to_update.has(E.key)) {
-			files_to_update.push_back(E.key);
-		}
-		if (!files_to_update.has(E.value)) {
-			files_to_update.push_back(E.value);
-		}
-	}
-	print_verbose("FileSystem: updating file infos.");
-	EditorFileSystem::get_singleton()->update_files(files_to_update);
-}
-
-void FileSystemDock::_update_dependencies_after_move(const HashMap<String, String> &p_renames, const HashSet<String> &p_file_owners) const {
-	// The following code assumes that the following holds:
-	// 1) EditorFileSystem contains the old paths/folder structure from before the rename/move.
-	// 2) ResourceLoader can use the new paths without needing to call rescan.
-
-	// The currently edited scene should be reloaded first, so get it's path (GH-82652).
-	const String &edited_scene_path = EditorNode::get_editor_data().get_scene_path(EditorNode::get_editor_data().get_edited_scene());
-	List<String> scenes_to_reload;
-	for (const String &E : p_file_owners) {
-		// Because we haven't called a rescan yet the found remap might still be an old path itself.
-		const HashMap<String, String>::ConstIterator I = p_renames.find(E);
-		const String file = I ? I->value : E;
-		print_verbose("Remapping dependencies for: " + file);
-		const Error err = ResourceLoader::rename_dependencies(file, p_renames);
-		if (err == OK) {
-			if (ResourceLoader::get_resource_type(file) == "PackedScene" && EditorNode::get_editor_data().get_edited_scene_from_path(file) != -1) {
-				if (file == edited_scene_path) {
-					scenes_to_reload.push_front(file);
-				} else {
-					scenes_to_reload.push_back(file);
-				}
-			}
-		} else {
-			EditorNode::get_singleton()->add_io_error(TTR("Unable to update dependencies for:") + "\n" + E + "\n");
-		}
-	}
-
-	for (const String &E : scenes_to_reload) {
-		EditorNode::get_singleton()->reload_scene(E);
-	}
-}
-
-void FileSystemDock::_update_project_settings_after_move(const HashMap<String, String> &p_renames, const HashMap<String, String> &p_folders_renames) {
-	// Find all project settings of type FILE and replace them if needed.
-	const HashMap<StringName, PropertyInfo> prop_info(ProjectSettings::get_singleton()->get_custom_property_info());
-	for (const KeyValue<StringName, PropertyInfo> &E : prop_info) {
-		if (E.value.hint == PROPERTY_HINT_FILE || E.value.hint == PROPERTY_HINT_FILE_PATH) {
-			String old_path = GLOBAL_GET(E.key);
-			if (p_renames.has(old_path)) {
-				ProjectSettings::get_singleton()->set_setting(E.key, p_renames[old_path]);
-			}
-		};
-	}
-
-	// Also search for the file in autoload, as they are stored differently from normal files.
-	List<PropertyInfo> property_list;
-	ProjectSettings::get_singleton()->get_property_list(&property_list);
-	for (const PropertyInfo &E : property_list) {
-		if (E.name.begins_with("autoload/")) {
-			// If the autoload resource paths has a leading "*", it indicates that it is a Singleton,
-			// so we have to handle both cases when updating.
-			String autoload = GLOBAL_GET(E.name);
-			String autoload_singleton = autoload.substr(1);
-			if (p_renames.has(autoload)) {
-				ProjectSettings::get_singleton()->set_setting(E.name, p_renames[autoload]);
-			} else if (autoload.begins_with("*") && p_renames.has(autoload_singleton)) {
-				ProjectSettings::get_singleton()->set_setting(E.name, "*" + p_renames[autoload_singleton]);
-			}
-		}
-	}
-
-	if (p_renames.has(main_scene_path)) {
-		main_scene_path = p_renames[main_scene_path];
-	}
-
-	// Update folder colors.
+void FileSystemDock::_update_folder_colors_after_move(const HashMap<String, String> &p_folders_renames) {
 	for (const KeyValue<String, String> &rename : p_folders_renames) {
 		if (assigned_folder_colors.has(rename.key)) {
 			assigned_folder_colors[rename.value] = assigned_folder_colors[rename.key];
@@ -1910,9 +1812,7 @@ void FileSystemDock::_rename_operation_confirm() {
 	_try_move_item(to_rename, new_path, file_renames, folder_renames);
 
 	int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
-	_update_resource_paths_after_move(file_renames);
-	_update_dependencies_after_move(file_renames, file_owners);
-	_update_project_settings_after_move(file_renames, folder_renames);
+	_update_folder_colors_after_move(folder_renames);
 	_update_favorites_after_move(file_renames, folder_renames);
 
 	EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
@@ -1923,7 +1823,7 @@ void FileSystemDock::_rename_operation_confirm() {
 	}
 
 	print_verbose("FileSystem: calling rescan.");
-	_rescan();
+	_rescan(old_path.get_base_dir(), !to_rename.is_file);
 }
 
 void FileSystemDock::_duplicate_operation_confirm(const String &p_path) {
@@ -2071,20 +1971,19 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 			if (to_move[i].path != new_paths[i]) {
 				_try_move_item(to_move[i], new_paths[i], file_renames, folder_renames);
 				is_moved = true;
+				EditorFileSystem::get_singleton()->pending_scan_fs_changes(to_move[i].is_file ? to_move[i].path.get_base_dir() : to_move[i].path.left(-1).get_base_dir(), !to_move[i].is_file);
 			}
 		}
 
 		if (is_moved) {
 			int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
-			_update_resource_paths_after_move(file_renames);
-			_update_dependencies_after_move(file_renames, file_owners);
-			_update_project_settings_after_move(file_renames, folder_renames);
+			_update_folder_colors_after_move(folder_renames);
 			_update_favorites_after_move(file_renames, folder_renames);
 
 			EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
 
 			print_verbose("FileSystem: calling rescan.");
-			_rescan();
+			_rescan(p_to_path, true);
 
 			current_path = p_to_path;
 			current_path_line_edit->set_text(current_path);
@@ -2871,7 +2770,7 @@ bool FileSystemDock::_matches_all_search_tokens(const String &p_text) {
 	return true;
 }
 
-void FileSystemDock::_rescan() {
+void FileSystemDock::_rescan(const String &p_dir, bool p_recursive) {
 	if (tree->has_focus()) {
 		had_focus = tree;
 	} else if (files->has_focus()) {
@@ -2879,7 +2778,7 @@ void FileSystemDock::_rescan() {
 	}
 
 	_set_scanning_mode();
-	EditorFileSystem::get_singleton()->scan();
+	EditorFileSystem::get_singleton()->pending_scan_fs_changes(p_dir, p_recursive);
 }
 
 void FileSystemDock::_change_split_mode() {

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -306,10 +306,8 @@ private:
 	void _try_move_item(const FileOrFolder &p_item, const String &p_new_path, HashMap<String, String> &p_file_renames, HashMap<String, String> &p_folder_renames);
 	void _try_duplicate_item(const FileOrFolder &p_item, const String &p_new_path) const;
 	void _before_move(HashSet<String> &r_file_owners) const;
-	void _update_dependencies_after_move(const HashMap<String, String> &p_renames, const HashSet<String> &p_file_owners) const;
-	void _update_resource_paths_after_move(const HashMap<String, String> &p_renames) const;
 	void _update_favorites_after_move(const HashMap<String, String> &p_files_renames, const HashMap<String, String> &p_folders_renames) const;
-	void _update_project_settings_after_move(const HashMap<String, String> &p_renames, const HashMap<String, String> &p_folders_renames);
+	void _update_folder_colors_after_move(const HashMap<String, String> &p_folders_renames);
 	String _get_unique_name(const FileOrFolder &p_entry, const String &p_at_path);
 
 	void _update_folder_colors_setting();
@@ -341,7 +339,7 @@ private:
 	void _push_to_history();
 
 	void _set_scanning_mode();
-	void _rescan();
+	void _rescan(const String &p_dir, bool p_recursive);
 
 	void _change_split_mode();
 	void _split_dragged(int p_offset);

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1115,22 +1115,7 @@ void EditorData::script_class_set_name(const String &p_path, const StringName &p
 }
 
 void EditorData::script_class_save_global_classes() {
-	LocalVector<StringName> global_classes;
-	ScriptServer::get_global_class_list(global_classes);
-	Array array_classes;
-	for (const StringName &class_name : global_classes) {
-		Dictionary d;
-		String *icon = _script_class_icon_paths.getptr(class_name);
-		d["class"] = class_name;
-		d["language"] = ScriptServer::get_global_class_language(class_name);
-		d["path"] = ScriptServer::get_global_class_path(class_name);
-		d["base"] = ScriptServer::get_global_class_base(class_name);
-		d["icon"] = icon ? *icon : String();
-		d["is_abstract"] = ScriptServer::is_global_class_abstract(class_name);
-		d["is_tool"] = ScriptServer::is_global_class_tool(class_name);
-		array_classes.push_back(d);
-	}
-	ProjectSettings::get_singleton()->store_global_class_list(array_classes);
+	ScriptServer::save_global_classes(_script_class_icon_paths);
 }
 
 void EditorData::script_class_load_icon_paths() {

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1083,6 +1083,10 @@ void EditorData::script_class_set_icon_path(const String &p_class, const String 
 	_script_class_icon_paths[p_class] = p_icon_path;
 }
 
+void EditorData::script_class_clear_icon_path(const StringName &p_class) {
+	_script_class_icon_paths.erase(p_class);
+}
+
 String EditorData::script_class_get_icon_path(const String &p_class, bool *r_valid) const {
 	String current = p_class;
 	while (true) {
@@ -1112,6 +1116,12 @@ StringName EditorData::script_class_get_name(const String &p_path) const {
 
 void EditorData::script_class_set_name(const String &p_path, const StringName &p_class) {
 	_script_class_file_to_path[p_path] = p_class;
+}
+
+void EditorData::script_class_clear_name(const String &p_path) {
+	if (_script_class_file_to_path.has(p_path)) {
+		_script_class_file_to_path.erase(p_path);
+	}
 }
 
 void EditorData::script_class_save_global_classes() {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -251,9 +251,11 @@ public:
 
 	StringName script_class_get_name(const String &p_path) const;
 	void script_class_set_name(const String &p_path, const StringName &p_class);
+	void script_class_clear_name(const String &p_path);
 
 	String script_class_get_icon_path(const String &p_class, bool *r_valid = nullptr) const;
 	void script_class_set_icon_path(const String &p_class, const String &p_icon_path);
+	void script_class_clear_icon_path(const StringName &p_class);
 	void script_class_clear_icon_paths() { _script_class_icon_paths.clear(); }
 	void script_class_save_global_classes();
 	void script_class_load_icon_paths();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1683,7 +1683,7 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 	Error err;
 
 	Ref<Resource> res;
-	if (force_textfile_extensions.has(p_resource.get_extension())) {
+	if (p_resource.validate_extension(force_textfile_extensions)) {
 		const String resource_type = ResourceLoader::get_resource_type(p_resource);
 		if (resource_type != "Translation" && ResourceLoader::exists(p_resource, "")) {
 			res = ResourceLoader::load(p_resource, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
@@ -1696,9 +1696,9 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 		}
 	} else if (ResourceLoader::exists(p_resource, "")) {
 		res = ResourceLoader::load(p_resource, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
-	} else if (textfile_extensions.has(p_resource.get_extension())) {
+	} else if (p_resource.validate_extension(textfile_extensions)) {
 		res = ScriptEditor::get_singleton()->open_file(p_resource);
-	} else if (other_file_extensions.has(p_resource.get_extension())) {
+	} else if (p_resource.validate_extension(other_file_extensions)) {
 		OS::get_singleton()->shell_open(ProjectSettings::get_singleton()->globalize_path(p_resource));
 		return OK;
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1151,7 +1151,7 @@ void EditorNode::_notification(int p_what) {
 				if (!extensions_match || updated_textfile_extensions.size() < textfile_extensions.size() || updated_other_file_extensions.size() < other_file_extensions.size()) {
 					textfile_extensions = updated_textfile_extensions;
 					other_file_extensions = updated_other_file_extensions;
-					EditorFileSystem::get_singleton()->scan();
+					EditorFileSystem::get_singleton()->update_extensions();
 				}
 			}
 
@@ -7048,7 +7048,7 @@ void EditorNode::_dropped_files(const Vector<String> &p_files) {
 
 	_add_dropped_files_recursive(p_files, to_path);
 
-	EditorFileSystem::get_singleton()->scan_changes();
+	EditorFileSystem::get_singleton()->pending_scan_fs_changes(to_path, true);
 }
 
 void EditorNode::_add_dropped_files_recursive(const Vector<String> &p_files, String to_path) {

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -1511,7 +1511,7 @@ Error ExportTemplateManager::install_android_template_from_file(const String &p_
 
 	ProgressDialog::get_singleton()->end_task("uncompress_src");
 	unzClose(pkg);
-	EditorFileSystem::get_singleton()->scan_changes();
+	EditorFileSystem::get_singleton()->pending_scan_fs_changes(parent_dir, true);
 	return OK;
 }
 

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -766,8 +766,6 @@ void DependencyRemoveDialog::show(const Vector<String> &p_folders, const Vector<
 		text->set_text(TTR("The files being removed are required by other resources in order for them to work.\nRemove them anyway? (Cannot be undone.)\nDepending on your filesystem configuration, the files will either be moved to the system trash or deleted permanently."));
 		popup_centered(Size2(500, 350));
 	}
-
-	EditorFileSystem::get_singleton()->scan_changes();
 }
 
 void DependencyRemoveDialog::ok_pressed() {
@@ -813,9 +811,7 @@ void DependencyRemoveDialog::ok_pressed() {
 
 	if (dirs_to_delete.is_empty()) {
 		// If we only deleted files we should only need to tell the file system about the files we touched.
-		for (int i = 0; i < files_to_delete.size(); ++i) {
-			EditorFileSystem::get_singleton()->update_file(files_to_delete[i]);
-		}
+		EditorFileSystem::get_singleton()->update_files(files_to_delete);
 	} else {
 		for (int i = 0; i < dirs_to_delete.size(); ++i) {
 			String path = OS::get_singleton()->get_resource_dir() + dirs_to_delete[i].replace_first("res://", "/");
@@ -826,9 +822,8 @@ void DependencyRemoveDialog::ok_pressed() {
 			} else {
 				emit_signal(SNAME("folder_removed"), dirs_to_delete[i]);
 			}
+			EditorFileSystem::get_singleton()->pending_scan_fs_changes(dirs_to_delete[i].left(-1).get_base_dir(), false);
 		}
-
-		EditorFileSystem::get_singleton()->scan_changes();
 	}
 
 	// If some files/dirs would be deleted, favorite dirs need to be updated
@@ -1164,7 +1159,7 @@ void OrphanResourcesDialog::show() {
 	popup_centered_ratio(0.4);
 }
 
-void OrphanResourcesDialog::_find_to_delete(TreeItem *p_item, List<String> &r_paths) {
+void OrphanResourcesDialog::_find_to_delete(TreeItem *p_item, Vector<String> &r_paths) {
 	while (p_item) {
 		if (p_item->get_cell_mode(0) == TreeItem::CELL_MODE_CHECK && p_item->is_checked(0)) {
 			r_paths.push_back(p_item->get_metadata(0));
@@ -1182,8 +1177,8 @@ void OrphanResourcesDialog::_delete_confirm() {
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	for (const String &E : paths) {
 		da->remove(E);
-		EditorFileSystem::get_singleton()->update_file(E);
 	}
+	EditorFileSystem::get_singleton()->update_files(paths);
 	refresh();
 }
 

--- a/editor/file_system/dependency_editor.h
+++ b/editor/file_system/dependency_editor.h
@@ -204,8 +204,8 @@ class OrphanResourcesDialog : public ConfirmationDialog {
 
 	bool _fill_owners(EditorFileSystemDirectory *efsd, HashMap<String, int> &refs, TreeItem *p_parent);
 
-	List<String> paths;
-	void _find_to_delete(TreeItem *p_item, List<String> &r_paths);
+	Vector<String> paths;
+	void _find_to_delete(TreeItem *p_item, Vector<String> &r_paths);
 	void _delete_confirm();
 	void _button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2166,7 +2166,7 @@ void EditorFileSystem::_update_script_classes() {
 	if (update_script_paths.is_empty()) {
 		// Ensure the global class file is always present; it's essential for exports to work.
 		if (!FileAccess::exists(ProjectSettings::get_singleton()->get_global_class_list_path())) {
-			ScriptServer::save_global_classes();
+			EditorNode::get_editor_data().script_class_save_global_classes();
 		}
 		return;
 	}
@@ -2591,8 +2591,8 @@ void EditorFileSystem::_register_global_class_script(const String &p_search_path
 	if (lang.is_empty()) {
 		return; // No lang found that can handle this global class
 	}
-
-	ScriptServer::add_global_class(p_script_update.name, p_script_update.extends, lang, p_target_path, p_script_update.is_abstract, p_script_update.is_tool);
+	ResourceUID::ID uid = first_scan && !scanning ? ResourceLoader::get_resource_uid(p_target_path) : get_file_uid(p_target_path);
+	ScriptServer::add_global_class(p_script_update.name, p_script_update.extends, lang, p_target_path, p_script_update.is_abstract, p_script_update.is_tool, uid);
 	EditorNode::get_editor_data().script_class_set_icon_path(p_script_update.name, p_script_update.icon_path);
 	EditorNode::get_editor_data().script_class_set_name(p_target_path, p_script_update.name);
 }

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1957,7 +1957,7 @@ void EditorFileSystem::_file_info_remove(EditorFileInfo *p_file, const String &p
 		_create_action(nullptr, p_file, p_path, ItemAction::ACTION_FILE_REMOVE, ItemAction::STEP_FILE_REMOVE);
 	}
 
-	_delete_internal_files(p_path);
+	_delete_internal_files(p_path, p_file, p_file->status);
 	_create_actions_from_uid_change(p_file, p_path, p_file->uid);
 
 	if (p_file->status & EditorFileInfo::IS_PACKEDSCENE) {
@@ -1984,7 +1984,7 @@ void EditorFileSystem::_file_info_update(EditorFileInfo *p_file, const String &p
 
 	if (p_file->status & EditorFileInfo::IS_IMPORTABLE) {
 		if (!(old_status & EditorFileInfo::IS_IMPORTABLE)) {
-			_delete_internal_files(p_path);
+			_delete_internal_files(p_path, p_file, old_status);
 			if (old_status & EditorFileInfo::IS_PACKEDSCENE) {
 				_scene_info_update(p_file, p_path);
 			} else if (old_status & EditorFileInfo::IS_SCRIPT) {
@@ -1996,7 +1996,7 @@ void EditorFileSystem::_file_info_update(EditorFileInfo *p_file, const String &p
 		_import_validate(p_file, p_path);
 		return;
 	} else if (old_status & EditorFileInfo::IS_IMPORTABLE) {
-		_delete_internal_files(p_path);
+		_delete_internal_files(p_path, p_file, old_status);
 	}
 
 	// Since the timestamp obtained is accurate to 1 second, so in projects using Git for version control,
@@ -2298,23 +2298,39 @@ void EditorFileSystem::pending_scan_fs_changes(const String &p_dir, bool p_recur
 	_pending_scan_fs_changes(efd, p_recursive);
 }
 
-void EditorFileSystem::_delete_internal_files(const String &p_file) {
+void EditorFileSystem::_delete_internal_files(const String &p_file, const EditorFileInfo *p_fi, uint32_t p_old_status) {
 	if (FileAccess::exists(p_file)) {
 		return; // It is just ignored because it is not supported, so there is no need to delete its internal files.
 	}
+
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+
+	if (p_fi) {
+		if (p_old_status & EditorFileInfo::IS_IMPORTABLE) {
+			for (const String &E : p_fi->import_dest_paths) {
+				da->remove(E);
+			}
+			da->remove(p_file + ".import");
+			const String base_path = ResourceFormatImporter::get_singleton()->get_import_base_path(p_file);
+			da->remove(base_path + ".md5");
+		} else if (!(p_old_status & EditorFileInfo::HAS_CUSTOM_UID_SUPPORT)) {
+			da->remove(p_file + ".uid");
+		}
+		return;
+	}
+
 	if (FileAccess::exists(p_file + ".import")) {
 		List<String> paths;
 		ResourceFormatImporter::get_singleton()->get_internal_resource_path_list(p_file, &paths);
-		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		for (const String &E : paths) {
 			da->remove(E);
-			da->remove(E.get_basename() + ".md5");
 		}
 		da->remove(p_file + ".import");
+	} else {
+		da->remove(p_file + ".uid");
 	}
-	if (FileAccess::exists(p_file + ".uid")) {
-		DirAccess::remove_absolute(p_file + ".uid");
-	}
+	const String base_path = ResourceFormatImporter::get_singleton()->get_import_base_path(p_file);
+	da->remove(base_path + ".md5");
 }
 
 void EditorFileSystem::_thread_func_sources(void *_userdata) {

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -298,7 +298,7 @@ void EditorFileSystem::_scan_for_uid_directory(const ScannedDirectory *p_scan_di
 
 		const String path = p_scan_dir->full_path.path_join(scan_file);
 		ResourceUID::ID uid = ResourceUID::INVALID_ID;
-		if (p_import_extensions.has(ext)) {
+		if (scan_file.validate_extension(p_import_extensions)) {
 			if (FileAccess::exists(path + ".import")) {
 				uid = ResourceFormatImporter::get_singleton()->get_resource_uid(path);
 			}
@@ -840,9 +840,11 @@ bool EditorFileSystem::_scan_import_support(const Vector<String> &reimports) {
 	}
 
 	for (int i = 0; i < reimports.size(); i++) {
-		HashMap<String, int>::Iterator E = import_support_test.find(reimports[i].get_extension().to_lower());
-		if (E) {
-			import_support_tested.write[E->value] = true;
+		const String file = reimports[i].get_file();
+		for (KeyValue<String, int> &E : import_support_test) {
+			if (file.right(E.key.length() + 1).nocasecmp_to("." + E.key) == 0) {
+				import_support_tested.write[E.value] = true;
+			}
 		}
 	}
 
@@ -998,7 +1000,7 @@ bool EditorFileSystem::_update_scan_actions() {
 					Vector<String> dependencies = _get_dependencies(full_path);
 					for (const String &dep : dependencies) {
 						const String &dependency_path = dep.contains("::") ? dep.get_slice("::", 0) : dep;
-						if (_can_import_file(dep)) {
+						if (dep.validate_extension(import_extensions)) {
 							reimports.push_back(dependency_path);
 						}
 					}
@@ -1238,10 +1240,9 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 	}
 
 	for (const String &scan_file : p_scan_dir->files) {
-		String ext = scan_file.get_extension().to_lower();
-		if (!valid_extensions.has(ext)) {
+		if (!scan_file.validate_extension(valid_extensions)) {
 			p_progress.increment();
-			continue; //invalid
+			continue; // Invalid.
 		}
 
 		String path = p_scan_dir->full_path.path_join(scan_file);
@@ -1257,7 +1258,9 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 		FileCache *fc = file_cache.getptr(path);
 		uint64_t mt = FileAccess::get_modified_time(path);
 
-		if (_can_import_file(scan_file)) {
+		const bool is_imported = scan_file.validate_extension(import_extensions);
+
+		if (is_imported) {
 			//is imported
 			uint64_t import_mt = FileAccess::get_modified_time(path + ".import");
 
@@ -1352,14 +1355,15 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 					}
 				}
 			} else {
-				//new or modified time
+				// New or modified time.
 				fi->type = ResourceLoader::get_resource_type(path);
 				fi->resource_script_class = ResourceLoader::get_resource_script_class(path);
-				if (fi->type == "" && textfile_extensions.has(ext)) {
-					fi->type = "TextFile";
-				}
-				if (fi->type == "" && other_file_extensions.has(ext)) {
-					fi->type = "OtherFile";
+				if (fi->type.is_empty()) {
+					if (scan_file.validate_extension(textfile_extensions)) {
+						fi->type = "TextFile";
+					} else if (scan_file.validate_extension(other_file_extensions)) {
+						fi->type = "OtherFile";
+					}
 				}
 				fi->uid = ResourceLoader::get_resource_uid(path);
 				fi->class_info = _get_global_script_class(fi->type, path);
@@ -1509,9 +1513,8 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanPr
 				}
 
 			} else {
-				String ext = f.get_extension().to_lower();
-				if (!valid_extensions.has(ext)) {
-					continue; //invalid
+				if (!f.validate_extension(valid_extensions)) {
+					continue; // Invalid.
 				}
 
 				int idx = p_dir->find_file_index(f);
@@ -1528,11 +1531,12 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanPr
 					fi->import_dest_paths = Vector<String>();
 					fi->type = ResourceLoader::get_resource_type(path);
 					fi->resource_script_class = ResourceLoader::get_resource_script_class(path);
-					if (fi->type == "" && textfile_extensions.has(ext)) {
-						fi->type = "TextFile";
-					}
-					if (fi->type == "" && other_file_extensions.has(ext)) {
-						fi->type = "OtherFile";
+					if (fi->type.is_empty()) {
+						if (f.validate_extension(textfile_extensions)) {
+							fi->type = "TextFile";
+						} else if (f.validate_extension(other_file_extensions)) {
+							fi->type = "OtherFile";
+						}
 					}
 					fi->class_info = _get_global_script_class(fi->type, path);
 					fi->import_valid = (fi->type == "TextFile" || fi->type == "OtherFile") ? true : ResourceLoader::is_import_valid(path);
@@ -1547,8 +1551,8 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanPr
 						scan_actions.push_back(ia);
 					}
 
-					if (_can_import_file(f)) {
-						//if it can be imported, and it was added, it needs to be reimported
+					if (f.validate_extension(import_extensions)) {
+						// If it can be imported, and it was added, it needs to be reimported.
 						ItemAction ia;
 						ia.action = ItemAction::ACTION_FILE_TEST_REIMPORT;
 						ia.dir = p_dir;
@@ -1578,8 +1582,7 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanPr
 		}
 
 		String path = cd.path_join(p_dir->files[i]->file);
-
-		if (_can_import_file(p_dir->files[i]->file)) {
+		if (p_dir->files[i]->file.validate_extension(import_extensions)) {
 			// Check here if file must be imported or not.
 			// Same logic as in _process_file_system, the last modifications dates
 			// needs to be trusted to prevent reading all the .import files and the md5
@@ -2441,11 +2444,12 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 			}
 		} else {
 			String type = ResourceLoader::get_resource_type(file);
-			if (type.is_empty() && textfile_extensions.has(file.get_extension())) {
-				type = "TextFile";
-			}
-			if (type.is_empty() && other_file_extensions.has(file.get_extension())) {
-				type = "OtherFile";
+			if (type.is_empty()) {
+				if (file.validate_extension(textfile_extensions)) {
+					type = "TextFile";
+				} else if (file.validate_extension(other_file_extensions)) {
+					type = "OtherFile";
+				}
 			}
 			String script_class = ResourceLoader::get_resource_script_class(file);
 
@@ -2768,11 +2772,12 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		fs->files[cpos]->deps = _get_dependencies(file);
 		fs->files[cpos]->uid = uid;
 		fs->files[cpos]->type = importer->get_resource_type();
-		if (fs->files[cpos]->type == "" && textfile_extensions.has(file.get_extension())) {
-			fs->files[cpos]->type = "TextFile";
-		}
-		if (fs->files[cpos]->type == "" && other_file_extensions.has(file.get_extension())) {
-			fs->files[cpos]->type = "OtherFile";
+		if (fs->files[cpos]->type.is_empty()) {
+			if (file.validate_extension(textfile_extensions)) {
+				fs->files[cpos]->type = "TextFile";
+			} else if (file.validate_extension(other_file_extensions)) {
+				fs->files[cpos]->type = "OtherFile";
+			}
 		}
 		fs->files[cpos]->import_valid = err == OK;
 
@@ -3762,18 +3767,8 @@ void EditorFileSystem::_update_extensions() {
 	extensionsl.clear();
 	ResourceFormatImporter::get_singleton()->get_recognized_extensions(&extensionsl);
 	for (const String &E : extensionsl) {
-		import_extensions.insert(!E.begins_with(".") ? "." + E : E);
+		import_extensions.insert(E);
 	}
-}
-
-bool EditorFileSystem::_can_import_file(const String &p_file) {
-	for (const String &F : import_extensions) {
-		if (p_file.right(F.length()).nocasecmp_to(F) == 0) {
-			return true;
-		}
-	}
-
-	return false;
 }
 
 void EditorFileSystem::add_import_format_support_query(Ref<EditorFileSystemImportFormatSupportQuery> p_query) {

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -978,7 +978,7 @@ bool EditorFileSystem::_update_scan_actions() {
 
 				// Restore another script with the same global class name if it exists.
 				if (!class_name.is_empty()) {
-					EditorFileSystemDirectory::FileInfo *old_fi = nullptr;
+					EditorFileInfo *old_fi = nullptr;
 					String old_file = _get_file_by_class_name(filesystem, class_name, old_fi);
 					if (!old_file.is_empty() && old_fi) {
 						_queue_update_script_class(old_file, ScriptClassInfoUpdate::from_file_info(old_fi));
@@ -1247,7 +1247,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 
 		String path = p_scan_dir->full_path.path_join(scan_file);
 
-		EditorFileSystemDirectory::FileInfo *fi = memnew(EditorFileSystemDirectory::FileInfo);
+		EditorFileInfo *fi = memnew(EditorFileInfo);
 		fi->file = scan_file;
 		p_dir->files.push_back(fi);
 
@@ -1521,7 +1521,7 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanPr
 
 				if (idx == -1) {
 					//never seen this file, add actition to add it
-					EditorFileSystemDirectory::FileInfo *fi = memnew(EditorFileSystemDirectory::FileInfo);
+					EditorFileInfo *fi = memnew(EditorFileInfo);
 					fi->file = f;
 
 					String path = cd.path_join(fi->file);
@@ -1651,7 +1651,7 @@ void EditorFileSystem::_delete_internal_files(const String &p_file) {
 
 int EditorFileSystem::_insert_actions_delete_files_directory(EditorFileSystemDirectory *p_dir) {
 	int nb_files = 0;
-	for (EditorFileSystemDirectory::FileInfo *fi : p_dir->files) {
+	for (EditorFileInfo *fi : p_dir->files) {
 		ItemAction ia;
 		ia.action = ItemAction::ACTION_FILE_REMOVE;
 		ia.dir = p_dir;
@@ -1692,8 +1692,8 @@ bool EditorFileSystem::_remove_invalid_global_class_names(const HashSet<String> 
 	return must_save;
 }
 
-String EditorFileSystem::_get_file_by_class_name(EditorFileSystemDirectory *p_dir, const String &p_class_name, EditorFileSystemDirectory::FileInfo *&r_file_info) {
-	for (EditorFileSystemDirectory::FileInfo *fi : p_dir->files) {
+String EditorFileSystem::_get_file_by_class_name(EditorFileSystemDirectory *p_dir, const String &p_class_name, EditorFileInfo *&r_file_info) {
+	for (EditorFileInfo *fi : p_dir->files) {
 		if (fi->class_info.name == p_class_name) {
 			r_file_info = fi;
 			return p_dir->get_path().path_join(fi->file);
@@ -1857,7 +1857,7 @@ void EditorFileSystem::_save_filesystem_cache(EditorFileSystemDirectory *p_dir, 
 	p_file->store_line("::" + p_dir->get_path() + "::" + String::num_int64(p_dir->modified_time));
 
 	for (int i = 0; i < p_dir->files.size(); i++) {
-		const EditorFileSystemDirectory::FileInfo *file_info = p_dir->files[i];
+		const EditorFileInfo *file_info = p_dir->files[i];
 		if (!file_info->import_group_file.is_empty()) {
 			group_file_cache.insert(file_info->import_group_file);
 		}
@@ -2115,7 +2115,7 @@ EditorFileSystem::ScriptClassInfo EditorFileSystem::_get_global_script_class(con
 	return info;
 }
 
-void EditorFileSystem::_update_file_icon_path(EditorFileSystemDirectory::FileInfo *file_info) {
+void EditorFileSystem::_update_file_icon_path(EditorFileInfo *file_info) {
 	String icon_path;
 	if (file_info->resource_script_class != StringName()) {
 		icon_path = EditorNode::get_editor_data().script_class_get_icon_path(file_info->resource_script_class);
@@ -2157,7 +2157,7 @@ void EditorFileSystem::_update_files_icon_path(EditorFileSystemDirectory *edp) {
 	for (EditorFileSystemDirectory *sub_dir : edp->subdirs) {
 		_update_files_icon_path(sub_dir);
 	}
-	for (EditorFileSystemDirectory::FileInfo *fi : edp->files) {
+	for (EditorFileInfo *fi : edp->files) {
 		_update_file_icon_path(fi);
 	}
 }
@@ -2405,7 +2405,7 @@ void EditorFileSystem::update_file(const String &p_file) {
 void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 	bool updated = false;
 	bool update_files_icon_cache = false;
-	Vector<EditorFileSystemDirectory::FileInfo *> files_to_update_icon_path;
+	Vector<EditorFileInfo *> files_to_update_icon_path;
 	for (const String &file : p_script_paths) {
 		ERR_CONTINUE(file.is_empty());
 		EditorFileSystemDirectory *fs = nullptr;
@@ -2467,7 +2467,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 					idx++;
 				}
 
-				EditorFileSystemDirectory::FileInfo *fi = memnew(EditorFileSystemDirectory::FileInfo);
+				EditorFileInfo *fi = memnew(EditorFileInfo);
 				fi->file = file_name;
 				fi->import_modified_time = 0;
 				fi->import_valid = (type == "TextFile" || type == "OtherFile") ? true : ResourceLoader::is_import_valid(file);
@@ -2487,7 +2487,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 				_save_late_updated_files(); //files need to be updated in the re-scan
 			}
 
-			EditorFileSystemDirectory::FileInfo *fi = fs->files[cpos];
+			EditorFileInfo *fi = fs->files[cpos];
 			const String old_script_class_icon_path = fi->class_info.icon_path;
 			const String old_class_name = fi->class_info.name;
 			fi->type = type;
@@ -2537,7 +2537,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 
 			// Restore another script as the global class name if multiple scripts had the same old class name.
 			if (!old_class_name.is_empty() && fi->class_info.name != old_class_name && ClassDB::is_parent_class(type, SNAME("Script"))) {
-				EditorFileSystemDirectory::FileInfo *old_fi = nullptr;
+				EditorFileInfo *old_fi = nullptr;
 				String old_file = _get_file_by_class_name(filesystem, old_class_name, old_fi);
 				if (!old_file.is_empty() && old_fi) {
 					_queue_update_script_class(old_file, ScriptClassInfoUpdate::from_file_info(old_fi));
@@ -2551,7 +2551,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 		if (update_files_icon_cache) {
 			_update_files_icon_path();
 		} else {
-			for (EditorFileSystemDirectory::FileInfo *fi : files_to_update_icon_path) {
+			for (EditorFileInfo *fi : files_to_update_icon_path) {
 				_update_file_icon_path(fi);
 			}
 		}
@@ -2601,7 +2601,7 @@ void EditorFileSystem::register_global_class_script(const String &p_search_path,
 	int index_file;
 	EditorFileSystemDirectory *efsd = find_file(p_search_path, &index_file);
 	if (efsd) {
-		const EditorFileSystemDirectory::FileInfo *fi = efsd->files[index_file];
+		const EditorFileInfo *fi = efsd->files[index_file];
 		EditorFileSystem::get_singleton()->_register_global_class_script(p_search_path, p_target_path, ScriptClassInfoUpdate::from_file_info(fi));
 	} else {
 		ScriptServer::remove_global_class_by_path(p_search_path);
@@ -3091,7 +3091,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 
 void EditorFileSystem::_find_group_files(EditorFileSystemDirectory *efd, HashMap<String, Vector<String>> &group_files, HashSet<String> &groups_to_reimport) {
 	int fc = efd->files.size();
-	const EditorFileSystemDirectory::FileInfo *const *files = efd->files.ptr();
+	const EditorFileInfo *const *files = efd->files.ptr();
 	for (int i = 0; i < fc; i++) {
 		if (groups_to_reimport.has(files[i]->import_group_file)) {
 			if (!group_files.has(files[i]->import_group_file)) {
@@ -3508,7 +3508,7 @@ bool EditorFileSystem::is_group_file(const String &p_path) const {
 
 void EditorFileSystem::_move_group_files(EditorFileSystemDirectory *efd, const String &p_group_file, const String &p_new_location) {
 	int fc = efd->files.size();
-	EditorFileSystemDirectory::FileInfo *const *files = efd->files.ptrw();
+	EditorFileInfo *const *files = efd->files.ptrw();
 	for (int i = 0; i < fc; i++) {
 		if (files[i]->import_group_file == p_group_file) {
 			files[i]->import_group_file = p_new_location;

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -236,7 +236,7 @@ EditorFileSystemDirectory::EditorFileSystemDirectory() {
 }
 
 EditorFileSystemDirectory::~EditorFileSystemDirectory() {
-	for (EditorFileSystemDirectory::FileInfo *fi : files) {
+	for (FileInfo *fi : files) {
 		memdelete(fi);
 	}
 
@@ -314,6 +314,57 @@ void EditorFileSystem::_scan_for_uid_directory(const ScannedDirectory *p_scan_di
 	}
 }
 
+void EditorFileSystem::_update_global_script_class_activation() {
+	Vector<StringName> to_removes;
+	for (KeyValue<StringName, ScriptClassAlternatives> &E : global_script_class_alternatives) {
+		ScriptClassAlternatives &scas = E.value;
+		if (scas.alternatives.is_empty()) {
+			to_removes.push_back(E.key);
+			continue;
+		}
+		if (!first_scan && scas.active) {
+			continue;
+		}
+		if (!scas.active) {
+			script_classes_updated = true;
+			if (scas.active_uid != ResourceUID::INVALID_ID) {
+				for (KeyValue<String, EditorFileInfo *> &F : scas.alternatives) {
+					if (F.value->uid == scas.active_uid) { // Think of it as a file move.
+						scas.active_path = F.key;
+						scas.active = true;
+						break;
+					}
+				}
+			}
+			if (!scas.active) {
+				scas.active = true;
+				if (scas.alternatives.has(scas.active_path)) { // Maybe the internal files have changed.
+					scas.active_uid = scas.alternatives[scas.active_path]->uid;
+				} else { // Seems to have been removed.
+					scas.active_path = scas.alternatives.begin()->key;
+					scas.active_uid = scas.alternatives.begin()->value->uid;
+				}
+			}
+		}
+		EditorFileInfo *fi = scas.alternatives[scas.active_path];
+		ERR_CONTINUE(fi == nullptr);
+		if (scas.icon_path != fi->class_info.icon_path) {
+			scas.icon_path = fi->class_info.icon_path;
+		}
+		fi->status |= EditorFileInfo::IS_ACTIVE_GLOBAL_CLASS_ALTERNATIVE;
+		_check_loader_or_saver_changed(fi->class_info);
+		ScriptServer::add_global_class(fi->class_info.name, fi->class_info.extends, fi->class_info.lang, scas.active_path, fi->class_info.is_abstract, fi->class_info.is_tool, fi->uid);
+		EditorNode::get_editor_data().script_class_set_icon_path(fi->class_info.name, fi->class_info.icon_path);
+		EditorNode::get_editor_data().script_class_set_name(scas.active_path, fi->class_info.name);
+	}
+	for (StringName &E : to_removes) {
+		script_classes_updated = true;
+		global_script_class_alternatives.erase(E);
+		EditorNode::get_editor_data().script_class_clear_icon_path(E);
+	}
+	_reload_loader_or_saver();
+}
+
 void EditorFileSystem::_first_scan_filesystem() {
 	EditorProgress ep = EditorProgress("first_scan_filesystem", TTR("Project initialization"), 5);
 	HashSet<String> existing_class_names;
@@ -334,6 +385,7 @@ void EditorFileSystem::_first_scan_filesystem() {
 	// At the same time, to prevent looping multiple times in all files, it looks for extensions.
 	ep.step(TTR("Loading global class names..."), 1, true);
 	_first_scan_process_scripts(first_scan_root_dir, gdextension_extensions, existing_class_names, extensions);
+	_update_global_script_class_activation();
 
 	// Removing invalid global class to prevent having invalid paths in ScriptServer.
 	bool save_scripts = _remove_invalid_global_class_names(existing_class_names);
@@ -360,6 +412,7 @@ void EditorFileSystem::_first_scan_filesystem() {
 	EditorNode::get_singleton()->init_plugins();
 
 	ep.step(TTR("Starting file scan..."), 5, true);
+	update_extensions();
 }
 
 void EditorFileSystem::_first_scan_process_scripts(const ScannedDirectory *p_scan_dir, List<String> &p_gdextension_extensions, HashSet<String> &p_existing_class_names, HashSet<String> &p_extensions) {
@@ -379,175 +432,216 @@ void EditorFileSystem::_first_scan_process_scripts(const ScannedDirectory *p_sca
 				break;
 			}
 		}
-		if (is_script) {
+
+		bool is_gdextension = p_gdextension_extensions.find(ext) != nullptr; // Check for GDExtensions.
+
+		if (is_script || is_gdextension) {
 			const String path = p_scan_dir->full_path.path_join(scan_file);
 			const String type = ResourceLoader::get_resource_type(path);
 
-			if (ClassDB::is_parent_class(type, SNAME("Script"))) {
+			if (is_script && ClassDB::is_parent_class(type, Script::get_class_static())) {
 				const ScriptClassInfo &info = _get_global_script_class(type, path);
-				ScriptClassInfoUpdate update(info);
-				update.type = type;
-				_register_global_class_script(path, path, update);
 
-				if (!info.name.is_empty()) {
-					p_existing_class_names.insert(info.name);
+				EditorFileInfo *fi = memnew(EditorFileInfo);
+				fi->status |= EditorFileInfo::IS_SCRIPT | EditorFileInfo::IS_ORPHAN;
+				fi->file = scan_file;
+				fi->type = type;
+				_script_class_info_update(fi, path, &info);
+				fi->uid = ResourceLoader::get_resource_uid(path);
+				script_file_info[path] = fi;
+
+				if (info.name.is_empty() || info.lang.is_empty()) {
+					continue;
 				}
-			}
-		}
+				p_existing_class_names.insert(info.name);
 
-		// Check for GDExtensions.
-		if (p_gdextension_extensions.find(ext)) {
-			const String path = p_scan_dir->full_path.path_join(scan_file);
-			const String type = ResourceLoader::get_resource_type(path);
-			if (type == SNAME("GDExtension")) {
+				if (ScriptServer::is_global_class(info.name)) {
+					ScriptClassAlternatives &scas = global_script_class_alternatives[info.name];
+					if (scas.active_path.is_empty()) { // Query only once.
+						scas.active_path = ScriptServer::get_global_class_path(info.name);
+						scas.active_uid = ScriptServer::get_global_class_uid(info.name);
+					}
+					if (!scas.active && scas.active_uid == fi->uid && scas.active_path == path) {
+						scas.active = true; // A perfect match.
+						scas.icon_path = fi->class_info.icon_path;
+					}
+				}
+			} else if (is_gdextension && type == GDExtension::get_class_static()) {
 				p_extensions.insert(path);
 			}
 		}
 	}
 }
+// Restore the file info cache to the last saved state from the cache file.
+bool EditorFileSystem::_load_filesystem_from_cache() {
+	const String fscache = EditorPaths::get_singleton()->get_project_settings_dir().path_join(CACHE_FILE_NAME);
+	Ref<FileAccess> f = FileAccess::open(fscache, FileAccess::READ);
+	if (f.is_null()) {
+		return false;
+	}
+
+	// Read the disk cache.
+	Vector<String> dirs;
+	String cpath;
+	EditorFileSystemDirectory *cur_dir = nullptr;
+	nb_files_total = 0;
+	bool is_first_line = true;
+	while (!f->eof_reached()) {
+		String l = f->get_line().strip_edges();
+		if (is_first_line) {
+			filesystem_settings_version_for_import = l;
+			revalidate_import_files = filesystem_settings_version_for_import != ResourceFormatImporter::get_singleton()->get_import_settings_hash();
+			is_first_line = false;
+			continue;
+		}
+		if (l.is_empty()) {
+			continue;
+		}
+
+		// Directory entries.
+		if (l.begins_with("::")) {
+			Vector<String> split = l.split("::");
+			ERR_CONTINUE(split.size() != 3);
+			cpath = split[1];
+			if (cpath == "res://") {
+				cur_dir = filesystem;
+				cur_dir->modified_time = split[2].to_int();
+				continue;
+			}
+
+			EditorFileSystemDirectory *parent = cur_dir;
+			Vector<String> prev_dirs = dirs;
+			dirs = cpath.substr(6, cpath.length() - 7).split("/");
+
+			int common_ancestor_count = 0;
+			int amount = prev_dirs.size();
+			bool fetch = false;
+			while (common_ancestor_count != amount) {
+				if (fetch) {
+					parent = parent->parent;
+					amount--;
+				} else {
+					fetch = prev_dirs[common_ancestor_count] != dirs[common_ancestor_count];
+					if (fetch) {
+						continue;
+					}
+					fetch = common_ancestor_count == dirs.size() - 1;
+					common_ancestor_count++;
+				}
+			}
+
+			while (common_ancestor_count < dirs.size() - 1) {
+				int idx = parent->find_dir_index(dirs[common_ancestor_count]);
+				if (idx == -1) {
+					EditorFileSystemDirectory *lost = memnew(EditorFileSystemDirectory);
+					lost->name = dirs[common_ancestor_count];
+					lost->parent = parent;
+					lost->parent->subdirs.push_back(lost);
+				} else {
+					parent = parent->get_subdir(idx);
+				}
+				common_ancestor_count++;
+			}
+
+			cur_dir = memnew(EditorFileSystemDirectory);
+			cur_dir->name = dirs[dirs.size() - 1];
+			cur_dir->parent = parent;
+			cur_dir->parent->subdirs.push_back(cur_dir);
+			cur_dir->modified_time = split[2].to_int();
+			continue;
+		}
+
+		// The last section (deps) may contain the same splitter, so limit the maxsplit to 8 to get the complete deps.
+		Vector<String> split = l.split("::", true, 8);
+		ERR_CONTINUE(split.size() < 9);
+
+		const String path = cpath.path_join(split[0]);
+		const bool is_reused = script_file_info.has(path);
+
+		EditorFileInfo *fi = is_reused ? script_file_info[path] : memnew(EditorFileInfo);
+		cur_dir->files.push_back(fi);
+		fi->parent = cur_dir;
+		fi->status &= ~(EditorFileInfo::FILE_ADD | EditorFileInfo::IS_ORPHAN);
+
+		fi->file = split[0];
+		_category_validate(fi, path);
+
+		if (is_reused) {
+			const StringName old_type = split[1].get_slicec('/', 0);
+			if (old_type != fi->type) {
+				if (!old_type.is_empty()) {
+					fi->status |= EditorFileInfo::TYPE_REMOVE;
+				}
+				if (!fi->type.is_empty()) {
+					fi->status |= EditorFileInfo::TYPE_ADD;
+				}
+			}
+			_create_actions_from_uid_change(fi, path, split[2].to_int());
+		} else {
+			fi->type = split[1].get_slicec('/', 0);
+			if (fi->type.is_empty() || fi->type == "OtherFile" || fi->type == "TextFile") {
+				fi->status &= ~EditorFileInfo::AS_RESOURCE;
+			} else if (fi->type == PackedScene::get_class_static()) {
+				fi->status |= EditorFileInfo::IS_PACKEDSCENE;
+			} else if (ClassDB::is_parent_class(fi->type, Script::get_class_static())) {
+				fi->status |= EditorFileInfo::IS_SCRIPT;
+			}
+			fi->uid = split[2].to_int();
+		}
+
+		fi->resource_script_class = split[1].get_slicec('/', 1);
+		fi->modified_time = split[3].to_int();
+		fi->import_modified_time = split[4].to_int();
+		fi->import_valid = split[5].to_int() != 0;
+		fi->import_group_file = split[6].strip_edges();
+		{
+			const Vector<String> &slices = split[7].split("<>");
+			ERR_CONTINUE(slices.size() < 7);
+			if (!is_reused) {
+				fi->class_info.name = slices[0];
+				fi->class_info.extends = slices[1];
+				fi->class_info.icon_path = slices[2];
+				fi->class_info.is_abstract = slices[3].to_int();
+				fi->class_info.is_tool = slices[4].to_int();
+			}
+			fi->import_md5 = slices[5];
+			fi->import_dest_paths = slices[6].split("<*>", false); // Make sure the path is not empty.
+		}
+		fi->deps = split[8].strip_edges().split("<>", false);
+
+		nb_files_total++;
+	}
+
+	return true;
+}
 
 void EditorFileSystem::_scan_filesystem() {
 	// On the first scan, the first_scan_root_dir is created in _first_scan_filesystem.
-	ERR_FAIL_COND(!scanning || new_filesystem || (first_scan && !first_scan_root_dir));
+	ERR_FAIL_COND(!scanning || (first_scan && !first_scan_root_dir));
 
-	//read .fscache
-	String cpath;
-
-	sources_changed.clear();
-	file_cache.clear();
-
-	String project = ProjectSettings::get_singleton()->get_resource_path();
-
-	String fscache = EditorPaths::get_singleton()->get_project_settings_dir().path_join(CACHE_FILE_NAME);
-	{
-		Ref<FileAccess> f = FileAccess::open(fscache, FileAccess::READ);
-
-		bool first = true;
-		if (f.is_valid()) {
-			//read the disk cache
-			while (!f->eof_reached()) {
-				String l = f->get_line().strip_edges();
-				if (first) {
-					if (first_scan) {
-						// only use this on first scan, afterwards it gets ignored
-						// this is so on first reimport we synchronize versions, then
-						// we don't care until editor restart. This is for usability mainly so
-						// your workflow is not killed after changing a setting by forceful reimporting
-						// everything there is.
-						filesystem_settings_version_for_import = l.strip_edges();
-						if (filesystem_settings_version_for_import != ResourceFormatImporter::get_singleton()->get_import_settings_hash()) {
-							revalidate_import_files = true;
-						}
-					}
-					first = false;
-					continue;
-				}
-				if (l.is_empty()) {
-					continue;
-				}
-
-				if (l.begins_with("::")) {
-					Vector<String> split = l.split("::");
-					ERR_CONTINUE(split.size() != 3);
-					const String &name = split[1];
-
-					cpath = name;
-
-				} else {
-					// The last section (deps) may contain the same splitter, so limit the maxsplit to 8 to get the complete deps.
-					Vector<String> split = l.split("::", true, 8);
-					ERR_CONTINUE(split.size() < 9);
-					String name = split[0];
-					String file;
-
-					file = name;
-					name = cpath.path_join(name);
-
-					FileCache fc;
-					fc.type = split[1].get_slicec('/', 0);
-					fc.resource_script_class = split[1].get_slicec('/', 1);
-					fc.uid = split[2].to_int();
-					fc.modification_time = split[3].to_int();
-					fc.import_modification_time = split[4].to_int();
-					fc.import_valid = split[5].to_int() != 0;
-					fc.import_group_file = split[6].strip_edges();
-					{
-						const Vector<String> &slices = split[7].split("<>");
-						ERR_CONTINUE(slices.size() < 7);
-						fc.class_info.name = slices[0];
-						fc.class_info.extends = slices[1];
-						fc.class_info.icon_path = slices[2];
-						fc.class_info.is_abstract = slices[3].to_int();
-						fc.class_info.is_tool = slices[4].to_int();
-						fc.import_md5 = slices[5];
-						fc.import_dest_paths = slices[6].split("<*>");
-					}
-					fc.deps = split[8].strip_edges().split("<>", false);
-
-					file_cache[name] = fc;
-				}
-			}
-		}
-	}
-
-	const String update_cache = EditorPaths::get_singleton()->get_project_settings_dir().path_join("filesystem_update4");
-	if (first_scan && FileAccess::exists(update_cache)) {
-		{
-			Ref<FileAccess> f2 = FileAccess::open(update_cache, FileAccess::READ);
-			String l = f2->get_line().strip_edges();
-			while (!l.is_empty()) {
-				dep_update_list.insert(l);
-				file_cache.erase(l); // Erase cache for this, so it gets updated.
-				l = f2->get_line().strip_edges();
-			}
-		}
-
-		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-		d->remove(update_cache); // Bye bye update cache.
-	}
+	bool update = !first_scan || _load_filesystem_from_cache();
 
 	EditorProgressBG scan_progress("efs", "ScanFS", 1000);
 	ScanProgress sp;
 	sp.hi = nb_files_total;
 	sp.progress = &scan_progress;
 
-	new_filesystem = memnew(EditorFileSystemDirectory);
-	new_filesystem->parent = nullptr;
-
-	ScannedDirectory *sd;
-	HashSet<String> *processed_files = nullptr;
 	// On the first scan, the first_scan_root_dir is created in _first_scan_filesystem.
 	if (first_scan) {
-		sd = first_scan_root_dir;
-		// Will be updated on scan.
-		ResourceUID::get_singleton()->clear();
 		ResourceUID::scan_for_uid_on_startup = nullptr;
-		processed_files = memnew(HashSet<String>());
+	}
+
+	if (update) {
+		_scan_fs_changes(filesystem, sp);
 	} else {
-		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-		sd = memnew(ScannedDirectory);
-		sd->full_path = "res://";
-		nb_files_total = _scan_new_dir(sd, d);
+		_process_file_system(first_scan_root_dir, filesystem, sp, nullptr);
 	}
 
-	_process_file_system(sd, new_filesystem, sp, processed_files);
-
-	if (first_scan) {
-		_process_removed_files(*processed_files);
-	}
-	dep_update_list.clear();
-	file_cache.clear(); //clear caches, no longer needed
-
+	_update_scan_uid_actions();
 	if (first_scan) {
 		memdelete(first_scan_root_dir);
 		first_scan_root_dir = nullptr;
-		memdelete(processed_files);
-	} else {
-		//on the first scan this is done from the main thread after re-importing
-		_save_filesystem_cache();
 	}
-
-	scanning = false;
 }
 
 void EditorFileSystem::_save_filesystem_cache() {
@@ -565,35 +659,34 @@ void EditorFileSystem::_save_filesystem_cache() {
 void EditorFileSystem::_thread_func(void *_userdata) {
 	EditorFileSystem *sd = (EditorFileSystem *)_userdata;
 	sd->_scan_filesystem();
+	sd->scanning_done.set();
 }
 
-bool EditorFileSystem::_is_test_for_reimport_needed(const String &p_path, uint64_t p_last_modification_time, uint64_t p_modification_time, uint64_t p_last_import_modification_time, uint64_t p_import_modification_time, const Vector<String> &p_import_dest_paths) {
-	// The idea here is to trust the cache. If the last modification times in the cache correspond
-	// to the last modification times of the files on disk, it means the files have not changed since
-	// the last import, and the files in .godot/imported (p_import_dest_paths) should all be valid.
-	if (p_last_modification_time != p_modification_time) {
+bool EditorFileSystem::_is_test_for_reimport_needed(EditorFileInfo *p_file, uint64_t p_modified_time, uint64_t p_import_modified_time) {
+	if (p_modified_time != p_file->modified_time) {
 		return true;
 	}
-	if (p_last_import_modification_time != p_import_modification_time) {
+	if (p_import_modified_time != p_file->import_modified_time) {
 		return true;
 	}
-	if (reimport_on_missing_imported_files) {
-		for (const String &path : p_import_dest_paths) {
-			if (!FileAccess::exists(path)) {
-				return true;
-			}
+	if (!reimport_on_missing_imported_files) {
+		return false;
+	}
+	for (const String &path : p_file->import_dest_paths) {
+		if (!FileAccess::exists(path)) {
+			return true;
 		}
 	}
 	return false;
 }
 
-bool EditorFileSystem::_test_for_reimport(const String &p_path, const String &p_expected_import_md5) {
-	if (p_expected_import_md5.is_empty()) {
+bool EditorFileSystem::_test_for_reimport(const String &p_path, EditorFileInfo *p_file) {
+	if (p_file->import_md5.is_empty()) {
 		// Marked as reimportation needed.
 		return true;
 	}
 	String new_md5 = FileAccess::get_md5(p_path + ".import");
-	if (p_expected_import_md5 != new_md5) {
+	if (p_file->import_md5 != new_md5) {
 		return true;
 	}
 
@@ -796,9 +889,7 @@ Vector<String> EditorFileSystem::_get_import_dest_paths(const String &p_path) {
 				// Invalid import (failed previous import), skip and let user attempt manual reimport to avoid reimport loop.
 				return Vector<String>();
 			}
-			if (assign.begins_with("path")) {
-				dest_paths.push_back(value);
-			} else if (assign == "files") {
+			if (assign == "dest_files") {
 				Array fa = value;
 				for (const Variant &dest_path : fa) {
 					dest_paths.push_back(dest_path);
@@ -818,7 +909,7 @@ Vector<String> EditorFileSystem::_get_import_dest_paths(const String &p_path) {
 	return dest_paths;
 }
 
-bool EditorFileSystem::_scan_import_support(const Vector<String> &reimports) {
+bool EditorFileSystem::_import_support_abort_scan(const Vector<String> &p_reimports) {
 	if (import_support_queries.is_empty()) {
 		return false;
 	}
@@ -839,8 +930,8 @@ bool EditorFileSystem::_scan_import_support(const Vector<String> &reimports) {
 		return false; //well nothing to do
 	}
 
-	for (int i = 0; i < reimports.size(); i++) {
-		const String file = reimports[i].get_file();
+	for (int i = 0; i < p_reimports.size(); i++) {
+		const String file = p_reimports[i].get_file();
 		for (KeyValue<String, int> &E : import_support_test) {
 			if (file.right(E.key.length() + 1).nocasecmp_to("." + E.key) == 0) {
 				import_support_tested.write[E.value] = true;
@@ -859,8 +950,489 @@ bool EditorFileSystem::_scan_import_support(const Vector<String> &reimports) {
 	return false;
 }
 
+void EditorFileSystem::_reset_uid_points() {
+	scan_uid_actions.clear();
+	ItemUIDAction ia;
+	uid_newly_add_end = scan_uid_actions.push_back(ia);
+	uid_move_end = scan_uid_actions.push_back(ia);
+}
+
+void EditorFileSystem::_reset_points() {
+	scan_actions.clear();
+	ItemAction ia;
+	normal = scan_actions.push_back(ia);
+	remove_point = scan_actions.push_back(ia);
+}
+
+void EditorFileSystem::_create_action(EditorFileSystemDirectory *p_dir, EditorFileInfo *p_fi, const String &p_path, const ItemAction::Action p_action, const ItemAction::Step p_step, const ResourceUID::ID p_old_uid) {
+	ItemAction ia;
+	ia.action = p_action;
+	ia.path = p_path;
+	ia.file = p_fi;
+	ia.dir = p_dir;
+	switch (p_step) {
+		case ItemAction::STEP_NORMAL: {
+			scan_actions.insert_before(normal, ia);
+		} break;
+		case ItemAction::STEP_CLEAR_STATUS: {
+			scan_actions.insert_after(normal, ia);
+		} break;
+		case ItemAction::STEP_FILE_REMOVE: {
+			scan_actions.insert_before(remove_point, ia);
+		} break;
+		case ItemAction::STEP_DIR_REMOVE: {
+			scan_actions.insert_after(remove_point, ia);
+		} break;
+		case ItemAction::STEP_MAX: {
+		} break;
+	}
+}
+
+void EditorFileSystem::_create_uid_action(EditorFileInfo *p_fi, const String &p_path, const ItemUIDAction::UIDAction p_action, const ItemUIDAction::UIDStep p_step, const ResourceUID::ID p_old_uid) {
+	ItemUIDAction ia;
+	ia.action = p_action;
+	ia.old_uid = p_old_uid;
+	ia.path = p_path;
+	ia.file = p_fi;
+	switch (p_step) {
+		case ItemUIDAction::STEP_UID_VALIDATE: {
+			scan_uid_actions.push_front(ia);
+		} break;
+		case ItemUIDAction::STEP_UID_NEWLY_ADD: {
+			scan_uid_actions.insert_before(uid_newly_add_end, ia);
+		} break;
+		case ItemUIDAction::STEP_UID_REMOVE: {
+			scan_uid_actions.insert_after(uid_newly_add_end, ia);
+		} break;
+		case ItemUIDAction::STEP_UID_PENDING_ADD: {
+			scan_uid_actions.insert_before(uid_move_end, ia);
+		} break;
+		case ItemUIDAction::STEP_UID_REGENERATE: {
+			scan_uid_actions.insert_after(uid_move_end, ia);
+		} break;
+		case ItemUIDAction::STEP_UID_MAX: {
+		} break;
+	}
+}
+
+void EditorFileSystem::_create_actions_from_uid_change(EditorFileInfo *p_fi, const String &p_path, const ResourceUID::ID p_old_uid) {
+	ERR_FAIL_NULL(p_fi);
+
+	if (!(p_fi->status & EditorFileInfo::AS_RESOURCE) || p_fi->status & EditorFileInfo::FILE_REMOVE) {
+		if (p_old_uid == ResourceUID::INVALID_ID) {
+			return;
+		}
+		// Files that are no longer as resource or no longer tracked.
+		_create_uid_action(p_fi, p_path, ItemUIDAction::ACTION_UID_REMOVE, ItemUIDAction::STEP_UID_REMOVE, p_old_uid);
+		return;
+	} else if (p_fi->status & EditorFileInfo::FILE_ADD) {
+		if (p_fi->uid == ResourceUID::INVALID_ID) {
+			// Newly added files. It is also possible that the skip/keep type import file was removed.
+			_create_uid_action(p_fi, p_path, ItemUIDAction::ACTION_UID_ADD, ItemUIDAction::STEP_UID_NEWLY_ADD, p_old_uid);
+		} else {
+			// The file was moved or duplicated.
+			_create_uid_action(p_fi, p_path, ItemUIDAction::ACTION_UID_PENDING_ADD, ItemUIDAction::STEP_UID_PENDING_ADD, p_old_uid);
+		}
+		return;
+	}
+
+	// File was updated.
+	if (p_old_uid != ResourceUID::INVALID_ID) {
+		if (p_fi->uid == p_old_uid) {
+			if (first_scan) {
+				// The UID cache may be invalid. Edge case.
+				_create_uid_action(p_fi, p_path, ItemUIDAction::ACTION_UID_PENDING_ADD, ItemUIDAction::STEP_UID_VALIDATE, p_old_uid);
+			}
+			return;
+		}
+		// The file was overwritten. Remove the old uid.
+		_create_uid_action(p_fi, p_path, ItemUIDAction::ACTION_UID_REMOVE, ItemUIDAction::STEP_UID_REMOVE, p_old_uid);
+	}
+
+	if (p_fi->uid == ResourceUID::INVALID_ID) {
+		// The internal files are removed. Re-add(create) the uid.
+		_create_uid_action(p_fi, p_path, ItemUIDAction::ACTION_UID_ADD, ItemUIDAction::STEP_UID_PENDING_ADD, p_old_uid);
+	} else {
+		// The file may be overwritten.
+		_create_uid_action(p_fi, p_path, ItemUIDAction::ACTION_UID_PENDING_ADD, ItemUIDAction::STEP_UID_PENDING_ADD, p_old_uid);
+	}
+}
+
+void EditorFileSystem::_update_dependencies_after_scan() {
+	List<String> scenes_to_reload;
+	const String &edited_scene_path = EditorNode::get_editor_data().get_scene_path(EditorNode::get_editor_data().get_edited_scene());
+
+	List<EditorFileSystemDirectory *> dirs;
+	dirs.push_back(filesystem);
+	List<EditorFileSystemDirectory *>::Element *dir = dirs.front();
+	while (dir) {
+		EditorFileSystemDirectory *&efsd = dir->get();
+		for (EditorFileSystemDirectory *subdir : efsd->subdirs) {
+			dirs.push_back(subdir);
+		}
+		dir = dir->next();
+		for (EditorFileInfo *fi : efsd->files) {
+			if (fi->status & EditorFileInfo::FILE_REMOVE) {
+				continue;
+			}
+			const String file_path = efsd->get_path().path_join(fi->file);
+			bool need_update_modified_time = false;
+
+			if (!(fi->status & EditorFileInfo::IS_SCRIPT)) {
+				fi->class_info.icon_path.clear();
+			}
+
+			bool is_affected_file_owner = false;
+			bool is_first_dep = true;
+			String dep_path;
+			Vector<String> new_deps;
+			for (String dep : fi->deps) {
+				// The string returned by `_get_dependencies()` does not contain the `type` field.
+				Vector<String> dep_infos = dep.split("::::");
+				if (dep_infos.size() == 1) {
+					dep_path = dep;
+					// In legacy projects, the UID might be missing. And some resources (json/po/mo/crt/key/pub) may not have a UID.
+					// TODO: An interactive repair dialog should be provided.
+					new_deps.push_back(dep);
+					ERR_PRINT_ONCE(vformat("The UID is missing from the path %s in the deps of %s.", dep, file_path));
+					continue;
+				} else {
+					ERR_CONTINUE(dep_infos.size() != 2);
+					const String uid_text = dep_infos[0];
+					const ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(uid_text);
+					if (moves.has(uid)) {
+						dep_path = moves[uid].target;
+						new_deps.push_back(uid_text + "::::" + dep_path);
+						is_affected_file_owner = true;
+					} else {
+						dep_path = dep_infos[1];
+						new_deps.push_back(dep);
+						if (untracks.has(uid)) {
+							// The dependency's old UID is no longer in use (a different UID may be regenerated), due to:
+							// 1. Its extension is no longer valid (Loader failure).
+							// 2. Only the file was moved, its uid/import file was not moved (Incomplete movement);
+							// 3. Its uid/import file and the filesystem cache file have been removed when the editor is launched (Accidentally removed and cannot be recovered).
+							WARN_PRINT(vformat("The dependency (path %s, UID %s) in file %s is untracked. Please fix this dependency promptly.", dep_path, uid_text, file_path));
+						} else if (first_scan) {
+							// Checks whether the dependency's path matches the UID cache record.
+							if (ResourceUID::get_singleton()->has_id(uid)) {
+								const String uid_path = ResourceUID::get_singleton()->get_id_path(uid);
+								if (uid_path != dep_path) {
+									WARN_PRINT(vformat("The path %s of dependency (UID %s) in file %s doesn's match the path %s in UID cache. Please fix this dependency promptly.", dep_path, uid_text, file_path, uid_path));
+								}
+							} else {
+								WARN_PRINT(vformat("The UID %s of dependency (path %s) in file %s was no longer in use. Please fix this dependency promptly.", uid_text, dep_path, file_path));
+							}
+						}
+					}
+				}
+
+				if (is_first_dep) {
+					is_first_dep = false;
+					int idx = -1;
+					EditorFileSystemDirectory *dep_dir = find_file(dep_path, &idx);
+					if (!dep_dir) {
+						continue;
+					}
+					EditorFileInfo *first_dep_fi = dep_dir->files[idx];
+					if (!(first_dep_fi->status & EditorFileInfo::IS_SCRIPT)) {
+						continue;
+					}
+					if (!ClassDB::is_parent_class(first_dep_fi->class_info.extends, fi->type)) {
+						continue;
+					}
+
+					// Update resource script class.
+					if (fi->resource_script_class != first_dep_fi->class_info.name) {
+						fi->resource_script_class = first_dep_fi->class_info.name;
+						const Error err = ResourceSaver::set_script_class(file_path, fi->resource_script_class);
+						if (err == OK) {
+							need_update_modified_time = true;
+						} else {
+							EditorNode::get_singleton()->add_io_error(TTR("Unable to update script class for:") + "\n" + file_path + "\n");
+						}
+					}
+
+					// Update resource icon.
+					if (!(fi->status & EditorFileInfo::IS_SCRIPT)) {
+						if (!first_dep_fi->class_info.icon_path.is_empty()) {
+							if (fi->class_info.icon_path == first_dep_fi->class_info.icon_path) {
+								continue;
+							}
+							fi->class_info.icon_path = first_dep_fi->class_info.icon_path;
+						} else {
+							// Update icon using the icon added via `add_custom_type()`.
+							// FIXME: Ensure that cached icons are updated promptly.
+							Ref<Texture2D> script_icon = EditorNode::get_singleton()->get_editor_data().get_script_icon(dep_path);
+							if (script_icon.is_null() || fi->class_info.icon_path == script_icon->get_path()) {
+								continue;
+							}
+							fi->class_info.icon_path = script_icon->get_path();
+						}
+					}
+				}
+			}
+			fi->deps = new_deps; // Update deps in file info.
+
+			// Update dependencies in files.
+			if (is_affected_file_owner) {
+				const Error err = ResourceLoader::rename_dependencies(file_path, move_paths);
+				if (err == OK) {
+					need_update_modified_time = true;
+					if (fi->status & EditorFileInfo::IS_PACKEDSCENE) {
+						if (file_path == edited_scene_path) {
+							scenes_to_reload.push_front(file_path);
+						} else {
+							scenes_to_reload.push_back(file_path);
+						}
+					}
+				} else {
+					EditorNode::get_singleton()->add_io_error(TTR("Unable to update dependencies for:") + "\n" + file_path + "\n");
+				}
+			}
+			if (need_update_modified_time) {
+				fi->modified_time = FileAccess::get_modified_time(file_path);
+			}
+		}
+	}
+
+	for (const String &E : scenes_to_reload) {
+		EditorNode::get_singleton()->reload_scene(E);
+	}
+}
+
+void EditorFileSystem::_update_resource_paths_after_scan() {
+	List<Ref<Resource>> cached;
+	ResourceCache::get_cached_resources(&cached);
+	Vector<Ref<Resource>> move_affected;
+	for (Ref<Resource> &r : cached) {
+		String base_path = r->get_path();
+		String extra_path;
+		int sep_pos = r->get_path().find("::");
+		if (sep_pos >= 0) {
+			extra_path = base_path.substr(sep_pos);
+			base_path = base_path.substr(0, sep_pos);
+		}
+		if (untrack_paths.has(base_path)) {
+			r->set_path(""); // Clear path.
+		}
+		if (move_paths.has(base_path)) {
+			base_path = move_paths[base_path];
+			r->set_path(base_path + extra_path + ".tmp~"); // Prevent circular overwriting.
+			move_affected.push_back(r);
+		}
+	}
+	for (Ref<Resource> &r : move_affected) {
+		r->set_path(r->get_path().trim_suffix(".tmp~"));
+	}
+}
+
+void EditorFileSystem::_update_project_settings_after_scan() {
+	bool need_save = false;
+
+	// Find all project settings of type FILE and replace them if needed.
+	const HashMap<StringName, PropertyInfo> &prop_info = ProjectSettings::get_singleton()->get_custom_property_info();
+	for (const KeyValue<StringName, PropertyInfo> &E : prop_info) {
+		if (E.value.hint == PROPERTY_HINT_FILE || E.value.hint == PROPERTY_HINT_FILE_PATH) {
+			const String old_path = GLOBAL_GET(E.key);
+			if (move_paths.has(old_path)) {
+				need_save = true;
+				ProjectSettings::get_singleton()->set_setting(E.key, move_paths[old_path]);
+			}
+		}
+	}
+
+	// Also search for the file in autoload, as they are stored differently from normal files.
+	List<PropertyInfo> property_list;
+	ProjectSettings::get_singleton()->get_property_list(&property_list);
+	for (const PropertyInfo &E : property_list) {
+		if (E.name.begins_with("autoload/")) {
+			// If the autoload resource paths has a leading "*", it indicates that it is a Singleton,
+			// so we have to handle both cases when updating.
+			const String autoload = GLOBAL_GET(E.name);
+			const String autoload_singleton = autoload.substr(1);
+			if (move_paths.has(autoload)) {
+				need_save = true;
+				ProjectSettings::get_singleton()->set_setting(E.name, move_paths[autoload]);
+			} else if (autoload.begins_with("*") && move_paths.has(autoload_singleton)) {
+				need_save = true;
+				ProjectSettings::get_singleton()->set_setting(E.name, "*" + move_paths[autoload_singleton]);
+			}
+		}
+	}
+
+	if (need_save) {
+		ProjectSettings::get_singleton()->save();
+	}
+}
+
+bool EditorFileSystem::_update_scan_uid_actions() {
+	bool fs_changed = false;
+
+	HashMap<ResourceUID::ID, Vector<String>> duplicates;
+	HashMap<String, ResourceUID::ID> tracks;
+	HashMap<ResourceUID::ID, String> retracks;
+
+	untracks.clear();
+	untrack_paths.clear();
+	moves.clear();
+	move_paths.clear();
+
+	EditorProgress *ep = nullptr;
+	if (scan_uid_actions.size() > (EditorFileSystem::ItemUIDAction::STEP_UID_MAX / 2 + 1)) {
+		ep = memnew(EditorProgress("_update_scan_uid_actions", TTR("Scanning UID actions..."), scan_uid_actions.size()));
+	}
+	int step_count = 0;
+	for (const ItemUIDAction &ia : scan_uid_actions) {
+		switch (ia.action) {
+			case ItemUIDAction::ACTION_UID_NONE: {
+				continue;
+			} break;
+			case ItemUIDAction::ACTION_UID_ADD: {
+				print_verbose(vformat(R"([%.6f] [ADD UID] old UID: "%s", UID: "%s", path: "%s".)",
+						OS::get_singleton()->get_ticks_usec() / 1000000.0f,
+						ResourceUID::get_singleton()->id_to_text(ia.old_uid),
+						ResourceUID::get_singleton()->id_to_text(ia.file->uid),
+						ia.path));
+				if (ia.old_uid == ResourceUID::INVALID_ID || ResourceUID::get_singleton()->has_id(ia.old_uid)) {
+					ia.file->uid = ResourceUID::get_singleton()->create_id_for_path(ia.path);
+				} else {
+					ia.file->uid = ia.old_uid;
+				}
+				ResourceUID::get_singleton()->add_id(ia.file->uid, ia.path);
+				tracks[ia.path] = ia.file->uid;
+				fs_changed = true;
+				// Update internal file.
+				if (ia.file->status & EditorFileInfo::IS_IMPORTABLE) {
+					const String internal_path = ia.path + ".import";
+					Ref<ConfigFile> cfg;
+					cfg.instantiate();
+					Error err = cfg->load(internal_path);
+					if (err == OK) {
+						cfg->set_value("remap", "uid", ResourceUID::get_singleton()->id_to_text(ia.file->uid));
+						err = cfg->save(internal_path);
+						ia.file->import_modified_time = FileAccess::get_modified_time(internal_path);
+					}
+				} else if (ia.file->status & EditorFileInfo::HAS_CUSTOM_UID_SUPPORT) {
+					ResourceSaver::set_uid(ia.path, ia.file->uid);
+					ia.file->modified_time = FileAccess::get_modified_time(ia.path);
+				} else {
+					const String internal_path = ia.path + ".uid";
+					Ref<FileAccess> f = FileAccess::open(internal_path, FileAccess::WRITE);
+					if (f.is_valid()) {
+						f->store_line(ResourceUID::get_singleton()->id_to_text(ia.file->uid));
+					}
+				}
+				print_verbose(vformat("[ADD UID] %s, %s", ia.path, ResourceUID::get_singleton()->id_to_text(ia.file->uid)));
+			} break;
+			case ItemUIDAction::ACTION_UID_REMOVE: {
+				print_verbose(vformat(R"([%.6f] [REMOVE UID] old UID: "%s", UID: "%s", path: "%s".)",
+						OS::get_singleton()->get_ticks_usec() / 1000000.0f,
+						ResourceUID::get_singleton()->id_to_text(ia.old_uid),
+						ResourceUID::get_singleton()->id_to_text(ia.file->uid),
+						ia.path));
+				untracks[ia.old_uid] = ia.path;
+				untrack_paths.insert(ia.path);
+				fs_changed = true;
+				if (!first_scan || ResourceUID::get_singleton()->has_id(ia.old_uid)) {
+					ResourceUID::get_singleton()->remove_id(ia.old_uid);
+				}
+			} break;
+			case ItemUIDAction::ACTION_UID_PENDING_ADD: {
+				print_verbose(vformat(R"([%.6f] [TEST ADD UID] old UID: "%s", UID: "%s", path: "%s".)",
+						OS::get_singleton()->get_ticks_usec() / 1000000.0f,
+						ResourceUID::get_singleton()->id_to_text(ia.old_uid),
+						ResourceUID::get_singleton()->id_to_text(ia.file->uid),
+						ia.path));
+				if (ResourceUID::get_singleton()->has_id(ia.file->uid)) {
+					const String cache_uid_path = ResourceUID::get_singleton()->get_id_path(ia.file->uid);
+					if (cache_uid_path != ia.path) {
+						duplicates[ia.file->uid].push_back(ia.path);
+						WARN_PRINT(vformat("Duplicate UID detected for Resource at \"%s\".\nOld Resource path: \"%s\". The new file UID was changed automatically.", ia.path, cache_uid_path));
+						if (ia.old_uid != ResourceUID::INVALID_ID && ia.old_uid != ia.file->uid && ResourceUID::get_singleton()->has_id(ia.old_uid)) {
+							// Files may be overwritten.
+							_create_uid_action(ia.file, ia.path, ItemUIDAction::ACTION_UID_ADD, ItemUIDAction::STEP_UID_PENDING_ADD, ia.old_uid);
+						} else {
+							// Files may be duplicate.
+							_create_uid_action(ia.file, ia.path, ItemUIDAction::ACTION_UID_ADD, ItemUIDAction::STEP_UID_REGENERATE);
+						}
+						step_count--;
+					}
+				} else {
+					retracks[ia.file->uid] = ia.path;
+					ResourceUID::get_singleton()->add_id(ia.file->uid, ia.path);
+				}
+			} break;
+			default: {
+			} break;
+		}
+
+		if (ep) {
+			ep->step(ia.path, step_count++, false);
+		}
+	}
+	memdelete_notnull(ep);
+
+	if (!retracks.is_empty() || !untracks.is_empty() || !tracks.is_empty()) {
+		print_verbose("======= Scan UID Analysis Start =======");
+
+		for (KeyValue<ResourceUID::ID, String> &E : untracks) {
+			HashMap<ResourceUID::ID, String>::Iterator I = retracks.find(E.key);
+			if (!I) {
+				print_verbose(vformat("[Untracked] %s, at %s.", ResourceUID::get_singleton()->id_to_text(E.key), E.value));
+				continue;
+			}
+			MoveItems mi;
+			mi.origin = E.value;
+			mi.target = I->value;
+			moves.insert(E.key, mi);
+			move_paths[mi.origin] = mi.target;
+
+			retracks.erase(E.key);
+		}
+
+		for (KeyValue<ResourceUID::ID, MoveItems> &E : moves) {
+			print_verbose(vformat("[Moved] %s, from %s to %s.", ResourceUID::get_singleton()->id_to_text(E.key), E.value.origin, E.value.target));
+			untracks.erase(E.key);
+			untrack_paths.erase(E.value.origin);
+		}
+
+		for (KeyValue<ResourceUID::ID, Vector<String>> &E : duplicates) {
+			for (const String &F : E.value) {
+				HashMap<String, ResourceUID::ID>::Iterator I = tracks.find(F);
+				ERR_CONTINUE(I == nullptr);
+				print_verbose(vformat("[Duplicated] %s, from %s to %s, %s.", ResourceUID::get_singleton()->id_to_text(E.key), ResourceUID::get_singleton()->get_id_path(E.key), F, ResourceUID::get_singleton()->id_to_text(I->value)));
+				tracks.erase(F);
+			}
+		}
+
+		for (KeyValue<String, ResourceUID::ID> &E : tracks) {
+			print_verbose(vformat("[Tracked] %s, at %s.", ResourceUID::get_singleton()->id_to_text(E.value), E.key));
+		}
+
+		for (KeyValue<ResourceUID::ID, String> &E : retracks) {
+			print_verbose(vformat("[Retracked] %s, at %s.", ResourceUID::get_singleton()->id_to_text(E.key), E.value));
+		}
+
+		print_verbose("======= Scan UID Analysis End =======");
+
+		_update_resource_paths_after_scan();
+	}
+
+	if (!first_scan) {
+		_update_global_script_class_activation();
+	}
+
+	_reset_uid_points();
+	return fs_changed;
+}
+
 bool EditorFileSystem::_update_scan_actions() {
+	update_actions_queued = false;
 	sources_changed.clear();
+
+	_update_dependencies_after_scan();
+	_update_project_settings_after_scan();
 
 	// We need to update the script global class names before the reimports to be sure that
 	// all the importer classes that depends on class names will work.
@@ -869,10 +1441,11 @@ bool EditorFileSystem::_update_scan_actions() {
 	bool fs_changed = false;
 
 	Vector<String> reimports;
+	Vector<String> overwrites;
 	Vector<String> reloads;
 
 	EditorProgress *ep = nullptr;
-	if (scan_actions.size() > 1) {
+	if (scan_actions.size() > (EditorFileSystem::ItemAction::STEP_MAX / 2 + 1)) {
 		ep = memnew(EditorProgress("_update_scan_actions", TTR("Scanning actions..."), scan_actions.size()));
 	}
 
@@ -880,156 +1453,54 @@ bool EditorFileSystem::_update_scan_actions() {
 	for (const ItemAction &ia : scan_actions) {
 		switch (ia.action) {
 			case ItemAction::ACTION_NONE: {
+				continue;
 			} break;
 			case ItemAction::ACTION_DIR_ADD: {
-				int idx = 0;
-				for (int i = 0; i < ia.dir->subdirs.size(); i++) {
-					if (ia.new_dir->name.filenocasecmp_to(ia.dir->subdirs[i]->name) < 0) {
-						break;
-					}
-					idx++;
-				}
-				if (idx == ia.dir->subdirs.size()) {
-					ia.dir->subdirs.push_back(ia.new_dir);
-				} else {
-					ia.dir->subdirs.insert(idx, ia.new_dir);
-				}
-
 				fs_changed = true;
 			} break;
 			case ItemAction::ACTION_DIR_REMOVE: {
-				ERR_CONTINUE(!ia.dir->parent);
-				ia.dir->parent->subdirs.erase(ia.dir);
+				ERR_CONTINUE(!ia.dir);
 				memdelete(ia.dir);
 				fs_changed = true;
 			} break;
-			case ItemAction::ACTION_FILE_ADD: {
-				int idx = 0;
-				for (int i = 0; i < ia.dir->files.size(); i++) {
-					if (ia.new_file->file.filenocasecmp_to(ia.dir->files[i]->file) < 0) {
-						break;
-					}
-					idx++;
-				}
-				if (idx == ia.dir->files.size()) {
-					ia.dir->files.push_back(ia.new_file);
-				} else {
-					ia.dir->files.insert(idx, ia.new_file);
-				}
-
-				fs_changed = true;
-
-				const String new_file_path = ia.dir->get_file_path(idx);
-				const ResourceUID::ID existing_id = ResourceLoader::get_resource_uid(new_file_path);
-				if (existing_id != ResourceUID::INVALID_ID) {
-					const bool id_known = ResourceUID::get_singleton()->has_id(existing_id);
-					const String old_path = id_known ? ResourceUID::get_singleton()->get_id_path(existing_id) : String();
-
-					if (id_known && old_path != new_file_path && FileAccess::exists(old_path)) {
-						const ResourceUID::ID new_id = ResourceUID::get_singleton()->create_id_for_path(new_file_path);
-						ResourceUID::get_singleton()->add_id(new_id, new_file_path);
-						ResourceSaver::set_uid(new_file_path, new_id);
-						WARN_PRINT(vformat("Duplicate UID detected for Resource at \"%s\".\nOld Resource path: \"%s\". The new file UID was changed automatically.", new_file_path, old_path));
-						ia.new_file->uid = new_id;
-					} else {
-						// Re-assign the UID to file, just in case it was pulled from cache.
-						ResourceSaver::set_uid(new_file_path, existing_id);
-
-						if (id_known) {
-							ResourceUID::get_singleton()->set_id(existing_id, new_file_path);
-						} else {
-							ResourceUID::get_singleton()->add_id(existing_id, new_file_path);
-						}
-
-						ia.new_file->uid = existing_id;
-					}
-				} else if (ResourceLoader::should_create_uid_file(new_file_path)) {
-					Ref<FileAccess> f = FileAccess::open(new_file_path + ".uid", FileAccess::WRITE);
-					if (f.is_valid()) {
-						ia.new_file->uid = ResourceUID::get_singleton()->create_id_for_path(new_file_path);
-						f->store_line(ResourceUID::get_singleton()->id_to_text(ia.new_file->uid));
-					}
-				}
-
-				if (ClassDB::is_parent_class(ia.new_file->type, SNAME("Script"))) {
-					_queue_update_script_class(new_file_path, ScriptClassInfoUpdate::from_file_info(ia.new_file));
-				}
-				if (ia.new_file->type == SNAME("PackedScene")) {
-					_queue_update_scene_groups(new_file_path);
-				}
-
-			} break;
 			case ItemAction::ACTION_FILE_REMOVE: {
-				int idx = ia.dir->find_file_index(ia.file);
-				ERR_CONTINUE(idx == -1);
-
-				const String file_path = ia.dir->get_file_path(idx);
-				const String class_name = ia.dir->files[idx]->class_info.name;
-				if (ClassDB::is_parent_class(ia.dir->files[idx]->type, SNAME("Script"))) {
-					_queue_update_script_class(file_path, ScriptClassInfoUpdate());
+				ERR_CONTINUE(!ia.file);
+				if (ia.file->status & EditorFileInfo::TYPE_REMOVE) {
+					overwrites.push_back(ia.path);
 				}
-				if (ia.dir->files[idx]->type == SNAME("PackedScene")) {
-					_queue_update_scene_groups(file_path);
-				}
-
-				_delete_internal_files(file_path);
-				memdelete(ia.dir->files[idx]);
-				ia.dir->files.remove_at(idx);
-
-				// Restore another script with the same global class name if it exists.
-				if (!class_name.is_empty()) {
-					EditorFileInfo *old_fi = nullptr;
-					String old_file = _get_file_by_class_name(filesystem, class_name, old_fi);
-					if (!old_file.is_empty() && old_fi) {
-						_queue_update_script_class(old_file, ScriptClassInfoUpdate::from_file_info(old_fi));
-					}
-				}
-
-				fs_changed = true;
-
-			} break;
-			case ItemAction::ACTION_FILE_TEST_REIMPORT: {
-				int idx = ia.dir->find_file_index(ia.file);
-				ERR_CONTINUE(idx == -1);
-				String full_path = ia.dir->get_file_path(idx);
-
-				bool need_reimport = _test_for_reimport(full_path, ia.dir->files[idx]->import_md5);
-				if (need_reimport) {
-					// Must reimport.
-					reimports.push_back(full_path);
-					Vector<String> dependencies = _get_dependencies(full_path);
-					for (const String &dep : dependencies) {
-						const String &dependency_path = dep.contains("::") ? dep.get_slice("::", 0) : dep;
-						if (dep.validate_extension(import_extensions)) {
-							reimports.push_back(dependency_path);
-						}
-					}
-				} else {
-					// Must not reimport, all was good.
-					// Update modified times, md5 and destination paths, to avoid reimport.
-					ia.dir->files[idx]->modified_time = FileAccess::get_modified_time(full_path);
-					ia.dir->files[idx]->import_modified_time = FileAccess::get_modified_time(full_path + ".import");
-					if (ia.dir->files[idx]->import_md5.is_empty()) {
-						ia.dir->files[idx]->import_md5 = FileAccess::get_md5(full_path + ".import");
-					}
-					ia.dir->files[idx]->import_dest_paths = _get_import_dest_paths(full_path);
-				}
-
+				ia.file->status &= ~EditorFileInfo::TEMPORARY;
+				memdelete(ia.file);
 				fs_changed = true;
 			} break;
-			case ItemAction::ACTION_FILE_RELOAD: {
-				int idx = ia.dir->find_file_index(ia.file);
-				ERR_CONTINUE(idx == -1);
-
-				// Only reloads the resources that are already loaded.
-				if (ResourceCache::has(ia.dir->get_file_path(idx))) {
-					reloads.push_back(ia.dir->get_file_path(idx));
+			case ItemAction::ACTION_FILE_ADD: {
+				ERR_CONTINUE(!ia.file);
+				ia.file->status &= ~EditorFileInfo::TEMPORARY;
+				fs_changed = true;
+			} break;
+			case ItemAction::ACTION_FILE_UPDATE: {
+				ERR_CONTINUE(!ia.file);
+				if (!(ia.file->status & EditorFileInfo::IS_IMPORTABLE)) {
+					if (ia.file->status & EditorFileInfo::TYPE_REMOVE) {
+						overwrites.push_back(ia.path);
+					} else if (!(ia.file->status & EditorFileInfo::TYPE_CHANGED)) {
+						reloads.push_back(ia.path);
+					}
 				}
+				ia.file->status &= ~EditorFileInfo::TEMPORARY;
+				fs_changed = true;
+			} break;
+			case ItemAction::ACTION_FILE_REIMPORT: {
+				if (ia.file) {
+					ia.file->status &= ~EditorFileInfo::TEMPORARY;
+				}
+				reimports.push_back(ia.path);
+			} break;
+			default: {
 			} break;
 		}
 
 		if (ep) {
-			ep->step(ia.file, step_count++, false);
+			ep->step(ia.path, step_count++, false);
 		}
 	}
 
@@ -1049,25 +1520,23 @@ bool EditorFileSystem::_update_scan_actions() {
 	}
 
 	if (!reimports.is_empty()) {
-		if (_scan_import_support(reimports)) {
+		if (_import_support_abort_scan(reimports)) {
 			return true;
 		}
 
 		reimport_files(reimports);
 	} else {
-		//reimport files will update the uid cache file so if nothing was reimported, update it manually
+		// Reimport files will update the uid cache file so if nothing was reimported, update it manually.
 		ResourceUID::get_singleton()->update_cache();
 	}
 
-	if (!reloads.is_empty()) {
-		// Update global class names, dependencies, etc...
-		update_files(reloads);
-	}
-
 	if (first_scan) {
-		//only on first scan this is valid and updated, then settings changed.
+		// Only on first scan this is valid and updated, then settings changed.
 		revalidate_import_files = false;
 		filesystem_settings_version_for_import = ResourceFormatImporter::get_singleton()->get_import_settings_hash();
+	}
+
+	if (fs_changed) {
 		_save_filesystem_cache();
 	}
 
@@ -1075,10 +1544,18 @@ bool EditorFileSystem::_update_scan_actions() {
 	// are updated. Script.cpp listens on resources_reload and reloads updated scripts.
 	_process_update_pending();
 
+	for (const String &path : overwrites) {
+		Ref<Resource> res = ResourceCache::get_ref(path);
+		if (res.is_null()) {
+			continue;
+		}
+		res->set_path("");
+	}
+
 	if (reloads.size()) {
 		emit_signal(SNAME("resources_reload"), reloads);
 	}
-	scan_actions.clear();
+	_reset_points();
 
 	return fs_changed;
 }
@@ -1118,21 +1595,18 @@ void EditorFileSystem::scan() {
 #endif
 	}
 
-	_update_extensions();
+	sources_changed.clear();
+	scanning_done.clear();
+	scanning = true;
+	scan_total = 0;
 
 	if (!use_threads) {
-		scanning = true;
-		scan_total = 0;
 		_scan_filesystem();
-		if (filesystem) {
-			memdelete(filesystem);
-		}
-		//file_type_cache.clear();
-		filesystem = new_filesystem;
-		new_filesystem = nullptr;
+		scanning_done.set();
+		dirty_directories.clear();
+		scan_changes_pending = false;
 		_update_scan_actions();
-		// Update all icons so they are loaded for the FileSystemDock.
-		_update_files_icon_path();
+		extensions_changed = false;
 		scanning = false;
 		// Set first_scan to false before the signals so the function doing_first_scan can return false
 		// in editor_node to start the export if needed.
@@ -1144,8 +1618,6 @@ void EditorFileSystem::scan() {
 		ERR_FAIL_COND(thread.is_started());
 		set_process(true);
 		Thread::Settings s;
-		scanning = true;
-		scan_total = 0;
 		s.priority = Thread::PRIORITY_LOW;
 		thread.start(_thread_func, this, s);
 	}
@@ -1205,7 +1677,7 @@ int EditorFileSystem::_scan_new_dir(ScannedDirectory *p_dir, Ref<DirAccess> &da)
 			String d = da->get_current_dir();
 
 			if (d == cd || !d.begins_with(cd)) {
-				da->change_dir(cd); //avoid recursion
+				da->change_dir(cd); // Avoid recursion.
 			} else {
 				ScannedDirectory *sd = memnew(ScannedDirectory);
 				sd->name = dir;
@@ -1224,8 +1696,389 @@ int EditorFileSystem::_scan_new_dir(ScannedDirectory *p_dir, Ref<DirAccess> &da)
 
 	p_dir->files = files;
 	nb_files_total_scan += files.size();
+	p_dir->count = nb_files_total_scan;
 
 	return nb_files_total_scan;
+}
+
+// Only called when a file info is added or when the file extension changes.
+void EditorFileSystem::_category_validate(EditorFileInfo *p_file, const String &p_path) {
+	if (ResourceLoader::has_custom_uid_support(p_path)) {
+		p_file->status |= EditorFileInfo::HAS_CUSTOM_UID_SUPPORT;
+	} else {
+		p_file->status &= ~EditorFileInfo::HAS_CUSTOM_UID_SUPPORT;
+	}
+
+	p_file->status &= ~EditorFileInfo::CATEGORY_CHANGED; // Clear the category bits.
+
+	if (p_file->file.validate_extension(import_extensions)) {
+		p_file->status |= EditorFileInfo::IS_IMPORTABLE;
+	}
+	if (p_file->file.validate_extension(textfile_extensions)) {
+		p_file->status |= EditorFileInfo::IS_TEXT;
+	}
+	if (p_file->file.validate_extension(other_file_extensions)) {
+		p_file->status |= EditorFileInfo::IS_OTHER;
+	}
+}
+
+// Analyze whether the type has changed and mark the types and changes of concern.
+void EditorFileSystem::_type_analysis(EditorFileInfo *p_file, const StringName &p_new_type) {
+	const StringName old_type = p_file->type;
+	p_file->type = p_new_type;
+	if (p_file->type.is_empty()) {
+		if (p_file->status & EditorFileInfo::IS_TEXT) {
+			p_file->type = "TextFile";
+		} else if (p_file->status & EditorFileInfo::IS_OTHER) {
+			p_file->type = "OtherFile";
+		}
+		p_file->status &= ~EditorFileInfo::AS_RESOURCE;
+	} else {
+		p_file->status |= EditorFileInfo::AS_RESOURCE;
+	}
+
+	if (old_type != p_file->type) {
+		if (!old_type.is_empty()) {
+			p_file->status |= EditorFileInfo::TYPE_REMOVE;
+		}
+		if (!p_file->type.is_empty()) {
+			p_file->status |= EditorFileInfo::TYPE_ADD;
+		}
+		if (p_file->type == PackedScene::get_class_static()) {
+			p_file->status |= EditorFileInfo::IS_PACKEDSCENE;
+		} else if (ClassDB::is_parent_class(p_file->type, Script::get_class_static())) {
+			p_file->status |= EditorFileInfo::IS_SCRIPT;
+		}
+	}
+}
+
+void EditorFileSystem::_import_validate(EditorFileInfo *p_file, const String &p_path) {
+	ERR_FAIL_NULL(p_file);
+	const ResourceUID::ID old_uid = p_file->uid;
+	const bool is_file_updated = !(p_file->status & EditorFileInfo::FILE_ADD);
+	if (!FileAccess::exists(p_path + ".import")) {
+		p_file->uid = ResourceUID::INVALID_ID;
+		_create_actions_from_uid_change(p_file, p_path, old_uid);
+		if (is_file_updated) {
+			_create_action(nullptr, p_file, p_path, ItemAction::ACTION_FILE_UPDATE);
+		}
+		_create_action(nullptr, p_file, p_path, ItemAction::ACTION_FILE_REIMPORT); // Import directly.
+		return;
+	}
+
+	const uint64_t mt = FileAccess::get_modified_time(p_path);
+	const uint64_t import_mt = FileAccess::get_modified_time(p_path + ".import");
+	StringName new_type;
+	ResourceFormatImporter::get_singleton()->get_resource_import_info(p_path, new_type, p_file->uid, p_file->import_group_file);
+	_type_analysis(p_file, new_type);
+
+	const bool is_uid_unchanged = old_uid == p_file->uid;
+	if (!is_uid_unchanged || first_scan) {
+		_create_actions_from_uid_change(p_file, p_path, old_uid);
+		if (is_file_updated) {
+			_create_action(nullptr, p_file, p_path, ItemAction::ACTION_FILE_UPDATE);
+		}
+	}
+
+	if (is_uid_unchanged && !_is_test_for_reimport_needed(p_file, mt, import_mt) &&
+			(!first_scan || !revalidate_import_files || ResourceFormatImporter::get_singleton()->are_import_settings_valid(p_path))) {
+		return;
+	}
+	bool need_reimport = _test_for_reimport(p_path, p_file);
+	if (need_reimport) {
+		if (is_file_updated && is_uid_unchanged && !first_scan) {
+			_create_action(nullptr, p_file, p_path, ItemAction::ACTION_FILE_UPDATE);
+		}
+		_create_action(nullptr, p_file, p_path, ItemAction::ACTION_FILE_REIMPORT); // Must reimport.
+		Vector<String> dependencies = _get_dependencies(p_path);
+		for (const String &dep : dependencies) {
+			const String &dependency_path = dep.contains("::") ? dep.get_slice("::", 0) : dep;
+			if (dependency_path.validate_extension(import_extensions)) {
+				// Import these.
+				_create_action(nullptr, nullptr, dependency_path, ItemAction::ACTION_FILE_REIMPORT);
+			}
+		}
+		return;
+	}
+	// Must not reimport, all was good.
+	// Update modified times, md5 and destination paths, to avoid reimport.
+	p_file->modified_time = mt;
+	p_file->import_modified_time = import_mt;
+	p_file->import_dest_paths = _get_import_dest_paths(p_path);
+}
+
+void EditorFileSystem::_check_loader_or_saver_changed(const ScriptClassInfo &p_class_info) {
+	if (p_class_info.extends == ResourceFormatLoader::get_class_static()) {
+		loader_changed = true;
+		need_update_extensions = true;
+	} else if (p_class_info.extends == ResourceFormatSaver::get_class_static()) {
+		saver_changed = true;
+	}
+}
+
+void EditorFileSystem::_reload_loader_or_saver() {
+	if (saver_changed) {
+		saver_changed = false;
+		ResourceSaver::remove_custom_savers();
+		ResourceSaver::add_custom_savers();
+	}
+	if (loader_changed) {
+		loader_changed = false;
+		ResourceLoader::remove_custom_loaders();
+		ResourceLoader::add_custom_loaders();
+	}
+}
+
+void EditorFileSystem::_global_script_class_info_remove(EditorFileInfo *p_file, const String &p_path) {
+	ERR_FAIL_NULL(p_file);
+	ScriptClassInfo &sci = p_file->class_info;
+	HashMap<StringName, ScriptClassAlternatives>::Iterator E = global_script_class_alternatives.find(sci.name);
+	ERR_FAIL_NULL_MSG(E, vformat("The file %s of the untracked global class %s was detected and removed.", p_path, sci.name));
+	ScriptClassAlternatives &scas = E->value;
+	scas.alternatives.erase(p_path);
+	p_file->status &= ~EditorFileInfo::IS_GLOBAL_CLASS_ALTERNATIVE;
+	if (p_file->status & EditorFileInfo::IS_ACTIVE_GLOBAL_CLASS_ALTERNATIVE) {
+		p_file->status &= ~EditorFileInfo::IS_ACTIVE_GLOBAL_CLASS_ALTERNATIVE;
+		_check_loader_or_saver_changed(sci);
+		scas.active = false;
+		ScriptServer::remove_global_class(sci.name);
+		EditorHelp::remove_doc(sci.name);
+		EditorNode::get_editor_data().script_class_clear_name(p_path);
+	}
+}
+
+void EditorFileSystem::_global_script_class_info_add(EditorFileInfo *p_file, const String &p_path) {
+	ERR_FAIL_NULL(p_file);
+	ScriptClassAlternatives &scas = global_script_class_alternatives[p_file->class_info.name];
+	scas.alternatives[p_path] = p_file;
+}
+
+void EditorFileSystem::_script_class_info_update(EditorFileInfo *p_file, const String &p_path, const ScriptClassInfo *p_sci) {
+	ERR_FAIL_NULL(p_file);
+	ERR_FAIL_NULL(p_sci);
+	if (p_file->status & EditorFileInfo::IS_GLOBAL_CLASS_ALTERNATIVE) {
+		_global_script_class_info_remove(p_file, p_path);
+	}
+	ScriptClassInfo &sci = p_file->class_info;
+	sci = *p_sci;
+	if (p_file->status & EditorFileInfo::IS_SCRIPT) {
+		{
+			MutexLock update_script_lock(update_script_mutex);
+			update_script_paths_documentation.insert(p_path);
+		}
+	} else {
+		EditorHelp::remove_script_doc_by_path(p_path);
+	}
+	if (sci.name.is_empty() || sci.lang.is_empty()) {
+		return; // No need to add global class info.
+	}
+	p_file->status |= EditorFileInfo::IS_GLOBAL_CLASS_ALTERNATIVE;
+	_global_script_class_info_add(p_file, p_path);
+}
+
+void EditorFileSystem::_scene_info_update(EditorFileInfo *p_file, const String &p_path) {
+	if (p_file->status & EditorFileInfo::IS_PACKEDSCENE) {
+		_queue_update_scene_groups(p_path);
+	} else {
+		ProjectSettings::get_singleton()->remove_scene_groups_cache(p_path);
+		EditorHelp::remove_script_doc_by_path(p_path);
+	}
+}
+
+void EditorFileSystem::_file_info_add(EditorFileSystemDirectory *p_dir, const String &p_dir_path, const String &p_file, bool p_insert) {
+	const String path = p_dir_path.path_join(p_file);
+	const bool is_reused = first_scan && script_file_info.has(path);
+
+	EditorFileInfo *fi = is_reused ? script_file_info[path] : memnew(EditorFileInfo);
+	fi->parent = p_dir;
+	if (p_insert) {
+		p_insert = false;
+		for (int idx = 0; idx < p_dir->files.size(); idx++) {
+			if (fi->file.filenocasecmp_to(p_dir->files[idx]->file) < 0) {
+				p_dir->files.insert(idx, fi);
+				p_insert = true;
+				break;
+			}
+		}
+		if (!p_insert) {
+			p_dir->files.push_back(fi);
+		}
+	} else {
+		p_dir->files.push_back(fi);
+	}
+	fi->status &= ~EditorFileInfo::IS_ORPHAN;
+	_create_action(p_dir, fi, path, ItemAction::ACTION_FILE_ADD);
+
+	fi->file = p_file;
+	_category_validate(fi, path);
+
+	if (fi->status & EditorFileSystemDirectory::FileInfo::IS_IMPORTABLE) {
+		_import_validate(fi, path);
+		return;
+	}
+
+	if (is_reused) {
+		if (!fi->type.is_empty()) {
+			fi->status |= EditorFileInfo::TYPE_ADD;
+		}
+	} else {
+		_type_analysis(fi, ResourceLoader::get_resource_type(path));
+		fi->uid = ResourceLoader::get_resource_uid(path);
+		if (fi->status & EditorFileInfo::IS_PACKEDSCENE) {
+			_scene_info_update(fi, path);
+		} else if (fi->status & EditorFileInfo::IS_SCRIPT) {
+			const ScriptClassInfo &sci = _get_global_script_class(fi->type, path);
+			_script_class_info_update(fi, path, &sci);
+		}
+	}
+
+	fi->modified_time = FileAccess::get_modified_time(path);
+	fi->import_md5 = "";
+	fi->deps = _get_dependencies(path);
+	fi->resource_script_class = ResourceLoader::get_resource_script_class(path);
+	fi->import_group_file = ResourceLoader::get_import_group_file(path);
+	fi->import_modified_time = 0;
+	fi->import_valid = !(fi->status & EditorFileInfo::AS_RESOURCE) || ResourceLoader::is_import_valid(path);
+
+	_create_actions_from_uid_change(fi, path, fi->uid);
+
+	// Update preview
+	EditorResourcePreview::get_singleton()->check_for_invalidation(path);
+}
+
+void EditorFileSystem::_file_info_remove(EditorFileInfo *p_file, const String &p_path, const int p_idx) {
+	if (p_file->status & EditorFileInfo::FILE_REMOVE) {
+		return;
+	}
+	p_file->status |= EditorFileInfo::FILE_REMOVE | EditorFileInfo::TYPE_REMOVE;
+	if (p_idx != -1) {
+		// Immediately remove it from the tree, but do not immediately release it.
+		p_file->parent->files.remove_at(p_idx);
+		_create_action(nullptr, p_file, p_path, ItemAction::ACTION_FILE_REMOVE, ItemAction::STEP_FILE_REMOVE);
+	}
+
+	_delete_internal_files(p_path);
+	_create_actions_from_uid_change(p_file, p_path, p_file->uid);
+
+	if (p_file->status & EditorFileInfo::IS_PACKEDSCENE) {
+		p_file->status &= ~EditorFileInfo::IS_PACKEDSCENE;
+		_scene_info_update(p_file, p_path);
+	} else if (p_file->status & EditorFileInfo::IS_SCRIPT) {
+		p_file->status &= ~EditorFileInfo::IS_SCRIPT;
+		ScriptClassInfo sci;
+		_script_class_info_update(p_file, p_path, &sci);
+	}
+}
+
+void EditorFileSystem::_file_info_update(EditorFileInfo *p_file, const String &p_path) {
+	// There is only one state for a file in the same frame.
+	// Files that have already been marked will not be marked again.
+	if (p_file->status & EditorFileInfo::FILE_CHANGED) {
+		return;
+	}
+
+	const uint32_t old_status = p_file->status;
+	if (extensions_changed && !first_scan) {
+		_category_validate(p_file, p_path);
+	}
+
+	if (p_file->status & EditorFileInfo::IS_IMPORTABLE) {
+		if (!(old_status & EditorFileInfo::IS_IMPORTABLE)) {
+			_delete_internal_files(p_path);
+			if (old_status & EditorFileInfo::IS_PACKEDSCENE) {
+				_scene_info_update(p_file, p_path);
+			} else if (old_status & EditorFileInfo::IS_SCRIPT) {
+				ScriptClassInfo sci;
+				_script_class_info_update(p_file, p_path, &sci);
+			}
+		}
+
+		_import_validate(p_file, p_path);
+		return;
+	} else if (old_status & EditorFileInfo::IS_IMPORTABLE) {
+		_delete_internal_files(p_path);
+	}
+
+	// Since the timestamp obtained is accurate to 1 second, so in projects using Git for version control,
+	// all files may have the same timestamp. Swapping directory structures may not change file timestamps.
+	// It is still necessary to compare the modified time, type, and uid.
+	const uint64_t mt = FileAccess::get_modified_time(p_path);
+	const ResourceUID::ID old_uid = p_file->uid;
+
+	if (force_detect || first_scan || mt != p_file->modified_time) {
+		if (!first_scan || !(p_file->status & EditorFileInfo::IS_SCRIPT)) {
+			_type_analysis(p_file, ResourceLoader::get_resource_type(p_path));
+		}
+		if ((p_file->status & EditorFileInfo::AS_RESOURCE)) {
+			p_file->uid = ResourceLoader::get_resource_uid(p_path);
+		}
+	}
+
+	if (mt == p_file->modified_time) {
+		if (!force_detect && !first_scan) {
+			return; // When the file timestamp accuracy is high enough.
+		}
+
+		if (!(p_file->status & EditorFileInfo::TYPE_CHANGED)) {
+			if (!(p_file->status & EditorFileInfo::AS_RESOURCE)) {
+				return; // No uid, no internal files.
+			}
+
+			if (old_uid == p_file->uid) {
+				// The UID is not changed, but prevents invalidation of the UID cache on editor startup.
+				if (first_scan && !(p_file->status & EditorFileInfo::IS_SCRIPT)) {
+					_create_actions_from_uid_change(p_file, p_path, old_uid);
+					_create_action(nullptr, p_file, p_path, ItemAction::ACTION_FILE_UPDATE);
+				}
+				return;
+			}
+		}
+	}
+
+	p_file->modified_time = mt;
+	p_file->import_modified_time = 0;
+	if (!first_scan || !(p_file->status & EditorFileInfo::IS_SCRIPT)) {
+		_create_actions_from_uid_change(p_file, p_path, old_uid);
+	}
+	_create_action(nullptr, p_file, p_path, ItemAction::ACTION_FILE_UPDATE, ItemAction::STEP_CLEAR_STATUS);
+
+	p_file->resource_script_class = ResourceLoader::get_resource_script_class(p_path);
+
+	if ((p_file->status | old_status) & EditorFileInfo::IS_PACKEDSCENE) {
+		_scene_info_update(p_file, p_path);
+	}
+	if ((p_file->status | old_status) & EditorFileInfo::IS_SCRIPT) {
+		const ScriptClassInfo &sci = _get_global_script_class(p_file->type, p_path);
+		_script_class_info_update(p_file, p_path, &sci);
+	}
+
+	p_file->import_group_file = ResourceLoader::get_import_group_file(p_path);
+	p_file->deps = _get_dependencies(p_path);
+	p_file->import_valid = !(p_file->status & EditorFileInfo::AS_RESOURCE) || ResourceLoader::is_import_valid(p_path);
+
+	// Update preview
+	EditorResourcePreview::get_singleton()->check_for_invalidation(p_path);
+}
+
+int EditorFileSystem::_dir_info_remove(EditorFileSystemDirectory *p_dir, const String &p_path, const int p_idx) {
+	if (p_idx != -1) {
+		p_dir->parent->subdirs.remove_at(p_idx);
+		_create_action(p_dir, nullptr, p_path, ItemAction::ACTION_DIR_REMOVE, ItemAction::STEP_DIR_REMOVE, ResourceUID::INVALID_ID);
+	}
+
+	int count = p_dir->files.size();
+
+	for (int i = 0; i < p_dir->files.size(); i++) {
+		EditorFileInfo *fi = p_dir->files[i];
+		_file_info_remove(fi, p_path.path_join(fi->file), -1);
+	}
+
+	for (int i = 0; i < p_dir->subdirs.size(); i++) {
+		EditorFileSystemDirectory *sub_dir = p_dir->subdirs[i];
+		count += _dir_info_remove(sub_dir, p_path.path_join(sub_dir->name), -1);
+	}
+
+	return count;
 }
 
 void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, EditorFileSystemDirectory *p_dir, ScanProgress &p_progress, HashSet<String> *r_processed_files) {
@@ -1244,220 +2097,40 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 			p_progress.increment();
 			continue; // Invalid.
 		}
-
-		String path = p_scan_dir->full_path.path_join(scan_file);
-
-		EditorFileInfo *fi = memnew(EditorFileInfo);
-		fi->file = scan_file;
-		p_dir->files.push_back(fi);
-
-		if (r_processed_files) {
-			r_processed_files->insert(path);
-		}
-
-		FileCache *fc = file_cache.getptr(path);
-		uint64_t mt = FileAccess::get_modified_time(path);
-
-		const bool is_imported = scan_file.validate_extension(import_extensions);
-
-		if (is_imported) {
-			//is imported
-			uint64_t import_mt = FileAccess::get_modified_time(path + ".import");
-
-			if (fc) {
-				fi->type = fc->type;
-				fi->resource_script_class = fc->resource_script_class;
-				fi->uid = fc->uid;
-				fi->deps = fc->deps;
-				fi->modified_time = mt;
-				fi->import_modified_time = import_mt;
-				fi->import_md5 = fc->import_md5;
-				fi->import_dest_paths = fc->import_dest_paths;
-				fi->import_valid = fc->import_valid;
-				fi->import_group_file = fc->import_group_file;
-				fi->class_info = fc->class_info;
-
-				// Ensures backward compatibility when the project is loaded for the first time with the added import_md5
-				// and import_dest_paths properties in the file cache.
-				if (fc->import_md5.is_empty()) {
-					fi->import_md5 = FileAccess::get_md5(path + ".import");
-					fi->import_dest_paths = _get_import_dest_paths(path);
-				}
-
-				// The method _is_test_for_reimport_needed checks if the files were modified and ensures that
-				// all the destination files still exist without reading the .import file.
-				// If something is different, we will queue a test for reimportation that will check
-				// the md5 of all files and import settings and, if necessary, execute a reimportation.
-				if (_is_test_for_reimport_needed(path, fc->modification_time, mt, fc->import_modification_time, import_mt, fi->import_dest_paths) ||
-						(revalidate_import_files && !ResourceFormatImporter::get_singleton()->are_import_settings_valid(path))) {
-					ItemAction ia;
-					ia.action = ItemAction::ACTION_FILE_TEST_REIMPORT;
-					ia.dir = p_dir;
-					ia.file = fi->file;
-					scan_actions.push_back(ia);
-				}
-
-				if (fc->type.is_empty()) {
-					fi->type = ResourceLoader::get_resource_type(path);
-					fi->resource_script_class = ResourceLoader::get_resource_script_class(path);
-					fi->import_group_file = ResourceLoader::get_import_group_file(path);
-					//there is also the chance that file type changed due to reimport, must probably check this somehow here (or kind of note it for next time in another file?)
-					//note: I think this should not happen any longer..
-				}
-
-				if (fc->uid == ResourceUID::INVALID_ID) {
-					// imported files should always have a UID, so attempt to fetch it.
-					fi->uid = ResourceLoader::get_resource_uid(path);
-				}
-
-			} else {
-				// Using get_resource_import_info() to prevent calling 3 times ResourceFormatImporter::_get_path_and_type.
-				ResourceFormatImporter::get_singleton()->get_resource_import_info(path, fi->type, fi->uid, fi->import_group_file);
-				fi->class_info = _get_global_script_class(fi->type, path);
-				fi->modified_time = 0;
-				fi->import_modified_time = 0;
-				fi->import_md5 = FileAccess::get_md5(path + ".import");
-				fi->import_dest_paths = Vector<String>();
-				fi->import_valid = (fi->type == "TextFile" || fi->type == "OtherFile") ? true : ResourceLoader::is_import_valid(path);
-
-				ItemAction ia;
-				ia.action = ItemAction::ACTION_FILE_TEST_REIMPORT;
-				ia.dir = p_dir;
-				ia.file = fi->file;
-				scan_actions.push_back(ia);
-			}
-		} else {
-			if (fc && fc->modification_time == mt) {
-				//not imported, so just update type if changed
-				fi->type = fc->type;
-				fi->resource_script_class = fc->resource_script_class;
-				fi->uid = fc->uid;
-				fi->modified_time = mt;
-				fi->deps = fc->deps;
-				fi->import_modified_time = 0;
-				fi->import_md5 = "";
-				fi->import_dest_paths = Vector<String>();
-				fi->import_valid = true;
-				fi->class_info = fc->class_info;
-
-				if (first_scan && ClassDB::is_parent_class(fi->type, SNAME("Script"))) {
-					bool update_script = false;
-					String old_class_name = fi->class_info.name;
-					fi->class_info = _get_global_script_class(fi->type, path);
-					if (old_class_name != fi->class_info.name) {
-						update_script = true;
-					} else if (!fi->class_info.name.is_empty() && (!ScriptServer::is_global_class(fi->class_info.name) || ScriptServer::get_global_class_path(fi->class_info.name) != path)) {
-						// This script has a class name but is not in the global class names or the path of the class has changed.
-						update_script = true;
-					}
-					if (update_script) {
-						_queue_update_script_class(path, ScriptClassInfoUpdate::from_file_info(fi));
-					}
-				}
-			} else {
-				// New or modified time.
-				fi->type = ResourceLoader::get_resource_type(path);
-				fi->resource_script_class = ResourceLoader::get_resource_script_class(path);
-				if (fi->type.is_empty()) {
-					if (scan_file.validate_extension(textfile_extensions)) {
-						fi->type = "TextFile";
-					} else if (scan_file.validate_extension(other_file_extensions)) {
-						fi->type = "OtherFile";
-					}
-				}
-				fi->uid = ResourceLoader::get_resource_uid(path);
-				fi->class_info = _get_global_script_class(fi->type, path);
-				fi->deps = _get_dependencies(path);
-				fi->modified_time = mt;
-				fi->import_modified_time = 0;
-				fi->import_md5 = "";
-				fi->import_dest_paths = Vector<String>();
-				fi->import_valid = true;
-
-				// Files in dep_update_list are forced for rescan to update dependencies. They don't need other updates.
-				if (!dep_update_list.has(path)) {
-					if (ClassDB::is_parent_class(fi->type, SNAME("Script"))) {
-						_queue_update_script_class(path, ScriptClassInfoUpdate::from_file_info(fi));
-					}
-					if (fi->type == SNAME("PackedScene")) {
-						_queue_update_scene_groups(path);
-					}
-				}
-			}
-
-			if (ResourceLoader::should_create_uid_file(path)) {
-				// Create a UID file and new UID, if it's invalid.
-				Ref<FileAccess> f = FileAccess::open(path + ".uid", FileAccess::WRITE);
-				if (f.is_valid()) {
-					if (fi->uid == ResourceUID::INVALID_ID) {
-						fi->uid = ResourceUID::get_singleton()->create_id_for_path(path);
-					} else {
-						WARN_PRINT(vformat("Missing .uid file for path \"%s\". The file was re-created from cache.", path));
-					}
-					f->store_line(ResourceUID::get_singleton()->id_to_text(fi->uid));
-				}
-			}
-		}
-
-		if (fi->uid != ResourceUID::INVALID_ID) {
-			if (ResourceUID::get_singleton()->has_id(fi->uid)) {
-				// Restrict UID dupe warning to first-scan since we know there are no file moves going on yet.
-				if (first_scan) {
-					// Warn if we detect files with duplicate UIDs.
-					const String other_path = ResourceUID::get_singleton()->get_id_path(fi->uid);
-					if (other_path != path) {
-						WARN_PRINT(vformat("UID duplicate detected between %s and %s.", path, other_path));
-					}
-				}
-				ResourceUID::get_singleton()->set_id(fi->uid, path);
-			} else {
-				ResourceUID::get_singleton()->add_id(fi->uid, path);
-			}
-		}
-
+		_file_info_add(p_dir, p_scan_dir->full_path, scan_file, false);
 		p_progress.increment();
 	}
 }
 
-void EditorFileSystem::_process_removed_files(const HashSet<String> &p_processed_files) {
-	for (const KeyValue<String, EditorFileSystem::FileCache> &kv : file_cache) {
-		if (!p_processed_files.has(kv.key)) {
-			if (ClassDB::is_parent_class(kv.value.type, SNAME("Script")) || ClassDB::is_parent_class(kv.value.type, SNAME("PackedScene"))) {
-				// A script has been removed from disk since the last startup. The documentation needs to be updated.
-				// There's no need to add the path in update_script_paths since that is exclusively for updating global class names,
-				// which is handled in _first_scan_filesystem before the full scan to ensure plugins and autoloads can be created.
-				MutexLock update_script_lock(update_script_mutex);
-				update_script_paths_documentation.insert(kv.key);
-			}
-		}
-	}
-}
-
 void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanProgress &p_progress, bool p_recursive) {
-	uint64_t current_mtime = FileAccess::get_modified_time(p_dir->get_path());
+	p_recursive |= p_dir->recursive;
+	p_dir->dirty = false;
+	p_dir->recursive = false;
 
 	bool updated_dir = false;
-	String cd = p_dir->get_path();
+	const String cd = p_dir->get_path();
 	int diff_nb_files = 0;
 
-	if (current_mtime != p_dir->modified_time || using_fat32_or_exfat) {
+	const uint64_t current_mtime = FileAccess::get_modified_time(cd);
+
+	if (scanning || force_detect || extensions_changed || current_mtime != p_dir->modified_time) {
 		updated_dir = true;
 		p_dir->modified_time = current_mtime;
-		//ooooops, dir changed, see what's going on
+		// Ooooops, dir changed, see what's going on.
 
-		//first mark everything as verified
+		// First mark everything as not verified.
 
 		for (int i = 0; i < p_dir->files.size(); i++) {
 			p_dir->files[i]->verified = false;
 		}
 
 		for (int i = 0; i < p_dir->subdirs.size(); i++) {
-			p_dir->get_subdir(i)->verified = false;
+			p_dir->subdirs[i]->verified = false;
 		}
 
 		diff_nb_files -= p_dir->files.size();
 
-		//then scan files and directories and check what's different
+		// Then scan files and directories and check what's different.
 
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 
@@ -1482,83 +2155,65 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanPr
 
 				int idx = p_dir->find_dir_index(f);
 				if (idx == -1) {
-					String dir_path = cd.path_join(f);
+					const String dir_path = cd.path_join(f);
 					if (_should_skip_directory(dir_path)) {
 						continue;
 					}
-
-					ScannedDirectory sd;
-					sd.name = f;
-					sd.full_path = dir_path;
 
 					EditorFileSystemDirectory *efd = memnew(EditorFileSystemDirectory);
 					efd->parent = p_dir;
 					efd->name = f;
 
-					Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-					d->change_dir(dir_path);
-					int nb_files_dir = _scan_new_dir(&sd, d);
-					p_progress.hi += nb_files_dir;
-					diff_nb_files += nb_files_dir;
-					_process_file_system(&sd, efd, p_progress, nullptr);
+					for (idx = 0; idx < p_dir->subdirs.size(); idx++) {
+						if (efd->name.filenocasecmp_to(p_dir->subdirs[idx]->name) < 0) {
+							break;
+						}
+					}
+					if (idx == p_dir->subdirs.size()) {
+						p_dir->subdirs.push_back(efd);
+					} else {
+						p_dir->subdirs.insert(idx, efd);
+					}
 
-					ItemAction ia;
-					ia.action = ItemAction::ACTION_DIR_ADD;
-					ia.dir = p_dir;
-					ia.file = f;
-					ia.new_dir = efd;
-					scan_actions.push_back(ia);
+					if (first_scan) {
+						Vector<String> dirs = dir_path.substr(6).split("/");
+						ScannedDirectory *dir = first_scan_root_dir;
+						for (String &D : dirs) {
+							for (ScannedDirectory *SD : dir->subdirs) {
+								if (SD->name == D) {
+									dir = SD;
+									break;
+								}
+							}
+						}
+						p_progress.hi += dir->count;
+						diff_nb_files += dir->count;
+						_process_file_system(dir, efd, p_progress, nullptr);
+					} else {
+						ScannedDirectory sd;
+						sd.name = f;
+						sd.full_path = dir_path;
+						Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+						d->change_dir(dir_path);
+						int nb_files_dir = _scan_new_dir(&sd, d);
+						p_progress.hi += nb_files_dir;
+						diff_nb_files += nb_files_dir;
+						_process_file_system(&sd, efd, p_progress, nullptr);
+					}
+
+					_create_action(p_dir, nullptr, dir_path, ItemAction::ACTION_DIR_ADD);
 				} else {
 					p_dir->subdirs[idx]->verified = true;
 				}
-
 			} else {
 				if (!f.validate_extension(valid_extensions)) {
 					continue; // Invalid.
 				}
 
 				int idx = p_dir->find_file_index(f);
-
 				if (idx == -1) {
-					//never seen this file, add actition to add it
-					EditorFileInfo *fi = memnew(EditorFileInfo);
-					fi->file = f;
-
-					String path = cd.path_join(fi->file);
-					fi->modified_time = FileAccess::get_modified_time(path);
-					fi->import_modified_time = 0;
-					fi->import_md5 = "";
-					fi->import_dest_paths = Vector<String>();
-					fi->type = ResourceLoader::get_resource_type(path);
-					fi->resource_script_class = ResourceLoader::get_resource_script_class(path);
-					if (fi->type.is_empty()) {
-						if (f.validate_extension(textfile_extensions)) {
-							fi->type = "TextFile";
-						} else if (f.validate_extension(other_file_extensions)) {
-							fi->type = "OtherFile";
-						}
-					}
-					fi->class_info = _get_global_script_class(fi->type, path);
-					fi->import_valid = (fi->type == "TextFile" || fi->type == "OtherFile") ? true : ResourceLoader::is_import_valid(path);
-					fi->import_group_file = ResourceLoader::get_import_group_file(path);
-
-					{
-						ItemAction ia;
-						ia.action = ItemAction::ACTION_FILE_ADD;
-						ia.dir = p_dir;
-						ia.file = f;
-						ia.new_file = fi;
-						scan_actions.push_back(ia);
-					}
-
-					if (f.validate_extension(import_extensions)) {
-						// If it can be imported, and it was added, it needs to be reimported.
-						ItemAction ia;
-						ia.action = ItemAction::ACTION_FILE_TEST_REIMPORT;
-						ia.dir = p_dir;
-						ia.file = f;
-						scan_actions.push_back(ia);
-					}
+					// Never seen this file, add actition to add it.
+					_file_info_add(p_dir, cd, f, true);
 					diff_nb_files++;
 				} else {
 					p_dir->files[idx]->verified = true;
@@ -1569,102 +2224,97 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanPr
 		da->list_dir_end();
 	}
 
-	for (int i = 0; i < p_dir->files.size(); i++) {
-		if (updated_dir && !p_dir->files[i]->verified) {
-			//this file was removed, add action to remove it
-			ItemAction ia;
-			ia.action = ItemAction::ACTION_FILE_REMOVE;
-			ia.dir = p_dir;
-			ia.file = p_dir->files[i]->file;
-			scan_actions.push_back(ia);
+	for (int i = p_dir->files.size() - 1; i >= 0; i--) {
+		EditorFileInfo *fi = p_dir->files[i];
+		const String path = cd.path_join(fi->file);
+
+		if (updated_dir && !fi->verified) {
+			// This file was removed, add action to remove it.
+			_file_info_remove(fi, path, i);
 			diff_nb_files--;
 			continue;
 		}
-
-		String path = cd.path_join(p_dir->files[i]->file);
-		if (p_dir->files[i]->file.validate_extension(import_extensions)) {
-			// Check here if file must be imported or not.
-			// Same logic as in _process_file_system, the last modifications dates
-			// needs to be trusted to prevent reading all the .import files and the md5
-			// each time the user switch back to Godot.
-			uint64_t mt = FileAccess::get_modified_time(path);
-			uint64_t import_mt = FileAccess::get_modified_time(path + ".import");
-			if (_is_test_for_reimport_needed(path, p_dir->files[i]->modified_time, mt, p_dir->files[i]->import_modified_time, import_mt, p_dir->files[i]->import_dest_paths)) {
-				ItemAction ia;
-				ia.action = ItemAction::ACTION_FILE_TEST_REIMPORT;
-				ia.dir = p_dir;
-				ia.file = p_dir->files[i]->file;
-				scan_actions.push_back(ia);
-			}
-		} else {
-			uint64_t mt = FileAccess::get_modified_time(path);
-
-			if (mt != p_dir->files[i]->modified_time) {
-				p_dir->files[i]->modified_time = mt; //save new time, but test for reload
-
-				ItemAction ia;
-				ia.action = ItemAction::ACTION_FILE_RELOAD;
-				ia.dir = p_dir;
-				ia.file = p_dir->files[i]->file;
-				scan_actions.push_back(ia);
-			}
+		if (fi->status & EditorFileInfo::FILE_ADD) {
+			continue; // Newly added.
 		}
+		_file_info_update(fi, path);
 
 		p_progress.increment();
 	}
 
-	for (int i = 0; i < p_dir->subdirs.size(); i++) {
-		if ((updated_dir && !p_dir->subdirs[i]->verified) || _should_skip_directory(p_dir->subdirs[i]->get_path())) {
+	for (int i = p_dir->subdirs.size() - 1; i >= 0; i--) {
+		EditorFileSystemDirectory *sub_dir = p_dir->subdirs[i];
+		const String sub_dir_path = cd.path_join(sub_dir->name);
+		if ((updated_dir && !sub_dir->verified) || _should_skip_directory(sub_dir_path)) {
 			// Add all the files of the folder to be sure _update_scan_actions process the removed files
 			// for global class names.
-			diff_nb_files += _insert_actions_delete_files_directory(p_dir->subdirs[i]);
-
-			//this directory was removed or ignored, add action to remove it
-			ItemAction ia;
-			ia.action = ItemAction::ACTION_DIR_REMOVE;
-			ia.dir = p_dir->subdirs[i];
-			scan_actions.push_back(ia);
+			diff_nb_files -= _dir_info_remove(sub_dir, sub_dir_path, i);
 			continue;
 		}
-		if (p_recursive) {
-			_scan_fs_changes(p_dir->get_subdir(i), p_progress);
+		if (p_recursive || sub_dir->dirty) {
+			_scan_fs_changes(sub_dir, p_progress, p_recursive);
 		}
 	}
 
 	nb_files_total = MAX(nb_files_total + diff_nb_files, 0);
 }
 
+void EditorFileSystem::scan_fs_changes(ScanProgress &p_progress) {
+	List<EditorFileSystemDirectory *>::Element *E = dirty_directories.front();
+	ERR_FAIL_NULL(E);
+	while (E) {
+		EditorFileSystemDirectory *efsd = E->get();
+		E = E->next();
+		dirty_directories.pop_front();
+		if (!efsd->dirty) {
+			continue;
+		}
+		_scan_fs_changes(efsd, p_progress, efsd->recursive);
+	}
+	_update_scan_uid_actions();
+}
+
+void EditorFileSystem::_pending_scan_fs_changes(EditorFileSystemDirectory *p_dir, bool p_recursive) {
+	if (full_scan_pending) {
+		return;
+	}
+	set_process(true);
+	if (p_dir == filesystem && p_recursive) {
+		full_scan_pending = true;
+		return;
+	}
+	p_dir->dirty = true;
+	p_dir->recursive |= p_recursive;
+	dirty_directories.push_back(p_dir);
+	scan_changes_pending = true;
+}
+
+void EditorFileSystem::pending_scan_fs_changes(const String &p_dir, bool p_recursive) {
+	if (full_scan_pending) {
+		return;
+	}
+	EditorFileSystemDirectory *efd = get_filesystem_path(p_dir);
+	ERR_FAIL_NULL(efd);
+	_pending_scan_fs_changes(efd, p_recursive);
+}
+
 void EditorFileSystem::_delete_internal_files(const String &p_file) {
+	if (FileAccess::exists(p_file)) {
+		return; // It is just ignored because it is not supported, so there is no need to delete its internal files.
+	}
 	if (FileAccess::exists(p_file + ".import")) {
 		List<String> paths;
 		ResourceFormatImporter::get_singleton()->get_internal_resource_path_list(p_file, &paths);
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		for (const String &E : paths) {
 			da->remove(E);
+			da->remove(E.get_basename() + ".md5");
 		}
 		da->remove(p_file + ".import");
 	}
 	if (FileAccess::exists(p_file + ".uid")) {
 		DirAccess::remove_absolute(p_file + ".uid");
 	}
-}
-
-int EditorFileSystem::_insert_actions_delete_files_directory(EditorFileSystemDirectory *p_dir) {
-	int nb_files = 0;
-	for (EditorFileInfo *fi : p_dir->files) {
-		ItemAction ia;
-		ia.action = ItemAction::ACTION_FILE_REMOVE;
-		ia.dir = p_dir;
-		ia.file = fi->file;
-		scan_actions.push_back(ia);
-		nb_files++;
-	}
-
-	for (EditorFileSystemDirectory *sub_dir : p_dir->subdirs) {
-		nb_files += _insert_actions_delete_files_directory(sub_dir);
-	}
-
-	return nb_files;
 }
 
 void EditorFileSystem::_thread_func_sources(void *_userdata) {
@@ -1674,7 +2324,7 @@ void EditorFileSystem::_thread_func_sources(void *_userdata) {
 		ScanProgress sp;
 		sp.progress = &pr;
 		sp.hi = efs->nb_files_total;
-		efs->_scan_fs_changes(efs->filesystem, sp);
+		efs->scan_fs_changes(sp);
 	}
 	efs->scanning_changes_done.set();
 }
@@ -1686,6 +2336,7 @@ bool EditorFileSystem::_remove_invalid_global_class_names(const HashSet<String> 
 	for (const StringName &class_name : global_classes) {
 		if (!p_existing_class_names.has(class_name)) {
 			ScriptServer::remove_global_class(class_name);
+			EditorHelp::remove_doc(class_name);
 			must_save = true;
 		}
 	}
@@ -1710,15 +2361,27 @@ String EditorFileSystem::_get_file_by_class_name(EditorFileSystemDirectory *p_di
 	return "";
 }
 
-void EditorFileSystem::scan_changes() {
+void EditorFileSystem::_scan_dirs_changes(bool p_full_scan) {
+	ERR_FAIL_NULL(filesystem);
+
 	if (first_scan || // Prevent a premature changes scan from inhibiting the first full scan
-			scanning || scanning_changes || thread.is_started()) {
-		scan_changes_pending = true;
-		set_process(true);
+			scanning || scanning_changes || thread.is_started() || updating_scan_actions) {
+		if (p_full_scan) {
+			full_scan_pending = true;
+		}
+		if (updating_scan_actions) {
+			set_process(true);
+		}
 		return;
 	}
 
-	_update_extensions();
+	if (p_full_scan) {
+		dirty_directories.clear();
+		filesystem->dirty = true;
+		filesystem->recursive = true;
+		dirty_directories.push_back(filesystem);
+	}
+
 	sources_changed.clear();
 	scanning_changes = true;
 	scanning_changes_done.clear();
@@ -1730,11 +2393,12 @@ void EditorFileSystem::scan_changes() {
 			sp.progress = &pr;
 			sp.hi = nb_files_total;
 			scan_total = 0;
-			_scan_fs_changes(filesystem, sp);
+			scan_fs_changes(sp);
 			if (_update_scan_actions()) {
 				emit_signal(SNAME("filesystem_changed"));
 			}
 		}
+		extensions_changed = false;
 		scanning_changes = false;
 		scanning_changes_done.set();
 		emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
@@ -1748,12 +2412,16 @@ void EditorFileSystem::scan_changes() {
 	}
 }
 
+void EditorFileSystem::scan_changes() {
+	_scan_dirs_changes();
+}
+
 void EditorFileSystem::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			Thread &active_thread = thread.is_started() ? thread : thread_sources;
 			if (use_threads && active_thread.is_started()) {
-				while (scanning) {
+				while (!scanning_done.is_set()) {
 					OS::get_singleton()->delay_usec(1000);
 				}
 				active_thread.wait_to_finish();
@@ -1761,14 +2429,8 @@ void EditorFileSystem::_notification(int p_what) {
 				set_process(false);
 			}
 
-			if (filesystem) {
-				memdelete(filesystem);
-			}
-			if (new_filesystem) {
-				memdelete(new_filesystem);
-			}
-			filesystem = nullptr;
-			new_filesystem = nullptr;
+			dirty_directories.clear();
+			scan_changes_pending = false;
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -1786,39 +2448,32 @@ void EditorFileSystem::_notification(int p_what) {
 
 				prevent_recursive_process_hack = true;
 
-				bool done_importing = false;
-
-				if (scanning_changes) {
-					if (scanning_changes_done.is_set()) {
-						set_process(false);
-
-						if (thread_sources.is_started()) {
-							thread_sources.wait_to_finish();
-						}
-						bool changed = _update_scan_actions();
-						// Set first_scan to false before the signals so the function doing_first_scan can return false
-						// in editor_node to start the export if needed.
-						first_scan = false;
-						scanning_changes = false;
-						done_importing = true;
-						ResourceImporter::load_on_startup = nullptr;
-						if (changed) {
-							emit_signal(SNAME("filesystem_changed"));
-						}
-						emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
-					}
-				} else if (!scanning && thread.is_started()) {
+				if (scanning_changes && scanning_changes_done.is_set()) {
 					set_process(false);
 
-					if (filesystem) {
-						memdelete(filesystem);
+					if (thread_sources.is_started()) {
+						thread_sources.wait_to_finish();
 					}
-					filesystem = new_filesystem;
-					new_filesystem = nullptr;
+					bool changed = _update_scan_actions();
+					// Set first_scan to false before the signals so the function doing_first_scan can return false
+					// in editor_node to start the export if needed.
+					first_scan = false;
+					extensions_changed = false;
+					scanning_changes = false;
+					ResourceImporter::load_on_startup = nullptr;
+					if (changed) {
+						emit_signal(SNAME("filesystem_changed"));
+					}
+					emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
+				} else if (scanning && scanning_done.is_set()) {
+					set_process(false);
+
+					dirty_directories.clear();
+					scan_changes_pending = false;
 					thread.wait_to_finish();
 					_update_scan_actions();
-					// Update all icons so they are loaded for the FileSystemDock.
-					_update_files_icon_path();
+					extensions_changed = false;
+					scanning = false;
 					// Set first_scan to false before the signals so the function doing_first_scan can return false
 					// in editor_node to start the export if needed.
 					first_scan = false;
@@ -1827,12 +2482,38 @@ void EditorFileSystem::_notification(int p_what) {
 					emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
 				}
 
-				if (done_importing && scan_changes_pending) {
-					scan_changes_pending = false;
-					scan_changes();
-				}
-
 				prevent_recursive_process_hack = false;
+			}
+			if (is_scanning()) {
+				break;
+			}
+			if (!first_scan && need_update_extensions) {
+				_reload_loader_or_saver();
+				update_extensions();
+				break;
+			}
+			// Another scan needs to be triggered during the scan.
+			if (scan_changes_pending || full_scan_pending) {
+				set_process(false);
+				scan_changes_pending = false;
+				bool full_scan = full_scan_pending;
+				full_scan_pending = false;
+				_scan_dirs_changes(full_scan);
+				break;
+			}
+			// The calls to _update_scan_actions() triggered by update_files() are merged into one.
+			// This is usually triggered when saving files.
+			if (update_actions_queued && !updating_scan_actions) {
+				updating_scan_actions = true;
+				set_process(false);
+				_update_scan_uid_actions();
+				if (!first_scan && need_update_extensions) {
+					update_extensions();
+				}
+				if (_update_scan_actions()) {
+					emit_signal(SNAME("filesystem_changed"));
+				}
+				updating_scan_actions = false;
 			}
 		} break;
 	}
@@ -1889,7 +2570,7 @@ void EditorFileSystem::_save_filesystem_cache(EditorFileSystemDirectory *p_dir, 
 bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirectory **r_d, int &r_file_pos) const {
 	//todo make faster
 
-	if (!filesystem || scanning) {
+	if (!filesystem || !scanning_done.is_set()) {
 		return false;
 	}
 
@@ -1997,7 +2678,7 @@ String EditorFileSystem::get_file_type(const String &p_file) const {
 }
 
 EditorFileSystemDirectory *EditorFileSystem::find_file(const String &p_file, int *r_index) const {
-	if (!filesystem || scanning) {
+	if (!filesystem || !scanning_done.is_set()) {
 		return nullptr;
 	}
 
@@ -2025,7 +2706,7 @@ ResourceUID::ID EditorFileSystem::get_file_uid(const String &p_path) const {
 }
 
 EditorFileSystemDirectory *EditorFileSystem::get_filesystem_path(const String &p_path) {
-	if (!filesystem || scanning) {
+	if (!filesystem || !scanning_done.is_set()) {
 		return nullptr;
 	}
 
@@ -2072,16 +2753,6 @@ EditorFileSystemDirectory *EditorFileSystem::get_filesystem_path(const String &p
 	return fs;
 }
 
-void EditorFileSystem::_save_late_updated_files() {
-	//files that already existed, and were modified, need re-scanning for dependencies upon project restart. This is done via saving this special file
-	String fscache = EditorPaths::get_singleton()->get_project_settings_dir().path_join("filesystem_update4");
-	Ref<FileAccess> f = FileAccess::open(fscache, FileAccess::WRITE);
-	ERR_FAIL_COND_MSG(f.is_null(), "Cannot create file '" + fscache + "'. Check user write permissions.");
-	for (const String &E : late_update_files) {
-		f->store_line(E);
-	}
-}
-
 Vector<String> EditorFileSystem::_get_dependencies(const String &p_path) {
 	// Avoid error spam on first opening of a not yet imported project by treating the following situation
 	// as a benign one, not letting the file open error happen: the resource is of an importable type but
@@ -2107,107 +2778,33 @@ Vector<String> EditorFileSystem::_get_dependencies(const String &p_path) {
 EditorFileSystem::ScriptClassInfo EditorFileSystem::_get_global_script_class(const String &p_type, const String &p_path) const {
 	ScriptClassInfo info;
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-		if (ScriptServer::get_language(i)->handles_global_class_type(p_type)) {
-			info.name = ScriptServer::get_language(i)->get_global_class_name(p_path, &info.extends, &info.icon_path, &info.is_abstract, &info.is_tool);
+		ScriptLanguage *lang = ScriptServer::get_language(i);
+		if (lang->handles_global_class_type(p_type)) {
+			info.lang = lang->get_name();
+			info.name = lang->get_global_class_name(p_path, &info.extends, &info.icon_path, &info.is_abstract, &info.is_tool);
 			break;
 		}
 	}
 	return info;
 }
 
-void EditorFileSystem::_update_file_icon_path(EditorFileInfo *file_info) {
-	String icon_path;
-	if (file_info->resource_script_class != StringName()) {
-		icon_path = EditorNode::get_editor_data().script_class_get_icon_path(file_info->resource_script_class);
-	} else if (file_info->class_info.icon_path.is_empty() && !file_info->deps.is_empty()) {
-		const String &script_dep = file_info->deps[0]; // Assuming the first dependency is a script.
-		const String &script_path = script_dep.contains("::") ? script_dep.get_slice("::", 2) : script_dep;
-		if (!script_path.is_empty()) {
-			String *cached = file_icon_cache.getptr(script_path);
-			if (cached) {
-				icon_path = *cached;
-			} else {
-				if (ClassDB::is_parent_class(ResourceLoader::get_resource_type(script_path), SNAME("Script"))) {
-					int script_file;
-					EditorFileSystemDirectory *efsd = find_file(script_path, &script_file);
-					if (efsd) {
-						icon_path = efsd->files[script_file]->class_info.icon_path;
-					}
-				}
-				file_icon_cache.insert(script_path, icon_path);
-			}
-		}
-	}
-
-	if (icon_path.is_empty() && !file_info->type.is_empty()) {
-		Ref<Texture2D> icon = EditorNode::get_singleton()->get_class_icon(file_info->type);
-		if (icon.is_valid()) {
-			icon_path = icon->get_path();
-		}
-	}
-
-	file_info->class_info.icon_path = icon_path;
-}
-
-void EditorFileSystem::_update_files_icon_path(EditorFileSystemDirectory *edp) {
-	if (!edp) {
-		edp = filesystem;
-		file_icon_cache.clear();
-	}
-	for (EditorFileSystemDirectory *sub_dir : edp->subdirs) {
-		_update_files_icon_path(sub_dir);
-	}
-	for (EditorFileInfo *fi : edp->files) {
-		_update_file_icon_path(fi);
-	}
-}
-
 void EditorFileSystem::_update_script_classes() {
-	if (update_script_paths.is_empty()) {
+	if (!script_classes_updated) {
 		// Ensure the global class file is always present; it's essential for exports to work.
 		if (!FileAccess::exists(ProjectSettings::get_singleton()->get_global_class_list_path())) {
 			EditorNode::get_editor_data().script_class_save_global_classes();
 		}
 		return;
 	}
-
-	{
-		MutexLock update_script_lock(update_script_mutex);
-
-		EditorProgress *ep = nullptr;
-		if (update_script_paths.size() > 1) {
-			if (MessageQueue::get_singleton()->is_flushing()) {
-				// Use background progress when message queue is flushing.
-				ep = memnew(EditorProgress("update_scripts_classes", TTR("Registering global classes..."), update_script_paths.size(), false, true));
-			} else {
-				ep = memnew(EditorProgress("update_scripts_classes", TTR("Registering global classes..."), update_script_paths.size()));
-			}
-		}
-
-		int step_count = 0;
-		for (const KeyValue<String, ScriptClassInfoUpdate> &E : update_script_paths) {
-			_register_global_class_script(E.key, E.key, E.value);
-			if (ep) {
-				ep->step(E.value.name, step_count++, false);
-			}
-		}
-
-		memdelete_notnull(ep);
-
-		update_script_paths.clear();
-	}
-
+	script_classes_updated = false;
 	EditorNode::get_editor_data().script_class_save_global_classes();
-
 	emit_signal("script_classes_updated");
+
+	// TODO: The scripts have been modified, so a rescan may be necessary.
 
 	// Rescan custom loaders and savers.
 	// Doing the following here because the `filesystem_changed` signal fires multiple times and isn't always followed by script classes update.
 	// So I thought it's better to do this when script classes really get updated
-	ResourceLoader::remove_custom_loaders();
-	ResourceLoader::add_custom_loaders();
-	ResourceSaver::remove_custom_savers();
-	ResourceSaver::add_custom_savers();
 }
 
 void EditorFileSystem::_update_script_documentation() {
@@ -2238,23 +2835,26 @@ void EditorFileSystem::_update_script_documentation() {
 			continue;
 		}
 
-		if (path.ends_with(".tscn")) {
+		if (efd->files[index]->status & EditorFileInfo::IS_PACKEDSCENE) {
 			Ref<PackedScene> packed_scene = ResourceLoader::load(path);
-			if (packed_scene.is_valid()) {
-				Ref<SceneState> state = packed_scene->get_state();
-				if (state.is_valid()) {
-					Vector<Ref<Resource>> sub_resources = state->get_sub_resources();
-					for (Ref<Resource> sub_resource : sub_resources) {
-						Ref<Script> scr = sub_resource;
-						if (scr.is_valid()) {
-							for (const DocData::ClassDoc &cd : scr->get_documentation()) {
-								EditorHelp::add_doc(cd);
-								if (!first_scan) {
-									// Update the documentation in the Script Editor if it is open.
-									ScriptEditor::get_singleton()->update_doc(cd.name);
-								}
-							}
-						}
+			if (packed_scene.is_null()) {
+				continue;
+			}
+			Ref<SceneState> state = packed_scene->get_state();
+			if (state.is_null()) {
+				continue;
+			}
+			Vector<Ref<Resource>> sub_resources = state->get_sub_resources();
+			for (Ref<Resource> &sub_resource : sub_resources) {
+				Ref<Script> scr = sub_resource;
+				if (scr.is_null()) {
+					continue;
+				}
+				for (const DocData::ClassDoc &cd : scr->get_documentation()) {
+					EditorHelp::add_doc(cd);
+					if (!first_scan) {
+						// Update the documentation in the Script Editor if it is open.
+						ScriptEditor::get_singleton()->update_doc(cd.name);
 					}
 				}
 			}
@@ -2319,15 +2919,9 @@ void EditorFileSystem::_process_update_pending() {
 	// because _update_script_documentation loads the scripts completely.
 	if (!EditorNode::is_cmdline_mode()) {
 		_update_script_documentation();
-		_update_pending_scene_groups();
+		// _update_pending_scene_groups();
+		ProjectSettings::get_singleton()->save_scene_groups_cache();
 	}
-}
-
-void EditorFileSystem::_queue_update_script_class(const String &p_path, const ScriptClassInfoUpdate &p_script_update) {
-	MutexLock update_script_lock(update_script_mutex);
-
-	update_script_paths.insert(p_path, p_script_update);
-	update_script_paths_documentation.insert(p_path);
 }
 
 void EditorFileSystem::_update_scene_groups() {
@@ -2374,20 +2968,24 @@ void EditorFileSystem::_update_scene_groups() {
 void EditorFileSystem::_update_pending_scene_groups() {
 	if (!FileAccess::exists(ProjectSettings::get_singleton()->get_scene_groups_cache_path())) {
 		_get_all_scenes(get_filesystem(), update_scene_paths);
-		_update_scene_groups();
-	} else if (!update_scene_paths.is_empty()) {
-		_update_scene_groups();
 	}
+	_update_scene_groups();
 }
 
 void EditorFileSystem::_queue_update_scene_groups(const String &p_path) {
-	MutexLock update_scene_lock(update_scene_mutex);
-	update_scene_paths.insert(p_path);
+	{
+		MutexLock update_scene_lock(update_scene_mutex);
+		update_scene_paths.insert(p_path);
+	}
+	{
+		MutexLock update_script_lock(update_script_mutex);
+		update_script_paths_documentation.insert(p_path);
+	}
 }
 
 void EditorFileSystem::_get_all_scenes(EditorFileSystemDirectory *p_dir, HashSet<String> &r_list) {
 	for (int i = 0; i < p_dir->get_file_count(); i++) {
-		if (p_dir->get_file_type(i) == SNAME("PackedScene")) {
+		if (p_dir->files[i]->status & EditorFileInfo::IS_PACKEDSCENE) {
 			r_list.insert(p_dir->get_file_path(i));
 		}
 	}
@@ -2402,11 +3000,9 @@ void EditorFileSystem::update_file(const String &p_file) {
 	update_files({ p_file });
 }
 
-void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
+void EditorFileSystem::update_files(const Vector<String> &p_files) {
 	bool updated = false;
-	bool update_files_icon_cache = false;
-	Vector<EditorFileInfo *> files_to_update_icon_path;
-	for (const String &file : p_script_paths) {
+	for (const String &file : p_files) {
 		ERR_CONTINUE(file.is_empty());
 		EditorFileSystemDirectory *fs = nullptr;
 		int cpos = -1;
@@ -2418,183 +3014,55 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 		}
 
 		if (!FileAccess::exists(file)) {
-			//was removed
-			_delete_internal_files(file);
-			if (cpos != -1) { // Might've never been part of the editor file system (*.* files deleted in Open dialog).
-				if (fs->files[cpos]->uid != ResourceUID::INVALID_ID) {
-					if (ResourceUID::get_singleton()->has_id(fs->files[cpos]->uid)) {
-						ResourceUID::get_singleton()->remove_id(fs->files[cpos]->uid);
-					}
-				}
-				if (ClassDB::is_parent_class(fs->files[cpos]->type, SNAME("Script"))) {
-					ScriptClassInfoUpdate update;
-					update.type = fs->files[cpos]->type;
-					_queue_update_script_class(file, update);
-					if (!fs->files[cpos]->class_info.icon_path.is_empty()) {
-						update_files_icon_cache = true;
-					}
-				}
-				if (fs->files[cpos]->type == SNAME("PackedScene")) {
-					_queue_update_scene_groups(file);
-				}
-
-				memdelete(fs->files[cpos]);
-				fs->files.remove_at(cpos);
+			// Was removed.
+			if (cpos == -1) { // Might've never been part of the editor file system (*.* files deleted in Open dialog).
+				_delete_internal_files(file);
+			} else {
+				_file_info_remove(fs->files[cpos], file, cpos);
 				updated = true;
 			}
 		} else {
-			String type = ResourceLoader::get_resource_type(file);
-			if (type.is_empty()) {
-				if (file.validate_extension(textfile_extensions)) {
-					type = "TextFile";
-				} else if (file.validate_extension(other_file_extensions)) {
-					type = "OtherFile";
-				}
-			}
-			String script_class = ResourceLoader::get_resource_script_class(file);
-
-			ResourceUID::ID uid = ResourceLoader::get_resource_uid(file);
-
 			if (cpos == -1) {
 				// The file did not exist, it was added.
-				int idx = 0;
-				String file_name = file.get_file();
-
-				for (int i = 0; i < fs->files.size(); i++) {
-					if (file.filenocasecmp_to(fs->files[i]->file) < 0) {
-						break;
-					}
-					idx++;
-				}
-
-				EditorFileInfo *fi = memnew(EditorFileInfo);
-				fi->file = file_name;
-				fi->import_modified_time = 0;
-				fi->import_valid = (type == "TextFile" || type == "OtherFile") ? true : ResourceLoader::is_import_valid(file);
-				fi->import_md5 = "";
-				fi->import_dest_paths = Vector<String>();
-
-				if (idx == fs->files.size()) {
-					fs->files.push_back(fi);
-				} else {
-					fs->files.insert(idx, fi);
-				}
-				cpos = idx;
+				_file_info_add(fs, file.get_base_dir(), file.get_file(), true);
 			} else {
-				//the file exists and it was updated, and was not added in this step.
-				//this means we must force upon next restart to scan it again, to get proper type and dependencies
-				late_update_files.insert(file);
-				_save_late_updated_files(); //files need to be updated in the re-scan
-			}
-
-			EditorFileInfo *fi = fs->files[cpos];
-			const String old_script_class_icon_path = fi->class_info.icon_path;
-			const String old_class_name = fi->class_info.name;
-			fi->type = type;
-			fi->resource_script_class = script_class;
-			fi->uid = uid;
-			fi->class_info = _get_global_script_class(type, file);
-			fi->import_group_file = ResourceLoader::get_import_group_file(file);
-			fi->modified_time = FileAccess::get_modified_time(file);
-			fi->deps = _get_dependencies(file);
-			fi->import_valid = (type == "TextFile" || type == "OtherFile") ? true : ResourceLoader::is_import_valid(file);
-
-			if (uid != ResourceUID::INVALID_ID) {
-				if (ResourceUID::get_singleton()->has_id(uid)) {
-					ResourceUID::get_singleton()->set_id(uid, file);
-				} else {
-					ResourceUID::get_singleton()->add_id(uid, file);
-				}
-
-				ResourceUID::get_singleton()->update_cache();
-			} else {
-				if (ResourceLoader::should_create_uid_file(file)) {
-					Ref<FileAccess> f = FileAccess::open(file + ".uid", FileAccess::WRITE);
-					if (f.is_valid()) {
-						const ResourceUID::ID id = ResourceUID::get_singleton()->create_id_for_path(file);
-						ResourceUID::get_singleton()->add_id(id, file);
-						f->store_line(ResourceUID::get_singleton()->id_to_text(id));
-						fi->uid = id;
-					}
-				}
-			}
-
-			// Update preview
-			EditorResourcePreview::get_singleton()->check_for_invalidation(file);
-
-			if (ClassDB::is_parent_class(fi->type, SNAME("Script"))) {
-				_queue_update_script_class(file, ScriptClassInfoUpdate::from_file_info(fi));
-			}
-			if (fi->type == SNAME("PackedScene")) {
-				_queue_update_scene_groups(file);
-			}
-
-			if (ClassDB::is_parent_class(fi->type, SNAME("Resource"))) {
-				files_to_update_icon_path.push_back(fi);
-			} else if (old_script_class_icon_path != fi->class_info.icon_path) {
-				update_files_icon_cache = true;
-			}
-
-			// Restore another script as the global class name if multiple scripts had the same old class name.
-			if (!old_class_name.is_empty() && fi->class_info.name != old_class_name && ClassDB::is_parent_class(type, SNAME("Script"))) {
-				EditorFileInfo *old_fi = nullptr;
-				String old_file = _get_file_by_class_name(filesystem, old_class_name, old_fi);
-				if (!old_file.is_empty() && old_fi) {
-					_queue_update_script_class(old_file, ScriptClassInfoUpdate::from_file_info(old_fi));
-				}
+				_file_info_update(fs->files[cpos], file);
 			}
 			updated = true;
 		}
 	}
-
-	if (updated) {
-		if (update_files_icon_cache) {
-			_update_files_icon_path();
-		} else {
-			for (EditorFileInfo *fi : files_to_update_icon_path) {
-				_update_file_icon_path(fi);
-			}
-		}
-		if (!is_scanning()) {
-			_process_update_pending();
-		}
-		if (!filesystem_changed_queued) {
-			filesystem_changed_queued = true;
-			callable_mp(this, &EditorFileSystem::_notify_filesystem_changed).call_deferred();
-		}
+	if (!updated || is_scanning() || update_actions_queued) {
+		return;
 	}
-}
-
-void EditorFileSystem::_notify_filesystem_changed() {
-	emit_signal("filesystem_changed");
-	filesystem_changed_queued = false;
+	set_process(true);
+	update_actions_queued = true;
 }
 
 HashSet<String> EditorFileSystem::get_valid_extensions() const {
 	return HashSet<String>(valid_extensions);
 }
 
-void EditorFileSystem::_register_global_class_script(const String &p_search_path, const String &p_target_path, const ScriptClassInfoUpdate &p_script_update) {
-	ScriptServer::remove_global_class_by_path(p_search_path); // First remove, just in case it changed
+void EditorFileSystem::_register_global_class_script(const String &p_search_path, const String &p_target_path, const EditorFileInfo *p_fi) {
+	ScriptServer::remove_global_class_by_path(p_search_path); // First remove, just in case it changed.
 
-	if (p_script_update.name.is_empty()) {
+	if (p_fi->class_info.name.is_empty()) {
 		return;
 	}
 
-	String lang;
-	for (int j = 0; j < ScriptServer::get_language_count(); j++) {
-		if (ScriptServer::get_language(j)->handles_global_class_type(p_script_update.type)) {
-			lang = ScriptServer::get_language(j)->get_name();
-			break;
+	String lang = p_fi->class_info.lang;
+	if (lang.is_empty()) {
+		for (int j = 0; j < ScriptServer::get_language_count(); j++) {
+			if (ScriptServer::get_language(j)->handles_global_class_type(p_fi->type)) {
+				lang = ScriptServer::get_language(j)->get_name();
+				break;
+			}
 		}
 	}
-	if (lang.is_empty()) {
-		return; // No lang found that can handle this global class
-	}
-	ResourceUID::ID uid = first_scan && !scanning ? ResourceLoader::get_resource_uid(p_target_path) : get_file_uid(p_target_path);
-	ScriptServer::add_global_class(p_script_update.name, p_script_update.extends, lang, p_target_path, p_script_update.is_abstract, p_script_update.is_tool, uid);
-	EditorNode::get_editor_data().script_class_set_icon_path(p_script_update.name, p_script_update.icon_path);
-	EditorNode::get_editor_data().script_class_set_name(p_target_path, p_script_update.name);
+	ERR_FAIL_COND(lang.is_empty()); // No lang found that can handle this global class.
+
+	ScriptServer::add_global_class(p_fi->class_info.name, p_fi->class_info.extends, lang, p_target_path, p_fi->class_info.is_abstract, p_fi->class_info.is_tool, p_fi->uid);
+	EditorNode::get_editor_data().script_class_set_icon_path(p_fi->class_info.name, p_fi->class_info.icon_path);
+	EditorNode::get_editor_data().script_class_set_name(p_target_path, p_fi->class_info.name);
 }
 
 void EditorFileSystem::register_global_class_script(const String &p_search_path, const String &p_target_path) {
@@ -2602,7 +3070,7 @@ void EditorFileSystem::register_global_class_script(const String &p_search_path,
 	EditorFileSystemDirectory *efsd = find_file(p_search_path, &index_file);
 	if (efsd) {
 		const EditorFileInfo *fi = efsd->files[index_file];
-		EditorFileSystem::get_singleton()->_register_global_class_script(p_search_path, p_target_path, ScriptClassInfoUpdate::from_file_info(fi));
+		EditorFileSystem::get_singleton()->_register_global_class_script(p_search_path, p_target_path, fi);
 	} else {
 		ScriptServer::remove_global_class_by_path(p_search_path);
 	}
@@ -2764,22 +3232,16 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		bool found = _find_file(file, &fs, cpos);
 		ERR_FAIL_COND_V_MSG(!found, ERR_UNCONFIGURED, vformat("Can't find file '%s' during group reimport.", file));
 
+		EditorFileInfo *fi = fs->files[cpos];
 		//update modified times, to avoid reimport
-		fs->files[cpos]->modified_time = FileAccess::get_modified_time(file);
-		fs->files[cpos]->import_modified_time = FileAccess::get_modified_time(file + ".import");
-		fs->files[cpos]->import_md5 = FileAccess::get_md5(file + ".import");
-		fs->files[cpos]->import_dest_paths = dest_paths;
-		fs->files[cpos]->deps = _get_dependencies(file);
-		fs->files[cpos]->uid = uid;
-		fs->files[cpos]->type = importer->get_resource_type();
-		if (fs->files[cpos]->type.is_empty()) {
-			if (file.validate_extension(textfile_extensions)) {
-				fs->files[cpos]->type = "TextFile";
-			} else if (file.validate_extension(other_file_extensions)) {
-				fs->files[cpos]->type = "OtherFile";
-			}
-		}
-		fs->files[cpos]->import_valid = err == OK;
+		fi->modified_time = FileAccess::get_modified_time(file);
+		fi->import_modified_time = FileAccess::get_modified_time(file + ".import");
+		fi->import_md5 = FileAccess::get_md5(file + ".import");
+		fi->import_dest_paths = dest_paths;
+		fi->deps = _get_dependencies(file);
+		fi->uid = uid;
+		_type_analysis(fi, importer->get_resource_type());
+		fi->import_valid = err == OK;
 
 		if (ResourceUID::get_singleton()->has_id(uid)) {
 			ResourceUID::get_singleton()->set_id(uid, file);
@@ -2811,9 +3273,11 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 
 	EditorFileSystemDirectory *fs = nullptr;
 	int cpos = -1;
+	EditorFileInfo *fi = nullptr;
 	if (p_update_file_system) {
 		bool found = _find_file(p_file, &fs, cpos);
 		ERR_FAIL_COND_V_MSG(!found, ERR_FILE_NOT_FOUND, vformat("Can't find file '%s' during file reimport.", p_file));
+		fi = fs->files[cpos];
 	}
 
 	//try to obtain existing params
@@ -2825,7 +3289,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		importer_name = p_custom_importer;
 	}
 
-	ResourceUID::ID uid = ResourceUID::INVALID_ID;
+	ResourceUID::ID uid = p_update_file_system ? fi->uid : ResourceUID::INVALID_ID;
 	Variant generator_parameters;
 	String group_file;
 	if (p_generator_parameters) {
@@ -2852,7 +3316,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 					importer_name = cf->get_value("remap", "importer");
 				}
 
-				if (cf->has_section_key("remap", "uid")) {
+				if (!p_update_file_system && cf->has_section_key("remap", "uid")) {
 					String uidt = cf->get_value("remap", "uid");
 					uid = ResourceUID::get_singleton()->text_to_id(uidt);
 				}
@@ -2873,13 +3337,13 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 	if (importer_name == "keep" || importer_name == "skip") {
 		//keep files, do nothing.
 		if (p_update_file_system) {
-			fs->files[cpos]->modified_time = FileAccess::get_modified_time(p_file);
-			fs->files[cpos]->import_modified_time = FileAccess::get_modified_time(p_file + ".import");
-			fs->files[cpos]->import_md5 = FileAccess::get_md5(p_file + ".import");
-			fs->files[cpos]->import_dest_paths = Vector<String>();
-			fs->files[cpos]->deps.clear();
-			fs->files[cpos]->type = "";
-			fs->files[cpos]->import_valid = false;
+			fi->modified_time = FileAccess::get_modified_time(p_file);
+			fi->import_modified_time = FileAccess::get_modified_time(p_file + ".import");
+			fi->import_md5 = FileAccess::get_md5(p_file + ".import");
+			fi->import_dest_paths = Vector<String>();
+			fi->deps.clear();
+			fi->type = "";
+			fi->import_valid = false;
 			EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
 		}
 		return OK;
@@ -2997,6 +3461,9 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 			Array genf;
 			for (const String &E : gen_files) {
 				genf.push_back(E);
+				if (dest_paths.has(E)) {
+					continue; // Files in formats such as obj will generate duplicate paths.
+				}
 				dest_paths.push_back(E);
 			}
 
@@ -3042,19 +3509,16 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 	}
 
 	if (p_update_file_system) {
-		// Update cpos, newly created files could've changed the index of the reimported p_file.
-		_find_file(p_file, &fs, cpos);
-
 		// Update modified times, to avoid reimport.
-		fs->files[cpos]->modified_time = FileAccess::get_modified_time(p_file);
-		fs->files[cpos]->import_modified_time = FileAccess::get_modified_time(p_file + ".import");
-		fs->files[cpos]->import_md5 = FileAccess::get_md5(p_file + ".import");
-		fs->files[cpos]->import_dest_paths = dest_paths;
-		fs->files[cpos]->deps = _get_dependencies(p_file);
-		fs->files[cpos]->type = importer->get_resource_type();
-		fs->files[cpos]->resource_script_class = ResourceLoader::get_resource_script_class(p_file);
-		fs->files[cpos]->uid = uid;
-		fs->files[cpos]->import_valid = fs->files[cpos]->type == "TextFile" ? true : ResourceLoader::is_import_valid(p_file);
+		fi->modified_time = FileAccess::get_modified_time(p_file);
+		fi->import_modified_time = FileAccess::get_modified_time(p_file + ".import");
+		fi->import_md5 = FileAccess::get_md5(p_file + ".import");
+		fi->import_dest_paths = dest_paths;
+		fi->deps = _get_dependencies(p_file);
+		_type_analysis(fi, importer->get_resource_type());
+		fi->resource_script_class = ResourceLoader::get_resource_script_class(p_file);
+		fi->uid = uid;
+		fi->import_valid = (fi->status & EditorFileInfo::AS_RESOURCE) || ResourceLoader::is_import_valid(p_file);
 	}
 
 	for (const String &path : gen_files) {
@@ -3235,9 +3699,12 @@ void EditorFileSystem::_refresh_filesystem() {
 	}
 	folders_to_sort.clear();
 
-	_update_scan_actions();
-
+	if (dirty_directories.is_empty()) {
+		// Avoid calling _update_scan_actions() repeatedly.
+		_update_scan_actions();
+	}
 	emit_signal(SNAME("filesystem_changed"));
+
 	refresh_queued = false;
 }
 
@@ -3575,11 +4042,16 @@ Error EditorFileSystem::make_dir_recursive(const String &p_path, const String &p
 	folders_to_sort.insert(parent->get_instance_id());
 
 	const PackedStringArray folders = p_path.trim_prefix(path).split("/", false);
+	bool exists = true;
 	for (const String &folder : folders) {
-		const int current = parent->find_dir_index(folder);
-		if (current > -1) {
-			parent = parent->get_subdir(current);
-			continue;
+		if (exists) {
+			const int current = parent->find_dir_index(folder);
+			if (current > -1) {
+				parent = parent->get_subdir(current);
+				continue;
+			}
+			exists = false;
+			_pending_scan_fs_changes(parent);
 		}
 
 		EditorFileSystemDirectory *efd = memnew(EditorFileSystemDirectory);
@@ -3602,8 +4074,7 @@ Error EditorFileSystem::copy_file(const String &p_from, const String &p_to) {
 	EditorFileSystemDirectory *parent = get_filesystem_path(p_to.get_base_dir());
 	ERR_FAIL_NULL_V(parent, ERR_FILE_NOT_FOUND);
 
-	ScanProgress sp;
-	_scan_fs_changes(parent, sp, false);
+	_pending_scan_fs_changes(parent, false);
 
 	_queue_refresh_filesystem();
 	return OK;
@@ -3657,8 +4128,7 @@ Error EditorFileSystem::copy_directory(const String &p_from, const String &p_to)
 
 	folders_to_sort.insert(efd->get_parent()->get_instance_id());
 
-	ScanProgress sp;
-	_scan_fs_changes(efd, sp);
+	_pending_scan_fs_changes(efd);
 
 	_queue_refresh_filesystem();
 	return success ? OK : FAILED;
@@ -3697,7 +4167,7 @@ ResourceUID::ID EditorFileSystem::_resource_saver_get_resource_id_for_path(const
 static void _scan_extensions_dir(EditorFileSystemDirectory *d, HashSet<String> &extensions) {
 	int fc = d->get_file_count();
 	for (int i = 0; i < fc; i++) {
-		if (d->get_file_type(i) == SNAME("GDExtension")) {
+		if (d->get_file_type(i) == GDExtension::get_class_static()) {
 			extensions.insert(d->get_file_path(i));
 		}
 	}
@@ -3735,11 +4205,12 @@ void EditorFileSystem::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("resources_reload", PropertyInfo(Variant::PACKED_STRING_ARRAY, "resources")));
 }
 
-void EditorFileSystem::_update_extensions() {
+void EditorFileSystem::update_extensions() {
 	valid_extensions.clear();
 	import_extensions.clear();
 	textfile_extensions.clear();
 	other_file_extensions.clear();
+	need_update_extensions = false;
 
 	List<String> extensionsl;
 	ResourceLoader::get_recognized_extensions_for_type("", &extensionsl);
@@ -3769,6 +4240,11 @@ void EditorFileSystem::_update_extensions() {
 	for (const String &E : extensionsl) {
 		import_extensions.insert(E);
 	}
+
+	extensions_changed = true;
+	if (!first_scan) {
+		_scan_dirs_changes();
+	}
 }
 
 void EditorFileSystem::add_import_format_support_query(Ref<EditorFileSystemImportFormatSupportQuery> p_query) {
@@ -3792,11 +4268,20 @@ EditorFileSystem::EditorFileSystem() {
 	filesystem = memnew(EditorFileSystemDirectory); //like, empty
 	filesystem->parent = nullptr;
 
-	new_filesystem = nullptr;
-
-	// This should probably also work on Unix and use the string it returns for FAT32 or exFAT
-	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	using_fat32_or_exfat = (da->get_filesystem_type() == "FAT32" || da->get_filesystem_type() == "EXFAT");
+	const int detect_mode = GLOBAL_GET("filesystem/on_scan/detect_mode");
+	force_detect = detect_mode == 1;
+	if (!force_detect) {
+		// This should probably also work on Unix and use the string it returns for FAT32 or exFAT
+		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		force_detect = da->get_filesystem_type() == "FAT32" || da->get_filesystem_type() == "EXFAT";
+		// Projects managed by version control systems may update file timestamps in batches. If the
+		// timestamp precision is insufficient, it is also necessary to compare the UID.
+		// FIXME: If a more accurate file timestamp is implemented, the following code can be removed.
+		force_detect |= DirAccess::exists("res://.git") ||
+				DirAccess::exists("res://.svn") ||
+				DirAccess::exists("res://CVS") ||
+				DirAccess::exists("res://.conf"); // For Unity Version Control.
+	}
 
 	scan_total = 0;
 	ResourceSaver::set_get_resource_id_for_path(_resource_saver_get_resource_id_for_path);
@@ -3804,9 +4289,23 @@ EditorFileSystem::EditorFileSystem() {
 	// Set the callback method that the ResourceFormatImporter will use
 	// if resources are loaded during the first scan.
 	ResourceImporter::load_on_startup = _load_resource_on_startup;
+
+	_reset_uid_points();
+	_reset_points();
 }
 
 EditorFileSystem::~EditorFileSystem() {
+	if (first_scan) {
+		// The scan thread is aborted during first scan.
+		for (KeyValue<String, EditorFileInfo *> &E : script_file_info) {
+			if (E.value->status & EditorFileInfo::IS_ORPHAN) {
+				memdelete(E.value);
+			}
+		}
+		if (first_scan_root_dir) {
+			memdelete(first_scan_root_dir);
+		}
+	}
 	if (filesystem) {
 		memdelete(filesystem);
 	}

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1118,7 +1118,7 @@ void EditorFileSystem::_update_dependencies_after_scan() {
 							if (ResourceUID::get_singleton()->has_id(uid)) {
 								const String uid_path = ResourceUID::get_singleton()->get_id_path(uid);
 								if (uid_path != dep_path) {
-									WARN_PRINT(vformat("The path %s of dependency (UID %s) in file %s doesn's match the path %s in UID cache. Please fix this dependency promptly.", dep_path, uid_text, file_path, uid_path));
+									WARN_PRINT(vformat("The path %s of dependency (UID %s) in file %s doesn't match the path %s in UID cache. Please fix this dependency promptly.", dep_path, uid_text, file_path, uid_path));
 								}
 							} else {
 								WARN_PRINT(vformat("The UID %s of dependency (path %s) in file %s was no longer in use. Please fix this dependency promptly.", uid_text, dep_path, file_path));

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -147,6 +147,9 @@ class EditorFileSystem : public Node {
 
 	_THREAD_SAFE_CLASS_
 
+	using EditorFileInfo = EditorFileSystemDirectory::FileInfo;
+	using ScriptClassInfo = EditorFileInfo::ScriptClassInfo;
+
 	struct ItemAction {
 		enum Action {
 			ACTION_NONE,
@@ -162,7 +165,7 @@ class EditorFileSystem : public Node {
 		EditorFileSystemDirectory *dir = nullptr;
 		String file;
 		EditorFileSystemDirectory *new_dir = nullptr;
-		EditorFileSystemDirectory::FileInfo *new_file = nullptr;
+		EditorFileInfo *new_file = nullptr;
 	};
 
 	struct ScannedDirectory {
@@ -207,8 +210,6 @@ class EditorFileSystem : public Node {
 	EditorFileSystemDirectory *filesystem = nullptr;
 
 	static EditorFileSystem *singleton;
-
-	using ScriptClassInfo = EditorFileSystemDirectory::FileInfo::ScriptClassInfo;
 
 	/* Used for reading the filesystem cache file */
 	struct FileCache {
@@ -298,7 +299,7 @@ class EditorFileSystem : public Node {
 		ScriptClassInfoUpdate() = default;
 		explicit ScriptClassInfoUpdate(const ScriptClassInfo &p_info) :
 				ScriptClassInfo(p_info) {}
-		static ScriptClassInfoUpdate from_file_info(const EditorFileSystemDirectory::FileInfo *p_fi) {
+		static ScriptClassInfoUpdate from_file_info(const EditorFileInfo *p_fi) {
 			ScriptClassInfoUpdate update;
 			update.type = p_fi->type;
 			update.name = p_fi->class_info.name;
@@ -364,10 +365,10 @@ class EditorFileSystem : public Node {
 
 	Vector<Ref<EditorFileSystemImportFormatSupportQuery>> import_support_queries;
 
-	void _update_file_icon_path(EditorFileSystemDirectory::FileInfo *file_info);
+	void _update_file_icon_path(EditorFileInfo *file_info);
 	void _update_files_icon_path(EditorFileSystemDirectory *edp = nullptr);
 	bool _remove_invalid_global_class_names(const HashSet<String> &p_existing_class_names);
-	String _get_file_by_class_name(EditorFileSystemDirectory *p_dir, const String &p_class_name, EditorFileSystemDirectory::FileInfo *&r_file_info);
+	String _get_file_by_class_name(EditorFileSystemDirectory *p_dir, const String &p_class_name, EditorFileInfo *&r_file_info);
 
 	void _register_global_class_script(const String &p_search_path, const String &p_target_path, const ScriptClassInfoUpdate &p_script_update);
 

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -309,7 +309,7 @@ class EditorFileSystem : public Node {
 	void _pending_scan_fs_changes(EditorFileSystemDirectory *p_dir, bool p_recursive = true);
 	void _scan_dirs_changes(bool p_full_scan = true);
 
-	void _delete_internal_files(const String &p_file);
+	void _delete_internal_files(const String &p_file, const EditorFileInfo *p_fi = nullptr, uint32_t p_old_status = 0);
 
 	HashSet<String> textfile_extensions;
 	HashSet<String> other_file_extensions;

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -277,7 +277,6 @@ class EditorFileSystem : public Node {
 
 	bool _test_for_reimport(const String &p_path, const String &p_expected_import_md5);
 	bool _is_test_for_reimport_needed(const String &p_path, uint64_t p_last_modification_time, uint64_t p_modification_time, uint64_t p_last_import_modification_time, uint64_t p_import_modification_time, const Vector<String> &p_import_dest_paths);
-	bool _can_import_file(const String &p_path);
 	Vector<String> _get_import_dest_paths(const String &p_path);
 
 	bool reimport_on_missing_imported_files;

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -48,12 +48,15 @@ class EditorFileSystemDirectory : public Object {
 
 	String name;
 	uint64_t modified_time;
-	bool verified = false; //used for checking changes
+	bool verified = true; // Used for checking changes.
+	bool dirty = true; // The files in the current directory need to be checked.
+	bool recursive = true; // Recursive checking is required.
 
 	EditorFileSystemDirectory *parent = nullptr;
 	Vector<EditorFileSystemDirectory *> subdirs;
 
 	struct FileInfo {
+		EditorFileSystemDirectory *parent = nullptr;
 		String file;
 		StringName type;
 		StringName resource_script_class; // If any resource has script with a global class name, its found here.
@@ -65,16 +68,44 @@ class EditorFileSystemDirectory : public Object {
 		bool import_valid = false;
 		String import_group_file;
 		Vector<String> deps;
-		bool verified = false; //used for checking changes
+		bool verified = true; // Used for checking changes.
 		// This is for script resources only.
 		struct ScriptClassInfo {
 			String name;
 			String extends;
+			String lang;
 			String icon_path;
 			bool is_abstract = false;
 			bool is_tool = false;
 		};
 		ScriptClassInfo class_info;
+		enum FileStatus {
+			NONE = 0,
+			FILE_ADD = 1,
+			FILE_REMOVE = 1 << 1,
+			FILE_UPDATE = 1 << 2, // For files that are indeed updated, some properties of their FileInfo need to be updated.
+			FILE_CHANGED = FILE_ADD | FILE_REMOVE | FILE_UPDATE,
+			TYPE_ADD = 1 << 4,
+			TYPE_REMOVE = 1 << 5,
+			TYPE_CHANGED = TYPE_ADD | TYPE_REMOVE,
+			TEMPORARY = FILE_CHANGED | TYPE_CHANGED,
+
+			IS_ORPHAN = 1 << 12,
+			HAS_CUSTOM_UID_SUPPORT = 1 << 13,
+
+			IS_SCRIPT = 1 << 16,
+			IS_PACKEDSCENE = 1 << 17,
+			IS_GLOBAL_CLASS_ALTERNATIVE = 1 << 18,
+			IS_ACTIVE_GLOBAL_CLASS_ALTERNATIVE = 1 << 19,
+			GLOBAL_CLASS_MASK = IS_GLOBAL_CLASS_ALTERNATIVE | IS_ACTIVE_GLOBAL_CLASS_ALTERNATIVE,
+
+			AS_RESOURCE = 1 << 28,
+			IS_IMPORTABLE = 1 << 29,
+			IS_OTHER = 1 << 30,
+			IS_TEXT = 1 << 31,
+			CATEGORY_CHANGED = IS_IMPORTABLE | IS_OTHER | IS_TEXT,
+		};
+		uint32_t status = AS_RESOURCE | FILE_ADD;
 	};
 
 	Vector<FileInfo *> files;
@@ -150,6 +181,28 @@ class EditorFileSystem : public Node {
 	using EditorFileInfo = EditorFileSystemDirectory::FileInfo;
 	using ScriptClassInfo = EditorFileInfo::ScriptClassInfo;
 
+	struct ItemUIDAction {
+		enum UIDAction {
+			ACTION_UID_NONE,
+			ACTION_UID_ADD,
+			ACTION_UID_REMOVE,
+			ACTION_UID_PENDING_ADD,
+		};
+		enum UIDStep {
+			STEP_UID_VALIDATE, // Verify the validity of the uid cache. Only when the editor starts.
+			STEP_UID_NEWLY_ADD, // Create and add new uids to files that do not have uids assigned to them.
+			STEP_UID_REMOVE, // Remove the outdated UID from the file info cache.
+			STEP_UID_PENDING_ADD, // Add the new UID obtained from the file.
+			STEP_UID_REGENERATE, // Recreate and add a new uid if the uid is already taken.
+			STEP_UID_MAX,
+		};
+
+		UIDAction action = ACTION_UID_NONE;
+		ResourceUID::ID old_uid = ResourceUID::INVALID_ID; // Only used for UID actions. Can be used as a fallback value or a delete value.
+		String path; // In order to reduce the count of path calculations.
+		EditorFileInfo *file = nullptr;
+	};
+
 	struct ItemAction {
 		enum Action {
 			ACTION_NONE,
@@ -157,44 +210,68 @@ class EditorFileSystem : public Node {
 			ACTION_DIR_REMOVE,
 			ACTION_FILE_ADD,
 			ACTION_FILE_REMOVE,
-			ACTION_FILE_TEST_REIMPORT,
-			ACTION_FILE_RELOAD
+			ACTION_FILE_UPDATE,
+			ACTION_FILE_REIMPORT,
+		};
+		enum Step {
+			STEP_NORMAL,
+			STEP_CLEAR_STATUS, // Clear the temporary flag of the file status for next use.
+			STEP_FILE_REMOVE,
+			STEP_DIR_REMOVE,
+			STEP_MAX,
 		};
 
 		Action action = ACTION_NONE;
+		String path; // In order to reduce the count of path calculations.
 		EditorFileSystemDirectory *dir = nullptr;
-		String file;
-		EditorFileSystemDirectory *new_dir = nullptr;
-		EditorFileInfo *new_file = nullptr;
+		EditorFileInfo *file = nullptr;
 	};
 
 	struct ScannedDirectory {
 		String name;
 		String full_path;
+		int count = 0;
 		Vector<ScannedDirectory *> subdirs;
 		List<String> files;
 
 		~ScannedDirectory();
 	};
 
+	bool extensions_changed = true;
+	SafeFlag scanning_done = SafeFlag(true);
 	bool use_threads = false;
 	Thread thread;
 	static void _thread_func(void *_userdata);
 
-	EditorFileSystemDirectory *new_filesystem = nullptr;
 	static ScannedDirectory *first_scan_root_dir;
 
-	bool filesystem_changed_queued = false;
+	bool update_actions_queued = false;
 	bool scanning = false;
 	bool importing = false;
 	bool first_scan = true;
 	bool scan_changes_pending = false;
+	bool full_scan_pending = false;
 	float scan_total;
 	String filesystem_settings_version_for_import;
 	bool revalidate_import_files = false;
 	static int nb_files_total;
 
-	void _notify_filesystem_changed();
+	bool _load_filesystem_from_cache();
+
+	void _category_validate(EditorFileInfo *p_file, const String &p_path);
+	void _type_analysis(EditorFileInfo *p_file, const StringName &p_new_type);
+	void _import_validate(EditorFileInfo *p_file, const String &p_path);
+	void _global_script_class_info_remove(EditorFileInfo *p_file, const String &p_path);
+	void _global_script_class_info_add(EditorFileInfo *p_file, const String &p_path);
+	void _script_class_info_update(EditorFileInfo *p_file, const String &p_path, const ScriptClassInfo *p_sci);
+	void _scene_info_update(EditorFileInfo *p_file, const String &p_path);
+
+	void _file_info_add(EditorFileSystemDirectory *p_parent_dir, const String &p_parent_path, const String &p_file, bool p_insert);
+	void _file_info_remove(EditorFileInfo *p_file, const String &p_path, const int p_idx);
+	void _file_info_update(EditorFileInfo *p_file, const String &p_path);
+
+	int _dir_info_remove(EditorFileSystemDirectory *p_dir, const String &p_path, const int p_idx);
+
 	void _scan_filesystem();
 	void _first_scan_filesystem();
 	void _first_scan_process_scripts(const ScannedDirectory *p_scan_dir, List<String> &p_gdextension_extensions, HashSet<String> &p_existing_class_names, HashSet<String> &p_extensions);
@@ -203,31 +280,9 @@ class EditorFileSystem : public Node {
 
 	static void _load_first_scan_root_dir();
 
-	HashSet<String> late_update_files;
-
-	void _save_late_updated_files();
-
 	EditorFileSystemDirectory *filesystem = nullptr;
 
 	static EditorFileSystem *singleton;
-
-	/* Used for reading the filesystem cache file */
-	struct FileCache {
-		StringName type;
-		String resource_script_class;
-		ResourceUID::ID uid = ResourceUID::INVALID_ID;
-		uint64_t modification_time = 0;
-		uint64_t import_modification_time = 0;
-		String import_md5;
-		Vector<String> import_dest_paths;
-		Vector<String> deps;
-		bool import_valid = false;
-		String import_group_file;
-		ScriptClassInfo class_info;
-	};
-
-	HashMap<String, FileCache> file_cache;
-	HashSet<String> dep_update_list;
 
 	struct ScanProgress {
 		float hi = 0;
@@ -247,10 +302,14 @@ class EditorFileSystem : public Node {
 
 	bool _find_file(const String &p_file, EditorFileSystemDirectory **r_d, int &r_file_pos) const;
 
+	List<EditorFileSystemDirectory *> dirty_directories;
+
 	void _scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanProgress &p_progress, bool p_recursive = true);
+	void scan_fs_changes(ScanProgress &p_progress);
+	void _pending_scan_fs_changes(EditorFileSystemDirectory *p_dir, bool p_recursive = true);
+	void _scan_dirs_changes(bool p_full_scan = true);
 
 	void _delete_internal_files(const String &p_file);
-	int _insert_actions_delete_files_directory(EditorFileSystemDirectory *p_dir);
 
 	HashSet<String> textfile_extensions;
 	HashSet<String> other_file_extensions;
@@ -267,17 +326,42 @@ class EditorFileSystem : public Node {
 	static void _thread_func_sources(void *_userdata);
 
 	List<String> sources_changed;
+	List<ItemUIDAction> scan_uid_actions;
+	List<ItemUIDAction>::Element *uid_newly_add_end = nullptr;
+	List<ItemUIDAction>::Element *uid_move_end = nullptr;
 	List<ItemAction> scan_actions;
+	List<ItemAction>::Element *normal = nullptr;
+	List<ItemAction>::Element *remove_point = nullptr;
 
+	void _reset_uid_points();
+	void _reset_points();
+	void _create_uid_action(EditorFileInfo *p_fi, const String &p_path, const ItemUIDAction::UIDAction p_action, const ItemUIDAction::UIDStep p_step, const ResourceUID::ID p_old_uid = ResourceUID::INVALID_ID);
+	void _create_action(EditorFileSystemDirectory *p_dir, EditorFileInfo *p_fi, const String &p_path, const ItemAction::Action p_action, const ItemAction::Step p_step = ItemAction::STEP_NORMAL, const ResourceUID::ID p_old_uid = ResourceUID::INVALID_ID);
+	void _create_actions_from_uid_change(EditorFileInfo *p_fi, const String &p_path, const ResourceUID::ID p_old_uid = ResourceUID::INVALID_ID);
+
+	struct MoveItems {
+		String origin;
+		String target;
+	};
+
+	HashMap<ResourceUID::ID, String> untracks;
+	HashSet<String> untrack_paths;
+	HashMap<ResourceUID::ID, MoveItems> moves;
+	HashMap<String, String> move_paths;
+
+	void _update_dependencies_after_scan();
+	void _update_resource_paths_after_scan();
+	void _update_project_settings_after_scan();
+
+	bool updating_scan_actions = false;
+	bool _update_scan_uid_actions();
 	bool _update_scan_actions();
-
-	void _update_extensions();
 
 	Error _reimport_file(const String &p_file, const HashMap<StringName, Variant> &p_custom_options = HashMap<StringName, Variant>(), const String &p_custom_importer = String(), Variant *generator_parameters = nullptr, bool p_update_file_system = true);
 	Error _reimport_group(const String &p_group_file, const Vector<String> &p_files);
 
-	bool _test_for_reimport(const String &p_path, const String &p_expected_import_md5);
-	bool _is_test_for_reimport_needed(const String &p_path, uint64_t p_last_modification_time, uint64_t p_modification_time, uint64_t p_last_import_modification_time, uint64_t p_import_modification_time, const Vector<String> &p_import_dest_paths);
+	bool _test_for_reimport(const String &p_path, EditorFileInfo *p_file);
+	bool _is_test_for_reimport_needed(EditorFileInfo *p_file, uint64_t p_modified_time, uint64_t p_import_modified_time);
 	Vector<String> _get_import_dest_paths(const String &p_path);
 
 	bool reimport_on_missing_imported_files;
@@ -294,31 +378,29 @@ class EditorFileSystem : public Node {
 		}
 	};
 
-	struct ScriptClassInfoUpdate : public ScriptClassInfo {
-		StringName type;
-		ScriptClassInfoUpdate() = default;
-		explicit ScriptClassInfoUpdate(const ScriptClassInfo &p_info) :
-				ScriptClassInfo(p_info) {}
-		static ScriptClassInfoUpdate from_file_info(const EditorFileInfo *p_fi) {
-			ScriptClassInfoUpdate update;
-			update.type = p_fi->type;
-			update.name = p_fi->class_info.name;
-			update.extends = p_fi->class_info.extends;
-			update.icon_path = p_fi->class_info.icon_path;
-			update.is_abstract = p_fi->class_info.is_abstract;
-			update.is_tool = p_fi->class_info.is_tool;
-			return update;
-		}
+	HashMap<String, EditorFileInfo *> script_file_info;
+	struct ScriptClassAlternatives {
+		bool active = false;
+		String active_path;
+		String icon_path;
+		ResourceUID::ID active_uid = ResourceUID::INVALID_ID;
+		HashMap<String, EditorFileInfo *> alternatives;
 	};
+	HashMap<StringName, ScriptClassAlternatives> global_script_class_alternatives;
+	void _update_global_script_class_activation();
+
+	bool script_classes_updated = false;
+	bool loader_changed = false;
+	bool saver_changed = false;
+	bool need_update_extensions = false;
+	void _check_loader_or_saver_changed(const ScriptClassInfo &p_class_info);
+	void _reload_loader_or_saver();
 
 	Mutex update_script_mutex;
-	HashMap<String, ScriptClassInfoUpdate> update_script_paths;
 	HashSet<String> update_script_paths_documentation;
-	void _queue_update_script_class(const String &p_path, const ScriptClassInfoUpdate &p_script_update);
 	void _update_script_classes();
 	void _update_script_documentation();
 	void _process_update_pending();
-	void _process_removed_files(const HashSet<String> &p_processed_files);
 	bool _should_reload_script(const String &p_path);
 
 	Mutex update_scene_mutex;
@@ -333,14 +415,13 @@ class EditorFileSystem : public Node {
 	static Error _resource_import(const String &p_path);
 	static Ref<Resource> _load_resource_on_startup(ResourceFormatImporter *p_importer, const String &p_path, Error *r_error, bool p_use_sub_threads, float *r_progress, ResourceLoaderConstants::CacheMode p_cache_mode);
 
-	bool using_fat32_or_exfat; // Workaround for projects in FAT32 or exFAT filesystem (pendrives, most of the time)
+	bool force_detect = false;
 
 	void _find_group_files(EditorFileSystemDirectory *efd, HashMap<String, Vector<String>> &group_files, HashSet<String> &groups_to_reimport);
 
 	void _move_group_files(EditorFileSystemDirectory *efd, const String &p_group_file, const String &p_new_location);
 
 	HashSet<String> group_file_cache;
-	HashMap<String, String> file_icon_cache;
 
 	bool refresh_queued = false;
 	HashSet<ObjectID> folders_to_sort;
@@ -361,16 +442,14 @@ class EditorFileSystem : public Node {
 	static ResourceUID::ID _resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate);
 
 	bool _scan_extensions();
-	bool _scan_import_support(const Vector<String> &reimports);
+	bool _import_support_abort_scan(const Vector<String> &p_reimports);
 
 	Vector<Ref<EditorFileSystemImportFormatSupportQuery>> import_support_queries;
 
-	void _update_file_icon_path(EditorFileInfo *file_info);
-	void _update_files_icon_path(EditorFileSystemDirectory *edp = nullptr);
 	bool _remove_invalid_global_class_names(const HashSet<String> &p_existing_class_names);
 	String _get_file_by_class_name(EditorFileSystemDirectory *p_dir, const String &p_class_name, EditorFileInfo *&r_file_info);
 
-	void _register_global_class_script(const String &p_search_path, const String &p_target_path, const ScriptClassInfoUpdate &p_script_update);
+	void _register_global_class_script(const String &p_search_path, const String &p_target_path, const EditorFileInfo *p_fi);
 
 protected:
 	void _notification(int p_what);
@@ -384,10 +463,12 @@ public:
 	bool is_importing() const { return importing; }
 	bool doing_first_scan() const { return first_scan; }
 	float get_scanning_progress() const;
+	void update_extensions();
 	void scan();
 	void scan_changes();
+	void pending_scan_fs_changes(const String &p_dir, bool p_recursive);
 	void update_file(const String &p_file);
-	void update_files(const Vector<String> &p_script_paths);
+	void update_files(const Vector<String> &p_files);
 	HashSet<String> get_valid_extensions() const;
 	void register_global_class_script(const String &p_search_path, const String &p_target_path);
 

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -770,13 +770,13 @@ String EditorResourcePicker::_get_resource_type(const Ref<Resource> &p_resource)
 	}
 	String res_type = p_resource->get_class();
 
-	Ref<Script> res_script = p_resource->get_script();
-	if (res_script.is_null()) {
+	int idx_in_dir = -1;
+	EditorFileSystemDirectory const *dir = EditorFileSystem::get_singleton()->find_file(p_resource->get_path(), &idx_in_dir);
+	if (!dir) {
 		return res_type;
 	}
 
-	// TODO: Replace with EditorFileSystem when PR #60606 is merged to use cached resource type.
-	String script_type = EditorNode::get_editor_data().script_class_get_name(res_script->get_path());
+	String script_type = dir->get_file_resource_script_class(idx_in_dir);
 	if (!script_type.is_empty()) {
 		res_type = script_type;
 	}

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -442,7 +442,7 @@ void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer, 
 	// Plugins are now loaded during the first scan. It's important not to start another scan,
 	// even a deferred one, as it would cause a scan during a scan at the next main thread iteration.
 	if (!EditorFileSystem::get_singleton()->doing_first_scan()) {
-		callable_mp(EditorFileSystem::get_singleton(), &EditorFileSystem::scan).call_deferred();
+		EditorFileSystem::get_singleton()->update_extensions();
 	}
 }
 
@@ -452,7 +452,7 @@ void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importe
 	// Plugins are now loaded during the first scan. It's important not to start another scan,
 	// even a deferred one, as it would cause a scan during a scan at the next main thread iteration.
 	if (!EditorNode::get_singleton()->is_exiting() && !EditorFileSystem::get_singleton()->doing_first_scan()) {
-		callable_mp(EditorFileSystem::get_singleton(), &EditorFileSystem::scan).call_deferred();
+		EditorFileSystem::get_singleton()->update_extensions();
 	}
 }
 
@@ -499,11 +499,17 @@ void EditorPlugin::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_p
 void EditorPlugin::add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(p_importer.is_null());
 	ResourceImporterScene::add_scene_importer(p_importer, p_first_priority);
+	if (!EditorFileSystem::get_singleton()->doing_first_scan()) {
+		EditorFileSystem::get_singleton()->update_extensions();
+	}
 }
 
 void EditorPlugin::remove_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer) {
 	ERR_FAIL_COND(p_importer.is_null());
 	ResourceImporterScene::remove_scene_importer(p_importer);
+	if (!EditorNode::get_singleton()->is_exiting() && !EditorFileSystem::get_singleton()->doing_first_scan()) {
+		EditorFileSystem::get_singleton()->update_extensions();
+	}
 }
 
 void EditorPlugin::add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin, bool p_first_priority) {

--- a/editor/plugins/plugin_config_dialog.cpp
+++ b/editor/plugins/plugin_config_dialog.cpp
@@ -56,8 +56,7 @@ void PluginConfigDialog::_on_confirmed() {
 	String path = "res://addons/" + _get_subfolder();
 
 	if (!_edit_mode) {
-		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-		if (d.is_null() || d->make_dir_recursive(path) != OK) {
+		if (EditorFileSystem::get_singleton()->make_dir_recursive(path) != OK) {
 			return;
 		}
 	}
@@ -74,7 +73,7 @@ void PluginConfigDialog::_on_confirmed() {
 	// Save and inform the editor.
 	cf->save(path.path_join("plugin.cfg"));
 	EditorNode::get_singleton()->get_project_settings()->update_plugins();
-	EditorFileSystem::get_singleton()->scan();
+	EditorFileSystem::get_singleton()->pending_scan_fs_changes(path, true);
 	_clear_fields();
 }
 

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -305,6 +305,8 @@ void register_editor_types() {
 	GLOBAL_DEF("editor/import/reimport_missing_imported_files", true);
 	GLOBAL_DEF("editor/import/use_multiple_threads", true);
 
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "filesystem/on_scan/detect_mode", PROPERTY_HINT_ENUM, "Auto,Force"), 0);
+
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/import/atlas_max_width", PROPERTY_HINT_RANGE, "128,8192,1,or_greater"), 2048);
 
 	GLOBAL_DEF("editor/export/convert_text_resources_to_binary", true);

--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -280,7 +280,7 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	}
 
 	// Check file extension.
-	String extension = p.get_extension();
+	const String file = p.get_file();
 	List<String> extensions;
 
 	// Get all possible extensions for script.
@@ -291,7 +291,7 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	bool found = false;
 	bool match = false;
 	for (const String &E : extensions) {
-		if (E.nocasecmp_to(extension) == 0) {
+		if (file.right(E.length() + 1).nocasecmp_to("." + E) == 0) {
 			found = true;
 			if (E == ScriptServer::get_language(language_menu->get_selected())->get_extension()) {
 				match = true;

--- a/editor/shader/shader_create_dialog.cpp
+++ b/editor/shader/shader_create_dialog.cpp
@@ -413,12 +413,9 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 	}
 
 	const ShaderCreateDialog::ShaderTypeData &current_type_data = type_data.get(current_type);
-	const String file_extension = stripped_file_path.get_extension();
 
-	for (const String &type_ext : current_type_data.extensions) {
-		if (type_ext.nocasecmp_to(file_extension) == 0) {
-			return "";
-		}
+	if (stripped_file_path.validate_extension(current_type_data.extensions)) {
+		return "";
 	}
 
 	return TTRC("Invalid extension for selected shader type.");

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2265,6 +2265,13 @@ void GDScriptLanguage::finish() {
 	script_list.clear();
 	function_list.clear();
 
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		GDExtensionManager::get_singleton()->disconnect("extension_loaded", callable_mp(this, &GDScriptLanguage::_extension_loaded));
+		GDExtensionManager::get_singleton()->disconnect("extension_unloading", callable_mp(this, &GDScriptLanguage::_extension_unloading));
+	}
+#endif // TOOLS_ENABLED
+
 	finishing = false;
 }
 

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -384,8 +384,8 @@ static bool generate_class_index_recursive(const String &p_dir) {
 			}
 			ERR_FAIL_COND_V_MSG(ScriptServer::is_global_class(class_name), false,
 					"Class name '" + class_name + "' from " + source_file + " is already used in " + ScriptServer::get_global_class_path(class_name));
-
-			ScriptServer::add_global_class(class_name, base_type, gdscript_name, source_file, is_abstract, is_tool);
+			ResourceUID::ID uid = ResourceLoader::get_resource_uid(source_file);
+			ScriptServer::add_global_class(class_name, base_type, gdscript_name, source_file, is_abstract, is_tool, uid);
 		}
 
 		next = dir->get_next();

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -89,6 +89,7 @@ func _init():
 	Ref<RefCounted> ref_counted = memnew(RefCounted);
 	ref_counted->set_script(gdscript);
 	CHECK_MESSAGE(int(ref_counted->get_meta("result")) == 42, "The script should assign object metadata successfully.");
+	GDScriptLanguage::get_singleton()->finish();
 }
 
 TEST_CASE("[Modules][GDScript] Loading keeps ResourceCache and GDScriptCache in sync") {

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -252,8 +252,8 @@ static void setup_global_classes(const String &p_dir) {
 			}
 			ERR_FAIL_COND_MSG(ScriptServer::is_global_class(class_name),
 					"Class name \"" + class_name + "\" from \"" + source_file + "\" is already used in \"" + ScriptServer::get_global_class_path(class_name) + "\".");
-
-			ScriptServer::add_global_class(class_name, base_type, GDScriptLanguage::get_singleton()->get_name(), source_file, is_abstract, is_tool);
+			ResourceUID::ID uid = ResourceLoader::get_resource_uid(source_file);
+			ScriptServer::add_global_class(class_name, base_type, GDScriptLanguage::get_singleton()->get_name(), source_file, is_abstract, is_tool, uid);
 		}
 		next = dir->get_next();
 	}

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -319,10 +319,10 @@ void test(TestType p_type) {
 	TypedArray<Dictionary> script_classes = ProjectSettings::get_singleton()->get_global_class_list();
 	for (int i = 0; i < script_classes.size(); i++) {
 		Dictionary c = script_classes[i];
-		if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
+		if (!c.has("class") || !c.has("language") || (!c.has("uid") && !c.has("path")) || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
 			continue;
 		}
-		ScriptServer::add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"]);
+		ScriptServer::add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"], ResourceUID::get_singleton()->text_to_id(c["uid"]));
 	}
 
 	Vector<uint8_t> buf;

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -414,7 +414,7 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		memdelete(efs);
 		finish_language();
 	}
-	TEST_CASE("[Editor][workspace][document_symbol]") {
+	TEST_CASE("[workspace][document_symbol]") {
 		EditorFileSystem *efs = memnew(EditorFileSystem);
 		GDScriptLanguageProtocol *proto = initialize(root);
 		REQUIRE(proto);

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -414,7 +414,7 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		memdelete(efs);
 		finish_language();
 	}
-	TEST_CASE("[workspace][document_symbol]") {
+	TEST_CASE("[Editor][workspace][document_symbol]") {
 		EditorFileSystem *efs = memnew(EditorFileSystem);
 		GDScriptLanguageProtocol *proto = initialize(root);
 		REQUIRE(proto);

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "editor_scene_exporter_gltf_settings.h"
 
+#include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "editor/editor_node.h"
 #include "editor/file_system/editor_file_system.h"
@@ -124,5 +125,8 @@ void SceneExporterGLTFPlugin::_export_scene_as_gltf() {
 	if (err != OK) {
 		ERR_PRINT(vformat("glTF2 save scene error %s.", itos(err)));
 	}
-	EditorFileSystem::get_singleton()->scan_changes();
+	String local_path = ProjectSettings::get_singleton()->localize_path(export_path.get_base_dir());
+	if (local_path.is_resource_file()) {
+		EditorFileSystem::get_singleton()->pending_scan_fs_changes(local_path, false);
+	}
 }

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -694,15 +694,16 @@ void FileDialog::update_file_name() {
 		if (idx == -1) {
 			idx += 1;
 		}
-		String filter_str = filters[idx];
 		String file_str = filename_edit->get_text();
-		String base_name = file_str.get_basename();
-		Vector<String> filter_substr = filter_str.split(";");
-		if (filter_substr.size() >= 2) {
-			file_str = base_name + "." + filter_substr[0].strip_edges().get_extension().to_lower();
+		String base_name;
+		if (ext_filter.is_empty() || !file_str.ends_with(ext_filter)) {
+			base_name = file_str.get_basename();
 		} else {
-			file_str = base_name + "." + filter_str.strip_edges().get_extension().to_lower();
+			base_name = file_str.substr(0, file_str.length() - ext_filter.length());
 		}
+		const String filter_str = filters[idx].get_slicec(';', 0).strip_edges();
+		ext_filter = filter_str.substr(filter_str.find_char('.')).to_lower();
+		file_str = base_name + ext_filter;
 		filename_edit->set_text(file_str);
 	}
 }
@@ -1139,6 +1140,7 @@ void FileDialog::_filename_filter_selected() {
 
 void FileDialog::update_filters() {
 	filter->clear();
+	ext_filter.clear();
 	processed_filters.clear();
 
 	if (filters.size() > 1) {

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -186,6 +186,7 @@ private:
 	DisplayMode display_mode = DISPLAY_THUMBNAILS;
 	FileSortOption file_sort = FileSortOption::NAME;
 
+	String ext_filter;
 	Vector<String> filters;
 	Vector<String> processed_filters;
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -2158,23 +2158,31 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 	return OK;
 }
 
-Error ResourceLoaderText::set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid) {
+Error ResourceLoaderText::set_info(Ref<FileAccess> p_f, ResourceUID::ID p_uid, const String &p_script_class) {
 	open(p_f, true);
 	ERR_FAIL_COND_V(error != OK, error);
 	ignore_resource_parsing = true;
+
+	if (p_uid != ResourceUID::INVALID_ID) {
+		res_uid = p_uid;
+	}
+
+	if (!p_script_class.is_empty()) {
+		script_class = p_script_class;
+	}
 
 	Ref<FileAccess> fw;
 
 	fw = FileAccess::open(local_path + ".uidren", FileAccess::WRITE);
 	if (is_scene) {
-		fw->store_string("[gd_scene format=" + itos(format_version) + " uid=\"" + ResourceUID::get_singleton()->id_to_text(p_uid) + "\"]");
+		fw->store_string("[gd_scene format=" + itos(format_version) + " uid=\"" + ResourceUID::get_singleton()->id_to_text(res_uid) + "\"]");
 	} else {
 		String script_res_text;
 		if (!script_class.is_empty()) {
 			script_res_text = "script_class=\"" + script_class + "\" ";
 		}
 
-		fw->store_string("[gd_resource type=\"" + res_type + "\" " + script_res_text + "format=" + itos(format_version) + " uid=\"" + ResourceUID::get_singleton()->id_to_text(p_uid) + "\"]");
+		fw->store_string("[gd_resource type=\"" + res_type + "\" " + script_res_text + "format=" + itos(format_version) + " uid=\"" + ResourceUID::get_singleton()->id_to_text(res_uid) + "\"]");
 	}
 
 	uint8_t c = f->get_8();
@@ -2201,12 +2209,7 @@ Error ResourceFormatSaverText::save(const Ref<Resource> &p_resource, const Strin
 	return saver.save(p_path, p_resource, p_flags);
 }
 
-Error ResourceFormatSaverText::set_uid(const String &p_path, ResourceUID::ID p_uid) {
-	String lc = p_path.to_lower();
-	if (!lc.ends_with(".tscn") && !lc.ends_with(".tres")) {
-		return ERR_FILE_UNRECOGNIZED;
-	}
-
+Error ResourceFormatSaverText::_set_info(const String &p_path, ResourceUID::ID p_uid, const String &p_script_class) {
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	Error err = OK;
 	{
@@ -2218,7 +2221,7 @@ Error ResourceFormatSaverText::set_uid(const String &p_path, ResourceUID::ID p_u
 		ResourceLoaderText loader;
 		loader.local_path = local_path;
 		loader.res_path = loader.local_path;
-		err = loader.set_uid(file, p_uid);
+		err = loader.set_info(file, p_uid, p_script_class);
 	}
 
 	if (err == OK) {
@@ -2228,6 +2231,22 @@ Error ResourceFormatSaverText::set_uid(const String &p_path, ResourceUID::ID p_u
 	}
 
 	return err;
+}
+
+Error ResourceFormatSaverText::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+	String lc = p_path.to_lower();
+	if (!lc.ends_with(".tscn") && !lc.ends_with(".tres")) {
+		return ERR_FILE_UNRECOGNIZED;
+	}
+	return _set_info(p_path, p_uid, String());
+}
+
+Error ResourceFormatSaverText::set_script_class(const String &p_path, const String &p_script_class) {
+	String lc = p_path.to_lower();
+	if (!lc.ends_with(".tres")) {
+		return ERR_FILE_UNRECOGNIZED;
+	}
+	return _set_info(p_path, ResourceUID::INVALID_ID, p_script_class);
 }
 
 bool ResourceFormatSaverText::recognize(const Ref<Resource> &p_resource) const {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1649,6 +1649,21 @@ String ResourceFormatSaverTextInstance::_write_resource(const Ref<Resource> &res
 	}
 }
 
+struct ScriptFirst {
+	int _priority(const PropertyInfo &p_a) const {
+		if (p_a.name == "metadata/_custom_type_script") {
+			return 0;
+		}
+		if (p_a.name == "script") {
+			return 1;
+		}
+		return 255;
+	}
+	bool operator()(const PropertyInfo &p_a, const PropertyInfo &p_b) const {
+		return _priority(p_a) < _priority(p_b);
+	}
+};
+
 void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, bool p_main) {
 	switch (p_variant.get_type()) {
 		case Variant::OBJECT: {
@@ -1680,13 +1695,12 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 			List<PropertyInfo> property_list;
 
 			res->get_property_list(&property_list);
-			property_list.sort();
+			property_list.sort_custom<ScriptFirst>();
 
 			List<PropertyInfo>::Element *I = property_list.front();
 
 			while (I) {
 				PropertyInfo pi = I->get();
-
 				if (pi.usage & PROPERTY_USAGE_STORAGE) {
 					Variant v = res->get(I->get().name);
 

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -129,7 +129,7 @@ private:
 public:
 	Ref<Resource> get_resource();
 	Error load();
-	Error set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid);
+	Error set_info(Ref<FileAccess> p_f, ResourceUID::ID p_uid, const String &p_script_class);
 	int get_stage() const;
 	int get_stage_count() const;
 	void set_translation_remapped(bool p_remapped);
@@ -210,10 +210,13 @@ public:
 class ResourceFormatSaverText : public ResourceFormatSaver {
 	GDSOFTCLASS(ResourceFormatSaverText, ResourceFormatSaver);
 
+	Error _set_info(const String &p_path, ResourceUID::ID p_uid, const String &p_script_class);
+
 public:
 	static ResourceFormatSaverText *singleton;
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
+	virtual Error set_script_class(const String &p_path, const String &p_script_class) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 


### PR DESCRIPTION
Closes godotengine/godot-proposals#13196

## Known limitations

Due to the limited precision of file modification timestamps obtained by Godot, file movements are primarily tracked using UIDs. However, not all files are assigned a UID.

<details>

<summary>Details</summary>

### The file timestamps are not precise enough

File change detection relies on the file's modification timestamp. However, the timestamp precision of the current file's modification time is **1 second**.

And when processing files in batches, the modification timestamps of many files may all fall within the same second. This is especially noticeable when updating files using version control software such as **Git**.

This is unlikely to be a problem in most cases. However, some unexpected issues may arise in cases of file overwriting. For example:

1. If similar directory structures exist, such as `res://a/x/` and `res://b/x/`.
2. You have already added these changes using `git` and committed them.
3. You accidentally removed the directories `res://a/` and `res://b/`.
4. Using `git restore .` to restore these directories might be a good idea.
5. After restoration, the timestamps of these restored files and directories are typically within the same second.
6. Back to the editor. The timestamps of these files will be recorded.
7. If you delete `res://a/` outside the editor and rename the original `res://b/` to `res://a/`.
8. Back to the editor again. The content under `res://a/x/` is likely not updated correctly.

#### Solutions

1. Ensure that each resource file is assigned a unique UID;
2. Determine if a file has been updated by relying on its modification time and UID (if both of these remain unchanged, then the file is considered unchanged; otherwise, the file is considered to have changed);
3. Always force checks for changes in directories (i.e., the addition or deletion of sub files/directories) in projects managed with `git` (identify via `res://.git/`).

### Some types of file move actions cannot be tracked because no UID was assigned

The order in which file extensions are processed is as follows:

1. Importable file types (Their `importer` is either `skip` or `keep`);
2. Resource file type (The file extension list is `json,po,mo,crt,pub,key`, #99540);
3. Text file types (The file extension list is `txt,md,cfg,ini,log,json,yml,yaml,toml,xml`, defined in `docks/filesystem/textfile_extensions`);
4. Other file types (The file extension list is `ico,icns`, defined in `docks/filesystem/other_file_extensions`);

Point 2 and Point 3 are somewhat repetitive. If we process 3 and 4 first, point 2 might be able to be merged into point 3.

#### TODO

However, from the perspective of using UID to track file movements, it might be better to assign UIDs to files with the above extensions.

### The directory move actions could not be tracked because no UID was assigned

This may affect the updating of directory colors, favorites.

#### TODO

Perhaps the UID assigned to the directory could be recorded in a `.uid` file.

### The `@icon` path for the script

Using the `uid://` path allows for effective tracking; otherwise, it might be difficult to analyze the movement of `@icon` files. Furthermore, there is no method to update the `@icon` path in the script files.

</details>

## Main processing flow

### Main flowchart

<details>

<summary>Flowchart</summary>

```mermaid
flowchart TD
    S0(["Launch editor (first scan)"]) --> P00["Update global script classes"]
    P00 --> PA00["Scan"]
    PA00 --> C00{Already build tree?}
    C00 --> |No| PB03[[Build filesystem tree]]
    C00 --> |Yes| PB02[[Update filesystem tree]]
    PB02 --> PE00["Scan dirs"]
    PB03 --> PM01[Update uid actions]

    S1(["Application focus in"]) --> PB01["Scan full changes"]
    S2([Extensions changed]) --> PB01
    PB01 --> C01{Is scanning?}
    C01 --> |No|PB12["Mark fs dirty"]
    C01 --> |Yes|PB11["Full scan pending"]
    PB11 --> |Delayed to the end of the scan|PB01
    PB12 --> PD00["Scan dirty dirs"]

    S3([Dir operations in editor]) --> PB13["Mark dir dirty"]
    PB13 --> |Delayed to the end of the frame| PD00

    PD00 -->PE00
    PE00 -->PM01

    S4([File operations in editor]) --> PC00["Update file(s)"]
    PC00 --> |Delayed to the end of the frame|PM01

    PM01 --> C02{"Is first scan?"}
    C02 --> |No| PM02[Update global script classes]
    PM02 --> PM03[[Update scan actions]]
    C02 --> |Yes| PM03
    PM03 --> Z([End])
```

</details>

### Trigger a scan/update

Several cases that trigger a scan/update:

1. Launch editor (scan fs recursively);
2. Application focus in (scan fs recursively);
3. Extensions changed (scan fs recursively);
4. Dir operations (scan specific dirs);
5. File operations (update and/or scan specific files and/or dirs);
6. Some plugins actively call certain functions (update and/or scan).

<details>

<summary>Details</summary>

In a sense, Case 1 is a special case of Case 2. One difference is that the file information is stored in the file in case 1, while it is stored in memory in case 2. Another difference is that in case 1, the editor is being launched, so it may read the file information first, rather than reading the file information in the cache file to ensure that certain modules are available.

In case 3, the fact that the directory timestamp has not changed should not be an obstacle to detecting new files. The reasons for the changes in the list of supported file extensions are likely as follows:

1. Modified the editor settings `docks/filesystem/textfile_extensions` and/or `docks/filesystem/other_file_extensions`.
2. Modify certain scripts that inherit from `ResourceFormatLoader`[^1];
3. Activate/deactivate certain importer plugins[^2];

[^1]: These scripts must be global script classes (`class_name`) and must be tool (`@tool`) scripts.

[^2]: Custom importer scripts must inherit from `EditorImportPlugin` and be tool (`@tool`) scripts, and use `add_import_plugin()`/`remove_import_plugin()` to add/remove them.

Cases 4 and 5 are usually caused by user interaction in the editor. Some file caches (such as uids and global script classes) are project-wide, but some processing methods are implemented on a file-by-file basis (depending on `update_file()`). Additionally, the current file timestamp precision is **1 second**, making frequent calls to some methods unsuitable (#110048). These are the reasons for delaying processing until the end of the frame. It should be noted that if these file/dir operations affect the scripts mentioned in case 3, a new full scan may be triggered when the processing is completed.

Case 6 is probably the most unpredictable. Here are just some suggestions:

1. File write operations are best performed in the main thread;
2. Avoid frequent fs scanning.

</details>

### Update file info

During the scanning process, most of the information in `FileInfo` is updated **immediately**. This information is generally **unrelated** to file movement. However, information that might be affected by file movement is updated with a delay.

<details>

<summary>Details</summary>

The `FileInfo.status` records the file status at the corresponding path:

1. File changes;
2. Type changes;
3. File categories;
4. Has custom uid support or not;
5. Whether it is treated as a resource file;
6. Whether its type is a Script;
7. Whether its type is a PackedScene;
8. Whether it is a global class alternative;
9. Whether it is the **active** global class alternative.

The `FileInfo.class_name.icon_path` is used not only for scripts but also for other types of resources. `FileInfo.resource_script_class` is used for any resource that has script with a global class name. These two might become invalid when the script changes. However, the script will definitely be in `FileInfo.deps`. Modify `Object::get_property_list()` to ensure that the first `dep` found in `_find_resources()` of `ResourceFormatSaverBinaryInstance`/`ResourceFormatSaverTextInstance` is the `script`.

</details>

### Update UID and track paths

File changes can be tracked by monitoring changes in the UID. Since we obtain a snapshot of the file system during the scan, we need to analyze the changes in UIDs in a specific order to infer the changes to the files.

1. Verify whether the `UID(f)` is cached in `ResourceUID`;
2. Create and add a new UID;
3. Remove UID;
4. Attempting to add `UID(f)`;
5. If `UID(f)` already exists in `ResourceUID`, try adding `UID(m)`; if it still exists, try creating and adding a new UID.

<details>

<summary>Details</summary>

The above order is derived by working backward from the file changes. We may store the UID in both the `FileInfo` and the file itself. Read the new UID from the file to update the UID in memory.

Compound operations can be viewed as deleting first, and the UID is unique. Adding a UID **before** removing the existing one ensures the uniqueness of the newly added UID.

```mermaid
flowchart LR

A001(["Check uid change"]) --> C001{"Can have uid now?"}
C001 --> |Yes|A003["Check file status"]
C001 --> |No|A002["Remove UID(m) if valid"]
A002 --> E003([3])
A003 --> C002{"File removed?"}
C002 --> |Yes|A002
C002 --> |No|C003{"File added?"}
C003 --> |No|C005{"UID(m) valid?"}
C005 --> |Yes|C006{"UID(m) == UID(f)?"}
C006 --> |No|A008["Remove UID(m)"]
C006 --> |Yes|A007["Try to add UID(f) during first scan"]
A007 --> E001([1])
A008 --> E003
A008 --> C007{"UID(f) valid?"}
C005 --> |No|C007
C007 --> |Yes|A009["Try to add UID(f), UID(m)"]
A009 --> E004([4])
C007 --> |No|A010["Try to add UID(m)"]
A010 --> E004
C003 --> |Yes|C004{"UID(f) valid?"}
C004 --> |No|A006["Create a new UID"]
A006 --> E002([2])
C004 --> |Yes|A005["Try to add UID(f)"]
A005 --> E004
```

</details>

### Analyze file changes based on path changes in UID

During each scan, we record the basic File operations in `FileInfo.status` and use UID to track path changes.

Based on the above UID tracking records, the file operations are inferred according to rules.

<details>

<summary>Details</summary>

File operation types include (`U` for UID, `P` for path):

1. Basic operations:
   1. File added (UID added), `PaUa`;
   2. File removed (UID removed), `PrUr`;
   3. File updated, `Pu`;
      1. UID added, `Ua`;
      2. UID removed, `Ur`;
      3. UID unchanged.
2. Compound operations:
   1. File moved/renamed, `P0U0r + P1U0a`;
   2. File overwriten, `P0U0r + P1U1r + P1U0a + ...`;
   3. File duplicated, `P0U0r + P0U0a + P1U0a + ...`.

</details>

### Update the caches after confirming the file has been moved

1. Update resource paths of instances in `ResourceCache`;
2. Update global script classes;
3. Update deps, resource script class, and icons;
4. Update project settings.

## Jobs

### Multi-dot extensions

Improve support for multi-dot extensions.

<details>

<summary>Tasks</summary>

- [x] Add a `String::validate_extension()` method to validate whether the path's extension is in the provided list of extensions.
- [x] Improved support for multi-dot extensions in the file system.
- [x] Improved support for multi-dot extensions in file dialogs.

</details>

### File status

Use `status` to record information such as the file category, type, and status.

<details>

<summary>Tasks</summary>

- [x] Classification.
  - [x] Custom uid support, tagged in `EditorFileSystem::_category_validate()`.
  - [x] Categorize files by file extension, tagged in `EditorFileSystem::_category_validate()`.
    - [x] Importable files.
    - [x] Text files.
    - [x] Other files.
  - [x] Classified by `type`, tagged in `EditorFileSystem::_type_analysis()`.
    - [x] As resources.
    - [x] Not a resource.
      - [x] OtherFile.
      - [x] TextFile.
      - [x] Empty type.
- [x] The existence status of files on the same path changes.
  - [x] File removed, tagged in `EditorFileSystem::_file_info_remove()`.
  - [x] File added, handled in `EditorFileSystem::_file_info_add()`.
  - [x] File updated, handled in `EditorFileSystem::_file_info_update()`.
- [x] Type changes, tagged in `EditorFileSystem::_type_analysis()`.
  - [x] Type removed.
    - [x] Clear the path of the cached instance, handled in `EditorFileSystem::_update_scan_actions()`.
  - [x] Type added.
  - [x] Type changed, equivalent to removing first and then adding.
    - [x] Clear the path of the cached instance, handled in `EditorFileSystem::_update_scan_actions()`.
  - [x] Type unchanged, just a file update.
    - [x] Reload the cached instance.
      - [x] Scripts.
      - [x] Scenes.
      - [x] Other resources, sent via the `resources_reload` signal, handled in `EditorNode::_resources_changed()`.

</details>

### File movement

Track changes to UIDs to analyze complex operations such as file movement.

<details>

<summary>Tasks</summary>

- [x] Sort the processing order based on changes in UID, handled in `EditorFileSystem::_create_actions_from_uid_change()`.
- [x] Update `ResourceUID` cache in order, handled in `EditorFileSystem::_update_scan_uid_actions()`.
- [x] Track file changes based on changes in UID, handled in `EditorFileSystem::_update_scan_uid_actions()`.
  - [x] Categorizing file changes.
    - [x] File untracked, the UID is no longer in use.
    - [x] File moved, the file path using the UID has changed.
    - [x] File duplicated, a new file path attempting to use the existing UID has been detected.
    - [x] File tracked, the UID was used for the first time.
    - [x] File retracked, the UID is already included in the file.
  - [ ] Process caches based on UID changes.
    - [x] Resource path in cached instances.
      - [x] Untracked files.
        - [x] Cleared.
      - [x] Moved files.
        - [x] Updated.
          - [x] Use the `.tmp~` temporary suffix to avoid path swapping cases.
    - [x] File owners and dependencies.
      - [x] Untracked files.
        - [x] Keep.
      - [x] Moved files.
        - [x] Update the `deps` in the owner's file info.
        - [x] Rename dependencies in the owner files.
        - [x] When the affected file owner is an opened scene file, reload occurs.
    - [x] Project settings.
      - [x] Update affected file paths.
    - [ ] Folder tracking has not yet been implemented. Use a `.uid` file to track?
      - [ ] Folder colors.
        - [x] In editor, call `FileSystemDock::_update_folder_colors_after_move()`.
        - [ ] Outside editor.
      - [ ] Favorites.
    - [ ] Update `ResourceCache::resource_path_cache`.
    - [ ] Provide a dialog that displays the changes.

</details>

### Script class info

Update class information in the script.

<details>

<summary>Tasks</summary>

- [x] Manage class info, handled in `EditorFileSystem::_script_class_info_update()`.
  - [x] Docs.
  - [x] Icons.
    - [x] Scripts.
      - [x] `class_info.icon_path`[^3].
    - [x] Resource files.
      - [x] `class_info.icon_path`[^3].
- [x] Manage global script class.
  - [x] Cache global script class alternatives.
  - [x] Handles updates for global script alternatives.
    - [x] Class info removed, handled in `EditorFileSystem::_global_script_class_info_remove()`.
    - [x] Class info added, handled in `EditorFileSystem::_global_script_class_info_add()`.
    - [x] Class info updated, equivalent to removing first and then adding, handled in `EditorFileSystem::_script_class_info_update()`.
  - [x] Maintaining active global script classes.
    - [x] Activate, handled in `EditorFileSystem::_update_global_script_class_activation()`.
      - [x] Register in `ScriptServer`.
      - [x] Register in `EditorData`.
        - [x] Class name.
        - [x] Icon.
      - [x] Generate its documentation.
    - [x] Deactivate, handled in `EditorFileSystem::_global_script_class_info_remove()`.
      - [x] Unregister in `ScriptServer`.
      - [x] Unregister in `EditorData`.
        - [x] Class name.
        - [x] Icon.
      - [x] Clear its documentation.
    - [x] Special class derived scripts.
      - [x] `ResourceFormatLoader`.
      - [x] `ResourceFormatSaver`.

[^3]: The icon displayed as the file icon conflicts with the icon specified in the script's icon field.

</details>

### Scenes

Update global scene groups and built-in scripts.

<details>

<summary>Tasks</summary>

- [x] Global scene groups.
- [x] Built-in scripts.
  - [x] Docs.

</details>

### Importable files

<details>

<summary>Tasks</summary>

- [x] Verify whether (re)importing is necessary, handled in `EditorFileSystem::_import_validate()`.

</details>

## Known issues

<details>

<summary>An error occurs when updating the tscn file that uses ViewportTexture</summary>

```bash
ERROR: Path to node is invalid: 'SubViewportContainer/SubViewport'.
   at: _setup_local_to_scene (scene/main/viewport.cpp:200)
```

`EditorFileSystem::_update_script_documentation()` will load and use the `PackedScene`. Resources that are not configured with a local scene in the editor will return the root of the currently edited scene when `Resource::get_local_scene()` is called.

</details>
