### PR TITLE
Notify changes on calling `ArrayMesh.clear_surfaces()`

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2020,6 +2020,8 @@ void ArrayMesh::clear_surfaces() {
 	RS::get_singleton()->mesh_clear(mesh);
 	surfaces.clear();
 	aabb = AABB();
+	notify_property_list_changed();
+	emit_changed();
 }
 
 void ArrayMesh::surface_remove(int p_surface) {


### PR DESCRIPTION
When calling `ArrayMesh.clear_surfaces()` while the Inspector is open, and then leaving the mesh without adding any new surfaces, the Godot Editor begins to continuously spam errors.
This commit fixes that issue.

Reproduction code:
https://gist.github.com/aoisensi/f544d06602cafca7f915c777459c653e

The sample lets you increase or decrease the number of surfaces using a button.
If you reduce the surface count to zero, the bug described above will occur.