### PR TITLE
Ensure correct unlocking of script editor history

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -476,6 +476,7 @@
 				node.CallDeferred(Node3D.MethodName.Rotate, new Vector3(1f, 0f, 0f), 1.571f);
 				[/csharp]
 				[/codeblocks]
+				For methods that are deferred from the same thread, the order of execution at idle time is identical to the order in which [code skip-lint]call_deferred[/code] was called.
 				See also [method Callable.call_deferred].
 				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods. Prefer using the names exposed in the [code]MethodName[/code] class to avoid allocating a new [StringName] on each call.
 				[b]Note:[/b] If you're looking to delay the function call by a frame, refer to the [signal SceneTree.process_frame] and [signal SceneTree.physics_frame] signals.

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -676,7 +676,6 @@ void ScriptEditor::_save_history() {
 void ScriptEditor::_save_previous_state(Dictionary p_state) {
 	if (lock_history) {
 		// Done as a result of a deferred call triggered by set_edit_state().
-		lock_history = false;
 		return;
 	}
 
@@ -3853,6 +3852,10 @@ void ScriptEditor::_update_selected_editor_menu() {
 	}
 }
 
+void ScriptEditor::_unlock_history() {
+	lock_history = false;
+}
+
 void ScriptEditor::_update_history_pos(int p_new_pos) {
 	Node *n = tab_container->get_current_tab_control();
 
@@ -3872,6 +3875,10 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 	if (seb) {
 		lock_history = true;
 		seb->set_edit_state(history[history_pos].state);
+		// `set_edit_state()` can modify the caret position which might trigger a
+		// request to save the history. Since `TextEdit::caret_changed` is emitted
+		// deferred, we need to defer unlocking of the history as well.
+		callable_mp(this, &ScriptEditor::_unlock_history).call_deferred();
 		seb->ensure_focus();
 
 		Ref<Script> scr = seb->get_edited_resource();

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -526,6 +526,7 @@ class ScriptEditor : public PanelContainer {
 
 	bool waiting_update_names;
 	bool lock_history = false;
+	void _unlock_history();
 
 	void _help_class_open(const String &p_class);
 	void _help_class_goto(const String &p_desc);


### PR DESCRIPTION
Related to and encountered while looking into https://github.com/godotengine/godot/issues/113042
Seems to be the same issue described in: Fixes https://github.com/godotengine/godot/issues/113502

The history can be locked, this is done when e.g. restoring the state from the history. Since this involves some deferred signals it can't be instantly unlocked. The approach till now was to unlock in some method that was connected to the deferred signal. But the signal is not consistently emitted. This PR instead defers the unlocking manually to ensure it always happens.

The fix relies on a certain behaviour of `call_deferred`.
The deferred call to emitting the signal happens before the deferred call to unlocking the history. So the method connected to the signal also runs before the history gets unlocked.

I added this to the documentation to ensure that this is considered stable enough to base a bugfix on it.
