### PR TITLE
Add unit tests for NodePath operators

### DIFF
--- a/tests/core/string/test_node_path.h
+++ b/tests/core/string/test_node_path.h
@@ -222,4 +222,51 @@ TEST_CASE("[NodePath] Slice") {
 			"Slice of an empty absolute path should be an empty absolute path.");
 }
 
+TEST_CASE("[NodePath] Comparison operators") {
+	const NodePath node_path_relative1 = NodePath("Path2D/PathFollow2D/Sprite2D:position:x");
+	const NodePath node_path_relative2 = NodePath("Path2D/PathFollow2D/Sprite2D:position:x");
+	const NodePath node_path_relative3 = NodePath("Path3D/PathFollow3D/Sprite3D:position:x");
+	const NodePath node_path_absolute1 = NodePath("/Path2D/PathFollow2D/Sprite2D:position:x");
+	const NodePath node_path_absolute2 = NodePath("/Path2D/PathFollow2D/Sprite2D:position:x");
+	const NodePath node_path_absolute3 = NodePath("/Path3D/PathFollow3D/Sprite3D:position:x");
+	SUBCASE("Operator== identical relative paths") {
+		CHECK_MESSAGE(
+				node_path_relative1 == node_path_relative2, "Relative paths should be equal");
+	}
+	SUBCASE("Operator== identical absolute paths") {
+		CHECK_MESSAGE(
+				node_path_absolute1 == node_path_absolute2, "Absolute paths should be equal");
+	}
+	SUBCASE("Operator== empty paths") {
+		const NodePath node_path_empty1;
+		const NodePath node_path_empty2 = NodePath("");
+		CHECK_MESSAGE(
+				node_path_empty1 == node_path_empty2, "Empty paths must be same");
+	}
+	SUBCASE("Operator!= absolute vs relative") {
+		CHECK_MESSAGE(
+				node_path_absolute1 != node_path_relative1, "Absolute and relative paths should differ");
+	}
+	SUBCASE("Operator!= different relative paths") {
+		CHECK_MESSAGE(
+				node_path_relative1 != node_path_relative3, "Relative paths are different");
+	}
+	SUBCASE("Operator!= different absolute paths") {
+		CHECK_MESSAGE(
+				node_path_absolute1 != node_path_absolute3, "Absolute paths are different");
+	}
+	SUBCASE("Operator= copy paths") {
+		NodePath node_path_copy;
+		node_path_copy = node_path_relative1;
+		CHECK_MESSAGE(
+				node_path_relative1 == node_path_copy, "Copy assignment should make paths equal");
+	}
+	SUBCASE("Operator= assign empty path") {
+		NodePath node_path_empty = NodePath("root/path");
+		node_path_empty = NodePath("");
+		CHECK_MESSAGE(
+				node_path_empty.is_empty(), "Assigning an empty NodePath should result in an empty path");
+	}
+}
+
 } // namespace TestNodePath


### PR DESCRIPTION
This PR introduces a dedicated test suite for the `NodePath` class operators to ensure correctness and prevent regressions.

## What's Included
- **Equality (`==`)** → verifies that identical paths are considered equal  
- **Inequality (`!=`)** → ensures different paths are correctly flagged as unequal  
- **Assignment (`=`)** → confirms that assigning one `NodePath` to another produces the expected result  
- **Empty paths** → validates behavior when working with empty `NodePath` instances  

## Motivation
- ✅ Strengthens confidence in `NodePath` operator semantics  
- ✅ Provides regression coverage for future changes to operator logic  
- ✅ Improves overall test completeness in the core engine  

## Notes
- Tests are written in **C++** using the existing unit test framework  
- No changes to engine logic — this PR **only adds tests**