### PR TITLE
Add prev-frame-transform access to RenderSceneData

### DIFF
--- a/doc/classes/RenderSceneData.xml
+++ b/doc/classes/RenderSceneData.xml
@@ -24,6 +24,28 @@
 				[b]Note:[/b] If more than one view is rendered, this will return a centered transform.
 			</description>
 		</method>
+		<method name="get_prev_cam_projection" qualifiers="const">
+			<return type="Projection" />
+			<description>
+				Returns the camera projection used to render the last frame.
+				[b]Note:[/b] If more than one view is rendered, this will return a combined projection.
+			</description>
+		</method>
+		<method name="get_prev_cam_transform" qualifiers="const">
+			<return type="Transform3D" />
+			<description>
+				Returns the camera transform used to render the last frame.
+				[b]Note:[/b] If more than one view is rendered, this will return a centered transform.
+			</description>
+		</method>
+		<method name="get_prev_view_projection" qualifiers="const">
+			<return type="Projection" />
+			<param index="0" name="view" type="int" />
+			<description>
+				Returns the view projection per view used to render the last frame.
+				[b]Note:[/b] If a single view is rendered, this returns the camera projection. If more than one view is rendered, this will return a projection for the given view including the eye offset.
+			</description>
+		</method>
 		<method name="get_uniform_buffer" qualifiers="const">
 			<return type="RID" />
 			<description>

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -45,6 +45,17 @@ Projection RenderSceneDataRD::get_cam_projection() const {
 	return correction * cam_projection;
 }
 
+Transform3D RenderSceneDataRD::get_prev_cam_transform() const {
+	return prev_cam_transform;
+}
+
+Projection RenderSceneDataRD::get_prev_cam_projection() const {
+	Projection prev_correction;
+	prev_correction.set_depth_correction(flip_y);
+	prev_correction.add_jitter_offset(prev_taa_jitter);
+	return prev_correction * prev_cam_projection;
+}
+
 uint32_t RenderSceneDataRD::get_view_count() const {
 	return view_count;
 }
@@ -63,6 +74,16 @@ Projection RenderSceneDataRD::get_view_projection(uint32_t p_view) const {
 	correction.add_jitter_offset(taa_jitter);
 
 	return correction * view_projection[p_view];
+}
+
+Projection RenderSceneDataRD::get_prev_view_projection(uint32_t p_view) const {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_view, view_count, Projection());
+
+	Projection prev_correction;
+	prev_correction.set_depth_correction(flip_y);
+	prev_correction.add_jitter_offset(prev_taa_jitter);
+
+	return prev_correction * prev_view_projection[p_view];
 }
 
 RID RenderSceneDataRD::create_uniform_buffer() {

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -89,10 +89,13 @@ public:
 
 	virtual Transform3D get_cam_transform() const override;
 	virtual Projection get_cam_projection() const override;
+	virtual Transform3D get_prev_cam_transform() const override;
+	virtual Projection get_prev_cam_projection() const override;
 
 	virtual uint32_t get_view_count() const override;
 	virtual Vector3 get_view_eye_offset(uint32_t p_view) const override;
 	virtual Projection get_view_projection(uint32_t p_view) const override;
+	virtual Projection get_prev_view_projection(uint32_t p_view) const override;
 
 	RID create_uniform_buffer();
 	void update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p_debug_mode, RID p_env, RID p_reflection_probe_instance, RID p_camera_attributes, bool p_pancake_shadows, const Size2i &p_screen_size, const Color &p_default_bg_color, float p_luminance_multiplier, bool p_opaque_render_buffers, bool p_apply_alpha_multiplier);

--- a/servers/rendering/storage/render_scene_data.cpp
+++ b/servers/rendering/storage/render_scene_data.cpp
@@ -33,10 +33,13 @@
 void RenderSceneData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cam_transform"), &RenderSceneData::get_cam_transform);
 	ClassDB::bind_method(D_METHOD("get_cam_projection"), &RenderSceneData::get_cam_projection);
+	ClassDB::bind_method(D_METHOD("get_prev_cam_transform"), &RenderSceneData::get_prev_cam_transform);
+	ClassDB::bind_method(D_METHOD("get_prev_cam_projection"), &RenderSceneData::get_prev_cam_projection);
 
 	ClassDB::bind_method(D_METHOD("get_view_count"), &RenderSceneData::get_view_count);
 	ClassDB::bind_method(D_METHOD("get_view_eye_offset", "view"), &RenderSceneData::get_view_eye_offset);
 	ClassDB::bind_method(D_METHOD("get_view_projection", "view"), &RenderSceneData::get_view_projection);
