### PR TITLE
Fix current tab when all tabs are hidden

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -394,6 +394,15 @@ void TabBar::_accessibility_action_focus(const Variant &p_data, int p_index) {
 	set_current_tab(p_index);
 }
 
+bool TabBar::_are_all_tabs_hidden() const {
+	for (const Tab &tab : tabs) {
+		if (!tab.hidden) {
+			return false;
+		}
+	}
+	return true;
+}
+
 void TabBar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -1083,6 +1092,10 @@ void TabBar::set_tab_hidden(int p_tab, bool p_hidden) {
 	}
 
 	tabs.write[p_tab].hidden = p_hidden;
+
+	if (_are_all_tabs_hidden()) {
+		current = -1;
+	}
 
 	_update_cache();
 	_ensure_no_over_offset();

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1093,7 +1093,7 @@ void TabBar::set_tab_hidden(int p_tab, bool p_hidden) {
 
 	tabs.write[p_tab].hidden = p_hidden;
 
-	if (_are_all_tabs_hidden()) {
+	if (p_hidden && _are_all_tabs_hidden()) {
 		current = -1;
 	}
 

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1084,7 +1084,7 @@ void TabBar::set_tab_hidden(int p_tab, bool p_hidden) {
 
 	tabs.write[p_tab].hidden = p_hidden;
 
-	if (p_hidden && !select_next_available() && !select_previous_available()) {
+	if (p_hidden && get_next_available() == -1 && get_previous_available() == -1) {
 		// No available tabs, deselect.
 		set_current_tab(-1);
 	}

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -394,15 +394,6 @@ void TabBar::_accessibility_action_focus(const Variant &p_data, int p_index) {
 	set_current_tab(p_index);
 }
 
-bool TabBar::_are_all_tabs_hidden() const {
-	for (const Tab &tab : tabs) {
-		if (!tab.hidden) {
-			return false;
-		}
-	}
-	return true;
-}
-
 void TabBar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -1093,8 +1084,9 @@ void TabBar::set_tab_hidden(int p_tab, bool p_hidden) {
 
 	tabs.write[p_tab].hidden = p_hidden;
 
-	if (p_hidden && _are_all_tabs_hidden()) {
-		current = -1;
+	if (p_hidden && !select_next_available() && !select_previous_available()) {
+		// No available tabs, deselect.
+		set_current_tab(-1);
 	}
 
 	_update_cache();

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -200,6 +200,8 @@ private:
 	void _accessibility_action_scroll_into_view(const Variant &p_data, int p_index);
 	void _accessibility_action_focus(const Variant &p_data, int p_index);
 
+	bool _are_all_tabs_hidden() const;
+
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -200,8 +200,6 @@ private:
 	void _accessibility_action_scroll_into_view(const Variant &p_data, int p_index);
 	void _accessibility_action_focus(const Variant &p_data, int p_index);
 
-	bool _are_all_tabs_hidden() const;
-
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -998,6 +998,7 @@ void TabContainer::set_tab_hidden(int p_tab, bool p_hidden) {
 		update_minimum_size();
 	}
 	callable_mp(this, &TabContainer::_repaint).call_deferred();
+	queue_redraw();
 }
 
 bool TabContainer::is_tab_hidden(int p_tab) const {

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -990,6 +990,10 @@ void TabContainer::set_tab_hidden(int p_tab, bool p_hidden) {
 		return;
 	}
 
+	if (!get_deselect_enabled() && p_hidden == false && get_current_tab() == -1) {
+		set_current_tab(p_tab);
+	}
+
 	tab_bar->set_tab_hidden(p_tab, p_hidden);
 	child->hide();
 


### PR DESCRIPTION
fixn't #113386

`set_tab_hidden()` did not update the `current`  tab index when all tabs became hidden.
This caused an inconsistent state where a tab appeared selected even though none were visible.
This change checks whether all tabs are hidden and sets current = -1 to correctly indicate that no tab is selected.