### PR TITLE
Add description for `MultiMesh`'s buffer property

### DIFF
--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -116,6 +116,22 @@
 	</methods>
 	<members>
 		<member name="buffer" type="PackedFloat32Array" setter="set_buffer" getter="get_buffer" default="PackedFloat32Array()">
+			Array containing transformation instructions for each mesh in the MultiMesh.
+			[codeblock lang=text]
+			2D:
+				- Position: 8 floats (8 floats for Transform2D)
+				- Position + Vertex color: 12 floats (8 floats for Transform2D, 4 floats for Color)
+				- Position + Custom data: 12 floats (8 floats for Transform2D, 4 floats of custom data)
+				- Position + Vertex color + Custom data: 16 floats (8 floats for Transform2D, 4 floats for Color, 4 floats of custom data)
+			3D:
+				- Position: 12 floats (12 floats for Transform3D)
+				- Position + Vertex color: 16 floats (12 floats for Transform3D, 4 floats for Color)
+				- Position + Custom data: 16 floats (12 floats for Transform3D, 4 floats of custom data)
+				- Position + Vertex color + Custom data: 20 floats (12 floats for Transform3D, 4 floats for Color, 4 floats of custom data)
+			[/codeblock]
+			Instance transforms are in row-major order. Specifically:
+			- For [Transform2D] the float-order is: [code](x.x, y.x, padding_float, origin.x, x.y, y.y, padding_float, origin.y)[/code].
+			- For [Transform3D] the float-order is: [code](basis.x.x, basis.y.x, basis.z.x, origin.x, basis.x.y, basis.y.y, basis.z.y, origin.y, basis.x.z, basis.y.z, basis.z.z, origin.z)[/code].
 		</member>
 		<member name="color_array" type="PackedColorArray" setter="_set_color_array" getter="_get_color_array" deprecated="Accessing this property is very slow. Use [method set_instance_color] and [method get_instance_color] instead.">
 			Array containing each [Color] used by all instances of this mesh.


### PR DESCRIPTION
* Fixes [MultiMesh resource buffer description #98917](https://github.com/godotengine/godot-docs/issues/9891)

Added previously non-existent description for [buffer](https://docs.godotengine.org/en/stable/classes/class_multimesh.html#class-multimesh-property-buffer) property in Multimesh class

Copied parts of buffer description from [multimesh_set_buffer()](https://docs.godotengine.org/en/stable/classes/class_renderingserver.html#class-renderingserver-method-multimesh-set-buffer)