### PR TITLE
Editor: Set initial focus for screen reader users

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1443,6 +1443,20 @@ void EditorNode::_sources_changed(bool p_exist) {
 		if (!singleton->cmdline_mode) {
 			EditorResourcePreview::get_singleton()->start();
 		}
+
+		// Set initial focus for screen reader users.
+		if (get_tree()->is_accessibility_enabled()) {
+			if (SceneTreeDock::get_singleton()->is_visible_in_tree()) {
+				SceneTreeDock::get_singleton()->get_tree_editor()->get_scene_tree()->grab_focus();
+			} else {
+				TabContainer *tab_container = EditorDockManager::get_singleton()->get_dock_tab_container(SceneTreeDock::get_singleton());
+				if (tab_container) {
+					// Another tab is active (e.g., Import) - focus the tab bar so user can switch.
+					tab_container->get_tab_bar()->grab_focus();
+				}
+			}
+		}
+
 		get_tree()->create_timer(1.0f)->connect("timeout", callable_mp(this, &EditorNode::_remove_lock_file));
 	}
 }


### PR DESCRIPTION
As a screen reader user, working with the Godot editor is tough because there's no initial focus, which is necessary for *any* focus events to process. This sets it to the scene tree, which seems like a good place for initial focus to land. With this in place, I can tab/arrow through the editor immediately when launched vs. having to hunt for and route to the scene tree manually with Orca each time.

Not sure if this should be screen-reader-gated or not. I went for the least invasive change here but arguably other keyboard users might benefit from there being an initial focus, and the scene tree being always available seems like the best candidate.