### PR TITLE
Stop showing Child is not a child of this node error in Search Results

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -4146,9 +4146,7 @@ void ScriptEditor::_start_find_in_files(bool with_replace) {
 	panel->set_replace_text(find_in_files_dialog->get_replace_text());
 	panel->start_search();
 
-	EditorNode::get_bottom_panel()->move_item_to_end(find_in_files);
 	find_in_files_button->show();
-	EditorNode::get_bottom_panel()->make_item_visible(find_in_files);
 }
 
 void ScriptEditor::_on_find_in_files_modified_files(const PackedStringArray &paths) {


### PR DESCRIPTION
Issue: #113174

When is Search Result Tab not in bottom editor panel <code>p_child->data.parent</code> points to <code>Control*</code> that is causing error because <code>Control* != EditorBottomPanel*</code>. <br>

When Search Result Tab created, then <code>p_child->data.parent</code> points to correct address.
<code>EditorBottomPanel* == EditorBottomPanel*</code><br>

Code in _node.cpp_ that is causing error:
<code>ERR_FAIL_COND_MSG(p_child->data.parent != this, "Child is not a child of this node.");</code>
