### PR TITLE
Split `GLOBAL_GET/DEF` into seperate header

### DIFF
--- a/core/config/global_def.h
+++ b/core/config/global_def.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/typedefs.h"
+
 struct PropertyInfo;
 class String;
 class StringName;
@@ -39,6 +41,7 @@ class Variant;
 Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
 Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
 Variant _GLOBAL_GET(const StringName &p_name);
+uint32_t _GLOBAL_GET_VERSION();
 
 #define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
 #define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
@@ -52,3 +55,26 @@ Variant _GLOBAL_GET(const StringName &p_name);
 #define GLOBAL_DEF_RST_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true, true)
 
 #define GLOBAL_DEF_INTERNAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, false, true)
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// Cached versions of GLOBAL_GET.
+// Cached but uses a typed variable for storage, this can be more efficient.
+// Variables prefixed with _ggc_ to avoid shadowing warnings.
+#define GLOBAL_GET_CACHED(m_type, m_setting_name) ([](const char *p_name) -> m_type {\
+static_assert(std::is_trivially_destructible<m_type>::value, "GLOBAL_GET_CACHED must use a trivial type that allows static lifetime.");\
+static m_type _ggc_local_var;\
+static uint32_t _ggc_local_version = 0;\
+static SpinLock _ggc_spin;\
+uint32_t _ggc_new_version = _GLOBAL_GET_VERSION();\
+if (_ggc_local_version != _ggc_new_version) {\
+	_ggc_spin.lock();\
+	_ggc_local_version = _ggc_new_version;\
+	_ggc_local_var = _GLOBAL_GET(p_name);\
+	m_type _ggc_temp = _ggc_local_var;\
+	_ggc_spin.unlock();\
+	return _ggc_temp;\
+}\
+_ggc_spin.lock();\
+m_type _ggc_temp2 = _ggc_local_var;\
+_ggc_spin.unlock();\
+return _ggc_temp2; })(m_setting_name)

