### PR TITLE
Add LogStream Engine: Native log streaming and visualization

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -166,6 +166,9 @@ env.core_sources += thirdparty_obj
 # Godot source files
 env.add_source_files(env.core_sources, "*.cpp")
 
+# LogStream sources
+env.add_source_files(env.core_sources, "logstream/*.cpp")
+
 # Generate disabled classes
 env.CommandNoCache(
     "disabled_classes.gen.h", env.Value(env.disabled_classes), env.Run(core_builders.disabled_class_builder)

--- a/core/logstream/log_stream.cpp
+++ b/core/logstream/log_stream.cpp
@@ -1,0 +1,124 @@
+// Godot LogStream core router implementation (scaffolding).
+#include "log_stream.h"
+
+#include "core/error/error_macros.h"
+#include "core/os/memory.h"
+#include "core/os/mutex.h"
+#include "core/templates/vector.h"
+
+LogStreamRouter *LogStreamRouter::singleton = nullptr;
+
+const char *LogStreamEntry::level_to_string(LogStreamEntry::Level p_level) {
+	switch (p_level) {
+		case LEVEL_ERROR:
+			return "error";
+		case LEVEL_WARNING:
+			return "warning";
+		case LEVEL_INFO:
+			return "info";
+		case LEVEL_DEBUG:
+			return "debug";
+		case LEVEL_VERBOSE:
+			return "verbose";
+	}
+	return "unknown";
+}
+
+LogStreamRouter *LogStreamRouter::get_singleton() {
+	return singleton;
+}
+
+void LogStreamRouter::create_singleton(const Config &p_config) {
+	if (singleton) {
+		return;
+	}
+	singleton = memnew(LogStreamRouter(p_config));
+}
+
+void LogStreamRouter::create_singleton() {
+	create_singleton(Config());
+}
+
+void LogStreamRouter::free_singleton() {
+	if (!singleton) {
+		return;
+	}
+	memdelete(singleton);
+	singleton = nullptr;
+}
+
+LogStreamRouter::LogStreamRouter(const Config &p_config) :
+		config(p_config) {
+	buffer.reserve(config.max_entries > 0 ? config.max_entries : 0);
+}
+
+LogStreamRouter::~LogStreamRouter() {
+	clear_sinks();
+}
+
+void LogStreamRouter::configure(const Config &p_config) {
+	MutexLock lock(mutex);
+	config = p_config;
+	prune_if_needed();
+}
+
+LogStreamRouter::Config LogStreamRouter::get_config() const {
+	MutexLock lock(mutex);
+	return config;
+}
+
+void LogStreamRouter::add_sink(LogStreamSink *p_sink) {
+	ERR_FAIL_NULL(p_sink);
+	MutexLock lock(mutex);
+	sinks.push_back(p_sink);
+}
+
+void LogStreamRouter::clear_sinks() {
+	MutexLock lock(mutex);
+	for (LogStreamSink *sink : sinks) {
+		memdelete(sink);
+	}
+	sinks.clear();
+}
+
+void LogStreamRouter::push_entry(const LogStreamEntry &p_entry) {
+	MutexLock lock(mutex);
+	if (!config.enabled) {
+		return;
+	}
+
+	LogStreamEntry entry = p_entry;
+	if (entry.seq == 0) {
+		entry.seq = ++seq_counter;
+	}
+
+	buffer.push_back(entry);
+	prune_if_needed();
+
+	for (LogStreamSink *sink : sinks) {
+		if (sink) {
+			sink->handle_entry(entry);
+		}
+	}
+}
+
+Vector<LogStreamEntry> LogStreamRouter::get_entries_snapshot() const {
+	MutexLock lock(mutex);
+	return buffer;
+}
+
+void LogStreamRouter::clear_entries() {
+	MutexLock lock(mutex);
+	buffer.clear();
+}
+
+void LogStreamRouter::prune_if_needed() {
+	if (config.max_entries <= 0) {
+		return;
+	}
+	const int max_entries = config.max_entries;
+	while (buffer.size() > max_entries) {
+		buffer.remove_at(0);
+	}
+}
+

--- a/core/logstream/log_stream.h
+++ b/core/logstream/log_stream.h
@@ -1,0 +1,77 @@
+// Godot LogStream core types and router scaffolding.
+#pragma once
+
+#include "core/os/mutex.h"
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
+
+class LogStreamSink;
+
+struct LogStreamEntry {
+	enum Level {
+		LEVEL_ERROR,
+		LEVEL_WARNING,
+		LEVEL_INFO,
+		LEVEL_DEBUG,
+		LEVEL_VERBOSE,
+	};
+
+	uint64_t seq = 0;
+	uint64_t timestamp_usec = 0;
+	Level level = LEVEL_INFO;
+	String message;
+	String file;
+	int line = -1;
+	String function;
+	String category;
+	Vector<String> stack;
+	String project;
+	String session_id;
+
+	static const char *level_to_string(Level p_level);
+};
+
+class LogStreamSink {
+public:
+	virtual void handle_entry(const LogStreamEntry &p_entry) = 0;
+	virtual void flush() {}
+	virtual ~LogStreamSink() {}
+};
+
+class LogStreamRouter {
+public:
+	struct Config {
+		bool enabled = true;
+		int max_entries = 5000;
+	};
+
+	static LogStreamRouter *get_singleton();
+	static void create_singleton(const Config &p_config);
+	static void create_singleton(); // Uses default config.
+	static void free_singleton();
+
+	explicit LogStreamRouter(const Config &p_config);
+	~LogStreamRouter();
+
+	void configure(const Config &p_config);
+	Config get_config() const;
+
+	void add_sink(LogStreamSink *p_sink);
+	void clear_sinks();
+
+	void push_entry(const LogStreamEntry &p_entry);
+	Vector<LogStreamEntry> get_entries_snapshot() const;
+	void clear_entries();
+
+private:
+	static LogStreamRouter *singleton;
+
+	mutable Mutex mutex;
+	Config config;
+	Vector<LogStreamEntry> buffer;
+	Vector<LogStreamSink *> sinks;
+	uint64_t seq_counter = 0;
+
+	void prune_if_needed();
+};
+

--- a/core/logstream/log_stream_file_sink.cpp
+++ b/core/logstream/log_stream_file_sink.cpp
@@ -1,0 +1,119 @@
+// File sink for LogStream entries (JSONL or plain text with optional rotation).
+#include "log_stream_file_sink.h"
+
+#include "core/os/os.h"
+
+LogStreamFileSink::LogStreamFileSink(const Config &p_config) :
+		config(p_config) {
+}
+
+LogStreamFileSink::~LogStreamFileSink() {
+	flush();
+	file.unref();
+}
+
+void LogStreamFileSink::configure(const Config &p_config) {
+	MutexLock lock(mutex);
+	config = p_config;
+}
+
+void LogStreamFileSink::handle_entry(const LogStreamEntry &p_entry) {
+	MutexLock lock(mutex);
+	if (!config.enabled) {
+		return;
+	}
+
+	ensure_file();
+	if (file.is_null()) {
+		return;
+	}
+
+	String line = config.jsonl ? serialize_jsonl(p_entry) : serialize_plain(p_entry);
+	file->store_string(line);
+	if (!line.ends_with("\n")) {
+		file->store_string("\n");
+	}
+	file->flush();
+	rotate_if_needed();
+}
+
+void LogStreamFileSink::flush() {
+	MutexLock lock(mutex);
+	if (file.is_valid()) {
+		file->flush();
+	}
+}
+
+void LogStreamFileSink::ensure_file() {
+	if (file.is_valid()) {
+		return;
+	}
+
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_USERDATA);
+	if (da.is_valid()) {
+		da->make_dir_recursive(config.path.get_base_dir());
+	}
+
+	file = FileAccess::open(config.path, FileAccess::WRITE_READ);
+	if (file.is_valid()) {
+		file->seek_end();
+	}
+}
+
+void LogStreamFileSink::rotate_if_needed() {
+	if (!file.is_valid() || config.max_size_mb <= 0) {
+		return;
+	}
+
+	const uint64_t max_bytes = (uint64_t)config.max_size_mb * 1024 * 1024;
+	const uint64_t len = file->get_position();
+	if (len < max_bytes) {
+		return;
+	}
+
+	String base_dir = config.path.get_base_dir();
+	String base_name = config.path.get_file().get_basename();
+	String extension = config.path.get_extension();
+	String timestamp = Time::get_singleton()->get_datetime_string_from_system().replace_char(':', '.');
+	String rotated = base_dir.path_join(vformat("%s.%s", base_name, timestamp));
+	if (!extension.is_empty()) {
+		rotated += "." + extension;
+	}
+
+	file.unref();
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_USERDATA);
+	if (da.is_valid()) {
+		da->rename(config.path, rotated);
+	}
+
+	file = FileAccess::open(config.path, FileAccess::WRITE);
+	if (file.is_valid()) {
+		file->seek_end();
+	}
+}
+
+String LogStreamFileSink::serialize_jsonl(const LogStreamEntry &p_entry) const {
+	Dictionary dict;
+	dict["seq"] = (int64_t)p_entry.seq;
+	dict["ts_usec"] = (int64_t)p_entry.timestamp_usec;
+	dict["level"] = LogStreamEntry::level_to_string(p_entry.level);
+	dict["message"] = p_entry.message;
+	dict["file"] = p_entry.file;
+	dict["line"] = p_entry.line;
+	dict["function"] = p_entry.function;
+	dict["category"] = p_entry.category;
+	dict["stack"] = p_entry.stack;
+	dict["project"] = p_entry.project;
+	dict["session_id"] = p_entry.session_id;
+	return JSON::stringify(dict);
+}
+
+String LogStreamFileSink::serialize_plain(const LogStreamEntry &p_entry) const {
+	String level = LogStreamEntry::level_to_string(p_entry.level);
+	String location;
+	if (!p_entry.file.is_empty() && p_entry.line > 0) {
+		location = vformat(" (%s:%d)", p_entry.file, p_entry.line);
+	}
+	return vformat("[%s] %s%s\n", level, p_entry.message, location);
+}
+

