### PR TITLE
Parallelize positional light culling.

### DIFF
--- a/servers/rendering/light_cull_planes.h
+++ b/servers/rendering/light_cull_planes.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  light_cull_planes.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/math/plane.h"
+
+// #define LIGHT_CULLER_DEBUG_DIRECTIONAL_LIGHT
+
+struct LightCullPlanes {
+	enum {
+		MAX_CULL_PLANES = 17,
+	};
+
+	void add_cull_plane(const Plane &p);
+	Plane cull_planes[MAX_CULL_PLANES];
+	int num_cull_planes = 0;
+#ifdef LIGHT_CULLER_DEBUG_DIRECTIONAL_LIGHT
+	uint32_t rejected_count = 0;
+#endif
+	// The whole regular light can be out of range of the view frustum, in which case all casters should be culled.
+	bool out_of_range = false;
+};


### PR DESCRIPTION
Distributes all positional light culling tasks to worker thread pools.

Test case:
- 32 omni lights rendering cube shadows every frame.
- 12K mesh instances in the scene.
- 16 worker threads.

`RendererSceneCull::_render_scene` results:
- Before: 4.39 ms average
- After: 3.59 ms average

### To Do
- [ ] Test that the culling hasn't broken in some way. Also ensure that the mesh instance updates and "animated_material_found" checks are applied correctly.
- [ ] Determine if there should be some kind of threshold to fall back to serial culling, like the other methods in the same function.