### PR TITLE
Disable Android devices mirroring for the Android editor

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2264,6 +2264,7 @@ bool EditorExportPlatformAndroid::should_update_export_options() {
 	return false;
 }
 
+#ifndef ANDROID_ENABLED
 bool EditorExportPlatformAndroid::poll_export() {
 	bool dc = devices_changed.is_set();
 	if (dc) {
@@ -2589,6 +2590,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 	CLEANUP_AND_RETURN(OK);
 #undef CLEANUP_AND_RETURN
 }
+#endif // ANDROID_ENABLED
 
 Ref<Texture2D> EditorExportPlatformAndroid::get_run_icon() const {
 	return run_icon;
@@ -4369,18 +4371,18 @@ void EditorExportPlatformAndroid::initialize() {
 		ImageLoaderSVG::create_image_from_string(img, _android_run_icon_svg, EDSCALE, upsample, false);
 		run_icon = ImageTexture::create_from_image(img);
 
-		devices_changed.set();
 #ifndef DISABLE_DEPRECATED
 		android_plugins_changed.set();
 #endif // DISABLE_DEPRECATED
 #ifndef ANDROID_ENABLED
+		devices_changed.set();
 		_create_editor_debug_keystore_if_needed();
 		_update_preset_status();
 		check_for_changes_thread.start(_check_for_changes_poll_thread, this);
-#else
-		android_editor_gradle_runner = memnew(AndroidEditorGradleRunner);
-#endif
 		use_scrcpy = EditorSettings::get_singleton()->get_project_metadata("android", "use_scrcpy", false);
+#else // ANDROID_ENABLED
+		android_editor_gradle_runner = memnew(AndroidEditorGradleRunner);
+#endif // ANDROID_ENABLED
 	}
 }
 

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -97,20 +97,21 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 	uint64_t last_gradle_build_time = 0;
 	String last_gradle_build_dir;
 
+#ifndef ANDROID_ENABLED
 	bool use_scrcpy = false;
 	Vector<Device> devices;
 	SafeFlag devices_changed;
 	Mutex device_lock;
-#ifndef ANDROID_ENABLED
+
 	Thread check_for_changes_thread;
 	SafeFlag quit_request;
 	SafeFlag has_runnable_preset;
 
 	static void _check_for_changes_poll_thread(void *ud);
 	void _update_preset_status();
-#else
+#else // ANDROID_ENABLED
 	AndroidEditorGradleRunner *android_editor_gradle_runner = nullptr;
-#endif
+#endif // ANDROID_ENABLED
 
 	String get_project_name(const Ref<EditorExportPreset> &p_preset, const String &p_name) const;
 
@@ -223,6 +224,7 @@ public:
 
 	virtual bool should_update_export_options() override;
 
+#ifndef ANDROID_ENABLED
 	virtual bool poll_export() override;
 
 	virtual int get_options_count() const override;
@@ -240,6 +242,7 @@ public:
 	virtual String get_device_architecture(int p_index) const override;
 
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
+#endif // ANDROID_ENABLED
 
 	virtual Ref<Texture2D> get_run_icon() const override;
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/108737; this PR disables the Android devices mirroring feature for the Android editor by moving the Android devices polling logic behind `#ifndef ANDROID_ENABLED` 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
