### PR TITLE
GUI: Add `BaseButton.custom_draw_mode` property

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -25,7 +25,7 @@
 		<method name="get_draw_mode" qualifiers="const">
 			<return type="int" enum="BaseButton.DrawMode" />
 			<description>
-				Returns the visual state used to draw the button. This is useful mainly when implementing your own draw code by either overriding _draw() or connecting to "draw" signal. The visual state of the button is defined by the [enum DrawMode] enum.
+				Returns the visual state used to draw the button. This is useful mainly when implementing your own draw code by either overriding [method CanvasItem._draw] or connecting to the [signal CanvasItem.draw] signal. The visual state of the button is defined by the [enum DrawMode] enum. You can override the return value using the [member custom_draw_mode] property.
 			</description>
 		</method>
 		<method name="is_hovered" qualifiers="const">
@@ -58,6 +58,9 @@
 		<member name="button_pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the button's state is pressed. Means the button is pressed down or toggled (if [member toggle_mode] is active). Only works if [member toggle_mode] is [code]true[/code].
 			[b]Note:[/b] Changing the value of [member button_pressed] will result in [signal toggled] to be emitted. If you want to change the pressed state without emitting that signal, use [method set_pressed_no_signal].
+		</member>
+		<member name="custom_draw_mode" type="int" setter="set_custom_draw_mode" getter="get_custom_draw_mode" enum="BaseButton.DrawMode" default="-1">
+			If a value other than [constant DRAW_AUTO] is set, [method get_draw_mode] will return it instead of using the default logic. This property can be useful for temporarily changing the visual state of the button using custom logic.
 		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false" keywords="enabled">
 			If [code]true[/code], the button is in disabled state and can't be clicked or toggled.
@@ -107,6 +110,9 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="DRAW_AUTO" value="-1" enum="DrawMode">
+			This state is only used with [member custom_draw_mode] to tell [method get_draw_mode] to use the default logic.
+		</constant>
 		<constant name="DRAW_NORMAL" value="0" enum="DrawMode">
 			The normal state (i.e. not pressed, not hovered, not toggled and enabled) of buttons.
 		</constant>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -361,7 +361,21 @@ bool BaseButton::is_hovered() const {
 	return status.hovering;
 }
 
+bool BaseButton::has_point(const Point2 &p_point) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	bool ret;
+	if (GDVIRTUAL_CALL(_has_point, p_point, ret)) {
+		return ret;
+	}
+	Rect2 rect = Rect2(Point2(), get_size()).grow(theme_cache.click_margin);
+	return rect.has_area() && rect.has_point(p_point);
+}
+
 BaseButton::DrawMode BaseButton::get_draw_mode() const {
+	if (custom_draw_mode != DRAW_AUTO) {
+		return custom_draw_mode;
+	}
+
 	if (status.disabled) {
 		return DRAW_DISABLED;
 	}
@@ -396,14 +410,17 @@ BaseButton::DrawMode BaseButton::get_draw_mode() const {
 	}
 }
 
