### PR TITLE
Check pipeline validity before freeing pipelines in PipelineDeferredRD

### DIFF
--- a/servers/rendering/renderer_rd/pipeline_deferred_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_deferred_rd.h
@@ -82,7 +82,9 @@ public:
 	}
 
 	~PipelineDeferredRD() {
-		free();
+#ifdef DEV_ENABLED
+		ERR_FAIL_COND_MSG(pipeline.is_valid(), "'free()' must be called manually before deconstruction and before the corresponding shader is freed.");
+#endif
 	}
 
 	void create_render_pipeline(RID p_shader, RD::FramebufferFormatID p_framebuffer_format, RD::VertexFormatID p_vertex_format, RD::RenderPrimitive p_render_primitive, const RD::PipelineRasterizationState &p_rasterization_state, const RD::PipelineMultisampleState &p_multisample_state, const RD::PipelineDepthStencilState &p_depth_stencil_state, const RD::PipelineColorBlendState &p_blend_state, BitField<RD::PipelineDynamicStateFlags> p_dynamic_state_flags = 0, uint32_t p_for_render_pass = 0, const Vector<RD::PipelineSpecializationConstant> &p_specialization_constants = Vector<RD::PipelineSpecializationConstant>()) {
@@ -119,6 +121,9 @@ public:
 		_wait();
 
 		if (pipeline.is_valid()) {
+#ifdef DEV_ENABLED
+			ERR_FAIL_COND_MSG(!(RD::get_singleton()->render_pipeline_is_valid(pipeline) || RD::get_singleton()->compute_pipeline_is_valid(pipeline)), "`free()` must be called  manually before the dependent shader is freed.");
+#endif
 			RD::get_singleton()->free_rid(pipeline);
 			pipeline = RID();
 		}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/113495

Pipelines are dependent on shaders and get freed when their dependent shaders are freed leading to PipelineDeferredRD holding a stale RID. It succeeds the `pipeline.is_valid()` check because that only checks for whether it is `0` or not. We need to also check if the pipeline itself is valid. 

Prior to https://github.com/godotengine/godot/commit/c78c3ba894ab3b80079a6249b35d047c6fd0a6c1 these errors didn't pop up since we were manually freeing each pipeline before the corresponding shader, but that is an antipattern in our codebase. We should trust shaders to clean up their dependent pipelines