### PR TITLE
GUI: Allow buttons to be pressed programmatically

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -34,6 +34,13 @@
 				Returns [code]true[/code] if the mouse has entered the button and has not left it yet.
 			</description>
 		</method>
+		<method name="press">
+			<return type="void" />
+			<description>
+				Presses the button. This causes the corresponding virtual method to be called and the corresponding signal to be emitted, depending on [member toggle_mode]. If [member disabled] is [code]true[/code], nothing happens.
+				[b]Note:[/b] This method does not change the visual state of the button and does not grab focus to the button.
+			</description>
+		</method>
 		<method name="set_pressed_no_signal">
 			<return type="void" />
 			<param index="0" name="pressed" type="bool" />

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -118,23 +118,7 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void BaseButton::_accessibility_action_click(const Variant &p_data) {
-	if (toggle_mode) {
-		status.pressed = !status.pressed;
-
-		if (status.pressed) {
-			_unpress_group();
-			if (button_group.is_valid()) {
-				button_group->emit_signal(SceneStringName(pressed), this);
-			}
-		}
-
-		_toggled(status.pressed);
-		_pressed();
-	} else {
-		_pressed();
-	}
-	queue_accessibility_update();
-	queue_redraw();
+	press();
 }
 
 void BaseButton::_notification(int p_what) {
@@ -260,14 +244,16 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 					status.pressing_inside = false;
 					status.touch_index = -1; // Action completed, release matching touch so later taps aren't dropped if a modal consumes the release.
 				}
+
 				status.pressed = !status.pressed;
+
 				_unpress_group();
 				if (button_group.is_valid()) {
 					button_group->emit_signal(SceneStringName(pressed), this);
 				}
+
 				_toggled(status.pressed);
 				_pressed();
-				queue_accessibility_update();
 			}
 		} else {
 			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (p_event->is_released() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
@@ -285,6 +271,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		}
 	}
 
+	queue_accessibility_update();
 	queue_redraw();
 }
 
