### PR TITLE
Accessibility: Re-apply stored name when recreating nodes

### DIFF
--- a/drivers/accesskit/accessibility_driver_accesskit.cpp
+++ b/drivers/accesskit/accessibility_driver_accesskit.cpp
@@ -612,6 +612,13 @@ _FORCE_INLINE_ void AccessibilityDriverAccessKit::_ensure_node(const RID &p_id, 
 
 		wd->update.insert(p_id);
 		p_ae->node = accesskit_node_new(p_ae->role);
+
+		// Re-apply stored name if any, so nodes recreated by _ensure_node
+		// retain their label even if the caller doesn't re-set all properties.
+		if (!p_ae->name.is_empty() || !p_ae->name_extra_info.is_empty()) {
+			String full_name = p_ae->name + " " + p_ae->name_extra_info;
+			accesskit_node_set_label(p_ae->node, full_name.utf8().ptr());
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix tab names not being announced by screen readers in the Godot editor
- When `_ensure_node()` recreates an AccessKit node, re-apply the stored name so it persists

## Problem
When TabContainer calls `accessibility_update_add_related_controls()`, it triggers `_ensure_node()` which creates a new empty node. TabBar only sets tab properties when `accessibility_item_dirty` is true, so recreated nodes were pushed without names, causing screen readers to announce "page tab" without the actual tab name (Scene, Inspector, etc.).

## Solution
In `_ensure_node()`, after creating a new node, check if a name was previously stored and re-apply it. This ensures tab names persist across node recreations.

## Test plan
- [x] Build with accessibility enabled
- [x] Open Godot editor with screen reader
- [x] Navigate to tabs (Scene, Import, FileSystem, etc.)
- [x] Verify screen reader announces tab names, not just "page tab"