### PR TITLE
Add render mode `keep_backface_normals` to shade backfaces with the same normals as frontfaces for correct shading of custom normals

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -278,6 +278,12 @@
 			For best results, the texture should be normalized (with [member heightmap_scale] reduced to compensate). In [url=https://gimp.org]GIMP[/url], this can be done using [b]Colors &gt; Auto &gt; Equalize[/b]. If the texture only uses a small part of its available range, the parallax effect may look strange, especially when the camera moves.
 			[b]Note:[/b] To reduce memory usage and improve loading times, you may be able to use a lower-resolution heightmap texture as most heightmaps are only comprised of low-frequency data.
 		</member>
+		<member name="keep_backface_normals" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], each backface will be shaded with the same normal vector as the frontface instead of pointing the normal vector of backfaces into the opposite direction. This means that frontfaces and backfaces will receive the same shading.
+			This is useful when using custom normals which differ from the actual geometry, e.g. stylized foliage billboards with spherical normals.
+			For example, when using billboards with a normal vector pointing straight up, this setting should be enabled; otherwise, backfaces will have their normal vector point straight [i]down[/i].
+			[b]Note:[/b] Only relevant if [member cull_mode] is not set to [constant CULL_BACK].
+		</member>
 		<member name="metallic" type="float" setter="set_metallic" getter="get_metallic" default="0.0">
 			A high value makes the material appear more like a metal. Non-metals use their albedo as the diffuse color and add diffuse to the specular reflection. With non-metals, the reflection appears on top of the albedo color. Metals use their albedo as a multiplier to the specular reflection and set the diffuse color to black resulting in a tinted reflection. Materials work better when fully metal or fully non-metal, values between [code]0[/code] and [code]1[/code] should only be used for blending between metal and non-metal sections. To alter the amount of reflection use [member roughness].
 		</member>
@@ -775,7 +781,10 @@
 		<constant name="FLAG_USE_FOV_OVERRIDE" value="24" enum="Flags">
 			Enables using [member fov_override].
 		</constant>
