### PR TITLE
Fix miscellaneous oddities around the class reference (part 7)

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -348,7 +348,7 @@
 			<return type="Array" />
 			<param index="0" name="deep_subresources_mode" type="int" default="1" />
 			<description>
-				Duplicates this array, deeply, like [method duplicate][code](true)[/code], with extra control over how subresources are handled.
+				Duplicates this array, deeply, like [method duplicate] when passing [code]true[/code], with extra control over how subresources are handled.
 				[param deep_subresources_mode] must be one of the values from [enum Resource.DeepDuplicateMode]. By default, only internal resources will be duplicated (recursively).
 			</description>
 		</method>

--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -160,7 +160,7 @@
 			Determines when depth rendering takes place. See also [member transparency].
 		</member>
 		<member name="depth_test" type="int" setter="set_depth_test" getter="get_depth_test" enum="BaseMaterial3D.DepthTest" default="0" experimental="May be affected by future rendering pipeline changes.">
-			Determines which comparison operator is used when testing depth. See [enum DepthTest].
+			Determines which comparison operator is used when testing depth.
 			[b]Note:[/b] Changing [member depth_test] to a non-default value only has a visible effect when used on a transparent material, or a material that has [member depth_draw_mode] set to [constant DEPTH_DRAW_DISABLED].
 		</member>
 		<member name="detail_albedo" type="Texture2D" setter="set_texture" getter="get_texture">
@@ -382,13 +382,13 @@
 			The primary color of the stencil effect.
 		</member>
 		<member name="stencil_compare" type="int" setter="set_stencil_compare" getter="get_stencil_compare" enum="BaseMaterial3D.StencilCompare" default="0" experimental="May be affected by future rendering pipeline changes.">
-			The comparison operator to use for stencil masking operations. See [enum StencilCompare].
+			The comparison operator to use for stencil masking operations.
 		</member>
 		<member name="stencil_flags" type="int" setter="set_stencil_flags" getter="get_stencil_flags" default="0" experimental="May be affected by future rendering pipeline changes.">
-			The flags dictating how the stencil operation behaves. See [enum StencilFlags].
+			The flags dictating how the stencil operation behaves.
 		</member>
 		<member name="stencil_mode" type="int" setter="set_stencil_mode" getter="get_stencil_mode" enum="BaseMaterial3D.StencilMode" default="0" experimental="May be affected by future rendering pipeline changes.">
-			The stencil effect mode. See [enum StencilMode].
+			The stencil effect mode.
 		</member>
 		<member name="stencil_outline_thickness" type="float" setter="set_stencil_effect_outline_thickness" getter="get_stencil_effect_outline_thickness" default="0.01" experimental="May be affected by future rendering pipeline changes.">
 			The outline thickness for [constant STENCIL_MODE_OUTLINE].
@@ -862,7 +862,7 @@
 			Enables stencil operations without a preset.
 		</constant>
 		<constant name="STENCIL_FLAG_READ" value="1" enum="StencilFlags">
-			The material will only be rendered where it passes a stencil comparison with existing stencil buffer values. See [enum StencilCompare].
+			The material will only be rendered where it passes a stencil comparison with existing stencil buffer values.
 		</constant>
 		<constant name="STENCIL_FLAG_WRITE" value="2" enum="StencilFlags">
 			The material will write the reference value to the stencil buffer where it passes the depth test.

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -633,7 +633,7 @@
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If [code]true[/code], the node will receive [constant NOTIFICATION_TRANSFORM_CHANGED] whenever global transform changes.
+				If [code]true[/code], the node will receive [constant NOTIFICATION_TRANSFORM_CHANGED] whenever its global transform changes.
 				[b]Note:[/b] Many canvas items such as [Camera2D] or [Light2D] automatically enable this in order to function correctly.
 			</description>
 		</method>

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -229,7 +229,7 @@
 			<return type="Dictionary" />
 			<param index="0" name="deep_subresources_mode" type="int" default="1" />
 			<description>
-				Duplicates this dictionary, deeply, like [method duplicate][code](true)[/code], with extra control over how subresources are handled.
+				Duplicates this dictionary, deeply, like [method duplicate] when passing [code]true[/code], with extra control over how subresources are handled.
 				[param deep_subresources_mode] must be one of the values from [enum Resource.DeepDuplicateMode]. By default, only internal resources will be duplicated (recursively).
 			</description>
 		</method>
@@ -508,7 +508,7 @@
 			<param index="0" name="key" type="Variant" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Sets the value of the element at the given [param key] to the given [param value]. This is the same as using the [code][][/code] operator ([code]dict[key] = value[/code]). Returns [code]true[/code] if the value is set successfully. Fails and returns [code]false[/code] if the dictionary is read-only, or if [param key] and [param value] don't match the dictionary's types.
+				Sets the value of the element at the given [param key] to the given [param value]. Returns [code]true[/code] if the value is set successfully. Fails and returns [code]false[/code] if the dictionary is read-only, or if [param key] and [param value] don't match the dictionary's types. This is the same as using the [code][][/code] operator ([code]dict[key] = value[/code]).
 			</description>
 		</method>
 		<method name="size" qualifiers="const">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -79,7 +79,7 @@
 			<description>
 				Returns [code]1[/code] if a screen reader, Braille display or other assistive app is active, [code]0[/code] otherwise. Returns [code]-1[/code] if status is unknown.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
-				[b]Note:[/b] Accessibility debugging tools, such as Accessibility Insights for Windows, macOS Accessibility Inspector, or AT-SPI Browser do not count as assistive apps and will not affect this value. To test your app with these tools, set [member ProjectSettings.accessibility/general/accessibility_support] to [code]1[/code].
+				[b]Note:[/b] Accessibility debugging tools, such as Accessibility Insights for Windows, Accessibility Inspector (macOS), or AT-SPI Browser (Linux/BSD), do not count as assistive apps and will not affect this value. To test your project with these tools, set [member ProjectSettings.accessibility/general/accessibility_support] to [code]1[/code].
 			</description>
 		</method>
 		<method name="accessibility_set_window_focused">