@@ -318,6 +305,29 @@ void BaseButton::set_disabled(bool p_disabled) {
 
 bool BaseButton::is_disabled() const {
 	return status.disabled;
+}
+
+void BaseButton::press() {
+	if (is_disabled()) {
+		return;
+	}
+
+	if (toggle_mode) {
+		status.pressed = !status.pressed;
+
+		_unpress_group();
+		if (button_group.is_valid()) {
+			button_group->emit_signal(SceneStringName(pressed), this);
+		}
+
+		_toggled(status.pressed);
+		_pressed();
+	} else {
+		_pressed();
+	}
+
+	queue_accessibility_update();
+	queue_redraw();
 }
 
 void BaseButton::set_pressed(bool p_pressed) {
@@ -485,21 +495,7 @@ void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	if (!is_disabled() && p_event->is_pressed() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
-		if (toggle_mode) {
-			status.pressed = !status.pressed;
-
-			_unpress_group();
-			if (button_group.is_valid()) {
-				button_group->emit_signal(SceneStringName(pressed), this);
-			}
-
-			_toggled(status.pressed);
-			_pressed();
-			queue_accessibility_update();
-		} else {
-			_pressed();
-		}
-		queue_redraw();
+		press();
 		accept_event();
 
 		if (shortcut_feedback && is_inside_tree()) {
@@ -590,23 +586,33 @@ PackedStringArray BaseButton::get_configuration_warnings() const {
 }
 
 void BaseButton::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("press"), &BaseButton::press);
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &BaseButton::set_pressed);
-	ClassDB::bind_method(D_METHOD("is_pressed"), &BaseButton::is_pressed);
 	ClassDB::bind_method(D_METHOD("set_pressed_no_signal", "pressed"), &BaseButton::set_pressed_no_signal);
+
+	ClassDB::bind_method(D_METHOD("is_pressed"), &BaseButton::is_pressed);
 	ClassDB::bind_method(D_METHOD("is_hovered"), &BaseButton::is_hovered);
+
 	ClassDB::bind_method(D_METHOD("set_toggle_mode", "enabled"), &BaseButton::set_toggle_mode);
 	ClassDB::bind_method(D_METHOD("is_toggle_mode"), &BaseButton::is_toggle_mode);
+
 	ClassDB::bind_method(D_METHOD("set_shortcut_in_tooltip", "enabled"), &BaseButton::set_shortcut_in_tooltip);
 	ClassDB::bind_method(D_METHOD("is_shortcut_in_tooltip_enabled"), &BaseButton::is_shortcut_in_tooltip_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_disabled", "disabled"), &BaseButton::set_disabled);
 	ClassDB::bind_method(D_METHOD("is_disabled"), &BaseButton::is_disabled);
+
 	ClassDB::bind_method(D_METHOD("set_action_mode", "mode"), &BaseButton::set_action_mode);
 	ClassDB::bind_method(D_METHOD("get_action_mode"), &BaseButton::get_action_mode);
+
 	ClassDB::bind_method(D_METHOD("set_button_mask", "mask"), &BaseButton::set_button_mask);
 	ClassDB::bind_method(D_METHOD("get_button_mask"), &BaseButton::get_button_mask);
+
 	ClassDB::bind_method(D_METHOD("get_draw_mode"), &BaseButton::get_draw_mode);
+
 	ClassDB::bind_method(D_METHOD("set_keep_pressed_outside", "enabled"), &BaseButton::set_keep_pressed_outside);
 	ClassDB::bind_method(D_METHOD("is_keep_pressed_outside"), &BaseButton::is_keep_pressed_outside);
+
 	ClassDB::bind_method(D_METHOD("set_shortcut_feedback", "enabled"), &BaseButton::set_shortcut_feedback);
 	ClassDB::bind_method(D_METHOD("is_shortcut_feedback"), &BaseButton::is_shortcut_feedback);
 
@@ -628,7 +634,7 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "button_pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press,Button Release"), "set_action_mode", "get_action_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask", PROPERTY_HINT_FLAGS, "Mouse Left, Mouse Right, Mouse Middle"), "set_button_mask", "get_button_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask", PROPERTY_HINT_FLAGS, "Mouse Left,Mouse Right,Mouse Middle"), "set_button_mask", "get_button_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_pressed_outside"), "set_keep_pressed_outside", "is_keep_pressed_outside");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "button_group", PROPERTY_HINT_RESOURCE_TYPE, ButtonGroup::get_class_static()), "set_button_group", "get_button_group");
 

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -109,14 +109,14 @@ public:
 
 	virtual bool has_point(const Point2 &p_point) const override;
 
-	/* Signals */
-
 	bool is_pressed() const; ///< return whether button is pressed (toggled in)
 	bool is_pressing() const; ///< return whether button is pressed (toggled in)
 	bool is_hovered() const;
 
+	void press();
 	void set_pressed(bool p_pressed); // Only works in toggle mode.
 	void set_pressed_no_signal(bool p_pressed);
+
 	void set_toggle_mode(bool p_on);
 	bool is_toggle_mode() const;
 


### PR DESCRIPTION
Currently, there's no simple, reliable, and complete way to programmatically press a button with `toggle_mode = false` (for `toggle_mode = true`, you can use the `button_pressed` property or its `set_pressed()` setter directly). Possible workarounds:

1. Manually emit the `pressed` signal. While this may work in simple cases, it ignores many factors: the `disabled`, `toggle_mode`, and `button_group` properties, the `_pressed()` and `_toggled()` virtual methods, and the presence of internal protected virtual methods `pressed()` and `toggled()` that are not accessible externally.
2. Use `Input.parse_input_event()` to simulate a button press using the `ui_accept` event or a mouse click. The problem is that this requires the button
   1. to have focus - you must `grab_focus()` to make `_gui_input()` working and ensure that `focus_mode` is set correctly, including ancestors, taking into account `focus_behavior_recursive`;
   2. to be clickable - you must ensure that `mouse_filter` is set correctly, including ancestors, taking into account `mouse_behavior_recursive`.
   3. Also, changing the current focus owner or handling input events can have unexpected side effects. Input events may be caught by another node or not be available at all (`Viewport.gui_disable_input`).

* See also https://github.com/godotengine/godot-proposals/issues/3438.