### PR TITLE
Fix: take over resource path when remapping after external moves to avoid path-collision error

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1588,7 +1588,7 @@ void FileSystemDock::_update_resource_paths_after_move(const HashMap<String, Str
 
 		if (p_renames.has(base_path)) {
 			base_path = p_renames[base_path];
-			r->set_path(base_path + extra_path);
+			r->set_path(base_path + extra_path, true);
 		}
 	}
 


### PR DESCRIPTION
Fixes: #112164 

When a script or resource is moved outside the editor and later restored to its previous location inside the editor, the resource cache can still hold an entry for the old path. Remapping the open resource without takeover triggers the error:

`ERROR: Another resource is loaded from path 'res://1.gd' (possible cyclic resource inclusion). at: set_path (core/io/resource.cpp:95)`

This PR updates the remapping logic to call set_path(..., _p_take_over_=true), allowing the current resource to take over the cache entry for the path and preventing the collision.