### PR TITLE
Improvements to TAA

### DIFF
--- a/servers/rendering/renderer_rd/effects/taa.cpp
+++ b/servers/rendering/renderer_rd/effects/taa.cpp
@@ -47,7 +47,7 @@ TAA::~TAA() {
 	taa_shader.version_free(shader_version);
 }
 
-void TAA::resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_prev_velocity, RID p_history, Size2 p_resolution, float p_z_near, float p_z_far) {
+void TAA::resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_history, Size2 p_resolution, float p_z_near, float p_z_far) {
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -76,11 +76,10 @@ void TAA::resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_pr
 	RD::Uniform u_frame_source(RD::UNIFORM_TYPE_IMAGE, 0, { p_frame });
 	RD::Uniform u_depth(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 1, { default_sampler, p_depth });
 	RD::Uniform u_velocity(RD::UNIFORM_TYPE_IMAGE, 2, { p_velocity });
-	RD::Uniform u_prev_velocity(RD::UNIFORM_TYPE_IMAGE, 3, { p_prev_velocity });
-	RD::Uniform u_history(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 4, { default_sampler, p_history });
-	RD::Uniform u_frame_dest(RD::UNIFORM_TYPE_IMAGE, 5, { p_temp });
+	RD::Uniform u_history(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 3, { default_sampler, p_history });
+	RD::Uniform u_frame_dest(RD::UNIFORM_TYPE_IMAGE, 4, { p_temp });
 
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_frame_source, u_depth, u_velocity, u_prev_velocity, u_history, u_frame_dest), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_frame_source, u_depth, u_velocity, u_history, u_frame_dest), 0);
 	RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(TAAResolvePushConstant));
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_resolution.width, p_resolution.height, 1);
 	RD::get_singleton()->compute_list_end();
@@ -91,7 +90,6 @@ void TAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_f
 
 	uint32_t view_count = p_render_buffers->get_view_count();
 	Size2i internal_size = p_render_buffers->get_internal_size();
-	Size2i target_size = p_render_buffers->get_target_size();
 
 	bool just_allocated = false;
 	if (!p_render_buffers->has_texture(SNAME("taa"), SNAME("history"))) {
@@ -99,8 +97,6 @@ void TAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_f
 
 		p_render_buffers->create_texture(SNAME("taa"), SNAME("history"), p_format, usage_bits);
 		p_render_buffers->create_texture(SNAME("taa"), SNAME("temp"), p_format, usage_bits);
-
-		p_render_buffers->create_texture(SNAME("taa"), SNAME("prev_velocity"), RD::DATA_FORMAT_R16G16_SFLOAT, usage_bits);
 
 		just_allocated = true;
 	}
@@ -112,17 +108,15 @@ void TAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_f
 		RID internal_texture = p_render_buffers->get_internal_texture(v);
 		RID velocity_buffer = p_render_buffers->get_velocity_buffer(false, v);
 		RID taa_history = p_render_buffers->get_texture_slice(SNAME("taa"), SNAME("history"), v, 0);
-		RID taa_prev_velocity = p_render_buffers->get_texture_slice(SNAME("taa"), SNAME("prev_velocity"), v, 0);
 
 		if (!just_allocated) {
 			RID depth_texture = p_render_buffers->get_depth_texture(v);
 			RID taa_temp = p_render_buffers->get_texture_slice(SNAME("taa"), SNAME("temp"), v, 0);
-			resolve(internal_texture, taa_temp, depth_texture, velocity_buffer, taa_prev_velocity, taa_history, Size2(internal_size.x, internal_size.y), p_z_near, p_z_far);
+			resolve(internal_texture, taa_temp, depth_texture, velocity_buffer, taa_history, Size2(internal_size.x, internal_size.y), p_z_near, p_z_far);
 			copy_effects->copy_to_rect(taa_temp, internal_texture, Rect2(0, 0, internal_size.x, internal_size.y));
 		}
 
 		copy_effects->copy_to_rect(internal_texture, taa_history, Rect2(0, 0, internal_size.x, internal_size.y));
-		copy_effects->copy_to_rect(velocity_buffer, taa_prev_velocity, Rect2(0, 0, target_size.x, target_size.y));
 	}
 
 	RD::get_singleton()->draw_command_end_label();

--- a/servers/rendering/renderer_rd/effects/taa.h
+++ b/servers/rendering/renderer_rd/effects/taa.h
@@ -54,7 +54,7 @@ private:
 	RID shader_version;
 	RID pipeline;
 
-	void resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_prev_velocity, RID p_history, Size2 p_resolution, float p_z_near, float p_z_far);
+	void resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_history, Size2 p_resolution, float p_z_near, float p_z_far);
 };
 
 } // namespace RendererRD


### PR DESCRIPTION
Directly superseding https://github.com/godotengine/godot/pull/113003 as the solution to the Edge
Resolves Issue with Thin Bright Moving Objects on a dark background becoming very Dark and vice-versa
Maintain Glow better 
Mostly Resolves https://github.com/godotengine/godot/issues/67332

### **Removed The Anti-Flicker Algorithm**

Was Causing Edge instability Problems, and was not maintaining intended thin moving objects well on a high contrast background objects (say bright bullet flying past a dark background, which FSR would maintain fine) and even outright light ghosting, and alternative anti flicker algorithms were ineffective or caused blur

### **Add Background Fast Background Convergence**

Resolves issue with Background Stars dimming when Rotating Camera (likely due to no valid Motion Vectors provided)

Note - The following are Images of a Video Playback of the Same Motion, because the Videos are Recorded at a Very High Bitrate and are colossal, otherwise they Completely fall apart to completely Compression Artifacts (and even with 100 Mb/s, the max Radeon ReLive supports suffers from significant Compression issues visible in the pictures provided) so these are for demonstration of a change, as this pathological case you need to see it live. 

Master

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/c805af71-0453-4d1c-bce2-e899559e2748" />

PR

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/368ec8ae-e64f-468a-9dee-0de278681aa8" />

### **Changed Disocclusion and History Clipping**

Resolved randomly appearing Low Res appearance caused by the Old History Clipping.

New Algorithm (It's safe to Ignore the slight Chroma issue, that's Bullet and Bullet Light ghosts, both of which are really bright and not actually visible live, likely due to some combination of Display and Eyes covering and it being an extremely short lived effect)

<img width="864" height="677" alt="image" src="https://github.com/user-attachments/assets/e83f748f-24a1-4eb2-811f-6c1f9dcafd77" />

Master with Variance Clipping in some instances (doesn't always occur)

<img width="873" height="621" alt="image" src="https://github.com/user-attachments/assets/a3adb5ec-b725-4b3e-bba5-a8b5958fa364" />

The Disocclusion was changed to use both velocities from the current frame velocities, with the current sample and the reprojected sample velocities, instead of current sample velocity and reprojected last frame velocity. This improves performance a little and prevents instances where Disocclusion was clearing the whole screen when changing movement
This was required with the new Clipping to minimize ghosting properly, as well as changing the Disocclusion scale and threshold which were set to 1 and 0 respectively (so removed) as this seems to have resulted in the best results in testing when using the new disocclusion

### **Remove The Tonemapping Step**

The Tonemapping Step caused issues with Glow Stability, and didn't actually change much else

Master

https://github.com/user-attachments/assets/b1346900-fb0a-43fa-9cba-ce848ba8d43e

PR Without Tonemapping Step

https://github.com/user-attachments/assets/f1f63707-4427-4645-a2da-0f36a6dd96c9

PR With Tonemapping Step

https://github.com/user-attachments/assets/2e3d59d4-25a3-436e-b49c-058cef6a3c2c


