### PR TITLE
Accessibility: Fix text field character count and line navigation

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -34,8 +34,10 @@
 			<param index="1" name="shaped_text" type="RID" />
 			<param index="2" name="min_height" type="float" />
 			<param index="3" name="insert_pos" type="int" default="-1" />
+			<param index="4" name="is_last_line" type="bool" default="false" />
 			<description>
 				Creates a new, empty accessibility sub-element from the shaped text buffer. Sub-elements are freed automatically when the parent element is freed, or can be freed early using the [method accessibility_free_element] method.
+				If [param is_last_line] is [code]true[/code], no trailing newline is appended to the text content. Set to [code]true[/code] for the last line in multi-line text fields and for single-line text fields.
 			</description>
 		</method>
 		<method name="accessibility_element_get_meta" qualifiers="const">

--- a/drivers/accesskit/accessibility_driver_accesskit.h
+++ b/drivers/accesskit/accessibility_driver_accesskit.h
@@ -113,7 +113,7 @@ public:
 
 	RID accessibility_create_element(DisplayServer::WindowID p_window_id, DisplayServer::AccessibilityRole p_role) override;
 	RID accessibility_create_sub_element(const RID &p_parent_rid, DisplayServer::AccessibilityRole p_role, int p_insert_pos = -1) override;
-	virtual RID accessibility_create_sub_text_edit_elements(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos = -1) override;
+	virtual RID accessibility_create_sub_text_edit_elements(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos = -1, bool p_is_last_line = false) override;
 	bool accessibility_has_element(const RID &p_id) const override;
 	void accessibility_free_element(const RID &p_id) override;
 

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -233,3 +233,10 @@ Validate extension JSON: Error: Field 'classes/EditorExportPreset/methods/get_sc
 Validate extension JSON: Error: Field 'classes/EditorExportPreset/methods/get_script_export_mode/return_value': type changed value in new API, from "int" to "enum::EditorExportPreset.ScriptExportMode".
 
 Change return type from `int` to `EditorExportPreset.ScriptExportMode` enum. Compatibility method registered.
+
+
+GH-113459
+---------
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/accessibility_create_sub_text_edit_elements/arguments': size changed value in new API, from 4 to 5.
+
+Optional argument added. Compatibility method registered.

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1311,7 +1311,7 @@ void LineEdit::_notification(int p_what) {
 			float text_off_x = x_ofs + scroll_offset;
 
 			if (accessibility_text_root_element.is_null()) {
-				accessibility_text_root_element = DisplayServer::get_singleton()->accessibility_create_sub_text_edit_elements(ae, using_placeholder ? RID() : text_rid, text_height);
+				accessibility_text_root_element = DisplayServer::get_singleton()->accessibility_create_sub_text_edit_elements(ae, using_placeholder ? RID() : text_rid, text_height, -1, true);
 			}
 
 			Transform2D text_xform;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -243,7 +243,8 @@ void TextEdit::Text::update_accessibility(int p_line, RID p_root) {
 	Line &l = text.write[p_line];
 	if (l.accessibility_text_root_element.is_empty()) {
 		for (int i = 0; i < l.data_buf->get_line_count(); i++) {
-			RID rid = DisplayServer::get_singleton()->accessibility_create_sub_text_edit_elements(p_root, l.data_buf->get_line_rid(i), max_line_height, p_line);
+			bool is_last_line = (p_line == text.size() - 1) && (i == l.data_buf->get_line_count() - 1);
+			RID rid = DisplayServer::get_singleton()->accessibility_create_sub_text_edit_elements(p_root, l.data_buf->get_line_rid(i), max_line_height, p_line, is_last_line);
 			l.accessibility_text_root_element.push_back(rid);
 		}
 	}
@@ -738,7 +739,6 @@ void TextEdit::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE:
 		case NOTIFICATION_ACCESSIBILITY_INVALIDATE: {
 			text.clear_accessibility();
-			accessibility_text_root_element_nl = RID();
 		} break;
 
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {
@@ -806,9 +806,6 @@ void TextEdit::_notification(int p_what) {
 					DisplayServer::get_singleton()->accessibility_update_add_action(text_aes[j], DisplayServer::AccessibilityAction::ACTION_SCROLL_INTO_VIEW, callable_mp(this, &TextEdit::_accessibility_action_scroll_into_view).bind(i, j));
 				}
 				lines_drawn += ac_buf->get_line_count();
-			}
-			if (accessibility_text_root_element_nl.is_null()) {
-				accessibility_text_root_element_nl = DisplayServer::get_singleton()->accessibility_create_sub_text_edit_elements(ae, RID(), get_line_height());
 			}
 
 			// Selection.

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -659,8 +659,6 @@ private:
 	bool draw_tabs = false;
 	bool draw_spaces = false;
 
-	RID accessibility_text_root_element_nl;
-
 	// FIXME: Helper method to draw unfilled rects, should be moved to RenderingServer.
 	void _draw_rect_unfilled(RID p_canvas_item, const Rect2 &p_rect, const Color &p_color, real_t p_width = -1.0, bool p_antialiased = false) const;
 

--- a/servers/display/display_server.compat.inc
+++ b/servers/display/display_server.compat.inc
@@ -38,9 +38,14 @@ Error DisplayServer::_file_dialog_with_options_show_bind_compat_98194(const Stri
 	return file_dialog_with_options_show(p_title, p_current_directory, p_root, p_filename, p_show_hidden, p_mode, p_filters, p_options, p_callback, MAIN_WINDOW_ID);
 }
 
+RID DisplayServer::_accessibility_create_sub_text_edit_elements_bind_compat_113459(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos) {
+	return accessibility_create_sub_text_edit_elements(p_parent_rid, p_shaped_text, p_min_height, p_insert_pos, false);
+}
+
 void DisplayServer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("file_dialog_show", "title", "current_directory", "filename", "show_hidden", "mode", "filters", "callback"), &DisplayServer::_file_dialog_show_bind_compat_98194);
 	ClassDB::bind_compatibility_method(D_METHOD("file_dialog_with_options_show", "title", "current_directory", "root", "filename", "show_hidden", "mode", "filters", "options", "callback"), &DisplayServer::_file_dialog_with_options_show_bind_compat_98194);
+	ClassDB::bind_compatibility_method(D_METHOD("accessibility_create_sub_text_edit_elements", "parent_rid", "shaped_text", "min_height", "insert_pos"), &DisplayServer::_accessibility_create_sub_text_edit_elements_bind_compat_113459, DEFVAL(-1));
 }
 
 #endif

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -648,9 +648,9 @@ RID DisplayServer::accessibility_create_sub_element(const RID &p_parent_rid, Dis
 	}
 }
 
