### PR TITLE
Windows: Make GPU preference symbols configurable at build time

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -215,6 +215,9 @@ def get_opts():
             "Path to the PIX runtime distribution (optional for D3D12)",
             os.path.join(d3d12_deps_folder, "pix"),
         ),
+        BoolVariable(
+            "prefer_high_performance_gpu", "Prefer high-performance GPU on NVIDIA Optimus/AMD PowerXpress systems", True
+        ),
     ]
 
 
@@ -910,6 +913,9 @@ def configure(env: "SConsEnvironment"):
 
     # At this point the env has been set up with basic tools/compilers.
     env.Prepend(CPPPATH=["#platform/windows"])
+
+    if env["prefer_high_performance_gpu"]:
+        env.Append(CPPDEFINES=["ENABLE_PREFER_HIGH_PERFORMANCE_GPU"])
 
     env.msvc = "mingw" not in env["TOOLS"]
     if env.msvc:

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -90,8 +90,10 @@
 #endif
 
 extern "C" {
+#ifdef ENABLE_PREFER_HIGH_PERFORMANCE_GPU
 __declspec(dllexport) DWORD NvOptimusEnablement = 1;
 __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+#endif // ENABLE_PREFER_HIGH_PERFORMANCE_GPU
 __declspec(dllexport) void NoHotPatch() {} // Disable Nahimic code injection.
 }
 


### PR DESCRIPTION
Currently, Godot always exports `NvOptimusEnablement` and `AmdPowerXpressRequestHighPerformance` symbols on Windows, forcing the use of  discrete GPU on hybrid graphics systems when using OpenGL/GLES.

This change adds a build-time option to disable these symbols, allowing applications to respect OS and driver settings instead. This is useful for:
- Laptop users wanting to save battery
- Non-game applications (desktop pets, tools, etc.)
- Projects that don't require high GPU performance

The default behavior is unchanged (`prefer_high_performance_gpu=yes`), preserving backward compatibility.

Usage:
```bash
# Respect system GPU preferences (disable the hardcoded symbols)
scons platform=windows prefer_high_performance_gpu=no

# Default behavior (equivalent to current hardcoded behavior)
scons platform=windows prefer_high_performance_gpu=yes
```

Note: Vulkan backend already supports runtime GPU selection via command-line arguments and is not affected by this change.