### PR TITLE
Subdivide the focus state of the window on X11

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2110,7 +2110,7 @@ void DisplayServerX11::delete_sub_window(DisplayServerEnums::WindowID p_id) {
 		XDestroyIC(wd.xic);
 		wd.xic = nullptr;
 	}
-	XDestroyWindow(x11_display, wd.x11_xim_window);
+
 #ifdef XKB_ENABLED
 	if (xkb_loaded_v05p) {
 		if (wd.xkb_state) {
@@ -2120,7 +2120,6 @@ void DisplayServerX11::delete_sub_window(DisplayServerEnums::WindowID p_id) {
 	}
 #endif
 
-	XUnmapWindow(x11_display, wd.x11_window);
 	XDestroyWindow(x11_display, wd.x11_window);
 
 	window_set_rect_changed_callback(Callable(), p_id);
@@ -2436,7 +2435,7 @@ void DisplayServerX11::window_set_transient(DisplayServerEnums::WindowID p_windo
 		// Set focus to parent sub window to avoid losing all focus when closing a nested sub-menu.
 		// RevertToPointerRoot is used to make sure we don't lose all focus in case
 		// a subwindow and its parent are both destroyed.
-		if (!wd_window.no_focus && !wd_window.is_popup && wd_window.focused) {
+		if (!supported_atoms.has("_NET_WM_STATE_FOCUSED") && !wd_window.no_focus && !wd_window.is_popup && wd_window.focused) {
 			if ((xwa.map_state == IsViewable) && !wd_parent.no_focus && !wd_window.is_popup && _window_focus_check()) {
 				_set_input_focus(wd_parent.x11_window, RevertToPointerRoot);
 			}
@@ -2572,6 +2571,14 @@ void DisplayServerX11::_update_wm_state_hints(DisplayServerEnums::WindowID p_win
 	wd.fullscreen = hints.has(fullscreen_atom);
 	wd.maximized = hints.has(maximized_horz_atom) && hints.has(maximized_vert_atom);
 	wd.minimized = hints.has(hidden_atom);
+
+	if (supported_atoms.has("_NET_WM_STATE_FOCUSED")) {
+		const bool old_focused = wd.focused;
+		wd.focused = hints.has(supported_atoms["_NET_WM_STATE_FOCUSED"]);
+		if (old_focused != wd.focused) {
+			_window_focus_changed(p_window);
+		}
+	}
 }
 
 Point2i DisplayServerX11::window_get_position(DisplayServerEnums::WindowID p_window) const {
@@ -4800,9 +4807,10 @@ void DisplayServerX11::process_events() {
 		}
 
 		if (!focus_found) {
-			uint64_t delta = OS::get_singleton()->get_ticks_msec() - time_since_no_focus;
+			const uint64_t delta = OS::get_singleton()->get_ticks_msec() - time_since_no_focus;
+			const uint64_t frames_delta = Engine::get_singleton()->get_process_frames() - frames_since_no_focus; // For time-consuming tasks.
 
-			if (delta > 250) {
+			if (delta > 250 && frames_delta > 15) {
 				//X11 can go between windows and have no focus for a while, when creating them or something else. Use this as safety to avoid unnecessary focus in/outs.
 				if (OS::get_singleton()->get_main_loop()) {
 					DEBUG_LOG_X11("All focus lost, triggering NOTIFICATION_APPLICATION_FOCUS_OUT\n");
@@ -4812,6 +4820,7 @@ void DisplayServerX11::process_events() {
 			}
 		} else {
 			time_since_no_focus = OS::get_singleton()->get_ticks_msec();
+			frames_since_no_focus = Engine::get_singleton()->get_process_frames();
 		}
 	}
 
@@ -4836,7 +4845,7 @@ void DisplayServerX11::process_events() {
 		XEvent &event = events[event_index];
 
 		bool ime_window_event = false;
-		DisplayServerEnums::WindowID window_id = DisplayServerEnums::MAIN_WINDOW_ID;
+		DisplayServerEnums::WindowID window_id = DisplayServerEnums::INVALID_WINDOW_ID;
 
 		// Assign the event to the relevant window
 		for (const KeyValue<DisplayServerEnums::WindowID, WindowData> &E : windows) {
@@ -4849,6 +4858,11 @@ void DisplayServerX11::process_events() {
 				ime_window_event = true;
 				break;
 			}
+		}
+
+		if (window_id == DisplayServerEnums::INVALID_WINDOW_ID) {
+			// Relevant window events will still be received even when the window is being destroyed. Ignore them.
+			continue;
 		}
 
 		if (XGetEventData(x11_display, &event.xcookie)) {
@@ -5109,98 +5123,26 @@ void DisplayServerX11::process_events() {
 				if (ime_window_event || (event.xfocus.detail == NotifyInferior)) {
 					break;
 				}
-
 				WindowData &wd = windows[window_id];
-				last_focused_window = window_id;
-				wd.focused = true;
+				wd.contents_focused = true;
 
-				// Keep track of focus order for overlapping windows.
-				static unsigned int focus_order = 0;
-				wd.focus_order = ++focus_order;
-
-				AccessibilityServer::get_singleton()->set_window_focused(window_id, true);
-				_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_FOCUS_IN);
-
-				if (mouse_mode_grab) {
-					// Show and update the cursor if confined and the window regained focus.
-
-					for (const KeyValue<DisplayServerEnums::WindowID, WindowData> &E : windows) {
-						if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CONFINED) {
-							XUndefineCursor(x11_display, E.value.x11_window);
-						} else if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED || mouse_mode == DisplayServerEnums::MOUSE_MODE_CONFINED_HIDDEN) { // Or re-hide it.
-							XDefineCursor(x11_display, E.value.x11_window, null_cursor);
-						}
-
-						XGrabPointer(
-								x11_display, E.value.x11_window, True,
-								ButtonPressMask | ButtonReleaseMask | PointerMotionMask,
-								GrabModeAsync, GrabModeAsync, E.value.x11_window, None, CurrentTime);
-					}
-				}
-#ifdef TOUCH_ENABLED
-				// Grab touch devices to avoid OS gesture interference
-				/*for (int i = 0; i < xi.touch_devices.size(); ++i) {
-					XIGrabDevice(x11_display, xi.touch_devices[i], x11_window, CurrentTime, None, XIGrabModeAsync, XIGrabModeAsync, False, &xi.touch_event_mask);
-				}*/
-#endif
-
-				if (!app_focused) {
-					if (OS::get_singleton()->get_main_loop()) {
-						OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
-					}
-					app_focused = true;
+				if (!supported_atoms.has("_NET_WM_STATE_FOCUSED") && !wd.no_focus && !wd.focused) {
+					wd.focused = true;
+					_window_focus_changed(window_id);
 				}
 			} break;
 
 			case FocusOut: {
 				DEBUG_LOG_X11("[%u] FocusOut window=%lu (%u), mode='%u' \n", frame, event.xfocus.window, window_id, event.xfocus.mode);
-				WindowData &wd = windows[window_id];
 				if (ime_window_event || (event.xfocus.detail == NotifyInferior)) {
 					break;
 				}
-				if (wd.ime_active) {
-					MutexLock mutex_lock(events_mutex);
-					XUnsetICFocus(wd.xic);
-					XUnmapWindow(x11_display, wd.x11_xim_window);
-					wd.ime_active = false;
-					im_text = String();
-					im_selection = Vector2i();
-					OS_Unix::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
+				WindowData &wd = windows[window_id];
+				wd.contents_focused = false;
+				if (!supported_atoms.has("_NET_WM_STATE_FOCUSED")) {
+					wd.focused = false;
+					_window_focus_changed(window_id);
 				}
-				wd.focused = false;
-
-				Input::get_singleton()->release_pressed_events();
-
-				AccessibilityServer::get_singleton()->set_window_focused(window_id, false);
-				_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_FOCUS_OUT);
-
-				if (mouse_mode_grab) {
-					for (const KeyValue<DisplayServerEnums::WindowID, WindowData> &E : windows) {
-						//dear X11, I try, I really try, but you never work, you do whatever you want.
-						if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED) {
-							// Show the cursor if we're in captured mode so it doesn't look weird.
-							XUndefineCursor(x11_display, E.value.x11_window);
-						}
-					}
-					XUngrabPointer(x11_display, CurrentTime);
-				}
-#ifdef TOUCH_ENABLED
-				// Ungrab touch devices so input works as usual while we are unfocused
-				/*for (int i = 0; i < xi.touch_devices.size(); ++i) {
-					XIUngrabDevice(x11_display, xi.touch_devices[i], CurrentTime);
-				}*/
-
-				// Release every pointer to avoid sticky points
-				for (const KeyValue<int, Vector2> &E : xi.state) {
-					Ref<InputEventScreenTouch> st;
-					st.instantiate();
-					st->set_index(E.key);
-					st->set_window_id(window_id);
-					st->set_position(E.value);
-					Input::get_singleton()->parse_input_event(st);
-				}
-				xi.state.clear();
-#endif
 			} break;
 
 			case ConfigureNotify: {
@@ -5290,7 +5232,7 @@ void DisplayServerX11::process_events() {
 
 					DisplayServerEnums::WindowID window_id_other = DisplayServerEnums::INVALID_WINDOW_ID;
 					Window wd_other_x11_window;
-					if (!wd.focused) {
+					if (!wd.contents_focused) {
 						// Propagate the event to the focused window,
 						// because it's received only on the topmost window.
 						// Note: This is needed for drag & drop to work between windows,
@@ -5663,6 +5605,96 @@ void DisplayServerX11::swap_buffers() {
 		gl_manager_egl->swap_buffers();
 	}
 #endif
+}
+
+void DisplayServerX11::_window_focus_changed(DisplayServerEnums::WindowID p_window) {
+	WindowData &wd = windows[p_window];
+
+	const bool mouse_mode_grab = mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED || mouse_mode == DisplayServerEnums::MOUSE_MODE_CONFINED || mouse_mode == DisplayServerEnums::MOUSE_MODE_CONFINED_HIDDEN;
+
+	if (wd.focused) {
+		last_focused_window = p_window;
+
+		// Keep track of focus order for overlapping windows.
+		static unsigned int focus_order = 0;
+		wd.focus_order = ++focus_order;
+
+		AccessibilityServer::get_singleton()->set_window_focused(p_window, true);
+		_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_FOCUS_IN);
+
+		if (mouse_mode_grab) {
+			// Show and update the cursor if confined and the window regained focus.
+
+			for (const KeyValue<DisplayServerEnums::WindowID, WindowData> &E : windows) {
+				if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CONFINED) {
+					XUndefineCursor(x11_display, E.value.x11_window);
+				} else if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED || mouse_mode == DisplayServerEnums::MOUSE_MODE_CONFINED_HIDDEN) { // Or re-hide it.
+					XDefineCursor(x11_display, E.value.x11_window, null_cursor);
+				}
+
+				XGrabPointer(
+						x11_display, E.value.x11_window, True,
+						ButtonPressMask | ButtonReleaseMask | PointerMotionMask,
+						GrabModeAsync, GrabModeAsync, E.value.x11_window, None, CurrentTime);
+			}
+		}
+#ifdef TOUCH_ENABLED
+		// Grab touch devices to avoid OS gesture interference
+		/*for (int i = 0; i < xi.touch_devices.size(); ++i) {
+			XIGrabDevice(x11_display, xi.touch_devices[i], x11_window, CurrentTime, None, XIGrabModeAsync, XIGrabModeAsync, False, &xi.touch_event_mask);
+		}*/
+#endif
+
+		if (!app_focused) {
+			if (OS::get_singleton()->get_main_loop()) {
+				OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
+			}
+			app_focused = true;
+		}
+	} else {
+		if (wd.ime_active) {
+			MutexLock mutex_lock(events_mutex);
+			XUnsetICFocus(wd.xic);
+			XUnmapWindow(x11_display, wd.x11_xim_window);
+			wd.ime_active = false;
+			im_text = String();
+			im_selection = Vector2i();
+			OS_Unix::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
+		}
+
+		Input::get_singleton()->release_pressed_events();
+
+		AccessibilityServer::get_singleton()->set_window_focused(p_window, false);
+		_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_FOCUS_OUT);
+
+		if (mouse_mode_grab) {
+			for (const KeyValue<DisplayServerEnums::WindowID, WindowData> &E : windows) {
+				//dear X11, I try, I really try, but you never work, you do whatever you want.
+				if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED) {
+					// Show the cursor if we're in captured mode so it doesn't look weird.
+					XUndefineCursor(x11_display, E.value.x11_window);
+				}
+			}
+			XUngrabPointer(x11_display, CurrentTime);
+		}
+#ifdef TOUCH_ENABLED
+		// Ungrab touch devices so input works as usual while we are unfocused
+		/*for (int i = 0; i < xi.touch_devices.size(); ++i) {
+			XIUngrabDevice(x11_display, xi.touch_devices[i], CurrentTime);
+		}*/
+
+		// Release every pointer to avoid sticky points
+		for (const KeyValue<int, Vector2> &E : xi.state) {
+			Ref<InputEventScreenTouch> st;
+			st.instantiate();
+			st->set_index(E.key);
+			st->set_window_id(p_window);
+			st->set_position(E.value);
+			Input::get_singleton()->parse_input_event(st);
+		}
+		xi.state.clear();
+#endif
+	}
 }
 
 void DisplayServerX11::_update_context(WindowData &wd) {
@@ -6654,6 +6686,53 @@ DisplayServerEnums::WindowID DisplayServerX11::_create_window(DisplayServerEnums
 	return id;
 }
 
+void DisplayServerX11::_fetch_supported_atoms() {
+	supported_atoms.clear();
+
+	Atom supported = XInternAtom(x11_display, "_NET_SUPPORTED", True);
+	if (supported == None) {
+		return;
+	}
+
+	Atom type;
+	int format;
+	unsigned long len;
+	unsigned long remaining;
+	unsigned char *data = nullptr;
+
+	int result = XGetWindowProperty(
+			x11_display,
+			DefaultRootWindow(x11_display),
+			supported,
+			0,
+			1024,
+			False,
+			XA_ATOM,
+			&type,
+			&format,
+			&len,
+			&remaining,
+			&data);
+	if (result != Success) {
+		return;
+	}
+
+	if (!data) {
+		return;
+	}
+
+	Atom *atoms = (Atom *)data;
+	LocalVector<char *> names;
+	names.resize(len);
+
+	XGetAtomNames(x11_display, atoms, len, names.ptr());
+	XFree(data);
+
+	for (unsigned long i = 0; i < len; i++) {
+		supported_atoms.insert(String::utf8(names[i]), atoms[i]);
+	}
+}
+
 static bool _is_xim_style_supported(const ::XIMStyle &p_style) {
 	const ::XIMStyle supported_preedit = XIMPreeditCallbacks | XIMPreeditPosition | XIMPreeditNothing | XIMPreeditNone;
 	const ::XIMStyle supported_status = XIMStatusNothing | XIMStatusNone;
@@ -7193,6 +7272,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		window_position = scr_rect.position + (scr_rect.size - p_resolution) / 2;
 	}
 
+	_fetch_supported_atoms();
 	DisplayServerEnums::WindowID main_window = _create_window(p_mode, p_vsync_mode, p_flags, Rect2i(window_position, p_resolution), p_parent_window);
 	if (main_window == DisplayServerEnums::INVALID_WINDOW_ID) {
 		r_error = ERR_CANT_CREATE;

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -172,6 +172,7 @@ class DisplayServerX11 : public DisplayServer {
 		ObjectID instance_id;
 
 		bool no_focus = false;
+		bool focused = false;
 
 		//better to guess on the fly, given WM can change it
 		//DisplayServerEnums::WindowMode mode;
@@ -182,7 +183,7 @@ class DisplayServerX11 : public DisplayServer {
 		bool resize_disabled = false;
 		bool no_min_btn = false;
 		bool no_max_btn = false;
-		bool focused = true;
+		bool contents_focused = true;
 		bool minimized = false;
 		bool maximized = false;
 		bool is_popup = false;
@@ -220,6 +221,9 @@ class DisplayServerX11 : public DisplayServer {
 	void _create_xic(WindowData &wd);
 	DisplayServerEnums::WindowID _create_window(DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, Window p_parent_window);
 
+	HashMap<String, Atom> supported_atoms;
+	void _fetch_supported_atoms();
+
 	String internal_clipboard;
 	String internal_clipboard_primary;
 	Window xdnd_source_window = 0;
@@ -251,7 +255,7 @@ class DisplayServerX11 : public DisplayServer {
 	MouseButton last_click_button_index = MouseButton::NONE;
 	bool app_focused = false;
 	uint64_t time_since_no_focus = 0;
-
+	uint64_t frames_since_no_focus = 0;
 	struct {
 		int opcode;
 		Vector<int> touch_devices;
@@ -348,6 +352,7 @@ class DisplayServerX11 : public DisplayServer {
 	DisplayServerEnums::Context context = DisplayServerEnums::CONTEXT_ENGINE;
 	bool swap_cancel_ok = false;
 
+	void _window_focus_changed(DisplayServerEnums::WindowID p_window);
 	DisplayServerEnums::WindowID _get_focused_window_or_popup() const;
 	bool _window_focus_check();
 


### PR DESCRIPTION
1. Use `focused` to track `_NET_WM_STATE_FOCUSED`;
2. Use `contents_focused` to track `FocusIn`/`FocusOut` events.

The first point prevents windows/programs from losing focus when dragging or resizing the window or performing certain time-consuming tasks. Windows set to `no_focus` will be failed to have their `focused` property set to `true`.

The `focused` and `no_focus` properties could previously both be `true` simultaneously, so the second point is for compatibility (to avoid not receiving the release event).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fix #113628.

======

<details>

<summary>Batch delete files</summary>

Before:

https://github.com/user-attachments/assets/f00350ad-dda2-46a1-b814-7d9f1f50d3e7


After:

https://github.com/user-attachments/assets/301fd8de-4f86-4054-9224-acc82bba56c0


</details>

<details>

<summary>Drag the window to different positions</summary>

Before:

https://github.com/user-attachments/assets/c1ba323e-5858-4e62-abd7-c74dd381b264 

After:

https://github.com/user-attachments/assets/796f2efc-de89-4bb7-a820-8d329a9b9d60

</details>