### PR TITLE
Rename `file` parameter to `path` in many FileAccess methods

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -50,14 +50,14 @@ Ref<FileAccess> FileAccess::create(AccessType p_access) {
 	return ret;
 }
 
-bool FileAccess::exists(const String &p_name) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && PackedData::get_singleton()->has_path(p_name)) {
+bool FileAccess::exists(const String &p_path) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && PackedData::get_singleton()->has_path(p_path)) {
 		return true;
 	}
 
 	// Using file_exists because it's faster than trying to open the file.
-	Ref<FileAccess> ret = create_for_path(p_name);
-	return ret->file_exists(p_name);
+	Ref<FileAccess> ret = create_for_path(p_path);
+	return ret->file_exists(p_path);
 }
 
 void FileAccess::_set_access_type(AccessType p_access) {
@@ -669,152 +669,152 @@ bool FileAccess::store_double(double p_dest) {
 	return store_64(m.l);
 }
 
-uint64_t FileAccess::get_modified_time(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+uint64_t FileAccess::get_modified_time(const String &p_path) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return 0;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	return fa->_get_modified_time(p_file);
+	return fa->_get_modified_time(p_path);
 }
 
-uint64_t FileAccess::get_access_time(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+uint64_t FileAccess::get_access_time(const String &p_path) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return 0;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, "Cannot create FileAccess for path '" + p_file + "'.");
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, "Cannot create FileAccess for path '" + p_path + "'.");
 
-	return fa->_get_access_time(p_file);
+	return fa->_get_access_time(p_path);
 }
 
-int64_t FileAccess::get_size(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return PackedData::get_singleton()->get_size(p_file);
+int64_t FileAccess::get_size(const String &p_path) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return PackedData::get_singleton()->get_size(p_path);
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), -1, "Cannot create FileAccess for path '" + p_file + "'.");
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), -1, "Cannot create FileAccess for path '" + p_path + "'.");
 
-	return fa->_get_size(p_file);
+	return fa->_get_size(p_path);
 }
 
-BitField<FileAccess::UnixPermissionFlags> FileAccess::get_unix_permissions(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+BitField<FileAccess::UnixPermissionFlags> FileAccess::get_unix_permissions(const String &p_path) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return 0;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	return fa->_get_unix_permissions(p_file);
+	return fa->_get_unix_permissions(p_path);
 }
 
-Error FileAccess::set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+Error FileAccess::set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return ERR_UNAVAILABLE;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	Error err = fa->_set_unix_permissions(p_file, p_permissions);
+	Error err = fa->_set_unix_permissions(p_path, p_permissions);
 	return err;
 }
 
-bool FileAccess::get_hidden_attribute(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+bool FileAccess::get_hidden_attribute(const String &p_path) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return false;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	return fa->_get_hidden_attribute(p_file);
+	return fa->_get_hidden_attribute(p_path);
 }
 
-Error FileAccess::set_hidden_attribute(const String &p_file, bool p_hidden) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+Error FileAccess::set_hidden_attribute(const String &p_path, bool p_hidden) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return ERR_UNAVAILABLE;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	Error err = fa->_set_hidden_attribute(p_file, p_hidden);
+	Error err = fa->_set_hidden_attribute(p_path, p_hidden);
 	return err;
 }
 
-bool FileAccess::get_read_only_attribute(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+bool FileAccess::get_read_only_attribute(const String &p_path) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return false;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	return fa->_get_read_only_attribute(p_file);
+	return fa->_get_read_only_attribute(p_path);
 }
 
-Error FileAccess::set_read_only_attribute(const String &p_file, bool p_ro) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+Error FileAccess::set_read_only_attribute(const String &p_path, bool p_ro) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return ERR_UNAVAILABLE;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	Error err = fa->_set_read_only_attribute(p_file, p_ro);
+	Error err = fa->_set_read_only_attribute(p_path, p_ro);
 	return err;
 }
 
