### PR TITLE
[RTL] Fix relative index getting out of sync.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4033,6 +4033,7 @@ void RichTextLabel::add_text(const String &p_text) {
 				//append text condition!
 				ItemText *ti = static_cast<ItemText *>(current->subitems.back()->get());
 				ti->text += line;
+				current_char_ofs += line.length();
 				_invalidate_current_line(main);
 
 			} else {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113532

```
Simple text
[b]Boldened text.[/b]
[fade length=18]Fade works fine.[/fade]
Any tag containing a bracket, [i]escaped or not, [lb]like this one[rb][/i] will offset CharFXTransform.relative_index
[fade length=18]Fade works fine.[/fade]
```

Before:
<img width="567" height="189" alt="Screenshot 2025-12-04 at 10 27 37" src="https://github.com/user-attachments/assets/6282d052-e55e-4d99-be3a-8989e9327c27" />

After:
<img width="567" height="189" alt="Screenshot 2025-12-04 at 10 27 10" src="https://github.com/user-attachments/assets/338d96f3-1803-4bd5-ab79-4ac0b9aa4c0c" />
