### PR TITLE
Fix stale error highlighting when navigating script history

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3878,6 +3878,8 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 		if (scr.is_valid()) {
 			notify_script_changed(scr);
 		}
+
+		seb->validate();
 	}
 
 	EditorHelp *eh = Object::cast_to<EditorHelp>(n);


### PR DESCRIPTION
Fixes: #113147

This PR fixes an issue where scripts were not being re-validated when navigating through the editor history. This caused error highlights to persist even after the underlying issue was resolved in another file.

I added a validate() call in ScriptEditor::_update_history_pos to ensure the script is re-analyzed upon history navigation, consistent with the behavior when switching tabs manually in ScriptEditor::_go_to_tab.