### PR TITLE
VisualShader: Fix the eta input from the refract node

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -4627,6 +4627,30 @@ String VisualShaderNodeVectorRefract::get_input_port_name(int p_port) const {
 	return String();
 }
 
+VisualShaderNodeVectorRefract::PortType VisualShaderNodeVectorRefract::get_input_port_type(int p_port) const {
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D:
+			if (p_port == 2) {
+				break;
+			}
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
+			if (p_port == 2) {
+				break;
+			}
+			return PORT_TYPE_VECTOR_3D;
+		case OP_TYPE_VECTOR_4D:
+			if (p_port == 2) {
+				break;
+			}
+			return PORT_TYPE_VECTOR_4D;
+		default:
+			break;
+	}
+
+	return PORT_TYPE_SCALAR;
+}
+
 int VisualShaderNodeVectorRefract::get_output_port_count() const {
 	return 1;
 }

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1896,6 +1896,7 @@ public:
 
 	virtual int get_input_port_count() const override;
 	virtual String get_input_port_name(int p_port) const override;
+	virtual PortType get_input_port_type(int p_port) const override;
 
 	virtual int get_output_port_count() const override;
 	virtual String get_output_port_name(int p_port) const override;


### PR DESCRIPTION
This PR changes the type of value taken by the refract node's eta input to a float type, since this is the value required by the `refract()` function for this parameter.
|Before|After|
|---------|---------|
|<img width="448" height="389" alt="before" src="https://github.com/user-attachments/assets/98d33c25-c504-4dfb-b445-7b7e8d25d1c6" />|<img width="450" height="395" alt="after" src="https://github.com/user-attachments/assets/22980044-bcef-4ecb-8786-bbe4c02d3d40" />|
