### PR TITLE
Exclude unsupported pixel formats from Linux camera feed

### DIFF
--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -44,6 +44,23 @@ void CameraFeedLinux::update_buffer_thread_func(void *p_func) {
 	}
 }
 
+bool CameraFeedLinux::is_format_supported(uint32_t p_pixel_format) {
+	switch (p_pixel_format) {
+		case V4L2_PIX_FMT_MJPEG:
+		case V4L2_PIX_FMT_JPEG:
+		case V4L2_PIX_FMT_YUV420:
+		case V4L2_PIX_FMT_YVU420:
+		case V4L2_PIX_FMT_YUYV:
+		case V4L2_PIX_FMT_YYUV:
+		case V4L2_PIX_FMT_YVYU:
+		case V4L2_PIX_FMT_UYVY:
+		case V4L2_PIX_FMT_VYUY:
+			return true;
+		default:
+			return false;
+	}
+}
+
 void CameraFeedLinux::_update_buffer() {
 	while (!exit_flag.is_set()) {
 		_read_frame();
@@ -105,6 +122,10 @@ void CameraFeedLinux::_query_device(const String &p_device_name) {
 }
 
 void CameraFeedLinux::_add_format(v4l2_fmtdesc p_description, v4l2_frmsize_discrete p_size, int p_frame_numerator, int p_frame_denominator) {
+	if (!CameraFeedLinux::is_format_supported(p_description.pixelformat)) {
+		return;
+	}
+
 	FeedFormat feed_format;
 	feed_format.width = p_size.width;
 	feed_format.height = p_size.height;

--- a/modules/camera/camera_feed_linux.h
+++ b/modules/camera/camera_feed_linux.h
@@ -52,6 +52,7 @@ private:
 	BufferDecoder *buffer_decoder = nullptr;
 
 	static void update_buffer_thread_func(void *p_func);
+	static bool is_format_supported(uint32_t p_pixel_format);
 
 	void _update_buffer();
 	void _query_device(const String &p_device_name);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
fixed: #113356
Filter the format list to only include supported formats (MJPEG, JPEG, and YUYV variants).