-PackedByteArray FileAccess::get_extended_attribute(const String &p_file, const String &p_attribute_name) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+PackedByteArray FileAccess::get_extended_attribute(const String &p_path, const String &p_attribute_name) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return PackedByteArray();
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), PackedByteArray(), vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), PackedByteArray(), vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	return fa->_get_extended_attribute(p_file, p_attribute_name);
+	return fa->_get_extended_attribute(p_path, p_attribute_name);
 }
 
-String FileAccess::get_extended_attribute_string(const String &p_file, const String &p_attribute_name) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+String FileAccess::get_extended_attribute_string(const String &p_path, const String &p_attribute_name) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return String();
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), String(), vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), String(), vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	PackedByteArray data = fa->_get_extended_attribute(p_file, p_attribute_name);
+	PackedByteArray data = fa->_get_extended_attribute(p_path, p_attribute_name);
 	if (data.is_empty()) {
 		return String();
 	}
 	return String::utf8((const char *)data.ptr(), data.size());
 }
 
-Error FileAccess::set_extended_attribute(const String &p_file, const String &p_attribute_name, const PackedByteArray &p_data) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+Error FileAccess::set_extended_attribute(const String &p_path, const String &p_attribute_name, const PackedByteArray &p_data) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return ERR_UNAVAILABLE;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	return fa->_set_extended_attribute(p_file, p_attribute_name, p_data);
+	return fa->_set_extended_attribute(p_path, p_attribute_name, p_data);
 }
 
-Error FileAccess::set_extended_attribute_string(const String &p_file, const String &p_attribute_name, const String &p_data) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+Error FileAccess::set_extended_attribute_string(const String &p_path, const String &p_attribute_name, const String &p_data) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return ERR_UNAVAILABLE;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
 	PackedByteArray data;
 	CharString cs = p_data.utf8();
@@ -823,29 +823,29 @@ Error FileAccess::set_extended_attribute_string(const String &p_file, const Stri
 		memcpy(data.ptrw(), cs.get_data(), cs.size());
 	}
 
-	return fa->_set_extended_attribute(p_file, p_attribute_name, data);
+	return fa->_set_extended_attribute(p_path, p_attribute_name, data);
 }
 
-Error FileAccess::remove_extended_attribute(const String &p_file, const String &p_attribute_name) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+Error FileAccess::remove_extended_attribute(const String &p_path, const String &p_attribute_name) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return ERR_UNAVAILABLE;
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	return fa->_remove_extended_attribute(p_file, p_attribute_name);
+	return fa->_remove_extended_attribute(p_path, p_attribute_name);
 }
 
-PackedStringArray FileAccess::get_extended_attributes_list(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
+PackedStringArray FileAccess::get_extended_attributes_list(const String &p_path) {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
 		return PackedStringArray();
 	}
 
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), PackedStringArray(), vformat("Cannot create FileAccess for path '%s'.", p_file));
+	Ref<FileAccess> fa = create_for_path(p_path);
+	ERR_FAIL_COND_V_MSG(fa.is_null(), PackedStringArray(), vformat("Cannot create FileAccess for path '%s'.", p_path));
 
