### PR TITLE
EmbeddedProcess: Fix invalid deferred call

### DIFF
--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -416,7 +416,7 @@ void EmbeddedProcess::_check_focused_process_id() {
 			if (modal_window->get_mode() == Window::MODE_MINIMIZED) {
 				modal_window->set_mode(Window::MODE_WINDOWED);
 			}
-			callable_mp(modal_window, &Window::grab_focus).call_deferred(false);
+			callable_mp(modal_window, &Window::grab_focus).call_deferred();
 		}
 	}
 }


### PR DESCRIPTION
Fixes #113318.
Follow-up to #110250.

`Window::grab_focus` does not take any argument.

---

Looks like this was an innocent find and replace issue, it happens :D

Note: as per https://github.com/godotengine/godot/issues/113318#issuecomment-3597760785 , I'm not sure if we should rely so much on calling `grab_focus`, as it's not necessarily effective (e.g. sway XWayland). I haven't done a full research on this though so TIWAGOS.

That said, this fixes the immediate issue of an error spam.