### PR TITLE
Fix bottom dock offsets and change Audio to EditorDock

### DIFF
--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
+#include "editor/docks/editor_dock.h"
 #include "editor/plugins/editor_plugin.h"
-#include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/control.h"
 #include "scene/gui/line_edit.h"
@@ -47,6 +47,7 @@
 
 class EditorAudioBuses;
 class EditorFileDialog;
+class HBoxContainer;
 class Timer;
 
 class EditorAudioBus : public PanelContainer {
@@ -148,8 +149,8 @@ protected:
 	void _notification(int p_what);
 };
 
-class EditorAudioBuses : public VBoxContainer {
-	GDCLASS(EditorAudioBuses, VBoxContainer);
+class EditorAudioBuses : public EditorDock {
+	GDCLASS(EditorAudioBuses, EditorDock);
 
 	HBoxContainer *top_hb = nullptr;
 
@@ -193,8 +194,6 @@ class EditorAudioBuses : public VBoxContainer {
 
 	EditorFileDialog *file_dialog = nullptr;
 	bool new_layout = false;
-
-	bool use_default_editor_size = true;
 
 	void _file_dialog_callback(const String &p_string);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6091,6 +6091,10 @@ void EditorNode::_load_editor_layout() {
 
 		if (overridden_default_layout >= 0) {
 			_layout_menu_option(overridden_default_layout);
+		} else {
+			ep.step(TTR("Loading docks..."), 1, true);
+			// Initialize some default values.
+			bottom_panel->load_layout_from_config(default_layout, EDITOR_NODE_CONFIG_SECTION);
 		}
 	} else {
 		ep.step(TTR("Loading docks..."), 1, true);
@@ -8797,6 +8801,12 @@ EditorNode::EditorNode() {
 	}
 	for (int i = 0; i < editor_dock_manager->get_vsplit_count(); i++) {
 		default_layout->set_value(docks_section, "dock_split_" + itos(i + 1), 0);
+	}
+
+	{
+		Dictionary offsets;
+		offsets["Audio"] = -450;
+		default_layout->set_value(EDITOR_NODE_CONFIG_SECTION, "bottom_panel_offsets", offsets);
 	}
 
 	_update_layouts_menu();

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -50,7 +50,7 @@ class EditorBottomPanel : public TabContainer {
 
 	int previous_tab = -1;
 	bool lock_panel_switching = false;
-	LocalVector<Control *> bottom_docks;
+	LocalVector<EditorDock *> bottom_docks;
 	LocalVector<Ref<Shortcut>> dock_shortcuts;
 	HashMap<String, int> dock_offsets;
 


### PR DESCRIPTION
Part of #113024
Fixes #112616

The way #111499 was implemented is not compatible with the new bottom panel. Not all bottom docks are children of the bottom panel, and also EditorDocks are not being added to `bottom_docks` list, so the code required some changes. The offsets are now stored in a Dictionary, so layout saving is no longer dependent on what dock happens to be at the bottom.

#112616 is fixed by adding a default Audio size to the default layout and loading it on initial launch (similar to #113232 in its original form).