### PR TITLE
GLTF: Use `const Vector` internally instead of `TypedArray` copies

### DIFF
--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -136,3 +136,41 @@ GH-109302
 Validate extension JSON: Error: Field 'classes/OpenXRExtensionWrapper/methods/_set_instance_create_info_and_get_next_pointer/arguments': size changed value in new API, from 1 to 2.
 Validate extension JSON: Error: Field 'classes/OpenXRExtensionWrapper/methods/_set_instance_create_info_and_get_next_pointer/arguments/0': type changed value in new API, from "void*" to "int".
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/OpenXRExtensionWrapper/methods/_get_requested_extensions': arguments
+
+
+GH-113172
+---------
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_accessors': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_additional_data': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_animation_player': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_animation_players_count': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_animations': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_base_path': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_buffer_views': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_buffers': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_cameras': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_create_animations': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_glb_data': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_handle_binary_image': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_images': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_import_as_skeleton_bones': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_json': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_lights': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_major_version': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_materials': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_meshes': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_minor_version': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_node_index': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_nodes': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_root_nodes': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_scene_name': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_scene_node': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_skeletons': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_skins': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_texture_samplers': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_textures': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_unique_animation_names': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_unique_names': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_use_named_skin_binds': is_const changed value in new API, from false to true.
+
+GLTFState getters made const. Compatibility methods registered.

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -39,12 +39,12 @@
 				The [param parent_node_index] parameter is the index of the parent [GLTFNode] in the state. If [code]-1[/code], the node will be a root node, otherwise the new node will be added to the parent's list of children. The index will also be written to the [member GLTFNode.parent] property of the new node.
 			</description>
 		</method>
-		<method name="get_accessors">
+		<method name="get_accessors" qualifiers="const">
 			<return type="GLTFAccessor[]" />
 			<description>
 			</description>
 		</method>
-		<method name="get_additional_data">
+		<method name="get_additional_data" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="extension_name" type="StringName" />
 			<description>
@@ -52,67 +52,67 @@
 				The argument should be the [GLTFDocumentExtension] name (does not have to match the extension name in the glTF file), and the return value can be anything you set. If nothing was set, the return value is [code]null[/code].
 			</description>
 		</method>
-		<method name="get_animation_player">
+		<method name="get_animation_player" qualifiers="const">
 			<return type="AnimationPlayer" />
-			<param index="0" name="idx" type="int" />
+			<param index="0" name="anim_player_index" type="int" />
 			<description>
 				Returns the [AnimationPlayer] node with the given index. These nodes are only used during the export process when converting Godot [AnimationPlayer] nodes to glTF animations.
 			</description>
 		</method>
-		<method name="get_animation_players_count">
+		<method name="get_animation_players_count" qualifiers="const">
 			<return type="int" />
-			<param index="0" name="idx" type="int" />
+			<param index="0" name="anim_player_index" type="int" />
 			<description>
 				Returns the number of [AnimationPlayer] nodes in this [GLTFState]. These nodes are only used during the export process when converting Godot [AnimationPlayer] nodes to glTF animations.
 			</description>
 		</method>
-		<method name="get_animations">
+		<method name="get_animations" qualifiers="const">
 			<return type="GLTFAnimation[]" />
 			<description>
 				Returns an array of all [GLTFAnimation]s in the glTF file. When importing, these will be generated as animations in an [AnimationPlayer] node. When exporting, these will be generated from Godot [AnimationPlayer] nodes.
 			</description>
 		</method>
-		<method name="get_buffer_views">
+		<method name="get_buffer_views" qualifiers="const">
 			<return type="GLTFBufferView[]" />
 			<description>
 			</description>
 		</method>
-		<method name="get_cameras">
+		<method name="get_cameras" qualifiers="const">
 			<return type="GLTFCamera[]" />
 			<description>
 				Returns an array of all [GLTFCamera]s in the glTF file. These are the cameras that the [member GLTFNode.camera] index refers to.
 			</description>
 		</method>
-		<method name="get_handle_binary_image" deprecated="Use [member handle_binary_image_mode] instead.">
+		<method name="get_handle_binary_image" qualifiers="const" deprecated="Use [member handle_binary_image_mode] instead.">
 			<return type="int" />
 			<description>
 				Deprecated untyped alias for [member handle_binary_image_mode]. When importing a glTF file with unimported raw binary images embedded inside of binary blob buffers, in data URIs, or separate files not imported by Godot, this controls how the images are handled.
 			</description>
 		</method>
-		<method name="get_images">
+		<method name="get_images" qualifiers="const">
 			<return type="Texture2D[]" />
 			<description>
 				Gets the images of the glTF file as an array of [Texture2D]s. These are the images that the [member GLTFTexture.src_image] index refers to.
 			</description>
 		</method>
-		<method name="get_lights">
+		<method name="get_lights" qualifiers="const">
 			<return type="GLTFLight[]" />
 			<description>
 				Returns an array of all [GLTFLight]s in the glTF file. These are the lights that the [member GLTFNode.light] index refers to.
 			</description>
 		</method>
-		<method name="get_materials">
+		<method name="get_materials" qualifiers="const">
 			<return type="Material[]" />
 			<description>
 			</description>
 		</method>
-		<method name="get_meshes">
+		<method name="get_meshes" qualifiers="const">
 			<return type="GLTFMesh[]" />
 			<description>
 				Returns an array of all [GLTFMesh]es in the glTF file. These are the meshes that the [member GLTFNode.mesh] index refers to.
 			</description>
 		</method>
-		<method name="get_node_index">
+		<method name="get_node_index" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="scene_node" type="Node" />
 			<description>
@@ -120,50 +120,50 @@
 				[b]Note:[/b] Not every Godot scene node will have a corresponding [GLTFNode], and not every [GLTFNode] will have a scene node generated. If there is no [GLTFNode] index for this scene node, [code]-1[/code] is returned.
 			</description>
 		</method>
-		<method name="get_nodes">
+		<method name="get_nodes" qualifiers="const">
 			<return type="GLTFNode[]" />
 			<description>
 				Returns an array of all [GLTFNode]s in the glTF file. These are the nodes that [member GLTFNode.children] and [member root_nodes] refer to. This includes nodes that may not be generated in the Godot scene, or nodes that may generate multiple Godot scene nodes.
 			</description>
 		</method>
-		<method name="get_scene_node">
+		<method name="get_scene_node" qualifiers="const">
 			<return type="Node" />
-			<param index="0" name="idx" type="int" />
+			<param index="0" name="gltf_node_index" type="int" />
 			<description>
 				Returns the Godot scene node that corresponds to the same index as the [GLTFNode] it was generated from. This is the inverse of [method get_node_index]. Useful during the import process.
 				[b]Note:[/b] Not every [GLTFNode] will have a scene node generated, and not every generated scene node will have a corresponding [GLTFNode]. If there is no scene node for this [GLTFNode] index, [code]null[/code] is returned.
 			</description>
 		</method>
-		<method name="get_skeletons">
+		<method name="get_skeletons" qualifiers="const">
 			<return type="GLTFSkeleton[]" />
 			<description>
 				Returns an array of all [GLTFSkeleton]s in the glTF file. These are the skeletons that the [member GLTFNode.skeleton] index refers to.
 			</description>
 		</method>
-		<method name="get_skins">
+		<method name="get_skins" qualifiers="const">
 			<return type="GLTFSkin[]" />
 			<description>
 				Returns an array of all [GLTFSkin]s in the glTF file. These are the skins that the [member GLTFNode.skin] index refers to.
 			</description>
 		</method>
-		<method name="get_texture_samplers">
+		<method name="get_texture_samplers" qualifiers="const">
 			<return type="GLTFTextureSampler[]" />
 			<description>
 				Retrieves the array of texture samplers that are used by the textures contained in the glTF.
 			</description>
 		</method>
-		<method name="get_textures">
+		<method name="get_textures" qualifiers="const">
 			<return type="GLTFTexture[]" />
 			<description>
 			</description>
 		</method>
-		<method name="get_unique_animation_names">
+		<method name="get_unique_animation_names" qualifiers="const">
 			<return type="String[]" />
 			<description>
 				Returns an array of unique animation names. This is only used during the import process.
 			</description>
 		</method>
-		<method name="get_unique_names">
+		<method name="get_unique_names" qualifiers="const">
 			<return type="String[]" />
 			<description>
 				Returns an array of unique node names. This is used in both the import process and export process.

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -145,16 +145,16 @@ Error GLTFDocumentExtensionPhysics::parse_node_extensions(Ref<GLTFState> p_state
 	return OK;
 }
 
