### PR TITLE
Fix scrollbar separation being at the wrong side in `ScrollContainer`with a RTL layout

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -360,7 +360,11 @@ void ScrollContainer::_reposition_children() {
 	}
 
 	if (reserve_vscroll) {
-		size.x -= v_scroll->get_minimum_size().x + theme_cache.scrollbar_h_separation;
+		int width = v_scroll->get_minimum_size().x + theme_cache.scrollbar_h_separation;
+		size.x -= width;
+		if (rtl) {
+			ofs.x += width;
+		}
 	}
 
 	for (int i = 0; i < get_child_count(); i++) {
@@ -368,19 +372,18 @@ void ScrollContainer::_reposition_children() {
 		if (!c || c == h_scroll || c == v_scroll || c == focus_panel || c == scroll_hint_top_left || c == scroll_hint_bottom_right) {
 			continue;
 		}
-		Size2 minsize = c->get_combined_minimum_size();
 
+		Size2 minsize = c->get_combined_minimum_size();
 		Rect2 r = Rect2(-Size2(get_h_scroll(), get_v_scroll()), minsize);
+
 		if (c->get_h_size_flags().has_flag(SIZE_EXPAND)) {
 			r.size.width = MAX(size.width, minsize.width);
 		}
 		if (c->get_v_size_flags().has_flag(SIZE_EXPAND)) {
 			r.size.height = MAX(size.height, minsize.height);
 		}
+
 		r.position += ofs;
-		if (rtl && reserve_vscroll) {
-			r.position.x += v_scroll->get_minimum_size().x;
-		}
 		r.position = r.position.floor();
 		fit_child_in_rect(c, r);
 	}


### PR DESCRIPTION
Without this, the separation is always applied to the right.