### PR TITLE
Make `NodePath` copy-on-write, to avoid it changing accidentally (through copies)

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -42,6 +42,7 @@ void NodePath::_update_hash_cache() const {
 
 void NodePath::prepend_period() {
 	if (data->path.size() && data->path[0].operator String() != ".") {
+		_copy_on_write();
 		data->path.insert(0, ".");
 		data->concatenated_path = StringName();
 		data->hash_cache_valid = false;
@@ -165,6 +166,29 @@ void NodePath::operator=(const NodePath &p_path) {
 	if (p_path.data && p_path.data->refcount.ref()) {
 		data = p_path.data;
 	}
+}
+
+void NodePath::_copy_on_write() {
+	if (!data) {
+		return; // No data; nothing to do.
+	}
+
+	if (data->refcount.get() == 1) {
+		return; // Already the only owner of data.
+	}
+
+	// Make a copy.
+	Data *new_data = memnew(Data);
+	new_data->refcount.init();
+	new_data->path = data->path;
+	new_data->subpath = data->subpath;
+	new_data->concatenated_path = data->concatenated_path;
+	new_data->concatenated_subpath = data->concatenated_subpath;
+	new_data->absolute = data->absolute;
+	new_data->hash_cache_valid = data->hash_cache_valid;
+	new_data->hash_cache = data->hash_cache;
+	unref();
+	data = new_data;
 }
 
 NodePath::operator String() const {
@@ -332,6 +356,7 @@ void NodePath::simplify() {
 	if (!data) {
 		return;
 	}
+	_copy_on_write();
 	for (int i = 0; i < data->path.size(); i++) {
 		if (data->path.size() == 1) {
 			break;

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -35,6 +35,10 @@
 
 #include <climits>
 
+// Represents a path to a node or property in a hierarchy of nodes
+// Note that NodePath is (effectively) const: If you hold a NodePath,
+// you can expect it to remain unchanged, even if you make copies of
+// it. This is achieved through copy-on-write (CoW).
 class [[nodiscard]] NodePath {
 	struct Data {
 		SafeRefCount refcount;
@@ -51,6 +55,10 @@ class [[nodiscard]] NodePath {
 	void unref();
 
 	void _update_hash_cache() const;
+
+	// Copies the underlying data.
+	// Every non-const function must call this before starting to mutate data.
+	void _copy_on_write();
 
 public:
 	bool is_absolute() const;


### PR DESCRIPTION
This changes `NodePath` to copy-on-write on mutation, protecting owners of `NodePath` that assume it's `const` / pass-by-value (which is likely all owners).
Effectively, this might fix a few obscure `NodePath` related bugs (explained later), at no cost to reading, and little cost to writing.

### Explanation

`NodePath` has no exposed mutating function. By all accounts, it could be assumed that `NodePath` is completely `const`. It is also passed by reference internally (`NodePath` is a pointer to a payload).

However, `NodePath` is _not_ fully `const`, because there are two internal functions (effectively 3, foreshadowing...) that mutate it in-place: `simplify()` and `prepend_period`.  Coupled with the pass-by-reference semantics, this means that any `NodePath` you own could change under you without you knowing, just because you accepted (or passed out) a copy of it, which was actually a reference. For example, `Node::path_cache` could be accidentally mutated, which would leave it with an incorrect path cache, leading to obscure bugs.

`simplify()` is called in only two places on newly created `NodePath` instances, so it should be safe. ~`prepend_period()` is not called at all.~ (called once now). This means we're safe, right?
Nope, because `simplify()` is actually used in the implementation of `simplified()`. This means that every call to `simplified()` actually modifies the callee `NodePath` in-place, even though it's marked as `const`. The function is called in 7 places in `resource_format_text`, all of which might be affected by this (rather obscure) bug. On the bright side, the `NodePath` would at worst only be simplified, not changed, but it still is unexpected.

We discussed the situation in a core meeting, and decided to make `NodePath` fully `const` to fix this issue.
However, looking at the implementation, i have decided `CoW` is actually more appropriate after all. The reason is that this approach was both simpler to implement and more efficient to execute. 
Note that `const` and `copy-on-write` are the same thing in implementation, except that `copy-on-write` has mutating methods (that only affect the held instance). 

### Note

I removed `prepend_period` because it has no callers. If there's desire to keep it (like for modules?) we could add a `_copy_on_write` call to it instead and keep it.