### PR TITLE
Fix various problems with the credits roll

### DIFF
--- a/editor/gui/credits_roll.h
+++ b/editor/gui/credits_roll.h
@@ -30,14 +30,14 @@
 
 #pragma once
 
-#include "scene/gui/popup.h"
+#include "scene/main/canvas_layer.h"
 
 class Label;
 class VBoxContainer;
 class Font;
 
-class CreditsRoll : public Popup {
-	GDCLASS(CreditsRoll, Popup);
+class CreditsRoll : public CanvasLayer {
+	GDCLASS(CreditsRoll, CanvasLayer);
 
 	enum class LabelSize {
 		NORMAL,
@@ -57,6 +57,9 @@ class CreditsRoll : public Popup {
 	Label *_create_label(const String &p_with_text, LabelSize p_size = LabelSize::NORMAL);
 	void _create_nothing(int p_size = -1);
 	String _build_string(const char *const *p_from) const;
+	void _visibility_changed();
+
+	virtual void input(const Ref<InputEvent> &p_event) override;
 
 protected:
 	void _notification(int p_what);

--- a/editor/gui/editor_about.h
+++ b/editor/gui/editor_about.h
@@ -54,6 +54,7 @@ private:
 	};
 
 	void _license_tree_selected();
+	void _credits_visibility_changed();
 	void _item_activated(int p_idx, ItemList *p_il);
 	void _item_list_resized(ItemList *p_il);
 	Label *_create_section(Control *p_parent, const String &p_name, const char *const *p_src, BitField<SectionFlags> p_flags = 0);


### PR DESCRIPTION
Our little credits roll is a cute Easter egg, and works great, as long as you don't mess around with the window while it plays at least. Most of the problems came from it being a `Popup`, which this PR fixes by turning it into a `CanvasLayer`.

- Fix credits not following the window's position and size.
- Fix it being off-center if the window is too small.
- Hide the About dialog while it plays, and pop it back when it stops.