### PR TITLE
Unmark `Node::is_editable_instance()` parameter as required

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2689,8 +2689,10 @@ void Node::set_editable_instance(RequiredParam<Node> rp_node, bool p_editable) {
 	p_node->_emit_editor_state_changed();
 }
 
-bool Node::is_editable_instance(RequiredParam<const Node> rp_node) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, false);
+bool Node::is_editable_instance(const Node *p_node) const {
+	if (!p_node) {
+		return false; // Easier, null is never editable. :)
+	}
 	ERR_FAIL_COND_V(!is_ancestor_of(p_node), false);
 	return p_node->data.editable_instance;
 }

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -622,7 +622,7 @@ public:
 	String get_editor_description() const;
 
 	void set_editable_instance(RequiredParam<Node> rp_node, bool p_editable);
-	bool is_editable_instance(RequiredParam<const Node> rp_node) const;
+	bool is_editable_instance(const Node *p_node) const;
 	Node *get_deepest_editable_node(Node *p_start_node) const;
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113490

I had marked the node parameter on `Node::is_editable_instance()` as required in https://github.com/godotengine/godot/pull/113282, but it turns out that one isn't really required. Sorry about that!

This PR reverts that one change
