### PR TITLE
Remove "None" option in Version Control Editor

### DIFF
--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -958,7 +958,6 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	metadata_selection = memnew(OptionButton);
 	metadata_selection->set_custom_minimum_size(Size2(100, 20));
-	metadata_selection->add_item("None", (int)EditorVCSInterface::VCSMetadata::NONE);
 	metadata_selection->add_item("Git", (int)EditorVCSInterface::VCSMetadata::GIT);
 	metadata_selection->select((int)EditorVCSInterface::VCSMetadata::GIT);
 	metadata_hb->add_child(metadata_selection);


### PR DESCRIPTION
Removed "None" option from Create Version Control Metadata dropdown box. Fixes #113419.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
