### PR TITLE
Gdextension compatibility for variant utility functions, add optional base argument to log.

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -588,14 +588,20 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 			bool vararg = Variant::is_utility_function_vararg(name);
 			func["is_vararg"] = Variant::is_utility_function_vararg(name);
 			func["hash"] = Variant::get_utility_function_hash(name);
+
 			Array arguments;
+			const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(name);
 			int argcount = Variant::get_utility_function_argument_count(name);
 			for (int i = 0; i < argcount; i++) {
 				Dictionary arg;
 				String argname = vararg ? "arg" + itos(i + 1) : Variant::get_utility_function_argument_name(name, i);
 				arg["name"] = argname;
 				arg["type"] = get_builtin_or_variant_type_name(Variant::get_utility_function_argument_type(name, i));
-				//no default value support in utility functions
+
+				const int dargidx = Variant::get_utility_function_default_argument_index(name, i);
+				if (dargidx >= 0) {
+					arg["default_value"] = def_args[dargidx].get_construct_string();
+				}
 				arguments.push_back(arg);
 			}
 

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -589,6 +589,17 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 			func["is_vararg"] = Variant::is_utility_function_vararg(name);
 			func["hash"] = Variant::get_utility_function_hash(name);
 
+			Vector<uint32_t> compat_hashes = Variant::get_utility_function_compatibility_hashes(name);
+			Array compatibility;
+			if (compat_hashes.size()) {
+				for (int j = 0; j < compat_hashes.size(); j++) {
+					compatibility.push_back(compat_hashes[j]);
+				}
+			}
+			if (compatibility.size() > 0) {
+				func["hash_compatibility"] = compatibility;
+			}
+
 			Array arguments;
 			const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(name);
 			int argcount = Variant::get_utility_function_argument_count(name);

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -871,12 +871,11 @@ static void gdextension_variant_get_constant_value(GDExtensionVariantType p_type
 }
 static GDExtensionPtrUtilityFunction gdextension_variant_get_ptr_utility_function(GDExtensionConstStringNamePtr p_function, GDExtensionInt p_hash) {
 	StringName function = *reinterpret_cast<const StringName *>(p_function);
-	uint32_t hash = Variant::get_utility_function_hash(function);
-	if (hash != p_hash) {
-		ERR_PRINT_ONCE("Error getting utility function " + function + ", hash mismatch.");
-		return nullptr;
+	GDExtensionPtrUtilityFunction ptr = (GDExtensionPtrUtilityFunction)Variant::get_ptr_utility_function_with_compatibility(function, p_hash);
+	if (!ptr) {
+		ERR_PRINT("Error getting utility function " + function + ", missing or hash mismatch.");
 	}
-	return (GDExtensionPtrUtilityFunction)Variant::get_ptr_utility_function(function);
+	return ptr;
 }
 
 //string helpers

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -689,7 +689,7 @@ _ALWAYS_INLINE_ double randd() {
 _ALWAYS_INLINE_ float randf() {
 	return (float)rand() / (float)UINT32_MAX;
 }
-double randfn(double p_mean, double p_deviation);
+double randfn(double p_mean = 0.0, double p_deviation = 1.0);
 
 double random(double p_from, double p_to);
 float random(float p_from, float p_to);

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -197,6 +197,13 @@ _ALWAYS_INLINE_ float log(float p_x) {
 	return std::log(p_x);
 }
 
+_ALWAYS_INLINE_ double log(double p_x, double p_base) {
+	return std::log(p_x) / std::log(p_base);
+}
+_ALWAYS_INLINE_ float log(float p_x, float p_base) {
+	return std::log(p_x) / std::log(p_base);
+}
+
 _ALWAYS_INLINE_ double log1p(double p_x) {
 	return std::log1p(p_x);
 }

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -811,6 +811,8 @@ public:
 	static int get_utility_function_argument_count(const StringName &p_name);
 	static Variant::Type get_utility_function_argument_type(const StringName &p_name, int p_arg);
 	static String get_utility_function_argument_name(const StringName &p_name, int p_arg);
+	static Vector<Variant> get_utility_function_default_arguments(const StringName &p_name);
+	static int get_utility_function_default_argument_index(const StringName &p_name, int p_arg);
 	static bool has_utility_function_return_value(const StringName &p_name);
 	static Variant::Type get_utility_function_return_type(const StringName &p_name);
 	static bool is_utility_function_vararg(const StringName &p_name);

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -814,6 +814,7 @@ public:
 
 	static ValidatedUtilityFunction get_validated_utility_function(const StringName &p_name);
 	static PTRUtilityFunction get_ptr_utility_function(const StringName &p_name);
+	static PTRUtilityFunction get_ptr_utility_function_with_compatibility(const StringName &p_name, uint32_t p_hash);
 
 	enum UtilityFunctionType {
 		UTILITY_FUNC_TYPE_MATH,
@@ -833,6 +834,7 @@ public:
 	static Variant::Type get_utility_function_return_type(const StringName &p_name);
 	static bool is_utility_function_vararg(const StringName &p_name);
 	static uint32_t get_utility_function_hash(const StringName &p_name);
+	static Vector<uint32_t> get_utility_function_compatibility_hashes(const StringName &p_name);
 
 	static void get_utility_function_list(List<StringName> *r_functions);
 	static int get_utility_function_count();

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1167,39 +1167,19 @@ String VariantUtilityFunctions::join_string(const Variant **p_args, int p_arg_co
 #define VCALL p_func(VariantCaster<P>::cast(*p_args[Is])...)
 #endif // DEBUG_ENABLED
 
-template <typename R, typename... P, size_t... Is>
-static _FORCE_INLINE_ void call_helperpr(R (*p_func)(P...), Variant *ret, const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
-	r_error.error = Callable::CallError::CALL_OK;
-	VCALLR;
-	(void)p_args; // avoid gcc warning
-	(void)r_error;
-}
-
-template <typename R, typename... P, size_t... Is>
-static _FORCE_INLINE_ void validated_call_helperpr(R (*p_func)(P...), Variant *ret, const Variant **p_args, IndexSequence<Is...>) {
-	*ret = p_func(VariantCaster<P>::cast(*p_args[Is])...);
-	(void)p_args;
-}
-
-template <typename R, typename... P, size_t... Is>
-static _FORCE_INLINE_ void ptr_call_helperpr(R (*p_func)(P...), void *ret, const void **p_args, IndexSequence<Is...>) {
-	PtrToArg<R>::encode(p_func(PtrToArg<P>::convert(p_args[Is])...), ret);
-	(void)p_args;
+template <typename R, typename... P>
+static _FORCE_INLINE_ void call_helperr(R (*p_func)(P...), Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
+	call_with_variant_args_static_ret_dv(p_func, p_args, p_argcount, *r_ret, r_error, p_defvals);
 }
 
 template <typename R, typename... P>
-static _FORCE_INLINE_ void call_helperr(R (*p_func)(P...), Variant *ret, const Variant **p_args, Callable::CallError &r_error) {
-	call_helperpr(p_func, ret, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
+static _FORCE_INLINE_ void validated_call_helperr(R (*p_func)(P...), Variant *r_ret, const Variant **p_args) {
+	call_with_validated_variant_args_static_method_ret(p_func, p_args, r_ret);
 }
 
 template <typename R, typename... P>
-static _FORCE_INLINE_ void validated_call_helperr(R (*p_func)(P...), Variant *ret, const Variant **p_args) {
-	validated_call_helperpr(p_func, ret, p_args, BuildIndexSequence<sizeof...(P)>{});
-}
-
-template <typename R, typename... P>
-static _FORCE_INLINE_ void ptr_call_helperr(R (*p_func)(P...), void *ret, const void **p_args) {
-	ptr_call_helperpr(p_func, ret, p_args, BuildIndexSequence<sizeof...(P)>{});
+static _FORCE_INLINE_ void ptr_call_helperr(R (*p_func)(P...), void *r_ret, const void **p_args) {
+	call_with_ptr_args_static_method_ret<R, P...>(p_func, p_args, r_ret);
 }
 
 template <typename R, typename... P>
@@ -1219,39 +1199,19 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helperr(R (*p_func)(P...)) {
 
 // WITHOUT RET
 
-template <typename... P, size_t... Is>
-static _FORCE_INLINE_ void call_helperp(void (*p_func)(P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
-	r_error.error = Callable::CallError::CALL_OK;
-	VCALL;
-	(void)p_args;
-	(void)r_error;
-}
-
-template <typename... P, size_t... Is>
-static _FORCE_INLINE_ void validated_call_helperp(void (*p_func)(P...), const Variant **p_args, IndexSequence<Is...>) {
-	p_func(VariantCaster<P>::cast(*p_args[Is])...);
-	(void)p_args;
-}
-
-template <typename... P, size_t... Is>
-static _FORCE_INLINE_ void ptr_call_helperp(void (*p_func)(P...), const void **p_args, IndexSequence<Is...>) {
-	p_func(PtrToArg<P>::convert(p_args[Is])...);
-	(void)p_args;
-}
-
 template <typename... P>
-static _FORCE_INLINE_ void call_helper(void (*p_func)(P...), const Variant **p_args, Callable::CallError &r_error) {
-	call_helperp(p_func, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
+static _FORCE_INLINE_ void call_helper(void (*p_func)(P...), const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
+	call_with_variant_args_static_dv(p_func, p_args, p_argcount, r_error, p_defvals);
 }
 
 template <typename... P>
 static _FORCE_INLINE_ void validated_call_helper(void (*p_func)(P...), const Variant **p_args) {
-	validated_call_helperp(p_func, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_validated_variant_args_static_method(p_func, p_args);
 }
 
 template <typename... P>
 static _FORCE_INLINE_ void ptr_call_helper(void (*p_func)(P...), const void **p_args) {
-	ptr_call_helperp(p_func, p_args, BuildIndexSequence<sizeof...(P)>{});
+	call_with_ptr_args_static_method<P...>(p_func, p_args);
 }
 
 template <typename... P>
@@ -1269,117 +1229,150 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 	return Variant::NIL;
 }
 
-#define FUNCBINDR(m_func, m_args, m_category)                                                                    \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args);                              \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args);                                      \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return get_arg_count_helperr(VariantUtilityFunctions::m_func);                                       \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg);                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return get_ret_type_helperr(VariantUtilityFunctions::m_func);                                        \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDR(m_func, m_args, m_category)                                                                                                      \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, p_argcount, p_defvals, r_error);                                          \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args);                                                                \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args);                                                                        \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return get_arg_count_helperr(VariantUtilityFunctions::m_func);                                                                         \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg);                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return get_ret_type_helperr(VariantUtilityFunctions::m_func);                                                                          \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVR(m_func, m_args, m_category)                                                                          \
-	class Func_##m_func {                                                                                               \
-	public:                                                                                                             \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {        \
-			r_error.error = Callable::CallError::CALL_OK;                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], r_error);                                              \
-		}                                                                                                               \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                            \
-			Callable::CallError ce;                                                                                     \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], ce);                                                   \
-		}                                                                                                               \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                           \
-			Callable::CallError ce;                                                                                     \
-			PtrToArg<Variant>::encode(VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), ce), ret); \
-		}                                                                                                               \
-		static int get_argument_count() {                                                                               \
-			return 1;                                                                                                   \
-		}                                                                                                               \
-		static Variant::Type get_argument_type(int p_arg) {                                                             \
-			return Variant::NIL;                                                                                        \
-		}                                                                                                               \
-		static Variant::Type get_return_type() {                                                                        \
-			return Variant::NIL;                                                                                        \
-		}                                                                                                               \
-		static bool has_return_type() {                                                                                 \
-			return true;                                                                                                \
-		}                                                                                                               \
-		static bool is_vararg() {                                                                                       \
-			return false;                                                                                               \
-		}                                                                                                               \
-		static Variant::UtilityFunctionType get_type() {                                                                \
-			return m_category;                                                                                          \
-		}                                                                                                               \
-	};                                                                                                                  \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDRD(m_func, m_args, m_defvals, m_category)                                                                                          \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args, p_argcount, p_defvals, r_error);                                          \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			validated_call_helperr(VariantUtilityFunctions::m_func, r_ret, p_args);                                                                \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			ptr_call_helperr(VariantUtilityFunctions::m_func, ret, p_args);                                                                        \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return get_arg_count_helperr(VariantUtilityFunctions::m_func);                                                                         \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return get_arg_type_helperr(VariantUtilityFunctions::m_func, p_arg);                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return get_ret_type_helperr(VariantUtilityFunctions::m_func);                                                                          \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, m_defvals)
 
-#define FUNCBINDVR2(m_func, m_args, m_category)                                                                                    \
-	class Func_##m_func {                                                                                                          \
-	public:                                                                                                                        \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {                   \
-			r_error.error = Callable::CallError::CALL_OK;                                                                          \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], r_error);                                             \
-		}                                                                                                                          \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                       \
-			Callable::CallError ce;                                                                                                \
-			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], ce);                                                  \
-		}                                                                                                                          \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                      \
-			Callable::CallError ce;                                                                                                \
-			Variant r;                                                                                                             \
-			r = VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), PtrToArg<Variant>::convert(p_args[1]), ce); \
-			PtrToArg<Variant>::encode(r, ret);                                                                                     \
-		}                                                                                                                          \
-		static int get_argument_count() {                                                                                          \
-			return 2;                                                                                                              \
-		}                                                                                                                          \
-		static Variant::Type get_argument_type(int p_arg) {                                                                        \
-			return Variant::NIL;                                                                                                   \
-		}                                                                                                                          \
-		static Variant::Type get_return_type() {                                                                                   \
-			return Variant::NIL;                                                                                                   \
-		}                                                                                                                          \
-		static bool has_return_type() {                                                                                            \
-			return true;                                                                                                           \
-		}                                                                                                                          \
-		static bool is_vararg() {                                                                                                  \
-			return false;                                                                                                          \
-		}                                                                                                                          \
-		static Variant::UtilityFunctionType get_type() {                                                                           \
-			return m_category;                                                                                                     \
-		}                                                                                                                          \
-	};                                                                                                                             \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVR(m_func, m_args, m_category)                                                                                                     \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], r_error);                                                                         \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError ce;                                                                                                                \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], ce);                                                                              \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Callable::CallError ce;                                                                                                                \
+			PtrToArg<Variant>::encode(VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), ce), ret);                            \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 1;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
+
+#define FUNCBINDVR2(m_func, m_args, m_category)                                                                                                    \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], r_error);                                                             \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError ce;                                                                                                                \
+			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], ce);                                                                  \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Callable::CallError ce;                                                                                                                \
+			Variant r;                                                                                                                             \
+			r = VariantUtilityFunctions::m_func(PtrToArg<Variant>::convert(p_args[0]), PtrToArg<Variant>::convert(p_args[1]), ce);                 \
+			PtrToArg<Variant>::encode(r, ret);                                                                                                     \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 2;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
 #define FUNCBINDVR3(m_func, m_args, m_category)                                                                                                                           \
 	class Func_##m_func {                                                                                                                                                 \
 	public:                                                                                                                                                               \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {                                                          \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {                        \
 			r_error.error = Callable::CallError::CALL_OK;                                                                                                                 \
 			*r_ret = VariantUtilityFunctions::m_func(*p_args[0], *p_args[1], *p_args[2], r_error);                                                                        \
 		}                                                                                                                                                                 \
@@ -1412,181 +1405,182 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 			return m_category;                                                                                                                                            \
 		}                                                                                                                                                                 \
 	};                                                                                                                                                                    \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARG(m_func, m_args, m_category)                                                               \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                     \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-			PtrToArg<Variant>::encode(r, ret);                                                                   \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 2;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVARARG(m_func, m_args, m_category)                                                                                                 \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                                                                 \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError c;                                                                                                                 \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                                                       \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Vector<Variant> args;                                                                                                                  \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                                                             \
