### PR TITLE
Remove legacy animation key insertion offset loop

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -5925,10 +5925,6 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 
 	resolve_insertion_offset(p_ofs);
 
-	while (animation->track_find_key(p_track, p_ofs, Animation::FIND_MODE_APPROX) != -1) { // Make sure insertion point is valid.
-		p_ofs += SECOND_DECIMAL;
-	}
-
 	Node *node = root->get_node_or_null(animation->track_get_path(p_track));
 	if (!node) {
 		EditorNode::get_singleton()->show_warning(TTR("Track path is invalid, so can't add a key."));


### PR DESCRIPTION
This PR removes the old 0.001s auto-offset logic when inserting keys in the AnimationTrackEditor. Inserting a key at an occupied time now overwrites the existing key, matching how Paste, Duplicate, and Move already behave.

The offset loop didn’t provide any protection and wasn’t used anywhere else in the editor. It only produced unintended “ghost keys” and made key insertion inconsistent with the rest of the workflow and Godot’s UndoRedo system already makes this overwrite fully reversible.

I’ve tested undo/redo, copy/paste, and key duplication with the loop removed, and everything behaves correctly. Overwrites are handled cleanly by UndoRedo, and no features seem to rely on the old offset behavior.

This makes key insertion predictable, consistent, and free of accidental offset keys.

Fixes #111741 