### PR TITLE
Fix DocGen and Access for GDScript Enums

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3591,7 +3591,15 @@ EditorHelpBit::HelpData EditorHelpBit::_get_constant_help_data(const StringName 
 
 	HelpData result;
 
-	const DocData::ClassDoc *class_doc = EditorHelp::get_doc(p_class_name);
+	const int dot_pos = String(p_class_name).rfind_char('.');
+	String class_name = p_class_name;
+	String constant_name = p_constant_name;
+	String enum_name = "";
+	if (dot_pos >= 0) {
+		class_name = String(p_class_name).left(dot_pos);
+		enum_name = String(p_class_name).substr(dot_pos + 1);
+	}
+	const DocData::ClassDoc *class_doc = EditorHelp::get_doc(class_name);
 	if (class_doc) {
 		// Non-native constants shouldn't be cached, nor translated.
 		const bool is_native = !class_doc->is_script_doc;
@@ -3618,7 +3626,11 @@ EditorHelpBit::HelpData EditorHelpBit::_get_constant_help_data(const StringName 
 				current.value = constant.value;
 			}
 
-			if (constant.name == p_constant_name) {
+			// Needs to differentiate:
+			// Constant X from a named Enum vs. Class Constant X
+			// Constant X from a named Enum vs. Constant X from an Unnamed Enum
+			bool unnamedMatch = enum_name.is_empty() && constant.enumeration == "@unnamed_enums";
+			if (constant.name == constant_name && (constant.enumeration == enum_name || unnamedMatch)) {
 				result = current;
 
 				if (!is_native) {


### PR DESCRIPTION
* Closes https://github.com/godotengine/godot/issues/113305.

Previously [modules/gdscript/editor/gdscript_docgen.cpp](https://github.com/godotengine/godot/compare/master...ColinSORourke:godot:EnumDocGen?expand=1#diff-069d958cd46f28005630a1bd25919869acc8c317e79d0cf26b4e30073fa8994c) would treat values of Named Enums identically to values of unnamed enums, and assign them all as ConstantDocs under MyClass.gd, using the values direct name as the ConstantDoc name.

```gdscript
// MyClass.gd
extends Node

## 1
enum {
	A = 0, ## 2
	B = 1, ## 3
}

## DocComment 4
enum NamedEnum {
	UP = 0, ## 5
	DOWN = 1, ## 6
}

## 7
enum OtherEnum {
	UP = 0, ## 8
	TOWN = 1, ## 9
	FUNK = 2, ## 10
}
```

Given the above code block, that would generate ConstantDoc mapping 
`MyClass.gd->class_docs.constants = {"A": 2, "B": 3, "UP": 5, "DOWN": 6, "UP":8, "TOWN":9, "FUNK":10}`

Then, through the lookup chain, _lookup_symbol_from_base would tell the tooltip generator to look up the docs for this NamedEnum.UP under class_name "MyClass.gd".NamedEnum, symbol name "UP", causing a failure to retrieve any class docs.

Edit: Previous version of this PR changed the Doc generation, newer version of this PR leaves Doc mapping untouched, and uses more Doc Information to correctly delineate Constants v. Enum Constants v. Named Enum Constants