### PR TITLE
Fix "Make Unique" button only working with left mouse click

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -698,8 +698,8 @@ void EditorResourcePicker::_button_input(const Ref<InputEvent> &p_event) {
 void EditorResourcePicker::_on_unique_button_pressed() {
 	if (Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
 		_edit_menu_cbk(OBJ_MENU_MAKE_UNIQUE);
-	} else if (Input::get_singleton()->is_mouse_button_pressed(MouseButton::RIGHT)) {
-		_edit_menu_cbk(_is_uniqueness_enabled(true) ? OBJ_MENU_MAKE_UNIQUE_RECURSIVE : OBJ_MENU_MAKE_UNIQUE);
+	} else if (Input::get_singleton()->is_mouse_button_pressed(MouseButton::RIGHT) && _is_uniqueness_enabled(true)) {
+		_edit_menu_cbk(OBJ_MENU_MAKE_UNIQUE_RECURSIVE);
 	}
 }
 


### PR DESCRIPTION
Fixes #113738 
Removed the Mouse button mask for right so the button only works for left click as suggested by the tooltip