### PR TITLE
Make `GetTypeInfo<>::VARIANT_TYPE` and `GetTypeInfo<>::METADATA` `constexpr`

### DIFF
--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -258,8 +258,8 @@ struct PtrToArg<Ref<T>> {
 
 template <typename T>
 struct GetTypeInfo<Ref<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -121,8 +121,8 @@ struct GDExtensionPtr {
 
 template <typename T>
 struct GetTypeInfo<GDExtensionConstPtr<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::INT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::INT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_POINTER, GDExtensionConstPtr<T>::get_name());
 	}
@@ -130,8 +130,8 @@ struct GetTypeInfo<GDExtensionConstPtr<T>> {
 
 template <typename T>
 struct GetTypeInfo<GDExtensionPtr<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::INT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::INT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_POINTER, GDExtensionPtr<T>::get_name());
 	}

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -67,24 +67,24 @@ struct GetTypeInfo;
 template <typename T>
 struct GetTypeInfo<T, std::enable_if_t<!std::is_same_v<T, GetSimpleTypeT<T>>>> : GetTypeInfo<GetSimpleTypeT<T>> {};
 
-#define MAKE_TYPE_INFO(m_type, m_var_type)                                            \
-	template <>                                                                       \
-	struct GetTypeInfo<m_type> {                                                      \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
+#define MAKE_TYPE_INFO(m_type, m_var_type)                                                \
+	template <>                                                                           \
+	struct GetTypeInfo<m_type> {                                                          \
+		static constexpr Variant::Type VARIANT_TYPE = m_var_type;                         \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() {                                     \
+			return PropertyInfo(VARIANT_TYPE, String());                                  \
+		}                                                                                 \
 	};
 
-#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata)    \
-	template <>                                                     \
-	struct GetTypeInfo<m_type> {                                    \
-		static const Variant::Type VARIANT_TYPE = m_var_type;       \
-		static const GodotTypeInfo::Metadata METADATA = m_metadata; \
-		static inline PropertyInfo get_class_info() {               \
-			return PropertyInfo(VARIANT_TYPE, String());            \
-		}                                                           \
+#define MAKE_TYPE_INFO_WITH_META(m_type, m_var_type, m_metadata)        \
+	template <>                                                         \
+	struct GetTypeInfo<m_type> {                                        \
+		static constexpr Variant::Type VARIANT_TYPE = m_var_type;       \
+		static constexpr GodotTypeInfo::Metadata METADATA = m_metadata; \
+		static inline PropertyInfo get_class_info() {                   \
+			return PropertyInfo(VARIANT_TYPE, String());                \
+		}                                                               \
 	};
 
 MAKE_TYPE_INFO(bool, Variant::BOOL)
@@ -141,8 +141,8 @@ MAKE_TYPE_INFO(IPAddress, Variant::STRING)
 //objectID
 template <>
 struct GetTypeInfo<ObjectID> {
-	static const Variant::Type VARIANT_TYPE = Variant::INT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_INT_IS_UINT64;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::INT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_INT_IS_UINT64;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_OBJECTID);
 	}
@@ -151,21 +151,21 @@ struct GetTypeInfo<ObjectID> {
 //for variant
 template <>
 struct GetTypeInfo<Variant> {
-	static const Variant::Type VARIANT_TYPE = Variant::NIL;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::NIL;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 	}
 };
 
-#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)                       \
-	template <>                                                                       \
-	struct GetTypeInfo<m_template<m_type>> {                                          \
-		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
-		static inline PropertyInfo get_class_info() {                                 \
-			return PropertyInfo(VARIANT_TYPE, String());                              \
-		}                                                                             \
+#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)                           \
+	template <>                                                                           \
+	struct GetTypeInfo<m_template<m_type>> {                                              \
+		static constexpr Variant::Type VARIANT_TYPE = m_var_type;                         \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
+		static inline PropertyInfo get_class_info() {                                     \
+			return PropertyInfo(VARIANT_TYPE, String());                                  \
+		}                                                                                 \
 	};
 
 MAKE_TEMPLATE_TYPE_INFO(Vector, Variant, Variant::ARRAY)
@@ -176,8 +176,8 @@ MAKE_TEMPLATE_TYPE_INFO(Vector, StringName, Variant::PACKED_STRING_ARRAY)
 
 template <typename T>
 struct GetTypeInfo<T *, std::enable_if_t<std::is_base_of_v<Object, T>>> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
 	}
@@ -192,7 +192,7 @@ class RequiredResult;
 template <typename T>
 struct GetTypeInfo<RequiredParam<T>, std::enable_if_t<std::is_base_of_v<Object, T>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_OBJECT_IS_REQUIRED;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_OBJECT_IS_REQUIRED;
 
 	template <typename U = T, std::enable_if_t<std::is_base_of_v<RefCounted, U>, int> = 0>
 	static inline PropertyInfo get_class_info() {
@@ -208,7 +208,7 @@ struct GetTypeInfo<RequiredParam<T>, std::enable_if_t<std::is_base_of_v<Object, 
 template <typename T>
 struct GetTypeInfo<RequiredResult<T>, std::enable_if_t<std::is_base_of_v<Object, T>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_OBJECT_IS_REQUIRED;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_OBJECT_IS_REQUIRED;
 
 	template <typename U = T, std::enable_if_t<std::is_base_of_v<RefCounted, U>, int> = 0>
 	static inline PropertyInfo get_class_info() {
@@ -237,8 +237,8 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 #define MAKE_ENUM_TYPE_INFO(m_enum)                                                                                                          \
 	template <>                                                                                                                              \
 	struct GetTypeInfo<m_enum> {                                                                                                             \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
+		static constexpr Variant::Type VARIANT_TYPE = Variant::INT;                                                                          \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                    \
 		static inline PropertyInfo get_class_info() {                                                                                        \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, \
 					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                       \
@@ -253,8 +253,8 @@ inline StringName __constant_get_enum_name(T param) {
 #define MAKE_BITFIELD_TYPE_INFO(m_enum)                                                                                                          \
 	template <>                                                                                                                                  \
 	struct GetTypeInfo<m_enum> {                                                                                                                 \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                  \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
+		static constexpr Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
 		static inline PropertyInfo get_class_info() {                                                                                            \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
 					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                           \
@@ -262,8 +262,8 @@ inline StringName __constant_get_enum_name(T param) {
 	};                                                                                                                                           \
 	template <>                                                                                                                                  \
 	struct GetTypeInfo<BitField<m_enum>> {                                                                                                       \
-		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                  \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                            \
+		static constexpr Variant::Type VARIANT_TYPE = Variant::INT;                                                                              \
+		static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                                        \
 		static inline PropertyInfo get_class_info() {                                                                                            \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_BITFIELD, \
 					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum)));                                           \
@@ -323,8 +323,8 @@ const String get_variant_type_identifier() {
 
 template <typename T>
 struct GetTypeInfo<TypedArray<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::ARRAY;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, GodotTypeInfo::Internal::get_variant_type_identifier<T>());
 	}
@@ -332,8 +332,8 @@ struct GetTypeInfo<TypedArray<T>> {
 
 template <typename K, typename V>
 struct GetTypeInfo<TypedDictionary<K, V>> {
-	static const Variant::Type VARIANT_TYPE = Variant::DICTIONARY;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static constexpr Variant::Type VARIANT_TYPE = Variant::DICTIONARY;
+	static constexpr GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::DICTIONARY, String(), PROPERTY_HINT_DICTIONARY_TYPE,
 				vformat("%s;%s", GodotTypeInfo::Internal::get_variant_type_identifier<K>(), GodotTypeInfo::Internal::get_variant_type_identifier<V>()));


### PR DESCRIPTION
Very minor core improvement with a few benefits:

- Using `constexpr` means the values can be used in a `constexpr` context. This came up a few times in PRs, although none of the PRs that needed this were merged yet.
- This guarantees that compilers can inline use of the value. If it isn't inlined, fetching the value can incur a cache miss cost, which is relatively expensive. 
    - Note that I would expect an optimizing compiler to inline the use anyway, but it's not guaranteed with `static const`.

I'm convinced that this will be needed sooner or later, but since this change should be risk-free, I think it makes sense to bring it in already, to enable future PRs to use it (without big diffs).