### PR TITLE
Use new dock system for ShaderFile Dock

### DIFF
--- a/editor/icons/RDShaderFile.svg
+++ b/editor/icons/RDShaderFile.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V6l-5-5zm1 2h6v3a1 1 0 0 0 1 1h3v3H3z"/><path fill="#e0e0e0" d="M10 2zM4 6h2v1H4zM8 8h4v1H8zM7 6h1v1H7zM4 4h3v1H4zM4 8h3v1H4z"/></svg>

--- a/editor/shader/shader_file_editor_plugin.cpp
+++ b/editor/shader/shader_file_editor_plugin.cpp
@@ -32,9 +32,9 @@
 
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
-#include "editor/gui/editor_bottom_panel.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/split_container.h"
 #include "servers/display/display_server.h"
@@ -62,13 +62,13 @@ void ShaderFileEditor::_version_selected(int p_option) {
 			continue;
 		}
 
-		Ref<Texture2D> icon;
+		Ref<Texture2D> outcome_icon;
 		if (bytecode->get_stage_compile_error(RD::ShaderStage(i)) != String()) {
-			icon = get_editor_theme_icon(SNAME("ImportFail"));
+			outcome_icon = get_editor_theme_icon(SNAME("ImportFail"));
 		} else {
-			icon = get_editor_theme_icon(SNAME("ImportCheck"));
+			outcome_icon = get_editor_theme_icon(SNAME("ImportCheck"));
 		}
-		stages[i]->set_button_icon(icon);
+		stages[i]->set_button_icon(outcome_icon);
 
 		if (first_found == -1) {
 			first_found = i;
@@ -133,12 +133,12 @@ void ShaderFileEditor::_update_options() {
 	StringName current_version;
 
 	for (int i = 0; i < version_list.size(); i++) {
-		String title = version_list[i];
-		if (title.is_empty()) {
-			title = "default";
+		String version_title = version_list[i];
+		if (version_title.is_empty()) {
+			version_title = "default";
 		}
 
-		Ref<Texture2D> icon;
+		Ref<Texture2D> outcome_icon;
 
 		Ref<RDShaderSPIRV> bytecode = shader_file->get_spirv(version_list[i]);
 		ERR_FAIL_COND(bytecode.is_null());
@@ -152,12 +152,12 @@ void ShaderFileEditor::_update_options() {
 		}
 
 		if (failed) {
-			icon = get_editor_theme_icon(SNAME("ImportFail"));
+			outcome_icon = get_editor_theme_icon(SNAME("ImportFail"));
 		} else {
-			icon = get_editor_theme_icon(SNAME("ImportCheck"));
+			outcome_icon = get_editor_theme_icon(SNAME("ImportCheck"));
 		}
 
-		versions->add_item(title, icon);
+		versions->add_item(version_title, outcome_icon);
 		versions->set_item_metadata(i, version_list[i]);
 
 		if (i == c) {
@@ -244,6 +244,16 @@ ShaderFileEditor *ShaderFileEditor::singleton = nullptr;
 
 ShaderFileEditor::ShaderFileEditor() {
 	singleton = this;
+
+	set_name(TTRC("ShaderFile"));
+	set_icon_name("RDShaderFile");
+	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_shader_file_bottom_panel", TTRC("Toggle ShaderFile Dock")));
+	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_available_layouts(EditorDock::DOCK_LAYOUT_ALL);
+	set_global(false);
+	set_transient(true);
+	set_custom_minimum_size(Size2(300, 200) * EDSCALE);
+
 	HSplitContainer *main_hs = memnew(HSplitContainer);
 
 	add_child(main_hs);
@@ -251,7 +261,7 @@ ShaderFileEditor::ShaderFileEditor() {
 	versions = memnew(ItemList);
 	versions->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	versions->connect(SceneStringName(item_selected), callable_mp(this, &ShaderFileEditor::_version_selected));
-	versions->set_custom_minimum_size(Size2i(200 * EDSCALE, 0));
+	versions->set_custom_minimum_size(Size2i(100 * EDSCALE, 0));
 	versions->set_theme_type_variation("TreeSecondary");
 	main_hs->add_child(versions);
 
@@ -267,7 +277,7 @@ ShaderFileEditor::ShaderFileEditor() {
 		"Compute"
 	};
 
-	stage_hb = memnew(HBoxContainer);
+	stage_hb = memnew(HFlowContainer);
 	main_vb->add_child(stage_hb);
 
 	Ref<ButtonGroup> bg;
@@ -301,21 +311,14 @@ bool ShaderFileEditorPlugin::handles(Object *p_object) const {
 
 void ShaderFileEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		button->show();
-		EditorNode::get_bottom_panel()->make_item_visible(shader_editor);
-
+		shader_editor->make_visible();
 	} else {
-		button->hide();
-		if (shader_editor->is_visible_in_tree()) {
-			EditorNode::get_bottom_panel()->hide_bottom_panel();
-		}
+		shader_editor->close();
 	}
 }
 
 ShaderFileEditorPlugin::ShaderFileEditorPlugin() {
 	shader_editor = memnew(ShaderFileEditor);
-
-	shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
-	button = EditorNode::get_bottom_panel()->add_item(TTRC("ShaderFile"), shader_editor, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_shader_file_bottom_panel", TTRC("Toggle ShaderFile Bottom Panel")));
-	button->hide();
+	EditorDockManager::get_singleton()->add_dock(shader_editor);
+	shader_editor->close();
 }

--- a/editor/shader/shader_file_editor_plugin.h
+++ b/editor/shader/shader_file_editor_plugin.h
@@ -30,20 +30,20 @@
 
 #pragma once
 
+#include "editor/docks/editor_dock.h"
 #include "editor/plugins/editor_plugin.h"
-#include "scene/gui/box_container.h"
-#include "scene/gui/panel_container.h"
 #include "scene/gui/rich_text_label.h"
 #include "servers/rendering/rendering_device_binds.h"
 
+class HFlowContainer;
 class ItemList;
 
-class ShaderFileEditor : public PanelContainer {
-	GDCLASS(ShaderFileEditor, PanelContainer);
+class ShaderFileEditor : public EditorDock {
+	GDCLASS(ShaderFileEditor, EditorDock);
 
 	Ref<RDShaderFile> shader_file;
 
-	HBoxContainer *stage_hb = nullptr;
+	HFlowContainer *stage_hb = nullptr;
 	ItemList *versions = nullptr;
 	Button *stages[RD::SHADER_STAGE_MAX];
 	RichTextLabel *error_text = nullptr;
@@ -69,7 +69,6 @@ class ShaderFileEditorPlugin : public EditorPlugin {
 	GDCLASS(ShaderFileEditorPlugin, EditorPlugin);
 
 	ShaderFileEditor *shader_editor = nullptr;
-	Button *button = nullptr;
 
 public:
 	virtual String get_plugin_name() const override { return "ShaderFile"; }


### PR DESCRIPTION
See #113024

Upgraded the Shader File Editor Dock to use the new system. The dock was flexible enough to allow in vertical orientation. There was no preexisting icon, so I made this for RDShaderFile: (it also has the benefit of giving an icon to existing `.glsl` files)
<img width="363" height="98" src="https://github.com/user-attachments/assets/6f56d29e-d289-42fc-a4f2-f415c3b0d3b6" />
