### PR TITLE
Add EditorInterface methods for easier access to project settings, export dialog, and asset library

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -293,6 +293,20 @@
 				Marks the current scene tab as unsaved.
 			</description>
 		</method>
+		<method name="open_export_dialog">
+			<return type="void" />
+			<description>
+				Opens the project export dialog window.
+			</description>
+		</method>
+		<method name="open_project_settings">
+			<return type="void" />
+			<param index="0" name="general_page" type="String" default="&quot;&quot;" />
+			<param index="1" name="filter" type="String" default="&quot;&quot;" />
+			<description>
+				Opens the project settings window at the optionally specified [param general_page], with an optional [param filter] applied.
+			</description>
+		</method>
 		<method name="open_scene_from_path">
 			<return type="void" />
 			<param index="0" name="scene_filepath" type="String" />
@@ -465,6 +479,13 @@
 			<param index="1" name="with_preview" type="bool" default="true" />
 			<description>
 				Saves the currently active scene as a file at [param path].
+			</description>
+		</method>
+		<method name="search_asset_library">
+			<return type="void" />
+			<param index="0" name="filter" type="String" />
+			<description>
+				Opens the Editor Asset Library and applies the specified [param filter] to the search bar.
 			</description>
 		</method>
 		<method name="select_file">

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -1614,6 +1614,25 @@ void EditorAssetLibrary::disable_community_support() {
 	support->get_popup()->set_item_checked(SUPPORT_COMMUNITY, false);
 }
 
+void EditorAssetLibrary::search(const String &p_filter_str) {
+	ERR_FAIL_COND(!is_visible());
+
+	// If Asset Library hasn't been opened yet, we must wait for the initial request to complete.
+	if (!filter->is_editable()) {
+		request->connect("request_completed", callable_mp(this, &EditorAssetLibrary::_on_request_completed).bind(p_filter_str), CONNECT_ONE_SHOT);
+	} else {
+		filter->set_text(p_filter_str);
+		filter->emit_signal(SceneStringName(text_changed), filter->get_text());
+	}
+}
+
+void EditorAssetLibrary::_on_request_completed(int p_result, int p_response_code, const PackedStringArray &p_headers, const PackedByteArray &p_body, const String &p_filter_str) {
+	ERR_FAIL_COND_MSG(p_response_code != 200, vformat("Asset Library HTTPRequest returned with response code %d.", p_response_code));
+
+	filter->set_text(p_filter_str);
+	filter->emit_signal(SceneStringName(text_changed), filter->get_text());
+}
+
 void EditorAssetLibrary::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("install_asset", PropertyInfo(Variant::STRING, "zip_path"), PropertyInfo(Variant::STRING, "name")));
 }
@@ -1830,6 +1849,11 @@ void AssetLibraryEditorPlugin::make_visible(bool p_visible) {
 	} else {
 		addon_library->hide();
 	}
+}
+
+void AssetLibraryEditorPlugin::search_assset_library(const String &p_filter) {
+	ERR_FAIL_COND_MSG(!is_available(), "Asset Library not available on the current platform.");
+	addon_library->search(p_filter);
 }
 
 AssetLibraryEditorPlugin::AssetLibraryEditorPlugin() {

--- a/editor/asset_library/asset_library_editor_plugin.h
+++ b/editor/asset_library/asset_library_editor_plugin.h
@@ -323,6 +323,8 @@ class EditorAssetLibrary : public PanelContainer {
 
 	void _update_asset_items_columns();
 
+	void _on_request_completed(int p_result, int p_response_code, const PackedStringArray &p_headers, const PackedByteArray &p_body, const String &p_search_string);
+
 	friend class EditorAssetLibraryItemDescription;
 	friend class EditorAssetLibraryItem;
 
@@ -333,6 +335,8 @@ protected:
 
 public:
 	void disable_community_support();
+
+	void search(const String &p_filter);
 
 	EditorAssetLibrary(bool p_templates_only = false);
 };
@@ -353,6 +357,8 @@ public:
 	//virtual bool get_remove_list(List<Node*> *p_list) { return canvas_item_editor->get_remove_list(p_list); }
 	//virtual Dictionary get_state() const;
 	//virtual void set_state(const Dictionary& p_state);
+
+	void search_assset_library(const String &p_filter);
 
 	AssetLibraryEditorPlugin();
 };

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -33,6 +33,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
+#include "editor/asset_library/asset_library_editor_plugin.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_main_screen.h"
@@ -52,6 +53,7 @@
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
+#include "editor/settings/project_settings_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "main/main.h"
 #include "scene/3d/light_3d.h"
