### PR TITLE
Editor: Fix infinite appending of docks without slots to config

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -600,6 +600,13 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 		}
 	}
 
+	// Clear the special dock slot for docks without default slots (index -1 = dock_0).
+	// This prevents closed docks from being infinitely appended to the config on each save.
+	const String no_slot_config_key = "dock_0";
+	if (p_layout->has_section_key(p_section, no_slot_config_key)) {
+		p_layout->erase_section_key(p_section, no_slot_config_key);
+	}
+
 	// Save docks in windows.
 	Dictionary floating_docks_dump;
 	for (WindowWrapper *wrapper : dock_windows) {


### PR DESCRIPTION
## Summary

Fixes #113281

This PR fixes a bug where docks without default slots were being infinitely appended to the editor layout config file.

## Root Cause

The clearing loop at lines 574-601 only clears dock slots 0 through `DOCK_SLOT_MAX` (generating config keys `dock_1` through `dock_15`). However, docks without default slots use index `-1`, which corresponds to the config key `dock_0`. This key was never cleared, so closed docks kept getting appended infinitely on each save.

## Changes Made

Added code after line 601 to explicitly clear the `dock_0` config key before saving closed docks, matching the behavior of regular dock slots.

## Testing

Tested with the reproduction steps provided in the issue:
1. Created a plugin with an `EditorDock` that has no default slot
2. Enabled the plugin
3. Pressed Ctrl+S multiple times
4. Verified that `dock_0` in `.godot/editor/editor_layout.cfg` no longer accumulates duplicate entries

The fix ensures that the special `-1` slot is properly cleared on each save, preventing the infinite appending behavior.