-	return fa->_get_extended_attributes_list(p_file);
+	return fa->_get_extended_attributes_list(p_path);
 }
 
 bool FileAccess::store_string(const String &p_string) {
@@ -966,8 +966,8 @@ String FileAccess::get_file_as_string(const String &p_path, Error *r_error) {
 	return ret;
 }
 
-String FileAccess::get_md5(const String &p_file) {
-	Ref<FileAccess> f = FileAccess::open(p_file, READ);
+String FileAccess::get_md5(const String &p_path) {
+	Ref<FileAccess> f = FileAccess::open(p_path, READ);
 	if (f.is_null()) {
 		return String();
 	}
@@ -993,12 +993,12 @@ String FileAccess::get_md5(const String &p_file) {
 	return String::md5(hash);
 }
 
-String FileAccess::get_multiple_md5(const Vector<String> &p_file) {
+String FileAccess::get_multiple_md5(const Vector<String> &p_paths) {
 	CryptoCore::MD5Context ctx;
 	ctx.start();
 
-	for (int i = 0; i < p_file.size(); i++) {
-		Ref<FileAccess> f = FileAccess::open(p_file[i], READ);
+	for (int i = 0; i < p_paths.size(); i++) {
+		Ref<FileAccess> f = FileAccess::open(p_paths[i], READ);
 		ERR_CONTINUE(f.is_null());
 
 		unsigned char step[32768];
@@ -1020,8 +1020,8 @@ String FileAccess::get_multiple_md5(const Vector<String> &p_file) {
 	return String::md5(hash);
 }
 
-String FileAccess::get_sha256(const String &p_file) {
-	Ref<FileAccess> f = FileAccess::open(p_file, READ);
+String FileAccess::get_sha256(const String &p_path) {
+	Ref<FileAccess> f = FileAccess::open(p_path, READ);
 	if (f.is_null()) {
 		return String();
 	}
@@ -1107,24 +1107,24 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("close"), &FileAccess::close);
 
 	ClassDB::bind_static_method("FileAccess", D_METHOD("file_exists", "path"), &FileAccess::exists);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("get_modified_time", "file"), &FileAccess::get_modified_time);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("get_access_time", "file"), &FileAccess::get_access_time);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("get_size", "file"), &FileAccess::get_size);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("get_modified_time", "path"), &FileAccess::get_modified_time);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("get_access_time", "path"), &FileAccess::get_access_time);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("get_size", "path"), &FileAccess::get_size);
 
-	ClassDB::bind_static_method("FileAccess", D_METHOD("get_unix_permissions", "file"), &FileAccess::get_unix_permissions);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("set_unix_permissions", "file", "permissions"), &FileAccess::set_unix_permissions);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("get_unix_permissions", "path"), &FileAccess::get_unix_permissions);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("set_unix_permissions", "path", "permissions"), &FileAccess::set_unix_permissions);
 
-	ClassDB::bind_static_method("FileAccess", D_METHOD("get_hidden_attribute", "file"), &FileAccess::get_hidden_attribute);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("set_hidden_attribute", "file", "hidden"), &FileAccess::set_hidden_attribute);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("set_read_only_attribute", "file", "ro"), &FileAccess::set_read_only_attribute);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("get_read_only_attribute", "file"), &FileAccess::get_read_only_attribute);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("get_hidden_attribute", "path"), &FileAccess::get_hidden_attribute);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("set_hidden_attribute", "path", "hidden"), &FileAccess::set_hidden_attribute);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("set_read_only_attribute", "path", "ro"), &FileAccess::set_read_only_attribute);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("get_read_only_attribute", "path"), &FileAccess::get_read_only_attribute);
 
-	ClassDB::bind_static_method("FileAccess", D_METHOD("get_extended_attribute", "file", "attribute_name"), &FileAccess::get_extended_attribute);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("get_extended_attribute_string", "file", "attribute_name"), &FileAccess::get_extended_attribute_string);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("set_extended_attribute", "file", "attribute_name", "data"), &FileAccess::set_extended_attribute);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("set_extended_attribute_string", "file", "attribute_name", "_data"), &FileAccess::set_extended_attribute_string);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("remove_extended_attribute", "file", "attribute_name"), &FileAccess::remove_extended_attribute);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("get_extended_attributes_list", "file"), &FileAccess::get_extended_attributes_list);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("get_extended_attribute", "path", "attribute_name"), &FileAccess::get_extended_attribute);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("get_extended_attribute_string", "path", "attribute_name"), &FileAccess::get_extended_attribute_string);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("set_extended_attribute", "path", "attribute_name", "data"), &FileAccess::set_extended_attribute);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("set_extended_attribute_string", "path", "attribute_name", "data"), &FileAccess::set_extended_attribute_string);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("remove_extended_attribute", "path", "attribute_name"), &FileAccess::remove_extended_attribute);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("get_extended_attributes_list", "path"), &FileAccess::get_extended_attributes_list);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "big_endian"), "set_big_endian", "is_big_endian");
 

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -94,18 +94,18 @@ public:
 #endif
 	bool real_is_double = false;
 
