### PR TITLE
Add note to SphereMesh's radius pointing to the height property

### DIFF
--- a/doc/classes/SphereMesh.xml
+++ b/doc/classes/SphereMesh.xml
@@ -20,7 +20,8 @@
 			Number of radial segments on the sphere.
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
-			Radius of sphere.
+			Radius of the sphere's equator.
+			[b]Note:[/b] To get a regular sphere, the sphere's radius must be equal to half its height.
 		</member>
 		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="32">
 			Number of segments along the height of the sphere.


### PR DESCRIPTION
See godotengine/godot-docs#11490 for the original issue.

The `SphereMesh` and `SphereShape3D` have different parameters.
While `SphereShape3D`'s `radius` parameter affects the radius of the whole sphere, `SphereMesh`'s `radius` parameter only relates to its equator's radius.

In this change, I update the documentation of `SphereMesh`'s `radius` to better reflect that it actually only refers to the equator. I also point to the `height` member.

I do not know how this impacts translations however. Please do tell me if there's some action I need to take to fix them/mark them as outdated.