### PR TITLE
Fix Debugger Dock not opening and unused BottomPanel code

### DIFF
--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -39,7 +39,6 @@
 #include "editor/gui/editor_version_button.h"
 #include "editor/scene/editor_scene_tabs.h"
 #include "editor/settings/editor_command_palette.h"
-#include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/separator.h"
@@ -148,12 +147,6 @@ void EditorBottomPanel::make_item_visible(Control *p_item, bool p_visible, bool 
 	EditorDock *dock = _get_dock_from_control(p_item);
 	ERR_FAIL_NULL(dock);
 	dock->set_visible(p_visible);
-}
-
-void EditorBottomPanel::move_item_to_end(Control *p_item) {
-	EditorDock *dock = _get_dock_from_control(p_item);
-	ERR_FAIL_NULL(dock);
-	move_child(dock, -1);
 }
 
 void EditorBottomPanel::hide_bottom_panel() {

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -51,7 +51,6 @@ class EditorBottomPanel : public TabContainer {
 	int previous_tab = -1;
 	bool lock_panel_switching = false;
 	LocalVector<EditorDock *> bottom_docks;
-	LocalVector<Ref<Shortcut>> dock_shortcuts;
 	HashMap<String, int> dock_offsets;
 
 	LocalVector<Button *> legacy_buttons;
@@ -74,7 +73,6 @@ public:
 	Button *add_item(String p_text, Control *p_item, const Ref<Shortcut> &p_shortcut = nullptr, bool p_at_front = false);
 	void remove_item(Control *p_item);
 	void make_item_visible(Control *p_item, bool p_visible = true, bool p_ignore_lock = false);
-	void move_item_to_end(Control *p_item);
 	void hide_bottom_panel();
 	void toggle_last_opened_bottom_panel();
 	void set_expanded(bool p_expanded);

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -375,7 +375,7 @@ void EditorRunBar::_run_native(const Ref<EditorExportPreset> &p_preset) {
 
 void EditorRunBar::_profiler_autostart_indicator_pressed() {
 	// Switch to the first profiler tab in the bottom panel.
-	EditorNode::get_singleton()->get_bottom_panel()->make_item_visible(EditorDebuggerNode::get_singleton(), true);
+	EditorDebuggerNode::get_singleton()->make_visible();
 
 	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false)) {
 		EditorDebuggerNode::get_singleton()->get_current_debugger()->switch_to_debugger(3);

--- a/editor/scene/2d/polygon_2d_editor_plugin.h
+++ b/editor/scene/2d/polygon_2d_editor_plugin.h
@@ -84,7 +84,6 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	Polygon2D *node = nullptr;
 	Polygon2D *previous_node = nullptr;
 
-	Button *dock_button = nullptr;
 	EditorDock *polygon_edit = nullptr;
 	Mode current_mode = MODE_MAX; // Uninitialized.
 	Button *mode_buttons[MODE_MAX];


### PR DESCRIPTION
This PR fixes a missed call to `EditorBottomPanel::make_visible()` for the Debugger dock (that now will throw errors). It also removes code in `EditorBottomPanel` that wasn't properly removed during the refactors. For example since `EditorDockManager` now handles shortcuts for the bottom panel, the bottom panel no longer needs to store a list of the shortcuts.