### PR TITLE
Windows: Make Direct3D 12 the default RD driver for new projects

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3313,6 +3313,7 @@
 			Two options are supported:
 			- [code]vulkan[/code] (default), Vulkan from native drivers. If [member rendering/rendering_device/fallback_to_vulkan] is enabled, this is used as a fallback if Direct3D 12 is not supported.
 			- [code]d3d12[/code], Direct3D 12 from native drivers. If [member rendering/rendering_device/fallback_to_d3d12] is enabled, this is used as a fallback if Vulkan is not supported.
+			[b]Note:[/b] Starting with Godot 4.6, new projects are configured by default to use [code]d3d12[/code] on Windows. Projects created before Godot 4.6 keep [code]vulkan[/code] for compatibility reasons, but it is recommended to switch them manually to [code]d3d12[/code].
 		</member>
 		<member name="rendering/rendering_device/fallback_to_d3d12" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the Forward+ renderer will fall back to Direct3D 12 if Vulkan is not supported. The fallback is always attempted regardless of this setting if Vulkan driver support was disabled at compile time.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7884,6 +7884,7 @@ void EditorNode::notify_settings_overrides_changed() {
 HashMap<String, Variant> EditorNode::get_initial_settings() {
 	HashMap<String, Variant> settings;
 	settings["physics/3d/physics_engine"] = "Jolt Physics";
+	settings["rendering/rendering_device/driver.windows"] = "d3d12";
 	return settings;
 }
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -233,6 +233,7 @@ def get_flags():
 
     return {
         "arch": arch,
+        "d3d12": True,
         "supported": ["d3d12", "dcomp", "library", "mono", "xaudio2"],
     }
 
@@ -923,7 +924,8 @@ def check_d3d12_installed(env, suffix):
         print_error(
             "The Direct3D 12 rendering driver requires dependencies to be installed.\n"
             "You can install them by running `python misc\\scripts\\install_d3d12_sdk_windows.py`.\n"
-            "See the documentation for more information:\n\t"
-            "https://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_windows.html"
+            "See the documentation for more information:\n"
+            "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_windows.html\n"
+            "Alternatively, disable this driver by compiling with `d3d12=no` explicitly."
         )
         sys.exit(255)


### PR DESCRIPTION
- Implements and closes https://github.com/godotengine/godot-proposals/issues/12234

Direct3D 12 support was added for the Windows platform in Godot 4.3 by @RandomShaper and further refined in later releases by @DarioSamo (both sponsored by W4 Games, so I'll obama-medal-meme my company a bit).
In the 4.6 release cycle, @blueskythlikesclouds focused on fixing known issues with Direct3D 12, with the aim of making it the default RenderingDevice driver for Windows (this time sponsored by the Godot Foundation :1st_place_medal:).

Why? Mainly because Vulkan support on Windows is giving us a lot of headache, with GPU drivers often being poorly maintained compared to their Direct3D 12 counterparts. We've seen many regressions in Nvidia and AMD drivers that would outright break Godot and games released with it (e.g. #109378 still ongoing). There are other issues such as Vulkan implicit layers which force us to use [hacks](https://github.com/godotengine/godot/blob/9dd6c4dbac70b28e8156255c3a2b78722772b036/main/main.cpp#L2081-L2097) to work around their harmful impact on Godot.

It's understandable, most Windows games use modern APIs target Direct3D 12 on Windows, and thus these are the drivers GPU vendors put most work and testing into.

So now that Direct3D 12 in Godot has more or less feature parity with Vulkan (see below), we want to try using it as the default option. See https://github.com/godotengine/godot-proposals/issues/12234 for more arguments in favor of defaulting to Direct3D 12.

Some important aspects:
- *Edit:* This only impacts **new projects** created in 4.6 or later. To use this new default in pre-existing Godot 4.5 projects, you should set the `rendering/rendering_device/driver.windows` project setting to `d3d12` manually.
- Vulkan is still available and can be selected via the `rendering/rendering_device/driver.windows` project setting, or `--rendering-driver vulkan` on the command line.
- ~This PR attempts to preserve the behavior of pre-existing projects by explicitly setting the driver to `vulkan` if it was unconfigured (default) prior to upgrading to 4.6. (Uses the approach added by @KoBeWi in #112607.) So by default, only new projects should default to `d3d12`.~
  * *Edit:* Took a different approach in the end with similar results. Now `vulkan` stays the default for this setting, but `d3d12` is configured automatically for new projects created in 4.6.
  * When upgrading from 4.5, you should therefore change `rendering/rendering_device/driver.windows` to `d3d12` if you want to use the new default (recommended).
- Compiling from source for Windows will now require downloading the dependencies needed by Direct3D 12. You can do it by running the `misc/scripts/install_d3d12_sdk_windows.py` script. Alternatively, you can compile with `d3d12=no` if you don't need it for your development work.
- For PCVR users, we're aware that the Direct3D 12 backend doesn't have full parity with Vulkan yet (missing VRS and foveated rendering IIUC). So if that's a problem for your needs, you can switch back to Vulkan with the aforementioned project setting.
- When using Wine to run Windows games on Linux/macOS, note that the system versions of Wine don't support Direct3D 12 by default. Godot should fallback gracefully to Vulkan in that case. On Steam/Proton, it should use Direct3D 12 by default through vkd3d-proton.