### PR TITLE
Add Adreno workaround to Mobile post process shader

### DIFF
--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -324,7 +324,7 @@ void ToneMapper::tonemapper_subpass(RD::DrawListID p_subpass_draw_list, RID p_so
 	tonemap_mobile.push_constant.white = p_settings.white;
 	tonemap_mobile.push_constant.luminance_multiplier = p_settings.luminance_multiplier;
 
-	uint32_t spec_constant = 0;
+	uint32_t spec_constant = TONEMAP_MOBILE_ADRENO_BUG;
 	spec_constant |= p_settings.use_bcs ? TONEMAP_MOBILE_FLAG_USE_BCS : 0;
 	//spec_constant |= p_settings.use_glow ? TONEMAP_MOBILE_FLAG_USE_GLOW : 0;
 	//spec_constant |= p_settings.glow_map_strength > 0.01 ? TONEMAP_MOBILE_FLAG_USE_GLOW_MAP : 0;

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -100,6 +100,7 @@ private:
 		TONEMAP_MOBILE_FLAG_GLOW_MODE_SOFTLIGHT = (1 << 15),
 		TONEMAP_MOBILE_FLAG_GLOW_MODE_REPLACE = (1 << 16),
 		TONEMAP_MOBILE_FLAG_GLOW_MODE_MIX = (1 << 17),
+		TONEMAP_MOBILE_ADRENO_BUG = (1 << 18), // Needs to be last so we force the pipeline cache to specify specializations for all variants.
 	};
 
 	struct TonemapPushConstant {

--- a/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
@@ -46,14 +46,12 @@ RID PipelineCacheRD::_generate_version(RD::VertexFormatID p_vertex_format_id, RD
 	uint32_t bool_index = 0;
 	uint32_t bool_specializations = p_bool_specializations;
 	while (bool_specializations) {
-		if (bool_specializations & (1 << bool_index)) {
-			RD::PipelineSpecializationConstant sc;
-			sc.bool_value = true;
-			sc.constant_id = bool_index;
-			sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_BOOL;
-			specialization_constants.push_back(sc);
-			bool_specializations &= ~(1 << bool_index);
-		}
+		RD::PipelineSpecializationConstant sc;
+		sc.bool_value = bool(bool_specializations & (1 << bool_index));
+		sc.constant_id = bool_index;
+		sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_BOOL;
+		specialization_constants.push_back(sc);
+		bool_specializations &= ~(1 << bool_index);
 		bool_index++;
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/112834

Through iterative code elimination I traced this issue down to a driver bug on Adreno devices. Basically, input attachments break in any shader using spec constants, even if the spec constants are unused. 

The most elegant workaround I have found involves relying on re-spirv to optimize out the spec constants. Re-spirv will patch the SPIRV with the actual value of the spec constant before it reaches the compiler in the GPU driver. This means that no spec constants (with a non-default value) actually reach the GPU driver and thus the bug is avoided. 

Our pipeline cache however relies on using _default_ values widely. Additionally, it is totally broken for values where the default is true. 

The old logic for the pipeline cache was to create a spec constant for any bool that is set to true. Therefore, if your spec constant defaults to true in the shader and you set it to false, it will never be used. I changed the logic to record all spec constants up to the highest one set to true. This doesn't fully eliminate the risk in using a default value of true, but I don't want to spend any effort solving theoretical bugs. The contained fix is enough to solve this issue. 

Overall, by specifying a proper spec constant on the CPU for each spec constant in the shader, we can rely on re-spirv to optimize them all out and give us a fully optimized shader that doesn't trigger the bug on Adreno!