### PR TITLE
Use ObjectID in ProgressDialog Window list

### DIFF
--- a/editor/gui/progress_dialog.cpp
+++ b/editor/gui/progress_dialog.cpp
@@ -157,8 +157,11 @@ void ProgressDialog::_popup() {
 	// will discard every key input.
 	EditorNode::get_singleton()->set_process_input(true);
 	// Disable all other windows to prevent interaction with them.
-	for (Window *w : host_windows) {
-		w->set_process_mode(PROCESS_MODE_DISABLED);
+	for (ObjectID wid : host_windows) {
+		Window *w = ObjectDB::get_instance<Window>(wid);
+		if (w) {
+			w->set_process_mode(PROCESS_MODE_DISABLED);
+		}
 	}
 
 	Size2 ms = main->get_combined_minimum_size();
@@ -256,21 +259,22 @@ void ProgressDialog::end_task(const String &p_task) {
 	if (tasks.is_empty()) {
 		hide();
 		EditorNode::get_singleton()->set_process_input(false);
-		for (Window *w : host_windows) {
-			w->set_process_mode(PROCESS_MODE_INHERIT);
+		for (ObjectID wid : host_windows) {
+			Window *w = ObjectDB::get_instance<Window>(wid);
+			if (w) {
+				w->set_process_mode(PROCESS_MODE_INHERIT);
+			}
 		}
 	} else {
 		_popup();
 	}
 }
 
-void ProgressDialog::add_host_window(Window *p_window) {
-	ERR_FAIL_NULL(p_window);
+void ProgressDialog::add_host_window(ObjectID p_window) {
 	host_windows.push_back(p_window);
 }
 
-void ProgressDialog::remove_host_window(Window *p_window) {
-	ERR_FAIL_NULL(p_window);
+void ProgressDialog::remove_host_window(ObjectID p_window) {
 	host_windows.erase(p_window);
 }
 
@@ -303,4 +307,8 @@ ProgressDialog::ProgressDialog() {
 	cancel->set_text(TTR("Cancel"));
 	cancel_hb->add_spacer();
 	cancel->connect(SceneStringName(pressed), callable_mp(this, &ProgressDialog::_cancel_pressed));
+}
+
+ProgressDialog::~ProgressDialog() {
+	singleton = nullptr;
 }

--- a/editor/gui/progress_dialog.h
+++ b/editor/gui/progress_dialog.h
@@ -79,7 +79,7 @@ class ProgressDialog : public CenterContainer {
 	PanelContainer *center_panel = nullptr;
 	VBoxContainer *main = nullptr;
 
-	LocalVector<Window *> host_windows;
+	LocalVector<ObjectID> host_windows;
 
 	Size2 main_border_size;
 
@@ -101,8 +101,9 @@ public:
 	bool task_step(const String &p_task, const String &p_state, int p_step = -1, bool p_force_redraw = true);
 	void end_task(const String &p_task);
 
-	void add_host_window(Window *p_window);
-	void remove_host_window(Window *p_window);
+	void add_host_window(ObjectID p_window);
+	void remove_host_window(ObjectID p_window);
 
 	ProgressDialog();
+	~ProgressDialog();
 };

--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -383,12 +383,12 @@ WindowWrapper::WindowWrapper() {
 	window_background->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
 	window->add_child(window_background);
 
-	ProgressDialog::get_singleton()->add_host_window(window);
+	ProgressDialog::get_singleton()->add_host_window(window_id);
 }
 
 WindowWrapper::~WindowWrapper() {
-	if (ObjectDB::get_instance(window_id)) {
-		ProgressDialog::get_singleton()->remove_host_window(window);
+	if (ProgressDialog::get_singleton()) {
+		ProgressDialog::get_singleton()->remove_host_window(window_id);
 	}
 }
 


### PR DESCRIPTION
Fixes #113276

Progress dialog has a LocalVector of pointers to Windows (nodes, not the OS lol). The `window` is a child of WindowWrapper. The condition in WindowWrapper's destructor was always false, because the Window is freed before the wrapper, and so the ObjectID was invalid. For the purpose of removing a pointer from a vector, it does not matter if it's valid or not, so that check just didn't make sense.

Funny how ObjectID is normally supposed to prevent crashes 🤦‍♂️