### PR TITLE
Ensure the mouse is visible when stopping a project-running session in the editor

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -325,6 +325,7 @@ void EditorDebuggerNode::stop(bool p_force) {
 	_break_state_changed();
 	breakpoints.clear();
 	EditorUndoRedoManager::get_singleton()->clear_history(EditorUndoRedoManager::REMOTE_HISTORY, false);
+	Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 	set_process(false);
 }
 

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -465,6 +465,8 @@ void GameView::_stop_pressed() {
 	_detach_script_debugger();
 	paused = false;
 
+	Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+
 	EditorNode::get_singleton()->set_unfocused_low_processor_usage_mode_enabled(true);
 	embedded_process->reset();
 	_update_ui();


### PR DESCRIPTION
Closes #113589 .

This is a simple small fix, which manually sets the mouse mode to visible at the end of a project debug session (i.e., when the project is stopped).
