### PR TITLE
Add feature to dump GDShader API (`--dump-shader-api`)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -75,6 +75,7 @@
 #include "servers/movie_writer/movie_writer.h"
 #include "servers/register_server_types.h"
 #include "servers/rendering/rendering_server_default.h"
+#include "servers/rendering/shader_api_dump.h"
 #include "servers/text/text_server.h"
 #include "servers/text/text_server_dummy.h"
 
@@ -282,6 +283,7 @@ static bool editor_pseudolocalization = false;
 static bool dump_gdextension_interface = false;
 static bool dump_gdextension_interface_header = false;
 static bool dump_extension_api = false;
+static bool dump_shader_api = false;
 static bool include_docs_in_extension_api_dump = false;
 static bool validate_extension_api = false;
 static String validate_extension_api_file;
@@ -712,6 +714,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--dump-gdextension-interface-json", "Generate a JSON dump of the GDExtension interface named \"gdextension_interface.json\" in the current folder.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--dump-extension-api", "Generate a JSON dump of the Godot API for GDExtension bindings named \"extension_api.json\" in the current folder.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--dump-extension-api-with-docs", "Generate JSON dump of the Godot API like the previous option, but including documentation.\n", CLI_OPTION_AVAILABILITY_EDITOR);
+	print_help_option("--dump-shader-api", "Generate a JSON dump of the Godot shader API for GDShader bindings named \"shader_api.json\" in the current folder.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--validate-extension-api <path>", "Validate an extension API file dumped (with one of the two previous options) from a previous version of the engine to ensure API compatibility.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("", "If incompatibilities or errors are detected, the exit code will be non-zero.\n");
 	print_help_option("--benchmark", "Benchmark the run time and print it to console.\n", CLI_OPTION_AVAILABILITY_EDITOR);
@@ -1597,6 +1600,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			dump_extension_api = true;
 			include_docs_in_extension_api_dump = true;
 			print_line("Dumping Extension API including documentation");
+			// Hack. Not needed but otherwise we end up detecting that this should
+			// run the project instead of a cmdline tool.
+			// Needs full refactoring to fix properly.
+			main_args.push_back(arg);
+		} else if (arg == "--dump-shader-api") {
+			// Register as an editor instance to use low-end fallback if relevant.
+			editor = true;
+			cmdline_tool = true;
+			dump_shader_api = true;
+			print_line("Dumping Shader API");
 			// Hack. Not needed but otherwise we end up detecting that this should
 			// run the project instead of a cmdline tool.
 			// Needs full refactoring to fix properly.
@@ -4166,6 +4179,13 @@ int Main::start() {
 			Engine::get_singleton()->set_editor_hint(true); // "extension_api.json" should always contains editor singletons.
 			bool valid = GDExtensionAPIDump::validate_extension_json_file(validate_extension_api_file) == OK;
 			return valid ? EXIT_SUCCESS : EXIT_FAILURE;
+		}
+	}
+
+	// GDShader API
+	{
+		if (dump_shader_api) {
+			GDShaderAPIDump::generate_shader_json_file("shader_api.json");
 		}
 	}
 

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -90,6 +90,7 @@ _arguments \
   '--build-solutions[build the scripting solutions (e.g. for C# projects)]' \
   '--dump-gdextension-interface[generate GDExtension header file 'gdextension_interface.h' in the current folder. This file is the base file required to implement a GDExtension.]' \
   '--dump-extension-api[generate JSON dump of the Godot API for GDExtension bindings named "extension_api.json" in the current folder]' \
