### PR TITLE
Fix TileMap Dock button placement and errors

### DIFF
--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -79,6 +79,7 @@ private:
 	bool transient = false;
 	bool closable = false;
 
+	DockLayout current_layout;
 	BitField<DockLayout> available_layouts = DOCK_LAYOUT_VERTICAL | DOCK_LAYOUT_FLOATING;
 
 	bool is_open = false;
@@ -144,6 +145,8 @@ public:
 	String get_effective_layout_key() const;
 
 	virtual void update_layout(DockLayout p_layout) { GDVIRTUAL_CALL(_update_layout, p_layout); }
+	DockLayout get_current_layout() const { return current_layout; }
+
 	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const { GDVIRTUAL_CALL(_save_layout_to_config, p_layout, p_section); }
 	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) { GDVIRTUAL_CALL(_load_layout_from_config, p_layout, p_section); }
 };

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -413,6 +413,7 @@ void EditorDockManager::_open_dock_in_window(EditorDock *p_dock, bool p_show_win
 
 	_move_dock(p_dock, nullptr);
 	p_dock->update_layout(EditorDock::DOCK_LAYOUT_FLOATING);
+	p_dock->current_layout = EditorDock::DOCK_LAYOUT_FLOATING;
 	wrapper->set_wrapped_control(p_dock);
 
 	p_dock->dock_window = wrapper;
@@ -499,7 +500,11 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 	}
 
 	if (p_target != closed_dock_parent) {
-		p_dock->update_layout(p_target->get_meta("dock_layout"));
+		EditorDock::DockLayout layout = p_target->get_meta("dock_layout");
+		if (layout != p_dock->current_layout) {
+			p_dock->update_layout(layout);
+			p_dock->current_layout = layout;
+		}
 		p_dock->dock_slot_index = p_target->get_meta("dock_slot");
 	}
 

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -2154,6 +2154,10 @@ void TileMapLayerEditorTilesPlugin::update_layout(EditorDock::DockLayout p_layou
 	tools_settings_vsep->set_vertical(is_vertical);
 	transform_separator->set_vertical(is_vertical);
 
+	wide_toolbar->set_visible(is_vertical);
+	bucket_contiguous_checkbox->reparent(is_vertical ? wide_toolbar : tools_settings);
+	scatter_controls_container->reparent(is_vertical ? wide_toolbar : tools_settings);
+
 	if (p_layout == EditorDock::DockLayout::DOCK_LAYOUT_FLOATING) {
 		patterns_mc->set_theme_type_variation("NoBorderHorizontalBottom");
 		patterns_item_list->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_TOP);
@@ -2308,7 +2312,7 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 	bucket_contiguous_checkbox->set_text(TTR("Contiguous"));
 	bucket_contiguous_checkbox->set_pressed(true);
 	bucket_contiguous_checkbox->hide();
-	wide_toolbar->add_child(bucket_contiguous_checkbox);
+	tools_settings->add_child(bucket_contiguous_checkbox);
 
 	// Random tile checkbox.
 	random_tile_toggle = memnew(Button);
@@ -2336,7 +2340,7 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 	scatter_spinbox->connect(SceneStringName(value_changed), callable_mp(this, &TileMapLayerEditorTilesPlugin::_on_scattering_spinbox_changed));
 	scatter_spinbox->set_accessibility_name(TTRC("Scattering:"));
 	scatter_controls_container->add_child(scatter_spinbox);
-	wide_toolbar->add_child(scatter_controls_container);
+	tools_settings->add_child(scatter_controls_container);
 
 	_on_random_tile_checkbox_toggled(false);
 
@@ -3483,6 +3487,9 @@ void TileMapLayerEditorTerrainsPlugin::update_layout(EditorDock::DockLayout p_la
 	tilemap_tiles_tools_buttons->set_vertical(is_vertical);
 	tools_settings->set_vertical(is_vertical);
 	tools_settings_vsep->set_vertical(is_vertical);
+
+	wide_toolbar->set_visible(is_vertical);
+	bucket_contiguous_checkbox->reparent(is_vertical ? wide_toolbar : tools_settings);
 }
 
 TileMapLayerEditorTerrainsPlugin::TileMapLayerEditorTerrainsPlugin() {
@@ -3601,7 +3608,7 @@ TileMapLayerEditorTerrainsPlugin::TileMapLayerEditorTerrainsPlugin() {
 	bucket_contiguous_checkbox->set_text(TTR("Contiguous"));
 	bucket_contiguous_checkbox->set_pressed(true);
 	bucket_contiguous_checkbox->hide();
-	wide_toolbar->add_child(bucket_contiguous_checkbox);
+	tools_settings->add_child(bucket_contiguous_checkbox);
 }
 
 TileMapLayer *TileMapLayerEditor::_get_edited_layer() const {
@@ -3806,6 +3813,8 @@ void TileMapLayerEditor::_update_layers_selector() {
 		select_next_layer->set_disabled(true);
 		select_previous_layer->set_disabled(true);
 	}
+
+	_update_layer_selector_layout(get_current_layout() == EditorDock::DockLayout::DOCK_LAYOUT_VERTICAL);
 }
 
 void TileMapLayerEditor::_clear_all_layers_highlighting() {
@@ -4421,12 +4430,22 @@ void TileMapLayerEditor::set_show_layer_selector(bool p_show_layer_selector) {
 	_update_layers_selector();
 }
 
+void TileMapLayerEditor::_update_layer_selector_layout(bool p_is_vertical) {
+	if (p_is_vertical && show_layers_selector) {
+		layer_selection_hbox->reparent(tile_map_wide_toolbar);
+		tile_map_wide_toolbar->move_child(layer_selection_hbox, 1);
+		layer_selection_hbox->set_vertical(false);
+	} else {
+		layer_selection_hbox->reparent(tile_map_toolbar);
+		tile_map_toolbar->move_child(layer_selection_hbox, -5);
+		layer_selection_hbox->set_vertical(p_is_vertical);
+	}
+}
+
 void TileMapLayerEditor::update_layout(DockLayout p_layout) {
 	bool is_vertical = (p_layout == EditorDock::DockLayout::DOCK_LAYOUT_VERTICAL);
-	tabs_panel->get_parent()->remove_child(tabs_panel);
 	tile_map_toolbar->set_vertical(is_vertical);
 	layer_selector_separator->set_vertical(is_vertical);
-	layer_selection_hbox->set_vertical(is_vertical);
 	tile_map_toolbar->set_h_size_flags(is_vertical ? SIZE_SHRINK_BEGIN : SIZE_EXPAND_FILL);
 	tile_map_toolbar->set_v_size_flags(is_vertical ? SIZE_EXPAND_FILL : SIZE_SHRINK_BEGIN);
 
@@ -4438,20 +4457,14 @@ void TileMapLayerEditor::update_layout(DockLayout p_layout) {
 	}
 
 	if (is_vertical) {
-		tile_map_wide_toolbar->add_child(tabs_panel);
+		tabs_panel->reparent(tile_map_wide_toolbar);
+		tile_map_wide_toolbar->move_child(tabs_panel, 0);
 	} else {
-		tile_map_toolbar->add_child(tabs_panel);
+		tabs_panel->reparent(tile_map_toolbar);
 		tile_map_toolbar->move_child(tabs_panel, 0);
 	}
 
-	for (TileMapLayerSubEditorPlugin::TabData &tab_data : tabs_data) {
-		tab_data.wide_toolbar->get_parent()->remove_child(tab_data.wide_toolbar);
-		if (is_vertical) {
-			tile_map_wide_toolbar->add_child(tab_data.wide_toolbar);
-		} else {
-			tile_map_toolbar->add_child(tab_data.wide_toolbar);
-		}
-	}
+	_update_layer_selector_layout(is_vertical);
 
 	// Propagate layout change to sub plugins
 	for (TileMapLayerSubEditorPlugin *tab_plugin : tabs_plugins) {
@@ -4523,7 +4536,7 @@ TileMapLayerEditor::TileMapLayerEditor() {
 
 		tab_data.wide_toolbar->hide();
 		if (!tab_data.wide_toolbar->get_parent()) {
-			tile_map_toolbar->add_child(tab_data.wide_toolbar);
+			tile_map_wide_toolbar->add_child(tab_data.wide_toolbar);
 		}
 	}
 

--- a/editor/scene/2d/tiles/tile_map_layer_editor.h
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.h
@@ -405,6 +405,7 @@ private:
 	void _clear_all_layers_highlighting();
 	void _update_all_layers_highlighting();
 	void _highlight_selected_layer_button_toggled(bool p_pressed);
+	void _update_layer_selector_layout(bool p_is_vertical);
 
 	Button *toggle_grid_button = nullptr;
 	void _on_grid_toggled(bool p_pressed);


### PR DESCRIPTION
This PR fixes a bug that while on a TileMap in vertical orientation, there was an extra wide control that is visible, increasing the size of the side bar unnecessarily. This PR moves that control to the top where all the other wide controls are.

It also improves the horizontal experience by having the wide controls be in the same place as before #113128 occurred.

Finally it fixes a span of errors when opening and closing the dock repeatedly in vertical orientation.

| Before | After |
| - | - |
| <img width="150" height="400" src="https://github.com/user-attachments/assets/4a7a3530-cf7e-431c-b1f7-dfcf09c7ed31" /> | <img width="150" height="400" src="https://github.com/user-attachments/assets/43032560-1e69-4946-80fd-46cb9b415612" /> |

*Bugsquad edit:* Fixes #114984