### PR TITLE
Skip ResourceLoader's progress query if not requested.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -53,10 +53,12 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 }
 
 ResourceLoader::ThreadLoadStatus ResourceLoader::load_threaded_get_status(const String &p_path, Array r_progress) {
-	float progress = 0;
-	::ResourceLoader::ThreadLoadStatus tls = ::ResourceLoader::load_threaded_get_status(p_path, &progress);
+	// Progress being the default array indicates the user hasn't requested for it to be computed.
 	// Default array should never be modified, it causes the hash of the method to change.
-	if (!ClassDB::is_default_array_arg(r_progress)) {
+	const bool return_progress = !ClassDB::is_default_array_arg(r_progress);
+	float progress = 0;
+	::ResourceLoader::ThreadLoadStatus tls = ::ResourceLoader::load_threaded_get_status(p_path, return_progress ? &progress : nullptr);
+	if (return_progress) {
 		r_progress.resize(1);
 		r_progress[0] = progress;
 	}


### PR DESCRIPTION
This complements https://github.com/godotengine/godot/pull/113114 in the sense that ResourceLoader's threaded progress computation should be skipped if not requested by the user. As it is now, progress is computed regardless only to be discarded if the user didn't specify an array to use for the returned value.

This also avoids the critical issue explained in the linked PR, where projects that use the background loader with several threads can end up causing infinite recursion scenarios when computing the loading progress, leading to a crash. However, the crash will remain possible for projects that do query the progress unless the linked PR is merged.

This one should be fairly safe to merge and results in a small optimization as well.