+			}                                                                                                                                      \
+			Vector<const Variant *> argsp;                                                                                                         \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				argsp.push_back(&args[i]);                                                                                                         \
+			}                                                                                                                                      \
+			Variant r;                                                                                                                             \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                                                         \
+			PtrToArg<Variant>::encode(r, ret);                                                                                                     \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 2;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARGS(m_func, m_args, m_category)                                                              \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                               \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                     \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-			PtrToArg<String>::encode(r.operator String(), ret);                                                  \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 1;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::STRING;                                                                              \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVARARGS(m_func, m_args, m_category)                                                                                                \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, r_error);                                                                 \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError c;                                                                                                                 \
+			*r_ret = VariantUtilityFunctions::m_func(p_args, p_argcount, c);                                                                       \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Vector<Variant> args;                                                                                                                  \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                                                             \
+			}                                                                                                                                      \
+			Vector<const Variant *> argsp;                                                                                                         \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				argsp.push_back(&args[i]);                                                                                                         \
+			}                                                                                                                                      \
+			Variant r;                                                                                                                             \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                                                         \
+			PtrToArg<String>::encode(r.operator String(), ret);                                                                                    \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 1;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::STRING;                                                                                                                \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category)                                          \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			r_error.error = Callable::CallError::CALL_OK;                                                        \
-			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, r_error);                                  \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			Callable::CallError c;                                                                               \
-			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, c);                                        \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			Vector<Variant> args;                                                                                \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
-			}                                                                                                    \
-			Vector<const Variant *> argsp;                                                                       \
-			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
-			}                                                                                                    \
-			Variant r;                                                                                           \
-			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return 1;                                                                                            \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return Variant::NIL;                                                                                 \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return true;                                                                                         \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category)                                                                            \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			r_error.error = Callable::CallError::CALL_OK;                                                                                          \
+			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, r_error);                                                                    \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			Callable::CallError c;                                                                                                                 \
+			VariantUtilityFunctions::m_func_cname(p_args, p_argcount, c);                                                                          \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			Vector<Variant> args;                                                                                                                  \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                                                             \
+			}                                                                                                                                      \
+			Vector<const Variant *> argsp;                                                                                                         \
+			for (int i = 0; i < p_argcount; i++) {                                                                                                 \
+				argsp.push_back(&args[i]);                                                                                                         \
+			}                                                                                                                                      \
+			Variant r;                                                                                                                             \
+			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                                                         \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return 1;                                                                                                                              \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return Variant::NIL;                                                                                                                   \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return true;                                                                                                                           \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
 #define FUNCBINDVARARGV(m_func, m_args, m_category) FUNCBINDVARARGV_CNAME(m_func, m_func, m_args, m_category)
 
