### PR TITLE
Update the version of the OpenXR Vendors plugin to the latest stable version

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -17,7 +17,7 @@ ext.versions = [
     splashscreenVersion: '1.0.1',
     // 'openxrLoaderVersion' should be set to XR_CURRENT_API_VERSION, see 'thirdparty/openxr'
     openxrLoaderVersion: '1.1.53',
-    openxrVendorsVersion: '4.2.1-stable',
+    openxrVendorsVersion: '4.2.2-stable',
     junitVersion       : '1.3.0',
     espressoCoreVersion: '3.7.0',
     kotlinTestVersion  : '1.3.11',


### PR DESCRIPTION
Update to version [4.2.2-stable](https://github.com/GodotVR/godot_openxr_vendors/releases/tag/4.2.2-stable) of the OpenXR Vendors plugin.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
