### PR TITLE
 Android: Add method to take persistable URI permission

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -790,8 +790,17 @@
 				[b]Note:[/b] On macOS, sandboxed apps will save security-scoped bookmarks to retain access to the opened folders across multiple sessions. Use [method OS.get_granted_permissions] to get a list of saved bookmarks.
 				[b]Note:[/b] On Android, this method uses the Android Storage Access Framework (SAF).
 				The file picker returns a URI instead of a filesystem path. This URI can be passed directly to [FileAccess] to perform read/write operations.
-				When using [constant FILE_DIALOG_MODE_OPEN_DIR], it returns a tree URI that grants full access to the selected directory. File operations inside this directory can be performed by passing a path in the form [code]treeUri#relative/path/to/file[/code] to [FileAccess].
-				Tree URIs should be saved and reused; they remain valid across app restarts as long as the directory is not moved, renamed, or deleted.
+				When using [constant FILE_DIALOG_MODE_OPEN_DIR], it returns a tree URI that grants full access to the selected directory. File operations inside this directory can be performed by passing a path on the form [code]treeUri#relative/path/to/file[/code] to [FileAccess].
+				To avoid opening the file picker again after each app restart, you can take persistable URI permission as follows:
+				[codeblocks]
+				[gdscript]
+				val uri = "content://com.android..." # URI of the selected file or folder.
+				val persist = true # Set to false to release the persistable permission.
+				var android_runtime = Engine.get_singleton("AndroidRuntime")
+				android_runtime.updatePersistableUriPermission(uri, persist)
+				[/gdscript]
+				[/codeblocks]
+				The persistable URI permission remains valid across app restarts as long as the directory is not moved, renamed, or deleted.
 			</description>
 		</method>
 		<method name="file_dialog_with_options_show">

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/io/FilePicker.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/io/FilePicker.kt
@@ -85,28 +85,12 @@ internal class FilePicker {
 						for (i in 0 until clipData.itemCount) {
 							val uri = clipData.getItemAt(i).uri
 							uri?.let {
-								try {
-									context.contentResolver.takePersistableUriPermission(
-										it,
-										Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-									)
-								} catch (e: SecurityException) {
-									Log.d(TAG, "Unable to persist URI: $it", e)
-								}
 								selectedFiles.add(it.toString())
 							}
 						}
 					} else {
 						val uri: Uri? = data?.data
 						uri?.let {
-							try {
-								context.contentResolver.takePersistableUriPermission(
-									it,
-									Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-								)
-							} catch (e: SecurityException) {
-								Log.w(TAG, "Unable to persist URI: $it", e)
-							}
 							selectedFiles.add(it.toString())
 						}
 					}


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/112215

Current logic was automatically taking persistable URI permission on each selected URI but there's a [maximum limit on total grants](https://android.googlesource.com/platform/frameworks/base/+/master/services/core/java/com/android/server/uri/UriGrantsManagerService.java#127)
On Android 11 and higher, limit is 512 and on older devices, it is 128 permission grants.

This PR adds a method in AndroidRuntime Plugin to take or release persistable URI permissions. It allows users to control when a permission should be persisted and when it should be released.