-RID DisplayServer::accessibility_create_sub_text_edit_elements(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos) {
+RID DisplayServer::accessibility_create_sub_text_edit_elements(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos, bool p_is_last_line) {
 	if (accessibility_driver) {
-		return accessibility_driver->accessibility_create_sub_text_edit_elements(p_parent_rid, p_shaped_text, p_min_height, p_insert_pos);
+		return accessibility_driver->accessibility_create_sub_text_edit_elements(p_parent_rid, p_shaped_text, p_min_height, p_insert_pos, p_is_last_line);
 	} else {
 		return RID();
 	}
@@ -1485,7 +1485,7 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("accessibility_create_element", "window_id", "role"), &DisplayServer::accessibility_create_element);
 	ClassDB::bind_method(D_METHOD("accessibility_create_sub_element", "parent_rid", "role", "insert_pos"), &DisplayServer::accessibility_create_sub_element, DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("accessibility_create_sub_text_edit_elements", "parent_rid", "shaped_text", "min_height", "insert_pos"), &DisplayServer::accessibility_create_sub_text_edit_elements, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("accessibility_create_sub_text_edit_elements", "parent_rid", "shaped_text", "min_height", "insert_pos", "is_last_line"), &DisplayServer::accessibility_create_sub_text_edit_elements, DEFVAL(-1), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("accessibility_has_element", "id"), &DisplayServer::accessibility_has_element);
 	ClassDB::bind_method(D_METHOD("accessibility_free_element", "id"), &DisplayServer::accessibility_free_element);
 	ClassDB::bind_method(D_METHOD("accessibility_element_set_meta", "id", "meta"), &DisplayServer::accessibility_element_set_meta);

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -50,6 +50,7 @@ class DisplayServer : public Object {
 	mutable HashMap<String, RID> menu_names;
 
 	RID _get_rid_from_name(NativeMenu *p_nmenu, const String &p_menu_root) const;
+	RID _accessibility_create_sub_text_edit_elements_bind_compat_113459(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos = -1);
 #endif
 
 	LocalVector<ObjectID> additional_outputs;
@@ -678,7 +679,7 @@ public:
 
 	virtual RID accessibility_create_element(WindowID p_window_id, DisplayServer::AccessibilityRole p_role);
 	virtual RID accessibility_create_sub_element(const RID &p_parent_rid, DisplayServer::AccessibilityRole p_role, int p_insert_pos = -1);
-	virtual RID accessibility_create_sub_text_edit_elements(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos = -1);
+	virtual RID accessibility_create_sub_text_edit_elements(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos = -1, bool p_is_last_line = false);
 	virtual bool accessibility_has_element(const RID &p_id) const;
 	virtual void accessibility_free_element(const RID &p_id);
 
@@ -910,7 +911,7 @@ public:
 
 	virtual RID accessibility_create_element(DisplayServer::WindowID p_window_id, DisplayServer::AccessibilityRole p_role) = 0;
 	virtual RID accessibility_create_sub_element(const RID &p_parent_rid, DisplayServer::AccessibilityRole p_role, int p_insert_pos = -1) = 0;
-	virtual RID accessibility_create_sub_text_edit_elements(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos = -1) = 0;
+	virtual RID accessibility_create_sub_text_edit_elements(const RID &p_parent_rid, const RID &p_shaped_text, float p_min_height, int p_insert_pos = -1, bool p_is_last_line = false) = 0;
 	virtual bool accessibility_has_element(const RID &p_id) const = 0;
 	virtual void accessibility_free_element(const RID &p_id) = 0;
 


### PR DESCRIPTION
## Summary

Fixes screen reader navigation in multi-line text fields. Previously, Orca would announce "blank" or incorrect content when arrowing through lines.

**Three fixes:**

1. **Remove trailing newline on last line**: The accessibility driver always appended `\n` to every line, including the last. For "Line 1\nLine 2\nLine 3" (20 chars), this caused `character_count` to be 21+. Added `is_last_line` parameter to `accessibility_create_sub_text_edit_elements()` to suppress the trailing newline on the final line.

2. **Link TextRuns for line detection**: AccessKit determines line boundaries via `previous_on_line`/`next_on_line` node properties. Without these links, each TextRun was treated as a separate "line", causing incorrect announcements. Now adjacent TextRuns within a line are properly linked.

3. **Remove dead code**: Removed unused `accessibility_text_root_element_nl` member that was creating a phantom newline element but never actually used.

## Test plan

With Orca running:
- [x] Open a multi-line TextEdit with "Line 1\nLine 2\nLine 3"
- [x] Arrow up/down through lines - each line should be announced correctly
- [x] Move to end of document, arrow up, then down - should announce "Line 3" (not "blank")
- [x] Check single-line LineEdit still works correctly