### PR TITLE
TabBar: Add options for tab sizing strategy

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -282,6 +282,9 @@
 		<member name="tab_count" type="int" setter="set_tab_count" getter="get_tab_count" default="0">
 			The number of tabs currently in the bar.
 		</member>
+		<member name="tab_sizing" type="int" setter="set_tab_sizing" getter="get_tab_sizing" enum="TabBar.SizingMode" default="0">
+			The sizing strategy used to determine tab widths.
+		</member>
 		<member name="tab_{index}/disabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the tab at [code]index[/code] is disabled.
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. tab_count - 1[/code] range.
@@ -374,6 +377,21 @@
 		</constant>
 		<constant name="ALIGNMENT_MAX" value="3" enum="AlignmentMode">
 			Represents the size of the [enum AlignmentMode] enum.
+		</constant>
+		<constant name="TAB_SIZING_FIT_CONTENT" value="0" enum="SizingMode">
+			Size tabs individually according to the size of their content.
+		</constant>
+		<constant name="TAB_SIZING_UNIFORM" value="1" enum="SizingMode">
+			Size tabs uniformly, with the widest tab determining the size of all tabs. This may trigger clipping sooner than other sizing modes due to increased tab sizes.
+		</constant>
+		<constant name="TAB_SIZING_JUSTIFY" value="2" enum="SizingMode">
+			Size tabs individually according to their content, expanding to the full width of the tab bar.
+		</constant>
+		<constant name="TAB_SIZING_EXPAND" value="3" enum="SizingMode">
+			Size tabs equally, expanding to the full width of the tab bar if there is room, otherwise fall back to [constant TAB_SIZING_FIT_CONTENT].
+		</constant>
+		<constant name="TAB_SIZING_MAX" value="4" enum="SizingMode">
+			Represents the size of the [enum SizingMode] enum.
 		</constant>
 		<constant name="CLOSE_BUTTON_SHOW_NEVER" value="0" enum="CloseButtonDisplayPolicy">
 			Never show the close buttons.

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -232,6 +232,9 @@
 		<member name="tab_focus_mode" type="int" setter="set_tab_focus_mode" getter="get_tab_focus_mode" enum="Control.FocusMode" default="2">
 			The focus access mode for the internal [TabBar] node.
 		</member>