-#define FUNCBIND(m_func, m_args, m_category)                                                                     \
-	class Func_##m_func {                                                                                        \
-	public:                                                                                                      \
-		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) { \
-			call_helper(VariantUtilityFunctions::m_func, p_args, r_error);                                       \
-		}                                                                                                        \
-		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                     \
-			validated_call_helper(VariantUtilityFunctions::m_func, p_args);                                      \
-		}                                                                                                        \
-		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
-			ptr_call_helper(VariantUtilityFunctions::m_func, p_args);                                            \
-		}                                                                                                        \
-		static int get_argument_count() {                                                                        \
-			return get_arg_count_helper(VariantUtilityFunctions::m_func);                                        \
-		}                                                                                                        \
-		static Variant::Type get_argument_type(int p_arg) {                                                      \
-			return get_arg_type_helper(VariantUtilityFunctions::m_func, p_arg);                                  \
-		}                                                                                                        \
-		static Variant::Type get_return_type() {                                                                 \
-			return get_ret_type_helper(VariantUtilityFunctions::m_func);                                         \
-		}                                                                                                        \
-		static bool has_return_type() {                                                                          \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static bool is_vararg() {                                                                                \
-			return false;                                                                                        \
-		}                                                                                                        \
-		static Variant::UtilityFunctionType get_type() {                                                         \
-			return m_category;                                                                                   \
-		}                                                                                                        \
-	};                                                                                                           \
-	register_utility_function<Func_##m_func>(#m_func, m_args)
+#define FUNCBIND(m_func, m_args, m_category)                                                                                                       \
+	class Func_##m_func {                                                                                                                          \
+	public:                                                                                                                                        \
+		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
+			call_helper(VariantUtilityFunctions::m_func, p_args, p_argcount, p_defvals, r_error);                                                  \
+		}                                                                                                                                          \
+		static void validated_call(Variant *r_ret, const Variant **p_args, int p_argcount) {                                                       \
+			validated_call_helper(VariantUtilityFunctions::m_func, p_args);                                                                        \
+		}                                                                                                                                          \
+		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                                                      \
+			ptr_call_helper(VariantUtilityFunctions::m_func, p_args);                                                                              \
+		}                                                                                                                                          \
+		static int get_argument_count() {                                                                                                          \
+			return get_arg_count_helper(VariantUtilityFunctions::m_func);                                                                          \
+		}                                                                                                                                          \
+		static Variant::Type get_argument_type(int p_arg) {                                                                                        \
+			return get_arg_type_helper(VariantUtilityFunctions::m_func, p_arg);                                                                    \
+		}                                                                                                                                          \
+		static Variant::Type get_return_type() {                                                                                                   \
+			return get_ret_type_helper(VariantUtilityFunctions::m_func);                                                                           \
+		}                                                                                                                                          \
+		static bool has_return_type() {                                                                                                            \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static bool is_vararg() {                                                                                                                  \
+			return false;                                                                                                                          \
+		}                                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                                           \
+			return m_category;                                                                                                                     \
+		}                                                                                                                                          \
+	};                                                                                                                                             \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
 struct VariantUtilityFunctionInfo {
-	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) = nullptr;
+	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) = nullptr;
 	Variant::ValidatedUtilityFunction validated_call_utility = nullptr;
 	Variant::PTRUtilityFunction ptr_call_utility = nullptr;
