### PR TITLE
Fix dotnet project export losing serialized data added in uncompiled code

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -71,13 +71,13 @@ namespace GodotTools.Build
             }
         }
 
-        public void BuildProject()
+        public bool BuildProject()
         {
             if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
-                return; // No project to build.
+                return true; // No project to build.
 
             if (!BuildManager.BuildProjectBlocking("Debug"))
-                return; // Build failed.
+                return false; // Build failed.
 
             // Notify running game for hot-reload.
             Internal.EditorDebuggerNodeReloadScripts();
@@ -90,6 +90,8 @@ namespace GodotTools.Build
                 BuildManager.UpdateLastValidBuildDateTime();
                 Internal.ReloadAssemblies(softReload: false);
             }
+
+            return true;
         }
 
         private void RebuildProject()

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -174,6 +174,9 @@ namespace GodotTools.Export
             if (!ProjectContainsDotNet())
                 return;
 
+            if (!GodotSharpEditor.Instance.MSBuildPanel.BuildProject())
+                throw new InvalidOperationException("Failed to build project. Check MSBuild panel for details.");
+
             string osName = GetExportPlatform().GetOsName();
 
             if (!TryDeterminePlatformFromOSName(osName, out string? platform))


### PR DESCRIPTION
Fixes #113265 

The C# export plugin only compiles for the export and not the editor, so when exporting converts `tscn` -> `scn`, it's instantiating the scene using the old code, which fails to load the signal. I'd imagine this would also affect properties, but I didn't test that explicitly. So this change makes sure the code changes are built for editor before any processing happens.

The conversion error was lingering to other attempts at exporting was due to caching and the files involved not actually changing.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