@@ -1845,7 +1845,7 @@
 			<return type="void" />
 			<param index="0" name="callable" type="Callable" />
 			<description>
-				Sets the [param callable] that should be called when hardware keyboard is connected/disconnected. [param callable] should accept a single [bool] parameter indicating whether the keyboard is connected (true) or disconnected (false).
+				Sets the callback that should be called when a hardware keyboard is connected or disconnected. [param callable] should accept a single [bool] argument indicating whether the keyboard has been connected ([code]true[/code]) or disconnected ([code]false[/code]).
 				[b]Note:[/b] This method is only implemented on Android.
 			</description>
 		</method>
@@ -1869,7 +1869,7 @@
 			<return type="void" />
 			<param index="0" name="callable" type="Callable" />
 			<description>
-				Sets the [param callable] that should be called when system theme settings are changed. Callback method should have zero arguments.
+				Sets the callback that should be called when the system's theme settings are changed. [param callable] should accept zero arguments.
 				[b]Note:[/b] This method is implemented on Android, iOS, macOS, Windows, and Linux (X11/Wayland).
 			</description>
 		</method>
@@ -2058,8 +2058,8 @@
 		<method name="virtual_keyboard_get_height" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the on-screen keyboard's height in pixels. Returns 0 if there is no keyboard or if it is currently hidden.
-				[b]Note:[/b] On Android 7 and 8, the keyboard height may return 0 the first time the keyboard is opened in non-immersive mode. This behavior does not occur in immersive mode.
+				Returns the on-screen keyboard's height in pixels. Returns [code]0[/code] if there is no keyboard or if it is currently hidden.
+				[b]Note:[/b] On Android 7 and 8, the keyboard height may return [code]0[/code] the first time the keyboard is opened in non-immersive mode. This behavior does not occur in immersive mode.
 			</description>
 		</method>
 		<method name="virtual_keyboard_hide">
@@ -2236,14 +2236,14 @@
 		<method name="window_maximize_on_title_dbl_click" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code], if double-click on a window title should maximize it.
+				Returns [code]true[/code] if double-clicking on a window's title should maximize it.
 				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="window_minimize_on_title_dbl_click" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code], if double-click on a window title should minimize it.
+				Returns [code]true[/code] if double-clicking on a window's title should minimize it.
 				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
@@ -2774,7 +2774,7 @@
 			Element is hidden for accessibility tools.
 		</constant>
 		<constant name="FLAG_MULTISELECTABLE" value="1" enum="AccessibilityFlags">
-			Element is support multiple item selection.
+			Element supports multiple item selection.
 		</constant>
 		<constant name="FLAG_REQUIRED" value="2" enum="AccessibilityFlags">
 			Element require user input.
@@ -3146,7 +3146,7 @@
 			[b]Note:[/b] This flag is implemented on macOS and Windows.
 		</constant>
 		<constant name="WINDOW_FLAG_MAX" value="13" enum="WindowFlags">
-			Max value of the [enum WindowFlags].
+			Represents the size of the [enum WindowFlags] enum.
 		</constant>
 		<constant name="WINDOW_EVENT_MOUSE_ENTER" value="0" enum="WindowEvent">
 			Sent when the mouse pointer enters the window.
@@ -3176,7 +3176,7 @@
 			[b]Note:[/b] This flag is implemented only on macOS.
 		</constant>
 		<constant name="WINDOW_EVENT_FORCE_CLOSE" value="8" enum="WindowEvent">
-			Sent when the window has been forcibly closed by the Display Server. The window shall immediately hide and clean any internal rendering references.
+			Sent when the window has been forcibly closed by the display server. The window will immediately hide and clean any internal rendering references.
 			[b]Note:[/b] This flag is implemented only on Linux (Wayland).
 		</constant>
 		<constant name="WINDOW_EDGE_TOP_LEFT" value="0" enum="WindowResizeEdge">

--- a/doc/classes/EditorExportPlatformExtension.xml
+++ b/doc/classes/EditorExportPlatformExtension.xml
@@ -15,8 +15,8 @@
 			<param index="0" name="preset" type="EditorExportPreset" />
 			<param index="1" name="debug" type="bool" />
 			<description>
-				Returns [code]true[/code], if specified [param preset] is valid and can be exported. Use [method set_config_error] and [method set_config_missing_templates] to set error details.
-				Usual implementation can call [method _has_valid_export_configuration] and [method _has_valid_project_configuration] to determine if export is possible.
+				Returns [code]true[/code] if the specified [param preset] is valid and can be exported. Use [method set_config_error] and [method set_config_missing_templates] to set error details.
+				Usual implementations call [method _has_valid_export_configuration] and [method _has_valid_project_configuration] to determine if exporting is possible.
 			</description>
 		</method>
 		<method name="_cleanup" qualifiers="virtual">

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -899,13 +899,14 @@
 			- [b]Auto[/b] ([code]0[/code]): Accessibility support is enabled, but updates to the accessibility information are processed only if an assistive app (such as a screen reader or a Braille display) is active (default).
 			- [b]Always Active[/b] ([code]1[/code]): Accessibility support is enabled, and updates to the accessibility information are always processed, regardless of the status of assistive apps.
 			- [b]Disabled[/b] ([code]2[/code]): Accessibility support is fully disabled.
-			[b]Note:[/b] Accessibility debugging tools, such as Accessibility Insights for Windows, Accessibility Inspector (macOS), or AT-SPI Browser (Linux/BSD) do not count as assistive apps. To test your project with these tools, use [b]Always Active[/b].
+			[b]Note:[/b] Accessibility debugging tools, such as Accessibility Insights for Windows, Accessibility Inspector (macOS), or AT-SPI Browser (Linux/BSD), do not count as assistive apps. To test the editor with these tools, use [b]Always Active[/b].
 		</member>
 		<member name="interface/editor/accept_dialog_cancel_ok_buttons" type="int" setter="" getter="">