+	Vector<Variant> default_arguments;
 	Vector<String> argnames;
 	bool is_vararg = false;
 	bool returns_value = false;
@@ -1600,7 +1594,7 @@ static AHashMap<StringName, VariantUtilityFunctionInfo> utility_function_table;
 static List<StringName> utility_function_name_table;
 
 template <typename T>
-static void register_utility_function(const String &p_name, const Vector<String> &argnames) {
+static void register_utility_function(const String &p_name, const Vector<String> &p_argnames, const Vector<Variant> &p_def_args) {
 	String name = p_name;
 	if (name.begins_with("_")) {
 		name = name.substr(1);
@@ -1613,10 +1607,11 @@ static void register_utility_function(const String &p_name, const Vector<String>
 	bfi.validated_call_utility = T::validated_call;
 	bfi.ptr_call_utility = T::ptrcall;
 	bfi.is_vararg = T::is_vararg();
-	bfi.argnames = argnames;
+	bfi.default_arguments = p_def_args;
+	bfi.argnames = p_argnames;
 	bfi.argcount = T::get_argument_count();
 	if (!bfi.is_vararg) {
-		ERR_FAIL_COND_MSG(argnames.size() != bfi.argcount, vformat("Wrong number of arguments binding utility function: '%s'.", name));
+		ERR_FAIL_COND_MSG(p_argnames.size() != bfi.argcount, vformat("Wrong number of arguments binding utility function: '%s'.", name));
 	}
 	bfi.get_arg_type = T::get_argument_type;
 	bfi.return_type = T::get_return_type();
@@ -1739,7 +1734,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(randf, sarray(), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(randi_range, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(randf_range, sarray("from", "to"), Variant::UTILITY_FUNC_TYPE_RANDOM);
-	FUNCBINDR(randfn, sarray("mean", "deviation"), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDRD(randfn, sarray("mean", "deviation"), varray(0.0, 1.0), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBIND(seed, sarray("base"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(rand_from_seed, sarray("seed"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 
@@ -1796,9 +1791,9 @@ void Variant::call_utility_function(const StringName &p_name, Variant *r_ret, co
 		return;
 	}
 
-	if (unlikely(!bfi->is_vararg && p_argcount < bfi->argcount)) {
+	if (unlikely(!bfi->is_vararg && p_argcount < bfi->argcount - bfi->default_arguments.size())) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
-		r_error.expected = bfi->argcount;
+		r_error.expected = bfi->argcount - bfi->default_arguments.size();
 		return;
 	}
 
@@ -1808,7 +1803,7 @@ void Variant::call_utility_function(const StringName &p_name, Variant *r_ret, co
 		return;
 	}
 
-	bfi->call_utility(r_ret, p_args, p_argcount, r_error);
+	bfi->call_utility(r_ret, p_args, p_argcount, bfi->default_arguments, r_error);
 }
 
 bool Variant::has_utility_function(const StringName &p_name) {
@@ -1860,6 +1855,7 @@ MethodInfo Variant::get_utility_function_info(const StringName &p_name) {
 			arg.name = bfi->argnames[i];
 			info.arguments.push_back(arg);
 		}
+		info.default_arguments = bfi->default_arguments;
 	}
 	return info;
 }
@@ -1880,6 +1876,24 @@ Variant::Type Variant::get_utility_function_argument_type(const StringName &p_na
 	}
 
 	return bfi->get_arg_type(p_arg);
+}
+
+Vector<Variant> Variant::get_utility_function_default_arguments(const StringName &p_name) {
+	const VariantUtilityFunctionInfo *bfi = utility_function_table.getptr(p_name);
+	if (!bfi) {
+		return varray();
+	}
+
+	return bfi->default_arguments;
+}
+
+int Variant::get_utility_function_default_argument_index(const StringName &p_name, int p_arg) {
+	const VariantUtilityFunctionInfo *bfi = utility_function_table.getptr(p_name);
+	if (!bfi) {
+		return -1;
+	}
+
+	return p_arg - (bfi->argcount - bfi->default_arguments.size());
 }
 
 String Variant::get_utility_function_argument_name(const StringName &p_name, int p_arg) {

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1229,7 +1229,7 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 	return Variant::NIL;
 }
 
-#define FUNCBINDR(m_func, m_args, m_category)                                                                                                      \
+#define DEF_FUNCBINDR(m_func, m_args, m_category)                                                                                                  \
 	class Func_##m_func {                                                                                                                          \
 	public:                                                                                                                                        \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
@@ -1259,10 +1259,23 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static Variant::UtilityFunctionType get_type() {                                                                                           \
 			return m_category;                                                                                                                     \
 		}                                                                                                                                          \
-	};                                                                                                                                             \
+	};
+
+#define FUNCBINDR(m_func, m_args, m_category) \
+	DEF_FUNCBINDR(m_func, m_args, m_category) \
 	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDRD(m_func, m_args, m_defvals, m_category)                                                                                          \
+#ifndef DISABLE_DEPRECATED
+#define FUNCBINDR_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	DEF_FUNCBINDR(m_func_cname, m_args, m_category)                \
+	register_utility_function_compat<Func_##m_func_cname>(#m_func, m_args, varray())
+#else
+#define FUNCBINDR_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	do {                                                           \
+	} while (0)
+#endif
+
+#define DEF_FUNCBINDRD(m_func, m_args, m_defvals, m_category)                                                                                      \
 	class Func_##m_func {                                                                                                                          \
 	public:                                                                                                                                        \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
@@ -1292,10 +1305,23 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static Variant::UtilityFunctionType get_type() {                                                                                           \
 			return m_category;                                                                                                                     \
 		}                                                                                                                                          \
-	};                                                                                                                                             \
+	};
+
+#define FUNCBINDRD(m_func, m_args, m_defvals, m_category) \
+	DEF_FUNCBINDRD(m_func, m_args, m_defvals, m_category) \
 	register_utility_function<Func_##m_func>(#m_func, m_args, m_defvals)
 
-#define FUNCBINDVR(m_func, m_args, m_category)                                                                                                     \
+#ifndef DISABLE_DEPRECATED
+#define FUNCBINDRD_COMPAT(m_func, m_func_cname, m_args, m_defvals, m_category) \
+	DEF_FUNCBINDRD(m_func_cname, m_args, m_defvals, m_category)                \
+	register_utility_function_compat<Func_##m_func_cname>(#m_func, m_args, m_defvals)
+#else
+#define FUNCBINDRD_COMPAT(m_func, m_func_cname, m_args, m_defvals, m_category) \
+	do {                                                                       \
+	} while (0)
+#endif
+
+#define DEF_FUNCBINDVR(m_func, m_args, m_category)                                                                                                 \
 	class Func_##m_func {                                                                                                                          \
 	public:                                                                                                                                        \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
@@ -1328,10 +1354,23 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static Variant::UtilityFunctionType get_type() {                                                                                           \
 			return m_category;                                                                                                                     \
 		}                                                                                                                                          \
-	};                                                                                                                                             \
+	};
+
+#define FUNCBINDVR(m_func, m_args, m_category) \
+	DEF_FUNCBINDVR(m_func, m_args, m_category) \
 	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVR2(m_func, m_args, m_category)                                                                                                    \
+#ifndef DISABLE_DEPRECATED
+#define FUNCBINDVR_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	DEF_FUNCBINDVR(m_func_cname, m_args, m_category)                \
+	register_utility_function_compat<Func_##m_func_cname>(#m_func, m_args, varray())
+#else
+#define FUNCBINDVR_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	do {                                                            \
+	} while (0)
+#endif
+
+#define DEF_FUNCBINDVR2(m_func, m_args, m_category)                                                                                                \
 	class Func_##m_func {                                                                                                                          \
 	public:                                                                                                                                        \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
@@ -1366,10 +1405,23 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static Variant::UtilityFunctionType get_type() {                                                                                           \
 			return m_category;                                                                                                                     \
 		}                                                                                                                                          \
-	};                                                                                                                                             \
+	};
+
+#define FUNCBINDVR2(m_func, m_args, m_category) \
+	DEF_FUNCBINDVR2(m_func, m_args, m_category) \
 	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVR3(m_func, m_args, m_category)                                                                                                                           \
