### PR TITLE
Improvements to ResourcePreloader editor

### DIFF
--- a/editor/scene/resource_preloader_editor_plugin.cpp
+++ b/editor/scene/resource_preloader_editor_plugin.cpp
@@ -31,17 +31,26 @@
 #include "resource_preloader_editor_plugin.h"
 
 #include "core/io/resource_loader.h"
+#include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
-#include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/tree.h"
+#include "scene/main/resource_preloader.h"
 
 void ResourcePreloaderEditor::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (preloader) {
+				_update_library();
+			}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			load->set_button_icon(get_editor_theme_icon(SNAME("Folder")));
 		} break;
@@ -56,12 +65,9 @@ void ResourcePreloaderEditor::_files_load_request(const Vector<String> &p_paths)
 		resource = ResourceLoader::load(path);
 
 		if (resource.is_null()) {
-			dialog->set_text(TTR("ERROR: Couldn't load resource!"));
-			dialog->set_title(TTR("Error!"));
-			//dialog->get_cancel()->set_text("Close");
-			dialog->set_ok_button_text(TTR("Close"));
+			dialog->set_text(TTRC("ERROR: Couldn't load resource!"));
 			dialog->popup_centered();
-			return; ///beh should show an error i guess
+			return; /// Beh, should show an error I guess.
 		}
 
 		String basename = path.get_file().get_basename();
