### PR TITLE
Use new dock system for Shader Editor Dock

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -834,6 +834,15 @@ void EditorDockManager::open_dock(EditorDock *p_dock, bool p_set_current) {
 	_update_layout();
 }
 
+void EditorDockManager::make_dock_floating(EditorDock *p_dock) {
+	ERR_FAIL_NULL(p_dock);
+	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot make unknown dock '%s' floating.", p_dock->get_display_title()));
+
+	if (!p_dock->dock_window) {
+		_open_dock_in_window(p_dock);
+	}
+}
+
 TabContainer *EditorDockManager::get_dock_tab_container(Control *p_dock) const {
 	return Object::cast_to<TabContainer>(p_dock->get_parent());
 }

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -146,6 +146,7 @@ public:
 	void close_dock(EditorDock *p_dock);
 	void open_dock(EditorDock *p_dock, bool p_set_current = true);
 	void focus_dock(EditorDock *p_dock);
+	void make_dock_floating(EditorDock *p_dock);
 
 	TabContainer *get_dock_tab_container(Control *p_dock) const;
 

--- a/editor/icons/ShaderDock.svg
+++ b/editor/icons/ShaderDock.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V6l-5-5zm1 2h6v3a1 1 0 0 0 1 1h3v6H3z"/><path fill="#e0e0e0" d="M10 11h2v1h-2zM4 6h2v1H4zM8 8h4v1H8zM7 6h1v1H7zM4 11h5v1H4zM4 4h3v1H4zM4 8h3v1H4z"/></svg>

