### PR TITLE
Do not attempt deleting local cache in `Resource::_teardown_duplicate_from_variant`.

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -368,11 +368,14 @@ Ref<Resource> Resource::_duplicate(const DuplicateParams &p_params) const {
 	ERR_FAIL_COND_V_MSG(p_params.local_scene && p_params.subres_mode != RESOURCE_DEEP_DUPLICATE_MAX, Ref<Resource>(), "Duplication for local-to-scene can't specify a deep duplicate mode.");
 
 	DuplicateRemapCacheT *remap_cache_backup = thread_duplicate_remap_cache;
+	bool remap_cache_needs_deallocation_backup = thread_duplicate_remap_cache_needs_deallocation;
 
 // These are for avoiding potential duplicates that can happen in custom code
 // from participating in the same duplication session (remap cache).
 #define BEFORE_USER_CODE thread_duplicate_remap_cache = nullptr;
-#define AFTER_USER_CODE thread_duplicate_remap_cache = remap_cache_backup;
+#define AFTER_USER_CODE                                \
+	thread_duplicate_remap_cache = remap_cache_backup; \
+	thread_duplicate_remap_cache_needs_deallocation = remap_cache_needs_deallocation_backup;
 
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
@@ -434,7 +437,9 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, DuplicateRe
 #endif
 
 	DuplicateRemapCacheT *remap_cache_backup = thread_duplicate_remap_cache;
+	bool remap_cache_needs_deallocation_backup = thread_duplicate_remap_cache_needs_deallocation;
 	thread_duplicate_remap_cache = &p_remap_cache;
+	thread_duplicate_remap_cache_needs_deallocation = false;
 
 	DuplicateParams params;
 	params.deep = true;
@@ -442,6 +447,7 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, DuplicateRe
 	const Ref<Resource> &dupe = _duplicate(params);
 
 	thread_duplicate_remap_cache = remap_cache_backup;
+	thread_duplicate_remap_cache_needs_deallocation = remap_cache_needs_deallocation_backup;
 
 	return dupe;
 }
@@ -504,6 +510,7 @@ Ref<Resource> Resource::duplicate(bool p_deep) const {
 	bool started_session = false;
 	if (!thread_duplicate_remap_cache) {
 		thread_duplicate_remap_cache = &remap_cache;
+		thread_duplicate_remap_cache_needs_deallocation = false;
 		started_session = true;
 	}
 
@@ -526,6 +533,7 @@ Ref<Resource> Resource::duplicate_deep(ResourceDeepDuplicateMode p_deep_subresou
 	bool started_session = false;
 	if (!thread_duplicate_remap_cache) {
 		thread_duplicate_remap_cache = &remap_cache;
+		thread_duplicate_remap_cache_needs_deallocation = false;
 		started_session = true;
 	}
 
@@ -571,6 +579,7 @@ Ref<Resource> Resource::_duplicate_from_variant(bool p_deep, ResourceDeepDuplica
 		}
 	} else {
 		thread_duplicate_remap_cache = memnew(DuplicateRemapCacheT);
+		thread_duplicate_remap_cache_needs_deallocation = true;
 	}
 
 	DuplicateParams params;
@@ -583,7 +592,7 @@ Ref<Resource> Resource::_duplicate_from_variant(bool p_deep, ResourceDeepDuplica
 }
 
 void Resource::_teardown_duplicate_from_variant() {
-	if (thread_duplicate_remap_cache) {
+	if (thread_duplicate_remap_cache && thread_duplicate_remap_cache_needs_deallocation) {
 		memdelete(thread_duplicate_remap_cache);
 		thread_duplicate_remap_cache = nullptr;
 	}

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -94,6 +94,7 @@ private:
 
 	using DuplicateRemapCacheT = HashMap<Ref<Resource>, Ref<Resource>>;
 	static thread_local inline DuplicateRemapCacheT *thread_duplicate_remap_cache = nullptr;
+	static thread_local inline bool thread_duplicate_remap_cache_needs_deallocation = true;
 
 	Variant _duplicate_recursive(const Variant &p_variant, const DuplicateParams &p_params, uint32_t p_usage = 0) const;
 	void _find_sub_resources(const Variant &p_variant, HashSet<Ref<Resource>> &p_resources_found);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112391
Likely regressions from https://github.com/godotengine/godot/pull/100673

`Dictionary::recursive_duplicate` (as well as `Array`) call `Resource::_teardown_duplicate_from_variant` to clean up cache which can be created by `Resource::_duplicate_from_variant` when finished. But if dictionary duplication was triggered in the process of resource duplication, cache is pointing to the local variable of `Resource::duplicate`, so it was trying to `memdelete` memory on stack.