### PR TITLE
Support unary '+' in Variant parser

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -417,8 +417,8 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 					break;
 				}
 				StringBuffer<> token_text;
-				if (cchar == '-') {
-					token_text += '-';
+				if (cchar == '-' || cchar == '+') {
+					token_text += cchar;
 					cchar = p_stream->get_char();
 				}
 				if (cchar >= '0' && cchar <= '9') {


### PR DESCRIPTION
This adds support for parsing '+' in Variants.

Currently, in an exported property, if you type `-1` it correctly assigns `-1`. However, if you assign `+1`, it is rejected as erroneous.

<img width="333" height="89" alt="image" src="https://github.com/user-attachments/assets/0e4667a6-5a01-4fe1-b931-913676d0e17f" />
<img width="341" height="90" alt="image" src="https://github.com/user-attachments/assets/3102c169-6b05-4d82-9646-42160e3e984c" />

I believe that this small change should fix it. Floats are later parsed with [`as_double()`](https://github.com/godotengine/godot/blob/7ed0b6167618f9c8c5df87c7e83da6003c081368/core/string/string_buffer.h#L154) which calls [`String::to_float`](https://github.com/godotengine/godot/blob/7ed0b6167618f9c8c5df87c7e83da6003c081368/core/string/ustring.cpp#L2574) which calls [`built_in_strtod`](https://github.com/godotengine/godot/blob/7ed0b6167618f9c8c5df87c7e83da6003c081368/core/string/ustring.cpp#L2352) which [handles `+` signs](https://github.com/godotengine/godot/blob/7ed0b6167618f9c8c5df87c7e83da6003c081368/core/string/ustring.cpp#L2424).