### PR TITLE
Fix DistractionFreeMode and BottomPanel

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -864,7 +864,7 @@ void EditorDockManager::focus_dock(EditorDock *p_dock) {
 		return;
 	}
 
-	if (!docks_visible) {
+	if (!docks_visible && p_dock->get_parent() != EditorNode::get_bottom_panel()) {
 		return;
 	}
 
@@ -912,7 +912,7 @@ void EditorDockManager::set_docks_visible(bool p_show) {
 		return;
 	}
 	docks_visible = p_show;
-	for (int i = 0; i < DockConstants::DOCK_SLOT_MAX; i++) {
+	for (int i = 0; i < DockConstants::DOCK_SLOT_BOTTOM; i++) {
 		dock_slots[i].container->set_visible(docks_visible && dock_slots[i].container->get_tab_count() > 0);
 	}
 	_update_layout();

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -115,10 +115,10 @@ void EditorBottomPanel::_repaint() {
 	pin_button->set_visible(!panel_collapsed);
 	expand_button->set_visible(!panel_collapsed);
 	if (expand_button->is_pressed()) {
-		EditorNode::get_top_split()->set_visible(panel_collapsed);
+		_expand_button_toggled(!panel_collapsed);
+	} else {
+		_theme_changed();
 	}
-
-	_theme_changed();
 }
 
 void EditorBottomPanel::save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const {


### PR DESCRIPTION
- Fix https://github.com/godotengine/godot/issues/113314
- Fix https://github.com/godotengine/godot/issues/113520

Also fix DistractionFreeMode button visibility between scene tabs and bottom panel.


https://github.com/user-attachments/assets/bdba7b62-8b69-42dd-b1cd-02a05cbad1be