### PR TITLE
Do not show `Physical` in the special key names.

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -475,7 +475,10 @@ String InputEventKey::as_text() const {
 	} else if (keycode != Key::NONE) {
 		kc = keycode_get_string(keycode);
 	} else if (physical_keycode != Key::NONE) {
-		kc = keycode_get_string(physical_keycode) + " - " + RTR("Physical");
+		kc = keycode_get_string(physical_keycode);
+		if ((physical_keycode & Key::SPECIAL) != Key::SPECIAL) {
+			kc += " - " + RTR("Physical");
+		}
 	} else {
 		kc = "(" + RTR("unset") + ")";
 	}

--- a/tests/core/input/test_input_event_key.h
+++ b/tests/core/input/test_input_event_key.h
@@ -123,26 +123,43 @@ TEST_CASE("[InputEventKey] Key correctly converts itself to text") {
 
 	// Key is None WITH a physical key AND modifiers.
 	none_key.set_physical_keycode(Key::ENTER);
-	CHECK(none_key.as_text() == "Ctrl+Enter - Physical");
+	CHECK(none_key.as_text() == "Ctrl+Enter");
+
+	none_key.set_physical_keycode(Key::W);
+	CHECK(none_key.as_text() == "Ctrl+W - Physical");
 
 	// Key is None WITH a physical key AND multiple modifiers, checks for correct ordering.
+	none_key.set_physical_keycode(Key::ENTER);
 	none_key.set_alt_pressed(true);
 	none_key.set_shift_pressed(true);
 #ifdef MACOS_ENABLED
-	CHECK(none_key.as_text() != "Ctrl+Shift+Option+Enter - Physical");
-	CHECK(none_key.as_text() == "Ctrl+Option+Shift+Enter - Physical");
+	CHECK(none_key.as_text() != "Ctrl+Shift+Option+Enter");
+	CHECK(none_key.as_text() == "Ctrl+Option+Shift+Enter");
 #else
-	CHECK(none_key.as_text() != "Ctrl+Shift+Alt+Enter - Physical");
-	CHECK(none_key.as_text() == "Ctrl+Alt+Shift+Enter - Physical");
+	CHECK(none_key.as_text() != "Ctrl+Shift+Alt+Enter");
+	CHECK(none_key.as_text() == "Ctrl+Alt+Shift+Enter");
+#endif
+	none_key.set_physical_keycode(Key::W);
+#ifdef MACOS_ENABLED
+	CHECK(none_key.as_text() != "Ctrl+Shift+Option+W - Physical");
+	CHECK(none_key.as_text() == "Ctrl+Option+Shift+W - Physical");
+#else
+	CHECK(none_key.as_text() != "Ctrl+Shift+Alt+W - Physical");
+	CHECK(none_key.as_text() == "Ctrl+Alt+Shift+W - Physical");
 #endif
 
 	InputEventKey none_key2;
 
 	// Key is None without modifiers with a physical key.
 	none_key2.set_keycode(Key::NONE);
+	none_key2.set_physical_keycode(Key::W);
+
+	CHECK(none_key2.as_text() == "W - Physical");
+
+	none_key2.set_keycode(Key::NONE);
 	none_key2.set_physical_keycode(Key::ENTER);
 
-	CHECK(none_key2.as_text() == "Enter - Physical");
+	CHECK(none_key2.as_text() == "Enter");
 
 	InputEventKey key;
 


### PR DESCRIPTION
Real events always have same `keycode` and `physical_keycode` for the special keys, `physical` differs only for symbol (letters, numbers) keys. So showing it in the text is redundant visual noise.