### PR TITLE
Fix `sprite_frames_editor_plugin` compilation with `deprecated=no`

### DIFF
--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/resource_loader.h"
 #include "core/os/keyboard.h"
+#include "core/string/translation_server.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/scene_tree_dock.h"
 #include "editor/editor_node.h"
@@ -316,13 +317,15 @@ void SpriteFramesEditor::_sheet_update_zoom_label() {
 	// (like in most image editors). Its lower bound is clamped to 1 as some people
 	// lower the editor scale to increase the available real estate,
 	// even if their display doesn't have a particularly low DPI.
+	TranslationServer *translation_server = TranslationServer::get_singleton();
+	String locale = translation_server->get_tool_locale();
 	if (sheet_zoom >= 10) {
-		zoom_text = TS->format_number(rtos(Math::round((sheet_zoom / MAX(1, EDSCALE)) * 100)));
+		zoom_text = translation_server->format_number(rtos(Math::round((sheet_zoom / MAX(1, EDSCALE)) * 100)), locale);
 	} else {
 		// 2 decimal places if the zoom is below 10%, 1 decimal place if it's below 1000%.
-		zoom_text = TS->format_number(rtos(Math::snapped((sheet_zoom / MAX(1, EDSCALE)) * 100, (sheet_zoom >= 0.1) ? 0.1 : 0.01)));
+		zoom_text = translation_server->format_number(rtos(Math::snapped((sheet_zoom / MAX(1, EDSCALE)) * 100, (sheet_zoom >= 0.1) ? 0.1 : 0.01)), locale);
 	}
-	zoom_text += " " + TS->percent_sign();
+	zoom_text += " " + translation_server->get_percent_sign(locale);
 	split_sheet_zoom_reset->set_text(zoom_text);
 }
 


### PR DESCRIPTION
Fixes compilation error in `sprite_frames_editor_plugin.cpp` when building with `deprecated=no`.

### Issue
When compiling Godot with `deprecated=no`, the following deprecated methods are disabled:
- `format_number()`
- `parse_number()`  
- `percent_sign()`

This caused compilation errors in `sprite_frames_editor_plugin.cpp` which was still using these deprecated APIs.
<img width="1057" height="253" alt="屏幕截图_20251204_034809" src="https://github.com/user-attachments/assets/e6956d29-55d0-413b-8d6b-6b329a991a68" />

### Solution
Updated `sprite_frames_editor_plugin.cpp` to use the new non-deprecated localization APIs:
- Replaced `TS->format_number()` with new equivalent
- Replaced `TS->percent_sign()` with new equivalent