--- a/editor/shader/shader_editor.h
+++ b/editor/shader/shader_editor.h
@@ -42,7 +42,7 @@ class ShaderEditor : public Control {
 public:
 	virtual void edit_shader(const Ref<Shader> &p_shader) = 0;
 	virtual void edit_shader_include(const Ref<ShaderInclude> &p_shader_inc) {}
-	virtual void use_menu_bar_items(MenuButton *p_file_menu, Button *p_make_floating) = 0;
+	virtual void use_menu_bar(MenuButton *p_file_menu) = 0;
 
 	virtual void apply_shaders() = 0;
 	virtual bool is_unsaved() const = 0;

--- a/editor/shader/shader_editor_plugin.h
+++ b/editor/shader/shader_editor_plugin.h
@@ -33,6 +33,7 @@
 #include "editor/plugins/editor_plugin.h"
 
 class CodeTextEditor;
+class EditorDock;
 class HSplitContainer;
 class ItemList;
 class MenuButton;
@@ -78,19 +79,16 @@ class ShaderEditorPlugin : public EditorPlugin {
 		CONTEXT,
 		CONTEXT_VALID_ITEM,
 	};
-
-	VBoxContainer *main_container = nullptr;
 	HSplitContainer *files_split = nullptr;
 
 	ItemList *shader_list = nullptr;
 	TabContainer *shader_tabs = nullptr;
-	HBoxContainer *empty_menu = nullptr;
 
 	MenuButton *file_menu = nullptr;
 	PopupMenu *context_menu = nullptr;
 
-	WindowWrapper *window_wrapper = nullptr;
-	Button *make_floating = nullptr;
+	EditorDock *shader_dock = nullptr;
+	Ref<Shortcut> make_floating_shortcut;
 
 	ShaderCreateDialog *shader_create_dialog = nullptr;
 
@@ -120,8 +118,6 @@ class ShaderEditorPlugin : public EditorPlugin {
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
-	void _window_changed(bool p_visible);
-
 	void _set_text_shader_zoom_factor(float p_zoom_factor);
 	void _update_shader_editor_zoom_factor(CodeTextEditor *p_shader_editor) const;
 
@@ -130,12 +126,13 @@ class ShaderEditorPlugin : public EditorPlugin {
 protected:
 	void _notification(int p_what);
 
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
 public:
 	virtual String get_plugin_name() const override { return "Shader"; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
-	virtual void selected_notify() override;
 
 	ShaderEditor *get_shader_editor(const Ref<Shader> &p_for_shader);
 

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -972,11 +972,10 @@ void TextShaderEditor::edit_shader_include(const Ref<ShaderInclude> &p_shader_in
 	code_editor->set_edited_shader_include(p_shader_inc);
 }
 
-void TextShaderEditor::use_menu_bar_items(MenuButton *p_file_menu, Button *p_make_floating) {
+void TextShaderEditor::use_menu_bar(MenuButton *p_file_menu) {
 	p_file_menu->set_switch_on_hover(true);
 	menu_bar_hbox->add_child(p_file_menu);
 	menu_bar_hbox->move_child(p_file_menu, 0);
-	menu_bar_hbox->add_child(p_make_floating);
 }
 
 void TextShaderEditor::save_external_data(const String &p_str) {
@@ -1283,7 +1282,6 @@ TextShaderEditor::TextShaderEditor() {
 	site_search->set_text(TTR("Online Docs"));
 	site_search->set_tooltip_text(TTR("Open Godot online documentation."));
 	menu_bar_hbox->add_child(site_search);
-	menu_bar_hbox->add_child(memnew(VSeparator));
 
 	menu_bar_hbox->add_theme_style_override(SceneStringName(panel), EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SNAME("ScriptEditorPanel"), EditorStringName(EditorStyles)));
 

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -191,7 +191,7 @@ protected:
 public:
 	virtual void edit_shader(const Ref<Shader> &p_shader) override;
 	virtual void edit_shader_include(const Ref<ShaderInclude> &p_shader_inc) override;
-	virtual void use_menu_bar_items(MenuButton *p_file_menu, Button *p_make_floating) override;
+	virtual void use_menu_bar(MenuButton *p_file_menu) override;
 
 	virtual void apply_shaders() override;
 	virtual bool is_unsaved() const override;

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -1564,11 +1564,10 @@ void VisualShaderEditor::edit_shader(const Ref<Shader> &p_shader) {
 	}
 }
 
-void VisualShaderEditor::use_menu_bar_items(MenuButton *p_file_menu, Button *p_make_floating) {
+void VisualShaderEditor::use_menu_bar(MenuButton *p_file_menu) {
 	p_file_menu->set_switch_on_hover(false);
 	toolbar_hflow->add_child(p_file_menu);
 	toolbar_hflow->move_child(p_file_menu, 2); // Toggle Files Panel button + separator.
-	toolbar_hflow->add_child(p_make_floating);
 }
 
 void VisualShaderEditor::apply_shaders() {
@@ -6735,7 +6734,6 @@ VisualShaderEditor::VisualShaderEditor() {
 	site_search->set_text(TTR("Online Docs"));
 	site_search->set_tooltip_text(TTR("Open Godot online documentation."));
 	toolbar_hflow->add_child(site_search);
-	toolbar_hflow->add_child(memnew(VSeparator));
 
 	VSeparator *separator = memnew(VSeparator);
 	toolbar_hflow->add_child(separator);

--- a/editor/shader/visual_shader_editor_plugin.h
+++ b/editor/shader/visual_shader_editor_plugin.h
@@ -654,7 +654,7 @@ protected:
 
 public:
 	virtual void edit_shader(const Ref<Shader> &p_shader) override;
-	virtual void use_menu_bar_items(MenuButton *p_file_menu, Button *p_make_floating) override;
+	virtual void use_menu_bar(MenuButton *p_file_menu) override;
 	virtual void apply_shaders() override;
 	virtual bool is_unsaved() const override;
 	virtual void save_external_data(const String &p_str = "") override;


### PR DESCRIPTION
See #113024

Upgraded the Shader Editor Dock to use the new system. I also added a `make_dock_floating()` function in `EditorDockManager` to force a dock to be floating through code.

Now that this is a dock, I removed the internal floating logic and button to use the Dock methods. The dock has to be made floating by right-clicking the tab or using the shortcut. Since all docks should be made floating this is standard behavior.

My primary motive in removing the floating button is leaving the door open to refactors that might make individual shader file editors docks (ie able to edit multiple shaders on screen at once). Leaving the button in would necessitate moving almost the entirety of the plugin into a new class extending dock, which would have to be reversed if it were refactored to edit multiple shaders on screen at once.

I also reordered the constructor to be more in line with the rest of the editor.