### PR TITLE
Fix laggy window resize on Wayland

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3443,8 +3443,8 @@ void WaylandThread::window_state_update_size(WindowState *p_ws, int p_width, int
 	bool using_fractional = p_ws->preferred_fractional_scale > 0;
 
 	// If neither is true we no-op.
-	bool scale_changed = true;
-	bool size_changed = true;
+	bool scale_changed = false;
+	bool size_changed = false;
 
 	if (p_ws->rect.size.width != p_width || p_ws->rect.size.height != p_height) {
 		p_ws->rect.size.width = p_width;


### PR DESCRIPTION
Title: Fix laggy window resize on Wayland

Description: scale_changed and size_changed are initialized to true, making the conditional assignments inside the function ineffective—they could only ever set true to true. 

This causes no issues on X11 (duh it's wayland_thread.cpp, what was i thinking...), however Wayland window resizing struggles big time. Changing the initial variables back to false fixes lag during window resize.

Regression from #101774?

