### PR TITLE
Include xkb-compose in `wayland_thread.h`

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -45,6 +45,7 @@
 #ifdef GLES3_ENABLED
 #include <wayland-egl-core.h>
 #endif
+#include <xkbcommon/xkbcommon-compose.h>
 #include <xkbcommon/xkbcommon.h>
 #endif // SOWRAP_ENABLED
 


### PR DESCRIPTION
This fixes builds without SOWRAP_ENABLED, as quite a few xkb functions are defined there.