-	virtual BitField<UnixPermissionFlags> _get_unix_permissions(const String &p_file) = 0;
-	virtual Error _set_unix_permissions(const String &p_file, BitField<UnixPermissionFlags> p_permissions) = 0;
+	virtual BitField<UnixPermissionFlags> _get_unix_permissions(const String &p_path) = 0;
+	virtual Error _set_unix_permissions(const String &p_path, BitField<UnixPermissionFlags> p_permissions) = 0;
 
-	virtual bool _get_hidden_attribute(const String &p_file) = 0;
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) = 0;
-	virtual bool _get_read_only_attribute(const String &p_file) = 0;
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) = 0;
+	virtual bool _get_hidden_attribute(const String &p_path) = 0;
+	virtual Error _set_hidden_attribute(const String &p_path, bool p_hidden) = 0;
+	virtual bool _get_read_only_attribute(const String &p_path) = 0;
+	virtual Error _set_read_only_attribute(const String &p_path, bool p_ro) = 0;
 
-	virtual PackedByteArray _get_extended_attribute(const String &p_file, const String &p_attribute_name) { return PackedByteArray(); }
-	virtual Error _set_extended_attribute(const String &p_file, const String &p_attribute_name, const PackedByteArray &p_data) { return ERR_UNAVAILABLE; }
-	virtual Error _remove_extended_attribute(const String &p_file, const String &p_attribute_name) { return ERR_UNAVAILABLE; }
-	virtual PackedStringArray _get_extended_attributes_list(const String &p_file) { return PackedStringArray(); }
+	virtual PackedByteArray _get_extended_attribute(const String &p_path, const String &p_attribute_name) { return PackedByteArray(); }
+	virtual Error _set_extended_attribute(const String &p_path, const String &p_attribute_name, const PackedByteArray &p_data) { return ERR_UNAVAILABLE; }
+	virtual Error _remove_extended_attribute(const String &p_path, const String &p_attribute_name) { return ERR_UNAVAILABLE; }
+	virtual PackedStringArray _get_extended_attributes_list(const String &p_path) { return PackedStringArray(); }
 
 protected:
 	static void _bind_methods();
@@ -113,9 +113,9 @@ protected:
 	AccessType get_access_type() const;
 	virtual String fix_path(const String &p_path) const;
 	virtual Error open_internal(const String &p_path, int p_mode_flags) = 0; ///< open a file
-	virtual uint64_t _get_modified_time(const String &p_file) = 0;
-	virtual uint64_t _get_access_time(const String &p_file) = 0;
-	virtual int64_t _get_size(const String &p_file) = 0;
+	virtual uint64_t _get_modified_time(const String &p_path) = 0;
+	virtual uint64_t _get_access_time(const String &p_path) = 0;
+	virtual int64_t _get_size(const String &p_path) = 0;
 	virtual void _set_access_type(AccessType p_access);
 
 	static inline FileCloseFailNotify close_fail_notify = nullptr;
@@ -234,7 +234,7 @@ public:
 
 	virtual void close() = 0;
 
-	virtual bool file_exists(const String &p_name) = 0; ///< return true if a file exists
+	virtual bool file_exists(const String &p_path) = 0; ///< return true if a file exists
 
 	virtual Error reopen(const String &p_path, int p_mode_flags); ///< does not change the AccessType
 
@@ -250,30 +250,30 @@ public:
 
 	static CreateFunc get_create_func(AccessType p_access);
 	static bool exists(const String &p_name); ///< return true if a file exists