@@ -142,11 +148,9 @@ void ResourcePreloaderEditor::_remove_resource(const String &p_to_remove) {
 void ResourcePreloaderEditor::_paste_pressed() {
 	Ref<Resource> r = EditorSettings::get_singleton()->get_resource_clipboard();
 	if (r.is_null()) {
-		dialog->set_text(TTR("Resource clipboard is empty!"));
-		dialog->set_title(TTR("Error!"));
-		dialog->set_ok_button_text(TTR("Close"));
+		dialog->set_text(TTRC("Resource clipboard is empty!"));
 		dialog->popup_centered();
-		return; ///beh should show an error i guess
+		return; /// Beh, should show an error I guess.
 	}
 
 	String name = r->get_name();
@@ -175,7 +179,10 @@ void ResourcePreloaderEditor::_paste_pressed() {
 
 void ResourcePreloaderEditor::_update_library() {
 	tree->clear();
-	tree->set_hide_root(true);
+	if (!preloader) {
+		return;
+	}
+
 	TreeItem *root = tree->create_item(nullptr);
 
 	List<StringName> rnames;
@@ -215,8 +222,6 @@ void ResourcePreloaderEditor::_update_library() {
 		}
 		ti->add_button(1, get_editor_theme_icon(SNAME("Remove")), BUTTON_REMOVE, false, TTR("Remove"));
 	}
-
-	//player->add_resource("default",resource);
 }
 
 void ResourcePreloaderEditor::_cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
@@ -242,13 +247,7 @@ void ResourcePreloaderEditor::_cell_button_pressed(Object *p_item, int p_column,
 
 void ResourcePreloaderEditor::edit(ResourcePreloader *p_preloader) {
 	preloader = p_preloader;
-
-	if (p_preloader) {
-		_update_library();
-	} else {
-		hide();
-		set_physics_process(false);
-	}
+	_update_library();
 }
 
 Variant ResourcePreloaderEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
@@ -346,7 +345,15 @@ void ResourcePreloaderEditor::_bind_methods() {
 }
 
 ResourcePreloaderEditor::ResourcePreloaderEditor() {
-	//add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel","Panel"));
+	set_name(TTRC("ResourcePreloader"));
+	set_icon_name("ResourcePreloader");
+	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_resource_preloader_bottom_panel", TTRC("Toggle ResourcePreloader Dock")));
+	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_available_layouts(EditorDock::DOCK_LAYOUT_ALL);
+	set_global(false);
+	set_transient(true);
+
+	set_custom_minimum_size(Size2(0, 250 * EDSCALE));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
@@ -355,11 +362,11 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	vbc->add_child(hbc);
 
 	load = memnew(Button);
-	load->set_tooltip_text(TTR("Load Resource"));
+	load->set_tooltip_text(TTRC("Load Resource"));
 	hbc->add_child(load);
 
 	paste = memnew(Button);
-	paste->set_text(TTR("Paste"));
+	paste->set_text(TTRC("Paste"));
 	hbc->add_child(paste);
 
 	file = memnew(EditorFileDialog);
@@ -368,19 +375,20 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	tree = memnew(Tree);
 	tree->connect("button_clicked", callable_mp(this, &ResourcePreloaderEditor::_cell_button_pressed));
 	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	tree->set_hide_root(true);
 	tree->set_columns(2);
 	tree->set_column_expand_ratio(0, 2);
 	tree->set_column_clip_content(0, true);
 	tree->set_column_expand_ratio(1, 3);
 	tree->set_column_clip_content(1, true);
-	tree->set_column_expand(0, true);
-	tree->set_column_expand(1, true);
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	SET_DRAG_FORWARDING_GCD(tree, ResourcePreloaderEditor);
 	vbc->add_child(tree);
 
 	dialog = memnew(AcceptDialog);
+	dialog->set_title(TTRC("Error!"));
+	dialog->set_ok_button_text(TTRC("Close"));
 	add_child(dialog);
 
 	load->connect(SceneStringName(pressed), callable_mp(this, &ResourcePreloaderEditor::_load_pressed));
@@ -400,29 +408,19 @@ void ResourcePreloaderEditorPlugin::edit(Object *p_object) {
 }
 
 bool ResourcePreloaderEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("ResourcePreloader");
+	return Object::cast_to<ResourcePreloader>(p_object);
 }
 
 void ResourcePreloaderEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		//preloader_editor->show();
-		button->show();
-		EditorNode::get_bottom_panel()->make_item_visible(preloader_editor);
-		//preloader_editor->set_process(true);
+		preloader_editor->make_visible();
 	} else {
-		if (preloader_editor->is_visible_in_tree()) {
-			EditorNode::get_bottom_panel()->hide_bottom_panel();
-		}
-		button->hide();
-		//preloader_editor->hide();
-		//preloader_editor->set_process(false);
+		preloader_editor->close();
 	}
 }
 
 ResourcePreloaderEditorPlugin::ResourcePreloaderEditorPlugin() {
 	preloader_editor = memnew(ResourcePreloaderEditor);
-	preloader_editor->set_custom_minimum_size(Size2(0, 250) * EDSCALE);
-
-	button = EditorNode::get_bottom_panel()->add_item(TTRC("ResourcePreloader"), preloader_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_resource_preloader_bottom_panel", TTRC("Toggle ResourcePreloader Bottom Panel")));
-	button->hide();
+	EditorDockManager::get_singleton()->add_dock(preloader_editor);
+	preloader_editor->close();
 }

--- a/editor/scene/resource_preloader_editor_plugin.h
+++ b/editor/scene/resource_preloader_editor_plugin.h
@@ -30,16 +30,17 @@
 
 #pragma once
 
+#include "editor/docks/editor_dock.h"
 #include "editor/plugins/editor_plugin.h"
-#include "scene/gui/dialogs.h"
-#include "scene/gui/panel_container.h"
-#include "scene/gui/tree.h"
-#include "scene/main/resource_preloader.h"
 
+class AcceptDialog;
+class Button;
 class EditorFileDialog;
+class ResourcePreloader;
+class Tree;
 
-class ResourcePreloaderEditor : public PanelContainer {
-	GDCLASS(ResourcePreloaderEditor, PanelContainer);
+class ResourcePreloaderEditor : public EditorDock {
+	GDCLASS(ResourcePreloaderEditor, EditorDock);
 
 	enum {
 		BUTTON_OPEN_SCENE,
@@ -84,7 +85,6 @@ class ResourcePreloaderEditorPlugin : public EditorPlugin {
 	GDCLASS(ResourcePreloaderEditorPlugin, EditorPlugin);
 
 	ResourcePreloaderEditor *preloader_editor = nullptr;
-	Button *button = nullptr;
 
 public:
 	virtual String get_plugin_name() const override { return "ResourcePreloader"; }


### PR DESCRIPTION
Part of #113024 and #104574 + some minor cleanup.

btw this probably the bottom dock most suited for vertical layout 🤔
<img width="687" height="1001" alt="image" src="https://github.com/user-attachments/assets/1a6c2dcf-e28d-4b53-aa60-3f18059d6299" />
Literally no layout changes and it looks like it was there from the beginning.