### PR TITLE
Add support for previewing 2D nodes in the 3D editor

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -86,6 +86,7 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/translations/editor_translation_preview_button.h"
 #include "editor/translations/editor_translation_preview_menu.h"
+#include "scene/2d/camera_2d.h"
 #include "scene/3d/audio_stream_player_3d.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/decal.h"
@@ -106,6 +107,7 @@
 #include "scene/resources/packed_scene.h"
 #include "scene/resources/sky.h"
 #include "scene/resources/surface_tool.h"
+#include "scene/resources/world_2d.h"
 
 constexpr real_t DISTANCE_DEFAULT = 4;
 
@@ -3251,6 +3253,8 @@ void Node3DEditorViewport::_project_settings_changed() {
 
 	const Viewport::AnisotropicFiltering anisotropic_filtering_level = Viewport::AnisotropicFiltering(int(GLOBAL_GET("rendering/textures/default_filters/anisotropic_filtering_level")));
 	viewport->set_anisotropic_filtering_level(anisotropic_filtering_level);
+
+	_update_camera_2d_preview_settings();
 }
 
 static void override_label_colors(Control *p_control) {
@@ -3351,6 +3355,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		case NOTIFICATION_RESIZED: {
 			callable_mp(this, &Node3DEditorViewport::update_transform_gizmo_view).call_deferred();
+			_update_camera_2d_preview_settings();
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -4241,6 +4246,13 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			view_display_menu->get_popup()->set_item_checked(idx, current);
 
 		} break;
+		case VIEW_2D_PREVIEW: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_2D_PREVIEW);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+			_toggle_2d_preview(current);
+		} break;
 		case VIEW_CINEMATIC_PREVIEW: {
 			int idx = view_display_menu->get_popup()->get_item_index(VIEW_CINEMATIC_PREVIEW);
 			bool current = view_display_menu->get_popup()->is_item_checked(idx);
@@ -4569,6 +4581,52 @@ void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
 	}
 }
 
+void Node3DEditorViewport::_toggle_2d_preview(bool p_enable) {
+	if (p_enable) {
+		// Enable 2D MSAA only when needed to improve performance.
+		viewport->set_msaa_2d(GLOBAL_GET("rendering/anti_aliasing/quality/msaa_2d"));
+		viewport->set_world_2d(EditorNode::get_singleton()->get_edited_scene()->get_viewport()->get_world_2d());
+		_update_camera_2d_preview_settings();
+	} else {
+		// Disable 2D MSAA, as we don't need it anymore until the preview is re-enabled.
+		viewport->set_msaa_2d(Viewport::MSAA_DISABLED);
+
+		// Assign an empty World2D to disable 2D preview.
+		Ref<World2D> empty_world;
+		empty_world.instantiate();
+		viewport->set_world_2d(empty_world);
+	}
+}
+
+void Node3DEditorViewport::_update_camera_2d_preview_settings() {
+	viewport->set_default_canvas_item_texture_filter(GLOBAL_GET("rendering/textures/canvas_textures/default_texture_filter"));
+
+	const Size2i viewport_current_size = viewport->get_size();
+	const Size2i viewport_project_size = Size2i(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+	preview_2d_camera->set_position(viewport_project_size / 2);
+
+	// Emulate font oversampling as it would behave in the running project.
+	// FIXME: This doesn't appear to have any effect. Is oversampling forcibly disabled in the editor? I couldn't find any references to this in the codebase.
+	viewport->set_use_oversampling(bool(GLOBAL_GET("gui/fonts/dynamic_fonts/use_oversampling")));
+
+	const bool integer_scaling = GLOBAL_GET("display/window/stretch/scale_mode") == "integer";
+	if (!integer_scaling && GLOBAL_GET("display/window/stretch/aspect") == "ignore") {
+		// Allow distortion to occur to match the `ignore` stretch aspect.
+		// Integer scaling does not allow distortion to occur, so skip this if enabled.
+		Vector2 factor = Vector2(float(viewport_current_size.width) / viewport_project_size.width, float(viewport_current_size.height) / viewport_project_size.height);
+		preview_2d_camera->set_zoom(factor);
+		viewport->set_oversampling_override(MAX(factor.x, factor.y));
+	} else {
+		// Keep aspect ratio.
+		float factor = MIN(float(viewport_current_size.width) / viewport_project_size.width, float(viewport_current_size.height) / viewport_project_size.height);
+		if (integer_scaling) {
+			factor = Math::floor(factor);
+		}
+		preview_2d_camera->set_zoom(Vector2(factor, factor));
+		viewport->set_oversampling_override(factor);
+	}
+}
+
 void Node3DEditorViewport::_toggle_cinema_preview(bool p_activate) {
 	previewing_cinema = p_activate;
 	_update_navigation_controls_visibility();
@@ -4866,6 +4924,18 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 		view_display_menu->get_popup()->set_item_checked(idx, half_res);
 		_update_shrink();
 	}
+	if (p_state.has("2d_preview")) {
+		previewing_2d = p_state["2d_preview"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_2D_PREVIEW);
+		view_display_menu->get_popup()->set_item_checked(idx, previewing_2d);
+
+		if (previewing_2d) {
+			print_line("Restoring 2D preview state.");
+			// If previous state was restored, make it effective.
+			_toggle_2d_preview(true);
+		}
+	}
 	if (p_state.has("cinematic_preview")) {
 		previewing_cinema = p_state["cinematic_preview"];
 
@@ -4935,6 +5005,7 @@ Dictionary Node3DEditorViewport::get_state() const {
 	d["information"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_INFORMATION));
 	d["frame_time"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_FRAME_TIME));
 	d["half_res"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_HALF_RESOLUTION));
