### PR TITLE
Fix wrong tab when TabContainer was not in tree

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -215,6 +215,7 @@
 		<member name="current_tab" type="int" setter="set_current_tab" getter="get_current_tab" default="-1">
 			The current tab index. When set, this index's [Control] node's [code]visible[/code] property is set to [code]true[/code] and all others are set to [code]false[/code].
 			A value of [code]-1[/code] means that no tab is selected.
+			[b]Note:[/b] Setting this property before the [TabContainer] is in the scene tree will not switch the current tab, even if the index is within bounds (but the property will still be assigned). The actual switch will happen when the container enters the tree.
 		</member>
 		<member name="deselect_enabled" type="bool" setter="set_deselect_enabled" getter="get_deselect_enabled" default="false">
 			If [code]true[/code], all tabs can be deselected so that no tab is selected. Click on the [member current_tab] to deselect it.

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -218,9 +218,9 @@ void TabContainer::_notification(int p_what) {
 				_refresh_tab_names();
 			}
 
-			if (setup_current_tab >= -1) {
+			if (setup_current_tab != INVALID_CURRENT_TAB) {
 				set_current_tab(setup_current_tab);
-				setup_current_tab = -2;
+				setup_current_tab = INVALID_CURRENT_TAB;
 			}
 		} break;
 
@@ -286,7 +286,7 @@ void TabContainer::_notification(int p_what) {
 			// beat it to the punch and make sure that the correct node is the only one visible first.
 			// Otherwise, it can prevent a tab change done right before this container was made visible.
 			Vector<Control *> controls = _get_tab_controls();
-			int current = setup_current_tab > -2 ? setup_current_tab : get_current_tab();
+			int current = get_current_tab();
 			for (int i = 0; i < controls.size(); i++) {
 				controls[i]->set_visible(i == current);
 			}
@@ -748,7 +748,7 @@ void TabContainer::set_current_tab(int p_current) {
 }
 
 int TabContainer::get_current_tab() const {
-	return tab_bar->get_current_tab();
+	return setup_current_tab != INVALID_CURRENT_TAB ? setup_current_tab : tab_bar->get_current_tab();
 }
 
 int TabContainer::get_previous_tab() const {

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -38,6 +38,8 @@
 class TabContainer : public Container {
 	GDCLASS(TabContainer, Container);
 
+	static constexpr int INVALID_CURRENT_TAB = -2;
+
 public:
 	enum TabPosition {
 		POSITION_TOP,
@@ -56,8 +58,7 @@ private:
 	bool theme_changing = false;
 	Vector<Control *> children_removing;
 	bool drag_to_rearrange_enabled = false;
-	// Set the default setup current tab to be an invalid index.
-	int setup_current_tab = -2;
+	int setup_current_tab = INVALID_CURRENT_TAB;
 	bool updating_visibility = false;
 
 	struct ThemeCache {

--- a/tests/scene/test_tab_container.h
+++ b/tests/scene/test_tab_container.h
@@ -362,24 +362,26 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		// Set the current tab before there are any tabs.
 		// This queues the current tab to update on entering the tree.
 		tab_container->set_current_tab(1);
-		CHECK(tab_container->get_current_tab() == -1);
+		CHECK(tab_container->get_tab_bar()->get_current_tab() == -1);
+		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
 
 		tab_container->add_child(tab0);
 		CHECK(tab_container->get_tab_count() == 1);
-		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_tab_bar()->get_current_tab() == 0);
+		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == -1);
 
 		tab_container->add_child(tab1);
 		CHECK(tab_container->get_tab_count() == 2);
-		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == -1);
 
 		tab_container->add_child(tab2);
 		CHECK(tab_container->get_tab_count() == 3);
-		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
@@ -389,7 +391,7 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		MessageQueue::get_singleton()->flush();
 		CHECK(tab_container->get_tab_count() == 3);
 		CHECK(tab_container->get_current_tab() == 1);
-		CHECK(tab_container->get_previous_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == 0); // Previous tab of TabBar.
 		SIGNAL_CHECK("tab_selected", { { 1 } });
 		SIGNAL_CHECK("tab_changed", { { 1 } });
 		CHECK_FALSE(tab0->is_visible());
@@ -399,21 +401,21 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 
 	SUBCASE("[TabContainer] cannot set current tab to an invalid value before tabs are set") {
 		tab_container->set_current_tab(100);
-		CHECK(tab_container->get_current_tab() == -1);
+		CHECK(tab_container->get_current_tab() == 100);
 		CHECK(tab_container->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
 
 		tab_container->add_child(tab0);
 		CHECK(tab_container->get_tab_count() == 1);
-		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_current_tab() == 100);
 		CHECK(tab_container->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
 
 		tab_container->add_child(tab1);
 		CHECK(tab_container->get_tab_count() == 2);
-		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_current_tab() == 100);
 		CHECK(tab_container->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
@@ -457,7 +459,8 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		tab1->show();
 		MessageQueue::get_singleton()->flush();
 		CHECK(tab_container->get_tab_count() == 2);
-		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_tab_bar()->get_current_tab() == 0);
+		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
@@ -486,7 +489,8 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 		tab2->show();
 		MessageQueue::get_singleton()->flush();
 		CHECK(tab_container->get_tab_count() == 3);
-		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_tab_bar()->get_current_tab() == 0);
+		CHECK(tab_container->get_current_tab() == 2);
 		CHECK(tab_container->get_previous_tab() == -1);
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
@@ -496,7 +500,8 @@ TEST_CASE("[SceneTree][TabContainer] initialization") {
 
 		// Whichever happens last will have priority.
 		tab_container->set_current_tab(1);
-		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_tab_bar()->get_current_tab() == 0);
+		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == -1);
 
 		// Current tab is set when entering the tree.


### PR DESCRIPTION
Fixes #109291

When testing this be sure to remove `.godot/exported` folder if you had tested the issue before.