### PR TITLE
Make `NodePath` always calculate its own hash, to avoid multithreading and performance issues

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -45,16 +45,7 @@ void NodePath::_update_hash_cache() const {
 		h = h ^ ssn[i].hash();
 	}
 
-	data->hash_cache_valid = true;
 	data->hash_cache = h;
-}
-
-void NodePath::prepend_period() {
-	if (data->path.size() && data->path[0].operator String() != ".") {
-		data->path.insert(0, ".");
-		data->concatenated_path = StringName();
-		data->hash_cache_valid = false;
-	}
 }
 
 bool NodePath::is_absolute() const {
@@ -117,10 +108,8 @@ bool NodePath::operator==(const NodePath &p_path) const {
 		return false;
 	}
 
-	if (data->hash_cache_valid && p_path.data->hash_cache_valid) {
-		if (data->hash_cache != p_path.data->hash_cache) {
-			return false;
-		}
+	if (data->hash_cache != p_path.data->hash_cache) {
+		return false;
 	}
 
 	if (data->absolute != p_path.data->absolute) {
@@ -360,7 +349,7 @@ void NodePath::simplify() {
 		}
 	}
 	data->concatenated_path = StringName();
-	data->hash_cache_valid = false;
+	_update_hash_cache();
 }
 
 NodePath NodePath::simplified() const {
@@ -378,7 +367,7 @@ NodePath::NodePath(const Vector<StringName> &p_path, bool p_absolute) {
 	data->refcount.init();
 	data->absolute = p_absolute;
 	data->path = p_path;
-	data->hash_cache_valid = false;
+	_update_hash_cache();
 }
 
 NodePath::NodePath(const Vector<StringName> &p_path, const Vector<StringName> &p_subpath, bool p_absolute) {
@@ -391,7 +380,7 @@ NodePath::NodePath(const Vector<StringName> &p_path, const Vector<StringName> &p
 	data->absolute = p_absolute;
 	data->path = p_path;
 	data->subpath = p_subpath;
-	data->hash_cache_valid = false;
+	_update_hash_cache();
 }
 
 NodePath::NodePath(const NodePath &p_path) {
@@ -455,9 +444,9 @@ NodePath::NodePath(const String &p_path) {
 	data->refcount.init();
 	data->absolute = absolute;
 	data->subpath = subpath;
-	data->hash_cache_valid = false;
 
 	if (slices == 0) {
+		_update_hash_cache();
 		return;
 	}
 	data->path.resize(slices);
@@ -478,6 +467,8 @@ NodePath::NodePath(const String &p_path) {
 			last_is_slash = false;
 		}
 	}
+
+	_update_hash_cache();
 }
 
 NodePath::~NodePath() {

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -43,8 +43,7 @@ class [[nodiscard]] NodePath {
 		StringName concatenated_path;
 		StringName concatenated_subpath;
 		bool absolute;
-		mutable bool hash_cache_valid;
-		mutable uint32_t hash_cache;
+		uint32_t hash_cache;
 	};
 
 	mutable Data *data = nullptr;
@@ -68,17 +67,7 @@ public:
 	NodePath rel_path_to(const NodePath &p_np) const;
 	NodePath get_as_property_path() const;
 
-	void prepend_period();
-
-	_FORCE_INLINE_ uint32_t hash() const {
-		if (!data) {
-			return 0;
-		}
-		if (!data->hash_cache_valid) {
-			_update_hash_cache();
-		}
-		return data->hash_cache;
-	}
+	_FORCE_INLINE_ uint32_t hash() const { return data ? data->hash_cache : 0; }
 
 	explicit operator String() const;
 	bool is_empty() const;


### PR DESCRIPTION
- Related to #113204 
- Follow-up of #113447 

This eliminates a theoretical race condition where `NodePath` `hash_cache` is read while it is incorrect. I think the race condition may not actually manifest because of hardware details, but this is not guaranteed. I explain this further below.

This change also optimizes `NodePath` by making `hash_cache` more available (e.g. for `operator==`, which can exit early more often).

## Explanation

The race condition exists if one thread is calling `_update_hash_cache` while another is getting the hash (e.g. `operator==`). In this situation, we have no guarantees that `hash_cache_valid` is set _after_ `hash_cache` is set, so there is a race condition where `hash_cache` can be read with an invalid value.

**I see three potential fixes:**

- Make `hash_cache` atomic or use thread fences (but this would incur a substantial cost on hash access).
- Assume `hash_cache` and `hash_cache_valid` are _effectively_ atomic by aligning them across a 64-bit boundary (they already are aligned right now, but we could make this explicit). This _should be_ safe in most architectures in practice, but it's not guaranteed by the C++ language, and assumes that the compiler uses the 64-bit setters for the values.
- Always calculate `hash_cache` (instead of lazily).

Always calculating `hash_cache` might seem wasteful at first, but calculating the hash cache at the constructors is actually ideal since most of the values should be in cache. This is assuming the hash cache is probably needed sooner or later — for example, nodes themselves are indexed by hash maps (which needs the hash cache), and so are properties.

A side effect benefit is that we can always assume `hash_cache` exists, which should make other operations (like `hash()` and `operator==`) more efficient.

## Side note

`prepend_period` is removed because it is unused. This is better addressed in #113204, but removing it here does eliminate a potential failure case already.