### PR TITLE
Fix OpenXR build failure when glTF module is disabled

### DIFF
--- a/modules/openxr/extensions/openxr_render_model_extension.cpp
+++ b/modules/openxr/extensions/openxr_render_model_extension.cpp
@@ -30,6 +30,7 @@
 
 #include "openxr_render_model_extension.h"
 
+#ifdef MODULE_GLTF_ENABLED
 #include "../openxr_api.h"
 #include "../openxr_interface.h"
 
@@ -792,3 +793,4 @@ OpenXRRenderModelData::OpenXRRenderModelData() {
 
 OpenXRRenderModelData::~OpenXRRenderModelData() {
 }
+#endif // MODULE_GLTF_ENABLED

--- a/modules/openxr/extensions/openxr_render_model_extension.h
+++ b/modules/openxr/extensions/openxr_render_model_extension.h
@@ -30,6 +30,9 @@
 
 #pragma once
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_GLTF_ENABLED
 #include "../openxr_uuid.h"
 #include "../util.h"
 #include "core/templates/rid_owner.h"
@@ -166,3 +169,4 @@ private:
 	EXT_PROTO_XRRESULT_FUNC1(xrDestroySpace, (XrSpace), space);
 	EXT_PROTO_XRRESULT_FUNC5(xrPathToString, (XrInstance), instance, (XrPath), path, (uint32_t), bufferCapacityInput, (uint32_t *), bufferCountOutput, (char *), buffer);
 };
+#endif // MODULE_GLTF_ENABLED

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -30,6 +30,8 @@
 
 #include "register_types.h"
 
+#include "modules/modules_enabled.gen.h"
+
 #include "action_map/openxr_action.h"
 #include "action_map/openxr_action_map.h"
 #include "action_map/openxr_action_set.h"
@@ -48,8 +50,10 @@
 #include "scene/openxr_composition_layer_cylinder.h"
 #include "scene/openxr_composition_layer_equirect.h"
 #include "scene/openxr_composition_layer_quad.h"
+#ifdef MODULE_GLTF_ENABLED
 #include "scene/openxr_render_model.h"
 #include "scene/openxr_render_model_manager.h"
+#endif
 #include "scene/openxr_visibility_mask.h"
 
 #include "extensions/openxr_android_thread_settings_extension.h"
@@ -73,7 +77,9 @@
 #include "extensions/openxr_palm_pose_extension.h"
 #include "extensions/openxr_performance_settings_extension.h"
 #include "extensions/openxr_pico_controller_extension.h"
+#ifdef MODULE_GLTF_ENABLED
 #include "extensions/openxr_render_model_extension.h"
+#endif
 #include "extensions/openxr_valve_analog_threshold_extension.h"
 #include "extensions/openxr_visibility_mask_extension.h"
 #include "extensions/openxr_wmr_controller_extension.h"
@@ -131,7 +137,9 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(OpenXRFrameSynthesisExtension);
 		GDREGISTER_CLASS(OpenXRFutureExtension);
 		GDREGISTER_CLASS(OpenXRAPIExtension);
+#ifdef MODULE_GLTF_ENABLED
 		GDREGISTER_CLASS(OpenXRRenderModelExtension);
+#endif
 		GDREGISTER_CLASS(OpenXRAndroidThreadSettingsExtension);
 
 		// Note, we're not registering all wrapper classes here, there is no point in exposing them
@@ -171,9 +179,11 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			Engine::get_singleton()->add_singleton(Engine::Singleton("OpenXRFutureExtension", future_extension));
 
 			// Register render model extension as a singleton.
+#ifdef MODULE_GLTF_ENABLED
 			OpenXRRenderModelExtension *render_model_extension = memnew(OpenXRRenderModelExtension);
 			OpenXRAPI::register_extension_wrapper(render_model_extension);
 			Engine::get_singleton()->add_singleton(Engine::Singleton("OpenXRRenderModelExtension", render_model_extension));
