### PR TITLE
Implement XFCE `exo-open` support in Linux `OS.shell_open`.

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -565,7 +565,15 @@ Error OS_LinuxBSD::shell_open(const String &p_uri) {
 		return OK;
 	}
 	ok = execute("kde-open", args, nullptr, &err_code);
-	return !err_code ? ok : FAILED;
+	if (ok == OK && !err_code) {
+		return OK;
+	}
+	// XFCE
+	ok = execute("exo-open", args, nullptr, &err_code);
+	if (ok == OK && !err_code) {
+		return OK;
+	}
+	return FAILED;
 }
 
 bool OS_LinuxBSD::_check_internal_feature_support(const String &p_feature) {


### PR DESCRIPTION
Added support for XFCE by executing 'exo-open' alongside 'kde-open'.

https://docs.xfce.org/xfce/exo/preferred-applications