### PR TITLE
Fix unscaled physics timers using process time instead of physics time

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -60,6 +60,7 @@ private:
 	uint32_t _frame_delay = 0;
 	uint64_t _frame_ticks = 0;
 	double _process_step = 0;
+	double _physics_step = 0;
 
 	int ips = 60;
 	int user_ips = 60;
@@ -140,6 +141,7 @@ public:
 	bool is_in_physics_frame() const { return _in_physics; }
 	uint64_t get_frame_ticks() const { return _frame_ticks; }
 	double get_process_step() const { return _process_step; }
+	double get_physics_step() const { return _physics_step; }
 	double get_physics_interpolation_fraction() const { return _physics_interpolation_fraction; }
 
 	void set_time_scale(double p_scale);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4886,6 +4886,7 @@ bool Main::iteration() {
 	double scaled_step = process_step * time_scale;
 
 	Engine::get_singleton()->_process_step = process_step;
+	Engine::get_singleton()->_physics_step = physics_step;
 	Engine::get_singleton()->_physics_interpolation_fraction = advance.interpolation_fraction;
 
 	uint64_t physics_process_ticks = 0;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -789,7 +789,7 @@ bool SceneTree::process(double p_time) {
 void SceneTree::process_timers(double p_delta, bool p_physics_frame) {
 	_THREAD_SAFE_METHOD_
 	const List<Ref<SceneTreeTimer>>::Element *L = timers.back(); // Last element.
-	const double unscaled_delta = Engine::get_singleton()->get_process_step();
+	const double unscaled_delta = p_physics_frame ? Engine::get_singleton()->get_physics_step() : Engine::get_singleton()->get_process_step();
 
 	for (List<Ref<SceneTreeTimer>>::Element *E = timers.front(); E;) {
 		List<Ref<SceneTreeTimer>>::Element *N = E->next();
@@ -822,7 +822,7 @@ void SceneTree::process_tweens(double p_delta, bool p_physics) {
 	_THREAD_SAFE_METHOD_
 	// This methods works similarly to how SceneTreeTimers are handled.
 	const List<Ref<Tween>>::Element *L = tweens.back();
-	const double unscaled_delta = Engine::get_singleton()->get_process_step();
+	const double unscaled_delta = p_physics ? Engine::get_singleton()->get_physics_step() : Engine::get_singleton()->get_process_step();
 
 	for (List<Ref<Tween>>::Element *E = tweens.front(); E;) {
 		List<Ref<Tween>>::Element *N = E->next();

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -73,7 +73,7 @@ void Timer::_notification(int p_what) {
 				return;
 			}
 			if (ignore_time_scale) {
-				time_left -= Engine::get_singleton()->get_process_step();
+				time_left -= Engine::get_singleton()->get_physics_step();
 			} else {
 				time_left -= get_physics_process_delta_time();
 			}


### PR DESCRIPTION
Fixes #106368, fixes #107203, and fixes #94355.

Changes the use of unscaled physics timers to use an unscaled physics step instead of an unscaled process step. The changes were made to NodeTimers, SceneTreeTimer, and Tweens, as they were all based on the same logic.

This is an MRP that showcases the number of ticks it takes for timers to time out under various circumstances.
[mrp-timer-framerate-issue.zip](https://github.com/user-attachments/files/23888984/mrp-timer-framerate-issue.zip)