+#ifndef DISABLE_DEPRECATED
+#define FUNCBINDVR2_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	DEF_FUNCBINDVR2(m_func_cname, m_args, m_category)                \
+	register_utility_function_compat<Func_##m_func_cname>(#m_func, m_args, varray())
+#else
+#define FUNCBINDVR2_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	do {                                                             \
+	} while (0)
+#endif
+
+#define DEF_FUNCBINDVR3(m_func, m_args, m_category)                                                                                                                       \
 	class Func_##m_func {                                                                                                                                                 \
 	public:                                                                                                                                                               \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {                        \
@@ -1404,10 +1456,23 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static Variant::UtilityFunctionType get_type() {                                                                                                                  \
 			return m_category;                                                                                                                                            \
 		}                                                                                                                                                                 \
-	};                                                                                                                                                                    \
+	};
+
+#define FUNCBINDVR3(m_func, m_args, m_category) \
+	DEF_FUNCBINDVR3(m_func, m_args, m_category) \
 	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARG(m_func, m_args, m_category)                                                                                                 \
+#ifndef DISABLE_DEPRECATED
+#define FUNCBINDVR3_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	DEF_FUNCBINDVR3(m_func_cname, m_args, m_category)                \
+	register_utility_function_compat<Func_##m_func_cname>(#m_func, m_args, varray())
+#else
+#define FUNCBINDVR3_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	do {                                                             \
+	} while (0)
+#endif
+
+#define DEF_FUNCBINDVARARG(m_func, m_args, m_category)                                                                                             \
 	class Func_##m_func {                                                                                                                          \
 	public:                                                                                                                                        \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
@@ -1449,10 +1514,23 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static Variant::UtilityFunctionType get_type() {                                                                                           \
 			return m_category;                                                                                                                     \
 		}                                                                                                                                          \
-	};                                                                                                                                             \
+	};
+
+#define FUNCBINDVARARG(m_func, m_args, m_category) \
+	DEF_FUNCBINDVARARG(m_func, m_args, m_category) \
 	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARGS(m_func, m_args, m_category)                                                                                                \
+#ifndef DISABLE_DEPRECATED
+#define FUNCBINDVARARG_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	DEF_FUNCBINDVARARG(m_func_cname, m_args, m_category)                \
+	register_utility_function_compat<Func_##m_func_cname>(#m_func, m_args, varray())
+#else
+#define FUNCBINDVARARG_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	do {                                                                \
+	} while (0)
+#endif
+
+#define DEF_FUNCBINDVARARGS(m_func, m_args, m_category)                                                                                            \
 	class Func_##m_func {                                                                                                                          \
 	public:                                                                                                                                        \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
