### PR TITLE
Switch to the opposite view by clicking on the same axis

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -439,6 +439,10 @@ void ViewportRotationControl::_process_click(int p_index, Vector2 p_position, bo
 		}
 	} else {
 		if (focused_axis > -1 && gizmo_activated) {
+			if (axis_menu_options[focused_axis] + 1 == viewport->view_type) {
+				// Switch to the opposite view
+				focused_axis += (focused_axis < 3) ? 3 : -3;
+			}
 			viewport->_menu_option(axis_menu_options[focused_axis]);
 			_update_focus();
 		}


### PR DESCRIPTION
You can now toggle the 3D viewport projection between opposite directions by clicking the same axis label again

https://github.com/user-attachments/assets/deda95b6-4a6f-4e15-be3f-436ac71d0c6e