### PR TITLE
CI: Bump Ruff version (0.13.1 → 0.14.7)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.1
+    rev: v0.14.7
     hooks:
       - id: ruff-check
         args: [--fix]


### PR DESCRIPTION
All python files were still valid after the update; no changes required