### PR TITLE
Fix Revert Button not decrementing Resource counter for custom Resources

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5179,7 +5179,7 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		undo_redo->add_do_property(object, p_name, p_value);
 		bool valid = false;
 		Variant value = object->get(p_name, &valid);
-		Variant::Type type = p_value.get_type();
+		Variant::Type type = value.get_type() != Variant::NIL ? value.get_type() : p_value.get_type();
 		if (valid) {
 			if (Object::cast_to<Control>(object) && (p_name == "anchors_preset" || p_name == "layout_mode")) {
 				undo_redo->add_undo_method(object, "_edit_set_state", Object::cast_to<Control>(object)->_edit_get_state());

--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -100,7 +100,7 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 		if (p_undo_redo) {
 			ur->add_undo_property(n, name, n->get(name));
 			Variant old_value = n->get(p_name);
-			Variant::Type type = old_value.get_type();
+			Variant::Type type = old_value.get_type() != Variant::NIL ? old_value.get_type() : new_value.get_type();
 			if ((type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && old_value != new_value) {
 				ur->add_do_method(EditorNode::get_singleton(), "update_node_reference", old_value, n, true);
 				ur->add_do_method(EditorNode::get_singleton(), "update_node_reference", new_value, n, false);


### PR DESCRIPTION
fix #113052
The reason why it happens is because, for custom Resources, its default value type is set to `NIL`, while for default ones it defaults to `OBJECT`
While this PR does not aim to fix this inconsistency, it solves the counter issue by checking both the previous and new value type. Though I suppose fixing this would be desirable.