-	static uint64_t get_modified_time(const String &p_file);
-	static uint64_t get_access_time(const String &p_file);
-	static int64_t get_size(const String &p_file);
-	static BitField<FileAccess::UnixPermissionFlags> get_unix_permissions(const String &p_file);
-	static Error set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions);
+	static uint64_t get_modified_time(const String &p_path);
+	static uint64_t get_access_time(const String &p_path);
+	static int64_t get_size(const String &p_path);
+	static BitField<FileAccess::UnixPermissionFlags> get_unix_permissions(const String &p_path);
+	static Error set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions);
 
-	static bool get_hidden_attribute(const String &p_file);
-	static Error set_hidden_attribute(const String &p_file, bool p_hidden);
-	static bool get_read_only_attribute(const String &p_file);
-	static Error set_read_only_attribute(const String &p_file, bool p_ro);
+	static bool get_hidden_attribute(const String &p_path);
+	static Error set_hidden_attribute(const String &p_path, bool p_hidden);
+	static bool get_read_only_attribute(const String &p_path);
+	static Error set_read_only_attribute(const String &p_path, bool p_ro);
 
-	static PackedByteArray get_extended_attribute(const String &p_file, const String &p_attribute_name);
-	static String get_extended_attribute_string(const String &p_file, const String &p_attribute_name);
-	static Error set_extended_attribute(const String &p_file, const String &p_attribute_name, const PackedByteArray &p_data);
-	static Error set_extended_attribute_string(const String &p_file, const String &p_attribute_name, const String &p_data);
-	static Error remove_extended_attribute(const String &p_file, const String &p_attribute_name);
-	static PackedStringArray get_extended_attributes_list(const String &p_file);
+	static PackedByteArray get_extended_attribute(const String &path, const String &p_attribute_name);
+	static String get_extended_attribute_string(const String &path, const String &p_attribute_name);
+	static Error set_extended_attribute(const String &p_path, const String &p_attribute_name, const PackedByteArray &p_data);
+	static Error set_extended_attribute_string(const String &p_path, const String &p_attribute_name, const String &p_data);
+	static Error remove_extended_attribute(const String &p_path, const String &p_attribute_name);
+	static PackedStringArray get_extended_attributes_list(const String &path);
 
 	static void set_backup_save(bool p_enable) { backup_save = p_enable; }
 	static bool is_backup_save_enabled() { return backup_save; }
 
-	static String get_md5(const String &p_file);
-	static String get_sha256(const String &p_file);
-	static String get_multiple_md5(const Vector<String> &p_file);
+	static String get_md5(const String &p_path);
+	static String get_sha256(const String &p_path);
+	static String get_multiple_md5(const Vector<String> &p_paths);
 
 	static Vector<uint8_t> get_file_as_bytes(const String &p_path, Error *r_error = nullptr);
 	static String get_file_as_string(const String &p_path, Error *r_error = nullptr);

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -126,9 +126,9 @@
 		</method>
 		<method name="get_access_time" qualifiers="static">
 			<return type="int" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<description>
-				Returns the last time the [param file] was accessed in Unix timestamp format, or [code]0[/code] on error. This Unix timestamp can be converted to another format using the [Time] singleton.
+				Returns the last time the file at the given [param path] was accessed, in Unix timestamp format, or [code]0[/code] on error. This Unix timestamp can be converted to another format using the [Time] singleton.
 			</description>
 		</method>
 		<method name="get_as_text" qualifiers="const">
@@ -173,10 +173,10 @@
 		</method>
 		<method name="get_extended_attribute" qualifiers="static">
 			<return type="PackedByteArray" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<param index="1" name="attribute_name" type="String" />
 			<description>
-				Reads the file extended attribute with name [param attribute_name] as a byte array.
+				Returns the extended attribute named [param attribute_name] of the file at the given [param path], as a byte array.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 				[b]Note:[/b] Extended attributes support depends on the file system. Attributes will be lost when the file is moved between incompatible file systems.
 				[b]Note:[/b] On Linux, only "user" namespace attributes are accessible, namespace prefix should not be included.
