### PR TITLE
Ensure paths in autoload info

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1487,6 +1487,12 @@ ProjectSettings::AutoloadInfo ProjectSettings::get_autoload(const StringName &p_
 	return autoloads[p_name];
 }
 
+void ProjectSettings::fix_autoload_paths() {
+	for (KeyValue<StringName, AutoloadInfo> &kv : autoloads) {
+		kv.value.path = ResourceUID::ensure_path(kv.value.path);
+	}
+}
+
 const HashMap<StringName, String> &ProjectSettings::get_global_groups_list() const {
 	return global_groups;
 }

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -223,6 +223,7 @@ public:
 	void remove_autoload(const StringName &p_autoload);
 	bool has_autoload(const StringName &p_autoload) const;
 	AutoloadInfo get_autoload(const StringName &p_name) const;
+	void fix_autoload_paths();
 
 	const HashMap<StringName, String> &get_global_groups_list() const;
 	void add_global_group(const StringName &p_name, const String &p_description);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2188,7 +2188,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	register_core_extensions(); // core extensions must be registered after globals setup and before display
 
-	ResourceUID::get_singleton()->load_from_cache(true); // load UUIDs from cache.
+	ResourceUID::get_singleton()->load_from_cache(true); // Load UUIDs from cache.
+	ProjectSettings::get_singleton()->fix_autoload_paths(); // Handles autoloads saved as UID.
 
 	if (ProjectSettings::get_singleton()->has_custom_feature("dedicated_server")) {
 		audio_driver = NULL_AUDIO_DRIVER;


### PR DESCRIPTION
Fixes #113057

I'm not sure how it affects cases when autoload script is moved and the info still points to the old path. But at least the autoloads still load and save correctly.

The alternative is fixing GDScript, but it assumes that autoloads are paths in many places; the reported issue might be not the only one. Not sure if converting paths at every check is worth it though.