### PR TITLE
X11: Fix input delay regression

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -379,7 +379,7 @@ class DisplayServerX11 : public DisplayServer {
 	SafeFlag events_thread_done;
 	LocalVector<XEvent> polled_events;
 	static void _poll_events_thread(void *ud);
-	bool _wait_for_events() const;
+	bool _wait_for_events(int timeout_seconds = 1, int timeout_microseconds = 0) const;
 	void _poll_events();
 	void _check_pending_events(LocalVector<XEvent> &r_events);
 


### PR DESCRIPTION
This PR lowers the timeout in `DisplayServerX11::_wait_for_events()` from 1 second to 1,000 microseconds in order to fix the issue of some input events being delayed, causing a noticeable stutter in relative mouse motion for example.

Timeout value of 1s:
https://github.com/user-attachments/assets/7c181edc-7ffa-4fec-afd5-7a8ff770ada5

Timeout value of 1,000us:
https://github.com/user-attachments/assets/00d824bd-cdac-4d9c-bd3b-b8b71aa6cfbe

This issue was not present in 4.5-stable, but was re-introduced in 4.5.1-stable as a side-effect of fixing a rare crash by removing a call to `_check_pending_events()` on the main thread during `DisplayServerX11::process_events()`.

This should solve the stutter up to 240hz (Though I've only been able to test 60hz, 144hz, and 165hz), and did not have a noticeable impact on CPU usage % on either of my machines in both the editor and running projects.

Fixes #113188