+#endif
 
 			// Register spatial entity extensions
 			OpenXRSpatialEntityExtension *spatial_entity_extension = memnew(OpenXRSpatialEntityExtension);
@@ -277,8 +287,10 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 #endif
 
 		GDREGISTER_CLASS(OpenXRVisibilityMask);
+#ifdef MODULE_GLTF_ENABLED
 		GDREGISTER_CLASS(OpenXRRenderModel);
 		GDREGISTER_CLASS(OpenXRRenderModelManager);
+#endif
 
 		GDREGISTER_CLASS(OpenXRSpatialEntityExtension);
 		GDREGISTER_VIRTUAL_CLASS(OpenXRSpatialEntityTracker);

--- a/modules/openxr/scene/openxr_render_model.cpp
+++ b/modules/openxr/scene/openxr_render_model.cpp
@@ -30,6 +30,8 @@
 
 #include "openxr_render_model.h"
 
+#ifdef MODULE_GLTF_ENABLED
+
 #include "../extensions/openxr_render_model_extension.h"
 #include "core/config/project_settings.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -166,3 +168,4 @@ void OpenXRRenderModel::set_render_model(RID p_render_model) {
 		_load_render_model_scene();
 	}
 }
+#endif // MODULE_GLTF_ENABLED

--- a/modules/openxr/scene/openxr_render_model.h
+++ b/modules/openxr/scene/openxr_render_model.h
@@ -30,6 +30,9 @@
 
 #pragma once
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_GLTF_ENABLED
 #include "scene/3d/node_3d.h"
 
 #include <openxr/openxr.h>
@@ -58,3 +61,4 @@ public:
 
 	String get_top_level_path() const;
 };
+#endif // MODULE_GLTF_ENABLED

--- a/modules/openxr/scene/openxr_render_model_manager.cpp
+++ b/modules/openxr/scene/openxr_render_model_manager.cpp
@@ -30,7 +30,9 @@
 
 #include "openxr_render_model_manager.h"
 
+#ifdef MODULE_GLTF_ENABLED
 #include "../extensions/openxr_render_model_extension.h"
+
 #include "../openxr_api.h"
 #include "core/config/project_settings.h"
 #include "scene/3d/xr/xr_nodes.h"
@@ -282,3 +284,4 @@ void OpenXRRenderModelManager::set_make_local_to_pose(const String &p_action) {
 String OpenXRRenderModelManager::get_make_local_to_pose() const {
 	return make_local_to_pose;
 }
+#endif // MODULE_GLTF_ENABLED

--- a/modules/openxr/scene/openxr_render_model_manager.h
+++ b/modules/openxr/scene/openxr_render_model_manager.h
@@ -30,6 +30,9 @@
 
 #pragma once
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_GLTF_ENABLED
 #include "openxr_render_model.h"
 
 #include "scene/3d/node_3d.h"
@@ -82,3 +85,4 @@ protected:
 };
 
 VARIANT_ENUM_CAST(OpenXRRenderModelManager::RenderModelTracker);
+#endif // MODULE_GLTF_ENABLED

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -176,7 +176,9 @@
 #include "tests/scene/test_convert_transform_modifier_3d.h"
 #include "tests/scene/test_copy_transform_modifier_3d.h"
 #include "tests/scene/test_decal.h"
+#ifdef MODULE_GLTF_ENABLED
 #include "tests/scene/test_gltf_document.h"
+#endif
 #include "tests/scene/test_path_3d.h"
 #include "tests/scene/test_path_follow_3d.h"
 #include "tests/scene/test_primitives.h"


### PR DESCRIPTION
Title: Fix OpenXR build failure when glTF module is disabled

Description: When compiling with module_gltf_enabled=no, the OpenXR module fails to link because it assumes GLTFDocument is always available. Additionally, the test suite attempts to run GLTF tests even when the module is disabled.

This PR adds #ifdef MODULE_GLTF_ENABLED guards to OpenXRRenderModelExtension and test_main.cpp to properly respect the build option.

Fixes #113427