### PR TITLE
Wayland: Misc keyboard touchups

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1613,6 +1613,16 @@ void WaylandThread::_wl_seat_on_capabilities(void *data, struct wl_seat *wl_seat
 			ss->xkb_compose_state = nullptr;
 		}
 
+		if (ss->xkb_keymap) {
+			xkb_keymap_unref(ss->xkb_keymap);
+			ss->xkb_keymap = nullptr;
+		}
+
+		if (ss->xkb_state) {
+			xkb_state_unref(ss->xkb_state);
+			ss->xkb_state = nullptr;
+		}
+
 		if (ss->wl_keyboard) {
 			wl_keyboard_destroy(ss->wl_keyboard);
 			ss->wl_keyboard = nullptr;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2295,7 +2295,7 @@ void WaylandThread::_wl_keyboard_on_repeat_info(void *data, struct wl_keyboard *
 	SeatState *ss = (SeatState *)data;
 	ERR_FAIL_NULL(ss);
 
-	ss->repeat_key_delay_msec = 1000 / rate;
+	ss->repeat_key_delay_msec = rate ? 1000 / rate : 0;
 	ss->repeat_start_delay_msec = delay;
 }
 

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -480,8 +480,11 @@ public:
 
 		xkb_layout_index_t current_layout_index = 0;
 
-		int32_t repeat_key_delay_msec = 0;
-		int32_t repeat_start_delay_msec = 0;
+		// Clients with `wl_seat`s older than version 4 do not support
+		// `wl_keyboard::repeat_info`, so we'll provide a reasonable default of 25
+		// keys per second, with a start delay of 600 milliseconds.
+		int32_t repeat_key_delay_msec = 1000 / 25;
+		int32_t repeat_start_delay_msec = 600;
 
 		xkb_keycode_t repeating_keycode = XKB_KEYCODE_INVALID;
 		uint64_t last_repeat_start_msec = 0;


### PR DESCRIPTION
This PR is a patchset, it should _not_ be squashed.

It introduces a bunch of tiny fixes (few lines each) to the Wayland keyboard implementation that I didn't feel were worth as separate PRs.

Each commit is properly formatted with a message but here's the tl;dr and some extra info:

### Wayland: Fix SIGFPE with repeat rate of 0

You can disable key repetition by setting the rate to 0, classic divide-by-zero.

Confimed before-and-after on sway with `sway input * repeat_rate 0`.

### Wayland: Add default keyboard repetition values

It is technically possible to have a compositor so old that it doesn't support the `repeat_info` event. Let's add some useful default values for key repetition (instead of 0), just in case.

Confirmed that it works on Weston with this patch:
```diff
--- a/libweston/input.c
+++ b/libweston/input.c
@@ -4330,7 +4330,7 @@ weston_seat_init(struct weston_seat *seat, struct weston_compositor *ec,
 	wl_signal_init(&seat->tablet_tool_added_signal);
 
 	seat->global = wl_global_create(ec->wl_display, &wl_seat_interface,
-					MIN(wl_seat_interface.version, 7),
+					MIN(wl_seat_interface.version, 3),
 					seat, bind_seat);
 
 	seat->compositor = ec;

```

Also double-checked that the existing `wl_keyboard::repeat_info` logic still works on sway, with `sway input * repeat_rate 10`.

### Destroy XKB keymap and state on seat capability change

I forgor :skull:

Luckily it eventually cleaned up anyways, but y'know.

--- 

They should all hopefully be cherry-pickable to 4.5. The SIGFPE one is particularly important.

I'm also planning to do some other changes (`wl_keyboard` version 10, key handling logic consolidation), but I think that those are juicy enough for their own PR.