### PR TITLE
Editor: Reduce width of script gutters

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -595,7 +595,7 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 	p_theme->set_constant("line_spacing", "CodeEdit", EDITOR_GET("text_editor/appearance/whitespace/line_spacing"));
 
 	const Color background_color = EDITOR_GET("text_editor/theme/highlighting/background_color");
-	Ref<StyleBoxFlat> code_edit_stylebox = make_flat_stylebox(background_color, p_config.widget_margin.x, p_config.widget_margin.y, p_config.widget_margin.x, p_config.widget_margin.y, p_config.corner_radius);
+	Ref<StyleBoxFlat> code_edit_stylebox = make_flat_stylebox(background_color, 0, p_config.widget_margin.y, p_config.widget_margin.x, p_config.widget_margin.y, p_config.corner_radius);
 	p_theme->set_stylebox(CoreStringName(normal), "CodeEdit", code_edit_stylebox);
 	p_theme->set_stylebox("read_only", "CodeEdit", code_edit_stylebox);
 	p_theme->set_stylebox("focus", "CodeEdit", memnew(StyleBoxEmpty));

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -54,7 +54,7 @@ void CodeEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			set_gutter_width(main_gutter, get_line_height());
+			_update_draw_main_gutter();
 			_update_line_number_gutter_width();
 			set_gutter_width(fold_gutter, get_line_height() / 1.2);
 			_clear_line_number_text_cache();
@@ -1312,6 +1312,8 @@ String CodeEdit::get_auto_brace_completion_close_key(const String &p_open_key) c
 /* Main Gutter */
 void CodeEdit::_update_draw_main_gutter() {
 	set_gutter_draw(main_gutter, draw_breakpoints || draw_bookmarks || draw_executing_lines);
+	int main_gutter_width = get_line_height() / (_is_bookmark_only() ? 2 : 1);
+	set_gutter_width(main_gutter, main_gutter_width);
 }
 
 void CodeEdit::set_draw_breakpoints_gutter(bool p_draw) {
@@ -1368,7 +1370,7 @@ void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 
 		bool shift_pressed = Input::get_singleton()->is_key_pressed(Key::SHIFT);
 
 		if (bookmarked || (hovering && !is_dragging_cursor() && shift_pressed)) {
-			int horizontal_padding = p_region.size.x / 2;
+			int horizontal_padding = p_region.size.x / (_is_bookmark_only() ? 8 : 2);
 			int vertical_padding = p_region.size.y / 4;
 
 			Color use_color = theme_cache.bookmark_color;
@@ -1582,12 +1584,14 @@ void CodeEdit::_clear_line_number_text_cache() {
 }
 
 void CodeEdit::_update_line_number_gutter_width() {
-	set_gutter_width(line_number_gutter, (line_number_digits + 1) * theme_cache.font->get_char_size('0', theme_cache.font_size).width);
+	int width_in_chars = line_number_digits + (!is_drawing_fold_gutter() ? 1 : 0); // Extra padding if there is no fold gutter.
+	set_gutter_width(line_number_gutter, width_in_chars * theme_cache.font->get_char_size('0', theme_cache.font_size).width);
 }
 
 /* Fold Gutter */
 void CodeEdit::set_draw_fold_gutter(bool p_draw) {
 	set_gutter_draw(fold_gutter, p_draw);
+	_update_line_number_gutter_width();
 }
 
 bool CodeEdit::is_drawing_fold_gutter() const {

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -97,6 +97,7 @@ private:
 	int main_gutter = -1;
 	void _update_draw_main_gutter();
 	void _main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 &p_region);
+	_FORCE_INLINE_ bool _is_bookmark_only() { return draw_bookmarks && !draw_executing_lines && !draw_breakpoints; }
 
 	// breakpoints
 	HashMap<int, bool> breakpointed_lines;


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/113181#issuecomment-3582422666

If script editors should be used in vertical orientations, unnecessary width in the gutters hurts even normal sized lines of code from being edited. 

This PR removes extra white-space in the script editors. It removes the left-margin on the panel, the arbitrary right-margin on the line numbers, and reduces the size of the main gutter if only the bookmarks are showing. Together these changes remove more than a third of the width of the shader editor gutter, which will help give more room to the user.

It might also be worth it to set `line_numbers_min_digits` to 2 for shaders as they are smaller files in general than `.gdscript` files

In the screenshots below I modified the code to display the positions of the gutters to better illustrate the changes
| Before: | After: |
| - | - |
| <img width="687" height="783" alt="" src="https://github.com/user-attachments/assets/57e710cd-f6fe-4a10-b03f-aa5429598721" /> | <img width="688" height="783" alt="" src="https://github.com/user-attachments/assets/aa60282d-b818-4206-8e39-03bb2697d0db" /> |