### PR TITLE
Use `RequiredParam`/`RequiredResult` in some high value places

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -415,9 +415,9 @@ bool Input::is_action_just_pressed(const StringName &p_action, bool p_exact) con
 	}
 }
 
-bool Input::is_action_just_pressed_by_event(const StringName &p_action, const Ref<InputEvent> &p_event, bool p_exact) const {
+bool Input::is_action_just_pressed_by_event(const StringName &p_action, RequiredParam<InputEvent> rp_event, bool p_exact) const {
 	ERR_FAIL_COND_V_MSG(!InputMap::get_singleton()->has_action(p_action), false, InputMap::get_singleton()->suggest_actions(p_action));
-	ERR_FAIL_COND_V(p_event.is_null(), false);
+	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, false);
 
 	if (disable_input) {
 		return false;
@@ -472,9 +472,9 @@ bool Input::is_action_just_released(const StringName &p_action, bool p_exact) co
 	}
 }
 
-bool Input::is_action_just_released_by_event(const StringName &p_action, const Ref<InputEvent> &p_event, bool p_exact) const {
+bool Input::is_action_just_released_by_event(const StringName &p_action, RequiredParam<InputEvent> rp_event, bool p_exact) const {
 	ERR_FAIL_COND_V_MSG(!InputMap::get_singleton()->has_action(p_action), false, InputMap::get_singleton()->suggest_actions(p_action));
-	ERR_FAIL_COND_V(p_event.is_null(), false);
+	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, false);
 
 	if (disable_input) {
 		return false;
@@ -1227,10 +1227,10 @@ void Input::set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p
 	set_custom_mouse_cursor_func(p_cursor, p_shape, p_hotspot);
 }
 
-void Input::parse_input_event(const Ref<InputEvent> &p_event) {
+void Input::parse_input_event(RequiredParam<InputEvent> rp_event) {
 	_THREAD_SAFE_METHOD_
 
-	ERR_FAIL_COND(p_event.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_event, rp_event);
 
 #ifdef DEBUG_ENABLED
 	uint64_t curr_frame = Engine::get_singleton()->get_process_frames();

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -321,8 +321,8 @@ public:
 	bool is_action_pressed(const StringName &p_action, bool p_exact = false) const;
 	bool is_action_just_pressed(const StringName &p_action, bool p_exact = false) const;
 	bool is_action_just_released(const StringName &p_action, bool p_exact = false) const;
-	bool is_action_just_pressed_by_event(const StringName &p_action, const Ref<InputEvent> &p_event, bool p_exact = false) const;
-	bool is_action_just_released_by_event(const StringName &p_action, const Ref<InputEvent> &p_event, bool p_exact = false) const;
+	bool is_action_just_pressed_by_event(const StringName &p_action, RequiredParam<InputEvent> p_event, bool p_exact = false) const;
+	bool is_action_just_released_by_event(const StringName &p_action, RequiredParam<InputEvent> p_event, bool p_exact = false) const;
 	float get_action_strength(const StringName &p_action, bool p_exact = false) const;
 	float get_action_raw_strength(const StringName &p_action, bool p_exact = false) const;
 
@@ -350,7 +350,7 @@ public:
 	void warp_mouse(const Vector2 &p_position);
 	Point2 warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect);
 
-	void parse_input_event(const Ref<InputEvent> &p_event);
+	void parse_input_event(RequiredParam<InputEvent> p_event);
 
 	void set_gravity(const Vector3 &p_gravity);
 	void set_accelerometer(const Vector3 &p_accel);

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -88,7 +88,7 @@ bool InputEvent::is_echo() const {
 	return false;
 }
 
-Ref<InputEvent> InputEvent::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
+RequiredResult<InputEvent> InputEvent::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	return Ref<InputEvent>(const_cast<InputEvent *>(this));
 }
 
@@ -736,7 +736,7 @@ bool InputEventMouseButton::is_double_click() const {
 	return double_click;
 }
 
-Ref<InputEvent> InputEventMouseButton::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
+RequiredResult<InputEvent> InputEventMouseButton::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Vector2 g = get_global_position();
 	Vector2 l = p_xform.xform(get_position() + p_local_ofs);
 
@@ -958,7 +958,7 @@ Vector2 InputEventMouseMotion::get_screen_velocity() const {
 	return screen_velocity;
 }
 
-Ref<InputEvent> InputEventMouseMotion::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
+RequiredResult<InputEvent> InputEventMouseMotion::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Ref<InputEventMouseMotion> mm;
 	mm.instantiate();
 
@@ -1364,7 +1364,7 @@ bool InputEventScreenTouch::is_double_tap() const {
 	return double_tap;
 }
 
-Ref<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
+RequiredResult<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Ref<InputEventScreenTouch> st;
 	st.instantiate();
 	st->set_device(get_device());
@@ -1487,7 +1487,7 @@ Vector2 InputEventScreenDrag::get_screen_velocity() const {
 	return screen_velocity;
 }
 
-Ref<InputEvent> InputEventScreenDrag::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
+RequiredResult<InputEvent> InputEventScreenDrag::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Ref<InputEventScreenDrag> sd;
 
 	sd.instantiate();
@@ -1706,7 +1706,7 @@ real_t InputEventMagnifyGesture::get_factor() const {
 	return factor;
 }
 
-Ref<InputEvent> InputEventMagnifyGesture::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
+RequiredResult<InputEvent> InputEventMagnifyGesture::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Ref<InputEventMagnifyGesture> ev;
 	ev.instantiate();
 
@@ -1748,7 +1748,7 @@ Vector2 InputEventPanGesture::get_delta() const {
 	return delta;
 }
 
-Ref<InputEvent> InputEventPanGesture::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
+RequiredResult<InputEvent> InputEventPanGesture::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Ref<InputEventPanGesture> ev;
 	ev.instantiate();
 

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -80,7 +80,7 @@ public:
 
 	virtual String as_text() const = 0;
 
-	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const;
+	virtual RequiredResult<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool p_exact_match, float p_deadzone, bool *r_pressed, float *r_strength, float *r_raw_strength) const;
 	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const;
@@ -246,7 +246,7 @@ public:
 	void set_double_click(bool p_double_click);
 	bool is_double_click() const;
 
-	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
+	virtual RequiredResult<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool p_exact_match, float p_deadzone, bool *r_pressed, float *r_strength, float *r_raw_strength) const override;
 	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const override;
@@ -294,7 +294,7 @@ public:
 	void set_screen_velocity(const Vector2 &p_velocity);
 	Vector2 get_screen_velocity() const;
 
-	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
+	virtual RequiredResult<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
 	virtual String _to_string() override;
 
@@ -384,7 +384,7 @@ public:
 	void set_double_tap(bool p_double_tap);
 	bool is_double_tap() const;
 
-	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
+	virtual RequiredResult<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
 	virtual String _to_string() override;
 
@@ -434,7 +434,7 @@ public:
 	void set_screen_velocity(const Vector2 &p_velocity);
 	Vector2 get_screen_velocity() const;
 
-	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
+	virtual RequiredResult<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
 	virtual String _to_string() override;
 
@@ -502,7 +502,7 @@ public:
 	void set_factor(real_t p_factor);
 	real_t get_factor() const;
 
-	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
+	virtual RequiredResult<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
 	virtual String _to_string() override;
 
@@ -520,7 +520,7 @@ public:
 	void set_delta(const Vector2 &p_delta);
 	Vector2 get_delta() const;
 
-	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
+	virtual RequiredResult<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
 	virtual String _to_string() override;
 

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -196,8 +196,8 @@ void InputMap::action_set_deadzone(const StringName &p_action, float p_deadzone)
 	input_map[p_action].deadzone = p_deadzone;
 }
 
