### PR TITLE
Wayland: Unify key handling logic

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1695,6 +1695,8 @@ void DisplayServerWayland::try_suspend() {
 void DisplayServerWayland::process_events() {
 	wayland_thread.mutex.lock();
 
+	wayland_thread.keyboard_echo_keys();
+
 	while (wayland_thread.has_message()) {
 		Ref<WaylandThread::Message> msg = wayland_thread.pop_message();
 
@@ -1836,8 +1838,6 @@ void DisplayServerWayland::process_events() {
 			continue;
 		}
 	}
-
-	wayland_thread.keyboard_echo_keys();
 
 	switch (suspend_state) {
 		case SuspendState::NONE: {

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -1037,6 +1037,8 @@ private:
 	static Ref<InputEventKey> _seat_state_get_key_event(SeatState *p_ss, xkb_keycode_t p_keycode, bool p_pressed);
 	static Ref<InputEventKey> _seat_state_get_unstuck_key_event(SeatState *p_ss, xkb_keycode_t p_keycode, bool p_pressed, Key p_key);
 
+	static void _seat_state_handle_xkb_keycode(SeatState *p_ss, xkb_keycode_t p_xkb_keycode, bool p_pressed, bool p_echo = false);
+
 	static void _wayland_state_update_cursor();
 
 	void _set_current_seat(struct wl_seat *p_seat);


### PR DESCRIPTION
Previously we had different logic for direct key presses and client-side key repetition, as one queued up input events and the other dispatched them directly (client-side key repetition is run from the main thread).

I kinda figured out that this difference doesn't really matter, as we can queue them up before the thread message dispatching logic. That's exactly what we do now, which allows us to make a single method for both of them, making the code much clearer and simplifying future maintenance.

This patch also includes a tiny fixup in the compose logic, which checks for the validity of the generated key event before actually working with it. The cases in which we can end up with an invalid reference are very few, so it's not the end of the world, but it's still absolutely a good idea to check, to avoid nasty surprises down the line.

---

This is purely a code structure change (behavior should be identical), but it makes adding new features a lot easier, including the bump to `wl_keyboard` version 10 (server-side key repetition).