### PR TITLE
Change `Node*D::reparent` to set its new transform before reparenting

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -143,13 +143,18 @@ void Node2D::_update_transform() {
 
 void Node2D::reparent(Node *p_parent, bool p_keep_global_transform) {
 	ERR_THREAD_GUARD;
+
 	if (p_keep_global_transform) {
-		Transform2D temp = get_global_transform();
-		Node::reparent(p_parent);
-		set_global_transform(temp);
-	} else {
-		Node::reparent(p_parent);
+		Transform2D new_local_transform = get_global_transform();
+		CanvasItem *new_parent = Object::cast_to<CanvasItem>(p_parent);
+		if (new_parent && !is_set_as_top_level()) {
+			new_local_transform = new_parent->get_global_transform().affine_inverse() * new_local_transform;
+		}
+
+		set_transform(new_local_transform);
 	}
+
+	Node::reparent(p_parent, p_keep_global_transform);
 }
 
 void Node2D::set_position(const Point2 &p_pos) {

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1022,13 +1022,18 @@ void Node3D::set_disable_gizmos(bool p_enabled) {
 
 void Node3D::reparent(Node *p_parent, bool p_keep_global_transform) {
 	ERR_THREAD_GUARD;
+
 	if (p_keep_global_transform) {
-		Transform3D temp = get_global_transform();
-		Node::reparent(p_parent, p_keep_global_transform);
-		set_global_transform(temp);
-	} else {
-		Node::reparent(p_parent, p_keep_global_transform);
+		Transform3D new_local_transform = get_global_transform();
+		Node3D *new_parent = Object::cast_to<Node3D>(p_parent);
+		if (new_parent && !is_set_as_top_level()) {
+			new_local_transform = new_parent->get_global_transform().affine_inverse() * new_local_transform;
+		}
+
+		set_transform(new_local_transform);
 	}
+
+	Node::reparent(p_parent, p_keep_global_transform);
 }
 
 void Node3D::set_disable_scale(bool p_enabled) {


### PR DESCRIPTION
Fixes #113058.

The current implementation of `Node*D::reparent`, when called with `keep_global_transform` at its default of `true`, does the following:

1. Cache the previous global transform.
2. Remove the node from its current parent, thus emitting `NOTIFICATION_EXIT_WORLD`.
3. Add the node to its new parent, thus emitting `NOTIFICATION_ENTER_WORLD`, but with a potentially new (incorrect) global transform, since the local transform is what's actually preserved in the transition.
4. Set the previous global transform again (and thus a new local transform).

This creates problems for nodes where the value of the global transform is important at the time of `NOTIFICATION_ENTER_WORLD`, like for example kinematic physics bodies, such as `CharacterBody3D`[^1].

This PR "fixes" that by changing `Node*D::reparent` to instead set the new local transform _before_ we do `remove_child`/`add_child`, so that the node already has the correct global transform by the time `add_child` is called.

This of course means that now we won't have the correct local/global transform when `NOTIFICATION_EXIT_WORLD`/`NOTIFICATION_EXIT_TREE` is emitted instead, so arguably just trades one bug for another, but I figured this might prompt some discussion for better a solution.

The proper solution to this (at least in my mind) would be to instead restore the previous global transform inbetween these two lines, as opposed to before/after them:

https://github.com/godotengine/godot/blob/7ed0b6167618f9c8c5df87c7e83da6003c081368/scene/main/node.cpp#L2077-L2078

... but I struggle to come up with a clean way of doing so.

[^1]: This seems to have "worked" with Godot Physics due to what to me looks like a bug in that implementation, but which is not present in the Jolt Physics implementation.