### PR TITLE
`EditorHelp`: Scroll to the only result found every time

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -4999,6 +4999,11 @@ bool FindBar::_search(bool p_search_previous) {
 		results_count = 0;
 		results_count_to_current = 0;
 	}
+
+	if (results_count == 1) {
+		rich_text_label->scroll_to_selection();
+	}
+
 	_update_matches_label();
 
 	return ret;


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/105968#pullrequestreview-2809633942

Force scroll to result on arrows press if it is the only result.

Before:

https://github.com/user-attachments/assets/9830d124-e391-4ee4-a65d-c7b643d26ca5


After:

https://github.com/user-attachments/assets/bd5ddb16-6074-4231-b052-34fad8ae4c37
