### PR TITLE
Fix property height in the inspector for control layout

### DIFF
--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -244,6 +244,7 @@ EditorPropertyAnchorsPreset::EditorPropertyAnchorsPreset() {
 	options = memnew(OptionButton);
 	options->set_clip_text(true);
 	options->set_flat(true);
+	options->set_theme_type_variation(SNAME("EditorInspectorButton"));
 	add_child(options);
 	add_focusable(options);
 	options->connect(SceneStringName(item_selected), callable_mp(this, &EditorPropertyAnchorsPreset::_option_selected));
@@ -426,6 +427,7 @@ EditorPropertySizeFlags::EditorPropertySizeFlags() {
 	flag_presets = memnew(OptionButton);
 	flag_presets->set_clip_text(true);
 	flag_presets->set_flat(true);
+	flag_presets->set_theme_type_variation(SNAME("EditorInspectorButton"));
 	vb->add_child(flag_presets);
 	add_focusable(flag_presets);
 	set_label_reference(flag_presets);


### PR DESCRIPTION
PR https://github.com/godotengine/godot/pull/112615/files looks to have missed OptionButton's for control anchors preset and container sizing. This PR should fix them:

Video starts with before:

[Screencast_20251205_000355.webm](https://github.com/user-attachments/assets/76a1c253-6458-414d-90bf-7e9ccd2b6d70)

[Screencast_20251205_000310.webm](https://github.com/user-attachments/assets/4e12125c-00bf-4962-a6b6-0c32908760d9)
