### PR TITLE
Fix AHashMap realloc cause AnimationPlayer crash (reverted)

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -164,10 +164,11 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 
 	double start = cd.get_start_time();
 	double end = cd.get_end_time();
+	AnimationData *p_from = &animation_set[cd.animation_name];
 
 	Animation::LoopedFlag looped_flag = Animation::LOOPED_FLAG_NONE;
 
-	switch (cd.from->animation->get_loop_mode()) {
+	switch (p_from->animation->get_loop_mode()) {
 		case Animation::LOOP_NONE: {
 			if (Animation::is_less_approx(next_pos, start)) {
 				next_pos = start;
@@ -207,7 +208,7 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 
 	// End detection.
 	if (p_is_current) {
-		if (cd.from->animation->get_loop_mode() == Animation::LOOP_NONE) {
+		if (p_from->animation->get_loop_mode() == Animation::LOOP_NONE) {
 			if (!backwards && Animation::is_less_or_equal_approx(prev_pos, end) && Math::is_equal_approx(next_pos, end)) {
 				// Playback finished.
 				next_pos = end; // Snap to the edge.
@@ -248,7 +249,7 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 	pi.is_external_seeking = !p_internal_seeked && !p_started;
 	pi.looped_flag = looped_flag;
 	pi.weight = p_blend;
-	make_animation_instance(cd.from->name, pi);
+	make_animation_instance(cd.animation_name, pi);
 }
 
 float AnimationPlayer::get_current_blend_amount() {
@@ -300,12 +301,13 @@ void AnimationPlayer::_blend_playback_data(double p_delta, bool p_started) {
 }
 
 bool AnimationPlayer::_blend_pre_process(double p_delta, int p_track_count, const AHashMap<NodePath, int> &p_track_map) {
-	if (!playback.current.from) {
+	if (playback.current.animation_name.is_empty()) {
 		_set_process(false);
 		return false;
 	}
 
-	tmp_from = playback.current.from->animation->get_instance_id();
+	AnimationData *p_from = &animation_set[playback.current.animation_name];
+	tmp_from = p_from->animation->get_instance_id();
 	end_reached = false;
 	end_notify = false;
 
@@ -316,10 +318,10 @@ bool AnimationPlayer::_blend_pre_process(double p_delta, int p_track_count, cons
 		playback.started = false;
 	}
 
-	AnimationData *prev_from = playback.current.from;
+	String prev_animation_name = playback.current.animation_name;
 	_blend_playback_data(p_delta, started);
 
-	if (prev_from != playback.current.from) {
+	if (prev_animation_name != playback.current.animation_name) {
 		return false; // Animation has been changed in the process (may be caused by method track), abort process.
 	}
 
@@ -333,7 +335,7 @@ void AnimationPlayer::_blend_capture(double p_delta) {
 void AnimationPlayer::_blend_post_process() {
 	if (end_reached) {
 		// If the method track changes current animation, the animation is not finished.
-		if (tmp_from == playback.current.from->animation->get_instance_id()) {
+		if (tmp_from == animation_set[playback.current.animation_name].animation->get_instance_id()) {
 			if (playback_queue.size()) {
 				if (!finished_anim.is_empty()) {
 					emit_signal(SceneStringName(animation_finished), finished_anim);
@@ -433,10 +435,10 @@ void AnimationPlayer::play_section_with_markers(const StringName &p_name, const 
 	ERR_FAIL_COND_MSG(p_start_marker && p_end_marker && Animation::is_greater_approx(start_time, end_time), vformat("End marker %s is placed earlier than start marker %s in animation: %s.", p_end_marker, p_start_marker, name));
 
 	if (p_start_marker && Animation::is_less_approx(start_time, 0)) {
-		WARN_PRINT_ED(vformat("Negative time start marker: %s is invalid in the section, so the start of the animation: %s is used instead.", p_start_marker, playback.current.from->animation->get_name()));
+		WARN_PRINT_ED(vformat("Negative time start marker: %s is invalid in the section, so the start of the animation: %s is used instead.", p_start_marker, playback.current.animation_name));
 	}
 	if (p_end_marker && Animation::is_less_approx(end_time, 0)) {
-		WARN_PRINT_ED(vformat("Negative time end marker: %s is invalid in the section, so the end of the animation: %s is used instead.", p_end_marker, playback.current.from->animation->get_name()));
+		WARN_PRINT_ED(vformat("Negative time end marker: %s is invalid in the section, so the end of the animation: %s is used instead.", p_end_marker, playback.current.animation_name));
 	}
 
 	play_section(name, start_time, end_time, p_custom_blend, p_custom_scale, p_from_end);
@@ -455,11 +457,11 @@ void AnimationPlayer::play_section(const StringName &p_name, double p_start_time
 
 	Playback &c = playback;
 
-	if (c.current.from) {
+	if (!c.current.animation_name.is_empty()) {
 		double blend_time = 0.0;
 		// Find if it can blend.
 		BlendKey bk;
-		bk.from = c.current.from->name;
+		bk.from = c.current.animation_name;
 		bk.to = name;
 
 		if (Animation::is_greater_or_equal_approx(p_custom_blend, 0)) {
@@ -471,7 +473,7 @@ void AnimationPlayer::play_section(const StringName &p_name, double p_start_time
 			if (blend_times.has(bk)) {
 				blend_time = blend_times[bk];
 			} else {
-				bk.from = c.current.from->name;
+				bk.from = c.current.animation_name;
 				bk.to = "*";
 
 				if (blend_times.has(bk)) {
@@ -498,7 +500,8 @@ void AnimationPlayer::play_section(const StringName &p_name, double p_start_time
 		_clear_playing_caches();
 	}
 
-	c.current.from = &animation_set[name];
+	c.current.animation_name = name;
+	c.current.animation_length = animation_set[name].animation->get_length();
 	c.current.speed_scale = p_custom_scale;
 	c.current.start_time = p_start_time;
 	c.current.end_time = p_end_time;
@@ -613,7 +616,8 @@ void AnimationPlayer::set_assigned_animation(const StringName &p_animation) {
 	} else {
 		ERR_FAIL_COND_MSG(!animation_set.has(p_animation), vformat("Animation not found: %s.", p_animation.operator String()));
 		playback.current.pos = 0;
-		playback.current.from = &animation_set[p_animation];
+		playback.current.animation_name = p_animation;
+		playback.current.animation_length = animation_set[p_animation].animation->get_length();
 		playback.current.start_time = -1;
 		playback.current.end_time = -1;
 		playback.assigned = p_animation;
@@ -658,12 +662,13 @@ void AnimationPlayer::seek_internal(double p_time, bool p_update, bool p_update_
 	_check_immediately_after_start();
 
 	playback.current.pos = p_time;
-	if (!playback.current.from) {
+	if (!playback.current.animation_name.is_empty()) {
 		if (playback.assigned) {
 			ERR_FAIL_COND_MSG(!animation_set.has(playback.assigned), vformat("Animation not found: %s.", playback.assigned));
-			playback.current.from = &animation_set[playback.assigned];
+			playback.current.animation_name = playback.assigned;
+			playback.current.animation_length = animation_set[playback.assigned].animation->get_length();
 		}
-		if (!playback.current.from) {
+		if (!playback.current.animation_name.is_empty()) {
 			return; // There is no animation.
 		}
 	}
@@ -699,37 +704,37 @@ void AnimationPlayer::_check_immediately_after_start() {
 }
 
 bool AnimationPlayer::is_valid() const {
-	return (playback.current.from);
+	return (!playback.current.animation_name.is_empty());
 }
 
 double AnimationPlayer::get_current_animation_position() const {
-	ERR_FAIL_NULL_V_MSG(playback.current.from, 0, "AnimationPlayer has no current animation.");
+	ERR_FAIL_COND_V_MSG(!playback.current.animation_name.is_empty(), 0, "AnimationPlayer has no current animation.");
 	return playback.current.pos;
 }
 
 double AnimationPlayer::get_current_animation_length() const {
-	ERR_FAIL_NULL_V_MSG(playback.current.from, 0, "AnimationPlayer has no current animation.");
-	return playback.current.from->animation->get_length();
+	ERR_FAIL_COND_V_MSG(!playback.current.animation_name.is_empty(), 0, "AnimationPlayer has no current animation.");
+	return playback.current.animation_length;
 }
 
 void AnimationPlayer::set_section_with_markers(const StringName &p_start_marker, const StringName &p_end_marker) {
-	ERR_FAIL_NULL_MSG(playback.current.from, "AnimationPlayer has no current animation.");
+	ERR_FAIL_COND_MSG(!playback.current.animation_name.is_empty(), "AnimationPlayer has no current animation.");
 	ERR_FAIL_COND_MSG(p_start_marker == p_end_marker && p_start_marker, vformat("Start marker and end marker cannot be the same marker: %s.", p_start_marker));
-	ERR_FAIL_COND_MSG(p_start_marker && !playback.current.from->animation->has_marker(p_start_marker), vformat("Marker %s not found in animation: %s.", p_start_marker, playback.current.from->animation->get_name()));
-	ERR_FAIL_COND_MSG(p_end_marker && !playback.current.from->animation->has_marker(p_end_marker), vformat("Marker %s not found in animation: %s.", p_end_marker, playback.current.from->animation->get_name()));
-	double start_time = p_start_marker ? playback.current.from->animation->get_marker_time(p_start_marker) : -1;
-	double end_time = p_end_marker ? playback.current.from->animation->get_marker_time(p_end_marker) : -1;
+	ERR_FAIL_COND_MSG(p_start_marker && !animation_set[playback.current.animation_name].animation->has_marker(p_start_marker), vformat("Marker %s not found in animation: %s.", p_start_marker, playback.current.animation_name));
+	ERR_FAIL_COND_MSG(p_end_marker && !animation_set[playback.current.animation_name].animation->has_marker(p_end_marker), vformat("Marker %s not found in animation: %s.", p_end_marker, playback.current.animation_name));
+	double start_time = p_start_marker ? animation_set[playback.current.animation_name].animation->get_marker_time(p_start_marker) : -1;
+	double end_time = p_end_marker ? animation_set[playback.current.animation_name].animation->get_marker_time(p_end_marker) : -1;
 	if (p_start_marker && Animation::is_less_approx(start_time, 0)) {
-		WARN_PRINT_ONCE_ED(vformat("Marker %s time must be positive in animation: %s.", p_start_marker, playback.current.from->animation->get_name()));
+		WARN_PRINT_ONCE_ED(vformat("Marker %s time must be positive in animation: %s.", p_start_marker, playback.current.animation_name));
 	}
 	if (p_end_marker && Animation::is_less_approx(end_time, 0)) {
-		WARN_PRINT_ONCE_ED(vformat("Marker %s time must be positive in animation: %s.", p_end_marker, playback.current.from->animation->get_name()));
+		WARN_PRINT_ONCE_ED(vformat("Marker %s time must be positive in animation: %s.", p_end_marker, playback.current.animation_name));
 	}
 	set_section(start_time, end_time);
 }
 
 void AnimationPlayer::set_section(double p_start_time, double p_end_time) {
-	ERR_FAIL_NULL_MSG(playback.current.from, "AnimationPlayer has no current animation.");
+	ERR_FAIL_COND_MSG(!playback.current.animation_name.is_empty(), "AnimationPlayer has no current animation.");
 	ERR_FAIL_COND_MSG(Animation::is_greater_or_equal_approx(p_start_time, 0) && Animation::is_greater_or_equal_approx(p_end_time, 0) && Animation::is_greater_or_equal_approx(p_start_time, p_end_time), vformat("Start time %f is greater than end time %f.", p_start_time, p_end_time));
 	playback.current.start_time = p_start_time;
 	playback.current.end_time = p_end_time;
@@ -742,12 +747,12 @@ void AnimationPlayer::reset_section() {
 }
 
 double AnimationPlayer::get_section_start_time() const {
-	ERR_FAIL_NULL_V_MSG(playback.current.from, playback.current.start_time, "AnimationPlayer has no current animation.");
+	ERR_FAIL_COND_V_MSG(!playback.current.animation_name.is_empty(), playback.current.start_time, "AnimationPlayer has no current animation.");
 	return playback.current.get_start_time();
 }
 
 double AnimationPlayer::get_section_end_time() const {
-	ERR_FAIL_NULL_V_MSG(playback.current.from, playback.current.end_time, "AnimationPlayer has no current animation.");
+	ERR_FAIL_COND_V_MSG(!playback.current.animation_name.is_empty(), playback.current.end_time, "AnimationPlayer has no current animation.");
 	return playback.current.get_end_time();
 }
 
@@ -779,7 +784,7 @@ void AnimationPlayer::_stop_internal(bool p_reset, bool p_keep_state) {
 	_clear_caches();
 	Playback &c = playback;
 	// c.blend.clear();
-	double start = c.current.from ? playback.current.get_start_time() : 0;
+	double start = (!c.current.animation_name.is_empty()) ? playback.current.get_start_time() : 0;
 	if (p_reset) {
 		c.blend.clear();
 		if (p_keep_state) {
@@ -789,7 +794,7 @@ void AnimationPlayer::_stop_internal(bool p_reset, bool p_keep_state) {
 			seek_internal(start, true, true, true);
 			is_stopping = false;
 		}
-		c.current.from = nullptr;
+		c.current.animation_name = String();
 		c.current.speed_scale = 1;
 		emit_signal(SNAME("current_animation_changed"), "");
 	}

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -65,20 +65,21 @@ private:
 	bool is_stopping = false;
 
 	struct PlaybackData {
-		AnimationData *from = nullptr;
+		String animation_name;
+		int animation_length = 0;
 		double pos = 0.0;
 		float speed_scale = 1.0;
 		double start_time = 0.0;
 		double end_time = 0.0;
 		double get_start_time() const {
-			if (from && (Animation::is_less_approx(start_time, 0) || Animation::is_greater_approx(start_time, from->animation->get_length()))) {
+			if ((!animation_name.is_empty()) && (Animation::is_less_approx(start_time, 0) || Animation::is_greater_approx(start_time, animation_length))) {
 				return 0;
 			}
 			return start_time;
 		}
 		double get_end_time() const {
-			if (from && (Animation::is_less_approx(end_time, 0) || Animation::is_greater_approx(end_time, from->animation->get_length()))) {
-				return from->animation->get_length();
+			if ((!animation_name.is_empty()) && (Animation::is_less_approx(end_time, 0) || Animation::is_greater_approx(end_time, animation_length))) {
+				return animation_length;
 			}
 			return end_time;
 		}


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/112038*

## Issue Description

When we create 15 (more than 12) animations with multiple `AnimationPlayer` in GDScript, the game will crash at the beginning of running.

The asan shows the relevant memory of `playback.current.from` is freed by `realloc`.

```
=================================================================
==287135==ERROR: AddressSanitizer: heap-use-after-free on address 0x515000554010 at pc 0x62e0145ab21e bp 0x7fff8df78af0 sp 0x7fff8df78ae8
READ of size 8 at 0x515000554010 thread T0
    #0 0x62e0145ab21d in Ref<Animation>::operator->() const /home/work/godot/./core/object/ref_counted.h:120:10
    #1 0x62e02aab5ad2 in AnimationPlayer::_blend_pre_process(double, int, AHashMap<NodePath, int, HashMapHasherDefault, HashMapComparatorDefault<NodePath, void>> const&) /home/work/godot/scene/animation/animation_player.cpp:324:13
    #2 0x62e02a8fb0f5 in AnimationMixer::_process_animation(double, bool) /home/work/godot/scene/animation/animation_mixer.cpp:1003:6
    #3 0x62e02a943ca0 in AnimationMixer::_notification(int) /home/work/godot/scene/animation/animation_mixer.cpp:2370:5
    #4 0x62e02a97538a in AnimationMixer::_notification_forwardv(int) /home/work/godot/scene/animation/animation_mixer.h:43:2
    #5 0x62e02aaeab98 in AnimationPlayer::_notification_forwardv(int) /home/work/godot/scene/animation/animation_player.h:37:2
    #6 0x62e0333d0f07 in Object::_notification_forward(int) /home/work/godot/core/object/object.cpp:993:2
    #7 0x62e011fad0f6 in Object::notification(int, bool) /home/work/godot/./core/object/object.h:919:4
    #8 0x62e026c252f2 in SceneTree::_process_group(SceneTree::ProcessGroup*, bool) /home/work/godot/scene/main/scene_tree.cpp:1201:8
    #9 0x62e026c117ae in SceneTree::_process(bool) /home/work/godot/scene/main/scene_tree.cpp:1281:8
    #10 0x62e026c1773e in SceneTree::process(double) /home/work/godot/scene/main/scene_tree.cpp:708:2
    #11 0x62e0124422f4 in Main::iteration() /home/work/godot/main/main.cpp:4859:44
    #12 0x62e011fcdcc5 in OS_LinuxBSD::run() /home/work/godot/platform/linuxbsd/os_linuxbsd.cpp:994:7
    #13 0x62e01202d805 in main /home/work/godot/platform/linuxbsd/godot_linuxbsd.cpp:121:6
    #14 0x7dc52482a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0x7dc52482a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #16 0x62e011ecd7e4 in _start (/home/work/local/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x209ad7e4) (BuildId: a4a626d0fcd74417)

0x515000554010 is located 272 bytes inside of 496-byte region [0x515000553f00,0x5150005540f0)
freed by thread T0 here:
    #0 0x62e011f68a50 in realloc (/home/work/local/godot.linuxbsd.editor.dev.x86_64.llvm.san+0x20a48a50) (BuildId: a4a626d0fcd74417)
    #1 0x62e031517268 in Memory::realloc_static(void*, unsigned long, bool) /home/work/godot/core/os/memory.cpp:170:21
    #2 0x62e02a9852b2 in AHashMap<StringName, AnimationMixer::AnimationData, HashMapHasherDefault, HashMapComparatorDefault<StringName, void>>::_resize_and_rehash(unsigned int) /home/work/godot/./core/templates/a_hash_map.h:219:47
    #3 0x62e02a9848f9 in AHashMap<StringName, AnimationMixer::AnimationData, HashMapHasherDefault, HashMapComparatorDefault<StringName, void>>::_insert_element(StringName const&, AnimationMixer::AnimationData const&, unsigned int) /home/work/godot/./core/templates/a_hash_map.h:243:4
    #4 0x62e02a94ca14 in AHashMap<StringName, AnimationMixer::AnimationData, HashMapHasherDefault, HashMapComparatorDefault<StringName, void>>::insert(StringName const&, AnimationMixer::AnimationData const&) /home/work/godot/./core/templates/a_hash_map.h:617:18
    #5 0x62e02a8dbc58 in AnimationMixer::_animation_set_cache_update() /home/work/godot/scene/animation/animation_mixer.cpp:166:19
    #6 0x62e02a8dd7e8 in AnimationMixer::_animation_added(StringName const&, StringName const&) /home/work/godot/scene/animation/animation_mixer.cpp:209:2
    #7 0x62e02a98a0d5 in void call_with_variant_args_helper<AnimationMixer, StringName const&, StringName const&, 0ul, 1ul>(AnimationMixer*, void (AnimationMixer::*)(StringName const&, StringName const&), Variant const**, Callable::CallError&, IndexSequence<0ul, 1ul>) /home/work/godot/./core/variant/binder_common.h:223:2
    #8 0x62e02a989ca4 in void call_with_variant_args<AnimationMixer, StringName const&, StringName const&>(AnimationMixer*, void (AnimationMixer::*)(StringName const&, StringName const&), Variant const**, int, Callable::CallError&) /home/work/godot/./core/variant/binder_common.h:337:2
    #9 0x62e02a989795 in CallableCustomMethodPointer<AnimationMixer, void, StringName const&, StringName const&>::call(Variant const**, int, Variant&, Callable::CallError&) const /home/work/godot/./core/object/callable_method_pointer.h:103:4
    #10 0x62e0323afacb in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const /home/work/godot/core/variant/callable.cpp:57:11
    #11 0x62e0323c80ff in CallableCustomBind::call(Variant const**, int, Variant&, Callable::CallError&) const /home/work/godot/core/variant/callable_bind.cpp:150:11
    #12 0x62e0323afacb in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const /home/work/godot/core/variant/callable.cpp:57:11
    #13 0x62e0333dc918 in Object::emit_signalp(StringName const&, Variant const**, int) /home/work/godot/core/object/object.cpp:1341:13
    #14 0x62e0227af355 in Error Object::emit_signal<StringName>(StringName const&, StringName) /home/work/godot/./core/object/object.h:967:10
    #15 0x62e02af69394 in AnimationLibrary::add_animation(StringName const&, Ref<Animation> const&) /home/work/godot/scene/resources/animation_library.cpp:59:2
    #16 0x62e02af87997 in void call_with_variant_args_ret_helper<__UnexistingClass, Error, StringName const&, Ref<Animation> const&, 0ul, 1ul>(__UnexistingClass*, Error (__UnexistingClass::*)(StringName const&, Ref<Animation> const&), Variant const**, Variant&, Callable::CallError&, IndexSequence<0ul, 1ul>) /home/work/godot/./core/variant/binder_common.h:672:10
    #17 0x62e02af874ec in void call_with_variant_args_ret_dv<__UnexistingClass, Error, StringName const&, Ref<Animation> const&>(__UnexistingClass*, Error (__UnexistingClass::*)(StringName const&, Ref<Animation> const&), Variant const**, int, Variant&, Callable::CallError&, Vector<Variant> const&) /home/work/godot/./core/variant/binder_common.h:454:2
    #18 0x62e02af8533f in MethodBindTR<Error, StringName const&, Ref<Animation> const&>::call(Object*, Variant const**, int, Callable::CallError&) const /home/work/godot/./core/object/method_bind.h:515:3
    #19 0x62e017d0a0ae in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /home/work/godot/modules/gdscript/gdscript_vm.cpp:2058:25
    #20 0x62e0173c5eb3 in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) /home/work/godot/modules/gdscript/gdscript.cpp:2059:22
    #21 0x62e0333cd7fc in Object::callp(StringName const&, Variant const**, int, Callable::CallError&) /home/work/godot/core/object/object.cpp:884:26
    #22 0x62e03246fd4d in Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) /home/work/godot/core/variant/variant_call.cpp:1419:27
    #23 0x62e017d065cb in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) /home/work/godot/modules/gdscript/gdscript_vm.cpp:1955:12
    #24 0x62e0173c5eb3 in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) /home/work/godot/modules/gdscript/gdscript.cpp:2059:22
    #25 0x62e026b0bd4a in Node::_gdvirtual__ready_call() /home/work/godot/scene/main/node.h:431:2
    #26 0x62e026a6f0e9 in Node::_notification(int) /home/work/godot/scene/main/node.cpp:273:4
    #27 0x62e0145f820a in Node::_notification_forwardv(int) /home/work/godot/./scene/main/node.h:51:2
    #28 0x62e014bbf8a8 in Node3D::_notification_forwardv(int) /home/work/godot/./scene/3d/node_3d.h:51:2
    #29 0x62e016b0c278 in VisualInstance3D::_notification_forwardv(int) /home/work/godot/./scene/3d/visual_instance_3d.h:38:2
```

## Explaination

### `AHashMap` will call `realloc` when meets auto grow factor

The default capacity of `AHashMap` is `16`.

https://github.com/godotengine/godot/blob/235a32ad11f40ecba26d6d9ceea8ab245c13adb0/core/templates/a_hash_map.h#L85

The auto expand factor of `AHashMap` is 0.75 (12 = 16 * 0.75).

https://github.com/godotengine/godot/blob/235a32ad11f40ecba26d6d9ceea8ab245c13adb0/core/templates/a_hash_map.h#L115-L117

When the size of `AHashMap` meets `12`, it will `realloc` its memory, grows to `32`.

https://github.com/godotengine/godot/blob/235a32ad11f40ecba26d6d9ceea8ab245c13adb0/core/templates/a_hash_map.h#L219

I guess when there is no enough continuous memory, `realloc` may allocate a new range of memory and free original memory. Because I cannot re-produce crash with only one `AnimationPlayer`.

### `AnimationPlayer` use a pointer to reference address from `AHashMap`

When we call `play(animation_name)`, we will store relevant address of `animation_set[name]` to a pointer named `playback.current.from`.

https://github.com/godotengine/godot/blob/235a32ad11f40ecba26d6d9ceea8ab245c13adb0/scene/animation/animation_player.cpp#L501

- First, we called `play()` to store an `AnimationData` address from `AHashMap` to `playback.current.from` of `AnimationPlayer`.
- Second, we keep adding animation and exceed  the auto grow factor, this time is 12, to trigger `realloc`.
- If `realloc` frees the original memory of `AHashMap`. Next time when we used `playback.current.from`, we will meet crashing. Because relevant memory is freed by `realloc`.

## Solution

The solution is **DON'T** reference the address of `AHashMap` element directly, because it may be freed when **AUTO GROW**. We can save animation name and get `AnimationData` with name when used.


