### PR TITLE
Skip convex decomposition when there are no vertices in ConvexPolygonShape3D

### DIFF
--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -1079,10 +1079,18 @@ Vector3 GodotConvexPolygonShape3D::get_moment_of_inertia(real_t p_mass) const {
 }
 
 void GodotConvexPolygonShape3D::_setup(const Vector<Vector3> &p_vertices) {
-	Error err = ConvexHullComputer::convex_hull(p_vertices, mesh);
-	if (err != OK) {
-		ERR_PRINT("Failed to build convex hull");
+	if (!p_vertices.is_empty()) {
+		// Don't try to create a convex hull if the mesh has no vertices.
+		// This prevents errors from being printed when using `ConvexPolygonShape3D.new()` then setting the points afterwards,
+		// which matches Jolt Physics behavior.
+		Error err = ConvexHullComputer::convex_hull(p_vertices, mesh);
+		if (err != OK) {
+			ERR_PRINT(vformat("Failed to build convex hull for mesh with %d vertices.", p_vertices.size()));
+		}
+	} else {
+		mesh = Geometry3D::MeshData();
 	}
+
 	extreme_vertices.resize(0);
 	vertex_neighbors.resize(0);
 


### PR DESCRIPTION
This prevents errors from being printed when creating new ConvexPolygonShape3D resources from code if the points are assigned after creation.

This also mentions the number of vertices when decomposition fails for added context.

The issue doesn't occur in Jolt Physics, only in GodotPhysics.

@Yinteger @TurqW Could you [test this PR locally](https://contributing.godotengine.org/en/latest/organization/pull_requests/testing.html) to make sure it resolves the issue?

- See https://github.com/godotengine/godot-docs-user-notes/discussions/572#discussioncomment-15017569.
