### PR TITLE
Expose the internal `Popup` instance inside `Tree`

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -209,6 +209,12 @@
 				If [param from] is [code]null[/code], this returns the first selected item.
 			</description>
 		</method>
+		<method name="get_popup_editor" qualifiers="const">
+			<return type="Popup" />
+			<description>
+				Returns the [Popup] used when editing a tree item.
+			</description>
+		</method>
 		<method name="get_pressed_button" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -255,6 +261,12 @@
 			<param index="0" name="column" type="int" />
 			<description>
 				Returns [code]true[/code] if the column has enabled expanding (see [method set_column_expand]).
+			</description>
+		</method>
+		<method name="is_editing">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if a cell is currently being edited.
 			</description>
 		</method>
 		<method name="scroll_to_item">

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4498,6 +4498,10 @@ bool Tree::is_editing() {
 	return popup_editor->is_visible();
 }
 
+Popup *Tree::get_popup_editor() const {
+	return popup_editor;
+}
+
 void Tree::set_editor_selection(int p_from_line, int p_to_line, int p_from_column, int p_to_column, int p_caret) {
 	if (p_from_column == -1 || p_to_column == -1) {
 		line_editor->select(p_from_line, p_to_line);
@@ -6620,6 +6624,8 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_edited"), &Tree::get_edited);
 	ClassDB::bind_method(D_METHOD("get_edited_column"), &Tree::get_edited_column);
 	ClassDB::bind_method(D_METHOD("edit_selected", "force_edit"), &Tree::edit_selected, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("is_editing"), &Tree::is_editing);
+	ClassDB::bind_method(D_METHOD("get_popup_editor"), &Tree::get_popup_editor);
 	ClassDB::bind_method(D_METHOD("get_custom_popup_rect"), &Tree::get_custom_popup_rect);
 	ClassDB::bind_method(D_METHOD("get_item_area_rect", "item", "column", "button_index"), &Tree::get_item_rect, DEFVAL(-1), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("get_item_at_position", "position"), &Tree::get_item_at_position);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -878,6 +878,7 @@ public:
 	Rect2 get_item_rect(TreeItem *p_item, int p_column = -1, int p_button = -1) const;
 	bool edit_selected(bool p_force_edit = false);
 	bool is_editing();
+	Popup *get_popup_editor() const;
 	void set_editor_selection(int p_from_line, int p_to_line, int p_from_column = -1, int p_to_column = -1, int p_caret = 0);
 
 	// First item that starts with the text, from the current focused item down and wraps around.


### PR DESCRIPTION
Hi @jonbonazza, as discussed, a simple yet effective `item_edit_canceled` signal for the `Tree` control, indicating when a user cancels or the popup closes and the change was not submitted.