### PR TITLE
Fix crash by shortcut setting in project manager

### DIFF
--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -48,7 +48,9 @@ EditorUndoRedoManager::History &EditorUndoRedoManager::get_or_create_history(int
 		history.id = p_idx;
 		history_map[p_idx] = history;
 
-		EditorNode::get_singleton()->get_log()->register_undo_redo(history.undo_redo);
+		if (EditorNode::get_singleton()) {
+			EditorNode::get_singleton()->get_log()->register_undo_redo(history.undo_redo);
+		}
 		EditorDebuggerNode::get_singleton()->register_undo_redo(history.undo_redo);
 	}
 	return history_map[p_idx];
@@ -67,12 +69,14 @@ int EditorUndoRedoManager::get_history_id_for_object(Object *p_object) const {
 	}
 
 	if (Node *node = Object::cast_to<Node>(p_object)) {
-		Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
+		if (EditorNode::get_singleton()) {
+			Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
 
-		if (edited_scene && (node == edited_scene || edited_scene->is_ancestor_of(node))) {
-			int idx = EditorNode::get_editor_data().get_current_edited_scene_history_id();
-			if (idx > 0) {
-				history_id = idx;
+			if (edited_scene && (node == edited_scene || edited_scene->is_ancestor_of(node))) {
+				int idx = EditorNode::get_editor_data().get_current_edited_scene_history_id();
+				if (idx > 0) {
+					history_id = idx;
+				}
 			}
 		}
 	}

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -39,6 +39,7 @@
 #include "core/version.h"
 #include "editor/asset_library/asset_library_editor_plugin.h"
 #include "editor/editor_string_names.h"
+#include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_about.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_title_bar.h"
@@ -1328,6 +1329,7 @@ ProjectManager::ProjectManager() {
 			EditorSettings::create();
 		}
 		EditorSettings::get_singleton()->set_optimize_save(false); // Just write settings as they come.
+		undo_redo_manager = memnew(EditorUndoRedoManager);
 
 		{
 			bool agile_input_event_flushing = EDITOR_GET("input/buffering/agile_event_flushing");
@@ -1950,4 +1952,6 @@ ProjectManager::~ProjectManager() {
 	}
 
 	EditorThemeManager::finalize();
+
+	memdelete(undo_redo_manager);
 }

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -38,6 +38,7 @@ class EditorAbout;
 class EditorAssetLibrary;
 class EditorFileDialog;
 class EditorTitleBar;
+class EditorUndoRedoManager;
 class HFlowContainer;
 class LineEdit;
 class MarginContainer;
@@ -62,6 +63,7 @@ class ProjectManager : public Control {
 	static Ref<Texture2D> _file_dialog_get_thumbnail(const String &p_path);
 
 	HashMap<String, Ref<Texture2D>> icon_type_cache;
+	EditorUndoRedoManager *undo_redo_manager = nullptr;
 
 	void _build_icon_type_cache(Ref<Theme> p_theme);
 


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/113361*

## Issue Description

When setting shortcuts in project manager, we used `EditorUndoRedoManager`. But `EditorUndoRedoManager` didn't init in project manager.

https://github.com/godotengine/godot/blob/f5918a9d35350bf6402dd1b4902ab539747d77a6/editor/settings/editor_settings_dialog.cpp#L345-L353

## Solution

First, allocate memory for `EditorUndoRedoManager` in project manager.

Second, check whether `EditorNode` is nullptr for preventing null pointer crashing. 

[project-setting.webm](https://github.com/user-attachments/assets/4b1d2704-0c91-489d-8d40-2a148dfef048)
