### PR TITLE
Fix loading old-style translation files

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -77,6 +77,7 @@ void Translation::_set_messages(const Dictionary &p_messages) {
 	for (const KeyValue<Variant, Variant> &kv : p_messages) {
 		switch (kv.key.get_type()) {
 			// Old version, no context or plural support.
+			case Variant::STRING:
 			case Variant::STRING_NAME: {
 				const MessageKey msg_key = { StringName(), kv.key };
 				_check_for_incompatibility(msg_key.msgctxt, msg_key.msgid);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Fixes regression introduced in #108862 .

Versions of Godot prior to current had unoptimized Translation files stored with their messages as Strings, rather than StringNames. 
<img width="597" height="187" alt="image" src="https://github.com/user-attachments/assets/c01098d7-0ce8-4a50-80b2-9f7622a2c809" />

As a result of #108862 's changes, the keys for unoptimized translations fail to load. This fixes it.

cc @timothyqiu 
