### PR TITLE
Fix built-in script live reloading

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -681,7 +681,15 @@ void RemoteDebugger::poll_events(bool p_is_idle) {
 			for (const Variant &v : script_paths_to_reload) {
 				const String &path = v;
 				Error err = OK;
-				Ref<Script> script = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+				Ref<Script> script = ResourceCache::get_ref(path);
+				if (script.is_null()) {
+					if (path.is_resource_file()) {
+						script = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+					} else {
+						// Built-in script that isn't in ResourceCache, no need to reload.
+						continue;
+					}
+				}
 				ERR_CONTINUE_MSG(err != OK, vformat("Could not reload script '%s': %s", path, error_names[err]));
 				ERR_CONTINUE_MSG(script.is_null(), vformat("Could not reload script '%s': Not a script!", path, error_names[err]));
 				scripts_to_reload.push_back(script);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1119,14 +1119,14 @@ void ScriptEditor::_mark_built_in_scripts_as_saved(const String &p_parent_path) 
 		}
 
 		Ref<Resource> edited_res = se->get_edited_resource();
-
 		if (!edited_res->is_built_in()) {
 			continue; // External script, who cares.
 		}
 
-		if (edited_res->get_path().get_slice("::", 0) == p_parent_path) {
-			se->tag_saved_version();
+		if (edited_res->get_path().get_slice("::", 0) != p_parent_path) {
+			continue; // Wrong scene.
 		}
+		se->tag_saved_version();
 
 		Ref<Script> scr = edited_res;
 		if (scr.is_valid()) {


### PR DESCRIPTION
When saving a built-in script while the game is running, it may trigger errors. The reasons are twofold:
- The debugger tries to reload all received paths, even scripts that aren't loaded. I don't know what's the purpose, but it does not work for built in scripts, as their scene has to be loaded for them to be recognized.
- The editor was sending unnecessary script paths. When you save a scene, all currently open built-in scripts would be live reloaded.

Fixes #105891