### PR TITLE
Update Blender importer to handle more Vertex Color options

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -198,19 +198,29 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	} else {
 		parameters_map["export_lights"] = false;
 	}
-	if (blender_major_version > 4 || (blender_major_version == 4 && blender_minor_version >= 2)) {
-		if (p_options.has(SNAME("blender/meshes/colors")) && p_options[SNAME("blender/meshes/colors")]) {
-			parameters_map["export_vertex_color"] = "MATERIAL";
+	if (p_options.has(SNAME("blender/meshes/vertex_colors"))) {
+		int32_t color_option = p_options["blender/meshes/vertex_colors"];
+		if (blender_major_version > 4 || (blender_major_version == 4 && blender_minor_version >= 2)) {
+			switch (color_option) {
+				case BLEND_VERTEX_COLOR_MATERIAL: {
+					parameters_map["export_vertex_color"] = "MATERIAL";
+				} break;
+				case BLEND_VERTEX_COLOR_ACTIVE: {
+					parameters_map["export_vertex_color"] = "ACTIVE";
+				} break;
+				case BLEND_VERTEX_COLOR_NONE: {
+					parameters_map["export_vertex_color"] = "NONE";
+				} break;
+			}
 		} else {
-			parameters_map["export_vertex_color"] = "NONE";
-		}
-	} else {
-		if (p_options.has(SNAME("blender/meshes/colors")) && p_options[SNAME("blender/meshes/colors")]) {
-			parameters_map["export_colors"] = true;
-		} else {
-			parameters_map["export_colors"] = false;
+			if (color_option == BLEND_VERTEX_COLOR_NONE) {
+				parameters_map["export_colors"] = false;
+			} else {
+				parameters_map["export_colors"] = true;
+			}
 		}
 	}
+
 	if (p_options.has(SNAME("blender/nodes/visible"))) {
 		int32_t visible = p_options["blender/nodes/visible"];
 		if (visible == BLEND_VISIBLE_VISIBLE_ONLY) {
@@ -376,7 +386,7 @@ void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, Li
 	ADD_OPTION_BOOL("blender/nodes/cameras", true);
 	ADD_OPTION_BOOL("blender/nodes/custom_properties", true);
 	ADD_OPTION_ENUM("blender/nodes/modifiers", "No Modifiers,All Modifiers", BLEND_MODIFIERS_ALL);
-	ADD_OPTION_BOOL("blender/meshes/colors", false);
+	ADD_OPTION_ENUM("blender/meshes/vertex_colors", "Material,Active,None", BLEND_VERTEX_COLOR_ACTIVE);
 	ADD_OPTION_BOOL("blender/meshes/uvs", true);
 	ADD_OPTION_BOOL("blender/meshes/normals", true);
 	ADD_OPTION_BOOL("blender/meshes/export_geometry_nodes_instances", false);
@@ -393,7 +403,16 @@ void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, Li
 	r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "gltf/naming_version", PROPERTY_HINT_ENUM, "Godot 4.0 or 4.1,Godot 4.2 to 4.4,Godot 4.5 or later"), 2));
 }
 
-///////////////////////////
+void EditorSceneFormatImporterBlend::handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {
+	if (p_import_params.has("blender/meshes/colors")) { // Legacy boolean option support.
+		if (bool(p_import_params["blender/meshes/colors"])) {
+			p_import_params["blender/meshes/vertex_colors"] = BLEND_VERTEX_COLOR_MATERIAL;
+		} else {
+			p_import_params["blender/meshes/vertex_colors"] = BLEND_VERTEX_COLOR_NONE;
+		}
+		p_import_params.erase("blender/meshes/colors");
+	}
+}
 
 static bool _test_blender_path(const String &p_path, String *r_err = nullptr) {
 	int major, minor;

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -64,6 +64,11 @@ public:
 		BLEND_MODIFIERS_NONE,
 		BLEND_MODIFIERS_ALL
 	};
+	enum {
+		BLEND_VERTEX_COLOR_MATERIAL,
+		BLEND_VERTEX_COLOR_ACTIVE,
+		BLEND_VERTEX_COLOR_NONE
+	};
 
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
@@ -73,6 +78,7 @@ public:
 			List<ResourceImporter::ImportOption> *r_options) override;
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option,
 			const HashMap<StringName, Variant> &p_options) override;
+	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 };
 
 class LineEdit;


### PR DESCRIPTION
Fixes #97953 

On Blender 4.2, Blender changed its export options for Vertex Color from `export_colors` that was a true/false variable to `export_vertex_color` which is an enum with multiple values. This PR matches updates the Godot interface to better access these options, namely `MATERIAL`, `ACTIVE` and `NONE`

<img width="435" height="267" alt="image" src="https://github.com/user-attachments/assets/7edc503e-221b-4d18-8e87-7186b83f365d" />

For compatibility, if a boolean is read from a `.import` config file, it is processed by `handle_compatibility_options` where a `false` is mapped to `NONE` and a `true` is mapped to `MATERIAL`

If a person uses a Blender version prior to 4.2, then selecting `NONE` will send `export_colors` a `false` value and any other option will send a `true` value.

`MATERIAL` is default for fresh models. According to https://docs.blender.org/api/current/bpy.ops.export_scene.html , this will "Export vertex color when used by material."