### PR TITLE
Fix crash in `SceneTreeDock` by pre-creating nodes for replacement

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -3025,6 +3025,9 @@ void SceneTreeDock::_create() {
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 		ur->create_action(TTR("Change type of node(s)"), UndoRedo::MERGE_DISABLE, selection.front()->get());
 
+		Vector<Node *> old_nodes;
+		Vector<Node *> new_nodes;
+
 		for (Node *n : selection) {
 			ERR_FAIL_NULL(n);
 
@@ -3033,7 +3036,16 @@ void SceneTreeDock::_create() {
 			ERR_FAIL_COND(!c);
 			Node *new_node = Object::cast_to<Node>(c);
 			ERR_FAIL_NULL(new_node);
-			replace_node(n, new_node);
+
+			old_nodes.push_back(n);
+			new_nodes.push_back(new_node);
+		}
+
+		for (int i = 0; i < old_nodes.size(); i++) {
+			Node *old_node = old_nodes[i];
+			Node *new_node = new_nodes[i];
+
+			replace_node(old_node, new_node);
 		}
 
 		ur->commit_action(false);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes #113018.

During a (root) `Node` replacement event such as changing its type in the UI, the old and new nodes are created and then immediately provided to `SceneTreeDock::replace_node`, at which point they may not have initialized fully.

This PR separates this single action into two steps:

1. Eagerly build _all_ old and new nodes from `selection`, into a `Vector<Node *>` for each
2. Iterate through `old_nodes` and `new_nodes`, calling `SceneTreeDock::replace_node` on each pair
## Before

Changing the node type, and saving the scene each time, would crash the editor after not many iterations.

https://github.com/user-attachments/assets/475bc6a3-6a4b-4097-9a25-006e7db827db

Sorry for the low resolution (480p), GitHub is limiting video uploads to 10MB today.


## After

I manually changed node type at least 20 times, saving the scene each time. No crash at all.

Video evidence of 100 successful re-types is [here, on YouTube](https://www.youtube.com/watch?v=nMqvV5Sdc8w). Way too long for 10MB.

## Testing

Okay attached is my MacOS-only, ChatGPT-created, terrible test-harness!

It fails with normally single digit iterations for `master`.
[Test113048.zip](https://github.com/user-attachments/files/23691541/Test113048.zip), 
[with minimal reproduction project ](https://github.com/user-attachments/files/23691611/issue-113018-2.zip)