-void InputMap::action_add_event(const StringName &p_action, const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND_MSG(p_event.is_null(), "It's not a reference to a valid InputEvent object.");
+void InputMap::action_add_event(const StringName &p_action, RequiredParam<InputEvent> rp_event) {
+	EXTRACT_PARAM_OR_FAIL_MSG(p_event, rp_event, "It's not a reference to a valid InputEvent object.");
 	ERR_FAIL_COND_MSG(!input_map.has(p_action), suggest_actions(p_action));
 	if (_find_event(input_map[p_action], p_event, true)) {
 		return; // Already added.
@@ -206,12 +206,14 @@ void InputMap::action_add_event(const StringName &p_action, const Ref<InputEvent
 	input_map[p_action].inputs.push_back(p_event);
 }
 
-bool InputMap::action_has_event(const StringName &p_action, const Ref<InputEvent> &p_event) {
+bool InputMap::action_has_event(const StringName &p_action, RequiredParam<InputEvent> rp_event) {
+	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, false);
 	ERR_FAIL_COND_V_MSG(!input_map.has(p_action), false, suggest_actions(p_action));
 	return (_find_event(input_map[p_action], p_event, true) != nullptr);
 }
 
-void InputMap::action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event) {
+void InputMap::action_erase_event(const StringName &p_action, RequiredParam<InputEvent> rp_event) {
+	EXTRACT_PARAM_OR_FAIL(p_event, rp_event);
 	ERR_FAIL_COND_MSG(!input_map.has(p_action), suggest_actions(p_action));
 
 	List<Ref<InputEvent>>::Element *E = _find_event(input_map[p_action], p_event, true);
@@ -251,7 +253,8 @@ const List<Ref<InputEvent>> *InputMap::action_get_events(const StringName &p_act
 	return &E->value.inputs;
 }
 
-bool InputMap::event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match) const {
+bool InputMap::event_is_action(RequiredParam<InputEvent> rp_event, const StringName &p_action, bool p_exact_match) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, false);
 	return event_get_action_status(p_event, p_action, p_exact_match);
 }
 

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -87,13 +87,13 @@ public:
 
 	float action_get_deadzone(const StringName &p_action);
 	void action_set_deadzone(const StringName &p_action, float p_deadzone);
-	void action_add_event(const StringName &p_action, const Ref<InputEvent> &p_event);
-	bool action_has_event(const StringName &p_action, const Ref<InputEvent> &p_event);
-	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event);
+	void action_add_event(const StringName &p_action, RequiredParam<InputEvent> p_event);
+	bool action_has_event(const StringName &p_action, RequiredParam<InputEvent> p_event);
+	void action_erase_event(const StringName &p_action, RequiredParam<InputEvent> p_event);
 	void action_erase_events(const StringName &p_action);
 
 	const List<Ref<InputEvent>> *action_get_events(const StringName &p_action);
-	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false) const;
+	bool event_is_action(RequiredParam<InputEvent> p_event, const StringName &p_action, bool p_exact_match = false) const;
 	int event_get_index(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false) const;
 	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false, bool *r_pressed = nullptr, float *r_strength = nullptr, float *r_raw_strength = nullptr, int *r_event_index = nullptr) const;
 

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -147,11 +147,9 @@ def generate_version(argcount, const=False, returns=False, required=False, compa
             callptrargsptr += ", "
         argtext += f"m_type{i + 1}"
         callargtext += f"m_type{i + 1} arg{i + 1}"
-        callsiargs += f"arg{i + 1}"
+        callsiargs += f"VariantInternal::make(arg{i + 1})"
         callsiargptrs += f"&vargs[{i}]"
-        callptrargs += (
-            f"PtrToArg<m_type{i + 1}>::EncodeT argval{i + 1} = (PtrToArg<m_type{i + 1}>::EncodeT)arg{i + 1};\\\n"
-        )
+        callptrargs += f"PtrToArg<m_type{i + 1}>::EncodeT argval{i + 1}; PtrToArg<m_type{i + 1}>::encode(arg{i + 1}, &argval{i + 1});\\\n"
         callptrargsptr += f"&argval{i + 1}"
 
     if argcount:

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -670,9 +670,9 @@ void call_with_variant_args_ret_helper(T *p_instance, R (T::*p_method)(P...), co
 	r_error.error = Callable::CallError::CALL_OK;
 
 #ifdef DEBUG_ENABLED
-	r_ret = (p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+	r_ret = VariantInternal::make((p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...));
 #else
-	r_ret = (p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
+	r_ret = VariantInternal::make((p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...));
 #endif
 }
 
@@ -681,9 +681,9 @@ void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_ar
 	r_error.error = Callable::CallError::CALL_OK;
 
 #ifdef DEBUG_ENABLED
-	r_ret = (p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+	r_ret = VariantInternal::make((p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...));
 #else
-	r_ret = (p_method)(VariantCaster<P>::cast(*p_args[Is])...);
+	r_ret = VariantInternal::make((p_method)(VariantCaster<P>::cast(*p_args[Is])...));
 #endif // DEBUG_ENABLED
 }
 
@@ -721,9 +721,9 @@ void call_with_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) co
 	r_error.error = Callable::CallError::CALL_OK;
 
 #ifdef DEBUG_ENABLED
-	r_ret = (p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+	r_ret = VariantInternal::make((p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...));
 #else
-	r_ret = (p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
+	r_ret = VariantInternal::make((p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...));
 #endif // DEBUG_ENABLED
 	(void)p_args;
 }
@@ -787,9 +787,9 @@ void call_with_variant_args_retc_static_helper(T *p_instance, R (*p_method)(T *,
 	r_error.error = Callable::CallError::CALL_OK;
 
 #ifdef DEBUG_ENABLED
-	r_ret = (p_method)(p_instance, VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+	r_ret = VariantInternal::make((p_method)(p_instance, VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...));
 #else
-	r_ret = (p_method)(p_instance, VariantCaster<P>::cast(*p_args[Is])...);
+	r_ret = VariantInternal::make((p_method)(p_instance, VariantCaster<P>::cast(*p_args[Is])...));
 #endif // DEBUG_ENABLED
 
 	(void)p_args;

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -253,8 +253,8 @@ struct PtrToArg<T *> {
 		return likely(p_ptr) ? *reinterpret_cast<T *const *>(p_ptr) : nullptr;
 	}
 	typedef Object *EncodeT;
-	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
-		*((T **)p_ptr) = p_var;
+	_FORCE_INLINE_ static void encode(const T *p_var, void *p_ptr) {
+		*((T **)p_ptr) = const_cast<T *>(p_var);
 	}
 };
 
@@ -264,8 +264,8 @@ struct PtrToArg<const T *> {
 		return likely(p_ptr) ? *reinterpret_cast<T *const *>(p_ptr) : nullptr;
 	}
 	typedef const Object *EncodeT;
-	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
-		*((T **)p_ptr) = p_var;
+	_FORCE_INLINE_ static void encode(const T *p_var, void *p_ptr) {
+		*((T **)p_ptr) = const_cast<T *>(p_var);
 	}
 };
 

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -40,6 +40,12 @@
 
 class RefCounted;
 
+template <typename T>
+struct GDExtensionConstPtr;
+
+template <typename T>
+struct GDExtensionPtr;
+
 class VariantInternal {
 	friend class Variant;
 
@@ -538,6 +544,29 @@ public:
 				ERR_FAIL_V(nullptr);
 		}
 		ERR_FAIL_V(nullptr);
+	}
+
+	// Used internally in GDExtension and Godot's binding system when converting to Variant
+	// from values that may include RequiredParam<T> or RequiredResult<T>.
+	template <typename T>
+	_FORCE_INLINE_ static Variant make(const T &v) {
+		return Variant(v);
+	}
+	template <typename T>
+	_FORCE_INLINE_ static Variant make(const GDExtensionConstPtr<T> &v) {
+		return v.operator Variant();
+	}
+	template <typename T>
+	_FORCE_INLINE_ static Variant make(const GDExtensionPtr<T> &v) {
+		return v.operator Variant();
+	}
+	template <typename T>
+	_FORCE_INLINE_ static Variant make(const RequiredParam<T> &v) {
+		return Variant(v._internal_ptr_dont_use());
+	}
+	template <typename T>
+	_FORCE_INLINE_ static Variant make(const RequiredResult<T> &v) {
+		return Variant(v._internal_ptr_dont_use());
 	}
 };
 

--- a/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
@@ -235,7 +235,7 @@ Vector2 GodotPhysicsDirectBodyState2D::get_contact_impulse(int p_contact_idx) co
 	return body->contacts[p_contact_idx].impulse;
 }
 
-PhysicsDirectSpaceState2D *GodotPhysicsDirectBodyState2D::get_space_state() {
+RequiredResult<PhysicsDirectSpaceState2D> GodotPhysicsDirectBodyState2D::get_space_state() {
 	return body->get_space()->get_direct_state();
 }
 

--- a/modules/godot_physics_2d/godot_body_direct_state_2d.h
+++ b/modules/godot_physics_2d/godot_body_direct_state_2d.h
@@ -101,7 +101,7 @@ public:
 	virtual Vector2 get_contact_collider_velocity_at_position(int p_contact_idx) const override;
 	virtual Vector2 get_contact_impulse(int p_contact_idx) const override;
 
-	virtual PhysicsDirectSpaceState2D *get_space_state() override;
+	virtual RequiredResult<PhysicsDirectSpaceState2D> get_space_state() override;
 
 	virtual real_t get_step() const override;
 };

--- a/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
@@ -244,7 +244,7 @@ Vector3 GodotPhysicsDirectBodyState3D::get_contact_collider_velocity_at_position
 	return body->contacts[p_contact_idx].collider_velocity_at_pos;
 }
 
-PhysicsDirectSpaceState3D *GodotPhysicsDirectBodyState3D::get_space_state() {
+RequiredResult<PhysicsDirectSpaceState3D> GodotPhysicsDirectBodyState3D::get_space_state() {
 	return body->get_space()->get_direct_state();
 }
 

--- a/modules/godot_physics_3d/godot_body_direct_state_3d.h
+++ b/modules/godot_physics_3d/godot_body_direct_state_3d.h
@@ -104,7 +104,7 @@ public:
 	virtual int get_contact_collider_shape(int p_contact_idx) const override;
 	virtual Vector3 get_contact_collider_velocity_at_position(int p_contact_idx) const override;
 
-	virtual PhysicsDirectSpaceState3D *get_space_state() override;
+	virtual RequiredResult<PhysicsDirectSpaceState3D> get_space_state() override;
 
 	virtual real_t get_step() const override;
 };

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -976,9 +976,10 @@ RID GodotPhysicsServer3D::soft_body_create() {
 	return rid;
 }
 
-void GodotPhysicsServer3D::soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) {
+void GodotPhysicsServer3D::soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> rp_rendering_server_handler) {
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(soft_body);
+	EXTRACT_PARAM_OR_FAIL(p_rendering_server_handler, rp_rendering_server_handler);
 
 	soft_body->update_rendering_server(p_rendering_server_handler);
 }

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -263,7 +263,7 @@ public:
 
 	virtual RID soft_body_create() override;
 
-	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) override;
+	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) override;
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) override;
 	virtual RID soft_body_get_space(RID p_body) const override;

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -985,9 +985,10 @@ RID JoltPhysicsServer3D::soft_body_create() {
 	return rid;
 }
 
-void JoltPhysicsServer3D::soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) {
+void JoltPhysicsServer3D::soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> rp_rendering_server_handler) {
 	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
+	EXTRACT_PARAM_OR_FAIL(p_rendering_server_handler, rp_rendering_server_handler);
 
 	return body->update_rendering_server(p_rendering_server_handler);
 }

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -300,7 +300,7 @@ public:
 
 	virtual RID soft_body_create() override;
 
-	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) override;
+	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) override;
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) override;
 	virtual RID soft_body_get_space(RID p_body) const override;

--- a/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
@@ -256,6 +256,6 @@ void JoltPhysicsDirectBodyState3D::integrate_forces() {
 	set_angular_velocity(angular_velocity);
 }
 
-PhysicsDirectSpaceState3D *JoltPhysicsDirectBodyState3D::get_space_state() {
+RequiredResult<PhysicsDirectSpaceState3D> JoltPhysicsDirectBodyState3D::get_space_state() {
 	return body->get_space()->get_direct_state();
 }

--- a/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.h
+++ b/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.h
@@ -115,5 +115,5 @@ public:
 
 	virtual void integrate_forces() override;
 
-	virtual PhysicsDirectSpaceState3D *get_space_state() override;
+	virtual RequiredResult<PhysicsDirectSpaceState3D> get_space_state() override;
 };

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -141,7 +141,7 @@ void Node2D::_update_transform() {
 	_notify_transform();
 }
 
