### PR TITLE
Codestyle: Remove unused private variables in `godot/scene`

### DIFF
--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -48,12 +48,6 @@ private:
 
 	};
 
-	struct Output {
-		AudioFrame vol;
-		int bus_index = 0;
-		Viewport *viewport = nullptr; //pointer only used for reference to previous mix
-	};
-
 	AudioStreamPlayerInternal *internal = nullptr;
 
 	SafeNumeric<float> setplay{ -1.0 };

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -122,14 +122,6 @@ private:
 		}
 	};
 
-	struct SortAxis {
-		const Particle *particles = nullptr;
-		Vector2 axis;
-		bool operator()(int p_a, int p_b) const {
-			return axis.dot(particles[p_a].transform[2]) < axis.dot(particles[p_b].transform[2]);
-		}
-	};
-
 	//
 
 	bool one_shot = false;
@@ -178,7 +170,6 @@ private:
 	Vector<Vector2> emission_points;
 	Vector<Vector2> emission_normals;
 	Vector<Color> emission_colors;
-	int emission_point_count = 0;
 	real_t emission_ring_inner_radius = 0.8;
 	real_t emission_ring_radius = 1.0;
 

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -56,7 +56,6 @@ class Polygon2D : public Node2D {
 
 	Size2 tex_scale = Vector2(1, 1);
 	Vector2 tex_ofs;
-	bool tex_tile = true;
 	real_t tex_rot = 0.0;
 	bool invert = false;
 	real_t invert_border = 100.0;

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -37,8 +37,6 @@ class Sprite2D : public Node2D {
 	GDCLASS(Sprite2D, Node2D);
 
 	Ref<Texture2D> texture;
-	Color specular_color;
-	real_t shininess = 0.0;
 
 #ifdef TOOLS_ENABLED
 	bool dragging_to_resize_rect = false;

--- a/scene/2d/visible_on_screen_notifier_2d.h
+++ b/scene/2d/visible_on_screen_notifier_2d.h
@@ -36,8 +36,6 @@ class Viewport;
 class VisibleOnScreenNotifier2D : public Node2D {
 	GDCLASS(VisibleOnScreenNotifier2D, Node2D);
 
-	HashSet<Viewport *> viewports;
-
 	Rect2 rect;
 	bool show_rect = true;
 

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -178,7 +178,6 @@ private:
 	Vector<Vector3> emission_points;
 	Vector<Vector3> emission_normals;
 	Vector<Color> emission_colors;
-	int emission_point_count = 0;
 	Vector3 emission_ring_axis;
 	real_t emission_ring_height = 0.0;
 	real_t emission_ring_radius = 0.0;

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -136,7 +136,6 @@ private:
 	RID text_rid;
 	Vector<RID> lines_rid;
 
-	RID base_material;
 	StandardMaterial3D::BillboardMode billboard_mode = StandardMaterial3D::BILLBOARD_DISABLED;
 	StandardMaterial3D::TextureFilter texture_filter = StandardMaterial3D::TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
 

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -229,12 +229,6 @@ private:
 	void _assign_lightmaps();
 	void _clear_lightmaps();
 
-	struct BakeTimeData {
-		String text;
-		int pass = 0;
-		uint64_t last_step = 0;
-	};
-
 	struct BSPSimplex {
 		int vertices[4] = {};
 		int planes[4] = {};

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -89,7 +89,6 @@ private:
 	bool cubic = true;
 	bool loop = true;
 	bool tilt_enabled = true;
-	bool transform_dirty = true;
 	bool use_model_front = false;
 	RotationMode rotation_mode = ROTATION_XYZ;
 

--- a/scene/3d/physics/spring_arm_3d.h
+++ b/scene/3d/physics/spring_arm_3d.h
@@ -40,7 +40,6 @@ class SpringArm3D : public Node3D {
 	HashSet<RID> excluded_objects;
 	real_t spring_length = 1.0;
 	real_t current_spring_length = 0.0;
-	bool keep_child_basis = false;
 	uint32_t mask = 1;
 	real_t margin = 0.01;
 

--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -52,7 +52,6 @@ private:
 		float albedo[3] = {}; //albedo in RGB24
 		float emission[3] = {}; //accumulated light in 16:16 fixed point (needs to be integer for moving lights fast)
 		float normal[3] = {};
-		uint32_t used_sides = 0;
 		float alpha = 0.0; //used for upsampling
 		uint16_t x = 0;
 		uint16_t y = 0;

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -48,9 +48,6 @@ class AnimationNodeAnimation : public AnimationRootNode {
 	bool stretch_time_scale = true;
 	double start_offset = 0.0;
 
-	uint64_t last_version = 0;
-	bool skip = false;
-
 public:
 	enum PlayMode {
 		PLAY_MODE_FORWARD,
@@ -342,9 +339,6 @@ class AnimationNodeTransition : public AnimationNodeSync {
 	StringName current_index = PNAME("current_index");
 	StringName current_state = PNAME("current_state");
 	StringName transition_request = PNAME("transition_request");
-
-	StringName prev_frame_current = "pf_current";
-	StringName prev_frame_current_idx = "pf_current_idx";
 
 	double xfade_time = 0.0;
 	Ref<Curve> xfade_curve;

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -126,7 +126,6 @@ private:
 
 	StringName autoplay;
 
-	bool reset_on_save = true;
 	bool movie_quit_on_finish = false;
 
 	void _play(const StringName &p_name, double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);

--- a/scene/gui/flow_container.h
+++ b/scene/gui/flow_container.h
@@ -52,7 +52,6 @@ private:
 	int cached_size = 0;
 	int cached_line_count = 0;
 	int cached_line_max_child_count = 0;
-	int cached_items_on_last_row = 0;
 
 	bool vertical = false;
 	bool reverse_fill = false;

--- a/scene/gui/graph_frame.h
+++ b/scene/gui/graph_frame.h
@@ -37,12 +37,6 @@ class HBoxContainer;
 class GraphFrame : public GraphElement {
 	GDCLASS(GraphFrame, GraphElement);
 
-	struct _MinSizeCache {
-		int min_size = 0;
-		bool will_stretch = false;
-		int final_size = 0;
-	};
-
 	struct ThemeCache {
 		Ref<StyleBox> panel;
 		Ref<StyleBox> panel_selected;

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -132,7 +132,6 @@ private:
 	int max_columns = 1;
 
 	Size2 fixed_icon_size;
-	Size2 max_item_size_cache;
 	Size2 fixed_tag_icon_size;
 
 	int defer_select_single = -1;

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -71,7 +71,6 @@ class MenuBar : public Control {
 	int active_menu = -1;
 
 	Vector2i old_mouse_pos;
-	ObjectID shortcut_context;
 
 	struct ThemeCache {
 		Ref<StyleBox> normal;

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -37,7 +37,6 @@
 class MenuButton : public Button {
 	GDCLASS(MenuButton, Button);
 
-	bool clicked = false;
 	bool switch_on_hover = false;
 	bool disable_shortcuts = false;
 	PopupMenu *popup = nullptr;

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -74,11 +74,9 @@ class ScrollBar : public Range {
 	Vector2 drag_node_accum;
 	Vector2 drag_node_from;
 	Vector2 last_drag_node_accum;
-	float last_drag_node_time = 0.0;
 	float time_since_motion = 0.0;
 	bool drag_node_touching = false;
 	bool drag_node_touching_deaccel = false;
-	bool click_handled = false;
 
 	bool scrolling = false;
 	double target_scroll = 0.0;

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -37,18 +37,11 @@
 class VideoStreamPlayer : public Control {
 	GDCLASS(VideoStreamPlayer, Control);
 
-	struct Output {
-		AudioFrame vol;
-		int bus_index = 0;
-		Viewport *viewport = nullptr; //pointer only used for reference to previous mix
-	};
 	Ref<VideoStreamPlayback> playback;
 	Ref<VideoStream> stream;
 
 	int sp_get_channel_count() const;
 	bool mix(AudioFrame *p_buffer, int p_frames);
-
-	RID stream_rid;
 
 	Ref<Texture2D> texture;
 	Size2 texture_size;

--- a/scene/resources/2d/navigation_polygon.h
+++ b/scene/resources/2d/navigation_polygon.h
@@ -41,7 +41,6 @@ class NavigationPolygon : public Resource {
 	Vector<Vector2> vertices;
 	Vector<Vector<int>> polygons;
 	Vector<Vector<Vector2>> outlines;
-	Vector<Vector<Vector2>> baked_outlines;
 
 	mutable Rect2 item_rect;
 	mutable bool rect_cache_dirty = true;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -168,7 +168,6 @@ private:
 
 	struct ValueTrack : public Track {
 		UpdateMode update_mode = UPDATE_CONTINUOUS;
-		bool update_on_seek = false;
 		LocalVector<TKey<Variant>> values;
 
 		ValueTrack() {

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -551,7 +551,6 @@ private:
 	float anisotropy = 0.0f;
 	float heightmap_scale = 0.0f;
 	float subsurface_scattering_strength = 0.0f;
-	float transmittance_amount = 0.0f;
 	Color transmittance_color;
 	float transmittance_depth = 0.0f;
 	float transmittance_boost = 0.0f;

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -334,8 +334,6 @@ private:
 	Vector3 emission_shape_offset;
 	Vector3 emission_shape_scale;
 
-	bool anim_loop = false;
-
 	bool turbulence_enabled;
 	Vector3 turbulence_noise_speed;
 	Ref<Texture2D> turbulence_color_ramp;


### PR DESCRIPTION
This PR removes unused private variables in the `godot/scene` folder that were declared in `.h` files and not in the corresponding `.cpp` file. As a conservative estimate it ignored files that had a `friend class` inside, just in case the variables were mentioned in another file.

I didn't attempt to look through the blame to see why each variable was removed, but I believe that if it is no longer referenced, it is better to remove now, and reinstate later if the functionality is desired.