### PR TITLE
GDExtension: Wrap deprecated interface functions in `#ifndef DISABLE_DEPRECATED` in generated headers

### DIFF
--- a/core/extension/make_interface_header.py
+++ b/core/extension/make_interface_header.py
@@ -60,6 +60,11 @@ extern "C" {
             check_type(kind, type, valid_data_types)
             valid_data_types[type["name"]] = True
 
+            deprecated = "deprecated" in type
+
+            if deprecated:
+                file.write("#ifndef DISABLE_DEPRECATED\n")
+
             if "description" in type:
                 write_doc(file, type["description"])
 
@@ -86,6 +91,9 @@ extern "C" {
             else:
                 raise Exception(f"Unknown kind of type: {kind}")
 
+            if deprecated:
+                file.write("#endif // DISABLE_DEPRECATED\n")
+
         for interface in data["interface"]:
             check_type("function", interface, valid_data_types)
             check_allowed_keys(
@@ -93,7 +101,15 @@ extern "C" {
                 ["name", "return_value", "arguments", "since", "description"],
                 ["see", "legacy_type_name", "deprecated"],
             )
+
+            deprecated = "deprecated" in interface
+            if deprecated:
+                file.write("#ifndef DISABLE_DEPRECATED\n\n")
+
             write_interface(file, interface)
+
+            if deprecated:
+                file.write("#endif // DISABLE_DEPRECATED\n\n")
 
         file.write("""\
 #ifdef __cplusplus


### PR DESCRIPTION
In the GDExtension interface source files, deprecated functions are wrapped in `#ifndef DISABLE_DEPRECATED` blocks:
<img width="365" height="216" alt="{1D424D16-1CB4-49C1-81FA-98A40D43A4DA}" src="https://github.com/user-attachments/assets/d2623f97-a5e9-4ee2-ac7b-22c178206155" />
<img width="494" height="226" alt="{E5D0DBB6-47DA-487F-848D-09D76507A822}" src="https://github.com/user-attachments/assets/e2f6ab6e-7ac3-4740-91d0-e64b035a5b01" />

However, the generated `gdextension_interface.gen.h` only marks them as deprecated in comments, without preprocessor guards. This inconsistency means extension authors cannot completely disable deprecated APIs at compile time.

After this change:
<img width="861" height="310" alt="{5DCABB64-3C9D-4E89-A6A4-3A9AF5CBB828}" src="https://github.com/user-attachments/assets/7ae2e375-2fc0-490c-a74d-ad384f81c8a7" />
<img width="1117" height="70" alt="{B07568BE-7943-415A-838E-0DC42D3196AA}" src="https://github.com/user-attachments/assets/46196024-ef8a-444b-89d3-0b998ce49967" />

@dsnopek 