### PR TITLE
Use new dock system for Debugger

### DIFF
--- a/editor/debugger/debugger_editor_plugin.cpp
+++ b/editor/debugger/debugger_editor_plugin.cpp
@@ -35,7 +35,6 @@
 #include "editor/debugger/editor_debugger_server.h"
 #include "editor/debugger/editor_file_server.h"
 #include "editor/editor_node.h"
-#include "editor/gui/editor_bottom_panel.h"
 #include "editor/run/run_instances_dialog.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_command_palette.h"
@@ -56,7 +55,7 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
 	file_server = memnew(EditorFileServer);
 
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
-	EditorNode::get_bottom_panel()->add_item(TTRC("Debugger"), debugger, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_debugger_bottom_panel", TTRC("Toggle Debugger Bottom Panel"), KeyModifierMask::ALT | Key::D));
+	EditorDockManager::get_singleton()->add_dock(debugger);
 
 	// Main editor debug menu.
 	debug_menu = p_debug_menu;

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -32,7 +32,7 @@
 
 #include "core/object/script_language.h"
 #include "editor/debugger/editor_debugger_server.h"
-#include "scene/gui/margin_container.h"
+#include "editor/docks/editor_dock.h"
 
 class Button;
 class DebugAdapterParser;
@@ -44,8 +44,8 @@ class ScriptEditorDebugger;
 class TabContainer;
 class UndoRedo;
 
-class EditorDebuggerNode : public MarginContainer {
-	GDCLASS(EditorDebuggerNode, MarginContainer);
+class EditorDebuggerNode : public EditorDock {
+	GDCLASS(EditorDebuggerNode, EditorDock);
 
 public:
 	enum CameraOverride {

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -73,7 +73,7 @@ void EditorDebuggerTree::_notification(int p_what) {
 			connect("item_mouse_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_rmb_selected));
 		} break;
 
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_READY: {
 			update_icon_max_width();
 		} break;
 	}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1070,12 +1070,7 @@ void ScriptEditorDebugger::_update_reason_content_height() {
 
 void ScriptEditorDebugger::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			le_set->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_live_edit_set));
-			le_clear->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_live_edit_clear));
-			error_tree->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditorDebugger::_error_selected));
-			error_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_error_activated));
-			breakpoints_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_breakpoint_tree_clicked));
+		case NOTIFICATION_POSTINITIALIZE: {
 			connect("started", callable_mp(expression_evaluator, &EditorExpressionEvaluator::on_start));
 		} break;
 
@@ -2206,6 +2201,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		breakpoints_tree->set_hide_root(true);
 		breakpoints_tree->set_theme_type_variation("TreeSecondary");
 		breakpoints_tree->connect("item_mouse_selected", callable_mp(this, &ScriptEditorDebugger::_breakpoints_item_rmb_selected));
+		breakpoints_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_breakpoint_tree_clicked));
 		breakpoints_tree->create_item();
 
 		parent_sc->add_child(breakpoints_tree);
@@ -2262,6 +2258,8 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		error_tree->set_allow_rmb_select(true);
 		error_tree->set_allow_reselect(true);
 		error_tree->set_theme_type_variation("TreeSecondary");
+		error_tree->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditorDebugger::_error_selected));
+		error_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_error_activated));
 		error_tree->connect("item_mouse_selected", callable_mp(this, &ScriptEditorDebugger::_error_tree_item_rmb_selected));
 		errors_tab->add_child(error_tree);
 
@@ -2412,8 +2410,10 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 			info_left->add_child(l);
 			lehb->add_child(live_edit_root);
 			le_set = memnew(Button(TTRC("Set From Tree")));
+			le_set->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_live_edit_set));
 			lehb->add_child(le_set);
 			le_clear = memnew(Button(TTRC("Clear")));
+			le_clear->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_live_edit_clear));
 			lehb->add_child(le_clear);
 			info_left->add_child(lehb);
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5321,7 +5321,7 @@ void EditorNode::_project_run_started() {
 	if (action_on_play == ACTION_ON_PLAY_OPEN_OUTPUT) {
 		editor_dock_manager->focus_dock(log);
 	} else if (action_on_play == ACTION_ON_PLAY_OPEN_DEBUGGER) {
-		bottom_panel->make_item_visible(EditorDebuggerNode::get_singleton());
+		editor_dock_manager->focus_dock(EditorDebuggerNode::get_singleton());
 	}
 }
 


### PR DESCRIPTION
See #113024

This PR updates the Debugger dock to use the new dock system. I tried to allow it to float but couldn't find a good way to avoid the `EditorDebuggerSession` from self-disconnecting because it thought the debugger was deleted.

The issue:
https://github.com/godotengine/godot/blame/369afc7b46d87dd28fc70976fc66875e76e36101/editor/debugger/editor_debugger_plugin.cpp#L124-L135