### PR TITLE
Resize right panel back to previous width

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8765,8 +8765,8 @@ EditorNode::EditorNode() {
 	editor_dock_manager->add_dock(history_dock);
 
 	// Add some offsets to left_r and main hsplits to make LEFT_R and RIGHT_L docks wider than minsize.
-	left_r_hsplit->set_split_offset(270 * EDSCALE);
-	main_hsplit->set_split_offset(-360 * EDSCALE);
+	left_r_hsplit->set_split_offset(280 * EDSCALE);
+	main_hsplit->set_split_offset(-280 * EDSCALE);
 
 	// Define corresponding default layout.
 
@@ -8777,7 +8777,7 @@ EditorNode::EditorNode() {
 	default_layout->set_value(docks_section, "dock_4", "FileSystem,History");
 	default_layout->set_value(docks_section, "dock_5", "Inspector,Signals,Groups");
 
-	int hsplits[] = { 0, 270, -270, 0 };
+	int hsplits[] = { 0, 280, -280, 0 };
 	DEV_ASSERT((int)std_size(hsplits) == editor_dock_manager->get_hsplit_count());
 	for (int i = 0; i < editor_dock_manager->get_hsplit_count(); i++) {
 		default_layout->set_value(docks_section, "dock_hsplit_" + itos(i + 1), hsplits[i]);


### PR DESCRIPTION
Mentioned in #113155 (but unrelated to the main issue mentioned there)

In #101787, I resized the right panel's default width from 270 to 360 pixels to fit all 4 docks. However, since one of the docks was moved in #112996, this is no longer required. Note that I've set it to 280 as it must be slightly larger than 270 to fit all 3 docks when using the new default theme.