### PR TITLE
Tweaks to `gdextension_interface.json` format

### DIFF
--- a/core/extension/gdextension_interface.json
+++ b/core/extension/gdextension_interface.json
@@ -332,11 +332,13 @@
             "name": "GDExtensionConstVariantPtr",
             "kind": "handle",
             "parent": "GDExtensionVariantPtr",
-            "const": true
+            "is_const": true
         },
         {
             "name": "GDExtensionUninitializedVariantPtr",
-            "kind": "handle"
+            "kind": "handle",
+            "parent": "GDExtensionVariantPtr",
+            "is_uninitialized": true
         },
         {
             "name": "GDExtensionStringNamePtr",
@@ -346,11 +348,13 @@
             "name": "GDExtensionConstStringNamePtr",
             "kind": "handle",
             "parent": "GDExtensionStringNamePtr",
-            "const": true
+            "is_const": true
         },
         {
             "name": "GDExtensionUninitializedStringNamePtr",
-            "kind": "handle"
+            "kind": "handle",
+            "parent": "GDExtensionStringNamePtr",
+            "is_uninitialized": true
         },
         {
             "name": "GDExtensionStringPtr",
@@ -360,11 +364,13 @@
             "name": "GDExtensionConstStringPtr",
             "kind": "handle",
             "parent": "GDExtensionStringPtr",
-            "const": true
+            "is_const": true
         },
         {
             "name": "GDExtensionUninitializedStringPtr",
-            "kind": "handle"
+            "kind": "handle",
+            "parent": "GDExtensionStringPtr",
+            "is_uninitialized": true
         },
         {
             "name": "GDExtensionObjectPtr",
@@ -374,12 +380,13 @@
             "name": "GDExtensionConstObjectPtr",
             "kind": "handle",
             "parent": "GDExtensionObjectPtr",
-            "const": true
+            "is_const": true
         },
         {
             "name": "GDExtensionUninitializedObjectPtr",
+            "kind": "handle",
             "parent": "GDExtensionObjectPtr",
-            "kind": "handle"
+            "is_uninitialized": true
         },
         {
             "name": "GDExtensionTypePtr",
@@ -389,16 +396,18 @@
             "name": "GDExtensionConstTypePtr",
             "kind": "handle",
             "parent": "GDExtensionTypePtr",
-            "const": true
+            "is_const": true
         },
         {
             "name": "GDExtensionUninitializedTypePtr",
-            "kind": "handle"
+            "kind": "handle",
+            "parent": "GDExtensionTypePtr",
+            "is_uninitialized": true
         },
         {
             "name": "GDExtensionMethodBindPtr",
             "kind": "handle",
-            "const": true
+            "is_const": true
         },
         {
             "name": "GDExtensionInt",
@@ -423,7 +432,7 @@
             "name": "GDExtensionConstRefPtr",
             "kind": "handle",
             "parent": "GDExtensionRefPtr",
-            "const": true
+            "is_const": true
         },
         {
             "name": "GDExtensionCallErrorType",
@@ -573,7 +582,7 @@
                 },
                 {
                     "name": "p_argument_count",
-                    "type": "int"
+                    "type": "int32_t"
                 }
             ]
         },
@@ -759,7 +768,7 @@
                 },
                 {
                     "name": "p_argument_count",
-                    "type": "int"
+                    "type": "int32_t"
                 }
             ]
         },
@@ -1852,6 +1861,7 @@
         {
             "name": "GDExtensionClassMethodFlags",
             "kind": "enum",
+            "is_bitfield": true,
             "values": [
                 {
                     "name": "GDEXTENSION_METHOD_FLAG_NORMAL",
@@ -6764,14 +6774,14 @@
                 },
                 {
                     "name": "p_elements",
-                    "type": "int",
+                    "type": "int32_t",
                     "description": [
                         "The number of element needed in the group."
                     ]
                 },
                 {
                     "name": "p_tasks",
-                    "type": "int",
+                    "type": "int32_t",
                     "description": [
                         "The number of tasks needed in the group."
                     ]

--- a/core/extension/gdextension_interface.schema.json
+++ b/core/extension/gdextension_interface.schema.json
@@ -54,6 +54,9 @@
                         },
                         "then": {
                             "properties": {
+                                "is_bitfield": {
+                                    "type": "boolean"
+                                },
                                 "values": {
                                     "type": "array",
                                     "items": {
@@ -91,7 +94,10 @@
                                 "parent": {
                                     "type": "string"
                                 },
-                                "const": {
+                                "is_const": {
+                                    "type": "boolean"
+                                },
+                                "is_uninitialized": {
                                     "type": "boolean"
                                 }
                             }

--- a/core/extension/gdextension_interface_header_generator.cpp
+++ b/core/extension/gdextension_interface_header_generator.cpp
@@ -97,7 +97,7 @@ void GDExtensionInterfaceHeaderGenerator::generate_gdextension_interface_header(
 		}
 		String kind = type_dict["kind"];
 		if (kind == "handle") {
-			type_dict["type"] = type_dict.get("const", false) ? "const void*" : "void*";
+			type_dict["type"] = type_dict.get("is_const", false) ? "const void*" : "void*";
 			write_simple_type(fa, type_dict);
 		} else if (kind == "alias") {
 			write_simple_type(fa, type_dict);

--- a/core/extension/make_interface_header.py
+++ b/core/extension/make_interface_header.py
@@ -6,7 +6,6 @@ import methods
 
 BASE_TYPES = [
     "void",
-    "int",
     "int8_t",
     "uint8_t",
     "int16_t",
@@ -64,18 +63,20 @@ extern "C" {
                 write_doc(file, type["description"])
 
             if kind == "handle":
-                check_allowed_keys(type, ["name", "kind"], ["const", "parent", "description", "deprecated"])
+                check_allowed_keys(
+                    type, ["name", "kind"], ["is_const", "is_uninitialized", "parent", "description", "deprecated"]
+                )
                 if "parent" in type and type["parent"] not in handles:
                     raise UnknownTypeError(type["parent"], type["name"])
                 # @todo In the future, let's write these as `struct *` so the compiler can help us with type checking.
-                type["type"] = "void*" if not type.get("const", False) else "const void*"
+                type["type"] = "void*" if not type.get("is_const", False) else "const void*"
                 write_simple_type(file, type)
                 handles.append(type["name"])
             elif kind == "alias":
                 check_allowed_keys(type, ["name", "kind", "type"], ["description", "deprecated"])
                 write_simple_type(file, type)
             elif kind == "enum":
-                check_allowed_keys(type, ["name", "kind", "values"], ["description", "deprecated"])
+                check_allowed_keys(type, ["name", "kind", "values"], ["is_bitfield", "description", "deprecated"])
                 write_enum_type(file, type)
             elif kind == "function":
                 check_allowed_keys(type, ["name", "kind", "return_value", "arguments"], ["description", "deprecated"])


### PR DESCRIPTION
Fixes the non-documentation parts of https://github.com/godotengine/godot/issues/113732

This makes the following tweaks:

- Renames the "const" field to "is_const" to match a similarly named field in `extension_api.json`
- The "uninitialized" handles now refer to their "parent" handle and have an `"is_uninitialized": true` flag
- Enums that are bitfields have the `"is_bitfield": true` flag
- All instances of `int` are replaced with `int32_t` and `int` is removed as a valid type. Now all int types _must_ have a size going forward!
