### PR TITLE
Change `rotate_toward` negative delta behavior.

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -597,15 +597,17 @@ _ALWAYS_INLINE_ float move_toward(float p_from, float p_to, float p_delta) {
 
 _ALWAYS_INLINE_ double rotate_toward(double p_from, double p_to, double p_delta) {
 	double difference = angle_difference(p_from, p_to);
-	double abs_difference = abs(difference);
-	// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
-	return p_from + CLAMP(p_delta, abs_difference - PI, abs_difference) * (difference >= 0.0 ? 1.0 : -1.0);
+	if (p_delta < 0.0 && is_zero_approx(difference)) { // prevent lock-up when delta is negative
+		return p_from + p_delta;
+	}
+	return move_toward(p_from, p_from + difference, p_delta);
 }
 _ALWAYS_INLINE_ float rotate_toward(float p_from, float p_to, float p_delta) {
 	float difference = angle_difference(p_from, p_to);
-	float abs_difference = abs(difference);
-	// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
-	return p_from + CLAMP(p_delta, abs_difference - (float)PI, abs_difference) * (difference >= 0.0f ? 1.0f : -1.0f);
+	if (p_delta < 0.0f && is_zero_approx(difference)) { // prevent lock-up when delta is negative
+		return p_from + p_delta;
+	}
+	return move_toward(p_from, p_from + difference, p_delta);
 }
 
 _ALWAYS_INLINE_ double linear_to_db(double p_linear) {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -648,6 +648,7 @@
 					elapsed += delta
 				[/codeblock]
 				[b]Note:[/b] This function lerps through the shortest path between [param from] and [param to]. However, when these two angles are approximately [code]PI + k * TAU[/code] apart for any integer [code]k[/code], it's not obvious which way they lerp due to floating-point precision errors. For example, [code]lerp_angle(0, PI, weight)[/code] lerps counter-clockwise, while [code]lerp_angle(0, PI + 5 * TAU, weight)[/code] lerps clockwise.
+				See also [method rotate_toward].
 			</description>
 		</method>
 		<method name="lerpf">
@@ -1125,8 +1126,9 @@
 			<param index="2" name="delta" type="float" />
 			<description>
 				Rotates [param from] toward [param to] by the [param delta] amount. Will not go past [param to].
-				Similar to [method move_toward], but interpolates correctly when the angles wrap around [constant @GDScript.TAU].
-				If [param delta] is negative, this function will rotate away from [param to], toward the opposite angle, and will not go past the opposite angle.
+				Similar to [method move_toward], but intended for use with rotations.
+				If [param delta] is negative, this function will rotate away from [param to]. However, it will have no destination, so it may oscillate if called repeatedly.
+				See also [method lerp_angle].
 			</description>
 		</method>
 		<method name="round">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -1118,6 +1118,7 @@ namespace Godot
         ///
         /// Similar to <see cref="Lerp(float, float, float)"/>,
         /// but interpolates correctly when the angles wrap around <see cref="Tau"/>.
+        /// See also <see cref="RotateToward(float, float, float)"/>.
         /// </summary>
         /// <param name="from">The start angle for interpolation.</param>
         /// <param name="to">The destination angle for interpolation.</param>
@@ -1133,6 +1134,7 @@ namespace Godot
         ///
         /// Similar to <see cref="Lerp(double, double, double)"/>,
         /// but interpolates correctly when the angles wrap around <see cref="Tau"/>.
+        /// See also <see cref="RotateToward(double, double, double)"/>.
         /// </summary>
         /// <param name="from">The start angle for interpolation.</param>
         /// <param name="to">The destination angle for interpolation.</param>
@@ -1458,8 +1460,9 @@ namespace Godot
 
         /// <summary>
         /// Rotates <paramref name="from"/> toward <paramref name="to"/> by the <paramref name="delta"/> amount. Will not go past <paramref name="to"/>.
-        /// Similar to <see cref="MoveToward(float, float, float)"/> but interpolates correctly when the angles wrap around <see cref="Tau"/>.
-        /// If <paramref name="delta"/> is negative, this function will rotate away from <paramref name="to"/>, toward the opposite angle, and will not go past the opposite angle.
+        /// Similar to <see cref="MoveToward(float, float, float)"/> but intended for use with rotations.
+        /// If <paramref name="delta"/> is negative, this function will rotate away from <paramref name="to"/>. However, it will have no destination, so it may oscillate if called repeatedly.
+        /// See also <see cref="LerpAngle(float, float, float)"/>.
         /// </summary>
         /// <param name="from">The start angle.</param>
         /// <param name="to">The angle to move towards.</param>
@@ -1468,14 +1471,18 @@ namespace Godot
         public static float RotateToward(float from, float to, float delta)
         {
             float difference = AngleDifference(from, to);
-            float absDifference = Math.Abs(difference);
-            return from + Math.Clamp(delta, absDifference - MathF.PI, absDifference) * (difference >= 0.0f ? 1.0f : -1.0f);
+            if (delta < 0.0f && IsZeroApprox(difference))
+            {
+                return from + delta;
+            }
+            return MoveToward(from, from + difference, delta);
         }
 
         /// <summary>
         /// Rotates <paramref name="from"/> toward <paramref name="to"/> by the <paramref name="delta"/> amount. Will not go past <paramref name="to"/>.
-        /// Similar to <see cref="MoveToward(double, double, double)"/> but interpolates correctly when the angles wrap around <see cref="Tau"/>.
-        /// If <paramref name="delta"/> is negative, this function will rotate away from <paramref name="to"/>, toward the opposite angle, and will not go past the opposite angle.
+        /// Similar to <see cref="MoveToward(double, double, double)"/> but intended for use with rotations.
+        /// If <paramref name="delta"/> is negative, this function will rotate away from <paramref name="to"/>. However, it will have no destination, so it may oscillate if called repeatedly.
+        /// See also <see cref="LerpAngle(double, double, double)"/>.
         /// </summary>
         /// <param name="from">The start angle.</param>
         /// <param name="to">The angle to move towards.</param>
@@ -1484,8 +1491,11 @@ namespace Godot
         public static double RotateToward(double from, double to, double delta)
         {
             double difference = AngleDifference(from, to);
-            double absDifference = Math.Abs(difference);
-            return from + Math.Clamp(delta, absDifference - Math.PI, absDifference) * (difference >= 0.0 ? 1.0 : -1.0);
+            if (delta < 0.0 && IsZeroApprox(difference))
+            {
+                return from + delta;
+            }
+            return MoveToward(from, from + difference, delta);
         }
 
         /// <summary>

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -440,6 +440,8 @@ TEST_CASE_TEMPLATE("[Math] rotate_toward", T, float, double) {
 	CHECK(Math::rotate_toward((T)-2.0, (T)1.0, (T)2.5) == doctest::Approx((T)0.5));
 	CHECK(Math::rotate_toward((T)-2.0, (T)Math::PI, (T)Math::PI) == doctest::Approx((T)-Math::PI));
 	CHECK(Math::rotate_toward((T)1.0, (T)Math::PI, (T)20.0) == doctest::Approx((T)Math::PI));
+	CHECK(Math::rotate_toward((T)Math::PI, (T)Math::PI, (T)0.0) == doctest::Approx((T)Math::PI));
+	CHECK(Math::rotate_toward((T)0.0, (T)Math::TAU, (T)Math::TAU) == doctest::Approx((T)0.0));
 
 	// Rotate away.
 	CHECK(Math::rotate_toward((T)0.0, (T)0.0, (T)-1.5) == doctest::Approx((T)-1.5));


### PR DESCRIPTION
Tries to address: https://github.com/godotengine/godot/issues/99083

Simplifies `rotate_toward` and removes most special handling for negative delta (except for an edge case that causes locking up). Positive delta should act the same.
Also updates the docs to accomodate.