@@ -185,10 +185,10 @@
 		</method>
 		<method name="get_extended_attribute_string" qualifiers="static">
 			<return type="String" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<param index="1" name="attribute_name" type="String" />
 			<description>
-				Reads the file extended attribute with name [param attribute_name] as a UTF-8 encoded string.
+				Returns the extended attribute named [param attribute_name] of the file at the given [param path], as a UTF-8 encoded string.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 				[b]Note:[/b] Extended attributes support depends on the file system. Attributes will be lost when the file is moved between incompatible file systems.
 				[b]Note:[/b] On Linux, only "user" namespace attributes are accessible, namespace prefix should not be included.
@@ -197,9 +197,9 @@
 		</method>
 		<method name="get_extended_attributes_list" qualifiers="static">
 			<return type="PackedStringArray" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<description>
-				Returns a list of file extended attributes.
+				Returns the list of extended attributes names of the file at the given [param path].
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 				[b]Note:[/b] Extended attributes support depends on the file system. Attributes will be lost when the file is moved between incompatible file systems.
 				[b]Note:[/b] On Linux, only "user" namespace attributes are accessible, namespace prefix should not be included.
@@ -236,9 +236,9 @@
 		</method>
 		<method name="get_hidden_attribute" qualifiers="static">
 			<return type="bool" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<description>
-				Returns [code]true[/code], if file [code]hidden[/code] attribute is set.
+				Returns [code]true[/code] if the [b]hidden[/b] attribute is set on the file at the given [param path].
 				[b]Note:[/b] This method is implemented on iOS, BSD, macOS, and Windows.
 			</description>
 		</method>
@@ -264,9 +264,9 @@
 		</method>
 		<method name="get_modified_time" qualifiers="static">
 			<return type="int" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<description>
-				Returns the last time the [param file] was modified in Unix timestamp format, or [code]0[/code] on error. This Unix timestamp can be converted to another format using the [Time] singleton.
+				Returns the last time the file at the given [param path] was modified, in Unix timestamp format, or [code]0[/code] on error. This Unix timestamp can be converted to another format using the [Time] singleton.
 			</description>
 		</method>
 		<method name="get_open_error" qualifiers="static">
@@ -302,9 +302,9 @@
 		</method>
 		<method name="get_read_only_attribute" qualifiers="static">
 			<return type="bool" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<description>
-				Returns [code]true[/code], if file [code]read only[/code] attribute is set.
+				Returns [code]true[/code] if the [b]read only[/b] attribute is set on the file at the given [param path].
 				[b]Note:[/b] This method is implemented on iOS, BSD, macOS, and Windows.
 			</description>
 		</method>
@@ -324,16 +324,16 @@
 		</method>
 		<method name="get_size" qualifiers="static">
 			<return type="int" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<description>
-				Returns the size of the file at the given path, in bytes, or [code]-1[/code] on error.
+				Returns the size of the file at the given [param path], in bytes, or [code]-1[/code] on error.
 			</description>
 		</method>
 		<method name="get_unix_permissions" qualifiers="static">
 			<return type="int" enum="FileAccess.UnixPermissionFlags" is_bitfield="true" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<description>
-				Returns the UNIX permissions of the file at the given path.
+				Returns the UNIX permissions of the file at the given [param path].
 				[b]Note:[/b] This method is implemented on iOS, Linux/BSD, and macOS.
 			</description>
 		</method>
@@ -396,10 +396,10 @@
 		</method>
 		<method name="remove_extended_attribute" qualifiers="static">
 			<return type="int" enum="Error" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<param index="1" name="attribute_name" type="String" />
 			<description>