--- a/core/logstream/log_stream_file_sink.h
+++ b/core/logstream/log_stream_file_sink.h
@@ -1,0 +1,41 @@
+// File sink for LogStream entries (JSONL or plain text with optional rotation).
+#pragma once
+
+#include "core/io/file_access.h"
+#include "core/io/dir_access.h"
+#include "core/io/json.h"
+#include "core/logstream/log_stream.h"
+#include "core/os/mutex.h"
+#include "core/os/time.h"
+
+class LogStreamFileSink : public LogStreamSink {
+public:
+	struct Config {
+		bool enabled = true;
+		String path;
+		bool jsonl = true;
+		int max_size_mb = 0; // 0 means no rotation.
+
+		Config() :
+				path("user://logs/editor.log") {}
+	};
+
+	explicit LogStreamFileSink(const Config &p_config);
+	~LogStreamFileSink() override;
+
+	void handle_entry(const LogStreamEntry &p_entry) override;
+	void flush() override;
+
+	void configure(const Config &p_config);
+
+private:
+	Mutex mutex;
+	Config config;
+	Ref<FileAccess> file;
+
+	void ensure_file();
+	void rotate_if_needed();
+	String serialize_jsonl(const LogStreamEntry &p_entry) const;
+	String serialize_plain(const LogStreamEntry &p_entry) const;
+};
+

--- a/core/logstream/log_stream_logger.cpp
+++ b/core/logstream/log_stream_logger.cpp
@@ -1,0 +1,83 @@
+// Logger adapter that forwards Godot log output into the LogStreamRouter.
+#include "log_stream_logger.h"
+
+#include <cstdio>
+
+#include "core/object/script_backtrace.h"
+#include "core/os/memory.h"
+#include "core/os/os.h"
+#include "core/string/print_string.h"
+
+static LogStreamEntry::Level _map_error_type(Logger::ErrorType p_type) {
+	switch (p_type) {
+		case Logger::ERR_WARNING:
+			return LogStreamEntry::LEVEL_WARNING;
+		case Logger::ERR_ERROR:
+		case Logger::ERR_SCRIPT:
+		case Logger::ERR_SHADER:
+		default:
+			return LogStreamEntry::LEVEL_ERROR;
+	}
+}
+
+static String _format_va(const char *p_format, va_list p_list) {
+	const int static_buf_size = 1024;
+	char static_buf[static_buf_size];
+	va_list list_copy;
+	va_copy(list_copy, p_list);
+	int len = vsnprintf(static_buf, static_buf_size, p_format, p_list);
+	String output;
+	if (len >= static_buf_size) {
+		char *buf = (char *)memalloc(len + 1);
+		if (buf) {
+			vsnprintf(buf, len + 1, p_format, list_copy);
+			output = String::utf8(buf, len);
+			memfree(buf);
+		}
+	} else {
+		output = String::utf8(static_buf, len);
+	}
+	va_end(list_copy);
+	return output;
+}
+
+LogStreamLogger::LogStreamLogger() {
+	// Don't create singleton here - EditorNode will create it with proper config
+}
+
+void LogStreamLogger::logv(const char *p_format, va_list p_list, bool p_err) {
+	if (!LogStreamRouter::get_singleton()) {
+		return;
+	}
+
+	LogStreamEntry entry;
+	entry.level = p_err ? LogStreamEntry::LEVEL_ERROR : LogStreamEntry::LEVEL_INFO;
+	entry.timestamp_usec = OS::get_singleton()->get_ticks_usec();
+	entry.message = _format_va(p_format, p_list);
+
+	LogStreamRouter::get_singleton()->push_entry(entry);
+}
+
+void LogStreamLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces) {
+	if (!LogStreamRouter::get_singleton()) {
+		return;
+	}
+
+	LogStreamEntry entry;
+	entry.level = _map_error_type(p_type);
+	entry.timestamp_usec = OS::get_singleton()->get_ticks_usec();
+	entry.message = p_rationale && *p_rationale ? String::utf8(p_rationale) : String::utf8(p_code);
+	entry.file = p_file ? String::utf8(p_file) : String();
+	entry.line = p_line;
+	entry.function = p_function ? String::utf8(p_function) : String();
+	entry.category = String(LogStreamEntry::level_to_string(entry.level));
+	entry.stack.resize(p_script_backtraces.size());
+	for (int i = 0; i < p_script_backtraces.size(); i++) {
+		if (p_script_backtraces[i].is_valid()) {
+			entry.stack.write[i] = p_script_backtraces[i]->format(0);
+		}
+	}
+
+	LogStreamRouter::get_singleton()->push_entry(entry);
+}
+

