### PR TITLE
OpenXR: Implement `play_area_changed` signal

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2099,7 +2099,7 @@ bool OpenXRAPI::poll_events() {
 				}
 
 				if (xr_interface) {
-					xr_interface->on_reference_space_change_pending();
+					xr_interface->on_reference_space_change_pending(event->referenceSpaceType);
 				}
 			} break;
 			case XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED: {

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -1408,8 +1408,32 @@ void OpenXRInterface::on_state_exiting() {
 	emit_signal(SNAME("instance_exiting"));
 }
 
-void OpenXRInterface::on_reference_space_change_pending() {
+void OpenXRInterface::on_reference_space_change_pending(XrReferenceSpaceType p_type) {
 	reference_stage_changing = true;
+
+	// Emit play area bounds changed signal when the reference space changes.
+	PlayAreaMode mode = XR_PLAY_AREA_UNKNOWN;
+
+	switch (p_type) {
+		case XR_REFERENCE_SPACE_TYPE_VIEW:
+			mode = XR_PLAY_AREA_3DOF;
+			break;
+		case XR_REFERENCE_SPACE_TYPE_LOCAL:
+			mode = XR_PLAY_AREA_SITTING;
+			break;
+		case XR_REFERENCE_SPACE_TYPE_STAGE:
+			mode = XR_PLAY_AREA_STAGE;
+			break;
+		case XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR:
+			mode = XR_PLAY_AREA_ROOMSCALE;
+			break;
+		default:
+			mode = XR_PLAY_AREA_UNKNOWN;
+			break;
+	}
+
+	print_verbose("OpenXR Interface: Play area changed, emitting signal.");
+	emit_signal(SNAME("play_area_changed"), mode);
 }
 
 void OpenXRInterface::on_refresh_rate_changes(float p_new_rate) {

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -213,7 +213,7 @@ public:
 	void on_state_stopping();
 	void on_state_loss_pending();
 	void on_state_exiting();
-	void on_reference_space_change_pending();
+	void on_reference_space_change_pending(XrReferenceSpaceType p_type);
 	void on_refresh_rate_changes(float p_new_rate);
 	void tracker_profile_changed(RID p_tracker, RID p_interaction_profile);
 


### PR DESCRIPTION
This implements the missing logic for the 'play_area_changed' in OpenXRInterface as described in bug #112270.

It modifies the existing 'on_reference_space_change_pending' method by receiving the XrReferenceSpaceType enum from the event and selects the appropriate PlayAreaMode, it finally emits the 'play_area_changed' signal.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
