### PR TITLE
[iOS] Fix use of `godot_path`.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -718,7 +718,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		// We need to test both possibilities as extensions for Linux binaries are optional
 		// (so both 'mygame.bin' and 'mygame' should be able to find 'mygame.pck').
 
-#ifdef MACOS_ENABLED
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
 		if (!found) {
 			// Attempt to load PCK from macOS .app bundle resources.
 			found = _load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().path_join(exec_basename + ".pck"), false, 0, true) || _load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().path_join(exec_filename + ".pck"), false, 0, true);
@@ -777,7 +777,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		return err;
 	}
 
-#ifdef MACOS_ENABLED
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
 	// Attempt to load project file from macOS .app bundle resources.
 	resource_path = OS::get_singleton()->get_bundle_resource_dir();
 	if (!resource_path.is_empty()) {

--- a/drivers/apple_embedded/main_utilities.mm
+++ b/drivers/apple_embedded/main_utilities.mm
@@ -52,19 +52,6 @@ void change_to_launch_dir(char **p_args) {
 	}
 }
 
-int add_path(int p_argc, char **p_args) {
-	NSString *str = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"godot_path"];
-	if (!str) {
-		return p_argc;
-	}
-
-	p_args[p_argc++] = (char *)"--path";
-	p_args[p_argc++] = (char *)[str cStringUsingEncoding:NSUTF8StringEncoding];
-	p_args[p_argc] = nullptr;
-
-	return p_argc;
-}
-
 int add_cmdline(int p_argc, char **p_args) {
 	NSArray *arr = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"godot_cmdline"];
 	if (!arr) {
@@ -89,7 +76,6 @@ int process_args(int p_argc, char **p_args, char **r_args) {
 		r_args[i] = p_args[i];
 	}
 	r_args[p_argc] = nullptr;
-	p_argc = add_path(p_argc, r_args);
 	p_argc = add_cmdline(p_argc, r_args);
 	return p_argc;
 }

--- a/drivers/apple_embedded/os_apple_embedded.h
+++ b/drivers/apple_embedded/os_apple_embedded.h
@@ -118,6 +118,7 @@ public:
 	virtual String get_cache_path() const override;
 	virtual String get_temp_path() const override;
 	virtual String get_resource_dir() const override;
+	virtual String get_bundle_resource_dir() const override;
 
 	virtual String get_locale() const override;
 

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -412,6 +412,15 @@ String OS_AppleEmbedded::get_resource_dir() const {
 #endif
 }
 
+String OS_AppleEmbedded::get_bundle_resource_dir() const {
+	NSString *str = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"godot_path"];
+	if (!str) {
+		return OS_Unix::get_bundle_resource_dir();
+	} else {
+		return String::utf8([str cStringUsingEncoding:NSUTF8StringEncoding]);
+	}
+}
+
 String OS_AppleEmbedded::get_locale() const {
 	NSString *preferredLanguage = [NSLocale preferredLanguages].firstObject;
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -996,7 +996,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 #if !defined(OVERRIDE_PATH_ENABLED) && !defined(TOOLS_ENABLED)
 	String old_cwd = OS::get_singleton()->get_cwd();
-#ifdef MACOS_ENABLED
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
 	String new_cwd = OS::get_singleton()->get_bundle_resource_dir();
 	if (new_cwd.is_empty() || !new_cwd.is_absolute_path()) {
 		new_cwd = OS::get_singleton()->get_executable_path().get_base_dir();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113439

It's not used in normal deployment, but it's mentioned in the [tutorials](https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_ios.html#active-development-considerations) for some reason (seem like a convoluted way to do it with zero benefits over reexporting PCK). `godot_path` is part of a signed bundle, so there are no reasons to restrict it from a security standpoint.