### PR TITLE
Fix memory management for ColorPalette in save file dialog

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -974,7 +974,8 @@ void ColorPicker::_palette_file_selected(const String &p_path) {
 #endif
 		} break;
 		case FileDialog::FileMode::FILE_MODE_SAVE_FILE: {
-			ColorPalette *palette = memnew(ColorPalette);
+			Ref<ColorPalette> palette;
+			palette.instantiate();
 			palette->set_colors(get_presets());
 			Error error = ResourceSaver::save(palette, p_path);
 			ERR_FAIL_COND_MSG(error != Error::OK, vformat("Cannot open color palette file for writing at: %s", p_path));


### PR DESCRIPTION
Using `Ref<T>`  instead of creating a raw pointer seems to have fixed #113556.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
