### PR TITLE
MultiMesh: Allow getting 3D transforms regardless of internal format

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4422,27 +4422,11 @@ void GLTFDocument::_convert_multi_mesh_instance_to_gltf(
 	gltf_mesh->set_mesh(ImporterMesh::from_mesh(mesh));
 	GLTFMeshIndex mesh_index = p_state->meshes.size();
 	p_state->meshes.push_back(gltf_mesh);
-	for (int32_t instance_i = 0; instance_i < multi_mesh->get_instance_count();
-			instance_i++) {
-		Transform3D transform;
-		if (multi_mesh->get_transform_format() == MultiMesh::TRANSFORM_2D) {
-			Transform2D xform_2d = multi_mesh->get_instance_transform_2d(instance_i);
-			transform.origin =
-					Vector3(xform_2d.get_origin().x, 0, xform_2d.get_origin().y);
-			real_t rotation = xform_2d.get_rotation();
-			Quaternion quaternion(Vector3(0, 1, 0), rotation);
-			Size2 scale = xform_2d.get_scale();
-			transform.basis.set_quaternion_scale(quaternion,
-					Vector3(scale.x, 0, scale.y));
-			transform = p_multi_mesh_instance->get_transform() * transform;
-		} else if (multi_mesh->get_transform_format() == MultiMesh::TRANSFORM_3D) {
-			transform = p_multi_mesh_instance->get_transform() *
-					multi_mesh->get_instance_transform(instance_i);
-		}
+	for (int32_t instance_i = 0; instance_i < multi_mesh->get_instance_count(); instance_i++) {
 		Ref<GLTFNode> new_gltf_node;
 		new_gltf_node.instantiate();
 		new_gltf_node->mesh = mesh_index;
-		new_gltf_node->transform = transform;
+		new_gltf_node->transform = multi_mesh->get_instance_transform(instance_i);
 		new_gltf_node->set_original_name(p_multi_mesh_instance->get_name());
 		new_gltf_node->set_name(_gen_unique_name(p_state, p_multi_mesh_instance->get_name()));
 		p_gltf_node->children.push_back(p_state->nodes.size());

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4449,27 +4449,11 @@ void GLTFDocument::_convert_multi_mesh_instance_to_gltf(
 	gltf_mesh->set_mesh(ImporterMesh::from_mesh(mesh));
 	GLTFMeshIndex mesh_index = p_state->meshes.size();
 	p_state->meshes.push_back(gltf_mesh);
-	for (int32_t instance_i = 0; instance_i < multi_mesh->get_instance_count();
-			instance_i++) {
-		Transform3D transform;
-		if (multi_mesh->get_transform_format() == MultiMesh::TRANSFORM_2D) {
-			Transform2D xform_2d = multi_mesh->get_instance_transform_2d(instance_i);
-			transform.origin =
-					Vector3(xform_2d.get_origin().x, 0, xform_2d.get_origin().y);
-			real_t rotation = xform_2d.get_rotation();
-			Quaternion quaternion(Vector3(0, 1, 0), rotation);
-			Size2 scale = xform_2d.get_scale();
-			transform.basis.set_quaternion_scale(quaternion,
-					Vector3(scale.x, 0, scale.y));
-			transform = p_multi_mesh_instance->get_transform() * transform;
-		} else if (multi_mesh->get_transform_format() == MultiMesh::TRANSFORM_3D) {
-			transform = p_multi_mesh_instance->get_transform() *
-					multi_mesh->get_instance_transform(instance_i);
-		}
+	for (int32_t instance_i = 0; instance_i < multi_mesh->get_instance_count(); instance_i++) {
 		Ref<GLTFNode> new_gltf_node;
 		new_gltf_node.instantiate();
 		new_gltf_node->mesh = mesh_index;
-		new_gltf_node->transform = transform;
+		new_gltf_node->transform = multi_mesh->get_instance_transform(instance_i);
 		new_gltf_node->set_original_name(p_multi_mesh_instance->get_name());
 		new_gltf_node->set_name(_gen_unique_name(p_state, p_multi_mesh_instance->get_name()));
 		p_gltf_node->children.push_back(p_state->nodes.size());

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -270,8 +270,18 @@ void MultiMesh::set_instance_transform_2d(int p_instance, const Transform2D &p_t
 
 Transform3D MultiMesh::get_instance_transform(int p_instance) const {
 	ERR_FAIL_INDEX_V_MSG(p_instance, instance_count, Transform3D(), "Instance index out of bounds. Instance index must be less than `instance_count` and greater than or equal to zero.");
-	ERR_FAIL_COND_V_MSG(transform_format == TRANSFORM_2D, Transform3D(), "Can't get Transform3D on a Multimesh configured to use Transform2D. Ensure that you have set the `transform_format` to `TRANSFORM_3D`.");
-	return RenderingServer::get_singleton()->multimesh_instance_get_transform(multimesh, p_instance);
+	if (likely(transform_format == TRANSFORM_3D)) {
+		return RenderingServer::get_singleton()->multimesh_instance_get_transform(multimesh, p_instance);
+	}
+	// Otherwise, convert 2D to 3D.
+	Transform3D ret;
+	const Transform2D transform_2d = RenderingServer::get_singleton()->multimesh_instance_get_transform_2d(multimesh, p_instance);
+	ret.basis.rows[0][0] = transform_2d.columns[0][0];
+	ret.basis.rows[1][0] = transform_2d.columns[0][1];
+	ret.basis.rows[0][1] = transform_2d.columns[1][0];
+	ret.basis.rows[1][1] = transform_2d.columns[1][1];
+	ret.origin = Vector3(transform_2d.columns[2][0], transform_2d.columns[2][1], 0.0f);
+	return ret;
 }
 
 Transform2D MultiMesh::get_instance_transform_2d(int p_instance) const {


### PR DESCRIPTION
MultiMesh is designed to be usable with both 2D and 3D transforms. Interestingly, MultiMeshInstance3D already allows using MultiMesh resources with 2D transforms. I assume this could be used for space savings in some hyper-optimized use case.

GLTFDocument had code in it to handle this case, by performing a conversion from 2D to 3D. However, the existing code had several bugs in it. For example, it incorrectly swapped Y into Z, and incorrectly multiplied the MultiMeshInstance3D's own transform. The correct behavior is also simpler, just... copy the values over, there's no need to recompute anything.

This PR moves the 2D to 3D conversion logic into MultiMesh itself, allowing always getting 3D transforms regardless of what mode it is in instead of erroring, and greatly simplifies the code in GLTFDocument.