### PR TITLE
Move initialization check for CanvasMaterial

### DIFF
--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -52,7 +52,6 @@
 
 Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_from, bool p_copy_params) {
 	ERR_FAIL_COND_V(p_from.is_null(), Ref<ShaderMaterial>());
-	ERR_FAIL_COND_V(!p_from->_is_initialized(), Ref<ShaderMaterial>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -497,5 +496,6 @@ bool CanvasItemMaterialConversionPlugin::handles(const Ref<Resource> &p_resource
 }
 
 Ref<Resource> CanvasItemMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
+	ERR_FAIL_COND_V(!Object::cast_to<CanvasItemMaterial>(*p_resource) || !Object::cast_to<CanvasItemMaterial>(*p_resource)->_is_initialized(), Ref<CanvasItemMaterial>());
 	return MaterialEditor::make_shader_material(p_resource);
 }


### PR DESCRIPTION
Materials all had a mandatory initialization check despite CanvasMaterials being the only ones that required initialization. This led to issues with material conversion, this PR moves the initialization check so that it only checks CanvasMaterials
- Closes #113647 
- Closes #112331

Supersedes #112458
CC @ColinSORourke 