### PR TITLE
Add special compat methods for EditorFileDialog enum functions 

### DIFF
--- a/core/extension/gdextension_special_compat_hashes.cpp
+++ b/core/extension/gdextension_special_compat_hashes.cpp
@@ -331,6 +331,12 @@ void GDExtensionSpecialCompatHashes::initialize() {
 	});
 	mappings.insert("EditorFileDialog", {
 		{ "add_filter", 233059325, 3388804757 },
+		{ "get_access", 778734016, 3344081076 },
+		{ "set_access", 3882893764, 4104413466 },
+		{ "get_display_mode", 3517174669, 1092104624 },
+		{ "set_display_mode", 3049004050, 2692197101 },
+		{ "get_file_mode", 2681044145, 4074825319 },
+		{ "set_file_mode", 274150415, 3654936397 },
 	});
 	mappings.insert("EditorImportPlugin", {
 		{ "append_import_external_resource", 3645925746, 320493106 },

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1370,7 +1370,7 @@ ProjectManager::ProjectManager() {
 		FileDialog::set_get_thumbnail_callback(callable_mp_static(ProjectManager::_file_dialog_get_thumbnail));
 
 		FileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
-		FileDialog::set_default_display_mode((EditorFileDialog::DisplayMode)EDITOR_GET("filesystem/file_dialog/display_mode").operator int());
+		FileDialog::set_default_display_mode((FileDialog::DisplayMode)EDITOR_GET("filesystem/file_dialog/display_mode").operator int());
 
 		int swap_cancel_ok = EDITOR_GET("interface/editor/accept_dialog_cancel_ok_buttons");
 		if (swap_cancel_ok != 0) { // 0 is auto, set in register_scene based on DisplayServer.


### PR DESCRIPTION
While the general derived-to-base compat mechanism works, there seems to be a problem when enum types are also moved between classes. This commit restores the original enums as dummies in the derived class, to restore compatibility.

Fixes compatibility breakage introduced by #111212.

---

Earlier implementation via compat methods: https://github.com/godotengine/godot/commit/25f21edfc4109d9f82294d554a0daaee44f7096a
Current approach uses the hardcoded special mapping, due to problem with C# codegen.
