### PR TITLE
BMP: Use real file size instead of size from header

### DIFF
--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -220,6 +220,11 @@ Error ImageLoaderBMP::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 			bmp_header.bmp_file_header.bmp_file_padding = f->get_32();
 			bmp_header.bmp_file_header.bmp_file_offset = f->get_32();
 
+			if (bmp_header.bmp_file_header.bmp_file_size != f->get_length()) {
+				WARN_PRINT(vformat("BMP file %s has incorrect file size in header", f->get_path()));
+				bmp_header.bmp_file_header.bmp_file_size = f->get_length();
+			}
+
 			// Info Header
 			bmp_header.bmp_info_header.bmp_header_size = f->get_32();
 			ERR_FAIL_COND_V_MSG(bmp_header.bmp_info_header.bmp_header_size < BITMAP_INFO_HEADER_MIN_SIZE, ERR_FILE_CORRUPT,


### PR DESCRIPTION
After running into another batch of BMP files (as part of older released games) that have invalid file sizes in the header, but load fine in any other piece of software (All windows built-in tools, gimp, etc) but fail to import in Godot, I am proposing to basically ignore any mismatch between the header and the actual file size.

Optionally, we could add a warning here that the file is broken, I would be happy to add that, if we feel that would add value.