### PR TITLE
[macOS] Do not use `openApplicationAtURL` for headless instances.

### DIFF
--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -61,21 +61,6 @@ int main(int argc, char **argv) {
 	bool is_embedded = false;
 	bool is_headless = false;
 
-	const char *headless_args[] = {
-		"--headless",
-		"-h",
-		"--help",
-		"/?",
-		"--version",
-		"--dump-gdextension-interface",
-		"--dump-extension-api",
-		"--dump-extension-api-with-docs",
-		"--validate-extension-api",
-		"--convert-3to4",
-		"--validate-conversion-3to4",
-		"--doctool",
-	};
-
 	for (int i = 0; i < argc; i++) {
 		if (strcmp("-NSDocumentRevisionsDebugMode", argv[i]) == 0) {
 			// remove "-NSDocumentRevisionsDebugMode" and the next argument
@@ -94,8 +79,8 @@ int main(int argc, char **argv) {
 		if (strcmp("--embedded", argv[i]) == 0) {
 			is_embedded = true;
 		}
-		for (size_t j = 0; j < std::size(headless_args); j++) {
-			if (strcmp(headless_args[j], argv[i]) == 0) {
+		for (size_t j = 0; j < std::size(OS_MacOS::headless_args); j++) {
+			if (strcmp(OS_MacOS::headless_args[j], argv[i]) == 0) {
 				is_headless = true;
 				break;
 			}

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -79,6 +79,23 @@ protected:
 	virtual void delete_main_loop() override;
 
 public:
+	static inline const char *headless_args[] = {
+		"--headless",
+		"-h",
+		"--help",
+		"/?",
+		"--version",
+		"--dump-gdextension-interface",
+		"--dump-extension-api",
+		"--dump-gdextension-interface-json",
+		"--dump-extension-api-with-docs",
+		"--validate-extension-api",
+		"--convert-3to4",
+		"--validate-conversion-3to4",
+		"--doctool",
+		"--test",
+	};
+
 	virtual void add_frame_delay(bool p_can_draw, bool p_wake_for_events) override;
 
 	virtual void set_cmdline_platform_args(const List<String> &p_args);

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -852,6 +852,13 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 }
 
 Error OS_MacOS::create_instance(const List<String> &p_arguments, ProcessID *r_child_id) {
+	// Do not run headless instance as app bundle, since it will never send `applicationDidFinishLaunching` and register as failed start after timeout.
+	for (size_t i = 0; i < std::size(OS_MacOS::headless_args); i++) {
+		if (p_arguments.find(String(OS_MacOS::headless_args[i]))) {
+			return OS_Unix::create_process(get_executable_path(), p_arguments, r_child_id, false);
+		}
+	}
+
 	// If executable is bundled, always execute editor instances as an app bundle to ensure app window is registered and activated correctly.
 	NSString *nsappname = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
 	if (nsappname != nil) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/111592

`openApplicationAtURL` used for launching GUI instances, is waiting for app to finish launching before returning, and since headless instance will never emit `applicationDidFinishLaunching` it was causing 20 sec freeze (timeout set for waiting) and error message (since `create_instance` return `ERR_TIMEOUT`) when running headless instance from the editor.