### PR TITLE
Change metadata properties to Variant

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -522,7 +522,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 	}
 
 	for (const KeyValue<StringName, Variant> &K : metadata) {
-		PropertyInfo pi = PropertyInfo(K.value.get_type(), "metadata/" + K.key.operator String());
+		PropertyInfo pi = PropertyInfo(Variant::NIL, "metadata/" + K.key.operator String(), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 		if (K.value.get_type() == Variant::OBJECT) {
 			pi.hint = PROPERTY_HINT_RESOURCE_TYPE;
 			Object *obj = K.value;

--- a/editor/gui/editor_variant_type_selectors.cpp
+++ b/editor/gui/editor_variant_type_selectors.cpp
@@ -123,6 +123,14 @@ void EditorVariantTypePopupMenu::_populate() {
 		if (type == Variant::RID || type == Variant::CALLABLE || type == Variant::SIGNAL) {
 			continue;
 		}
+		if (meta_property) {
+			if (type == Variant::NIL) {
+				continue;
+			} else if (type == Variant::OBJECT) {
+				names.push_back("Resource");
+				continue;
+			}
+		}
 
 		names.push_back(Variant::get_type_name(type));
 	}
@@ -130,7 +138,8 @@ void EditorVariantTypePopupMenu::_populate() {
 	names.sort_custom<CompareVariantTypeNames>();
 
 	for (const String &name : names) {
-		add_item(name, Variant::get_type_by_name(name));
+		int id = Variant::get_type_by_name(name);
+		add_item(name, id == Variant::VARIANT_MAX ? Variant::OBJECT : id); // Condition to handle Resource.
 	}
 }
 
@@ -174,8 +183,9 @@ void EditorVariantTypePopupMenu::_popup_base(const Rect2i &p_bounds) {
 	PopupMenu::_popup_base(p_bounds);
 }
 
-EditorVariantTypePopupMenu::EditorVariantTypePopupMenu(bool p_remove_item) {
+EditorVariantTypePopupMenu::EditorVariantTypePopupMenu(bool p_remove_item, bool p_meta_property) {
 	remove_item = p_remove_item;
+	meta_property = p_meta_property;
 	set_search_bar_enabled(true);
 	set_search_bar_min_item_count(10);
 }

--- a/editor/gui/editor_variant_type_selectors.h
+++ b/editor/gui/editor_variant_type_selectors.h
@@ -52,6 +52,7 @@ class EditorVariantTypePopupMenu : public PopupMenu {
 	GDCLASS(EditorVariantTypePopupMenu, PopupMenu);
 
 	bool remove_item = false;
+	bool meta_property = false;
 	bool icons_dirty = true;
 
 	void _populate();
@@ -62,5 +63,5 @@ protected:
 	virtual void _popup_base(const Rect2i &p_bounds = Rect2i()) override;
 
 public:
-	EditorVariantTypePopupMenu(bool p_remove_item);
+	EditorVariantTypePopupMenu(bool p_remove_item, bool p_meta_property = false);
 };

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -98,7 +98,8 @@ void EditorPropertyVariant::_change_type(int p_to_type) {
 
 void EditorPropertyVariant::_popup_edit_menu() {
 	if (change_type == nullptr) {
-		change_type = memnew(EditorVariantTypePopupMenu(false));
+		bool is_meta = get_edited_property().operator String().begins_with("metadata/");
+		change_type = memnew(EditorVariantTypePopupMenu(false, is_meta));
 		change_type->connect(SceneStringName(id_pressed), callable_mp(this, &EditorPropertyVariant::_change_type));
 		content->add_child(change_type);
 	}


### PR DESCRIPTION
Changes metadata properties type to Variant, so you can change their type:
<img width="437" height="96" alt="image" src="https://github.com/user-attachments/assets/12eb6df1-7e0b-486f-9b75-5c0fdfff8e0f" />
Should we keep the type selector when creating new metadata?