-				Removes file extended attribute with name [param attribute_name].
+				Removes the extended attribute named [param attribute_name] from the file at the given [param path].
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 				[b]Note:[/b] Extended attributes support depends on the file system. Attributes will be lost when the file is moved between incompatible file systems.
 				[b]Note:[/b] On Linux, only "user" namespace attributes are accessible, namespace prefix should not be included.
@@ -430,11 +430,11 @@
 		</method>
 		<method name="set_extended_attribute" qualifiers="static">
 			<return type="int" enum="Error" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<param index="1" name="attribute_name" type="String" />
 			<param index="2" name="data" type="PackedByteArray" />
 			<description>
-				Writes file extended attribute with name [param attribute_name] as a byte array.
+				Writes the extended attribute named [param attribute_name] to the file at the given [param path].
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 				[b]Note:[/b] Extended attributes support depends on the file system. Attributes will be lost when the file is moved between incompatible file systems.
 				[b]Note:[/b] On Linux, only "user" namespace attributes are accessible, namespace prefix should not be included.
@@ -443,11 +443,11 @@
 		</method>
 		<method name="set_extended_attribute_string" qualifiers="static">
 			<return type="int" enum="Error" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<param index="1" name="attribute_name" type="String" />
-			<param index="2" name="_data" type="String" />
+			<param index="2" name="data" type="String" />
 			<description>
-				Writes file extended attribute with name [param attribute_name] as a UTF-8 encoded string.
+				Writes the extended attribute named [param attribute_name] to the file at the given [param path], as a UTF-8 encoded string.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 				[b]Note:[/b] Extended attributes support depends on the file system. Attributes will be lost when the file is moved between incompatible file systems.
 				[b]Note:[/b] On Linux, only "user" namespace attributes are accessible, namespace prefix should not be included.
@@ -456,28 +456,28 @@
 		</method>
 		<method name="set_hidden_attribute" qualifiers="static">
 			<return type="int" enum="Error" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<param index="1" name="hidden" type="bool" />
 			<description>
-				Sets file [b]hidden[/b] attribute.
+				Sets the [b]hidden[/b] attribute on the file at the given [param path].
 				[b]Note:[/b] This method is implemented on iOS, BSD, macOS, and Windows.
 			</description>
 		</method>
 		<method name="set_read_only_attribute" qualifiers="static">
 			<return type="int" enum="Error" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<param index="1" name="ro" type="bool" />
 			<description>
-				Sets file [b]read only[/b] attribute.
+				Sets the [b]read only[/b] attribute on the file at the given [param path].
 				[b]Note:[/b] This method is implemented on iOS, BSD, macOS, and Windows.
 			</description>
 		</method>
 		<method name="set_unix_permissions" qualifiers="static">
 			<return type="int" enum="Error" />
-			<param index="0" name="file" type="String" />
+			<param index="0" name="path" type="String" />
 			<param index="1" name="permissions" type="int" enum="FileAccess.UnixPermissionFlags" is_bitfield="true" />
 			<description>
-				Sets file UNIX permissions.
+				Sets the UNIX permissions of the file at the given [param path] to [param permissions].
 				[b]Note:[/b] This method is implemented on iOS, Linux/BSD, and macOS.
 			</description>
 		</method>


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/107536#discussion_r2146997169

There are several methods in **FileAccess** whose parameter's name is `file`. This is not just inconsistent, but misleading because these methods purely accept a _path_ to a file.
In a class all about accessing any given file's raw data, this distinction matters quite a lot, I feel.

It looks like these methods were added over time, each deriving from the last ( d454e1a1e0f805f590d9a39ee959a1414b794b64 8aa6f29b5627aef27ee2eedef72976d08022fa06 85d3be80701798a6c69dad7b002ba5762df180d6 ). They're quite advanced and certainly targeted towards tech-savvy users, so naming the path `file` here may come naturally to them. Other **FileAccess** methods just name the same kind of parameter `path`, hence my belief that this is an oddity worth fixing.

This PR renames the parameters in all affected methods from `file` to `path`. Each corresponding description in the class reference has been updated, as well.