### PR TITLE
Fix `TextEdit` does not auto scroll properly on certain vertical sizes

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6587,7 +6587,7 @@ void TextEdit::set_line_as_last_visible(int p_line, int p_wrap_index) {
 		set_v_scroll(0);
 		return;
 	}
-	set_v_scroll(Math::round(get_scroll_pos_for_line(first_line, next_line.y) + _get_visible_lines_offset()));
+	set_v_scroll(get_scroll_pos_for_line(first_line, next_line.y) + _get_visible_lines_offset());
 }
 
 int TextEdit::get_last_full_visible_line() const {
@@ -8616,9 +8616,12 @@ void TextEdit::_update_scrollbars() {
 	updating_scrolls = true;
 
 	if (!fit_content_height && total_rows > visible_rows) {
+		double visible_rows_exact = (double)_get_control_height() / (double)get_line_height();
+		double fractional_visible_rows = visible_rows_exact - (double)visible_rows;
+		fractional_visible_rows = CLAMP(fractional_visible_rows, 0.0, 1.0);
 		v_scroll->show();
-		v_scroll->set_max(total_rows + _get_visible_lines_offset());
-		v_scroll->set_page(visible_rows + _get_visible_lines_offset());
+		v_scroll->set_max(total_rows);
+		v_scroll->set_page(visible_rows + fractional_visible_rows);
 		set_v_scroll(get_v_scroll());
 	} else {
 		first_visible_line = 0;

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -7484,14 +7484,14 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 
 	// First visible line.
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
 	text_edit->set_line_as_first_visible(visible_lines);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == visible_lines);
-	CHECK(text_edit->get_v_scroll() == visible_lines);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(visible_lines)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7511,7 +7511,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_first_visible(5, 1);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 5);
-	CHECK(text_edit->get_v_scroll() == 11);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(11)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 6);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 1);
 
@@ -7522,7 +7522,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_first_visible(0);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7530,7 +7530,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_last_visible(visible_lines * 2);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == visible_lines);
-	CHECK(text_edit->get_v_scroll() == visible_lines);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(visible_lines)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7551,7 +7551,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_last_visible(visible_lines + 5, 1);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 16);
-	CHECK(text_edit->get_v_scroll() == 32.0);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(32.0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines + 5);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7562,7 +7562,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_first_visible(0);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7570,7 +7570,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_center_visible(visible_lines + (visible_lines / 2));
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == visible_lines);
-	CHECK(text_edit->get_v_scroll() == visible_lines);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(visible_lines)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7591,7 +7591,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_center_visible(visible_lines + (visible_lines / 2) + 5, 1);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == visible_lines + (visible_lines / 2));
-	CHECK(text_edit->get_v_scroll() == (visible_lines * 3));
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double((visible_lines * 3))));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 1);
 
@@ -7603,14 +7603,14 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	MessageQueue::get_singleton()->flush();
 
 	CHECK(text_edit->get_first_visible_line() == (visible_lines * 2) + 3);
-	CHECK(text_edit->get_v_scroll() == (visible_lines * 4) + 6);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double((visible_lines * 4))) + 6);
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) + 8);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
 	text_edit->set_scroll_past_end_of_file_enabled(false);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == (visible_lines * 2) + 3);
-	CHECK(text_edit->get_v_scroll() == (visible_lines * 4) - 4);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double((visible_lines * 4))) - 4);
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) + 8);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7621,7 +7621,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_first_visible(0);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7635,14 +7635,14 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->is_caret_visible());
 	CHECK(text_edit->get_first_visible_line() == 5);
-	CHECK(text_edit->get_v_scroll() == 5);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(5)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines - 1) + 5);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
 	text_edit->center_viewport_to_caret();
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == visible_lines - 5);
-	CHECK(text_edit->get_v_scroll() == visible_lines - 5);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(visible_lines - 5)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 6);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7650,7 +7650,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->adjust_viewport_to_caret();
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == visible_lines - 5);
-	CHECK(text_edit->get_v_scroll() == visible_lines - 5);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(visible_lines - 5)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 6);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7661,7 +7661,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->is_caret_visible());
 	CHECK(text_edit->get_first_visible_line() == 1);
-	CHECK(text_edit->get_v_scroll() == 1);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(1)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7669,14 +7669,14 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_first_visible(0);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
 	text_edit->adjust_viewport_to_caret();
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7691,7 +7691,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	MessageQueue::get_singleton()->flush();
 
 	CHECK(text_edit->get_first_visible_line() == (visible_lines / 2) + 6);
-	CHECK(text_edit->get_v_scroll() == (visible_lines + (visible_lines / 2)) + 1);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double((visible_lines + (visible_lines / 2)))) + 1);
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines) + 5);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 1);
@@ -7699,7 +7699,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->center_viewport_to_caret();
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == visible_lines);
-	CHECK(text_edit->get_v_scroll() == (visible_lines * 2) + 1);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double((visible_lines * 2))) + 1);
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 11);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 1);
 
