### PR TITLE
Fix the issue of no scan after dir creation and/or deletion

### DIFF
--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -41,6 +41,7 @@ class EditorFileDialog : public FileDialog {
 
 protected:
 	virtual void _item_menu_id_pressed(int p_option) override;
+	virtual void _dir_contents_changed() override;
 
 	virtual bool _should_use_native_popup() const override;
 	virtual bool _should_hide_file(const String &p_file) const override;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1064,8 +1064,11 @@ void FileDialog::_file_list_select_first() {
 }
 
 void FileDialog::_delete_confirm() {
-	OS::get_singleton()->move_to_trash(_get_item_path(_get_selected_file_idx()));
-	invalidate();
+	Error err = OS::get_singleton()->move_to_trash(_get_item_path(_get_selected_file_idx()));
+	if (err == OK) {
+		invalidate();
+		_dir_contents_changed();
+	}
 }
 
 void FileDialog::_filename_filter_selected() {
@@ -1537,6 +1540,7 @@ FileDialog::Access FileDialog::get_access() const {
 void FileDialog::_make_dir_confirm() {
 	Error err = dir_access->make_dir(new_dir_name->get_text().strip_edges());
 	if (err == OK) {
+		_dir_contents_changed();
 		_change_dir(new_dir_name->get_text().strip_edges());
 		update_filters();
 		_push_history();

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -368,6 +368,7 @@ protected:
 
 	bool _can_use_native_popup() const;
 	virtual void _item_menu_id_pressed(int p_option);
+	virtual void _dir_contents_changed() {}
 
 	virtual bool _should_use_native_popup() const;
 	virtual bool _should_hide_file(const String &p_file) const { return false; }


### PR DESCRIPTION
When `EditorFileDialog` creates/deletes a directory during interactive operation, it needs to notify `EditorFileSystem` to scan and detect the filesystem change.

Fix https://github.com/godotengine/godot/pull/111212#discussion_r2587004076.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
