### PR TITLE
LinuxBSD: Fixes a formatting error when running Godot editor with Wayland prefer enabled.

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -4330,7 +4330,7 @@ void WaylandThread::window_set_borderless(DisplayServer::WindowID p_window_id, b
 		// possible to destroy the frame more than once, by setting the visibility
 		// to false multiple times and thus crashing.
 		if (visible_current != visible_target) {
-			print_verbose(vformat("Setting libdecor frame visibility to %d", visible_target));
+			print_verbose(vformat("Setting libdecor frame visibility to %s", visible_target));
 			libdecor_frame_set_visibility(ws.libdecor_frame, visible_target);
 		}
 	}


### PR DESCRIPTION
In `WaylandThread::window_set_borderless`, the verbose logging used `%d` to format a boolean value, causing vformat to error as it doesn't support bool type. This changes the specifier to `%s` to let Variant handle the conversion properly.

Before:
<img width="1146" height="925" alt="屏幕截图_20251129_100619" src="https://github.com/user-attachments/assets/8ba4a92b-5f6a-4a93-acc3-097627f97aae" />

After:
<img width="532" height="38" alt="屏幕截图_20251129_101850" src="https://github.com/user-attachments/assets/2207348c-9eb3-4dec-97dd-c9b7061e182c" />

Tested with libdecor enabled on Linux/Wayland, warning is gone and output displays correctly.