@@ -1494,10 +1572,23 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static Variant::UtilityFunctionType get_type() {                                                                                           \
 			return m_category;                                                                                                                     \
 		}                                                                                                                                          \
-	};                                                                                                                                             \
+	};
+
+#define FUNCBINDVARARGS(m_func, m_args, m_category) \
+	DEF_FUNCBINDVARARGS(m_func, m_args, m_category) \
 	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category)                                                                            \
+#ifndef DISABLE_DEPRECATED
+#define FUNCBINDVARARGS_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	DEF_FUNCBINDVARARGS(m_func_cname, m_args, m_category)                \
+	register_utility_function_compat<Func_##m_func_cname>(#m_func, m_args, varray())
+#else
+#define FUNCBINDVARARGS_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	do {                                                                 \
+	} while (0)
+#endif
+
+#define DEF_FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category)                                                                        \
 	class Func_##m_func {                                                                                                                          \
 	public:                                                                                                                                        \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
@@ -1538,12 +1629,27 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static Variant::UtilityFunctionType get_type() {                                                                                           \
 			return m_category;                                                                                                                     \
 		}                                                                                                                                          \
-	};                                                                                                                                             \
+	};
+
+#define FUNCBINDVARARGV(m_func, m_args, m_category)               \
+	DEF_FUNCBINDVARARGV_CNAME(m_func, m_func, m_args, m_category) \
 	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBINDVARARGV(m_func, m_args, m_category) FUNCBINDVARARGV_CNAME(m_func, m_func, m_args, m_category)
+#define FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category) \
+	DEF_FUNCBINDVARARGV_CNAME(m_func, m_func_cname, m_args, m_category) \
+	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
 
-#define FUNCBIND(m_func, m_args, m_category)                                                                                                       \
+#ifndef DISABLE_DEPRECATED
+#define FUNCBINDVARARGV_COMPAT(m_func, m_func_cname, m_args, m_category)  \
+	FUNCBINDVARARGV_CNAME(m_func_cname, m_func_cname, m_args, m_category) \
+	register_utility_function_compat<Func_##m_func_cname>(#m_func, m_args, varray())
+#else
+#define FUNCBINDVARARGV_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	do {                                                                 \
+	} while (0)
+#endif
+
+#define DEF_FUNCBIND(m_func, m_args, m_category)                                                                                                   \
 	class Func_##m_func {                                                                                                                          \
 	public:                                                                                                                                        \
 		static void call(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) { \
@@ -1573,8 +1679,21 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static Variant::UtilityFunctionType get_type() {                                                                                           \
 			return m_category;                                                                                                                     \
 		}                                                                                                                                          \
-	};                                                                                                                                             \
+	};
+
+#define FUNCBIND(m_func, m_args, m_category) \
+	DEF_FUNCBIND(m_func, m_args, m_category) \
 	register_utility_function<Func_##m_func>(#m_func, m_args, varray())
+
+#ifndef DISABLE_DEPRECATED
+#define FUNCBIND_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	DEF_FUNCBIND(m_func_cname, m_args, m_category)                \
+	register_utility_function_compat<Func_##m_func_cname>(#m_func, m_args, varray())
+#else
+#define FUNCBIND_COMPAT(m_func, m_func_cname, m_args, m_category) \
+	do {                                                          \
+	} while (0)
+#endif
 
 struct VariantUtilityFunctionInfo {
 	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, const Vector<Variant> &p_defvals, Callable::CallError &r_error) = nullptr;
@@ -1588,10 +1707,46 @@ struct VariantUtilityFunctionInfo {
 	Variant::Type (*get_arg_type)(int) = nullptr;
 	Variant::Type return_type;
 	Variant::UtilityFunctionType type;
+
+	uint32_t get_hash() const {
+		uint32_t hash = hash_murmur3_one_32(is_vararg);
+		hash = hash_murmur3_one_32(returns_value, hash);
+		if (returns_value) {
+			hash = hash_murmur3_one_32(return_type, hash);
+		}
+		hash = hash_murmur3_one_32(argcount, hash);
+		for (int i = 0; i < argcount; i++) {
+			hash = hash_murmur3_one_32(get_arg_type(i), hash);
+		}
+
+		return hash_fmix32(hash);
+	}
 };
 
 static AHashMap<StringName, VariantUtilityFunctionInfo> utility_function_table;
 static List<StringName> utility_function_name_table;