--- a/core/logstream/log_stream_logger.h
+++ b/core/logstream/log_stream_logger.h
@@ -1,0 +1,15 @@
+// Logger adapter that forwards Godot log output into the LogStreamRouter.
+#pragma once
+
+#include "core/io/logger.h"
+#include "core/logstream/log_stream.h"
+
+class LogStreamLogger : public Logger {
+public:
+	LogStreamLogger();
+	~LogStreamLogger() override {}
+
+	void logv(const char *p_format, va_list p_list, bool p_err) override _PRINTF_FORMAT_ATTRIBUTE_2_0;
+	void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify = false, ErrorType p_type = ERR_ERROR, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces = {}) override;
+};
+

--- a/core/logstream/log_stream_websocket_sink.cpp
+++ b/core/logstream/log_stream_websocket_sink.cpp
@@ -1,0 +1,42 @@
+// Placeholder WebSocket sink for LogStream entries (batched buffer, no network yet).
+#include "log_stream_websocket_sink.h"
+
+#include "core/os/os.h"
+
+LogStreamWebSocketSink::LogStreamWebSocketSink(const Config &p_config) :
+		config(p_config) {
+}
+
+void LogStreamWebSocketSink::configure(const Config &p_config) {
+	MutexLock lock(mutex);
+	config = p_config;
+	pending.clear();
+}
+
+void LogStreamWebSocketSink::handle_entry(const LogStreamEntry &p_entry) {
+	MutexLock lock(mutex);
+	if (!config.enabled) {
+		return;
+	}
+	pending.push_back(p_entry);
+	flush_if_needed_locked();
+}
+
+void LogStreamWebSocketSink::flush() {
+	MutexLock lock(mutex);
+	pending.clear();
+	last_flush_usec = OS::get_singleton()->get_ticks_usec();
+}
+
+void LogStreamWebSocketSink::flush_if_needed_locked() {
+	const bool count_ready = config.batch_size > 0 && pending.size() >= config.batch_size;
+	const uint64_t now = OS::get_singleton()->get_ticks_usec();
+	const bool time_ready = config.batch_msec > 0 && (now - last_flush_usec) >= (uint64_t)config.batch_msec * 1000;
+
+	if (count_ready || time_ready) {
+		// TODO: send over WebSocket when implemented.
+		pending.clear();
+		last_flush_usec = now;
+	}
+}
+

--- a/core/logstream/log_stream_websocket_sink.h
+++ b/core/logstream/log_stream_websocket_sink.h
@@ -1,0 +1,37 @@
+// Placeholder WebSocket sink for LogStream entries.
+#pragma once
+
+#include "core/logstream/log_stream.h"
+#include "core/os/mutex.h"
+
+class LogStreamWebSocketSink : public LogStreamSink {
+public:
+	struct Config {
+		bool enabled = false;
+		int port;
+		int batch_size;
+		int batch_msec;
+		String auth_token;
+
+		Config() :
+				port(17865),
+				batch_size(50),
+				batch_msec(100) {}
+	};
+
+	explicit LogStreamWebSocketSink(const Config &p_config);
+	~LogStreamWebSocketSink() override = default;
+
+	void handle_entry(const LogStreamEntry &p_entry) override;
+	void flush() override;
+	void configure(const Config &p_config);
+
+private:
+	Mutex mutex;
+	Config config;
+	Vector<LogStreamEntry> pending;
+	uint64_t last_flush_usec = 0;
+
+	void flush_if_needed_locked();
+};
+

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -34,6 +34,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/json.h"
+#include "core/logstream/log_stream_logger.h"
 #include "core/os/midi_driver.h"
 #include "core/version_generated.gen.h"
 
@@ -78,6 +79,9 @@ void OS::_set_logger(CompositeLogger *p_logger) {
 		memdelete(_logger);
 	}
 	_logger = p_logger;
+	if (_logger) {
+		_logger->add_logger(memnew(LogStreamLogger));
+	}
 }
 
 void OS::add_logger(Logger *p_logger) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -44,6 +44,9 @@
 #include "core/os/time.h"
 #include "core/string/print_string.h"
 #include "core/string/translation_server.h"
+#include "core/logstream/log_stream.h"
+#include "core/logstream/log_stream_file_sink.h"
+#include "editor/log_stream_websocket_sink.h"
 #include "core/version.h"
 #include "editor/editor_string_names.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
@@ -133,6 +136,7 @@
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
 #include "editor/import/resource_importer_wav.h"
+#include "editor/log_stream_dock.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/inspector/editor_preview_plugins.h"
 #include "editor/inspector/editor_properties.h"
@@ -7882,6 +7886,48 @@ void EditorNode::notify_settings_overrides_changed() {
 	settings_overrides_changed = true;
 }
 
+void EditorNode::_setup_logstream_from_settings() {
+	EditorSettings *es = EditorSettings::get_singleton();
+	if (!es) {
+		return;
+	}
+
+	LogStreamRouter::Config cfg;
+	cfg.enabled = es->get_setting("logstream/enabled");
+	cfg.max_entries = es->get_setting("logstream/max_entries");
+	LogStreamRouter::create_singleton(cfg);
+	LogStreamRouter *router = LogStreamRouter::get_singleton();
+	if (!router) {
+		return;
+	}
+	router->configure(cfg);
+	router->clear_sinks();
+
+	// File sink
+	LogStreamFileSink::Config fc;
+	fc.enabled = es->get_setting("logstream/file_logging/enabled");
+	fc.path = es->get_setting("logstream/file_logging/path");
+	fc.jsonl = String(es->get_setting("logstream/file_logging/format")) != "plain";
+	fc.max_size_mb = es->get_setting("logstream/file_logging/max_size_mb");
+	router->add_sink(memnew(LogStreamFileSink(fc)));
+
+	// WebSocket sink
+	EditorLogStreamWebSocketSink::Config wc;
+	wc.enabled = es->get_setting("logstream/websocket/enabled");
+	wc.port = es->get_setting("logstream/websocket/port");
+	wc.batch_size = es->get_setting("logstream/websocket/batch_size");
+	wc.batch_msec = es->get_setting("logstream/websocket/batch_msec");
+	wc.auth_token = es->get_setting("logstream/websocket/auth_token");
+	websocket_sink = memnew(EditorLogStreamWebSocketSink(wc));
+	router->add_sink(websocket_sink);
+}
+
+void EditorNode::_poll_websocket_sink() {
+	if (websocket_sink) {
+		websocket_sink->poll_server();
+	}
+}
+
 // Returns the list of project settings to add to new projects. This is used by the
 // project manager creation dialog, but also applies to empty `project.godot` files
 // to cover the command line workflow of creating projects using `touch project.godot`.
