### PR TITLE
Update native menu icons after Node dock split

### DIFF
--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -113,7 +113,8 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 	native_menu_icons.insert("FileAccess");
 	native_menu_icons.insert("Folder");
 	native_menu_icons.insert("AnimationTrackList");
-	native_menu_icons.insert("Object");
+	native_menu_icons.insert("Signals");
+	native_menu_icons.insert("Groups");
 	native_menu_icons.insert("History");
 
 	// The names of the icons to exclude from the standard color conversion.


### PR DESCRIPTION
See #101787

After this split, the `Groups` and `Signals` icons were now used in native icons, but the native icons list wasn't updated, so dark and light icons were not generated, leading to inconsistent icons in the native menus.

| Before | After |
| - | - |
| <img width="455" height="170" alt="Screenshot 2025-11-24 at 4 45 17 PM" src="https://github.com/user-attachments/assets/436edbfa-98c1-49f1-941f-80d24db56438" /> | <img width="465" height="178" alt="Screenshot 2025-11-24 at 4 44 09 PM" src="https://github.com/user-attachments/assets/a5c79681-6bca-44bd-80ab-de208ec028fe" /> |