### PR TITLE
Remove extra `NOTIFICATION_VISIBILITY_CHANGED` notifications in docks

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -786,14 +786,15 @@ void EditorDockManager::close_dock(EditorDock *p_dock) {
 		return;
 	}
 
+	p_dock->is_open = false;
+
 	EditorBottomPanel *bottom_panel = EditorNode::get_bottom_panel();
 	if (get_dock_tab_container(p_dock) == bottom_panel && bottom_panel->get_current_tab_control() == p_dock) {
 		bottom_panel->hide_bottom_panel();
 	}
-	_move_dock(p_dock, closed_dock_parent);
-
-	p_dock->is_open = false;
+	// Hide before moving to remove inconsistent signals.
 	p_dock->hide();
+	_move_dock(p_dock, closed_dock_parent);
 
 	_update_layout();
 }
@@ -807,7 +808,6 @@ void EditorDockManager::open_dock(EditorDock *p_dock, bool p_set_current) {
 	}
 
 	p_dock->is_open = true;
-	p_dock->show();
 
 	// Open dock to its previous location.
 	if (p_dock->dock_slot_index != DockConstants::DOCK_SLOT_NONE) {
@@ -822,6 +822,7 @@ void EditorDockManager::open_dock(EditorDock *p_dock, bool p_set_current) {
 		return;
 	}
 
+	p_dock->show();
 	_update_layout();
 }
 
@@ -977,7 +978,9 @@ PopupMenu *EditorDockManager::get_docks_menu() {
 EditorDockManager::EditorDockManager() {
 	singleton = this;
 
-	closed_dock_parent = EditorNode::get_singleton()->get_gui_base();
+	closed_dock_parent = memnew(Control);
+	closed_dock_parent->hide();
+	EditorNode::get_singleton()->get_gui_base()->add_child(closed_dock_parent);
 
 	dock_context_popup = memnew(DockContextPopup);
 	EditorNode::get_singleton()->get_gui_base()->add_child(dock_context_popup);


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/113034#issuecomment-3566705258
Related: #113024

When upgrading docks to the new system, I first noticed that docks treated the `NOTIFICATION_{ENTER, EXIT}_TREE` like constructors and destructors, only being called once. When they used the `EditorBottomPanel`, this was valid, but now that they use the `EditorDockManager`, this is no longer true. Thus, any actions that must be done once, should be moved.

In https://github.com/godotengine/godot/pull/113034#issuecomment-3566705258, the underlying bug was a case where `NOTIFICATION_VISIBILITY_CHANGED` was used to know when the panel was enabled or disabled. This is valid if the notification only happened when both the enabled and visible, and disabled and not visible. However, due to an ordering issue with `EditorDockManager`, the `NOTIFICATION_VISIBILITY_CHANGED(true)` was emitted when closing the dock, and `NOTIFICATION_VISIBILITY_CHANGED(false)` was emitted when opening the dock, leading to incorrect assumptions. 

This PR swaps the order of operations so that the notification is only emitted correctly, to preserve assumptions. This has the benefit of removing unnecessary operations when opening and closing docks.

|  | `EditorDock::open()` | `EditorDock::close()` |
| - | - | - |
| Before: | NOTIFICATION_VISIBILITY_CHANGED <br>NOTIFICATION_EXIT_TREE<br> NOTIFICATION_VISIBILITY_CHANGED <br> NOTIFICATION_ENTER_TREE <br> NOTIFICATION_VISIBILITY_CHANGED <br> NOTIFICATION_VISIBILITY_CHANGED | NOTIFICATION_EXIT_TREE <br> NOTIFICATION_VISIBILITY_CHANGED <br> NOTIFICATION_ENTER_TREE <br> NOTIFICATION_VISIBILITY_CHANGED |
| After: | NOTIFICATION_EXIT_TREE <br> NOTIFICATION_ENTER_TREE <br> NOTIFICATION_VISIBILITY_CHANGED | NOTIFICATION_VISIBILITY_CHANGED <br> NOTIFICATION_EXIT_TREE <br> NOTIFICATION_ENTER_TREE |
