### PR TITLE
Fix MJPEG camera decoding on Linux

### DIFF
--- a/modules/camera/SCsub
+++ b/modules/camera/SCsub
@@ -26,6 +26,8 @@ elif env["platform"] in ["ios", "visionos"]:
     env.Append(MODULES_EXTERNAL=["_camera"])
 
 elif env["platform"] == "linuxbsd":
+    if env["builtin_libjpeg_turbo"]:
+        env_camera.Prepend(CPPPATH=["#thirdparty/libjpeg-turbo/src"])
     env_camera.add_source_files(env.modules_sources, "camera_linux.cpp")
     env_camera.add_source_files(env.modules_sources, "camera_feed_linux.cpp")
     env_camera.add_source_files(env.modules_sources, "buffer_decoder.cpp")

--- a/modules/camera/buffer_decoder.cpp
+++ b/modules/camera/buffer_decoder.cpp
@@ -198,15 +198,112 @@ void CopyBufferDecoder::decode(StreamingBuffer p_buffer) {
 	camera_feed->set_rgb_image(image);
 }
 
+// libjpeg-turbo is used directly here (instead of Image::load_jpg_from_buffer) for two reasons:
+// 1. We decompress to YUV planes via tj3DecompressToYUVPlanes8 and let the GPU shader do
+//    YUV->RGB conversion (modules/jpg's API only exposes RGB/grayscale output).
+// 2. The tjhandle is reused across frames to avoid per-frame setup cost in the streaming path.
 JpegBufferDecoder::JpegBufferDecoder(CameraFeed *p_camera_feed) :
 		BufferDecoder(p_camera_feed) {
+	tj_instance = tj3Init(TJINIT_DECOMPRESS);
+	if (tj_instance) {
+		// Allow partial/corrupt JPEG decoding for streaming sources like cameras.
+		tj3Set(tj_instance, TJPARAM_STOPONWARNING, 0);
+	}
+	y_image.instantiate();
+	cbcr_image.instantiate();
+}
+
+JpegBufferDecoder::~JpegBufferDecoder() {
+	if (tj_instance) {
+		tj3Destroy(tj_instance);
+		tj_instance = nullptr;
+	}
 }
 
 void JpegBufferDecoder::decode(StreamingBuffer p_buffer) {
-	image_data.resize(p_buffer.length);
-	uint8_t *dst = (uint8_t *)image_data.ptrw();
-	memcpy(dst, p_buffer.start, p_buffer.length);
-	if (image->load_jpg_from_buffer(image_data) == OK) {
-		camera_feed->set_rgb_image(image);
+	if (!tj_instance) {
+		return;
 	}
+
+	size_t data_size = p_buffer.bytes_used > 0 ? p_buffer.bytes_used : p_buffer.length;
+	uint8_t *src = (uint8_t *)p_buffer.start;
+
+	// Verify JPEG SOI marker (FFD8).
+	if (data_size < 2 || src[0] != 0xFF || src[1] != 0xD8) {
+		return;
+	}
+
+	if (tj3DecompressHeader(tj_instance, src, data_size) < 0) {
+		return;
+	}
+
+	const int jpeg_width = tj3Get(tj_instance, TJPARAM_JPEGWIDTH);
+	const int jpeg_height = tj3Get(tj_instance, TJPARAM_JPEGHEIGHT);
+	const TJCS colorspace = (TJCS)tj3Get(tj_instance, TJPARAM_COLORSPACE);
+	const TJSAMP subsamp = (TJSAMP)tj3Get(tj_instance, TJPARAM_SUBSAMP);
+
+	if (tj3Get(tj_instance, TJPARAM_PRECISION) > 8) {
+		return;
+	}
+
+	// Grayscale images: decode directly.
+	if (colorspace == TJCS_GRAY || subsamp == TJSAMP_GRAY) {
+		// Resize buffer only if dimensions changed.
+		if (jpeg_width != buffer_width || jpeg_height != buffer_height) {
+			buffer_width = jpeg_width;
+			buffer_height = jpeg_height;
+			y_plane_buffer.resize(buffer_width * buffer_height);
+		}
+
+		if (tj3Decompress8(tj_instance, src, data_size, y_plane_buffer.ptrw(), 0, TJPF_GRAY) < 0) {
+			return;
+		}
+
+		image->set_data(buffer_width, buffer_height, false, Image::FORMAT_L8, y_plane_buffer);
+		camera_feed->set_rgb_image(image);
+		return;
+	}
+
+	// Color images: decode to YUV planes and pass to GPU shader for conversion.
+	const int y_plane_width = tj3YUVPlaneWidth(0, jpeg_width, subsamp);
+	const int y_plane_height = tj3YUVPlaneHeight(0, jpeg_height, subsamp);
+	const int cb_plane_width = tj3YUVPlaneWidth(1, jpeg_width, subsamp);
+	const int cb_plane_height = tj3YUVPlaneHeight(1, jpeg_height, subsamp);
+	const size_t y_size = (size_t)y_plane_width * y_plane_height;
+	const size_t cb_size = (size_t)cb_plane_width * cb_plane_height;
+
+	// Resize buffers only if dimensions changed.
+	if (jpeg_width != buffer_width || jpeg_height != buffer_height) {
+		buffer_width = jpeg_width;
+		buffer_height = jpeg_height;
+
+		y_plane_buffer.resize(y_size);
+		cb_plane_buffer.resize(cb_size);
+		cr_plane_buffer.resize(cb_size);
+		// CbCr interleaved buffer (LA8 format: L=Cb, A=Cr).
+		cbcr_buffer.resize(cb_size * 2);
+	}
+
+	// Set up YUV plane pointers (separate buffers, no extra copy needed for Y).
+	uint8_t *y_ptr = y_plane_buffer.ptrw();
+	uint8_t *cb_ptr = cb_plane_buffer.ptrw();
+	uint8_t *cr_ptr = cr_plane_buffer.ptrw();
+
+	unsigned char *planes[3] = { y_ptr, cb_ptr, cr_ptr };
+	int strides[3] = { y_plane_width, cb_plane_width, cb_plane_width };
+
+	if (tj3DecompressToYUVPlanes8(tj_instance, src, data_size, planes, strides) < 0) {
+		return;
+	}
+
+	// Interleave Cb and Cr into RG8 format for GPU shader (R=Cb, G=Cr).
+	uint8_t *cbcr_dst = cbcr_buffer.ptrw();
+	for (size_t i = 0; i < cb_size; i++) {
+		*cbcr_dst++ = cb_ptr[i]; // R channel = Cb (U)
+		*cbcr_dst++ = cr_ptr[i]; // G channel = Cr (V)
+	}
+
+	y_image->set_data(y_plane_width, y_plane_height, false, Image::FORMAT_L8, y_plane_buffer);
+	cbcr_image->set_data(cb_plane_width, cb_plane_height, false, Image::FORMAT_RG8, cbcr_buffer);
+	camera_feed->set_ycbcr_images(y_image, cbcr_image);
 }

--- a/modules/camera/buffer_decoder.h
+++ b/modules/camera/buffer_decoder.h
@@ -33,11 +33,14 @@
 #include "core/io/image.h"
 #include "core/templates/vector.h"
 
+#include <turbojpeg.h>
+
 class CameraFeed;
 
 struct StreamingBuffer {
 	void *start = nullptr;
 	size_t length = 0;
+	size_t bytes_used = 0; // Actual data size (for variable-length formats like MJPEG)
 };
 
 class BufferDecoder {
@@ -105,9 +108,18 @@ public:
 
 class JpegBufferDecoder : public BufferDecoder {
 private:
-	Vector<uint8_t> image_data;
+	tjhandle tj_instance = nullptr;
+	Vector<uint8_t> y_plane_buffer; // Y plane for decoding and Image::set_data.
+	Vector<uint8_t> cb_plane_buffer; // Cb plane for decoding.
+	Vector<uint8_t> cr_plane_buffer; // Cr plane for decoding.
+	Vector<uint8_t> cbcr_buffer; // Interleaved CbCr (RG8 format).
+	Ref<Image> y_image;
+	Ref<Image> cbcr_image;
+	int buffer_width = 0;
+	int buffer_height = 0;
 
 public:
 	JpegBufferDecoder(CameraFeed *p_camera_feed);
+	~JpegBufferDecoder();
 	virtual void decode(StreamingBuffer p_buffer) override;
 };

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -197,7 +197,9 @@ void CameraFeedLinux::_read_frame() {
 		return;
 	}
 
-	buffer_decoder->decode(buffers[buffer.index]);
+	StreamingBuffer streaming_buffer = buffers[buffer.index];
+	streaming_buffer.bytes_used = buffer.bytesused;
+	buffer_decoder->decode(streaming_buffer);
 
 	if (ioctl(file_descriptor, VIDIOC_QBUF, &buffer) == -1) {
 		print_error(vformat("ioctl(VIDIOC_QBUF) error: %d.", errno));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
fixed #113357 
MJPEG streams from cameras have two issues:
1. V4L2 buffer size is allocated for the maximum frame size, which is larger than the actual JPEG data size. Passing the entire buffer to the decoder causes it to fail due to invalid trailing data.
2. Real-time streams may have partially corrupted frames. The standard JPEG decoder strictly rejects these as errors.

→ **Solution**:
- Use `v4l2_buffer.bytesused` to get the actual frame size.
- Add an internal function that decodes using libjpeg-turbo's lenient mode (tolerates partial corruption).