-			How to position the Cancel and OK buttons in the editor's [AcceptDialog]s. Different platforms have different standard behaviors for this, which can be overridden using this setting. This is useful if you use Godot both on Windows and macOS/Linux and your Godot muscle memory is stronger than your OS specific one.
-			- [b]Auto[/b] follows the platform convention: OK first on Windows, KDE, and LXQt, Cancel first on macOS and other Linux desktop environments.
-			- [b]Cancel First[/b] forces the ordering Cancel/OK.
-			- [b]OK First[/b] forces the ordering OK/Cancel.
+			How to position the Cancel and OK buttons in the editor's [AcceptDialog] windows. Different platforms have different conventions for this, which can be overridden through this setting to avoid accidental clicks when using Godot on multiple platforms.
+			- [b]Auto[/b] follows the platform convention: OK first on Windows, KDE, and LXQt; Cancel first on macOS and other Linux desktop environments.
+			- [b]Cancel First[/b] forces the Cancel/OK ordering.
+			- [b]OK First[/b] forces the OK/Cancel ordering.
+			To check if these buttons are swapped at runtime, use [method DisplayServer.get_swap_cancel_ok].
 		</member>
 		<member name="interface/editor/automatically_open_screenshots" type="bool" setter="" getter="">
 			If [code]true[/code], automatically opens screenshots with the default program associated to [code].png[/code] files after a screenshot is taken using the [b]Editor &gt; Take Screenshot[/b] action.

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -238,7 +238,7 @@
 			<return type="bool" />
 			<param index="0" name="file" type="String" />
 			<description>
-				Returns [code]true[/code], if file [code]hidden[/code] attribute is set.
+				Returns [code]true[/code] if the [b]hidden[/b] attribute is set on the file at the given path.
 				[b]Note:[/b] This method is implemented on iOS, BSD, macOS, and Windows.
 			</description>
 		</method>
@@ -304,7 +304,7 @@
 			<return type="bool" />
 			<param index="0" name="file" type="String" />
 			<description>
-				Returns [code]true[/code], if file [code]read only[/code] attribute is set.
+				Returns [code]true[/code] if the [b]read only[/b] attribute is set on the file at the given path.
 				[b]Note:[/b] This method is implemented on iOS, BSD, macOS, and Windows.
 			</description>
 		</method>
@@ -417,15 +417,15 @@
 			<return type="void" />
 			<param index="0" name="position" type="int" />
 			<description>
-				Changes the file reading/writing cursor to the specified position (in bytes from the beginning of the file). This changes the value returned by [method get_position].
+				Sets the file cursor to the specified position in bytes, from the beginning of the file. This changes the value returned by [method get_position].
 			</description>
 		</method>
 		<method name="seek_end">
 			<return type="void" />
 			<param index="0" name="position" type="int" default="0" />
 			<description>
-				Changes the file reading/writing cursor to the specified position (in bytes from the end of the file). This changes the value returned by [method get_position].
-				[b]Note:[/b] This is an offset, so you should use negative numbers or the file cursor will be at the end of the file.
+				Sets the file cursor to the specified position in bytes, from the end of the file. This changes the value returned by [method get_position].
+				[b]Note:[/b] This is an offset, so you should use negative numbers otherwise the file cursor will be at the end of the file.
 			</description>
 		</method>
 		<method name="set_extended_attribute" qualifiers="static">
@@ -565,7 +565,7 @@
 			<param index="0" name="values" type="PackedStringArray" />
 			<param index="1" name="delim" type="String" default="&quot;,&quot;" />
 			<description>
-				Store the given [PackedStringArray] in the file as a line formatted in the CSV (Comma-Separated Values) format. You can pass a different delimiter [param delim] to use other than the default [code]","[/code] (comma). This delimiter must be one-character long.
+				Stores the given [PackedStringArray] in the file as a line formatted in the CSV (Comma-Separated Values) format. You can pass a different delimiter [param delim] to use other than the default [code]","[/code] (comma). This delimiter must be one-character long.
 				Text will be encoded as UTF-8. Returns [code]true[/code] if the operation is successful.
 				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
 			</description>

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -123,7 +123,7 @@
 			<param index="0" name="flag" type="int" enum="FileDialog.Customization" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				Toggles the specified customization [param flag], allowing to customize features available in this [FileDialog]. See [enum Customization] for options.
+				Sets the specified customization [param flag], allowing to customize the features available in this [FileDialog].
 			</description>
 		</method>
 		<method name="set_favorite_list" qualifiers="static">

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -322,14 +322,14 @@
 			<return type="bool" />
 			<param index="0" name="language" type="String" />
 			<description>
