### PR TITLE
Fix typo "END_SECTIOn" macro undef to END_SECTION for scene_tree_dock.cpp

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4027,7 +4027,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	END_SECTION()
 
 #undef BEGIN_SECTION
-#undef END_SECTIOn
+#undef END_SECTION
 
 	Vector<String> p_paths;
 	Node *root = EditorNode::get_singleton()->get_edited_scene();


### PR DESCRIPTION
I noticed that #92390 got merged despite undef'ing the non-existent `END_SECTIOn` macro thanks to a lowercase `n` leaving the END_SECTION macro to pollute the rest of the file. Not really that big a deal since its a source file but thought it better to prevent continued pollution of the rest of the source file anyway.

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/119549*