### PR TITLE
Fix project path resetting when canceling folder browse in project manager

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -835,6 +835,14 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 	if (mode == MODE_IMPORT && !p_is_confirmed) {
 		return;
 	}
+
+	Size2 popup_size = Size2(500, 0) * EDSCALE;
+
+	if (mode == MODE_NEW && !p_is_confirmed) {
+		popup_centered(popup_size);
+		return;
+	}
+
 	if (mode == MODE_RENAME) {
 		// Name and path are set in `ProjectManager::_rename_project`.
 		project_path->set_editable(false);
@@ -962,7 +970,7 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 
 	_validate_path();
 
-	popup_centered(Size2(500, 0) * EDSCALE);
+	popup_centered(popup_size);
 }
 
 void ProjectDialog::_notification(int p_what) {


### PR DESCRIPTION
### Issue
When creating a new project, if the user:
1. Opens the project creation dialog (default path A is shown)
2. Clicks "Browse" and selects a different path B
3. Clicks "Browse" again and presses "Cancel"

https://github.com/user-attachments/assets/67659b4d-e989-489c-a989-a9ae295e8d66

The project path incorrectly reverts to the default path A instead of preserving the user-selected path B.

### Root Cause
In `ProjectDialog::show_dialog()`, the path resetting logic is executed unconditionally after the folder browser closes, regardless of whether the user confirmed or canceled the selection.

### Fix
For new project creation mode (`MODE_NEW`), skip the path resetting logic when the dialog is shown without confirmation (`p_is_confirmed=false`). This preserves the previously selected path when the user cancels the folder browser.

### Testing
- Reproduced the issue before the fix
- Verified the path is now correctly preserved after canceling the browse dialog
- Tested creating a project with the new behavior - works as expected

**Note**: This is a minimal fix. A more comprehensive refactoring could separate the path initialization logic from the dialog display logic for better maintainability.