-bool _will_gltf_shape_become_subnode(Ref<GLTFState> p_state, const Ref<GLTFNode> p_gltf_node, GLTFNodeIndex p_gltf_node_index) {
+bool _will_gltf_shape_become_subnode(const Ref<GLTFState> &p_state, const Ref<GLTFNode> &p_gltf_node, GLTFNodeIndex p_gltf_node_index) {
 	if (p_gltf_node->has_additional_data(StringName("GLTFPhysicsBody"))) {
 		return true;
 	}
-	const TypedArray<GLTFNode> state_gltf_nodes = p_state->get_nodes();
+	const Vector<Ref<GLTFNode>> &state_gltf_nodes = p_state->get_nodes();
 	const GLTFNodeIndex parent_index = p_gltf_node->get_parent();
 	if (parent_index == -1 || parent_index >= state_gltf_nodes.size()) {
 		return true;
 	}
-	const Ref<GLTFNode> parent_gltf_node = state_gltf_nodes[parent_index];
+	const Ref<GLTFNode> &parent_gltf_node = state_gltf_nodes[parent_index];
 	const Variant parent_body_maybe = parent_gltf_node->get_additional_data(StringName("GLTFPhysicsBody"));
 	if (parent_body_maybe.get_type() != Variant::NIL) {
 		Ref<GLTFPhysicsBody> parent_body = parent_body_maybe;
@@ -181,10 +181,10 @@ bool _will_gltf_shape_become_subnode(Ref<GLTFState> p_state, const Ref<GLTFNode>
 	return true;
 }
 
-NodePath _get_scene_node_path_for_shape_index(Ref<GLTFState> p_state, const GLTFNodeIndex p_shape_index) {
-	TypedArray<GLTFNode> state_gltf_nodes = p_state->get_nodes();
+NodePath _get_scene_node_path_for_shape_index(const Ref<GLTFState> &p_state, const GLTFNodeIndex p_shape_index) {
+	const Vector<Ref<GLTFNode>> &state_gltf_nodes = p_state->get_nodes();
 	for (GLTFNodeIndex node_index = 0; node_index < state_gltf_nodes.size(); node_index++) {
-		const Ref<GLTFNode> gltf_node = state_gltf_nodes[node_index];
+		const Ref<GLTFNode> &gltf_node = state_gltf_nodes[node_index];
 		ERR_CONTINUE(gltf_node.is_null());
 		// Check if this node has a shape index and if it matches the one we are looking for.
 		Variant shape_index_maybe = gltf_node->get_additional_data(StringName("GLTFPhysicsColliderShapeIndex"));
@@ -247,9 +247,9 @@ Ref<GLTFObjectModelProperty> GLTFDocumentExtensionPhysics::import_object_model_p
 	} else if (p_split_json_pointer[0] == "nodes" && p_split_json_pointer[2] == "extensions" && p_split_json_pointer[4] == "motion") {
 		if (p_split_json_pointer[3] == "OMI_physics_body" || p_split_json_pointer[3] == "KHR_physics_rigid_bodies") {
 			const GLTFNodeIndex node_index = p_split_json_pointer[1].to_int();
-			const TypedArray<GLTFNode> all_gltf_nodes = p_state->get_nodes();
+			const Vector<Ref<GLTFNode>> &all_gltf_nodes = p_state->get_nodes();
 			ERR_FAIL_INDEX_V_MSG(node_index, all_gltf_nodes.size(), ret, "GLTF Physics: The node index " + itos(node_index) + " is not in the state nodes (size: " + itos(all_gltf_nodes.size()) + ").");
-			const Ref<GLTFNode> gltf_node = all_gltf_nodes[node_index];
+			const Ref<GLTFNode> &gltf_node = all_gltf_nodes[node_index];
 			NodePath node_path;
 			if (p_partial_paths.is_empty()) {
 				node_path = gltf_node->get_scene_node_path(p_state);
@@ -283,7 +283,7 @@ Ref<GLTFObjectModelProperty> GLTFDocumentExtensionPhysics::import_object_model_p
 	return ret;
 }
 
-void _setup_shape_mesh_resource_from_index_if_needed(Ref<GLTFState> p_state, Ref<GLTFPhysicsShape> p_gltf_shape) {
+void _setup_shape_mesh_resource_from_index_if_needed(const Ref<GLTFState> &p_state, const Ref<GLTFPhysicsShape> &p_gltf_shape) {
 	GLTFMeshIndex shape_mesh_index = p_gltf_shape->get_mesh_index();
 	if (shape_mesh_index == -1) {
 		return; // No mesh for this shape.
@@ -292,9 +292,9 @@ void _setup_shape_mesh_resource_from_index_if_needed(Ref<GLTFState> p_state, Ref
 	if (importer_mesh.is_valid()) {
 		return; // The mesh resource is already set up.
 	}
-	TypedArray<GLTFMesh> state_meshes = p_state->get_meshes();
+	const Vector<Ref<GLTFMesh>> &state_meshes = p_state->get_meshes();
 	ERR_FAIL_INDEX_MSG(shape_mesh_index, state_meshes.size(), "glTF Physics: When importing '" + p_state->get_scene_name() + "', the shape mesh index " + itos(shape_mesh_index) + " is not in the state meshes (size: " + itos(state_meshes.size()) + ").");
-	Ref<GLTFMesh> gltf_mesh = state_meshes[shape_mesh_index];
+	const Ref<GLTFMesh> &gltf_mesh = state_meshes[shape_mesh_index];
 	ERR_FAIL_COND(gltf_mesh.is_null());
 	importer_mesh = gltf_mesh->get_mesh();
 	ERR_FAIL_COND(importer_mesh.is_null());
@@ -346,7 +346,7 @@ CollisionObject3D *_get_ancestor_collision_object(Node *p_scene_parent) {
 	return nullptr;
 }
 
-Node3D *_generate_shape_node_and_body_if_needed(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Ref<GLTFPhysicsShape> p_physics_shape, CollisionObject3D *p_col_object, bool p_is_trigger) {
+Node3D *_generate_shape_node_and_body_if_needed(const Ref<GLTFState> &p_state, const Ref<GLTFNode> &p_gltf_node, const Ref<GLTFPhysicsShape> &p_physics_shape, CollisionObject3D *p_col_object, bool p_is_trigger) {
 	// If we need to generate a body node, do so.
 	CollisionObject3D *body_node = nullptr;
 	if (p_is_trigger || p_physics_shape->get_is_trigger()) {
@@ -372,7 +372,7 @@ Node3D *_generate_shape_node_and_body_if_needed(Ref<GLTFState> p_state, Ref<GLTF
 }
 
 // Either add the child to the parent, or return the child if there is no parent.
-Node3D *_add_physics_node_to_given_node(Node3D *p_current_node, Node3D *p_child, Ref<GLTFNode> p_gltf_node) {
+Node3D *_add_physics_node_to_given_node(Node3D *p_current_node, Node3D *p_child, const Ref<GLTFNode> &p_gltf_node) {
 	if (!p_current_node) {
 		return p_child;
 	}
@@ -389,10 +389,10 @@ Node3D *_add_physics_node_to_given_node(Node3D *p_current_node, Node3D *p_child,
 	return p_current_node;
 }
 
-Array _get_ancestor_compound_trigger_nodes(Ref<GLTFState> p_state, TypedArray<GLTFNode> p_state_nodes, CollisionObject3D *p_ancestor_col_obj) {
+Array _get_ancestor_compound_trigger_nodes(const Ref<GLTFState> &p_state, const Vector<Ref<GLTFNode>> &p_state_nodes, CollisionObject3D *p_ancestor_col_obj) {
 	GLTFNodeIndex ancestor_index = p_state->get_node_index(p_ancestor_col_obj);
 	ERR_FAIL_INDEX_V(ancestor_index, p_state_nodes.size(), Array());
-	Ref<GLTFNode> ancestor_gltf_node = p_state_nodes[ancestor_index];
+	const Ref<GLTFNode> &ancestor_gltf_node = p_state_nodes[ancestor_index];
 	Variant compound_trigger_nodes = ancestor_gltf_node->get_additional_data(StringName("GLTFPhysicsCompoundTriggerNodes"));
 	if (compound_trigger_nodes.is_array()) {
 		return compound_trigger_nodes;
@@ -439,7 +439,7 @@ Node3D *GLTFDocumentExtensionPhysics::generate_scene_node(Ref<GLTFState> p_state
 		ancestor_col_obj = _get_ancestor_collision_object(p_scene_parent);
 		if (Object::cast_to<Area3D>(ancestor_col_obj) && gltf_physics_trigger_shape.is_valid()) {
 			// At this point, we found an ancestor Area3D node. But do we want to use it for this trigger shape?
-			TypedArray<GLTFNode> state_nodes = p_state->get_nodes();
+			const Vector<Ref<GLTFNode>> &state_nodes = p_state->get_nodes();
 			GLTFNodeIndex self_index = state_nodes.find(p_gltf_node);
 			Array compound_trigger_nodes = _get_ancestor_compound_trigger_nodes(p_state, state_nodes, ancestor_col_obj);
 			// Check if the ancestor specifies compound trigger nodes, and if this node is in there.
@@ -497,13 +497,13 @@ bool _are_all_faces_equal(const Vector<Face3> &p_a, const Vector<Face3> &p_b) {
 	return true;
 }
 
-GLTFMeshIndex _get_or_insert_mesh_in_state(Ref<GLTFState> p_state, Ref<ImporterMesh> p_mesh) {
+GLTFMeshIndex _get_or_insert_mesh_in_state(const Ref<GLTFState> &p_state, const Ref<ImporterMesh> &p_mesh) {
 	ERR_FAIL_COND_V(p_mesh.is_null(), -1);
-	TypedArray<GLTFMesh> state_meshes = p_state->get_meshes();
+	Vector<Ref<GLTFMesh>> state_meshes = p_state->get_meshes();
 	Vector<Face3> mesh_faces = p_mesh->get_faces();
 	// De-duplication: If the state already has the mesh we need, use that one.
 	for (GLTFMeshIndex i = 0; i < state_meshes.size(); i++) {
-		Ref<GLTFMesh> state_gltf_mesh = state_meshes[i];
+		const Ref<GLTFMesh> &state_gltf_mesh = state_meshes[i];
 		ERR_CONTINUE(state_gltf_mesh.is_null());
 		Ref<ImporterMesh> state_importer_mesh = state_gltf_mesh->get_mesh();
 		ERR_CONTINUE(state_importer_mesh.is_null());
@@ -540,7 +540,7 @@ void GLTFDocumentExtensionPhysics::convert_scene_node(Ref<GLTFState> p_state, Re
 		if (cast_to<Area3D>(ancestor_col_obj)) {
 			p_gltf_node->set_additional_data(StringName("GLTFPhysicsTriggerShape"), gltf_shape);
 			// Write explicit member shape nodes to the ancestor compound trigger node.
-			TypedArray<GLTFNode> state_nodes = p_state->get_nodes();
+			const Vector<Ref<GLTFNode>> &state_nodes = p_state->get_nodes();
 			GLTFNodeIndex self_index = state_nodes.size(); // The current p_gltf_node will be inserted next.
 			Array compound_trigger_nodes = _get_ancestor_compound_trigger_nodes(p_state, p_state->get_nodes(), ancestor_col_obj);
 			compound_trigger_nodes.push_back(double(self_index));
@@ -553,7 +553,7 @@ void GLTFDocumentExtensionPhysics::convert_scene_node(Ref<GLTFState> p_state, Re
 	}
 }
 
-Array _get_or_create_state_shapes_in_state(Ref<GLTFState> p_state) {
+Array _get_or_create_state_shapes_in_state(const Ref<GLTFState> &p_state) {
 	Dictionary state_json = p_state->get_json();
 	Dictionary state_extensions;
 	if (state_json.has("extensions")) {
@@ -577,7 +577,7 @@ Array _get_or_create_state_shapes_in_state(Ref<GLTFState> p_state) {
 	return state_shapes;
 }
 
-GLTFShapeIndex _export_node_shape(Ref<GLTFState> p_state, Ref<GLTFPhysicsShape> p_physics_shape) {
+GLTFShapeIndex _export_node_shape(const Ref<GLTFState> &p_state, const Ref<GLTFPhysicsShape> &p_physics_shape) {
 	Array state_shapes = _get_or_create_state_shapes_in_state(p_state);
 	GLTFShapeIndex size = state_shapes.size();
 	Dictionary shape_property;
@@ -597,14 +597,14 @@ GLTFShapeIndex _export_node_shape(Ref<GLTFState> p_state, Ref<GLTFPhysicsShape> 
 
 Error GLTFDocumentExtensionPhysics::export_preserialize(Ref<GLTFState> p_state) {
 	// Note: Need to do _export_node_shape before exporting animations, so export_node is too late.
-	TypedArray<GLTFNode> state_gltf_nodes = p_state->get_nodes();
+	const Vector<Ref<GLTFNode>> &state_gltf_nodes = p_state->get_nodes();
 	for (Ref<GLTFNode> gltf_node : state_gltf_nodes) {
-		Ref<GLTFPhysicsShape> collider_shape = gltf_node->get_additional_data(StringName("GLTFPhysicsColliderShape"));
+		const Ref<GLTFPhysicsShape> collider_shape = gltf_node->get_additional_data(StringName("GLTFPhysicsColliderShape"));
 		if (collider_shape.is_valid()) {
 			GLTFShapeIndex collider_shape_index = _export_node_shape(p_state, collider_shape);
 			gltf_node->set_additional_data(StringName("GLTFPhysicsColliderShapeIndex"), collider_shape_index);
 		}
-		Ref<GLTFPhysicsShape> trigger_shape = gltf_node->get_additional_data(StringName("GLTFPhysicsTriggerShape"));
+		const Ref<GLTFPhysicsShape> trigger_shape = gltf_node->get_additional_data(StringName("GLTFPhysicsTriggerShape"));
 		if (trigger_shape.is_valid()) {
 			GLTFShapeIndex trigger_shape_index = _export_node_shape(p_state, trigger_shape);
 			gltf_node->set_additional_data(StringName("GLTFPhysicsTriggerShapeIndex"), trigger_shape_index);
@@ -661,9 +661,9 @@ Ref<GLTFObjectModelProperty> GLTFDocumentExtensionPhysics::export_object_model_p
 		split_json_pointer.append("extensions");
 		split_json_pointer.append("OMI_physics_shape");
 		split_json_pointer.append("shapes");
-		TypedArray<GLTFNode> state_gltf_nodes = p_state->get_nodes();
+		const Vector<Ref<GLTFNode>> &state_gltf_nodes = p_state->get_nodes();
 		ERR_FAIL_INDEX_V(p_gltf_node_index, state_gltf_nodes.size(), ret);
-		Ref<GLTFNode> gltf_node = state_gltf_nodes[p_gltf_node_index];
+		const Ref<GLTFNode> &gltf_node = state_gltf_nodes[p_gltf_node_index];
 		Variant shape_index_maybe = gltf_node->get_additional_data(StringName("GLTFPhysicsColliderShapeIndex"));
 		String shape_type;
 		if (shape_index_maybe.get_type() == Variant::INT) {

--- a/modules/gltf/gltf_state.compat.inc
+++ b/modules/gltf/gltf_state.compat.inc
@@ -1,0 +1,212 @@
+/**************************************************************************/
+/*  gltf_state.compat.inc                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+// Non-const getters for compatibility.
+int32_t GLTFState::_get_handle_binary_image_bind_compat_113172() {
+	return get_handle_binary_image();
+}
+
+Dictionary GLTFState::_get_json_bind_compat_113172() {
+	return get_json();
+}
+
+int GLTFState::_get_major_version_bind_compat_113172() {
+	return get_major_version();
+}
+
+int GLTFState::_get_minor_version_bind_compat_113172() {
+	return get_minor_version();
+}
+
+Vector<uint8_t> GLTFState::_get_glb_data_bind_compat_113172() {
+	return get_glb_data();
+}
+
+bool GLTFState::_get_use_named_skin_binds_bind_compat_113172() {
+	return get_use_named_skin_binds();
+}
+
+bool GLTFState::_get_discard_meshes_and_materials_bind_compat_113172() {
+	return get_discard_meshes_and_materials();
+}
+
+TypedArray<GLTFNode> GLTFState::_get_nodes_bind_compat_113172() {
+	return get_nodes_bind();
+}
+
+TypedArray<PackedByteArray> GLTFState::_get_buffers_bind_compat_113172() {
+	return get_buffers_bind();
+}
+
+TypedArray<GLTFBufferView> GLTFState::_get_buffer_views_bind_compat_113172() {
+	return get_buffer_views_bind();
+}
+
+TypedArray<GLTFAccessor> GLTFState::_get_accessors_bind_compat_113172() {
+	return get_accessors_bind();
+}
+
+TypedArray<GLTFMesh> GLTFState::_get_meshes_bind_compat_113172() {
+	return get_meshes_bind();
+}
+
+TypedArray<Material> GLTFState::_get_materials_bind_compat_113172() {
+	return get_materials_bind();
+}
+
+String GLTFState::_get_scene_name_bind_compat_113172() {
+	return get_scene_name();
+}
+
+String GLTFState::_get_base_path_bind_compat_113172() {
+	return get_base_path();
+}
+
+String GLTFState::_get_extract_path_bind_compat_113172() {
+	return get_extract_path();
+}
+
+String GLTFState::_get_extract_prefix_bind_compat_113172() {
+	return get_extract_prefix();
+}
+
+PackedInt32Array GLTFState::_get_root_nodes_bind_compat_113172() {
+	return get_root_nodes();
+}
+
+TypedArray<GLTFTexture> GLTFState::_get_textures_bind_compat_113172() {
+	return get_textures_bind();
+}
+
+TypedArray<GLTFTextureSampler> GLTFState::_get_texture_samplers_bind_compat_113172() {
+	return get_texture_samplers_bind();
+}
+
+TypedArray<Texture2D> GLTFState::_get_images_bind_compat_113172() {
+	return get_images_bind();
+}
+
+TypedArray<GLTFSkin> GLTFState::_get_skins_bind_compat_113172() {
+	return get_skins_bind();
+}
+
+TypedArray<GLTFCamera> GLTFState::_get_cameras_bind_compat_113172() {
+	return get_cameras_bind();
+}
+
+TypedArray<GLTFLight> GLTFState::_get_lights_bind_compat_113172() {
+	return get_lights_bind();
+}
+
+TypedArray<String> GLTFState::_get_unique_names_bind_compat_113172() {
+	return get_unique_names_bind();
+}
+
+TypedArray<String> GLTFState::_get_unique_animation_names_bind_compat_113172() {
+	return get_unique_animation_names_bind();
+}
+
+TypedArray<GLTFSkeleton> GLTFState::_get_skeletons_bind_compat_113172() {
+	return get_skeletons_bind();
+}
+
+bool GLTFState::_get_create_animations_bind_compat_113172() {
+	return get_create_animations();
+}
+
+bool GLTFState::_get_import_as_skeleton_bones_bind_compat_113172() {
+	return get_import_as_skeleton_bones();
+}
+
+TypedArray<GLTFAnimation> GLTFState::_get_animations_bind_compat_113172() {
+	return get_animations_bind();
+}
+
+Node *GLTFState::_get_scene_node_bind_compat_113172(GLTFNodeIndex p_gltf_node_index) {
+	return get_scene_node(p_gltf_node_index);
+}
+
+GLTFNodeIndex GLTFState::_get_node_index_bind_compat_113172(Node *p_node) {
+	return get_node_index(p_node);
+}
+
+int GLTFState::_get_animation_players_count_bind_compat_113172(int p_anim_player_index) {
+	return get_animation_players_count(p_anim_player_index);
+}
+
+AnimationPlayer *GLTFState::_get_animation_player_bind_compat_113172(int p_anim_player_index) {
+	return get_animation_player(p_anim_player_index);
+}
+
+Variant GLTFState::_get_additional_data_bind_compat_113172(const StringName &p_extension_name) {
+	return get_additional_data(p_extension_name);
+}
+
+void GLTFState::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_handle_binary_image"), &GLTFState::_get_handle_binary_image_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_json"), &GLTFState::_get_json_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_major_version"), &GLTFState::_get_major_version_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_minor_version"), &GLTFState::_get_minor_version_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_glb_data"), &GLTFState::_get_glb_data_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_use_named_skin_binds"), &GLTFState::_get_use_named_skin_binds_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_discard_meshes_and_materials"), &GLTFState::_get_discard_meshes_and_materials_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_nodes"), &GLTFState::_get_nodes_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_buffers"), &GLTFState::_get_buffers_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_buffer_views"), &GLTFState::_get_buffer_views_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_accessors"), &GLTFState::_get_accessors_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_meshes"), &GLTFState::_get_meshes_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_materials"), &GLTFState::_get_materials_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_scene_name"), &GLTFState::_get_scene_name_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_base_path"), &GLTFState::_get_base_path_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_extract_path"), &GLTFState::_get_extract_path_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_extract_prefix"), &GLTFState::_get_extract_prefix_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_root_nodes"), &GLTFState::_get_root_nodes_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_textures"), &GLTFState::_get_textures_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_texture_samplers"), &GLTFState::_get_texture_samplers_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_images"), &GLTFState::_get_images_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_skins"), &GLTFState::_get_skins_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_cameras"), &GLTFState::_get_cameras_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_lights"), &GLTFState::_get_lights_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_unique_names"), &GLTFState::_get_unique_names_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_unique_animation_names"), &GLTFState::_get_unique_animation_names_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_skeletons"), &GLTFState::_get_skeletons_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_create_animations"), &GLTFState::_get_create_animations_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_import_as_skeleton_bones"), &GLTFState::_get_import_as_skeleton_bones_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_animations"), &GLTFState::_get_animations_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_scene_node", "idx"), &GLTFState::_get_scene_node_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_node_index", "node"), &GLTFState::_get_node_index_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_animation_players_count", "idx"), &GLTFState::_get_animation_players_count_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_animation_player", "idx"), &GLTFState::_get_animation_player_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_additional_data", "extension_name"), &GLTFState::_get_additional_data_bind_compat_113172);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "gltf_state.h"
+#include "gltf_state.compat.inc"
 
 #include "gltf_template_convert.h"
 
@@ -49,20 +50,20 @@ void GLTFState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_glb_data", "glb_data"), &GLTFState::set_glb_data);
 	ClassDB::bind_method(D_METHOD("get_use_named_skin_binds"), &GLTFState::get_use_named_skin_binds);
 	ClassDB::bind_method(D_METHOD("set_use_named_skin_binds", "use_named_skin_binds"), &GLTFState::set_use_named_skin_binds);
-	ClassDB::bind_method(D_METHOD("get_nodes"), &GLTFState::get_nodes);
-	ClassDB::bind_method(D_METHOD("set_nodes", "nodes"), &GLTFState::set_nodes);
-	ClassDB::bind_method(D_METHOD("get_buffers"), &GLTFState::get_buffers);
-	ClassDB::bind_method(D_METHOD("set_buffers", "buffers"), &GLTFState::set_buffers);
-	ClassDB::bind_method(D_METHOD("get_buffer_views"), &GLTFState::get_buffer_views);
-	ClassDB::bind_method(D_METHOD("set_buffer_views", "buffer_views"), &GLTFState::set_buffer_views);
-	ClassDB::bind_method(D_METHOD("get_accessors"), &GLTFState::get_accessors);
-	ClassDB::bind_method(D_METHOD("set_accessors", "accessors"), &GLTFState::set_accessors);
-	ClassDB::bind_method(D_METHOD("get_meshes"), &GLTFState::get_meshes);
-	ClassDB::bind_method(D_METHOD("set_meshes", "meshes"), &GLTFState::set_meshes);
-	ClassDB::bind_method(D_METHOD("get_animation_players_count", "idx"), &GLTFState::get_animation_players_count);
-	ClassDB::bind_method(D_METHOD("get_animation_player", "idx"), &GLTFState::get_animation_player);
-	ClassDB::bind_method(D_METHOD("get_materials"), &GLTFState::get_materials);
-	ClassDB::bind_method(D_METHOD("set_materials", "materials"), &GLTFState::set_materials);
+	ClassDB::bind_method(D_METHOD("get_nodes"), &GLTFState::get_nodes_bind);
+	ClassDB::bind_method(D_METHOD("set_nodes", "nodes"), &GLTFState::set_nodes_bind);
+	ClassDB::bind_method(D_METHOD("get_buffers"), &GLTFState::get_buffers_bind);
+	ClassDB::bind_method(D_METHOD("set_buffers", "buffers"), &GLTFState::set_buffers_bind);
+	ClassDB::bind_method(D_METHOD("get_buffer_views"), &GLTFState::get_buffer_views_bind);
+	ClassDB::bind_method(D_METHOD("set_buffer_views", "buffer_views"), &GLTFState::set_buffer_views_bind);
+	ClassDB::bind_method(D_METHOD("get_accessors"), &GLTFState::get_accessors_bind);
+	ClassDB::bind_method(D_METHOD("set_accessors", "accessors"), &GLTFState::set_accessors_bind);
+	ClassDB::bind_method(D_METHOD("get_meshes"), &GLTFState::get_meshes_bind);
+	ClassDB::bind_method(D_METHOD("set_meshes", "meshes"), &GLTFState::set_meshes_bind);
+	ClassDB::bind_method(D_METHOD("get_animation_players_count", "anim_player_index"), &GLTFState::get_animation_players_count);
+	ClassDB::bind_method(D_METHOD("get_animation_player", "anim_player_index"), &GLTFState::get_animation_player);
+	ClassDB::bind_method(D_METHOD("get_materials"), &GLTFState::get_materials_bind);
+	ClassDB::bind_method(D_METHOD("set_materials", "materials"), &GLTFState::set_materials_bind);
 	ClassDB::bind_method(D_METHOD("get_scene_name"), &GLTFState::get_scene_name);
 	ClassDB::bind_method(D_METHOD("set_scene_name", "scene_name"), &GLTFState::set_scene_name);
 	ClassDB::bind_method(D_METHOD("get_base_path"), &GLTFState::get_base_path);
@@ -71,31 +72,31 @@ void GLTFState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_filename", "filename"), &GLTFState::set_filename);
 	ClassDB::bind_method(D_METHOD("get_root_nodes"), &GLTFState::get_root_nodes);
 	ClassDB::bind_method(D_METHOD("set_root_nodes", "root_nodes"), &GLTFState::set_root_nodes);
-	ClassDB::bind_method(D_METHOD("get_textures"), &GLTFState::get_textures);
-	ClassDB::bind_method(D_METHOD("set_textures", "textures"), &GLTFState::set_textures);
-	ClassDB::bind_method(D_METHOD("get_texture_samplers"), &GLTFState::get_texture_samplers);
-	ClassDB::bind_method(D_METHOD("set_texture_samplers", "texture_samplers"), &GLTFState::set_texture_samplers);
-	ClassDB::bind_method(D_METHOD("get_images"), &GLTFState::get_images);
-	ClassDB::bind_method(D_METHOD("set_images", "images"), &GLTFState::set_images);
-	ClassDB::bind_method(D_METHOD("get_skins"), &GLTFState::get_skins);
-	ClassDB::bind_method(D_METHOD("set_skins", "skins"), &GLTFState::set_skins);
-	ClassDB::bind_method(D_METHOD("get_cameras"), &GLTFState::get_cameras);
-	ClassDB::bind_method(D_METHOD("set_cameras", "cameras"), &GLTFState::set_cameras);
-	ClassDB::bind_method(D_METHOD("get_lights"), &GLTFState::get_lights);
-	ClassDB::bind_method(D_METHOD("set_lights", "lights"), &GLTFState::set_lights);
-	ClassDB::bind_method(D_METHOD("get_unique_names"), &GLTFState::get_unique_names);
-	ClassDB::bind_method(D_METHOD("set_unique_names", "unique_names"), &GLTFState::set_unique_names);
-	ClassDB::bind_method(D_METHOD("get_unique_animation_names"), &GLTFState::get_unique_animation_names);
-	ClassDB::bind_method(D_METHOD("set_unique_animation_names", "unique_animation_names"), &GLTFState::set_unique_animation_names);
-	ClassDB::bind_method(D_METHOD("get_skeletons"), &GLTFState::get_skeletons);
-	ClassDB::bind_method(D_METHOD("set_skeletons", "skeletons"), &GLTFState::set_skeletons);
+	ClassDB::bind_method(D_METHOD("get_textures"), &GLTFState::get_textures_bind);
+	ClassDB::bind_method(D_METHOD("set_textures", "textures"), &GLTFState::set_textures_bind);
+	ClassDB::bind_method(D_METHOD("get_texture_samplers"), &GLTFState::get_texture_samplers_bind);
+	ClassDB::bind_method(D_METHOD("set_texture_samplers", "texture_samplers"), &GLTFState::set_texture_samplers_bind);
+	ClassDB::bind_method(D_METHOD("get_images"), &GLTFState::get_images_bind);
+	ClassDB::bind_method(D_METHOD("set_images", "images"), &GLTFState::set_images_bind);
+	ClassDB::bind_method(D_METHOD("get_skins"), &GLTFState::get_skins_bind);
+	ClassDB::bind_method(D_METHOD("set_skins", "skins"), &GLTFState::set_skins_bind);
+	ClassDB::bind_method(D_METHOD("get_cameras"), &GLTFState::get_cameras_bind);
+	ClassDB::bind_method(D_METHOD("set_cameras", "cameras"), &GLTFState::set_cameras_bind);
+	ClassDB::bind_method(D_METHOD("get_lights"), &GLTFState::get_lights_bind);
+	ClassDB::bind_method(D_METHOD("set_lights", "lights"), &GLTFState::set_lights_bind);
+	ClassDB::bind_method(D_METHOD("get_unique_names"), &GLTFState::get_unique_names_bind);
+	ClassDB::bind_method(D_METHOD("set_unique_names", "unique_names"), &GLTFState::set_unique_names_bind);
+	ClassDB::bind_method(D_METHOD("get_unique_animation_names"), &GLTFState::get_unique_animation_names_bind);
+	ClassDB::bind_method(D_METHOD("set_unique_animation_names", "unique_animation_names"), &GLTFState::set_unique_animation_names_bind);
+	ClassDB::bind_method(D_METHOD("get_skeletons"), &GLTFState::get_skeletons_bind);
+	ClassDB::bind_method(D_METHOD("set_skeletons", "skeletons"), &GLTFState::set_skeletons_bind);
 	ClassDB::bind_method(D_METHOD("get_create_animations"), &GLTFState::get_create_animations);
 	ClassDB::bind_method(D_METHOD("set_create_animations", "create_animations"), &GLTFState::set_create_animations);
 	ClassDB::bind_method(D_METHOD("get_import_as_skeleton_bones"), &GLTFState::get_import_as_skeleton_bones);
 	ClassDB::bind_method(D_METHOD("set_import_as_skeleton_bones", "import_as_skeleton_bones"), &GLTFState::set_import_as_skeleton_bones);
-	ClassDB::bind_method(D_METHOD("get_animations"), &GLTFState::get_animations);
-	ClassDB::bind_method(D_METHOD("set_animations", "animations"), &GLTFState::set_animations);
-	ClassDB::bind_method(D_METHOD("get_scene_node", "idx"), &GLTFState::get_scene_node);
+	ClassDB::bind_method(D_METHOD("get_animations"), &GLTFState::get_animations_bind);
+	ClassDB::bind_method(D_METHOD("set_animations", "animations"), &GLTFState::set_animations_bind);
+	ClassDB::bind_method(D_METHOD("get_scene_node", "gltf_node_index"), &GLTFState::get_scene_node);
 	ClassDB::bind_method(D_METHOD("get_node_index", "scene_node"), &GLTFState::get_node_index);
 	ClassDB::bind_method(D_METHOD("get_additional_data", "extension_name"), &GLTFState::get_additional_data);
 	ClassDB::bind_method(D_METHOD("set_additional_data", "extension_name", "additional_data"), &GLTFState::set_additional_data);
@@ -140,6 +141,7 @@ void GLTFState::_bind_methods() {
 	BIND_ENUM_CONSTANT(HANDLE_BINARY_IMAGE_MODE_EMBED_AS_BASISU);
 	BIND_ENUM_CONSTANT(HANDLE_BINARY_IMAGE_MODE_EMBED_AS_UNCOMPRESSED);
 
+#ifndef DISABLE_DEPRECATED
 	// Deprecated non-type-safe versions for backward compatibility, remove in Godot 5.0.
 	ClassDB::bind_method(D_METHOD("get_handle_binary_image"), &GLTFState::get_handle_binary_image);
 	ClassDB::bind_method(D_METHOD("set_handle_binary_image", "method"), &GLTFState::set_handle_binary_image);
@@ -148,6 +150,7 @@ void GLTFState::_bind_methods() {
 	BIND_CONSTANT(HANDLE_BINARY_EXTRACT_TEXTURES);
 	BIND_CONSTANT(HANDLE_BINARY_EMBED_AS_BASISU);
 	BIND_CONSTANT(HANDLE_BINARY_EMBED_AS_UNCOMPRESSED);
+#endif // DISABLE_DEPRECATED
 }
 
 void GLTFState::add_used_extension(const String &p_extension_name, bool p_required) {
@@ -161,7 +164,7 @@ void GLTFState::add_used_extension(const String &p_extension_name, bool p_requir
 	}
 }
 
-Dictionary GLTFState::get_json() {
+Dictionary GLTFState::get_json() const {
 	return Dictionary(json);
 }
 
@@ -169,7 +172,7 @@ void GLTFState::set_json(const Dictionary &p_json) {
 	json = Dictionary(p_json);
 }
 
-int GLTFState::get_major_version() {
+int GLTFState::get_major_version() const {
 	return major_version;
 }
 
@@ -177,7 +180,7 @@ void GLTFState::set_major_version(int p_major_version) {
 	major_version = p_major_version;
 }
 
-int GLTFState::get_minor_version() {
+int GLTFState::get_minor_version() const {
 	return minor_version;
 }
 
@@ -193,7 +196,7 @@ void GLTFState::set_copyright(const String &p_copyright) {
 	copyright = p_copyright;
 }
 
-Vector<uint8_t> GLTFState::get_glb_data() {
+Vector<uint8_t> GLTFState::get_glb_data() const {
 	return Vector<uint8_t>(glb_data);
 }
 
@@ -201,7 +204,7 @@ void GLTFState::set_glb_data(const Vector<uint8_t> &p_glb_data) {
 	glb_data = Vector<uint8_t>(p_glb_data);
 }
 
-bool GLTFState::get_use_named_skin_binds() {
+bool GLTFState::get_use_named_skin_binds() const {
 	return use_named_skin_binds;
 }
 
@@ -209,55 +212,55 @@ void GLTFState::set_use_named_skin_binds(bool p_use_named_skin_binds) {
 	use_named_skin_binds = p_use_named_skin_binds;
 }
 
-TypedArray<GLTFNode> GLTFState::get_nodes() {
+TypedArray<GLTFNode> GLTFState::get_nodes_bind() const {
 	return GLTFTemplateConvert::to_array(nodes);
 }
 
-void GLTFState::set_nodes(const TypedArray<GLTFNode> &p_nodes) {
+void GLTFState::set_nodes_bind(const TypedArray<GLTFNode> &p_nodes) {
 	GLTFTemplateConvert::set_from_array(nodes, p_nodes);
 }
 
-TypedArray<PackedByteArray> GLTFState::get_buffers() {
+TypedArray<PackedByteArray> GLTFState::get_buffers_bind() const {
 	return GLTFTemplateConvert::to_array(buffers);
 }
 
-void GLTFState::set_buffers(const TypedArray<PackedByteArray> &p_buffers) {
+void GLTFState::set_buffers_bind(const TypedArray<PackedByteArray> &p_buffers) {
 	GLTFTemplateConvert::set_from_array(buffers, p_buffers);
 }
 
-TypedArray<GLTFBufferView> GLTFState::get_buffer_views() {
+TypedArray<GLTFBufferView> GLTFState::get_buffer_views_bind() const {
 	return GLTFTemplateConvert::to_array(buffer_views);
 }
 
-void GLTFState::set_buffer_views(const TypedArray<GLTFBufferView> &p_buffer_views) {
+void GLTFState::set_buffer_views_bind(const TypedArray<GLTFBufferView> &p_buffer_views) {
 	GLTFTemplateConvert::set_from_array(buffer_views, p_buffer_views);
 }
 
-TypedArray<GLTFAccessor> GLTFState::get_accessors() {
+TypedArray<GLTFAccessor> GLTFState::get_accessors_bind() const {
 	return GLTFTemplateConvert::to_array(accessors);
 }
 
-void GLTFState::set_accessors(const TypedArray<GLTFAccessor> &p_accessors) {
+void GLTFState::set_accessors_bind(const TypedArray<GLTFAccessor> &p_accessors) {
 	GLTFTemplateConvert::set_from_array(accessors, p_accessors);
 }
 
-TypedArray<GLTFMesh> GLTFState::get_meshes() {
+TypedArray<GLTFMesh> GLTFState::get_meshes_bind() const {
 	return GLTFTemplateConvert::to_array(meshes);
 }
 
-void GLTFState::set_meshes(const TypedArray<GLTFMesh> &p_meshes) {
+void GLTFState::set_meshes_bind(const TypedArray<GLTFMesh> &p_meshes) {
 	GLTFTemplateConvert::set_from_array(meshes, p_meshes);
 }
 
-TypedArray<Material> GLTFState::get_materials() {
+TypedArray<Material> GLTFState::get_materials_bind() const {
 	return GLTFTemplateConvert::to_array(materials);
 }
 
-void GLTFState::set_materials(const TypedArray<Material> &p_materials) {
+void GLTFState::set_materials_bind(const TypedArray<Material> &p_materials) {
 	GLTFTemplateConvert::set_from_array(materials, p_materials);
 }
 
-String GLTFState::get_scene_name() {
+String GLTFState::get_scene_name() const {
 	return scene_name;
 }
 
@@ -265,7 +268,7 @@ void GLTFState::set_scene_name(const String &p_scene_name) {
 	scene_name = p_scene_name;
 }
 
-PackedInt32Array GLTFState::get_root_nodes() {
+PackedInt32Array GLTFState::get_root_nodes() const {
 	return root_nodes;
 }
 
@@ -273,79 +276,79 @@ void GLTFState::set_root_nodes(const PackedInt32Array &p_root_nodes) {
 	root_nodes = PackedInt32Array(p_root_nodes);
 }
 
-TypedArray<GLTFTexture> GLTFState::get_textures() {
+TypedArray<GLTFTexture> GLTFState::get_textures_bind() const {
 	return GLTFTemplateConvert::to_array(textures);
 }
 
-void GLTFState::set_textures(const TypedArray<GLTFTexture> &p_textures) {
+void GLTFState::set_textures_bind(const TypedArray<GLTFTexture> &p_textures) {
 	GLTFTemplateConvert::set_from_array(textures, p_textures);
 }
 
-TypedArray<GLTFTextureSampler> GLTFState::get_texture_samplers() {
+TypedArray<GLTFTextureSampler> GLTFState::get_texture_samplers_bind() const {
 	return GLTFTemplateConvert::to_array(texture_samplers);
 }
 
-void GLTFState::set_texture_samplers(const TypedArray<GLTFTextureSampler> &p_texture_samplers) {
+void GLTFState::set_texture_samplers_bind(const TypedArray<GLTFTextureSampler> &p_texture_samplers) {
 	GLTFTemplateConvert::set_from_array(texture_samplers, p_texture_samplers);
 }
 
-TypedArray<Texture2D> GLTFState::get_images() {
+TypedArray<Texture2D> GLTFState::get_images_bind() const {
 	return GLTFTemplateConvert::to_array(images);
 }
 
-void GLTFState::set_images(const TypedArray<Texture2D> &p_images) {
+void GLTFState::set_images_bind(const TypedArray<Texture2D> &p_images) {
 	GLTFTemplateConvert::set_from_array(images, p_images);
 }
 
-TypedArray<GLTFSkin> GLTFState::get_skins() {
+TypedArray<GLTFSkin> GLTFState::get_skins_bind() const {
 	return GLTFTemplateConvert::to_array(skins);
 }
 
-void GLTFState::set_skins(const TypedArray<GLTFSkin> &p_skins) {
+void GLTFState::set_skins_bind(const TypedArray<GLTFSkin> &p_skins) {
 	GLTFTemplateConvert::set_from_array(skins, p_skins);
 }
 
-TypedArray<GLTFCamera> GLTFState::get_cameras() {
+TypedArray<GLTFCamera> GLTFState::get_cameras_bind() const {
 	return GLTFTemplateConvert::to_array(cameras);
 }
 
-void GLTFState::set_cameras(const TypedArray<GLTFCamera> &p_cameras) {
+void GLTFState::set_cameras_bind(const TypedArray<GLTFCamera> &p_cameras) {
 	GLTFTemplateConvert::set_from_array(cameras, p_cameras);
 }
 
-TypedArray<GLTFLight> GLTFState::get_lights() {
+TypedArray<GLTFLight> GLTFState::get_lights_bind() const {
 	return GLTFTemplateConvert::to_array(lights);
 }
 
-void GLTFState::set_lights(const TypedArray<GLTFLight> &p_lights) {
+void GLTFState::set_lights_bind(const TypedArray<GLTFLight> &p_lights) {
 	GLTFTemplateConvert::set_from_array(lights, p_lights);
 }
 
-TypedArray<String> GLTFState::get_unique_names() {
+TypedArray<String> GLTFState::get_unique_names_bind() const {
 	return GLTFTemplateConvert::to_array(unique_names);
 }
 
-void GLTFState::set_unique_names(const TypedArray<String> &p_unique_names) {
+void GLTFState::set_unique_names_bind(const TypedArray<String> &p_unique_names) {
 	GLTFTemplateConvert::set_from_array(unique_names, p_unique_names);
 }
 
-TypedArray<String> GLTFState::get_unique_animation_names() {
+TypedArray<String> GLTFState::get_unique_animation_names_bind() const {
 	return GLTFTemplateConvert::to_array(unique_animation_names);
 }
 
-void GLTFState::set_unique_animation_names(const TypedArray<String> &p_unique_animation_names) {
+void GLTFState::set_unique_animation_names_bind(const TypedArray<String> &p_unique_animation_names) {
 	GLTFTemplateConvert::set_from_array(unique_animation_names, p_unique_animation_names);
 }
 
-TypedArray<GLTFSkeleton> GLTFState::get_skeletons() {
+TypedArray<GLTFSkeleton> GLTFState::get_skeletons_bind() const {
 	return GLTFTemplateConvert::to_array(skeletons);
 }
 
-void GLTFState::set_skeletons(const TypedArray<GLTFSkeleton> &p_skeletons) {
+void GLTFState::set_skeletons_bind(const TypedArray<GLTFSkeleton> &p_skeletons) {
 	GLTFTemplateConvert::set_from_array(skeletons, p_skeletons);
 }
 
-bool GLTFState::get_create_animations() {
+bool GLTFState::get_create_animations() const {
 	return create_animations;
 }
 
@@ -353,7 +356,7 @@ void GLTFState::set_create_animations(bool p_create_animations) {
 	create_animations = p_create_animations;
 }
 
-bool GLTFState::get_import_as_skeleton_bones() {
+bool GLTFState::get_import_as_skeleton_bones() const {
 	return import_as_skeleton_bones;
 }
 
@@ -361,22 +364,22 @@ void GLTFState::set_import_as_skeleton_bones(bool p_import_as_skeleton_bones) {
 	import_as_skeleton_bones = p_import_as_skeleton_bones;
 }
 
-TypedArray<GLTFAnimation> GLTFState::get_animations() {
+TypedArray<GLTFAnimation> GLTFState::get_animations_bind() const {
 	return GLTFTemplateConvert::to_array(animations);
 }
 
-void GLTFState::set_animations(const TypedArray<GLTFAnimation> &p_animations) {
+void GLTFState::set_animations_bind(const TypedArray<GLTFAnimation> &p_animations) {
 	GLTFTemplateConvert::set_from_array(animations, p_animations);
 }
 
-Node *GLTFState::get_scene_node(GLTFNodeIndex idx) {
-	if (!scene_nodes.has(idx)) {
+Node *GLTFState::get_scene_node(GLTFNodeIndex p_gltf_node_index) const {
+	if (!scene_nodes.has(p_gltf_node_index)) {
 		return nullptr;
 	}
-	return scene_nodes[idx];
+	return scene_nodes[p_gltf_node_index];
 }
 
-GLTFNodeIndex GLTFState::get_node_index(Node *p_node) {
+GLTFNodeIndex GLTFState::get_node_index(Node *p_node) const {
 	for (KeyValue<GLTFNodeIndex, Node *> x : scene_nodes) {
 		if (x.value == p_node) {
 			return x.key;
@@ -385,24 +388,24 @@ GLTFNodeIndex GLTFState::get_node_index(Node *p_node) {
 	return -1;
 }
 
-int GLTFState::get_animation_players_count(int idx) {
+int GLTFState::get_animation_players_count(int p_anim_player_index) const {
 	return animation_players.size();
 }
 
-AnimationPlayer *GLTFState::get_animation_player(int idx) {
-	ERR_FAIL_INDEX_V(idx, animation_players.size(), nullptr);
-	return animation_players[idx];
+AnimationPlayer *GLTFState::get_animation_player(int p_anim_player_index) const {
+	ERR_FAIL_INDEX_V(p_anim_player_index, animation_players.size(), nullptr);
+	return animation_players[p_anim_player_index];
 }
 
 void GLTFState::set_discard_meshes_and_materials(bool p_discard_meshes_and_materials) {
 	discard_meshes_and_materials = p_discard_meshes_and_materials;
 }
 
-bool GLTFState::get_discard_meshes_and_materials() {
+bool GLTFState::get_discard_meshes_and_materials() const {
 	return discard_meshes_and_materials;
 }
 
-String GLTFState::get_base_path() {
+String GLTFState::get_base_path() const {
 	return base_path;
 }
 
@@ -413,7 +416,7 @@ void GLTFState::set_base_path(const String &p_base_path) {
 	}
 }
 
-String GLTFState::get_extract_path() {
+String GLTFState::get_extract_path() const {
 	return extract_path;
 }
 
@@ -421,7 +424,7 @@ void GLTFState::set_extract_path(const String &p_extract_path) {
 	extract_path = p_extract_path;
 }
 
-String GLTFState::get_extract_prefix() {
+String GLTFState::get_extract_prefix() const {
 	return extract_prefix;
 }
 
@@ -440,7 +443,7 @@ void GLTFState::set_filename(const String &p_filename) {
 	}
 }
 
-Variant GLTFState::get_additional_data(const StringName &p_extension_name) {
+Variant GLTFState::get_additional_data(const StringName &p_extension_name) const {
 	return additional_data[p_extension_name];
 }
 

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -121,6 +121,46 @@ protected:
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	// Non-const getters for compatibility.
+	int32_t _get_handle_binary_image_bind_compat_113172();
+	Dictionary _get_json_bind_compat_113172();
+	int _get_major_version_bind_compat_113172();
+	int _get_minor_version_bind_compat_113172();
+	Vector<uint8_t> _get_glb_data_bind_compat_113172();
+	bool _get_use_named_skin_binds_bind_compat_113172();
+	bool _get_discard_meshes_and_materials_bind_compat_113172();
+	TypedArray<GLTFNode> _get_nodes_bind_compat_113172();
+	TypedArray<PackedByteArray> _get_buffers_bind_compat_113172();
+	TypedArray<GLTFBufferView> _get_buffer_views_bind_compat_113172();
+	TypedArray<GLTFAccessor> _get_accessors_bind_compat_113172();
+	TypedArray<GLTFMesh> _get_meshes_bind_compat_113172();
+	TypedArray<Material> _get_materials_bind_compat_113172();
+	String _get_scene_name_bind_compat_113172();
+	String _get_base_path_bind_compat_113172();
+	String _get_extract_path_bind_compat_113172();
+	String _get_extract_prefix_bind_compat_113172();
+	PackedInt32Array _get_root_nodes_bind_compat_113172();
+	TypedArray<GLTFTexture> _get_textures_bind_compat_113172();
+	TypedArray<GLTFTextureSampler> _get_texture_samplers_bind_compat_113172();
+	TypedArray<Texture2D> _get_images_bind_compat_113172();
+	TypedArray<GLTFSkin> _get_skins_bind_compat_113172();
+	TypedArray<GLTFCamera> _get_cameras_bind_compat_113172();
+	TypedArray<GLTFLight> _get_lights_bind_compat_113172();
+	TypedArray<String> _get_unique_names_bind_compat_113172();
+	TypedArray<String> _get_unique_animation_names_bind_compat_113172();
+	TypedArray<GLTFSkeleton> _get_skeletons_bind_compat_113172();
+	bool _get_create_animations_bind_compat_113172();
+	bool _get_import_as_skeleton_bones_bind_compat_113172();
+	TypedArray<GLTFAnimation> _get_animations_bind_compat_113172();
+	Node *_get_scene_node_bind_compat_113172(GLTFNodeIndex p_gltf_node_index);
+	GLTFNodeIndex _get_node_index_bind_compat_113172(Node *p_node);
+	int _get_animation_players_count_bind_compat_113172(int p_anim_player_index);
+	AnimationPlayer *_get_animation_player_bind_compat_113172(int p_anim_player_index);
+	Variant _get_additional_data_bind_compat_113172(const StringName &p_extension_name);
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
 	double get_bake_fps() const {
 		return bake_fps;
@@ -134,131 +174,155 @@ public:
 	GLTFBufferViewIndex append_data_to_buffers(const Vector<uint8_t> &p_data, const bool p_deduplication);
 	GLTFNodeIndex append_gltf_node(Ref<GLTFNode> p_gltf_node, Node *p_godot_scene_node, GLTFNodeIndex p_parent_node_index);
 
+	// Deprecated, use HandleBinaryImageMode instead.
 	enum GLTFHandleBinary {
 		HANDLE_BINARY_DISCARD_TEXTURES = 0,
 		HANDLE_BINARY_EXTRACT_TEXTURES,
 		HANDLE_BINARY_EMBED_AS_BASISU,
 		HANDLE_BINARY_EMBED_AS_UNCOMPRESSED, // If this value changes from 3, ResourceImporterScene::pre_import must be changed as well.
 	};
-	int32_t get_handle_binary_image() {
+	int32_t get_handle_binary_image() const {
 		return handle_binary_image_mode;
 	}
 	void set_handle_binary_image(int32_t p_handle_binary_image) {
 		handle_binary_image_mode = (HandleBinaryImageMode)p_handle_binary_image;
 	}
-	HandleBinaryImageMode get_handle_binary_image_mode() { return handle_binary_image_mode; }
+	HandleBinaryImageMode get_handle_binary_image_mode() const { return handle_binary_image_mode; }
 	void set_handle_binary_image_mode(HandleBinaryImageMode p_handle_binary_image) { handle_binary_image_mode = p_handle_binary_image; }
 
-	Dictionary get_json();
+	Dictionary get_json() const;
 	void set_json(const Dictionary &p_json);
 
-	int get_major_version();
+	int get_major_version() const;
 	void set_major_version(int p_major_version);
 
-	int get_minor_version();
+	int get_minor_version() const;
 	void set_minor_version(int p_minor_version);
 
 	String get_copyright() const;
 	void set_copyright(const String &p_copyright);
 
-	Vector<uint8_t> get_glb_data();
+	Vector<uint8_t> get_glb_data() const;
 	void set_glb_data(const Vector<uint8_t> &p_glb_data);
 
-	bool get_use_named_skin_binds();
+	bool get_use_named_skin_binds() const;
 	void set_use_named_skin_binds(bool p_use_named_skin_binds);
 
-	bool get_discard_textures();
-	void set_discard_textures(bool p_discard_textures);
-
-	bool get_embed_as_basisu();
-	void set_embed_as_basisu(bool p_embed_as_basisu);
-
-	bool get_extract_textures();
-	void set_extract_textures(bool p_extract_textures);
-
-	bool get_discard_meshes_and_materials();
+	bool get_discard_meshes_and_materials() const;
 	void set_discard_meshes_and_materials(bool p_discard_meshes_and_materials);
 
-	TypedArray<GLTFNode> get_nodes();
-	void set_nodes(const TypedArray<GLTFNode> &p_nodes);
+	const Vector<Ref<GLTFNode>> &get_nodes() const { return nodes; }
+	void set_nodes(const Vector<Ref<GLTFNode>> &p_nodes) { nodes = p_nodes; }
+	TypedArray<GLTFNode> get_nodes_bind() const;
+	void set_nodes_bind(const TypedArray<GLTFNode> &p_nodes);
 
-	TypedArray<PackedByteArray> get_buffers();
-	void set_buffers(const TypedArray<PackedByteArray> &p_buffers);
+	const Vector<PackedByteArray> &get_buffers() const { return buffers; }
+	void set_buffers(const Vector<PackedByteArray> &p_buffers) { buffers = p_buffers; }
+	TypedArray<PackedByteArray> get_buffers_bind() const;
+	void set_buffers_bind(const TypedArray<PackedByteArray> &p_buffers);
 
-	TypedArray<GLTFBufferView> get_buffer_views();
-	void set_buffer_views(const TypedArray<GLTFBufferView> &p_buffer_views);
+	const Vector<Ref<GLTFBufferView>> &get_buffer_views() const { return buffer_views; }
+	void set_buffer_views(const Vector<Ref<GLTFBufferView>> &p_buffer_views) { buffer_views = p_buffer_views; }
+	TypedArray<GLTFBufferView> get_buffer_views_bind() const;
+	void set_buffer_views_bind(const TypedArray<GLTFBufferView> &p_buffer_views);
 
-	TypedArray<GLTFAccessor> get_accessors();
-	void set_accessors(const TypedArray<GLTFAccessor> &p_accessors);
+	const Vector<Ref<GLTFAccessor>> &get_accessors() const { return accessors; }
+	void set_accessors(const Vector<Ref<GLTFAccessor>> &p_accessors) { accessors = p_accessors; }
+	TypedArray<GLTFAccessor> get_accessors_bind() const;
+	void set_accessors_bind(const TypedArray<GLTFAccessor> &p_accessors);
 
-	TypedArray<GLTFMesh> get_meshes();
-	void set_meshes(const TypedArray<GLTFMesh> &p_meshes);
+	const Vector<Ref<GLTFMesh>> &get_meshes() const { return meshes; }
+	void set_meshes(const Vector<Ref<GLTFMesh>> &p_meshes) { meshes = p_meshes; }
+	TypedArray<GLTFMesh> get_meshes_bind() const;
+	void set_meshes_bind(const TypedArray<GLTFMesh> &p_meshes);
 
-	TypedArray<Material> get_materials();
-	void set_materials(const TypedArray<Material> &p_materials);
+	const Vector<Ref<Material>> &get_materials() const { return materials; }
+	void set_materials(const Vector<Ref<Material>> &p_materials) { materials = p_materials; }
+	TypedArray<Material> get_materials_bind() const;
+	void set_materials_bind(const TypedArray<Material> &p_materials);
 
-	String get_scene_name();
+	String get_scene_name() const;
 	void set_scene_name(const String &p_scene_name);
 
-	String get_base_path();
+	String get_base_path() const;
 	void set_base_path(const String &p_base_path);
 
-	String get_extract_path();
+	String get_extract_path() const;
 	void set_extract_path(const String &p_extract_path);
 
-	String get_extract_prefix();
+	String get_extract_prefix() const;
 	void set_extract_prefix(const String &p_extract_prefix);
 
 	String get_filename() const;
 	void set_filename(const String &p_filename);
 
-	PackedInt32Array get_root_nodes();
+	PackedInt32Array get_root_nodes() const;
 	void set_root_nodes(const PackedInt32Array &p_root_nodes);
 
-	TypedArray<GLTFTexture> get_textures();
-	void set_textures(const TypedArray<GLTFTexture> &p_textures);
+	const Vector<Ref<GLTFTexture>> &get_textures() const { return textures; }
+	void set_textures(const Vector<Ref<GLTFTexture>> &p_textures) { textures = p_textures; }
+	TypedArray<GLTFTexture> get_textures_bind() const;
+	void set_textures_bind(const TypedArray<GLTFTexture> &p_textures);
 
-	TypedArray<GLTFTextureSampler> get_texture_samplers();
-	void set_texture_samplers(const TypedArray<GLTFTextureSampler> &p_texture_samplers);
+	const Vector<Ref<GLTFTextureSampler>> &get_texture_samplers() const { return texture_samplers; }
+	void set_texture_samplers(const Vector<Ref<GLTFTextureSampler>> &p_texture_samplers) { texture_samplers = p_texture_samplers; }
+	TypedArray<GLTFTextureSampler> get_texture_samplers_bind() const;
+	void set_texture_samplers_bind(const TypedArray<GLTFTextureSampler> &p_texture_samplers);
 
-	TypedArray<Texture2D> get_images();
-	void set_images(const TypedArray<Texture2D> &p_images);
+	const Vector<Ref<Texture2D>> &get_images() const { return images; }
+	void set_images(const Vector<Ref<Texture2D>> &p_images) { images = p_images; }
+	TypedArray<Texture2D> get_images_bind() const;
+	void set_images_bind(const TypedArray<Texture2D> &p_images);
 
-	TypedArray<GLTFSkin> get_skins();
-	void set_skins(const TypedArray<GLTFSkin> &p_skins);
+	const Vector<Ref<GLTFSkin>> &get_skins() const { return skins; }
+	void set_skins(const Vector<Ref<GLTFSkin>> &p_skins) { skins = p_skins; }
+	TypedArray<GLTFSkin> get_skins_bind() const;
+	void set_skins_bind(const TypedArray<GLTFSkin> &p_skins);
 
-	TypedArray<GLTFCamera> get_cameras();
-	void set_cameras(const TypedArray<GLTFCamera> &p_cameras);
+	const Vector<Ref<GLTFCamera>> &get_cameras() const { return cameras; }
+	void set_cameras(const Vector<Ref<GLTFCamera>> &p_cameras) { cameras = p_cameras; }
+	TypedArray<GLTFCamera> get_cameras_bind() const;
+	void set_cameras_bind(const TypedArray<GLTFCamera> &p_cameras);
 
-	TypedArray<GLTFLight> get_lights();
-	void set_lights(const TypedArray<GLTFLight> &p_lights);
+	const Vector<Ref<GLTFLight>> &get_lights() const { return lights; }
+	void set_lights(const Vector<Ref<GLTFLight>> &p_lights) { lights = p_lights; }
+	TypedArray<GLTFLight> get_lights_bind() const;
+	void set_lights_bind(const TypedArray<GLTFLight> &p_lights);
 
-	TypedArray<String> get_unique_names();
-	void set_unique_names(const TypedArray<String> &p_unique_names);
+	const HashSet<String> &get_unique_names() const { return unique_names; }
+	void set_unique_names(const HashSet<String> &p_unique_names) { unique_names = p_unique_names; }
+	TypedArray<String> get_unique_names_bind() const;
+	void set_unique_names_bind(const TypedArray<String> &p_unique_names);
 
-	TypedArray<String> get_unique_animation_names();
-	void set_unique_animation_names(const TypedArray<String> &p_unique_names);
+	const HashSet<String> &get_unique_animation_names() const { return unique_animation_names; }
+	void set_unique_animation_names(const HashSet<String> &p_unique_animation_names) { unique_animation_names = p_unique_animation_names; }
+	TypedArray<String> get_unique_animation_names_bind() const;
+	void set_unique_animation_names_bind(const TypedArray<String> &p_unique_names);
 
-	TypedArray<GLTFSkeleton> get_skeletons();
-	void set_skeletons(const TypedArray<GLTFSkeleton> &p_skeletons);
+	const Vector<Ref<GLTFSkeleton>> &get_skeletons() const { return skeletons; }
+	void set_skeletons(const Vector<Ref<GLTFSkeleton>> &p_skeletons) { skeletons = p_skeletons; }
+	TypedArray<GLTFSkeleton> get_skeletons_bind() const;
+	void set_skeletons_bind(const TypedArray<GLTFSkeleton> &p_skeletons);
 
-	bool get_create_animations();
+	bool get_create_animations() const;
 	void set_create_animations(bool p_create_animations);
 
-	bool get_import_as_skeleton_bones();
+	bool get_import_as_skeleton_bones() const;
 	void set_import_as_skeleton_bones(bool p_import_as_skeleton_bones);
 
-	TypedArray<GLTFAnimation> get_animations();
-	void set_animations(const TypedArray<GLTFAnimation> &p_animations);
+	const Vector<Ref<GLTFAnimation>> &get_animations() const { return animations; }
+	void set_animations(const Vector<Ref<GLTFAnimation>> &p_animations) { animations = p_animations; }
+	TypedArray<GLTFAnimation> get_animations_bind() const;
+	void set_animations_bind(const TypedArray<GLTFAnimation> &p_animations);
 
-	Node *get_scene_node(GLTFNodeIndex idx);
-	GLTFNodeIndex get_node_index(Node *p_node);
+	Node *get_scene_node(GLTFNodeIndex p_gltf_node_index) const;
+	GLTFNodeIndex get_node_index(Node *p_node) const;
 
-	int get_animation_players_count(int idx);
+	int get_animation_players_count(int p_anim_player_index) const;
 
-	AnimationPlayer *get_animation_player(int idx);
+	AnimationPlayer *get_animation_player(int p_anim_player_index) const;
 
-	Variant get_additional_data(const StringName &p_extension_name);
+	Variant get_additional_data(const StringName &p_extension_name) const;
 	void set_additional_data(const StringName &p_extension_name, Variant p_additional_data);
 };
 

--- a/modules/gltf/structures/gltf_accessor.cpp
+++ b/modules/gltf/structures/gltf_accessor.cpp
@@ -550,7 +550,7 @@ bool GLTFAccessor::is_equal_exact(const Ref<GLTFAccessor> &p_other) const {
 
 // Private decode functions.
 
-PackedInt64Array GLTFAccessor::_decode_sparse_indices(const Ref<GLTFState> &p_gltf_state, const TypedArray<GLTFBufferView> &p_buffer_views) const {
+PackedInt64Array GLTFAccessor::_decode_sparse_indices(const Ref<GLTFState> &p_gltf_state, const Vector<Ref<GLTFBufferView>> &p_buffer_views) const {
 	const int64_t bytes_per_component = _get_bytes_per_component(sparse_indices_component_type);
 	PackedInt64Array numbers;
 	ERR_FAIL_INDEX_V(sparse_indices_buffer_view, p_buffer_views.size(), numbers);
@@ -589,7 +589,7 @@ PackedInt64Array GLTFAccessor::_decode_sparse_indices(const Ref<GLTFState> &p_gl
 }
 
 template <typename T>
-Vector<T> GLTFAccessor::_decode_raw_numbers(const Ref<GLTFState> &p_gltf_state, const TypedArray<GLTFBufferView> &p_buffer_views, bool p_sparse_values) const {
+Vector<T> GLTFAccessor::_decode_raw_numbers(const Ref<GLTFState> &p_gltf_state, const Vector<Ref<GLTFBufferView>> &p_buffer_views, bool p_sparse_values) const {
 	const int64_t bytes_per_component = _get_bytes_per_component(component_type);
 	const int64_t bytes_per_vector = _get_bytes_per_vector();
 	const int64_t vector_size = _get_vector_size();
@@ -732,7 +732,7 @@ Vector<T> GLTFAccessor::_decode_raw_numbers(const Ref<GLTFState> &p_gltf_state, 
 
 template <typename T>
 Vector<T> GLTFAccessor::_decode_as_numbers(const Ref<GLTFState> &p_gltf_state) const {
-	const TypedArray<GLTFBufferView> &p_buffer_views = p_gltf_state->get_buffer_views();
+	const Vector<Ref<GLTFBufferView>> &p_buffer_views = p_gltf_state->get_buffer_views();
 	Vector<T> ret_numbers = _decode_raw_numbers<T>(p_gltf_state, p_buffer_views, false);
 	if (sparse_count == 0) {
 		return ret_numbers;
@@ -1440,10 +1440,10 @@ GLTFAccessorIndex GLTFAccessor::store_accessor_data_into_state(const Ref<GLTFSta
 	ERR_FAIL_COND_V_MSG(buffer_view_index == -1, -1, "glTF export: Accessor failed to write new buffer view into glTF state.");
 	set_buffer_view(buffer_view_index);
 	// Add the new accessor to the state, but check for duplicates first.
-	TypedArray<GLTFAccessor> state_accessors = p_gltf_state->get_accessors();
+	Vector<Ref<GLTFAccessor>> state_accessors = p_gltf_state->get_accessors();
 	const GLTFAccessorIndex accessor_count = state_accessors.size();
 	for (GLTFAccessorIndex i = 0; i < accessor_count; i++) {
-		Ref<GLTFAccessor> existing_accessor = state_accessors[i];
+		const Ref<GLTFAccessor> &existing_accessor = state_accessors[i];
 		if (is_equal_exact(existing_accessor)) {
 			// An identical accessor already exists in the state, so just return the index.
 			return i;
@@ -1675,10 +1675,10 @@ GLTFAccessorIndex GLTFAccessor::encode_new_sparse_accessor_from_vec3s(const Ref<
 		const PackedFloat64Array filtered_numbers = accessor->_filter_numbers(dense_values);
 		accessor->_calculate_min_and_max(filtered_numbers);
 		// Add the new accessor to the state, but check for duplicates first.
-		TypedArray<GLTFAccessor> state_accessors = p_gltf_state->get_accessors();
+		Vector<Ref<GLTFAccessor>> state_accessors = p_gltf_state->get_accessors();
 		const GLTFAccessorIndex accessor_count = state_accessors.size();
 		for (GLTFAccessorIndex i = 0; i < accessor_count; i++) {
-			Ref<GLTFAccessor> existing_accessor = state_accessors[i];
+			const Ref<GLTFAccessor> &existing_accessor = state_accessors[i];
 			if (accessor->is_equal_exact(existing_accessor)) {
 				// An identical accessor already exists in the state, so just return the index.
 				return i;

--- a/modules/gltf/structures/gltf_accessor.h
+++ b/modules/gltf/structures/gltf_accessor.h
@@ -95,9 +95,9 @@ private:
 	int64_t _get_bytes_per_vector() const;
 
 	// Private decode functions.
-	PackedInt64Array _decode_sparse_indices(const Ref<GLTFState> &p_gltf_state, const TypedArray<GLTFBufferView> &p_buffer_views) const;
+	PackedInt64Array _decode_sparse_indices(const Ref<GLTFState> &p_gltf_state, const Vector<Ref<GLTFBufferView>> &p_buffer_views) const;
 	template <typename T>
-	Vector<T> _decode_raw_numbers(const Ref<GLTFState> &p_gltf_state, const TypedArray<GLTFBufferView> &p_buffer_views, bool p_sparse_values) const;
+	Vector<T> _decode_raw_numbers(const Ref<GLTFState> &p_gltf_state, const Vector<Ref<GLTFBufferView>> &p_buffer_views, bool p_sparse_values) const;
 	template <typename T>
 	Vector<T> _decode_as_numbers(const Ref<GLTFState> &p_gltf_state) const;
 

--- a/modules/gltf/structures/gltf_buffer_view.cpp
+++ b/modules/gltf/structures/gltf_buffer_view.cpp
@@ -110,7 +110,7 @@ void GLTFBufferView::set_vertex_attributes(bool p_attributes) {
 
 Vector<uint8_t> GLTFBufferView::load_buffer_view_data(const Ref<GLTFState> p_gltf_state) const {
 	ERR_FAIL_COND_V(p_gltf_state.is_null(), Vector<uint8_t>());
-	const TypedArray<Vector<uint8_t>> &buffers = p_gltf_state->get_buffers();
+	const Vector<PackedByteArray> &buffers = p_gltf_state->get_buffers();
 	ERR_FAIL_INDEX_V(buffer, buffers.size(), Vector<uint8_t>());
 	const PackedByteArray &buffer_data = buffers[buffer];
 	const int64_t byte_end = byte_offset + byte_length;
@@ -127,11 +127,11 @@ GLTFBufferViewIndex GLTFBufferView::write_new_buffer_view_into_state(const Ref<G
 		ERR_FAIL_COND_V_MSG(p_byte_stride < 4 || p_byte_stride % 4 != 0, -1, "glTF export: Vertex attributes using TARGET_ARRAY_BUFFER must have a byte stride that is a multiple of 4 as required by section 3.6.2.4 of the glTF specification.");
 	}
 	// Check for duplicate buffer views before adding a new one.
-	TypedArray<GLTFBufferView> state_buffer_views = p_gltf_state->get_buffer_views();
+	Vector<Ref<GLTFBufferView>> state_buffer_views = p_gltf_state->get_buffer_views();
 	const int buffer_view_index = state_buffer_views.size();
 	if (p_deduplicate) {
 		for (int i = 0; i < buffer_view_index; i++) {
-			const Ref<GLTFBufferView> existing_buffer_view = state_buffer_views[i];
+			const Ref<GLTFBufferView> &existing_buffer_view = state_buffer_views[i];
 			if (existing_buffer_view->get_byte_offset() % p_alignment == 0 &&
 					existing_buffer_view->get_byte_length() == p_input_data.size() &&
 					existing_buffer_view->get_byte_stride() == p_byte_stride &&
@@ -145,7 +145,7 @@ GLTFBufferViewIndex GLTFBufferView::write_new_buffer_view_into_state(const Ref<G
 		}
 	}
 	// Write the data into the buffer at the specified index.
-	TypedArray<PackedByteArray> state_buffers = p_gltf_state->get_buffers();
+	Vector<PackedByteArray> state_buffers = p_gltf_state->get_buffers();
 	if (state_buffers.size() <= p_buffer_index) {
 		state_buffers.resize(p_buffer_index + 1);
 	}
@@ -160,7 +160,7 @@ GLTFBufferViewIndex GLTFBufferView::write_new_buffer_view_into_state(const Ref<G
 	state_buffer.resize(byte_offset + input_data_size);
 	uint8_t *buffer_ptr = state_buffer.ptrw();
 	memcpy(buffer_ptr + byte_offset, p_input_data.ptr(), input_data_size);
-	state_buffers[p_buffer_index] = state_buffer;
+	state_buffers.set(p_buffer_index, state_buffer);
 	p_gltf_state->set_buffers(state_buffers);
 	// Create a new GLTFBufferView that references the new buffer.
 	Ref<GLTFBufferView> buffer_view;


### PR DESCRIPTION
This PR fixes a performance regression introduced in PR #109103. As part of moving the accessor code from GLTFDocument to GLTFAccessor, I replaced the internal `Vector` uses with calls to the exposed `TypedArray` versions. This seemed harmless, but in fact, an astonishing **98%** of CPU time in the array decode functions is spent converting between `Vector` and `TypedArray`. It seems that it is absolutely performance critical for us to use `Vector` internally.

The fix in this PR is simple: Add new functions that let us use `Vector` internally. We still need to keep the `TypedArray` versions around, but discourage their use, therefore I have their internal names suffixed with `_bind`. At the same time, since this PR changes this code, I figured I may as well make all the getters `const`, which also requires binding compatibility functions. As such, this PR does involve a lot of boilerplate changes, but there isn't much functionally different in here.

I have tested this on the TPS demo, which is where @akien-mga noticed the performance regression. I can reproduce the atrocious import times in master after PR #109103, nearly 10 minutes for me to import the TPS demo from scratch, and this PR restores the speed found in 4.5, a bit over 2 minutes of total time, with most of the time no longer spent importing the glTF files.