### PR TITLE
Fix `String::rfindn` for strings with only one character.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3211,11 +3211,6 @@ int String::rfindn(const String &p_str, int p_from) const {
 		return -1; // Still out of bounds
 	}
 
-	if (str_len == 1) {
-		// Optimize with single-char implementation.
-		return span().rfind(p_str[0], p_from);
-	}
-
 	const char32_t *src = get_data();
 	const char32_t *str = p_str.get_data();
 


### PR DESCRIPTION
Our test for rfindn (https://github.com/godot-rust/gdext/blob/5e75d1c7f76762e754ffa9c9c17218068ebb1be0/itest/rust/src/builtin_tests/string/gstring_test.rs#L164) started failing while searching for one-character long sequences (i.e. `"Hello World".rfindn("O")` returns -1 instead of 7)

I was a bit confused where new function should go (do lowercase spans even make sense???), so I just monkey'd implementation of `strings_equal_lower`.

- _Bugsquad edit: Fixes regression from https://github.com/godotengine/godot/pull/101247_