### PR TITLE
Add inline parameters hints to script editor

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -380,12 +380,32 @@ public:
 		int location = -1;
 	};
 
+	enum InlineHintKind {
+		INLINE_HINT_PARAMETER,
+		INLINE_HINT_COLOR,
+	};
+
+	struct InlineHint {
+		InlineHintKind kind;
+
+		String label;
+
+		struct {
+			int line;
+			int column;
+		} position;
+
+		Variant data;
+	};
+
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) { return ERR_UNAVAILABLE; }
 
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const = 0;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) = 0;
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) {}
 	virtual void remove_named_global_constant(const StringName &p_name) {}
+
+	virtual Error generate_inline_info(const String &p_code, const String &p_path, HashMap<int, Vector<InlineHint>> *r_inline_info) { return ERR_UNAVAILABLE; }
 
 	/* MULTITHREAD FUNCTIONS */
 

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -725,6 +725,9 @@
 		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="6">
 			Width of the scrollbar in the code completion popup.
 		</theme_item>
+		<theme_item name="inline_hint_font_scale_percentage" data_type="constant" type="int" default="70">
+			Font size of inline hints as a percentage of the text font size.
+		</theme_item>
 		<theme_item name="bookmark" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] to draw in the bookmark gutter for bookmarked lines.
 		</theme_item>
@@ -754,6 +757,9 @@
 		</theme_item>
 		<theme_item name="completion" data_type="style" type="StyleBox">
 			[StyleBox] for the code completion popup.
+		</theme_item>
+		<theme_item name="inline_parameter_hint" data_type="style" type="StyleBox">
+			[StyleBox] for inline parameter hints.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1366,9 +1366,6 @@
 		<member name="text_editor/appearance/caret/type" type="int" setter="" getter="">
 			The shape of the caret to use in the script editor. [b]Line[/b] displays a vertical line to the left of the current character, whereas [b]Block[/b] displays an outline over the current character.
 		</member>
-		<member name="text_editor/appearance/enable_inline_color_picker" type="bool" setter="" getter="">
-			If [code]true[/code], displays a colored button before any [Color] constructor in the script editor. Clicking on them allows the color to be modified through a color picker.
-		</member>
 		<member name="text_editor/appearance/guidelines/line_length_guideline_hard_column" type="int" setter="" getter="">
 			The column at which to display a subtle line as a line length guideline for scripts. This should generally be greater than [member text_editor/appearance/guidelines/line_length_guideline_soft_column].
 		</member>
@@ -1389,6 +1386,15 @@
 		</member>
 		<member name="text_editor/appearance/gutters/show_line_numbers" type="bool" setter="" getter="">
 			If [code]true[/code], displays line numbers in a gutter at the left.
