### PR TITLE
Add bottom dock tab style setting

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -89,6 +89,9 @@
 		<member name="dock_shortcut" type="Shortcut" setter="set_dock_shortcut" getter="get_dock_shortcut">
 			The shortcut used to open the dock. This property can only be set before this dock is added via [method EditorPlugin.add_dock].
 		</member>
+		<member name="force_show_icon" type="bool" setter="set_force_show_icon" getter="get_force_show_icon" default="false">
+			If [code]true[/code], the dock will always display an icon, regardless of [member EditorSettings.interface/editor/dock_tab_style] or [member EditorSettings.interface/editor/bottom_dock_tab_style].
+		</member>
 		<member name="global" type="bool" setter="set_global" getter="is_global" default="true">
 			If [code]true[/code], the dock appears in the [b]Editor &gt; Editor Docks[/b] menu and can be closed. Non-global docks can still be closed using [method close].
 		</member>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -910,6 +910,9 @@
 		<member name="interface/editor/automatically_open_screenshots" type="bool" setter="" getter="">
 			If [code]true[/code], automatically opens screenshots with the default program associated to [code].png[/code] files after a screenshot is taken using the [b]Editor &gt; Take Screenshot[/b] action.
 		</member>
+		<member name="interface/editor/bottom_dock_tab_style" type="int" setter="" getter="">
+			Tab style of editor docks located at the bottom.
+		</member>
 		<member name="interface/editor/code_font" type="String" setter="" getter="">
 			The font to use for the script editor. Must be a resource of a [Font] type such as a [code].ttf[/code] or [code].otf[/code] font file.
 		</member>
@@ -943,7 +946,7 @@
 			If set to [b]Custom[/b], the scaling value in [member interface/editor/custom_display_scale] will be used.
 		</member>
 		<member name="interface/editor/dock_tab_style" type="int" setter="" getter="">
-			Tab style of editor docks.
+			Tab style of editor docks, except bottom docks.
 		</member>
 		<member name="interface/editor/dragging_hover_wait_seconds" type="float" setter="" getter="">
 			During a drag-and-drop, this is how long to wait over a UI element before it triggers a reaction (e.g. a section unfolds to show nested items).

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -67,6 +67,10 @@ void EditorDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_dock_icon"), &EditorDock::get_dock_icon);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "dock_icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_dock_icon", "get_dock_icon");
 
+	ClassDB::bind_method(D_METHOD("set_force_show_icon", "force"), &EditorDock::set_force_show_icon);
+	ClassDB::bind_method(D_METHOD("get_force_show_icon"), &EditorDock::get_force_show_icon);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "force_show_icon"), "set_force_show_icon", "get_force_show_icon");
+
 	ClassDB::bind_method(D_METHOD("set_title_color", "color"), &EditorDock::set_title_color);
 	ClassDB::bind_method(D_METHOD("get_title_color"), &EditorDock::get_title_color);
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "title_color"), "set_title_color", "get_title_color");
@@ -141,6 +145,14 @@ void EditorDock::set_dock_icon(const Ref<Texture2D> &p_icon) {
 		return;
 	}
 	dock_icon = p_icon;
+	emit_signal("tab_style_changed");
+}
+
+void EditorDock::set_force_show_icon(bool p_force) {
+	if (force_show_icon == p_force) {
+		return;
+	}
+	force_show_icon = p_force;
 	emit_signal("tab_style_changed");
 }
 

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -58,6 +58,7 @@ private:
 	String layout_key;
 	StringName icon_name;
 	Ref<Texture2D> dock_icon;
+	bool force_show_icon = false;
 	Color title_color = Color(0, 0, 0, 0);
 	Ref<Shortcut> shortcut;
 	DockConstants::DockSlot default_slot = DockConstants::DOCK_SLOT_NONE;
