### PR TITLE
CI: Bump SCons version [4.10.0→4.10.1]

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: x64
   scons-version:
     description: The SCons version to use.
-    default: 4.10.0
+    default: 4.10.1
 
 runs:
   using: composite


### PR DESCRIPTION
SCons 4.10.1 released [2 weeks ago](https://scons.org/scons-4101-is-available.html). It's a smaller update, but one that'll enable VS2026 support once it's inevitably added to the `windows-2025` runner.