### PR TITLE
Wayland: Fix trailing garbage error while using the embedder on Jay

### DIFF
--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -1207,7 +1207,6 @@ WaylandEmbedder::MessageStatus WaylandEmbedder::handle_request(LocalObjectHandle
 	DEBUG_LOG_WAYLAND_EMBED(vformat("Client #%d -> %s::%s(%s) l0x%x g0x%x", client->socket, interface->name, message.name, message.signature, local_id, global_id));
 
 	const uint32_t *body = msg_data + 2;
-	size_t body_len = msg_len - (WL_WORD_SIZE * 2);
 
 	if (registry_globals_names.has(global_id)) {
 		int global_name = registry_globals_names[global_id];
@@ -1623,7 +1622,7 @@ WaylandEmbedder::MessageStatus WaylandEmbedder::handle_request(LocalObjectHandle
 			// Args: int x, int y, int width, int height.
 			pos_data->anchor_rect = Rect2i(body[0], body[1], body[2], body[3]);
 
-			send_wayland_message(compositor_socket, global_id, p_opcode, body, body_len);
+			send_wayland_message(compositor_socket, global_id, p_opcode, { body[0], body[1], body[2], body[3] });
 			return MessageStatus::HANDLED;
 		}
 	}


### PR DESCRIPTION
`send_wayland_message` takes in the number of words, not its byte size. This meant that we were sending quite a bit of out-of-bounds stuff alongside the four arguments required by `xdg_positioner::set_anchor_rect`, which triggered an assertion on Jay.

This didn't pop up before because the C wayland server library does not seem to check this, but it's a valid (and useful!) assertion for other server implementations nonetheless.

This patch switches to the initializer_list syntax to make the intent clearer.

---

Confirmed that fixes the editor on Jay. I'm not sure if there are other instances of this but, judging from the fact that `body_len` became unused I think we're in the clear for now :D