-		<constant name="FLAG_MAX" value="25" enum="Flags">
+		<constant name="FLAG_KEEP_BACKFACE_NORMALS" value="25" enum="Flags">
+			Enables using [member keep_backface_normals].
+		</constant>
+		<constant name="FLAG_MAX" value="26" enum="Flags">
 			Represents the size of the [enum Flags] enum.
 		</constant>
 		<constant name="DIFFUSE_BURLEY" value="0" enum="DiffuseMode">

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2027,11 +2027,11 @@ void main() {
 
 #ifdef NORMAL_USED
 	vec3 normal = normal_interp;
-#if defined(DO_SIDE_CHECK)
+#if defined(DO_SIDE_CHECK) && !defined(AVOID_SIDE_CHECK)
 	if (!gl_FrontFacing) {
 		normal = -normal;
 	}
-#endif // DO_SIDE_CHECK
+#endif // DO_SIDE_CHECK && !AVOID_SIDE_CHECK
 #endif // NORMAL_USED
 
 #ifdef UV_USED

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1391,6 +1391,7 @@ MaterialStorage::MaterialStorage() {
 		actions.render_mode_defines["ensure_correct_normals"] = "#define ENSURE_CORRECT_NORMALS\n";
 		actions.render_mode_defines["cull_front"] = "#define DO_SIDE_CHECK\n";
 		actions.render_mode_defines["cull_disabled"] = "#define DO_SIDE_CHECK\n";
+		actions.render_mode_defines["keep_backface_normals"] = "#define AVOID_SIDE_CHECK\n";
 		actions.render_mode_defines["particle_trails"] = "#define USE_PARTICLE_TRAILS\n";
 		actions.render_mode_defines["depth_prepass_alpha"] = "#define USE_OPAQUE_PREPASS\n";
 
@@ -3003,6 +3004,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	actions.render_mode_values["cull_disabled"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_DISABLED);
 	actions.render_mode_values["cull_front"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_FRONT);
 	actions.render_mode_values["cull_back"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_BACK);
+	actions.render_mode_flags["keep_backface_normals"] = &keep_backface_normals;
 
 	actions.render_mode_flags["unshaded"] = &unshaded;
 	actions.render_mode_flags["wireframe"] = &wireframe;

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -302,6 +302,7 @@ struct SceneShaderData : public ShaderData {
 	DepthDraw depth_draw;
 	DepthTest depth_test;
 	RS::CullMode cull_mode;
+	bool keep_backface_normals;
 
 	StencilCompare stencil_compare;
 	uint32_t stencil_flags;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -824,6 +824,9 @@ void BaseMaterial3D::_update_shader() {
 		case CULL_MAX:
 			break; // Internal value, skip.
 	}
+	if (flags[FLAG_KEEP_BACKFACE_NORMALS]) {
+		code += ", keep_backface_normals";
+	}
 	switch (diffuse_mode) {
 		case DIFFUSE_BURLEY:
 			code += ", diffuse_burley";
@@ -2445,6 +2448,7 @@ void BaseMaterial3D::set_cull_mode(CullMode p_mode) {
 
 	cull_mode = p_mode;
 	_queue_shader_change();
+	notify_property_list_changed();
 }
 
 BaseMaterial3D::CullMode BaseMaterial3D::get_cull_mode() const {
@@ -2616,6 +2620,10 @@ void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
 		}
 
 		if (p_property.name == "fov_override" && !flags[FLAG_USE_FOV_OVERRIDE]) {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		}
+
+		if (p_property.name == "keep_backface_normals" && cull_mode == CULL_BACK) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
@@ -3582,6 +3590,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_antialiasing_edge", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_alpha_antialiasing_edge", "get_alpha_antialiasing_edge");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Subtract,Multiply,Premultiplied Alpha"), "set_blend_mode", "get_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mode", PROPERTY_HINT_ENUM, "Back,Front,Disabled"), "set_cull_mode", "get_cull_mode");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "keep_backface_normals"), "set_flag", "get_flag", FLAG_KEEP_BACKFACE_NORMALS);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "depth_draw_mode", PROPERTY_HINT_ENUM, "Opaque Only,Always,Never"), "set_depth_draw_mode", "get_depth_draw_mode");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "no_depth_test"), "set_flag", "get_flag", FLAG_DISABLE_DEPTH_TEST);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "depth_test", PROPERTY_HINT_ENUM, "Default,Inverted"), "set_depth_test", "get_depth_test");
@@ -3875,6 +3884,7 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_DISABLE_SPECULAR_OCCLUSION);
 	BIND_ENUM_CONSTANT(FLAG_USE_Z_CLIP_SCALE);
 	BIND_ENUM_CONSTANT(FLAG_USE_FOV_OVERRIDE);
+	BIND_ENUM_CONSTANT(FLAG_KEEP_BACKFACE_NORMALS);
 	BIND_ENUM_CONSTANT(FLAG_MAX);
 
 	BIND_ENUM_CONSTANT(DIFFUSE_BURLEY);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -279,6 +279,7 @@ public:
 		FLAG_DISABLE_SPECULAR_OCCLUSION,
 		FLAG_USE_Z_CLIP_SCALE,
 		FLAG_USE_FOV_OVERRIDE,
+		FLAG_KEEP_BACKFACE_NORMALS,
 		FLAG_MAX
 	};
 
@@ -604,6 +605,7 @@ private:
 	DepthDrawMode depth_draw_mode = DEPTH_DRAW_OPAQUE_ONLY;
 	DepthTest depth_test = DEPTH_TEST_DEFAULT;
 	CullMode cull_mode = CULL_BACK;
+	bool keep_backface_normals = true;
 	bool flags[FLAG_MAX] = {};
 	SpecularMode specular_mode = SPECULAR_SCHLICK_GGX;
 	DiffuseMode diffuse_mode = DIFFUSE_BURLEY;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -56,6 +56,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	depth_test_invertedi = 0;
 	alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 	int cull_modei = RS::CULL_MODE_BACK;
+	keep_backface_normals = false;
 
 	uses_point_size = false;
 	uses_alpha = false;
@@ -114,6 +115,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	actions.render_mode_values["cull_disabled"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_DISABLED);
 	actions.render_mode_values["cull_front"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_FRONT);
 	actions.render_mode_values["cull_back"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_BACK);
+	actions.render_mode_flags["keep_backface_normals"] = &keep_backface_normals;
 
 	actions.render_mode_flags["unshaded"] = &unshaded;
 	actions.render_mode_flags["wireframe"] = &wireframe;
@@ -834,6 +836,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.render_mode_defines["ensure_correct_normals"] = "#define ENSURE_CORRECT_NORMALS\n";
 		actions.render_mode_defines["cull_front"] = "#define DO_SIDE_CHECK\n";
 		actions.render_mode_defines["cull_disabled"] = "#define DO_SIDE_CHECK\n";
+		actions.render_mode_defines["keep_backface_normals"] = "#define AVOID_SIDE_CHECK\n";
 		actions.render_mode_defines["particle_trails"] = "#define USE_PARTICLE_TRAILS\n";
 		actions.render_mode_defines["depth_prepass_alpha"] = "#define USE_OPAQUE_PREPASS\n";
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -266,6 +266,7 @@ public:
 		bool uses_screen_texture_mipmaps = false;
 		bool uses_z_clip_scale = false;
 		RS::CullMode cull_mode = RS::CULL_MODE_DISABLED;
+		bool keep_backface_normals = false;
 
 		bool stencil_enabled = false;
 		uint32_t stencil_flags = 0;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -58,6 +58,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	depth_test_invertedi = 0;
 	alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 	cull_mode = RS::CULL_MODE_BACK;
+	keep_backface_normals = false;
 
 	uses_point_size = false;
 	uses_alpha = false;
@@ -114,6 +115,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	actions.render_mode_values["cull_disabled"] = Pair<int *, int>(&cull_mode, RS::CULL_MODE_DISABLED);
 	actions.render_mode_values["cull_front"] = Pair<int *, int>(&cull_mode, RS::CULL_MODE_FRONT);
 	actions.render_mode_values["cull_back"] = Pair<int *, int>(&cull_mode, RS::CULL_MODE_BACK);
+	actions.render_mode_flags["keep_backface_normals"] = &keep_backface_normals;
 
 	actions.render_mode_flags["unshaded"] = &unshaded;
 	actions.render_mode_flags["wireframe"] = &wireframe;
@@ -769,6 +771,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.render_mode_defines["ensure_correct_normals"] = "#define ENSURE_CORRECT_NORMALS\n";
 		actions.render_mode_defines["cull_front"] = "#define DO_SIDE_CHECK\n";
 		actions.render_mode_defines["cull_disabled"] = "#define DO_SIDE_CHECK\n";
+		actions.render_mode_defines["keep_backface_normals"] = "#define AVOID_SIDE_CHECK\n";
 		actions.render_mode_defines["particle_trails"] = "#define USE_PARTICLE_TRAILS\n";
 		actions.render_mode_defines["depth_prepass_alpha"] = "#define USE_OPAQUE_PREPASS\n";
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -241,6 +241,7 @@ public:
 		int depth_test_invertedi = 0;
 		int alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 		int cull_mode = RS::CULL_MODE_BACK;
+		bool keep_backface_normals = false;
 
 		bool uses_point_size = false;
 		bool uses_alpha = false;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1217,11 +1217,11 @@ void fragment_shader(in SceneData scene_data) {
 
 #ifdef NORMAL_USED
 	vec3 normal_highp = normal_interp;
-#if defined(DO_SIDE_CHECK)
+#if defined(DO_SIDE_CHECK) && !defined(AVOID_SIDE_CHECK)
 	if (!gl_FrontFacing) {
 		normal_highp = -normal_highp;
 	}
-#endif // DO_SIDE_CHECK
+#endif // DO_SIDE_CHECK && !AVOID_SIDE_CHECK
 #endif // NORMAL_USED
 
 #ifdef UV_USED

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1137,11 +1137,11 @@ void main() {
 
 #ifdef NORMAL_USED
 	vec3 normal_highp = normal_interp;
-#if defined(DO_SIDE_CHECK)
+#if defined(DO_SIDE_CHECK) && !defined(AVOID_SIDE_CHECK)
 	if (!gl_FrontFacing) {
 		normal_highp = -normal_highp;
 	}
-#endif // DO_SIDE_CHECK
+#endif // DO_SIDE_CHECK && !AVOID_SIDE_CHECK
 #endif // NORMAL_USED
 
 #ifdef UV_USED

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -233,6 +233,7 @@ ShaderTypes::ShaderTypes() {
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_draw"), "opaque", "always", "never" });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_prepass_alpha") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_test"), { "default", "disabled", "inverted" } });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("keep_backface_normals") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("sss_mode_skin") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("cull"), "back", "front", "disabled" });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("unshaded") });


### PR DESCRIPTION
When `cull_mode` is set to something other than `CULL_BACK`, backfaces are rendered. By default, these backfaces have their normal vector point into the opposite direction of frontfaces.

This makes sense when normals are consistent with the geometry. However, this is not always the case. For example, stylized vegetation often has billboards whose normals point into the same direction as the surface underneath to produce consistent, smooth shading. See e.g. here: https://simonschreibt.de/gat/airborn-trees/

With Godot's default behavior, these custom normals point straight *down* for backfaces:

<img width="1219" height="678" alt="image" src="https://github.com/user-attachments/assets/3b4b0f43-25a3-4136-b5be-61c5a4282f90" />

This has been reported before: https://github.com/godotengine/godot/issues/42411 That issue has been closed, presumably because of the suggested workaround:

```
void fragment ()
{
	if (!FRONT_FACING) {
		NORMAL = -NORMAL;
	}
}
```

This does work, but it's not an ideal solution. Firstly, it's not documented anywhere, you have to find the issue to know the workaround. Secondly, it requires a custom shader.

This PR introduces a new render mode to shaders called `keep_backface_normals`. This render mode avoids the default behavior and keeps backface normals pointing into the same direction as frontface normals, causing stylized geometry with modified normals to look as intended.

<img width="1478" height="760" alt="image" src="https://github.com/user-attachments/assets/372b973d-85f1-4763-88d6-69daec2eb930" />

<img width="1478" height="579" alt="image" src="https://github.com/user-attachments/assets/0d331210-70d7-4af4-a080-c7cd136cfb16" />


I decided to use a render mode rather than a material flag to avoid users from needing to fall back to the workaround when using a custom shader. It wouldn't be a big deal for code shaders, but with VisualShaders, building that condition is pretty tedious.

This is my first time working with the engine's rendering code, so please let me know if anything should be changed!

I've tested the PR on my Linux PC (Nvidia GPU) with the Forward+, Mobile, and Compatibility renderers.
Here's the project from the screenshot above, if anyone else wants to do further testing: [backface-normal-test.zip](https://github.com/user-attachments/files/23773281/backface-normal-test.zip)


I'll add the render mode to the shading reference when/if the PR is merged.

Thanks!