### PR TITLE
Fix overlap between texts in Make Unique (Recursive) Popup

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2342,6 +2342,9 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			if (p_item->cells[i].icon.is_valid()) {
 				text_width -= _get_cell_icon_size(p_item->cells[i]).x + theme_cache.h_separation;
 			}
+			if (p_item->cells[i].mode == TreeItem::CELL_MODE_CHECK) {
+				text_width -= (theme_cache.checked->get_width() + theme_cache.h_separation);
+			}
 
 			p_item->cells.write[i].text_buf->set_width(text_width);
 


### PR DESCRIPTION
When a TreeIcon is set to have a checkbox, its text might overlap a bit with property name's (or the "..." can get pretty close of it):

![default behavior](https://github.com/user-attachments/assets/95fb9d37-c1b1-4d41-bd92-e427a1ecf767)

This may just be a slight issue, but for https://github.com/godotengine/godot/pull/112711, which have title columns, it actually overlaps a ton:

![okso](https://github.com/user-attachments/assets/284894d6-7873-4c3c-8330-99c6ce6b8e06)

Since this should be fixed regardless of whether the column titles stays or not, I decided to make a separate, focused PR on the matter. Now it doesn't touch property's text anymore:

![sdsad](https://github.com/user-attachments/assets/489ad331-fe5f-47ca-85ee-877c2a715a4d)

>[!Note]
>Since the bit of code I've added can also trim any text from a TreeItem with a checkbox, other unrelated areas to the popup might be affected. I've taken a look at areas I know have those (such as project settings) and the text stayed the same, so hopefully this doesn't cause a regression