### PR TITLE
Fix kinematic bodies returning stale transforms when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -544,6 +544,14 @@ JoltBody3D::~JoltBody3D() {
 	}
 }
 
+Transform3D JoltBody3D::get_transform_unscaled() const {
+	if (in_space() && is_kinematic()) {
+		return kinematic_transform;
+	}
+
+	return JoltShapedObject3D::get_transform_unscaled();
+}
+
 void JoltBody3D::set_transform(Transform3D p_transform) {
 	JOLT_ENSURE_SCALE_NOT_ZERO(p_transform, vformat("An invalid transform was passed to physics body '%s'.", to_string()));
 

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -155,6 +155,7 @@ public:
 	JoltBody3D();
 	virtual ~JoltBody3D() override;
 
+	virtual Transform3D get_transform_unscaled() const override;
 	void set_transform(Transform3D p_transform);
 
 	Variant get_state(PhysicsServer3D::BodyState p_state) const;

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.h
@@ -75,7 +75,7 @@ public:
 	explicit JoltShapedObject3D(ObjectType p_object_type);
 	virtual ~JoltShapedObject3D() override;
 
-	Transform3D get_transform_unscaled() const;
+	virtual Transform3D get_transform_unscaled() const;
 	Transform3D get_transform_scaled() const;
 
 	Vector3 get_scale() const { return scale; }


### PR DESCRIPTION
Fixes #109885.
Relates to #76256.
~~Supersedes #113654.~~

Because Godot doesn't distinguish between moving (i.e. integrating a velocity) a kinematic body (e.g. `CharacterBody3D`) and "teleporting" (i.e. just setting its transform) a kinematic body, both Godot Physics and the Jolt Physics integration are forced to assume that we only ever move kinematic body whenever its transform is changed. To achieve this both implementations apply transform changes to a separate transform that is then used to move the body (and calculate velocities) at the next physics step. This inherently leads to the actual transform always being stale after applying transformations.

While returning the "stale" transform might be considered the more correct behavior, it seems to trip people up (e.g. #76256 and #109885) and leaves you with little recourse if you do actually want that latest transform you set, since there is no interface for retrieving the "desired transform", even including something like `Node3D.force_update_transform()`.

This PR changes the Jolt Physics implementations of `PhysicsDirectBodyState3D::get_transform()` and `PhysicsServer3D.body_get_state(body_rid, PhysicsServer3D.BODY_STATE_TRANSFORM)` to always return the "desired transform" if the body is in the kinematic mode.

> [!IMPORTANT]
> Note the following:
>
> 1. This will essentially trade one bug for another (arguably lesser) bug since you still won't have actually moved the body, so any physics queries you perform after changing the transform will still behave as if the body still has whatever transform it had at the start of the physics frame.
> 2. This will create a discrepancy with Godot Physics, which does not do this.
> 3. Godot Physics does however force a "teleport" of the body on the first transform change after it's been set to kinematic, which is why this technically resolves [#109885](https://github.com/godotengine/godot/issues/109885), but this PR does not achieve it in the same way as Godot Physics, and I would argue it probably shouldn't.