### PR TITLE
Use new dock system for SpriteFrames Dock

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -613,7 +613,9 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 		window_dump["window_screen_rect"] = DisplayServer::get_singleton()->screen_get_usable_rect(screen);
 
 		String name = dock->get_effective_layout_key();
-		floating_docks_dump[name] = window_dump;
+		if (!dock->transient) {
+			floating_docks_dump[name] = window_dump;
+		}
 
 		// Append to regular dock section so we know where to restore it to.
 		int dock_slot_id = dock->dock_slot_index;

--- a/editor/scene/sprite_frames_editor_plugin.h
+++ b/editor/scene/sprite_frames_editor_plugin.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "editor/docks/editor_dock.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
@@ -37,7 +38,6 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/spin_box.h"
-#include "scene/gui/split_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 #include "scene/resources/image_texture.h"
@@ -69,8 +69,8 @@ public:
 	static Ref<ClipboardAnimation> from_sprite_frames(const Ref<SpriteFrames> &p_frames, const String &p_anim);
 };
 
-class SpriteFramesEditor : public HSplitContainer {
-	GDCLASS(SpriteFramesEditor, HSplitContainer);
+class SpriteFramesEditor : public EditorDock {
+	GDCLASS(SpriteFramesEditor, EditorDock);
 
 	Ref<SpriteFrames> frames;
 	Node *animated_sprite = nullptr;
@@ -313,7 +313,6 @@ class SpriteFramesEditorPlugin : public EditorPlugin {
 	GDCLASS(SpriteFramesEditorPlugin, EditorPlugin);
 
 	SpriteFramesEditor *frames_editor = nullptr;
-	Button *button = nullptr;
 
 public:
 	virtual String get_plugin_name() const override { return "SpriteFrames"; }


### PR DESCRIPTION
See #113024

This PR updates the SpriteFrames docks to use the new dock system. The layout is very horizontal but with some changes, it seems possible to make it vertical. That can be done in a follow-up PR.

<img width="818" height="347" src="https://github.com/user-attachments/assets/cf3d43f6-b23d-4bb0-82f0-7a65635149c5" />

This PR also contains a fix for transient docks, where it would be opened if the layout was saved while it was floating, leading to crash cases where the dock knew it wasn't editing anything, but it was able to be opened by loading the layout, so it was unsafely accessing the nullptr.