### PR TITLE
Improve style changed signal in EditorDock

### DIFF
--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -39,6 +39,10 @@ void EditorDock::_set_default_slot_bind(EditorPlugin::DockSlot p_slot) {
 	default_slot = (DockConstants::DockSlot)p_slot;
 }
 
+void EditorDock::_emit_changed() {
+	emit_signal(SNAME("_tab_style_changed"));
+}
+
 void EditorDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open"), &EditorDock::open);
 	ClassDB::bind_method(D_METHOD("make_visible"), &EditorDock::make_visible);
@@ -90,9 +94,10 @@ void EditorDock::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_available_layouts", "layouts"), &EditorDock::set_available_layouts);
 	ClassDB::bind_method(D_METHOD("get_available_layouts"), &EditorDock::get_available_layouts);
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "available_layouts", PROPERTY_HINT_FLAGS, "Vertical:1,Horizontal:2,Floating:3"), "set_available_layouts", "get_available_layouts");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "available_layouts", PROPERTY_HINT_FLAGS, "Vertical:1,Horizontal:2,Floating:4"), "set_available_layouts", "get_available_layouts");
 
 	ADD_SIGNAL(MethodInfo("closed"));
+	ADD_SIGNAL(MethodInfo("_tab_style_changed"));
 
 	BIND_BITFIELD_FLAG(DOCK_LAYOUT_VERTICAL);
 	BIND_BITFIELD_FLAG(DOCK_LAYOUT_HORIZONTAL);
@@ -102,10 +107,6 @@ void EditorDock::_bind_methods() {
 	GDVIRTUAL_BIND(_update_layout, "layout");
 	GDVIRTUAL_BIND(_save_layout_to_config, "config", "section");
 	GDVIRTUAL_BIND(_load_layout_from_config, "config", "section");
-}
-
-EditorDock::EditorDock() {
-	add_user_signal(MethodInfo("tab_style_changed"));
 }
 
 void EditorDock::open() {
@@ -129,7 +130,7 @@ void EditorDock::set_title(const String &p_title) {
 		return;
 	}
 	title = p_title;
-	emit_signal("tab_style_changed");
+	_emit_changed();
 }
 
 void EditorDock::set_global(bool p_global) {
@@ -147,7 +148,7 @@ void EditorDock::set_icon_name(const StringName &p_name) {
 		return;
 	}
 	icon_name = p_name;
-	emit_signal("tab_style_changed");
+	_emit_changed();
 }
 
 void EditorDock::set_dock_icon(const Ref<Texture2D> &p_icon) {
@@ -155,7 +156,7 @@ void EditorDock::set_dock_icon(const Ref<Texture2D> &p_icon) {
 		return;
 	}
 	dock_icon = p_icon;
-	emit_signal("tab_style_changed");
+	_emit_changed();
 }
 
 void EditorDock::set_force_show_icon(bool p_force) {
@@ -163,7 +164,7 @@ void EditorDock::set_force_show_icon(bool p_force) {
 		return;
 	}
 	force_show_icon = p_force;
-	emit_signal("tab_style_changed");
+	_emit_changed();
 }
 
 void EditorDock::set_title_color(const Color &p_color) {
@@ -171,7 +172,7 @@ void EditorDock::set_title_color(const Color &p_color) {
 		return;
 	}
 	title_color = p_color;
-	emit_signal("tab_style_changed");
+	_emit_changed();
 }
 
 void EditorDock::set_dock_shortcut(const Ref<Shortcut> &p_shortcut) {

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -77,6 +77,8 @@ private:
 	void _set_default_slot_bind(EditorPlugin::DockSlot p_slot);
 	EditorPlugin::DockSlot _get_default_slot_bind() const { return (EditorPlugin::DockSlot)default_slot; }
 
+	void _emit_changed();
+
 protected:
 	static void _bind_methods();
 
@@ -85,8 +87,6 @@ protected:
 	GDVIRTUAL2(_load_layout_from_config, Ref<ConfigFile>, const String &)
 
 public:
-	EditorDock();
-
 	void open();
 	void make_visible();
 	void close();

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -902,7 +902,7 @@ void EditorDockManager::add_dock(EditorDock *p_dock) {
 
 	p_dock->dock_slot_index = p_dock->default_slot;
 	all_docks.push_back(p_dock);
-	p_dock->connect("tab_style_changed", callable_mp(this, &EditorDockManager::_update_tab_style).bind(p_dock));
+	p_dock->connect("_tab_style_changed", callable_mp(this, &EditorDockManager::_update_tab_style).bind(p_dock));
 	p_dock->connect("renamed", callable_mp(this, &EditorDockManager::_update_tab_style).bind(p_dock));
 
 	if (p_dock->default_slot != DockConstants::DOCK_SLOT_NONE) {
@@ -921,7 +921,7 @@ void EditorDockManager::remove_dock(EditorDock *p_dock) {
 	_move_dock(p_dock, nullptr);
 
 	all_docks.erase(p_dock);
-	p_dock->disconnect("tab_style_changed", callable_mp(this, &EditorDockManager::_update_tab_style));
+	p_dock->disconnect("_tab_style_changed", callable_mp(this, &EditorDockManager::_update_tab_style));
 	p_dock->disconnect("renamed", callable_mp(this, &EditorDockManager::_update_tab_style));
 	_update_layout();
 }


### PR DESCRIPTION
Changes `tab_style_changed` signal from user signal to properly registered internal signal. Also added `_emit_changed()` method that emits the signal using `SNAME`.