### PR TITLE
Allow converting from Mesh to ImporterMesh

### DIFF
--- a/doc/classes/ImporterMesh.xml
+++ b/doc/classes/ImporterMesh.xml
@@ -42,6 +42,13 @@
 				Removes all surfaces and blend shapes from this [ImporterMesh].
 			</description>
 		</method>
+		<method name="from_mesh" qualifiers="static">
+			<return type="ImporterMesh" />
+			<param index="0" name="mesh" type="Mesh" />
+			<description>
+				Converts the given [Mesh] into an [ImporterMesh] by copying all its surfaces, blend shapes, materials, and metadata into a new [ImporterMesh] object.
+			</description>
+		</method>
 		<method name="generate_lods">
 			<return type="void" />
 			<param index="0" name="normal_merge_angle" type="float" />

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -64,13 +64,13 @@ Mesh::BlendShapeMode ImporterMesh::get_blend_shape_mode() const {
 	return blend_shape_mode;
 }
 
-void ImporterMesh::add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes, const Dictionary &p_lods, const Ref<Material> &p_material, const String &p_name, const uint64_t p_flags) {
+void ImporterMesh::add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes, const Dictionary &p_lods, const Ref<Material> &p_material, const String &p_surface_name, const uint64_t p_flags) {
 	ERR_FAIL_COND(p_blend_shapes.size() != blend_shapes.size());
 	ERR_FAIL_COND(p_arrays.size() != Mesh::ARRAY_MAX);
 	Surface s;
 	s.primitive = p_primitive;
 	s.arrays = p_arrays;
-	s.name = p_name;
+	s.name = p_surface_name;
 	s.flags = p_flags;
 
 	Vector<Vector3> vertex_array = p_arrays[Mesh::ARRAY_VERTEX];
@@ -625,6 +625,44 @@ Ref<ArrayMesh> ImporterMesh::get_mesh(const Ref<ArrayMesh> &p_base) {
 	}
 
 	return mesh;
+}
+
+Ref<ImporterMesh> ImporterMesh::from_mesh(const Ref<Mesh> &p_mesh) {
+	Ref<ImporterMesh> importer_mesh;
+	importer_mesh.instantiate();
+	if (p_mesh.is_null()) {
+		return importer_mesh;
+	}
+	Ref<ArrayMesh> array_mesh = p_mesh;
+	// Convert blend shape mode and names if any.
+	if (p_mesh->get_blend_shape_count() > 0) {
+		ArrayMesh::BlendShapeMode shape_mode = ArrayMesh::BLEND_SHAPE_MODE_NORMALIZED;
+		if (array_mesh.is_valid()) {
+			shape_mode = array_mesh->get_blend_shape_mode();
+		}
+		importer_mesh->set_blend_shape_mode(shape_mode);
+		for (int morph_i = 0; morph_i < p_mesh->get_blend_shape_count(); morph_i++) {
+			importer_mesh->add_blend_shape(p_mesh->get_blend_shape_name(morph_i));
+		}
+	}
+	// Add surfaces one by one.
+	for (int32_t surface_i = 0; surface_i < p_mesh->get_surface_count(); surface_i++) {
+		Ref<Material> mat = p_mesh->surface_get_material(surface_i);
+		String surface_name;
+		if (array_mesh.is_valid()) {
+			surface_name = array_mesh->surface_get_name(surface_i);
+		}
+		if (surface_name.is_empty() && mat.is_valid()) {
+			surface_name = mat->get_name();
+		}
+		importer_mesh->add_surface(p_mesh->surface_get_primitive_type(surface_i), p_mesh->surface_get_arrays(surface_i),
+				p_mesh->surface_get_blend_shape_arrays(surface_i), p_mesh->surface_get_lods(surface_i),
+				mat, surface_name, p_mesh->surface_get_format(surface_i));
+	}
+	// Merge metadata.
+	importer_mesh->merge_meta_from(*p_mesh);
+	importer_mesh->set_name(p_mesh->get_name());
+	return importer_mesh;
 }
 
 void ImporterMesh::clear() {
@@ -1255,6 +1293,7 @@ void ImporterMesh::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("generate_lods", "normal_merge_angle", "normal_split_angle", "bone_transform_array"), &ImporterMesh::_generate_lods_bind);
 	ClassDB::bind_method(D_METHOD("get_mesh", "base_mesh"), &ImporterMesh::get_mesh, DEFVAL(Ref<ArrayMesh>()));
+	ClassDB::bind_static_method("ImporterMesh", D_METHOD("from_mesh", "mesh"), &ImporterMesh::from_mesh);
 	ClassDB::bind_method(D_METHOD("clear"), &ImporterMesh::clear);
 
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &ImporterMesh::_set_data);

--- a/scene/resources/3d/importer_mesh.h
+++ b/scene/resources/3d/importer_mesh.h
@@ -93,7 +93,7 @@ public:
 
 	static String validate_blend_shape_name(const String &p_name);
 
-	void add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), const Ref<Material> &p_material = Ref<Material>(), const String &p_name = String(), const uint64_t p_flags = 0);
+	void add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), const Ref<Material> &p_material = Ref<Material>(), const String &p_surface_name = String(), const uint64_t p_flags = 0);
 	int get_surface_count() const;
 
 	void set_blend_shape_mode(Mesh::BlendShapeMode p_blend_shape_mode);
@@ -133,5 +133,6 @@ public:
 
 	bool has_mesh() const;
 	Ref<ArrayMesh> get_mesh(const Ref<ArrayMesh> &p_base = Ref<ArrayMesh>());
+	static Ref<ImporterMesh> from_mesh(const Ref<Mesh> &p_mesh);
 	void clear();
 };


### PR DESCRIPTION
ImporterMesh is designed primarily for use during the import process, as the name implies. However, the GLTF module needs to do the reverse as well, when exporting a glTF file from Godot.

In master, GLTFDocument contained duplicate code for converting ImporterMesh to Mesh. I could just deduplicate this within GLTFDocument, but in the near future, I will need to reference this function outside of GLTFDocument (specifically, `GLTFDocumentExtensionMultiMesh` in PR #112866). This PR moves this functionality to ImporterMesh, and exposes it.

This PR also fixes a minor bug where the material name was used as the surface name, taking priority over the... actual surface name. To make this clearer, I also renamed the `ImporterMesh::add_surface` parameter `p_name` to `p_surface_name` to explicitly indicate that this should be the surface name and not the material name.