### PR TITLE
Expand Hide button in `EditorHelp` search

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -4933,7 +4933,7 @@ FindBar::FindBar() {
 	hide_button->set_tooltip_text(TTR("Hide"));
 	hide_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	hide_button->connect(SceneStringName(pressed), callable_mp(this, &FindBar::_hide_bar));
-	hide_button->set_v_size_flags(SIZE_SHRINK_CENTER);
+	hide_button->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(hide_button);
 }
 


### PR DESCRIPTION
Before (4.6 dev5):


https://github.com/user-attachments/assets/ce379de8-f9ec-49bd-802e-81f4dc5d3755

After:


https://github.com/user-attachments/assets/057687a9-7537-4623-9b4e-428bc8b68c96