@@ -8806,6 +8852,19 @@ EditorNode::EditorNode() {
 
 	log = memnew(EditorLog);
 	editor_dock_manager->add_dock(log);
+	log_stream_dock = memnew(LogStreamDock);
+	editor_dock_manager->add_dock(log_stream_dock);
+	_setup_logstream_from_settings();
+
+	// Timer for polling WebSocket sink (needed to accept connections even when idle)
+	websocket_poll_timer = memnew(Timer);
+	websocket_poll_timer->set_wait_time(0.1); // Poll every 100ms
+	websocket_poll_timer->set_autostart(true);
+	websocket_poll_timer->connect("timeout", callable_mp(this, &EditorNode::_poll_websocket_sink));
+	add_child(websocket_poll_timer);
+
+	// React to settings changes for logstream.
+	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorNode::_setup_logstream_from_settings));
 
 	center_split->connect(SceneStringName(resized), callable_mp(this, &EditorNode::_vp_resized));
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -81,6 +81,8 @@ class EditorFolding;
 class EditorLayoutsDialog;
 class EditorLog;
 class EditorMainScreen;
+class LogStreamDock;
+class EditorLogStreamWebSocketSink;
 class EditorNativeShaderSourceVisualizer;
 class EditorPluginList;
 class EditorResourcePreview;
@@ -262,6 +264,9 @@ private:
 	EditorQuickOpenDialog *quick_open_dialog = nullptr;
 	EditorExport *editor_export = nullptr;
 	EditorLog *log = nullptr;
+	LogStreamDock *log_stream_dock = nullptr;
+	EditorLogStreamWebSocketSink *websocket_sink = nullptr;
+	Timer *websocket_poll_timer = nullptr;
 	EditorNativeShaderSourceVisualizer *native_shader_source_visualizer = nullptr;
 	EditorPluginList *editor_plugins_force_input_forwarding = nullptr;
 	EditorPluginList *editor_plugins_force_over = nullptr;
@@ -705,6 +710,8 @@ private:
 
 	void _progress_dialog_visibility_changed();
 	void _load_error_dialog_visibility_changed();
+	void _setup_logstream_from_settings();
+	void _poll_websocket_sink();
 
 	void _execute_upgrades();
 

