### PR TITLE
Range: Don't use min for snap offset when it's too big

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -189,8 +189,13 @@ double Range::_calc_value(double p_val, double p_step) const {
 	}
 
 	if (p_step > 0) {
-		// Subtract min to support cases like min = 0.1, step = 0.2, snaps to 0.1, 0.3, 0.5, etc.
-		p_val = _snapped_r128(p_val - shared->min, p_step) + shared->min;
+		if (Math::abs(shared->min) > p_step * 1e14) {
+			// Min is too big to use for snapping offset, so snap without it.
+			p_val = _snapped_r128(p_val, p_step);
+		} else {
+			// Subtract min to support cases like min = 0.1, step = 0.2, snaps to 0.1, 0.3, 0.5, etc.
+			p_val = _snapped_r128(p_val - shared->min, p_step) + shared->min;
+		}
 	}
 
 	if (_rounded_values) {


### PR DESCRIPTION
A user complained to me that they set the min value to a huge negative number, and then the snapping does not work:

https://github.com/user-attachments/assets/7c724306-a580-4e00-90d5-a70fe81ddea2

This PR disables the min snap offset when min is so large that adding or subtracting the step size would not reliably change the number, the snapping offset behavior is skipped, and it just snaps directly:

https://github.com/user-attachments/assets/f7d160f5-e34b-4a77-b2db-5099b9cbe3e2