-void Node2D::reparent(Node *p_parent, bool p_keep_global_transform) {
+void Node2D::reparent(RequiredParam<Node> p_parent, bool p_keep_global_transform) {
 	ERR_THREAD_GUARD;
 	if (p_keep_global_transform) {
 		Transform2D temp = get_global_transform();

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -73,7 +73,7 @@ public:
 
 	virtual void _edit_set_rect(const Rect2 &p_edit_rect) override;
 #endif
-	virtual void reparent(Node *p_parent, bool p_keep_global_transform = true) override;
+	virtual void reparent(RequiredParam<Node> p_parent, bool p_keep_global_transform = true) override;
 
 	void set_position(const Point2 &p_pos);
 	void set_rotation(real_t p_radians);

--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -501,8 +501,8 @@ bool Area2D::has_overlapping_areas() const {
 	return !area_map.is_empty();
 }
 
-bool Area2D::overlaps_area(Node *p_area) const {
-	ERR_FAIL_NULL_V(p_area, false);
+bool Area2D::overlaps_area(RequiredParam<Node> rp_area) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_area, rp_area, false);
 	HashMap<ObjectID, AreaState>::ConstIterator E = area_map.find(p_area->get_instance_id());
 	if (!E) {
 		return false;
@@ -510,8 +510,8 @@ bool Area2D::overlaps_area(Node *p_area) const {
 	return E->value.in_tree;
 }
 
-bool Area2D::overlaps_body(Node *p_body) const {
-	ERR_FAIL_NULL_V(p_body, false);
+bool Area2D::overlaps_body(RequiredParam<Node> rp_body) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_body, rp_body, false);
 	HashMap<ObjectID, BodyState>::ConstIterator E = body_map.find(p_body->get_instance_id());
 	if (!E) {
 		return false;

--- a/scene/2d/physics/area_2d.h
+++ b/scene/2d/physics/area_2d.h
@@ -185,8 +185,8 @@ public:
 	bool has_overlapping_bodies() const;
 	bool has_overlapping_areas() const;
 
-	bool overlaps_area(Node *p_area) const;
-	bool overlaps_body(Node *p_body) const;
+	bool overlaps_area(RequiredParam<Node> p_area) const;
+	bool overlaps_body(RequiredParam<Node> p_body) const;
 
 	void set_audio_bus_override(bool p_override);
 	bool is_overriding_audio_bus() const;

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -418,9 +418,9 @@ Object *CollisionObject2D::shape_owner_get_owner(uint32_t p_owner) const {
 	return ObjectDB::get_instance(shapes[p_owner].owner_id);
 }
 
-void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape) {
+void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape2D> rp_shape) {
 	ERR_FAIL_COND(!shapes.has(p_owner));
-	ERR_FAIL_COND(p_shape.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_shape, rp_shape);
 
 	ShapeData &sd = shapes[p_owner];
 	ShapeData::Shape s;

--- a/scene/2d/physics/collision_object_2d.h
+++ b/scene/2d/physics/collision_object_2d.h
@@ -112,7 +112,7 @@ protected:
 
 	virtual void _space_changed(const RID &p_new_space);
 
-	GDVIRTUAL3(_input_event, Viewport *, Ref<InputEvent>, int)
+	GDVIRTUAL3(_input_event, RequiredParam<Viewport>, RequiredParam<InputEvent>, int)
 	GDVIRTUAL0(_mouse_enter)
 	GDVIRTUAL0(_mouse_exit)
 	GDVIRTUAL1(_mouse_shape_enter, int)
@@ -154,7 +154,7 @@ public:
 	void shape_owner_set_one_way_collision_margin(uint32_t p_owner, real_t p_margin);
 	real_t get_shape_owner_one_way_collision_margin(uint32_t p_owner) const;
 
-	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape);
+	void shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape2D> p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
 	Ref<Shape2D> shape_owner_get_shape(uint32_t p_owner, int p_shape) const;
 	int shape_owner_get_shape_index(uint32_t p_owner, int p_shape) const;

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -156,15 +156,15 @@ TypedArray<PhysicsBody2D> PhysicsBody2D::get_collision_exceptions() {
 	return ret;
 }
 
-void PhysicsBody2D::add_collision_exception_with(Node *p_node) {
-	ERR_FAIL_NULL(p_node);
+void PhysicsBody2D::add_collision_exception_with(RequiredParam<Node> rp_node) {
+	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
 	ERR_FAIL_NULL_MSG(physics_body, "Collision exception only works between two nodes that inherit from PhysicsBody2D.");
 	PhysicsServer2D::get_singleton()->body_add_collision_exception(get_rid(), physics_body->get_rid());
 }
 
-void PhysicsBody2D::remove_collision_exception_with(Node *p_node) {
-	ERR_FAIL_NULL(p_node);
+void PhysicsBody2D::remove_collision_exception_with(RequiredParam<Node> rp_node) {
+	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
 	ERR_FAIL_NULL_MSG(physics_body, "Collision exception only works between two nodes that inherit from PhysicsBody2D.");
 	PhysicsServer2D::get_singleton()->body_remove_collision_exception(get_rid(), physics_body->get_rid());

--- a/scene/2d/physics/physics_body_2d.h
+++ b/scene/2d/physics/physics_body_2d.h
@@ -54,6 +54,6 @@ public:
 	Vector2 get_gravity() const;
 
 	TypedArray<PhysicsBody2D> get_collision_exceptions();
-	void add_collision_exception_with(Node *p_node); //must be physicsbody
-	void remove_collision_exception_with(Node *p_node);
+	void add_collision_exception_with(RequiredParam<Node> p_node); //must be physicsbody
+	void remove_collision_exception_with(RequiredParam<Node> p_node);
 };

--- a/scene/2d/physics/ray_cast_2d.cpp
+++ b/scene/2d/physics/ray_cast_2d.cpp
@@ -267,8 +267,8 @@ void RayCast2D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void RayCast2D::add_exception(const CollisionObject2D *p_node) {
-	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject2D.");
+void RayCast2D::add_exception(RequiredParam<const CollisionObject2D> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject2D.");
 	add_exception_rid(p_node->get_rid());
 }
 
@@ -276,8 +276,8 @@ void RayCast2D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void RayCast2D::remove_exception(const CollisionObject2D *p_node) {
-	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject2D.");
+void RayCast2D::remove_exception(RequiredParam<const CollisionObject2D> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject2D.");
 	remove_exception_rid(p_node->get_rid());
 }
 

--- a/scene/2d/physics/ray_cast_2d.h
+++ b/scene/2d/physics/ray_cast_2d.h
@@ -97,9 +97,9 @@ public:
 	Vector2 get_collision_normal() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(const CollisionObject2D *p_node);
+	void add_exception(RequiredParam<const CollisionObject2D> p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(const CollisionObject2D *p_node);
+	void remove_exception(RequiredParam<const CollisionObject2D> p_node);
 	void clear_exceptions();
 
 	RayCast2D();

--- a/scene/2d/physics/rigid_body_2d.h
+++ b/scene/2d/physics/rigid_body_2d.h
@@ -141,7 +141,7 @@ protected:
 
 	void _validate_property(PropertyInfo &p_property) const;
 
-	GDVIRTUAL1(_integrate_forces, PhysicsDirectBodyState2D *)
+	GDVIRTUAL1(_integrate_forces, RequiredParam<PhysicsDirectBodyState2D>)
 
 	void _apply_body_mode();
 

--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -347,8 +347,8 @@ void ShapeCast2D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void ShapeCast2D::add_exception(const CollisionObject2D *p_node) {
-	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject2D.");
+void ShapeCast2D::add_exception(RequiredParam<const CollisionObject2D> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject2D.");
 	add_exception_rid(p_node->get_rid());
 }
 
@@ -356,8 +356,8 @@ void ShapeCast2D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void ShapeCast2D::remove_exception(const CollisionObject2D *p_node) {
-	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject2D.");
+void ShapeCast2D::remove_exception(RequiredParam<const CollisionObject2D> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject2D.");
 	remove_exception_rid(p_node->get_rid());
 }
 

--- a/scene/2d/physics/shape_cast_2d.h
+++ b/scene/2d/physics/shape_cast_2d.h
@@ -112,9 +112,9 @@ public:
 	real_t get_closest_collision_unsafe_fraction() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(const CollisionObject2D *p_node);
+	void add_exception(RequiredParam<const CollisionObject2D> p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(const CollisionObject2D *p_node);
+	void remove_exception(RequiredParam<const CollisionObject2D> p_node);
 	void clear_exceptions();
 
 	PackedStringArray get_configuration_warnings() const override;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1020,7 +1020,7 @@ void Node3D::set_disable_gizmos(bool p_enabled) {
 #endif
 }
 
-void Node3D::reparent(Node *p_parent, bool p_keep_global_transform) {
+void Node3D::reparent(RequiredParam<Node> p_parent, bool p_keep_global_transform) {
 	ERR_THREAD_GUARD;
 	if (p_keep_global_transform) {
 		Transform3D temp = get_global_transform();

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -289,7 +289,7 @@ public:
 	virtual void set_transform_gizmo_visible(bool p_enabled) { data.transform_gizmo_visible = p_enabled; }
 	virtual bool is_transform_gizmo_visible() const { return data.transform_gizmo_visible; }
 #endif
-	virtual void reparent(Node *p_parent, bool p_keep_global_transform = true) override;
+	virtual void reparent(RequiredParam<Node> p_parent, bool p_keep_global_transform = true) override;
 
 	void set_disable_gizmos(bool p_enabled);
 	void update_gizmos();

--- a/scene/3d/physics/area_3d.cpp
+++ b/scene/3d/physics/area_3d.cpp
@@ -568,8 +568,8 @@ bool Area3D::has_overlapping_areas() const {
 	return !area_map.is_empty();
 }
 
-bool Area3D::overlaps_area(Node *p_area) const {
-	ERR_FAIL_NULL_V(p_area, false);
+bool Area3D::overlaps_area(RequiredParam<Node> rp_area) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_area, rp_area, false);
 	HashMap<ObjectID, AreaState>::ConstIterator E = area_map.find(p_area->get_instance_id());
 	if (!E) {
 		return false;
@@ -577,8 +577,8 @@ bool Area3D::overlaps_area(Node *p_area) const {
 	return E->value.in_tree;
 }
 
-bool Area3D::overlaps_body(Node *p_body) const {
-	ERR_FAIL_NULL_V(p_body, false);
+bool Area3D::overlaps_body(RequiredParam<Node> rp_body) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_body, rp_body, false);
 	HashMap<ObjectID, BodyState>::ConstIterator E = body_map.find(p_body->get_instance_id());
 	if (!E) {
 		return false;

--- a/scene/3d/physics/area_3d.h
+++ b/scene/3d/physics/area_3d.h
@@ -204,8 +204,8 @@ public:
 	bool has_overlapping_bodies() const;
 	bool has_overlapping_areas() const;
 
-	bool overlaps_area(Node *p_area) const;
-	bool overlaps_body(Node *p_body) const;
+	bool overlaps_area(RequiredParam<Node> p_area) const;
+	bool overlaps_body(RequiredParam<Node> p_body) const;
 
 	void set_audio_bus_override(bool p_override);
 	bool is_overriding_audio_bus() const;

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -608,9 +608,9 @@ Object *CollisionObject3D::shape_owner_get_owner(uint32_t p_owner) const {
 	return ObjectDB::get_instance(shapes[p_owner].owner_id);
 }
 
-void CollisionObject3D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape3D> &p_shape) {
+void CollisionObject3D::shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape3D> rp_shape) {
 	ERR_FAIL_COND(!shapes.has(p_owner));
-	ERR_FAIL_COND(p_shape.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_shape, rp_shape);
 
 	ShapeData &sd = shapes[p_owner];
 	ShapeData::ShapeBase s;

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -123,7 +123,7 @@ protected:
 	void set_only_update_transform_changes(bool p_enable);
 	bool is_only_update_transform_changes_enabled() const;
 
-	GDVIRTUAL5(_input_event, Camera3D *, Ref<InputEvent>, Vector3, Vector3, int)
+	GDVIRTUAL5(_input_event, RequiredParam<Camera3D>, RequiredParam<InputEvent>, Vector3, Vector3, int)
 	GDVIRTUAL0(_mouse_enter)
 	GDVIRTUAL0(_mouse_exit)
 public:
@@ -157,7 +157,7 @@ public:
 	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
 	bool is_shape_owner_disabled(uint32_t p_owner) const;
 
-	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape3D> &p_shape);
+	void shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape3D> p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
 	Ref<Shape3D> shape_owner_get_shape(uint32_t p_owner, int p_shape) const;
 	int shape_owner_get_shape_index(uint32_t p_owner, int p_shape) const;

--- a/scene/3d/physics/physical_bone_3d.h
+++ b/scene/3d/physics/physical_bone_3d.h
@@ -197,7 +197,7 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
-	GDVIRTUAL1(_integrate_forces, PhysicsDirectBodyState3D *)
+	GDVIRTUAL1(_integrate_forces, RequiredParam<PhysicsDirectBodyState3D>)
 	static void _body_state_changed_callback(void *p_instance, PhysicsDirectBodyState3D *p_state);
 	void _body_state_changed(PhysicsDirectBodyState3D *p_state);
 

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -70,15 +70,15 @@ TypedArray<PhysicsBody3D> PhysicsBody3D::get_collision_exceptions() {
 	return ret;
 }
 
-void PhysicsBody3D::add_collision_exception_with(Node *p_node) {
-	ERR_FAIL_NULL(p_node);
+void PhysicsBody3D::add_collision_exception_with(RequiredParam<Node> rp_node) {
+	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(p_node);
 	ERR_FAIL_NULL_MSG(collision_object, "Collision exception only works between two nodes that inherit from CollisionObject3D (such as Area3D or PhysicsBody3D).");
 	PhysicsServer3D::get_singleton()->body_add_collision_exception(get_rid(), collision_object->get_rid());
 }
 
-void PhysicsBody3D::remove_collision_exception_with(Node *p_node) {
-	ERR_FAIL_NULL(p_node);
+void PhysicsBody3D::remove_collision_exception_with(RequiredParam<Node> rp_node) {
+	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(p_node);
 	ERR_FAIL_NULL_MSG(collision_object, "Collision exception only works between two nodes that inherit from CollisionObject3D (such as Area3D or PhysicsBody3D).");
 	PhysicsServer3D::get_singleton()->body_remove_collision_exception(get_rid(), collision_object->get_rid());

--- a/scene/3d/physics/physics_body_3d.h
+++ b/scene/3d/physics/physics_body_3d.h
@@ -65,6 +65,6 @@ public:
 	virtual real_t get_inverse_mass() const;
 
 	TypedArray<PhysicsBody3D> get_collision_exceptions();
-	void add_collision_exception_with(Node *p_node); //must be physicsbody
-	void remove_collision_exception_with(Node *p_node);
+	void add_collision_exception_with(RequiredParam<Node> p_node); //must be physicsbody
+	void remove_collision_exception_with(RequiredParam<Node> p_node);
 };

--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -265,8 +265,8 @@ void RayCast3D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void RayCast3D::add_exception(const CollisionObject3D *p_node) {
-	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject3D.");
+void RayCast3D::add_exception(RequiredParam<const CollisionObject3D> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject3D.");
 	add_exception_rid(p_node->get_rid());
 }
 
@@ -274,8 +274,8 @@ void RayCast3D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void RayCast3D::remove_exception(const CollisionObject3D *p_node) {
-	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject3D.");
+void RayCast3D::remove_exception(RequiredParam<const CollisionObject3D> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject3D.");
 	remove_exception_rid(p_node->get_rid());
 }
 

--- a/scene/3d/physics/ray_cast_3d.h
+++ b/scene/3d/physics/ray_cast_3d.h
@@ -127,9 +127,9 @@ public:
 	int get_collision_face_index() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(const CollisionObject3D *p_node);
+	void add_exception(RequiredParam<const CollisionObject3D> p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(const CollisionObject3D *p_node);
+	void remove_exception(RequiredParam<const CollisionObject3D> p_node);
 	void clear_exceptions();
 
 	RayCast3D();

--- a/scene/3d/physics/rigid_body_3d.h
+++ b/scene/3d/physics/rigid_body_3d.h
@@ -135,7 +135,7 @@ protected:
 
 	void _validate_property(PropertyInfo &p_property) const;
 
-	GDVIRTUAL1(_integrate_forces, PhysicsDirectBodyState3D *)
+	GDVIRTUAL1(_integrate_forces, RequiredParam<PhysicsDirectBodyState3D>)
 
 	virtual void _body_state_changed(PhysicsDirectBodyState3D *p_state);
 

--- a/scene/3d/physics/shape_cast_3d.cpp
+++ b/scene/3d/physics/shape_cast_3d.cpp
@@ -441,8 +441,8 @@ void ShapeCast3D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void ShapeCast3D::add_exception(const CollisionObject3D *p_node) {
-	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject3D.");
+void ShapeCast3D::add_exception(RequiredParam<const CollisionObject3D> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject3D.");
 	add_exception_rid(p_node->get_rid());
 }
 
@@ -450,8 +450,8 @@ void ShapeCast3D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void ShapeCast3D::remove_exception(const CollisionObject3D *p_node) {
-	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject3D.");
+void ShapeCast3D::remove_exception(RequiredParam<const CollisionObject3D> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject3D.");
 	remove_exception_rid(p_node->get_rid());
 }
 

--- a/scene/3d/physics/shape_cast_3d.h
+++ b/scene/3d/physics/shape_cast_3d.h
@@ -135,9 +135,9 @@ public:
 	bool is_colliding() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(const CollisionObject3D *p_node);
+	void add_exception(RequiredParam<const CollisionObject3D> p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(const CollisionObject3D *p_node);
+	void remove_exception(RequiredParam<const CollisionObject3D> p_node);
 	void clear_exceptions();
 
 	virtual PackedStringArray get_configuration_warnings() const override;

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -614,15 +614,15 @@ TypedArray<PhysicsBody3D> SoftBody3D::get_collision_exceptions() {
 	return ret;
 }
 
-void SoftBody3D::add_collision_exception_with(Node *p_node) {
-	ERR_FAIL_NULL(p_node);
+void SoftBody3D::add_collision_exception_with(RequiredParam<Node> rp_node) {
+	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(p_node);
 	ERR_FAIL_NULL_MSG(collision_object, "Collision exception only works between two nodes that inherit from CollisionObject3D (such as Area3D or PhysicsBody3D).");
 	PhysicsServer3D::get_singleton()->soft_body_add_collision_exception(physics_rid, collision_object->get_rid());
 }
 
-void SoftBody3D::remove_collision_exception_with(Node *p_node) {
-	ERR_FAIL_NULL(p_node);
+void SoftBody3D::remove_collision_exception_with(RequiredParam<Node> rp_node) {
+	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(p_node);
 	ERR_FAIL_NULL_MSG(collision_object, "Collision exception only works between two nodes that inherit from CollisionObject3D (such as Area3D or PhysicsBody3D).");
 	PhysicsServer3D::get_singleton()->soft_body_remove_collision_exception(physics_rid, collision_object->get_rid());

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -177,8 +177,8 @@ public:
 	real_t get_drag_coefficient();
 
 	TypedArray<PhysicsBody3D> get_collision_exceptions();
-	void add_collision_exception_with(Node *p_node);
-	void remove_collision_exception_with(Node *p_node);
+	void add_collision_exception_with(RequiredParam<Node> p_node);
+	void remove_collision_exception_with(RequiredParam<Node> p_node);
 
 	Vector3 get_point_transform(int p_point_index);
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -95,8 +95,8 @@ void Tween::_stop_internal(bool p_reset) {
 	}
 }
 
-RequiredResult<PropertyTweener> Tween::tween_property(const Object *p_target, const NodePath &p_property, Variant p_to, double p_duration) {
-	ERR_FAIL_NULL_V(p_target, nullptr);
+RequiredResult<PropertyTweener> Tween::tween_property(RequiredParam<const Object> rp_target, const NodePath &p_property, Variant p_to, double p_duration) {
+	EXTRACT_PARAM_OR_FAIL_V(p_target, rp_target, nullptr);
 	CHECK_VALID();
 
 	Vector<StringName> property_subnames = p_property.get_as_property_path().get_subnames();
@@ -149,11 +149,11 @@ RequiredResult<MethodTweener> Tween::tween_method(const Callable &p_callback, co
 	return tweener;
 }
 
-RequiredResult<SubtweenTweener> Tween::tween_subtween(const Ref<Tween> &p_subtween) {
+RequiredResult<SubtweenTweener> Tween::tween_subtween(RequiredParam<Tween> rp_subtween) {
 	CHECK_VALID();
 
 	// Ensure that the subtween being added is not null.
-	ERR_FAIL_COND_V(p_subtween.is_null(), nullptr);
+	EXTRACT_PARAM_OR_FAIL_V(p_subtween, rp_subtween, nullptr);
 
 	Ref<SubtweenTweener> tweener;
 	tweener.instantiate(p_subtween);
@@ -221,8 +221,8 @@ void Tween::clear() {
 	tweeners.clear();
 }
 
-RequiredResult<Tween> Tween::bind_node(const Node *p_node) {
-	ERR_FAIL_NULL_V(p_node, this);
+RequiredResult<Tween> Tween::bind_node(RequiredParam<const Node> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, this);
 
 	bound_node = p_node->get_instance_id();
 	is_bound = true;

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -143,11 +143,11 @@ protected:
 	virtual String _to_string() override;
 
 public:
-	RequiredResult<PropertyTweener> tween_property(const Object *p_target, const NodePath &p_property, Variant p_to, double p_duration);
+	RequiredResult<PropertyTweener> tween_property(RequiredParam<const Object> p_target, const NodePath &p_property, Variant p_to, double p_duration);
 	RequiredResult<IntervalTweener> tween_interval(double p_time);
 	RequiredResult<CallbackTweener> tween_callback(const Callable &p_callback);
 	RequiredResult<MethodTweener> tween_method(const Callable &p_callback, const Variant p_from, Variant p_to, double p_duration);
-	RequiredResult<SubtweenTweener> tween_subtween(const Ref<Tween> &p_subtween);
+	RequiredResult<SubtweenTweener> tween_subtween(RequiredParam<Tween> p_subtween);
 	void append(Ref<Tweener> p_tweener);
 
 	bool custom_step(double p_delta);
@@ -160,7 +160,7 @@ public:
 	bool is_valid();
 	void clear();
 
-	RequiredResult<Tween> bind_node(const Node *p_node);
+	RequiredResult<Tween> bind_node(RequiredParam<const Node> p_node);
 	RequiredResult<Tween> set_process_mode(TweenProcessMode p_mode);
 	TweenProcessMode get_process_mode() const;
 	RequiredResult<Tween> set_pause_mode(TweenPauseMode p_mode);

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -92,8 +92,8 @@ void Container::_sort_children() {
 	pending_sort = false;
 }
 
-void Container::fit_child_in_rect(Control *p_child, const Rect2 &p_rect) {
-	ERR_FAIL_NULL(p_child);
+void Container::fit_child_in_rect(RequiredParam<Control> rp_child, const Rect2 &p_rect) {
+	EXTRACT_PARAM_OR_FAIL(p_child, rp_child);
 	ERR_FAIL_COND(p_child->get_parent() != this);
 
 	bool rtl = is_layout_rtl();

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -65,7 +65,7 @@ public:
 		NOTIFICATION_SORT_CHILDREN = 51,
 	};
 
-	void fit_child_in_rect(Control *p_child, const Rect2 &p_rect);
+	void fit_child_in_rect(RequiredParam<Control> p_child, const Rect2 &p_rect);
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const;
 	virtual Vector<int> get_allowed_size_flags_vertical() const;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -179,7 +179,7 @@ bool Control::_edit_use_rect() const {
 }
 #endif // DEBUG_ENABLED
 
-void Control::reparent(Node *p_parent, bool p_keep_global_transform) {
+void Control::reparent(RequiredParam<Node> p_parent, bool p_keep_global_transform) {
 	ERR_MAIN_THREAD_GUARD;
 	if (p_keep_global_transform) {
 		Transform2D temp = get_global_transform();
@@ -3332,9 +3332,9 @@ bool Control::has_theme_constant(const StringName &p_name, const StringName &p_t
 
 /// Local property overrides.
 
-void Control::add_theme_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon) {
+void Control::add_theme_icon_override(const StringName &p_name, RequiredParam<Texture2D> rp_icon) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(p_icon.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_icon, rp_icon);
 
 	if (data.theme_icon_override.has(p_name)) {
 		data.theme_icon_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
@@ -3345,9 +3345,9 @@ void Control::add_theme_icon_override(const StringName &p_name, const Ref<Textur
 	_notify_theme_override_changed();
 }
 
-void Control::add_theme_style_override(const StringName &p_name, const Ref<StyleBox> &p_style) {
+void Control::add_theme_style_override(const StringName &p_name, RequiredParam<StyleBox> rp_style) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(p_style.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_style, rp_style);
 
 	if (data.theme_style_override.has(p_name)) {
 		data.theme_style_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
@@ -3358,9 +3358,9 @@ void Control::add_theme_style_override(const StringName &p_name, const Ref<Style
 	_notify_theme_override_changed();
 }
 
-void Control::add_theme_font_override(const StringName &p_name, const Ref<Font> &p_font) {
+void Control::add_theme_font_override(const StringName &p_name, RequiredParam<Font> rp_font) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(p_font.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
 
 	if (data.theme_font_override.has(p_name)) {
 		data.theme_font_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -415,9 +415,9 @@ protected:
 	GDVIRTUAL1RC(Object *, _make_custom_tooltip, String)
 
 	GDVIRTUAL0RC(String, _accessibility_get_contextual_info);
-	GDVIRTUAL1RC(String, _get_accessibility_container_name, const Node *)
+	GDVIRTUAL1RC(String, _get_accessibility_container_name, RequiredParam<const Node>)
 
-	GDVIRTUAL1(_gui_input, Ref<InputEvent>)
+	GDVIRTUAL1(_gui_input, RequiredParam<InputEvent>)
 
 public:
 	enum {
@@ -465,7 +465,7 @@ public:
 	virtual bool _edit_use_rect() const override;
 #endif // DEBUG_ENABLED
 
-	virtual void reparent(Node *p_parent, bool p_keep_global_transform = true) override;
+	virtual void reparent(RequiredParam<Node> p_parent, bool p_keep_global_transform = true) override;
 
 	// Editor integration.
 
@@ -674,9 +674,9 @@ public:
 	void begin_bulk_theme_override();
 	void end_bulk_theme_override();
 
-	void add_theme_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon);
-	void add_theme_style_override(const StringName &p_name, const Ref<StyleBox> &p_style);
-	void add_theme_font_override(const StringName &p_name, const Ref<Font> &p_font);
+	void add_theme_icon_override(const StringName &p_name, RequiredParam<Texture2D> p_icon);
+	void add_theme_style_override(const StringName &p_name, RequiredParam<StyleBox> p_style);
+	void add_theme_font_override(const StringName &p_name, RequiredParam<Font> p_font);
 	void add_theme_font_size_override(const StringName &p_name, int p_font_size);
 	void add_theme_color_override(const StringName &p_name, const Color &p_color);
 	void add_theme_constant_override(const StringName &p_name, int p_constant);

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -51,7 +51,7 @@ protected:
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;
 
-	GDVIRTUAL1RC(bool, _propagate_input_event, Ref<InputEvent>);
+	GDVIRTUAL1RC(bool, _propagate_input_event, RequiredParam<InputEvent>);
 
 public:
 	void set_stretch(bool p_enable);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -884,49 +884,49 @@ void CanvasItem::draw_circle(const Point2 &p_pos, real_t p_radius, const Color &
 	draw_ellipse(p_pos, p_radius, p_radius, p_color, p_filled, p_width, p_antialiased);
 }
 
-void CanvasItem::draw_texture(const Ref<Texture2D> &p_texture, const Point2 &p_pos, const Color &p_modulate) {
+void CanvasItem::draw_texture(RequiredParam<Texture2D> rp_texture, const Point2 &p_pos, const Color &p_modulate) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 
-	ERR_FAIL_COND(p_texture.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
 
 	p_texture->draw(canvas_item, p_pos, p_modulate, false);
 }
 
-void CanvasItem::draw_texture_rect(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) {
+void CanvasItem::draw_texture_rect(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 
-	ERR_FAIL_COND(p_texture.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
 	p_texture->draw_rect(canvas_item, p_rect, p_tile, p_modulate, p_transpose);
 }
 
-void CanvasItem::draw_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) {
+void CanvasItem::draw_texture_rect_region(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	ERR_FAIL_COND(p_texture.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
 	p_texture->draw_rect_region(canvas_item, p_rect, p_src_rect, p_modulate, p_transpose, p_clip_uv);
 }
 
-void CanvasItem::draw_msdf_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, double p_outline, double p_pixel_range, double p_scale) {
+void CanvasItem::draw_msdf_texture_rect_region(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, double p_outline, double p_pixel_range, double p_scale) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	ERR_FAIL_COND(p_texture.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
 	RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(canvas_item, p_rect, p_texture->get_rid(), p_src_rect, p_modulate, p_outline, p_pixel_range, p_scale);
 }
 
-void CanvasItem::draw_lcd_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate) {
+void CanvasItem::draw_lcd_texture_rect_region(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	ERR_FAIL_COND(p_texture.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
 	RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(canvas_item, p_rect, p_texture->get_rid(), p_src_rect, p_modulate);
 }
 
-void CanvasItem::draw_style_box(const Ref<StyleBox> &p_style_box, const Rect2 &p_rect) {
+void CanvasItem::draw_style_box(RequiredParam<StyleBox> rp_style_box, const Rect2 &p_rect) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 
-	ERR_FAIL_COND(p_style_box.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_style_box, rp_style_box);
 
 	p_style_box->draw(canvas_item, p_rect);
 }
@@ -995,67 +995,67 @@ void CanvasItem::draw_colored_polygon(const Vector<Point2> &p_points, const Colo
 	draw_polygon(p_points, { p_color }, p_uvs, p_texture);
 }
 
-void CanvasItem::draw_mesh(const Ref<Mesh> &p_mesh, const Ref<Texture2D> &p_texture, const Transform2D &p_transform, const Color &p_modulate) {
+void CanvasItem::draw_mesh(RequiredParam<Mesh> rp_mesh, const Ref<Texture2D> &p_texture, const Transform2D &p_transform, const Color &p_modulate) {
 	ERR_THREAD_GUARD;
-	ERR_FAIL_COND(p_mesh.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_mesh, rp_mesh);
 	RID texture_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 
 	RenderingServer::get_singleton()->canvas_item_add_mesh(canvas_item, p_mesh->get_rid(), p_transform, p_modulate, texture_rid);
 }
 
-void CanvasItem::draw_multimesh(const Ref<MultiMesh> &p_multimesh, const Ref<Texture2D> &p_texture) {
+void CanvasItem::draw_multimesh(RequiredParam<MultiMesh> rp_multimesh, const Ref<Texture2D> &p_texture) {
 	ERR_THREAD_GUARD;
-	ERR_FAIL_COND(p_multimesh.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_multimesh, rp_multimesh);
 	RID texture_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 	RenderingServer::get_singleton()->canvas_item_add_multimesh(canvas_item, p_multimesh->get_rid(), texture_rid);
 }
 
-void CanvasItem::draw_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, const Color &p_modulate, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
+void CanvasItem::draw_string(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, const Color &p_modulate, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	ERR_FAIL_COND(p_font.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
 
 	p_font->draw_string(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_modulate, p_jst_flags, p_direction, p_orientation, p_oversampling);
 }
 
-void CanvasItem::draw_multiline_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_max_lines, const Color &p_modulate, BitField<TextServer::LineBreakFlag> p_brk_flags, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
+void CanvasItem::draw_multiline_string(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_max_lines, const Color &p_modulate, BitField<TextServer::LineBreakFlag> p_brk_flags, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	ERR_FAIL_COND(p_font.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
 
 	p_font->draw_multiline_string(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_max_lines, p_modulate, p_brk_flags, p_jst_flags, p_direction, p_orientation, p_oversampling);
 }
 
-void CanvasItem::draw_string_outline(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_size, const Color &p_modulate, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
+void CanvasItem::draw_string_outline(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_size, const Color &p_modulate, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	ERR_FAIL_COND(p_font.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
 
 	p_font->draw_string_outline(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_size, p_modulate, p_jst_flags, p_direction, p_orientation, p_oversampling);
 }
 
-void CanvasItem::draw_multiline_string_outline(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_max_lines, int p_size, const Color &p_modulate, BitField<TextServer::LineBreakFlag> p_brk_flags, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
+void CanvasItem::draw_multiline_string_outline(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_max_lines, int p_size, const Color &p_modulate, BitField<TextServer::LineBreakFlag> p_brk_flags, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	ERR_FAIL_COND(p_font.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
 
 	p_font->draw_multiline_string_outline(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_max_lines, p_size, p_modulate, p_brk_flags, p_jst_flags, p_direction, p_orientation, p_oversampling);
 }
 
-void CanvasItem::draw_char(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, int p_font_size, const Color &p_modulate, float p_oversampling) const {
+void CanvasItem::draw_char(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_char, int p_font_size, const Color &p_modulate, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 	ERR_FAIL_COND(p_char.length() != 1);
-	ERR_FAIL_COND(p_font.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
 
 	p_font->draw_char(canvas_item, p_pos, p_char[0], p_font_size, p_modulate, p_oversampling);
 }
 
-void CanvasItem::draw_char_outline(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, int p_font_size, int p_size, const Color &p_modulate, float p_oversampling) const {
+void CanvasItem::draw_char_outline(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_char, int p_font_size, int p_size, const Color &p_modulate, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 	ERR_FAIL_COND(p_char.length() != 1);
-	ERR_FAIL_COND(p_font.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
 
 	p_font->draw_char_outline(canvas_item, p_pos, p_char[0], p_font_size, p_size, p_modulate, p_oversampling);
 }
@@ -1257,9 +1257,9 @@ Vector2 CanvasItem::make_canvas_position_local(const Vector2 &screen_point) cons
 	return local_matrix.xform(screen_point);
 }
 
-Ref<InputEvent> CanvasItem::make_input_local(const Ref<InputEvent> &p_event) const {
+RequiredResult<InputEvent> CanvasItem::make_input_local(RequiredParam<InputEvent> rp_event) const {
 	ERR_READ_THREAD_GUARD_V(Ref<InputEvent>());
-	ERR_FAIL_COND_V(p_event.is_null(), p_event);
+	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, Ref<InputEvent>());
 	ERR_FAIL_COND_V(!is_inside_tree(), p_event);
 
 	return p_event->xformed_by((get_canvas_transform() * get_global_transform()).affine_inverse());

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -316,27 +316,27 @@ public:
 	void draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_filled = true, real_t p_width = -1.0, bool p_antialiased = false);
 	void draw_ellipse(const Point2 &p_pos, real_t p_major, real_t p_minor, const Color &p_color, bool p_filled = true, real_t p_width = -1.0, bool p_antialiased = false);
 	void draw_circle(const Point2 &p_pos, real_t p_radius, const Color &p_color, bool p_filled = true, real_t p_width = -1.0, bool p_antialiased = false);
-	void draw_texture(const Ref<Texture2D> &p_texture, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1, 1));
-	void draw_texture_rect(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false);
-	void draw_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
-	void draw_msdf_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), double p_outline = 0.0, double p_pixel_range = 4.0, double p_scale = 1.0);
-	void draw_lcd_texture_rect_region(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1));
-	void draw_style_box(const Ref<StyleBox> &p_style_box, const Rect2 &p_rect);
+	void draw_texture(RequiredParam<Texture2D> rp_texture, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1, 1));
+	void draw_texture_rect(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false);
+	void draw_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+	void draw_msdf_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), double p_outline = 0.0, double p_pixel_range = 4.0, double p_scale = 1.0);
+	void draw_lcd_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1));
+	void draw_style_box(RequiredParam<StyleBox> p_style_box, const Rect2 &p_rect);
 	void draw_primitive(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture2D> p_texture = Ref<Texture2D>());
 	void draw_polygon(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs = Vector<Point2>(), Ref<Texture2D> p_texture = Ref<Texture2D>());
 	void draw_colored_polygon(const Vector<Point2> &p_points, const Color &p_color, const Vector<Point2> &p_uvs = Vector<Point2>(), Ref<Texture2D> p_texture = Ref<Texture2D>());
 
-	void draw_mesh(const Ref<Mesh> &p_mesh, const Ref<Texture2D> &p_texture, const Transform2D &p_transform = Transform2D(), const Color &p_modulate = Color(1, 1, 1));
-	void draw_multimesh(const Ref<MultiMesh> &p_multimesh, const Ref<Texture2D> &p_texture);
+	void draw_mesh(RequiredParam<Mesh> p_mesh, const Ref<Texture2D> &p_texture, const Transform2D &p_transform = Transform2D(), const Color &p_modulate = Color(1, 1, 1));
+	void draw_multimesh(RequiredParam<MultiMesh> p_multimesh, const Ref<Texture2D> &p_texture);
 
-	void draw_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = Font::DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
-	void draw_multiline_string(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = Font::DEFAULT_FONT_SIZE, int p_max_lines = -1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::LineBreakFlag> p_brk_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
+	void draw_string(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = Font::DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
+	void draw_multiline_string(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = Font::DEFAULT_FONT_SIZE, int p_max_lines = -1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::LineBreakFlag> p_brk_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
 
-	void draw_string_outline(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = Font::DEFAULT_FONT_SIZE, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
-	void draw_multiline_string_outline(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = Font::DEFAULT_FONT_SIZE, int p_max_lines = -1, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::LineBreakFlag> p_brk_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
+	void draw_string_outline(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = Font::DEFAULT_FONT_SIZE, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
+	void draw_multiline_string_outline(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = Font::DEFAULT_FONT_SIZE, int p_max_lines = -1, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::LineBreakFlag> p_brk_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
 
-	void draw_char(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, int p_font_size = Font::DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1.0, 1.0, 1.0), float p_oversampling = 0.0) const;
-	void draw_char_outline(const Ref<Font> &p_font, const Point2 &p_pos, const String &p_char, int p_font_size = Font::DEFAULT_FONT_SIZE, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), float p_oversampling = 0.0) const;
+	void draw_char(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_char, int p_font_size = Font::DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1.0, 1.0, 1.0), float p_oversampling = 0.0) const;
+	void draw_char_outline(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_char, int p_font_size = Font::DEFAULT_FONT_SIZE, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), float p_oversampling = 0.0) const;
 
 	void draw_set_transform(const Point2 &p_offset, real_t p_rot = 0.0, const Size2 &p_scale = Size2(1.0, 1.0));
 	void draw_set_transform_matrix(const Transform2D &p_matrix);
@@ -387,7 +387,7 @@ public:
 	virtual void set_use_parent_material(bool p_use_parent_material);
 	bool get_use_parent_material() const;
 
-	Ref<InputEvent> make_input_local(const Ref<InputEvent> &p_event) const;
+	RequiredResult<InputEvent> make_input_local(RequiredParam<InputEvent> p_event) const;
 	Vector2 make_canvas_position_local(const Vector2 &screen_point) const;
 
 	Vector2 get_global_mouse_position() const;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -494,9 +494,9 @@ void Node::_propagate_physics_interpolation_reset_requested(bool p_requested) {
 	data.blocked--;
 }
 
-void Node::move_child(Node *p_child, int p_index) {
+void Node::move_child(RequiredParam<Node> rp_child, int p_index) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Moving child node positions inside the SceneTree is only allowed from the main thread. Use call_deferred(\"move_child\",child,index).");
-	ERR_FAIL_NULL(p_child);
+	EXTRACT_PARAM_OR_FAIL(p_child, rp_child);
 	ERR_FAIL_COND_MSG(p_child->data.parent != this, "Child is not a child of this node.");
 
 	_update_children_cache();
@@ -1720,9 +1720,9 @@ void Node::add_child(RequiredParam<Node> rp_child, bool p_force_readable_name, I
 	_add_child_nocheck(p_child, p_child->data.name, p_internal);
 }
 
-void Node::add_sibling(Node *p_sibling, bool p_force_readable_name) {
+void Node::add_sibling(RequiredParam<Node> rp_sibling, bool p_force_readable_name) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Adding a sibling to a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"add_sibling\",node).");
-	ERR_FAIL_NULL(p_sibling);
+	EXTRACT_PARAM_OR_FAIL(p_sibling, rp_sibling);
 	ERR_FAIL_COND_MSG(p_sibling == this, vformat("Can't add sibling '%s' to itself.", p_sibling->get_name())); // adding to itself!
 	ERR_FAIL_NULL(data.parent);
 	ERR_FAIL_COND_MSG(data.parent->data.blocked > 0, "Parent node is busy setting up children, `add_sibling()` failed. Consider using `add_sibling.call_deferred(sibling)` instead.");
@@ -1732,9 +1732,9 @@ void Node::add_sibling(Node *p_sibling, bool p_force_readable_name) {
 	data.parent->_move_child(p_sibling, get_index() + 1);
 }
 
-void Node::remove_child(Node *p_child) {
+void Node::remove_child(RequiredParam<Node> rp_child) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Removing children from a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"remove_child\",node).");
-	ERR_FAIL_NULL(p_child);
+	EXTRACT_PARAM_OR_FAIL(p_child, rp_child);
 	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy adding/removing children, `remove_child()` can't be called at this time. Consider using `remove_child.call_deferred(child)` instead.");
 	ERR_FAIL_COND(p_child->data.parent != this);
 
@@ -2039,9 +2039,9 @@ TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_ty
 	return ret;
 }
 
-void Node::reparent(Node *p_parent, bool p_keep_global_transform) {
+void Node::reparent(RequiredParam<Node> rp_parent, bool p_keep_global_transform) {
 	ERR_THREAD_GUARD
-	ERR_FAIL_NULL(p_parent);
+	EXTRACT_PARAM_OR_FAIL(p_parent, rp_parent);
 	ERR_FAIL_NULL_MSG(data.parent, "Node needs a parent to be reparented.");
 	ERR_FAIL_COND_MSG(p_parent == this, vformat("Can't reparent '%s' to itself.", p_parent->get_name()));
 
@@ -2136,8 +2136,8 @@ Window *Node::get_last_exclusive_window() const {
 	return w;
 }
 
-bool Node::is_ancestor_of(const Node *p_node) const {
-	ERR_FAIL_NULL_V(p_node, false);
+bool Node::is_ancestor_of(RequiredParam<const Node> rp_node) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, false);
 	Node *p = p_node->data.parent;
 	while (p) {
 		if (p == this) {
@@ -2149,10 +2149,10 @@ bool Node::is_ancestor_of(const Node *p_node) const {
 	return false;
 }
 
-bool Node::is_greater_than(const Node *p_node) const {
+bool Node::is_greater_than(RequiredParam<const Node> rp_node) const {
 	// parent->get_child(1) > parent->get_child(0) > parent
 
-	ERR_FAIL_NULL_V(p_node, false);
+	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, false);
 	ERR_FAIL_COND_V(!data.tree, false);
 	ERR_FAIL_COND_V(p_node->data.tree != data.tree, false);
 
@@ -2326,8 +2326,8 @@ Node *Node::find_common_parent_with(const Node *p_node) const {
 	return const_cast<Node *>(common_parent);
 }
 
-NodePath Node::get_path_to(const Node *p_node, bool p_use_unique_path) const {
-	ERR_FAIL_NULL_V(p_node, NodePath());
+NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_path) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, NodePath());
 
 	if (this == p_node) {
 		return NodePath(".");
@@ -2673,9 +2673,9 @@ String Node::get_editor_description() const {
 	return data.editor_description;
 }
 
-void Node::set_editable_instance(Node *p_node, bool p_editable) {
+void Node::set_editable_instance(RequiredParam<Node> rp_node, bool p_editable) {
 	ERR_THREAD_GUARD
-	ERR_FAIL_NULL(p_node);
+	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	ERR_FAIL_COND(!is_ancestor_of(p_node));
 	if (!p_editable) {
 		p_node->data.editable_instance = false;
@@ -2689,10 +2689,8 @@ void Node::set_editable_instance(Node *p_node, bool p_editable) {
 	p_node->_emit_editor_state_changed();
 }
 
-bool Node::is_editable_instance(const Node *p_node) const {
-	if (!p_node) {
-		return false; // Easier, null is never editable. :)
-	}
+bool Node::is_editable_instance(RequiredParam<const Node> rp_node) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, false);
 	ERR_FAIL_COND_V(!is_ancestor_of(p_node), false);
 	return p_node->data.editable_instance;
 }
@@ -3187,9 +3185,9 @@ static void find_owned_by(Node *p_by, Node *p_node, List<Node *> *p_owned) {
 	}
 }
 
-void Node::replace_by(Node *p_node, bool p_keep_groups) {
+void Node::replace_by(RequiredParam<Node> rp_node, bool p_keep_groups) {
 	ERR_THREAD_GUARD
-	ERR_FAIL_NULL(p_node);
+	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	ERR_FAIL_COND(p_node->data.parent);
 
 	List<Node *> owned = data.owned;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -432,10 +432,10 @@ protected:
 	GDVIRTUAL0RC(Vector<String>, _get_accessibility_configuration_warnings)
 	GDVIRTUAL0RC(Vector<String>, _get_configuration_warnings)
 
-	GDVIRTUAL1(_input, Ref<InputEvent>)
-	GDVIRTUAL1(_shortcut_input, Ref<InputEvent>)
-	GDVIRTUAL1(_unhandled_input, Ref<InputEvent>)
-	GDVIRTUAL1(_unhandled_key_input, Ref<InputEvent>)
+	GDVIRTUAL1(_input, RequiredParam<InputEvent>)
+	GDVIRTUAL1(_shortcut_input, RequiredParam<InputEvent>)
+	GDVIRTUAL1(_unhandled_input, RequiredParam<InputEvent>)
+	GDVIRTUAL1(_unhandled_key_input, RequiredParam<InputEvent>)
 
 	GDVIRTUAL0RC(RID, _get_focused_accessibility_element)
 
@@ -513,8 +513,8 @@ public:
 	InternalMode get_internal_mode() const;
 
 	void add_child(RequiredParam<Node> rp_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
-	void add_sibling(Node *p_sibling, bool p_force_readable_name = false);
-	void remove_child(Node *p_child);
+	void add_sibling(RequiredParam<Node> rp_sibling, bool p_force_readable_name = false);
+	void remove_child(RequiredParam<Node> rp_child);
 
 	/// Optimal way to iterate the children of this node.
 	/// The caller is responsible to ensure:
@@ -534,7 +534,7 @@ public:
 	bool has_node_and_resource(const NodePath &p_path) const;
 	Node *get_node_and_resource(const NodePath &p_path, Ref<Resource> &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property = true) const;
 
-	virtual void reparent(Node *p_parent, bool p_keep_global_transform = true);
+	virtual void reparent(RequiredParam<Node> p_parent, bool p_keep_global_transform = true);
 	Node *get_parent() const;
 	Node *find_parent(const String &p_pattern) const;
 
@@ -553,11 +553,11 @@ public:
 	_FORCE_INLINE_ bool is_inside_tree() const { return data.tree; }
 	bool is_internal() const { return data.internal_mode != INTERNAL_MODE_DISABLED; }
 
-	bool is_ancestor_of(const Node *p_node) const;
-	bool is_greater_than(const Node *p_node) const;
+	bool is_ancestor_of(RequiredParam<const Node> p_node) const;
+	bool is_greater_than(RequiredParam<const Node> p_node) const;
 
 	NodePath get_path() const;
-	NodePath get_path_to(const Node *p_node, bool p_use_unique_path = false) const;
+	NodePath get_path_to(RequiredParam<const Node> p_node, bool p_use_unique_path = false) const;
 	Node *find_common_parent_with(const Node *p_node) const;
 
 	void add_to_group(const StringName &p_identifier, bool p_persistent = false);
@@ -572,7 +572,7 @@ public:
 	void get_groups(List<GroupInfo> *p_groups) const;
 	int get_persistent_group_count() const;
 
-	void move_child(Node *p_child, int p_index);
+	void move_child(RequiredParam<Node> p_child, int p_index);
 	void _move_child(Node *p_child, int p_index, bool p_ignore_end = false);
 
 	void set_owner(Node *p_owner);
@@ -621,8 +621,8 @@ public:
 	void set_editor_description(const String &p_editor_description);
 	String get_editor_description() const;
 
-	void set_editable_instance(Node *p_node, bool p_editable);
-	bool is_editable_instance(const Node *p_node) const;
+	void set_editable_instance(RequiredParam<Node> p_node, bool p_editable);
+	bool is_editable_instance(RequiredParam<const Node> p_node) const;
 	Node *get_deepest_editable_node(Node *p_start_node) const;
 
 #ifdef TOOLS_ENABLED
@@ -742,7 +742,7 @@ public:
 		return binds;
 	}
 
-	void replace_by(Node *p_node, bool p_keep_groups = false);
+	void replace_by(RequiredParam<Node> p_node, bool p_keep_groups = false);
 
 	void set_process_mode(ProcessMode p_mode);
 	ProcessMode get_process_mode() const;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1609,9 +1609,9 @@ void SceneTree::_flush_delete_queue() {
 	}
 }
 
-void SceneTree::queue_delete(Object *p_object) {
+void SceneTree::queue_delete(RequiredParam<Object> rp_object) {
 	_THREAD_SAFE_METHOD_
-	ERR_FAIL_NULL(p_object);
+	EXTRACT_PARAM_OR_FAIL(p_object, rp_object);
 	p_object->_is_queued_for_deletion = true;
 	delete_queue.push_back(p_object->get_instance_id());
 }
@@ -1684,8 +1684,8 @@ Error SceneTree::change_scene_to_file(const String &p_path) {
 	return change_scene_to_packed(new_scene);
 }
 
-Error SceneTree::change_scene_to_packed(const Ref<PackedScene> &p_scene) {
-	ERR_FAIL_COND_V_MSG(p_scene.is_null(), ERR_INVALID_PARAMETER, "Can't change to a null scene. Use unload_current_scene() if you wish to unload it.");
+Error SceneTree::change_scene_to_packed(RequiredParam<PackedScene> rp_scene) {
+	EXTRACT_PARAM_OR_FAIL_V_MSG(p_scene, rp_scene, ERR_INVALID_PARAMETER, "Can't change to a null scene. Use unload_current_scene() if you wish to unload it.");
 
 	Node *new_scene = p_scene->instantiate();
 	ERR_FAIL_NULL_V(new_scene, ERR_CANT_CREATE);
@@ -1693,8 +1693,8 @@ Error SceneTree::change_scene_to_packed(const Ref<PackedScene> &p_scene) {
 	return change_scene_to_node(new_scene);
 }
 
-Error SceneTree::change_scene_to_node(Node *p_node) {
-	ERR_FAIL_NULL_V_MSG(p_node, ERR_INVALID_PARAMETER, "Can't change to a null node. Use unload_current_scene() if you wish to unload it.");
+Error SceneTree::change_scene_to_node(RequiredParam<Node> rp_node) {
+	EXTRACT_PARAM_OR_FAIL_V_MSG(p_node, rp_node, ERR_INVALID_PARAMETER, "Can't change to a null node. Use unload_current_scene() if you wish to unload it.");
 	ERR_FAIL_COND_V_MSG(p_node->is_inside_tree(), ERR_UNCONFIGURED, "The new scene node can't already be inside scene tree.");
 
 	// If called again while a change is pending.
@@ -1739,7 +1739,7 @@ void SceneTree::add_current_scene(Node *p_current) {
 	root->add_child(p_current);
 }
 
-Ref<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, bool p_process_always, bool p_process_in_physics, bool p_ignore_time_scale) {
+RequiredResult<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, bool p_process_always, bool p_process_in_physics, bool p_ignore_time_scale) {
 	_THREAD_SAFE_METHOD_
 	Ref<SceneTreeTimer> stt;
 	stt.instantiate();

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -407,7 +407,7 @@ public:
 
 	int get_node_count() const;
 
-	void queue_delete(Object *p_object);
+	void queue_delete(RequiredParam<Object> p_object);
 
 	Vector<Node *> get_nodes_in_group(const StringName &p_group);
 	Node *get_first_node_in_group(const StringName &p_group);
@@ -423,12 +423,12 @@ public:
 	void set_current_scene(Node *p_scene);
 	Node *get_current_scene() const;
 	Error change_scene_to_file(const String &p_path);
-	Error change_scene_to_packed(const Ref<PackedScene> &p_scene);
-	Error change_scene_to_node(Node *p_node);
+	Error change_scene_to_packed(RequiredParam<PackedScene> p_scene);
+	Error change_scene_to_node(RequiredParam<Node> p_node);
 	Error reload_current_scene();
 	void unload_current_scene();
 
-	Ref<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false);
+	RequiredResult<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false);
 	RequiredResult<Tween> create_tween();
 	void remove_tween(const Ref<Tween> &p_tween);
 	TypedArray<Tween> get_processed_tweens();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3453,10 +3453,10 @@ void Viewport::_drop_mouse_over(Control *p_until_control) {
 	gui.sending_mouse_enter_exit_notifications = false;
 }
 
-void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
+void Viewport::push_input(RequiredParam<InputEvent> rp_event, bool p_local_coords) {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_COND(!is_inside_tree());
-	ERR_FAIL_COND(p_event.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_event, rp_event);
 
 	if (disable_input || disable_input_override) {
 		return;
@@ -3522,11 +3522,11 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 }
 
 #ifndef DISABLE_DEPRECATED
-void Viewport::push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
+void Viewport::push_unhandled_input(RequiredParam<InputEvent> rp_event, bool p_local_coords) {
 	ERR_MAIN_THREAD_GUARD;
 	WARN_DEPRECATED_MSG(R"*(The "push_unhandled_input()" method is deprecated, use "push_input()" instead.)*");
 	ERR_FAIL_COND(!is_inside_tree());
-	ERR_FAIL_COND(p_event.is_null());
+	EXTRACT_PARAM_OR_FAIL(p_event, rp_event);
 
 	local_input_handled = false;
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -609,9 +609,9 @@ public:
 	Vector2 get_camera_rect_size() const;
 
 	void push_text_input(const String &p_text);
-	void push_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
+	void push_input(RequiredParam<InputEvent> p_event, bool p_local_coords = false);
 #ifndef DISABLE_DEPRECATED
-	void push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
+	void push_unhandled_input(RequiredParam<InputEvent> p_event, bool p_local_coords = false);
 #endif // DISABLE_DEPRECATED
 	void notify_mouse_entered();
 	void notify_mouse_exited();

--- a/scene/resources/2d/shape_2d.cpp
+++ b/scene/resources/2d/shape_2d.cpp
@@ -46,20 +46,20 @@ real_t Shape2D::get_custom_solver_bias() const {
 	return custom_bias;
 }
 
-bool Shape2D::collide_with_motion(const Transform2D &p_local_xform, const Vector2 &p_local_motion, const Ref<Shape2D> &p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion) {
-	ERR_FAIL_COND_V(p_shape.is_null(), false);
+bool Shape2D::collide_with_motion(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape, rp_shape, false);
 	int r;
 	return PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, p_local_motion, p_shape->get_rid(), p_shape_xform, p_shape_motion, nullptr, 0, r);
 }
 
-bool Shape2D::collide(const Transform2D &p_local_xform, const Ref<Shape2D> &p_shape, const Transform2D &p_shape_xform) {
-	ERR_FAIL_COND_V(p_shape.is_null(), false);
+bool Shape2D::collide(const Transform2D &p_local_xform, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape, rp_shape, false);
 	int r;
 	return PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, Vector2(), p_shape->get_rid(), p_shape_xform, Vector2(), nullptr, 0, r);
 }
 
-PackedVector2Array Shape2D::collide_with_motion_and_get_contacts(const Transform2D &p_local_xform, const Vector2 &p_local_motion, const Ref<Shape2D> &p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion) {
-	ERR_FAIL_COND_V(p_shape.is_null(), PackedVector2Array());
+PackedVector2Array Shape2D::collide_with_motion_and_get_contacts(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape, rp_shape, PackedVector2Array());
 	const int max_contacts = 16;
 	Vector2 result[max_contacts * 2];
 	int contacts = 0;
@@ -77,8 +77,8 @@ PackedVector2Array Shape2D::collide_with_motion_and_get_contacts(const Transform
 	return results;
 }
 
-PackedVector2Array Shape2D::collide_and_get_contacts(const Transform2D &p_local_xform, const Ref<Shape2D> &p_shape, const Transform2D &p_shape_xform) {
-	ERR_FAIL_COND_V(p_shape.is_null(), PackedVector2Array());
+PackedVector2Array Shape2D::collide_and_get_contacts(const Transform2D &p_local_xform, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape, rp_shape, PackedVector2Array());
 	const int max_contacts = 16;
 	Vector2 result[max_contacts * 2];
 	int contacts = 0;

--- a/scene/resources/2d/shape_2d.h
+++ b/scene/resources/2d/shape_2d.h
@@ -49,11 +49,11 @@ public:
 	void set_custom_solver_bias(real_t p_bias);
 	real_t get_custom_solver_bias() const;
 
-	bool collide_with_motion(const Transform2D &p_local_xform, const Vector2 &p_local_motion, const Ref<Shape2D> &p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion);
-	bool collide(const Transform2D &p_local_xform, const Ref<Shape2D> &p_shape, const Transform2D &p_shape_xform);
+	bool collide_with_motion(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion);
+	bool collide(const Transform2D &p_local_xform, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform);
 
-	PackedVector2Array collide_with_motion_and_get_contacts(const Transform2D &p_local_xform, const Vector2 &p_local_motion, const Ref<Shape2D> &p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion);
-	PackedVector2Array collide_and_get_contacts(const Transform2D &p_local_xform, const Ref<Shape2D> &p_shape, const Transform2D &p_shape_xform);
+	PackedVector2Array collide_with_motion_and_get_contacts(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion);
+	PackedVector2Array collide_and_get_contacts(const Transform2D &p_local_xform, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform);
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) {}
 	virtual Rect2 get_rect() const { return Rect2(); }

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -336,8 +336,8 @@ void PhysicsShapeQueryParameters2D::_bind_methods() {
 
 ///////////////////////////////////////////////////////
 
-Dictionary PhysicsDirectSpaceState2D::_intersect_ray(const Ref<PhysicsRayQueryParameters2D> &p_ray_query) {
-	ERR_FAIL_COND_V(p_ray_query.is_null(), Dictionary());
+Dictionary PhysicsDirectSpaceState2D::_intersect_ray(RequiredParam<PhysicsRayQueryParameters2D> rp_ray_query) {
+	EXTRACT_PARAM_OR_FAIL_V(p_ray_query, rp_ray_query, Dictionary());
 
 	RayResult result;
 	bool res = intersect_ray(p_ray_query->get_parameters(), result);
@@ -357,8 +357,8 @@ Dictionary PhysicsDirectSpaceState2D::_intersect_ray(const Ref<PhysicsRayQueryPa
 	return d;
 }
 
-TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_point(const Ref<PhysicsPointQueryParameters2D> &p_point_query, int p_max_results) {
-	ERR_FAIL_COND_V(p_point_query.is_null(), Array());
+TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_point(RequiredParam<PhysicsPointQueryParameters2D> rp_point_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_point_query, rp_point_query, TypedArray<Dictionary>());
 
 	Vector<ShapeResult> ret;
 	ret.resize(p_max_results);
@@ -382,8 +382,8 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_point(const Ref<Phy
 	return r;
 }
 
-TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(p_shape_query.is_null(), TypedArray<Dictionary>());
+TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Dictionary>());
 
 	Vector<ShapeResult> sr;
 	sr.resize(p_max_results);
@@ -402,8 +402,8 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(const Ref<Phy
 	return ret;
 }
 
-Vector<real_t> PhysicsDirectSpaceState2D::_cast_motion(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query) {
-	ERR_FAIL_COND_V(p_shape_query.is_null(), Vector<real_t>());
+Vector<real_t> PhysicsDirectSpaceState2D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, Vector<real_t>());
 
 	real_t closest_safe, closest_unsafe;
 	bool res = cast_motion(p_shape_query->get_parameters(), closest_safe, closest_unsafe);
@@ -417,8 +417,8 @@ Vector<real_t> PhysicsDirectSpaceState2D::_cast_motion(const Ref<PhysicsShapeQue
 	return ret;
 }
 
-TypedArray<Vector2> PhysicsDirectSpaceState2D::_collide_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(p_shape_query.is_null(), TypedArray<Vector2>());
+TypedArray<Vector2> PhysicsDirectSpaceState2D::_collide_shape(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Vector2>());
 
 	Vector<Vector2> ret;
 	ret.resize(p_max_results * 2);
@@ -435,8 +435,8 @@ TypedArray<Vector2> PhysicsDirectSpaceState2D::_collide_shape(const Ref<PhysicsS
 	return r;
 }
 
-Dictionary PhysicsDirectSpaceState2D::_get_rest_info(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query) {
-	ERR_FAIL_COND_V(p_shape_query.is_null(), Dictionary());
+Dictionary PhysicsDirectSpaceState2D::_get_rest_info(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, Dictionary());
 
 	ShapeRestInfo sri;
 
@@ -613,8 +613,8 @@ void PhysicsTestMotionResult2D::_bind_methods() {
 
 ///////////////////////////////////////
 
-bool PhysicsServer2D::_body_test_motion(RID p_body, const Ref<PhysicsTestMotionParameters2D> &p_parameters, const Ref<PhysicsTestMotionResult2D> &p_result) {
-	ERR_FAIL_COND_V(p_parameters.is_null(), false);
+bool PhysicsServer2D::_body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters2D> rp_parameters, const Ref<PhysicsTestMotionResult2D> &p_result) {
+	EXTRACT_PARAM_OR_FAIL_V(p_parameters, rp_parameters, false);
 
 	MotionResult *result_ptr = nullptr;
 	if (p_result.is_valid()) {

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -112,7 +112,7 @@ public:
 	virtual real_t get_step() const = 0;
 	virtual void integrate_forces();
 
-	virtual PhysicsDirectSpaceState2D *get_space_state() = 0;
+	virtual RequiredResult<PhysicsDirectSpaceState2D> get_space_state() = 0;
 
 	PhysicsDirectBodyState2D();
 };
@@ -124,12 +124,12 @@ class PhysicsShapeQueryParameters2D;
 class PhysicsDirectSpaceState2D : public Object {
 	GDCLASS(PhysicsDirectSpaceState2D, Object);
 
-	Dictionary _intersect_ray(const Ref<PhysicsRayQueryParameters2D> &p_ray_query);
-	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters2D> &p_point_query, int p_max_results = 32);
-	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32);
-	Vector<real_t> _cast_motion(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query);
-	TypedArray<Vector2> _collide_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32);
-	Dictionary _get_rest_info(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query);
+	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters2D> p_ray_query);
+	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters2D> p_point_query, int p_max_results = 32);
+	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query, int p_max_results = 32);
+	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query);
+	TypedArray<Vector2> _collide_shape(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query, int p_max_results = 32);
+	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query);
 
 protected:
 	static void _bind_methods();
@@ -216,7 +216,7 @@ class PhysicsServer2D : public Object {
 
 	static PhysicsServer2D *singleton;
 
-	virtual bool _body_test_motion(RID p_body, const Ref<PhysicsTestMotionParameters2D> &p_parameters, const Ref<PhysicsTestMotionResult2D> &p_result = Ref<PhysicsTestMotionResult2D>());
+	virtual bool _body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters2D> p_parameters, const Ref<PhysicsTestMotionResult2D> &p_result = Ref<PhysicsTestMotionResult2D>());
 
 protected:
 	static void _bind_methods();

--- a/servers/physics_2d/physics_server_2d_dummy.h
+++ b/servers/physics_2d/physics_server_2d_dummy.h
@@ -103,7 +103,7 @@ public:
 	virtual real_t get_step() const override { return 0; }
 	virtual void integrate_forces() override {}
 
-	virtual PhysicsDirectSpaceState2D *get_space_state() override { return space_state_dummy; }
+	virtual RequiredResult<PhysicsDirectSpaceState2D> get_space_state() override { return space_state_dummy; }
 
 	PhysicsDirectBodyState2DDummy(PhysicsDirectSpaceState2D *p_space_state_dummy) {
 		space_state_dummy = p_space_state_dummy;

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -109,7 +109,7 @@ public:
 	EXBIND0RC(real_t, get_step)
 	EXBIND0(integrate_forces)
 
-	EXBIND0R(PhysicsDirectSpaceState2D *, get_space_state)
+	EXBIND0R(RequiredResult<PhysicsDirectSpaceState2D>, get_space_state)
 
 	PhysicsDirectBodyState2DExtension();
 };

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -360,8 +360,8 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 
 /////////////////////////////////////
 
-Dictionary PhysicsDirectSpaceState3D::_intersect_ray(const Ref<PhysicsRayQueryParameters3D> &p_ray_query) {
-	ERR_FAIL_COND_V(p_ray_query.is_null(), Dictionary());
+Dictionary PhysicsDirectSpaceState3D::_intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query) {
+	EXTRACT_PARAM_OR_FAIL_V(p_ray_query, rp_ray_query, Dictionary());
 
 	RayResult result;
 	bool res = intersect_ray(p_ray_query->get_parameters(), result);
@@ -382,8 +382,8 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(const Ref<PhysicsRayQueryPa
 	return d;
 }
 
-TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results) {
-	ERR_FAIL_COND_V(p_point_query.is_null(), TypedArray<Dictionary>());
+TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(RequiredParam<PhysicsPointQueryParameters3D> rp_point_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_point_query, rp_point_query, TypedArray<Dictionary>());
 
 	Vector<ShapeResult> ret;
 	ret.resize(p_max_results);
@@ -407,8 +407,8 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(const Ref<Phy
 	return r;
 }
 
-TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(p_shape_query.is_null(), TypedArray<Dictionary>());
+TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Dictionary>());
 
 	Vector<ShapeResult> sr;
 	sr.resize(p_max_results);
@@ -427,8 +427,8 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(const Ref<Phy
 	return ret;
 }
 
-Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query) {
-	ERR_FAIL_COND_V(p_shape_query.is_null(), Vector<real_t>());
+Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, Vector<real_t>());
 
 	real_t closest_safe = 1.0f, closest_unsafe = 1.0f;
 	bool res = cast_motion(p_shape_query->get_parameters(), closest_safe, closest_unsafe);
@@ -442,8 +442,8 @@ Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(const Ref<PhysicsShapeQue
 	return ret;
 }
 
-TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(p_shape_query.is_null(), TypedArray<Vector3>());
+TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Vector3>());
 
 	Vector<Vector3> ret;
 	ret.resize(p_max_results * 2);
@@ -460,8 +460,8 @@ TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsS
 	return r;
 }
 
-Dictionary PhysicsDirectSpaceState3D::_get_rest_info(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query) {
-	ERR_FAIL_COND_V(p_shape_query.is_null(), Dictionary());
+Dictionary PhysicsDirectSpaceState3D::_get_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query) {
+	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, Dictionary());
 
 	ShapeRestInfo sri;
 
@@ -656,8 +656,8 @@ void PhysicsTestMotionResult3D::_bind_methods() {
 
 ///////////////////////////////////////
 
-bool PhysicsServer3D::_body_test_motion(RID p_body, const Ref<PhysicsTestMotionParameters3D> &p_parameters, const Ref<PhysicsTestMotionResult3D> &p_result) {
-	ERR_FAIL_COND_V(p_parameters.is_null(), false);
+bool PhysicsServer3D::_body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters3D> rp_parameters, const Ref<PhysicsTestMotionResult3D> &p_result) {
+	EXTRACT_PARAM_OR_FAIL_V(p_parameters, rp_parameters, false);
 
 	MotionResult *result_ptr = nullptr;
 	if (p_result.is_valid()) {

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -113,7 +113,7 @@ public:
 	virtual real_t get_step() const = 0;
 	virtual void integrate_forces();
 
-	virtual PhysicsDirectSpaceState3D *get_space_state() = 0;
+	virtual RequiredResult<PhysicsDirectSpaceState3D> get_space_state() = 0;
 
 	PhysicsDirectBodyState3D();
 };
@@ -126,12 +126,12 @@ class PhysicsDirectSpaceState3D : public Object {
 	GDCLASS(PhysicsDirectSpaceState3D, Object);
 
 private:
-	Dictionary _intersect_ray(const Ref<PhysicsRayQueryParameters3D> &p_ray_query);
-	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results = 32);
-	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
-	Vector<real_t> _cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
-	TypedArray<Vector3> _collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
-	Dictionary _get_rest_info(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
+	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> p_ray_query);
+	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters3D> p_point_query, int p_max_results = 32);
+	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results = 32);
+	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query);
+	TypedArray<Vector3> _collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results = 32);
+	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query);
 
 protected:
 	static void _bind_methods();
@@ -238,7 +238,7 @@ class PhysicsServer3D : public Object {
 
 	static PhysicsServer3D *singleton;
 
-	virtual bool _body_test_motion(RID p_body, const Ref<PhysicsTestMotionParameters3D> &p_parameters, const Ref<PhysicsTestMotionResult3D> &p_result = Ref<PhysicsTestMotionResult3D>());
+	virtual bool _body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters3D> p_parameters, const Ref<PhysicsTestMotionResult3D> &p_result = Ref<PhysicsTestMotionResult3D>());
 
 protected:
 	static void _bind_methods();
@@ -576,7 +576,7 @@ public:
 
 	virtual RID soft_body_create() = 0;
 
-	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) = 0;
+	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) = 0;
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) = 0;
 	virtual RID soft_body_get_space(RID p_body) const = 0;

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -105,7 +105,7 @@ public:
 	virtual real_t get_step() const override { return 0; }
 	virtual void integrate_forces() override {}
 
-	virtual PhysicsDirectSpaceState3D *get_space_state() override { return space_state_dummy; }
+	virtual RequiredResult<PhysicsDirectSpaceState3D> get_space_state() override { return space_state_dummy; }
 
 	PhysicsDirectBodyState3DDummy(PhysicsDirectSpaceState3D *p_space_state_dummy) {
 		space_state_dummy = p_space_state_dummy;
@@ -312,7 +312,7 @@ public:
 
 	virtual RID soft_body_create() override { return RID(); }
 
-	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) override {}
+	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) override {}
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) override {}
 	virtual RID soft_body_get_space(RID p_body) const override { return RID(); }

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -111,7 +111,7 @@ public:
 	EXBIND0RC(real_t, get_step)
 
 	EXBIND0(integrate_forces)
-	EXBIND0R(PhysicsDirectSpaceState3D *, get_space_state)
+	EXBIND0R(RequiredResult<PhysicsDirectSpaceState3D>, get_space_state)
 
 	PhysicsDirectBodyState3DExtension();
 };
@@ -411,7 +411,7 @@ public:
 
 	EXBIND0R(RID, soft_body_create)
 
-	EXBIND2(soft_body_update_rendering_server, RID, PhysicsServer3DRenderingServerHandler *)
+	EXBIND2(soft_body_update_rendering_server, RID, RequiredParam<PhysicsServer3DRenderingServerHandler>)
 
 	EXBIND2(soft_body_set_space, RID, RID)
 	EXBIND1RC(RID, soft_body_get_space, RID)

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -286,7 +286,7 @@ public:
 
 	FUNCRID(soft_body)
 
-	FUNC2(soft_body_update_rendering_server, RID, PhysicsServer3DRenderingServerHandler *)
+	FUNC2(soft_body_update_rendering_server, RID, RequiredParam<PhysicsServer3DRenderingServerHandler>)
 
 	FUNC2(soft_body_set_space, RID, RID)
 	FUNC1RC(RID, soft_body_get_space, RID)

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -620,4 +620,17 @@ TEST_CASE("[Object] RequiredParam Ref<T>") {
 	CHECK_EQ(ref->get_reference_count(), extract->get_reference_count());
 }
 
+TEST_CASE("[Object] RequiredResult") {
+	Ref<RefCounted> ref;
+	ref.instantiate();
+
+	RequiredResult<RefCounted> required = ref;
+
+	Ref<RefCounted> unpacked = required;
+	Variant var = Ref<RefCounted>(required);
+
+	CHECK_EQ(ref, unpacked);
+	CHECK_EQ(ref, var);
+}
+
 } // namespace TestObject

--- a/tests/scene/test_split_container.h
+++ b/tests/scene/test_split_container.h
@@ -1783,7 +1783,7 @@ TEST_CASE("[SceneTree][SplitContainer] More children") {
 
 	SUBCASE("[SplitContainer] Duplicate") {
 		// Make sure dynamically added internal draggers duplicate properly.
-		SplitContainer *duplicate = (SplitContainer *)split_container->duplicate();
+		SplitContainer *duplicate = (SplitContainer *)(Node *)split_container->duplicate();
 		MessageQueue::get_singleton()->flush();
 		CHECK(duplicate->get_child_count(false) == split_container->get_child_count(false));
 		CHECK(duplicate->get_child_count(true) == split_container->get_child_count(true));

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -291,7 +291,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 
 	SUBCASE("[Viewport][GuiInputEvent] nullptr as argument doesn't lead to a crash.") {
 		ERR_PRINT_OFF;
-		root->push_input(nullptr);
+		root->push_input(Ref<InputEvent>());
 		ERR_PRINT_ON;
 	}
 


### PR DESCRIPTION
Now that https://github.com/godotengine/godot/pull/86079 is merged, we've got to mark some more things as required!

Since we don't have too much time before the feature freeze, the goal of this PR is to try and mark the things that would provide the highest value to developers (and we'll get everything else later for Godot 4.7).

Which things are high value is guided by some crowd-sourced feedback that @Bromeon got from the Godot Rust community (see [spreadsheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vRJU5bsFRjzEJeL-HmHqJP0C9Oj0Sj-A5f1mcY2vxusAcfRBO-OaVYxAoRJ9q5cx8uEUJj9y1vh8ZP_/pubhtml)) and some notes from @migueldeicaza with regard to SwiftGodot.

I've focused on these areas:

- The classes high-up in the hierarchy (like `Node`, `Control`, `CanvasItem`, etc)
- Physics and Input (because they're used in most games)
- Tween (because it was called out by Rust developers)

Total number of things marked as required: **139** ([tracking spreadsheet](https://docs.google.com/spreadsheets/d/1DMB7hff-ybhdTkdFCPWDfuMUG7MQXCFtj2BW1hKRFwM/edit?usp=sharing))

~~**Marking this as DRAFT for now, because I'd still like to mark more stuff, but I'll take it out of DRAFT in 1-2 days.**~~

This is also a great opportunity to test `RequiredParam<T>` and `RequiredResult<T>` in more contexts, and see if we missed anything in their design.

It's already turn up a couple of things:

- Some changes are required for them to work in `GDVIRTUAL*()`. One of the changes is something I've wanted to do for a long time (use `PtrToArg<T>::encode()` to encode the arguments - doing this with a cast has bothered me for so long)
- ~~There is an "ambiguous overload for 'operator='" error for `Ref<T> v = RequiredResult<T>()` which I'm not sure how to fix - advice would be appreciated!~~ I have a solution for this now. I've removed the `operator Variant()` from `RequiredResult<T>` and added an internal helper method for the handful of situations when we need to generically convert from `RequiredResult<T>` to `Variant`