@@ -103,6 +105,31 @@ EditorToaster *EditorInterface::get_editor_toaster() const {
 
 EditorUndoRedoManager *EditorInterface::get_editor_undo_redo() const {
 	return EditorUndoRedoManager::get_singleton();
+}
+
+void EditorInterface::open_project_settings(const String &p_general_page, const String &p_filter) {
+	ProjectSettingsEditor *project_settings = EditorNode::get_singleton()->get_project_settings();
+
+	if (!p_general_page.is_empty()) {
+		project_settings->set_general_page(p_general_page);
+	}
+	if (!p_filter.is_empty()) {
+		project_settings->set_filter(p_filter);
+	}
+
+	project_settings->popup_project_settings(false);
+}
+
+void EditorInterface::open_export_dialog() {
+	EditorNode::get_singleton()->open_export_dialog();
+}
+
+void EditorInterface::search_asset_library(const String &p_filter) {
+	AssetLibraryEditorPlugin *asset_lib = EditorNode::get_singleton()->get_asset_library();
+	ERR_FAIL_NULL_MSG(asset_lib, "Asset Library not available.");
+
+	set_main_screen_editor("AssetLib");
+	asset_lib->search_assset_library(p_filter);
 }
 
 AABB EditorInterface::_calculate_aabb_for_scene(Node *p_node, AABB &p_scene_aabb) {
@@ -829,6 +856,10 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
 	ClassDB::bind_method(D_METHOD("get_editor_toaster"), &EditorInterface::get_editor_toaster);
 	ClassDB::bind_method(D_METHOD("get_editor_undo_redo"), &EditorInterface::get_editor_undo_redo);
+
+	ClassDB::bind_method(D_METHOD("open_project_settings", "general_page", "filter"), &EditorInterface::open_project_settings, DEFVAL(""), DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("open_export_dialog"), &EditorInterface::open_export_dialog);
+	ClassDB::bind_method(D_METHOD("search_asset_library", "filter"), &EditorInterface::search_asset_library);
 
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -48,6 +48,7 @@ class EditorSettings;
 class EditorToaster;
 class EditorUndoRedoManager;
 class FileSystemDock;
+class LineEdit;
 class Mesh;
 class Node;
 class PropertySelector;
@@ -145,6 +146,10 @@ public:
 
 	String get_current_feature_profile() const;
 	void set_current_feature_profile(const String &p_profile_name);
+
+	void open_project_settings(const String &p_general_page = "", const String &p_filter = "");
+	void open_export_dialog();
+	void search_asset_library(const String &p_filter);
 
 	// Editor dialogs.
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7432,6 +7432,10 @@ bool EditorNode::is_editor_dimmed() const {
 	return dimmed;
 }
 
+void EditorNode::open_export_dialog() {
+	project_export->popup_export();
+}
+
 void EditorNode::open_export_template_manager() {
 	export_template_manager->popup_manager();
 }
@@ -8953,7 +8957,8 @@ EditorNode::EditorNode() {
 	TextEditor::register_editor();
 
 	if (AssetLibraryEditorPlugin::is_available()) {
-		add_editor_plugin(memnew(AssetLibraryEditorPlugin));
+		asset_library_plugin = memnew(AssetLibraryEditorPlugin);
+		add_editor_plugin(asset_library_plugin);
 	} else {
 		print_verbose("Asset Library not available (due to using Web editor, or SSL support disabled).");
 	}

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -64,6 +64,7 @@ class Window;
 
 class AudioStreamImportSettingsDialog;
 class AudioStreamPreviewGenerator;
+class AssetLibraryEditorPlugin;
 class BackgroundProgress;
 class DependencyErrorDialog;
 class DockSplitContainer;
@@ -274,6 +275,8 @@ private:
 
 	ProjectExportDialog *project_export = nullptr;
 	ProjectSettingsEditor *project_settings_editor = nullptr;
+
+	AssetLibraryEditorPlugin *asset_library_plugin = nullptr;
 
 	FBXImporterManager *fbx_importer_manager = nullptr;
 
@@ -795,6 +798,8 @@ public:
 
 	ProjectSettingsEditor *get_project_settings() { return project_settings_editor; }
 
+	AssetLibraryEditorPlugin *get_asset_library() { return asset_library_plugin; }
+
 	void trigger_menu_option(int p_option, bool p_confirmed);
 	bool has_previous_closed_scenes() const;
 
@@ -982,6 +987,7 @@ public:
 	void save_editor_layout_delayed();
 	void save_default_environment();
 
+	void open_export_dialog();
 	void open_export_template_manager();
 
 	void reload_scene(const String &p_path);


### PR DESCRIPTION
Recently I created a tool in the OpenXR vendor's repo to help users set up new XR projects for standalone VR as fast as possible: https://github.com/GodotVR/godot_openxr_vendors/pull/387

This tool opens project settings, the export dialog, and searches the asset library. However it does so in an incredibly hacky way; manually searching through the control nodes of the editor.

This PR adds some methods to `EditorInterface` to make such hacks unnecessary.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/13702*