### PR TITLE
SCons: Fix logic when passing `optimize=auto` explicitly from command-line

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -515,7 +515,7 @@ if env["optimize"] == "auto":
         opt_level = "speed_trace"
     else:  # Release
         opt_level = "speed"
-    env["optimize"] = ARGUMENTS.get("optimize", opt_level)
+    env["optimize"] = opt_level
 
 env["debug_symbols"] = methods.get_cmdline_bool("debug_symbols", env.dev_build)
 


### PR DESCRIPTION
- Fixes #113119.