### PR TITLE
Refactor VCS metatada creation to append to existing file or create new file if not found

### DIFF
--- a/editor/version_control/editor_vcs_interface.cpp
+++ b/editor/version_control/editor_vcs_interface.cpp
@@ -388,19 +388,16 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
         } else {
             f = FileAccess::open(path, FileAccess::WRITE);
         }
-        if (f.is_valid()) {
-            String current_content = f->get_as_text();
-            if (current_content.find("* text=auto eol=lf") == -1) {
-                f->seek_end();
-                if (!current_content.is_empty()) {
-                    f->store_line("");
-                }
-                f->store_line("# Normalize EOL for all files that Git considers text files.");
-                f->store_line("* text=auto eol=lf");
+        ERR_FAIL_COND_MSG(f.is_null(), "Could not open .gitattributes for writing.");
+        current_content = f->get_as_text();
+        if (!current_content.contains("* text=auto eol=lf")) {
+            f->seek_end();
+            if (!current_content.is_empty()) {
+                f->store_line("");
             }
-            f->close();
-        } else {
-             ERR_FAIL_MSG("Could not open .gitattributes for writing.");
+            f->store_line("# Normalize EOL for all files that Git considers text files.");
+            f->store_line("* text=auto eol=lf");
         }
+        f->close();
     }
 }

--- a/editor/version_control/editor_vcs_interface.cpp
+++ b/editor/version_control/editor_vcs_interface.cpp
@@ -382,7 +382,7 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 		}
 		f->close();
 		path = p_dir.path_join(".gitattributes");
-		f = Ref<FileAccess>(); 
+		f = Ref<FileAccess>();
 		if (FileAccess::exists(path)) {
 			f = FileAccess::open(path, FileAccess::READ_WRITE);
 		} else {

--- a/editor/version_control/editor_vcs_interface.cpp
+++ b/editor/version_control/editor_vcs_interface.cpp
@@ -368,22 +368,19 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
         } else {
             f = FileAccess::open(path, FileAccess::WRITE);
         }
-        if (f.is_valid()) {
-            String current_content = f->get_as_text();
+        ERR_FAIL_COND_MSG(f.is_null(), "Could not open .gitignore for writing.");
+        String current_content = f->get_as_text();
 
-            if (current_content.find(".godot/") == -1) {
-                f->seek_end();
-                if (!current_content.is_empty()) {
-                    f->store_line("");
-                }
-                f->store_line("# Godot 4+ specific ignores");
-                f->store_line(".godot/");
-                f->store_line("/android/");
+        if (!current_content.contains(".godot/")) {
+            f->seek_end();
+            if (!current_content.is_empty()) {
+               f->store_line("");
             }
-            f->close();
-        } else {
-            ERR_FAIL_MSG("Could not open .gitignore for writing.");
+            f->store_line("# Godot 4+ specific ignores");
+            f->store_line(".godot/");
+            f->store_line("/android/");
         }
+        f->close();
         path = p_dir.path_join(".gitattributes");
         f = Ref<FileAccess>(); 
         if (FileAccess::exists(path)) {

--- a/editor/version_control/editor_vcs_interface.cpp
+++ b/editor/version_control/editor_vcs_interface.cpp
@@ -360,44 +360,44 @@ void EditorVCSInterface::set_singleton(EditorVCSInterface *p_singleton) {
 }
 
 void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_type, String &p_dir) {
-    if (p_vcs_metadata_type == VCSMetadata::GIT) {
-        String path = p_dir.path_join(".gitignore");
-        Ref<FileAccess> f;
-        if (FileAccess::exists(path)) {
-            f = FileAccess::open(path, FileAccess::READ_WRITE);
-        } else {
-            f = FileAccess::open(path, FileAccess::WRITE);
-        }
-        ERR_FAIL_COND_MSG(f.is_null(), "Could not open .gitignore for writing.");
-        String current_content = f->get_as_text();
+	if (p_vcs_metadata_type == VCSMetadata::GIT) {
+		String path = p_dir.path_join(".gitignore");
+		Ref<FileAccess> f;
+		if (FileAccess::exists(path)) {
+			f = FileAccess::open(path, FileAccess::READ_WRITE);
+		} else {
+			f = FileAccess::open(path, FileAccess::WRITE);
+		}
+		ERR_FAIL_COND_MSG(f.is_null(), "Could not open .gitignore for writing.");
+		String current_content = f->get_as_text();
 
-        if (!current_content.contains(".godot/")) {
-            f->seek_end();
-            if (!current_content.is_empty()) {
-               f->store_line("");
-            }
-            f->store_line("# Godot 4+ specific ignores");
-            f->store_line(".godot/");
-            f->store_line("/android/");
-        }
-        f->close();
-        path = p_dir.path_join(".gitattributes");
-        f = Ref<FileAccess>(); 
-        if (FileAccess::exists(path)) {
-            f = FileAccess::open(path, FileAccess::READ_WRITE);
-        } else {
-            f = FileAccess::open(path, FileAccess::WRITE);
-        }
-        ERR_FAIL_COND_MSG(f.is_null(), "Could not open .gitattributes for writing.");
-        current_content = f->get_as_text();
-        if (!current_content.contains("* text=auto eol=lf")) {
-            f->seek_end();
-            if (!current_content.is_empty()) {
-                f->store_line("");
-            }
-            f->store_line("# Normalize EOL for all files that Git considers text files.");
-            f->store_line("* text=auto eol=lf");
-        }
-        f->close();
-    }
+		if (!current_content.contains(".godot/")) {
+			f->seek_end();
+			if (!current_content.is_empty()) {
+				f->store_line("");
+			}
+			f->store_line("# Godot 4+ specific ignores");
+			f->store_line(".godot/");
+			f->store_line("/android/");
+		}
+		f->close();
+		path = p_dir.path_join(".gitattributes");
+		f = Ref<FileAccess>(); 
+		if (FileAccess::exists(path)) {
+			f = FileAccess::open(path, FileAccess::READ_WRITE);
+		} else {
+			f = FileAccess::open(path, FileAccess::WRITE);
+		}
+		ERR_FAIL_COND_MSG(f.is_null(), "Could not open .gitattributes for writing.");
+		current_content = f->get_as_text();
+		if (!current_content.contains("* text=auto eol=lf")) {
+			f->seek_end();
+			if (!current_content.is_empty()) {
+				f->store_line("");
+			}
+			f->store_line("# Normalize EOL for all files that Git considers text files.");
+			f->store_line("* text=auto eol=lf");
+		}
+		f->close();
+	}
 }

--- a/editor/version_control/editor_vcs_interface.cpp
+++ b/editor/version_control/editor_vcs_interface.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_vcs_interface.h"
 
-#include "core/error/error_macros.h"
-#include "core/io/file_access.h"
 #include "editor/editor_node.h"
 
 EditorVCSInterface *EditorVCSInterface::singleton = nullptr;


### PR DESCRIPTION
When creating VCS metadata, already existing files were truncated and any configuration within them was lost. The changes in this PR make sure that, if an existing file is found, the default Godot VCS metadata is appended to it, and only if it does not already exist (to reduce file bloat). Tested locally and works as intended.

Fixes #113335 
