### PR TITLE
Clean up FindInFiles code

### DIFF
--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -33,8 +33,8 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h"
 #include "core/os/os.h"
+#include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
@@ -52,33 +52,31 @@
 #include "scene/gui/tree.h"
 #include "scene/main/scene_tree.h"
 
-const char *FindInFiles::SIGNAL_RESULT_FOUND = "result_found";
-
 // TODO: Would be nice in Vector and Vectors.
 template <typename T>
-inline void pop_back(T &container) {
-	container.resize(container.size() - 1);
+inline void pop_back(T &r_container) {
+	r_container.resize(r_container.size() - 1);
 }
 
-static bool find_next(const String &line, const String &pattern, int from, bool match_case, bool whole_words, int &out_begin, int &out_end) {
-	int end = from;
+static bool find_next(const String &p_line, const String &p_pattern, int p_from, bool p_match_case, bool p_whole_words, int &r_out_begin, int &r_out_end) {
+	int end = p_from;
 
 	while (true) {
-		int begin = match_case ? line.find(pattern, end) : line.findn(pattern, end);
+		int begin = p_match_case ? p_line.find(p_pattern, end) : p_line.findn(p_pattern, end);
 
 		if (begin == -1) {
 			return false;
 		}
 
-		end = begin + pattern.length();
-		out_begin = begin;
-		out_end = end;
+		end = begin + p_pattern.length();
+		r_out_begin = begin;
+		r_out_end = end;
 
-		if (whole_words) {
-			if (begin > 0 && (is_ascii_identifier_char(line[begin - 1]))) {
+		if (p_whole_words) {
+			if (begin > 0 && is_ascii_identifier_char(p_line[begin - 1])) {
 				continue;
 			}
-			if (end < line.size() && (is_ascii_identifier_char(line[end]))) {
+			if (end < p_line.size() && is_ascii_identifier_char(p_line[end])) {
 				continue;
 			}
 		}
@@ -89,35 +87,35 @@ static bool find_next(const String &line, const String &pattern, int from, bool 
 
 //--------------------------------------------------------------------------------
 
-void FindInFiles::set_search_text(const String &p_pattern) {
-	_pattern = p_pattern;
+void FindInFilesSearch::set_search_text(const String &p_pattern) {
+	pattern = p_pattern;
 }
 
-void FindInFiles::set_whole_words(bool p_whole_word) {
-	_whole_words = p_whole_word;
+void FindInFilesSearch::set_whole_words(bool p_whole_word) {
+	whole_words = p_whole_word;
 }
 
-void FindInFiles::set_match_case(bool p_match_case) {
-	_match_case = p_match_case;
+void FindInFilesSearch::set_match_case(bool p_match_case) {
+	match_case = p_match_case;
 }
 
-void FindInFiles::set_folder(const String &folder) {
-	_root_dir = folder;
+void FindInFilesSearch::set_folder(const String &p_folder) {
+	root_dir = p_folder;
 }
 
-void FindInFiles::set_filter(const HashSet<String> &exts) {
-	_extension_filter = exts;
+void FindInFilesSearch::set_filter(const HashSet<String> &p_exts) {
+	extension_filter = p_exts;
 }
 
-void FindInFiles::set_includes(const HashSet<String> &p_include_wildcards) {
-	_include_wildcards = p_include_wildcards;
+void FindInFilesSearch::set_includes(const HashSet<String> &p_include_wildcards) {
+	include_wildcards = p_include_wildcards;
 }
 
-void FindInFiles::set_excludes(const HashSet<String> &p_exclude_wildcards) {
-	_exclude_wildcards = p_exclude_wildcards;
+void FindInFilesSearch::set_excludes(const HashSet<String> &p_exclude_wildcards) {
+	exclude_wildcards = p_exclude_wildcards;
 }
 
-void FindInFiles::_notification(int p_what) {
+void FindInFilesSearch::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_PROCESS: {
 			_process();
@@ -125,38 +123,38 @@ void FindInFiles::_notification(int p_what) {
 	}
 }
 
-void FindInFiles::start() {
-	if (_pattern.is_empty()) {
+void FindInFilesSearch::start() {
+	if (pattern.is_empty()) {
 		print_verbose("Nothing to search, pattern is empty");
 		emit_signal(SceneStringName(finished));
 		return;
 	}
-	if (_extension_filter.is_empty()) {
+	if (extension_filter.is_empty()) {
 		print_verbose("Nothing to search, filter matches no files");
 		emit_signal(SceneStringName(finished));
 		return;
 	}
 
 	// Init search.
-	_current_dir = "";
+	current_dir = "";
 	PackedStringArray init_folder;
-	init_folder.push_back(_root_dir);
-	_folders_stack.clear();
-	_folders_stack.push_back(init_folder);
+	init_folder.push_back(root_dir);
+	folders_stack.clear();
+	folders_stack.push_back(init_folder);
 
-	_initial_files_count = 0;
+	initial_files_count = 0;
 
-	_searching = true;
+	searching = true;
 	set_process(true);
 }
 
-void FindInFiles::stop() {
-	_searching = false;
-	_current_dir = "";
+void FindInFilesSearch::stop() {
+	searching = false;
+	current_dir = "";
 	set_process(false);
 }
 
-void FindInFiles::_process() {
+void FindInFilesSearch::_process() {
 	// This part can be moved to a thread if needed.
 
 	OS &os = *OS::get_singleton();
@@ -170,11 +168,11 @@ void FindInFiles::_process() {
 	}
 }
 
-void FindInFiles::_iterate() {
-	if (_folders_stack.size() != 0) {
+void FindInFilesSearch::_iterate() {
+	if (folders_stack.size() != 0) {
 		// Scan folders first so we can build a list of files and have progress info later.
 
-		PackedStringArray &folders_to_scan = _folders_stack.write[_folders_stack.size() - 1];
+		PackedStringArray &folders_to_scan = folders_stack.write[folders_stack.size() - 1];
 
 		if (folders_to_scan.size() != 0) {
 			// Scan one folder below.
@@ -182,54 +180,54 @@ void FindInFiles::_iterate() {
 			String folder_name = folders_to_scan[folders_to_scan.size() - 1];
 			pop_back(folders_to_scan);
 
-			_current_dir = _current_dir.path_join(folder_name);
+			current_dir = current_dir.path_join(folder_name);
 
 			PackedStringArray sub_dirs;
-			PackedStringArray files_to_scan;
-			_scan_dir("res://" + _current_dir, sub_dirs, files_to_scan);
+			PackedStringArray new_files_to_scan;
+			_scan_dir("res://" + current_dir, sub_dirs, new_files_to_scan);
 
-			_folders_stack.push_back(sub_dirs);
-			_files_to_scan.append_array(files_to_scan);
+			folders_stack.push_back(sub_dirs);
+			files_to_scan.append_array(new_files_to_scan);
 
 		} else {
 			// Go back one level.
 
-			pop_back(_folders_stack);
-			_current_dir = _current_dir.get_base_dir();
+			pop_back(folders_stack);
+			current_dir = current_dir.get_base_dir();
 
-			if (_folders_stack.is_empty()) {
+			if (folders_stack.is_empty()) {
 				// All folders scanned.
-				_initial_files_count = _files_to_scan.size();
+				initial_files_count = files_to_scan.size();
 			}
 		}
 
-	} else if (_files_to_scan.size() != 0) {
+	} else if (files_to_scan.size() != 0) {
 		// Then scan files.
 
-		String fpath = _files_to_scan[_files_to_scan.size() - 1];
-		pop_back(_files_to_scan);
+		String fpath = files_to_scan[files_to_scan.size() - 1];
+		pop_back(files_to_scan);
 		_scan_file(fpath);
 
 	} else {
 		print_verbose("Search complete");
 		set_process(false);
-		_current_dir = "";
-		_searching = false;
+		current_dir = "";
+		searching = false;
 		emit_signal(SceneStringName(finished));
 	}
 }
 
-float FindInFiles::get_progress() const {
-	if (_initial_files_count != 0) {
-		return static_cast<float>(_initial_files_count - _files_to_scan.size()) / static_cast<float>(_initial_files_count);
+float FindInFilesSearch::get_progress() const {
+	if (initial_files_count != 0) {
+		return static_cast<float>(initial_files_count - files_to_scan.size()) / static_cast<float>(initial_files_count);
 	}
 	return 0;
 }
 
-void FindInFiles::_scan_dir(const String &path, PackedStringArray &out_folders, PackedStringArray &out_files_to_scan) {
-	Ref<DirAccess> dir = DirAccess::open(path);
+void FindInFilesSearch::_scan_dir(const String &p_path, PackedStringArray &r_out_folders, PackedStringArray &r_out_files_to_scan) {
+	Ref<DirAccess> dir = DirAccess::open(p_path);
 	if (dir.is_null()) {
-		print_verbose("Cannot open directory! " + path);
+		print_verbose("Cannot open directory! " + p_path);
 		return;
 	}
 
@@ -247,8 +245,8 @@ void FindInFiles::_scan_dir(const String &path, PackedStringArray &out_folders, 
 		// If there is a .gdignore file in the directory, clear all the files/folders
 		// to be searched on this path and skip searching the directory.
 		if (file == ".gdignore") {
-			out_folders.clear();
-			out_files_to_scan.clear();
+			r_out_folders.clear();
+			r_out_files_to_scan.clear();
 			break;
 		}
 
@@ -262,30 +260,30 @@ void FindInFiles::_scan_dir(const String &path, PackedStringArray &out_folders, 
 		}
 
 		if (dir->current_is_dir()) {
-			out_folders.push_back(file);
+			r_out_folders.push_back(file);
 
 		} else {
 			String file_ext = file.get_extension();
-			if (_extension_filter.has(file_ext)) {
-				String file_path = path.path_join(file);
-				bool case_sensitive = dir->is_case_sensitive(path);
+			if (extension_filter.has(file_ext)) {
+				String file_path = p_path.path_join(file);
+				bool case_sensitive = dir->is_case_sensitive(p_path);
 
-				if (!_exclude_wildcards.is_empty() && _is_file_matched(_exclude_wildcards, file_path, case_sensitive)) {
+				if (!exclude_wildcards.is_empty() && _is_file_matched(exclude_wildcards, file_path, case_sensitive)) {
 					continue;
 				}
 
-				if (_include_wildcards.is_empty() || _is_file_matched(_include_wildcards, file_path, case_sensitive)) {
-					out_files_to_scan.push_back(file_path);
+				if (include_wildcards.is_empty() || _is_file_matched(include_wildcards, file_path, case_sensitive)) {
+					r_out_files_to_scan.push_back(file_path);
 				}
 			}
 		}
 	}
 }
 
-void FindInFiles::_scan_file(const String &fpath) {
-	Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ);
+void FindInFilesSearch::_scan_file(const String &p_fpath) {
+	Ref<FileAccess> f = FileAccess::open(p_fpath, FileAccess::READ);
 	if (f.is_null()) {
-		print_verbose(String("Cannot open file ") + fpath);
+		print_verbose("Cannot open file " + p_fpath);
 		return;
 	}
 
@@ -300,13 +298,13 @@ void FindInFiles::_scan_file(const String &fpath) {
 
 		String line = f->get_line();
 
-		while (find_next(line, _pattern, end, _match_case, _whole_words, begin, end)) {
-			emit_signal(SNAME(SIGNAL_RESULT_FOUND), fpath, line_number, begin, end, line);
+		while (find_next(line, pattern, end, match_case, whole_words, begin, end)) {
+			emit_signal(SNAME("result_found"), p_fpath, line_number, begin, end, line);
 		}
 	}
 }
 
-bool FindInFiles::_is_file_matched(const HashSet<String> &p_wildcards, const String &p_file_path, bool p_case_sensitive) const {
+bool FindInFilesSearch::_is_file_matched(const HashSet<String> &p_wildcards, const String &p_file_path, bool p_case_sensitive) const {
 	const String file_path = "/" + p_file_path.replace_char('\\', '/') + "/";
 
 	for (const String &wildcard : p_wildcards) {
@@ -319,8 +317,8 @@ bool FindInFiles::_is_file_matched(const HashSet<String> &p_wildcards, const Str
 	return false;
 }
 
-void FindInFiles::_bind_methods() {
-	ADD_SIGNAL(MethodInfo(SIGNAL_RESULT_FOUND,
+void FindInFilesSearch::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("result_found",
 			PropertyInfo(Variant::STRING, "path"),
 			PropertyInfo(Variant::INT, "line_number"),
 			PropertyInfo(Variant::INT, "begin"),
@@ -331,182 +329,40 @@ void FindInFiles::_bind_methods() {
 }
 
 //-----------------------------------------------------------------------------
-const char *FindInFilesDialog::SIGNAL_FIND_REQUESTED = "find_requested";
-const char *FindInFilesDialog::SIGNAL_REPLACE_REQUESTED = "replace_requested";
 
-FindInFilesDialog::FindInFilesDialog() {
-	set_min_size(Size2(500 * EDSCALE, 0));
-	set_title(TTRC("Find in Files"));
-
-	VBoxContainer *vbc = memnew(VBoxContainer);
-	vbc->set_anchor_and_offset(SIDE_LEFT, Control::ANCHOR_BEGIN, 8 * EDSCALE);
-	vbc->set_anchor_and_offset(SIDE_TOP, Control::ANCHOR_BEGIN, 8 * EDSCALE);
-	vbc->set_anchor_and_offset(SIDE_RIGHT, Control::ANCHOR_END, -8 * EDSCALE);
-	vbc->set_anchor_and_offset(SIDE_BOTTOM, Control::ANCHOR_END, -8 * EDSCALE);
-	add_child(vbc);
-
-	GridContainer *gc = memnew(GridContainer);
-	gc->set_columns(2);
-	vbc->add_child(gc);
-
-	Label *find_label = memnew(Label);
-	find_label->set_text(TTRC("Find:"));
-	gc->add_child(find_label);
-
-	_search_text_line_edit = memnew(LineEdit);
-	_search_text_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	_search_text_line_edit->set_accessibility_name(TTRC("Find:"));
-	_search_text_line_edit->connect(SceneStringName(text_changed), callable_mp(this, &FindInFilesDialog::_on_search_text_modified));
-	_search_text_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_search_text_submitted));
-	gc->add_child(_search_text_line_edit);
-
-	_replace_label = memnew(Label);
-	_replace_label->set_text(TTRC("Replace:"));
-	_replace_label->hide();
-	gc->add_child(_replace_label);
-
-	_replace_text_line_edit = memnew(LineEdit);
-	_replace_text_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	_replace_text_line_edit->set_accessibility_name(TTRC("Replace:"));
-	_replace_text_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_replace_text_submitted));
-	_replace_text_line_edit->hide();
-	gc->add_child(_replace_text_line_edit);
-
-	gc->add_child(memnew(Control)); // Space to maintain the grid alignment.
-
-	{
-		HBoxContainer *hbc = memnew(HBoxContainer);
-
-		_whole_words_checkbox = memnew(CheckBox);
-		_whole_words_checkbox->set_text(TTRC("Whole Words"));
-		hbc->add_child(_whole_words_checkbox);
-
-		_match_case_checkbox = memnew(CheckBox);
-		_match_case_checkbox->set_text(TTRC("Match Case"));
-		hbc->add_child(_match_case_checkbox);
-
-		gc->add_child(hbc);
+void FindInFilesDialog::set_search_text(const String &p_text) {
+	if (!p_text.is_empty()) {
+		search_text_line_edit->set_text(p_text);
+		_on_search_text_modified(p_text);
 	}
-
-	Label *folder_label = memnew(Label);
-	folder_label->set_text(TTRC("Folder:"));
-	gc->add_child(folder_label);
-
-	{
-		HBoxContainer *hbc = memnew(HBoxContainer);
-
-		Label *prefix_label = memnew(Label);
-		prefix_label->set_text("res://");
-		prefix_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-		hbc->add_child(prefix_label);
-
-		_folder_line_edit = memnew(LineEdit);
-		_folder_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		_folder_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_search_text_submitted));
-		_folder_line_edit->set_accessibility_name(TTRC("Folder:"));
-		hbc->add_child(_folder_line_edit);
-
-		Button *folder_button = memnew(Button);
-		folder_button->set_accessibility_name(TTRC("Select Folder"));
-		folder_button->set_text("...");
-		folder_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesDialog::_on_folder_button_pressed));
-		hbc->add_child(folder_button);
-
-		_folder_dialog = memnew(EditorFileDialog);
-		_folder_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_DIR);
-		_folder_dialog->connect("dir_selected", callable_mp(this, &FindInFilesDialog::_on_folder_selected));
-		add_child(_folder_dialog);
-
-		gc->add_child(hbc);
-	}
-
-	Label *includes_label = memnew(Label);
-	includes_label->set_text(TTRC("Includes:"));
-	includes_label->set_tooltip_text(TTRC("Include the files with the following expressions. Use \",\" to separate."));
-	includes_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
-	gc->add_child(includes_label);
-
-	_includes_line_edit = memnew(LineEdit);
-	_includes_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	_includes_line_edit->set_placeholder(TTRC("example: scripts,scenes/*/test.gd"));
-	_includes_line_edit->set_accessibility_name(TTRC("Includes:"));
-	_includes_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_search_text_submitted));
-	gc->add_child(_includes_line_edit);
-
-	Label *excludes_label = memnew(Label);
-	excludes_label->set_text(TTRC("Excludes:"));
-	excludes_label->set_tooltip_text(TTRC("Exclude the files with the following expressions. Use \",\" to separate."));
-	excludes_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
-	gc->add_child(excludes_label);
-
-	_excludes_line_edit = memnew(LineEdit);
-	_excludes_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	_excludes_line_edit->set_placeholder(TTRC("example: res://addons,scenes/test/*.gd"));
-	_excludes_line_edit->set_accessibility_name(TTRC("Excludes:"));
-	_excludes_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_search_text_submitted));
-	gc->add_child(_excludes_line_edit);
-
-	Label *filter_label = memnew(Label);
-	filter_label->set_text(TTRC("Filters:"));
-	filter_label->set_tooltip_text(TTRC("Include the files with the following extensions. Add or remove them in ProjectSettings."));
-	filter_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
-	gc->add_child(filter_label);
-
-	_filters_container = memnew(HBoxContainer);
-	gc->add_child(_filters_container);
-
-	_find_button = add_button(TTRC("Find..."), false, "find");
-	_find_button->set_disabled(true);
-
-	_replace_button = add_button(TTRC("Replace..."), false, "replace");
-	_replace_button->set_disabled(true);
-
-	Button *cancel_button = get_ok_button();
-	cancel_button->set_text(TTRC("Cancel"));
-
-	_mode = SEARCH_MODE;
-}
-
-void FindInFilesDialog::set_search_text(const String &text) {
-	if (_mode == SEARCH_MODE) {
-		if (!text.is_empty()) {
-			_search_text_line_edit->set_text(text);
-			_on_search_text_modified(text);
-		}
-		callable_mp((Control *)_search_text_line_edit, &Control::grab_focus).call_deferred(false);
-		_search_text_line_edit->select_all();
-	} else if (_mode == REPLACE_MODE) {
-		if (!text.is_empty()) {
-			_search_text_line_edit->set_text(text);
-			callable_mp((Control *)_replace_text_line_edit, &Control::grab_focus).call_deferred(false);
-			_replace_text_line_edit->select_all();
-			_on_search_text_modified(text);
-		} else {
-			callable_mp((Control *)_search_text_line_edit, &Control::grab_focus).call_deferred(false);
-			_search_text_line_edit->select_all();
-		}
+	if (replace_mode && !p_text.is_empty()) {
+		callable_mp((Control *)replace_text_line_edit, &Control::grab_focus).call_deferred(false);
+		replace_text_line_edit->select_all();
+	} else {
+		callable_mp((Control *)search_text_line_edit, &Control::grab_focus).call_deferred(false);
+		search_text_line_edit->select_all();
 	}
 }
 
-void FindInFilesDialog::set_replace_text(const String &text) {
-	_replace_text_line_edit->set_text(text);
+void FindInFilesDialog::set_replace_text(const String &p_text) {
+	replace_text_line_edit->set_text(p_text);
 }
 
-void FindInFilesDialog::set_find_in_files_mode(FindInFilesMode p_mode) {
-	if (_mode == p_mode) {
+void FindInFilesDialog::set_replace_mode(bool p_replace) {
+	if (replace_mode == p_replace) {
 		return;
 	}
 
-	_mode = p_mode;
+	replace_mode = p_replace;
 
-	if (p_mode == SEARCH_MODE) {
-		set_title(TTRC("Find in Files"));
-		_replace_label->hide();
-		_replace_text_line_edit->hide();
-	} else if (p_mode == REPLACE_MODE) {
+	if (replace_mode) {
 		set_title(TTRC("Replace in Files"));
-		_replace_label->show();
-		_replace_text_line_edit->show();
+		replace_label->show();
+		replace_text_line_edit->show();
+	} else {
+		set_title(TTRC("Find in Files"));
+		replace_label->hide();
+		replace_text_line_edit->hide();
 	}
 
 	// Recalculate the dialog size after hiding child controls.
@@ -514,31 +370,31 @@ void FindInFilesDialog::set_find_in_files_mode(FindInFilesMode p_mode) {
 }
 
 String FindInFilesDialog::get_search_text() const {
-	return _search_text_line_edit->get_text();
+	return search_text_line_edit->get_text();
 }
 
 String FindInFilesDialog::get_replace_text() const {
-	return _replace_text_line_edit->get_text();
+	return replace_text_line_edit->get_text();
 }
 
 bool FindInFilesDialog::is_match_case() const {
-	return _match_case_checkbox->is_pressed();
+	return match_case_checkbox->is_pressed();
 }
 
 bool FindInFilesDialog::is_whole_words() const {
-	return _whole_words_checkbox->is_pressed();
+	return whole_words_checkbox->is_pressed();
 }
 
 String FindInFilesDialog::get_folder() const {
-	String text = _folder_line_edit->get_text();
-	return text.strip_edges();
+	String p_text = folder_line_edit->get_text();
+	return p_text.strip_edges();
 }
 
 HashSet<String> FindInFilesDialog::get_filter() const {
-	// Could check the _filters_preferences but it might not have been generated yet.
+	// Could check the filters_preferences but it might not have been generated yet.
 	HashSet<String> filters;
-	for (int i = 0; i < _filters_container->get_child_count(); ++i) {
-		CheckBox *cb = static_cast<CheckBox *>(_filters_container->get_child(i));
+	for (int i = 0; i < filters_container->get_child_count(); ++i) {
+		CheckBox *cb = static_cast<CheckBox *>(filters_container->get_child(i));
 		if (cb->is_pressed()) {
 			filters.insert(cb->get_text());
 		}
@@ -548,30 +404,30 @@ HashSet<String> FindInFilesDialog::get_filter() const {
 
 HashSet<String> FindInFilesDialog::get_includes() const {
 	HashSet<String> includes;
-	String text = _includes_line_edit->get_text();
+	String p_text = includes_line_edit->get_text();
 
-	if (text.is_empty()) {
+	if (p_text.is_empty()) {
 		return includes;
 	}
 
-	PackedStringArray wildcards = text.split(",", false);
+	PackedStringArray wildcards = p_text.split(",", false);
 	for (const String &wildcard : wildcards) {
-		includes.insert(validate_filter_wildcard(wildcard));
+		includes.insert(_validate_filter_wildcard(wildcard));
 	}
 	return includes;
 }
 
 HashSet<String> FindInFilesDialog::get_excludes() const {
 	HashSet<String> excludes;
-	String text = _excludes_line_edit->get_text();
+	String p_text = excludes_line_edit->get_text();
 
-	if (text.is_empty()) {
+	if (p_text.is_empty()) {
 		return excludes;
 	}
 
-	PackedStringArray wildcards = text.split(",", false);
+	PackedStringArray wildcards = p_text.split(",", false);
 	for (const String &wildcard : wildcards) {
-		excludes.insert(validate_filter_wildcard(wildcard));
+		excludes.insert(_validate_filter_wildcard(wildcard));
 	}
 	return excludes;
 }
@@ -581,18 +437,18 @@ void FindInFilesDialog::_notification(int p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible()) {
 				// Extensions might have changed in the meantime, we clean them and instance them again.
-				for (int i = 0; i < _filters_container->get_child_count(); i++) {
-					_filters_container->get_child(i)->queue_free();
+				for (int i = 0; i < filters_container->get_child_count(); i++) {
+					filters_container->get_child(i)->queue_free();
 				}
 				Array exts = GLOBAL_GET("editor/script/search_in_file_extensions");
 				for (int i = 0; i < exts.size(); ++i) {
 					CheckBox *cb = memnew(CheckBox);
 					cb->set_text(exts[i]);
-					if (!_filters_preferences.has(exts[i])) {
-						_filters_preferences[exts[i]] = true;
+					if (!filters_preferences.has(exts[i])) {
+						filters_preferences[exts[i]] = true;
 					}
-					cb->set_pressed(_filters_preferences[exts[i]]);
-					_filters_container->add_child(cb);
+					cb->set_pressed(filters_preferences[exts[i]]);
+					filters_container->add_child(cb);
 				}
 			}
 		} break;
@@ -600,65 +456,58 @@ void FindInFilesDialog::_notification(int p_what) {
 }
 
 void FindInFilesDialog::_on_folder_button_pressed() {
-	_folder_dialog->popup_file_dialog();
+	folder_dialog->popup_file_dialog();
 }
 
 void FindInFilesDialog::custom_action(const String &p_action) {
-	for (int i = 0; i < _filters_container->get_child_count(); ++i) {
-		CheckBox *cb = static_cast<CheckBox *>(_filters_container->get_child(i));
-		_filters_preferences[cb->get_text()] = cb->is_pressed();
+	for (int i = 0; i < filters_container->get_child_count(); ++i) {
+		CheckBox *cb = static_cast<CheckBox *>(filters_container->get_child(i));
+		filters_preferences[cb->get_text()] = cb->is_pressed();
 	}
 
 	if (p_action == "find") {
-		emit_signal(SNAME(SIGNAL_FIND_REQUESTED));
-		hide();
+		emit_signal(SNAME("find_requested"));
 	} else if (p_action == "replace") {
-		emit_signal(SNAME(SIGNAL_REPLACE_REQUESTED));
-		hide();
+		emit_signal(SNAME("replace_requested"));
 	}
+	hide();
 }
 
-void FindInFilesDialog::_on_search_text_modified(const String &text) {
-	ERR_FAIL_NULL(_find_button);
-	ERR_FAIL_NULL(_replace_button);
+void FindInFilesDialog::_on_search_text_modified(const String &p_text) {
+	ERR_FAIL_NULL(find_button);
+	ERR_FAIL_NULL(replace_button);
 
-	_find_button->set_disabled(get_search_text().is_empty());
-	_replace_button->set_disabled(get_search_text().is_empty());
+	find_button->set_disabled(get_search_text().is_empty());
+	replace_button->set_disabled(get_search_text().is_empty());
 }
 
-void FindInFilesDialog::_on_search_text_submitted(const String &text) {
+void FindInFilesDialog::_on_search_text_submitted(const String &p_text) {
 	// This allows to trigger a global search without leaving the keyboard.
-	if (!_find_button->is_disabled()) {
-		if (_mode == SEARCH_MODE) {
-			custom_action("find");
-		}
+	if (!replace_mode && !find_button->is_disabled()) {
+		custom_action("find");
 	}
 
-	if (!_replace_button->is_disabled()) {
-		if (_mode == REPLACE_MODE) {
-			custom_action("replace");
-		}
+	if (replace_mode && !replace_button->is_disabled()) {
+		custom_action("replace");
 	}
 }
 
-void FindInFilesDialog::_on_replace_text_submitted(const String &text) {
+void FindInFilesDialog::_on_replace_text_submitted(const String &p_text) {
 	// This allows to trigger a global search without leaving the keyboard.
-	if (!_replace_button->is_disabled()) {
-		if (_mode == REPLACE_MODE) {
-			custom_action("replace");
-		}
+	if (replace_mode && !replace_button->is_disabled()) {
+		custom_action("replace");
 	}
 }
 
-void FindInFilesDialog::_on_folder_selected(String path) {
-	int i = path.find("://");
+void FindInFilesDialog::_on_folder_selected(String p_path) {
+	int i = p_path.find("://");
 	if (i != -1) {
-		path = path.substr(i + 3);
+		p_path = p_path.substr(i + 3);
 	}
-	_folder_line_edit->set_text(path);
+	folder_line_edit->set_text(p_path);
 }
 
-String FindInFilesDialog::validate_filter_wildcard(const String &p_expression) const {
+String FindInFilesDialog::_validate_filter_wildcard(const String &p_expression) const {
 	String ret = p_expression.replace_char('\\', '/');
 	if (ret.begins_with("./")) {
 		// Relative to the project root.
@@ -682,207 +531,224 @@ String FindInFilesDialog::validate_filter_wildcard(const String &p_expression) c
 }
 
 void FindInFilesDialog::_bind_methods() {
-	ADD_SIGNAL(MethodInfo(SIGNAL_FIND_REQUESTED));
-	ADD_SIGNAL(MethodInfo(SIGNAL_REPLACE_REQUESTED));
+	ADD_SIGNAL(MethodInfo("find_requested"));
+	ADD_SIGNAL(MethodInfo("replace_requested"));
 }
 
-//-----------------------------------------------------------------------------
-const char *FindInFilesPanel::SIGNAL_RESULT_SELECTED = "result_selected";
-const char *FindInFilesPanel::SIGNAL_FILES_MODIFIED = "files_modified";
-const char *FindInFilesPanel::SIGNAL_CLOSE_BUTTON_CLICKED = "close_button_clicked";
-
-FindInFilesPanel::FindInFilesPanel() {
-	_finder = memnew(FindInFiles);
-	_finder->connect(FindInFiles::SIGNAL_RESULT_FOUND, callable_mp(this, &FindInFilesPanel::_on_result_found));
-	_finder->connect(SceneStringName(finished), callable_mp(this, &FindInFilesPanel::_on_finished));
-	add_child(_finder);
+FindInFilesDialog::FindInFilesDialog() {
+	set_min_size(Size2(500 * EDSCALE, 0));
+	set_title(TTRC("Find in Files"));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
-	vbc->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 0);
-	vbc->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, 0);
-	vbc->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
-	vbc->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
+	vbc->set_anchor_and_offset(SIDE_LEFT, Control::ANCHOR_BEGIN, 8 * EDSCALE);
+	vbc->set_anchor_and_offset(SIDE_TOP, Control::ANCHOR_BEGIN, 8 * EDSCALE);
+	vbc->set_anchor_and_offset(SIDE_RIGHT, Control::ANCHOR_END, -8 * EDSCALE);
+	vbc->set_anchor_and_offset(SIDE_BOTTOM, Control::ANCHOR_END, -8 * EDSCALE);
 	add_child(vbc);
+
+	GridContainer *gc = memnew(GridContainer);
+	gc->set_columns(2);
+	vbc->add_child(gc);
+
+	Label *find_label = memnew(Label);
+	find_label->set_text(TTRC("Find:"));
+	gc->add_child(find_label);
+
+	search_text_line_edit = memnew(LineEdit);
+	search_text_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_text_line_edit->set_accessibility_name(TTRC("Find:"));
+	search_text_line_edit->connect(SceneStringName(text_changed), callable_mp(this, &FindInFilesDialog::_on_search_text_modified));
+	search_text_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_search_text_submitted));
+	gc->add_child(search_text_line_edit);
+
+	replace_label = memnew(Label);
+	replace_label->set_text(TTRC("Replace:"));
+	replace_label->hide();
+	gc->add_child(replace_label);
+
+	replace_text_line_edit = memnew(LineEdit);
+	replace_text_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	replace_text_line_edit->set_accessibility_name(TTRC("Replace:"));
+	replace_text_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_replace_text_submitted));
+	replace_text_line_edit->hide();
+	gc->add_child(replace_text_line_edit);
+
+	gc->add_child(memnew(Control)); // Space to maintain the grid alignment.
 
 	{
 		HBoxContainer *hbc = memnew(HBoxContainer);
-		hbc->set_alignment(BoxContainer::ALIGNMENT_END);
 
-		_find_label = memnew(Label);
-		_find_label->set_text(TTRC("Find:"));
-		hbc->add_child(_find_label);
+		whole_words_checkbox = memnew(CheckBox);
+		whole_words_checkbox->set_text(TTRC("Whole Words"));
+		hbc->add_child(whole_words_checkbox);
 
-		_search_text_label = memnew(Label);
-		_search_text_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
-		_search_text_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		_search_text_label->set_focus_mode(FOCUS_ACCESSIBILITY);
-		_search_text_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
-		_search_text_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-		hbc->add_child(_search_text_label);
+		match_case_checkbox = memnew(CheckBox);
+		match_case_checkbox->set_text(TTRC("Match Case"));
+		hbc->add_child(match_case_checkbox);
 
-		_progress_bar = memnew(ProgressBar);
-		_progress_bar->set_h_size_flags(SIZE_EXPAND_FILL);
-		_progress_bar->set_v_size_flags(SIZE_SHRINK_CENTER);
-		_progress_bar->set_stretch_ratio(2.0);
-		_progress_bar->set_visible(false);
-		hbc->add_child(_progress_bar);
-
-		_status_label = memnew(Label);
-		_status_label->set_focus_mode(FOCUS_ACCESSIBILITY);
-		hbc->add_child(_status_label);
-
-		_keep_results_button = memnew(CheckButton);
-		_keep_results_button->set_text(TTRC("Keep Results"));
-		_keep_results_button->set_tooltip_text(TTRC("Keep these results and show subsequent results in a new window"));
-		_keep_results_button->set_pressed(false);
-		hbc->add_child(_keep_results_button);
-
-		_refresh_button = memnew(Button);
-		_refresh_button->set_text(TTRC("Refresh"));
-		_refresh_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_refresh_button_clicked));
-		_refresh_button->hide();
-		hbc->add_child(_refresh_button);
-
-		_cancel_button = memnew(Button);
-		_cancel_button->set_text(TTRC("Cancel"));
-		_cancel_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_cancel_button_clicked));
-		_cancel_button->hide();
-		hbc->add_child(_cancel_button);
-
-		_close_button = memnew(Button);
-		_close_button->set_text(TTRC("Close"));
-		_close_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_close_button_clicked));
-		hbc->add_child(_close_button);
-
-		vbc->add_child(hbc);
+		gc->add_child(hbc);
 	}
 
-	_results_mc = memnew(MarginContainer);
-	_results_mc->set_theme_type_variation("NoBorderHorizontal");
-	_results_mc->set_v_size_flags(SIZE_EXPAND_FILL);
-	vbc->add_child(_results_mc);
-
-	_results_display = memnew(Tree);
-	_results_display->set_accessibility_name(TTRC("Search Results"));
-	_results_display->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	_results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
-	_results_display->connect(SceneStringName(item_selected), callable_mp(this, &FindInFilesPanel::_on_result_selected));
-	_results_display->connect("item_edited", callable_mp(this, &FindInFilesPanel::_on_item_edited));
-	_results_display->connect("button_clicked", callable_mp(this, &FindInFilesPanel::_on_button_clicked));
-	_results_display->set_hide_root(true);
-	_results_display->set_select_mode(Tree::SELECT_ROW);
-	_results_display->set_allow_rmb_select(true);
-	_results_display->set_allow_reselect(true);
-	_results_display->add_theme_constant_override("inner_item_margin_left", 0);
-	_results_display->add_theme_constant_override("inner_item_margin_right", 0);
-	_results_display->create_item(); // Root
-	_results_mc->add_child(_results_display);
+	Label *folder_label = memnew(Label);
+	folder_label->set_text(TTRC("Folder:"));
+	gc->add_child(folder_label);
 
 	{
-		_replace_container = memnew(HBoxContainer);
+		HBoxContainer *hbc = memnew(HBoxContainer);
 
-		Label *replace_label = memnew(Label);
-		replace_label->set_text(TTRC("Replace:"));
-		_replace_container->add_child(replace_label);
+		Label *prefix_label = memnew(Label);
+		prefix_label->set_text("res://");
+		prefix_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+		hbc->add_child(prefix_label);
 
-		_replace_line_edit = memnew(LineEdit);
-		_replace_line_edit->set_accessibility_name(TTRC("Replace:"));
-		_replace_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
-		_replace_line_edit->connect(SceneStringName(text_changed), callable_mp(this, &FindInFilesPanel::_on_replace_text_changed));
-		_replace_container->add_child(_replace_line_edit);
+		folder_line_edit = memnew(LineEdit);
+		folder_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		folder_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_search_text_submitted));
+		folder_line_edit->set_accessibility_name(TTRC("Folder:"));
+		hbc->add_child(folder_line_edit);
 
-		_replace_all_button = memnew(Button);
-		_replace_all_button->set_text(TTRC("Replace all (no undo)"));
-		_replace_all_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_replace_all_clicked));
-		_replace_container->add_child(_replace_all_button);
+		Button *folder_button = memnew(Button);
+		folder_button->set_accessibility_name(TTRC("Select Folder"));
+		folder_button->set_text("...");
+		folder_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesDialog::_on_folder_button_pressed));
+		hbc->add_child(folder_button);
 
-		_replace_container->hide();
+		folder_dialog = memnew(EditorFileDialog);
+		folder_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_DIR);
+		folder_dialog->connect("dir_selected", callable_mp(this, &FindInFilesDialog::_on_folder_selected));
+		add_child(folder_dialog);
 
-		vbc->add_child(_replace_container);
+		gc->add_child(hbc);
 	}
+
+	Label *includes_label = memnew(Label);
+	includes_label->set_text(TTRC("Includes:"));
+	includes_label->set_tooltip_text(TTRC("Include the files with the following expressions. Use \",\" to separate."));
+	includes_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+	gc->add_child(includes_label);
+
+	includes_line_edit = memnew(LineEdit);
+	includes_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	includes_line_edit->set_placeholder(TTRC("example: scripts,scenes/*/test.gd"));
+	includes_line_edit->set_accessibility_name(TTRC("Includes:"));
+	includes_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_search_text_submitted));
+	gc->add_child(includes_line_edit);
+
+	Label *excludes_label = memnew(Label);
+	excludes_label->set_text(TTRC("Excludes:"));
+	excludes_label->set_tooltip_text(TTRC("Exclude the files with the following expressions. Use \",\" to separate."));
+	excludes_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+	gc->add_child(excludes_label);
+
+	excludes_line_edit = memnew(LineEdit);
+	excludes_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	excludes_line_edit->set_placeholder(TTRC("example: res://addons,scenes/test/*.gd"));
+	excludes_line_edit->set_accessibility_name(TTRC("Excludes:"));
+	excludes_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_search_text_submitted));
+	gc->add_child(excludes_line_edit);
+
+	Label *filter_label = memnew(Label);
+	filter_label->set_text(TTRC("Filters:"));
+	filter_label->set_tooltip_text(TTRC("Include the files with the following extensions. Add or remove them in ProjectSettings."));
+	filter_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+	gc->add_child(filter_label);
+
+	filters_container = memnew(HBoxContainer);
+	gc->add_child(filters_container);
+
+	find_button = add_button(TTRC("Find..."), false, "find");
+	find_button->set_disabled(true);
+
+	replace_button = add_button(TTRC("Replace..."), false, "replace");
+	replace_button->set_disabled(true);
+
+	Button *cancel_button = get_ok_button();
+	cancel_button->set_text(TTRC("Cancel"));
 }
 
-void FindInFilesPanel::set_with_replace(bool with_replace) {
-	_with_replace = with_replace;
-	_replace_container->set_visible(with_replace);
+//-----------------------------------------------------------------------------
+
+void FindInFilesPanel::set_with_replace(bool p_with_replace) {
+	with_replace = p_with_replace;
+	replace_container->set_visible(p_with_replace);
 
 	if (with_replace) {
 		// Results show checkboxes on their left so they can be opted out.
-		_results_display->set_columns(2);
-		_results_display->set_column_expand(0, false);
-		_results_display->set_column_custom_minimum_width(0, 48 * EDSCALE);
+		results_display->set_columns(2);
+		results_display->set_column_expand(0, false);
+		results_display->set_column_custom_minimum_width(0, 48 * EDSCALE);
 	} else {
 		// Results are single-cell items.
-		_results_display->set_column_expand(0, true);
-		_results_display->set_columns(1);
+		results_display->set_column_expand(0, true);
+		results_display->set_columns(1);
 	}
 }
 
-void FindInFilesPanel::set_replace_text(const String &text) {
-	_replace_line_edit->set_text(text);
+void FindInFilesPanel::set_replace_text(const String &p_text) {
+	replace_line_edit->set_text(p_text);
 }
 
 bool FindInFilesPanel::is_keep_results() const {
-	return _keep_results_button->is_pressed();
+	return keep_results_button->is_pressed();
 }
 
 void FindInFilesPanel::set_search_labels_visibility(bool p_visible) {
-	_find_label->set_visible(p_visible);
-	_search_text_label->set_visible(p_visible);
-	_close_button->set_visible(p_visible);
+	find_label->set_visible(p_visible);
+	search_text_label->set_visible(p_visible);
+	close_button->set_visible(p_visible);
 }
 
-void FindInFilesPanel::clear() {
-	_file_items.clear();
-	_file_items_results_count.clear();
-	_result_items.clear();
-	_results_display->clear();
-	_results_display->create_item(); // Root
+void FindInFilesPanel::_clear() {
+	file_items.clear();
+	file_items_results_count.clear();
+	result_items.clear();
+	results_display->clear();
+	results_display->create_item(); // Root
 }
 
 void FindInFilesPanel::start_search() {
-	clear();
+	_clear();
 
-	_status_label->set_text(TTRC("Searching..."));
-	_search_text_label->set_text(_finder->get_search_text());
-	_search_text_label->set_tooltip_text(_finder->get_search_text());
+	status_label->set_text(TTRC("Searching..."));
+	search_text_label->set_text(finder->get_search_text());
+	search_text_label->set_tooltip_text(finder->get_search_text());
 
-	int label_min_width = _search_text_label->get_minimum_size().x + _search_text_label->get_character_bounds(0).size.x;
-	_search_text_label->set_custom_minimum_size(Size2(label_min_width, 0));
+	int label_min_width = search_text_label->get_minimum_size().x + search_text_label->get_character_bounds(0).size.x;
+	search_text_label->set_custom_minimum_size(Size2(label_min_width, 0));
 
 	set_process(true);
-	_progress_bar->set_visible(true);
+	progress_bar->set_visible(true);
 
-	_finder->start();
+	finder->start();
 
-	update_replace_buttons();
-	_refresh_button->hide();
-	_cancel_button->show();
+	_update_replace_buttons();
+	refresh_button->hide();
+	cancel_button->show();
 }
 
 void FindInFilesPanel::stop_search() {
-	_finder->stop();
+	finder->stop();
 
-	_status_label->set_text("");
-	update_replace_buttons();
-	_progress_bar->set_visible(false);
-	_refresh_button->show();
-	_cancel_button->hide();
+	status_label->set_text("");
+	_update_replace_buttons();
+	progress_bar->set_visible(false);
+	refresh_button->show();
+	cancel_button->hide();
 }
 
 void FindInFilesPanel::update_layout(EditorDock::DockLayout p_layout) {
 	bool new_floating = (p_layout == EditorDock::DOCK_LAYOUT_FLOATING);
-	if (_floating == new_floating) {
+	if (floating == new_floating) {
 		return;
 	}
-	_floating = new_floating;
+	floating = new_floating;
 
-	if (_floating) {
-		_results_mc->set_theme_type_variation("NoBorderHorizontalBottom");
-		_results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
+	if (floating) {
+		results_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	} else {
-		_results_mc->set_theme_type_variation("NoBorderHorizontal");
-		_results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
+		results_mc->set_theme_type_variation("NoBorderHorizontal");
+		results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	}
 }
 
@@ -892,18 +758,18 @@ void FindInFilesPanel::_notification(int p_what) {
 			_on_theme_changed();
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			update_matches_text();
+			_update_matches_text();
 
-			TreeItem *file_item = _results_display->get_root()->get_first_child();
+			TreeItem *file_item = results_display->get_root()->get_first_child();
 			while (file_item) {
-				if (_with_replace) {
+				if (with_replace) {
 					file_item->set_button_tooltip_text(0, file_item->get_button_by_id(0, FIND_BUTTON_REPLACE), TTR("Replace all matches in file"));
 				}
 				file_item->set_button_tooltip_text(0, file_item->get_button_by_id(0, FIND_BUTTON_REMOVE), TTR("Remove result"));
 
 				TreeItem *result_item = file_item->get_first_child();
 				while (result_item) {
-					if (_with_replace) {
+					if (with_replace) {
 						result_item->set_button_tooltip_text(1, file_item->get_button_by_id(0, FIND_BUTTON_REPLACE), TTR("Replace"));
 						result_item->set_button_tooltip_text(1, file_item->get_button_by_id(0, FIND_BUTTON_REMOVE), TTR("Remove result"));
 					} else {
@@ -916,23 +782,23 @@ void FindInFilesPanel::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_PROCESS: {
-			_progress_bar->set_as_ratio(_finder->get_progress());
+			progress_bar->set_as_ratio(finder->get_progress());
 		} break;
 	}
 }
 
-void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, int begin, int end, String text) {
+void FindInFilesPanel::_on_result_found(const String &p_fpath, int p_line_number, int p_begin, int p_end, const String &p_text) {
 	TreeItem *file_item;
 	Ref<Texture2D> remove_texture = get_editor_theme_icon(SNAME("Close"));
 	Ref<Texture2D> replace_texture = get_editor_theme_icon(SNAME("ReplaceText"));
 
-	HashMap<String, TreeItem *>::Iterator E = _file_items.find(fpath);
+	HashMap<String, TreeItem *>::Iterator E = file_items.find(p_fpath);
 	if (!E) {
-		file_item = _results_display->create_item();
-		file_item->set_text(0, fpath);
-		file_item->set_metadata(0, fpath);
+		file_item = results_display->create_item();
+		file_item->set_text(0, p_fpath);
+		file_item->set_metadata(0, p_fpath);
 
-		if (_with_replace) {
+		if (with_replace) {
 			file_item->add_button(0, replace_texture, FIND_BUTTON_REPLACE, false, TTR("Replace all matches in file"));
 		}
 		file_item->add_button(0, remove_texture, FIND_BUTTON_REMOVE, false, TTR("Remove result"));
@@ -942,41 +808,40 @@ void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, in
 		// so we override their width so they can expand to full width.
 		file_item->set_expand_right(0, true);
 
-		_file_items[fpath] = file_item;
-		_file_items_results_count[file_item] = 1;
+		file_items[p_fpath] = file_item;
+		file_items_results_count[file_item] = 1;
 	} else {
 		file_item = E->value;
-		_file_items_results_count[file_item]++;
+		file_items_results_count[file_item]++;
 	}
 
-	Color file_item_color = _results_display->get_theme_color(SceneStringName(font_color)) * Color(1, 1, 1, 0.67);
+	Color file_item_color = results_display->get_theme_color(SceneStringName(font_color)) * Color(1, 1, 1, 0.67);
 	file_item->set_custom_color(0, file_item_color);
 	file_item->set_selectable(0, false);
 
-	int text_index = _with_replace ? 1 : 0;
+	int text_index = with_replace ? 1 : 0;
 
-	TreeItem *item = _results_display->create_item(file_item);
+	TreeItem *item = results_display->create_item(file_item);
 
 	// Do this first because it resets properties of the cell...
 	item->set_cell_mode(text_index, TreeItem::CELL_MODE_CUSTOM);
 
 	// Trim result item line.
-	int old_text_size = text.size();
-	text = text.strip_edges(true, false);
-	int chars_removed = old_text_size - text.size();
-	String start = vformat("%3s: ", line_number);
+	String trimmed_text = p_text.strip_edges(true, false);
+	int chars_removed = p_text.size() - trimmed_text.size();
+	String start = vformat("%3s: ", p_line_number);
 
-	item->set_text(text_index, start + text);
-	item->set_custom_draw_callback(text_index, callable_mp(this, &FindInFilesPanel::draw_result_text));
+	item->set_text(text_index, start + trimmed_text);
+	item->set_custom_draw_callback(text_index, callable_mp(this, &FindInFilesPanel::_draw_result_text));
 
 	Result r;
-	r.line_number = line_number;
-	r.begin = begin;
-	r.end = end;
-	r.begin_trimmed = begin - chars_removed + start.size() - 1;
-	_result_items[item] = r;
+	r.line_number = p_line_number;
+	r.begin = p_begin;
+	r.end = p_end;
+	r.begin_trimmed = p_begin - chars_removed + start.size() - 1;
+	result_items[item] = r;
 
-	if (_with_replace) {
+	if (with_replace) {
 		item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 		item->set_checked(0, true);
 		item->set_editable(0, true);
@@ -988,24 +853,24 @@ void FindInFilesPanel::_on_result_found(const String &fpath, int line_number, in
 }
 
 void FindInFilesPanel::_on_theme_changed() {
-	_results_display->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("source"), EditorStringName(EditorFonts)));
-	_results_display->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size(SNAME("source_size"), EditorStringName(EditorFonts)));
+	results_display->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("source"), EditorStringName(EditorFonts)));
+	results_display->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size(SNAME("source_size"), EditorStringName(EditorFonts)));
 
-	Color file_item_color = _results_display->get_theme_color(SceneStringName(font_color)) * Color(1, 1, 1, 0.67);
+	Color file_item_color = results_display->get_theme_color(SceneStringName(font_color)) * Color(1, 1, 1, 0.67);
 	Ref<Texture2D> remove_texture = get_editor_theme_icon(SNAME("Close"));
 	Ref<Texture2D> replace_texture = get_editor_theme_icon(SNAME("ReplaceText"));
 
-	TreeItem *file_item = _results_display->get_root()->get_first_child();
+	TreeItem *file_item = results_display->get_root()->get_first_child();
 	while (file_item) {
 		file_item->set_custom_color(0, file_item_color);
-		if (_with_replace) {
+		if (with_replace) {
 			file_item->set_button(0, file_item->get_button_by_id(0, FIND_BUTTON_REPLACE), replace_texture);
 		}
 		file_item->set_button(0, file_item->get_button_by_id(0, FIND_BUTTON_REMOVE), remove_texture);
 
 		TreeItem *result_item = file_item->get_first_child();
 		while (result_item) {
-			if (_with_replace) {
+			if (with_replace) {
 				result_item->set_button(1, result_item->get_button_by_id(1, FIND_BUTTON_REPLACE), replace_texture);
 				result_item->set_button(1, result_item->get_button_by_id(1, FIND_BUTTON_REMOVE), remove_texture);
 			} else {
@@ -1019,38 +884,39 @@ void FindInFilesPanel::_on_theme_changed() {
 	}
 }
 
-void FindInFilesPanel::draw_result_text(Object *item_obj, Rect2 rect) {
-	TreeItem *item = Object::cast_to<TreeItem>(item_obj);
+void FindInFilesPanel::_draw_result_text(Object *p_item_obj, const Rect2 &p_rect) {
+	TreeItem *item = Object::cast_to<TreeItem>(p_item_obj);
 	if (!item) {
 		return;
 	}
 
-	HashMap<TreeItem *, Result>::Iterator E = _result_items.find(item);
+	HashMap<TreeItem *, Result>::Iterator E = result_items.find(item);
 	if (!E) {
 		return;
 	}
 	Result r = E->value;
-	String item_text = item->get_text(_with_replace ? 1 : 0);
-	Ref<Font> font = _results_display->get_theme_font(SceneStringName(font));
-	int font_size = _results_display->get_theme_font_size(SceneStringName(font_size));
+	String item_text = item->get_text(with_replace ? 1 : 0);
+	Ref<Font> font = results_display->get_theme_font(SceneStringName(font));
+	int font_size = results_display->get_theme_font_size(SceneStringName(font_size));
 
-	Rect2 match_rect = rect;
+	Rect2 match_rect = p_rect;
 	match_rect.position.x += font->get_string_size(item_text.left(r.begin_trimmed), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x - 1;
-	match_rect.size.x = font->get_string_size(_search_text_label->get_text(), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + 1;
+	match_rect.size.x = font->get_string_size(search_text_label->get_text(), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + 1;
 	match_rect.position.y += 1 * EDSCALE;
 	match_rect.size.y -= 2 * EDSCALE;
 
-	_results_display->draw_rect(match_rect, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.33), false, 2.0);
-	_results_display->draw_rect(match_rect, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.17), true);
+	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+	results_display->draw_rect(match_rect, Color(accent_color, 0.33), false, 2.0);
+	results_display->draw_rect(match_rect, Color(accent_color, 0.17), true);
 
 	// Text is drawn by Tree already.
 }
 
 void FindInFilesPanel::_on_item_edited() {
-	TreeItem *item = _results_display->get_selected();
+	TreeItem *item = results_display->get_selected();
 
 	// Change opacity to half if checkbox is checked, otherwise full.
-	Color use_color = _results_display->get_theme_color(SceneStringName(font_color));
+	Color use_color = results_display->get_theme_color(SceneStringName(font_color));
 	if (!item->is_checked(0)) {
 		use_color.a *= 0.5;
 	}
@@ -1058,11 +924,11 @@ void FindInFilesPanel::_on_item_edited() {
 }
 
 void FindInFilesPanel::_on_finished() {
-	update_matches_text();
-	update_replace_buttons();
-	_progress_bar->set_visible(false);
-	_refresh_button->show();
-	_cancel_button->hide();
+	_update_matches_text();
+	_update_replace_buttons();
+	progress_bar->set_visible(false);
+	refresh_button->show();
+	cancel_button->hide();
 }
 
 void FindInFilesPanel::_on_refresh_button_clicked() {
@@ -1074,12 +940,12 @@ void FindInFilesPanel::_on_cancel_button_clicked() {
 }
 
 void FindInFilesPanel::_on_close_button_clicked() {
-	emit_signal(SNAME(SIGNAL_CLOSE_BUTTON_CLICKED));
+	emit_signal(SNAME("close_button_clicked"));
 }
 
 void FindInFilesPanel::_on_result_selected() {
-	TreeItem *item = _results_display->get_selected();
-	HashMap<TreeItem *, Result>::Iterator E = _result_items.find(item);
+	TreeItem *item = results_display->get_selected();
+	HashMap<TreeItem *, Result>::Iterator E = result_items.find(item);
 
 	if (!E) {
 		return;
@@ -1089,19 +955,17 @@ void FindInFilesPanel::_on_result_selected() {
 	TreeItem *file_item = item->get_parent();
 	String fpath = file_item->get_metadata(0);
 
-	emit_signal(SNAME(SIGNAL_RESULT_SELECTED), fpath, r.line_number, r.begin, r.end);
+	emit_signal(SNAME("result_selected"), fpath, r.line_number, r.begin, r.end);
 }
 
-void FindInFilesPanel::_on_replace_text_changed(const String &text) {
-	update_replace_buttons();
+void FindInFilesPanel::_on_replace_text_changed(const String &p_text) {
+	_update_replace_buttons();
 }
 
 void FindInFilesPanel::_on_replace_all_clicked() {
-	String replace_text = get_replace_text();
+	String replace_text = _get_replace_text();
 
-	PackedStringArray modified_files;
-
-	for (KeyValue<String, TreeItem *> &E : _file_items) {
+	for (KeyValue<String, TreeItem *> &E : file_items) {
 		TreeItem *file_item = E.value;
 		String fpath = file_item->get_metadata(0);
 
@@ -1111,85 +975,81 @@ void FindInFilesPanel::_on_replace_all_clicked() {
 				continue;
 			}
 
-			HashMap<TreeItem *, Result>::Iterator F = _result_items.find(item);
+			HashMap<TreeItem *, Result>::Iterator F = result_items.find(item);
 			ERR_FAIL_COND(!F);
 			locations.push_back(F->value);
 		}
 
 		if (locations.size() != 0) {
 			// Results are sorted by file, so we can batch replaces.
-			apply_replaces_in_file(fpath, locations, replace_text);
-			modified_files.push_back(fpath);
+			_apply_replaces_in_file(fpath, locations, replace_text);
 		}
 	}
 
 	// Hide replace bar so we can't trigger the action twice without doing a new search.
-	_replace_container->hide();
+	replace_container->hide();
 
-	emit_signal(SNAME(SIGNAL_FILES_MODIFIED), modified_files);
+	emit_signal(SNAME("files_modified"));
 }
 
 void FindInFilesPanel::_on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index) {
 	const String file_path = p_item->get_metadata(0);
 
 	if (p_id == FIND_BUTTON_REPLACE) {
-		const String replace_text = get_replace_text();
+		const String replace_text = _get_replace_text();
 		Vector<Result> locations;
-		PackedStringArray modified_files;
-		if (_file_items.has(file_path)) {
+		if (file_items.has(file_path)) {
 			for (TreeItem *item = p_item->get_first_child(); item; item = item->get_next()) {
-				HashMap<TreeItem *, Result>::Iterator F = _result_items.find(item);
+				HashMap<TreeItem *, Result>::Iterator F = result_items.find(item);
 				ERR_FAIL_COND(!F);
 				locations.push_back(F->value);
 			}
-			apply_replaces_in_file(file_path, locations, replace_text);
-			modified_files.push_back(file_path);
+			_apply_replaces_in_file(file_path, locations, replace_text);
 		} else {
-			locations.push_back(_result_items.find(p_item)->value);
+			locations.push_back(result_items.find(p_item)->value);
 			const String path = p_item->get_parent()->get_metadata(0);
-			apply_replaces_in_file(path, locations, replace_text);
-			modified_files.push_back(path);
+			_apply_replaces_in_file(path, locations, replace_text);
 		}
-		emit_signal(SNAME(SIGNAL_FILES_MODIFIED), modified_files);
+		emit_signal(SNAME("files_modified"));
 	}
 
-	_result_items.erase(p_item);
-	if (_file_items_results_count.has(p_item)) {
+	result_items.erase(p_item);
+	if (file_items_results_count.has(p_item)) {
 		int match_count = p_item->get_child_count();
 
 		for (int i = 0; i < match_count; i++) {
 			TreeItem *child_item = p_item->get_child(i);
-			_result_items.erase(child_item);
+			result_items.erase(child_item);
 		}
 
 		p_item->clear_children();
-		_file_items.erase(file_path);
-		_file_items_results_count.erase(p_item);
+		file_items.erase(file_path);
+		file_items_results_count.erase(p_item);
 	}
 
 	TreeItem *item_parent = p_item->get_parent();
 	if (item_parent) {
-		if (_file_items_results_count.has(item_parent)) {
-			_file_items_results_count[item_parent]--;
+		if (file_items_results_count.has(item_parent)) {
+			file_items_results_count[item_parent]--;
 		}
-		if (item_parent->get_child_count() < 2 && item_parent != _results_display->get_root()) {
-			_file_items.erase(item_parent->get_metadata(0));
+		if (item_parent->get_child_count() < 2 && item_parent != results_display->get_root()) {
+			file_items.erase(item_parent->get_metadata(0));
 			get_tree()->queue_delete(item_parent);
 		}
 	}
 	get_tree()->queue_delete(p_item);
-	update_matches_text();
+	_update_matches_text();
 }
 
 // Same as get_line, but preserves line ending characters.
 class ConservativeGetLine {
 public:
-	String get_line(Ref<FileAccess> f) {
+	String get_line(Ref<FileAccess> p_file) {
 		_line_buffer.clear();
 
-		char32_t c = f->get_8();
+		char32_t c = p_file->get_8();
 
-		while (!f->eof_reached()) {
+		while (!p_file->eof_reached()) {
 			if (c == '\n') {
 				_line_buffer.push_back(c);
 				_line_buffer.push_back(0);
@@ -1203,7 +1063,7 @@ public:
 				_line_buffer.push_back(c);
 			}
 
-			c = f->get_8();
+			c = p_file->get_8();
 		}
 
 		_line_buffer.push_back(0);
@@ -1214,13 +1074,13 @@ private:
 	Vector<char> _line_buffer;
 };
 
-void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<Result> &locations, const String &new_text) {
+void FindInFilesPanel::_apply_replaces_in_file(const String &p_fpath, const Vector<Result> &p_locations, const String &p_new_text) {
 	// If the file is already open, I assume the editor will reload it.
 	// If there are unsaved changes, the user will be asked on focus,
 	// however that means either losing changes or losing replaces.
 
-	Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ);
-	ERR_FAIL_COND_MSG(f.is_null(), "Cannot open file from path '" + fpath + "'.");
+	Ref<FileAccess> f = FileAccess::open(p_fpath, FileAccess::READ);
+	ERR_FAIL_COND_MSG(f.is_null(), "Cannot open file from path '" + p_fpath + "'.");
 
 	String buffer;
 	int current_line = 1;
@@ -1228,12 +1088,12 @@ void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<
 	ConservativeGetLine conservative;
 
 	String line = conservative.get_line(f);
-	String search_text = _finder->get_search_text();
+	String search_text = finder->get_search_text();
 
 	int offset = 0;
 
-	for (int i = 0; i < locations.size(); ++i) {
-		int repl_line_number = locations[i].line_number;
+	for (int i = 0; i < p_locations.size(); ++i) {
+		int repl_line_number = p_locations[i].line_number;
 
 		while (current_line < repl_line_number) {
 			buffer += line;
@@ -1242,19 +1102,19 @@ void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<
 			offset = 0;
 		}
 
-		int repl_begin = locations[i].begin + offset;
-		int repl_end = locations[i].end + offset;
+		int repl_begin = p_locations[i].begin + offset;
+		int repl_end = p_locations[i].end + offset;
 
 		int _;
-		if (!find_next(line, search_text, repl_begin, _finder->is_match_case(), _finder->is_whole_words(), _, _)) {
+		if (!find_next(line, search_text, repl_begin, finder->is_match_case(), finder->is_whole_words(), _, _)) {
 			// Make sure the replace is still valid in case the file was tampered with.
-			print_verbose(String("Occurrence no longer matches, replace will be ignored in {0}: line {1}, col {2}").format(varray(fpath, repl_line_number, repl_begin)));
+			print_verbose(vformat(R"(Occurrence no longer matches, replace will be ignored in "%s": line %d, col %d.)", p_fpath, repl_line_number, repl_begin));
 			continue;
 		}
 
-		line = line.left(repl_begin) + new_text + line.substr(repl_end);
+		line = line.left(repl_begin) + p_new_text + line.substr(repl_end);
 		// Keep an offset in case there are successive replaces in the same line.
-		offset += new_text.length() - (repl_end - repl_begin);
+		offset += p_new_text.length() - (repl_end - repl_begin);
 	}
 
 	buffer += line;
@@ -1265,26 +1125,26 @@ void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<
 
 	// Now the modified contents are in the buffer, rewrite the file with our changes.
 
-	Error err = f->reopen(fpath, FileAccess::WRITE);
-	ERR_FAIL_COND_MSG(err != OK, "Cannot create file in path '" + fpath + "'.");
+	Error err = f->reopen(p_fpath, FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(err != OK, "Cannot create file in path '" + p_fpath + "'.");
 
 	f->store_string(buffer);
 }
 
-String FindInFilesPanel::get_replace_text() {
-	return _replace_line_edit->get_text();
+String FindInFilesPanel::_get_replace_text() {
+	return replace_line_edit->get_text();
 }
 
-void FindInFilesPanel::update_replace_buttons() {
-	bool disabled = _finder->is_searching();
+void FindInFilesPanel::_update_replace_buttons() {
+	bool disabled = finder->is_searching();
 
-	_replace_all_button->set_disabled(disabled);
+	replace_all_button->set_disabled(disabled);
 }
 
-void FindInFilesPanel::update_matches_text() {
+void FindInFilesPanel::_update_matches_text() {
 	String results_text;
-	int result_count = _result_items.size();
-	int file_count = _file_items.size();
+	int result_count = result_items.size();
+	int file_count = file_items.size();
 
 	if (result_count == 1 && file_count == 1) {
 		results_text = vformat(TTR("%d match in %d file"), result_count, file_count);
@@ -1294,81 +1154,157 @@ void FindInFilesPanel::update_matches_text() {
 		results_text = vformat(TTR("%d matches in %d files"), result_count, file_count);
 	}
 
-	_status_label->set_text(results_text);
+	status_label->set_text(results_text);
 
-	TreeItem *file_item = _results_display->get_root()->get_first_child();
+	TreeItem *file_item = results_display->get_root()->get_first_child();
 	while (file_item) {
-		int file_matches_count = _file_items_results_count[file_item];
+		int file_matches_count = file_items_results_count[file_item];
 		file_item->set_text(0, (String)file_item->get_metadata(0) + " (" + vformat(TTRN("%d match", "%d matches", file_matches_count), file_matches_count) + ")");
 		file_item = file_item->get_next();
 	}
 }
 
 void FindInFilesPanel::_bind_methods() {
-	ClassDB::bind_method("_on_result_found", &FindInFilesPanel::_on_result_found);
-	ClassDB::bind_method("_on_finished", &FindInFilesPanel::_on_finished);
-
-	ADD_SIGNAL(MethodInfo(SIGNAL_RESULT_SELECTED,
+	ADD_SIGNAL(MethodInfo("result_selected",
 			PropertyInfo(Variant::STRING, "path"),
 			PropertyInfo(Variant::INT, "line_number"),
 			PropertyInfo(Variant::INT, "begin"),
 			PropertyInfo(Variant::INT, "end")));
 
-	ADD_SIGNAL(MethodInfo(SIGNAL_FILES_MODIFIED, PropertyInfo(Variant::STRING, "paths")));
+	ADD_SIGNAL(MethodInfo("files_modified"));
 
-	ADD_SIGNAL(MethodInfo(SIGNAL_CLOSE_BUTTON_CLICKED));
+	ADD_SIGNAL(MethodInfo("close_button_clicked"));
+}
+
+FindInFilesPanel::FindInFilesPanel() {
+	finder = memnew(FindInFilesSearch);
+	finder->connect("result_found", callable_mp(this, &FindInFilesPanel::_on_result_found));
+	finder->connect(SceneStringName(finished), callable_mp(this, &FindInFilesPanel::_on_finished));
+	add_child(finder);
+
+	VBoxContainer *vbc = memnew(VBoxContainer);
+	vbc->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 0);
+	vbc->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, 0);
+	vbc->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
+	vbc->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
+	add_child(vbc);
+
+	{
+		HBoxContainer *hbc = memnew(HBoxContainer);
+		hbc->set_alignment(BoxContainer::ALIGNMENT_END);
+
+		find_label = memnew(Label);
+		find_label->set_text(TTRC("Find:"));
+		hbc->add_child(find_label);
+
+		search_text_label = memnew(Label);
+		search_text_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
+		search_text_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		search_text_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+		search_text_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+		search_text_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+		hbc->add_child(search_text_label);
+
+		progress_bar = memnew(ProgressBar);
+		progress_bar->set_h_size_flags(SIZE_EXPAND_FILL);
+		progress_bar->set_v_size_flags(SIZE_SHRINK_CENTER);
+		progress_bar->set_stretch_ratio(2.0);
+		progress_bar->set_visible(false);
+		hbc->add_child(progress_bar);
+
+		status_label = memnew(Label);
+		status_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+		hbc->add_child(status_label);
+
+		keep_results_button = memnew(CheckButton);
+		keep_results_button->set_text(TTRC("Keep Results"));
+		keep_results_button->set_tooltip_text(TTRC("Keep these results and show subsequent results in a new window"));
+		keep_results_button->set_pressed(false);
+		hbc->add_child(keep_results_button);
+
+		refresh_button = memnew(Button);
+		refresh_button->set_text(TTRC("Refresh"));
+		refresh_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_refresh_button_clicked));
+		refresh_button->hide();
+		hbc->add_child(refresh_button);
+
+		cancel_button = memnew(Button);
+		cancel_button->set_text(TTRC("Cancel"));
+		cancel_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_cancel_button_clicked));
+		cancel_button->hide();
+		hbc->add_child(cancel_button);
+
+		close_button = memnew(Button);
+		close_button->set_text(TTRC("Close"));
+		close_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_close_button_clicked));
+		hbc->add_child(close_button);
+
+		vbc->add_child(hbc);
+	}
+
+	results_mc = memnew(MarginContainer);
+	results_mc->set_theme_type_variation("NoBorderHorizontal");
+	results_mc->set_v_size_flags(SIZE_EXPAND_FILL);
+	vbc->add_child(results_mc);
+
+	results_display = memnew(Tree);
+	results_display->set_accessibility_name(TTRC("Search Results"));
+	results_display->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
+	results_display->connect(SceneStringName(item_selected), callable_mp(this, &FindInFilesPanel::_on_result_selected));
+	results_display->connect("item_edited", callable_mp(this, &FindInFilesPanel::_on_item_edited));
+	results_display->connect("button_clicked", callable_mp(this, &FindInFilesPanel::_on_button_clicked));
+	results_display->set_hide_root(true);
+	results_display->set_select_mode(Tree::SELECT_ROW);
+	results_display->set_allow_rmb_select(true);
+	results_display->set_allow_reselect(true);
+	results_display->add_theme_constant_override("inner_item_margin_left", 0);
+	results_display->add_theme_constant_override("inner_item_margin_right", 0);
+	results_display->create_item(); // Root
+	results_mc->add_child(results_display);
+
+	{
+		replace_container = memnew(HBoxContainer);
+
+		Label *replace_label = memnew(Label);
+		replace_label->set_text(TTRC("Replace:"));
+		replace_container->add_child(replace_label);
+
+		replace_line_edit = memnew(LineEdit);
+		replace_line_edit->set_accessibility_name(TTRC("Replace:"));
+		replace_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
+		replace_line_edit->connect(SceneStringName(text_changed), callable_mp(this, &FindInFilesPanel::_on_replace_text_changed));
+		replace_container->add_child(replace_line_edit);
+
+		replace_all_button = memnew(Button);
+		replace_all_button->set_text(TTRC("Replace all (no undo)"));
+		replace_all_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_replace_all_clicked));
+		replace_container->add_child(replace_all_button);
+
+		replace_container->hide();
+
+		vbc->add_child(replace_container);
+	}
 }
 
 //-----------------------------------------------------------------------------
 
-FindInFilesContainer::FindInFilesContainer() {
-	set_name(TTRC("Search Results"));
-	set_icon_name("Search");
-	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_search_results_bottom_panel", TTRC("Toggle Search Results Bottom Panel")));
-	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
-	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
-	set_global(false);
-	set_transient(true);
-	set_closable(true);
-	set_custom_minimum_size(Size2(0, 200 * EDSCALE));
-
-	_tabs = memnew(TabContainer);
-	_tabs->set_tabs_visible(false);
-	add_child(_tabs);
-
-	_tabs->set_drag_to_rearrange_enabled(true);
-	_tabs->get_tab_bar()->set_select_with_rmb(true);
-	_tabs->get_tab_bar()->set_tab_close_display_policy(TabBar::CLOSE_BUTTON_SHOW_ACTIVE_ONLY);
-	_tabs->get_tab_bar()->connect("tab_close_pressed", callable_mp(this, &FindInFilesContainer::_on_tab_close_pressed));
-	_tabs->get_tab_bar()->connect(SceneStringName(gui_input), callable_mp(this, &FindInFilesContainer::_bar_input));
-
-	_tabs_context_menu = memnew(PopupMenu);
-	add_child(_tabs_context_menu);
-	_tabs_context_menu->add_item(TTRC("Close Tab"), PANEL_CLOSE);
-	_tabs_context_menu->add_item(TTRC("Close Other Tabs"), PANEL_CLOSE_OTHERS);
-	_tabs_context_menu->add_item(TTRC("Close Tabs to the Right"), PANEL_CLOSE_RIGHT);
-	_tabs_context_menu->add_item(TTRC("Close All Tabs"), PANEL_CLOSE_ALL);
-	_tabs_context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &FindInFilesContainer::_bar_menu_option));
-
-	EditorNode::get_singleton()->get_gui_base()->connect(SceneStringName(theme_changed), callable_mp(this, &FindInFilesContainer::_on_theme_changed));
-}
-
 FindInFilesPanel *FindInFilesContainer::_create_new_panel() {
-	int index = _tabs->get_current_tab();
+	int index = tabs->get_current_tab();
 	FindInFilesPanel *panel = memnew(FindInFilesPanel);
-	_tabs->add_child(panel);
-	_tabs->move_child(panel, index + 1); // New panel is added after the current activated panel.
-	_tabs->set_current_tab(index + 1);
+	tabs->add_child(panel);
+	tabs->move_child(panel, index + 1); // New panel is added after the current activated panel.
+	tabs->set_current_tab(index + 1);
 	_update_bar_visibility();
 
-	panel->connect(FindInFilesPanel::SIGNAL_RESULT_SELECTED, callable_mp(this, &FindInFilesContainer::_on_find_in_files_result_selected));
-	panel->connect(FindInFilesPanel::SIGNAL_FILES_MODIFIED, callable_mp(this, &FindInFilesContainer::_on_find_in_files_modified_files));
-	panel->connect(FindInFilesPanel::SIGNAL_CLOSE_BUTTON_CLICKED, callable_mp(this, &FindInFilesContainer::_on_find_in_files_close_button_clicked).bind(panel));
+	panel->connect("result_selected", callable_mp(this, &FindInFilesContainer::_result_selected));
+	panel->connect("files_modified", callable_mp(this, &FindInFilesContainer::_files_modified));
+	panel->connect("close_button_clicked", callable_mp(this, &FindInFilesContainer::_close_panel).bind(panel));
 	return panel;
 }
 
 FindInFilesPanel *FindInFilesContainer::_get_current_panel() {
-	return Object::cast_to<FindInFilesPanel>(_tabs->get_current_tab_control());
+	return Object::cast_to<FindInFilesPanel>(tabs->get_current_tab_control());
 }
 
 FindInFilesPanel *FindInFilesContainer::get_panel_for_results(const String &p_label) {
@@ -1378,11 +1314,11 @@ FindInFilesPanel *FindInFilesContainer::get_panel_for_results(const String &p_la
 		panel = _get_current_panel();
 	} else {
 		// Find the first panel which does not keep results.
-		for (int i = 0; i < _tabs->get_tab_count(); i++) {
-			FindInFilesPanel *p = Object::cast_to<FindInFilesPanel>(_tabs->get_tab_control(i));
+		for (int i = 0; i < tabs->get_tab_count(); i++) {
+			FindInFilesPanel *p = Object::cast_to<FindInFilesPanel>(tabs->get_tab_control(i));
 			if (p && !p->is_keep_results()) {
 				panel = p;
-				_tabs->set_current_tab(i);
+				tabs->set_current_tab(i);
 				break;
 			}
 		}
@@ -1391,18 +1327,8 @@ FindInFilesPanel *FindInFilesContainer::get_panel_for_results(const String &p_la
 			panel = _create_new_panel();
 		}
 	}
-	_tabs->set_tab_title(_tabs->get_current_tab(), p_label);
+	tabs->set_tab_title(tabs->get_current_tab(), p_label);
 	return panel;
-}
-
-void FindInFilesContainer::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("result_selected",
-			PropertyInfo(Variant::STRING, "path"),
-			PropertyInfo(Variant::INT, "line_number"),
-			PropertyInfo(Variant::INT, "begin"),
-			PropertyInfo(Variant::INT, "end")));
-
-	ADD_SIGNAL(MethodInfo("files_modified", PropertyInfo(Variant::STRING, "paths")));
 }
 
 void FindInFilesContainer::_notification(int p_what) {
@@ -1425,52 +1351,52 @@ void FindInFilesContainer::_on_theme_changed() {
 	}
 }
 
-void FindInFilesContainer::_on_find_in_files_result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end) {
+void FindInFilesContainer::_result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end) {
 	emit_signal(SNAME("result_selected"), p_fpath, p_line_number, p_begin, p_end);
 }
 
-void FindInFilesContainer::_on_find_in_files_modified_files(const PackedStringArray &p_paths) {
-	emit_signal(SNAME("files_modified"), p_paths);
+void FindInFilesContainer::_files_modified() {
+	emit_signal(SNAME("files_modified"));
 }
 
-void FindInFilesContainer::_on_find_in_files_close_button_clicked(FindInFilesPanel *p_panel) {
-	ERR_FAIL_COND_MSG(p_panel->get_parent() != _tabs, "This panel is not a child!");
-	_tabs->remove_child(p_panel);
+void FindInFilesContainer::_close_panel(FindInFilesPanel *p_panel) {
+	ERR_FAIL_COND_MSG(p_panel->get_parent() != tabs, "This panel is not a child!");
+	tabs->remove_child(p_panel);
 	p_panel->queue_free();
 	_update_bar_visibility();
-	if (_tabs->get_tab_count() == 0) {
+	if (tabs->get_tab_count() == 0) {
 		close();
 	}
 }
 
-void FindInFilesContainer::update_layout(EditorDock::DockLayout p_layout) {
-	for (Node *node : _tabs->iterate_children()) {
-		FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(node);
-		if (panel) {
-			panel->update_layout(p_layout);
-		}
+void FindInFilesContainer::_on_dock_closed() {
+	while (tabs->get_tab_count() > 0) {
+		Control *tab = tabs->get_tab_control(0);
+		tabs->remove_child(tab);
+		tab->queue_free();
 	}
+	_update_bar_visibility();
 }
 
 void FindInFilesContainer::_on_tab_close_pressed(int p_tab) {
-	FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(_tabs->get_tab_control(p_tab));
+	FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(tabs->get_tab_control(p_tab));
 	if (panel) {
-		_on_find_in_files_close_button_clicked(panel);
+		_close_panel(panel);
 	}
 }
 
 void FindInFilesContainer::_update_bar_visibility() {
-	if (!_update_bar) {
+	if (!update_bar) {
 		return;
 	}
 
 	// If tab count <= 1, behaves like this is not a TabContainer and the bar is hidden.
-	bool bar_visible = _tabs->get_tab_count() > 1;
-	_tabs->set_tabs_visible(bar_visible);
+	bool bar_visible = tabs->get_tab_count() > 1;
+	tabs->set_tabs_visible(bar_visible);
 
 	// Hide or show the search labels based on the visibility of the bar, as the search terms are displayed in the title of each tab.
-	for (int i = 0; i < _tabs->get_tab_count(); i++) {
-		FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(_tabs->get_tab_control(i));
+	for (int i = 0; i < tabs->get_tab_count(); i++) {
+		FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(tabs->get_tab_control(i));
 		if (panel) {
 			panel->set_search_labels_visibility(!bar_visible);
 		}
@@ -1478,58 +1404,158 @@ void FindInFilesContainer::_update_bar_visibility() {
 }
 
 void FindInFilesContainer::_bar_menu_option(int p_option) {
-	int tab_index = _tabs->get_current_tab();
+	int tab_index = tabs->get_current_tab();
 	switch (p_option) {
 		case PANEL_CLOSE: {
 			_on_tab_close_pressed(tab_index);
 		} break;
 		case PANEL_CLOSE_OTHERS: {
-			_update_bar = false;
-			FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(_tabs->get_tab_control(tab_index));
-			for (int i = _tabs->get_tab_count() - 1; i >= 0; i--) {
-				FindInFilesPanel *p = Object::cast_to<FindInFilesPanel>(_tabs->get_tab_control(i));
+			update_bar = false;
+			FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(tabs->get_tab_control(tab_index));
+			for (int i = tabs->get_tab_count() - 1; i >= 0; i--) {
+				FindInFilesPanel *p = Object::cast_to<FindInFilesPanel>(tabs->get_tab_control(i));
 				if (p != panel) {
-					_on_find_in_files_close_button_clicked(p);
+					_close_panel(p);
 				}
 			}
-			_update_bar = true;
+			update_bar = true;
 			_update_bar_visibility();
 		} break;
 		case PANEL_CLOSE_RIGHT: {
-			_update_bar = false;
-			for (int i = _tabs->get_tab_count() - 1; i > tab_index; i--) {
+			update_bar = false;
+			for (int i = tabs->get_tab_count() - 1; i > tab_index; i--) {
 				_on_tab_close_pressed(i);
 			}
-			_update_bar = true;
+			update_bar = true;
 			_update_bar_visibility();
 		} break;
 		case PANEL_CLOSE_ALL: {
-			_update_bar = false;
-			for (int i = _tabs->get_tab_count() - 1; i >= 0; i--) {
+			update_bar = false;
+			for (int i = tabs->get_tab_count() - 1; i >= 0; i--) {
 				_on_tab_close_pressed(i);
 			}
-			_update_bar = true;
+			update_bar = true;
 		} break;
 	}
 }
 
 void FindInFilesContainer::_bar_input(const Ref<InputEvent> &p_input) {
-	int tab_id = _tabs->get_tab_bar()->get_hovered_tab();
+	int tab_id = tabs->get_tab_bar()->get_hovered_tab();
 	Ref<InputEventMouseButton> mb = p_input;
 
 	if (tab_id >= 0 && mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
-		_tabs_context_menu->set_item_disabled(_tabs_context_menu->get_item_index(PANEL_CLOSE_RIGHT), tab_id == _tabs->get_tab_count() - 1);
-		_tabs_context_menu->set_position(_tabs->get_tab_bar()->get_screen_position() + mb->get_position());
-		_tabs_context_menu->reset_size();
-		_tabs_context_menu->popup();
+		tabs_context_menu->set_item_disabled(tabs_context_menu->get_item_index(PANEL_CLOSE_RIGHT), tab_id == tabs->get_tab_count() - 1);
+		tabs_context_menu->set_position(tabs->get_tab_bar()->get_screen_position() + mb->get_position());
+		tabs_context_menu->reset_size();
+		tabs_context_menu->popup();
 	}
 }
 
-void FindInFilesContainer::_on_dock_closed() {
-	while (_tabs->get_tab_count() > 0) {
-		Control *tab = _tabs->get_tab_control(0);
-		_tabs->remove_child(tab);
-		tab->queue_free();
+void FindInFilesContainer::update_layout(EditorDock::DockLayout p_layout) {
+	for (Node *node : tabs->iterate_children()) {
+		FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(node);
+		if (panel) {
+			panel->update_layout(p_layout);
+		}
 	}
-	_update_bar_visibility();
+}
+
+void FindInFilesContainer::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("result_selected",
+			PropertyInfo(Variant::STRING, "path"),
+			PropertyInfo(Variant::INT, "line_number"),
+			PropertyInfo(Variant::INT, "begin"),
+			PropertyInfo(Variant::INT, "end")));
+
+	ADD_SIGNAL(MethodInfo("files_modified"));
+}
+
+FindInFilesContainer::FindInFilesContainer() {
+	set_name(TTRC("Search Results"));
+	set_icon_name("Search");
+	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_search_results_bottom_panel", TTRC("Toggle Search Results Bottom Panel")));
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
+	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
+	set_global(false);
+	set_transient(true);
+	set_closable(true);
+	set_custom_minimum_size(Size2(0, 200 * EDSCALE));
+
+	tabs = memnew(TabContainer);
+	tabs->set_tabs_visible(false);
+	add_child(tabs);
+
+	tabs->set_drag_to_rearrange_enabled(true);
+	tabs->get_tab_bar()->set_select_with_rmb(true);
+	tabs->get_tab_bar()->set_tab_close_display_policy(TabBar::CLOSE_BUTTON_SHOW_ACTIVE_ONLY);
+	tabs->get_tab_bar()->connect("tab_close_pressed", callable_mp(this, &FindInFilesContainer::_on_tab_close_pressed));
+	tabs->get_tab_bar()->connect(SceneStringName(gui_input), callable_mp(this, &FindInFilesContainer::_bar_input));
+
+	tabs_context_menu = memnew(PopupMenu);
+	add_child(tabs_context_menu);
+	tabs_context_menu->add_item(TTRC("Close Tab"), PANEL_CLOSE);
+	tabs_context_menu->add_item(TTRC("Close Other Tabs"), PANEL_CLOSE_OTHERS);
+	tabs_context_menu->add_item(TTRC("Close Tabs to the Right"), PANEL_CLOSE_RIGHT);
+	tabs_context_menu->add_item(TTRC("Close All Tabs"), PANEL_CLOSE_ALL);
+	tabs_context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &FindInFilesContainer::_bar_menu_option));
+
+	EditorNode::get_singleton()->get_gui_base()->connect(SceneStringName(theme_changed), callable_mp(this, &FindInFilesContainer::_on_theme_changed));
+}
+
+void FindInFiles::_start_search(bool p_with_replace) {
+	FindInFilesPanel *panel = container->get_panel_for_results((p_with_replace ? TTR("Replace:") : TTR("Find:")) + " " + dialog->get_search_text());
+	FindInFilesSearch *search = panel->get_finder();
+
+	search->set_search_text(dialog->get_search_text());
+	search->set_match_case(dialog->is_match_case());
+	search->set_whole_words(dialog->is_whole_words());
+	search->set_folder(dialog->get_folder());
+	search->set_filter(dialog->get_filter());
+	search->set_includes(dialog->get_includes());
+	search->set_excludes(dialog->get_excludes());
+
+	panel->set_with_replace(p_with_replace);
+	panel->set_replace_text(dialog->get_replace_text());
+	panel->start_search();
+
+	container->make_visible();
+}
+
+void FindInFiles::open_dialog(const String &p_initial_text, bool p_replace) {
+	dialog->set_replace_mode(p_replace);
+	dialog->set_search_text(p_initial_text);
+	if (p_replace) {
+		dialog->set_replace_text(String());
+	}
+	dialog->popup_centered();
+}
+
+void FindInFiles::_result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end) {
+	emit_signal(SNAME("result_selected"), p_fpath, p_line_number, p_begin, p_end);
+}
+
+void FindInFiles::_files_modified() {
+	emit_signal(SNAME("files_modified"));
+}
+
+void FindInFiles::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("result_selected",
+			PropertyInfo(Variant::STRING, "path"),
+			PropertyInfo(Variant::INT, "line_number"),
+			PropertyInfo(Variant::INT, "begin"),
+			PropertyInfo(Variant::INT, "end")));
+	ADD_SIGNAL(MethodInfo("files_modified"));
+}
+
+FindInFiles::FindInFiles() {
+	dialog = memnew(FindInFilesDialog);
+	dialog->connect("find_requested", callable_mp(this, &FindInFiles::_start_search).bind(false));
+	dialog->connect("replace_requested", callable_mp(this, &FindInFiles::_start_search).bind(true));
+	EditorNode::get_singleton()->get_gui_base()->add_child(dialog);
+
+	container = memnew(FindInFilesContainer);
+	EditorDockManager::get_singleton()->add_dock(container);
+	container->close();
+	container->connect("result_selected", callable_mp(this, &FindInFiles::_result_selected));
+	container->connect("files_modified", callable_mp(this, &FindInFiles::_files_modified));
 }

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -34,61 +34,56 @@
 #include "editor/docks/editor_dock.h"
 #include "scene/gui/dialogs.h"
 
-// Performs the actual search
-class FindInFiles : public Node {
-	GDCLASS(FindInFiles, Node);
+// Performs the actual search.
+class FindInFilesSearch : public Node {
+	GDCLASS(FindInFilesSearch, Node);
+
+	// Config.
+	String pattern;
+	HashSet<String> extension_filter;
+	HashSet<String> include_wildcards;
+	HashSet<String> exclude_wildcards;
+	String root_dir;
+	bool whole_words = true;
+	bool match_case = true;
+
+	// State.
+	bool searching = false;
+	String current_dir;
+	Vector<PackedStringArray> folders_stack;
+	Vector<String> files_to_scan;
+	int initial_files_count = 0;
+
+	void _process();
+	void _iterate();
+	void _scan_dir(const String &p_path, PackedStringArray &r_out_folders, PackedStringArray &r_out_files_to_scan);
+	void _scan_file(const String &p_fpath);
+
+	bool _is_file_matched(const HashSet<String> &p_wildcards, const String &p_file_path, bool p_case_sensitive) const;
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
 
 public:
-	static const char *SIGNAL_RESULT_FOUND;
-	static const char *SIGNAL_FINISHED;
-
 	void set_search_text(const String &p_pattern);
 	void set_whole_words(bool p_whole_word);
 	void set_match_case(bool p_match_case);
-	void set_folder(const String &folder);
-	void set_filter(const HashSet<String> &exts);
+	void set_folder(const String &p_folder);
+	void set_filter(const HashSet<String> &p_exts);
 	void set_includes(const HashSet<String> &p_include_wildcards);
 	void set_excludes(const HashSet<String> &p_exclude_wildcards);
 
-	String get_search_text() const { return _pattern; }
+	String get_search_text() const { return pattern; }
 
-	bool is_whole_words() const { return _whole_words; }
-	bool is_match_case() const { return _match_case; }
+	bool is_whole_words() const { return whole_words; }
+	bool is_match_case() const { return match_case; }
 
 	void start();
 	void stop();
 
-	bool is_searching() const { return _searching; }
+	bool is_searching() const { return searching; }
 	float get_progress() const;
-
-protected:
-	void _notification(int p_what);
-
-	static void _bind_methods();
-
-private:
-	void _process();
-	void _iterate();
-	void _scan_dir(const String &path, PackedStringArray &out_folders, PackedStringArray &out_files_to_scan);
-	void _scan_file(const String &fpath);
-
-	bool _is_file_matched(const HashSet<String> &p_wildcards, const String &p_file_path, bool p_case_sensitive) const;
-
-	// Config
-	String _pattern;
-	HashSet<String> _extension_filter;
-	HashSet<String> _include_wildcards;
-	HashSet<String> _exclude_wildcards;
-	String _root_dir;
-	bool _whole_words = true;
-	bool _match_case = true;
-
-	// State
-	bool _searching = false;
-	String _current_dir;
-	Vector<PackedStringArray> _folders_stack;
-	Vector<String> _files_to_scan;
-	int _initial_files_count = 0;
 };
 
 class LineEdit;
@@ -96,25 +91,47 @@ class CheckBox;
 class FileDialog;
 class HBoxContainer;
 
-// Prompts search parameters
+// Prompts search parameters.
 class FindInFilesDialog : public AcceptDialog {
 	GDCLASS(FindInFilesDialog, AcceptDialog);
 
+	void _on_folder_button_pressed();
+	void _on_folder_selected(String p_path);
+	void _on_search_text_modified(const String &p_text);
+	void _on_search_text_submitted(const String &p_text);
+	void _on_replace_text_submitted(const String &p_text);
+
+	String _validate_filter_wildcard(const String &p_expression) const;
+
+	bool replace_mode = false;
+	LineEdit *search_text_line_edit = nullptr;
+
+	Label *replace_label = nullptr;
+	LineEdit *replace_text_line_edit = nullptr;
+
+	LineEdit *folder_line_edit = nullptr;
+	CheckBox *match_case_checkbox = nullptr;
+	CheckBox *whole_words_checkbox = nullptr;
+	Button *find_button = nullptr;
+	Button *replace_button = nullptr;
+	FileDialog *folder_dialog = nullptr;
+	HBoxContainer *filters_container = nullptr;
+	LineEdit *includes_line_edit = nullptr;
+	LineEdit *excludes_line_edit = nullptr;
+
+	HashMap<String, bool> filters_preferences;
+
+protected:
+	void _notification(int p_what);
+
+	virtual void custom_action(const String &p_action) override;
+	static void _bind_methods();
+
 public:
-	enum FindInFilesMode {
-		SEARCH_MODE,
-		REPLACE_MODE
-	};
+	void set_search_text(const String &p_text);
+	void set_replace_text(const String &p_text);
 
-	static const char *SIGNAL_FIND_REQUESTED;
-	static const char *SIGNAL_REPLACE_REQUESTED;
-
-	FindInFilesDialog();
-
-	void set_search_text(const String &text);
-	void set_replace_text(const String &text);
-
-	void set_find_in_files_mode(FindInFilesMode p_mode);
+	void set_replace_mode(bool p_replace);
 
 	String get_search_text() const;
 	String get_replace_text() const;
@@ -125,39 +142,7 @@ public:
 	HashSet<String> get_includes() const;
 	HashSet<String> get_excludes() const;
 
-protected:
-	void _notification(int p_what);
-
-	void _visibility_changed();
-	void custom_action(const String &p_action) override;
-	static void _bind_methods();
-
-private:
-	void _on_folder_button_pressed();
-	void _on_folder_selected(String path);
-	void _on_search_text_modified(const String &text);
-	void _on_search_text_submitted(const String &text);
-	void _on_replace_text_submitted(const String &text);
-
-	String validate_filter_wildcard(const String &p_expression) const;
-
-	FindInFilesMode _mode;
-	LineEdit *_search_text_line_edit = nullptr;
-
-	Label *_replace_label = nullptr;
-	LineEdit *_replace_text_line_edit = nullptr;
-
-	LineEdit *_folder_line_edit = nullptr;
-	CheckBox *_match_case_checkbox = nullptr;
-	CheckBox *_whole_words_checkbox = nullptr;
-	Button *_find_button = nullptr;
-	Button *_replace_button = nullptr;
-	FileDialog *_folder_dialog = nullptr;
-	HBoxContainer *_filters_container = nullptr;
-	LineEdit *_includes_line_edit = nullptr;
-	LineEdit *_excludes_line_edit = nullptr;
-
-	HashMap<String, bool> _filters_preferences;
+	FindInFilesDialog();
 };
 
 class Button;
@@ -166,48 +151,11 @@ class Tree;
 class TreeItem;
 class ProgressBar;
 
-// Display search results
+// Display search results.
 class FindInFilesPanel : public MarginContainer {
 	GDCLASS(FindInFilesPanel, MarginContainer);
 
-public:
-	static const char *SIGNAL_RESULT_SELECTED;
-	static const char *SIGNAL_FILES_MODIFIED;
-	static const char *SIGNAL_CLOSE_BUTTON_CLICKED;
-
-	FindInFilesPanel();
-
-	FindInFiles *get_finder() const { return _finder; }
-
-	void set_with_replace(bool with_replace);
-	void set_replace_text(const String &text);
-	bool is_keep_results() const;
-	void set_search_labels_visibility(bool p_visible);
-
-	void start_search();
-	void stop_search();
-
-	void update_layout(EditorDock::DockLayout p_layout);
-
-protected:
-	static void _bind_methods();
-
-	void _notification(int p_what);
-
-private:
-	void _on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index);
-	void _on_result_found(const String &fpath, int line_number, int begin, int end, String text);
-	void _on_theme_changed();
-	void _on_finished();
-	void _on_refresh_button_clicked();
-	void _on_cancel_button_clicked();
-	void _on_close_button_clicked();
-	void _on_result_selected();
-	void _on_item_edited();
-	void _on_replace_text_changed(const String &text);
-	void _on_replace_all_clicked();
-
-	enum {
+	enum FindButtons {
 		FIND_BUTTON_REPLACE,
 		FIND_BUTTON_REMOVE,
 	};
@@ -219,36 +167,67 @@ private:
 		int begin_trimmed = 0;
 	};
 
-	void apply_replaces_in_file(const String &fpath, const Vector<Result> &locations, const String &new_text);
-	void update_replace_buttons();
-	void update_matches_text();
-	String get_replace_text();
+	FindInFilesSearch *finder = nullptr;
+	Label *find_label = nullptr;
+	Label *search_text_label = nullptr;
+	Tree *results_display = nullptr;
+	Label *status_label = nullptr;
+	CheckButton *keep_results_button = nullptr;
+	Button *refresh_button = nullptr;
+	Button *cancel_button = nullptr;
+	Button *close_button = nullptr;
+	ProgressBar *progress_bar = nullptr;
+	HashMap<String, TreeItem *> file_items;
+	HashMap<TreeItem *, int> file_items_results_count;
+	HashMap<TreeItem *, Result> result_items;
+	bool with_replace = false;
 
-	void draw_result_text(Object *item_obj, Rect2 rect);
+	HBoxContainer *replace_container = nullptr;
+	LineEdit *replace_line_edit = nullptr;
+	Button *replace_all_button = nullptr;
 
-	void clear();
+	bool floating = false;
+	MarginContainer *results_mc = nullptr;
 
-	FindInFiles *_finder = nullptr;
-	Label *_find_label = nullptr;
-	Label *_search_text_label = nullptr;
-	Tree *_results_display = nullptr;
-	Label *_status_label = nullptr;
-	CheckButton *_keep_results_button = nullptr;
-	Button *_refresh_button = nullptr;
-	Button *_cancel_button = nullptr;
-	Button *_close_button = nullptr;
-	ProgressBar *_progress_bar = nullptr;
-	HashMap<String, TreeItem *> _file_items;
-	HashMap<TreeItem *, int> _file_items_results_count;
-	HashMap<TreeItem *, Result> _result_items;
-	bool _with_replace = false;
+	void _on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index);
+	void _on_result_found(const String &p_fpath, int p_line_number, int p_begin, int p_end, const String &p_text);
+	void _on_theme_changed();
+	void _on_finished();
+	void _on_refresh_button_clicked();
+	void _on_cancel_button_clicked();
+	void _on_close_button_clicked();
+	void _on_result_selected();
+	void _on_item_edited();
+	void _on_replace_text_changed(const String &p_text);
+	void _on_replace_all_clicked();
 
-	HBoxContainer *_replace_container = nullptr;
-	LineEdit *_replace_line_edit = nullptr;
-	Button *_replace_all_button = nullptr;
+	void _apply_replaces_in_file(const String &p_fpath, const Vector<Result> &p_locations, const String &p_new_text);
+	void _update_replace_buttons();
+	void _update_matches_text();
+	String _get_replace_text();
 
-	bool _floating = false;
-	MarginContainer *_results_mc = nullptr;
+	void _draw_result_text(Object *p_item_obj, const Rect2 &p_rect);
+
+	void _clear();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	FindInFilesSearch *get_finder() const { return finder; }
+
+	void set_with_replace(bool p_with_replace);
+	void set_replace_text(const String &p_text);
+	bool is_keep_results() const;
+	void set_search_labels_visibility(bool p_visible);
+
+	void start_search();
+	void stop_search();
+
+	void update_layout(EditorDock::DockLayout p_layout);
+
+	FindInFilesPanel();
 };
 
 class PopupMenu;
@@ -261,39 +240,58 @@ class TabContainer;
 class FindInFilesContainer : public EditorDock {
 	GDCLASS(FindInFilesContainer, EditorDock);
 
-	enum {
+	enum PanelMenuOptions {
 		PANEL_CLOSE,
 		PANEL_CLOSE_OTHERS,
 		PANEL_CLOSE_RIGHT,
 		PANEL_CLOSE_ALL,
 	};
 
-	void _on_theme_changed();
+	TabContainer *tabs = nullptr;
+	bool update_bar = true;
+	PopupMenu *tabs_context_menu = nullptr;
+
 	void _on_tab_close_pressed(int p_tab);
 	void _update_bar_visibility();
 	void _bar_menu_option(int p_option);
 	void _bar_input(const Ref<InputEvent> &p_input);
-	void _on_dock_closed();
-
-	TabContainer *_tabs = nullptr;
-	bool _update_bar = true;
-	PopupMenu *_tabs_context_menu = nullptr;
+	void _on_theme_changed();
 
 	FindInFilesPanel *_create_new_panel();
 	FindInFilesPanel *_get_current_panel();
 
+	void _result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end);
+	void _files_modified();
+	void _close_panel(FindInFilesPanel *p_panel);
+	void _on_dock_closed();
+
 protected:
-	static void _bind_methods();
 	void _notification(int p_what);
-
-	void _on_find_in_files_result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end);
-	void _on_find_in_files_modified_files(const PackedStringArray &p_paths);
-	void _on_find_in_files_close_button_clicked(FindInFilesPanel *p_panel);
-
-	virtual void update_layout(EditorDock::DockLayout p_layout) override;
+	static void _bind_methods();
 
 public:
-	FindInFilesContainer();
+	virtual void update_layout(EditorDock::DockLayout p_layout) override;
 
 	FindInFilesPanel *get_panel_for_results(const String &p_label);
+
+	FindInFilesContainer();
+};
+
+class FindInFiles : public Object {
+	GDCLASS(FindInFiles, Object);
+
+	FindInFilesDialog *dialog = nullptr;
+	FindInFilesContainer *container = nullptr;
+
+	void _start_search(bool p_with_replace);
+	void _result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end);
+	void _files_modified();
+
+protected:
+	static void _bind_methods();
+
+public:
+	void open_dialog(const String &p_initial_text, bool p_replace = false);
+
+	FindInFiles();
 };

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -48,7 +48,6 @@
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/doc/editor_help.h"
 #include "editor/doc/editor_help_search.h"
-#include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/docks/signals_dock.h"
@@ -1103,7 +1102,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			open_find_in_files_dialog("");
 		} break;
 		case REPLACE_IN_FILES: {
-			_on_replace_in_files_requested("");
+			open_find_in_files_dialog("", true);
 		} break;
 		case SEARCH_HELP: {
 			help_search_dialog->popup_dialog();
@@ -2349,8 +2348,8 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 		teb->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 		teb->connect("request_save_history", callable_mp(this, &ScriptEditor::_save_history));
 		teb->connect("request_save_previous_state", callable_mp(this, &ScriptEditor::_save_previous_state));
-		teb->connect("search_in_files_requested", callable_mp(this, &ScriptEditor::open_find_in_files_dialog));
-		teb->connect("replace_in_files_requested", callable_mp(this, &ScriptEditor::_on_replace_in_files_requested));
+		teb->connect("search_in_files_requested", callable_mp(this, &ScriptEditor::open_find_in_files_dialog).bind(false));
+		teb->connect("replace_in_files_requested", callable_mp(this, &ScriptEditor::open_find_in_files_dialog).bind(true));
 		teb->connect("go_to_method", callable_mp(this, &ScriptEditor::script_goto_method));
 
 		if (script_editor_cache->has_section(p_resource->get_path())) {
@@ -2603,10 +2602,8 @@ void ScriptEditor::_auto_format_text(ScriptEditorBase *p_seb) {
 	}
 }
 
-void ScriptEditor::open_find_in_files_dialog(const String &text) {
-	find_in_files_dialog->set_find_in_files_mode(FindInFilesDialog::SEARCH_MODE);
-	find_in_files_dialog->set_search_text(text);
-	find_in_files_dialog->popup_centered();
+void ScriptEditor::open_find_in_files_dialog(const String &p_initial_text, bool p_replace) {
+	find_in_files->open_dialog(p_initial_text, p_replace);
 }
 
 void ScriptEditor::open_script_create_dialog(const String &p_base_name, const String &p_base_path) {
@@ -3661,13 +3658,6 @@ void ScriptEditor::_script_changed() {
 	SignalsDock::get_singleton()->update_lists();
 }
 
-void ScriptEditor::_on_replace_in_files_requested(const String &text) {
-	find_in_files_dialog->set_find_in_files_mode(FindInFilesDialog::REPLACE_MODE);
-	find_in_files_dialog->set_search_text(text);
-	find_in_files_dialog->set_replace_text("");
-	find_in_files_dialog->popup_centered();
-}
-
 void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int line_number, int begin, int end) {
 	if (ResourceLoader::exists(fpath)) {
 		Ref<Resource> res = ResourceLoader::load(fpath);
@@ -3754,26 +3744,7 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 	}
 }
 
-void ScriptEditor::_start_find_in_files(bool with_replace) {
-	FindInFilesPanel *panel = find_in_files->get_panel_for_results(with_replace ? TTR("Replace:") + " " + find_in_files_dialog->get_search_text() : TTR("Find:") + " " + find_in_files_dialog->get_search_text());
-	FindInFiles *f = panel->get_finder();
-
-	f->set_search_text(find_in_files_dialog->get_search_text());
-	f->set_match_case(find_in_files_dialog->is_match_case());
-	f->set_whole_words(find_in_files_dialog->is_whole_words());
-	f->set_folder(find_in_files_dialog->get_folder());
-	f->set_filter(find_in_files_dialog->get_filter());
-	f->set_includes(find_in_files_dialog->get_includes());
-	f->set_excludes(find_in_files_dialog->get_excludes());
-
-	panel->set_with_replace(with_replace);
-	panel->set_replace_text(find_in_files_dialog->get_replace_text());
-	panel->start_search();
-
-	find_in_files->make_visible();
-}
-
-void ScriptEditor::_on_find_in_files_modified_files(const PackedStringArray &paths) {
+void ScriptEditor::_on_find_in_files_modified_files() {
 	_test_script_times_on_disk();
 	_update_modified_scripts_for_external_editor();
 }
@@ -4184,14 +4155,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	add_child(help_search_dialog);
 	help_search_dialog->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 
-	find_in_files_dialog = memnew(FindInFilesDialog);
-	find_in_files_dialog->connect(FindInFilesDialog::SIGNAL_FIND_REQUESTED, callable_mp(this, &ScriptEditor::_start_find_in_files).bind(false));
-	find_in_files_dialog->connect(FindInFilesDialog::SIGNAL_REPLACE_REQUESTED, callable_mp(this, &ScriptEditor::_start_find_in_files).bind(true));
-	add_child(find_in_files_dialog);
-
-	find_in_files = memnew(FindInFilesContainer);
-	EditorDockManager::get_singleton()->add_dock(find_in_files);
-	find_in_files->close();
+	find_in_files = memnew(FindInFiles);
 	find_in_files->connect("result_selected", callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
 	find_in_files->connect("files_modified", callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));
 
@@ -4215,6 +4179,10 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	register_syntax_highlighter(config_file_syntax_highlighter);
 
 	_update_online_doc();
+}
+
+ScriptEditor::~ScriptEditor() {
+	memdelete(find_in_files);
 }
 
 void ScriptEditorPlugin::_focus_another_editor() {

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -78,8 +78,7 @@ public:
 };
 
 class EditorScriptCodeCompletionCache;
-class FindInFilesContainer;
-class FindInFilesDialog;
+class FindInFiles;
 
 class ScriptEditor : public PanelContainer {
 	GDCLASS(ScriptEditor, PanelContainer);
@@ -197,8 +196,7 @@ class ScriptEditor : public PanelContainer {
 	Button *script_back = nullptr;
 	Button *script_forward = nullptr;
 
-	FindInFilesDialog *find_in_files_dialog = nullptr;
-	FindInFilesContainer *find_in_files = nullptr;
+	FindInFiles *find_in_files = nullptr;
 
 	WindowWrapper *window_wrapper = nullptr;
 
@@ -384,10 +382,8 @@ class ScriptEditor : public PanelContainer {
 	Ref<TextFile> _load_text_file(const String &p_path, Error *r_error) const;
 	Error _save_text_file(Ref<TextFile> p_text_file, const String &p_path);
 
-	void _on_replace_in_files_requested(const String &text);
-	void _on_find_in_files_result_selected(const String &fpath, int line_number, int begin, int end);
-	void _start_find_in_files(bool with_replace);
-	void _on_find_in_files_modified_files(const PackedStringArray &paths);
+	void _on_find_in_files_result_selected(const String &p_path, int p_line_number, int p_begin, int p_end);
+	void _on_find_in_files_modified_files();
 
 	void _set_script_zoom_factor(float p_zoom_factor);
 	void _update_code_editor_zoom_factor(CodeTextEditor *p_code_text_editor);
@@ -409,7 +405,7 @@ public:
 	bool is_files_panel_toggled();
 	void apply_scripts() const;
 	void reload_scripts(bool p_refresh_only = false);
-	void open_find_in_files_dialog(const String &text);
+	void open_find_in_files_dialog(const String &p_initial_text = "", bool p_replace = false);
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);
 	void open_text_file_create_dialog(const String &p_base_path, const String &p_base_name = "");
 	Ref<Resource> open_file(const String &p_file);
@@ -464,6 +460,7 @@ public:
 	static void register_create_script_editor_function(CreateScriptEditorFunc p_func);
 
 	ScriptEditor(WindowWrapper *p_wrapper);
+	~ScriptEditor();
 };
 
 class ScriptEditorPlugin : public EditorPlugin {


### PR DESCRIPTION
Clean up Find in Files code
Changes variable names to not use underscore prefix, parameters to use appropriate `p_` / `r_` prefixes, signals to strings instead of variables for the name, reorders private/public member order in header, to match our usual style.
Also some minor other changes: The `_mode` variable in FindInFilesDialog and the `FindInFilesMode` enum is removed in favor of a bool `replace_mode`. `vformat` is used instead of `String.format`. Removed the string array being passed to `files_modified` signal, its unused.

Moves Find in Files setup out of ScriptEditor since it is unrelated to ScriptEditor. Adds a new FindInFiles class for this (the other one is renamed FindInFilesSearch to be more clear). Maybe this could become a singleton or its own plugin in the future?
This does create more signal forwarding, but I want to further clean up signals in the future, many of them can be removed. 

~Note, the error `ERROR: Child is not a child of this node.` when starting a search is unrelated, see https://github.com/godotengine/godot/issues/113024~