### PR TITLE
Add support for profiling system calls from GDScript with the tracy integration.

### DIFF
--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -51,10 +51,10 @@
 
 #include <tracy/Tracy.hpp>
 
-namespace TracyInternal {
-const char *intern_name(const StringName &p_name);
-const tracy::SourceLocationData *intern_source_location(const void *p_function_ptr, const StringName &p_file, const StringName &p_function, uint32_t p_line);
-} //namespace TracyInternal
+// Hijacking the tracy namespace so we can use their macros.
+namespace tracy {
+const SourceLocationData *intern_source_location(const void *p_function_ptr, const StringName &p_file, const StringName &p_function, const StringName &p_name, uint32_t p_line, bool p_is_script);
+} //namespace tracy
 
 // Define tracing macros.
 #define GodotProfileFrameMark FrameMark
@@ -72,8 +72,11 @@ const tracy::SourceLocationData *intern_source_location(const void *p_function_p
 	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location, TracyLine){ m_zone_name, TracyFunction, TracyFile, (uint32_t)TracyLine, 0 }; \
 	new (&__godot_tracy_zone_##m_group_name) tracy::ScopedZone(&TracyConcat(__tracy_source_location, TracyLine), TRACY_CALLSTACK, true)
 #endif
-#define GodotProfileZoneGroupedFirstScript(m_varname, m_ptr, m_file, m_function, m_line) \
-	tracy::ScopedZone __godot_tracy_zone_##m_group_name(TracyInternal::intern_source_location(m_ptr, m_file, m_function, m_line))
+
+#define GodotProfileZoneScript(m_ptr, m_file, m_function, m_name, m_line) \
+	tracy::ScopedZone __godot_tracy_script(tracy::intern_source_location(m_ptr, m_file, m_function, m_name, m_line, true))
+#define GodotProfileZoneScriptSystemCall(m_ptr, m_file, m_function, m_name, m_line) \
+	tracy::ScopedZone __godot_tracy_zone_system_call(tracy::intern_source_location(m_ptr, m_file, m_function, m_name, m_line, false))
 
 // Memory allocation
 #define GodotProfileAlloc(m_ptr, m_size) TracyAlloc(m_ptr, m_size)
@@ -111,7 +114,9 @@ struct PerfettoGroupedEventEnder {
 #define GodotProfileZoneGrouped(m_group_name, m_zone_name) \
 	__godot_perfetto_zone_##m_group_name._end_now();       \
 	TRACE_EVENT_BEGIN("godot", m_zone_name);
-#define GodotProfileZoneGroupedFirstScript(m_varname, m_ptr, m_file, m_function, m_line) \\ TODO
+
+#define GodotProfileZoneScript(m_ptr, m_file, m_function, m_name, m_line)
+#define GodotProfileZoneScriptSystemCall(m_ptr, m_file, m_function, m_name, m_line)
 
 #define GodotProfileAlloc(m_ptr, m_size)
 #define GodotProfileFree(m_ptr)
@@ -169,7 +174,8 @@ private:
 #define GodotProfileZone(m_zone_name) \
 	GodotProfileZoneGroupedFirst(__COUNTER__, m_zone_name)
 
-#define GodotProfileZoneGroupedFirstScript(m_varname, m_ptr, m_file, m_function, m_line)
+#define GodotProfileZoneScript(m_ptr, m_file, m_function, m_name, m_line)
+#define GodotProfileZoneScriptSystemCall(m_ptr, m_file, m_function, m_name, m_line)
 
 // Instruments has its own memory profiling, so these are no-ops.
 #define GodotProfileAlloc(m_ptr, m_size)
@@ -202,10 +208,11 @@ void godot_cleanup_profiler();
 // There must be a one to one correspondence of GodotProfileAlloc and GodotProfileFree calls.
 #define GodotProfileFree(m_ptr)
 
-// Define a zone with custom source information (for scripting)
-// m_varname is equivalent to GodotProfileZoneGrouped varnames.
+// Define a zone for a script call (dynamic source location).
 // m_ptr is a pointer to the function instance, which will be used for the lookup.
-// m_file, m_function are StringNames, m_line is a uint32_t, all used for the source location.
-#define GodotProfileZoneGroupedFirstScript(m_varname, m_ptr, m_file, m_function, m_line)
+// m_file, m_function, m_name are StringNames, and m_line is uint32_t
+#define GodotProfileZoneScript(m_ptr, m_file, m_function, m_name, m_line)
+// Define a zone for a system call from a script (dynamic source location).
+#define GodotProfileZoneScriptSystemCall(m_ptr, m_file, m_function, m_name, m_line)
 
 #endif

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -496,7 +496,7 @@ void (*type_init_function_table[])(Variant *) = {
 #define METHOD_CALL_ON_FREED_INSTANCE_ERROR(method_pointer) "Cannot call method '" + (method_pointer)->get_name() + "' on a previously freed instance."
 
 Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err, CallState *p_state) {
-	GodotProfileZoneGroupedFirstScript(zone, this, source, name, _initial_line);
+	GodotProfileZoneScript(this, source, name, name, _initial_line);
 
 	OPCODES_TABLE;
 
@@ -1907,6 +1907,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(methodname_idx < 0 || methodname_idx >= _global_names_count);
 				const StringName *methodname = &_global_names_ptr[methodname_idx];
 
+				GodotProfileZoneScriptSystemCall(methodname, source, name, *methodname, line);
+
 				GET_INSTRUCTION_ARG(base, argc);
 				Variant **argptrs = instruction_args;
 
@@ -2027,6 +2029,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
 				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
 
+				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
+
 				GET_INSTRUCTION_ARG(base, argc);
 
 #ifdef DEBUG_ENABLED
@@ -2112,6 +2116,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(methodname_idx < 0 || methodname_idx >= _global_names_count);
 				const StringName *methodname = &_global_names_ptr[methodname_idx];
 
+				GodotProfileZoneScriptSystemCall(methodname, source, name, *methodname, line);
+
 				int argc = _code_ptr[ip + 3];
 				GD_ERR_BREAK(argc < 0);
 
@@ -2141,6 +2147,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				GD_ERR_BREAK(_code_ptr[ip + 1] < 0 || _code_ptr[ip + 1] >= _methods_count);
 				MethodBind *method = _methods_ptr[_code_ptr[ip + 1]];
+
+				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
 
 				int argc = _code_ptr[ip + 2];
 				GD_ERR_BREAK(argc < 0);
@@ -2188,6 +2196,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
 				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
 
+				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
+
 				Variant **argptrs = instruction_args;
 
 #ifdef DEBUG_ENABLED
@@ -2224,6 +2234,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
 				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
 
+				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
+
 				Variant **argptrs = instruction_args;
 #ifdef DEBUG_ENABLED
 				uint64_t call_time = 0;
@@ -2259,6 +2271,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
 				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
+
+				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
 
 				GET_INSTRUCTION_ARG(base, argc);
 
@@ -2311,6 +2325,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
 				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
+
+				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
 
 				GET_INSTRUCTION_ARG(base, argc);
 #ifdef DEBUG_ENABLED
@@ -2482,6 +2498,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				}
 #endif
 				const StringName *methodname = &_global_names_ptr[self_fun];
+
+				GodotProfileZoneScriptSystemCall(methodname, source, name, *methodname, line);
 
 				Variant **argptrs = instruction_args;
 


### PR DESCRIPTION
- Follow-up of #113279 
- Implements the rest of https://github.com/godotengine/godot/pull/112707

Adds support for profiling system calls from GDScript:

<img width="841" height="213" alt="SCR-20251205-oaes" src="https://github.com/user-attachments/assets/0f3f73f6-5296-4e10-8b30-e93a28e624cb" />

The initial work has been done by @enetheru, although I ended up with a different implementation to theirs. The reason is that #112707 used the "rename" / "dynamic name" API, which leads to a lot of data leaks. As in the previous PR, that means that RAM quickly fills up when profiling.
This PR doesn't leak large amounts of data, which means it should be possible to profile (almost) indefinitely.

### Approach

This uses the implementation from #113279 to intern source location data. I just needed to add a few parameters to make it compatible with both.

For now, this implementation seems to be fast enough (very little overhead), though we need to keep an eye on it. If tracing starts slowing people's games down, there's a number of things we could do in the future:

- Add a compile time parameter for not tracing system calls
- Somehow improve the interning mechanism's speed
- Make the GDScript VM complicit in caching profile data, such that it can be retrieved during execution

I'm also not 100% sure that the approach of using e.g. `methodname` (the pointer the the `StringName`) is extremely robust, but I think the worst that could happen is misleading file names / lines for a particular system call.