### PR TITLE
Fix delayed transform updates for kinematic bodies in Jolt Physics

### DIFF
--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -559,9 +559,10 @@ void JoltBody3D::set_transform(Transform3D p_transform) {
 	if (!in_space()) {
 		jolt_settings->mPosition = to_jolt_r(p_transform.origin);
 		jolt_settings->mRotation = to_jolt(p_transform.basis);
-	} else if (is_kinematic()) {
-		kinematic_transform = p_transform;
 	} else {
+		if (is_kinematic()) {
+			kinematic_transform = p_transform;
+		}
 		space->get_body_iface().SetPositionAndRotation(jolt_body->GetID(), to_jolt_r(p_transform.origin), to_jolt(p_transform.basis), JPH::EActivation::DontActivate);
 	}
 


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/109086 fixes the issue in https://github.com/godotengine/godot/issues/76256 in GodotPhysics2/3D. This pr fixes the same problem, except for Jolt Physics.

I'm not very familiar with the physics servers but this seems to work. I don't know why I have to set `kinematic_transform` as well, but if I don't then the transform gets set back at some point.