### PR TITLE
Allow `override.cfg` to add autoloads to the front of the list.

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -219,7 +219,7 @@ public:
 	bool check_changed_settings_in_group(const String &p_setting_prefix) const;
 
 	const HashMap<StringName, AutoloadInfo> &get_autoload_list() const;
-	void add_autoload(const AutoloadInfo &p_autoload);
+	void add_autoload(const AutoloadInfo &p_autoload, bool p_front_insert = false);
 	void remove_autoload(const StringName &p_autoload);
 	bool has_autoload(const StringName &p_autoload) const;
 	AutoloadInfo get_autoload(const StringName &p_name) const;


### PR DESCRIPTION
Necessary to support mod loader after https://github.com/godotengine/godot/pull/111909

Allows to add `autoload_prepend` section in the `override.cfg` with autoloads to load before default project autoloads.

```
[autoload_prepend]
AutoloadOverride="*res://autoload_override.gd"
```

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/discussions/6137