### PR TITLE
Reduce internal dialog count in FileDialog

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -211,6 +211,35 @@ void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> 
 	}
 }
 
+void FileDialog::_show_error(const String &p_error) {
+	if (!error_dialog) {
+		error_dialog = memnew(AcceptDialog);
+		error_dialog->set_title(ETR("Error!"));
+		add_child(error_dialog, false, INTERNAL_MODE_FRONT);
+	}
+	error_dialog->set_text(p_error);
+	error_dialog->popup_centered(Size2(250, 50));
+}
+
+void FileDialog::_show_confirm(const String &p_what, const Callable &p_callback) {
+	if (!confirm_dialog) {
+		confirm_dialog = memnew(ConfirmationDialog);
+		add_child(confirm_dialog, false, INTERNAL_MODE_FRONT);
+		confirm_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &FileDialog::_end_confirm), CONNECT_DEFERRED);
+	}
+	confirm_callback = p_callback;
+	confirm_dialog->set_text(p_what);
+	confirm_dialog->connect(SceneStringName(confirmed), confirm_callback);
+	confirm_dialog->popup_centered(Size2(250, 80));
+}
+
+void FileDialog::_end_confirm() {
+	if (!confirm_dialog->is_visible()) {
+		confirm_dialog->disconnect(SceneStringName(confirmed), confirm_callback);
+		confirm_callback = Callable();
+	}
+}
+
 bool FileDialog::_should_use_native_popup() const {
 	return _can_use_native_popup() && (use_native_dialog || OS::get_singleton()->is_sandboxed());
 }
