### PR TITLE
Remove call to `PhysicsServer3D` from Jolt Physics implementation

### DIFF
--- a/modules/jolt_physics/joints/jolt_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_joint_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "jolt_joint_3d.h"
 
+#include "../jolt_physics_server_3d.h"
 #include "../jolt_project_settings.h"
 #include "../misc/jolt_type_conversions.h"
 #include "../objects/jolt_body_3d.h"
@@ -209,7 +210,7 @@ void JoltJoint3D::set_collision_disabled(bool p_disabled) {
 		return;
 	}
 
-	PhysicsServer3D *physics_server = PhysicsServer3D::get_singleton();
+	JoltPhysicsServer3D *physics_server = JoltPhysicsServer3D::get_singleton();
 
 	if (collision_disabled) {
 		physics_server->body_add_collision_exception(body_a->get_rid(), body_b->get_rid());


### PR DESCRIPTION
Fixes #113620.

The Jolt Physics implementation of `PhysicsServer3D::joint_disable_collisions_between_bodies` currently calls out to `PhysicsServer3D` inside of it, by calling `PhysicsServer3D::body_add_collision_exception`. This seems to cause deadlocks as of #112506, for reasons that are currently unclear.

However, there's no need to go through `PhysicsServer3D` (and thus `PhysicsServer3DWrapMT`) since we'll always be on the server thread at this point anyway. Simply switching to use `JoltPhysicsServer3D` resolves the problem.