### PR TITLE
Improve `Normalize()`

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -50,7 +50,7 @@ real_t Vector2::length_squared() const {
 }
 
 void Vector2::normalize() {
-	real_t l = x * x + y * y;
+	real_t l = length_squared();
 	if (l != 0) {
 		l = Math::sqrt(l);
 		x /= l;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -547,9 +547,7 @@ real_t Vector3::length_squared() const {
 
 void Vector3::normalize() {
 	real_t lengthsq = length_squared();
-	if (lengthsq == 0) {
-		x = y = z = 0;
-	} else {
+	if (lengthsq != 0) {
 		real_t length = Math::sqrt(lengthsq);
 		x /= length;
 		y /= length;

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -80,9 +80,7 @@ real_t Vector4::length() const {
 
 void Vector4::normalize() {
 	real_t lengthsq = length_squared();
-	if (lengthsq == 0) {
-		x = y = z = w = 0;
-	} else {
+	if (lengthsq != 0) {
 		real_t length = Math::sqrt(lengthsq);
 		x /= length;
 		y /= length;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -527,7 +527,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the vector scaled to unit length. Equivalent to <c>v / v.Length()</c>.
+        /// Returns the vector scaled to unit length if possible. Equivalent to <c>v / v.Length()</c> if the vector is non-0, no-op if it is.
         /// </summary>
         /// <returns>A normalized version of the vector.</returns>
         public readonly Vector2 Normalized()

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -93,11 +93,7 @@ namespace Godot
         {
             real_t lengthsq = LengthSquared();
 
-            if (lengthsq == 0)
-            {
-                X = Y = 0f;
-            }
-            else
+            if (lengthsq != 0)
             {
                 real_t length = Mathf.Sqrt(lengthsq);
                 X /= length;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -538,7 +538,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the vector scaled to unit length. Equivalent to <c>v / v.Length()</c>.
+        /// Returns the vector scaled to unit length if possible. Equivalent to <c>v / v.Length()</c> if the vector is non-0, no-op if it is.
         /// </summary>
         /// <returns>A normalized version of the vector.</returns>
         public readonly Vector3 Normalized()

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -109,11 +109,7 @@ namespace Godot
         {
             real_t lengthsq = LengthSquared();
 
-            if (lengthsq == 0)
-            {
-                X = Y = Z = 0f;
-            }
-            else
+            if (lengthsq != 0)
             {
                 real_t length = Mathf.Sqrt(lengthsq);
                 X /= length;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -125,11 +125,7 @@ namespace Godot
         {
             real_t lengthsq = LengthSquared();
 
-            if (lengthsq == 0)
-            {
-                X = Y = Z = W = 0f;
-            }
-            else
+            if (lengthsq != 0)
             {
                 real_t length = Mathf.Sqrt(lengthsq);
                 X /= length;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -479,7 +479,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the vector scaled to unit length. Equivalent to <c>v / v.Length()</c>.
+        /// Returns the vector scaled to unit length if possible. Equivalent to <c>v / v.Length()</c> if the vector is non-0, no-op if it is.
         /// </summary>
         /// <returns>A normalized version of the vector.</returns>
         public readonly Vector4 Normalized()

--- a/tests/core/math/test_vector2.h
+++ b/tests/core/math/test_vector2.h
@@ -181,6 +181,9 @@ TEST_CASE("[Vector2] Normalization methods") {
 	CHECK_MESSAGE(
 			Vector2(1, 1).normalized().is_equal_approx(Vector2(Math::SQRT12, Math::SQRT12)),
 			"Vector2 normalized should work as expected.");
+	CHECK_MESSAGE(
+			Vector2(0, 0).normalized() == Vector2(0, 0),
+			"Vector2 normalized should leave 0 vector unchanged.");
 
 	Vector2 vector = Vector2(3.2, -5.4);
 	vector.normalize();

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -198,6 +198,9 @@ TEST_CASE("[Vector3] Normalization methods") {
 	CHECK_MESSAGE(
 			Vector3(1, 1, 1).normalized().is_equal_approx(Vector3(Math::SQRT13, Math::SQRT13, Math::SQRT13)),
 			"Vector3 normalized should work as expected.");
+	CHECK_MESSAGE(
+			Vector3(0, 0, 0).normalized() == Vector3(0, 0, 0),
+			"Vector3 normalized should leave 0 vector unchanged.");
 
 	Vector3 vector = Vector3(3.2, -5.4, 6);
 	vector.normalize();

--- a/tests/core/math/test_vector4.h
+++ b/tests/core/math/test_vector4.h
@@ -130,6 +130,9 @@ TEST_CASE("[Vector4] Normalization methods") {
 	CHECK_MESSAGE(
 			Vector4(1, 1, 1, 1).normalized().is_equal_approx(Vector4(0.5, 0.5, 0.5, 0.5)),
 			"Vector4 normalized should work as expected.");
+	CHECK_MESSAGE(
+			Vector4(0, 0, 0, 0).normalized() == Vector4(0, 0, 0, 0),
+			"Vector4 normalized should leave 0 vector unchanged.");
 }
 
 TEST_CASE("[Vector4] Operators") {


### PR DESCRIPTION
this is basically reverting a minor part of https://github.com/godotengine/godot/commit/c577ec6ae46f8c6d848cae46c0e447e6607b3f33#diff-753c819e82472bbcffb9f8d93406448ee63ea9dc68f2bdd6423aa2de582ead0bL55-L58 , because it makes no sense, at least for me.

Note that https://github.com/godotengine/godot/blob/master/core/math/vector2.cpp#L52 is still OK, but https://github.com/godotengine/godot/blame/3ecd8560fd90a615d80a447b04e713bb2c600fe4/core/math/vector3.h#L349 and https://github.com/godotengine/godot/blame/master/core/math/vector4.cpp#L84 still exhibit this - I think it should be fixed there as well. ~I'm limiting myself to C# here because it's most important for me personally, plus the possible blast radius is minuscule.~ changed in C as well for consistency as requested.

---

Rationale:

current code and documentation is inconsistent between v2 and v3/v4 and between C and C#.
