### PR TITLE
GDScript: Ensure correct caching of cyclic references

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -3054,11 +3054,7 @@ Ref<GDScript> GDScriptLanguage::get_script_by_fully_qualified_name(const String 
 Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Error err;
 	bool ignoring = p_cache_mode == CACHE_MODE_IGNORE || p_cache_mode == CACHE_MODE_IGNORE_DEEP;
-	Ref<GDScript> scr = GDScriptCache::get_full_script_no_resource_cache(p_original_path, err, "", ignoring);
-	// Reset `path_cache` so that when resource loader uses `set_path()` later, the script gets added to the cache.
-	if (scr.is_valid()) {
-		scr->set_path_cache(String());
-	}
+	Ref<GDScript> scr = GDScriptCache::get_full_script(p_original_path, err, "", ignoring);
 
 	if (err && scr.is_valid()) {
 		// If !scr.is_valid(), the error was likely from scr->load_source_code(), which already generates an error.

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -124,14 +124,6 @@ public:
 	/**
 	 * Returns a fully loaded GDScript using an already cached script if one exists.
 	 *
-	 * If a new script is created, the resource will only have its patch_cache set, so it won't be present in the ResourceCache.
-	 * Mismatches between GDScriptCache and ResourceCache might trigger complex issues so when using this method ensure
-	 * that the script is added to the resource cache or removed from the GDScript cache.
-	 */
-	static Ref<GDScript> get_full_script_no_resource_cache(const String &p_path, Error &r_error, const String &p_owner = String(), bool p_update_from_disk = false);
-	/**
-	 * Returns a fully loaded GDScript using an already cached script if one exists.
-	 *
 	 * The returned instance is present in GDScriptCache and ResourceCache.
 	 */
 	static Ref<GDScript> get_full_script(const String &p_path, Error &r_error, const String &p_owner = String(), bool p_update_from_disk = false);


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot/pull/109345
Requires and includes https://github.com/godotengine/godot/pull/113580

Fixes https://github.com/godotengine/godot/issues/113588

Explanation:

- the original idea of this fix is to only set the path for non fully loaded scripts without caching them in the ResourceCache
- In the original PR I applied another change on top which tried to ensure, that fully loaded scripts would be cached by the `ResourceLoader`
  - In hindsight this does not seem to be necessary. And for cyclic references it did not work. Because the GDScript compiler cached the fully loaded script before returning control to the resource loader.
  - The resource loader only sets the path on resources if the resource is not already part of the cache. However the GDScript resource format loader did reset the path before returning control to ensure that Scripts get cached when the ResourceLoader sets it. In the cyclic reference case the ResourceFormatLoader did reset the path but the ResourceLoader did not set it again, because the script was already added to the cache by the compiler.
  - With this PR the ResourceFormatLoaderGDScript is once again responsible for adding fully loaded scripts to the cache (as it was the case before https://github.com/godotengine/godot/pull/109345). This seems to work fine, the `ResourceCache` can handle it and we can ensure that fully loaded scripts always have their path set correctly.

---

I retested a lot of MRP's with this PR + https://github.com/godotengine/godot/pull/113580

And so far those issues seem to still be fixed with this change:
- https://github.com/godotengine/godot/issues/95909
- https://github.com/godotengine/godot/issues/95789 -> Original MRP does not crash. The issue probably needs to be rechecked at some point because there is quite a lot of comments.
- https://github.com/godotengine/godot/issues/93433
- https://github.com/godotengine/godot/issues/110394
- https://github.com/godotengine/godot/issues/87397
- https://github.com/godotengine/godot/issues/99006 -> builtin output panel seems to be somewhat broken when printing every frame? But the console output shows that the reload does work.
- https://github.com/godotengine/godot/issues/101615 -> although this one always was a bit inconsistent for me

---

> [!NOTE]
> With the original PR I always had the intention of "fixing forward" as in getting it out and investigating and addressing regressions. I don't think we will be able to make this resource mess work out of the box in a single PR.
> What I did not intend was to get this merged so close to release. In fact I suggested giving the original PR a try early in the dev cycle but that never happened.
> So if the production team decides for a revert instead of merging my followups that's fine by me.
> Just would be nice to give this another try in the next dev cycle if we go with a revert.