### PR TITLE
Fix Editor Docks not updating tab styles when loading layout

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -703,26 +703,21 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 				dock->load_layout_from_config(p_layout, section_name);
 				continue;
 			}
+
 			if (allow_floating_docks && floating_docks_dump.has(name)) {
 				_restore_dock_to_saved_window(dock, floating_docks_dump[name]);
-			} else if (i >= 0) {
-				if (dock->transient && !dock->is_open) {
-					dock->dock_slot_index = i;
+			} else if (i >= 0 && !(dock->transient && !dock->is_open)) {
+				// Safe to include transient open docks here because they won't be in the closed dock dump.
+				if (closed_docks.has(name)) {
+					dock->is_open = false;
+					dock->hide();
+					_move_dock(dock, closed_dock_parent);
 				} else {
+					dock->is_open = true;
 					_move_dock(dock, dock_slots[i].container, 0);
 				}
 			}
 			dock->load_layout_from_config(p_layout, section_name);
-
-			if (!dock->transient) {
-				if (closed_docks.has(name)) {
-					_move_dock(dock, closed_dock_parent);
-					dock->is_open = false;
-					dock->hide();
-				} else {
-					dock->is_open = true;
-				}
-			}
 
 			dock->dock_slot_index = i;
 			dock->previous_tab_index = i >= 0 ? j : 0;


### PR DESCRIPTION
Currently, after closing a global dock, and reopening using `Editor -> Editor Layout -> Default`, the styles of docks are defaulted to text only, not respecting any editor settings. This is especially visible when you have icon-only docks:
<img width="276" height="104" src="https://github.com/user-attachments/assets/e56e3768-6dd3-4883-a942-9fa22b1ab960" />

The core issue was that the DockManager only updated tab styles if `dock->is_open == true`, so I rearranged the code to be more succinct and place the `is_open = true` before moving the dock. This also helps to remove an extra call to `_move_dock`.

cc @KoBeWi I tried not to break the transient logic but I might have missed something.