### PR TITLE
Wayland: Fix compiling with `libdecor=no`

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1536,10 +1536,11 @@ Error DisplayServerWayland::embed_process(WindowID p_window, OS::ProcessID p_pid
 		ERR_FAIL_NULL_V(ws, ERR_BUG);
 
 		struct xdg_toplevel *toplevel = ws->xdg_toplevel;
-
+#ifdef LIBDECOR_ENABLED
 		if (toplevel == nullptr && ws->libdecor_frame) {
 			toplevel = libdecor_frame_get_xdg_toplevel(ws->libdecor_frame);
 		}
+#endif
 
 		ERR_FAIL_NULL_V(toplevel, ERR_CANT_CREATE);
 


### PR DESCRIPTION
#107435 used libdecor without a feature guard which lead to build fails.
Fixes compiling with libdecor=no as per https://github.com/godotengine/godot/pull/107435#discussion_r2550376134

@deralmas does this seem like the standard way of guarding for libdecor?