### PR TITLE
Apply default renderer setting immediately in Project Manager

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -916,6 +916,21 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 				rendering_device_checked = true;
 			}
 
+			// Apply the current default renderer setting.
+			String default_renderer_type = "forward_plus";
+			if (EditorSettings::get_singleton()->has_setting("project_manager/default_renderer")) {
+				default_renderer_type = EditorSettings::get_singleton()->get_setting("project_manager/default_renderer");
+			}
+			List<BaseButton *> buttons;
+			renderer_button_group->get_buttons(&buttons);
+			for (BaseButton *button : buttons) {
+				if (button->get_meta(SNAME("rendering_method")) == default_renderer_type) {
+					button->set_pressed(true);
+					_renderer_selected();
+					break;
+				}
+			}
+
 			name_container->show();
 			install_path_container->hide();
 			renderer_container->show();


### PR DESCRIPTION
Fixes #113362

The default renderer setting (`project_manager/default_renderer`) was only read during `ProjectDialog` initialization, so changes made in Settings would not take effect until the Project Manager was restarted.

## Changes
The setting is now re-read each time the "Create New Project" dialog is shown, applying the current value immediately.

  Before:
- Setting read once during dialog initialization
- Changes required restarting Project Manager to take effect

  After:
- Setting read every time Create dialog opens
- Changes apply immediately when creating new project

## Implementation
Added code in `show_dialog()` for `MODE_NEW` that:
1. Reads the current `project_manager/default_renderer` setting
2. Updates the selected renderer button to match
3. Calls `_renderer_selected()` to update the UI

## Impact
- Users can change default renderer and immediately see it reflected when creating projects
- No restart required for this setting to take effect
- More intuitive user experience
