### PR TITLE
Avoid nested parentheses in physical/Unicode InputEventKey text conversion

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -405,7 +405,7 @@ String InputEventKey::as_text_physical_keycode() const {
 	if (physical_keycode != Key::NONE) {
 		kc = keycode_get_string(physical_keycode);
 	} else {
-		kc = "(" + RTR("Unset") + ")";
+		kc = "(" + RTR("unset") + ")";
 	}
 
 	if (kc.is_empty()) {
@@ -422,7 +422,7 @@ String InputEventKey::as_text_keycode() const {
 	if (keycode != Key::NONE) {
 		kc = keycode_get_string(keycode);
 	} else {
-		kc = "(" + RTR("Unset") + ")";
+		kc = "(" + RTR("unset") + ")";
 	}
 
 	if (kc.is_empty()) {
@@ -439,7 +439,7 @@ String InputEventKey::as_text_key_label() const {
 	if (key_label != Key::NONE) {
 		kc = keycode_get_string(key_label);
 	} else {
-		kc = "(" + RTR("Unset") + ")";
+		kc = "(" + RTR("unset") + ")";
 	}
 
 	if (kc.is_empty()) {
@@ -471,13 +471,13 @@ String InputEventKey::as_text() const {
 	String kc;
 
 	if (keycode == Key::NONE && physical_keycode == Key::NONE && key_label != Key::NONE) {
-		kc = keycode_get_string(key_label) + " (Unicode)";
+		kc = keycode_get_string(key_label) + " - Unicode";
 	} else if (keycode != Key::NONE) {
 		kc = keycode_get_string(keycode);
 	} else if (physical_keycode != Key::NONE) {
-		kc = keycode_get_string(physical_keycode) + " (" + RTR("Physical") + ")";
+		kc = keycode_get_string(physical_keycode) + " - " + RTR("Physical");
 	} else {
-		kc = "(" + RTR("Unset") + ")";
+		kc = "(" + RTR("unset") + ")";
 	}
 
 	if (kc.is_empty()) {
@@ -508,7 +508,7 @@ String InputEventKey::_to_string() {
 		kc = itos((int64_t)physical_keycode) + " (" + keycode_get_string(physical_keycode) + ")";
 		physical = "true";
 	} else {
-		kc = "(" + RTR("Unset") + ")";
+		kc = "(" + RTR("unset") + ")";
 	}
 
 	String mods = InputEventWithModifiers::as_text();

--- a/editor/settings/event_listener_line_edit.cpp
+++ b/editor/settings/event_listener_line_edit.cpp
@@ -94,7 +94,7 @@ String EventListenerLineEdit::get_event_text(const Ref<InputEvent> &p_event, boo
 		}
 
 		if (text.is_empty()) {
-			text = "(" + TTR("Unset") + ")";
+			text = "(" + TTR("unset") + ")";
 		}
 	} else {
 		text = p_event->as_text();

--- a/tests/core/input/test_input_event_key.h
+++ b/tests/core/input/test_input_event_key.h
@@ -110,30 +110,30 @@ TEST_CASE("[InputEventKey] Key correctly converts itself to text") {
 	// These next three tests test the functionality of getting a key that is set to None
 	// as text. These cases are a bit weird, since None has no textual representation
 	// (find_keycode_name(Key::NONE) results in a nullptr). Thus, these tests look weird
-	// with only (Physical) or a lonely modifier with (Physical) but (as far as I
+	// with only "- Physical" or a lonely modifier with "- Physical" but (as far as I
 	// understand the code, that is intended behavior.
 
 	// Key is None without a physical key.
 	none_key.set_keycode(Key::NONE);
-	CHECK(none_key.as_text() == "(Unset)");
+	CHECK(none_key.as_text() == "(unset)");
 
 	// Key is none and has modifiers.
 	none_key.set_ctrl_pressed(true);
-	CHECK(none_key.as_text() == "Ctrl+(Unset)");
+	CHECK(none_key.as_text() == "Ctrl+(unset)");
 
 	// Key is None WITH a physical key AND modifiers.
 	none_key.set_physical_keycode(Key::ENTER);
-	CHECK(none_key.as_text() == "Ctrl+Enter (Physical)");
+	CHECK(none_key.as_text() == "Ctrl+Enter - Physical");
 
 	// Key is None WITH a physical key AND multiple modifiers, checks for correct ordering.
 	none_key.set_alt_pressed(true);
 	none_key.set_shift_pressed(true);
 #ifdef MACOS_ENABLED
-	CHECK(none_key.as_text() != "Ctrl+Shift+Option+Enter (Physical)");
-	CHECK(none_key.as_text() == "Ctrl+Option+Shift+Enter (Physical)");
+	CHECK(none_key.as_text() != "Ctrl+Shift+Option+Enter - Physical");
+	CHECK(none_key.as_text() == "Ctrl+Option+Shift+Enter - Physical");
 #else
-	CHECK(none_key.as_text() != "Ctrl+Shift+Alt+Enter (Physical)");
-	CHECK(none_key.as_text() == "Ctrl+Alt+Shift+Enter (Physical)");
+	CHECK(none_key.as_text() != "Ctrl+Shift+Alt+Enter - Physical");
+	CHECK(none_key.as_text() == "Ctrl+Alt+Shift+Enter - Physical");
 #endif
 
 	InputEventKey none_key2;
@@ -142,7 +142,7 @@ TEST_CASE("[InputEventKey] Key correctly converts itself to text") {
 	none_key2.set_keycode(Key::NONE);
 	none_key2.set_physical_keycode(Key::ENTER);
 
-	CHECK(none_key2.as_text() == "Enter (Physical)");
+	CHECK(none_key2.as_text() == "Enter - Physical");
 
 	InputEventKey key;
 
@@ -175,7 +175,7 @@ TEST_CASE("[InputEventKey] Key correctly converts itself to text") {
 TEST_CASE("[InputEventKey] Key correctly converts its state to a string representation") {
 	InputEventKey none_key;
 
-	CHECK(none_key.to_string() == "InputEventKey: keycode=(Unset), mods=none, physical=false, location=unspecified, pressed=false, echo=false");
+	CHECK(none_key.to_string() == "InputEventKey: keycode=(unset), mods=none, physical=false, location=unspecified, pressed=false, echo=false");
 	// Set physical key to Escape.
 	none_key.set_physical_keycode(Key::ESCAPE);
 	CHECK(none_key.to_string() == "InputEventKey: keycode=4194305 (Escape), mods=none, physical=true, location=unspecified, pressed=false, echo=false");


### PR DESCRIPTION
This was visible in tooltips displayed in shortcuts, including in the editor itself.

For example, "Forward (W (Physical))" is now displayed as "Forward (W - Physical)".

Additionally, this changes `(unset)` to use lowercase, so that it stands out more compared to other keys. This also better matches what the editor displays when you have no scenes open:

<img width="135" height="38" alt="image" src="https://github.com/user-attachments/assets/1d76bafb-8b82-4d82-8e5e-c9c42b3564d0" />
<br>

Ideally, we'd go for live translation according to the user's current keyboard layout, but this has several caveats:

- Covering every keyboard layout on all platforms is a difficult task. The user may also change their keyboard layout at runtime (although this is uncommon).
- Live translation isn't suitable for every use case, e.g. in the input map editor where we want the Physical/Unicode labels to remain visible. Even if we go with live translation, we'd still need to keep the traditional method in place.
  - It would be safe to apply live translation in shortcut tooltips at least still.

___

- This closes https://github.com/godotengine/godot-proposals/issues/13301
(the symbols part is tracked in https://github.com/godotengine/godot-proposals/issues/3010).

## Preview

Before | After
-|-
<img width="506" height="145" alt="Image" src="https://github.com/user-attachments/assets/22a12d78-8606-422c-bcbd-fef6bb997f9f" /> | <img width="506" height="145" alt="Image" src="https://github.com/user-attachments/assets/3337280e-3fc7-4307-a71a-20a0af0fa651" />