+		<member name="tab_sizing" type="int" setter="set_tab_sizing" getter="get_tab_sizing" enum="TabBar.SizingMode" default="0">
+			The sizing strategy used to determine tab widths.
+		</member>
 		<member name="tab_{index}/disabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the tab at [code]index[/code] is disabled.
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. get_tab_count() - 1[/code] range.

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -59,11 +59,13 @@ Size2 TabBar::get_minimum_size() const {
 
 	int y_margin = MAX(MAX(MAX(theme_cache.tab_unselected_style->get_minimum_size().height, theme_cache.tab_hovered_style->get_minimum_size().height), theme_cache.tab_selected_style->get_minimum_size().height), theme_cache.tab_disabled_style->get_minimum_size().height);
 	int max_tab_width = 0;
+	int visible_tabs_count = 0;
 
 	for (int i = 0; i < tabs.size(); i++) {
 		if (tabs[i].hidden) {
 			continue;
 		}
+		visible_tabs_count++;
 
 		int ofs = ms.width;
 
@@ -121,6 +123,11 @@ Size2 TabBar::get_minimum_size() const {
 		if (ms.width - ofs > max_tab_width) {
 			max_tab_width = ms.width - ofs;
 		}
+	}
+
+	if (tab_sizing == TAB_SIZING_UNIFORM && visible_tabs_count > 0) {
+		int total_separation = (visible_tabs_count - 1) * theme_cache.tab_separation;
+		ms.width = (max_tab_width * visible_tabs_count) + total_separation;
 	}
 
 	if (clip_tabs) {
@@ -1239,19 +1246,105 @@ void TabBar::_update_cache(bool p_update_hover) {
 	int limit = combined_max.width > 0 ? MIN(combined_max.width, get_size().width) : get_size().width;
 	int limit_minus_buttons = limit - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
 
+	// Calculate sizing information for the chosen tab sizing mode.
+	int visible_count = 0;
+	int total_base_width = 0;
+	int max_base_width = 0;
+
+	for (int i = 0; i < tabs.size(); i++) {
+		// Update text buffer so that the sizing calculations use the correct text size.
+		tabs.write[i].text_buf->set_width(-1);
+		tabs.write[i].size_text = Math::ceil(tabs[i].text_buf->get_size().x);
+
+		int tab_width = get_tab_width(i);
+		tabs.write[i].size_cache = tab_width;
+
+		if (tabs[i].hidden) {
+			continue;
+		}
+
+		total_base_width += tab_width;
+		max_base_width = MAX(max_base_width, tab_width);
+		visible_count++;
+	}
+
+	bool can_expand = false;
+	int expand_remainder = 0;
+	float justify_ratio = 1.0;
+	int uniform_width = 0;
+
+	if (visible_count > 0 && tab_sizing != TAB_SIZING_FIT_CONTENT) {
+		int total_separation = MAX(0, visible_count - 1) * theme_cache.tab_separation;
+		int available_space = limit - total_separation;
+
+		if (tab_sizing == TAB_SIZING_UNIFORM) {
+			// All tabs take the width of the largest tab.
+			uniform_width = max_base_width;
+		} else if (tab_sizing == TAB_SIZING_EXPAND) {
+			// Distribute space equally among all tabs.
+			int width_per_tab = available_space / visible_count;
+			// Only expand if the resulting width fits the largest tab, otherwise fall back to fit content.
+			if (width_per_tab >= max_base_width) {
+				can_expand = true;
+				uniform_width = width_per_tab;
+				expand_remainder = available_space % visible_count;
+			}
+		} else if (tab_sizing == TAB_SIZING_JUSTIFY) {
+			// Scale tabs proportionally to fill the space, if we have space to fill.
+			if (total_base_width <= available_space) {
+				can_expand = true;
+				justify_ratio = (float)available_space / (float)total_base_width;
+
+				// Recalculate the remainder that results from integer rounding.
+				int simulated_total = 0;
+				for (int i = 0; i < tabs.size(); i++) {
+					if (tabs[i].hidden) {
+						continue;
+					}
+					simulated_total += (int)(tabs[i].size_cache * justify_ratio);
+				}
+				expand_remainder = available_space - simulated_total;
+			}
+		}
+	}
+
 	int w = 0;
+	int visible_index = 0;
 
 	max_drawn_tab = tabs.size() - 1;
 
 	for (int i = 0; i < tabs.size(); i++) {
-		tabs.write[i].text_buf->set_width(-1);
-		tabs.write[i].size_text = Math::ceil(tabs[i].text_buf->get_size().x);
-		tabs.write[i].size_cache = get_tab_width(i);
+		int natural_width = tabs[i].size_cache;
+		int final_width = natural_width;
+
+		// Apply sizing.
+		if (!tabs[i].hidden) {
+			if (tab_sizing == TAB_SIZING_UNIFORM) {
+				final_width = uniform_width;
+			} else if (can_expand) {
+				if (tab_sizing == TAB_SIZING_EXPAND) {
+					final_width = uniform_width;
+				} else if (tab_sizing == TAB_SIZING_JUSTIFY) {
+					final_width = (int)(final_width * justify_ratio);
+				}
+
+				// Distribute remaining pixels.
+				if (visible_index < expand_remainder) {
+					final_width++;
+				}
+				visible_index++;
+			}
+		}
+
+		tabs.write[i].size_cache = final_width;
 		tabs.write[i].accessibility_item_dirty = true;
 
 		tabs.write[i].truncated = effective_max_width > 0 && effective_max_width < INT_MAX && tabs[i].size_cache > effective_max_width;
 		if (tabs[i].truncated) {
-			int size_textless = tabs[i].size_cache - tabs[i].size_text;
+			int size_textless = natural_width;
+			if (!tabs[i].text.is_empty()) {
+				size_textless -= tabs[i].size_text;
+			}
 			int mw = MAX(size_textless, effective_max_width);
 
 			tabs.write[i].size_text = MAX(mw - size_textless, 1);
@@ -1787,6 +1880,24 @@ TabBar::AlignmentMode TabBar::get_tab_alignment() const {
 	return tab_alignment;
 }
 
+void TabBar::set_tab_sizing(SizingMode p_sizing) {
+	ERR_FAIL_INDEX(p_sizing, TAB_SIZING_MAX);
+
+	if (tab_sizing == p_sizing) {
+		return;
+	}
+
+	tab_sizing = p_sizing;
+
+	_update_cache();
+	queue_redraw();
+	update_minimum_size();
+}
+
+TabBar::SizingMode TabBar::get_tab_sizing() const {
+	return tab_sizing;
+}
+
 void TabBar::set_clip_tabs(bool p_clip_tabs) {
 	if (clip_tabs == p_clip_tabs) {
 		return;
@@ -2188,6 +2299,8 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_idx_at_point", "point"), &TabBar::get_tab_idx_at_point);
 	ClassDB::bind_method(D_METHOD("set_tab_alignment", "alignment"), &TabBar::set_tab_alignment);
 	ClassDB::bind_method(D_METHOD("get_tab_alignment"), &TabBar::get_tab_alignment);
+	ClassDB::bind_method(D_METHOD("set_tab_sizing", "tab_sizing"), &TabBar::set_tab_sizing);
+	ClassDB::bind_method(D_METHOD("get_tab_sizing"), &TabBar::get_tab_sizing);
 	ClassDB::bind_method(D_METHOD("set_clip_tabs", "clip_tabs"), &TabBar::set_clip_tabs);
 	ClassDB::bind_method(D_METHOD("get_clip_tabs"), &TabBar::get_clip_tabs);
 	ClassDB::bind_method(D_METHOD("get_tab_offset"), &TabBar::get_tab_offset);
@@ -2228,6 +2341,7 @@ void TabBar::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_tab", PROPERTY_HINT_RANGE, "-1,4096,1"), "set_current_tab", "get_current_tab");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_tab_alignment", "get_tab_alignment");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_sizing", PROPERTY_HINT_ENUM, "Fit Content,Uniform,Justify,Expand"), "set_tab_sizing", "get_tab_sizing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_tabs"), "set_clip_tabs", "get_clip_tabs");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "close_with_middle_mouse"), "set_close_with_middle_mouse", "get_close_with_middle_mouse");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_close_display_policy", PROPERTY_HINT_ENUM, "Show Never,Show Active Only,Show Always"), "set_tab_close_display_policy", "get_tab_close_display_policy");
@@ -2246,6 +2360,12 @@ void TabBar::_bind_methods() {
 	BIND_ENUM_CONSTANT(ALIGNMENT_CENTER);
 	BIND_ENUM_CONSTANT(ALIGNMENT_RIGHT);
 	BIND_ENUM_CONSTANT(ALIGNMENT_MAX);
+
+	BIND_ENUM_CONSTANT(TAB_SIZING_FIT_CONTENT);
+	BIND_ENUM_CONSTANT(TAB_SIZING_UNIFORM);
+	BIND_ENUM_CONSTANT(TAB_SIZING_JUSTIFY);
+	BIND_ENUM_CONSTANT(TAB_SIZING_EXPAND);
+	BIND_ENUM_CONSTANT(TAB_SIZING_MAX);
 
 	BIND_ENUM_CONSTANT(CLOSE_BUTTON_SHOW_NEVER);
 	BIND_ENUM_CONSTANT(CLOSE_BUTTON_SHOW_ACTIVE_ONLY);

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -62,6 +62,14 @@ public:
 		DRAW_MAX,
 	};
 
+	enum SizingMode {
+		TAB_SIZING_FIT_CONTENT,
+		TAB_SIZING_UNIFORM,
+		TAB_SIZING_JUSTIFY,
+		TAB_SIZING_EXPAND,
+		TAB_SIZING_MAX
+	};
+
 private:
 	struct Tab {
 		mutable RID accessibility_item_element;
@@ -112,6 +120,7 @@ private:
 	int current = -1;
 	int previous = -1;
 	AlignmentMode tab_alignment = ALIGNMENT_LEFT;
+	SizingMode tab_sizing = TAB_SIZING_FIT_CONTENT;
 	bool clip_tabs = true;
 	int rb_hover = -1;
 	bool rb_pressing = false;
@@ -270,6 +279,9 @@ public:
 	void set_tab_alignment(AlignmentMode p_alignment);
 	AlignmentMode get_tab_alignment() const;
 
+	void set_tab_sizing(SizingMode p_sizing);
+	SizingMode get_tab_sizing() const;
+
 	void set_clip_tabs(bool p_clip_tabs);
 	bool get_clip_tabs() const;
 
@@ -340,4 +352,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(TabBar::AlignmentMode);
+VARIANT_ENUM_CAST(TabBar::SizingMode);
 VARIANT_ENUM_CAST(TabBar::CloseButtonDisplayPolicy);

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -784,6 +784,19 @@ TabBar::AlignmentMode TabContainer::get_tab_alignment() const {
 	return tab_bar->get_tab_alignment();
 }
 
+void TabContainer::set_tab_sizing(TabBar::SizingMode p_sizing) {
+	if (tab_bar->get_tab_sizing() == p_sizing) {
+		return;
+	}
+
+	tab_bar->set_tab_sizing(p_sizing);
+	_update_margins();
+}
+
+TabBar::SizingMode TabContainer::get_tab_sizing() const {
+	return tab_bar->get_tab_sizing();
+}
+
 void TabContainer::set_tabs_position(TabPosition p_tabs_position) {
 	ERR_FAIL_INDEX(p_tabs_position, POSITION_MAX);
 	if (p_tabs_position == tabs_position) {
@@ -1195,6 +1208,8 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_control", "tab_idx"), &TabContainer::get_tab_control);
 	ClassDB::bind_method(D_METHOD("set_tab_alignment", "alignment"), &TabContainer::set_tab_alignment);
 	ClassDB::bind_method(D_METHOD("get_tab_alignment"), &TabContainer::get_tab_alignment);
+	ClassDB::bind_method(D_METHOD("set_tab_sizing", "tab_sizing"), &TabContainer::set_tab_sizing);
+	ClassDB::bind_method(D_METHOD("get_tab_sizing"), &TabContainer::get_tab_sizing);
 	ClassDB::bind_method(D_METHOD("set_tabs_position", "tabs_position"), &TabContainer::set_tabs_position);
 	ClassDB::bind_method(D_METHOD("get_tabs_position"), &TabContainer::get_tabs_position);
 	ClassDB::bind_method(D_METHOD("set_clip_tabs", "clip_tabs"), &TabContainer::set_clip_tabs);
@@ -1249,6 +1264,7 @@ void TabContainer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("pre_popup_pressed"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_tab_alignment", "get_tab_alignment");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_sizing", PROPERTY_HINT_ENUM, "Fit Content,Uniform,Justify,Expand"), "set_tab_sizing", "get_tab_sizing");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_tab", PROPERTY_HINT_RANGE, "-1,4096,1"), "set_current_tab", "get_current_tab");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tabs_position", PROPERTY_HINT_ENUM, "Top,Bottom"), "set_tabs_position", "get_tabs_position");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_tabs"), "set_clip_tabs", "get_clip_tabs");

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -178,6 +178,9 @@ public:
 	void set_tab_alignment(TabBar::AlignmentMode p_alignment);
 	TabBar::AlignmentMode get_tab_alignment() const;
 
+	void set_tab_sizing(TabBar::SizingMode p_sizing);
+	TabBar::SizingMode get_tab_sizing() const;
+
 	void set_tabs_position(TabPosition p_tab_position);
 	TabPosition get_tabs_position() const;
 

--- a/tests/scene/test_tab_bar.cpp
+++ b/tests/scene/test_tab_bar.cpp
@@ -868,6 +868,224 @@ TEST_CASE("[SceneTree][TabBar] layout and offset") {
 		CHECK(tab_bar->get_tab_rect(2).position.x == tab_rects[1].size.x);
 	}
 
+	SUBCASE("[TabBar] tab separation") {
+		tab_bar->set_tab_alignment(TabBar::ALIGNMENT_LEFT);
+		tab_bar->set_clip_tabs(false);
+
+		// Set separation to 0 first.
+		tab_bar->add_theme_constant_override("tab_separation", 0);
+		MessageQueue::get_singleton()->flush();
+
+		tab_rects = {
+			tab_bar->get_tab_rect(0),
+			tab_bar->get_tab_rect(1),
+			tab_bar->get_tab_rect(2)
+		};
+
+		// Verify adjacency.
+		CHECK(tab_rects[1].position.x == tab_rects[0].position.x + tab_rects[0].size.x);
+		CHECK(tab_rects[2].position.x == tab_rects[1].position.x + tab_rects[1].size.x);
+
+		// Apply separation.
+		int separation = 20;
+		tab_bar->add_theme_constant_override("tab_separation", separation);
+		MessageQueue::get_singleton()->flush();
+
+		Vector<Rect2> rects_sep = {
+			tab_bar->get_tab_rect(0),
+			tab_bar->get_tab_rect(1),
+			tab_bar->get_tab_rect(2)
+		};
+
+		// Tab 0 should not move.
+		CHECK(rects_sep[0].position.x == tab_rects[0].position.x);
+
+		// Tab 1 should move by 1 * separation.
+		CHECK(rects_sep[1].position.x == tab_rects[1].position.x + separation);
+
+		// Tab 2 should move by 2 * separation.
+		CHECK(rects_sep[2].position.x == tab_rects[2].position.x + (separation * 2));
+
+		// Verify minimum size increased by total separation (separation * (tab_count - 1)).
+		Size2 min_size_0 = Size2(tab_rects[0].size.x + tab_rects[1].size.x + tab_rects[2].size.x, tab_rects[0].size.y);
+		Size2 expected_min_size = min_size_0;
+		expected_min_size.x += separation * 2;
+
+		CHECK(tab_bar->get_minimum_size().x == expected_min_size.x);
+	}
+
+	SUBCASE("[TabBar] hidden tabs remove separation") {
+		// Setup: Left alignment, no clipping, explicit separation.
+		tab_bar->set_tab_alignment(TabBar::ALIGNMENT_LEFT);
+		tab_bar->set_clip_tabs(false);
+		int separation = 20;
+		tab_bar->add_theme_constant_override("tab_separation", separation);
+
+		tab_bar->clear_tabs();
+		tab_bar->add_tab("A");
+		tab_bar->add_tab("B");
+		tab_bar->add_tab("C");
+		MessageQueue::get_singleton()->flush();
+
+		// All tabs visible. Layout: [A] - 20px - [B] - 20px - [C].
+		tab_rects = {
+			tab_bar->get_tab_rect(0),
+			tab_bar->get_tab_rect(1),
+			tab_bar->get_tab_rect(2)
+		};
+
+		CHECK(tab_rects[1].position.x == tab_rects[0].position.x + tab_rects[0].size.x + separation);
+		CHECK(tab_rects[2].position.x == tab_rects[1].position.x + tab_rects[1].size.x + separation);
+
+		// Hide middle tab. Layout: [A] - 20px - [C].
+		// The separation belonging to B should not be present.
+		tab_bar->set_tab_hidden(1, true);
+		MessageQueue::get_singleton()->flush();
+
+		tab_rects = {
+			tab_bar->get_tab_rect(0),
+			tab_bar->get_tab_rect(1),
+			tab_bar->get_tab_rect(2)
+		};
+
+		// Position of C should now be right after A + 1 separation.
+		float expected_c_pos = tab_rects[0].position.x + tab_rects[0].size.x + separation;
+		CHECK(tab_rects[2].position.x == expected_c_pos);
+	}
+
+	SUBCASE("[TabBar] sizing modes") {
+		tab_bar->clear_tabs();
+		tab_bar->set_tab_alignment(TabBar::ALIGNMENT_LEFT);
+		tab_bar->set_clip_tabs(false);
+
+		// Ensure we have a defined width that is larger than the content.
+		tab_bar->set_size(Size2(1000, 100));
+
+		tab_bar->add_tab("S"); // Small
+		tab_bar->add_tab("Medium"); // Medium
+		tab_bar->add_tab("Large Text"); // Large
+		MessageQueue::get_singleton()->flush();
+
+		// Get baseline sizes (Fit Content).
+		float width_s = tab_bar->get_tab_rect(0).size.x;
+		float width_m = tab_bar->get_tab_rect(1).size.x;
+		float width_l = tab_bar->get_tab_rect(2).size.x;
+
+		// Fit Content Sizing: Tabs adjust width to fit their content.
+		CHECK(tab_bar->get_tab_sizing() == TabBar::TAB_SIZING_FIT_CONTENT);
+		CHECK(width_s < width_m);
+		CHECK(width_m < width_l);
+
+		// Uniform Sizing: All tabs should become the size of the largest tab ("Large Text").
+		tab_bar->set_tab_sizing(TabBar::TAB_SIZING_UNIFORM);
+		MessageQueue::get_singleton()->flush();
+
+		CHECK(tab_bar->get_tab_rect(0).size.x == width_l);
+		CHECK(tab_bar->get_tab_rect(1).size.x == width_l);
+		CHECK(tab_bar->get_tab_rect(2).size.x == width_l);
+
+		// Justify Sizing: Tabs fill the space, but keep relative size differences based on content.
+		tab_bar->set_tab_sizing(TabBar::TAB_SIZING_JUSTIFY);
+		MessageQueue::get_singleton()->flush();
+
+		float justify_width_0 = tab_bar->get_tab_rect(0).size.x;
+		float justify_width_1 = tab_bar->get_tab_rect(1).size.x;
+		float justify_width_2 = tab_bar->get_tab_rect(2).size.x;
+
+		// Order implies size difference is preserved.
+		CHECK(justify_width_0 < justify_width_1);
+		CHECK(justify_width_1 < justify_width_2);
+
+		// Even the smallest tab should be wider than its natural size because we have 1000px to fill.
+		CHECK(justify_width_0 > width_s);
+
+		// Expand Sizing: Tabs should be equal width, dividing the 1000px available space (minus margins/separations).
+		tab_bar->set_tab_sizing(TabBar::TAB_SIZING_EXPAND);
+		MessageQueue::get_singleton()->flush();
+
+		float expand_width_0 = tab_bar->get_tab_rect(0).size.x;
+		float expand_width_1 = tab_bar->get_tab_rect(1).size.x;
+		float expand_width_2 = tab_bar->get_tab_rect(2).size.x;
+
+		// Allow 1px difference for rounding errors in distribution.
+		CHECK(Math::abs(expand_width_0 - expand_width_1) <= 1.0f);
+		CHECK(Math::abs(expand_width_1 - expand_width_2) <= 1.0f);
+
+		// They should be significantly larger than the "Large" natural width because they are filling 1000px.
+		CHECK(expand_width_0 > width_l);
+
+		// Verify they fill the width (approximate check).
+		float total_width = expand_width_0 + expand_width_1 + expand_width_2;
+		CHECK(total_width > 900.0f); // Sanity check against container size.
+	}
+
+	SUBCASE("[TabBar] separation reduces expand sizing width") {
+		tab_bar->clear_tabs();
+		tab_bar->set_size(Size2(200, 50));
+		tab_bar->set_tab_sizing(TabBar::TAB_SIZING_EXPAND);
+
+		// Add 2 tabs.
+		tab_bar->add_tab("1");
+		tab_bar->add_tab("2");
+		MessageQueue::get_singleton()->flush();
+
+		// Available space = 200. Each tab = 100.
+		tab_bar->add_theme_constant_override("tab_separation", 0);
+		MessageQueue::get_singleton()->flush();
+		float width_sep_0 = tab_bar->get_tab_rect(0).size.x;
+		CHECK(Math::is_equal_approx(width_sep_0, 100.0f));
+
+		// Separation = 50. Available space = 200 - 50 = 150. Each tab = 75.
+		int separation = 50;
+		tab_bar->add_theme_constant_override("tab_separation", separation);
+		MessageQueue::get_singleton()->flush();
+
+		float width_sep_50 = tab_bar->get_tab_rect(0).size.x;
+		CHECK(Math::is_equal_approx(width_sep_50, 75.0f));
+
+		// Ensure layout is contiguous: [Tab 75] [Sep 50] [Tab 75] = 200 total.
+		Rect2 r1 = tab_bar->get_tab_rect(0);
+		Rect2 r2 = tab_bar->get_tab_rect(1);
+		CHECK(r2.position.x == r1.size.x + separation);
+	}
+
+	SUBCASE("[TabBar] max width caps sizing modes") {
+		tab_bar->clear_tabs();
+		tab_bar->set_size(Size2(1000, 50));
+
+		// Create a tab with very long text that naturally exceeds the max width.
+		tab_bar->add_tab("This is a very long tab title that should exceed 200px");
+		MessageQueue::get_singleton()->flush();
+
+		float standard_tab_width = tab_bar->get_tab_rect(0).size.x;
+
+		// Set constraint.
+		int max_w = 200;
+		tab_bar->set_max_tab_width(max_w);
+		MessageQueue::get_singleton()->flush();
+
+		// Verify the unconstrained width is greater than max width, then verify the current width is constrained.
+		CHECK(standard_tab_width > max_w);
+
+		// Fit Content: Width should be constrained to 200px.
+		CHECK(tab_bar->get_tab_rect(0).size.x == max_w);
+
+		// Uniform: Width should be constrained to 200px.
+		tab_bar->set_tab_sizing(TabBar::TAB_SIZING_UNIFORM);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_bar->get_tab_rect(0).size.x == max_w);
+
+		// Justify: Width should be constrained to 200px.
+		tab_bar->set_tab_sizing(TabBar::TAB_SIZING_JUSTIFY);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_bar->get_tab_rect(0).size.x == max_w);
+
+		// Expand: Width should be constrained to 200px.
+		tab_bar->set_tab_sizing(TabBar::TAB_SIZING_EXPAND);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_bar->get_tab_rect(0).size.x == max_w);
+	}
+
 	memdelete(tab_bar);
 }
 


### PR DESCRIPTION
Adds the following tab sizing strategies:
- Fit Content: Default behavior. Tabs are sized according to their content.
- Uniform: Tabs are sized equally (uniformly), with the widest tab determining the size of all tabs.
- Justify: Tabs are sized according to their content, but also expand to fill the tab bar width.
- Expand: Tabs are sized equally, and expand to fill the tab bar width, if there is room for all tabs to be sized equally.

A new "Tab Sizing" option is now available in both TabBar and TabContainer nodes. The default is "Fit Content".

Closes [proposal #8397](https://github.com/godotengine/godot-proposals/discussions/8397).