@@ -7707,7 +7707,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->adjust_viewport_to_caret();
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == visible_lines);
-	CHECK(text_edit->get_v_scroll() == (visible_lines * 2) + 1);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double((visible_lines * 2))) + 1);
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 11);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 1);
 
@@ -7718,7 +7718,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->is_caret_visible());
 	CHECK(text_edit->get_first_visible_line() == 1);
-	CHECK(text_edit->get_v_scroll() == 3);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(3)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines / 2) + 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 1);
 	CHECK(text_edit->get_caret_wrap_index() == 1);
@@ -7727,14 +7727,14 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->is_caret_visible());
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 11);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
 	text_edit->adjust_viewport_to_caret();
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 11);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7745,7 +7745,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_line_as_first_visible(0);
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7769,7 +7769,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, MouseButtonMask::NONE, Key::NONE);
 	CHECK(text_edit->get_v_scroll() > v_scroll);
 	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, MouseButtonMask::NONE, Key::NONE);
-	CHECK(text_edit->get_v_scroll() == v_scroll);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(v_scroll)));
 
 	// smooth scroll speed.
 	text_edit->set_smooth_scroll_enabled(true);
@@ -7780,7 +7780,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_v_scroll() >= v_scroll);
 	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, MouseButtonMask::NONE, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
-	CHECK(text_edit->get_v_scroll() == v_scroll);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(v_scroll)));
 
 	v_scroll = text_edit->get_v_scroll();
 	text_edit->set_v_scroll_speed(10000);
@@ -7789,7 +7789,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_v_scroll() >= v_scroll);
 	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, MouseButtonMask::NONE, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
-	CHECK(text_edit->get_v_scroll() == v_scroll);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(v_scroll)));
 
 	ERR_PRINT_OFF;
 	CHECK(text_edit->get_scroll_pos_for_line(-1) == 0);
@@ -7811,7 +7811,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_smooth_scroll_enabled(false);
 
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
@@ -7820,7 +7820,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 1);
 	CHECK(text_edit->get_first_visible_line() == 1);
-	CHECK(text_edit->get_v_scroll() == 1);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(1)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7829,7 +7829,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 1);
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7839,7 +7839,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 21);
 	CHECK(text_edit->get_first_visible_line() == 0);
-	CHECK(text_edit->get_v_scroll() == 0);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(0)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7848,7 +7848,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 41);
 	CHECK(text_edit->get_first_visible_line() == 20);
-	CHECK(text_edit->get_v_scroll() == 20);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(20)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines - 1) * 2);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7857,7 +7857,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 21);
 	CHECK(text_edit->get_first_visible_line() == 20);
-	CHECK(text_edit->get_v_scroll() == 20);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(20)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines - 1) * 2);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7866,7 +7866,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 1);
 	CHECK(text_edit->get_first_visible_line() == 1);
-	CHECK(text_edit->get_v_scroll() == 1);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(1)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7879,7 +7879,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 2);
 	CHECK(text_edit->get_first_visible_line() == 2);
-	CHECK(text_edit->get_v_scroll() == 2);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(2)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines + 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7888,7 +7888,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 2);
 	CHECK(text_edit->get_first_visible_line() == 1);
-	CHECK(text_edit->get_v_scroll() == 1);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(1)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7898,7 +7898,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 22);
 	CHECK(text_edit->get_first_visible_line() == 1);
-	CHECK(text_edit->get_v_scroll() == 1);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(1)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7907,7 +7907,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 42);
 	CHECK(text_edit->get_first_visible_line() == 21);
-	CHECK(text_edit->get_v_scroll() == 21);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(21)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7916,7 +7916,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 22);
 	CHECK(text_edit->get_first_visible_line() == 21);
-	CHECK(text_edit->get_v_scroll() == 21);
+	CHECK(Math::is_equal_approx(Math::floor(text_edit->get_v_scroll()), double(21)));
 	CHECK(text_edit->get_last_full_visible_line() == (visible_lines * 2) - 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
@@ -7925,7 +7925,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 2);
 	CHECK(text_edit->get_first_visible_line() == 2);
-	CHECK(text_edit->get_v_scroll() == 2);
+	CHECK(Math::is_equal_approx(text_edit->get_v_scroll(), double(2)));
 	CHECK(text_edit->get_last_full_visible_line() == visible_lines + 1);
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);


### PR DESCRIPTION
Closes #113290 

This issue fixes the text edit that it doesn't scroll all the way to the bottom under certain sizes.

I am attaching some examples that I used to reproduce and fix the issue.

Unfixed Build

[Screencast from 2025-12-01 15-51-13.webm](https://github.com/user-attachments/assets/d13ec8f6-9a88-4d87-8125-6c6e7a1a11fa)

Fixed Build

[Screencast from 2025-12-01 15-51-35.webm](https://github.com/user-attachments/assets/d61c1285-d16d-4003-835c-ec7bbe236518)

Fixed With Scrollbar Range

[Screencast from 2025-12-01 16-43-16.webm](https://github.com/user-attachments/assets/448550bd-1340-4f11-82f4-07e766dbbca6)
