### PR TITLE
[XR] Update the shortcuts to play current / specific scene based on the last selected XR run mode option

### DIFF
--- a/editor/run/editor_run_bar.h
+++ b/editor/run/editor_run_bar.h
@@ -53,6 +53,12 @@ class EditorRunBar : public MarginContainer {
 		RUN_CUSTOM,
 	};
 
+	enum RunXRModeMenuItem {
+		INVALID = -1,
+		OFF = 0,
+		ON = 1,
+	};
+
 	PanelContainer *main_panel = nullptr;
 	HBoxContainer *main_hbox = nullptr;
 	HBoxContainer *outer_hbox = nullptr;
@@ -90,10 +96,10 @@ class EditorRunBar : public MarginContainer {
 
 	void _movie_maker_item_pressed(int p_id);
 	void _write_movie_toggled(bool p_enabled);
-	void _quick_run_selected(const String &p_file_path, int p_id = -1);
+	void _quick_run_selected(const String &p_file_path, int p_menu_item = RunXRModeMenuItem::INVALID);
 
-	void _play_current_pressed(int p_id = -1);
-	void _play_custom_pressed(int p_id = -1);
+	void _play_current_pressed(int p_menu_item = RunXRModeMenuItem::INVALID);
+	void _play_custom_pressed(int p_menu_item = RunXRModeMenuItem::INVALID);
 
 	void _run_scene(const String &p_scene_path = "", const Vector<String> &p_run_args = Vector<String>());
 	void _run_native(const Ref<EditorExportPreset> &p_preset);
@@ -101,7 +107,7 @@ class EditorRunBar : public MarginContainer {
 	void _profiler_autostart_indicator_pressed();
 
 private:
-	static Vector<String> _get_xr_mode_play_args(int p_xr_mode_id);
+	static Vector<String> _get_xr_mode_play_args(RunXRModeMenuItem p_menu_item);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
This is a follow-up to https://github.com/godotengine/godot/pull/101116 which added a drop-down menu to configure whether a scene that is part of an XR project should be launched in XR mode or regular mode.

The addition broke the attached shortcut for XR projects as the shortcut now triggers the popup menu to show instead of running the selected scene. This PR fixes that issue and automatically updates the shortcut based on the last selected option.

**Before:**


https://github.com/user-attachments/assets/45f346ed-b401-4582-8f43-0e21fe12080e



**After:**


https://github.com/user-attachments/assets/ef72d0a0-04c6-45f1-b06b-504380cb2a20



Fixes https://github.com/godotengine/godot/issues/111055

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
