### PR TITLE
Fix dock opening focus

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -77,6 +77,7 @@
 			<return type="void" />
 			<description>
 				Opens the dock. It will appear in the last used dock slot. If the dock has no default slot, it will be opened floating.
+				[b]Note:[/b] This does not focus the dock. If you want to open and focus the dock, use [method make_visible].
 			</description>
 		</method>
 	</methods>

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -105,7 +105,7 @@ EditorDock::EditorDock() {
 
 void EditorDock::open() {
 	if (!is_open) {
-		EditorDockManager::get_singleton()->open_dock(this);
+		EditorDockManager::get_singleton()->open_dock(this, false);
 	}
 }
 

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -374,7 +374,7 @@ void TileMapEditorPlugin::_update_tile_map() {
 		Ref<TileSet> tile_set = edited_layer->get_tile_set();
 		if (tile_set.is_valid() && tile_set_id != tile_set->get_instance_id()) {
 			tile_set_plugin_singleton->edit(tile_set.ptr());
-			tile_set_plugin_singleton->make_visible(true);
+			tile_set_plugin_singleton->make_visible_no_focus();
 			tile_set_id = tile_set->get_instance_id();
 		} else if (tile_set.is_null()) {
 			tile_set_plugin_singleton->edit(nullptr);
@@ -411,7 +411,7 @@ void TileMapEditorPlugin::_edit_tile_map_layer(TileMapLayer *p_tile_map_layer, b
 	Ref<TileSet> tile_set = p_tile_map_layer->get_tile_set();
 	if (tile_set.is_valid()) {
 		tile_set_plugin_singleton->edit(tile_set.ptr());
-		tile_set_plugin_singleton->make_visible(true);
+		tile_set_plugin_singleton->make_visible_no_focus();
 		tile_set_id = tile_set->get_instance_id();
 	} else {
 		tile_set_plugin_singleton->edit(nullptr);
@@ -480,7 +480,7 @@ bool TileMapEditorPlugin::handles(Object *p_object) const {
 
 void TileMapEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		editor->open();
+		editor->make_visible();
 	} else {
 		editor->close();
 	}
@@ -533,10 +533,14 @@ bool TileSetEditorPlugin::handles(Object *p_object) const {
 
 void TileSetEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		editor->open();
+		editor->make_visible();
 	} else {
 		editor->close();
 	}
+}
+
+void TileSetEditorPlugin::make_visible_no_focus() {
+	editor->open();
 }
 
 ObjectID TileSetEditorPlugin::get_edited_tileset() const {

--- a/editor/scene/2d/tiles/tiles_editor_plugin.h
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.h
@@ -165,6 +165,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
+	void make_visible_no_focus();
 	ObjectID get_edited_tileset() const;
 
 	TileSetEditorPlugin();


### PR DESCRIPTION
EditorDock have `open()` and `make_visible()` methods, which are very similar. The main difference is that `open()` does nothing if the dock is already opened. If it's closed, the method will open it and make focused (i.e. switch to tab, open bottom panel etc.).

This PR changes `open()` to _not_ focus the dock. There is `make_visible()` for that.

Also changed some `open()` calls to `make_visible()`, to fix some docks not being properly focused when they should.