### PR TITLE
Fix MovieWriter checking wrong directory for disk space

### DIFF
--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -114,7 +114,7 @@ void MovieWriter::begin(const Size2i &p_movie_size, uint32_t p_fps, const String
 
 	// Check for available disk space and warn the user if needed.
 	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	String path = p_base_path.get_basename();
+	String path = p_base_path.get_base_dir();
 	if (path.is_relative_path()) {
 		path = "res://" + path;
 	}


### PR DESCRIPTION
Fixes #113391

MovieWriter was incorrectly checking disk space on the current working directory instead of the target output directory specified in `--write-movie`.

## Changes
Changed `get_basename()` to `get_base_dir()` in `movie_writer.cpp:117` to properly extract the directory path where the movie file will be written.

Before:
- `get_basename()` on `/path/to/output.avi` → `/path/to/output` (not a valid directory)
- `dir->open()` would open the current working directory

After:
- `get_base_dir()` on `/path/to/output.avi` → `/path/to` (correct directory)
- `dir->open()` opens the actual target directory

## Impact
- Users will now get accurate disk space warnings for the target directory
- Prevents false positives when CWD has low space but target has plenty
- Prevents missing warnings when target has low space but CWD has plenty
