### PR TITLE
Use additive blending for suns in ProceduralSkyMaterial to fix dark suns

### DIFF
--- a/scene/resources/3d/sky_material.cpp
+++ b/scene/resources/3d/sky_material.cpp
@@ -327,10 +327,10 @@ void sky() {
 		float sun_angle = dot(LIGHT0_DIRECTION, EYEDIR);
 		float sun_size = cos(LIGHT0_SIZE);
 		if (sun_angle > sun_size) {
-			sky = LIGHT0_COLOR * LIGHT0_ENERGY;
+			sky += LIGHT0_COLOR * LIGHT0_ENERGY;
 		} else if (sun_angle > sun_angle_max) {
 			float c2 = (sun_size - sun_angle) / (sun_size - sun_angle_max);
-			sky = mix(sky, LIGHT0_COLOR * LIGHT0_ENERGY, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
+			sky += LIGHT0_COLOR * LIGHT0_ENERGY * clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0);
 		}
 	}
 
@@ -338,10 +338,10 @@ void sky() {
 		float sun_angle = dot(LIGHT1_DIRECTION, EYEDIR);
 		float sun_size = cos(LIGHT1_SIZE);
 		if (sun_angle > sun_size) {
-			sky = LIGHT1_COLOR * LIGHT1_ENERGY;
+			sky += LIGHT1_COLOR * LIGHT1_ENERGY;
 		} else if (sun_angle > sun_angle_max) {
 			float c2 = (sun_size - sun_angle) / (sun_size - sun_angle_max);
-			sky = mix(sky, LIGHT1_COLOR * LIGHT1_ENERGY, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
+			sky += LIGHT1_COLOR * LIGHT1_ENERGY * clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0);
 		}
 	}
 
@@ -349,10 +349,10 @@ void sky() {
 		float sun_angle = dot(LIGHT2_DIRECTION, EYEDIR);
 		float sun_size = cos(LIGHT2_SIZE);
 		if (sun_angle > sun_size) {
-			sky = LIGHT2_COLOR * LIGHT2_ENERGY;
+			sky += LIGHT2_COLOR * LIGHT2_ENERGY;
 		} else if (sun_angle > sun_angle_max) {
 			float c2 = (sun_size - sun_angle) / (sun_size - sun_angle_max);
-			sky = mix(sky, LIGHT2_COLOR * LIGHT2_ENERGY, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
+			sky += LIGHT2_COLOR * LIGHT2_ENERGY * clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0);
 		}
 	}
 
@@ -360,10 +360,10 @@ void sky() {
 		float sun_angle = dot(LIGHT3_DIRECTION, EYEDIR);
 		float sun_size = cos(LIGHT3_SIZE);
 		if (sun_angle > sun_size) {
-			sky = LIGHT3_COLOR * LIGHT3_ENERGY;
+			sky += LIGHT3_COLOR * LIGHT3_ENERGY;
 		} else if (sun_angle > sun_angle_max) {
 			float c2 = (sun_size - sun_angle) / (sun_size - sun_angle_max);
-			sky = mix(sky, LIGHT3_COLOR * LIGHT3_ENERGY, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
+			sky += LIGHT3_COLOR * LIGHT3_ENERGY * clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0);
 		}
 	}
 


### PR DESCRIPTION
This prevents dark DirectionalLight3D colors from creating splotches in the sky, which is a commonly encountered issue when working on day/night cycle systems.

This affects how bright suns are rendered too, with a greater impact on heavily saturated colors.

If we consider the visual difference to be too important, we'll probably want to add a **Sun Blend Mode** property to control this (although ProceduralSkyMaterial is already quite complex as it is). If we want a compatible solution that still addresses the original issue, we could perform premultiplied alpha blending instead, with the "alpha" value being determined by the color's HSV value.

- See https://github.com/godotengine/godot-proposals/issues/13748.

**Testing project:** [test_sky_sun.zip](https://github.com/user-attachments/files/23828339/test_sky_sun.zip)

## Preview

*The scene has 4 suns.*

Before | After
-|-
<img width="1152" height="648" alt="Screenshot_20251128_193658" src="https://github.com/user-attachments/assets/8c7caf2c-732f-4671-9262-f353312bb28e" /> | <img width="1152" height="648" alt="Screenshot_20251128_193706" src="https://github.com/user-attachments/assets/0b3a3454-628e-42ba-933c-11b6e01c8f32" />
