### PR TITLE
Hide "Open documentation" context menu button in project manager

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1605,7 +1605,7 @@ void EditorProperty::_update_popup() {
 			menu->add_icon_item(theme_cache.revert_icon, TTR("Revert Value"), MENU_REVERT_VALUE);
 		}
 	}
-	if (!doc_path.is_empty()) {
+	if (!doc_path.is_empty() && ScriptEditor::get_singleton() && EditorNode::get_singleton()) {
 		menu->add_separator();
 		menu->add_icon_item(theme_cache.help_icon, TTR("Open Documentation"), MENU_OPEN_DOCUMENTATION);
 	}


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/113328 crash by hiding the "Open documentation" button from the context menu while the ScriptEditor  and EditorNode do not exist.

The EditorNode or internals of the ScriptEditor are not fully loaded in the project manager leading to crashes when the context menu tries to open an editor build-in documentation page.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