--- a/editor/log_stream_dock.cpp
+++ b/editor/log_stream_dock.cpp
@@ -1,0 +1,398 @@
+// Minimal LogStream dock UI.
+#include "log_stream_dock.h"
+
+#include "core/logstream/log_stream.h"
+#include "core/io/json.h"
+#include "core/os/os.h"
+#include "editor/script/script_editor_plugin.h"
+#include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/panel_container.h"
+#include "scene/gui/rich_text_label.h"
+#include "scene/gui/spin_box.h"
+#include "scene/main/timer.h"
+
+LogStreamDock *LogStreamDock::singleton = nullptr;
+
+LogStreamDock *LogStreamDock::get_singleton() {
+	return singleton;
+}
+
+static Color _level_color(LogStreamEntry::Level p_level) {
+	switch (p_level) {
+		case LogStreamEntry::LEVEL_ERROR:
+			return Color(1, 0.35, 0.35); // red
+		case LogStreamEntry::LEVEL_WARNING:
+			return Color(1, 0.75, 0.35); // orange/yellow
+		case LogStreamEntry::LEVEL_INFO:
+			return Color(0.8, 0.8, 0.8); // light gray
+		case LogStreamEntry::LEVEL_DEBUG:
+			return Color(0.65, 0.8, 1.0); // blue-ish
+		case LogStreamEntry::LEVEL_VERBOSE:
+			return Color(0.7, 0.7, 1.0); // soft blue
+	}
+	return Color(1, 1, 1);
+}
+
+static String _format_entry_bbcode(const LogStreamEntry &e) {
+	const Color c = _level_color(e.level);
+	String color_tag = vformat("[color=#%02x%02x%02x]", int(c.r * 255), int(c.g * 255), int(c.b * 255));
+	String level = LogStreamEntry::level_to_string(e.level);
+	String ts = e.timestamp_usec > 0 ? vformat("%0.3f", e.timestamp_usec / 1000000.0) : String();
+	String line = color_tag;
+	if (!ts.is_empty()) {
+		line += vformat("[%s] ", ts);
+	}
+	line += vformat("[%s] %s", level, e.message);
+	if (!e.function.is_empty()) {
+		line += vformat(" (%s)", e.function);
+	}
+	if (!e.file.is_empty() && e.line > 0) {
+		line += vformat(" [url=%s:%d]%s:%d[/url]", e.file, e.line, e.file, e.line);
+	}
+	if (!e.category.is_empty()) {
+		line += vformat(" {%s}", e.category);
+	}
+	line += "[/color]";
+	return line;
+}
+
+LogStreamDock::LogStreamDock() {
+	singleton = this;
+
+	VBoxContainer *root = memnew(VBoxContainer);
+	add_child(root);
+
+	HBoxContainer *controls = memnew(HBoxContainer);
+	root->add_child(controls);
+
+	chk_error = memnew(CheckBox);
+	chk_error->set_text("Error");
+	chk_error->set_pressed(true);
+	controls->add_child(chk_error);
+
+	chk_warning = memnew(CheckBox);
+	chk_warning->set_text("Warn");
+	chk_warning->set_pressed(true);
+	controls->add_child(chk_warning);
+
+	chk_info = memnew(CheckBox);
+	chk_info->set_text("Info");
+	chk_info->set_pressed(true);
+	controls->add_child(chk_info);
+
+	chk_debug = memnew(CheckBox);
+	chk_debug->set_text("Debug");
+	controls->add_child(chk_debug);
+
+	chk_verbose = memnew(CheckBox);
+	chk_verbose->set_text("Verbose");
+	controls->add_child(chk_verbose);
+
+	search_box = memnew(LineEdit);
+	search_box->set_placeholder(TTR("Search..."));
+	search_box->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+	search_box->connect(SceneStringName(text_changed), callable_mp(this, &LogStreamDock::_on_search_changed));
+	controls->add_child(search_box);
+
+	pause_button = memnew(Button);
+	pause_button->set_text(TTR("Pause"));
+	pause_button->connect(SceneStringName(pressed), callable_mp(this, &LogStreamDock::_on_pause_toggled));
+	controls->add_child(pause_button);
+
+	chk_autoscroll = memnew(CheckBox);
+	chk_autoscroll->set_text(TTR("Auto-scroll"));
+	chk_autoscroll->set_pressed(true);
+	chk_autoscroll->connect(SceneStringName(pressed), callable_mp(this, &LogStreamDock::_on_autoscroll_toggled));
+	controls->add_child(chk_autoscroll);
+
+	clear_button = memnew(Button);
+	clear_button->set_text(TTR("Clear"));
+	clear_button->connect(SceneStringName(pressed), callable_mp(this, &LogStreamDock::_on_clear));
+	controls->add_child(clear_button);
+
+	export_button = memnew(Button);
+	export_button->set_text(TTR("Export"));
+	export_button->connect(SceneStringName(pressed), callable_mp(this, &LogStreamDock::_on_export));
+	controls->add_child(export_button);
+
+	Button *toggle_ts = memnew(Button);
+	toggle_ts->set_text(TTR("TS"));
+	toggle_ts->set_toggle_mode(true);
+	toggle_ts->set_pressed(true);
+	toggle_ts->connect(SceneStringName(pressed), callable_mp(this, &LogStreamDock::_on_toggle_timestamp));
+	controls->add_child(toggle_ts);
+
+	Button *toggle_cat = memnew(Button);
+	toggle_cat->set_text(TTR("Cat"));
+	toggle_cat->set_toggle_mode(true);
+	toggle_cat->set_pressed(true);
+	toggle_cat->connect(SceneStringName(pressed), callable_mp(this, &LogStreamDock::_on_toggle_category));
+	controls->add_child(toggle_cat);
+
+	max_display_spin = memnew(SpinBox);
+	max_display_spin->set_min(100);
+	max_display_spin->set_max(20000);
+	max_display_spin->set_step(100);
+	max_display_spin->set_value(max_display_entries);
+	max_display_spin->set_custom_minimum_size(Size2(120 * EDSCALE, 0));
+	max_display_spin->connect(SceneStringName(value_changed), callable_mp(this, &LogStreamDock::_on_max_display_changed));
+	controls->add_child(max_display_spin);
+
+	log_label = memnew(RichTextLabel);
+	log_label->set_v_size_flags(SIZE_EXPAND_FILL);
+	log_label->set_use_bbcode(true);
+	log_label->set_scroll_active(true);
+	log_label->set_selection_enabled(true);
+	log_label->connect("meta_clicked", callable_mp(this, &LogStreamDock::_on_log_meta_clicked));
+	root->add_child(log_label);
+
+	timer = memnew(Timer);
+	timer->set_wait_time(0.5);
+	timer->set_one_shot(false);
+	timer->set_autostart(true);
+	timer->connect("timeout", callable_mp(this, &LogStreamDock::_on_timer_timeout));
+	add_child(timer);
+}
+
+void LogStreamDock::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		_load_filter_state();
+	} else if (p_what == NOTIFICATION_EXIT_TREE) {
+		_save_filter_state();
+		if (timer) {
+			timer->stop();
+		}
+	}
+}
+
+void LogStreamDock::_on_timer_timeout() {
+	if (paused) {
+		return;
+	}
+	refresh();
+}
+
+void LogStreamDock::_on_pause_toggled() {
+	paused = !paused;
+	pause_button->set_text(paused ? TTR("Resume") : TTR("Pause"));
+	if (!paused) {
+		refresh();
+	}
+}
+
+void LogStreamDock::_on_autoscroll_toggled() {
+	paused = !chk_autoscroll->is_pressed();
+	pause_button->set_text(paused ? TTR("Resume") : TTR("Pause"));
+	if (!paused) {
+		refresh();
+	}
+}
+
+void LogStreamDock::_on_clear() {
+	if (LogStreamRouter::get_singleton()) {
+		LogStreamRouter::get_singleton()->clear_entries();
+	}
+	log_label->clear();
+	last_seq_rendered = 0;
+}
+
+void LogStreamDock::_on_export() {
+	if (!LogStreamRouter::get_singleton()) {
+		return;
+	}
+	String export_path = "user://logs/logstream_export.jsonl";
+	Ref<FileAccess> fa = FileAccess::open(export_path, FileAccess::WRITE);
+	if (fa.is_null()) {
+		return;
+	}
+
+	Vector<LogStreamEntry> entries = _filter_entries(LogStreamRouter::get_singleton()->get_entries_snapshot());
+	for (const LogStreamEntry &e : entries) {
+		Dictionary d;
+		d["seq"] = (int64_t)e.seq;
+		d["ts_usec"] = (int64_t)e.timestamp_usec;
+		d["level"] = LogStreamEntry::level_to_string(e.level);
+		d["message"] = e.message;
+		d["file"] = e.file;
+		d["line"] = e.line;
+		d["function"] = e.function;
+		d["category"] = e.category;
+		d["stack"] = e.stack;
+		d["project"] = e.project;
+		d["session_id"] = e.session_id;
+		fa->store_string(JSON::stringify(d) + "\n");
+	}
+	fa->flush();
+}
+
+void LogStreamDock::_on_search_changed(const String &p_text) {
+	if (!paused) {
+		refresh();
+	}
+	last_seq_rendered = 0; // force full redraw with new filter
+}
+
+void LogStreamDock::_on_toggle_timestamp() {
+	show_timestamp = !show_timestamp;
+	refresh();
+}
+
+void LogStreamDock::_on_toggle_category() {
+	show_category = !show_category;
+	refresh();
+}
+
+void LogStreamDock::_on_max_display_changed(double p_value) {
+	max_display_entries = (int)p_value;
+	if (!paused) {
+		refresh();
+	} else {
+		last_seq_rendered = 0;
+	}
+}
+
+void LogStreamDock::_on_log_meta_clicked(const Variant &p_meta) {
+	String meta = p_meta;
+	if (!meta.contains_char(':')) {
+		return;
+	}
+	const PackedStringArray parts = meta.rsplit(":", true, 1);
+	if (parts.size() != 2) {
+		return;
+	}
+	String path = parts[0];
+	int line = parts[1].to_int() - 1;
+
+	if (path.begins_with("res://")) {
+		if (ResourceLoader::exists(path)) {
+			const Ref<Resource> res = ResourceLoader::load(path);
+			if (res.is_valid()) {
+				ScriptEditor::get_singleton()->edit(res, line, 0);
+				return;
+			}
+		}
+	}
+	if (!ScriptEditorPlugin::open_in_external_editor(path, line, -1, true)) {
+		OS::get_singleton()->shell_open(path);
+	}
+}
+
+bool LogStreamDock::_allow_level(LogStreamEntry::Level p_level) const {
+	switch (p_level) {
+		case LogStreamEntry::LEVEL_ERROR:
+			return chk_error->is_pressed();
+		case LogStreamEntry::LEVEL_WARNING:
+			return chk_warning->is_pressed();
+		case LogStreamEntry::LEVEL_INFO:
+			return chk_info->is_pressed();
+		case LogStreamEntry::LEVEL_DEBUG:
+			return chk_debug->is_pressed();
+		case LogStreamEntry::LEVEL_VERBOSE:
+			return chk_verbose->is_pressed();
+	}
+	return true;
+}
+
+Vector<LogStreamEntry> LogStreamDock::_filter_entries(const Vector<LogStreamEntry> &p_entries) const {
+	Vector<LogStreamEntry> out;
+	String query = search_box->get_text();
+	for (const LogStreamEntry &e : p_entries) {
+		if (!_allow_level(e.level)) {
+			continue;
+		}
+		if (!query.is_empty()) {
+			if (!e.message.containsn(query) && !e.file.containsn(query) && !e.category.containsn(query)) {
+				continue;
+			}
+		}
+		out.push_back(e);
+	}
+	return out;
+}
+
+void LogStreamDock::refresh() {
+	if (!LogStreamRouter::get_singleton()) {
+		return;
+	}
+	Vector<LogStreamEntry> all_entries = LogStreamRouter::get_singleton()->get_entries_snapshot();
+	Vector<LogStreamEntry> entries = _filter_entries(all_entries);
+
+	const bool full_redraw = last_seq_rendered == 0;
+	if (full_redraw) {
+		log_label->clear();
+	}
+
+	// Limit displayed entries to keep UI responsive.
+	if (entries.size() > max_display_entries) {
+		entries = entries.slice(entries.size() - max_display_entries, max_display_entries);
+		log_label->clear();
+	}
+
+	for (const LogStreamEntry &e : entries) {
+		if (!full_redraw && e.seq <= last_seq_rendered) {
+			continue;
+		}
+		LogStreamEntry copy = e;
+		if (!show_timestamp) {
+			copy.timestamp_usec = 0;
+		}
+		if (!show_category) {
+			copy.category = "";
+		}
+		log_label->append_text(_format_entry_bbcode(copy) + "\n");
+		last_seq_rendered = MAX(last_seq_rendered, e.seq);
+	}
+	log_label->scroll_to_line(log_label->get_line_count());
+}
+
+void LogStreamDock::_load_filter_state() {
+	EditorSettings *es = EditorSettings::get_singleton();
+	if (!es) {
+		return;
+	}
+	if (!bool(es->get_setting("logstream/ui/persist_filters"))) {
+		return;
+	}
+	chk_error->set_pressed(bool(es->get_setting("logstream/ui/filter_error")));
+	chk_warning->set_pressed(bool(es->get_setting("logstream/ui/filter_warning")));
+	chk_info->set_pressed(bool(es->get_setting("logstream/ui/filter_info")));
+	chk_debug->set_pressed(bool(es->get_setting("logstream/ui/filter_debug")));
+	chk_verbose->set_pressed(bool(es->get_setting("logstream/ui/filter_verbose")));
+	search_box->set_text(es->get_setting("logstream/ui/search"));
+	show_timestamp = bool(es->get_setting("logstream/ui/show_timestamp"));
+	show_category = bool(es->get_setting("logstream/ui/show_category"));
+	max_display_entries = int(es->get_setting("logstream/ui/max_display"));
+	if (max_display_spin) {
+		max_display_spin->set_value(max_display_entries);
+	}
+	chk_autoscroll->set_pressed(es->get_setting("logstream/ui/auto_scroll"));
+	paused = !chk_autoscroll->is_pressed();
+	last_seq_rendered = 0;
+}
+
+void LogStreamDock::_save_filter_state() {
+	EditorSettings *es = EditorSettings::get_singleton();
+	if (!es) {
+		return;
+	}
+	if (!bool(es->get_setting("logstream/ui/persist_filters"))) {
+		return;
+	}
+	es->set_setting("logstream/ui/filter_error", chk_error->is_pressed());
+	es->set_setting("logstream/ui/filter_warning", chk_warning->is_pressed());
+	es->set_setting("logstream/ui/filter_info", chk_info->is_pressed());
+	es->set_setting("logstream/ui/filter_debug", chk_debug->is_pressed());
+	es->set_setting("logstream/ui/filter_verbose", chk_verbose->is_pressed());
+	es->set_setting("logstream/ui/search", search_box->get_text());
+	es->set_setting("logstream/ui/show_timestamp", show_timestamp);
+	es->set_setting("logstream/ui/show_category", show_category);
+	es->set_setting("logstream/ui/max_display", max_display_entries);
+	es->set_setting("logstream/ui/auto_scroll", chk_autoscroll->is_pressed());
+	es->save();
+}
+