+  '--dump-shader-api[generate a JSON dump of the Godot shader API for GDShader bindings named "shader_api.json" in the current folder]' \
   '--benchmark[benchmark the run time and print it to console]' \
   '--benchmark-file[benchmark the run time and save it to a given file in JSON format]:path to output JSON file' \
   '--test[run all unit tests; run with "--test --help" for more information]'

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -93,6 +93,7 @@ _complete_godot_options() {
 --build-solutions
 --dump-gdextension-interface
 --dump-extension-api
+--dump-shader-api
 --benchmark
 --benchmark-file
 --test

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -111,6 +111,7 @@ complete -c godot -l no-docbase -d "Disallow dumping the base types (used with -
 complete -c godot -l build-solutions -d "Build the scripting solutions (e.g. for C# projects)"
 complete -c godot -l dump-gdextension-interface -d "Generate GDExtension header file 'gdextension_interface.h' in the current folder. This file is the base file required to implement a GDExtension"
 complete -c godot -l dump-extension-api -d "Generate JSON dump of the Godot API for GDExtension bindings named 'extension_api.json' in the current folder"
+complete -c godot -l dump-shader-api -d "Generate a JSON dump of the Godot shader API for GDShader bindings named 'shader_api.json' in the current folder"
 complete -c godot -l benchmark -d "Benchmark the run time and print it to console"
 complete -c godot -l benchmark-file -d "Benchmark the run time and save it to a given file in JSON format" -x
 complete -c godot -l test -d "Run all unit tests; run with '--test --help' for more information" -x

--- a/servers/rendering/shader_api_dump.cpp
+++ b/servers/rendering/shader_api_dump.cpp
@@ -1,0 +1,578 @@
+/**************************************************************************/
+/*  shader_api_dump.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "shader_api_dump.h"
+
+#include "core/io/file_access.h"
+#include "core/io/json.h"
+#include "rendering_server.h"
+#include "servers/rendering/shader_language.h"
+#include "servers/rendering/shader_types.h"
+
+#ifdef TOOLS_ENABLED
+
+// Generates a JSON-compatible representation of Godot's shader API.
+// A TypeScript definition of the expected data is provided below:
+//
+// {
+//     datatypes: Array<{
+//         name: string,
+//         indexing_return_type: string,
+//         size: number,
+//         component_count: number,
+//         indexing_size: number,
+//         swizzle_field_count: number,
+//         is_scalar: boolean,
+//         is_float: boolean,
+//         is_sampler: boolean,
+//         operators: Array<{
+//             name: string,
+//             return_type: string,
+//             right_type?: string, // only defined if a binary operator
+//         }>,
+//     }>,
+//     modes: Array<{
+//         name: string,
+//         render_modes: Array<{
+//             name: string,
+//             options?: Array<string>
+//         }>,
+//         stencil_modes: Array<{
+//             name: string,
+//             options?: Array<string>
+//         }>,
+//         stages: Array<{
+//             name: string,
+//             can_discard: boolean,
+//             main_function: boolean,
+//             built_ins: Array<{
+//                 name: string,
+//                 type: string,
+//                 constant: boolean,
+//                 values?: Array<boolean | number>,
+//             }>,
+//             stage_functions: Array<{
+//                 name: string,
+//                 arguments: Array<{
+//                     name: string,
+//                     type: string,
+//                 }>,
+//                 return_type: string,
+//                 skip_function: string,
+//             }>,
+//         }>,
+//     }>,
+//     functions: Array<{
+//         name: string,
+//         is_frag_only: boolean,
+//         overloads: Array<{
+//             return_type: string,
+//             is_high_end: boolean,
+//             arguments: Array<{
+//                 name: string,
+//                 type: string,
+//                 is_out: boolean,
+//                 is_const: boolean,
+//                 min?: number, // only defined if is_const is true
+//                 max?: number, // only defined if is_const is true
+//             }>,
+//         }>,
+//     }>,
+// }
+Dictionary GDShaderAPIDump::generate_shader_api() {
+	ShaderAPI api = {
+		generate_datatypes(),
+		generate_modes(),
+		generate_functions()
+	};
+	return api_to_dictionary(api);
+}
+
+void GDShaderAPIDump::generate_shader_json_file(const String &p_path) {
+	Dictionary api = generate_shader_api();
+	Ref<JSON> json;
+	json.instantiate();
+
+	String text = json->stringify(api, "\t", false) + "\n";
+	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(fa.is_null(), vformat("Cannot open file '%s' for writing.", p_path));
+	fa->store_string(text);
+}
+
+Vector<GDShaderAPIDump::ShaderAPIDatatype> GDShaderAPIDump::generate_datatypes() {
+	using Operator = ShaderLanguage::Operator;
+	using DataType = ShaderLanguage::DataType;
+
+	Vector<ShaderAPIDatatype> datatypes;
+
+	for (int type_index = DataType::TYPE_VOID; type_index < DataType::TYPE_MAX; type_index++) {
+		DataType type = static_cast<DataType>(type_index);
+
+		// No benefit to dumping void type.
+		if (type == DataType::TYPE_VOID) {
+			continue;
+		}
+
+		// Struct type is a generic representation of all structs that cannot be represented in JSON.
+		if (type == DataType::TYPE_STRUCT) {
+			continue;
+		}
+
+		// Iterate through all operators and all types to find all possible operator combinations.
+		Vector<ShaderAPIDatatype::Operator> operators;
+		int operator_index = Operator::OP_EQUAL;
+		while (operator_index < Operator::OP_MAX) {
+			Operator op = static_cast<Operator>(operator_index);
+
+			int other_type_index = DataType::TYPE_VOID;
+			while (other_type_index < DataType::TYPE_MAX) {
+				DataType other_type = static_cast<DataType>(other_type_index);
+
+				DataType return_type = DataType::TYPE_VOID;
+				bool unary = false;
+				bool valid = ShaderLanguage::get_datatype_operator_result(type, op, other_type, &return_type, &unary);
+				if (valid) {
+					ShaderAPIDatatype::Operator api_operator = {
+						get_operator_name(op),
+						return_type,
+						unary ? DataType::TYPE_VOID : other_type,
+					};
+					operators.push_back(api_operator);
+				}
+
+				// If unary, don't iterate through every "other" type.
+				if (unary) {
+					break;
+				}
+
+				other_type_index++;
+			}
+
+			operator_index++;
+		}
+
+		ShaderAPIDatatype datatype = {
+			ShaderLanguage::get_datatype_name(type),
+			ShaderLanguage::get_datatype_indexed_type(type),
+			operators,
+			ShaderLanguage::get_datatype_size(type),
+			ShaderLanguage::get_datatype_component_count(type),
+			ShaderLanguage::get_datatype_indexed_size(type),
+			ShaderLanguage::get_datatype_swizzle_field_count(type),
+			ShaderLanguage::is_scalar_type(type),
+			ShaderLanguage::is_float_type(type),
+			ShaderLanguage::is_sampler_type(type),
+		};
+		datatypes.push_back(datatype);
+	}
+
+	return datatypes;
+}
+
+Vector<GDShaderAPIDump::ShaderAPIMode> GDShaderAPIDump::generate_modes() {
+	using ShaderMode = RenderingServer::ShaderMode;
+
+	Vector<ShaderAPIMode> modes;
+
+	ShaderTypes *shader_types = ShaderTypes::get_singleton();
+	const List<String> &types_list = shader_types->get_types_list();
+
+	for (int shader_index = ShaderMode::SHADER_SPATIAL; shader_index < ShaderMode::SHADER_MAX; shader_index++) {
+		ShaderMode shader_mode = static_cast<ShaderMode>(shader_index);
+
+		Vector<ShaderAPIMode::Stage> stages;
+		for (const KeyValue<StringName, ShaderLanguage::FunctionInfo> &name_to_function_info : shader_types->get_functions(shader_mode)) {
+			const ShaderLanguage::FunctionInfo &function_info = name_to_function_info.value;
+
+			Vector<ShaderAPIMode::Stage::BuiltIn> built_ins;
+			for (const KeyValue<StringName, ShaderLanguage::BuiltInInfo> &name_to_built_in : function_info.built_ins) {
+				ShaderAPIMode::Stage::BuiltIn built_in = {
+					name_to_built_in.key,
+					name_to_built_in.value.type,
+					name_to_built_in.value.constant,
+					name_to_built_in.value.values,
+				};
+				built_ins.push_back(built_in);
+			}
+
+			Vector<ShaderAPIMode::Stage::StageFunction> stage_functions;
+			for (const KeyValue<StringName, ShaderLanguage::StageFunctionInfo> &name_to_stage_function : function_info.stage_functions) {
+				Vector<ShaderAPIMode::Stage::StageFunction::Argument> arguments;
+				for (const ShaderLanguage::StageFunctionInfo::Argument &argument : name_to_stage_function.value.arguments) {
+					arguments.push_back({ argument.name,
+							argument.type });
+				}
+
+				ShaderAPIMode::Stage::StageFunction stage_function = {
+					name_to_stage_function.key,
+					arguments,
+					name_to_stage_function.value.return_type,
+					name_to_stage_function.value.skip_function
+				};
+				stage_functions.push_back(stage_function);
+			}
+
+			ShaderAPIMode::Stage stage = {
+				name_to_function_info.key,
+				built_ins,
+				stage_functions,
+				function_info.can_discard,
+				function_info.main_function
+			};
+
+			stages.push_back(stage);
+		}
+
+		ShaderAPIMode mode = {
+			types_list.get(shader_index),
+			stages,
+			shader_types->get_modes(shader_mode),
+			shader_types->get_stencil_modes(shader_mode),
+		};
+
+		modes.push_back(mode);
+	}
+
+	return modes;
+}
+
+Vector<GDShaderAPIDump::ShaderAPIFunction> GDShaderAPIDump::generate_functions() {
+	HashMap<String, Vector<ShaderAPIFunction::Overload>> function_overloads;
+
+	HashMap<String, Vector<int>> out_args = collect_out_arguments();
+	HashMap<String, const ShaderLanguage::BuiltinFuncConstArgs *> const_int_args = collect_const_int_arguments();
+
+	int idx = 0;
+	while (ShaderLanguage::builtin_func_defs[idx].name) {
+		const ShaderLanguage::BuiltinFuncDef &def = ShaderLanguage::builtin_func_defs[idx];
+
+		String function_name = String(def.name);
+
+		Vector<ShaderAPIFunction::Overload::Argument> arguments;
+		int argument_idx = 0;
+		const Vector<int> *out_arg_indexes = out_args.getptr(function_name);
+		const ShaderLanguage::BuiltinFuncConstArgs **const_int_arg = const_int_args.getptr(function_name);
+		while (def.args[argument_idx] != ShaderLanguage::DataType::TYPE_VOID) {
+			bool is_out = out_arg_indexes != nullptr ? out_arg_indexes->has(argument_idx) : false;
+
+			const ShaderLanguage::BuiltinFuncConstArgs *const_data = nullptr;
+			if (const_int_arg != nullptr && (*const_int_arg)->arg == argument_idx) {
+				const_data = (*const_int_arg);
+			}
+
+			ShaderAPIFunction::Overload::Argument argument = {
+				String(def.args_names[argument_idx]),
+				def.args[argument_idx],
+				is_out,
+				const_data
+			};
+			arguments.push_back(argument);
+
+			argument_idx++;
+		}
+
+		// add overload to function
+		ShaderAPIFunction::Overload overload = {
+			arguments,
+			def.rettype,
+			def.high_end
+		};
+
+		if (function_overloads.has(function_name)) {
+			function_overloads.get(function_name).push_back(overload);
+		} else {
+			function_overloads.insert(function_name, Vector({ overload }));
+		}
+
+		idx++;
+	}
+
+	Vector<ShaderAPIFunction> functions;
+
+	HashSet<String> frag_only_functions = collect_frag_only_functions();
+	for (KeyValue<String, Vector<GDShaderAPIDump::ShaderAPIFunction::Overload>> &f : function_overloads) {
+		String name = f.key;
+		ShaderAPIFunction function = {
+			name,
+			f.value,
+			frag_only_functions.has(name)
+		};
+		functions.push_back(function);
+	}
+
+	return functions;
+}
+
+// The key is the function name.
+// The value is a list of argument indexes that are "out".
+HashMap<String, Vector<int>> GDShaderAPIDump::collect_out_arguments() {
+	HashMap<String, Vector<int>> out_args;
+	int idx = 0;
+	while (ShaderLanguage::builtin_func_out_args[idx].name) {
+		const ShaderLanguage::BuiltinFuncOutArgs &args = ShaderLanguage::builtin_func_out_args[idx];
+		Vector<int> argument_indexes;
+		for (int i = 0; i < ShaderLanguage::BuiltinFuncOutArgs::MAX_ARGS; i++) {
+			if (args.arguments[i] >= 0) {
+				argument_indexes.push_back(args.arguments[i]);
+			}
+		}
+		out_args.insert(String(args.name), argument_indexes);
+		idx++;
+	}
+	return out_args;
+}
+
+// The key is the function name.
+// The value is a reference to the BuiltinFuncConstArgs where the argument index, min, and max can be obtained.
+HashMap<String, const ShaderLanguage::BuiltinFuncConstArgs *> GDShaderAPIDump::collect_const_int_arguments() {
+	HashMap<String, const ShaderLanguage::BuiltinFuncConstArgs *> const_int_args;
+	int idx = 0;
+	while (ShaderLanguage::builtin_func_const_args[idx].name) {
+		const ShaderLanguage::BuiltinFuncConstArgs &arg = ShaderLanguage::builtin_func_const_args[idx];
+		const_int_args.insert(String(arg.name), &arg);
+		idx++;
+	}
+	return const_int_args;
+}
+
+HashSet<String> GDShaderAPIDump::collect_frag_only_functions() {
+	HashSet<String> frag_only_functions;
+	int idx = 0;
+	while (ShaderLanguage::builtin_func_const_args[idx].name) {
+		const ShaderLanguage::BuiltinEntry &entry = ShaderLanguage::frag_only_func_defs[idx];
+		frag_only_functions.insert(String(entry.name));
+		idx++;
+	}
+	return frag_only_functions;
+}
+
+String GDShaderAPIDump::get_operator_name(ShaderLanguage::Operator p_op) {
+	switch (p_op) {
+		case ShaderLanguage::Operator::OP_NEGATE:
+			return "unary-";
+		case ShaderLanguage::Operator::OP_POST_INCREMENT:
+			return "post++";
+		case ShaderLanguage::Operator::OP_POST_DECREMENT:
+			return "post--";
+		default:
+			break;
+	}
+	return ShaderLanguage::get_operator_text(p_op);
+}
+
+Dictionary GDShaderAPIDump::api_to_dictionary(const ShaderAPI &p_api) {
+	Dictionary api_dictionary;
+
+	// datatypes
+	{
+		Array datatypes_array;
+		for (const ShaderAPIDatatype &datatype : p_api.datatypes) {
+			datatypes_array.push_back(api_datatype_to_dictionary(datatype));
+		}
+		api_dictionary["datatypes"] = datatypes_array;
+	}
+
+	// modes
+	{
+		Array modes_array;
+		for (const ShaderAPIMode &mode : p_api.modes) {
+			modes_array.push_back(api_mode_to_dictionary(mode));
+		}
+		api_dictionary["modes"] = modes_array;
+	}
+
+	// functions
+	{
+		Array functions_array;
+		for (const ShaderAPIFunction &function : p_api.functions) {
+			functions_array.push_back(api_function_to_dictionary(function));
+		}
+		api_dictionary["functions"] = functions_array;
+	}
+
+	return api_dictionary;
+}
+
+Dictionary GDShaderAPIDump::api_datatype_to_dictionary(const ShaderAPIDatatype &p_datatype) {
+	Dictionary datatype;
+	datatype["name"] = p_datatype.name;
+	datatype["indexing_return_type"] = ShaderLanguage::get_datatype_name(p_datatype.indexing_return_type);
+	datatype["size"] = p_datatype.size;
+	datatype["component_count"] = p_datatype.component_count;
+	datatype["indexing_size"] = p_datatype.indexing_size;
+	datatype["swizzle_field_count"] = p_datatype.swizzle_field_count;
+	datatype["is_scalar"] = p_datatype.is_scalar;
+	datatype["is_float"] = p_datatype.is_float;
+	datatype["is_sampler"] = p_datatype.is_sampler;
+
+	Array operators;
+	for (const ShaderAPIDatatype::Operator &op : p_datatype.operators) {
+		Dictionary operator_data;
+		operator_data["name"] = op.name;
+		operator_data["return_type"] = ShaderLanguage::get_datatype_name(op.return_type);
+		if (op.right_type != ShaderLanguage::DataType::TYPE_VOID) {
+			operator_data["right_type"] = ShaderLanguage::get_datatype_name(op.right_type);
+		}
+		operators.push_back(operator_data);
+	}
+	datatype["operators"] = operators;
+
+	return datatype;
+}
+
+Dictionary GDShaderAPIDump::api_mode_to_dictionary(const ShaderAPIMode &p_mode) {
+	const auto mode_to_dictionary = [](const ShaderLanguage::ModeInfo &mode) -> Dictionary {
+		Dictionary mode_data;
+		mode_data["name"] = mode.name;
+		if (!mode.options.is_empty()) {
+			Array options;
+			for (const StringName &option : mode.options) {
+				options.push_back(option);
+			}
+			mode_data["options"] = options;
+		}
+		return mode_data;
+	};
+
+	Dictionary mode;
+	mode["name"] = p_mode.name;
+
+	Array stages;
+	for (const ShaderAPIMode::Stage &function : p_mode.stages) {
+		Dictionary function_data;
+		function_data["name"] = function.name;
+		function_data["can_discard"] = function.can_discard;
+		function_data["main_function"] = function.main_function;
+
+		// built_ins
+		Array built_ins;
+		for (const ShaderAPIMode::Stage::BuiltIn &built_in : function.built_ins) {
+			Dictionary built_in_data;
+			built_in_data["name"] = built_in.name;
+			built_in_data["type"] = ShaderLanguage::get_datatype_name(built_in.type);
+			built_in_data["constant"] = built_in.constant;
+			if (!built_in.values.is_empty()) {
+				Array values;
+				for (const ShaderLanguage::Scalar &value : built_in.values) {
+					switch (built_in.type) {
+						case ShaderLanguage::TYPE_BOOL:
+							values.push_back(value.boolean);
+							break;
+						case ShaderLanguage::TYPE_INT:
+							values.push_back(value.sint);
+							break;
+						case ShaderLanguage::TYPE_UINT:
+							values.push_back(value.uint);
+							break;
+						default:
+							values.push_back(value.real);
+							break;
+					}
+				}
+				built_in_data["values"] = values;
+			}
+			built_ins.push_back(built_in_data);
+		}
+		function_data["built_ins"] = built_ins;
+
+		// stage_functions
+		Array stage_functions;
+		for (const ShaderAPIMode::Stage::StageFunction &stage_function : function.stage_functions) {
+			Dictionary stage_function_data;
+			stage_function_data["name"] = stage_function.name;
+			stage_function_data["return_type"] = ShaderLanguage::get_datatype_name(stage_function.return_type);
+			stage_function_data["skip_function"] = stage_function.skip_function;
+
+			Array arguments;
+			for (const ShaderAPIMode::Stage::StageFunction::Argument &argument : stage_function.arguments) {
+				Dictionary argument_data;
+				argument_data["name"] = argument.name;
+				argument_data["type"] = ShaderLanguage::get_datatype_name(argument.type);
+				arguments.push_back(argument_data);
+			}
+			stage_function_data["arguments"] = arguments;
+
+			stage_functions.push_back(stage_function_data);
+		}
+		function_data["stage_functions"] = stage_functions;
+
+		stages.push_back(function_data);
+	}
+	mode["stages"] = stages;
+
+	Array modes;
+	for (const ShaderLanguage::ModeInfo &render_mode : p_mode.render_modes) {
+		modes.push_back(mode_to_dictionary(render_mode));
+	}
+	mode["render_modes"] = modes;
+
+	Array stencil_modes;
+	for (const ShaderLanguage::ModeInfo &stencil_mode : p_mode.stencil_modes) {
+		stencil_modes.push_back(mode_to_dictionary(stencil_mode));
+	}
+	mode["stencil_modes"] = stencil_modes;
+
+	return mode;
+}
+
+Dictionary GDShaderAPIDump::api_function_to_dictionary(const ShaderAPIFunction &p_function) {
+	Dictionary function;
+	function["name"] = p_function.name;
+	function["is_frag_only"] = p_function.is_frag_only;
+
+	Array overloads;
+	for (const ShaderAPIFunction::Overload &overload : p_function.overloads) {
+		Dictionary overload_data;
+
+		Array arguments;
+		for (const ShaderAPIFunction::Overload::Argument &argument : overload.arguments) {
+			Dictionary argument_data;
+			argument_data["name"] = argument.name;
+			argument_data["type"] = ShaderLanguage::get_datatype_name(argument.type);
+			argument_data["is_out"] = argument.is_out;
+			argument_data["is_const"] = argument.const_data != nullptr;
+			if (argument.const_data != nullptr) {
+				argument_data["min"] = argument.const_data->min;
+				argument_data["max"] = argument.const_data->max;
+			}
+			arguments.push_back(argument_data);
+		}
+		overload_data["arguments"] = arguments;
+
+		overload_data["return_type"] = ShaderLanguage::get_datatype_name(overload.return_type);
+		overload_data["is_high_end"] = overload.is_high_end;
+
+		overloads.push_back(overload_data);
+	}
+	function["overloads"] = overloads;
+
+	return function;
+}
+#endif

--- a/servers/rendering/shader_api_dump.h
+++ b/servers/rendering/shader_api_dump.h
@@ -1,0 +1,147 @@
+/**************************************************************************/
+/*  shader_api_dump.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "servers/rendering/shader_language.h"
+
+#ifdef TOOLS_ENABLED
+
+class GDShaderAPIDump {
+public:
+	static Dictionary generate_shader_api();
+	static void generate_shader_json_file(const String &p_path);
+
+private:
+	// datatypes
+
+	struct ShaderAPIDatatype {
+		struct Operator {
+			String name;
+			ShaderLanguage::DataType return_type;
+			ShaderLanguage::DataType right_type;
+		};
+
+		String name;
+		ShaderLanguage::DataType indexing_return_type;
+		Vector<Operator> operators;
+		uint32_t size;
+		uint32_t component_count;
+		uint32_t indexing_size;
+		uint32_t swizzle_field_count;
+		bool is_scalar;
+		bool is_float;
+		bool is_sampler;
+	};
+
+	// modes
+
+	struct ShaderAPIMode {
+		struct Stage {
+			struct BuiltIn {
+				StringName name;
+				ShaderLanguage::DataType type;
+				bool constant;
+				Vector<ShaderLanguage::Scalar> values;
+			};
+
+			struct StageFunction {
+				struct Argument {
+					StringName name;
+					ShaderLanguage::DataType type;
+				};
+
+				StringName name;
+				Vector<Argument> arguments;
+				ShaderLanguage::DataType return_type;
+				String skip_function;
+			};
+
+			StringName name;
+			Vector<BuiltIn> built_ins;
+			Vector<StageFunction> stage_functions;
+			bool can_discard;
+			bool main_function;
+		};
+
+		String name;
+		Vector<Stage> stages;
+		Vector<ShaderLanguage::ModeInfo> render_modes;
+		Vector<ShaderLanguage::ModeInfo> stencil_modes;
+	};
+
+	// functions
+
+	struct ShaderAPIFunction {
+		struct Overload {
+			struct Argument {
+				String name;
+				ShaderLanguage::DataType type;
+				bool is_out;
+
+				// if not nullptr, this argument is const.
+				// min and max can be referenced from the pointer.
+				const ShaderLanguage::BuiltinFuncConstArgs *const_data;
+			};
+
+			Vector<Argument> arguments;
+			ShaderLanguage::DataType return_type;
+			bool is_high_end;
+		};
+
+		String name;
+		Vector<Overload> overloads;
+		bool is_frag_only;
+	};
+
+	// api
+
+	struct ShaderAPI {
+		Vector<ShaderAPIDatatype> datatypes;
+		Vector<ShaderAPIMode> modes;
+		Vector<ShaderAPIFunction> functions;
+	};
+
+	static Vector<ShaderAPIDatatype> generate_datatypes();
+	static Vector<ShaderAPIMode> generate_modes();
+	static Vector<ShaderAPIFunction> generate_functions();
+
+	static HashMap<String, Vector<int>> collect_out_arguments();
+	static HashMap<String, const ShaderLanguage::BuiltinFuncConstArgs *> collect_const_int_arguments();
+	static HashSet<String> collect_frag_only_functions();
+
+	static String get_operator_name(ShaderLanguage::Operator p_op);
+
+	static Dictionary api_to_dictionary(const ShaderAPI &p_api);
+	static Dictionary api_datatype_to_dictionary(const ShaderAPIDatatype &p_datatype);
+	static Dictionary api_mode_to_dictionary(const ShaderAPIMode &p_mode);
+	static Dictionary api_function_to_dictionary(const ShaderAPIFunction &p_function);
+};
+#endif

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -1563,195 +1563,19 @@ bool ShaderLanguage::_validate_operator(const BlockNode *p_block, const Function
 
 	switch (p_op->op) {
 		case OP_EQUAL:
-		case OP_NOT_EQUAL: {
-			if ((!p_op->arguments[0]->is_indexed() && p_op->arguments[0]->get_array_size() > 0) || (!p_op->arguments[1]->is_indexed() && p_op->arguments[1]->get_array_size() > 0)) {
-				break; // don't accept arrays
-			}
-
-			DataType na = p_op->arguments[0]->get_datatype();
-			DataType nb = p_op->arguments[1]->get_datatype();
-			valid = na == nb;
-			ret_type = TYPE_BOOL;
-		} break;
+		case OP_NOT_EQUAL:
 		case OP_LESS:
 		case OP_LESS_EQUAL:
 		case OP_GREATER:
-		case OP_GREATER_EQUAL: {
-			if ((!p_op->arguments[0]->is_indexed() && p_op->arguments[0]->get_array_size() > 0) || (!p_op->arguments[1]->is_indexed() && p_op->arguments[1]->get_array_size() > 0)) {
-				break; // don't accept arrays
-			}
-
-			DataType na = p_op->arguments[0]->get_datatype();
-			DataType nb = p_op->arguments[1]->get_datatype();
-
-			valid = na == nb && (na == TYPE_UINT || na == TYPE_INT || na == TYPE_FLOAT);
-			ret_type = TYPE_BOOL;
-
-		} break;
+		case OP_GREATER_EQUAL:
 		case OP_AND:
-		case OP_OR: {
-			if ((!p_op->arguments[0]->is_indexed() && p_op->arguments[0]->get_array_size() > 0) || (!p_op->arguments[1]->is_indexed() && p_op->arguments[1]->get_array_size() > 0)) {
-				break; // don't accept arrays
-			}
-
-			DataType na = p_op->arguments[0]->get_datatype();
-			DataType nb = p_op->arguments[1]->get_datatype();
-
-			valid = na == nb && na == TYPE_BOOL;
-			ret_type = TYPE_BOOL;
-
-		} break;
-		case OP_NOT: {
-			if (!p_op->arguments[0]->is_indexed() && p_op->arguments[0]->get_array_size() > 0) {
-				break; // don't accept arrays
-			}
-
-			DataType na = p_op->arguments[0]->get_datatype();
-			valid = na == TYPE_BOOL;
-			ret_type = TYPE_BOOL;
-
-		} break;
-		case OP_INCREMENT:
-		case OP_DECREMENT:
-		case OP_POST_INCREMENT:
-		case OP_POST_DECREMENT:
-		case OP_NEGATE: {
-			if (!p_op->arguments[0]->is_indexed() && p_op->arguments[0]->get_array_size() > 0) {
-				break; // don't accept arrays
-			}
-
-			DataType na = p_op->arguments[0]->get_datatype();
-			valid = na > TYPE_BVEC4 && na < TYPE_MAT2;
-			ret_type = na;
-		} break;
+		case OP_OR:
 		case OP_ADD:
 		case OP_SUB:
 		case OP_MUL:
-		case OP_DIV: {
-			if ((!p_op->arguments[0]->is_indexed() && p_op->arguments[0]->get_array_size() > 0) || (!p_op->arguments[1]->is_indexed() && p_op->arguments[1]->get_array_size() > 0)) {
-				break; // don't accept arrays
-			}
-
-			DataType na = p_op->arguments[0]->get_datatype();
-			DataType nb = p_op->arguments[1]->get_datatype();
-
-			if (na > nb) {
-				//make things easier;
-				SWAP(na, nb);
-			}
-
-			if (na == nb) {
-				valid = (na > TYPE_BVEC4 && na <= TYPE_MAT4);
-				ret_type = na;
-			} else if (na == TYPE_INT && nb == TYPE_IVEC2) {
-				valid = true;
-				ret_type = TYPE_IVEC2;
-			} else if (na == TYPE_INT && nb == TYPE_IVEC3) {
-				valid = true;
-				ret_type = TYPE_IVEC3;
-			} else if (na == TYPE_INT && nb == TYPE_IVEC4) {
-				valid = true;
-				ret_type = TYPE_IVEC4;
-			} else if (na == TYPE_UINT && nb == TYPE_UVEC2) {
-				valid = true;
-				ret_type = TYPE_UVEC2;
-			} else if (na == TYPE_UINT && nb == TYPE_UVEC3) {
-				valid = true;
-				ret_type = TYPE_UVEC3;
-			} else if (na == TYPE_UINT && nb == TYPE_UVEC4) {
-				valid = true;
-				ret_type = TYPE_UVEC4;
-			} else if (na == TYPE_FLOAT && nb == TYPE_VEC2) {
-				valid = true;
-				ret_type = TYPE_VEC2;
-			} else if (na == TYPE_FLOAT && nb == TYPE_VEC3) {
-				valid = true;
-				ret_type = TYPE_VEC3;
-			} else if (na == TYPE_FLOAT && nb == TYPE_VEC4) {
-				valid = true;
-				ret_type = TYPE_VEC4;
-			} else if (na == TYPE_FLOAT && nb == TYPE_MAT2) {
-				valid = true;
-				ret_type = TYPE_MAT2;
-			} else if (na == TYPE_FLOAT && nb == TYPE_MAT3) {
-				valid = true;
-				ret_type = TYPE_MAT3;
-			} else if (na == TYPE_FLOAT && nb == TYPE_MAT4) {
-				valid = true;
-				ret_type = TYPE_MAT4;
-			} else if (p_op->op == OP_MUL && na == TYPE_VEC2 && nb == TYPE_MAT2) {
-				valid = true;
-				ret_type = TYPE_VEC2;
-			} else if (p_op->op == OP_MUL && na == TYPE_VEC3 && nb == TYPE_MAT3) {
-				valid = true;
-				ret_type = TYPE_VEC3;
-			} else if (p_op->op == OP_MUL && na == TYPE_VEC4 && nb == TYPE_MAT4) {
-				valid = true;
-				ret_type = TYPE_VEC4;
-			}
-		} break;
+		case OP_DIV:
 		case OP_ASSIGN_MOD:
-		case OP_MOD: {
-			/*
-			 * The operator modulus (%) operates on signed or unsigned integers or integer vectors. The operand
-			 * types must both be signed or both be unsigned. The operands cannot be vectors of differing size. If
-			 * one operand is a scalar and the other vector, then the scalar is applied component-wise to the vector,
-			 * resulting in the same type as the vector. If both are vectors of the same size, the result is computed
-			 * component-wise.
-			 */
-
-			if ((!p_op->arguments[0]->is_indexed() && p_op->arguments[0]->get_array_size() > 0) || (!p_op->arguments[1]->is_indexed() && p_op->arguments[1]->get_array_size() > 0)) {
-				break; // don't accept arrays
-			}
-
-			DataType na = p_op->arguments[0]->get_datatype();
-			DataType nb = p_op->arguments[1]->get_datatype();
-
-			if (na == TYPE_INT && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_INT;
-			} else if (na == TYPE_IVEC2 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC2;
-			} else if (na == TYPE_IVEC3 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC3;
-			} else if (na == TYPE_IVEC4 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC4;
-			} else if (na == TYPE_IVEC2 && nb == TYPE_IVEC2) {
-				valid = true;
-				ret_type = TYPE_IVEC2;
-			} else if (na == TYPE_IVEC3 && nb == TYPE_IVEC3) {
-				valid = true;
-				ret_type = TYPE_IVEC3;
-			} else if (na == TYPE_IVEC4 && nb == TYPE_IVEC4) {
-				valid = true;
-				ret_type = TYPE_IVEC4;
-				/////
-			} else if (na == TYPE_UINT && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UINT;
-			} else if (na == TYPE_UVEC2 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC2;
-			} else if (na == TYPE_UVEC3 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC3;
-			} else if (na == TYPE_UVEC4 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC4;
-			} else if (na == TYPE_UVEC2 && nb == TYPE_UVEC2) {
-				valid = true;
-				ret_type = TYPE_UVEC2;
-			} else if (na == TYPE_UVEC3 && nb == TYPE_UVEC3) {
-				valid = true;
-				ret_type = TYPE_UVEC3;
-			} else if (na == TYPE_UVEC4 && nb == TYPE_UVEC4) {
-				valid = true;
-				ret_type = TYPE_UVEC4;
-			}
-		} break;
+		case OP_MOD:
 		case OP_ASSIGN_SHIFT_LEFT:
 		case OP_ASSIGN_SHIFT_RIGHT:
 		case OP_SHIFT_LEFT:
