### PR TITLE
Fix properties for container sizing not clipping in the inspector

### DIFF
--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -439,6 +439,7 @@ EditorPropertySizeFlags::EditorPropertySizeFlags() {
 
 	flag_expand = memnew(CheckBox);
 	flag_expand->set_text(TTR("Expand"));
+	flag_expand->set_clip_text(true);
 	vb->add_child(flag_expand);
 	add_focusable(flag_expand);
 	flag_expand->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertySizeFlags::_expand_toggled));


### PR DESCRIPTION
| Before | After |
|-|-|
|<img width="239" height="191" alt="Screenshot_20251205_113654" src="https://github.com/user-attachments/assets/3085b1dd-e2f8-44f2-856b-aeefb4d8acba" />|<img width="239" height="191" alt="Screenshot_20251205_113923" src="https://github.com/user-attachments/assets/a85fc6fa-d7ff-4d85-b2af-8ded14593056" />|