### PR TITLE
Add `split_lines` to String

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1302,6 +1302,43 @@ Vector<int> String::split_ints_mk(const Vector<String> &p_splitters, bool p_allo
 	return ret;
 }
 
+Vector<String> String::split_lines() const {
+	Vector<String> ret;
+	if (is_empty()) {
+		return ret;
+	}
+	int from = 0;
+	int end = length();
+	int current = 0;
+	while (current < end) {
+		char32_t chr = get_data()[current];
+		if (chr == '\r') {
+			ret.append(substr(from, current - from));
+			if (current + 1 < end && get_data()[current + 1] == '\n') {
+				// CRLF
+				current += 2;
+				from = current; // Next line starts after \r\n
+			} else {
+				current++;
+				from = current; // Next line starts after \r
+			}
+		} else if (chr == '\n') {
+			ret.append(substr(from, current - from));
+			current++;
+			from = current; // Next line starts after \n
+		} else {
+			current++;
+		}
+	}
+
+	// Like Python, we drop the last empty line
+	if (from < end) {
+		ret.append(substr(from, end - from));
+	}
+
+	return ret;
+}
+
 String String::join(const Vector<String> &parts) const {
 	if (parts.is_empty()) {
 		return String();

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -489,6 +489,7 @@ public:
 	Vector<float> split_floats_mk(const Vector<String> &p_splitters, bool p_allow_empty = true) const;
 	Vector<int> split_ints(const String &p_splitter, bool p_allow_empty = true) const;
 	Vector<int> split_ints_mk(const Vector<String> &p_splitters, bool p_allow_empty = true) const;
+	Vector<String> split_lines() const;
 
 	String join(const Vector<String> &parts) const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2054,6 +2054,7 @@ static void _register_variant_builtin_methods_string() {
 	bind_string_methodv(split, static_cast<Vector<String> (String::*)(const String &, bool, int) const>(&String::split), sarray("delimiter", "allow_empty", "maxsplit"), varray("", true, 0));
 	bind_string_methodv(rsplit, static_cast<Vector<String> (String::*)(const String &, bool, int) const>(&String::rsplit), sarray("delimiter", "allow_empty", "maxsplit"), varray("", true, 0));
 	bind_string_method(split_floats, sarray("delimiter", "allow_empty"), varray(true));
+	bind_string_method(split_lines, sarray(), varray());
 	bind_string_method(join, sarray("parts"), varray());
 
 	bind_string_method(to_upper, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -990,6 +990,13 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="split_lines" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Splits the string into lines separated by line breaks. Line breaks include the newline ([code]\n[/code]) and the carriage return ([code]\r[/code]) characters.
+				[b]Note:[/b] If the last line is empty, it is not added to the result.
+			</description>
+		</method>
 		<method name="strip_edges" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="left" type="bool" default="true" />

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -891,6 +891,13 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="split_lines" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Splits the string into lines separated by line breaks. Line breaks include the newline ([code]\n[/code]) and the carriage return ([code]\r[/code]) characters.
+				[b]Note:[/b] If the last line is empty, it is not added to the result.
+			</description>
+		</method>
 		<method name="strip_edges" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="left" type="bool" default="true" />

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -858,6 +858,18 @@ TEST_CASE("[String] Splitting") {
 			CHECK(mk[i] == slices[i]);
 		}
 	}
+
+	{
+		const String s = "123\r\n\r\n456\n789\rABC\r\n\n";
+		const Vector<String> arr = s.split_lines();
+		CHECK(arr.size() == 6);
+		CHECK(arr[0] == "123");
+		CHECK(arr[1] == "");
+		CHECK(arr[2] == "456");
+		CHECK(arr[3] == "789");
+		CHECK(arr[4] == "ABC");
+		CHECK(arr[5] == "");
+	}
 }
 
 TEST_CASE("[String] format") {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Closes https://github.com/godotengine/godot-proposals/issues/9233

This PR adds the function `split_lines()` to String and StringName.

I've considered making the behavior identical to [Python's `splitlines()`](https://docs.python.org/3.13/library/stdtypes.html#str.splitlines), but Python's implementation covers not just CR/LF but also other obscure unicode linebreak characters, and the current `FileAccess.get_line()` implementation only checks CR/LF.

Therefore, `split_lines()` here behaves basically the same as storing the string into a file and then splitting the content into lines with `FileAccess.get_line()`. The exact behaviors are described in the updated documentation.

The `[String] Splitting` unit test has been expanded to cover this new function.