### PR TITLE
Remove `is_penetrated` check from IK as role overlap/excessive behavior

### DIFF
--- a/scene/3d/iterate_ik_3d.cpp
+++ b/scene/3d/iterate_ik_3d.cpp
@@ -522,10 +522,6 @@ void IterateIK3D::_process_joints(double p_delta, Skeleton3D *p_skeleton, Iterat
 	double distance_to_target_sq = INFINITY;
 	int iteration_count = 0;
 
-	if (p_setting->is_penetrated(p_destination)) {
-		return;
-	}
-
 	// To prevent oscillation, if it has been processed at least once and target was reached, abort iterating.
 	if (p_setting->simulated) {
 		distance_to_target_sq = p_setting->chain[p_setting->chain.size() - 1].distance_squared_to(p_destination);

--- a/scene/3d/iterate_ik_3d.h
+++ b/scene/3d/iterate_ik_3d.h
@@ -149,31 +149,6 @@ public:
 
 		bool simulated = false;
 
-		bool is_penetrated(const Vector3 &p_destination) {
-			bool ret = false;
-			Vector3 chain_dir = (chain[chain.size() - 1] - chain[0]).normalized();
-			bool is_straight = true;
-			for (uint32_t i = 1; i < chain.size() - 1; i++) {
-				Vector3 dir = (chain[i] - chain[0]).normalized();
-				if (!dir.is_equal_approx(chain_dir)) {
-					is_straight = false;
-					break;
-				}
-			}
-			if (is_straight) {
-				Vector3 to_target = (p_destination - chain[0]);
-				double proj = to_target.dot(chain_dir);
-				double total_length = 0;
-				for (uint32_t i = 0; i < solver_info_list.size(); i++) {
-					if (solver_info_list[i]) {
-						total_length += solver_info_list[i]->length;
-					}
-				}
-				ret = proj >= 0 && proj <= total_length && (to_target.normalized().is_equal_approx(chain_dir));
-			}
-			return ret;
-		}
-
 		// Make rotation as bone pose from chain coordinates.
 		// p_extra is delta angle limitation.
 		void cache_current_joint_rotations(Skeleton3D *p_skeleton, double p_angular_delta_limit = Math::PI) {


### PR DESCRIPTION
In the early implementation of IK, `angular_delta_limit` was not present, allowing rotations of up to 180 degrees always. In that case, it seemed preferable to have this for stability.

However, with the implementation of `angular_delta_limit` and [LimitAngularVelocityModifier3D](https://github.com/godotengine/godot/pull/111184), this check has become less important and is instead causing issues where calculations are not performed in reachable states (especially with FABRIK). Therefore, I will remove the `is_penetrated` check.

The following video shows the results under the same settings:

Before:

https://github.com/user-attachments/assets/66038dd2-1d82-4f96-a29f-53c610086582

After fix:

https://github.com/user-attachments/assets/0206272a-410d-4846-a7eb-8594bbac47c5


