### PR TITLE
Assign layout key to Debugger

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -63,6 +63,7 @@ EditorDebuggerNode *EditorDebuggerNode::singleton = nullptr;
 EditorDebuggerNode::EditorDebuggerNode() {
 	set_name(TTRC("Debugger"));
 	set_icon_name("Debug");
+	set_layout_key("Debugger");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_debugger_bottom_panel", TTRC("Toggle Debugger Dock"), KeyModifierMask::ALT | Key::D));
 	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL);


### PR DESCRIPTION
The Debugger changes title based on the number of errors, you can end up with e.g. "Debugger (4)" in your layout file. This PR fixes it.