### PR TITLE
AudioServer to have function to access microphone buffer directly

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -124,11 +124,32 @@
 				Returns the name of the current audio driver. The default usually depends on the operating system, but may be overridden via the [code]--audio-driver[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url]. [code]--headless[/code] also automatically sets the audio driver to [code]Dummy[/code]. See also [member ProjectSettings.audio/driver/driver].
 			</description>
 		</method>
+		<method name="get_input_buffer_length_frames" experimental="">
+			<return type="int" />
+			<description>
+				Returns the absolute size of the microphone input buffer. This is set to a multiple of the audio latency and can be used to estimate the minimum rate at which the frames need to be fetched.
+			</description>
+		</method>
 		<method name="get_input_device_list">
 			<return type="PackedStringArray" />
 			<description>
 				Returns the names of all audio input devices detected on the system.
 				[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
+			</description>
+		</method>
+		<method name="get_input_frames" experimental="">
+			<return type="PackedVector2Array" />
+			<param index="0" name="frames" type="int" />
+			<description>
+				Returns a [PackedVector2Array] containing exactly [param frames] audio samples from the internal microphone buffer if available, otherwise returns an empty [PackedVector2Array].
+				The buffer is filled at the rate of [method get_input_mix_rate] frames per second when [method set_input_device_active] has successfully been set to [code]true[/code].
+				The samples are signed floating-point PCM values between [code]-1[/code] and [code]1[/code].
+			</description>
+		</method>
+		<method name="get_input_frames_available" experimental="">
+			<return type="int" />
+			<description>
+				Returns the number of frames available to read using [method get_input_frames].
 			</description>
 		</method>
 		<method name="get_input_mix_rate" qualifiers="const">
@@ -328,6 +349,14 @@
 			<description>
 				If set to [code]true[/code], all instances of [AudioStreamPlayback] will call [method AudioStreamPlayback._tag_used_streams] every mix step.
 				[b]Note:[/b] This is enabled by default in the editor, as it is used by editor plugins for the audio stream previews.
+			</description>
+		</method>
+		<method name="set_input_device_active" experimental="">
+			<return type="int" enum="Error" />
+			<param index="0" name="active" type="bool" />
+			<description>
+				If [param active] is [code]true[/code], starts the microphone input stream specified by [member input_device] or returns an error if it failed.
+				If [param active] is [code]false[/code], stops the input stream if it is running.
 			</description>
 		</method>
 		<method name="swap_bus_effects">

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -555,6 +555,8 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			}
 
 			// User selected a new input device, finish the current one so we'll init the new input device
