### PR TITLE
Change `environment_get_glow_hdr_bleed_threshold` error handling

### DIFF
--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -615,7 +615,7 @@ RS::EnvironmentGlowBlendMode RendererEnvironmentStorage::environment_get_glow_bl
 
 float RendererEnvironmentStorage::environment_get_glow_hdr_bleed_threshold(RID p_env) const {
 	Environment *env = environment_owner.get_or_null(p_env);
-	ERR_FAIL_NULL_V(env, 0.0);
+	ERR_FAIL_NULL_V(env, 1.0);
 	return env->glow_hdr_bleed_threshold;
 }
 


### PR DESCRIPTION
#112471 reverted the change of `glow_hdr_bleed_threshold` from `1.0` to `0.0`. But one spot was missed: the error handling. This PR reintroduces the intended error handling behaviour from Godot 4.5 and earlier.