@@ -1760,52 +1584,20 @@ bool ShaderLanguage::_validate_operator(const BlockNode *p_block, const Function
 				break; // don't accept arrays
 			}
 
-			DataType na = p_op->arguments[0]->get_datatype();
-			DataType nb = p_op->arguments[1]->get_datatype();
-
-			if (na == TYPE_INT && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_INT;
-			} else if (na == TYPE_IVEC2 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC2;
-			} else if (na == TYPE_IVEC3 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC3;
-			} else if (na == TYPE_IVEC4 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC4;
-			} else if (na == TYPE_IVEC2 && nb == TYPE_IVEC2) {
-				valid = true;
-				ret_type = TYPE_IVEC2;
-			} else if (na == TYPE_IVEC3 && nb == TYPE_IVEC3) {
-				valid = true;
-				ret_type = TYPE_IVEC3;
-			} else if (na == TYPE_IVEC4 && nb == TYPE_IVEC4) {
-				valid = true;
-				ret_type = TYPE_IVEC4;
-			} else if (na == TYPE_UINT && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UINT;
-			} else if (na == TYPE_UVEC2 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC2;
-			} else if (na == TYPE_UVEC3 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC3;
-			} else if (na == TYPE_UVEC4 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC4;
-			} else if (na == TYPE_UVEC2 && nb == TYPE_UVEC2) {
-				valid = true;
-				ret_type = TYPE_UVEC2;
-			} else if (na == TYPE_UVEC3 && nb == TYPE_UVEC3) {
-				valid = true;
-				ret_type = TYPE_UVEC3;
-			} else if (na == TYPE_UVEC4 && nb == TYPE_UVEC4) {
-				valid = true;
-				ret_type = TYPE_UVEC4;
+			valid = get_datatype_operator_result(p_op->arguments[0]->get_datatype(), p_op->op, p_op->arguments[1]->get_datatype(), &ret_type, nullptr);
+		} break;
+		case OP_NOT:
+		case OP_INCREMENT:
+		case OP_DECREMENT:
+		case OP_POST_INCREMENT:
+		case OP_POST_DECREMENT:
+		case OP_NEGATE:
+		case OP_BIT_INVERT: {
+			if (!p_op->arguments[0]->is_indexed() && p_op->arguments[0]->get_array_size() > 0) {
+				break; // don't accept arrays
 			}
+
+			valid = get_datatype_operator_result(p_op->arguments[0]->get_datatype(), p_op->op, TYPE_VOID, &ret_type, nullptr);
 		} break;
 		case OP_ASSIGN: {
 			int sa = 0;
@@ -1833,86 +1625,13 @@ bool ShaderLanguage::_validate_operator(const BlockNode *p_block, const Function
 		case OP_ASSIGN_ADD:
 		case OP_ASSIGN_SUB:
 		case OP_ASSIGN_MUL:
-		case OP_ASSIGN_DIV: {
-			int sa = 0;
-			int sb = 0;
-			if (!p_op->arguments[0]->is_indexed()) {
-				sa = p_op->arguments[0]->get_array_size();
-			}
-			if (!p_op->arguments[1]->is_indexed()) {
-				sb = p_op->arguments[1]->get_array_size();
-			}
-			if (sa > 0 || sb > 0) {
-				break; // don't accept arrays
-			}
-
-			DataType na = p_op->arguments[0]->get_datatype();
-			DataType nb = p_op->arguments[1]->get_datatype();
-
-			if (na == nb) {
-				valid = (na > TYPE_BVEC4 && na <= TYPE_MAT4);
-				ret_type = na;
-			} else if (na == TYPE_IVEC2 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC2;
-			} else if (na == TYPE_IVEC3 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC3;
-			} else if (na == TYPE_IVEC4 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC4;
-			} else if (na == TYPE_UVEC2 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC2;
-			} else if (na == TYPE_UVEC3 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC3;
-			} else if (na == TYPE_UVEC4 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC4;
-			} else if (na == TYPE_VEC2 && nb == TYPE_FLOAT) {
-				valid = true;
-				ret_type = TYPE_VEC2;
-			} else if (na == TYPE_VEC3 && nb == TYPE_FLOAT) {
-				valid = true;
-				ret_type = TYPE_VEC3;
-			} else if (na == TYPE_VEC4 && nb == TYPE_FLOAT) {
-				valid = true;
-				ret_type = TYPE_VEC4;
-			} else if (na == TYPE_MAT2 && nb == TYPE_FLOAT) {
-				valid = true;
-				ret_type = TYPE_MAT2;
-			} else if (na == TYPE_MAT3 && nb == TYPE_FLOAT) {
-				valid = true;
-				ret_type = TYPE_MAT3;
-			} else if (na == TYPE_MAT4 && nb == TYPE_FLOAT) {
-				valid = true;
-				ret_type = TYPE_MAT4;
-			} else if (p_op->op == OP_ASSIGN_MUL && na == TYPE_VEC2 && nb == TYPE_MAT2) {
-				valid = true;
-				ret_type = TYPE_VEC2;
-			} else if (p_op->op == OP_ASSIGN_MUL && na == TYPE_VEC3 && nb == TYPE_MAT3) {
-				valid = true;
-				ret_type = TYPE_VEC3;
-			} else if (p_op->op == OP_ASSIGN_MUL && na == TYPE_VEC4 && nb == TYPE_MAT4) {
-				valid = true;
-				ret_type = TYPE_VEC4;
-			}
-		} break;
+		case OP_ASSIGN_DIV:
 		case OP_ASSIGN_BIT_AND:
 		case OP_ASSIGN_BIT_OR:
 		case OP_ASSIGN_BIT_XOR:
 		case OP_BIT_AND:
 		case OP_BIT_OR:
 		case OP_BIT_XOR: {
-			/*
-			 * The bitwise operators and (&), exclusive-or (^), and inclusive-or (|). The operands must be of type
-			 * signed or unsigned integers or integer vectors. The operands cannot be vectors of differing size. If
-			 * one operand is a scalar and the other a vector, the scalar is applied component-wise to the vector,
-			 * resulting in the same type as the vector. The fundamental types of the operands (signed or unsigned)
-			 * must match.
-			 */
-
 			int sa = 0;
 			int sb = 0;
 			if (!p_op->arguments[0]->is_indexed()) {
@@ -1925,67 +1644,7 @@ bool ShaderLanguage::_validate_operator(const BlockNode *p_block, const Function
 				break; // don't accept arrays
 			}
 
-			DataType na = p_op->arguments[0]->get_datatype();
-			DataType nb = p_op->arguments[1]->get_datatype();
-
-			if (na > nb && p_op->op >= OP_BIT_AND) {
-				//can swap for non assign
-				SWAP(na, nb);
-			}
-
-			if (na == TYPE_INT && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_INT;
-			} else if (na == TYPE_IVEC2 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC2;
-			} else if (na == TYPE_IVEC3 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC3;
-			} else if (na == TYPE_IVEC4 && nb == TYPE_INT) {
-				valid = true;
-				ret_type = TYPE_IVEC4;
-			} else if (na == TYPE_IVEC2 && nb == TYPE_IVEC2) {
-				valid = true;
-				ret_type = TYPE_IVEC2;
-			} else if (na == TYPE_IVEC3 && nb == TYPE_IVEC3) {
-				valid = true;
-				ret_type = TYPE_IVEC3;
-			} else if (na == TYPE_IVEC4 && nb == TYPE_IVEC4) {
-				valid = true;
-				ret_type = TYPE_IVEC4;
-				/////
-			} else if (na == TYPE_UINT && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UINT;
-			} else if (na == TYPE_UVEC2 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC2;
-			} else if (na == TYPE_UVEC3 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC3;
-			} else if (na == TYPE_UVEC4 && nb == TYPE_UINT) {
-				valid = true;
-				ret_type = TYPE_UVEC4;
-			} else if (na == TYPE_UVEC2 && nb == TYPE_UVEC2) {
-				valid = true;
-				ret_type = TYPE_UVEC2;
-			} else if (na == TYPE_UVEC3 && nb == TYPE_UVEC3) {
-				valid = true;
-				ret_type = TYPE_UVEC3;
-			} else if (na == TYPE_UVEC4 && nb == TYPE_UVEC4) {
-				valid = true;
-				ret_type = TYPE_UVEC4;
-			}
-		} break;
-		case OP_BIT_INVERT: { //unaries
-			if (!p_op->arguments[0]->is_indexed() && p_op->arguments[0]->get_array_size() > 0) {
-				break; // don't accept arrays
-			}
-
-			DataType na = p_op->arguments[0]->get_datatype();
-			valid = na >= TYPE_INT && na < TYPE_FLOAT;
-			ret_type = na;
+			valid = get_datatype_operator_result(p_op->arguments[0]->get_datatype(), p_op->op, p_op->arguments[1]->get_datatype(), &ret_type, nullptr);
 		} break;
 		case OP_SELECT_IF: {
 			int sa = 0;
@@ -5212,6 +4871,453 @@ uint32_t ShaderLanguage::get_datatype_component_count(ShaderLanguage::DataType p
 	return 0U;
 }
 
+ShaderLanguage::DataType ShaderLanguage::get_datatype_indexed_type(DataType p_type) {
+	switch (p_type) {
+		case TYPE_BVEC2:
+		case TYPE_BVEC3:
+		case TYPE_BVEC4:
+			return TYPE_BOOL;
+		case TYPE_VEC2:
+		case TYPE_VEC3:
+		case TYPE_VEC4:
+			return TYPE_FLOAT;
+		case TYPE_IVEC2:
+		case TYPE_IVEC3:
+		case TYPE_IVEC4:
+			return TYPE_INT;
+		case TYPE_UVEC2:
+		case TYPE_UVEC3:
+		case TYPE_UVEC4:
+			return TYPE_UINT;
+		case TYPE_MAT2:
+			return TYPE_VEC2;
+		case TYPE_MAT3:
+			return TYPE_VEC3;
+		case TYPE_MAT4:
+			return TYPE_VEC4;
+		default:
+			break;
+	}
+	return TYPE_VOID;
+}
+
+uint32_t ShaderLanguage::get_datatype_indexed_size(DataType p_type) {
+	switch (p_type) {
+		case TYPE_BVEC2:
+		case TYPE_VEC2:
+		case TYPE_IVEC2:
+		case TYPE_UVEC2:
+		case TYPE_MAT2:
+			return 2;
+		case TYPE_BVEC3:
+		case TYPE_VEC3:
+		case TYPE_IVEC3:
+		case TYPE_UVEC3:
+		case TYPE_MAT3:
+			return 3;
+		case TYPE_BVEC4:
+		case TYPE_VEC4:
+		case TYPE_IVEC4:
+		case TYPE_UVEC4:
+		case TYPE_MAT4:
+			return 4;
+		default:
+			break;
+	}
+	return 0;
+}
+
+uint32_t ShaderLanguage::get_datatype_swizzle_field_count(DataType p_type) {
+	switch (p_type) {
+		case TYPE_BVEC2:
+		case TYPE_IVEC2:
+		case TYPE_UVEC2:
+		case TYPE_VEC2:
+			return 2;
+		case TYPE_BVEC3:
+		case TYPE_IVEC3:
+		case TYPE_UVEC3:
+		case TYPE_VEC3:
+			return 3;
+		case TYPE_BVEC4:
+		case TYPE_IVEC4:
+		case TYPE_UVEC4:
+		case TYPE_VEC4:
+			return 4;
+		default:
+			break;
+	}
+	return 0;
+}
+
+bool ShaderLanguage::get_datatype_operator_result(DataType p_type, Operator p_op, DataType p_other_type, DataType *r_ret_type, bool *r_unary) {
+	bool valid = false;
+	bool unary = false;
+	DataType ret_type = TYPE_VOID;
+
+	switch (p_op) {
+		case OP_EQUAL:
+		case OP_NOT_EQUAL: {
+			valid = p_type == p_other_type;
+			ret_type = TYPE_BOOL;
+		} break;
+
+		case OP_LESS:
+		case OP_LESS_EQUAL:
+		case OP_GREATER:
+		case OP_GREATER_EQUAL: {
+			valid = p_type == p_other_type && (p_type == TYPE_UINT || p_type == TYPE_INT || p_type == TYPE_FLOAT);
+			ret_type = TYPE_BOOL;
+		} break;
+
+		case OP_AND:
+		case OP_OR: {
+			valid = p_type == p_other_type && p_type == TYPE_BOOL;
+			ret_type = TYPE_BOOL;
+		} break;
+
+		case OP_NOT: {
+			valid = p_type == TYPE_BOOL;
+			unary = true;
+			ret_type = TYPE_BOOL;
+		} break;
+
+		case OP_INCREMENT:
+		case OP_DECREMENT:
+		case OP_POST_INCREMENT:
+		case OP_POST_DECREMENT:
+		case OP_NEGATE: {
+			valid = p_type > TYPE_BVEC4 && p_type < TYPE_MAT2;
+			unary = true;
+			ret_type = p_type;
+		} break;
+
+		case OP_ADD:
+		case OP_SUB:
+		case OP_MUL:
+		case OP_DIV: {
+			DataType na = p_type;
+			DataType nb = p_other_type;
+
+			if (na > nb) {
+				//make things easier;
+				SWAP(na, nb);
+			}
+
+			if (na == nb) {
+				valid = (na > TYPE_BVEC4 && na <= TYPE_MAT4);
+				ret_type = na;
+			} else if (na == TYPE_INT && nb == TYPE_IVEC2) {
+				valid = true;
+				ret_type = TYPE_IVEC2;
+			} else if (na == TYPE_INT && nb == TYPE_IVEC3) {
+				valid = true;
+				ret_type = TYPE_IVEC3;
+			} else if (na == TYPE_INT && nb == TYPE_IVEC4) {
+				valid = true;
+				ret_type = TYPE_IVEC4;
+			} else if (na == TYPE_UINT && nb == TYPE_UVEC2) {
+				valid = true;
+				ret_type = TYPE_UVEC2;
+			} else if (na == TYPE_UINT && nb == TYPE_UVEC3) {
+				valid = true;
+				ret_type = TYPE_UVEC3;
+			} else if (na == TYPE_UINT && nb == TYPE_UVEC4) {
+				valid = true;
+				ret_type = TYPE_UVEC4;
+			} else if (na == TYPE_FLOAT && nb == TYPE_VEC2) {
+				valid = true;
+				ret_type = TYPE_VEC2;
+			} else if (na == TYPE_FLOAT && nb == TYPE_VEC3) {
+				valid = true;
+				ret_type = TYPE_VEC3;
+			} else if (na == TYPE_FLOAT && nb == TYPE_VEC4) {
+				valid = true;
+				ret_type = TYPE_VEC4;
+			} else if (na == TYPE_FLOAT && nb == TYPE_MAT2) {
+				valid = true;
+				ret_type = TYPE_MAT2;
+			} else if (na == TYPE_FLOAT && nb == TYPE_MAT3) {
+				valid = true;
+				ret_type = TYPE_MAT3;
+			} else if (na == TYPE_FLOAT && nb == TYPE_MAT4) {
+				valid = true;
+				ret_type = TYPE_MAT4;
+			} else if (p_op == OP_MUL && na == TYPE_VEC2 && nb == TYPE_MAT2) {
+				valid = true;
+				ret_type = TYPE_VEC2;
+			} else if (p_op == OP_MUL && na == TYPE_VEC3 && nb == TYPE_MAT3) {
+				valid = true;
+				ret_type = TYPE_VEC3;
+			} else if (p_op == OP_MUL && na == TYPE_VEC4 && nb == TYPE_MAT4) {
+				valid = true;
+				ret_type = TYPE_VEC4;
+			}
+		} break;
+
+		case OP_ASSIGN_MOD:
+		case OP_MOD: {
+			/*
+			 * The operator modulus (%) operates on signed or unsigned integers or integer vectors. The operand
+			 * types must both be signed or both be unsigned. The operands cannot be vectors of differing size. If
+			 * one operand is a scalar and the other vector, then the scalar is applied component-wise to the vector,
+			 * resulting in the same type as the vector. If both are vectors of the same size, the result is computed
+			 * component-wise.
+			 */
+
+			DataType na = p_type;
+			DataType nb = p_other_type;
+
+			if (na == TYPE_INT && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_INT;
+			} else if (na == TYPE_IVEC2 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC2;
+			} else if (na == TYPE_IVEC3 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC3;
+			} else if (na == TYPE_IVEC4 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC4;
+			} else if (na == TYPE_IVEC2 && nb == TYPE_IVEC2) {
+				valid = true;
+				ret_type = TYPE_IVEC2;
+			} else if (na == TYPE_IVEC3 && nb == TYPE_IVEC3) {
+				valid = true;
+				ret_type = TYPE_IVEC3;
+			} else if (na == TYPE_IVEC4 && nb == TYPE_IVEC4) {
+				valid = true;
+				ret_type = TYPE_IVEC4;
+				/////
+			} else if (na == TYPE_UINT && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UINT;
+			} else if (na == TYPE_UVEC2 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC2;
+			} else if (na == TYPE_UVEC3 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC3;
+			} else if (na == TYPE_UVEC4 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC4;
+			} else if (na == TYPE_UVEC2 && nb == TYPE_UVEC2) {
+				valid = true;
+				ret_type = TYPE_UVEC2;
+			} else if (na == TYPE_UVEC3 && nb == TYPE_UVEC3) {
+				valid = true;
+				ret_type = TYPE_UVEC3;
+			} else if (na == TYPE_UVEC4 && nb == TYPE_UVEC4) {
+				valid = true;
+				ret_type = TYPE_UVEC4;
+			}
+		} break;
+
+		case OP_ASSIGN_SHIFT_LEFT:
+		case OP_ASSIGN_SHIFT_RIGHT:
+		case OP_SHIFT_LEFT:
+		case OP_SHIFT_RIGHT: {
+			DataType na = p_type;
+			DataType nb = p_other_type;
+
+			if (na == TYPE_INT && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_INT;
+			} else if (na == TYPE_IVEC2 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC2;
+			} else if (na == TYPE_IVEC3 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC3;
+			} else if (na == TYPE_IVEC4 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC4;
+			} else if (na == TYPE_IVEC2 && nb == TYPE_IVEC2) {
+				valid = true;
+				ret_type = TYPE_IVEC2;
+			} else if (na == TYPE_IVEC3 && nb == TYPE_IVEC3) {
+				valid = true;
+				ret_type = TYPE_IVEC3;
+			} else if (na == TYPE_IVEC4 && nb == TYPE_IVEC4) {
+				valid = true;
+				ret_type = TYPE_IVEC4;
+			} else if (na == TYPE_UINT && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UINT;
+			} else if (na == TYPE_UVEC2 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC2;
+			} else if (na == TYPE_UVEC3 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC3;
+			} else if (na == TYPE_UVEC4 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC4;
+			} else if (na == TYPE_UVEC2 && nb == TYPE_UVEC2) {
+				valid = true;
+				ret_type = TYPE_UVEC2;
+			} else if (na == TYPE_UVEC3 && nb == TYPE_UVEC3) {
+				valid = true;
+				ret_type = TYPE_UVEC3;
+			} else if (na == TYPE_UVEC4 && nb == TYPE_UVEC4) {
+				valid = true;
+				ret_type = TYPE_UVEC4;
+			}
+		} break;
+
+		case OP_ASSIGN: {
+			valid = p_type == p_other_type;
+			ret_type = p_type;
+		} break;
+
+		case OP_ASSIGN_ADD:
+		case OP_ASSIGN_SUB:
+		case OP_ASSIGN_MUL:
+		case OP_ASSIGN_DIV: {
+			DataType na = p_type;
+			DataType nb = p_other_type;
+
+			if (na == nb) {
+				valid = (na > TYPE_BVEC4 && na <= TYPE_MAT4);
+				ret_type = na;
+			} else if (na == TYPE_IVEC2 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC2;
+			} else if (na == TYPE_IVEC3 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC3;
+			} else if (na == TYPE_IVEC4 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC4;
+			} else if (na == TYPE_UVEC2 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC2;
+			} else if (na == TYPE_UVEC3 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC3;
+			} else if (na == TYPE_UVEC4 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC4;
+			} else if (na == TYPE_VEC2 && nb == TYPE_FLOAT) {
+				valid = true;
+				ret_type = TYPE_VEC2;
+			} else if (na == TYPE_VEC3 && nb == TYPE_FLOAT) {
+				valid = true;
+				ret_type = TYPE_VEC3;
+			} else if (na == TYPE_VEC4 && nb == TYPE_FLOAT) {
+				valid = true;
+				ret_type = TYPE_VEC4;
+			} else if (na == TYPE_MAT2 && nb == TYPE_FLOAT) {
+				valid = true;
+				ret_type = TYPE_MAT2;
+			} else if (na == TYPE_MAT3 && nb == TYPE_FLOAT) {
+				valid = true;
+				ret_type = TYPE_MAT3;
+			} else if (na == TYPE_MAT4 && nb == TYPE_FLOAT) {
+				valid = true;
+				ret_type = TYPE_MAT4;
+			} else if (p_op == OP_ASSIGN_MUL && na == TYPE_VEC2 && nb == TYPE_MAT2) {
+				valid = true;
+				ret_type = TYPE_VEC2;
+			} else if (p_op == OP_ASSIGN_MUL && na == TYPE_VEC3 && nb == TYPE_MAT3) {
+				valid = true;
+				ret_type = TYPE_VEC3;
+			} else if (p_op == OP_ASSIGN_MUL && na == TYPE_VEC4 && nb == TYPE_MAT4) {
+				valid = true;
+				ret_type = TYPE_VEC4;
+			}
+		} break;
+
+		case OP_ASSIGN_BIT_AND:
+		case OP_ASSIGN_BIT_OR:
+		case OP_ASSIGN_BIT_XOR:
+		case OP_BIT_AND:
+		case OP_BIT_OR:
+		case OP_BIT_XOR: {
+			/*
+			 * The bitwise operators and (&), exclusive-or (^), and inclusive-or (|). The operands must be of type
+			 * signed or unsigned integers or integer vectors. The operands cannot be vectors of differing size. If
+			 * one operand is a scalar and the other a vector, the scalar is applied component-wise to the vector,
+			 * resulting in the same type as the vector. The fundamental types of the operands (signed or unsigned)
+			 * must match.
+			 */
+
+			DataType na = p_type;
+			DataType nb = p_other_type;
+
+			if (na > nb && p_op >= OP_BIT_AND) {
+				//can swap for non assign
+				SWAP(na, nb);
+			}
+
+			if (na == TYPE_INT && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_INT;
+			} else if (na == TYPE_IVEC2 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC2;
+			} else if (na == TYPE_IVEC3 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC3;
+			} else if (na == TYPE_IVEC4 && nb == TYPE_INT) {
+				valid = true;
+				ret_type = TYPE_IVEC4;
+			} else if (na == TYPE_IVEC2 && nb == TYPE_IVEC2) {
+				valid = true;
+				ret_type = TYPE_IVEC2;
+			} else if (na == TYPE_IVEC3 && nb == TYPE_IVEC3) {
+				valid = true;
+				ret_type = TYPE_IVEC3;
+			} else if (na == TYPE_IVEC4 && nb == TYPE_IVEC4) {
+				valid = true;
+				ret_type = TYPE_IVEC4;
+				/////
+			} else if (na == TYPE_UINT && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UINT;
+			} else if (na == TYPE_UVEC2 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC2;
+			} else if (na == TYPE_UVEC3 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC3;
+			} else if (na == TYPE_UVEC4 && nb == TYPE_UINT) {
+				valid = true;
+				ret_type = TYPE_UVEC4;
+			} else if (na == TYPE_UVEC2 && nb == TYPE_UVEC2) {
+				valid = true;
+				ret_type = TYPE_UVEC2;
+			} else if (na == TYPE_UVEC3 && nb == TYPE_UVEC3) {
+				valid = true;
+				ret_type = TYPE_UVEC3;
+			} else if (na == TYPE_UVEC4 && nb == TYPE_UVEC4) {
+				valid = true;
+				ret_type = TYPE_UVEC4;
+			}
+		} break;
+
+		case OP_BIT_INVERT: {
+			valid = p_type >= TYPE_INT && p_type < TYPE_FLOAT;
+			unary = true;
+			ret_type = p_type;
+		} break;
+
+		default: {
+			break;
+		}
+	}
+
+	if (r_ret_type) {
+		*r_ret_type = ret_type;
+	}
+	if (r_unary) {
+		*r_unary = unary;
+	}
+
+	return valid;
+}
+
 void ShaderLanguage::get_keyword_list(List<String> *r_keywords) {
 	HashSet<String> kws;
 
@@ -7199,109 +7305,16 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						member_struct_name = expr->get_datatype_name();
 					}
 				} else {
-					switch (expr->get_datatype()) {
-						case TYPE_BVEC2:
-						case TYPE_VEC2:
-						case TYPE_IVEC2:
-						case TYPE_UVEC2:
-						case TYPE_MAT2:
-							if (index->type == Node::NODE_TYPE_CONSTANT) {
-								uint32_t index_constant = static_cast<ConstantNode *>(index)->values[0].uint;
-								if (index_constant >= 2) {
-									_set_error(vformat(RTR("Index [%d] out of range [%d..%d]."), index_constant, 0, 1));
-									return nullptr;
-								}
-							}
-
-							switch (expr->get_datatype()) {
-								case TYPE_BVEC2:
-									member_type = TYPE_BOOL;
-									break;
-								case TYPE_VEC2:
-									member_type = TYPE_FLOAT;
-									break;
-								case TYPE_IVEC2:
-									member_type = TYPE_INT;
-									break;
-								case TYPE_UVEC2:
-									member_type = TYPE_UINT;
-									break;
-								case TYPE_MAT2:
-									member_type = TYPE_VEC2;
-									break;
-								default:
-									break;
-							}
-
-							break;
-						case TYPE_BVEC3:
-						case TYPE_VEC3:
-						case TYPE_IVEC3:
-						case TYPE_UVEC3:
-						case TYPE_MAT3:
-							if (index->type == Node::NODE_TYPE_CONSTANT) {
-								uint32_t index_constant = static_cast<ConstantNode *>(index)->values[0].uint;
-								if (index_constant >= 3) {
-									_set_error(vformat(RTR("Index [%d] out of range [%d..%d]."), index_constant, 0, 2));
-									return nullptr;
-								}
-							}
-
-							switch (expr->get_datatype()) {
-								case TYPE_BVEC3:
-									member_type = TYPE_BOOL;
-									break;
-								case TYPE_VEC3:
-									member_type = TYPE_FLOAT;
-									break;
-								case TYPE_IVEC3:
-									member_type = TYPE_INT;
-									break;
-								case TYPE_UVEC3:
-									member_type = TYPE_UINT;
-									break;
-								case TYPE_MAT3:
-									member_type = TYPE_VEC3;
-									break;
-								default:
-									break;
-							}
-							break;
-						case TYPE_BVEC4:
-						case TYPE_VEC4:
-						case TYPE_IVEC4:
-						case TYPE_UVEC4:
-						case TYPE_MAT4:
-							if (index->type == Node::NODE_TYPE_CONSTANT) {
-								uint32_t index_constant = static_cast<ConstantNode *>(index)->values[0].uint;
-								if (index_constant >= 4) {
-									_set_error(vformat(RTR("Index [%d] out of range [%d..%d]."), index_constant, 0, 3));
-									return nullptr;
-								}
-							}
-
-							switch (expr->get_datatype()) {
-								case TYPE_BVEC4:
-									member_type = TYPE_BOOL;
-									break;
-								case TYPE_VEC4:
-									member_type = TYPE_FLOAT;
-									break;
-								case TYPE_IVEC4:
-									member_type = TYPE_INT;
-									break;
-								case TYPE_UVEC4:
-									member_type = TYPE_UINT;
-									break;
-								case TYPE_MAT4:
-									member_type = TYPE_VEC4;
-									break;
-								default:
-									break;
-							}
-							break;
-						default: {
-							_set_error(vformat(RTR("An object of type '%s' can't be indexed."), (expr->get_datatype() == TYPE_STRUCT ? expr->get_datatype_name() : get_datatype_name(expr->get_datatype()))));
+					member_type = get_datatype_indexed_type(expr->get_datatype());
+					if (member_type == TYPE_VOID) {
+						_set_error(vformat(RTR("An object of type '%s' can't be indexed."), (expr->get_datatype() == TYPE_STRUCT ? expr->get_datatype_name() : get_datatype_name(expr->get_datatype()))));
+						return nullptr;
+					}
+					if (index->type == Node::NODE_TYPE_CONSTANT) {
+						uint32_t size = get_datatype_indexed_size(expr->get_datatype());
+						uint32_t index_constant = static_cast<ConstantNode *>(index)->values[0].uint;
+						if (index_constant >= size) {
+							_set_error(vformat(RTR("Index [%d] out of range [%d..%d]."), index_constant, 0, size - 1));
 							return nullptr;
 						}
 					}
@@ -11973,33 +11986,7 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 			const char coordt[4] = { 's', 't', 'p', 'q' };
 			const String theme_color_names[4] = { "axis_x_color", "axis_y_color", "axis_z_color", "axis_w_color" };
 
-			int limit = 0;
-
-			switch (completion_base) {
-				case TYPE_BVEC2:
-				case TYPE_IVEC2:
-				case TYPE_UVEC2:
-				case TYPE_VEC2: {
-					limit = 2;
-
-				} break;
-				case TYPE_BVEC3:
-				case TYPE_IVEC3:
-				case TYPE_UVEC3:
-				case TYPE_VEC3: {
-					limit = 3;
-
-				} break;
-				case TYPE_BVEC4:
-				case TYPE_IVEC4:
-				case TYPE_UVEC4:
-				case TYPE_VEC4: {
-					limit = 4;
-
-				} break;
-				default: {
-				}
-			}
+			int limit = get_datatype_swizzle_field_count(completion_base);
 
 			for (int i = 0; i < limit; i++) {
 				r_options->push_back(ScriptLanguage::CodeCompletionOption(String::chr(colv[i]), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT, ScriptLanguage::LOCATION_OTHER, theme_color_names[i]));

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -856,6 +856,10 @@ public:
 	static PropertyInfo uniform_to_property_info(const ShaderNode::Uniform &p_uniform);
 	static uint32_t get_datatype_size(DataType p_type);
 	static uint32_t get_datatype_component_count(DataType p_type);
+	static DataType get_datatype_indexed_type(DataType p_type);
+	static uint32_t get_datatype_indexed_size(DataType p_type);
+	static uint32_t get_datatype_swizzle_field_count(DataType p_type);
+	static bool get_datatype_operator_result(DataType p_type, Operator p_op, DataType p_other_type, DataType *r_ret_type, bool *r_unary);
 
 	static void get_keyword_list(List<String> *r_keywords);
 	static bool is_control_flow_keyword(String p_keyword);
@@ -965,6 +969,38 @@ public:
 		String file;
 		int line = 0;
 	};
+
+	struct BuiltinFuncDef {
+		enum { MAX_ARGS = 5 };
+		const char *name;
+		DataType rettype;
+		const DataType args[MAX_ARGS];
+		const char *args_names[MAX_ARGS];
+		SubClassTag tag;
+		bool high_end;
+	};
+
+	struct BuiltinFuncOutArgs { //arguments used as out in built in functions
+		enum { MAX_ARGS = 2 };
+		const char *name;
+		const int arguments[MAX_ARGS];
+	};
+
+	struct BuiltinFuncConstArgs {
+		const char *name;
+		int arg;
+		int min;
+		int max;
+	};
+
+	struct BuiltinEntry {
+		const char *name;
+	};
+
+	static const BuiltinFuncDef builtin_func_defs[];
+	static const BuiltinFuncOutArgs builtin_func_out_args[];
+	static const BuiltinFuncConstArgs builtin_func_const_args[];
+	static const BuiltinEntry frag_only_func_defs[];
 
 private:
 	struct KeyWord {
@@ -1142,33 +1178,6 @@ private:
 	Vector<Scalar> _eval_vector(const Vector<Scalar> &p_va, const Vector<Scalar> &p_vb, DataType p_left_type, DataType p_right_type, DataType p_ret_type, Operator p_op, bool &r_is_valid);
 	Vector<Scalar> _eval_vector_transform(const Vector<Scalar> &p_va, const Vector<Scalar> &p_vb, DataType p_left_type, DataType p_right_type, DataType p_ret_type);
 
-	struct BuiltinEntry {
-		const char *name;
-	};
-
-	struct BuiltinFuncDef {
-		enum { MAX_ARGS = 5 };
-		const char *name;
-		DataType rettype;
-		const DataType args[MAX_ARGS];
-		const char *args_names[MAX_ARGS];
-		SubClassTag tag;
-		bool high_end;
-	};
-
-	struct BuiltinFuncOutArgs { //arguments used as out in built in functions
-		enum { MAX_ARGS = 2 };
-		const char *name;
-		const int arguments[MAX_ARGS];
-	};
-
-	struct BuiltinFuncConstArgs {
-		const char *name;
-		int arg;
-		int min;
-		int max;
-	};
-
 	CompletionType completion_type;
 	ShaderNode::Uniform::Hint current_uniform_hint = ShaderNode::Uniform::HINT_NONE;
 	TextureFilter current_uniform_filter = FILTER_DEFAULT;
@@ -1192,10 +1201,6 @@ private:
 	bool is_discard_supported = false;
 
 	bool _get_completable_identifier(BlockNode *p_block, CompletionType p_type, StringName &identifier);
-	static const BuiltinFuncDef builtin_func_defs[];
-	static const BuiltinFuncOutArgs builtin_func_out_args[];
-	static const BuiltinFuncConstArgs builtin_func_const_args[];
-	static const BuiltinEntry frag_only_func_defs[];
 
 	static bool is_const_suffix_lut_initialized;
 


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/13808!

Adds the `--dump-shader-api` command line argument that generates a `shader_api.json` containing the entirety of the GDShader API (basically a shader equivalent of `--dump-extension-api`).

## Example

Here is the `shader_api.json` file that is generated on this build if you'd like to take a quick look:
[shader_api.json](https://github.com/user-attachments/files/24019966/shader_api.json)

### Data Type Example
Every built-in data type is documented. `mat3` looks like this:
```json
{
	"name": "mat3",
	"indexing_return_type": "vec3",
	"size": 48,
	"component_count": 9,
	"indexing_size": 3,
	"swizzle_field_count": 0,
	"is_scalar": false,
	"is_float": true,
	"is_sampler": false,
	"operators": [
		{
			"name": "==",
			"return_type": "bool",
			"right_type": "mat3"
		},
		{
			"name": "!=",
			"return_type": "bool",
			"right_type": "mat3"
		},
		...
	]
}
```

### Mode Example
Since constants/inputs are unique to certain modes (`spatial`, `canvas_item`, etc.) and even specific phases within those modes, each mode is documented. For example, the `particles` mode looks like this:
```json
{
	"name": "particles",
	"stages": [
		{
			"name": "start",
			"can_discard": false,
			"main_function": true,
			"built_ins": [
				{
					"name": "COLOR",
					"type": "vec4",
					"constant": false
				},
				{
					"name": "VELOCITY",
					"type": "vec3",
					"constant": false
				},
				{
					"name": "MASS",
					"type": "float",
					"constant": false
				},
				...
			],
			"stage_functions": [
				{
					"name": "emit_subparticle",
					"return_type": "bool",
					"skip_function": "",
					"arguments": [
						{
							"name": "xform",
							"type": "mat4"
						},
						{
							"name": "velocity",
							"type": "vec3"
						},
						...
					]
				}
			]
		},
		...
	]
}
```

### Function Example
Finally, functions that can be used anywhere are generated together. Each of its overloads are provided, listing precisely which argument combinations are valid and their return types. `sin` looks like this:
```json
{
	"name": "sin",
	"is_frag_only": false,
	"overloads": [
		{
			"arguments": [
				{
					"name": "angle",
					"type": "float",
					"is_out": false,
					"is_const": false
				}
			],
			"return_type": "float",
			"is_high_end": false
		},
		{
			"arguments": [
				{
					"name": "angle",
					"type": "vec2",
					"is_out": false,
					"is_const": false
				}
			],
			"return_type": "vec2",
			"is_high_end": false
		},
		...
	]
}
```

## JSON Structure

The `shader_api.json` structure currently looks like this. I've tried to use consistent naming with `extension_api.json` where possible.
```ts
{
    datatypes: Array<{
        name: string,
        indexing_return_type: string,
        size: number, // size of the type in memory
        component_count: number, // the number of scalars the type represents (ShaderLanguage::get_datatype_component_count)
        indexing_size: number, // the type can only be indexed within the rage of [0...indexing_size)
        swizzle_field_count: number, // the number of axes that can be swizzled; 0 if the type cannot swizzle
        is_scalar: boolean, // is bool, int, uint, or float
        is_float: boolean,
        is_sampler: boolean,
        operators: Array<{
            name: string,
            return_type: string,
            right_type?: string, // only defined if a binary operator
        }>,
    }>,
    modes: Array<{ // the different shader modes, i.e. spatial, canvas_item, sky, etc.
        name: string,
        render_modes: Array<{
            name: string,
            options?: Array<string>
        }>,
        stencil_modes: Array<{
            name: string,
            options?: Array<string>
        }>,
        stages: Array<{ // the mode's stages, i.e. vertex/fragment/light in spatial, or start/process in particles
            name: string,
            can_discard: boolean,
            main_function: boolean,
            built_ins: Array<{ // all the available built in input values, i.e. IN_SHADOW_PASS, VERTEX, etc.
                name: string,
                type: string,
                constant: boolean,
                values?: Array<boolean | number>,
            }>,
            stage_functions: Array<{ // functions unique to this specific mode and stage
                name: string,
                arguments: Array<{
                    name: string,
                    type: string,
                }>,
                return_type: string,
                skip_function: string,
            }>,
        }>,
    }>,
    functions: Array<{
        name: string,
        is_frag_only: boolean, // true if this function is a fragment-only function (in ShaderLanguage::frag_only_func_defs)
        overloads: Array<{
            return_type: string,
            is_high_end: boolean, // if true, this function isn't allowed in Compatibility (I think?); name based on ShaderLanguage::BuiltinFuncDef::high_end
            arguments: Array<{
                name: string,
                type: string,
                is_out: boolean, // true if argument is an "out" argument (in ShaderLanguage::builtin_func_out_args)
                is_const: boolean, // true if argument must be an int constant (in ShaderLanguage::builtin_func_const_args)
                min?: number, // only defined if is_const is true
                max?: number, // only defined if is_const is true
            }>,
        }>,
    }>,
}
```

## Changes to Existing Code

This PR mainly just adds the `shader_api_dump.cpp/h` files, but code in `shader_language.cpp/h` needed to be modified to provide access to information. The most drastic change was extracting the operator validation out of `_validate_operator` to create a more generic `get_datatype_operator_result` that validates an operation given one or two `DataType`s and an `Operator`.

