### PR TITLE
Use nearest-neighbor scaling to align textures to the next block size for VRAM compression

### DIFF
--- a/modules/astcenc/image_compress_astcenc.cpp
+++ b/modules/astcenc/image_compress_astcenc.cpp
@@ -98,16 +98,15 @@ void _compress_astc(Image *r_img, Image::UsedChannels p_channels, Image::Compres
 
 	// Compress image data and (if required) mipmaps.
 	const bool has_mipmaps = r_img->has_mipmaps();
+
 	int width = r_img->get_width();
 	int height = r_img->get_height();
-	int required_width = (width % block_x) != 0 ? width + (block_x - (width % block_x)) : width;
-	int required_height = (height % block_y) != 0 ? height + (block_y - (height % block_y)) : height;
+	width = (width % block_x) != 0 ? width + (block_x - (width % block_x)) : width;
+	height = (height % block_y) != 0 ? height + (block_y - (height % block_y)) : height;
 
-	if (width != required_width || height != required_height) {
-		// Resize texture to fit block size.
-		r_img->resize(required_width, required_height);
-		width = required_width;
-		height = required_height;
+	if (r_img->get_width() != width || r_img->get_height() != height) {
+		// Align the image to the block size.
+		r_img->resize(width, height, Image::INTERPOLATE_NEAREST);
 	}
 
 	print_verbose(vformat("astcenc: Encoding image size %dx%d to format %s%s.", width, height, Image::get_format_name(target_format), has_mipmaps ? ", with mipmaps" : ""));

--- a/modules/basis_universal/image_compress_basisu.h
+++ b/modules/basis_universal/image_compress_basisu.h
@@ -46,13 +46,6 @@ constexpr uint32_t BASIS_DECOMPRESS_FLAG_KTX2 = 1 << 31;
 void basis_universal_init();
 
 #ifdef TOOLS_ENABLED
-struct BasisRGBAF {
-	uint32_t r;
-	uint32_t g;
-	uint32_t b;
-	uint32_t a;
-};
-
 Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedChannels p_channels, const Image::BasisUniversalPackerParams &p_basisu_params);
 #endif
 

--- a/modules/bcdec/image_decompress_bcdec.cpp
+++ b/modules/bcdec/image_decompress_bcdec.cpp
@@ -272,7 +272,7 @@ void image_decompress_bcdec(Image *p_image) {
 			break;
 	}
 
-	int mm_count = p_image->get_mipmap_count();
+	int mm_count = p_image->has_mipmaps() ? Image::get_image_required_mipmaps(width, height, target_format) : 0;
 	int64_t target_size = Image::get_image_data_size(width, height, target_format, p_image->has_mipmaps());
 
 	// Decompressed data.

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -441,11 +441,12 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 		return ERR_INVALID_DATA;
 	}
 
-	int img_width = r_img->get_width();
-	int img_height = r_img->get_height();
-	if (img_width % 4 != 0 || img_height % 4 != 0) {
-		img_width = img_width <= 2 ? img_width : (img_width + 3) & ~3;
-		img_height = img_height <= 2 ? img_height : (img_height + 3) & ~3;
+	int img_width = (r_img->get_width() + 3) & ~0x03;
+	int img_height = (r_img->get_height() + 3) & ~0x03;
+
+	if (r_img->get_width() != img_width || r_img->get_height() != img_height) {
+		// Align the image to 4x4 texels.
+		r_img->resize(img_width, img_height, Image::INTERPOLATE_NEAREST);
 	}
 
 	Error err = OK;
@@ -549,38 +550,9 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 		dst_texture_format.height = (height + 3) >> 2;
 		dst_texture_format.width = (width + 3) >> 2;
 
-		// Pad textures to nearest block by smearing.
-		if (width != src_mip_w || height != src_mip_h) {
-			const uint8_t *src_mip_read = r_img->ptr() + src_mip_ofs;
-
-			// Reserve the buffer for padded image data.
-			int px_size = Image::get_format_pixel_size(r_img->get_format());
-			src_image_ptr[0].resize(width * height * px_size);
-			uint8_t *ptrw = src_image_ptr[0].ptrw();
-
-			int x = 0, y = 0;
-			for (y = 0; y < src_mip_h; y++) {
-				for (x = 0; x < src_mip_w; x++) {
-					memcpy(ptrw + (width * y + x) * px_size, src_mip_read + (src_mip_w * y + x) * px_size, px_size);
-				}
-
-				// First, smear in x.
-				for (; x < width; x++) {
-					memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - 1) * px_size, px_size);
-				}
-			}
-
-			// Then, smear in y.
-			for (; y < height; y++) {
-				for (x = 0; x < width; x++) {
-					memcpy(ptrw + (width * y + x) * px_size, ptrw + (width * y + x - width) * px_size, px_size);
-				}
-			}
-		} else {
-			// Create a buffer filled with the source mip layer data.
-			src_image_ptr[0].resize(src_mip_size);
-			memcpy(src_image_ptr[0].ptrw(), r_img->ptr() + src_mip_ofs, src_mip_size);
-		}
+		// Create a buffer filled with the source mip layer data.
+		src_image_ptr[0].resize(src_mip_size);
+		memcpy(src_image_ptr[0].ptrw(), r_img->ptr() + src_mip_ofs, src_mip_size);
 
 		// Create the textures on the GPU.
 		RID src_texture;

