### PR TITLE
Fix node reordering under a PackedScene parent

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -826,12 +826,34 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				selection.reverse();
 			}
 
+			HashMap<Node *, int> owned_child_count_cache;
 			bool is_nowhere_to_move = false;
 			for (Node *E : selection) {
 				// `move_child` + `get_index` doesn't really work for internal nodes.
 				ERR_FAIL_COND_MSG(E->is_internal(), "Trying to move internal node, this is not supported.");
 
-				if ((MOVING_DOWN && (E->get_index() == E->get_parent()->get_child_count(false) - 1)) || (MOVING_UP && (E->get_index() == 0))) {
+				Node *parent_node = E->get_parent();
+
+				// If the parent node is a packed scene, prevent moving the selection before its owned children
+				int owned_child_count = 0;
+				if (owned_child_count_cache.has(parent_node)) {
+					owned_child_count = owned_child_count_cache.get(parent_node);
+				} else {
+					if (parent_node->is_instance() // packed
+							&& parent_node != edited_scene // not inherited
+							&& !edited_scene->is_editable_instance(parent_node) // not editable
+					) {
+						for (int i = 0; i < parent_node->get_child_count(false); i++) {
+							Node *sibling = parent_node->get_child(i, false);
+							if (sibling->get_owner() == parent_node) {
+								owned_child_count += 1;
+							}
+						}
+					}
+					owned_child_count_cache.insert(parent_node, owned_child_count);
+				}
+
+				if ((MOVING_DOWN && (E->get_index() == parent_node->get_child_count(false) - 1)) || (MOVING_UP && (E->get_index() == owned_child_count))) {
 					is_nowhere_to_move = true;
 					break;
 				}

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -795,6 +795,21 @@ void SceneTreeEditor::_move_node_item(TreeItem *p_parent, HashMap<Node *, Cached
 	}
 
 	Node *node = p_I->key;
+	Node *parent_node = node->get_parent();
+
+	// If the parent node is a packed scene, skip its owned children
+	int owned_child_count = 0;
+	if (parent_node->is_instance() // packed
+			&& parent_node != get_scene_node() // not inherited
+			&& !get_scene_node()->is_editable_instance(parent_node) // not editable
+	) {
+		for (int i = 0; i < parent_node->get_child_count(false); i++) {
+			Node *sibling = parent_node->get_child(i, false);
+			if (sibling->get_owner() == parent_node) {
+				owned_child_count += 1;
+			}
+		}
+	}
 
 	int current_node_index = node->get_index(false);
 	int current_item_index = -1;
@@ -815,12 +830,12 @@ void SceneTreeEditor::_move_node_item(TreeItem *p_parent, HashMap<Node *, Cached
 		bool already_in_correct_location;
 		if (current_item_index >= 0) {
 			// If we just re-parented we know our index.
-			already_in_correct_location = current_item_index == current_node_index;
+			already_in_correct_location = current_item_index == current_node_index - owned_child_count;
 		} else if (p_correct_prev) {
 			// It's cheaper to check if we're set up correctly by checking via correct_prev if we can
 			already_in_correct_location = item->get_prev() == p_correct_prev;
 		} else {
-			already_in_correct_location = item->get_index() == current_node_index;
+			already_in_correct_location = item->get_index() == current_node_index - owned_child_count;
 		}
 
 		// Are we already in the right place?
@@ -837,7 +852,7 @@ void SceneTreeEditor::_move_node_item(TreeItem *p_parent, HashMap<Node *, Cached
 		} else {
 			TreeItem *prev_item = p_correct_prev;
 			if (!prev_item) {
-				prev_item = p_parent->get_child(CLAMP(current_node_index - 1, 0, p_parent->get_child_count() - 1));
+				prev_item = p_parent->get_child(CLAMP(current_node_index - owned_child_count - 1, 0, p_parent->get_child_count() - 1));
 			}
 			item->move_after(prev_item);
 		}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113038

Fixes several bugs that occur when the parent node is an instanced PackedScene:
- `Ctrl+Up` allowed moving a node before the last scene-defined (inherited) child, which should not be possible
- During subtree updates after node reordering, the TreeItem index is now calculated taking into account the number of inherited children of the parent