### PR TITLE
Fix D3D12 looking blurry in the editor at fullscreen.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -5819,15 +5819,15 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 #if defined(RD_ENABLED)
 				if (window.create_completed && rendering_context && window.rendering_context_window_created) {
 					// Note: Trigger resize event to update swapchains when window is minimized/restored, even if size is not changed.
-					rendering_context->window_set_size(window_id, window.width, window.height);
+					rendering_context->window_set_size(window_id, window.width + off_x, window.height);
 				}
 #endif
 #if defined(GLES3_ENABLED)
 				if (window.create_completed && gl_manager_native && window.gl_native_window_created) {
-					gl_manager_native->window_resize(window_id, window.width, window.height);
+					gl_manager_native->window_resize(window_id, window.width + off_x, window.height);
 				}
 				if (window.create_completed && gl_manager_angle && window.gl_angle_window_created) {
-					gl_manager_angle->window_resize(window_id, window.width, window.height);
+					gl_manager_angle->window_resize(window_id, window.width + off_x, window.height);
 				}
 #endif
 			}
@@ -6634,7 +6634,8 @@ Error DisplayServerWindows::_create_rendering_context_window(WindowID p_window_i
 	Error err = rendering_context->window_create(p_window_id, &wpd);
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to create %s window.", rendering_driver));
 
-	rendering_context->window_set_size(p_window_id, wd.width, wd.height);
+	int off_x = (wd.multiwindow_fs || (!wd.fullscreen && wd.borderless && wd.maximized)) ? FS_TRANSP_BORDER : 0;
+	rendering_context->window_set_size(p_window_id, wd.width + off_x, wd.height);
 	wd.rendering_context_window_created = true;
 
 	return OK;


### PR DESCRIPTION
Fixes #113634.

The window resolution without the transparent border is passed to the rendering drivers, but Vulkan and OpenGL force it to the actual window resolution anyway. D3D12 is the only one that actually respects it, but this ends up causing the swap chain to be stretched horizontally by 2 pixels. The behavior can be made consistent across all the rendering drivers by simply passing the actual window resolution.