### PR TITLE
Android: Fix memory issues in `_variant_to_jvalue()`

### DIFF
--- a/platform/android/java/app/src/instrumented/assets/test/base_test.gd
+++ b/platform/android/java/app/src/instrumented/assets/test/base_test.gd
@@ -42,3 +42,10 @@ func assert_equal(actual, expected):
 	else:
 		__assert_fail()
 		print ("    |-> Expected '%s' but got '%s'" % [expected, actual])
+
+func assert_true(value):
+	if value:
+		__assert_pass()
+	else:
+		__assert_fail()
+		print ("    |-> Expected '%s' to be truthy" % value)

--- a/platform/android/java/app/src/instrumented/assets/test/javaclasswrapper/java_class_wrapper_tests.gd
+++ b/platform/android/java/app/src/instrumented/assets/test/javaclasswrapper/java_class_wrapper_tests.gd
@@ -18,6 +18,8 @@ func run_tests():
 
 	__exec_test(test_big_integers)
 
+	__exec_test(test_callable)
+
 	print("JavaClassWrapper tests finished.")
 	print("Tests started: " + str(_test_started))
 	print("Tests completed: " + str(_test_completed))
@@ -142,3 +144,14 @@ func test_big_integers():
 	assert_equal(TestClass.testArgLong(4242424242), "4242424242")
 	assert_equal(TestClass.testArgLong(-4242424242), "-4242424242")
 	assert_equal(TestClass.testDictionary({a = 4242424242, b = -4242424242}), "{a=4242424242, b=-4242424242}")
+
+func test_callable():
+	var android_runtime = Engine.get_singleton("AndroidRuntime")
+	assert_true(android_runtime != null)
+
+	var cb1_data := {called = false}
+	var cb1 = func():
+		cb1_data['called'] = true
+		return null
+	android_runtime.createRunnableFromGodotCallable(cb1).run()
+	assert_equal(cb1_data['called'], true)

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -393,7 +393,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 			} break;
 			case ARG_TYPE_CLASS: {
 				if (p_args[i]->get_type() == Variant::DICTIONARY) {
-					argv[i].l = _variant_to_jvalue(env, Variant::DICTIONARY, p_args[i]).l;
+					argv[i].l = _variant_to_jobject(env, Variant::DICTIONARY, p_args[i]);
 				} else {
 					Ref<JavaObject> jo = *p_args[i];
 					if (jo.is_valid()) {

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -536,7 +536,7 @@ JNIEXPORT jobject JNICALL Java_org_godotengine_godot_GodotLib_getEditorProjectMe
 		String key = jstring_to_string(p_key, env);
 		Variant default_value = _jobject_to_variant(env, p_default_value);
 		Variant data = EditorSettings::get_singleton()->get_project_metadata(section, key, default_value);
-		result = _variant_to_jvalue(env, data.get_type(), &data, true);
+		result.l = _variant_to_jobject(env, data.get_type(), &data);
 	}
 #else
 	WARN_PRINT("Access to the Editor Settings Project Metadata is only available on Editor builds");

--- a/platform/android/jni_utils.h
+++ b/platform/android/jni_utils.h
@@ -38,7 +38,7 @@
 
 #include <jni.h>
 
-jvalue _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_arg, bool force_jobject = false, int p_depth = 0);
+jobject _variant_to_jobject(JNIEnv *env, Variant::Type p_type, const Variant *p_arg, int p_depth = 0);
 
 String _get_class_name(JNIEnv *env, jclass cls, bool *array);
 

--- a/platform/android/variant/callable_jni.cpp
+++ b/platform/android/variant/callable_jni.cpp
@@ -91,8 +91,7 @@ JNIEXPORT jobject JNICALL Java_org_godotengine_godot_variant_Callable_nativeCall
 		Callable::CallError err;
 		Variant result;
 		callable.callp(argptrs, count, result, err);
-		jvalue jresult = _variant_to_jvalue(p_env, result.get_type(), &result, true);
-		ret = jresult.l;
+		ret = _variant_to_jobject(p_env, result.get_type(), &result);
 	}
 
 	// Manually invoke the destructor to decrease the reference counts for the variant arguments.
@@ -107,8 +106,7 @@ JNIEXPORT jobject JNICALL Java_org_godotengine_godot_variant_Callable_nativeCall
 	Callable callable = _generate_callable(p_env, p_object_id, p_method_name, p_parameters);
 	if (callable.is_valid()) {
 		Variant result = callable.call();
-		jvalue jresult = _variant_to_jvalue(p_env, result.get_type(), &result, true);
-		return jresult.l;
+		return _variant_to_jobject(p_env, result.get_type(), &result);
 	} else {
 		return nullptr;
 	}


### PR DESCRIPTION
There's some issues in `_variant_to_jvalue()` which mostly stem from `jvalue` being a `union` (so, all the fields are stored on an overlapping chunk of memory) and the code seems to be treating it sort of like it's a `struct` (or at least like it's 32-bits rather than 64-bits?).

For example, the `jvalue value` isn't initialized to anything, so it starts out with junk memory, but the default case is to set `value.i = 0`, which will only set the lower 32-bits and leave the upper 32-bits with junk in them:

https://github.com/godotengine/godot/blob/9dd6c4dbac70b28e8156255c3a2b78722772b036/platform/android/jni_utils.cpp#L273-L275

Also, the function may set other fields like `value.z`, `value.j` or `value.f` (when `force_object` is `false`), but at the end, it will overwrite anything that's there by setting `value.l`:

https://github.com/godotengine/godot/blob/9dd6c4dbac70b28e8156255c3a2b78722772b036/platform/android/jni_utils.cpp#L277

This PR fixes all that by:

- Initializing the `jvalue value` to zero (which also means we don't need a default case or some of the `else` branches, we can just leave it as-is)
- Keeping track of if the value is an object or not, and only if it is will it set `value.l` at the end

Some aspects of the bugs addressed here are a regression caused by https://github.com/godotengine/godot/pull/107075 (which I discovered after rebasing https://github.com/godotengine/godot/pull/111732), but some are pre-existing problems.