### PR TITLE
Fix AnimationMixer error spam by respecting cache validity on invalid `root_node`

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -660,6 +660,7 @@ bool AnimationMixer::_update_caches() {
 
 	Node *parent = get_node_or_null(root_node);
 	if (!parent) {
+		WARN_PRINT_ONCE(vformat("'%s' is an invalid root_node path, caches will not be built, please check the root_node assignment on: %s", root_node, get_path()));
 		cache_valid = false;
 		return false;
 	}
@@ -1000,7 +1001,7 @@ bool AnimationMixer::_update_caches() {
 
 void AnimationMixer::_process_animation(double p_delta, bool p_update_only) {
 	_blend_init();
-	if (_blend_pre_process(p_delta, track_count, track_map)) {
+	if (cache_valid && _blend_pre_process(p_delta, track_count, track_map)) {
 		_blend_capture(p_delta);
 		_blend_calc_total_weight();
 		_blend_process(p_delta, p_update_only);


### PR DESCRIPTION
### Description

When an AnimationMixer has an invalid root_node path assigned, attempting to play an animation causes the engine to spam the console with "No animation in cache" errors on every frame. This makes debugging extremely difficult and obscures real issues.

For example:
```
extends Node3D

@export_node_path("AnimationPlayer")
var path_to_animation_player: NodePath
@export
var animation_library: AnimationLibrary

func _ready() -> void:
	var animation_player: AnimationPlayer = get_node(path_to_animation_player)
	var library_name := 'test'
	animation_player.add_animation_library(library_name, animation_library)
	animation_player.root_node = NodePath('2025/11/25')
	animation_player.play('%s/%s' % [library_name, animation_library.get_animation_list()[0]])
```

it gives `No animation in cache` errors on every frame:
<img width="499" height="248" alt="p1" src="https://github.com/user-attachments/assets/dc1bbd5e-3f90-443a-b2ee-ee4c45346e42" />

### Root Cause

The `_update_caches()` method correctly detects an invalid `root_node` and sets `cache_valid = false`. However, `_blend_pre_process()` was returning `true`, which allowed `_process_animation()` to continue executing the entire blending pipeline (`_blend_calc_total_weight()`, `_blend_process()`, etc.). These downstream functions then fail due to missing caches and spam errors repeatedly.

### Proposed Solution

* Changed the return value of `_blend_pre_process()` from `true` to `cache_valid`. This ensures that if caches are not built (due to invalid `root_node` or other reasons), the entire blending process is skipped immediately.
* Enhanced the warning in `_update_caches()` to be more descriptive and use `WARN_PRINT_ONCE`, providing developers with an immediate, actionable message instead of vague downstream errors.

After these changes, it gives:
<img width="902" height="56" alt="{5A4D21D3-E0AE-4CC7-B7ED-286FC398A538}" src="https://github.com/user-attachments/assets/16685071-463d-4afe-ad0f-2327b119f227" />



