### PR TITLE
Fix empty 2D skeleton modification keeps printing error messages

### DIFF
--- a/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.cpp
@@ -253,6 +253,9 @@ void SkeletonModification2DCCDIK::_draw_editor_gizmo() {
 		if (!ccdik_data_chain[i].editor_draw_gizmo) {
 			continue;
 		}
+		if (ccdik_data_chain[i].bone_idx < 0) {
+			continue;
+		}
 
 		Bone2D *operation_bone = stack->skeleton->get_bone(ccdik_data_chain[i].bone_idx);
 		editor_draw_angle_constraints(operation_bone, ccdik_data_chain[i].constraint_angle_min, ccdik_data_chain[i].constraint_angle_max,

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.cpp
@@ -180,7 +180,7 @@ void SkeletonModification2DLookAt::_setup_modification(SkeletonModificationStack
 }
 
 void SkeletonModification2DLookAt::_draw_editor_gizmo() {
-	if (!enabled || !is_setup) {
+	if (!enabled || !is_setup || bone_idx < 0) {
 		return;
 	}
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
@@ -217,7 +217,7 @@ void SkeletonModification2DTwoBoneIK::_setup_modification(SkeletonModificationSt
 }
 
 void SkeletonModification2DTwoBoneIK::_draw_editor_gizmo() {
-	if (!enabled || !is_setup) {
+	if (!enabled || !is_setup || joint_one_bone_idx < 0) {
 		return;
 	}
 


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/109350*

## Issue Description

When we create an empty skeleton modification, editor will try to call `_draw_editor_gizmo()` every idle frame, but forget to consider whether `bone_idx` is valid.

## Solution

Check `bone_idx` before calling `get_bone()` can prevent printing error message in every frame.