--- a/editor/log_stream_dock.h
+++ b/editor/log_stream_dock.h
@@ -1,0 +1,68 @@
+// Minimal LogStream dock UI.
+#pragma once
+
+#include "editor/docks/editor_dock.h"
+#include "core/logstream/log_stream.h"
+
+class Button;
+class CheckBox;
+class LineEdit;
+class RichTextLabel;
+class SpinBox;
+class Timer;
+class EditorSettings;
+class ScriptEditorPlugin;
+
+class LogStreamDock : public EditorDock {
+	GDCLASS(LogStreamDock, EditorDock);
+
+public:
+	LogStreamDock();
+	~LogStreamDock() override = default;
+
+	static LogStreamDock *get_singleton();
+
+	void refresh();
+
+private:
+	static LogStreamDock *singleton;
+
+	RichTextLabel *log_label = nullptr;
+	CheckBox *chk_error = nullptr;
+	CheckBox *chk_warning = nullptr;
+	CheckBox *chk_info = nullptr;
+	CheckBox *chk_debug = nullptr;
+	CheckBox *chk_verbose = nullptr;
+	CheckBox *chk_autoscroll = nullptr;
+	LineEdit *search_box = nullptr;
+	Button *pause_button = nullptr;
+	Button *clear_button = nullptr;
+	Button *export_button = nullptr;
+	SpinBox *max_display_spin = nullptr;
+	Timer *timer = nullptr;
+	bool paused = false;
+	bool show_timestamp = true;
+	bool show_category = true;
+	uint64_t last_seq_rendered = 0;
+	int max_display_entries = 2000;
+
+	void _on_timer_timeout();
+	void _on_pause_toggled();
+	void _on_clear();
+	void _on_export();
+	void _on_search_changed(const String &p_text);
+	void _on_log_meta_clicked(const Variant &p_meta);
+	void _on_toggle_timestamp();
+	void _on_toggle_category();
+	void _on_autoscroll_toggled();
+	void _on_max_display_changed(double p_value);
+
+	bool _allow_level(LogStreamEntry::Level p_level) const;
+	Vector<LogStreamEntry> _filter_entries(const Vector<LogStreamEntry> &p_entries) const;
+	void _load_filter_state();
+	void _save_filter_state();
+
+protected:
+	void _notification(int p_what);
+};
+