-				Returns [code]true[/code], if font supports given language ([url=https://en.wikipedia.org/wiki/ISO_639-1]ISO 639[/url] code).
+				Returns [code]true[/code] if the font supports the given language (as a [url=https://en.wikipedia.org/wiki/ISO_639-1]ISO 639[/url] code).
 			</description>
 		</method>
 		<method name="is_script_supported" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="script" type="String" />
 			<description>
-				Returns [code]true[/code], if font supports given script ([url=https://en.wikipedia.org/wiki/ISO_15924]ISO 15924[/url] code).
+				Returns [code]true[/code] if the font supports the given script (as a [url=https://en.wikipedia.org/wiki/ISO_15924]ISO 15924[/url] code).
 			</description>
 		</method>
 		<method name="set_cache_capacity">

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -307,14 +307,14 @@
 			<return type="void" />
 			<param index="0" name="type" type="int" />
 			<description>
-				Disallows to disconnect nodes when dragging from the left port of the [GraphNode]'s slot if it has the specified type. Use this to disable disconnection previously allowed with [method add_valid_left_disconnect_type].
+				Disallows to disconnect nodes when dragging from the left port of the [GraphNode]'s slot if it has the specified type. Use this to disable a disconnection previously allowed with [method add_valid_left_disconnect_type].
 			</description>
 		</method>
 		<method name="remove_valid_right_disconnect_type">
 			<return type="void" />
 			<param index="0" name="type" type="int" />
 			<description>
-				Disallows to disconnect nodes when dragging from the right port of the [GraphNode]'s slot if it has the specified type. Use this to disable disconnection previously allowed with [method add_valid_right_disconnect_type].
+				Disallows to disconnect nodes when dragging from the right port of the [GraphNode]'s slot if it has the specified type. Use this to disable a disconnection previously allowed with [method add_valid_right_disconnect_type].
 			</description>
 		</method>
 		<method name="set_connection_activity">
@@ -591,7 +591,7 @@
 			The outline color of the selection rectangle.
 		</theme_item>
 		<theme_item name="connection_hover_thickness" data_type="constant" type="int" default="0">
-			Widen the line of the connection when the mouse is hovering over it by a percentage factor. A value of [code]0[/code] disables the highlight. A value of [code]100[/code] doubles the line width.
+			Widens the line of a connection when the mouse is hovering over it by a percentage factor. A value of [code]0[/code] disables the highlight. A value of [code]100[/code] doubles the line width.
 		</theme_item>
 		<theme_item name="port_hotzone_inner_extent" data_type="constant" type="int" default="22">
 			The horizontal range within which a port can be grabbed (inner side).

--- a/doc/classes/JSONRPC.xml
+++ b/doc/classes/JSONRPC.xml
@@ -75,8 +75,8 @@
 			<param index="1" name="callback" type="Callable" />
 			<description>
 				Registers a callback for the given method name.
-				- [param name] The name that clients can use to access the callback.
-				- [param callback] The callback which will handle the specific method.
+				- [param name]: The name that clients can use to access the callback.
+				- [param callback]: The callback which will handle the specified method.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -261,7 +261,7 @@
 	</methods>
 	<members>
 		<member name="alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
-			Text alignment as defined in the [enum HorizontalAlignment] enum.
+			The text's horizontal alignment.
 		</member>
 		<member name="backspace_deletes_composite_character_enabled" type="bool" setter="set_backspace_deletes_composite_character_enabled" getter="is_backspace_deletes_composite_character_enabled" default="false">
 			If [code]true[/code] and [member caret_mid_grapheme] is [code]false[/code], backspace deletes an entire composite character such as ❤️‍🩹, instead of deleting part of the composite character.

--- a/doc/classes/MenuBar.xml
+++ b/doc/classes/MenuBar.xml
@@ -40,20 +40,20 @@
 			<return type="bool" />
 			<param index="0" name="menu" type="int" />
 			<description>
-				Returns [code]true[/code], if menu item is disabled.
+				Returns [code]true[/code] if the menu item is disabled.
 			</description>
 		</method>
 		<method name="is_menu_hidden" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="menu" type="int" />
 			<description>
-				Returns [code]true[/code], if menu item is hidden.
+				Returns [code]true[/code] if the menu item is hidden.
 			</description>
 		</method>
 		<method name="is_native_menu" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code], if system global menu is supported and used by this [MenuBar].
+				Returns [code]true[/code] if the current system's global menu is supported and used by this [MenuBar].
 			</description>
 		</method>
 		<method name="set_disable_shortcuts">

--- a/doc/classes/Mutex.xml
+++ b/doc/classes/Mutex.xml
@@ -6,7 +6,6 @@
 	<description>
 		A synchronization mutex (mutual exclusion). This is used to synchronize multiple [Thread]s, and is equivalent to a binary [Semaphore]. It guarantees that only one thread can access a critical section at a time.
 		This is a reentrant mutex, meaning that it can be locked multiple times by one thread, provided it also unlocks it as many times.
-		[b]Warning:[/b] Mutexes must be used carefully to avoid deadlocks.
 		[b]Warning:[/b] To ensure proper cleanup without crashes or deadlocks, the following conditions must be met:
 		- When a [Mutex]'s reference count reaches zero and it is therefore destroyed, no threads (including the one on which the destruction will happen) must have it locked.
 		- When a [Thread]'s reference count reaches zero and it is therefore destroyed, it must not have any mutex locked.

--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -207,10 +207,10 @@
 	</members>
 	<constants>
 		<constant name="SAMPLE_PARTITION_CONVEX_PARTITION" value="0" enum="SamplePartitionType">
-			Convex partitioning that yields navigation mesh with convex polygons.
+			Convex partitioning that results in a navigation mesh with convex polygons.
 		</constant>
 		<constant name="SAMPLE_PARTITION_TRIANGULATE" value="1" enum="SamplePartitionType">
-			Triangulation partitioning that yields navigation mesh with triangle polygons.
+			Triangulation partitioning that results in a navigation mesh with triangle polygons.
 		</constant>
 		<constant name="SAMPLE_PARTITION_MAX" value="2" enum="SamplePartitionType">
 			Represents the size of the [enum SamplePartitionType] enum.

--- a/doc/classes/Path3D.xml
+++ b/doc/classes/Path3D.xml
@@ -14,8 +14,7 @@
 			A [Curve3D] describing the path.
 		</member>
 		<member name="debug_custom_color" type="Color" setter="set_debug_custom_color" getter="get_debug_custom_color" default="Color(0, 0, 0, 1)">
-			The custom color to use to draw the shape in the editor.
-			If set to [code]Color(0.0, 0.0, 0.0)[/code] (by default), the color set in EditorSettings is used.
+			The custom color used to draw the path in the editor. If set to [constant Color.BLACK] (as by default), the color set in [member ProjectSettings.debug/shapes/paths/geometry_color] is used.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -203,7 +203,7 @@
 			Output latency of the [AudioServer]. Equivalent to calling [method AudioServer.get_output_latency], it is not recommended to call this every frame.
 		</constant>
 		<constant name="NAVIGATION_ACTIVE_MAPS" value="24" enum="Monitor">
-			Number of active navigation maps in [NavigationServer2D] and [NavigationServer3D]. This also includes the two empty default navigation maps created by World2D and World3D.
+			Number of active navigation maps in [NavigationServer2D] and [NavigationServer3D]. This also includes the empty default navigation maps created by [World2D] and [World3D] instances.
 		</constant>
 		<constant name="NAVIGATION_REGION_COUNT" value="25" enum="Monitor">
 			Number of active navigation regions in [NavigationServer2D] and [NavigationServer3D].
@@ -248,7 +248,7 @@
 			Number of pipeline compilations that were triggered to optimize the current scene. These compilations are done in the background and should not cause any stutters whatsoever.
 		</constant>
 		<constant name="NAVIGATION_2D_ACTIVE_MAPS" value="39" enum="Monitor">
-			Number of active navigation maps in the [NavigationServer2D]. This also includes the two empty default navigation maps created by World2D.
+			Number of active navigation maps in the [NavigationServer2D]. This also includes the empty default navigation maps created by [World2D] instances.
 		</constant>
 		<constant name="NAVIGATION_2D_REGION_COUNT" value="40" enum="Monitor">
 			Number of active navigation regions in the [NavigationServer2D].
@@ -278,7 +278,7 @@
 			Number of active navigation obstacles in the [NavigationServer2D].
 		</constant>
 		<constant name="NAVIGATION_3D_ACTIVE_MAPS" value="49" enum="Monitor">
-			Number of active navigation maps in the [NavigationServer3D]. This also includes the two empty default navigation maps created by World3D.
+			Number of active navigation maps in the [NavigationServer3D]. This also includes the empty default navigation maps created by [World3D] instances.
 		</constant>
 		<constant name="NAVIGATION_3D_REGION_COUNT" value="50" enum="Monitor">
 			Number of active navigation regions in the [NavigationServer3D].

--- a/doc/classes/PortableCompressedTexture2D.xml
+++ b/doc/classes/PortableCompressedTexture2D.xml
@@ -40,7 +40,7 @@
 		<method name="is_keeping_all_compressed_buffers" qualifiers="static">
 			<return type="bool" />
 			<description>
-				Return whether the flag is overridden for all textures of this type.
+				Returns [code]true[/code] if the flag is overridden for all textures of this type.
 			</description>
 		</method>
 		<method name="set_basisu_compressor_params">
@@ -56,7 +56,7 @@
 			<return type="void" />
 			<param index="0" name="keep" type="bool" />
 			<description>
-				Overrides the flag globally for all textures of this type. This is used primarily by the editor.
+				If [param keep] is [code]true[/code], overrides the flag globally for all textures of this type. This is used primarily by the editor.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -277,7 +277,7 @@
 			- [b]Auto[/b] ([code]0[/code]): Accessibility support is enabled, but updates to the accessibility information are processed only if an assistive app (such as a screen reader or a Braille display) is active (default).
 			- [b]Always Active[/b] ([code]1[/code]): Accessibility support is enabled, and updates to the accessibility information are always processed, regardless of the status of assistive apps.
 			- [b]Disabled[/b] ([code]2[/code]): Accessibility support is fully disabled.
-			[b]Note:[/b] Accessibility debugging tools, such as Accessibility Insights for Windows, Accessibility Inspector (macOS), or AT-SPI Browser (Linux/BSD) do not count as assistive apps. To test your project with these tools, use [b]Always Active[/b].
+			[b]Note:[/b] Accessibility debugging tools, such as Accessibility Insights for Windows, Accessibility Inspector (macOS), or AT-SPI Browser (Linux/BSD), do not count as assistive apps. To test your project with these tools, use [b]Always Active[/b].
 		</member>
 		<member name="accessibility/general/updates_per_second" type="int" setter="" getter="" default="60">
 			The number of accessibility information updates per second.
@@ -486,8 +486,8 @@
 			Sets the [url=https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory]AVAudioSessionCategory[/url] on iOS. Use the [code]Playback[/code] category to get sound output, even if the phone is in silent mode.
 		</member>
 		<member name="audio/general/text_to_speech" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], text-to-speech support is enabled on startup, otherwise it is enabled first time TTS method is used, see [method DisplayServer.tts_get_voices] and [method DisplayServer.tts_speak].
-			[b]Note:[/b] Enabling TTS can cause addition idle CPU usage and interfere with the sleep mode, so consider disabling it if TTS is not used.
+			If [code]true[/code], text-to-speech support is enabled on startup, otherwise it is enabled the first time any TTS method is used. See also [method DisplayServer.tts_get_voices] and [method DisplayServer.tts_speak].
+			[b]Note:[/b] Enabling TTS can cause additional idle CPU usage and interfere with the sleep mode, so consider disabling it if TTS is not used.
 		</member>
 		<member name="audio/video/video_delay_compensation_ms" type="int" setter="" getter="" default="0">
 			Setting to hardcode audio delay when playing video. Best to leave this unchanged unless you know what you are doing.
@@ -1231,10 +1231,11 @@
 			If [code]true[/code], snaps [Control] node vertices to the nearest pixel to ensure they remain crisp even when the camera moves or zooms.
 		</member>
 		<member name="gui/common/swap_cancel_ok" type="int" setter="" getter="" default="0">
-			How to position the Cancel and OK buttons in the project's [AcceptDialog]s. Different platforms have different standard behaviors for this, which can be overridden using this setting.
-			- [b]Auto[/b] ([code]0[/code]) follows the platform convention: OK first on Windows, KDE, and LXQt, Cancel first on macOS and other Linux desktop environments. [method DisplayServer.get_swap_cancel_ok] can be used to query whether buttons are swapped at run-time.
-			- [b]Cancel First[/b] ([code]1[/code]) forces the ordering Cancel/OK.
-			- [b]OK First[/b] ([code]2[/code]) forces the ordering OK/Cancel.
+			How to position the Cancel and OK buttons in the project's [AcceptDialog] windows. Different platforms have different conventions for this, which can be overridden through this setting.
+			- [b]Auto[/b] follows the platform convention: OK first on Windows, KDE, and LXQt; Cancel first on macOS and other Linux desktop environments.
+			- [b]Cancel First[/b] forces the Cancel/OK ordering.
+			- [b]OK First[/b] forces the OK/Cancel ordering.
+			To check if these buttons are swapped at runtime, use [method DisplayServer.get_swap_cancel_ok].
 			[b]Note:[/b] This doesn't affect native dialogs such as the ones spawned by [method DisplayServer.dialog_show].
 		</member>
 		<member name="gui/common/text_edit_undo_stack_max_size" type="int" setter="" getter="" default="1024">

--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -64,7 +64,7 @@
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="0" />
 		<member name="step" type="float" setter="set_step" getter="get_step" default="0.01">
-			If greater than 0, [member value] will always be rounded to a multiple of this property's value above [member min_value]. For example, if [member min_value] is [code]0.1[/code] and step is 0.2, then [member value] is limited to [code]0.1[/code], [code]0.3[/code], [code]0.5[/code], and so on. If [member rounded] is also [code]true[/code], [member value] will first be rounded to a multiple of this property's value, then rounded to the nearest integer.
+			If greater than [code]0.0[/code], [member value] will always be rounded to a multiple of this property's value above [member min_value]. For example, if [member min_value] is [code]0.1[/code] and step is [code]0.2[/code], then [member value] is limited to [code]0.1[/code], [code]0.3[/code], [code]0.5[/code], and so on. If [member rounded] is also [code]true[/code], [member value] will first be rounded to a multiple of this property's value, then rounded to the nearest integer.
 		</member>
 		<member name="value" type="float" setter="set_value" getter="get_value" default="0.0">
 			Range's current value. Changing this property (even via code) will trigger [signal value_changed] signal. Use [method set_value_no_signal] if you want to avoid it.

--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -105,7 +105,7 @@
 			<return type="void" />
 			<param index="0" name="node" type="CollisionObject2D" />
 			<description>
-				Removes a collision exception so the ray can report collisions with the specified specified [param node].
+				Removes a collision exception so the ray can report collisions with the specified [param node].
 			</description>
 		</method>
 		<method name="remove_exception_rid">

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -66,8 +66,7 @@
 			<return type="Resource" />
 			<param index="0" name="deep_subresources_mode" type="int" enum="Resource.DeepDuplicateMode" default="1" />
 			<description>
-				Duplicates this resource, deeply, like [method duplicate][code](true)[/code], with extra control over how subresources are handled.
-				[param deep_subresources_mode] must be one of the values from [enum DeepDuplicateMode].
+				Duplicates this resource, deeply, like [method duplicate] when passing [code]true[/code], with extra control over how subresources are handled.
 			</description>
 		</method>
 		<method name="emit_changed">

--- a/doc/classes/ResourceUID.xml
+++ b/doc/classes/ResourceUID.xml
@@ -37,7 +37,7 @@
 			<return type="String" />
 			<param index="0" name="path_or_uid" type="String" />
 			<description>
-				Returns a path, converting [param path_or_uid] if necessary. Prints an error if provided an invalid UID.
+				Returns a path, converting [param path_or_uid] if necessary. Fails and returns an empty string if an invalid UID is provided.
 			</description>
 		</method>
 		<method name="get_id_path" qualifiers="const">

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -112,7 +112,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="key" type="StringName" />
 			<description>
-				Returns the metadata for the bone at index [param bone_idx] with [param key].
+				Returns the metadata with the given [param key] for the bone at index [param bone_idx].
 			</description>
 		</method>
 		<method name="get_bone_meta_list" qualifiers="const">
@@ -199,7 +199,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="key" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the bone at index [param bone_idx] has metadata with the key [param key].
+				Returns [code]true[/code] if the bone at index [param bone_idx] has metadata with the given [param key].
 			</description>
 		</method>
 		<method name="is_bone_enabled" qualifiers="const">
@@ -300,7 +300,7 @@
 			<param index="1" name="key" type="StringName" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets the metadata for the bone at index [param bone_idx], setting the [param key] meta to [param value].
+				Sets the metadata with the given [param key] to [param value] for the bone at index [param bone_idx].
 			</description>
 		</method>
 		<method name="set_bone_name">

--- a/doc/classes/SkeletonModifier3D.xml
+++ b/doc/classes/SkeletonModifier3D.xml
@@ -39,13 +39,13 @@
 		<method name="_validate_bone_names" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				Called when bone name and index need to be validated such as the timing of the entering tree or changing skeleton.
+				Called when bone names and indices need to be validated, such as when entering the scene tree or changing skeleton.
 			</description>
 		</method>
 		<method name="get_skeleton" qualifiers="const">
 			<return type="Skeleton3D" />
 			<description>
-				Get parent [Skeleton3D] node if found.
+				Returns the parent [Skeleton3D] node if it exists. Otherwise, returns [code]null[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SpringArm3D.xml
+++ b/doc/classes/SpringArm3D.xml
@@ -39,7 +39,7 @@
 	</methods>
 	<members>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
-			The layers against which the collision check shall be done. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
+			The layers against which the collision check will be done. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.01">
 			When the collision check is made, a candidate length for the SpringArm3D is given.

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -782,7 +782,7 @@
 			<return type="String" />
 			<param index="0" name="chars" type="String" />
 			<description>
-				Removes any occurrence of the characters in [param chars]. See also [method remove_char].
+				Removes all occurrences of the characters in [param chars]. See also [method remove_char].
 			</description>
 		</method>
 		<method name="repeat" qualifiers="const">

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -683,7 +683,7 @@
 			<return type="String" />
 			<param index="0" name="chars" type="String" />
 			<description>
-				Removes any occurrence of the characters in [param chars]. See also [method remove_char].
+				Removes all occurrences of the characters in [param chars]. See also [method remove_char].
 			</description>
 		</method>
 		<method name="repeat" qualifiers="const">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -583,14 +583,14 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
-				Returns [code]true[/code], if font supports given language ([url=https://en.wikipedia.org/wiki/ISO_639-1]ISO 639[/url] code).
+				Returns [code]true[/code] if the font supports the given language (as a [url=https://en.wikipedia.org/wiki/ISO_639-1]ISO 639[/url] code).
 			</description>
 		</method>
 		<method name="font_is_modulate_color_glyphs" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				Returns [code]true[/code], if color modulation is applied when drawing colored glyphs.
+				Returns [code]true[/code] if color modulation is applied when drawing the font's colored glyphs.
 			</description>
 		</method>
 		<method name="font_is_multichannel_signed_distance_field" qualifiers="const">
@@ -605,7 +605,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
-				Returns [code]true[/code], if font supports given script (ISO 15924 code).
+				Returns [code]true[/code] if the font supports the given script (as a [url=https://en.wikipedia.org/wiki/ISO_15924]ISO 15924[/url] code).
 			</description>
 		</method>
 		<method name="font_remove_glyph">

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -561,14 +561,14 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
-				Returns [code]true[/code], if font supports given language ([url=https://en.wikipedia.org/wiki/ISO_639-1]ISO 639[/url] code).
+				Returns [code]true[/code] if the font supports the given language (as a [url=https://en.wikipedia.org/wiki/ISO_639-1]ISO 639[/url] code).
 			</description>
 		</method>
 		<method name="_font_is_modulate_color_glyphs" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				Returns [code]true[/code], if color modulation is applied when drawing colored glyphs.
+				Returns [code]true[/code] if color modulation is applied when drawing the font's colored glyphs.
 			</description>
 		</method>
 		<method name="_font_is_multichannel_signed_distance_field" qualifiers="virtual const">
@@ -583,7 +583,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
-				Returns [code]true[/code], if font supports given script (ISO 15924 code).
+				Returns [code]true[/code] if the font supports the given script (as a [url=https://en.wikipedia.org/wiki/ISO_15924]ISO 15924[/url] code).
 			</description>
 		</method>
 		<method name="_font_remove_glyph" qualifiers="virtual required">

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -5,8 +5,7 @@
 	</brief_description>
 	<description>
 		A unit of execution in a process. Can run methods on [Object]s simultaneously. The use of synchronization via [Mutex] or [Semaphore] is advised if working with shared objects.
-		[b]Warning:[/b]
-		To ensure proper cleanup without crashes or deadlocks, when a [Thread]'s reference count reaches zero and it is therefore destroyed, the following conditions must be met:
+		[b]Warning:[/b] To ensure proper cleanup without crashes or deadlocks, when a [Thread]'s reference count reaches zero and it is therefore destroyed, the following conditions must be met:
 		- It must not have any [Mutex] objects locked.
 		- It must not be waiting on any [Semaphore] objects.
 		- [method wait_to_finish] should have been called on it.

--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -108,7 +108,7 @@
 		<method name="_get_tracking_status" qualifiers="virtual const">
 			<return type="int" enum="XRInterface.TrackingStatus" />
 			<description>
-				Returns an [enum XRInterface.TrackingStatus] specifying the current status of our tracking.
+				Returns the current status of our tracking.
 			</description>
 		</method>
 		<method name="_get_transform_for_view" qualifiers="virtual">

--- a/modules/gltf/doc_classes/GLTFNode.xml
+++ b/modules/gltf/doc_classes/GLTFNode.xml
@@ -84,7 +84,7 @@
 			If this glTF node has a skin, the index of the [GLTFSkin] in the [GLTFState] that describes the skin's properties. If -1, this node does not have a skin.
 		</member>
 		<member name="visible" type="bool" setter="set_visible" getter="get_visible" default="true">
-			If [code]true[/code], the GLTF node is visible. If [code]false[/code], the GLTF node is not visible. This is translated to the [member Node3D.visible] property in the Godot scene, and is exported to [code]KHR_node_visibility[/code] when [code]false[/code].
+			If [code]true[/code], the GLTF node is visible. If [code]false[/code], the GLTF node is not visible. This is converted to the [member Node3D.visible] property in the Godot scene, and is exported to [code]KHR_node_visibility[/code] when [code]false[/code].
 		</member>
 		<member name="xform" type="Transform3D" setter="set_xform" getter="get_xform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			The transform of the glTF node relative to its parent. This property is usually unused since the position, rotation, and scale properties are preferred.

--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -20,7 +20,7 @@
 		<method name="get_available_display_refresh_rates" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns display refresh rates supported by the current HMD. Only returned if this feature is supported by the OpenXR runtime and after the interface has been initialized.
+				Returns a list of display refresh rates supported by the current HMD. Only returned if this feature is supported by the OpenXR runtime and after the interface has been initialized.
 			</description>
 		</method>
 		<method name="get_hand_joint_angular_velocity" qualifiers="const" deprecated="Use [method XRHandTracker.get_hand_joint_angular_velocity] obtained from [method XRServer.get_tracker] instead.">
@@ -108,8 +108,8 @@
 		<method name="is_foveation_supported" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if OpenXR's foveation extension is supported, the interface must be initialized before this returns a valid value.
-				[b]Note:[/b] This feature is only available on the Compatibility renderer and currently only available on some stand alone headsets. For Vulkan set [member Viewport.vrs_mode] to [code]VRS_XR[/code] on desktop.
+				Returns [code]true[/code] if OpenXR's foveation extension is supported. The interface must be initialized before this returns a valid value.
+				[b]Note:[/b] When using the Vulkan rendering driver, [member Viewport.vrs_mode] must be set to [constant Viewport.VRS_XR] to support foveation.
 			</description>
 		</method>
 		<method name="is_hand_interaction_supported" qualifiers="const">
@@ -162,11 +162,11 @@
 			The display refresh rate for the current HMD. Only functional if this feature is supported by the OpenXR runtime and after the interface has been initialized.
 		</member>
 		<member name="foveation_dynamic" type="bool" setter="set_foveation_dynamic" getter="get_foveation_dynamic" default="false">
-			Enable dynamic foveation adjustment, the interface must be initialized before this is accessible. If enabled foveation will automatically adjusted between low and [member foveation_level].
+			If [code]true[/code], enables dynamic foveation adjustment. The interface must be initialized before this is accessible. If enabled, foveation will automatically be adjusted between low and [member foveation_level].
 			[b]Note:[/b] Only works on the Compatibility renderer.
 		</member>
 		<member name="foveation_level" type="int" setter="set_foveation_level" getter="get_foveation_level" default="0">
-			Set foveation level from 0 (off) to 3 (high), the interface must be initialized before this is accessible.
+			The foveation level, from [code]0[/code] (off) to [code]3[/code] (high). The interface must be initialized before this is accessible.
 			[b]Note:[/b] Only works on the Compatibility renderer.
 		</member>
 		<member name="render_target_size_multiplier" type="float" setter="set_render_target_size_multiplier" getter="get_render_target_size_multiplier" default="1.0">
@@ -274,7 +274,7 @@
 			The session is about to be lost. [signal session_loss_pending] is emitted when we change to this state.
 		</constant>
 		<constant name="SESSION_STATE_EXITING" value="8" enum="SessionState">
-			The OpenXR instance is about to be destroyed and we're existing. [signal instance_exiting] is emitted when we change to this state.
+			The OpenXR instance is about to be destroyed and we're exiting. [signal instance_exiting] is emitted when we change to this state.
 		</constant>
 		<constant name="HAND_LEFT" value="0" enum="Hand">
 			Left hand.

--- a/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
@@ -12,6 +12,7 @@
 		After these steps, the connection should become connected. Keep on reading or look into the tutorial for more information.
 	</description>
 	<tutorials>
+		<link title="High-level multiplayer">$DOCS_URL/tutorials/networking/high_level_multiplayer.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_ice_candidate">

--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -12,7 +12,7 @@
 	</tutorials>
 	<members>
 		<member name="apk_expansion/SALT" type="String" setter="" getter="">
-			Array of random bytes that the licensing Policy uses to create an [url=https://developer.android.com/google/play/licensing/adding-licensing#impl-Obfuscator]Obfuscator[/url].
+			Array of random bytes that the licensing policy uses to create an [url=https://developer.android.com/google/play/licensing/adding-licensing#impl-Obfuscator]Obfuscator[/url].
 		</member>
 		<member name="apk_expansion/enable" type="bool" setter="" getter="">
 			If [code]true[/code], project resources are stored in the separate APK expansion file, instead of the APK.
@@ -607,7 +607,7 @@
 			Allows an application to write to the user dictionary.
 		</member>
 		<member name="screen/background_color" type="Color" setter="" getter="">
-			The background color used for the root window. Default is [code]black[/code].
+			The background color used for the root window. By default it's [constant Color.BLACK].
 		</member>
 		<member name="screen/edge_to_edge" type="bool" setter="" getter="">
 			If [code]true[/code], this makes the navigation and status bars translucent and allows the application content to extend edge to edge.

--- a/platform/web/doc_classes/EditorExportPlatformWeb.xml
+++ b/platform/web/doc_classes/EditorExportPlatformWeb.xml
@@ -84,8 +84,8 @@
 			[b]Note:[/b] Some browsers have a hard cap on the number of threads that can be allocated, so it is best to be cautious and keep this number low.
 		</member>
 		<member name="threads/godot_pool_size" type="int" setter="" getter="">
-			Override for the default size of the [WorkerThreadPool]. This setting is used when [member ProjectSettings.threading/worker_pool/max_threads] size is set to -1 (which it is by default). This size must be smaller than [member threads/emscripten_pool_size] otherwise deadlocks may occur.
-			When using threads this size needs to be large enough to accommodate features that rely on having a dedicated thread like [member ProjectSettings.physics/2d/run_on_separate_thread] or [member ProjectSettings.rendering/driver/threads/thread_model]. In general, it is best to ensure that this is at least 4 and is at least 2 or 3 less than [member threads/emscripten_pool_size].
+			Override for the default size of the [WorkerThreadPool]. This setting is used when [member ProjectSettings.threading/worker_pool/max_threads] size is set to [code]-1[/code] (which it is by default). This size must be smaller than [member threads/emscripten_pool_size] otherwise deadlocks may occur.
+			When using threads, this size needs to be large enough to accommodate features that rely on having a dedicated thread like [member ProjectSettings.physics/2d/run_on_separate_thread] or [member ProjectSettings.rendering/driver/threads/thread_model]. In general, it is best to ensure that this is at least [code]4[/code] and is at least [code]2[/code] or [code]3[/code] less than [member threads/emscripten_pool_size].
 		</member>
 		<member name="variant/extensions_support" type="bool" setter="" getter="">
 			If [code]true[/code] enables [GDExtension] support for this web build.


### PR DESCRIPTION
Continuation of https://github.com/godotengine/godot/pull/107536

This PR addressed yet yet another huge chunk of class reference oddities I remembered to note down for later while localizing the class reference. Some of these are clear typos, some are inconsistencies, some are just awkward.

Of particular note:
- Add tutorial in **WebRTCPeerConnection**
	- See https://github.com/godotengine/godot/pull/109907/files#r2561388386
- Reword some Skeleton3D-related descriptions
- Replace a few occurrences of "shall" and "yield" with more common alternatives
- Replace nasty `[method duplicate][code](true)[/code]`
- Standardize the descriptions of both `ProjectSettings.gui/common/swap_cancel_ok` and `EditorSettings.interface/editor/accept_dialog_cancel_ok_buttons`
	- It may seem like the removal of corresponding integers is a notable loss of information, but usage of `DisplayServer.get_swap_cancel_ok` should be encouraged, instead.
- Shift `Dictionary.set`'s description around
	- Note that this originates from #112261 . If you have suggestions feel free to say
- Consistently refer to the "file cursor" as such in **FileAccess**
- Encompass numerical values in `[code]` tags more often
- Mention return value in `ResourceUID.ensure_path`
- Remove unnecessary commas after "Returns [code]true[/code]"
- Remove redundant leftover references to enums
	- Remember https://github.com/godotengine/godot/pull/106159
- Removed redundant warning in **Mutex**
- Fix poor grammar in `ProjectSettings.audio/general/text_to_speech`
- Fix inconsistent common "Accessibility debugging tools" note
- Fix entirely incorrect sentence in `Path3D.debug_custom_color`
- Fix `Performance.NAVIGATION_2D/3D_ACTIVE_MAPS` mentioning two maps, leftover from the NavigationServer split
- Fix some missing articles on the way
- Fix "parameters" being referred as "arguments" in a few places

For some of the descriptions affected, additional tweaks have been made to justify a whole translation string change.
