### PR TITLE
Update `libgodot.h` to use `gdextension_interface.gen.h`

### DIFF
--- a/core/extension/libgodot.h
+++ b/core/extension/libgodot.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "gdextension_interface.h"
+#include "gdextension_interface.gen.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This fixes a regression from https://github.com/godotengine/godot/pull/107845

I forgot to update the `#include` in `libgodot.h` - this fixes that!