### PR TITLE
Revert "Fix `EditorExportPlugin::_export_file()` ignoring GDScripts"

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1339,8 +1339,6 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		}
 
 		bool do_export = true;
-		bool skip_all = false;
-		int skipped_i = export_plugins.size() - 1;
 		for (int i = 0; i < export_plugins.size(); i++) {
 			if (GDVIRTUAL_IS_OVERRIDDEN_PTR(export_plugins[i], _export_file)) {
 				export_plugins.write[i]->_export_file_script(path, type, features_psa);
@@ -1356,30 +1354,26 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				}
 			}
 
-			if (export_plugins[i]->skipped) {
-				do_export = false;
-				skip_all = true;
-				skipped_i = i;
-				break;
-			}
-		}
-
-		for (int i = 0; i <= skipped_i; i++) {
-			if (!skip_all) {
-				for (const EditorExportPlugin::ExtraFile &extra_file : export_plugins[i]->extra_files) {
-					err = save_proxy.save_file(p_udata, extra_file.path, extra_file.data, idx, total, enc_in_filters, enc_ex_filters, key, seed);
-					if (err != OK) {
-						return err;
-					}
-					if (extra_file.remap) {
-						do_export = false; // If remap, do not.
-						path_remaps.push_back(path);
-						path_remaps.push_back(extra_file.path);
-					}
+			for (int j = 0; j < export_plugins[i]->extra_files.size(); j++) {
+				err = save_proxy.save_file(p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+				if (err != OK) {
+					return err;
+				}
+				if (export_plugins[i]->extra_files[j].remap) {
+					do_export = false; // If remap, do not.
+					path_remaps.push_back(path);
+					path_remaps.push_back(export_plugins[i]->extra_files[j].path);
 				}
 			}
 
+			if (export_plugins[i]->skipped) {
+				do_export = false;
+			}
 			export_plugins.write[i]->_clear();
+
+			if (!do_export) {
+				break;
+			}
 		}
 		if (!do_export) {
 			continue;


### PR DESCRIPTION
This reverts commit 9504b0ff7aa1b86651b8a9de45015dd6a256f5d7.

This broke exporting C# projects to Android in debug builds.

- Fixes #112918.
- Fixes #112397.
- Reverts #109815.
- Reopens #93487.

CC @Muller-Castro 

#109815 can be attempted again with more testing to ensure that C# debug exports still work on Android (the fix might be simple, but since the regression is pretty severe compared to the fixed bug, for now we just revert to fix C# support).