### PR TITLE
Prevent editor crash when project settings change, a camera preview is active, and the camera goes away.

### DIFF
--- a/editor/scene/3d/camera_3d_editor_plugin.cpp
+++ b/editor/scene/3d/camera_3d_editor_plugin.cpp
@@ -80,7 +80,16 @@ Camera3DEditor::Camera3DEditor() {
 }
 
 void Camera3DPreview::_update_sub_viewport_size() {
-	sub_viewport->set_size(Node3DEditor::get_camera_viewport_size(camera));
+	if (sub_viewport != nullptr) {
+		sub_viewport->set_size(Node3DEditor::get_camera_viewport_size(camera));
+	}
+}
+
+void Camera3DPreview::_camera_exiting() {
+	if (sub_viewport != nullptr) {
+		sub_viewport->queue_free();
+		sub_viewport = nullptr;
+	}
 }
 
 Camera3DPreview::Camera3DPreview(Camera3D *p_camera) :
@@ -95,6 +104,7 @@ Camera3DPreview::Camera3DPreview(Camera3D *p_camera) :
 
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Camera3DPreview::_update_sub_viewport_size));
 	_update_sub_viewport_size();
+	camera->connect(SceneStringName(tree_exiting), callable_mp(this, &Camera3DPreview::_camera_exiting));
 }
 
 bool EditorInspectorPluginCamera3DPreview::can_handle(Object *p_object) {

--- a/editor/scene/3d/camera_3d_editor_plugin.h
+++ b/editor/scene/3d/camera_3d_editor_plugin.h
@@ -59,6 +59,7 @@ class Camera3DPreview : public TexturePreview {
 	SubViewport *sub_viewport = nullptr;
 
 	void _update_sub_viewport_size();
+	void _camera_exiting();
 
 public:
 	Camera3DPreview(Camera3D *p_camera);


### PR DESCRIPTION
When the project settings are changed, and you have a Camera3D preview showing,
but the underlying Camera is removed, this crashes Godot as the callback for
_update_sub_viewport_size attempts to dereference an object that has already
been released.
    
To prevent this, we track the lifetime of the camera object, and if it goes
away, we clear our state.

This showed up in Xogot's crashlogs.
