### PR TITLE
Fix CreateDialog returning wrong type

### DIFF
--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -621,7 +621,7 @@ String CreateDialog::get_selected_type() {
 		return String();
 	}
 
-	String type = selected->get_text(0);
+	String type = selected->get_text(0).get_slicec(' ', 0);
 	return ClassDB::class_exists(type) ? type : String(selected->get_meta("_script_path", ""));
 }
 

--- a/editor/scene/scene_create_dialog.cpp
+++ b/editor/scene/scene_create_dialog.cpp
@@ -90,7 +90,7 @@ void SceneCreateDialog::browse_types() {
 }
 
 void SceneCreateDialog::on_type_picked() {
-	other_type_display->set_text(select_node_dialog->get_selected_type().get_slicec(' ', 0));
+	other_type_display->set_text(select_node_dialog->get_selected_type());
 	if (node_type_other->is_pressed()) {
 		validation_panel->update();
 	} else {

--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -492,7 +492,7 @@ void ScriptCreateDialog::_file_selected(const String &p_file) {
 }
 
 void ScriptCreateDialog::_create() {
-	parent_name->set_text(select_class->get_selected_type().get_slicec(' ', 0));
+	parent_name->set_text(select_class->get_selected_type());
 	_parent_name_changed(parent_name->get_text());
 }
 


### PR DESCRIPTION
Fixes #113498

A better fix would be doing what `instantiate_selected()` does
https://github.com/godotengine/godot/blob/2ecefada8d8ae0071ee05bb53e3e2f7cdff3853f/editor/gui/create_dialog.cpp#L640-L644
but for now it's safer to just get slice.