### PR TITLE
Use Unicode arrow symbols throughout the editor

### DIFF
--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -367,7 +367,7 @@ void AnimationLibraryEditor::_load_files(const PackedStringArray &p_paths) {
 					show_error_diag = true;
 					const Ref<PackedScene> scene = res;
 					if (scene.is_valid()) {
-						error_dialog->set_text(TTR("The file you selected is an imported scene from a 3D model such as glTF or FBX.\n\nIn Godot, 3D models can be imported as either scenes or animation libraries, which is why they show up here.\n\nIf you want to use animations from this 3D model, open the Advanced Import Settings\ndialog and save the animations using Actions... -> Set Animation Save Paths,\nor import the whole scene as a single AnimationLibrary in the Import dock."));
+						error_dialog->set_text(TTR(U"The file you selected is an imported scene from a 3D model such as glTF or FBX.\n\nIn Godot, 3D models can be imported as either scenes or animation libraries, which is why they show up here.\n\nIf you want to use animations from this 3D model, open the Advanced Import Settings\ndialog and save the animations using Actions... → Set Animation Save Paths,\nor import the whole scene as a single AnimationLibrary in the Import dock."));
 					} else {
 						error_dialog->set_text(TTR("The file you selected is not a valid AnimationLibrary.\n\nIf the animations you want are inside of this file, save them to a separate file first."));
 					}

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -758,7 +758,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			if (closest_for_tooltip >= 0) {
 				String from = transition_lines[closest_for_tooltip].from_node;
 				String to = transition_lines[closest_for_tooltip].to_node;
-				String tooltip = from + " -> " + to;
+				String tooltip = from + U" → " + to;
 				state_machine_draw->set_tooltip_text(tooltip);
 			} else {
 				state_machine_draw->set_tooltip_text("");
@@ -2222,7 +2222,7 @@ bool EditorAnimationMultiTransitionEdit::_get(const StringName &p_name, Variant 
 	StringName prop = String(p_name).get_slicec('/', 1);
 
 	if (prop == "transition_path") {
-		r_property = String(transitions[index].from) + " -> " + transitions[index].to;
+		r_property = String(transitions[index].from) + U" → " + transitions[index].to;
 		return true;
 	}
 

--- a/editor/plugins/plugin_config_dialog.cpp
+++ b/editor/plugins/plugin_config_dialog.cpp
@@ -229,7 +229,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	plugin_edit_hidden_controls.push_back(subfolder_lb);
 
 	subfolder_edit = memnew(LineEdit);
-	subfolder_edit->set_placeholder("\"my_plugin\" -> res://addons/my_plugin");
+	subfolder_edit->set_placeholder(U"\"my_plugin\" → res://addons/my_plugin");
 	subfolder_edit->set_tooltip_text(TTR("Optional. The folder name should generally use `snake_case` naming (avoid spaces and special characters).\nIf left empty, the folder will be named after the plugin name converted to `snake_case`."));
 	subfolder_edit->set_accessibility_name(TTRC("Subfolder:"));
 	subfolder_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -305,7 +305,7 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	script_edit = memnew(LineEdit);
 	script_edit->set_tooltip_text(TTR("Optional. The name of the script file. If left empty, will default to the subfolder name."));
-	script_edit->set_placeholder("\"plugin.gd\" -> res://addons/my_plugin/plugin.gd");
+	script_edit->set_placeholder(U"\"plugin.gd\" → res://addons/my_plugin/plugin.gd");
 	script_edit->set_accessibility_name(TTRC("Script Name:"));
 	script_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(script_edit);

--- a/editor/scene/2d/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/scene/2d/tiles/tile_proxies_manager_dialog.cpp
@@ -96,7 +96,7 @@ void TileProxiesManagerDialog::_update_lists() {
 	Array proxies = tile_set->get_source_level_tile_proxies();
 	for (int i = 0; i < proxies.size(); i++) {
 		Array proxy = proxies[i];
-		String text = vformat("%s", proxy[0]).rpad(5) + "-> " + vformat("%s", proxy[1]);
+		String text = vformat("%s", proxy[0]).rpad(5) + U"→ " + vformat("%s", proxy[1]);
 		int id = source_level_list->add_item(text);
 		source_level_list->set_item_metadata(id, proxy[0]);
 	}
@@ -104,7 +104,7 @@ void TileProxiesManagerDialog::_update_lists() {
 	proxies = tile_set->get_coords_level_tile_proxies();
 	for (int i = 0; i < proxies.size(); i++) {
 		Array proxy = proxies[i];
-		String text = vformat("%s, %s", proxy[0], proxy[1]).rpad(17) + "-> " + vformat("%s, %s", proxy[2], proxy[3]);
+		String text = vformat("%s, %s", proxy[0], proxy[1]).rpad(17) + U"→ " + vformat("%s, %s", proxy[2], proxy[3]);
 		int id = coords_level_list->add_item(text);
 		coords_level_list->set_item_metadata(id, proxy.slice(0, 2));
 	}
@@ -112,7 +112,7 @@ void TileProxiesManagerDialog::_update_lists() {
 	proxies = tile_set->get_alternative_level_tile_proxies();
 	for (int i = 0; i < proxies.size(); i++) {
 		Array proxy = proxies[i];
-		String text = vformat("%s, %s, %s", proxy[0], proxy[1], proxy[2]).rpad(24) + "-> " + vformat("%s, %s, %s", proxy[3], proxy[4], proxy[5]);
+		String text = vformat("%s, %s, %s", proxy[0], proxy[1], proxy[2]).rpad(24) + U"→ " + vformat("%s, %s, %s", proxy[3], proxy[4], proxy[5]);
 		int id = alternative_level_list->add_item(text);
 		alternative_level_list->set_item_metadata(id, proxy.slice(0, 3));
 	}

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -6301,7 +6301,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	locked_label->hide();
 
 	zoom_limit_label = memnew(Label);
-	zoom_limit_label->set_text(TTRC("To zoom further, change the camera's clipping planes (View -> Settings...)"));
+	zoom_limit_label->set_text(TTRC(U"To zoom further, change the camera's clipping planes (View → Settings...)"));
 	zoom_limit_label->set_name("ZoomLimitMessageLabel");
 	zoom_limit_label->add_theme_color_override(SceneStringName(font_color), Color(1, 1, 1, 1));
 	zoom_limit_label->hide();

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -6024,7 +6024,7 @@ void VisualShaderEditor::_varying_validate() {
 		if (has_error) {
 			error += "\n";
 		}
-		error += vformat(TTR("Boolean type cannot be used with `%s` varying mode."), "Vertex -> [Fragment, Light]");
+		error += vformat(TTR("Boolean type cannot be used with `%s` varying mode."), U"Vertex → [Fragment, Light]");
 		has_error = true;
 	}
 
@@ -6992,8 +6992,8 @@ VisualShaderEditor::VisualShaderEditor() {
 
 		varying_mode = memnew(OptionButton);
 		hb->add_child(varying_mode);
-		varying_mode->add_item("Vertex -> [Fragment, Light]");
-		varying_mode->add_item("Fragment -> Light");
+		varying_mode->add_item(U"Vertex → [Fragment, Light]");
+		varying_mode->add_item(U"Fragment → Light");
 		varying_mode->set_accessibility_name(TTRC("Varying Mode"));
 		varying_mode->connect(SceneStringName(item_selected), callable_mp(this, &VisualShaderEditor::_varying_mode_changed));
 

--- a/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.cpp
+++ b/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.cpp
@@ -183,13 +183,13 @@ void AudioStreamInteractiveTransitionEditor::_update_transitions() {
 			if (!exists) {
 				if (audio_stream_interactive->has_transition(AudioStreamInteractive::CLIP_ANY, to)) {
 					from = AudioStreamInteractive::CLIP_ANY;
-					tooltip = vformat(TTR("Using Any Clip -> %s."), audio_stream_interactive->get_clip_name(to));
+					tooltip = vformat(TTR(U"Using any clip → %s."), audio_stream_interactive->get_clip_name(to));
 				} else if (audio_stream_interactive->has_transition(from, AudioStreamInteractive::CLIP_ANY)) {
 					to = AudioStreamInteractive::CLIP_ANY;
-					tooltip = vformat(TTR("Using %s -> Any Clip."), audio_stream_interactive->get_clip_name(from));
+					tooltip = vformat(TTR(U"Using %s → Any clip."), audio_stream_interactive->get_clip_name(from));
 				} else if (audio_stream_interactive->has_transition(AudioStreamInteractive::CLIP_ANY, AudioStreamInteractive::CLIP_ANY)) {
 					from = to = AudioStreamInteractive::CLIP_ANY;
-					tooltip = TTR("Using All Clips -> Any Clip.");
+					tooltip = TTR(U"Using all clips → Any clip.");
 				} else {
 					tooltip = TTR("No transition available.");
 				}

--- a/modules/objectdb_profiler/editor/snapshot_data.cpp
+++ b/modules/objectdb_profiler/editor/snapshot_data.cpp
@@ -264,7 +264,7 @@ void GameStateSnapshot::_get_rc_cycles(
 		SnapshotDataObject *next_obj = p_obj->snapshot->objects[next_child.value];
 		String next_name = next_obj == p_source_obj ? "self" : next_obj->get_name();
 		String current_name = p_obj == p_source_obj ? "self" : p_obj->get_name();
-		String child_path = current_name + "[\"" + next_child.key + "\"] -> " + next_name;
+		String child_path = current_name + "[\"" + next_child.key + U"\"] → " + next_name;
 		if (p_current_path != "") {
 			child_path = p_current_path + "\n" + child_path;
 		}


### PR DESCRIPTION
This does not apply to text printed to the Output panel, as the fixed-width font may not have the glyph in its character set (or if it does, the arrow character may be hard to read).

- This closes https://github.com/godotengine/godot-proposals/issues/13759.

## Preview

<img width="504" height="35" alt="Image" src="https://github.com/user-attachments/assets/443367a7-d9ec-4375-8981-b96985a75573" />

<br>
<img width="519" height="289" alt="Image" src="https://github.com/user-attachments/assets/f7b556b4-e852-4214-9be6-21ba2cd1a981" />

<br>
<img width="226" height="93" alt="Image" src="https://github.com/user-attachments/assets/340bce1c-9fda-47be-a376-88af5ff0e5f8" />