-bool BaseButton::has_point(const Point2 &p_point) const {
-	ERR_READ_THREAD_GUARD_V(false);
-	bool ret;
-	if (GDVIRTUAL_CALL(_has_point, p_point, ret)) {
-		return ret;
+void BaseButton::set_custom_draw_mode(DrawMode p_draw_mode) {
+	if (custom_draw_mode == p_draw_mode) {
+		return;
 	}
-	Rect2 rect = Rect2(Point2(), get_size()).grow(theme_cache.click_margin);
-	return rect.has_area() && rect.has_point(p_point);
+
+	custom_draw_mode = p_draw_mode;
+	queue_redraw();
+}
+
+BaseButton::DrawMode BaseButton::get_custom_draw_mode() const {
+	return custom_draw_mode;
 }
 
 void BaseButton::set_toggle_mode(bool p_on) {
@@ -605,8 +622,13 @@ void BaseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_button_mask", "mask"), &BaseButton::set_button_mask);
 	ClassDB::bind_method(D_METHOD("get_button_mask"), &BaseButton::get_button_mask);
 	ClassDB::bind_method(D_METHOD("get_draw_mode"), &BaseButton::get_draw_mode);
+
+	ClassDB::bind_method(D_METHOD("set_custom_draw_mode", "draw_mode"), &BaseButton::set_custom_draw_mode);
+	ClassDB::bind_method(D_METHOD("get_custom_draw_mode"), &BaseButton::get_custom_draw_mode);
+
 	ClassDB::bind_method(D_METHOD("set_keep_pressed_outside", "enabled"), &BaseButton::set_keep_pressed_outside);
 	ClassDB::bind_method(D_METHOD("is_keep_pressed_outside"), &BaseButton::is_keep_pressed_outside);
+
 	ClassDB::bind_method(D_METHOD("set_shortcut_feedback", "enabled"), &BaseButton::set_shortcut_feedback);
 	ClassDB::bind_method(D_METHOD("is_shortcut_feedback"), &BaseButton::is_shortcut_feedback);
 
@@ -632,6 +654,8 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_pressed_outside"), "set_keep_pressed_outside", "is_keep_pressed_outside");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "button_group", PROPERTY_HINT_RESOURCE_TYPE, ButtonGroup::get_class_static()), "set_button_group", "get_button_group");
 
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "custom_draw_mode", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_custom_draw_mode", "get_custom_draw_mode");
+
 	ADD_GROUP("Shortcut", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, Shortcut::get_class_static()), "set_shortcut", "get_shortcut");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_feedback"), "set_shortcut_feedback", "is_shortcut_feedback");
@@ -639,6 +663,7 @@ void BaseButton::_bind_methods() {
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, BaseButton, click_margin);
 
+	BIND_ENUM_CONSTANT(DRAW_AUTO);
 	BIND_ENUM_CONSTANT(DRAW_NORMAL);
 	BIND_ENUM_CONSTANT(DRAW_PRESSED);
 	BIND_ENUM_CONSTANT(DRAW_HOVER);

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -40,6 +40,15 @@ class BaseButton : public Control {
 	GDCLASS(BaseButton, Control);
 
 public:
+	enum DrawMode {
+		DRAW_AUTO = -1,
+		DRAW_NORMAL,
+		DRAW_PRESSED,
+		DRAW_HOVER,
+		DRAW_DISABLED,
+		DRAW_HOVER_PRESSED,
+	};
+
 	enum ActionMode {
 		ACTION_MODE_BUTTON_PRESS,
 		ACTION_MODE_BUTTON_RELEASE,
@@ -58,6 +67,8 @@ private:
 	bool shortcut_feedback = true;
 	Ref<Shortcut> shortcut;
 	ObjectID shortcut_context;
+
+	DrawMode custom_draw_mode = DRAW_AUTO;
 
 	ActionMode action_mode = ACTION_MODE_BUTTON_RELEASE;
 	struct Status {
@@ -97,19 +108,12 @@ protected:
 	GDVIRTUAL1(_toggled, bool)
 
 public:
-	enum DrawMode {
-		DRAW_NORMAL,
-		DRAW_PRESSED,
-		DRAW_HOVER,
-		DRAW_DISABLED,
-		DRAW_HOVER_PRESSED,
-	};
+	virtual bool has_point(const Point2 &p_point) const override;
 
 	DrawMode get_draw_mode() const;
 
-	virtual bool has_point(const Point2 &p_point) const override;
-
-	/* Signals */
+	void set_custom_draw_mode(DrawMode p_draw_mode);
+	DrawMode get_custom_draw_mode() const;
 
 	bool is_pressed() const; ///< return whether button is pressed (toggled in)
 	bool is_pressing() const; ///< return whether button is pressed (toggled in)

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -148,6 +148,10 @@ Ref<StyleBox> Button::_get_current_stylebox() const {
 				stylebox = theme_cache.disabled;
 			}
 		} break;
+
+		case DRAW_AUTO: {
+			// Unreachable.
+		} break;
 	}
 
 	return stylebox;
@@ -306,7 +310,6 @@ void Button::_notification(int p_what) {
 					if (has_theme_color(SNAME("icon_hover_pressed_color"))) {
 						icon_modulate_color = theme_cache.icon_hover_pressed_color;
 					}
-
 				} break;
 				case DRAW_PRESSED: {
 					if (has_theme_color(SNAME("font_pressed_color"))) {
@@ -317,14 +320,12 @@ void Button::_notification(int p_what) {
 					if (has_theme_color(SNAME("icon_pressed_color"))) {
 						icon_modulate_color = theme_cache.icon_pressed_color;
 					}
-
 				} break;
 				case DRAW_HOVER: {
 					font_color = theme_cache.font_hover_color;
 					if (has_theme_color(SNAME("icon_hover_color"))) {
 						icon_modulate_color = theme_cache.icon_hover_color;
 					}
-
 				} break;
 				case DRAW_DISABLED: {
 					font_color = theme_cache.font_disabled_color;
@@ -333,7 +334,9 @@ void Button::_notification(int p_what) {
 					} else {
 						icon_modulate_color.a = 0.4;
 					}
-
+				} break;
+				case DRAW_AUTO: {
+					// Unreachable.
 				} break;
 			}
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -267,7 +267,6 @@ void LinkButton::_notification(int p_what) {
 					} else {
 						color = theme_cache.font_color;
 					}
-
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
 				} break;
 				case DRAW_HOVER_PRESSED:
@@ -277,19 +276,18 @@ void LinkButton::_notification(int p_what) {
 					} else {
 						color = theme_cache.font_color;
 					}
-
 					do_underline = underline_mode != UNDERLINE_MODE_NEVER;
-
 				} break;
 				case DRAW_HOVER: {
 					color = theme_cache.font_hover_color;
 					do_underline = underline_mode != UNDERLINE_MODE_NEVER;
-
 				} break;
 				case DRAW_DISABLED: {
 					color = theme_cache.font_disabled_color;
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
-
+				} break;
+				case DRAW_AUTO: {
+					// Unreachable.
 				} break;
 			}
 

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -136,7 +136,6 @@ void TextureButton::_notification(int p_what) {
 						} else {
 							texdraw = hover;
 						}
-
 					} else {
 						texdraw = pressed;
 					}
