### PR TITLE
Add platform lifecycle callbacks to CameraServer base class

### DIFF
--- a/drivers/apple_embedded/godot_view_controller.mm
+++ b/drivers/apple_embedded/godot_view_controller.mm
@@ -38,6 +38,7 @@
 #import "os_apple_embedded.h"
 
 #include "core/config/project_settings.h"
+#include "servers/camera/camera_server.h"
 
 #import <AVFoundation/AVFoundation.h>
 #import <GameController/GameController.h>
@@ -237,6 +238,24 @@
 }
 
 // MARK: Orientation
+
+#if TARGET_OS_IPHONE
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+	[super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+	[coordinator animateAlongsideTransition:nil
+								 completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+									 // Get the new interface orientation after rotation completes (iOS only)
+									 UIInterfaceOrientation orientation = self.view.window.windowScene.interfaceOrientation;
+
+									 // Notify camera server of orientation change
+									 CameraServer *camera_server = CameraServer::get_singleton();
+									 if (camera_server) {
+										 camera_server->handle_display_rotation_change((int)orientation);
+									 }
+								 }];
+}
+#endif // TARGET_OS_IPHONE
 
 - (UIRectEdge)preferredScreenEdgesDeferringSystemGestures {
 	if (GLOBAL_GET("display/window/ios/suppress_ui_gesture")) {

--- a/modules/camera/camera_android.cpp
+++ b/modules/camera/camera_android.cpp
@@ -622,7 +622,7 @@ void CameraAndroid::set_monitoring_feeds(bool p_monitoring_feeds) {
 	}
 }
 
-void CameraAndroid::handle_pause() {
+void CameraAndroid::handle_application_pause() {
 	for (int i = 0; i < feeds.size(); i++) {
 		Ref<CameraFeedAndroid> feed = feeds[i];
 		if (feed.is_valid()) {
@@ -631,7 +631,7 @@ void CameraAndroid::handle_pause() {
 	}
 }
 
-void CameraAndroid::handle_resume() {
+void CameraAndroid::handle_application_resume() {
 	for (int i = 0; i < feeds.size(); i++) {
 		Ref<CameraFeedAndroid> feed = feeds[i];
 		if (feed.is_valid()) {
@@ -640,7 +640,7 @@ void CameraAndroid::handle_resume() {
 	}
 }
 
-void CameraAndroid::handle_rotation_change() {
+void CameraAndroid::handle_display_rotation_change(int) {
 	for (int i = 0; i < feeds.size(); i++) {
 		Ref<CameraFeedAndroid> feed = feeds[i];
 		if (feed.is_valid()) {

--- a/modules/camera/camera_android.h
+++ b/modules/camera/camera_android.h
@@ -113,9 +113,9 @@ private:
 
 public:
 	void set_monitoring_feeds(bool p_monitoring_feeds) override;
-	void handle_pause();
-	void handle_resume();
-	void handle_rotation_change();
+	void handle_application_pause() override;
+	void handle_application_resume() override;
+	void handle_display_rotation_change(int p_orientation) override;
 
 	~CameraAndroid();
 };

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -766,7 +766,7 @@ class Godot private constructor(val context: Context) {
 
 		if (currentConfig.orientation != newConfig.orientation) {
 			runOnRenderThread {
-				GodotLib.onScreenRotationChange()
+				GodotLib.onScreenRotationChange(newConfig.orientation)
 			}
 		}
 		currentConfig = newConfig

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
@@ -297,8 +297,9 @@ public class GodotLib {
 
 	/**
 	 * Invoked when the screen orientation changes.
+	 * @param orientation the new screen orientation
 	 */
-	static native void onScreenRotationChange();
+	static native void onScreenRotationChange(int orientation);
 
 	/**
 	 * @return true if input must be dispatched from the render thread. If false, input is

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -53,12 +53,7 @@
 #include "main/main.h"
 #include "servers/rendering/rendering_server.h"
 
-#include "modules/modules_enabled.gen.h" // For camera.
-
-#ifdef MODULE_CAMERA_ENABLED
-#include "modules/camera/camera_android.h"
 #include "servers/camera/camera_server.h"
-#endif
 
 #ifndef XR_DISABLED
 #include "servers/xr/xr_server.h"
@@ -606,12 +601,10 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererResumed(JNI
 
 	// We force redraw to ensure we render at least once when resuming the app.
 	Main::force_redraw();
-#ifdef MODULE_CAMERA_ENABLED
-	CameraAndroid *camera_android = Object::cast_to<CameraAndroid>(CameraServer::get_singleton());
-	if (camera_android) {
-		camera_android->handle_resume();
+	CameraServer *camera_server = CameraServer::get_singleton();
+	if (camera_server) {
+		camera_server->handle_application_resume();
 	}
-#endif // MODULE_CAMERA_ENABLED
 	if (os_android->get_main_loop()) {
 		os_android->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_RESUMED);
 	}
@@ -622,29 +615,25 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererPaused(JNIE
 		return;
 	}
 
-#ifdef MODULE_CAMERA_ENABLED
-	CameraAndroid *camera_android = Object::cast_to<CameraAndroid>(CameraServer::get_singleton());
-	if (camera_android) {
-		camera_android->handle_pause();
+	CameraServer *camera_server = CameraServer::get_singleton();
+	if (camera_server) {
+		camera_server->handle_application_pause();
 	}
-#endif // MODULE_CAMERA_ENABLED
 
 	if (os_android->get_main_loop()) {
 		os_android->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_PAUSED);
 	}
 }
 
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onScreenRotationChange(JNIEnv *env, jclass clazz) {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onScreenRotationChange(JNIEnv *env, jclass clazz, jint p_orientation) {
 	if (step.get() <= STEP_SETUP) {
 		return;
 	}
 
-#ifdef MODULE_CAMERA_ENABLED
-	CameraAndroid *camera_android = Object::cast_to<CameraAndroid>(CameraServer::get_singleton());
-	if (camera_android) {
-		camera_android->handle_rotation_change();
+	CameraServer *camera_server = CameraServer::get_singleton();
+	if (camera_server) {
+		camera_server->handle_display_rotation_change(p_orientation);
 	}
-#endif // MODULE_CAMERA_ENABLED
 }
 
 JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_shouldDispatchInputToRenderThread(JNIEnv *env, jclass clazz) {

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -72,7 +72,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_hardwareKeyboardConne
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_filePickerCallback(JNIEnv *env, jclass clazz, jboolean p_ok, jobjectArray p_selected_paths);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererResumed(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererPaused(JNIEnv *env, jclass clazz);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onScreenRotationChange(JNIEnv *env, jclass clazz);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onScreenRotationChange(JNIEnv *env, jclass clazz, jint p_orientation);
 JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_shouldDispatchInputToRenderThread(JNIEnv *env, jclass clazz);
 JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getProjectResourceDir(JNIEnv *env, jclass clazz);
 JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_isEditorHint(JNIEnv *env, jclass clazz);

--- a/servers/camera/camera_server.h
+++ b/servers/camera/camera_server.h
@@ -111,6 +111,11 @@ public:
 	// Intended for use with custom CameraServer implementation.
 	RID feed_texture(int p_id, FeedImage p_texture);
 
+	// Platform lifecycle callbacks (virtual, default empty implementation).
+	virtual void handle_application_pause() {}
+	virtual void handle_application_resume() {}
+	virtual void handle_display_rotation_change(int p_orientation) { (void)p_orientation; }
+
 	CameraServer();
 	~CameraServer();
 };


### PR DESCRIPTION
## Summary
Add virtual lifecycle callbacks to `CameraServer` base class for handling platform events such as application pause/resume and display rotation changes.

## Background
This PR extracts the iOS display rotation notification mechanism from #106305.

By adding virtual callbacks to the `CameraServer` base class, future camera implementations (including iOS) can receive orientation change events from the platform layer.

As a side benefit, this also cleans up Android's existing rotation handling by removing the direct dependency from platform code (`java_godot_lib_jni.cpp`) to the camera module, eliminating `#ifdef MODULE_CAMERA_ENABLED` guards.
