### PR TITLE
Make dock tabs switch on button release

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -955,6 +955,7 @@ void EditorDockManager::register_dock_slot(DockConstants::DockSlot p_dock_slot, 
 	slot.container = p_tab_container;
 	p_tab_container->set_popup(dock_context_popup);
 	p_tab_container->connect("pre_popup_pressed", callable_mp(dock_context_popup, &DockContextPopup::select_current_dock_in_dock_slot).bind(p_dock_slot));
+	p_tab_container->get_tab_bar()->set_switch_on_release(true);
 	p_tab_container->get_tab_bar()->connect("tab_rmb_clicked", callable_mp(this, &EditorDockManager::_dock_container_popup).bind(p_tab_container));
 	p_tab_container->set_drag_to_rearrange_enabled(true);
 	p_tab_container->set_tabs_rearrange_group(1);

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -223,7 +223,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		if (mb->is_pressed()) {
+		if (mb->is_pressed() != switch_on_release) {
 			Point2 pos = mb->get_position();
 			bool selecting = mb->get_button_index() == MouseButton::LEFT || (select_with_rmb && mb->get_button_index() == MouseButton::RIGHT);
 

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -119,6 +119,7 @@ private:
 
 	bool select_with_rmb = false;
 	bool deselect_enabled = false;
+	bool switch_on_release = false;
 
 	int cb_hover = -1;
 	bool cb_pressing = false;
@@ -328,6 +329,8 @@ public:
 
 	void set_max_tab_width(int p_width);
 	int get_max_tab_width() const;
+
+	void set_switch_on_release(bool p_switch) { switch_on_release = p_switch; }
 
 	Rect2 get_tab_rect(int p_tab) const;
 	Size2 get_minimum_size() const override;


### PR DESCRIPTION
Makes the dock tabs switch on button release instead of press.
- Allows to drag docks without switching.
- Allows to cancel switching (like when you click dock, but change your mind).
- Fixes #113485 (note that this PR applies to side docks too)