### PR TITLE
Fix reentrancy guard in `CommandQueueMT::_flush`

### DIFF
--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -157,12 +157,12 @@ class CommandQueueMT {
 	}
 
 	void _flush() {
-		MutexLock lock(mutex);
-
 		if (unlikely(flush_read_ptr)) {
 			// Re-entrant call.
 			return;
 		}
+
+		MutexLock lock(mutex);
 
 		alignas(uint64_t) char cmd_local_mem[MAX_COMMAND_SIZE];
 


### PR DESCRIPTION
Maybe fixes #113627.

#112506 moved the `MutexLock` in `CommandQueueMT::_flush` to happen before the reentrancy guard, as opposed to after, rendering the reentrancy guard more or less useless, as seen in #113620.

This moves the `MutexLock` back to its original place, after the reentrancy guard, which probably breaks something else instead.

I imagine this could also be fixed by changing `CommandQueueMT::mutex` to be a `Mutex` instead of a `BinaryMutex`, but I assume there's a good reason for it being a `BinaryMutex`.