### PR TITLE
Prevent double counting and cyclical error when gathering Resources

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1769,7 +1769,9 @@ void EditorNode::gather_resources(const Variant &p_variant, List<Ref<Resource>> 
 					r_list.push_back(res);
 				}
 			}
-			gather_resources(v, r_list, p_subresources, p_allow_external);
+			if (Object::cast_to<Node>(v) == nullptr) {
+				gather_resources(v, r_list, p_subresources, p_allow_external);
+			}
 		}
 		return;
 	}
@@ -1793,8 +1795,12 @@ void EditorNode::gather_resources(const Variant &p_variant, List<Ref<Resource>> 
 					r_list.push_back(res_value);
 				}
 			}
-			gather_resources(kv.key, r_list, p_subresources, p_allow_external);
-			gather_resources(kv.value, r_list, p_subresources, p_allow_external);
+			if (Object::cast_to<Node>(kv.key) == nullptr) {
+				gather_resources(kv.key, r_list, p_subresources, p_allow_external);
+			}
+			if (Object::cast_to<Node>(kv.value) == nullptr) {
+				gather_resources(kv.value, r_list, p_subresources, p_allow_external);
+			}
 		}
 		return;
 	}
@@ -1809,12 +1815,10 @@ void EditorNode::gather_resources(const Variant &p_variant, List<Ref<Resource>> 
 
 		Variant property_value = p_variant.get(E.name);
 		Variant::Type property_type = property_value.get_type();
-
 		if (property_type == Variant::ARRAY || property_type == Variant::DICTIONARY) {
 			gather_resources(property_value, r_list, p_subresources, p_allow_external);
 			continue;
 		}
-
 		Ref<Resource> res = property_value;
 		if (res.is_null()) {
 			continue;

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5186,9 +5186,9 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 			} else {
 				undo_redo->add_undo_property(object, p_name, value);
 			}
-			// We'll use Editor Selection to get the currently edited Node.
 			Node *N = Object::cast_to<Node>(object);
-			if (N && (type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && value != p_value) {
+			bool double_counting = Object::cast_to<Node>(p_value) == N || Object::cast_to<Node>(value) == N;
+			if (N && !double_counting && (type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && value != p_value) {
 				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", value, N, true);
 				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, false);
 				// Perhaps an inefficient way of updating the resource count.


### PR DESCRIPTION
Fixes #113340
When nodes were being set in the inspector, it would try to get its Resources and add it to Resource counter. In the best case scenario, the counter would be 1 off due to counting a Node's Resources twice. in the worse one, a cyclical Reference would happen, crashing the Editor. This PR aims to fix both of these issues 