### PR TITLE
Restore `FileDialog::_popup_base`

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -95,6 +95,21 @@ bool FileDialog::_can_use_native_popup() const {
 	return DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE);
 }
 
+void FileDialog::_popup_base(const Rect2i &p_screen_rect) {
+#ifdef TOOLS_ENABLED
+	if (is_part_of_edited_scene()) {
+		ConfirmationDialog::_popup_base(p_screen_rect);
+		return;
+	}
+#endif
+
+	if (_should_use_native_popup()) {
+		_native_popup();
+	} else {
+		ConfirmationDialog::_popup_base(p_screen_rect);
+	}
+}
+
 void FileDialog::set_visible(bool p_visible) {
 	if (p_visible) {
 		_update_option_controls();

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -374,6 +374,8 @@ protected:
 	virtual bool _should_hide_file(const String &p_file) const { return false; }
 	virtual Color _get_folder_color(const String &p_path) const { return theme_cache.folder_icon_color; }
 
+	virtual void _popup_base(const Rect2i &p_screen_rect = Rect2i()) override;
+
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	bool _set(const StringName &p_name, const Variant &p_value) { return property_helper.property_set_value(p_name, p_value); }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113735

This was removed in https://github.com/godotengine/godot/pull/111212, and while override is not necessary for functionality, default `Window::_popup_base` do a bunch of stuff unneeded (and non-functional) when native dialog is used.