### PR TITLE
Round `ProgressBar` percentage instead of truncating

### DIFF
--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -165,7 +165,7 @@ void ProgressBar::_notification(int p_what) {
 					ratio = CLAMP(percentage, is_lesser_allowed() ? percentage : 0, is_greater_allowed() ? percentage : 1);
 				}
 
-				String txt = itos(int(ratio * 100));
+				String txt = itos(int(Math::round(ratio * 100)));
 
 				if (is_localizing_numeral_system()) {
 					const String &lang = _get_locale();


### PR DESCRIPTION
Updated to round before converting ratio to int, to make percentage display more accurate

Fixes #113529

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
