### PR TITLE
Increase Tree vertical separation to improve touch usability

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -627,7 +627,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_color("title_button_color", "Tree", p_config.font_color);
 			p_theme->set_color("drop_position_color", "Tree", p_config.accent_color);
 
-			p_theme->set_constant("v_separation", "Tree", Math::pow(p_config.base_margin * 0.2 * EDSCALE, 3));
+			int tree_v_sep = p_config.enable_touch_optimizations ? p_config.separation_margin : Math::pow(p_config.base_margin * 0.2 * EDSCALE, 3);
+			p_theme->set_constant("v_separation", "Tree", tree_v_sep);
 			p_theme->set_constant("h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
 			p_theme->set_constant("guide_width", "Tree", p_config.border_width);
 			p_theme->set_constant("item_margin", "Tree", MAX(3 * p_config.increased_margin * EDSCALE, 12 * EDSCALE));


### PR DESCRIPTION
In the modern theme, the `v_separation` of tree nodes is reduced. While it looks good visually, it hurts touch usability of the Android Editor.
This PR increases the separation (by switching the logic to use separation_margin, as the classic theme does) when `enable_touch_optimizations` editor setting is enabled.

| Before | After |
|--------|--------|
| ![Screenshot_2025-12-06-13-53-02-567_org godotengine editor v4](https://github.com/user-attachments/assets/910d1687-c8a9-425a-bc8b-a4d1f4cee8de) | ![Screenshot_2025-12-06-13-37-08-241_org godotengine editor v4 debug](https://github.com/user-attachments/assets/c0d98f7c-5a63-44f4-8191-f2157a0df28b) |
| ![Screenshot_2025-12-06-13-47-25-401_org godotengine editor v4](https://github.com/user-attachments/assets/837abf6c-4b1d-42b4-982d-1024bc36b946) | ![Screenshot_2025-12-06-13-46-16-929_org godotengine editor v4 debug](https://github.com/user-attachments/assets/75c3e5b8-b39e-4d9b-acf5-2e6ea0a52833) | 