+			// (If `AudioServer.set_input_device()` did not set the value when the microphone was running,
+			//  this section with its problematic error handling could be deleted.)
 			if (ad->input_device_name != ad->new_input_device) {
 				ad->input_device_name = ad->new_input_device;
 				ad->finish_input_device();
@@ -691,6 +693,10 @@ void AudioDriverPulseAudio::finish() {
 }
 
 Error AudioDriverPulseAudio::init_input_device() {
+	if (pa_rec_str) {
+		return ERR_ALREADY_IN_USE;
+	}
+
 	// If there is a specified input device, check that it is really present
 	if (input_device_name != "Default") {
 		PackedStringArray list = get_input_device_list();

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -542,6 +542,10 @@ Error AudioDriverWASAPI::init_output_device(bool p_reinit) {
 }
 
 Error AudioDriverWASAPI::init_input_device(bool p_reinit) {
+	if (audio_input.active.is_set()) {
+		return ERR_ALREADY_IN_USE;
+	}
+
 	Error err = audio_device_init(&audio_input, true, p_reinit);
 	if (err != OK) {
 		// We've tried to init the device, but have failed. Time to clean up.
@@ -1023,11 +1027,9 @@ Error AudioDriverWASAPI::input_stop() {
 	if (audio_input.active.is_set()) {
 		audio_input.audio_client->Stop();
 		audio_input.active.clear();
-
-		return OK;
 	}
 
-	return FAILED;
+	return OK;
 }
 
 PackedStringArray AudioDriverWASAPI::get_input_device_list() {

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -232,6 +232,9 @@ private:
 	bool debug_mute = false;
 #endif // DEBUG_ENABLED
 
+	bool input_device_active = false;
+	int input_buffer_ofs = 0;
+
 	struct Bus {
 		StringName name;
 		bool solo = false;
@@ -492,6 +495,10 @@ public:
 	PackedStringArray get_input_device_list();
 	String get_input_device();
 	void set_input_device(const String &p_name);
+	Error set_input_device_active(bool p_is_active);
+	int get_input_frames_available();
+	int get_input_buffer_length_frames();
+	PackedVector2Array get_input_frames(int p_frames);
 
 	void set_enable_tagging_used_audio_streams(bool p_enable);
 

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -442,14 +442,9 @@ void AudioStreamPlaybackMicrophone::start(double p_from_pos) {
 		return;
 	}
 
-	if (!GLOBAL_GET_CACHED(bool, "audio/driver/enable_input")) {
-		WARN_PRINT("You must enable the project setting \"audio/driver/enable_input\" to use audio capture.");
-		return;
-	}
-
 	input_ofs = 0;
 
-	if (AudioDriver::get_singleton()->input_start() == OK) {
+	if (AudioServer::get_singleton()->set_input_device_active(true) == OK) {
 		active = true;
 		begin_resample();
 	}
@@ -457,7 +452,7 @@ void AudioStreamPlaybackMicrophone::start(double p_from_pos) {
 
 void AudioStreamPlaybackMicrophone::stop() {
 	if (active) {
-		AudioDriver::get_singleton()->input_stop();
+		AudioServer::get_singleton()->set_input_device_active(false);
 		active = false;
 	}
 }


### PR DESCRIPTION
Direct access to the audio data in the microphone buffer is necessary to overcome the design flaw of connecting the Audio Input stream (microphone) to the Audio Output stream under the mistaken assumption that they will always proceed at exactly the same rate for all time on every platform.

A diagram of the current design and the improved situation [can be seen here]( https://github.com/godotengine/godot/pull/105244#issuecomment-2830480213).

The following issues are illustrative of the flaw in the current design.
* Issue #112836 (which has been replicated on 3 platforms, not only Android)
* Issue #80173
* Issue #95120
* Issue #86428 -- which works by packing zero values into the audio stream when the buffer under-runs, causing a degradation of the sound quality (such as _Garbling_)
* (Observed Godot3) Issue #54544 

This PR is a re-implementation of three previous attempts to find an appropriate place for a `get_microphone_frames()` function:
 * PR #100508 
 * PR #105244 
 * PR #108773 

This also resolves godotengine/godot-proposals#11347 (proposal).

A comprehensive demo is at:
https://github.com/goatchurchprime/godot-demo-projects/tree/gtch/mic_input/audio/mic_input

This PR adds four new functions to `AudioServer`: 

```GDScript
set_input_device_active(active : bool) -> int
get_input_buffer_length_frames() -> int
get_input_frames_available() -> int
get_input_frames(frames : int) -> PackedVector2Array
```

In the class [AudioEffectCapture](https://docs.godotengine.org/en/stable/classes/class_audioeffectcapture.html#methods), the function that is equivalent to `get_input_frames()` is known as `get_buffer()`.

The function `get_buffer_length_frames()` is necessary to predict when the overflow is likely to occur. 

The function `set_input_device_active()` provides direct control of exactly when the microphone stream is turned on and off, rather than it currently being done by the existence of an active `AudioStreamMicrophone` playback object.

This could mean that we never have to call `AudioServer.set_input_device()` while the input device is active, which leads to [problematic situations](https://github.com/godotengine/godot/blob/master/drivers/pulseaudio/audio_driver_pulseaudio.cpp#L557) where the error case of a failure to start the new device cannot be properly handled. Instead you would call `set_input_device_active(false)`, then change the device, before calling `set_input_device_active(true)` which can return an error if it doesn't work.

### Stuff to do
* <strike>Review the function names and whether it needs `get_input_device_active()` and member variable `input_device_active` and functions to be const.</strike>
* <strike>Write the docs</strike>
* <strike>Make AudioStreamMicrophonePlayback use the `input_device_active` interface, and check it still works as before (if none of these new functions are used).</strike>
