### PR TITLE
Codestyle: Remove unused private variables in `expression.h`

### DIFF
--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -36,17 +36,8 @@ class Expression : public RefCounted {
 	GDCLASS(Expression, RefCounted);
 
 private:
-	struct Input {
-		Variant::Type type = Variant::NIL;
-		String name;
-	};
-
-	Vector<Input> inputs;
-	Variant::Type output_type = Variant::NIL;
-
 	String expression;
 
-	bool sequenced = false;
 	int str_ofs = 0;
 	bool expression_dirty = false;
 


### PR DESCRIPTION
See #113706 and #113709

I used the same methods, and it only resulted in this file containing unused private variables in `godot/code`. The method only examined the raw text and not any intermediate representation, but had success in the other folders, which is why this surprised me. I didn't use an exhaustive method so there might be others but it is worth it to remove variables that even naive methods could find. It might be interesting to use the compiled `clangd/index` folder that I have in the future for a smarter method.