### PR TITLE
Fix error message when closing the project manager on Wayland

### DIFF
--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -2962,7 +2962,9 @@ void WaylandEmbedder::handle_fd(int p_fd, int p_revents) {
 
 WaylandEmbedder::~WaylandEmbedder() {
 	shutdown();
-	proxy_thread.wait_to_finish();
+	if (proxy_thread.is_started()) {
+		proxy_thread.wait_to_finish();
+	}
 }
 
 #endif // TOOLS_ENABLED


### PR DESCRIPTION
This PR fixes the cause that would make this message popup whenever the project manager was closed if Wayland was enabled in the editor:
```
ERROR: Attempt of waiting to finish on a thread that was never started.
```