### PR TITLE
Fix crash when capturing ObjectDB snapshot

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -817,11 +817,13 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 
 	HashSet<String> exported_members;
 
-	List<PropertyInfo> pinfo;
-	p_instance->get_property_list(&pinfo);
-	for (const PropertyInfo &E : pinfo) {
-		if (E.usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CATEGORY)) {
-			exported_members.insert(E.name);
+	if (p_instance) {
+		List<PropertyInfo> pinfo;
+		p_instance->get_property_list(&pinfo);
+		for (const PropertyInfo &E : pinfo) {
+			if (E.usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CATEGORY)) {
+				exported_members.insert(E.name);
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes the crash mentioned [here](https://github.com/godotengine/godot/pull/111622#issuecomment-3596196273).

`SceneDebuggerObject::_parse_script_properties` can be called with a `p_instance` that's `nullptr`, leading to a crash when `p_instance` is dereferenced to invoke `get_property_list`, as introduced in #111622.

https://github.com/godotengine/godot/blob/7a207b3eaa6ebeb020a83b52467ddcab9ee1ccf4/scene/debugger/scene_debugger.cpp#L776-L779

https://github.com/godotengine/godot/blob/7a207b3eaa6ebeb020a83b52467ddcab9ee1ccf4/scene/debugger/scene_debugger.cpp#L820-L821