### PR TITLE
Fix PropertyEditor height bug.

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -317,6 +317,9 @@ void EditorProperty::_notification(int p_what) {
 				int child_room = size.width * (1.0 - split_ratio);
 				int separation = 4 * EDSCALE;
 				int height = label.is_empty() ? 0 : theme_cache.font->get_height(theme_cache.font_size) + separation;
+				if (!bottom_editor && height < size.height) {
+					height = size.height;
+				}
 				int half_padding = theme_cache.padding / 2;
 				bool no_children = true;
 


### PR DESCRIPTION
Fix #113542.


|before|after|
|-|-|
|<img width="266" height="282" alt="屏幕截图 2025-12-04 102229" src="https://github.com/user-attachments/assets/0a33aff7-51a6-4ecd-9542-5abedd072cf8" />|<img width="261" height="282" alt="image" src="https://github.com/user-attachments/assets/5dc23500-8d33-410a-8f28-ac3e6db3d714" />|

ps: Ignore the button's different language...