@@ -105,6 +106,9 @@ public:
 
 	void set_dock_icon(const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_dock_icon() const { return dock_icon; }
+
+	void set_force_show_icon(bool p_force);
+	bool get_force_show_icon() const { return force_show_icon; }
 
 	void set_title_color(const Color &p_color);
 	Color get_title_color() const { return title_color; }

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -540,24 +540,32 @@ void EditorDockManager::_update_tab_style(EditorDock *p_dock) {
 
 	tab_container->get_tab_bar()->set_font_color_override_all(index, p_dock->title_color);
 
-	const TabStyle style = (TabStyle)EDITOR_GET("interface/editor/dock_tab_style").operator int();
+	const TabStyle style = (tab_container == EditorNode::get_bottom_panel())
+			? (TabStyle)EDITOR_GET("interface/editor/bottom_dock_tab_style").operator int()
+			: (TabStyle)EDITOR_GET("interface/editor/dock_tab_style").operator int();
 	const Ref<Texture2D> icon = _get_dock_icon(p_dock, callable_mp((Control *)tab_container, &Control::get_editor_theme_icon));
+	bool assign_icon = p_dock->force_show_icon;
 	switch (style) {
 		case TabStyle::TEXT_ONLY: {
 			tab_container->set_tab_title(index, p_dock->get_display_title());
-			tab_container->set_tab_icon(index, Ref<Texture2D>());
 			tab_container->set_tab_tooltip(index, String());
 		} break;
 		case TabStyle::ICON_ONLY: {
 			tab_container->set_tab_title(index, icon.is_valid() ? String() : p_dock->get_display_title());
-			tab_container->set_tab_icon(index, icon);
 			tab_container->set_tab_tooltip(index, p_dock->get_display_title());
+			assign_icon = true;
 		} break;
 		case TabStyle::TEXT_AND_ICON: {
 			tab_container->set_tab_title(index, p_dock->get_display_title());
-			tab_container->set_tab_icon(index, icon);
 			tab_container->set_tab_tooltip(index, String());
+			assign_icon = true;
 		} break;
+	}
+
+	if (assign_icon) {
+		tab_container->set_tab_icon(index, icon);
+	} else {
+		tab_container->set_tab_icon(index, Ref<Texture2D>());
 	}
 }
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -39,9 +39,11 @@
 #include "editor/editor_string_names.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/script/script_editor_plugin.h"
+#include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "modules/regex/regex.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/separator.h"
 #include "scene/main/timer.h"
 #include "scene/resources/font.h"
@@ -286,11 +288,8 @@ void EditorLog::add_message(const String &p_msg, MessageType p_type) {
 }
 
 void EditorLog::_set_dock_tab_icon(Ref<Texture2D> p_icon) {
-	// TODO: Remove this hack once EditorLog is converted to a dock.
-	EditorDock *parent = Object::cast_to<EditorDock>(get_parent());
-	if (parent) {
-		parent->set_dock_icon(p_icon);
-	}
+	set_dock_icon(p_icon);
+	set_force_show_icon(p_icon.is_valid());
 }
 
 void EditorLog::register_undo_redo(UndoRedo *p_undo_redo) {
@@ -488,6 +487,14 @@ void EditorLog::_reset_message_counts() {
 }
 
 EditorLog::EditorLog() {
+	set_name(TTRC("Output"));
+	set_icon_name("Output");
+	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_output_bottom_panel", TTRC("Toggle Output Dock"), KeyModifierMask::ALT | Key::O));
+	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
+	set_global(false);
+	set_transient(true);
+
 	save_state_timer = memnew(Timer);
 	save_state_timer->set_wait_time(2);
 	save_state_timer->set_one_shot(true);
@@ -497,7 +504,8 @@ EditorLog::EditorLog() {
 	line_limit = int(EDITOR_GET("run/output/max_lines"));
 	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorLog::_editor_settings_changed));
 
-	HBoxContainer *hb = this;
+	HBoxContainer *hb = memnew(HBoxContainer);
+	add_child(hb);
 
 	VBoxContainer *vb_left = memnew(VBoxContainer);
 	vb_left->set_custom_minimum_size(Size2(0, 180) * EDSCALE);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/os/thread.h"
-#include "scene/gui/box_container.h"
+#include "editor/docks/editor_dock.h"
 #include "scene/gui/button.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/rich_text_label.h"
@@ -39,8 +39,8 @@
 class Timer;
 class UndoRedo;
 
-class EditorLog : public HBoxContainer {
-	GDCLASS(EditorLog, HBoxContainer);
+class EditorLog : public EditorDock {
+	GDCLASS(EditorLog, EditorDock);
 
 public:
 	enum MessageType {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1054,10 +1054,6 @@ void EditorNode::_notification(int p_what) {
 				theme->set_constant("hover_switch_wait_msec", "TabBar", (float)EDITOR_GET("interface/editor/dragging_hover_wait_seconds") * 1000);
 			}
 
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/dock_tab_style")) {
-				editor_dock_manager->update_tab_styles();
-			}
-
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/scene_tabs")) {
 				scene_tabs->update_scene_tabs();
 			}
@@ -5323,7 +5319,7 @@ void EditorNode::_project_run_started() {
 
 	int action_on_play = EDITOR_GET("run/bottom_panel/action_on_play");
 	if (action_on_play == ACTION_ON_PLAY_OPEN_OUTPUT) {
-		bottom_panel->make_item_visible(log);
+		editor_dock_manager->focus_dock(log);
 	} else if (action_on_play == ACTION_ON_PLAY_OPEN_DEBUGGER) {
 		bottom_panel->make_item_visible(EditorDebuggerNode::get_singleton());
 	}
@@ -8793,7 +8789,7 @@ EditorNode::EditorNode() {
 	center_split->set_dragger_visibility(SplitContainer::DRAGGER_HIDDEN);
 
 	log = memnew(EditorLog);
-	bottom_panel->add_item(TTRC("Output"), log, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_output_bottom_panel", TTRC("Toggle Output Bottom Panel"), KeyModifierMask::ALT | Key::O));
+	editor_dock_manager->add_dock(log);
 
 	center_split->connect(SceneStringName(resized), callable_mp(this, &EditorNode::_vp_resized));
 

--- a/editor/icons/Output.svg
+++ b/editor/icons/Output.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><circle cx="4" cy="4" r="4" fill="#e0e0e0"/></svg>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -444,6 +444,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Editor
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/localize_settings", true, "")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/dock_tab_style", 0, "Text Only,Icon Only,Text and Icon")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/bottom_dock_tab_style", 0, "Text Only,Icon Only,Text and Icon")
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/ui_layout_direction", 0, "Based on Application Locale,Left-to-Right,Right-to-Left,Based on System Locale", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	// Display what the Auto display scale setting effectively corresponds to.


### PR DESCRIPTION
Fixes #113054

This PR adds a new `interface/editor/bottom_dock_tab_style` editor setting, which can be used to set the tab style for bottom docks separately (I assume most users wouldn't want them icon-only, even if they use that option for vertical docks, idk).

Also adds a new EditorDock property - `force_show_icon`. EditorLog (aka Output) uses it to display error icon even if tabs are text-only.

And finally, Output is now EditorDock (part of #113024). I assigned it a new icon, which is error icon but white
<img width="422" height="89" alt="image" src="https://github.com/user-attachments/assets/35921145-ef77-44d3-9cc4-5162d436e3c4" />
It only shows when bottom dock icons are enabled (other docks don't have icons yet).