### PR TITLE
Fix VoxelGI glossy reflection artifacts

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -486,7 +486,7 @@ vec4 voxel_cone_trace(texture3D probe, vec3 cell_size, vec3 pos, vec3 direction,
 	float dist = p_bias;
 	vec4 color = vec4(0.0);
 
-	while (dist < max_distance && color.a < 0.95) {
+	while (dist < max_distance && color.a < 1.0) {
 		float diameter = max(1.0, 2.0 * tan_half_angle * dist);
 		vec3 uvw_pos = (pos + dist * direction) * cell_size;
 		float half_diameter = diameter * 0.5;
@@ -509,7 +509,7 @@ vec4 voxel_cone_trace_45_degrees(texture3D probe, vec3 cell_size, vec3 pos, vec3
 	float radius = max(0.5, dist);
 	float lod_level = log2(radius * 2.0);
 
-	while (dist < max_distance && color.a < 0.95) {
+	while (dist < max_distance && color.a < 1.0) {
 		vec3 uvw_pos = (pos + dist * direction) * cell_size;
 
 		//check if outside, then break


### PR DESCRIPTION
- Fixes #50842

*Bugsquad edit:*
- Seems to fix #84746 too.

## Visual Comparisons

Godot 4.5-stable:
<img width="1105" height="828" alt="testscene-stable-4 5" src="https://github.com/user-attachments/assets/7c20857f-aa29-4887-94a3-8bc2b146f312" />

This PR:
<img width="1105" height="828" alt="testscene-fixed" src="https://github.com/user-attachments/assets/2150b605-da53-4d78-a98f-c462df2fe360" />

Godot 4.5-stable:
<img width="1920" height="1080" alt="bistro2-stable-4 5" src="https://github.com/user-attachments/assets/a0c40cbb-6f32-493b-a123-f2ea17de906c" />

This PR:
<img width="1920" height="1080" alt="bistro2-fixed" src="https://github.com/user-attachments/assets/20137587-2b05-49b1-a95b-68e8ec76d952" />

Godot 4.5-stable:
<img width="1225" height="828" alt="bistro-stable-4 5" src="https://github.com/user-attachments/assets/9f18202d-5914-4c3c-9cb4-fd57e42ec287" />

This PR:
<img width="1225" height="828" alt="bistro-fixed" src="https://github.com/user-attachments/assets/f4d3dd9a-b345-495b-acef-c61f3315f844" />

## Performance Comparisons

Performance test scene 1: Bistro with fully static VoxelGI and a spinning cube.
<img width="1920" height="1080" alt="bistro-with-cube" src="https://github.com/user-attachments/assets/a3d761a2-a97e-43c6-b9dd-71f11103738d" />

Performance test scene 2: Bistro with fully static VoxelGI, spinning cube, and large mirror.
<img width="1920" height="1080" alt="bistro2-with-cube" src="https://github.com/user-attachments/assets/06732179-be34-4aea-bad5-75c6763398a4" />

Scene 1 benchmark results:
- 4.5-stable: 97fps
- PR: 96fps
- 4.5-stable (6 cones): 81fps
- PR (6 cones): 79fps

Scene 2 benchmark results:
- 4.5-stable: 92fps
- PR: 89fps
- 4.5-stable (6 cones): 78fps
- PR (6 cones): 75fps

Setup:
- 1920x1080 exclusive fullscreen
- AMD RX570 4GB
- Linux X11, Mesa RADV drivers 25.0.7

This PR fixes the VoxelGI reflection issue visible in the screenshots above (issue #50842), by making comparisons to voxel alpha during cone tracing more strict.

I'm not too sure *why* this works, it's something that I tried to see if it'd fix the problem, and it did, so I decided to open this PR.

There is a performance loss from running the loop more times (due to stricter stop conditions), but overall the performance loss seems negligeable, at least on my hardware.

(testing scene in the first set of images is the VoxelGI test scene from [Calinou's VoxelGI oversampling PR](https://github.com/godotengine/godot/pull/55419), with an added light so that reflections wouldn't be completely black)