### PR TITLE
Fix documentation typos and broken links

### DIFF
--- a/modules/gdscript/tests/README.md
+++ b/modules/gdscript/tests/README.md
@@ -9,7 +9,7 @@ for information about creating and running GDScript integration tests.
 
 # GDScript Autocompletion tests
 
-The `script/completion` folder contains test for the GDScript autocompletion.
+The `scripts/completion` folder contains tests for the GDScript autocompletion.
 
 Each test case consists of at least one `.gd` file, which contains the code, and one `.cfg` file, which contains expected results and configuration. Inside of the GDScript file the character `➡` represents the cursor position, at which autocompletion is invoked.
 

--- a/platform/visionos/README.md
+++ b/platform/visionos/README.md
@@ -3,9 +3,9 @@
 This folder contains the C++, Objective-C and Objective-C++ code for the visionOS
 platform port.
 
-This platform derives from the Apple Embedded abstract platform ([`drivers/apple_embedded`](drivers/apple_embedded)).
+This platform derives from the Apple Embedded abstract platform ([`drivers/apple_embedded`](/drivers/apple_embedded)).
 
-This platform uses shared Apple code ([`drivers/apple`](drivers/apple)).
+This platform uses shared Apple code ([`drivers/apple`](/drivers/apple)).
 
 See also [`misc/dist/apple_embedded_xcode`](/misc/dist/apple_embedded_xcode) folder for the Xcode
 project template used for packaging the iOS export templates.


### PR DESCRIPTION
This pull request includes minor documentation improvements for the GDScript and visionOS modules. The changes correct folder paths and improve clarity in the README files.

Documentation updates:

* Corrected the folder name from `script/completion` to `scripts/completion` and improved grammar in the GDScript autocompletion tests section of `modules/gdscript/tests/README.md`.
* Updated file path links in `platform/visionos/README.md` to use absolute paths for better navigation and clarity.
