### PR TITLE
Doc: Add missing `func` keyword to `EditorDock._update_layout` example

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -56,7 +56,7 @@
 			<description>
 				Implement this method to handle the layout switching for this dock. [param layout] is one of the [enum DockLayout] constants.
 				[codeblock]
-				_update_layout(layout):
+				func _update_layout(layout):
 					box_container.vertical = (layout == DOCK_LAYOUT_VERTICAL)
 				[/codeblock]
 			</description>


### PR DESCRIPTION
## Summary

Fixes #113324

This PR fixes a documentation error in the `EditorDock._update_layout` code example where the `func` keyword was missing from the method declaration.

## Issue

The code snippet demonstrating how to override the `_update_layout` method was missing the required `func` keyword, making it invalid GDScript syntax.

## Changes Made

Added the `func` keyword to the `_update_layout` method in the code example at line 59 of `doc/classes/EditorDock.xml`.

Before:
```gdscript
_update_layout(layout):
    box_container.vertical = (layout == DOCK_LAYOUT_VERTICAL)
After:
func _update_layout(layout):
    box_container.vertical = (layout == DOCK_LAYOUT_VERTICAL)
