### PR TITLE
[Unix] Remove leading `..` from absolute paths and apply `simplify_path` to Unix current directory path.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4189,6 +4189,9 @@ String String::simplify_path() const {
 		}
 	}
 	Vector<String> dirs = s.split("/", false);
+	bool absolute_path = is_absolute_path();
+
+	absolute_path = absolute_path && !begins_with("res://"); // FIXME: Some code (GLTF importer) rely on accessing files up from `res://`, this probably should be disabled in the future.
 
 	for (int i = 0; i < dirs.size(); i++) {
 		String d = dirs[i];
@@ -4200,6 +4203,9 @@ String String::simplify_path() const {
 				dirs.remove_at(i);
 				dirs.remove_at(i - 1);
 				i -= 2;
+			} else if (absolute_path && i == 0) {
+				dirs.remove_at(i);
+				i--;
 			}
 		}
 	}

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -52,6 +52,10 @@
 #include <mntent.h>
 #endif
 
+String DirAccessUnix::fix_path(const String &p_path) const {
+	return DirAccess::fix_path(p_path).simplify_path();
+}
+
 Error DirAccessUnix::list_dir_begin() {
 	list_dir_end(); //close any previous dir opening!
 

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -50,6 +50,7 @@ protected:
 	String current_dir;
 	virtual String fix_unicode_name(const char *p_name) const { return String::utf8(p_name); }
 	virtual bool is_hidden(const String &p_name);
+	virtual String fix_path(const String &p_path) const override;
 
 public:
 	typedef void (*RemoveNotificationFunc)(const String &p_file);


### PR DESCRIPTION
- Removes all leading `..` from absolute paths in `simplify_path`.
- Apply `simplify_path` in the Unix `fix_path` (same is already done on Windows).

Fixes https://github.com/godotengine/godot/issues/113497
