### PR TITLE
Wayland: Implement compose and dead key support

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -469,6 +469,8 @@ public:
 		struct xkb_context *xkb_context = nullptr;
 		struct xkb_keymap *xkb_keymap = nullptr;
 		struct xkb_state *xkb_state = nullptr;
+		struct xkb_compose_state *xkb_compose_state = nullptr;
+		struct xkb_compose_table *xkb_compose_table = nullptr;
 
 		const char *keymap_buffer = nullptr;
 		uint32_t keymap_buffer_size = 0;


### PR DESCRIPTION
Fixes #94445.

Should make the life of people with international keyboards and such a lot better :D

This mirrors the approach used in the X11 backend, using XKB.

Had some trouble figuring out where to put the composing logic, especially since we have some pretty convoluted key handling logic (due echoing and whatnot), but I think that I found a good solution.

Unfortunately I had to duplicate some logic between echoing and direct key handling (as was already the case), but it would've been a lot more complicated to put everything in a method, as we need to dispatch the input events differently in both cases.