### PR TITLE
fix missing compatilbity binding in gltf_state

### DIFF
--- a/modules/gltf/gltf_state.compat.inc
+++ b/modules/gltf/gltf_state.compat.inc
@@ -171,6 +171,10 @@ Variant GLTFState::_get_additional_data_bind_compat_113172(const StringName &p_e
 	return get_additional_data(p_extension_name);
 }
 
+GLTFState::HandleBinaryImageMode GLTFState::_get_handle_binary_image_mode_bind_compat_113172() {
+	return get_handle_binary_image_mode();
+}
+
 void GLTFState::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_handle_binary_image"), &GLTFState::_get_handle_binary_image_bind_compat_113172);
 	ClassDB::bind_compatibility_method(D_METHOD("get_json"), &GLTFState::_get_json_bind_compat_113172);
@@ -207,6 +211,7 @@ void GLTFState::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_animation_players_count", "idx"), &GLTFState::_get_animation_players_count_bind_compat_113172);
 	ClassDB::bind_compatibility_method(D_METHOD("get_animation_player", "idx"), &GLTFState::_get_animation_player_bind_compat_113172);
 	ClassDB::bind_compatibility_method(D_METHOD("get_additional_data", "extension_name"), &GLTFState::_get_additional_data_bind_compat_113172);
+	ClassDB::bind_compatibility_method(D_METHOD("get_handle_binary_image_mode"), &GLTFState::_get_handle_binary_image_mode_bind_compat_113172);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -158,6 +158,7 @@ protected:
 	int _get_animation_players_count_bind_compat_113172(int p_anim_player_index);
 	AnimationPlayer *_get_animation_player_bind_compat_113172(int p_anim_player_index);
 	Variant _get_additional_data_bind_compat_113172(const StringName &p_extension_name);
+	HandleBinaryImageMode _get_handle_binary_image_mode_bind_compat_113172();
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
In #113172, there were a bunch of compatibility bindings added for the changed methods, but there was one missing for `get_handle_binary_image_mode()`. This fixes the issue.

cc @aaronfranke 