### PR TITLE
Ensure resources with only UID as path show the appropriate tooltip if they're linked

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1744,7 +1744,8 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 }
 
 bool EditorNode::is_resource_internal_to_scene(Ref<Resource> p_resource) {
-	bool inside_scene = !get_edited_scene() || get_edited_scene()->get_scene_file_path() == p_resource->get_path().get_slice("::", 0);
+	String owner_path = p_resource->get_path().get_slice("::", 0);
+	bool inside_scene = !get_edited_scene() || owner_path.is_empty() || get_edited_scene()->get_scene_file_path() == owner_path;
 	return inside_scene || p_resource->get_path().is_empty();
 }
 


### PR DESCRIPTION
This was a quirk from https://github.com/godotengine/godot/pull/109458 I wasn't able to figure out how to solve. Basically some Resources are created only with a UID as their path. If they're duplicated a bunch, the link icon (🔗 ) shows up with a tooltip indicating whether they're an external or internal Resource . Unfortunetly, paths with only UIDs were getting this tooltip, which is wrong (this Resource is not external):

<details>

<summary>Before</summary>

<img width="642" height="492" alt="image" src="https://github.com/user-attachments/assets/cdada2ff-194a-42cb-95be-21fb13fee9c7" />

</details>

This is gone as soon as you save the scene, the Resource path is set to mention the scene they belong in, and all is fine. But it may trip up some users who haven't saved their scene, or wait to add everything and then hit save. 
Also, ever since this PR has gotten attention,  people talked about how easier it is to explain Resource to beginners now, how more intuitive it is. Therefore, I moved this piece of code from https://github.com/godotengine/godot/pull/112748 and am adding here. I suppose it's fine because it's more of a bug than a feature, and I want wholeheartedly to support a better UX for people, specially beginners, and having an accurate description serves that.

So now the tooltip shows a fitting description:


<details>

<summary>After</summary>

<img width="617" height="476" alt="image" src="https://github.com/user-attachments/assets/d25c3e34-6421-449e-9276-1f96c7f3f145" />

</details>



Also, depending on how https://github.com/godotengine/godot/issues/113414#issuecomment-3599405646 is fixed (especially if we remove the special handling for external scenes altogether and just allows them to be duplicated like before), the issue this PR intends to fix could be aggravated, since you'd be able to make an internal Resource that is framed as external unique without making its parent unique first.