### PR TITLE
Allow maximizing sprite related dialogs

### DIFF
--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -2410,6 +2410,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	delete_dialog->connect(SceneStringName(confirmed), callable_mp(this, &SpriteFramesEditor::_animation_remove_confirmed));
 
 	split_sheet_dialog = memnew(ConfirmationDialog);
+	split_sheet_dialog->set_flag(Window::FLAG_MAXIMIZE_DISABLED, false);
 	add_child(split_sheet_dialog);
 	split_sheet_dialog->set_title(TTRC("Select Frames"));
 	split_sheet_dialog->connect(SceneStringName(confirmed), callable_mp(this, &SpriteFramesEditor::_sheet_add_frames));
@@ -2654,7 +2655,9 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	file_split_sheet->set_title(TTRC("Create Frames from Sprite Sheet"));
 	file_split_sheet->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	add_child(file_split_sheet);
-	file_split_sheet->connect("file_selected", callable_mp(this, &SpriteFramesEditor::_prepare_sprite_sheet));
+	// Deferred so file dialog is hidden when sprite sheet dialog popups. Otherwise, after allowing
+	// sprite sheet dialog to be maximized, it would complain about already having exclusive child window.
+	file_split_sheet->connect("file_selected", callable_mp(this, &SpriteFramesEditor::_prepare_sprite_sheet), CONNECT_DEFERRED);
 
 	// Config scale.
 	scale_ratio = 1.2f;

--- a/editor/scene/texture/texture_region_editor_plugin.cpp
+++ b/editor/scene/texture/texture_region_editor_plugin.cpp
@@ -1160,6 +1160,7 @@ void TextureRegionEditor::_bind_methods() {
 
 TextureRegionEditor::TextureRegionEditor() {
 	set_title(TTR("Region Editor"));
+	set_flag(FLAG_MAXIMIZE_DISABLED, false);
 	set_process_shortcut_input(true);
 	set_ok_button_text(TTR("Close"));
 	// Handled manually, to allow canceling dragging.


### PR DESCRIPTION
Re-allows maximizing:
- texture region editor,
- frames selection dialog for SpriteFrames.

This was possible before, regression from #105107.

Before<br>(v4.6.dev5.official [f5918a9d3])|After<br>(this PR)
-|-
<img width="1250" height="734" alt="Godot_v4 6-dev5_win64_nnh1PfH6u8" src="https://github.com/user-attachments/assets/1282d05e-3477-4634-8721-6a81650f3bbf" />|<img width="1250" height="734" alt="godot windows editor dev x86_64_3F39XSgDK2" src="https://github.com/user-attachments/assets/39192f6d-0c47-4f23-951b-990f92dd2646" />
<img width="962" height="572" alt="Godot_v4 6-dev5_win64_FA4778hbOg" src="https://github.com/user-attachments/assets/d30b79c7-1981-4357-9f55-103363e9473b" />|<img width="962" height="572" alt="godot windows editor dev x86_64_7bduBQySiL" src="https://github.com/user-attachments/assets/192ca48b-be3c-4e3a-832d-fba460ef5d26" />