@@ -492,13 +521,13 @@ void FileDialog::_action_pressed() {
 
 		String file_name = file_text.strip_edges().get_file();
 		if (!valid || file_name.is_empty()) {
-			exterr->popup_centered(Size2(250, 80));
+			_show_error(ETR("Invalid extension, or empty filename."));
 			return;
 		}
 
 		if (customization_flags[CUSTOMIZATION_OVERWRITE_WARNING] && (dir_access->file_exists(f) || dir_access->is_bundle(f))) {
-			confirm_save->set_text(vformat(atr(ETR("File \"%s\" already exists.\nDo you want to overwrite it?")), f));
-			confirm_save->popup_centered(Size2(250, 80));
+			_show_confirm(vformat(atr(ETR("File \"%s\" already exists.\nDo you want to overwrite it?")), f),
+					callable_mp(this, &FileDialog::_save_confirm_pressed));
 		} else {
 			_save_to_recent();
 			hide();
@@ -667,7 +696,8 @@ void FileDialog::_item_menu_id_pressed(int p_option) {
 
 		case ITEM_MENU_DELETE: {
 			if (selected > -1) {
-				delete_dialog->popup_centered(Size2(250, 80));
+				_show_confirm(ETR("Delete the selected file?\nDepending on your filesystem configuration, the files will either be moved to the system trash or deleted permanently."),
+						callable_mp(this, &FileDialog::_delete_confirm));
 			}
 		} break;
 
@@ -1544,12 +1574,26 @@ void FileDialog::_make_dir_confirm() {
 		update_filters();
 		_push_history();
 	} else {
-		mkdirerr->popup_centered(Size2(250, 50));
+		_show_error(ETR("Could not create folder."));
 	}
 	new_dir_name->set_text(""); // reset label
 }
 
 void FileDialog::_make_dir() {
+	if (!make_dir_dialog) {
+		make_dir_dialog = memnew(ConfirmationDialog);
+		make_dir_dialog->set_title(ETR("Create Folder"));
+		add_child(make_dir_dialog, false, INTERNAL_MODE_FRONT);
+		make_dir_dialog->connect(SceneStringName(confirmed), callable_mp(this, &FileDialog::_make_dir_confirm));
+
+		VBoxContainer *makevb = memnew(VBoxContainer);
+		make_dir_dialog->add_child(makevb);
+
+		new_dir_name = memnew(LineEdit);
+		new_dir_name->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
+		makevb->add_margin_child(ETR("Name:"), new_dir_name);
+		make_dir_dialog->register_text_enter(new_dir_name);
+	}
 	make_dir_dialog->popup_centered(Size2(250, 80));
 	new_dir_name->grab_focus();
 }
@@ -2519,36 +2563,6 @@ FileDialog::FileDialog() {
 	grid_select_options->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	grid_select_options->set_columns(2);
 	main_vbox->add_child(grid_select_options);
-
-	confirm_save = memnew(ConfirmationDialog);
-	add_child(confirm_save, false, INTERNAL_MODE_FRONT);
-	confirm_save->connect(SceneStringName(confirmed), callable_mp(this, &FileDialog::_save_confirm_pressed));
-
-	delete_dialog = memnew(ConfirmationDialog);
-	delete_dialog->set_text(ETR("Delete the selected file?\nDepending on your filesystem configuration, the files will either be moved to the system trash or deleted permanently."));
-	add_child(delete_dialog, false, INTERNAL_MODE_FRONT);
-	delete_dialog->connect(SceneStringName(confirmed), callable_mp(this, &FileDialog::_delete_confirm));
-
-	make_dir_dialog = memnew(ConfirmationDialog);
-	make_dir_dialog->set_title(ETR("Create Folder"));
-	add_child(make_dir_dialog, false, INTERNAL_MODE_FRONT);
-	make_dir_dialog->connect(SceneStringName(confirmed), callable_mp(this, &FileDialog::_make_dir_confirm));
-
-	VBoxContainer *makevb = memnew(VBoxContainer);
-	make_dir_dialog->add_child(makevb);
-
-	new_dir_name = memnew(LineEdit);
-	new_dir_name->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
-	makevb->add_margin_child(ETR("Name:"), new_dir_name);
-	make_dir_dialog->register_text_enter(new_dir_name);
-
-	mkdirerr = memnew(AcceptDialog);
-	mkdirerr->set_text(ETR("Could not create folder."));
-	add_child(mkdirerr, false, INTERNAL_MODE_FRONT);
-
-	exterr = memnew(AcceptDialog);
-	exterr->set_text(ETR("Invalid extension, or empty filename."));
-	add_child(exterr, false, INTERNAL_MODE_FRONT);
 
 	item_menu = memnew(PopupMenu);
 	item_menu->connect(SceneStringName(id_pressed), callable_mp(this, &FileDialog::_item_menu_id_pressed));

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -252,12 +252,11 @@ private:
 	FlowContainer *flow_checkbox_options = nullptr;
 	GridContainer *grid_select_options = nullptr;
 
-	ConfirmationDialog *delete_dialog = nullptr;
-	ConfirmationDialog *make_dir_dialog = nullptr;
 	LineEdit *new_dir_name = nullptr;
-	AcceptDialog *mkdirerr = nullptr;
-	AcceptDialog *exterr = nullptr;
-	ConfirmationDialog *confirm_save = nullptr;
+	ConfirmationDialog *make_dir_dialog = nullptr;
+	AcceptDialog *error_dialog = nullptr;
+	ConfirmationDialog *confirm_dialog = nullptr;
+	Callable confirm_callback;
 
 	struct ThemeCache {
 		int thumbnail_size = 64;
@@ -352,9 +351,11 @@ private:
 	void _native_popup();
 	void _native_dialog_cb(bool p_ok, const Vector<String> &p_files, int p_filter);
 	void _native_dialog_cb_with_options(bool p_ok, const Vector<String> &p_files, int p_filter, const Dictionary &p_selected_options);
+	void _show_error(const String &p_error);
+	void _show_confirm(const String &p_what, const Callable &p_callback);
+	void _end_confirm();
 
 	bool _is_open_should_be_disabled();
-	void _thumbnail_callback(const Ref<Texture2D> &p_texture, const String &p_path);
 
 	TypedArray<Dictionary> _get_options() const;
 	void _update_option_controls();


### PR DESCRIPTION
FileDialog has a few internal dialogs for various purposes. Not all of them are needed, and none of them need to be created immediately. This PR:
- Removes some Accept/ConfirmationDialogs in favor of new methods: `_show_error()` and `_show_accept()`, which reuse single dialog.
- All sub-dialogs are now lazy-initialized, i.e. only created once needed.