### PR TITLE
Fix `ScriptEditor` history update issues

### DIFF
--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -523,6 +523,8 @@ class ScriptEditor : public PanelContainer {
 
 	void _history_forward();
 	void _history_back();
+	void _history_store_current_state();
+	bool _history_is_valid();
 
 	bool waiting_update_names;
 	bool lock_history = false;


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/107911

This fixes two things, one is that sometimes the history would not update anymore causing the linked issue (cause for this was line [3873](https://github.com/godotengine/godot/pull/113729/files#:~:text=lock%5Fhistory%20%3D%20true%3B)). The other is that closing a file when in the middle of the history would cut off the tail of the history even though it is still valid (line [906](https://github.com/godotengine/godot/pull/113729/files#:~:text=history%2Eresize%28history%5Fpos%20%2B%201%29%3B,-for)).

Also I added two helper functions to replace code used multiple times, making the code more readable (in my opinion, at least helped me with debugging). Are these changes valid? If so should I make a extra PR or a proposal?