--- a/core/config/global_def.h
+++ b/core/config/global_def.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  resource_importer_texture_settings.cpp                                */
+/*  global_def.h                                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,27 +28,27 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "resource_importer_texture_settings.h"
+#pragma once
 
-#include "core/config/global_def.h"
-#include "core/os/os.h"
+struct PropertyInfo;
+class String;
+class StringName;
+class Variant;
 
-// ResourceImporterTextureSettings contains code used by
-// multiple texture importers and the export dialog.
-bool ResourceImporterTextureSettings::should_import_s3tc_bptc() {
-	if (GLOBAL_GET("rendering/textures/vram_compression/import_s3tc_bptc")) {
-		return true;
-	}
-	// If the project settings override is not enabled, import
-	// S3TC/BPTC only when the host operating system needs it.
-	return OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_S3TC_BPTC;
-}
+// Not a macro any longer.
+Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
+Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
+Variant _GLOBAL_GET(const StringName &p_name);
 
-bool ResourceImporterTextureSettings::should_import_etc2_astc() {
-	if (GLOBAL_GET("rendering/textures/vram_compression/import_etc2_astc")) {
-		return true;
-	}
-	// If the project settings override is not enabled, import
-	// ETC2/ASTC only when the host operating system needs it.
-	return OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_ETC2_ASTC;
-}
+#define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
+#define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
+#define GLOBAL_DEF_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true)
+#define GLOBAL_DEF_RST_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true)
+#define GLOBAL_GET(m_var) _GLOBAL_GET(m_var)
+
+#define GLOBAL_DEF_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, true)
+#define GLOBAL_DEF_RST_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, false, true)
+#define GLOBAL_DEF_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true, true)
+#define GLOBAL_DEF_RST_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true, true)
+
+#define GLOBAL_DEF_INTERNAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, false, true)

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1327,6 +1327,10 @@ Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p
 	return ret;
 }
 
+Variant _GLOBAL_GET(const StringName &p_name) {
+	return ProjectSettings::get_singleton()->get_setting_with_override(p_name);
+}
+
 void ProjectSettings::_add_property_info_bind(const Dictionary &p_info) {
 	ERR_FAIL_COND_MSG(!p_info.has("name"), "Property info is missing \"name\" field.");
 	ERR_FAIL_COND_MSG(!p_info.has("type"), "Property info is missing \"type\" field.");

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -43,6 +43,7 @@
 #include "core/variant/typed_array.h"
 #include "core/variant/variant_parser.h"
 #include "core/version.h"
+#include "global_def.h"
 #include "servers/rendering/rendering_server.h"
 
 #ifdef TOOLS_ENABLED
@@ -1329,6 +1330,10 @@ Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p
 
 Variant _GLOBAL_GET(const StringName &p_name) {
 	return ProjectSettings::get_singleton()->get_setting_with_override(p_name);
+}
+
+uint32_t _GLOBAL_GET_VERSION() {
+	return ProjectSettings::get_singleton()->get_version();
 }
 
 void ProjectSettings::_add_property_info_bind(const Dictionary &p_info) {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -252,26 +252,3 @@ public:
 	ProjectSettings(const String &p_path);
 	~ProjectSettings();
 };
-
-/////////////////////////////////////////////////////////////////////////////////////////
-// Cached versions of GLOBAL_GET.
-// Cached but uses a typed variable for storage, this can be more efficient.
-// Variables prefixed with _ggc_ to avoid shadowing warnings.
-#define GLOBAL_GET_CACHED(m_type, m_setting_name) ([](const char *p_name) -> m_type {\
-static_assert(std::is_trivially_destructible<m_type>::value, "GLOBAL_GET_CACHED must use a trivial type that allows static lifetime.");\
-static m_type _ggc_local_var;\
-static uint32_t _ggc_local_version = 0;\
-static SpinLock _ggc_spin;\
-uint32_t _ggc_new_version = ProjectSettings::get_singleton()->get_version();\
-if (_ggc_local_version != _ggc_new_version) {\
-	_ggc_spin.lock();\
-	_ggc_local_version = _ggc_new_version;\
-	_ggc_local_var = ProjectSettings::get_singleton()->get_setting_with_override(p_name);\
-	m_type _ggc_temp = _ggc_local_var;\
-	_ggc_spin.unlock();\
-	return _ggc_temp;\
-}\
-_ggc_spin.lock();\
-m_type _ggc_temp2 = _ggc_local_var;\
-_ggc_spin.unlock();\
-return _ggc_temp2; })(m_setting_name)

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/config/global_def.h"
 #include "core/object/object.h"
 #include "core/templates/rb_map.h"
 
@@ -251,23 +252,6 @@ public:
 	ProjectSettings(const String &p_path);
 	~ProjectSettings();
 };
-
-// Not a macro any longer.
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
-Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
-
-#define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
-#define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
-#define GLOBAL_DEF_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true)
-#define GLOBAL_DEF_RST_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true)
-#define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get_setting_with_override(m_var)
-
-#define GLOBAL_DEF_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, true)
-#define GLOBAL_DEF_RST_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, false, true)
-#define GLOBAL_DEF_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true, true)
-#define GLOBAL_DEF_RST_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true, true)
-
-#define GLOBAL_DEF_INTERNAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, false, true)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 // Cached versions of GLOBAL_GET.

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -30,7 +30,7 @@
 
 #include "remote_debugger.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/engine_profiler.h"

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -30,7 +30,7 @@
 
 #include "remote_debugger_peer.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
 

--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -38,7 +38,7 @@
 
 // Optional physics interpolation warnings try to include the path to the relevant node.
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/main/node.h"
 #endif
 

--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -30,7 +30,6 @@
 
 #include "compression.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/zip_io.h"
 
 #include "thirdparty/misc/fastlz.h"

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -30,7 +30,7 @@
 
 #include "image.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/error/error_macros.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -30,7 +30,7 @@
 
 #include "packet_peer.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/marshalls.h"
 
 /* helpers / binders */

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -30,7 +30,7 @@
 
 #include "stream_peer_tcp.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 void StreamPeerTCP::accept_socket(Ref<NetSocket> p_sock, const NetSocket::Address &p_addr) {
 	_sock = p_sock;

--- a/core/io/stream_peer_uds.cpp
+++ b/core/io/stream_peer_uds.cpp
@@ -30,7 +30,7 @@
 
 #include "stream_peer_uds.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 void StreamPeerUDS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("bind", "path"), &StreamPeerUDS::bind);

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -30,7 +30,7 @@
 
 #include "message_queue.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 

--- a/drivers/accesskit/accessibility_driver_accesskit.cpp
+++ b/drivers/accesskit/accessibility_driver_accesskit.cpp
@@ -32,7 +32,6 @@
 
 #include "accessibility_driver_accesskit.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "core/version.h"
 

--- a/drivers/apple_embedded/app_delegate_service.mm
+++ b/drivers/apple_embedded/app_delegate_service.mm
@@ -34,7 +34,7 @@
 #import "godot_view_controller.h"
 #import "os_apple_embedded.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/os/main_loop.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #include "main/main.h"