--- a/editor/log_stream_websocket_sink.cpp
+++ b/editor/log_stream_websocket_sink.cpp
@@ -1,0 +1,320 @@
+// Editor-only WebSocket sink for LogStream.
+#include "log_stream_websocket_sink.h"
+
+#include "core/io/json.h"
+#include "core/os/os.h"
+
+static Dictionary _entry_to_dict(const LogStreamEntry &p_entry) {
+	Dictionary d;
+	d["seq"] = (int64_t)p_entry.seq;
+	d["ts_usec"] = (int64_t)p_entry.timestamp_usec;
+	d["level"] = LogStreamEntry::level_to_string(p_entry.level);
+	d["message"] = p_entry.message;
+	d["file"] = p_entry.file;
+	d["line"] = p_entry.line;
+	d["function"] = p_entry.function;
+	d["category"] = p_entry.category;
+	d["stack"] = p_entry.stack;
+	d["project"] = p_entry.project;
+	d["session_id"] = p_entry.session_id;
+	return d;
+}
+
+EditorLogStreamWebSocketSink::EditorLogStreamWebSocketSink(const Config &p_config) :
+		config(p_config) {
+}
+
+void EditorLogStreamWebSocketSink::configure(const Config &p_config) {
+	MutexLock lock(mutex);
+	config = p_config;
+	pending.clear();
+
+	// Close existing connections
+	for (KeyValue<int, PeerData> &E : peers) {
+		if (E.value.ws.is_valid()) {
+			E.value.ws->close();
+		}
+	}
+	peers.clear();
+	pending_peers.clear();
+
+	// Stop server
+	if (tcp_server.is_valid()) {
+		tcp_server->stop();
+		tcp_server.unref();
+	}
+}
+
+void EditorLogStreamWebSocketSink::ensure_server() {
+	if (tcp_server.is_valid() && tcp_server->is_listening()) {
+		return;
+	}
+
+	tcp_server.instantiate();
+	Error err = tcp_server->listen(config.port, IPAddress("*"));
+	if (err == OK) {
+		print_line(vformat("LogStream WebSocket server started on port %d", config.port));
+	} else {
+		ERR_PRINT(vformat("LogStream WebSocket server failed to start on port %d: %d", config.port, err));
+		tcp_server.unref();
+	}
+}
+
+void EditorLogStreamWebSocketSink::accept_new_connections() {
+	if (tcp_server.is_null() || !tcp_server->is_listening()) {
+		return;
+	}
+
+	while (tcp_server->is_connection_available()) {
+		Ref<StreamPeerTCP> tcp = tcp_server->take_connection();
+		if (tcp.is_null()) {
+			print_line("WebSocket sink: took null TCP connection");
+			continue;
+		}
+
+		print_line(vformat("WebSocket sink: new TCP connection from %s:%d", tcp->get_connected_host(), tcp->get_connected_port()));
+
+		Ref<WebSocketPeer> ws = Ref<WebSocketPeer>(WebSocketPeer::create());
+		if (ws.is_null()) {
+			print_line("WebSocket sink: failed to create WebSocketPeer");
+			continue;
+		}
+
+		Error err = ws->accept_stream(tcp);
+		if (err != OK) {
+			print_line(vformat("WebSocket sink: accept_stream failed: %d", err));
+			continue;
+		}
+
+		int peer_id = next_peer_id++;
+		PendingPeer pp;
+		pp.ws = ws;
+		pp.connect_time = OS::get_singleton()->get_ticks_msec();
+		pending_peers[peer_id] = pp;
+		print_line(vformat("WebSocket sink: added pending peer %d, total pending=%d", peer_id, pending_peers.size()));
+	}
+}
+
+void EditorLogStreamWebSocketSink::poll_pending_peers() {
+	Vector<int> to_remove;
+	Vector<int> to_promote;
+	uint64_t now = OS::get_singleton()->get_ticks_msec();
+
+	// First, collect all pending peer IDs to avoid iterator corruption
+	Vector<int> peer_ids;
+	for (const KeyValue<int, PendingPeer> &E : pending_peers) {
+		peer_ids.push_back(E.key);
+	}
+
+	// Now process each peer safely
+	for (int peer_id : peer_ids) {
+		// Check if peer still exists (might have been removed by another operation)
+		if (!pending_peers.has(peer_id)) {
+			continue;
+		}
+
+		PendingPeer &pp = pending_peers[peer_id];
+		Ref<WebSocketPeer> ws = pp.ws;
+		if (ws.is_null()) {
+			print_line(vformat("WebSocket sink: pending peer %d has null ws", peer_id));
+			to_remove.push_back(peer_id);
+			continue;
+		}
+
+		// Poll to advance handshake
+		ws->poll();
+		WebSocketPeer::State state = ws->get_ready_state();
+		uint64_t elapsed = now - pp.connect_time;
+
+		print_line(vformat("WebSocket sink: polling pending peer %d, state=%d, elapsed=%dms", peer_id, state, elapsed));
+
+		if (state == WebSocketPeer::STATE_OPEN) {
+			// Handshake complete, promote to full peer
+			print_line(vformat("WebSocket sink: promoting peer %d to full peer", peer_id));
+			to_promote.push_back(peer_id);
+		} else if (state == WebSocketPeer::STATE_CLOSED || state == WebSocketPeer::STATE_CLOSING) {
+			// Failed
+			print_line(vformat("WebSocket sink: pending peer %d closed/closing, removing", peer_id));
+			to_remove.push_back(peer_id);
+		} else if (state == WebSocketPeer::STATE_CONNECTING) {
+			// Still connecting, check timeout
+			if (now - pp.connect_time > 3000) { // 3 second timeout
+				print_line(vformat("WebSocket sink: pending peer %d handshake timeout", peer_id));
+				ws->close();
+				to_remove.push_back(peer_id);
+			}
+		}
+	}
+
+	// Promote successful connections
+	for (int peer_id : to_promote) {
+		if (!pending_peers.has(peer_id)) {
+			print_line(vformat("WebSocket sink: ERROR - peer %d not in pending_peers during promotion", peer_id));
+			continue;
+		}
+		PendingPeer &pp = pending_peers[peer_id];
+		if (pp.ws.is_null()) {
+			print_line(vformat("WebSocket sink: ERROR - peer %d has null ws during promotion", peer_id));
+			pending_peers.erase(peer_id);
+			continue;
+		}
+		PeerData pd;
+		pd.ws = pp.ws;
+		pd.authed = config.auth_token.is_empty(); // Auto-auth if no token required
+		peers[peer_id] = pd;
+		pending_peers.erase(peer_id);
+		print_line(vformat("WebSocket sink: peer %d promoted! authed=%s, total peers=%d", peer_id, pd.authed ? "true" : "false", peers.size()));
+	}
+
+	// Remove failed connections
+	for (int peer_id : to_remove) {
+		if (pending_peers.has(peer_id)) {
+			pending_peers.erase(peer_id);
+			print_line(vformat("WebSocket sink: removed pending peer %d", peer_id));
+		}
+	}
+}
+
+void EditorLogStreamWebSocketSink::poll_peers() {
+	// Remove disconnected peers
+	Vector<int> to_remove;
+
+	for (KeyValue<int, PeerData> &E : peers) {
+		Ref<WebSocketPeer> ws = E.value.ws;
+		if (ws.is_null()) {
+			to_remove.push_back(E.key);
+			continue;
+		}
+
+		ws->poll();
+		WebSocketPeer::State state = ws->get_ready_state();
+
+		if (state == WebSocketPeer::STATE_CLOSED || state == WebSocketPeer::STATE_CLOSING) {
+			to_remove.push_back(E.key);
+			continue;
+		}
+
+		// Handle incoming messages (for auth)
+		if (!E.value.authed && !config.auth_token.is_empty()) {
+			while (ws->get_available_packet_count() > 0) {
+				const uint8_t *buf = nullptr;
+				int len = 0;
+				Error err = ws->get_packet(&buf, len);
+				if (err != OK || buf == nullptr || len == 0) {
+					continue;
+				}
+
+				String msg = String::utf8((const char *)buf, len);
+				if (msg == config.auth_token) {
+					E.value.authed = true;
+				} else {
+					// Wrong token, disconnect
+					ws->close();
+					to_remove.push_back(E.key);
+					break;
+				}
+			}
+		}
+	}
+
+	// Remove disconnected/rejected peers
+	for (int peer_id : to_remove) {
+		peers.erase(peer_id);
+	}
+}
+
+void EditorLogStreamWebSocketSink::poll() {
+	accept_new_connections();
+	poll_pending_peers();
+	poll_peers();
+}
+
+void EditorLogStreamWebSocketSink::poll_server() {
+	MutexLock lock(mutex);
+	if (!config.enabled) {
+		return;
+	}
+	ensure_server();
+	poll();
+
+	// Flush pending logs if time threshold met (even if no new logs arrived)
+	if (!pending.is_empty()) {
+		uint64_t now = OS::get_singleton()->get_ticks_usec();
+		flush_if_ready(now);
+	}
+}
+
+void EditorLogStreamWebSocketSink::handle_entry(const LogStreamEntry &p_entry) {
+	MutexLock lock(mutex);
+	if (!config.enabled) {
+		return;
+	}
+	ensure_server();
+	poll();
+
+	pending.push_back(p_entry);
+	print_line(vformat("WebSocket sink: received log, pending=%d, peers=%d", pending.size(), peers.size()));
+	uint64_t now = OS::get_singleton()->get_ticks_usec();
+	flush_if_ready(now);
+}
+
+void EditorLogStreamWebSocketSink::flush() {
+	MutexLock lock(mutex);
+	if (!config.enabled || pending.is_empty()) {
+		return;
+	}
+	ensure_server();
+	poll();
+	send_batch(pending);
+	pending.clear();
+	last_flush_usec = OS::get_singleton()->get_ticks_usec();
+}
+
+void EditorLogStreamWebSocketSink::flush_if_ready(uint64_t p_now) {
+	const bool count_ready = config.batch_size > 0 && pending.size() >= config.batch_size;
+	const bool time_ready = config.batch_msec > 0 && (p_now - last_flush_usec) >= (uint64_t)config.batch_msec * 1000;
+	if (!count_ready && !time_ready) {
+		return;
+	}
+	if (pending.is_empty()) {
+		return;
+	}
+	send_batch(pending);
+	pending.clear();
+	last_flush_usec = p_now;
+}
+
+void EditorLogStreamWebSocketSink::send_batch(const Vector<LogStreamEntry> &p_batch) {
+	if (peers.is_empty()) {
+		print_line(vformat("WebSocket sink: send_batch called but no peers connected"));
+		return;
+	}
+
+	print_line(vformat("WebSocket sink: sending batch of %d entries to %d peers", p_batch.size(), peers.size()));
+
+	// Build JSON array
+	Array arr;
+	for (const LogStreamEntry &e : p_batch) {
+		arr.push_back(_entry_to_dict(e));
+	}
+	String payload = JSON::stringify(arr);
+	Vector<uint8_t> bytes = payload.to_utf8_buffer();
+
+	// Send to all authenticated peers
+	int sent_count = 0;
+	for (KeyValue<int, PeerData> &E : peers) {
+		if (E.value.authed && E.value.ws.is_valid()) {
+			Ref<WebSocketPeer> ws = E.value.ws;
+			if (ws->get_ready_state() == WebSocketPeer::STATE_OPEN) {
+				ws->send_text(payload);
+				sent_count++;
+				print_line(vformat("WebSocket sink: sent batch to peer %d", E.key));
+			} else {
+				print_line(vformat("WebSocket sink: peer %d not open (state=%d)", E.key, ws->get_ready_state()));
+			}
+		} else {
+			print_line(vformat("WebSocket sink: peer %d not authed or ws invalid (authed=%d, valid=%d)", E.key, E.value.authed, E.value.ws.is_valid()));
+		}
+	}
+	print_line(vformat("WebSocket sink: sent to %d/%d peers", sent_count, peers.size()));
+}

