### PR TITLE
Wayland: Work around window scale ambiguity

### DIFF
--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -236,6 +236,11 @@ void WindowWrapper::restore_window_from_saved_position(const Rect2 p_window_rect
 	int screen = p_screen;
 	Rect2 restored_screen_rect = p_screen_rect;
 
+	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SELF_FITTING_WINDOWS)) {
+		window_rect = Rect2i();
+		restored_screen_rect = Rect2i();
+	}
+
 	if (screen < 0 || screen >= DisplayServer::get_singleton()->get_screen_count()) {
 		// Fallback to the main window screen if the saved screen is not available.
 		screen = get_window()->get_window_id();

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1226,6 +1226,15 @@ Size2i DisplayServerWayland::window_get_size_with_decorations(DisplayServer::Win
 	return windows[p_window_id].rect.size;
 }
 
+float DisplayServerWayland::window_get_scale(WindowID p_window_id) const {
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	const WaylandThread::WindowState *ws = wayland_thread.window_get_state(p_window_id);
+	ERR_FAIL_NULL_V(ws, 1);
+
+	return wayland_thread.window_state_get_scale_factor(ws);
+}
+
 void DisplayServerWayland::window_set_mode(WindowMode p_mode, DisplayServer::WindowID p_window_id) {
 	MutexLock mutex_lock(wayland_thread.mutex);
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -290,6 +290,8 @@ public:
 	virtual Size2i window_get_size(WindowID p_window_id = MAIN_WINDOW_ID) const override;
 	virtual Size2i window_get_size_with_decorations(WindowID p_window_id = MAIN_WINDOW_ID) const override;
 
+	virtual float window_get_scale(WindowID p_window_id = MAIN_WINDOW_ID) const override;
+
 	virtual void window_set_mode(WindowMode p_mode, WindowID p_window_id = MAIN_WINDOW_ID) override;
 	virtual WindowMode window_get_mode(WindowID p_window_id = MAIN_WINDOW_ID) const override;
 

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3425,7 +3425,7 @@ int WaylandThread::window_state_get_preferred_buffer_scale(WindowState *p_ws) {
 	return max_size;
 }
 
-double WaylandThread::window_state_get_scale_factor(WindowState *p_ws) {
+double WaylandThread::window_state_get_scale_factor(const WindowState *p_ws) {
 	ERR_FAIL_NULL_V(p_ws, 1);
 
 	if (p_ws->fractional_scale > 0) {
@@ -3957,6 +3957,10 @@ struct wl_surface *WaylandThread::window_get_wl_surface(DisplayServer::WindowID 
 }
 
 WaylandThread::WindowState *WaylandThread::window_get_state(DisplayServer::WindowID p_window_id) {
+	return windows.getptr(p_window_id);
+}
+
+const WaylandThread::WindowState *WaylandThread::window_get_state(DisplayServer::WindowID p_window_id) const {
 	return windows.getptr(p_window_id);
 }
 

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -1076,7 +1076,7 @@ public:
 	void seat_state_echo_keys(SeatState *p_ss);
 
 	static int window_state_get_preferred_buffer_scale(WindowState *p_ws);
-	static double window_state_get_scale_factor(WindowState *p_ws);
+	static double window_state_get_scale_factor(const WindowState *p_ws);
 	static void window_state_update_size(WindowState *p_ws, int p_width, int p_height);
 
 	static Vector2i scale_vector2i(const Vector2i &p_vector, double p_amount);
@@ -1097,6 +1097,7 @@ public:
 
 	struct wl_surface *window_get_wl_surface(DisplayServer::WindowID p_window_id) const;
 	WindowState *window_get_state(DisplayServer::WindowID p_window_id);
+	const WindowState *window_get_state(DisplayServer::WindowID p_window_id) const;
 
 	void window_start_resize(DisplayServer::WindowResizeEdge p_edge, DisplayServer::WindowID p_window);
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -702,6 +702,15 @@ void Window::_clear_window() {
 
 	bool had_focus = has_focus();
 
+	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SELF_FITTING_WINDOWS)) {
+		float win_scale = DisplayServer::get_singleton()->window_get_scale(window_id);
+
+		Size2i adjusted_size = Size2i(size.width / win_scale, size.height / win_scale);
+		Size2i adjusted_pos = Size2i(position.x / win_scale, position.y / win_scale);
+
+		_rect_changed_callback(Rect2i(adjusted_pos, adjusted_size));
+	}
+
 	if (transient_parent && transient_parent->window_id != DisplayServer::INVALID_WINDOW_ID) {
 		DisplayServer::get_singleton()->window_set_transient(window_id, DisplayServer::INVALID_WINDOW_ID);
 	}

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -493,6 +493,11 @@ public:
 	virtual Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const = 0;
 	virtual Size2i window_get_size_with_decorations(WindowID p_window = MAIN_WINDOW_ID) const = 0;
 
+	virtual float window_get_scale(WindowID p_window = MAIN_WINDOW_ID) const {
+		int screen = window_get_current_screen(p_window);
+		return screen_get_scale(screen);
+	}
+
 	virtual void window_set_mode(WindowMode p_mode, WindowID p_window = MAIN_WINDOW_ID) = 0;
 	virtual WindowMode window_get_mode(WindowID p_window = MAIN_WINDOW_ID) const = 0;
 


### PR DESCRIPTION
Fixes #110643.

This is a workaround to a very annoying problem, and I'm really not sure how to explain it in simple terms[^simple_terms].

On Godot, each window's size is exactly that of the underlying buffer (let's call it an "absolute size").

On Wayland and MacOS, windows have a dpi-independent "logical size". If the system scale factor isn't 1, the underlying buffer grows/shrinks to accommodate that.

This difference causes some very annoying issues which currently require workarounds[^macos].

The biggest issue here is that, since the engine uses absolute units, there's no way to tell the reason behind the resize. This means that whenever the buffer changes size to account for scaling, that is effectively treated as the actual window size (as if the user resized it themselves) and stored e.g. in the `Window` node.

Whenever a `Window` node `hide()`s and `show()`s, the size will be adjusted and fed back, meaning that the effective window will grow more and more.

While it may be possible to make the Wayland backend "buffer-centric" it's discouraged to as the API is really not built for that and it would cause bad user UX. Additionally, after some discussion it looks like there's no way around it, with "logical size" being a concept we need for good engine-wide per-viewport dynamic DPI scaling anyways, so I'm proposing the following workaround in the meantime:

 - Add a new (unbound) method in DS: `window_get_scale`. By default, it returns the window's screen scale, but on Wayland it returns the actual per-window scale.

 - Only on platforms with `FEATURE_SELF_ADJUSTING_WINDOWS`[^feature_flag], in `window.cpp`, we "unscale" the window rect whenever the window is unmapped.

 - [Editor specific] Additionally, on platforms with the above flag, we also use the default position and screen whenever it is restored from memory. That system is already, as is, very limited on Wayland anyways, being limited to storing the size. Perhaps a more proper fix would be to do the adjusting every time the window size is saved, but I tried to be as little invasive as possible.

[^simple_terms]: This is also, despite my habits, why I didn't put comments or stuff like that. I have no idea how to put it into words decently, as this is some _very_ annoying and specific stuff. Any tip is appreciated.

[^macos]: MacOS has its own workarounds that don't apply in our case. I'll omit them for brevity.

[^feature_flag]: Yes, I'm aware that `FEATURE_SELF_ADJUSTING_WINDOWS` is becoming the "Wayland" flag and that's another pet peeve of mine that we should eventually discuss. Personally I'd keep the feature flag check instead of hardcoding the DS name simply because and hypothetical custom platform/ds could benefit from this too. If that's too broad, we could do the hardcoded check, I'm fine with both options.