### PR TITLE
GDScript: Require constant metatypes for type nodes

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -890,7 +890,7 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 							}
 							[[fallthrough]];
 						default:
-							push_error(vformat(R"("%s" is a %s but does not contain a type.)", first, member.get_type_name()), p_type);
+							push_error(vformat(R"("%s" is a %s, so it can't be used as a type.)", first, member.get_type_name()), p_type);
 							return bad_type;
 					}
 				}
@@ -912,7 +912,7 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 				if (!result.is_set()) {
 					push_error(vformat(R"(Could not find type "%s" under base "%s".)", p_type->type_chain[i]->name, base.to_string()), p_type->type_chain[1]);
 					return bad_type;
-				} else if (!result.is_meta_type) {
+				} else if (!result.is_meta_type || !result.is_constant) {
 					push_error(vformat(R"(Member "%s" under base "%s" is not a valid type.)", p_type->type_chain[i]->name, base.to_string()), p_type->type_chain[1]);
 					return bad_type;
 				}

--- a/modules/gdscript/tests/scripts/analyzer/errors/typehint_non_const.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/typehint_non_const.gd
@@ -1,0 +1,14 @@
+class UserDef:
+	static var ItemStatic = preload("../../utils.notest.gd")
+
+static var ItemStatic = preload("../../utils.notest.gd")
+var Item = preload("../../utils.notest.gd")
+
+var member1: UserDef.ItemStatic
+var member2: Item
+var member3: ItemStatic
+
+func test() -> void:
+	var local1: UserDef.ItemStatic
+	var local2: Item
+	var local3: ItemStatic

--- a/modules/gdscript/tests/scripts/analyzer/errors/typehint_non_const.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/typehint_non_const.out
@@ -1,0 +1,7 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 7: Member "ItemStatic" under base "UserDef" is not a valid type.
+>> ERROR at line 8: "Item" is a variable, so it can't be used as a type.
+>> ERROR at line 9: "ItemStatic" is a variable, so it can't be used as a type.
+>> ERROR at line 12: Member "ItemStatic" under base "UserDef" is not a valid type.
+>> ERROR at line 13: "Item" is a variable, so it can't be used as a type.
+>> ERROR at line 14: "ItemStatic" is a variable, so it can't be used as a type.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113045

Fixes as in, it now fails in the analyzer instead of some arbitrary compiler bug. Typehints must be constant. Stuff using them relies on guarantees that are only given if they are constant. If anything behaves different it clearly is a bug to me.
