### PR TITLE
Add a naming-convention option for nodes dragged into the script editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1288,6 +1288,9 @@
 		<member name="project_manager/directory_naming_convention" type="int" setter="" getter="">
 			Directory naming convention for the project manager. Options are "No convention" (project name is directory name), "kebab-case" (default), "snake_case", "camelCase", "PascalCase", or "Title Case".
 		</member>
+		<member name="project_manager/dropped_node_naming_convention" type="int" setter="" getter="">
+			Dropped node naming convention for the project manager. Options are "snake_case" (default), "camelCase", or "PascalCase".
+		</member>
 		<member name="project_manager/sorting_order" type="int" setter="" getter="">
 			The sorting order to use in the project manager. When changing the sorting order in the project manager, this setting is set permanently in the editor settings.
 		</member>

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -52,6 +52,7 @@ void QuickSettingsDialog::_fetch_setting_values() {
 	editor_network_modes.clear();
 	editor_check_for_updates.clear();
 	editor_directory_naming_conventions.clear();
+	editor_dropped_node_naming_convention.clear();
 
 	{
 		List<PropertyInfo> editor_settings_properties;
@@ -72,6 +73,8 @@ void QuickSettingsDialog::_fetch_setting_values() {
 				editor_check_for_updates = pi.hint_string.split(",");
 			} else if (pi.name == "project_manager/directory_naming_convention") {
 				editor_directory_naming_conventions = pi.hint_string.split(",");
+			} else if (pi.name == "project_manager/dropped_node_naming_convention") {
+				editor_dropped_node_naming_convention = pi.hint_string.split(",");
 			}
 		}
 	}
@@ -164,6 +167,19 @@ void QuickSettingsDialog::_update_current_values() {
 			}
 		}
 	}
+
+	// Dropped node naming options.
+	{
+		const int current_directory_naming = EDITOR_GET("project_manager/dropped_node_naming_convention");
+
+		for (int i = 0; i < editor_dropped_node_naming_convention.size(); i++) {
+			const String &dropped_node_naming_value = editor_dropped_node_naming_convention[i];
+			if (current_directory_naming == i) {
+				dropped_node_naming_convention_button->set_text(dropped_node_naming_value);
+				dropped_node_naming_convention_button->select(i);
+			}
+		}
+	}
 }
 
 void QuickSettingsDialog::_add_setting_control(const String &p_text, Control *p_control) {
@@ -210,6 +226,10 @@ void QuickSettingsDialog::_check_for_update_selected(int p_id) {
 
 void QuickSettingsDialog::_directory_naming_convention_selected(int p_id) {
 	_set_setting_value("project_manager/directory_naming_convention", p_id);
+}
+
+void QuickSettingsDialog::_dropped_node_naming_convention(int p_id) {
+	_set_setting_value("project_manager/dropped_node_naming_convention", p_id);
 }
 
 void QuickSettingsDialog::_set_setting_value(const String &p_setting, const Variant &p_value, bool p_restart_required) {
@@ -395,6 +415,20 @@ QuickSettingsDialog::QuickSettingsDialog() {
 			}
 
 			_add_setting_control(TTRC("Directory Naming Convention"), directory_naming_convention_button);
+		}
+
+		// Dropped node naming options.
+		{
+			dropped_node_naming_convention_button = memnew(OptionButton);
+			dropped_node_naming_convention_button->set_fit_to_longest_item(false);
+			dropped_node_naming_convention_button->connect(SceneStringName(item_selected), callable_mp(this, &QuickSettingsDialog::_dropped_node_naming_convention));
+
+			for (int i = 0; i < editor_dropped_node_naming_convention.size(); i++) {
+				const String &dropped_node_naming_convention = editor_dropped_node_naming_convention[i];
+				dropped_node_naming_convention_button->add_item(dropped_node_naming_convention, i);
+			}
+
+			_add_setting_control(TTRC("Dropped Node Naming Convention"), dropped_node_naming_convention_button);
 		}
 
 		_update_current_values();

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -51,6 +51,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	Vector<String> editor_network_modes;
 	Vector<String> editor_check_for_updates;
 	Vector<String> editor_directory_naming_conventions;
+	Vector<String> editor_dropped_node_naming_convention;
 
 	void _fetch_setting_values();
 	void _update_current_values();
@@ -70,6 +71,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	OptionButton *network_mode_option_button = nullptr;
 	OptionButton *check_for_update_button = nullptr;
 	OptionButton *directory_naming_convention_button = nullptr;
+	OptionButton *dropped_node_naming_convention_button = nullptr;
 
 	Label *custom_theme_label = nullptr;
 	EditorSettingsDialog *editor_settings_dialog = nullptr;
@@ -82,6 +84,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	void _network_mode_selected(int p_id);
 	void _check_for_update_selected(int p_id);
 	void _directory_naming_convention_selected(int p_id);
+	void _dropped_node_naming_convention(int p_id);
 	void _set_setting_value(const String &p_setting, const Variant &p_value, bool p_restart_required = false);
 	void _show_full_settings();
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -2439,7 +2439,23 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 					}
 				}
 
-				String variable_name = String(node->get_name()).to_snake_case().validate_unicode_identifier();
+				String variable_name = String(node->get_name());
+				int naming_convention = (int)EDITOR_GET("project_manager/dropped_node_naming_convention");
+				switch (naming_convention) {
+					case 0: // snake_case
+						variable_name = variable_name.to_snake_case().validate_unicode_identifier();
+						break;
+					case 1: // camelCase
+						variable_name = variable_name.to_camel_case().validate_unicode_identifier();
+						break;
+					case 2: // PascalCase
+						variable_name = variable_name.to_pascal_case().validate_unicode_identifier();
+						break;
+					default:
+						ERR_FAIL_MSG("Invalid dropped node naming convention.");
+						break;
+				}
+
 				if (use_type) {
 					StringName class_name = node->get_class_name();
 					Ref<Script> node_script = node->get_script();
@@ -2470,8 +2486,23 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 				if (!node) {
 					continue;
 				}
+				String variable_name = String(node->get_name());
+				int naming_convention = (int)EDITOR_GET("project_manager/dropped_node_naming_convention");
+				switch (naming_convention) {
+					case 0: // snake_case
+						variable_name = variable_name.to_snake_case().validate_unicode_identifier();
+						break;
+					case 1: // camelCase
+						variable_name = variable_name.to_camel_case().validate_unicode_identifier();
+						break;
+					case 2: // PascalCase
+						variable_name = variable_name.to_pascal_case().validate_unicode_identifier();
+						break;
+					default:
+						ERR_FAIL_MSG("Invalid dropped node naming convention.");
+						break;
+				}
 
-				String variable_name = String(node->get_name()).to_snake_case().validate_unicode_identifier();
 				StringName class_name = node->get_class_name();
 				Ref<Script> node_script = node->get_script();
 				if (node_script.is_valid()) {

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1123,6 +1123,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// TRANSLATORS: Project Manager here refers to the tool used to create/manage Godot projects.
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Last Edited,Name,Path")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/directory_naming_convention", 1, "No convention,kebab-case,snake_case,camelCase,PascalCase,Title Case")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/dropped_node_naming_convention", 0, "snake_case,camelCase,PascalCase")
 
 #if defined(WEB_ENABLED)
 	// Web platform only supports `gl_compatibility`.


### PR DESCRIPTION
I used the same approach as the existing ‘Directory Naming Convention’ setting. Variable name formatting relies on the existing helpers: to_snake_case(), to_pascal_case(), and to_camel_case().

Closes godotengine/godot-proposals#13619