### PR TITLE
Add non-public `{Line,Text}Edit::_set_text()` to fix `text_submitted` signal emission on Web

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -437,26 +437,27 @@ void DisplayServerAndroid::window_set_drop_files_callback(const Callable &p_call
 	// Not supported on Android.
 }
 
-void DisplayServerAndroid::_window_callback(const Callable &p_callable, const Variant &p_arg, bool p_deferred) const {
+template <typename... Args>
+void DisplayServerAndroid::_window_callback(const Callable &p_callable, bool p_deferred, const Args &...p_rest_args) const {
 	if (p_callable.is_valid()) {
 		if (p_deferred) {
-			p_callable.call_deferred(p_arg);
+			p_callable.call_deferred(p_rest_args...);
 		} else {
-			p_callable.call(p_arg);
+			p_callable.call(p_rest_args...);
 		}
 	}
 }
 
 void DisplayServerAndroid::send_window_event(DisplayServer::WindowEvent p_event, bool p_deferred) const {
-	_window_callback(window_event_callback, int(p_event), p_deferred);
+	_window_callback(window_event_callback, p_deferred, int(p_event));
 }
 
 void DisplayServerAndroid::send_input_event(const Ref<InputEvent> &p_event) const {
-	_window_callback(input_event_callback, p_event);
+	_window_callback(input_event_callback, false, p_event);
 }
 
 void DisplayServerAndroid::send_input_text(const String &p_text) const {
-	_window_callback(input_text_callback, p_text);
+	_window_callback(input_text_callback, false, p_text, false);
 }
 
 void DisplayServerAndroid::_dispatch_input_events(const Ref<InputEvent> &p_event) {

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -96,7 +96,8 @@ class DisplayServerAndroid : public DisplayServer {
 
 	Callable file_picker_callback;
 
-	void _window_callback(const Callable &p_callable, const Variant &p_arg, bool p_deferred = false) const;
+	template <typename... Args>
+	void _window_callback(const Callable &p_callable, bool p_deferred, const Args &...p_rest_args) const;
 
 	static void _dispatch_input_events(const Ref<InputEvent> &p_event);
 

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -796,7 +796,7 @@ void DisplayServerWeb::_vk_input_text_callback(const String &p_text, int p_curso
 		return;
 	}
 	// Call input_text
-	ds->input_text_callback.call(p_text);
+	ds->input_text_callback.call(p_text, true);
 	// Insert key right to reach position.
 	Input *input = Input::get_singleton();
 	Ref<InputEventKey> k;

--- a/platform/web/eslint.config.cjs
+++ b/platform/web/eslint.config.cjs
@@ -157,6 +157,7 @@ module.exports = [
 				'GodotFS': true,
 				'GodotOS': true,
 				'GodotAudio': true,
+				'GodotInput': true,
 				'GodotRuntime': true,
 				'IDHandler': true,
 				'XRWebGLLayer': true,

--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -30,7 +30,7 @@
 
 const GodotDisplayVK = {
 
-	$GodotDisplayVK__deps: ['$GodotRuntime', '$GodotConfig', '$GodotEventListeners'],
+	$GodotDisplayVK__deps: ['$GodotRuntime', '$GodotConfig', '$GodotEventListeners', '$GodotInput'],
 	$GodotDisplayVK__postset: 'GodotOS.atexit(function(resolve, reject) { GodotDisplayVK.clear(); resolve(); });',
 	$GodotDisplayVK: {
 		textinput: null,
@@ -61,6 +61,17 @@ const GodotDisplayVK = {
 					input_cb(c_str, elem.selectionEnd);
 					GodotRuntime.free(c_str);
 				}, false);
+				if (what === 'input') {
+					// Handling the "Enter" key.
+					const onKey = (pEvent, pEventName) => {
+						if (pEvent.key !== 'Enter') {
+							return;
+						}
+						GodotInput.onKeyEvent(pEventName === 'keydown', pEvent);
+					};
+					GodotEventListeners.add(elem, 'keydown', (pEvent) => onKey(pEvent, 'keydown'), false);
+					GodotEventListeners.add(elem, 'keyup', (pEvent) => onKey(pEvent, 'keyup'), false);
+				}
 				GodotEventListeners.add(elem, 'blur', function (evt) {
 					elem.style.display = 'none';
 					elem.readonly = true;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ ignore-words-list = [
 	"ot",
 	"outin",
 	"parm",
+	"pEvent",
 	"requestor",
 	"streamin",
 	"te",

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2109,22 +2109,39 @@ void LineEdit::delete_text(int p_from_column, int p_to_column) {
 	}
 }
 
-void LineEdit::set_text(String p_text) {
+void LineEdit::_set_text(String p_text, bool p_emit_signal) {
 	clear_internal();
+
+	String previous_text = get_text();
 	insert_text_at_caret(p_text);
-	_create_undo_state();
+
+	if (get_text() != previous_text) {
+		_create_undo_state();
+		if (p_emit_signal) {
+			_text_changed();
+		}
+	}
 
 	queue_redraw();
 	caret_column = 0;
 	scroll_offset = 0.0;
 }
 
+void LineEdit::set_text(String p_text) {
+	_set_text(p_text);
+}
+
 void LineEdit::set_text_with_selection(const String &p_text) {
 	Selection selection_copy = selection;
 
 	clear_internal();
+
+	String previous_text = get_text();
 	insert_text_at_caret(p_text);
-	_create_undo_state();
+
+	if (get_text() != previous_text) {
+		_create_undo_state();
+	}
 
 	int tlen = text.length();
 	selection = selection_copy;
@@ -3299,6 +3316,10 @@ void LineEdit::_validate_property(PropertyInfo &p_property) const {
 }
 
 void LineEdit::_bind_methods() {
+	// Private exposed API.
+	ClassDB::bind_method(D_METHOD("_set_text", "text", "emit_signal"), &LineEdit::_set_text, DEFVAL(false));
+
+	// Public API.
 	ClassDB::bind_method(D_METHOD("has_ime_text"), &LineEdit::has_ime_text);
 	ClassDB::bind_method(D_METHOD("cancel_ime"), &LineEdit::cancel_ime);
 	ClassDB::bind_method(D_METHOD("apply_ime"), &LineEdit::apply_ime);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -342,6 +342,7 @@ public:
 	void delete_char();
 	void delete_text(int p_from_column, int p_to_column);
 
+	void _set_text(String p_text, bool p_emit_signal = false);
 	void set_text(String p_text);
 	String get_text() const;
 	void set_text_with_selection(const String &p_text); // Set text, while preserving selection.

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -853,6 +853,7 @@ public:
 	// Text manipulation
 	void clear();
 
+	void _set_text(const String &p_text, bool p_emit_signal = false);
 	void set_text(const String &p_text);
 	String get_text() const;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2828,16 +2828,22 @@ void Viewport::_post_gui_grab_click_focus() {
 
 ///////////////////////////////
 
-void Viewport::push_text_input(const String &p_text) {
+void Viewport::_push_text_input(const String &p_text, bool p_emit_signal) {
 	ERR_MAIN_THREAD_GUARD;
 	if (gui.subwindow_focused) {
 		gui.subwindow_focused->push_text_input(p_text);
 		return;
 	}
 
-	if (gui.key_focus) {
-		gui.key_focus->call("set_text", p_text);
+	StringName set_text_method = SNAME("_set_text");
+	if (!gui.key_focus || !gui.key_focus->has_method(set_text_method)) {
+		return;
 	}
+	gui.key_focus->call(set_text_method, p_text, p_emit_signal);
+}
+
+void Viewport::push_text_input(const String &p_text) {
+	_push_text_input(p_text, false);
 }
 
 Viewport::SubWindowResize Viewport::_sub_window_get_resize_margin(Window *p_subwindow, const Point2 &p_point) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -608,6 +608,7 @@ public:
 	Vector2 get_camera_coords(const Vector2 &p_viewport_coords) const;
 	Vector2 get_camera_rect_size() const;
 
+	void _push_text_input(const String &p_text, bool p_emit_text_changed_signal = false);
 	void push_text_input(const String &p_text);
 	void push_input(RequiredParam<InputEvent> rp_event, bool p_local_coords = false);
 #ifndef DISABLE_DEPRECATED

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1860,8 +1860,8 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	}
 }
 
-void Window::_window_input_text(const String &p_text) {
-	push_text_input(p_text);
+void Window::_window_input_text(const String &p_text, bool p_emit_signal) {
+	_push_text_input(p_text, p_emit_signal);
 }
 
 void Window::_window_drop_files(const Vector<String> &p_files) {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -244,7 +244,7 @@ private:
 	friend class Viewport; //friend back, can call the methods below
 
 	void _window_input(const Ref<InputEvent> &p_ev);
-	void _window_input_text(const String &p_text);
+	void _window_input_text(const String &p_text, bool p_emit_signal = false);
 	void _window_drop_files(const Vector<String> &p_files);
 	void _rect_changed_callback(const Rect2i &p_callback);
 	void _event_callback(DisplayServer::WindowEvent p_event);


### PR DESCRIPTION
Supersedes #106540
Fixes https://github.com/godotengine/godot/issues/106539
Fixes https://github.com/godotengine/godot/issues/103771
Partially fixes https://github.com/godotengine/godot/issues/76215

> [!NOTE]
> This solution is not perfect. For the Web platform, as we rely on a hack to edit text, the text cursor position in the executed callbacks will be wrong. But this solution is the best we can have until we refactor the way we edit text externally (i.e. to make it work with changes not made by keyboards, such as phones autocorrect.)

This PR also fixes the Web platform issue where pressing `Enter` wouldn't trigger the `text_submitted` signal. It is solved by the Web stack by sending the correct `InputEvent` when editing `LineEdit`s.

I added @pippenpaddleopsicopolis as co-author to recognize his efforts towards fixing this issue.