### PR TITLE
Codestyle: Remove unused private variables in `godot/editor`

### DIFF
--- a/editor/animation/animation_bezier_editor.h
+++ b/editor/animation/animation_bezier_editor.h
@@ -62,8 +62,6 @@ class AnimationBezierTrackEdit : public Control {
 	bool read_only = false;
 	int selected_track = -1;
 
-	Vector<Rect2> view_rects;
-
 	Ref<Texture2D> bezier_icon;
 	Ref<Texture2D> bezier_handle_icon;
 	Ref<Texture2D> selected_icon;
@@ -107,8 +105,6 @@ class AnimationBezierTrackEdit : public Control {
 	bool _is_track_displayed(int p_track_index);
 	bool _is_track_curves_displayed(int p_track_index);
 
-	Vector2 insert_at_pos;
-
 	typedef Pair<int, int> IntPair;
 
 	bool moving_selection_attempt = false;
@@ -141,7 +137,6 @@ class AnimationBezierTrackEdit : public Control {
 	int moving_handle_track = 0;
 	Vector2 moving_handle_left;
 	Vector2 moving_handle_right;
-	int moving_handle_mode = 0; // value from Animation::HandleMode
 
 	struct PairHasher {
 		static _FORCE_INLINE_ uint32_t hash(const Pair<int, int> &p_value) {

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -49,9 +49,6 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNodeBlendSpace1D> blend_space;
 	bool read_only = false;
 
-	HBoxContainer *goto_parent_hb = nullptr;
-	Button *goto_parent = nullptr;
-
 	PanelContainer *panel = nullptr;
 	Button *tool_blend = nullptr;
 	Button *tool_select = nullptr;

--- a/editor/animation/animation_track_editor_plugins.h
+++ b/editor/animation/animation_track_editor_plugins.h
@@ -34,8 +34,6 @@
 
 class AnimationTrackEditBool : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditBool, AnimationTrackEdit);
-	Ref<Texture2D> icon_checked;
-	Ref<Texture2D> icon_unchecked;
 
 public:
 	virtual int get_key_height() const override;

--- a/editor/debugger/debug_adapter/debug_adapter_server.h
+++ b/editor/debugger/debug_adapter/debug_adapter_server.h
@@ -39,7 +39,6 @@ class DebugAdapterServer : public EditorPlugin {
 	DebugAdapterProtocol protocol;
 
 	int remote_port = 6006;
-	bool thread_running = false;
 	bool started = false;
 	bool polling = false;
 	static void thread_func(void *p_userdata);

--- a/editor/debugger/editor_expression_evaluator.h
+++ b/editor/debugger/editor_expression_evaluator.h
@@ -36,15 +36,12 @@ class Button;
 class CheckBox;
 class EditorDebuggerInspector;
 class LineEdit;
-class RemoteDebuggerPeer;
 class ScriptEditorDebugger;
 
 class EditorExpressionEvaluator : public VBoxContainer {
 	GDCLASS(EditorExpressionEvaluator, VBoxContainer)
 
 private:
-	Ref<RemoteDebuggerPeer> peer;
-
 	LineEdit *expression_input = nullptr;
 	CheckBox *clear_on_run_checkbox = nullptr;
 	Button *evaluate_btn = nullptr;

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -124,8 +124,6 @@ private:
 	int total_metrics = 0;
 	int last_metric = -1;
 
-	int max_functions = 0;
-
 	bool updating_frame = false;
 
 	int hover_metric = -1;

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -112,17 +112,13 @@ class EditorHelp : public VBoxContainer {
 	int description_line = 0;
 
 	RichTextLabel *class_desc = nullptr;
-	HSplitContainer *h_split = nullptr;
 	inline static DocTools *doc = nullptr;
 	inline static DocTools *ext_doc = nullptr;
 
-	ConfirmationDialog *search_dialog = nullptr;
 	LineEdit *search = nullptr;
 	FindBar *find_bar = nullptr;
 	HBoxContainer *status_bar = nullptr;
 	Button *toggle_files_button = nullptr;
-
-	String base_path;
 
 	struct ThemeCache {
 		Ref<StyleBox> background_style;

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -177,7 +177,6 @@ private:
 	PackedStringArray searched_tokens;
 	Vector<String> uncollapsed_paths_before_search;
 
-	TextureRect *search_icon = nullptr;
 	HBoxContainer *path_hb = nullptr;
 
 	FileListDisplayMode file_list_display_mode;

--- a/editor/docks/import_dock.h
+++ b/editor/docks/import_dock.h
@@ -52,9 +52,6 @@ class ImportDock : public EditorDock {
 	MenuButton *preset = nullptr;
 	EditorInspector *import_opts = nullptr;
 
-	List<PropertyInfo> properties;
-	HashMap<StringName, Variant> property_values;
-
 	ConfirmationDialog *reimport_confirm = nullptr;
 	Label *cleanup_warning = nullptr;
 	Label *label_warning = nullptr;

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -130,7 +130,6 @@ class SceneTreeDock : public EditorDock {
 	SceneTreeEditor *scene_tree = nullptr;
 	Control *remote_tree = nullptr;
 
-	HBoxContainer *tool_hbc = nullptr;
 	void _tool_selected(int p_tool, bool p_confirm_override = false);
 	void _property_selected(int p_idx);
 
@@ -167,7 +166,6 @@ class SceneTreeDock : public EditorDock {
 
 	LineEdit *filter = nullptr;
 	PopupMenu *filter_quick_menu = nullptr;
-	TextureRect *filter_icon = nullptr;
 
 	PopupMenu *menu = nullptr;
 	PopupMenu *menu_subresources = nullptr;

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -88,7 +88,6 @@ class ProjectExportDialog : public ConfirmationDialog {
 
 	Label *empty_label = nullptr;
 
-	Button *button_export = nullptr;
 	bool updating = false;
 
 	RichTextLabel *result_dialog_log = nullptr;

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -172,7 +172,6 @@ class CodeTextEditor : public VBoxContainer {
 	Label *line_and_col_txt = nullptr;
 	Label *indentation_txt = nullptr;
 
-	Label *info = nullptr;
 	Timer *idle = nullptr;
 	float idle_time = 0.0f;
 	float idle_time_with_errors = 0.0f;

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -41,7 +41,6 @@ class EditorSpinSlider : public Range {
 	String suffix;
 	int updown_offset = -1;
 	bool hover_updown = false;
-	bool mouse_hover = false;
 
 	TextureRect *grabber = nullptr;
 	int grabber_range = 1;

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -117,7 +117,6 @@ private:
 	mutable const HashMap<StringName, Variant> *current_options = nullptr;
 	mutable const Dictionary *current_options_dict = nullptr;
 	List<ResourceImporter::ImportOption> *current_option_list = nullptr;
-	InternalImportCategory current_category = INTERNAL_IMPORT_CATEGORY_MAX;
 
 protected:
 	GDVIRTUAL1(_get_internal_import_options, int)

--- a/editor/import/fbx_importer_manager.h
+++ b/editor/import/fbx_importer_manager.h
@@ -39,7 +39,6 @@ class FBXImporterManager : public ConfirmationDialog {
 
 	bool is_importing = false;
 
-	Label *message = nullptr;
 	LineEdit *fbx_path = nullptr;
 	Button *fbx_path_browse = nullptr;
 	EditorFileDialog *browse_dialog = nullptr;

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -240,7 +240,6 @@ class EditorPropertyDictionary : public EditorProperty {
 	PanelContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
 	PanelContainer *add_panel = nullptr;
-	EditorSpinSlider *size_sliderv = nullptr;
 	Button *button_add_item = nullptr;
 	EditorPaginator *paginator = nullptr;
 	LocalVector<Slot> slots;

--- a/editor/scene/2d/tiles/atlas_merging_dialog.h
+++ b/editor/scene/2d/tiles/atlas_merging_dialog.h
@@ -54,7 +54,6 @@ private:
 
 	// GUI.
 	ItemList *atlas_merging_atlases_list = nullptr;
-	EditorPropertyVector2i *texture_region_size_editor_property = nullptr;
 	EditorPropertyInteger *columns_editor_property = nullptr;
 	TextureRect *preview = nullptr;
 	Label *select_2_atlases_label = nullptr;

--- a/editor/scene/2d/tiles/tile_atlas_view.h
+++ b/editor/scene/2d/tiles/tile_atlas_view.h
@@ -48,11 +48,6 @@ private:
 	Ref<TileSetAtlasSource> tile_set_atlas_source;
 	int source_id = TileSet::INVALID_SOURCE;
 
-	enum DragType {
-		DRAG_TYPE_NONE,
-		DRAG_TYPE_PAN,
-	};
-	DragType drag_type = DRAG_TYPE_NONE;
 	float previous_zoom = 1.0;
 	EditorZoomWidget *zoom_widget = nullptr;
 	Button *button_center_view = nullptr;

--- a/editor/scene/2d/tiles/tile_set_editor.h
+++ b/editor/scene/2d/tiles/tile_set_editor.h
@@ -97,7 +97,6 @@ private:
 	Label *patterns_help_label = nullptr;
 	void _patterns_item_list_gui_input(const Ref<InputEvent> &p_event);
 	void _pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture);
-	bool select_last_pattern = false;
 	void _update_patterns_list();
 
 	// Expanded editor.

--- a/editor/scene/3d/bone_map_editor_plugin.h
+++ b/editor/scene/3d/bone_map_editor_plugin.h
@@ -78,7 +78,6 @@ public:
 class BoneMapperItem : public VBoxContainer {
 	GDCLASS(BoneMapperItem, VBoxContainer);
 
-	int button_id = -1;
 	StringName profile_bone_name;
 
 	Ref<BoneMap> bone_map;

--- a/editor/scene/3d/camera_3d_editor_plugin.h
+++ b/editor/scene/3d/camera_3d_editor_plugin.h
@@ -39,7 +39,6 @@ class SubViewport;
 class Camera3DEditor : public Control {
 	GDCLASS(Camera3DEditor, Control);
 
-	Panel *panel = nullptr;
 	Button *preview = nullptr;
 	Node *node = nullptr;
 

--- a/editor/scene/3d/gizmos/gizmo_3d_helper.h
+++ b/editor/scene/3d/gizmos/gizmo_3d_helper.h
@@ -37,7 +37,6 @@ class Camera3D;
 class Gizmo3DHelper : public RefCounted {
 	GDCLASS(Gizmo3DHelper, RefCounted);
 
-	int current_handle_id;
 	Variant initial_value;
 	Transform3D initial_transform;
 

--- a/editor/scene/3d/polygon_3d_editor_plugin.h
+++ b/editor/scene/3d/polygon_3d_editor_plugin.h
@@ -64,8 +64,6 @@ class Polygon3DEditor : public HBoxContainer {
 	MeshInstance3D *pointsm = nullptr;
 	Ref<ArrayMesh> m;
 
-	MenuButton *options = nullptr;
-
 	int edited_point = 0;
 	Vector2 edited_point_pos;
 	PackedVector2Array pre_move_edit;

--- a/editor/scene/curve_editor_plugin.h
+++ b/editor/scene/curve_editor_plugin.h
@@ -111,7 +111,6 @@ private:
 	Transform2D _world_to_view;
 
 	Ref<Curve> curve;
-	PopupMenu *_presets_menu = nullptr;
 
 	int selected_index = -1;
 	int hovered_index = -1;

--- a/editor/scene/scene_tree_editor.h
+++ b/editor/scene/scene_tree_editor.h
@@ -111,7 +111,6 @@ class SceneTreeEditor : public Control {
 
 	Tree *tree = nullptr;
 	Node *selected = nullptr;
-	ObjectID instance_node;
 
 	String filter;
 	String filter_term_warning;

--- a/editor/script/script_create_dialog.h
+++ b/editor/script/script_create_dialog.h
@@ -63,7 +63,6 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	EditorFileDialog *file_browse = nullptr;
 	CheckBox *built_in = nullptr;
 	CheckBox *use_templates = nullptr;
-	VBoxContainer *path_vb = nullptr;
 	AcceptDialog *alert = nullptr;
 	CreateDialog *select_class = nullptr;
 
@@ -75,7 +74,6 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool supports_built_in = false;
 	bool can_inherit_from_file = false;
 	bool is_parent_name_valid = false;
-	bool is_class_name_valid = false;
 	bool is_built_in = false;
 	bool is_using_templates = true;
 	bool built_in_enabled = true;

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -327,7 +327,6 @@ class ScriptEditor : public PanelContainer {
 	MenuButton *debug_menu = nullptr;
 	PopupMenu *context_menu = nullptr;
 	Timer *autosave_timer = nullptr;
-	uint64_t idle = 0;
 
 	PopupMenu *recent_scripts = nullptr;
 	PopupMenu *theme_submenu = nullptr;
@@ -356,7 +355,6 @@ class ScriptEditor : public PanelContainer {
 	AcceptDialog *error_dialog = nullptr;
 	ConfirmationDialog *erase_tab_confirm = nullptr;
 	ScriptCreateDialog *script_create_dialog = nullptr;
-	Button *scripts_visible = nullptr;
 	FindReplaceBar *find_replace_bar = nullptr;
 
 	float zoom_factor = 1.0f;

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -74,8 +74,6 @@ class ScriptTextEditor : public ScriptEditorBase {
 
 	List<Connection> missing_connections;
 
-	Vector<String> member_keywords;
-
 	HBoxContainer *edit_hb = nullptr;
 
 	MenuButton *edit_menu = nullptr;

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -47,8 +47,6 @@ class TreeItem;
 class EditorSettingsDialog : public AcceptDialog {
 	GDCLASS(EditorSettingsDialog, AcceptDialog);
 
-	bool updating = false;
-
 	TabContainer *tabs = nullptr;
 	Control *tab_general = nullptr;
 	Control *tab_shortcuts = nullptr;

--- a/editor/settings/event_listener_line_edit.h
+++ b/editor/settings/event_listener_line_edit.h
@@ -47,7 +47,6 @@ class EventListenerLineEdit : public LineEdit {
 
 	int allowed_input_types = INPUT_KEY | INPUT_MOUSE_BUTTON | INPUT_JOY_BUTTON | INPUT_JOY_MOTION;
 	bool ignore_next_event = true;
-	bool share_keycodes = false;
 	Ref<InputEvent> event;
 
 	bool _is_event_allowed(const Ref<InputEvent> &p_event) const;

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -143,10 +143,8 @@ class TextShaderEditor : public ShaderEditor {
 	Button *site_search = nullptr;
 	PopupMenu *context_menu = nullptr;
 	RichTextLabel *warnings_panel = nullptr;
-	uint64_t idle = 0;
 
 	GotoLinePopup *goto_line_popup = nullptr;
-	ConfirmationDialog *erase_tab_confirm = nullptr;
 	ConfirmationDialog *disk_changed = nullptr;
 
 	ShaderTextEditor *code_editor = nullptr;


### PR DESCRIPTION
This PR removes unused private variables in the `godot/editor` folder that were declared in `.h` files and not in the corresponding `.cpp` file. As a conservative estimate it ignored files that had a `friend class` inside, just in case the variables were mentioned in another file.

I didn't attempt to look through the blame to see why each variable was removed, but I believe that if it is no longer referenced, it is better to remove now, and reinstate later if the functionality is desired.