### PR TITLE
Set shader path before compilation

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2281,6 +2281,7 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 	}
 
 	if (shader->data) {
+		shader->data->set_path_hint(shader->path_hint);
 		shader->data->set_code(p_code);
 	}
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -263,8 +263,8 @@ public:
 			}
 
 			RSG::material_storage->shader_initialize(shader, false);
-			RSG::material_storage->shader_set_code(shader, p_code);
 			RSG::material_storage->shader_set_path_hint(shader, p_path_hint);
+			RSG::material_storage->shader_set_code(shader, p_code);
 		} else {
 			command_queue.push(RSG::material_storage, &RendererMaterialStorage::shader_initialize, shader, false);
 			command_queue.push(RSG::material_storage, &RendererMaterialStorage::shader_set_code, shader, p_code);


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/113431

Related https://github.com/godotengine/godot/pull/112954 https://github.com/godotengine/godot/issues/113394

Correctly sets the shader path before compiling the shader ensuring compilation errors contain the correct path

## Before
<img width="532" height="152" alt="521198186-79fd81fa-9907-4058-9d8f-0339defc1b67" src="https://github.com/user-attachments/assets/6f5ef208-51db-4ecc-8791-f070f7de7586" />

## After
<img width="819" height="143" alt="image" src="https://github.com/user-attachments/assets/efd3495b-db5c-4409-9dd7-f8a1795ef3b5" />
