### PR TITLE
Update the documentation for `Tree.create_item(), Tree.set_columns() & Tree.clear()` & add error messages.

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -40,6 +40,7 @@
 			<return type="void" />
 			<description>
 				Clears the tree. This removes all items.
+				Prints an error and does not allow clearing the tree if called during mouse selection.
 			</description>
 		</method>
 		<method name="create_item">
@@ -50,6 +51,7 @@
 				Creates an item in the tree and adds it as a child of [param parent], which can be either a valid [TreeItem] or [code]null[/code].
 				If [param parent] is [code]null[/code], the root item will be the parent, or the new item will be the root itself if the tree is empty.
 				The new item will be the [param index]-th child of parent, or it will be the last child if there are not enough siblings.
+				Prints an error and returns [code]null[/code] if called during mouse selection, or if the [param parent] does not belong to this tree.
 			</description>
 		</method>
 		<method name="deselect_all">
@@ -365,6 +367,7 @@
 		</member>
 		<member name="columns" type="int" setter="set_columns" getter="get_columns" default="1">
 			The number of columns.
+			Prints an error and does not allow setting the columns during mouse selection.
 		</member>
 		<member name="drop_mode_flags" type="int" setter="set_drop_mode_flags" getter="get_drop_mode_flags" default="0">
 			The drop mode as an OR combination of flags. See [enum DropModeFlags] constants. Once dropping is done, reverts to [constant DROP_MODE_DISABLED]. Setting this during [method Control._can_drop_data] is recommended.

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5323,7 +5323,7 @@ Size2 Tree::get_minimum_size() const {
 }
 
 TreeItem *Tree::create_item(TreeItem *p_parent, int p_index) {
-	ERR_FAIL_COND_V(blocked > 0, nullptr);
+	ERR_FAIL_COND_V_MSG(blocked > 0, nullptr, "The tree cannot create items during mouse selection events.");
 
 	TreeItem *ti = nullptr;
 
@@ -5487,7 +5487,7 @@ bool Tree::is_anything_selected() {
 }
 
 void Tree::clear() {
-	ERR_FAIL_COND(blocked > 0);
+	ERR_FAIL_COND_MSG(blocked > 0, "The tree cannot be cleared during mouse selection events.");
 
 	if (pressing_for_editor) {
 		if (range_drag_enabled) {
@@ -5764,7 +5764,7 @@ void Tree::propagate_set_columns(TreeItem *p_item) {
 
 void Tree::set_columns(int p_columns) {
 	ERR_FAIL_COND(p_columns < 1);
-	ERR_FAIL_COND(blocked > 0);
+	ERR_FAIL_COND_MSG(blocked > 0, "The number of columns cannot be changed during mouse selection events.");
 
 	if (columns.size() > p_columns) {
 		for (int i = p_columns; i < columns.size(); i++) {


### PR DESCRIPTION
TL;DR
- Updates the documentation for `Tree.create_item(), Tree.set_columns() & Tree.clear()`
- Adds error messages for `Tree.create_item(), Tree.set_columns() & Tree.clear()`
- Closes #103101
- Supersedes #105969.

This PR updates the documentation for `Tree.create_item(), Tree.set_columns() & Tree.clear()` & tells the user that all 3 methods can fail during mouse selection events. It also adds error messages for `Tree.create_item(), Tree.set_columns() & Tree.clear()` 


The user will get the following error message if attempting to use any of the 3 methods during mouse selection events (Following @RedMser's comment in https://github.com/godotengine/godot/pull/105969#pullrequestreview-2810059679):

<img width="945" height="290" alt="image" src="https://github.com/user-attachments/assets/3949c691-6753-44f6-aa3d-045d1447af81" />

(This is a test using the script provided by @kleonc in https://github.com/godotengine/godot/issues/103101#issuecomment-2673123694)

Text version:
```
E 0:00:02:715   tree.gd:14 @ _on_item_selected(): The tree cannot create items during mouse selection events.
  <C++ Error>   Condition "blocked > 0" is true. Returning: nullptr
  <C++ Source>  scene\gui\tree.cpp:5188 @ Tree::create_item()
  <Stack Trace> tree.gd:14 @ _on_item_selected()
```

(We use `ERR_FAIL_COND_V_MSG` instead of `ERR_FAIL_COND_MSG` here because Godot expects us to return a value or else we get build errors. We just return `nullptr` in this case.)

### MRP:
You can test with [this](https://github.com/user-attachments/files/23776082/113178-mrp.zip)
If you face any issues while testing, feel free to ping me.
(The `set_text` issue is expected, it is triggered by the first issue.)
(Note: I used the build made by GitHub actions.)

> [!NOTE]
> Contributed by 2LazyDevs.