### PR TITLE
Fix profiler cleanup with `--test`.

### DIFF
--- a/main/main.h
+++ b/main/main.h
@@ -93,6 +93,7 @@ public:
 	bool run_test = false;                                         \
 	int return_code = Main::test_entrypoint(argc, argv, run_test); \
 	if (run_test) {                                                \
+		godot_cleanup_profiler();                                  \
 		return return_code;                                        \
 	}
 
@@ -100,5 +101,6 @@ public:
 	bool run_test = false;                                         \
 	int return_code = Main::test_entrypoint(argc, argv, run_test); \
 	if (run_test) {                                                \
+		godot_cleanup_profiler();                                  \
 		return return_code;                                        \
 	}


### PR DESCRIPTION
Fixes crash on exit when using `--test` with enabled Tracy profiler. Test overrides `main` and cleanup was never called.

```
[doctest] test cases:   1251 |   1251 passed | 0 failed | 3 skipped
[doctest] assertions: 416569 | 416569 passed | 0 failed |
[doctest] Status: SUCCESS!
ERROR: Pages in use exist at exit in PagedAllocator: N13TracyInternal16StringInternDataE
   at: ~PagedAllocator (core/templates/paged_allocator.h:169)
libc++abi: terminating due to uncaught exception of type std::__1::system_error: recursive_mutex lock failed: Invalid argument
```