### PR TITLE
Expose 'Resource::set_resource_id_for_path'

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -726,6 +726,7 @@ void Resource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("setup_local_to_scene"), &Resource::setup_local_to_scene);
 	ClassDB::bind_method(D_METHOD("reset_state"), &Resource::reset_state);
 
+	ClassDB::bind_static_method("Resource", D_METHOD("set_resource_id_for_path", "original_path", "path", "id"), &Resource::set_resource_id_for_path);
 	ClassDB::bind_method(D_METHOD("set_id_for_path", "path", "id"), &Resource::set_id_for_path);
 	ClassDB::bind_method(D_METHOD("get_id_for_path", "path"), &Resource::get_id_for_path);
 

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -138,6 +138,16 @@
 				Sets the resource's path to [param path] without involving the resource cache. Useful for handling [enum ResourceFormatLoader.CacheMode] values when implementing a custom resource format by extending [ResourceFormatLoader] and [ResourceFormatSaver].
 			</description>
 		</method>
+		<method name="set_resource_id_for_path" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="original_path" type="String" />
+			<param index="1" name="path" type="String" />
+			<param index="2" name="id" type="String" />
+			<description>
+				Static version of [method set_id_for_path] that allows you to change the resource at [param original_path] without the need to load the resource first with this class.
+				[b]Note:[/b] This method is only implemented when running in an editor context.
+			</description>
+		</method>
 		<method name="setup_local_to_scene" deprecated="This method should only be called internally.">
 			<return type="void" />
 			<description>


### PR DESCRIPTION
This PR exposes `Resource::set_resource_id_for_path` that is already used by `Resource` class under the hood. 

The main benifit of this instead of using `Resource::set_id_for_path` is that you dont actually need to load the file just to remap it to a different path in the virtual filesystem, making it possible to remap entire folders worth of assets really fast by skipping the need to unnecessary load potentially heavy resources since `set_resource_id_for_path` communicates with the resource cache directly.

Here is the proposal, closes: https://github.com/godotengine/godot-proposals/issues/13732