### PR TITLE
Check if OpenXR is enabled with feature tags of export preset

### DIFF
--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -109,17 +109,15 @@ static Ref<OpenXRInterface> openxr_interface;
 #ifdef TOOLS_ENABLED
 static void _editor_init() {
 	if (OpenXRAPI::openxr_is_enabled(false)) {
-		// Only add our OpenXR action map editor if OpenXR is enabled for our project
-
 		if (openxr_interaction_profile_metadata == nullptr) {
 			// If we didn't initialize our actionmap metadata at startup, we initialize it now.
 			openxr_interaction_profile_metadata = memnew(OpenXRInteractionProfileMetadata);
 			ERR_FAIL_NULL(openxr_interaction_profile_metadata);
 		}
-
-		OpenXREditorPlugin *openxr_plugin = memnew(OpenXREditorPlugin());
-		EditorNode::get_singleton()->add_editor_plugin(openxr_plugin);
 	}
+
+	OpenXREditorPlugin *openxr_plugin = memnew(OpenXREditorPlugin());
+	EditorNode::get_singleton()->add_editor_plugin(openxr_plugin);
 }
 #endif
 


### PR DESCRIPTION
This fixes a regression caused by https://github.com/godotengine/godot/pull/106891 that I noticed when exporting "Museum of All Things" with Godot master

MOAT has some export presets that have OpenXR enabled and some that don't - this is being done with feature tags:

<img width="679" height="71" alt="Selection_407" src="https://github.com/user-attachments/assets/8b4a3851-2191-4e11-a4cf-89b3a323e340" />

This worked fine in Godot 4.4 and 4.5 with the godot_openxr_vendors plugin

The problem is that the export plugin that will include the Khronos OpenXR loader will only be added to the editor if the main `xr/openxr/enabled` setting is set. However, the Gradle build will still remove the OpenXR loader from the godot_openxr_vendors plugin regardless.

So, this PR makes it so that the export plugin is always added, but then it'll check the project setting while considering the feature tags used by the export preset that is being exported (via `EditorExportPlatform::get_project_setting()`)

This isn't as "clean" as it could be, because the same editor plugin that adds the action map editor adds the export plugin, so we can no longer enable/disable that based on the main OpenXR setting. This could be cleaner if we had two editor plugins (one to add the export plugin, and another for the action map editor), but this really affects such a tiny amount of code, I'm not sure it's worth it?