### PR TITLE
Fix export warning remaining visible after deleting last export preset

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -264,6 +264,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		export_error->hide();
 		export_templates_error->hide();
 		export_texture_format_error->hide();
+		export_warning->hide();
 		return;
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Summary:
When deleting the last export preset in the Project Export dialog, the warning bar at the bottom remains visible even though no preset is selected.

What the Cause is:
It appears that the __edit_preset() function hides all preset dependent error labels when there is no valid preset index, but does not hid export_warning. This would explain why the previous warning text remains visible.

Fix:
The fix is to hide export_warning when p_index is invalid.

For testing steps, create an export preset that triggers a warning. Delete the preset, and the warning bar should now correctly disappear.

This fixes #113428