+	d["2d_preview"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_2D_PREVIEW));
 	d["cinematic_preview"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_CINEMATIC_PREVIEW));
 	if (previewing) {
 		d["previewing"] = EditorNode::get_singleton()->get_edited_scene()->get_path_to(previewing);
@@ -6237,6 +6308,9 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	viewport = memnew(SubViewport);
 	viewport->set_disable_input(true);
 
+	preview_2d_camera = memnew(Camera2D);
+	viewport->add_child(preview_2d_camera);
+
 	c->add_child(viewport);
 	surface = memnew(Control);
 	SET_DRAG_FORWARDING_CD(surface, Node3DEditorViewport);
@@ -6368,6 +6442,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GRID), true);
 
 	view_display_menu->get_popup()->add_separator();
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_2d_preview", TTRC("2D Preview")), VIEW_2D_PREVIEW);
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_cinematic_preview", TTRC("Cinematic Preview")), VIEW_CINEMATIC_PREVIEW);
 
 	view_display_menu->get_popup()->add_separator();

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -168,6 +168,7 @@ class Node3DEditorViewport : public Control {
 		// > Keep in sync with menu.
 
 		VIEW_LOCK_ROTATION,
+		VIEW_2D_PREVIEW,
 		VIEW_CINEMATIC_PREVIEW,
 		VIEW_AUTO_ORTHOGONAL,
 		VIEW_MAX
@@ -256,6 +257,7 @@ private:
 	Control *surface = nullptr;
 	SubViewport *viewport = nullptr;
 	Camera3D *camera = nullptr;
+	Camera2D *preview_2d_camera = nullptr;
 	bool transforming = false;
 	bool orthogonal;
 	bool auto_orthogonal;
@@ -501,12 +503,15 @@ private:
 	Camera3D *preview = nullptr;
 
 	bool previewing_camera = false;
+	bool previewing_2d = false;
 	bool previewing_cinema = false;
 	bool _is_node_locked(const Node *p_node) const;
 	void _preview_exited_scene();
 	void _preview_camera_property_changed();
 	void _update_centered_labels();
 	void _toggle_camera_preview(bool);
+	void _toggle_2d_preview(bool p_enable);
+	void _update_camera_2d_preview_settings();
 	void _toggle_cinema_preview(bool);
 	void _init_gizmo_instance(int p_idx);
 	void _finish_gizmo_instances();


### PR DESCRIPTION
The option can be toggled on a per-viewport basis in the **Perspective** menu. It can be used at the same time as Camera3D preview or cinematic preview if desired.

- This closes https://github.com/godotengine/godot-proposals/issues/2635.

**Testing project:** [test_3d_2d_preview.zip](https://github.com/user-attachments/files/24038838/test_3d_2d_preview.zip)

## Preview

![Image](https://github.com/user-attachments/assets/9d230982-200d-4e60-bcf4-cccd75141fb3)

## TODO

- [x] Fix "Invalid world_2d" warning being printed when the 2D preview is disabled.
  - Fixed thanks to @ryevdokimov's comment: https://github.com/godotengine/godot/pull/113759#discussion_r2796883412
- [ ] Fix font oversampling not being taken into account.
- [ ] Handle situations where UI elements would be drawn with different anchor positions or a different scale in the running project, either due to the **Stretch Scale** project setting or the viewport being narrower than the project's viewport aspect ratio when using the `expand` stretch aspect (for landscape games), or wider (for portrait games). Also handle the `disabled` stretch mode.
  - This can be done by reducing the base viewport resolution 2D elements are drawn at (so they reposition themselves according to anchors), then adjusting the Camera2D zoom to match. I'm not sure how to do the first part without affecting what's serialized in the scene file.
- [ ] Draw black bars if using the `keep`, `keep_width` or `keep_height` stretch aspects according to the current aspect ratio. (When using integer scaling, black bars may be drawn on 4 edges rather than just 2.)
- [ ] Consider adding a default keyboard shortcut to toggle the 2D preview.
  - See https://github.com/godotengine/godot/pull/93579 for inspiration.
