### PR TITLE
Fix `OpenXRExportPlugin::_get_name() must be overridden` error

### DIFF
--- a/modules/openxr/editor/openxr_editor_plugin.h
+++ b/modules/openxr/editor/openxr_editor_plugin.h
@@ -41,6 +41,7 @@ class OpenXRExportPlugin : public EditorExportPlugin {
 	GDCLASS(OpenXRExportPlugin, EditorExportPlugin)
 
 public:
+	virtual String get_name() const override { return "OpenXRExportPlugin"; }
 	virtual bool supports_platform(const Ref<EditorExportPlatform> &p_export_platform) const override;
 	virtual PackedStringArray get_android_dependencies(const Ref<EditorExportPlatform> &p_export_platform, bool p_debug) const override;
 


### PR DESCRIPTION
Another tiny fix for the changes from https://github.com/godotengine/godot/pull/106891

At the moment, if you do an Android export with OpenXR enabled, this error will be printed:

```
ERROR: editor/export/editor_export_plugin.h:139 - Required virtual method OpenXRExportPlugin::_get_name must be overridden before calling.
```

And this PR fixes that!