--- a/editor/log_stream_websocket_sink.h
+++ b/editor/log_stream_websocket_sink.h
@@ -1,0 +1,63 @@
+// Editor-only WebSocket sink for LogStream.
+#pragma once
+
+#include "core/io/stream_peer_tcp.h"
+#include "core/io/tcp_server.h"
+#include "core/logstream/log_stream.h"
+#include "core/os/mutex.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/hash_set.h"
+#include "modules/websocket/websocket_peer.h"
+
+class EditorLogStreamWebSocketSink : public LogStreamSink {
+public:
+	struct Config {
+		bool enabled = false;
+		int port;
+		int batch_size;
+		int batch_msec;
+		String auth_token;
+
+		Config() :
+				port(17865),
+				batch_size(50),
+				batch_msec(100) {}
+	};
+
+	explicit EditorLogStreamWebSocketSink(const Config &p_config = Config());
+	~EditorLogStreamWebSocketSink() override = default;
+
+	void handle_entry(const LogStreamEntry &p_entry) override;
+	void flush() override;
+	void configure(const Config &p_config);
+	void poll_server(); // Call regularly to accept connections/handle messages
+
+private:
+	struct PendingPeer {
+		Ref<WebSocketPeer> ws;
+		uint64_t connect_time = 0;
+	};
+
+	struct PeerData {
+		Ref<WebSocketPeer> ws;
+		bool authed = false;
+	};
+
+	mutable Mutex mutex;
+	Config config;
+	Ref<TCPServer> tcp_server;
+	HashMap<int, PendingPeer> pending_peers;
+	HashMap<int, PeerData> peers;
+	int next_peer_id = 1;
+	Vector<LogStreamEntry> pending;
+	uint64_t last_flush_usec = 0;
+
+	void ensure_server();
+	void poll();
+	void accept_new_connections();
+	void poll_pending_peers();
+	void poll_peers();
+	void flush_if_ready(uint64_t p_now);
+	void send_batch(const Vector<LogStreamEntry> &p_batch);
+};
+

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -401,6 +401,20 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set(m_name, m_default_value);                                                             \
 	hints[m_name] = PropertyInfo(m_type, m_name, m_property_hint, m_hint_string, m_usage);
 
+	// LogStream defaults
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "logstream/enabled", true, "");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "logstream/max_entries", 5000, "100,20000,100");
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "logstream/file_logging/enabled", true, "");
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "logstream/file_logging/path", "user://logs/editor.log", "");
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "logstream/file_logging/format", "jsonl,plain", "");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "logstream/file_logging/max_size_mb", 0, "0,1024,16");
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "logstream/websocket/enabled", false, "");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "logstream/websocket/port", 17865, "1,65535,1");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "logstream/websocket/batch_size", 50, "1,500,1");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "logstream/websocket/batch_msec", 100, "10,2000,10");
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "logstream/websocket/auth_token", "", "");
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "logstream/ui/persist_filters", true, "");
+
 	/* Languages */
 
 	{


### PR DESCRIPTION
- Add LogStreamRouter core singleton with ring buffer and sink architecture
- Add LogStreamLogger to intercept engine logs via CompositeLogger
- Add LogStreamFileSink with JSONL/plain format and size-based rotation
- Add EditorLogStreamWebSocketSink for live log streaming over WebSocket
  - Uses TCPServer + WSLPeer for standard WebSocket client compatibility
  - Supports batching (50 logs or 100ms interval) and optional auth token
  - Fixed iterator corruption and added proper peer lifecycle management
- Add LogStreamDock editor panel with filters, search, pause, export
  - Color-coded log levels, timestamps, categories, file:line links
  - Virtualized rendering with configurable max display entries
- Add editor settings for LogStream configuration (logstream/*)
- Integrate with EditorNode initialization and settings change detection
- Add Python WebSocket test clients for verification

This implementation follows the PRD requirements for native log streaming directly into the Godot editor with minimal performance impact.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