--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -148,12 +148,12 @@ void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels, Image::
 		return; //do not compress, already compressed
 	}
 
-	int w = p_image->get_width();
-	int h = p_image->get_height();
+	int w = (p_image->get_width() + 3) & ~0x03;
+	int h = (p_image->get_height() + 3) & ~0x03;
 
-	if (w % 4 != 0 || h % 4 != 0) {
-		w = w <= 2 ? w : (w + 3) & ~3;
-		h = h <= 2 ? h : (h + 3) & ~3;
+	if (p_image->get_width() != w || p_image->get_height() != h) {
+		// Align the image to 4x4 texels.
+		p_image->resize(w, h, Image::INTERPOLATE_NEAREST);
 	}
 
 	bool is_ldr = (p_image->get_format() <= Image::FORMAT_RGBA8);

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -163,8 +163,6 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 
 	// Compress image data and (if required) mipmaps.
 	const bool has_mipmaps = r_img->has_mipmaps();
-	int width = r_img->get_width();
-	int height = r_img->get_height();
 
 	/*
 	The first mipmap level of a compressed texture must be a multiple of 4. Quote from D3D11.3 spec:
@@ -184,9 +182,12 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 	the surface pitch, which can encompass additional padding beyond the physical surface size.
 	*/
 
-	if (width % 4 != 0 || height % 4 != 0) {
-		width = width <= 2 ? width : (width + 3) & ~3;
-		height = height <= 2 ? height : (height + 3) & ~3;
+	int width = (r_img->get_width() + 3) & ~0x03;
+	int height = (r_img->get_height() + 3) & ~0x03;
+
+	if (r_img->get_width() != width || r_img->get_height() != height) {
+		// Align the image to 4x4 texels.
+		r_img->resize(width, height, Image::INTERPOLATE_NEAREST);
 	}
 
 	// Multiple-of-4 should be guaranteed by above.

--- a/modules/etcpak/image_decompress_etcpak.cpp
+++ b/modules/etcpak/image_decompress_etcpak.cpp
@@ -214,7 +214,7 @@ void _decompress_etc(Image *p_image) {
 			break;
 	}
 
-	int mm_count = p_image->get_mipmap_count();
+	int mm_count = p_image->has_mipmaps() ? Image::get_image_required_mipmaps(width, height, target_format) : 0;
 	int64_t target_size = Image::get_image_data_size(width, height, target_format, p_image->has_mipmaps());
 
 	// Decompressed data.


### PR DESCRIPTION
Supersedes #115307
Should fix #113121

Changes the texture compressors' padding algorithm to instead align the textures to the nearest block size using nearest-neighbor scaling. This corrects the mipmap count of compressed textures and fixes some edge cases that would otherwise occur with the previous approach.

### Rationale:
Currently, Godot makes use of a very simple padding algorithm to align a texture's resolution to the necessary block size (commonly 4x4, but ASTC allows many more). While said algorithm is fairly fast and avoids smearing low-resolution images (unlike Lanczos or Bicubic), it also comes with several drawbacks:
- smeared lines at the right and bottom parts of a texture: I was initially hoping this could've been avoided by setting the resolution of a block-compressed texture to the same value as the source texture's, but sadly this feature isn't supported by all rendering backends, especially WebGL.
- Mipmap-related issues: Such as the one linked above,
- Duplicate code: The same code appears in effectively each compressor module. I'm also fairly certain each instance contains minor bugs.

While these problems could be fixed/improved, ultimately I've decided to simply switch to nearest-neighbor scaling, which is faster than the other algorithms and doesn't blur low-resolution images as much.

Testing project: [compress-tester.zip](https://github.com/user-attachments/files/27087410/compress-tester.zip)

The testing project displays the last mipmap of an entirely white texture, which is the desired result. If the color changes during compression it means the last mipmap is incorrectly handled and filled with garbage data.

Comparison:
| Before | After |
|--------|-------|
| <img width="1164" height="666" alt="old" src="https://github.com/user-attachments/assets/a203ce7b-4578-4570-b59a-d60897f26c03" /> | <img width="1164" height="659" alt="new" src="https://github.com/user-attachments/assets/87e34724-7544-4371-917a-d8a21199c310" /> |

