### PR TITLE
Ensure usage of `DATA_FORMAT_R32_SFLOAT` for depth resolve on Forward+

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -730,11 +730,8 @@ uint32_t RenderSceneBuffersRD::get_color_usage_bits(bool p_resolve, bool p_msaa,
 }
 
 RD::DataFormat RenderSceneBuffersRD::get_depth_format(bool p_resolve, bool p_msaa, bool p_storage) {
-	// TODO Our rendering engine does not support just having a depth attachment, it always assumed we combine with stencil.
-	// We thus can't configure our depth resolve with RD::DATA_FORMAT_R32_SFLOAT.
-	// We should add support for TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT or add a TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT
-
-	if (p_resolve && !RenderingDevice::get_singleton()->has_feature(RD::SUPPORTS_FRAMEBUFFER_DEPTH_RESOLVE)) {
+	if (p_resolve && (p_storage || !RenderingDevice::get_singleton()->has_feature(RD::SUPPORTS_FRAMEBUFFER_DEPTH_RESOLVE))) {
+		// Use R32 for resolve on Forward+ (p_storage == true), or if we don't support depth resolve.
 		return RD::DATA_FORMAT_R32_SFLOAT;
 	} else {
 		const RenderingDeviceCommons::DataFormat preferred_formats[2] = {


### PR DESCRIPTION
PR #78598 introduced the ability to resolve the depth buffer during subpasses however this required the use of a depth resolve buffer with the same format as is used for the MSAA version of the depth buffer.

On Forward+ we're not using the extension but handling resolve in shaders. This requires the `TEXTURE_USAGE_STORAGE_BIT` bit to be set, something not supported on the depth formats that include a stencil buffer.

This PR changes the logic so if Forward+ is used, we use `DATA_FORMAT_R32_SFLOAT` as before.

Fixed #113022