### PR TITLE
Correctly set GDScript internal path for shallow scripts

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1078,6 +1078,13 @@ void GDScript::set_path_cache(const String &p_path) {
 	if (is_root_script()) {
 		Script::set_path_cache(p_path);
 	}
+
+	path = p_path;
+	path_valid = true;
+
+	for (KeyValue<StringName, Ref<GDScript>> &kv : subclasses) {
+		kv.value->set_path_cache(p_path);
+	}
 }
 
 void GDScript::set_path(const String &p_path, bool p_take_over) {

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -153,7 +153,7 @@ thread_local SafeBinaryMutex<GDScriptCache::BINARY_MUTEX_TAG>::TLSData SafeBinar
 SafeBinaryMutex<GDScriptCache::BINARY_MUTEX_TAG> GDScriptCache::mutex;
 
 void GDScriptCache::move_script(const String &p_from, const String &p_to) {
-	if (singleton == nullptr || p_from == p_to) {
+	if (singleton == nullptr || p_from == p_to || p_from.is_empty()) {
 		return;
 	}
 


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot/pull/109345
Fixes https://github.com/godotengine/godot/issues/113577 (the original MRP, the stuff mentioned in the comments needs separate MRPs to be sure).

So yeah turns out `GDScript` stores its path in two places. Once in the Resource members and onetime for itself. In theory there is a getter method that correctly resolves which path is currently valid. However we often use the internal member instead of relying on the getter method so we need to set the GDScript internal member as well when setting the path cache for not fully loaded scripts.

I checked all usages of this path members. None of them seem caching related except for the one usage in `set_path`. So setting this early should not cause other side effects on the cache.
