### PR TITLE
MacOS: Fix focus grab warning on macOS when running game in embedded mode.

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -357,7 +357,9 @@ void GameView::_instance_starting(int p_idx, List<String> &r_arguments) {
 
 		_show_update_window_wrapper();
 
-		embedded_process->grab_focus();
+		if (embedded_process->get_focus_mode_with_override() != FOCUS_NONE) {
+			embedded_process->grab_focus();
+		}
 	}
 
 	_update_arguments_for_instance(p_idx, r_arguments);
@@ -444,7 +446,10 @@ void GameView::_play_pressed() {
 			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_GAME);
 			// Reset the normal size of the bottom panel when fully expanded.
 			EditorNode::get_singleton()->get_bottom_panel()->set_expanded(false);
-			embedded_process->grab_focus();
+
+			if (embedded_process->get_focus_mode_with_override() != FOCUS_NONE) {
+				embedded_process->grab_focus();
+			}
 		}
 		embedded_process->embed_process(current_process_id);
 		_update_ui();


### PR DESCRIPTION
Fixes focus grab warning on macOS when running game in embedded mode.

## Issue
<img width="1490" height="964" alt="图片" src="https://github.com/user-attachments/assets/77abffb0-d883-4ee4-977b-9c981e4cea4c" />

When running a game with "Embed Game on Next Play" enabled on macOS, the following warning is printed:
"This control can't grab focus. Use set_focus_mode() and set_focus_behavior_recursive() 
to allow a control to get focus."

## Root Cause
`EmbeddedProcessMacOS` is explicitly configured with `set_focus_mode(FOCUS_NONE)` in its constructor,
while `GameView` unconditionally calls `grab_focus()` on it when starting the game instance.

The focus is intentionally delegated to the child `layer_host` which uses `FOCUS_ALL`.
However, `grab_focus()` on the parent process still triggers the warning even though this
is the intended design on macOS.

## Solution
Add a focus mode check before calling `grab_focus()` in `GameView::_play_pressed()` and
`GameView::_instance_starting()`. This prevents the warning when the control is explicitly
set to not accept focus, matching the macOS-specific implementation's design.

### Changes Made
- Added `if (embedded_process->get_focus_mode_with_override() != FOCUS_NONE)` guard
  before `embedded_process->grab_focus()` calls in `game_view.cpp`

## Testing
- Tested on macOS: warning no longer appears when launching game in embedded mode
- Verified other platforms (Windows/Linux) remain unaffected
- Confirmed focus behavior still works correctly in embedded game window