--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/config/global_def.h"
 #include "core/input/input.h"
 #include "servers/display/display_server.h"
 

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -32,7 +32,7 @@
 
 #ifdef COREAUDIO_ENABLED
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/os/os.h"
 
 #define kOutputBus 0

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -33,7 +33,7 @@
 #include "d3d12_hooks.h"
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/string/ustring.h"
 #include "core/templates/local_vector.h"
 #include "core/version.h"

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -32,7 +32,7 @@
 
 #include "d3d12_hooks.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/marshalls.h"
 #include "servers/rendering/rendering_device.h"
 #include "thirdparty/zlib/zlib.h"

--- a/drivers/gles3/effects/cubemap_filter.cpp
+++ b/drivers/gles3/effects/cubemap_filter.cpp
@@ -33,7 +33,7 @@
 #include "cubemap_filter.h"
 
 #include "../storage/texture_storage.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 using namespace GLES3;
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -35,7 +35,7 @@
 #include "rasterizer_gles3.h"
 #include "rasterizer_scene_gles3.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/transform_interpolator.h"
 #include "servers/rendering/rendering_server_default.h"

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -33,7 +33,7 @@
 
 #ifdef GLES3_ENABLED
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/dir_access.h"
 #include "core/io/image.h"
 #include "core/os/os.h"

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -34,6 +34,8 @@
 
 #include "../rasterizer_gles3.h"
 
+#include "core/config/global_def.h"
+
 #ifdef WEB_ENABLED
 #include <emscripten/html5_webgl.h>
 #endif

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -33,7 +33,7 @@
 #include "light_storage.h"
 #include "../rasterizer_gles3.h"
 #include "../rasterizer_scene_gles3.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "texture_storage.h"
 
 using namespace GLES3;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -32,7 +32,7 @@
 
 #ifdef PULSEAUDIO_ENABLED
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/os/os.h"
 #include "core/version.h"
 

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -34,7 +34,7 @@
 
 #include "vk_enum_string_helper.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/version.h"
 
 #include "rendering_device_driver_vulkan.h"

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -30,7 +30,7 @@
 
 #include "rendering_device_driver_vulkan.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/marshalls.h"
 #include "vulkan_hooks.h"
 

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -32,7 +32,6 @@
 
 #include "audio_driver_wasapi.h"
 
-#include "core/config/project_settings.h"
 #include "core/os/os.h"
 
 #include <functiondiscoverykeys.h>

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -33,7 +33,6 @@
 #include "dir_access_windows.h"
 #include "file_access_windows.h"
 
-#include "core/config/project_settings.h"
 #include "core/os/memory.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -31,7 +31,7 @@
 #include "animation_track_editor.h"
 
 #include "animation_track_editor_plugins.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/error/error_macros.h"
 #include "core/input/input.h"
 #include "core/string/translation_server.h"

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -30,7 +30,7 @@
 
 #include "editor_audio_buses.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/input/input.h"
 #include "core/io/resource_saver.h"
 #include "core/os/keyboard.h"

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -30,7 +30,6 @@
 
 #include "editor_export.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/main/timer.h"

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_export_platform_apple_embedded.h"
 
+#include "core/config/global_def.h"
 #include "core/io/json.h"
 #include "core/io/plist.h"
 #include "core/string/translation_server.h"

--- a/editor/export/shader_baker_export_plugin.cpp
+++ b/editor/export/shader_baker_export_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "shader_baker_export_plugin.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/dir_access.h"
 #include "core/version.h"
 #include "editor/editor_node.h"

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -32,7 +32,7 @@
 
 #include "unicode_ranges.inc"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/string/translation.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -31,7 +31,7 @@
 #include "resource_importer_texture_atlas.h"
 
 #include "atlas_import_failed.xpm"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/math/geometry_2d.h"

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -30,6 +30,7 @@
 
 #include "register_editor_types.h"
 
+#include "core/config/global_def.h"
 #include "core/object/script_language.h"
 #include "editor/animation/animation_tree_editor_plugin.h"
 #include "editor/audio/audio_stream_editor_plugin.h"

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -30,7 +30,7 @@
 
 #include "editor_run_bar.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_node.h"

--- a/editor/scene/2d/camera_2d_editor_plugin.cpp
+++ b/editor/scene/2d/camera_2d_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "camera_2d_editor_plugin.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/canvas_item_editor_plugin.h"

--- a/editor/scene/3d/mesh_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "mesh_editor_plugin.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/button.h"
 #include "scene/main/viewport.h"

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -30,7 +30,7 @@
 
 #include "connections_dialog.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/templates/hash_set.h"
 #include "editor/doc/editor_help.h"
 #include "editor/docks/scene_tree_dock.h"

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -30,7 +30,7 @@
 
 #include "editor_scene_tabs.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -30,7 +30,7 @@
 
 #include "theme_editor_preview.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "material_editor_plugin.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -30,7 +30,7 @@
 
 #include "scene_tree_editor.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/object/script_language.h"
 #include "editor/animation/animation_player_editor_plugin.h"
 #include "editor/docks/editor_dock_manager.h"

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -30,7 +30,7 @@
 
 #include "editor_build_profile.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/json.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/translations/template_generator.cpp
