### PR TITLE
Fix SplitContainer crash on change type

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -750,7 +750,7 @@ void SplitContainer::_resort() {
 
 void SplitContainer::_update_draggers() {
 	const int valid_child_count = (int)valid_children.size();
-	const int dragger_count = valid_child_count - 1;
+	const int dragger_count = MAX(valid_child_count - 1, 1);
 	const int draggers_size_diff = dragger_count - (int)dragging_area_controls.size();
 
 	// Add new draggers.
@@ -768,7 +768,10 @@ void SplitContainer::_update_draggers() {
 		const int remove_at = (int)dragging_area_controls.size() - 1;
 		SplitContainerDragger *dragger = dragging_area_controls[remove_at];
 		dragging_area_controls.remove_at(remove_at);
-		remove_child(dragger);
+		// replace_by removes all children, so make sure it is a child before removing.
+		if (dragger->get_parent() == this) {
+			remove_child(dragger);
+		}
 		memdelete(dragger);
 	}
 


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/113158

The crash was happening because `_update_draggers` expects to never be called if there is 0 or 1 valid children, but it is deferred so it can be.

There is also errors printed about removing children that aren't children, so I added a check for that.

It looks like replacing nodes doesn't delete their internal children, but it does unparent them. I'm not sure if that behavior is correct, but I'll leave it to a future PR.
