### PR TITLE
Clarify wording for mouse_entered and mouse_exited

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1196,14 +1196,15 @@
 		</signal>
 		<signal name="mouse_entered">
 			<description>
-				Emitted when the mouse cursor enters the control's (or any child control's) visible area, that is not occluded behind other Controls or Windows, provided its [member mouse_filter] lets the event reach it and regardless if it's currently focused or not.
-				[b]Note:[/b] [member CanvasItem.z_index] doesn't affect, which Control receives the signal.
+				Emitted when the mouse cursor enters the control's visible area. This area is defined as the node's own area plus the area of all its child controls, minus the parts that are occluded behind other Controls or Windows. The control's and its childrens' [member mouse_filter] must be configured such that the mouse event can reach this node. The signal is emitted regardless of whether this control currently has focus or not.
+				[b]Note:[/b] For the purpose of mouse_entered, whether a control's area occludes another control is determined by scene tree order. [member CanvasItem.z_index] doesn't affect this.
 			</description>
 		</signal>
 		<signal name="mouse_exited">
 			<description>
-				Emitted when the mouse cursor leaves the control's (and all child control's) visible area, that is not occluded behind other Controls or Windows, provided its [member mouse_filter] lets the event reach it and regardless if it's currently focused or not.
-				[b]Note:[/b] [member CanvasItem.z_index] doesn't affect, which Control receives the signal.
+				Emitted when the mouse cursor leaves the control's visible area. This area is defined as the node's own area plus the area of all its child controls, minus the parts that are occluded behind other Controls or Windows. The control's and its childrens' [member mouse_filter] must be configured such that the mouse event can reach this node. The signal is emitted regardless of whether this control currently has focus or not.
+
+				[b]Note:[/b] For the purpose of mouse_exited, whether a control's area occludes another control is determined by scene tree order. [member CanvasItem.z_index] doesn't affect this.
 				[b]Note:[/b] If you want to check whether the mouse truly left the area, ignoring any top nodes, you can use code like this:
 				[codeblock]
 				func _on_mouse_exited():

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1196,15 +1196,14 @@
 		</signal>
 		<signal name="mouse_entered">
 			<description>
-				Emitted when the mouse cursor enters the control's visible area. This area is defined as the node's own area plus the area of all its child controls, minus the parts that are occluded behind other Controls or Windows. The control's and its childrens' [member mouse_filter] must be configured such that the mouse event can reach this node. The signal is emitted regardless of whether this control currently has focus or not.
-				[b]Note:[/b] For the purpose of mouse_entered, whether a control's area occludes another control is determined by scene tree order. [member CanvasItem.z_index] doesn't affect this.
+				Emitted when the mouse cursor enters the control's visible area. This area is defined as the node's own area plus the area of all its child controls, minus the parts that are occluded behind other Controls or Windows. The control's and its children's [member mouse_filter] must be configured such that the mouse event can reach this node. The signal is emitted regardless of whether this control currently has focus or not.
+				[b]Note:[/b] For the purpose of [signal mouse_entered], whether a control's area occludes another control is determined by scene tree order. [member CanvasItem.z_index] doesn't affect this.
 			</description>
 		</signal>
 		<signal name="mouse_exited">
 			<description>
-				Emitted when the mouse cursor leaves the control's visible area. This area is defined as the node's own area plus the area of all its child controls, minus the parts that are occluded behind other Controls or Windows. The control's and its childrens' [member mouse_filter] must be configured such that the mouse event can reach this node. The signal is emitted regardless of whether this control currently has focus or not.
-
-				[b]Note:[/b] For the purpose of mouse_exited, whether a control's area occludes another control is determined by scene tree order. [member CanvasItem.z_index] doesn't affect this.
+				Emitted when the mouse cursor leaves the control's visible area. This area is defined as the node's own area plus the area of all its child controls, minus the parts that are occluded behind other Controls or Windows. The control's and its children's [member mouse_filter] must be configured such that the mouse event can reach this node. The signal is emitted regardless of whether this control currently has focus or not.
+				[b]Note:[/b] For the purpose of [signal mouse_exited], whether a control's area occludes another control is determined by scene tree order. [member CanvasItem.z_index] doesn't affect this.
 				[b]Note:[/b] If you want to check whether the mouse truly left the area, ignoring any top nodes, you can use code like this:
 				[codeblock]
 				func _on_mouse_exited():


### PR DESCRIPTION
The documentation for `mouse_entered` and especially `mouse_exited` in `Control` are quite a mouthful:

> Emitted when the mouse cursor leaves the control's (and all child control's) visible area, that is not occluded behind other Controls or Windows, provided its mouse_filter lets the event reach it and regardless if it's currently focused or not.
> 
> Note: CanvasItem.z_index doesn't affect, which Control receives the signal.

Once I arrive at the last bit (`regardless if...`), it is quite unreadable for me, because I don't know which way everything is bracketed, so to speak. This PR is an attempt to improve that. Let me know what you think :)

Besides the clarification, I extended the Note regarding the z_index, because as the sentence was written, my reaction was: "Okay, so the z_index doesn't affect it. Why should it, resp. what _does_ affect it?". I think the Note came about because users where confused that the scene tree order is what's relevant, and not the z_index, so I stated this explicitly.