+++ b/editor/translations/template_generator.cpp
@@ -30,7 +30,7 @@
 
 #include "template_generator.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/translations/editor_translation.h"
 #include "editor/translations/editor_translation_parser.h"
 

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -30,7 +30,7 @@
 
 #include "image_compress_basisu.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/image.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"

--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -32,7 +32,7 @@
 
 #include "image_compress_basisu.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 void initialize_basis_universal_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -30,7 +30,7 @@
 
 #include "image_compress_betsy.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 #include "betsy_bc1.h"
 

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -37,7 +37,7 @@
 #include "editor/editor_scene_importer_fbx2gltf.h"
 #include "editor/editor_scene_importer_ufbx.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/editor_node.h"
 
 static void _editor_init() {

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -48,7 +48,7 @@
 #include "editor/editor_scene_importer_blend.h"
 #include "editor/editor_scene_importer_gltf.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/editor_node.h"
 #include "editor/settings/editor_settings.h"
 

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -34,7 +34,6 @@
 #include "godot_broad_phase_2d_bvh.h"
 #include "godot_collision_solver_2d.h"
 
-#include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/os/os.h"
 

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -33,7 +33,7 @@
 #include "godot_collision_solver_2d.h"
 #include "godot_physics_server_2d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "godot_area_pair_2d.h"
 #include "godot_body_pair_2d.h"
 

--- a/modules/godot_physics_2d/register_types.cpp
+++ b/modules/godot_physics_2d/register_types.cpp
@@ -30,7 +30,7 @@
 
 #include "register_types.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "godot_physics_server_2d.h"
 #include "servers/physics_2d/physics_server_2d.h"
 #include "servers/physics_2d/physics_server_2d_wrap_mt.h"

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -33,7 +33,7 @@
 #include "godot_collision_solver_3d.h"
 #include "godot_physics_server_3d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "godot_area_pair_3d.h"
 #include "godot_body_pair_3d.h"
 

--- a/modules/godot_physics_3d/register_types.cpp
+++ b/modules/godot_physics_3d/register_types.cpp
@@ -30,6 +30,7 @@
 
 #include "register_types.h"
 
+#include "core/config/global_def.h"
 #include "godot_physics_server_3d.h"
 #include "servers/physics_3d/physics_server_3d.h"
 #include "servers/physics_3d/physics_server_3d_wrap_mt.h"

--- a/modules/jolt_physics/register_types.cpp
+++ b/modules/jolt_physics/register_types.cpp
@@ -34,6 +34,7 @@
 #include "jolt_physics_server_3d.h"
 #include "jolt_project_settings.h"
 
+#include "core/config/global_def.h"
 #include "servers/physics_3d/physics_server_3d_wrap_mt.h"
 
 PhysicsServer3D *create_jolt_physics_server() {

--- a/modules/jpg/movie_writer_mjpeg.cpp
+++ b/modules/jpg/movie_writer_mjpeg.cpp
@@ -29,7 +29,8 @@
 /**************************************************************************/
 
 #include "movie_writer_mjpeg.h"
-#include "core/config/project_settings.h"
+
+#include "core/config/global_def.h"
 #include "core/io/file_access.h"
 
 uint32_t MovieWriterMJPEG::get_audio_mix_rate() const {

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -35,7 +35,7 @@
 #include "lm_compute.glsl.gen.h"
 #include "lm_raster.glsl.gen.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/dir_access.h"
 #include "core/math/geometry_2d.h"
 #include "editor/file_system/editor_paths.h"

--- a/modules/lightmapper_rd/register_types.cpp
+++ b/modules/lightmapper_rd/register_types.cpp
@@ -32,7 +32,7 @@
 
 #include "lightmapper_rd.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/3d/lightmapper.h"
 
 #ifndef _3D_DISABLED

--- a/modules/mbedtls/register_types.cpp
+++ b/modules/mbedtls/register_types.cpp
@@ -35,7 +35,7 @@
 #include "packet_peer_mbed_dtls.h"
 #include "stream_peer_mbedtls.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 #if MBEDTLS_VERSION_MAJOR >= 3
 #include <psa/crypto.h>

--- a/modules/mbedtls/tls_context_mbedtls.cpp
+++ b/modules/mbedtls/tls_context_mbedtls.cpp
@@ -30,7 +30,7 @@
 
 #include "tls_context_mbedtls.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/settings/editor_settings.h"

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -37,7 +37,7 @@
 #include "../utils/path_utils.h"
 #include "code_completion.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/debugger/editor_debugger_node.h"

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -30,7 +30,7 @@
 
 #include "path_utils.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/os/os.h"

--- a/modules/navigation_2d/2d/nav_map_builder_2d.cpp
+++ b/modules/navigation_2d/2d/nav_map_builder_2d.cpp
@@ -37,7 +37,7 @@
 #include "nav_map_iteration_2d.h"
 #include "nav_region_iteration_2d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 using namespace Nav2D;
 

--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
@@ -32,7 +32,7 @@
 
 #include "nav_mesh_generator_2d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "scene/resources/2d/navigation_polygon.h"
 

--- a/modules/navigation_2d/2d/nav_region_builder_2d.cpp
+++ b/modules/navigation_2d/2d/nav_region_builder_2d.cpp
@@ -35,7 +35,7 @@
 #include "../triangle2.h"
 #include "nav_region_iteration_2d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 using namespace Nav2D;
 

--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -38,7 +38,7 @@
 #include "nav_obstacle_2d.h"
 #include "nav_region_2d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/object/worker_thread_pool.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 

--- a/modules/navigation_2d/nav_region_2d.cpp
+++ b/modules/navigation_2d/nav_region_2d.cpp
@@ -35,7 +35,7 @@
 #include "2d/nav_mesh_queries_2d.h"
 #include "2d/nav_region_builder_2d.h"
 #include "2d/nav_region_iteration_2d.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 using namespace Nav2D;
 

--- a/modules/navigation_3d/3d/nav_map_builder_3d.cpp
+++ b/modules/navigation_3d/3d/nav_map_builder_3d.cpp
@@ -36,7 +36,7 @@
 #include "nav_map_iteration_3d.h"
 #include "nav_region_iteration_3d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 using namespace Nav3D;
 

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
@@ -30,7 +30,7 @@
 
 #include "nav_mesh_generator_3d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/os/thread.h"
 #include "scene/3d/node_3d.h"
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"

--- a/modules/navigation_3d/3d/nav_region_builder_3d.cpp
+++ b/modules/navigation_3d/3d/nav_region_builder_3d.cpp
@@ -34,7 +34,7 @@
 #include "../nav_region_3d.h"
 #include "nav_region_iteration_3d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 using namespace Nav3D;
 

--- a/modules/navigation_3d/nav_map_3d.cpp
+++ b/modules/navigation_3d/nav_map_3d.cpp
@@ -38,7 +38,7 @@
 #include "nav_obstacle_3d.h"
 #include "nav_region_3d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/object/worker_thread_pool.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 

--- a/modules/navigation_3d/nav_region_3d.cpp
+++ b/modules/navigation_3d/nav_region_3d.cpp
@@ -35,7 +35,7 @@
 #include "3d/nav_mesh_queries_3d.h"
 #include "3d/nav_region_builder_3d.h"
 #include "3d/nav_region_iteration_3d.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 using namespace Nav3D;
 

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -30,7 +30,7 @@
 
 #include "openxr_action_map_editor.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "editor/editor_node.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_file_dialog.h"

--- a/modules/openxr/extensions/openxr_debug_utils_extension.cpp
+++ b/modules/openxr/extensions/openxr_debug_utils_extension.cpp
@@ -31,7 +31,7 @@
 #include "openxr_debug_utils_extension.h"
 
 #include "../openxr_api.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/string/print_string.h"
 
 #include <openxr/openxr.h>

--- a/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
+++ b/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
@@ -30,7 +30,7 @@
 
 #include "openxr_eye_gaze_interaction.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/os/os.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"

--- a/modules/openxr/extensions/openxr_fb_foveation_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_foveation_extension.cpp
@@ -29,7 +29,8 @@
 /**************************************************************************/
 
 #include "openxr_fb_foveation_extension.h"
-#include "core/config/project_settings.h"
+
+#include "core/config/global_def.h"
 #include "openxr_eye_gaze_interaction.h"
 
 #include "../openxr_platform_inc.h"

--- a/modules/openxr/extensions/openxr_frame_synthesis_extension.cpp
+++ b/modules/openxr/extensions/openxr_frame_synthesis_extension.cpp
@@ -30,7 +30,7 @@
 
 #include "openxr_frame_synthesis_extension.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/xr/xr_server.h"
 

--- a/modules/openxr/extensions/openxr_hand_interaction_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_interaction_extension.cpp
@@ -31,7 +31,7 @@
 #include "openxr_hand_interaction_extension.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 #include <openxr/openxr.h>
 

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -32,7 +32,7 @@
 
 #include "../openxr_api.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/string/print_string.h"
 #include "servers/xr/xr_server.h"
 

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -34,7 +34,7 @@
 #include "openxr_util.h"
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/os/memory.h"
 #include "core/profiling/profiling.h"
 #include "core/version.h"

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -91,7 +91,7 @@
 #include "extensions/platform/openxr_android_extension.h"
 #endif
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "main/main.h"
 
 #ifdef TOOLS_ENABLED

--- a/modules/openxr/scene/openxr_render_model.cpp
+++ b/modules/openxr/scene/openxr_render_model.cpp
@@ -31,7 +31,7 @@
 #include "openxr_render_model.h"
 
 #include "../extensions/openxr_render_model_extension.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/xr/xr_nodes.h"
 #include "scene/resources/3d/primitive_meshes.h"

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -30,7 +30,7 @@
 
 #include "raycast_occlusion_cull.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/templates/local_vector.h"
 

--- a/modules/theora/editor/movie_writer_ogv.cpp
+++ b/modules/theora/editor/movie_writer_ogv.cpp
@@ -30,7 +30,7 @@
 
 #include "movie_writer_ogv.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/file_access.h"
 #include "rgb2yuv.h"
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -30,7 +30,7 @@
 
 #include "video_stream_theora.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/image.h"
 #include "scene/resources/image_texture.h"
 

--- a/modules/webp/webp_common.cpp
+++ b/modules/webp/webp_common.cpp
@@ -30,7 +30,7 @@
 
 #include "webp_common.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 #include <webp/decode.h>
 #include <webp/encode.h>

--- a/modules/webrtc/register_types.cpp
+++ b/modules/webrtc/register_types.cpp
@@ -36,7 +36,7 @@
 #include "webrtc_peer_connection.h"
 #include "webrtc_peer_connection_extension.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 void initialize_webrtc_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {

--- a/modules/webrtc/webrtc_data_channel.cpp
+++ b/modules/webrtc/webrtc_data_channel.cpp
@@ -30,7 +30,7 @@
 
 #include "webrtc_data_channel.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 void WebRTCDataChannel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("poll"), &WebRTCDataChannel::poll);

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -30,7 +30,7 @@
 
 #include "remote_debugger_peer_websocket.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 Error RemoteDebuggerPeerWebSocket::connect_to_host(const String &p_uri) {
 	ws_peer = Ref<WebSocketPeer>(WebSocketPeer::create());

--- a/platform/android/tts_android.cpp
+++ b/platform/android/tts_android.cpp
@@ -34,6 +34,8 @@
 #include "os_android.h"
 #include "thread_jandroid.h"
 
+#include "core/config/global_def.h"
+
 bool TTS_Android::initialized = false;
 jobject TTS_Android::tts = nullptr;
 jclass TTS_Android::cls = nullptr;

--- a/platform/android/tts_android.h
+++ b/platform/android/tts_android.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/config/project_settings.h"
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
 #include "core/variant/array.h"

--- a/platform/ios/display_layer_ios.mm
+++ b/platform/ios/display_layer_ios.mm
@@ -33,7 +33,7 @@
 #import "display_server_ios.h"
 #import "os_ios.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/os/keyboard.h"
 #include "main/main.h"
 #include "servers/audio/audio_server.h"

--- a/platform/ios/godot_view_ios.mm
+++ b/platform/ios/godot_view_ios.mm
@@ -32,8 +32,9 @@
 
 #import "display_layer_ios.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/error/error_macros.h"
+#include "core/variant/variant.h"
 
 @interface GDTViewIOS ()
 

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -33,7 +33,6 @@
 #include "logo_svg.gen.h"
 #include "run_icon_svg.gen.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/platform/linuxbsd/freedesktop_screensaver.cpp
+++ b/platform/linuxbsd/freedesktop_screensaver.cpp
@@ -32,7 +32,8 @@
 
 #ifdef DBUS_ENABLED
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
+#include "core/variant/variant.h"
 
 #ifdef SOWRAP_ENABLED
 #include "dbus-so_wrap.h"

--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -30,7 +30,7 @@
 
 #include "tts_linux.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/text/text_server.h"
 
 TTS_Linux *TTS_Linux::singleton = nullptr;

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -39,6 +39,7 @@
 #define DEBUG_LOG_WAYLAND(...)
 #endif
 
+#include "core/config/global_def.h"
 #include "core/os/main_loop.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -35,7 +35,7 @@
 #include "x11/detect_prime_x11.h"
 #include "x11/key_mapping_x11.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/file_access.h"
 #include "core/math/math_funcs.h"
 #include "core/os/main_loop.h"

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -52,7 +52,7 @@
 #import "embedded_debugger.h"
 #import "macos_quartz_core_spi.h"
 
-#import "core/config/project_settings.h"
+#import "core/config/global_def.h"
 #import "core/debugger/engine_debugger.h"
 #import "core/io/marshalls.h"
 #import "core/os/main_loop.h"

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -32,7 +32,7 @@
 #import "key_mapping_macos.h"
 #import "tts_macos.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "drivers/png/png_driver_common.h"
 
 #import <Carbon/Carbon.h>

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -33,7 +33,7 @@
 #include "logo_svg.gen.h"
 #include "run_icon_svg.gen.h"
 
-#include "core/io/image_loader.h"
+#include "core/config/global_def.h"
 #include "core/io/plist.h"
 #include "core/string/translation_server.h"
 #include "drivers/png/png_driver_common.h"

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -35,7 +35,7 @@
 #include "scene/main/window.h"
 #include "wgl_detect_version.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/io/xml_parser.h"

--- a/platform/windows/export/template_modifier.cpp
+++ b/platform/windows/export/template_modifier.cpp
@@ -30,7 +30,6 @@
 
 #include "template_modifier.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/image.h"
 

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -32,7 +32,7 @@
 
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/version.h"
 
 #include "thirdparty/misc/nvapi_minimal.h"

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -31,7 +31,7 @@
 #include "audio_stream_player_2d.h"
 #include "audio_stream_player_2d.compat.inc"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/2d/audio_listener_2d.h"
 #include "scene/audio/audio_stream_player_internal.h"
 #include "scene/main/viewport.h"

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -31,7 +31,7 @@
 #include "audio_stream_player_3d.h"
 #include "audio_stream_player_3d.compat.inc"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/3d/audio_listener_3d.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/velocity_tracker_3d.h"

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -30,7 +30,7 @@
 
 #include "light_3d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 void Light3D::set_param(Param p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -30,7 +30,7 @@
 
 #include "occluder_instance_3d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/triangulate.h"

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -30,8 +30,6 @@
 
 #include "visual_instance_3d.h"
 
-#include "core/config/project_settings.h"
-
 AABB VisualInstance3D::get_aabb() const {
 	AABB ret;
 	GDVIRTUAL_CALL(_get_aabb, ret);

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -30,7 +30,7 @@
 
 #include "voxel_gi.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "mesh_instance_3d.h"
 #include "multimesh_instance_3d.h"
 #include "scene/resources/camera_attributes.h"

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -30,7 +30,7 @@
 
 #include "voxelizer.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 static _FORCE_INLINE_ void get_uv_and_normal(const Vector3 &p_pos, const Vector3 *p_vtx, const Vector2 *p_uv, const Vector3 *p_normal, Vector2 &r_uv, Vector3 &r_normal) {
 	if (p_pos.is_equal_approx(p_vtx[0])) {

--- a/scene/3d/xr/xr_hand_modifier_3d.cpp
+++ b/scene/3d/xr/xr_hand_modifier_3d.cpp
@@ -30,7 +30,7 @@
 
 #include "xr_hand_modifier_3d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/xr/xr_server.h"
 
 void XRHandModifier3D::_bind_methods() {

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -30,7 +30,7 @@
 
 #include "xr_nodes.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/main/viewport.h"
 #include "servers/xr/xr_interface.h"
 

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -30,7 +30,7 @@
 
 #include "item_list.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/os/os.h"
 #include "scene/theme/theme_db.h"
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -31,7 +31,7 @@
 #include "line_edit.h"
 #include "line_edit.compat.inc"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/input/input_map.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -30,7 +30,7 @@
 
 #include "scroll_container.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/gui/panel_container.h"
 #include "scene/main/window.h"
 #include "scene/theme/theme_db.h"

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -30,7 +30,7 @@
 
 #include "register_scene_types.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "scene/animation/animation_blend_space_1d.h"

--- a/scene/resources/2d/shape_2d.cpp
+++ b/scene/resources/2d/shape_2d.cpp
@@ -30,7 +30,7 @@
 
 #include "shape_2d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/physics_2d/physics_server_2d.h"
 
 RID Shape2D::get_rid() const {

--- a/scene/resources/3d/sky_material.cpp
+++ b/scene/resources/3d/sky_material.cpp
@@ -30,7 +30,7 @@
 
 #include "sky_material.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/version.h"
 
 Mutex ProceduralSkyMaterial::shader_mutex;

--- a/scene/resources/3d/world_3d.cpp
+++ b/scene/resources/3d/world_3d.cpp
@@ -30,7 +30,7 @@
 
 #include "world_3d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/resources/camera_attributes.h"
 #include "scene/resources/environment.h"

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -30,7 +30,7 @@
 
 #include "camera_attributes.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/rendering/rendering_server.h"
 
 void CameraAttributes::set_exposure_multiplier(float p_multiplier) {

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -30,7 +30,7 @@
 
 #include "environment.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/resources/gradient_texture.h"
 #include "servers/rendering/rendering_server.h"
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -31,7 +31,7 @@
 #include "material.h"
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/error/error_macros.h"
 #include "core/version.h"
 #include "scene/main/scene_tree.h"

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -30,7 +30,7 @@
 
 #include "portable_compressed_texture.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/marshalls.h"
 #include "scene/resources/bit_map.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -30,7 +30,7 @@
 
 #include "world_2d.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "scene/2d/visible_on_screen_notifier_2d.h"
 #include "servers/rendering/rendering_server.h"
 

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -30,7 +30,7 @@
 
 #include "theme_db.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/resource_loader.h"
 #include "scene/gui/control.h"
 #include "scene/main/node.h"

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -30,7 +30,7 @@
 
 #include "audio_server.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/error/error_macros.h"
 #include "core/io/resource_loader.h"

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -30,7 +30,7 @@
 
 #include "servers_debugger.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/engine_profiler.h"
 #include "core/io/resource_loader.h"

--- a/servers/movie_writer/movie_writer_pngwav.cpp
+++ b/servers/movie_writer/movie_writer_pngwav.cpp
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 #include "movie_writer_pngwav.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/config/project_settings.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -31,7 +31,7 @@
 #include "register_server_types.h"
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 #include "audio/audio_effect.h"
 #include "audio/audio_server.h"

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -30,7 +30,7 @@
 
 #include "renderer_canvas_cull.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/transform_interpolator.h"
 #include "renderer_viewport.h"

--- a/servers/rendering/renderer_compositor.cpp
+++ b/servers/rendering/renderer_compositor.cpp
@@ -30,7 +30,7 @@
 
 #include "renderer_compositor.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 
 #ifndef XR_DISABLED
 #include "servers/xr/xr_server.h"

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 #include "copy_effects.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"

--- a/servers/rendering/renderer_rd/effects/smaa.cpp
+++ b/servers/rendering/renderer_rd/effects/smaa.cpp
@@ -30,7 +30,7 @@
 
 #include "smaa.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/image_loader.h"
 #include "servers/rendering/renderer_rd/effects/smaa_area_tex.gen.h"
 #include "servers/rendering/renderer_rd/effects/smaa_search_tex.gen.h"

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -30,7 +30,7 @@
 
 #include "ss_effects.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/rendering/renderer_rd/effects/copy_effects.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h"

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -30,7 +30,7 @@
 
 #include "gi.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 #include "sky.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/math/math_defs.h"
 #include "servers/rendering/renderer_rd/effects/copy_effects.h"
 #include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -29,7 +29,8 @@
 /**************************************************************************/
 
 #include "render_forward_clustered.h"
-#include "core/config/project_settings.h"
+
+#include "core/config/global_def.h"
 #include "servers/rendering/renderer_rd/environment/fog.h"
 #include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/light_storage.h"

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -29,7 +29,8 @@
 /**************************************************************************/
 
 #include "scene_shader_forward_clustered.h"
-#include "core/config/project_settings.h"
+
+#include "core/config/global_def.h"
 #include "core/math/math_defs.h"
 #include "render_forward_clustered.h"
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 #include "render_forward_mobile.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/light_storage.h"
 #include "servers/rendering/renderer_rd/storage_rd/mesh_storage.h"

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 #include "scene_shader_forward_mobile.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/math/math_defs.h"
 #include "render_forward_mobile.h"
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -30,7 +30,7 @@
 
 #include "renderer_canvas_render_rd.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/math_defs.h"
 #include "core/math/math_funcs.h"

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -30,7 +30,7 @@
 
 #include "renderer_compositor_rd.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/io/dir_access.h"
 
 #include "servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h"

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 #include "light_storage.h"
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "texture_storage.h"
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -30,7 +30,7 @@
 
 #include "renderer_viewport.h"
 
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #include "core/math/transform_interpolator.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/profiling/profiling.h"

--- a/servers/rendering/storage/mesh_storage.cpp
+++ b/servers/rendering/storage/mesh_storage.cpp
@@ -33,7 +33,7 @@
 #include "core/math/transform_interpolator.h"
 
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
-#include "core/config/project_settings.h"
+#include "core/config/global_def.h"
 #endif
 
 RID RendererMeshStorage::multimesh_allocate() {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13697

About half of the users only use `GLOBAL_GET/DEF` so they can remove their dependency to `project_settings.h`.

Performance of `GLOBAL_GET` not tested yet, but as we have `GLOBAL_GET_CACHED` we can always switch to that for better performance (that's also why I left cached version untouched).