### PR TITLE
Fix replace parent node and paste child nodes then move cause crash

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -3045,6 +3045,7 @@ void SceneTreeDock::_create() {
 		}
 
 		ur->commit_action(false);
+		tree_clicked = false;
 	} else if (current_option == TOOL_REPARENT_TO_NEW_NODE) {
 		const List<Node *> &selection = editor_selection->get_top_selected_node_list();
 		ERR_FAIL_COND(selection.is_empty());


### PR DESCRIPTION
- *Fixes: https://github.com/godotengine/godot/issues/113453*

## Issue Descripion

As described in #113453, if we first change parent node type, then paste child nodes, then move nodes in editor. We will attempt to move the invalid nodes from before the changes.

## Solution

~~We can set `pending_click_select = nullptr` in `paste_nodes()` to prevent using invalid node.~~

Edited: We should clean `tree_clicked = false` after `replace_node()`, then later mouse click event won't select node by mistake.

[replace-paste-move-crash.webm](https://github.com/user-attachments/assets/1391865e-d259-4bc8-9cb3-1969243c5aa7)

## Explaination

When we execute "change type", we click mouse right key to display context menu, which will trigger `input()` to mark `tree_clicked = true` and save `pending_click_select = current_node`.

https://github.com/godotengine/godot/blob/9f5309a2a498ae2adfe2e7ac48d9813fd8ecc490/editor/docks/scene_tree_dock.cpp#L148-L152

But after executing `replace_node()`, `tree_clicked` is still `true`. That makes when triggered `_handle_select`, the `pending_click_select` always updated.

https://github.com/godotengine/godot/blob/9f5309a2a498ae2adfe2e7ac48d9813fd8ecc490/editor/docks/scene_tree_dock.cpp#L1871-L1877

Whenever we click mouse to trigger next `input()`, the `pending_click_select` will update to `editor_selection` with `push_item`. That makes the current selection changed and causes crash.

https://github.com/godotengine/godot/blob/9f5309a2a498ae2adfe2e7ac48d9813fd8ecc490/editor/docks/scene_tree_dock.cpp#L154-L157

