### PR TITLE
Fix native FileDialogs popping up when `use_native_dialog` is modified

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -2210,7 +2210,7 @@ void FileDialog::set_use_native_dialog(bool p_native) {
 #endif
 
 	// Replace the built-in dialog with the native one if it's currently visible.
-	if (is_inside_tree() && _should_use_native_popup()) {
+	if (is_inside_tree() && is_visible() && _should_use_native_popup()) {
 		ConfirmationDialog::set_visible(false);
 		_native_popup();
 	}


### PR DESCRIPTION
As the title says, this fixes a regression where native FileDialogs would popup any time `use_native_dialog` changes by adding back in a check erroneously removed in #111212.

Fixes #113745