+
+#ifndef DISABLE_DEPRECATED
+static AHashMap<StringName, LocalVector<VariantUtilityFunctionInfo>> utility_function_compat_table;
+#endif
+
+template <typename T>
+static void _populate_utility_function_info(VariantUtilityFunctionInfo &r_bfi, const String &p_name, const Vector<String> &p_argnames, const Vector<Variant> &p_def_args) {
+	r_bfi.call_utility = T::call;
+	r_bfi.validated_call_utility = T::validated_call;
+	r_bfi.ptr_call_utility = T::ptrcall;
+	r_bfi.is_vararg = T::is_vararg();
+	r_bfi.default_arguments = p_def_args;
+	r_bfi.argnames = p_argnames;
+	r_bfi.argcount = T::get_argument_count();
+	if (!r_bfi.is_vararg) {
+		ERR_FAIL_COND_MSG(p_argnames.size() != r_bfi.argcount, vformat("Wrong number of arguments binding utility function: '%s'.", p_name));
+	}
+	r_bfi.get_arg_type = T::get_argument_type;
+	r_bfi.return_type = T::get_return_type();
+	r_bfi.type = T::get_type();
+	r_bfi.returns_value = T::has_return_type();
+}
 
 template <typename T>
 static void register_utility_function(const String &p_name, const Vector<String> &p_argnames, const Vector<Variant> &p_def_args) {
@@ -1603,24 +1758,39 @@ static void register_utility_function(const String &p_name, const Vector<String>
 	ERR_FAIL_COND(utility_function_table.has(sname));
 
 	VariantUtilityFunctionInfo bfi;
-	bfi.call_utility = T::call;
-	bfi.validated_call_utility = T::validated_call;
-	bfi.ptr_call_utility = T::ptrcall;
-	bfi.is_vararg = T::is_vararg();
-	bfi.default_arguments = p_def_args;
-	bfi.argnames = p_argnames;
-	bfi.argcount = T::get_argument_count();
-	if (!bfi.is_vararg) {
-		ERR_FAIL_COND_MSG(p_argnames.size() != bfi.argcount, vformat("Wrong number of arguments binding utility function: '%s'.", name));
-	}
-	bfi.get_arg_type = T::get_argument_type;
-	bfi.return_type = T::get_return_type();
-	bfi.type = T::get_type();
-	bfi.returns_value = T::has_return_type();
+	_populate_utility_function_info<T>(bfi, name, p_argnames, p_def_args);
+
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND(!bfi.is_vararg && bfi.argcount != bfi.argnames.size());
+#endif // DEBUG_ENABLED
 
 	utility_function_table.insert(sname, bfi);
 	utility_function_name_table.push_back(sname);
 }
+
+#ifndef DISABLE_DEPRECATED
+template <typename T>
+static void register_utility_function_compat(const String &p_name, const Vector<String> &p_argnames, const Vector<Variant> &p_def_args) {
+	String name = p_name;
+	if (name.begins_with("_")) {
+		name = name.substr(1);
+	}
+	StringName sname = name;
+	ERR_FAIL_COND(!utility_function_table.has(sname));
+
+	VariantUtilityFunctionInfo bfi;
+	_populate_utility_function_info<T>(bfi, name, p_argnames, p_def_args);
+
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND(!bfi.is_vararg && bfi.argcount != bfi.argnames.size());
+#endif // DEBUG_ENABLED
+
+	if (!utility_function_compat_table.has(name)) {
+		utility_function_compat_table.insert(name, LocalVector<VariantUtilityFunctionInfo>());
+	}
+	utility_function_compat_table[name].push_back(bfi);
+}
+#endif
 
 void Variant::_register_variant_utility_functions() {
 	// Math
@@ -1828,6 +1998,28 @@ Variant::PTRUtilityFunction Variant::get_ptr_utility_function(const StringName &
 	return bfi->ptr_call_utility;
 }
 
+Variant::PTRUtilityFunction Variant::get_ptr_utility_function_with_compatibility(const StringName &p_name, uint32_t p_hash) {
+	{
+		const VariantUtilityFunctionInfo *bfi = utility_function_table.getptr(p_name);
+		if (bfi && bfi->get_hash() == p_hash) {
+			return bfi->ptr_call_utility;
+		}
+	}
+
+#ifndef DISABLE_DEPRECATED
+	const LocalVector<VariantUtilityFunctionInfo> *compat_functions = utility_function_compat_table.getptr(p_name);
+	if (compat_functions) {
+		for (const VariantUtilityFunctionInfo &bfi : *compat_functions) {
+			if (bfi.get_hash() == p_hash) {
+				return bfi.ptr_call_utility;
+			}
+		}
+	}
+#endif
+
+	return nullptr;
+}
+
 Variant::UtilityFunctionType Variant::get_utility_function_type(const StringName &p_name) {
 	const VariantUtilityFunctionInfo *bfi = utility_function_table.getptr(p_name);
 	if (!bfi) {
@@ -1935,18 +2127,20 @@ bool Variant::is_utility_function_vararg(const StringName &p_name) {
 uint32_t Variant::get_utility_function_hash(const StringName &p_name) {
 	const VariantUtilityFunctionInfo *bfi = utility_function_table.getptr(p_name);
 	ERR_FAIL_NULL_V(bfi, 0);
+	return bfi->get_hash();
+}
 
-	uint32_t hash = hash_murmur3_one_32(bfi->is_vararg);
-	hash = hash_murmur3_one_32(bfi->returns_value, hash);
-	if (bfi->returns_value) {
-		hash = hash_murmur3_one_32(bfi->return_type, hash);
+Vector<uint32_t> Variant::get_utility_function_compatibility_hashes(const StringName &p_name) {
+	Vector<uint32_t> function_hashes;
+#ifndef DISABLE_DEPRECATED
+	const LocalVector<VariantUtilityFunctionInfo> *compat_functions = utility_function_compat_table.getptr(p_name);
+	if (compat_functions) {
+		for (const VariantUtilityFunctionInfo &bfi : *compat_functions) {
+			function_hashes.push_back(bfi.get_hash());
+		}
 	}
-	hash = hash_murmur3_one_32(bfi->argcount, hash);
-	for (int i = 0; i < bfi->argcount; i++) {
-		hash = hash_murmur3_one_32(bfi->get_arg_type(i), hash);
-	}
-
-	return hash_fmix32(hash);
+#endif
+	return function_hashes;
 }
 
 void Variant::get_utility_function_list(List<StringName> *r_functions) {

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -333,9 +333,15 @@ double VariantUtilityFunctions::pow(double x, double y) {
 	return Math::pow(x, y);
 }
 
-double VariantUtilityFunctions::log(double x) {
-	return Math::log(x);
+double VariantUtilityFunctions::log(double x, double base) {
+	return Math::log(x, base);
 }
+
+#ifndef DISABLE_DEPRECATED
+double VariantUtilityFunctions::_log_compat(double x) {
+	return log(x, Math::E);
+}
+#endif
 
 double VariantUtilityFunctions::exp(double x) {
 	return Math::exp(x);
@@ -1843,7 +1849,8 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(snappedi, sarray("x", "step"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(pow, sarray("base", "exp"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(log, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDRD(log, sarray("x", "base"), varray(Math::E), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR_COMPAT(log, _log_compat, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(exp, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(is_nan, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -118,7 +118,7 @@ struct VariantUtilityFunctions {
 	static void randomize();
 	static int64_t randi();
 	static double randf();
-	static double randfn(double mean, double deviation);
+	static double randfn(double mean = 0.0, double deviation = 1.0);
 	static int64_t randi_range(int64_t from, int64_t to);
 	static double randf_range(double from, double to);
 	static void seed(int64_t s);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -67,7 +67,10 @@ struct VariantUtilityFunctions {
 	static double signf(double x);
 	static int64_t signi(int64_t x);
 	static double pow(double x, double y);
-	static double log(double x);
+	static double log(double x, double base);
+#ifndef DISABLE_DEPRECATED
+	static double _log_compat(double x);
+#endif
 	static double exp(double x);
 	static bool is_nan(double x);
 	static bool is_inf(double x);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1037,8 +1037,8 @@
 		</method>
 		<method name="randfn">
 			<return type="float" />
-			<param index="0" name="mean" type="float" />
-			<param index="1" name="deviation" type="float" />
+			<param index="0" name="mean" type="float" default="0.0" />
+			<param index="1" name="deviation" type="float" default="1.0" />
 			<description>
 				Returns a [url=https://en.wikipedia.org/wiki/Normal_distribution]normally-distributed[/url], pseudo-random floating-point value from the specified [param mean] and a standard [param deviation]. This is also known as a Gaussian distribution.
 				[b]Note:[/b] This method uses the [url=https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform]Box-Muller transform[/url] algorithm.

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -677,11 +677,14 @@
 		<method name="log">
 			<return type="float" />
 			<param index="0" name="x" type="float" />
+			<param index="1" name="base" type="float" default="2.7182817" />
 			<description>
-				Returns the [url=https://en.wikipedia.org/wiki/Natural_logarithm]natural logarithm[/url] of [param x] (base [url=https://en.wikipedia.org/wiki/E_(mathematical_constant)][i]e[/i][/url], with [i]e[/i] being approximately 2.71828). This is the amount of time needed to reach a certain level of continuous growth.
-				[b]Note:[/b] This is not the same as the "log" function on most calculators, which uses a base 10 logarithm. To use base 10 logarithm, use [code]log(x) / log(10)[/code].
+				Returns the [url=https://en.wikipedia.org/wiki/Logarithm]logarithm[/url] of [param x] to [param base].
+				The default base of [url=https://en.wikipedia.org/wiki/E_(mathematical_constant)][i]e[/i][/url] provides the [url=https://en.wikipedia.org/wiki/Natural_logarithm]natural logarithm[/url]. This is the amount of time needed to reach a certain level of continuous growth.
+				[b]Note:[/b] By default this is not the same as the "log" function on most calculators, which use the [url=https://en.wikipedia.org/wiki/Common_logarithm]common logarithm[/url]. To use this logarithm, set the base to 10: [code]log(x, 10)[/code].
 				[codeblock]
 				log(10) # Returns 2.302585
+				log(10, 2) # Returns 3.321928
 				[/codeblock]
 				[b]Note:[/b] The logarithm of [code]0[/code] returns [code]-inf[/code], while negative values return [code]-nan[/code].
 			</description>

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -1007,6 +1007,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 			if (Variant::is_utility_function_vararg(E)) {
 				md.qualifiers = "vararg";
 			} else {
+				const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(E);
 				for (int i = 0; i < Variant::get_utility_function_argument_count(E); i++) {
 					PropertyInfo pi;
 					pi.type = Variant::get_utility_function_argument_type(E, i);
@@ -1016,6 +1017,12 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 					}
 					DocData::ArgumentDoc ad;
 					DocData::argument_doc_from_arginfo(ad, pi);
+
+					const int dargidx = Variant::get_utility_function_default_argument_index(E, i);
+					if (dargidx >= 0) {
+						ad.default_value = DocData::get_default_value_string(def_args[dargidx]);
+					}
+
 					md.arguments.push_back(ad);
 				}
 			}

--- a/misc/extension_api_validation/4.5-stable/GH-113736.txt
+++ b/misc/extension_api_validation/4.5-stable/GH-113736.txt
@@ -1,0 +1,5 @@
+GH-113736
+---------
+Validate extension JSON: Error: Field 'utility_functions/log/arguments': size changed value in new API, from 1 to 2.
+
+Optional argument added. Compatibility method registered.

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -77,6 +77,7 @@ static MethodInfo info_from_utility_func(const StringName &p_function) {
 			pi.type = Variant::get_utility_function_argument_type(p_function, i);
 			info.arguments.push_back(pi);
 		}
+		info.default_arguments = Variant::get_utility_function_default_arguments(p_function);
 	}
 
 	return info;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -623,6 +623,20 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			if (!call->is_super && call->callee->type == GDScriptParser::Node::IDENTIFIER && GDScriptParser::get_builtin_type(call->function_name) < Variant::VARIANT_MAX) {
 				gen->write_construct(result, GDScriptParser::get_builtin_type(call->function_name), arguments);
 			} else if (!call->is_super && call->callee->type == GDScriptParser::Node::IDENTIFIER && Variant::has_utility_function(call->function_name)) {
+				const int arg_count = Variant::get_utility_function_argument_count(call->function_name);
+
+				if (call->arguments.size() < arg_count) {
+					const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(call->function_name);
+
+					for (int i = call->arguments.size(); i < arg_count; i++) {
+						const int dargidx = Variant::get_utility_function_default_argument_index(call->function_name, i);
+
+						if (dargidx >= 0) {
+							arguments.push_back(codegen.add_constant(def_args[dargidx]));
+						}
+					}
+				}
+
 				// Variant utility function.
 				gen->write_call_utility(result, call->function_name, arguments);
 			} else if (!call->is_super && call->callee->type == GDScriptParser::Node::IDENTIFIER && GDScriptUtilityFunctions::function_exists(call->function_name)) {

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -2204,11 +2204,18 @@ TEST_CASE("[Variant] Utility functions") {
 		if (Variant::is_utility_function_vararg(E)) {
 			md.is_vararg = true;
 		} else {
+			const Vector<Variant> def_args = Variant::get_utility_function_default_arguments(E);
 			for (int i = 0; i < Variant::get_utility_function_argument_count(E); i++) {
 				ArgumentData arg;
 				arg.type = Variant::get_utility_function_argument_type(E, i);
 				arg.name = Variant::get_utility_function_argument_name(E, i);
 				arg.position = i;
+
+				const int dargidx = Variant::get_utility_function_default_argument_index(E, i);
+				if (dargidx >= 0) {
+					arg.has_defval = true;
+					arg.defval = def_args[dargidx];
+				}
 
 				md.arguments.push_back(arg);
 			}
@@ -2224,6 +2231,13 @@ TEST_CASE("[Variant] Utility functions") {
 
 				TEST_COND((arg.name.is_empty() || arg.name.begins_with("_unnamed_arg")),
 						vformat("Unnamed argument in position %d of function '%s'.", arg.position, E.name));
+
+				if (arg.has_defval) {
+					const bool arg_defval_assignable_to_type = arg.type == arg.defval.get_type();
+
+					TEST_COND(!arg_defval_assignable_to_type,
+							vformat("Invalid default value for parameter '%s' of function '%s'.", arg.name, E.name));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/10337
Implement compatibility bindings system for Variant methods
https://github.com/godotengine/godot-proposals/issues/10337

Fixes https://github.com/godotengine/godot-proposals/issues/6652
Add an optional base argument to log()
https://github.com/godotengine/godot-proposals/issues/6652

This PR is included, required for log:
Add support for default arguments in utility functions
https://github.com/godotengine/godot/pull/95017

Implemented in same manner as this PR which is already merged:
GDExtension: Add system for builtin method compatibility
https://github.com/godotengine/godot/pull/112290

Unblocks this proposal, but I'm not convinced on the implementation of this one:
https://github.com/godotengine/godot-proposals/issues/4425
https://github.com/godotengine/godot/pull/104408