@@ -160,6 +159,9 @@ void TextureButton::_notification(int p_what) {
 					} else {
 						texdraw = disabled;
 					}
+				} break;
+				case DRAW_AUTO: {
+					// Unreachable.
 				} break;
 			}
 


### PR DESCRIPTION
* Extracted from #113074.

`BaseButton` has a `get_draw_mode()` method, which abstracts the button's appearance for all `BaseButton` descendants. However, there's no way to customize this logic. A workaround is to use `add_theme_*_override()` to temporarily dynamically override the appearance of specific `BaseButton` descendants. However, this is cumbersome (due to the large number of theme properties), inconvenient, and rather fragile (you must consider that the button may already have theme overrides, or there may be a need to change them dynamically in other code). It's more convenient and reliable to be able to customize the draw mode rather than change theme properties.

Initially, I wanted to add a virtual method named `_get_draw_mode()`, but I ran into two problems:

1. You can't use `GDVIRTUAL0R(DrawMode, _get_draw_mode)` because `VARIANT_ENUM_CAST(BaseButton::DrawMode)` is located outside the class.
2. Even if you use `int` instead of `DrawMode`, you'll still often need to have a `_draw_mode` property in your script/extension that you would return in `_get_draw_mode()`. Also, having a built-in property helps avoid some boilerplate (no need to call `queue_redraw()`, no need to check if the draw mode has changed).

Therefore, I think the `custom_draw_mode` property makes more sense than the virtual method `get_draw_mode()`. It's similar to `Control.custom_minimum_size`.