+	ClassDB::bind_method(D_METHOD("get_prev_view_projection", "view"), &RenderSceneData::get_prev_view_projection);
 
 	ClassDB::bind_method(D_METHOD("get_uniform_buffer"), &RenderSceneData::get_uniform_buffer);
 }
@@ -63,6 +66,18 @@ Projection RenderSceneDataExtension::get_cam_projection() const {
 	return ret;
 }
 
+Transform3D RenderSceneDataExtension::get_prev_cam_transform() const {
+	Transform3D ret;
+	GDVIRTUAL_CALL(_get_prev_cam_transform, ret);
+	return ret;
+}
+
+Projection RenderSceneDataExtension::get_prev_cam_projection() const {
+	Projection ret;
+	GDVIRTUAL_CALL(_get_prev_cam_projection, ret);
+	return ret;
+}
+
 uint32_t RenderSceneDataExtension::get_view_count() const {
 	uint32_t ret = 0;
 	GDVIRTUAL_CALL(_get_view_count, ret);
@@ -78,6 +93,12 @@ Vector3 RenderSceneDataExtension::get_view_eye_offset(uint32_t p_view) const {
 Projection RenderSceneDataExtension::get_view_projection(uint32_t p_view) const {
 	Projection ret;
 	GDVIRTUAL_CALL(_get_view_projection, p_view, ret);
+	return ret;
+}
+
+Projection RenderSceneDataExtension::get_prev_view_projection(uint32_t p_view) const {
+	Projection ret;
+	GDVIRTUAL_CALL(_get_prev_view_projection, p_view, ret);
 	return ret;
 }
 

--- a/servers/rendering/storage/render_scene_data.h
+++ b/servers/rendering/storage/render_scene_data.h
@@ -44,10 +44,13 @@ protected:
 public:
 	virtual Transform3D get_cam_transform() const = 0;
 	virtual Projection get_cam_projection() const = 0;
+	virtual Transform3D get_prev_cam_transform() const = 0;
+	virtual Projection get_prev_cam_projection() const = 0;
 
 	virtual uint32_t get_view_count() const = 0;
 	virtual Vector3 get_view_eye_offset(uint32_t p_view) const = 0;
 	virtual Projection get_view_projection(uint32_t p_view) const = 0;
+	virtual Projection get_prev_view_projection(uint32_t p_view) const = 0;
 
 	virtual RID get_uniform_buffer() const = 0;
 };
@@ -61,19 +64,25 @@ protected:
 public:
 	virtual Transform3D get_cam_transform() const override;
 	virtual Projection get_cam_projection() const override;
+	virtual Transform3D get_prev_cam_transform() const override;
+	virtual Projection get_prev_cam_projection() const override;
 
 	virtual uint32_t get_view_count() const override;
 	virtual Vector3 get_view_eye_offset(uint32_t p_view) const override;
 	virtual Projection get_view_projection(uint32_t p_view) const override;
+	virtual Projection get_prev_view_projection(uint32_t p_view) const override;
 
 	virtual RID get_uniform_buffer() const override;
 
 	GDVIRTUAL0RC(Transform3D, _get_cam_transform)
 	GDVIRTUAL0RC(Projection, _get_cam_projection)
+	GDVIRTUAL0RC(Transform3D, _get_prev_cam_transform)
+	GDVIRTUAL0RC(Projection, _get_prev_cam_projection)
 
 	GDVIRTUAL0RC(uint32_t, _get_view_count)
 	GDVIRTUAL1RC(Vector3, _get_view_eye_offset, uint32_t)
 	GDVIRTUAL1RC(Projection, _get_view_projection, uint32_t)
+	GDVIRTUAL1RC(Projection, _get_prev_view_projection, uint32_t)
 
 	GDVIRTUAL0RC(RID, _get_uniform_buffer)
 };


### PR DESCRIPTION
Implements my proposal https://github.com/godotengine/godot-proposals/issues/13785

Test project:
[add-prev-cam.zip](https://github.com/user-attachments/files/23934416/add-prev-cam.zip)

In the test project I compare the returned previous transforms with the one I manually cached, which should always be exactly the same. I also compare the returned previous transforms and the current transforms to make sure they are different when the camera change (moving, rotating, changing window aspect ratio, etc.).

![Screenshot_20251204_211357](https://github.com/user-attachments/assets/22e7eacf-d9b6-4ea4-aba1-dfe9f24564b4)
