### PR TITLE
Fix mediump/lowp precision qualifiers crash in Vulkan shader compiler

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -138,9 +138,9 @@ static String _interpstr(SL::DataInterpolation p_interp) {
 static String _prestr(SL::DataPrecision p_pres, bool p_force_highp = false) {
 	switch (p_pres) {
 		case SL::PRECISION_LOWP:
-			return "lowp ";
+			return RS::get_singleton()->is_low_end() ? "lowp " : "";
 		case SL::PRECISION_MEDIUMP:
-			return "mediump ";
+			return RS::get_singleton()->is_low_end() ? "mediump " : "";
 		case SL::PRECISION_HIGHP:
 			return "highp ";
 		case SL::PRECISION_DEFAULT:


### PR DESCRIPTION
Vulkan GLSL does not support mediump and lowp precision qualifiers — these are only valid in OpenGL ES. The shader compiler was unconditionally outputting these keywords for all rendering backends, causing glslang to fail when parsing the shader code for Vulkan compilation. This pr fixes it

Fixes #113665