### PR TITLE
[macOS] Fix profiler cleanup.

### DIFF
--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -132,6 +132,8 @@ int main(int argc, char **argv) {
 
 	os->run();
 
+	// Note: `os->run()` will never return if `OS_MacOS_NSApp` is used. Use `OS_MacOS_NSApp::cleanup()` for cleanup.
+
 	int exit_code = os->get_exit_code();
 
 	memdelete(os);

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -1076,7 +1076,7 @@ OS_MacOS::OS_MacOS(const char *p_execpath, int p_argc, char **p_argv) {
 // MARK: - OS_MacOS_NSApp
 
 void OS_MacOS_NSApp::run() {
-	[NSApp run];
+	[NSApp run]; // Note: this call will never return. Use `OS_MacOS_NSApp::cleanup()` for cleanup.
 }
 
 static bool sig_received = false;
@@ -1154,8 +1154,7 @@ void OS_MacOS_NSApp::start_main() {
 }
 
 void OS_MacOS_NSApp::terminate() {
-	godot_cleanup_profiler();
-
+	// Note: This method only sends app termination request. Use `OS_MacOS_NSApp::cleanup()` for cleanup.
 	if (pre_wait_observer) {
 		CFRunLoopRemoveObserver(CFRunLoopGetCurrent(), pre_wait_observer, kCFRunLoopCommonModes);
 		CFRelease(pre_wait_observer);
@@ -1175,6 +1174,7 @@ void OS_MacOS_NSApp::cleanup() {
 			Main::cleanup();
 		}
 	}
+	godot_cleanup_profiler();
 }
 
 OS_MacOS_NSApp::OS_MacOS_NSApp(const char *p_execpath, int p_argc, char **p_argv) :


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113523

Also adds few comments about macOS UI app lifecycle to the relevant methods to avoid using wrong one for cleanup in the future.