+		</member>
+		<member name="text_editor/appearance/inline_hints/color_hints_enabled" type="bool" setter="" getter="">
+			If [code]true[/code], displays a colored button before any [Color] constructor in the script editor. Clicking on them allows the color to be modified through a color picker.
+		</member>
+		<member name="text_editor/appearance/inline_hints/inline_hints_enabled" type="bool" setter="" getter="">
+			If [code]true[/code], displays inline hints in code. See [member text_editor/appearance/inline_hints/color_hints_enabled] and [member text_editor/appearance/inline_hints/parameter_hints_enabled].
+		</member>
+		<member name="text_editor/appearance/inline_hints/parameter_hints_enabled" type="bool" setter="" getter="">
+			If [code]true[/code], displays parameter names inline next to their corresponding arguments in function calls.
 		</member>
 		<member name="text_editor/appearance/lines/autowrap_mode" type="int" setter="" getter="">
 			If [member text_editor/appearance/lines/word_wrap] is set to [code]1[/code], sets text wrapping mode. To see how each mode behaves, see [enum TextServer.AutowrapMode].

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1161,6 +1161,11 @@ void CodeTextEditor::update_editor_settings() {
 	idle_time = EDITOR_GET("text_editor/completion/idle_parse_delay");
 	idle_time_with_errors = EDITOR_GET("text_editor/completion/idle_parse_delay_with_errors_found");
 
+	// Inline hints
+	text_editor->set_inline_hints_enabled(EDITOR_GET("text_editor/appearance/inline_hints/inline_hints_enabled"));
+	text_editor->set_inline_hint_type_enabled(SNAME("parameter"), EDITOR_GET("text_editor/appearance/inline_hints/parameter_hints_enabled"));
+	text_editor->set_inline_hint_type_enabled(SNAME("color"), EDITOR_GET("text_editor/appearance/inline_hints/color_hints_enabled"));
+
 	// Appearance: Guidelines
 	if (EDITOR_GET("text_editor/appearance/guidelines/show_line_length_guidelines")) {
 		TypedArray<int> guideline_cols;
@@ -1902,6 +1907,8 @@ CodeTextEditor::CodeTextEditor() {
 	text_editor->set_highlight_matching_braces_enabled(true);
 	text_editor->set_auto_indent_enabled(true);
 	text_editor->set_deselect_on_focus_loss_enabled(false);
+
+	EditorNode::get_singleton()->setup_color_picker(text_editor->get_inline_color_picker());
 
 	status_bar = memnew(HBoxContainer);
 	add_child(status_bar);

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -52,6 +52,7 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
 
@@ -447,170 +448,95 @@ void ScriptTextEditor::add_callback(const String &p_function, const PackedString
 	code_editor->get_text_editor()->end_complex_operation();
 }
 
-bool ScriptTextEditor::_is_valid_color_info(const Dictionary &p_info) {
-	if (p_info.get_valid("color").get_type() != Variant::COLOR) {
-		return false;
-	}
-	if (!p_info.get_valid("color_end").is_num() || !p_info.get_valid("color_mode").is_num()) {
-		return false;
-	}
-	return true;
-}
-
-Array ScriptTextEditor::_inline_object_parse(const String &p_text) {
+void ScriptTextEditor::_enrich_inline_color_info(Dictionary &r_color_info) {
 	Array result;
-	int i_end_previous = 0;
-	int i_start = p_text.find("Color");
+	int line_index = static_cast<int>(r_color_info["line"]) - 1;
+	int column = static_cast<int>(r_color_info["column"]);
 
-	while (i_start != -1) {
-		// Ignore words that just have "Color" in them.
-		if (i_start != 0 && ('_' + p_text.substr(i_start - 1, 1)).is_valid_ascii_identifier()) {
-			i_end_previous = MAX(i_end_previous, i_start);
-			i_start = p_text.find("Color", i_start + 1);
-			continue;
-		}
+	String line_text = get_code_editor()->get_text_editor()->get_line(line_index);
 
-		const int i_par_start = p_text.find_char('(', i_start + 5);
-		const int i_par_end = p_text.find_char(')', i_start + 5);
-		if (i_par_start == -1 || i_par_end == -1) {
-			i_end_previous = MAX(i_end_previous, i_start);
-			i_start = p_text.find("Color", i_start + 1);
-			continue;
-		}
+	int i_start = get_code_editor()->get_text_editor()->get_character_position_from_column(line_index, column);
+	int i_par_start = line_text.find_char('(', i_start + 5);
+	int i_par_end = line_text.find_char(')', i_start + 5);
 
-		Dictionary color_info;
-		color_info["column"] = i_start;
-		color_info["width_ratio"] = 1.0;
-		color_info["color_end"] = i_par_end;
+	const String fn_name = line_text.substr(i_start + 5, i_par_start - i_start - 5).strip_edges();
+	const String s_params = line_text.substr(i_par_start + 1, i_par_end - i_par_start - 1);
+	bool has_added_color = false;
 
-		const String fn_name = p_text.substr(i_start + 5, i_par_start - i_start - 5);
-		const String s_params = p_text.substr(i_par_start + 1, i_par_end - i_par_start - 1);
-		bool has_added_color = false;
-
-		if (fn_name.is_empty()) {
-			String stripped = s_params.strip_edges(true, true);
-			if (stripped.length() > 1 && (stripped[0] == '"' || stripped[0] == '\'')) {
-				// String constructor.
-				const char32_t string_delimiter = stripped[0];
-				if (stripped[stripped.length() - 1] == string_delimiter) {
-					const String color_string = stripped.substr(1, stripped.length() - 2);
-					if (!color_string.contains_char(string_delimiter)) {
-						color_info["color"] = Color::from_string(color_string, Color());
-						color_info["color_mode"] = MODE_STRING;
-						has_added_color = true;
-					}
-				}
-			} else if (stripped.length() == 10 && stripped.begins_with("0x")) {
-				// Hex constructor.
-				const String color_string = stripped.substr(2);
-				if (color_string.is_valid_hex_number(false)) {
-					color_info["color"] = Color::from_string(color_string, Color());
-					color_info["color_mode"] = MODE_HEX;
+	if (fn_name.is_empty()) {
+		String stripped = s_params.strip_edges(true, true);
+		if (stripped.length() > 1 && (stripped[0] == '"' || stripped[0] == '\'')) {
+			// String constructor.
+			const char32_t string_delimiter = stripped[0];
+			if (stripped[stripped.length() - 1] == string_delimiter) {
+				const String color_string = stripped.substr(1, stripped.length() - 2);
+				if (!color_string.contains_char(string_delimiter)) {
+					r_color_info["color"] = Color::from_string(color_string, Color());
+					r_color_info["color_mode"] = MODE_STRING;
 					has_added_color = true;
 				}
-			} else if (stripped.is_empty()) {
-				// Empty Color() constructor.
-				color_info["color"] = Color();
-				color_info["color_mode"] = MODE_RGB;
+			}
+		} else if (stripped.length() == 10 && stripped.begins_with("0x")) {
+			// Hex constructor.
+			const String color_string = stripped.substr(2);
+			if (color_string.is_valid_hex_number(false)) {
+				r_color_info["color"] = Color::from_string(color_string, Color());
+				r_color_info["color_mode"] = MODE_HEX;
 				has_added_color = true;
 			}
+		} else if (stripped.is_empty()) {
+			// Empty Color() constructor.
+			r_color_info["color"] = Color();
+			r_color_info["color_mode"] = MODE_RGB;
+			has_added_color = true;
 		}
-		// Float & int parameters.
-		if (!has_added_color && s_params.size() > 0) {
-			const PackedStringArray s_params_split = s_params.split(",", false, 4);
-			PackedFloat64Array params;
-			bool valid_floats = true;
-			for (const String &s_param : s_params_split) {
-				// Only allow float literals, expressions won't be evaluated and could get replaced.
-				if (!s_param.strip_edges().is_valid_float()) {
-					valid_floats = false;
-					break;
-				}
-				params.push_back(s_param.to_float());
-			}
-			if (valid_floats && params.size() == 3) {
-				if (fn_name == ".from_rgba8") {
-					params.push_back(255);
-				} else {
-					params.push_back(1.0);
-				}
-			}
-			if (valid_floats && params.size() == 4) {
-				has_added_color = true;
-				if (fn_name == ".from_ok_hsl") {
-					color_info["color"] = Color::from_ok_hsl(params[0], params[1], params[2], params[3]);
-					color_info["color_mode"] = MODE_OKHSL;
-				} else if (fn_name == ".from_hsv") {
-					color_info["color"] = Color::from_hsv(params[0], params[1], params[2], params[3]);
-					color_info["color_mode"] = MODE_HSV;
-				} else if (fn_name == ".from_rgba8") {
-					color_info["color"] = Color::from_rgba8(int(params[0]), int(params[1]), int(params[2]), int(params[3]));
-					color_info["color_mode"] = MODE_RGB8;
-				} else if (fn_name.is_empty()) {
-					color_info["color"] = Color(params[0], params[1], params[2], params[3]);
-					color_info["color_mode"] = MODE_RGB;
-				} else {
-					has_added_color = false;
-				}
-			}
-		}
-
-		if (has_added_color) {
-			result.push_back(color_info);
-			i_end_previous = i_par_end + 1;
-		}
-		i_end_previous = MAX(i_end_previous, i_start);
-		i_start = p_text.find("Color", i_start + 1);
 	}
-	return result;
-}
-
-void ScriptTextEditor::_inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect) {
-	if (_is_valid_color_info(p_info)) {
-		Rect2 col_rect = p_rect.grow(-4);
-		if (color_alpha_texture.is_null()) {
-			color_alpha_texture = inline_color_picker->get_theme_icon("sample_bg", "ColorPicker");
+	// Float & int parameters.
+	if (!has_added_color && s_params.size() > 0) {
+		const PackedStringArray s_params_split = s_params.split(",", false, 4);
+		PackedFloat64Array params;
+		bool valid_floats = true;
+		for (const String &s_param : s_params_split) {
+			// Only allow float literals, expressions won't be evaluated and could get replaced.
+			if (!s_param.strip_edges().is_valid_float()) {
+				valid_floats = false;
+				break;
+			}
+			params.push_back(s_param.to_float());
 		}
-		RID text_ci = code_editor->get_text_editor()->get_text_canvas_item();
-		RS::get_singleton()->canvas_item_add_rect(text_ci, p_rect.grow(-3), Color(1, 1, 1));
-		color_alpha_texture->draw_rect(text_ci, col_rect);
-		RS::get_singleton()->canvas_item_add_rect(text_ci, col_rect, Color(p_info["color"]));
+		if (valid_floats && params.size() == 3) {
+			if (fn_name == ".from_rgba8") {
+				params.push_back(255);
+			} else {
+				params.push_back(1.0);
+			}
+		}
+		if (valid_floats && params.size() == 4) {
+			has_added_color = true;
+			if (fn_name == ".from_ok_hsl") {
+				r_color_info["color"] = Color::from_ok_hsl(params[0], params[1], params[2], params[3]);
+				r_color_info["color_mode"] = MODE_OKHSL;
+			} else if (fn_name == ".from_hsv") {
+				r_color_info["color"] = Color::from_hsv(params[0], params[1], params[2], params[3]);
+				r_color_info["color_mode"] = MODE_HSV;
+			} else if (fn_name == ".from_rgba8") {
+				r_color_info["color"] = Color::from_rgba8(int(params[0]), int(params[1]), int(params[2]), int(params[3]));
+				r_color_info["color_mode"] = MODE_RGB8;
+			} else if (fn_name.is_empty()) {
+				r_color_info["color"] = Color(params[0], params[1], params[2], params[3]);
+				r_color_info["color_mode"] = MODE_RGB;
+			} else {
+				has_added_color = false;
+			}
+		}
+	}
+	r_color_info["color_end"] = i_par_end;
+	if (!has_added_color) {
+		r_color_info["type"] = "invalid";
 	}
 }
 
-void ScriptTextEditor::_inline_object_handle_click(const Dictionary &p_info, const Rect2 &p_rect) {
-	if (_is_valid_color_info(p_info)) {
-		inline_color_picker->set_pick_color(p_info["color"]);
-		inline_color_line = p_info["line"];
-		inline_color_start = p_info["column"];
-		inline_color_end = p_info["color_end"];
-
-		// Reset tooltip hover timer.
-		code_editor->get_text_editor()->set_symbol_tooltip_on_hover_enabled(false);
-		code_editor->get_text_editor()->set_symbol_tooltip_on_hover_enabled(true);
-
-		_update_color_constructor_options();
-		inline_color_options->select(p_info["color_mode"]);
-		EditorNode::get_singleton()->setup_color_picker(inline_color_picker);
-
-		// Move popup above the line if it's too low.
-		float_t view_h = get_viewport_rect().size.y;
-		float_t pop_h = inline_color_popup->get_contents_minimum_size().y;
-		float_t pop_y = p_rect.get_end().y;
-		float_t pop_x = p_rect.position.x;
-		if (pop_y + pop_h > view_h) {
-			pop_y = p_rect.position.y - pop_h;
-		}
-		// Move popup to the right if it's too high.
-		if (pop_y < 0) {
-			pop_x = p_rect.get_end().x;
-		}
-
-		inline_color_popup->popup(Rect2(pop_x, pop_y, 0, 0));
-	}
-}
-
-String ScriptTextEditor::_picker_color_stringify(const Color &p_color, COLOR_MODE p_mode) {
+String ScriptTextEditor::_stringify_color(const Color &p_color, COLOR_MODE p_mode) {
 	String result;
 	String fname;
 	Vector<String> str_params;
@@ -663,22 +589,19 @@ String ScriptTextEditor::_picker_color_stringify(const Color &p_color, COLOR_MOD
 	return result;
 }
 
-void ScriptTextEditor::_picker_color_changed(const Color &p_color) {
-	_update_color_constructor_options();
-	_update_color_text();
-}
-
-void ScriptTextEditor::_update_color_constructor_options() {
-	int item_count = inline_color_options->get_item_count();
+void ScriptTextEditor::_update_color_constructor_options(const Dictionary &p_info, OptionButton *p_options, ColorPicker *p_picker) {
+	int item_count = p_options->get_item_count();
 	// Update or add each constructor as an option.
 	for (int i = 0; i < MODE_MAX; i++) {
-		String option_text = _picker_color_stringify(inline_color_picker->get_pick_color(), (COLOR_MODE)i);
+		String option_text = _stringify_color(p_picker->get_pick_color(), (COLOR_MODE)i);
 		if (i >= item_count) {
-			inline_color_options->add_item(option_text);
+			p_options->add_item(option_text);
 		} else {
-			inline_color_options->set_item_text(i, option_text);
+			p_options->set_item_text(i, option_text);
 		}
 	}
+
+	p_options->select(p_info.get("color_mode", 0));
 }
 
 void ScriptTextEditor::_update_background_color() {
@@ -719,28 +642,8 @@ void ScriptTextEditor::_update_background_color() {
 	}
 }
 
-void ScriptTextEditor::_update_color_text() {
-	if (inline_color_line < 0) {
-		return;
-	}
-	String result = inline_color_options->get_item_text(inline_color_options->get_selected_id());
-	code_editor->get_text_editor()->begin_complex_operation();
-	code_editor->get_text_editor()->remove_text(inline_color_line, inline_color_start, inline_color_line, inline_color_end + 1);
-	inline_color_end = inline_color_start + result.size() - 2;
-	code_editor->get_text_editor()->insert_text(result, inline_color_line, inline_color_start);
-	code_editor->get_text_editor()->end_complex_operation();
-}
-
 void ScriptTextEditor::update_settings() {
 	code_editor->get_text_editor()->set_gutter_draw(connection_gutter, EDITOR_GET("text_editor/appearance/gutters/show_info_gutter"));
-	if (EDITOR_GET("text_editor/appearance/enable_inline_color_picker")) {
-		code_editor->get_text_editor()->set_inline_object_handlers(
-				callable_mp(this, &ScriptTextEditor::_inline_object_parse),
-				callable_mp(this, &ScriptTextEditor::_inline_object_draw),
-				callable_mp(this, &ScriptTextEditor::_inline_object_handle_click));
-	} else {
-		code_editor->get_text_editor()->set_inline_object_handlers(Callable(), Callable(), Callable());
-	}
 	TextEditorBase::update_settings();
 }
 
@@ -860,9 +763,13 @@ void ScriptTextEditor::_validate_script() {
 		}
 		script_is_valid = true;
 	}
+
+	script->get_language()->generate_inline_info(text, script->get_path(), &inline_hints);
+
 	_update_connected_methods();
 	_update_warnings();
 	_update_errors();
+	_update_inline_info();
 	_update_background_color();
 
 	if (!pending_dragged_exports.is_empty()) {
@@ -1016,6 +923,39 @@ void ScriptTextEditor::_update_errors() {
 			te->set_line_gutter_item_color(i, 1, default_line_number_color);
 		}
 	}
+}
+
+void ScriptTextEditor::_update_inline_info() {
+	for (const ScriptLanguage::ScriptError &err : errors) {
+		if (inline_hints.has(err.line)) {
+			inline_hints.erase(err.line);
+		}
+	}
+
+	HashMap<int, TypedArray<Dictionary>> marshalled_inline_hints;
+
+	for (const KeyValue<int, Vector<ScriptLanguage::InlineHint>> &KV : inline_hints) {
+		marshalled_inline_hints[KV.key].reserve(KV.value.size());
+
+		for (const ScriptLanguage::InlineHint &hint : KV.value) {
+			Dictionary marshaled;
+
+			marshaled["line"] = hint.position.line;
+			marshaled["column"] = hint.position.column;
+
+			if (hint.kind == ScriptLanguage::INLINE_HINT_COLOR) {
+				marshaled["kind"] = SNAME("color");
+				_enrich_inline_color_info(marshaled);
+			} else if (hint.kind == ScriptLanguage::INLINE_HINT_PARAMETER) {
+				marshaled["kind"] = SNAME("parameter");
+				marshaled["name"] = hint.label;
+			}
+
+			marshalled_inline_hints[KV.key].push_back(marshaled);
+		}
+	}
+
+	code_editor->get_text_editor()->update_inline_hints(marshalled_inline_hints);
 }
 
 static Vector<Node *> _find_all_node_for_script(Node *p_base, Node *p_current, const Ref<Script> &p_script) {
@@ -1866,9 +1806,6 @@ void ScriptTextEditor::_notification(int p_what) {
 			[[fallthrough]];
 		case NOTIFICATION_ENTER_TREE: {
 			code_editor->get_text_editor()->set_gutter_width(connection_gutter, code_editor->get_text_editor()->get_line_height());
-			Ref<Font> code_font = get_theme_font("font", "CodeEdit");
-			inline_color_options->add_theme_font_override("font", code_font);
-			inline_color_options->get_popup()->add_theme_font_override("font", code_font);
 		} break;
 	}
 }
@@ -2646,6 +2583,8 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor->get_text_editor()->set_gutter_overwritable(connection_gutter, true);
 	code_editor->get_text_editor()->set_gutter_type(connection_gutter, TextEdit::GUTTER_TYPE_ICON);
 
+	code_editor->get_text_editor()->set_inline_color_picker_handlers(callable_mp(this, &ScriptTextEditor::_update_color_constructor_options), Callable());
+
 	errors_panel = memnew(RichTextLabel);
 	errors_panel->set_custom_minimum_size(Size2(0, 100 * EDSCALE));
 	errors_panel->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -2659,23 +2598,6 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor->get_text_editor()->set_symbol_tooltip_on_hover_enabled(true);
 
 	color_panel = memnew(PopupPanel);
-
-	inline_color_popup = memnew(PopupPanel);
-	add_child(inline_color_popup);
-
-	inline_color_picker = memnew(ColorPicker);
-	inline_color_picker->set_mouse_filter(MOUSE_FILTER_STOP);
-	inline_color_picker->set_deferred_mode(true);
-	inline_color_picker->set_hex_visible(false);
-	inline_color_picker->connect("color_changed", callable_mp(this, &ScriptTextEditor::_picker_color_changed));
-	inline_color_popup->add_child(inline_color_picker);
-
-	inline_color_options = memnew(OptionButton);
-	inline_color_options->set_h_size_flags(SIZE_FILL);
-	inline_color_options->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
-	inline_color_options->set_fit_to_longest_item(false);
-	inline_color_options->connect("item_selected", callable_mp(this, &ScriptTextEditor::_update_color_text).unbind(1));
-	inline_color_picker->get_slider_container()->add_sibling(inline_color_options);
 
 	connection_info_dialog = memnew(ConnectionInfoDialog);
 

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -68,16 +68,9 @@ class ScriptTextEditor : public CodeEditorBase {
 	List<ScriptLanguage::ScriptError> errors;
 	HashMap<String, List<ScriptLanguage::ScriptError>> depended_errors;
 	HashSet<int> safe_lines;
+	HashMap<int, Vector<ScriptLanguage::InlineHint>> inline_hints;
 
 	List<Connection> missing_connections;
-
-	int inline_color_line = -1;
-	int inline_color_start = -1;
-	int inline_color_end = -1;
-	PopupPanel *inline_color_popup = nullptr;
-	ColorPicker *inline_color_picker = nullptr;
-	OptionButton *inline_color_options = nullptr;
-	Ref<Texture2D> color_alpha_texture;
 
 	ScriptEditorQuickOpen *quick_open = nullptr;
 	ConnectionInfoDialog *connection_info_dialog = nullptr;
@@ -164,6 +157,7 @@ protected:
 
 	void _update_warnings();
 	void _update_errors();
+	void _update_inline_info();
 
 	static void _code_complete_scripts(void *p_ud, const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force);
 	virtual void _code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) override;
@@ -174,15 +168,11 @@ protected:
 	void _error_clicked(const Variant &p_line);
 	virtual bool _warning_clicked(const Variant &p_line) override;
 
-	bool _is_valid_color_info(const Dictionary &p_info);
-	Array _inline_object_parse(const String &p_text);
-	void _inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect);
-	void _inline_object_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
-	String _picker_color_stringify(const Color &p_color, COLOR_MODE p_mode);
-	void _picker_color_changed(const Color &p_color);
-	void _update_color_constructor_options();
+	void _enrich_inline_color_info(Dictionary &r_color_info);
+	String _stringify_color(const Color &p_color, COLOR_MODE p_mode);
+	void _update_color_constructor_options(const Dictionary &p_info, OptionButton *p_options, ColorPicker *p_picker);
+
 	void _update_background_color();
-	void _update_color_text();
 
 	void _notification(int p_what);
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -752,7 +752,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/theme/highlighting/comment_markers/notice_list", "INFO,NOTE,NOTICE,TEST,TESTING");
 
 	// Appearance
-	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/appearance/enable_inline_color_picker", true, "");
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/appearance/inline_hints/inline_hints_enabled", true, "");
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/appearance/inline_hints/parameter_hints_enabled", true, "");
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/appearance/inline_hints/color_hints_enabled", true, "");
 
 	// Appearance: Caret
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/caret/type", 0, "Line,Block")

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -513,6 +513,8 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 			colors["text_editor/theme/highlighting/completion_background_color"] = p_config.base_color.lerp(Color(0, 0, 0), p_config.contrast * 0.3).clamp();
 			colors["text_editor/theme/highlighting/completion_selected_color"] = alpha1;
 			colors["text_editor/theme/highlighting/completion_existing_color"] = alpha2;
+			colors["text_editor/theme/highlighting/inline_parameter_hint_background_color"] = alpha1;
+
 			// Same opacity as the scroll grabber editor icon.
 			colors["text_editor/theme/highlighting/completion_scroll_color"] = Color(mono_value, mono_value, mono_value, 0.29);
 			colors["text_editor/theme/highlighting/completion_scroll_hovered_color"] = Color(mono_value, mono_value, mono_value, 0.4);
@@ -599,6 +601,10 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 	p_theme->set_stylebox(CoreStringName(normal), "CodeEdit", code_edit_stylebox);
 	p_theme->set_stylebox("read_only", "CodeEdit", code_edit_stylebox);
 	p_theme->set_stylebox("focus", "CodeEdit", memnew(StyleBoxEmpty));
+
+	const Color inline_parameter_hint_background_color = EDITOR_GET("text_editor/theme/highlighting/inline_parameter_hint_background_color");
+	Ref<StyleBoxFlat> code_edit_parameter_hint_stylebox = make_flat_stylebox(inline_parameter_hint_background_color, -1, -1, -1, -1, p_config.corner_radius);
+	p_theme->set_stylebox("inline_parameter_hint", "CodeEdit", code_edit_parameter_hint_stylebox);
 
 	/* clang-format off */
 	p_theme->set_color("completion_background_color",     "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_background_color"));

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -606,6 +606,7 @@ public:
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_forced, String &r_call_hint) override;
 #ifdef TOOLS_ENABLED
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
+	virtual Error generate_inline_info(const String &p_code, const String &p_path, HashMap<int, Vector<InlineHint>> *r_inline_info) override;
 #endif
 	virtual String _get_indentation() const;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -31,6 +31,7 @@
 #include "gdscript.h"
 
 #include "gdscript_analyzer.h"
+#include "gdscript_inline_info_generator.h"
 #include "gdscript_parser.h"
 #include "gdscript_tokenizer.h"
 #include "gdscript_utility_functions.h"
@@ -4633,6 +4634,19 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	}
 
 	return ERR_CANT_RESOLVE;
+}
+
+Error GDScriptLanguage::generate_inline_info(const String &p_code, const String &p_path, HashMap<int, Vector<InlineHint>> *r_inline_info) {
+	GDScriptParser parser;
+	parser.parse(p_code, p_path, true);
+
+	GDScriptAnalyzer analyzer{ &parser };
+	analyzer.analyze();
+
+	GDScriptInlineInfoGenerator generator{ &parser };
+	Error err = generator.generate(r_inline_info);
+
+	return err;
 }
 
 #endif // TOOLS_ENABLED

--- a/modules/gdscript/gdscript_inline_info_generator.cpp
+++ b/modules/gdscript/gdscript_inline_info_generator.cpp
@@ -1,0 +1,486 @@
+/**************************************************************************/
+/*  gdscript_inline_info_generator.cpp                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_inline_info_generator.h"
+
+void GDScriptInlineInfoGenerator::add_color_info(GDScriptParser::Node *p_node) {
+	ScriptLanguage::InlineHint hint;
+
+	hint.kind = ScriptLanguage::INLINE_HINT_COLOR;
+	hint.label = "color";
+	hint.position.line = p_node->start_line;
+	hint.position.column = p_node->start_column;
+
+	(*inline_info)[p_node->start_line].push_back(hint);
+}
+
+void GDScriptInlineInfoGenerator::add_parameters_info(GDScriptParser::Node *p_node, const PropertyInfo &p_info) {
+	ScriptLanguage::InlineHint hint;
+
+	hint.kind = ScriptLanguage::INLINE_HINT_PARAMETER;
+	hint.label = p_info.name;
+	hint.position.line = p_node->start_line;
+	hint.position.column = p_node->start_column;
+
+	(*inline_info)[p_node->start_line].push_back(hint);
+}
+
+void GDScriptInlineInfoGenerator::visit_class(GDScriptParser::ClassNode *p_class) {
+	parser->current_class = p_class;
+
+	for (GDScriptParser::ClassNode::Member &member : p_class->members) {
+		switch (member.type) {
+			case GDScriptParser::ClassNode::Member::CLASS:
+				visit_class(member.m_class);
+				break;
+			case GDScriptParser::ClassNode::Member::VARIABLE:
+				visit_variable(member.variable);
+				break;
+			case GDScriptParser::ClassNode::Member::CONSTANT:
+				visit_constant(member.constant);
+				break;
+			case GDScriptParser::ClassNode::Member::FUNCTION:
+				visit_function(member.function);
+				break;
+			default:
+				break;
+		}
+	}
+
+	if (p_class->get_datatype().class_type->outer) {
+		parser->current_class = p_class->get_datatype().class_type->outer;
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_variable(GDScriptParser::VariableNode *p_variable) {
+	if (p_variable->initializer) {
+		visit_expression(p_variable->initializer);
+	}
+	if (p_variable->property == GDScriptParser::VariableNode::PROP_SETGET) {
+		if (p_variable->setter) {
+			visit_function(p_variable->setter);
+		}
+		if (p_variable->getter) {
+			visit_function(p_variable->getter);
+		}
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_constant(GDScriptParser::ConstantNode *p_constant) {
+	if (p_constant->initializer) {
+		visit_expression(p_constant->initializer);
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_function(GDScriptParser::FunctionNode *p_function) {
+	if (p_function->body) {
+		visit_suite(p_function->body);
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_suite(GDScriptParser::SuiteNode *p_suite) {
+	for (GDScriptParser::Node *statement : p_suite->statements) {
+		visit_statement(statement);
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_statement(GDScriptParser::Node *p_statement) {
+	switch (p_statement->type) {
+		case GDScriptParser::Node::VARIABLE:
+			visit_variable(static_cast<GDScriptParser::VariableNode *>(p_statement));
+			break;
+		case GDScriptParser::Node::CONSTANT:
+			visit_constant(static_cast<GDScriptParser::ConstantNode *>(p_statement));
+			break;
+		case GDScriptParser::Node::IF:
+			visit_if(static_cast<GDScriptParser::IfNode *>(p_statement));
+			break;
+		case GDScriptParser::Node::FOR:
+			visit_for(static_cast<GDScriptParser::ForNode *>(p_statement));
+			break;
+		case GDScriptParser::Node::WHILE:
+			visit_while(static_cast<GDScriptParser::WhileNode *>(p_statement));
+			break;
+		case GDScriptParser::Node::MATCH:
+			visit_match(static_cast<GDScriptParser::MatchNode *>(p_statement));
+			break;
+		case GDScriptParser::Node::RETURN:
+			visit_return(static_cast<GDScriptParser::ReturnNode *>(p_statement));
+			break;
+		case GDScriptParser::Node::ASSERT:
+			visit_assert(static_cast<GDScriptParser::AssertNode *>(p_statement));
+			break;
+		case GDScriptParser::Node::BREAK:
+		case GDScriptParser::Node::CONTINUE:
+		case GDScriptParser::Node::PASS:
+		case GDScriptParser::Node::BREAKPOINT:
+			break;
+		default:
+			if (p_statement->is_expression()) {
+				visit_expression(static_cast<GDScriptParser::ExpressionNode *>(p_statement));
+			}
+			break;
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_if(GDScriptParser::IfNode *p_if) {
+	if (p_if->condition) {
+		visit_expression(p_if->condition);
+	}
+	if (p_if->true_block) {
+		visit_suite(p_if->true_block);
+	}
+	if (p_if->false_block) {
+		visit_suite(p_if->false_block);
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_for(GDScriptParser::ForNode *p_for) {
+	if (p_for->list) {
+		visit_expression(p_for->list);
+	}
+	if (p_for->loop) {
+		visit_suite(p_for->loop);
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_while(GDScriptParser::WhileNode *p_while) {
+	if (p_while->condition) {
+		visit_expression(p_while->condition);
+	}
+	if (p_while->loop) {
+		visit_suite(p_while->loop);
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_match(GDScriptParser::MatchNode *p_match) {
+	visit_expression(p_match->test);
+
+	for (GDScriptParser::MatchBranchNode *branch : p_match->branches) {
+		for (GDScriptParser::PatternNode *pattern : branch->patterns) {
+			if (pattern->pattern_type == GDScriptParser::PatternNode::PT_EXPRESSION) {
+				visit_expression(pattern->expression);
+			}
+		}
+		if (branch->guard_body) {
+			visit_suite(branch->guard_body);
+		}
+		if (branch->block) {
+			visit_suite(branch->block);
+		}
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_return(GDScriptParser::ReturnNode *p_return) {
+	if (p_return->return_value) {
+		visit_expression(p_return->return_value);
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_assert(GDScriptParser::AssertNode *p_assert) {
+	if (p_assert->condition) {
+		visit_expression(p_assert->condition);
+	}
+	if (p_assert->message) {
+		visit_expression(p_assert->message);
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_expression(GDScriptParser::ExpressionNode *p_expression) {
+	if (p_expression == nullptr) {
+		return;
+	}
+
+	switch (p_expression->type) {
+		case GDScriptParser::Node::CALL:
+			visit_call(static_cast<GDScriptParser::CallNode *>(p_expression));
+			break;
+		case GDScriptParser::Node::AWAIT:
+			if (static_cast<GDScriptParser::AwaitNode *>(p_expression)->to_await) {
+				visit_expression(static_cast<GDScriptParser::AwaitNode *>(p_expression)->to_await);
+			}
+			break;
+		case GDScriptParser::Node::ASSIGNMENT: {
+			GDScriptParser::AssignmentNode *assign = static_cast<GDScriptParser::AssignmentNode *>(p_expression);
+			if (assign->assignee) {
+				visit_expression(assign->assignee);
+			}
+			if (assign->assigned_value) {
+				visit_expression(assign->assigned_value);
+			}
+			break;
+		}
+		case GDScriptParser::Node::BINARY_OPERATOR: {
+			GDScriptParser::BinaryOpNode *binop = static_cast<GDScriptParser::BinaryOpNode *>(p_expression);
+			if (binop->left_operand) {
+				visit_expression(binop->left_operand);
+			}
+			if (binop->right_operand) {
+				visit_expression(binop->right_operand);
+			}
+			break;
+		}
+		case GDScriptParser::Node::UNARY_OPERATOR: {
+			GDScriptParser::UnaryOpNode *unop = static_cast<GDScriptParser::UnaryOpNode *>(p_expression);
+			if (unop->operand) {
+				visit_expression(unop->operand);
+			}
+			break;
+		}
+		case GDScriptParser::Node::TERNARY_OPERATOR: {
+			GDScriptParser::TernaryOpNode *ternary = static_cast<GDScriptParser::TernaryOpNode *>(p_expression);
+			if (ternary->condition) {
+				visit_expression(ternary->condition);
+			}
+			if (ternary->true_expr) {
+				visit_expression(ternary->true_expr);
+			}
+			if (ternary->false_expr) {
+				visit_expression(ternary->false_expr);
+			}
+			break;
+		}
+		case GDScriptParser::Node::SUBSCRIPT: {
+			GDScriptParser::SubscriptNode *subscript = static_cast<GDScriptParser::SubscriptNode *>(p_expression);
+			if (subscript->base) {
+				visit_expression(subscript->base);
+			}
+			if (subscript->index) {
+				visit_expression(subscript->index);
+			}
+			break;
+		}
+		case GDScriptParser::Node::ARRAY: {
+			GDScriptParser::ArrayNode *array = static_cast<GDScriptParser::ArrayNode *>(p_expression);
+			for (GDScriptParser::ExpressionNode *element : array->elements) {
+				visit_expression(element);
+			}
+			break;
+		}
+		case GDScriptParser::Node::DICTIONARY: {
+			GDScriptParser::DictionaryNode *dict = static_cast<GDScriptParser::DictionaryNode *>(p_expression);
+			for (const GDScriptParser::DictionaryNode::Pair &pair : dict->elements) {
+				visit_expression(pair.key);
+				visit_expression(pair.value);
+			}
+			break;
+		}
+		case GDScriptParser::Node::CAST: {
+			GDScriptParser::CastNode *cast = static_cast<GDScriptParser::CastNode *>(p_expression);
+			if (cast->operand) {
+				visit_expression(cast->operand);
+			}
+			break;
+		}
+		case GDScriptParser::Node::LAMBDA: {
+			GDScriptParser::LambdaNode *lambda = static_cast<GDScriptParser::LambdaNode *>(p_expression);
+			visit_function(lambda->function);
+			break;
+		}
+
+		default:
+			break;
+	}
+}
+
+void GDScriptInlineInfoGenerator::visit_call(GDScriptParser::CallNode *p_call) {
+	if (p_call->callee) {
+		visit_expression(p_call->callee);
+	}
+
+	MethodInfo function_info;
+
+	GDScriptParser::Node::Type callee_type = p_call->get_callee_type();
+
+	if (callee_type == GDScriptParser::Node::SUBSCRIPT) {
+		GDScriptParser::SubscriptNode *subscript = static_cast<GDScriptParser::SubscriptNode *>(p_call->callee);
+		function_info = get_method_info_on_base(subscript->base, p_call->function_name);
+
+		if (p_call->is_static && subscript->base->type == GDScriptParser::Node::IDENTIFIER) {
+			GDScriptParser::IdentifierNode *identifier = static_cast<GDScriptParser::IdentifierNode *>(subscript->base);
+			if (identifier->name == SNAME("Color")) {
+				add_color_info(identifier);
+			}
+		}
+
+	} else if (p_call->is_super || callee_type == GDScriptParser::Node::IDENTIFIER) {
+		Variant::Type builtin_type = GDScriptParser::get_builtin_type(p_call->function_name);
+		bool is_valid_builtin_type = builtin_type < Variant::VARIANT_MAX;
+
+		if (is_valid_builtin_type) {
+			if (builtin_type == Variant::COLOR) {
+				add_color_info(p_call);
+			}
+
+			List<MethodInfo> constructors;
+			Variant::get_constructor_list(builtin_type, &constructors);
+
+			for (const MethodInfo &constructor_info : constructors) {
+				bool arity_matches = p_call->arguments.size() <= constructor_info.arguments.size() && p_call->arguments.size() >= constructor_info.arguments.size() - constructor_info.default_arguments.size();
+				if (!arity_matches) {
+					continue;
+				}
+
+				bool type_matches = true;
+				for (int i = 0; i < p_call->arguments.size() && type_matches; i++) {
+					const PropertyInfo &parameter = constructor_info.arguments[i];
+					const PropertyInfo argument = p_call->arguments[i]->get_datatype().to_property_info(parameter.name);
+
+					type_matches = Variant::can_convert_strict(argument.type, parameter.type) && parameter.class_name == argument.class_name;
+				}
+
+				if (type_matches) {
+					function_info = constructor_info;
+					break;
+				}
+			}
+
+		} else if (Variant::has_utility_function(p_call->function_name)) {
+			function_info = Variant::get_utility_function_info(p_call->function_name);
+		} else if (GDScriptUtilityFunctions::function_exists(p_call->function_name)) {
+			function_info = GDScriptUtilityFunctions::get_function_info(p_call->function_name);
+		} else {
+			function_info = get_method_info_on_base(parser->current_class, p_call->function_name);
+		}
+	}
+
+	long hint_count = MIN(p_call->arguments.size(), function_info.arguments.size());
+	for (int i = 0; i < p_call->arguments.size(); i++) {
+		GDScriptParser::ExpressionNode *argument = p_call->arguments[i];
+		if (i < hint_count) {
+			const PropertyInfo &parameter = function_info.arguments[i];
+			add_parameters_info(argument, parameter);
+		}
+
+		visit_expression(argument);
+	}
+}
+
+MethodInfo GDScriptInlineInfoGenerator::get_method_info_on_base(GDScriptParser::Node *p_base, const StringName &p_function) {
+	GDScriptParser::DataType base_datatype = p_base->get_datatype();
+
+	MethodInfo info;
+
+	switch (base_datatype.kind) {
+		case GDScriptParser::DataType::BUILTIN: {
+			if (Variant::has_builtin_method(base_datatype.builtin_type, p_function)) {
+				info = Variant::get_builtin_method_info(base_datatype.builtin_type, p_function);
+			}
+			break;
+		}
+		case GDScriptParser::DataType::SCRIPT: {
+			Ref<GDScript> script = base_datatype.script_type;
+
+			if (script.is_valid()) {
+				info = script->get_method_info(p_function);
+			}
+			break;
+		}
+		case GDScriptParser::DataType::UNRESOLVED:
+		case GDScriptParser::DataType::NATIVE:
+		case GDScriptParser::DataType::CLASS: {
+			StringName function_to_find = p_function;
+			StringName base_name;
+
+			if (base_datatype.kind == GDScriptParser::DataType::NATIVE) {
+				base_name = base_datatype.native_type;
+			} else if (base_datatype.kind == GDScriptParser::DataType::CLASS) {
+				base_name = base_datatype.to_string();
+			} else if (base_datatype.kind == GDScriptParser::DataType::UNRESOLVED && p_base->type == GDScriptParser::Node::IDENTIFIER) {
+				base_name = static_cast<GDScriptParser::IdentifierNode *>(p_base)->name;
+			}
+
+			// Special case for static methods on builtins, which are UNRESOLVED.
+			Variant::Type builtin_type = GDScriptParser::get_builtin_type(base_name);
+			bool is_valid_builtin_type = builtin_type < Variant::VARIANT_MAX;
+
+			// Special case for the constructor, that refers to the _init method.
+			if (p_function == SNAME("new")) {
+				function_to_find = GDScriptLanguage::get_singleton()->strings._init;
+			}
+
+			if (is_valid_builtin_type) {
+				info = Variant::get_builtin_method_info(builtin_type, function_to_find);
+
+			} else if (ClassDB::class_exists(base_name)) {
+				while (ClassDB::class_exists(base_name)) {
+					if (ClassDB::has_method(base_name, function_to_find, true)) {
+						ClassDB::get_method_info(base_name, function_to_find, &info);
+						break;
+					}
+					base_name = ClassDB::get_parent_class(base_name);
+				}
+
+			} else {
+				GDScriptParser::ClassNode *base_class = base_datatype.class_type;
+				bool function_found = false;
+
+				while (!function_found && base_class != nullptr) {
+					if (base_class->has_member(function_to_find)) {
+						GDScriptParser::ClassNode::Member member = base_class->get_member(function_to_find);
+
+						if (member.type == GDScriptParser::ClassNode::Member::FUNCTION) {
+							info = member.function->info;
+						}
+						function_found = true;
+					}
+
+					base_class = base_class->base_type.class_type;
+				}
+			}
+			break;
+		}
+		case GDScriptParser::DataType::ENUM:
+		case GDScriptParser::DataType::VARIANT:
+		case GDScriptParser::DataType::RESOLVING:
+			break;
+	}
+
+	return info;
+}
+
+Error GDScriptInlineInfoGenerator::generate(HashMap<int, Vector<ScriptLanguage::InlineHint>> *p_info) {
+	ERR_FAIL_NULL_V(p_info, FAILED);
+
+	inline_info = p_info;
+	inline_info->clear();
+
+	GDScriptParser::ClassNode *root_node = parser->get_tree();
+	ERR_FAIL_NULL_V_MSG(root_node, FAILED, "Couldn't generate inline info. The code must be parsed before generation.");
+	ERR_FAIL_COND_V_MSG(!root_node->resolved_body || !root_node->resolved_interface, FAILED, "Couldn't generate inline info. The code must be analyzed before generation.");
+
+	visit_class(root_node);
+
+	return OK;
+}
+
+GDScriptInlineInfoGenerator::GDScriptInlineInfoGenerator(GDScriptParser *p_parser) {
+	parser = p_parser;
+}

--- a/modules/gdscript/gdscript_inline_info_generator.h
+++ b/modules/gdscript/gdscript_inline_info_generator.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  gdscript_inline_info_generator.h                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdscript_parser.h"
+
+class GDScriptInlineInfoGenerator {
+	GDScriptParser *parser = nullptr;
+	HashMap<int, Vector<ScriptLanguage::InlineHint>> *inline_info = nullptr;
+
+	void add_color_info(GDScriptParser::Node *p_node);
+	void add_parameters_info(GDScriptParser::Node *p_node, const PropertyInfo &p_info);
+
+	// Visitor functions.
+	void visit_class(GDScriptParser::ClassNode *p_class);
+	void visit_variable(GDScriptParser::VariableNode *p_variable);
+	void visit_constant(GDScriptParser::ConstantNode *p_constant);
+	void visit_function(GDScriptParser::FunctionNode *p_function);
+	void visit_suite(GDScriptParser::SuiteNode *p_suite);
+	void visit_statement(GDScriptParser::Node *p_statement);
+	void visit_if(GDScriptParser::IfNode *p_if);
+	void visit_for(GDScriptParser::ForNode *p_for);
+	void visit_while(GDScriptParser::WhileNode *p_while);
+	void visit_match(GDScriptParser::MatchNode *p_match);
+	void visit_return(GDScriptParser::ReturnNode *p_return);
+	void visit_assert(GDScriptParser::AssertNode *p_assert);
+	void visit_expression(GDScriptParser::ExpressionNode *p_expression);
+	void visit_call(GDScriptParser::CallNode *p_call);
+
+	// Utility functions.
+	MethodInfo get_method_info_on_base(GDScriptParser::Node *p_base, const StringName &p_function);
+
+public:
+	Error generate(HashMap<int, Vector<ScriptLanguage::InlineHint>> *p_info);
+	GDScriptInlineInfoGenerator(GDScriptParser *p_parser);
+};

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1339,6 +1339,7 @@ public:
 
 private:
 	friend class GDScriptAnalyzer;
+	friend class GDScriptInlineInfoGenerator;
 	friend class GDScriptParserRef;
 
 	bool _is_tool = false;

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -37,6 +37,9 @@
 #include "core/string/string_builder.h"
 #include "core/string/translation_server.h"
 #include "core/string/ustring.h"
+#include "scene/gui/color_picker.h"
+#include "scene/gui/grid_container.h"
+#include "scene/gui/option_button.h"
 #include "scene/theme/theme_db.h"
 
 void CodeEdit::_apply_project_settings() {
@@ -2201,6 +2204,76 @@ void CodeEdit::set_code_hint_draw_below(bool p_below) {
 	queue_redraw();
 }
 
+/* Inline Hints */
+void CodeEdit::set_inline_hints_enabled(bool p_enabled) {
+	if (p_enabled) {
+		set_inline_object_handlers(
+				callable_mp(this, &CodeEdit::_inline_hint_provide),
+				callable_mp(this, &CodeEdit::_inline_hint_draw),
+				callable_mp(this, &CodeEdit::_inline_hint_handle_click));
+	} else {
+		set_inline_object_handlers(Callable(), Callable(), Callable());
+	}
+
+	if (inline_hints_enabled != p_enabled) {
+		invalidate_all_line_caches();
+	}
+
+	inline_hints_enabled = p_enabled;
+}
+
+void CodeEdit::set_inline_hint_type_enabled(const StringName &p_type, bool p_enabled) {
+	if (p_enabled) {
+		if (!enabled_hint_types.has(p_type)) {
+			enabled_hint_types.push_back(p_type);
+			invalidate_all_line_caches();
+		}
+	} else {
+		bool was_type_removed = enabled_hint_types.erase(p_type);
+		if (was_type_removed) {
+			invalidate_all_line_caches();
+		}
+	}
+}
+
+void CodeEdit::update_inline_hints(const HashMap<int, TypedArray<Dictionary>> &p_inline_info) {
+	for (const KeyValue<int, TypedArray<Dictionary>> &hints : p_inline_info) {
+		int line_number = hints.key;
+		int line_index = line_number - 1;
+
+		const TypedArray<Dictionary> &info = hints.value;
+		inline_hints[line_number] = info.duplicate(true);
+		inline_hint_line_cache[line_index] = get_line(line_index);
+
+		invalidate_line_cache(line_index, false);
+	}
+
+	LocalVector<int> to_delete;
+	for (const KeyValue<int, TypedArray<Dictionary>> &hints : inline_hints) {
+		int line_number = hints.key;
+
+		if (!p_inline_info.has(line_number)) {
+			to_delete.push_back(line_number);
+		}
+	}
+
+	for (int line : to_delete) {
+		int line_index = line - 1;
+		inline_hints.erase(line);
+		inline_hint_line_cache.erase(line_index);
+		invalidate_line_cache(line_index, false);
+	}
+}
+
+void CodeEdit::set_inline_color_picker_handlers(const Callable &p_options_updater, const Callable &p_change_handler) {
+	inline_color_picker_options_updater = p_options_updater;
+	inline_color_picker_change_handler = p_change_handler;
+}
+
+ColorPicker *CodeEdit::get_inline_color_picker() {
+	return inline_color_picker;
+}
+
 /* Code Completion */
 void CodeEdit::set_code_completion_enabled(bool p_enable) {
 	code_completion_enabled = p_enable;
@@ -3066,6 +3139,11 @@ void CodeEdit::_bind_methods() {
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, CodeEdit, code_hint_style, "panel", "TooltipPanel");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, CodeEdit, code_hint_color, "font_color", "TooltipLabel");
 
+	/* Inline hints */
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, CodeEdit, inline_parameter_hint_style, "inline_parameter_hint");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_CONSTANT, CodeEdit, inline_parameter_hint_font_scale_percentage, "inline_hint_font_scale_percentage");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, CodeEdit, inline_color_hint_alpha_texture, "sample_bg", "ColorPicker");
+
 	/* Line length guideline */
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CodeEdit, line_length_guideline_color);
 
@@ -3534,6 +3612,228 @@ TypedArray<String> CodeEdit::_get_delimiters(DelimiterType p_type) const {
 	return r_delimiters;
 }
 
+/* Inline Hints */
+Array CodeEdit::_inline_hint_provide(const String &p_text, int p_line) {
+	Array result;
+
+	int line_number = p_line + 1;
+	if (inline_hints.has(line_number)) {
+		for (Dictionary hint : inline_hints[line_number]) {
+			ERR_CONTINUE(!hint.get("kind", Variant()).is_string());
+
+			StringName type = hint["kind"];
+
+			if (!enabled_hint_types.has(type)) {
+				continue;
+			}
+
+			if (type == SNAME("parameter")) {
+				int font_size = Math::round(theme_cache.font_size * theme_cache.inline_parameter_hint_font_scale_percentage * 0.01);
+				Size2 hint_size = theme_cache.font->get_string_size(String(hint["name"]) + ": ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
+				hint["width"] = hint_size.x;
+				hint["height"] = hint_size.y;
+
+			} else if (type == SNAME("color")) {
+				float space_size = theme_cache.font->get_char_size(' ', theme_cache.font_size).x;
+				hint["is_clickable"] = true;
+				hint["width"] = theme_cache.font_size + space_size;
+				hint["height"] = theme_cache.font_size;
+			}
+			result.append(hint);
+		}
+	}
+
+	return result;
+}
+
+void CodeEdit::_inline_hint_draw(const Dictionary &p_info, const Rect2 &p_rect) {
+	RID text_canvas_item = get_text_canvas_item();
+	const Ref<Font> &font = theme_cache.font;
+
+	const StringName type = p_info.get("kind", Variant());
+	if (type == SNAME("parameter")) {
+		const Ref<StyleBox> &stylebox = theme_cache.inline_parameter_hint_style;
+
+		Color font_color = theme_cache.code_hint_color;
+		font_color.a = 0.5;
+
+		int font_size = Math::round(theme_cache.font_size * theme_cache.inline_parameter_hint_font_scale_percentage * 0.01);
+
+		real_t space_width = font->get_char_size(' ', font_size).x;
+		Vector2 text_origin_offset = Vector2(0.5 * space_width, font->get_ascent(font_size));
+
+		Rect2 background_rect = p_rect.grow_side(SIDE_RIGHT, -0.5 * space_width);
+
+		stylebox->draw(text_canvas_item, background_rect);
+		font->draw_string(text_canvas_item, p_rect.position + text_origin_offset, String(p_info["name"]) + ":", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_color);
+
+	} else if (type == SNAME("color")) {
+		real_t space_width = font->get_char_size(' ', theme_cache.font_size).x;
+
+		Rect2 base_rect = p_rect.grow_individual(-0.5 * space_width, 0.0, -0.5 * space_width, 0.0);
+
+		Rect2 col_rect = base_rect.grow(-1);
+		RS::get_singleton()->canvas_item_add_rect(text_canvas_item, base_rect, Color(1, 1, 1));
+		theme_cache.inline_color_hint_alpha_texture->draw_rect(text_canvas_item, col_rect);
+
+		RS::get_singleton()->canvas_item_add_rect(text_canvas_item, col_rect, Color(p_info["color"]));
+	}
+}
+
+void CodeEdit::_inline_hint_handle_click(const Dictionary &p_info, const Rect2 &p_rect) {
+	const StringName type = p_info.get("kind", Variant());
+
+	if (type == SNAME("color")) {
+		inline_color_picker->set_pick_color(p_info["color"]);
+
+		// Reset tooltip hover timer.
+		set_symbol_tooltip_on_hover_enabled(false);
+		set_symbol_tooltip_on_hover_enabled(true);
+
+		inline_color_picker_options_updater.call(p_info, inline_color_options, inline_color_picker);
+		current_inline_color_hint_line = p_info["line"];
+		current_inline_color_hint_column = p_info["column"];
+
+		// Move popup above the line if it's too low.
+		float_t view_h = get_viewport_rect().size.y;
+		float_t pop_h = inline_color_popup->get_contents_minimum_size().y;
+		float_t pop_y = p_rect.get_end().y;
+		float_t pop_x = p_rect.position.x;
+		if (pop_y + pop_h > view_h) {
+			pop_y = p_rect.position.y - pop_h;
+		}
+		// Move popup to the right if it's too high.
+		if (pop_y < 0) {
+			pop_x = p_rect.get_end().x;
+		}
+
+		inline_color_popup->popup(Rect2(pop_x, pop_y, 0, 0));
+	}
+}
+
+void CodeEdit::_update_inline_hint_cache(int p_from_line, int p_to_line) {
+	if (p_to_line == -1) {
+		p_to_line = get_line_count() - 1;
+	}
+
+	int start_line = MIN(p_from_line, p_to_line);
+	int end_line = MAX(p_from_line, p_to_line);
+
+	for (int line_idx = start_line; line_idx <= end_line; line_idx++) {
+		if (!inline_hint_line_cache.has(p_from_line)) {
+			continue;
+		}
+
+		const String new_line = get_line(line_idx);
+		const String &old_line = inline_hint_line_cache[line_idx];
+
+		int max_line_length = MIN(new_line.length(), old_line.length());
+
+		// Get unedited left part of the line.
+		int left_unedited_length = max_line_length;
+		for (int i = 0; i < max_line_length; i++) {
+			if (new_line[i] != old_line[i]) {
+				left_unedited_length = i;
+				break;
+			}
+		}
+
+		// Get unedited right part of the line.
+		int right_unedited_length = max_line_length - left_unedited_length;
+		for (int i = 0; i < max_line_length - left_unedited_length; i++) {
+			int new_idx = new_line.length() - i - 1;
+			int old_idx = old_line.length() - i - 1;
+
+			if (new_line[new_idx] != old_line[old_idx]) {
+				right_unedited_length = i;
+				break;
+			}
+		}
+
+		// Get beginning column of the edit.
+		int edit_begin_column = 1;
+		for (int i = 0; i < left_unedited_length; i++) {
+			edit_begin_column += old_line[i] == '\t' ? get_tab_size() : 1;
+		}
+
+		// Get the column difference.
+		int deleted_column_count = 0;
+		for (int i = left_unedited_length; i < old_line.length() - right_unedited_length; i++) {
+			deleted_column_count += old_line[i] == '\t' ? get_tab_size() : 1;
+		}
+		int added_column_count = 0;
+		for (int i = left_unedited_length; i < new_line.length() - right_unedited_length; i++) {
+			added_column_count += new_line[i] == '\t' ? get_tab_size() : 1;
+		}
+		int column_difference = added_column_count - deleted_column_count;
+
+		TypedArray<Dictionary> line_hints = inline_hints[line_idx + 1];
+		for (int i = line_hints.size() - 1; i >= 0; i--) {
+			Dictionary hint = line_hints[i];
+			int column = hint["column"];
+			if (column > edit_begin_column) {
+				if (column <= edit_begin_column + deleted_column_count) {
+					line_hints.remove_at(i);
+				} else {
+					hint["column"] = column + column_difference;
+				}
+			}
+		}
+		inline_hint_line_cache[line_idx] = new_line;
+		invalidate_line_cache(line_idx, true);
+	}
+}
+
+void CodeEdit::_inline_color_picker_update_text_current() {
+	ERR_FAIL_COND(!inline_hints.has(current_inline_color_hint_line));
+	Variant search_result;
+	for (Dictionary hint : inline_hints[current_inline_color_hint_line]) {
+		int column = hint.get("column", -1);
+		if (column == current_inline_color_hint_column) {
+			search_result = hint;
+			break;
+		}
+	}
+	ERR_FAIL_COND(search_result.get_type() != Variant::DICTIONARY);
+	Dictionary current_hint = search_result;
+
+	_inline_color_picker_update_text(current_hint);
+}
+
+void CodeEdit::_inline_color_picker_update_text(Dictionary &p_hint) {
+	String result = inline_color_options->get_item_text(inline_color_options->get_selected_id());
+	int line_number = p_hint["line"];
+	int column = p_hint["column"];
+	int column_char_offset = get_character_position_from_column(line_number - 1, column);
+	int end = p_hint["color_end"];
+
+	p_hint["color_end"] = column_char_offset + result.length() - 1;
+
+	begin_complex_operation();
+	remove_text(line_number - 1, column_char_offset, line_number - 1, end + 1);
+	insert_text(result, line_number - 1, column_char_offset);
+	end_complex_operation();
+}
+
+void CodeEdit::_inline_color_picker_color_changed(const Color &p_color) {
+	ERR_FAIL_COND(!inline_hints.has(current_inline_color_hint_line));
+	Variant search_result;
+	for (Dictionary hint : inline_hints[current_inline_color_hint_line]) {
+		int column = hint.get("column", -1);
+		if (column == current_inline_color_hint_column) {
+			search_result = hint;
+			break;
+		}
+	}
+	ERR_FAIL_COND(search_result.get_type() != Variant::DICTIONARY);
+	Dictionary current_hint = search_result;
+
+	inline_color_picker_options_updater.call(current_hint, inline_color_options, inline_color_picker);
+	current_hint["color"] = p_color;
+
+	_inline_color_picker_update_text(current_hint);
+}
+
 /* Code Completion */
 void CodeEdit::_update_scroll_selected_line(float p_mouse_y) {
 	float percent = (float)(p_mouse_y - code_completion_scroll_rect.position.y) / code_completion_scroll_rect.size.height;
@@ -3851,7 +4151,7 @@ bool CodeEdit::_should_reset_selected_option_for_new_options(const Vector<Script
 
 void CodeEdit::_lines_edited_from(int p_from_line, int p_to_line) {
 	_update_delimiter_cache(p_from_line, p_to_line);
-
+	_update_inline_hint_cache(p_from_line, p_to_line);
 	if (p_from_line == p_to_line) {
 		return;
 	}
@@ -3961,6 +4261,25 @@ CodeEdit::CodeEdit() {
 	symbol_tooltip_timer->set_one_shot(true);
 	symbol_tooltip_timer->connect("timeout", callable_mp(this, &CodeEdit::_on_symbol_tooltip_timer_timeout));
 	add_child(symbol_tooltip_timer, false, INTERNAL_MODE_FRONT);
+
+	/* Inline color picker */
+	inline_color_popup = memnew(PopupPanel);
+	add_child(inline_color_popup);
+
+	inline_color_picker = memnew(ColorPicker);
+	inline_color_picker->set_mouse_filter(MOUSE_FILTER_STOP);
+	inline_color_picker->set_deferred_mode(true);
+	inline_color_picker->set_hex_visible(false);
+	inline_color_picker->connect("color_changed", callable_mp(this, &CodeEdit::_inline_color_picker_color_changed));
+	inline_color_popup->add_child(inline_color_picker);
+
+	inline_color_options = memnew(OptionButton);
+	inline_color_options->set_h_size_flags(SIZE_FILL);
+	inline_color_options->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
+	inline_color_options->set_fit_to_longest_item(false);
+	inline_color_options->connect(SceneStringName(item_selected), callable_mp(this, &CodeEdit::_inline_color_picker_update_text_current).unbind(1));
+
+	inline_color_picker->get_slider_container()->add_sibling(inline_color_options);
 
 	/* Fold Lines Private signal */
 	add_user_signal(MethodInfo("_fold_line_updated"));

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -33,6 +33,9 @@
 #include "core/object/script_language.h"
 #include "scene/gui/text_edit.h"
 
+class OptionButton;
+class ColorPicker;
+
 class CodeEdit : public TextEdit {
 	GDCLASS(CodeEdit, TextEdit)
 
@@ -204,6 +207,33 @@ private:
 	bool code_hint_draw_below = true;
 	int code_hint_xpos = -0xFFFF;
 
+	/* Inline Hints */
+	bool inline_hints_enabled = false;
+	LocalVector<StringName> enabled_hint_types;
+
+	HashMap<int, TypedArray<Dictionary>> inline_hints;
+	HashMap<int, String> inline_hint_line_cache;
+
+	PopupPanel *inline_color_popup = nullptr;
+	ColorPicker *inline_color_picker = nullptr;
+	OptionButton *inline_color_options = nullptr;
+
+	Callable inline_color_picker_options_updater;
+	Callable inline_color_picker_change_handler;
+
+	int current_inline_color_hint_line = -1;
+	int current_inline_color_hint_column = -1;
+
+	Array _inline_hint_provide(const String &p_text, int p_line);
+	void _inline_hint_draw(const Dictionary &p_info, const Rect2 &p_rect);
+	void _inline_hint_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
+
+	void _update_inline_hint_cache(int p_from_line, int p_to_line);
+
+	void _inline_color_picker_update_text_current();
+	void _inline_color_picker_update_text(Dictionary &p_hint);
+	void _inline_color_picker_color_changed(const Color &p_color);
+
 	/* Code Completion */
 	bool code_completion_enabled = false;
 	bool code_completion_forced = false;
@@ -285,6 +315,13 @@ private:
 		/* Code hint */
 		Ref<StyleBox> code_hint_style;
 		Color code_hint_color;
+
+		/* Inline parameter hint */
+		Ref<StyleBox> inline_parameter_hint_style;
+		int inline_parameter_hint_font_scale_percentage = 75;
+
+		/* Inline color hint*/
+		Ref<Texture2D> inline_color_hint_alpha_texture;
 
 		/* Line length guideline */
 		Color line_length_guideline_color;
@@ -477,6 +514,14 @@ public:
 	/* Code hint */
 	void set_code_hint(const String &p_hint);
 	void set_code_hint_draw_below(bool p_below);
+
+	/* Inline hints */
+	void set_inline_hints_enabled(bool p_enabled);
+	void set_inline_hint_type_enabled(const StringName &p_type, bool p_enabled);
+	void update_inline_hints(const HashMap<int, TypedArray<Dictionary>> &p_inline_info);
+	void set_inline_color_picker_handlers(const Callable &p_options_updater, const Callable &p_change_handler);
+
+	ColorPicker *get_inline_color_picker();
 
 	/* Code Completion */
 	void set_code_completion_enabled(bool p_enable);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -952,11 +952,11 @@ void ColorPicker::_quick_open_palette_file_selected(const String &p_path) {
 	_palette_file_selected(p_path);
 }
 
+#endif // ifdef TOOLS_ENABLED
+
 GridContainer *ColorPicker::get_slider_container() {
 	return slider_gc;
 }
-
-#endif // ifdef TOOLS_ENABLED
 
 void ColorPicker::_palette_file_selected(const String &p_path) {
 	switch (file_dialog->get_file_mode()) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -104,8 +104,8 @@ void TextEdit::Text::set_draw_control_chars(bool p_enabled) {
 	is_dirty = true;
 }
 
-void TextEdit::Text::set_inline_object_parser(const Callable &p_parser) {
-	inline_object_parser = p_parser;
+void TextEdit::Text::set_inline_object_provider(const Callable &p_provider) {
+	inline_object_provider = p_provider;
 	is_dirty = true;
 	invalidate_all();
 }
@@ -168,6 +168,23 @@ int TextEdit::Text::get_line_wrap_amount(int p_line) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), 0);
 
 	return text[p_line].line_count - 1;
+}
+
+int TextEdit::Text::get_character_position_from_column(int p_line, int p_column) const {
+	ERR_FAIL_COND_V(p_line >= text.size(), -1);
+
+	const String &line = text[p_line].data;
+	int column_count = 0;
+
+	for (int i = 0; i < line.length(); i++) {
+		column_count += (line[i] == '\t') ? get_tab_size() : 1;
+
+		if (column_count >= p_column) {
+			return i;
+		}
+	}
+
+	return line.length();
 }
 
 Vector<Vector2i> TextEdit::Text::get_line_wrap_ranges(int p_line) const {
@@ -255,10 +272,13 @@ inline bool is_inline_info_valid(const Variant &p_info) {
 		return false;
 	}
 	Dictionary info = p_info;
-	if (!info.get_valid("column").is_num() || !info.get_valid("width_ratio").is_num()) {
-		return false;
-	}
-	return true;
+
+	bool is_valid = info.get_valid("line").is_num() &&
+			info.get_valid("column").is_num() &&
+			info.get_valid("width").is_num() &&
+			info.get_valid("height").is_num();
+
+	return is_valid;
 }
 
 void TextEdit::Text::invalidate_cache(int p_line, bool p_text_changed) {
@@ -296,30 +316,39 @@ void TextEdit::Text::invalidate_cache(int p_line, bool p_text_changed) {
 	const String &text_with_ime = (!text_line.ime_data.is_empty()) ? text_line.ime_data : text_line.data;
 	const Array &bidi_override_with_ime = (!text_line.ime_data.is_empty()) ? text_line.ime_bidi_override : text_line.bidi_override;
 
-	if (p_text_changed) {
-		int from = 0;
-		if (inline_object_parser.is_valid()) {
-			// Insert inline object.
-			Variant parsed_result = inline_object_parser.call(text_with_ime);
-			if (parsed_result.is_array()) {
-				Array object_infos = parsed_result;
-				for (Variant val : object_infos) {
-					if (!is_inline_info_valid(val)) {
-						continue;
-					}
-					Dictionary info = val;
-					int start = info["column"];
-					float width_ratio = info["width_ratio"];
-					String left_string = text_with_ime.substr(from, start - from);
-					text_line.data_buf->add_string(left_string, font, font_size, language);
-					text_line.data_buf->add_object(info, Vector2(font_height * width_ratio, font_height), INLINE_ALIGNMENT_CENTER, 0);
-					from = start;
+	int from = 0;
+	// Update inline objects.
+	if (inline_object_provider.is_valid()) {
+		Variant inline_objects = inline_object_provider.call(text_with_ime, p_line);
+
+		if (inline_objects.is_array()) {
+			Array object_infos = inline_objects;
+			if (object_infos.size() > 0) {
+				text_line.data_buf->clear();
+				p_text_changed = true;
+			}
+
+			for (Variant val : object_infos) {
+				if (!is_inline_info_valid(val)) {
+					continue;
 				}
+				Dictionary info = val;
+				int start = get_character_position_from_column(p_line, info["column"]);
+				float inline_width = info["width"];
+				float inline_height = info["height"];
+				String left_string = text_with_ime.substr(from, start - from);
+				text_line.data_buf->add_string(left_string, font, font_size, language);
+				text_line.data_buf->add_object(info, Vector2(inline_width, inline_height), INLINE_ALIGNMENT_CENTER, 0);
+				from = start;
 			}
 		}
+	}
+
+	if (p_text_changed) {
 		String remaining_string = text_with_ime.substr(from);
 		text_line.data_buf->add_string(remaining_string, font, font_size, language);
 	}
+
 	if (!bidi_override_with_ime.is_empty()) {
 		TS->shaped_text_set_bidi_override(text_line.data_buf->get_rid(), bidi_override_with_ime);
 	}
@@ -330,18 +359,6 @@ void TextEdit::Text::invalidate_cache(int p_line, bool p_text_changed) {
 		int spans = TS->shaped_get_span_count(r);
 		for (int i = 0; i < spans; i++) {
 			TS->shaped_set_span_update_font(r, i, font->get_rids(), font_size, font->get_opentype_features());
-		}
-
-		// Update inline object sizes.
-		for (int i = 0; i < text_line.data_buf->get_line_count(); i++) {
-			for (Variant key : text_line.data_buf->get_line_objects(i)) {
-				if (!is_inline_info_valid(key)) {
-					continue;
-				}
-				Dictionary info = key;
-				float width_ratio = info["width_ratio"];
-				text_line.data_buf->resize_object(info, Vector2(font_height * width_ratio, font_height), INLINE_ALIGNMENT_CENTER, 0);
-			}
 		}
 	}
 
@@ -2406,7 +2423,6 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 							continue;
 						}
 						Dictionary info = inline_key.duplicate();
-						info["line"] = line;
 						Rect2 obj_rect = ldata->get_line_object_rect(wrap_i, inline_key);
 						obj_rect.position.x += xmargin_beg + wrap_indent - first_visible_col;
 
@@ -3623,6 +3639,11 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 			if (!is_inline_info_valid(k)) {
 				continue;
 			}
+			Dictionary info = k;
+			if (!info.get("is_clickable", false)) {
+				continue;
+			}
+
 			Rect2 obj_rect = ldata->get_line_object_rect(wrap_i, k);
 			obj_rect.position.x += xmargin_beg + wrap_indent - first_visible_col;
 			if (p_pos.x > obj_rect.position.x && p_pos.x < obj_rect.get_end().x) {
@@ -4465,10 +4486,22 @@ Point2i TextEdit::get_next_visible_line_index_offset_from(int p_line_from, int p
 	return Point2i(num_total, wrap_index);
 }
 
-void TextEdit::set_inline_object_handlers(const Callable &p_parser, const Callable &p_drawer, const Callable &p_click_handler) {
+int TextEdit::get_character_position_from_column(int p_line, int p_column) const {
+	return text.get_character_position_from_column(p_line, p_column);
+}
+
+void TextEdit::set_inline_object_handlers(const Callable &p_provider, const Callable &p_drawer, const Callable &p_click_handler) {
 	inline_object_drawer = p_drawer;
 	inline_object_click_handler = p_click_handler;
-	text.set_inline_object_parser(p_parser);
+	text.set_inline_object_provider(p_provider);
+}
+
+void TextEdit::invalidate_line_cache(int p_line, bool p_text_changed) {
+	text.invalidate_cache(p_line, false);
+}
+
+void TextEdit::invalidate_all_line_caches() {
+	text.invalidate_all_lines();
 }
 
 // Overridable actions

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -185,7 +185,7 @@ private:
 		String custom_word_separators;
 		bool use_default_word_separators = true;
 		bool use_custom_word_separators = false;
-		Callable inline_object_parser;
+		Callable inline_object_provider;
 
 		mutable bool max_line_width_dirty = true;
 		mutable bool max_line_height_dirty = true;
@@ -208,7 +208,7 @@ private:
 		void set_font_size(int p_font_size);
 		void set_direction_and_language(TextServer::Direction p_direction, const String &p_language);
 		void set_draw_control_chars(bool p_enabled);
-		void set_inline_object_parser(const Callable &p_parser);
+		void set_inline_object_provider(const Callable &p_provider);
 
 		int get_line_height() const;
 		int get_line_width(int p_line, int p_wrap_index = -1) const;
@@ -231,6 +231,7 @@ private:
 		void set_brk_flags(BitField<TextServer::LineBreakFlag> p_flags);
 		BitField<TextServer::LineBreakFlag> get_brk_flags() const;
 		int get_line_wrap_amount(int p_line) const;
+		int get_character_position_from_column(int p_line, int p_column) const;
 
 		const Vector<RID> get_accessibility_elements(int p_line);
 		void update_accessibility(int p_line, RID p_root);
@@ -885,7 +886,12 @@ public:
 	int get_next_visible_line_offset_from(int p_line_from, int p_visible_amount) const;
 	Point2i get_next_visible_line_index_offset_from(int p_line_from, int p_wrap_index_from, int p_visible_amount) const;
 
-	void set_inline_object_handlers(const Callable &p_parser, const Callable &p_drawer, const Callable &p_click_handler);
+	int get_character_position_from_column(int p_line, int p_column) const;
+
+	void set_inline_object_handlers(const Callable &p_provider, const Callable &p_drawer, const Callable &p_click_handler);
+
+	void invalidate_line_cache(int p_line, bool p_text_changed = false);
+	void invalidate_all_line_caches();
 
 	// Overridable actions
 	void handle_unicode_input(const uint32_t p_unicode, int p_caret = -1);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -487,6 +487,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("focus", "CodeEdit", focus);
 	theme->set_stylebox("read_only", "CodeEdit", style_line_edit_read_only);
 	theme->set_stylebox("completion", "CodeEdit", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
+	theme->set_stylebox("inline_parameter_hint", "CodeEdit", make_flat_stylebox(Color(1.0, 1.0, 1.0, 0.05), -1, -1, -1, -1, 3));
 
 	theme->set_icon("tab", "CodeEdit", icons["text_edit_tab"]);
 	theme->set_icon("space", "CodeEdit", icons["text_edit_space"]);
@@ -535,6 +536,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("completion_lines", "CodeEdit", 7);
 	theme->set_constant("completion_max_width", "CodeEdit", 50);
 	theme->set_constant("completion_scroll_width", "CodeEdit", 6);
+	theme->set_constant("inline_hint_font_scale_percentage", "CodeEdit", 70);
 	theme->set_constant("line_spacing", "CodeEdit", Math::round(4 * scale));
 	theme->set_constant("outline_size", "CodeEdit", 0);
 


### PR DESCRIPTION
Addition of inline hints to the script editor as suggested in https://github.com/godotengine/godot-proposals/discussions/10732.


https://github.com/user-attachments/assets/992094b1-227c-477a-9642-5468d34ba32c


This feature can be disabled in the editor settings.

### Notes:
- Additional hints (like array indices) could be easily added in the future
- It should be possible to support other languages than GDScript.
- I took the liberty of moving some of the inline color picker  (see #105724) code, so that the inline color blocks are also considered as inline hints.

_Bugsquad edit:_
- _Closes https://github.com/godotengine/godot-proposals/discussions/10732_
- _Related to https://github.com/godotengine/godot-proposals/discussions/7683_
