### PR TITLE
[FileDialog] Use base dir instead of ".." when going up.

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -534,7 +534,7 @@ bool FileDialog::_is_open_should_be_disabled() {
 }
 
 void FileDialog::_go_up() {
-	_change_dir("..");
+	_change_dir(get_current_dir().trim_suffix("/").get_base_dir());
 	_push_history();
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113497
Alternative https://github.com/godotengine/godot/pull/113575, does not change any code behavior, just uses `_go_up` from former editor dialog.