### PR TITLE
Fix bad D3D12 SRV breaking MSAA with OpenXR

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1820,7 +1820,7 @@ RDD::TextureID RenderingDeviceDriverD3D12::_texture_create_shared_from_slice(Tex
 					uav_desc.Texture2DArray.ArraySize = 1;
 					uav_desc.Texture2DArray.PlaneSlice = 0;
 				} else if ((srv_desc.ViewDimension == D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY || (srv_desc.ViewDimension == D3D12_SRV_DIMENSION_TEXTURE2DMS && p_layer))) {
-					srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+					srv_desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY;
 					srv_desc.Texture2DMSArray.FirstArraySlice = p_layer;
 					srv_desc.Texture2DMSArray.ArraySize = 1;
 


### PR DESCRIPTION
I found MSAA+D3D12+OpenXR was broken. The first error I see is this when I try:

```
E 0:00:06:696   RenderingDeviceDriverD3D12::render_pipeline_create: Create(Graphics)PipelineState failed with error 0x887a0005.
  <C++ Error>   Condition "!(((HRESULT)(res)) >= 0)" is true. Returning: PipelineID()
  <C++ Source>  drivers\d3d12\rendering_device_driver_d3d12.cpp:5402 @ RenderingDeviceDriverD3D12::render_pipeline_create()
```

and then it spews errors because the device is lost (0x887a0005=DXGI_ERROR_DEVICE_REMOVED).  I used `--gpu-validation --gpu-abort` which showed that the original error was here in `RenderingDeviceDriverD3D12::uniform_set_create`:

```
device->CreateShaderResourceView(texture_info->resource, &texture_info->view_descs.srv, desc_heap_walkers.resources.get_curr_cpu_handle());
```

The validation layer said:

> DX ERROR: ID3D12Device::CreateShaderResourceView: The Dimensions of the View are invalid due to at least one of the following conditions. [...] With the current FirstArraySlice, ArraySize (value = 0) must be between 1 and 2, inclusively, or -1 to default to all slices from FirstArraySlice, in order that the View fit on the Texture. [ STATE_CREATION ERROR #31: ]

This was a bit misleading because the ArraySize was set correctly in the Texture2DMSArray section, but it was looking at the Texture2DArray section (which is uninitialized) because the ViewDimension was set wrong. So thankfully this was a 2 letter fix.