### PR TITLE
Rework `Camera3D` preview

### DIFF
--- a/editor/scene/3d/camera_3d_editor_plugin.h
+++ b/editor/scene/3d/camera_3d_editor_plugin.h
@@ -33,7 +33,6 @@
 #include "editor/plugins/editor_plugin.h"
 #include "editor/scene/texture/texture_editor_plugin.h"
 
-class Camera3D;
 class SubViewport;
 
 class Camera3DEditor : public Control {
@@ -52,14 +51,18 @@ public:
 	Camera3DEditor();
 };
 
-class Camera3DPreview : public TexturePreview {
-	GDCLASS(Camera3DPreview, TexturePreview);
+class Camera3DPreview : public MarginContainer {
+	GDCLASS(Camera3DPreview, MarginContainer);
 
 	Camera3D *camera = nullptr;
+	AspectRatioContainer *centering_container = nullptr;
 	SubViewport *sub_viewport = nullptr;
+
+	static bool camera_preview_folded;
 
 	void _update_sub_viewport_size();
 	void _project_settings_changed();
+	void _toggle_folding(bool p_folded);
 
 public:
 	Camera3DPreview(Camera3D *p_camera);


### PR DESCRIPTION
Bugfix:
- Fix https://github.com/godotengine/godot/issues/101716 (see solution suggested in https://github.com/godotengine/godot/issues/101716#issuecomment-2600771589).
- Most likely also fix https://github.com/godotengine/godot/issues/101755 (but I can not reproduce it in current master).

Enhancement:
- Addresses a problem raised in https://github.com/godotengine/godot/pull/90778#issuecomment-2849314171 (there is no way to collapse preview).

---

### Implementation details

#### 1. Visual glitches during selection and switching

Instead of reusing `TexturePreview` and getting `SubViewport` texture, `Camera3DPreview` is now not inherited from `TexturePreview` and uses the following structure: `AspectRatioContainer` -> `SubViewportContainer` -> `SubViewport`. 

#### 2. Collapsing preview

Now preview uses `FoldableContainer` and can be collapsed.
Folding state is stored the same way as preview grid state in `StyleBoxPreview` - using static variable. This means that all `Camera3DPreview` in editor will have the same folding state. This state is not saved/loaded on editor start/quit, therefore it is saved only during the current session. 
By default preview is not folded.
The only thing I'm not sure about is the `FoldableContainer` theme - should I create a new style variation to make it visually more appropriate, or leave everything as it is.  Most likely new style variation will be better, I'll try to make later.

---

### How it looks in editor

https://github.com/user-attachments/assets/4bf47905-bc7b-44cc-9528-cf8cf33d004c