### PR TITLE
Add FXAA support to the Compatibility renderer

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -154,6 +154,7 @@ Copyright: 2014-present Godot Engine contributors
 License: Expat and WOL
 
 Files: servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+ drivers/gles3/shaders/effects/post.glsl
 Comment: NVidia's FXAA 3.11, simplified by Simon Rodriguez
 Copyright: 2014-2015, NVIDIA CORPORATION
  2017 Simon Rodriguez

--- a/drivers/gles3/effects/post_effects.cpp
+++ b/drivers/gles3/effects/post_effects.cpp
@@ -91,7 +91,8 @@ void PostEffects::_draw_screen_triangle() {
 void PostEffects::post_copy(
 		GLuint p_dest_framebuffer, Size2i p_dest_size, GLuint p_source_color,
 		GLuint p_source_depth, bool p_ssao_enabled, int p_ssao_quality_level, float p_ssao_strength, float p_ssao_radius,
-		Size2i p_source_size, float p_luminance_multiplier, const Glow::Level *p_glow_buffers, float p_glow_intensity,
+		Size2i p_source_size, float p_luminance_multiplier, RSE::ViewportScreenSpaceAA p_screen_space_aa,
+		const Glow::Level *p_glow_buffers, float p_glow_intensity,
 		float p_srgb_white, uint32_t p_view, bool p_use_multiview, uint64_t p_spec_constants) {
 	glDisable(GL_DEPTH_TEST);
 	glDepthMask(GL_FALSE);
@@ -104,6 +105,9 @@ void PostEffects::post_copy(
 	uint64_t flags = p_spec_constants;
 	if (p_use_multiview) {
 		flags |= PostShaderGLES3::USE_MULTIVIEW;
+	}
+	if (p_screen_space_aa == RSE::VIEWPORT_SCREEN_SPACE_AA_FXAA) {
+		flags |= PostShaderGLES3::USE_FXAA;
 	}
 	if (p_glow_buffers != nullptr) {
 		flags |= PostShaderGLES3::USE_GLOW;
@@ -150,11 +154,14 @@ void PostEffects::post_copy(
 				post.shader_version, mode, flags);
 	}
 
+	if (p_screen_space_aa == RSE::VIEWPORT_SCREEN_SPACE_AA_FXAA || p_glow_buffers != nullptr) {
+		post.shader.version_set_uniform(PostShaderGLES3::PIXEL_SIZE, 1.0 / p_source_size.x, 1.0 / p_source_size.y, post.shader_version, mode, flags);
+	}
+
 	if (p_glow_buffers != nullptr) {
 		glActiveTexture(GL_TEXTURE1);
 		glBindTexture(GL_TEXTURE_2D, p_glow_buffers[0].color);
 
-		post.shader.version_set_uniform(PostShaderGLES3::PIXEL_SIZE, 1.0 / p_source_size.x, 1.0 / p_source_size.y, post.shader_version, mode, flags);
 		post.shader.version_set_uniform(PostShaderGLES3::GLOW_INTENSITY, p_glow_intensity, post.shader_version, mode, flags);
 		post.shader.version_set_uniform(PostShaderGLES3::SRGB_WHITE, p_srgb_white, post.shader_version, mode, flags);
 	}

--- a/drivers/gles3/effects/post_effects.h
+++ b/drivers/gles3/effects/post_effects.h
@@ -60,7 +60,8 @@ public:
 
 	void post_copy(GLuint p_dest_framebuffer, Size2i p_dest_size, GLuint p_source_color,
 			GLuint p_source_depth, bool p_ssao_enabled, int p_ssao_quality_level, float p_ssao_strength, float p_ssao_radius,
-			Size2i p_source_size, float p_luminance_multiplier, const Glow::Level *p_glow_buffers, float p_glow_intensity,
+			Size2i p_source_size, float p_luminance_multiplier, RSE::ViewportScreenSpaceAA p_screen_space_aa,
+			const Glow::Level *p_glow_buffers, float p_glow_intensity,
 			float p_srgb_white, uint32_t p_view = 0, bool p_use_multiview = false, uint64_t p_spec_constants = 0);
 };
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2271,26 +2271,33 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	GLES3::Config *config = GLES3::Config::get_singleton();
 	RENDER_TIMESTAMP("Setup 3D Scene");
 
-	bool apply_environment_effects_in_post = false;
-	bool is_reflection_probe = p_reflection_probe.is_valid();
-
 	Ref<RenderSceneBuffersGLES3> rb = p_render_buffers;
 	ERR_FAIL_COND(rb.is_null());
 
+	bool apply_environment_effects_in_post = false;
+
 	if (rb->get_scaling_3d_mode() != RSE::VIEWPORT_SCALING_3D_MODE_OFF) {
-		// If we're scaling, we apply tonemapping etc. in post, so disable it during rendering
+		// If we're scaling, we apply tonemapping etc. in post, so disable it during rendering.
 		apply_environment_effects_in_post = true;
 	}
 
-	GLES3::RenderTarget *rt = nullptr; // No render target for reflection probe
+	GLES3::RenderTarget *rt = nullptr; // No render target for reflection probe.
+	bool is_reflection_probe = p_reflection_probe.is_valid();
 	if (!is_reflection_probe) {
 		rt = texture_storage->get_render_target(rb->render_target);
 		ERR_FAIL_NULL(rt);
 	}
 
+	bool fxaa_enabled = rb->get_screen_space_aa() == RSE::VIEWPORT_SCREEN_SPACE_AA_FXAA;
+	if (fxaa_enabled) {
+		// The tonemap pass is required when FXAA is enabled, as FXAA is performed within that pass.
+		apply_environment_effects_in_post = true;
+	}
+
 	bool glow_enabled = false;
 	bool ssao_enabled = false;
 	bool use_bcs = false;
+
 	if (p_environment.is_valid()) {
 		// We apply tonemapping, etc. in post when any of these are true. In this
 		// case, set apply_environment_effects_in_post to true to skip tonemapping during rendering.
@@ -2298,7 +2305,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		ssao_enabled = environment_get_ssao_enabled(p_environment);
 		use_bcs = environment_get_adjustments_enabled(p_environment);
 		bool canvas_tonemapping = environment_get_background(p_environment) == RSE::ENV_BG_CANVAS && environment_get_tone_mapper(p_environment) != RSE::ENV_TONE_MAPPER_LINEAR;
-		if (glow_enabled || ssao_enabled || use_bcs || canvas_tonemapping) {
+		if (glow_enabled || ssao_enabled || use_bcs || fxaa_enabled || canvas_tonemapping) {
 			apply_environment_effects_in_post = true;
 		}
 	}
@@ -2947,7 +2954,7 @@ void RasterizerSceneGLES3::_render_post_processing(const RenderDataGLES3 *p_rend
 			// Copy color buffer
 			post_effects->post_copy(fbo_rt, target_size, color,
 					depth_buffer, ssao_enabled, ssao_quality, ssao_strength, ssao_radius,
-					internal_size, p_render_data->luminance_multiplier, glow_buffers, glow_intensity,
+					internal_size, p_render_data->luminance_multiplier, rb->get_screen_space_aa(), glow_buffers, glow_intensity,
 					srgb_white, 0, false, bcs_spec_constants);
 
 			// Copy depth buffer
@@ -3021,7 +3028,7 @@ void RasterizerSceneGLES3::_render_post_processing(const RenderDataGLES3 *p_rend
 				glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, write_color, 0, v);
 				post_effects->post_copy(fbos[2], target_size, source_color,
 						read_depth, ssao_enabled, ssao_quality, ssao_strength, ssao_radius,
-						internal_size, p_render_data->luminance_multiplier, glow_buffers, glow_intensity,
+						internal_size, p_render_data->luminance_multiplier, rb->get_screen_space_aa(), glow_buffers, glow_intensity,
 						srgb_white, v, true, bcs_spec_constants);
 			}
 

--- a/drivers/gles3/shaders/effects/post.glsl
+++ b/drivers/gles3/shaders/effects/post.glsl
@@ -5,6 +5,7 @@ mode_default =
 #[specializations]
 
 USE_MULTIVIEW = false
+USE_FXAA = false
 USE_GLOW = false
 USE_LUMINANCE_MULTIPLIER = false
 USE_BCS = false
@@ -46,9 +47,12 @@ uniform sampler2D source_color; // texunit:0
 uniform float view;
 uniform float luminance_multiplier;
 
+#if defined(USE_FXAA) || defined(USE_GLOW)
+uniform vec2 pixel_size;
+#endif // defined(USE_FXAA) || defined(USE_GLOW)
+
 #ifdef USE_GLOW
 uniform sampler2D glow_color; // texunit:1
-uniform vec2 pixel_size;
 uniform float glow_intensity;
 uniform float srgb_white;
 
@@ -114,6 +118,386 @@ uniform sampler2D depth_buffer; // texunit:3
 #endif
 #endif
 
+#ifdef USE_FXAA
+
+// FXAA 3.11 compact, Ported from https://github.com/kosua20/Rendu/blob/master/resources/common/shaders/screens/fxaa.frag
+///////////////////////////////////////////////////////////////////////////////////
+// MIT License
+//
+// Copyright (c) 2017 Simon Rodriguez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////////
+
+// Nvidia Original FXAA 3.11 License
+//----------------------------------------------------------------------------------
+// File:        es3-kepler\FXAA/FXAA3_11.h
+// SDK Version: v3.00
+// Email:       gameworks@nvidia.com
+// Site:        http://developer.nvidia.com/
+//
+// Copyright (c) 2014-2015, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//----------------------------------------------------------------------------------
+//
+//                    NVIDIA FXAA 3.11 by TIMOTHY LOTTES
+//
+//----------------------------------------------------------------------------------
+
+float QUALITY(float q) {
+	return (q < 5 ? 1.0 : (q > 5 ? (q < 10 ? 2.0 : (q < 11 ? 4.0 : 8.0)) : 1.5));
+}
+
+// `srgb` must use nonlinear sRGB-encoded values to produce an approximate luma.
+float rgb2luma(vec3 srgb) {
+	const vec3 rec709_luminance_weights = vec3(0.2126, 0.7152, 0.0722);
+	return dot(srgb, rec709_luminance_weights);
+}
+
+vec3 do_fxaa(vec3 color, vec2 uv_interp) {
+	const float EDGE_THRESHOLD_MIN = 0.0312;
+	const float EDGE_THRESHOLD_MAX = 0.125;
+	const int ITERATIONS = 12;
+	const float SUBPIXEL_QUALITY = 0.75;
+
+#ifdef USE_LUMINANCE_MULTIPLIER
+	float combined_luminance_multiplier = 1.0 / luminance_multiplier;
+#else
+	float combined_luminance_multiplier = 1.0;
+#endif
+
+#ifdef USE_MULTIVIEW
+	float lumaUp = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, 1)).xyz * combined_luminance_multiplier);
+	float lumaDown = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, -1)).xyz * combined_luminance_multiplier);
+	float lumaLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 0)).xyz * combined_luminance_multiplier);
+	float lumaRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 0)).xyz * combined_luminance_multiplier);
+
+	float lumaCenter = rgb2luma(color);
+
+	float lumaMin = min(lumaCenter, min(min(lumaUp, lumaDown), min(lumaLeft, lumaRight)));
+	float lumaMax = max(lumaCenter, max(max(lumaUp, lumaDown), max(lumaLeft, lumaRight)));
+
+	float lumaRange = lumaMax - lumaMin;
+
+	if (lumaRange < max(EDGE_THRESHOLD_MIN, lumaMax * EDGE_THRESHOLD_MAX)) {
+		return color;
+	}
+
+	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, -1)).xyz * combined_luminance_multiplier);
+	float lumaUpRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 1)).xyz * combined_luminance_multiplier);
+	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 1)).xyz * combined_luminance_multiplier);
+	float lumaDownRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, -1)).xyz * combined_luminance_multiplier);
+
+	float lumaDownUp = lumaDown + lumaUp;
+	float lumaLeftRight = lumaLeft + lumaRight;
+
+	float lumaLeftCorners = lumaDownLeft + lumaUpLeft;
+	float lumaDownCorners = lumaDownLeft + lumaDownRight;
+	float lumaRightCorners = lumaDownRight + lumaUpRight;
+	float lumaUpCorners = lumaUpRight + lumaUpLeft;
+
+	float edgeHorizontal = abs(-2.0 * lumaLeft + lumaLeftCorners) + abs(-2.0 * lumaCenter + lumaDownUp) * 2.0 + abs(-2.0 * lumaRight + lumaRightCorners);
+	float edgeVertical = abs(-2.0 * lumaUp + lumaUpCorners) + abs(-2.0 * lumaCenter + lumaLeftRight) * 2.0 + abs(-2.0 * lumaDown + lumaDownCorners);
+
+	bool isHorizontal = (edgeHorizontal >= edgeVertical);
+
+	float stepLength = isHorizontal ? pixel_size.y : pixel_size.x;
+
+	float luma1 = isHorizontal ? lumaDown : lumaLeft;
+	float luma2 = isHorizontal ? lumaUp : lumaRight;
+	float gradient1 = luma1 - lumaCenter;
+	float gradient2 = luma2 - lumaCenter;
+
+	bool is1Steepest = abs(gradient1) >= abs(gradient2);
+
+	float gradientScaled = 0.25 * max(abs(gradient1), abs(gradient2));
+
+	float lumaLocalAverage = 0.0;
+	if (is1Steepest) {
+		stepLength = -stepLength;
+		lumaLocalAverage = 0.5 * (luma1 + lumaCenter);
+	} else {
+		lumaLocalAverage = 0.5 * (luma2 + lumaCenter);
+	}
+
+	vec2 currentUv = uv_interp;
+	if (isHorizontal) {
+		currentUv.y += stepLength * 0.5;
+	} else {
+		currentUv.x += stepLength * 0.5;
+	}
+
+	vec2 offset = isHorizontal ? vec2(pixel_size.x, 0.0) : vec2(0.0, pixel_size.y);
+	vec3 uv1 = vec3(currentUv - offset * QUALITY(0), ViewIndex);
+	vec3 uv2 = vec3(currentUv + offset * QUALITY(0), ViewIndex);
+
+	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
+	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
+	lumaEnd1 -= lumaLocalAverage;
+	lumaEnd2 -= lumaLocalAverage;
+
+	bool reached1 = abs(lumaEnd1) >= gradientScaled;
+	bool reached2 = abs(lumaEnd2) >= gradientScaled;
+	bool reachedBoth = reached1 && reached2;
+
+	if (!reached1) {
+		uv1 -= vec3(offset * QUALITY(1), 0.0);
+	}
+	if (!reached2) {
+		uv2 += vec3(offset * QUALITY(1), 0.0);
+	}
+
+	if (!reachedBoth) {
+		for (int i = 2; i < ITERATIONS; i++) {
+			if (!reached1) {
+				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
+				lumaEnd1 = lumaEnd1 - lumaLocalAverage;
+			}
+			if (!reached2) {
+				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
+				lumaEnd2 = lumaEnd2 - lumaLocalAverage;
+			}
+			reached1 = abs(lumaEnd1) >= gradientScaled;
+			reached2 = abs(lumaEnd2) >= gradientScaled;
+			reachedBoth = reached1 && reached2;
+			if (!reached1) {
+				uv1 -= vec3(offset * QUALITY(i), 0.0);
+			}
+			if (!reached2) {
+				uv2 += vec3(offset * QUALITY(i), 0.0);
+			}
+			if (reachedBoth) {
+				break;
+			}
+		}
+	}
+
+	float distance1 = isHorizontal ? (uv_interp.x - uv1.x) : (uv_interp.y - uv1.y);
+	float distance2 = isHorizontal ? (uv2.x - uv_interp.x) : (uv2.y - uv_interp.y);
+
+	bool isDirection1 = distance1 < distance2;
+	float distanceFinal = min(distance1, distance2);
+
+	float edgeThickness = (distance1 + distance2);
+
+	bool isLumaCenterSmaller = lumaCenter < lumaLocalAverage;
+
+	bool correctVariation1 = (lumaEnd1 < 0.0) != isLumaCenterSmaller;
+	bool correctVariation2 = (lumaEnd2 < 0.0) != isLumaCenterSmaller;
+
+	bool correctVariation = isDirection1 ? correctVariation1 : correctVariation2;
+
+	float pixelOffset = -distanceFinal / edgeThickness + 0.5;
+
+	float finalOffset = correctVariation ? pixelOffset : 0.0;
+
+	float lumaAverage = (1.0 / 12.0) * (2.0 * (lumaDownUp + lumaLeftRight) + lumaLeftCorners + lumaRightCorners);
+
+	float subPixelOffset1 = clamp(abs(lumaAverage - lumaCenter) / lumaRange, 0.0, 1.0);
+	float subPixelOffset2 = (-2.0 * subPixelOffset1 + 3.0) * subPixelOffset1 * subPixelOffset1;
+
+	float subPixelOffsetFinal = subPixelOffset2 * subPixelOffset2 * SUBPIXEL_QUALITY;
+
+	finalOffset = max(finalOffset, subPixelOffsetFinal);
+
+	vec3 finalUv = vec3(uv_interp, ViewIndex);
+	if (isHorizontal) {
+		finalUv.y += finalOffset * stepLength;
+	} else {
+		finalUv.x += finalOffset * stepLength;
+	}
+
+	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * combined_luminance_multiplier;
+	return finalColor;
+
+#else
+	float lumaUp = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, 1)).xyz * combined_luminance_multiplier);
+	float lumaDown = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, -1)).xyz * combined_luminance_multiplier);
+	float lumaLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 0)).xyz * combined_luminance_multiplier);
+	float lumaRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 0)).xyz * combined_luminance_multiplier);
+
+	float lumaCenter = rgb2luma(color);
+
+	float lumaMin = min(lumaCenter, min(min(lumaUp, lumaDown), min(lumaLeft, lumaRight)));
+	float lumaMax = max(lumaCenter, max(max(lumaUp, lumaDown), max(lumaLeft, lumaRight)));
+
+	float lumaRange = lumaMax - lumaMin;
+
+	if (lumaRange < max(EDGE_THRESHOLD_MIN, lumaMax * EDGE_THRESHOLD_MAX)) {
+		return color;
+	}
+
+	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, -1)).xyz * combined_luminance_multiplier);
+	float lumaUpRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 1)).xyz * combined_luminance_multiplier);
+	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 1)).xyz * combined_luminance_multiplier);
+	float lumaDownRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, -1)).xyz * combined_luminance_multiplier);
+
+	float lumaDownUp = lumaDown + lumaUp;
+	float lumaLeftRight = lumaLeft + lumaRight;
+
+	float lumaLeftCorners = lumaDownLeft + lumaUpLeft;
+	float lumaDownCorners = lumaDownLeft + lumaDownRight;
+	float lumaRightCorners = lumaDownRight + lumaUpRight;
+	float lumaUpCorners = lumaUpRight + lumaUpLeft;
+
+	float edgeHorizontal = abs(-2.0 * lumaLeft + lumaLeftCorners) + abs(-2.0 * lumaCenter + lumaDownUp) * 2.0 + abs(-2.0 * lumaRight + lumaRightCorners);
+	float edgeVertical = abs(-2.0 * lumaUp + lumaUpCorners) + abs(-2.0 * lumaCenter + lumaLeftRight) * 2.0 + abs(-2.0 * lumaDown + lumaDownCorners);
+
+	bool isHorizontal = (edgeHorizontal >= edgeVertical);
+
+	float stepLength = isHorizontal ? pixel_size.y : pixel_size.x;
+
+	float luma1 = isHorizontal ? lumaDown : lumaLeft;
+	float luma2 = isHorizontal ? lumaUp : lumaRight;
+	float gradient1 = luma1 - lumaCenter;
+	float gradient2 = luma2 - lumaCenter;
+
+	bool is1Steepest = abs(gradient1) >= abs(gradient2);
+
+	float gradientScaled = 0.25 * max(abs(gradient1), abs(gradient2));
+
+	float lumaLocalAverage = 0.0;
+	if (is1Steepest) {
+		stepLength = -stepLength;
+		lumaLocalAverage = 0.5 * (luma1 + lumaCenter);
+	} else {
+		lumaLocalAverage = 0.5 * (luma2 + lumaCenter);
+	}
+
+	vec2 currentUv = uv_interp;
+	if (isHorizontal) {
+		currentUv.y += stepLength * 0.5;
+	} else {
+		currentUv.x += stepLength * 0.5;
+	}
+
+	vec2 offset = isHorizontal ? vec2(pixel_size.x, 0.0) : vec2(0.0, pixel_size.y);
+	vec2 uv1 = currentUv - offset * QUALITY(0);
+	vec2 uv2 = currentUv + offset * QUALITY(0);
+
+	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
+	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
+	lumaEnd1 -= lumaLocalAverage;
+	lumaEnd2 -= lumaLocalAverage;
+
+	bool reached1 = abs(lumaEnd1) >= gradientScaled;
+	bool reached2 = abs(lumaEnd2) >= gradientScaled;
+	bool reachedBoth = reached1 && reached2;
+
+	if (!reached1) {
+		uv1 -= offset * QUALITY(1);
+	}
+	if (!reached2) {
+		uv2 += offset * QUALITY(1);
+	}
+
+	if (!reachedBoth) {
+		for (int i = 2; i < ITERATIONS; i++) {
+			if (!reached1) {
+				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
+				lumaEnd1 = lumaEnd1 - lumaLocalAverage;
+			}
+			if (!reached2) {
+				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
+				lumaEnd2 = lumaEnd2 - lumaLocalAverage;
+			}
+			reached1 = abs(lumaEnd1) >= gradientScaled;
+			reached2 = abs(lumaEnd2) >= gradientScaled;
+			reachedBoth = reached1 && reached2;
+			if (!reached1) {
+				uv1 -= offset * QUALITY(i);
+			}
+			if (!reached2) {
+				uv2 += offset * QUALITY(i);
+			}
+			if (reachedBoth) {
+				break;
+			}
+		}
+	}
+
+	float distance1 = isHorizontal ? (uv_interp.x - uv1.x) : (uv_interp.y - uv1.y);
+	float distance2 = isHorizontal ? (uv2.x - uv_interp.x) : (uv2.y - uv_interp.y);
+
+	bool isDirection1 = distance1 < distance2;
+	float distanceFinal = min(distance1, distance2);
+
+	float edgeThickness = (distance1 + distance2);
+
+	bool isLumaCenterSmaller = lumaCenter < lumaLocalAverage;
+
+	bool correctVariation1 = (lumaEnd1 < 0.0) != isLumaCenterSmaller;
+	bool correctVariation2 = (lumaEnd2 < 0.0) != isLumaCenterSmaller;
+
+	bool correctVariation = isDirection1 ? correctVariation1 : correctVariation2;
+
+	float pixelOffset = -distanceFinal / edgeThickness + 0.5;
+
+	float finalOffset = correctVariation ? pixelOffset : 0.0;
+
+	float lumaAverage = (1.0 / 12.0) * (2.0 * (lumaDownUp + lumaLeftRight) + lumaLeftCorners + lumaRightCorners);
+
+	float subPixelOffset1 = clamp(abs(lumaAverage - lumaCenter) / lumaRange, 0.0, 1.0);
+	float subPixelOffset2 = (-2.0 * subPixelOffset1 + 3.0) * subPixelOffset1 * subPixelOffset1;
+
+	float subPixelOffsetFinal = subPixelOffset2 * subPixelOffset2 * SUBPIXEL_QUALITY;
+
+	finalOffset = max(finalOffset, subPixelOffsetFinal);
+
+	vec2 finalUv = uv_interp;
+	if (isHorizontal) {
+		finalUv.y += finalOffset * stepLength;
+	} else {
+		finalUv.x += finalOffset * stepLength;
+	}
+
+	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * combined_luminance_multiplier;
+	return finalColor;
+
+#endif
+}
+#endif // USE_FXAA
+
 in vec2 uv_interp;
 
 layout(location = 0) out vec4 frag_color;
@@ -128,6 +512,10 @@ void main() {
 #ifdef USE_LUMINANCE_MULTIPLIER
 	color = color / luminance_multiplier;
 #endif
+
+#ifdef USE_FXAA
+	color.rgb = do_fxaa(color.rgb, uv_interp);
+#endif // USE_FXAA
 
 #ifdef USE_GLOW
 	// Glow blending is performed before srgb_to_linear because

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -135,7 +135,7 @@ void RenderSceneBuffersGLES3::configure(const RenderSceneBuffersConfiguration *p
 	//anisotropic_filtering_level = p_config->get_anisotropic_filtering_level();
 	render_target = p_config->get_render_target();
 	msaa3d.mode = p_config->get_msaa_3d();
-	//screen_space_aa = p_config->get_screen_space_aa();
+	screen_space_aa = p_config->get_screen_space_aa();
 	//use_debanding = p_config->get_use_debanding();
 	view_count = config->multiview_supported ? p_config->get_view_count() : 1;
 

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -45,7 +45,7 @@ public:
 	Size2i target_size; // Size of our output buffer (render target).
 	RSE::ViewportScaling3DMode scaling_3d_mode = RSE::VIEWPORT_SCALING_3D_MODE_OFF;
 	//float fsr_sharpness = 0.2f;
-	//RSE::ViewportScreenSpaceAA screen_space_aa = RSE::VIEWPORT_SCREEN_SPACE_AA_DISABLED;
+	RSE::ViewportScreenSpaceAA screen_space_aa = RSE::VIEWPORT_SCREEN_SPACE_AA_DISABLED;
 	//bool use_taa = false;
 	//bool use_debanding = false;
 	uint32_t view_count = 1;
@@ -159,7 +159,7 @@ public:
 	_FORCE_INLINE_ RSE::ViewportScaling3DMode get_scaling_3d_mode() const { return scaling_3d_mode; }
 	//_FORCE_INLINE_ float get_fsr_sharpness() const { return fsr_sharpness; }
 	_FORCE_INLINE_ RSE::ViewportMSAA get_msaa_3d() const { return msaa3d.mode; }
-	//_FORCE_INLINE_ RSE::ViewportScreenSpaceAA get_screen_space_aa() const { return screen_space_aa; }
+	_FORCE_INLINE_ RSE::ViewportScreenSpaceAA get_screen_space_aa() const { return screen_space_aa; }
 	//_FORCE_INLINE_ bool get_use_taa() const { return use_taa; }
 	//_FORCE_INLINE_ bool get_use_debanding() const { return use_debanding; }
 };

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -544,11 +544,13 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	const int ITERATIONS = 12;
 	const float SUBPIXEL_QUALITY = 0.75;
 
+	float combined_luminance_multiplier = exposure * params.luminance_multiplier;
+
 #ifdef USE_MULTIVIEW
-	float lumaUp = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaDown = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, -1)).xyz * exposure * params.luminance_multiplier);
-	float lumaLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 0)).xyz * exposure * params.luminance_multiplier);
-	float lumaRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 0)).xyz * exposure * params.luminance_multiplier);
+	float lumaUp = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, 1)).xyz * combined_luminance_multiplier);
+	float lumaDown = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, -1)).xyz * combined_luminance_multiplier);
+	float lumaLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 0)).xyz * combined_luminance_multiplier);
+	float lumaRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 0)).xyz * combined_luminance_multiplier);
 
 	float lumaCenter = rgb2luma(color);
 
@@ -561,10 +563,10 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 		return color;
 	}
 
-	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, -1)).xyz * exposure * params.luminance_multiplier);
-	float lumaUpRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaDownRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, -1)).xyz * exposure * params.luminance_multiplier);
+	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, -1)).xyz * combined_luminance_multiplier);
+	float lumaUpRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 1)).xyz * combined_luminance_multiplier);
+	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 1)).xyz * combined_luminance_multiplier);
+	float lumaDownRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, -1)).xyz * combined_luminance_multiplier);
 
 	float lumaDownUp = lumaDown + lumaUp;
 	float lumaLeftRight = lumaLeft + lumaRight;
@@ -609,8 +611,8 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	vec3 uv1 = vec3(currentUv - offset * QUALITY(0), ViewIndex);
 	vec3 uv2 = vec3(currentUv + offset * QUALITY(0), ViewIndex);
 
-	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * exposure * params.luminance_multiplier);
-	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * exposure * params.luminance_multiplier);
+	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
+	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
 	lumaEnd1 -= lumaLocalAverage;
 	lumaEnd2 -= lumaLocalAverage;
 
@@ -628,11 +630,11 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	if (!reachedBoth) {
 		for (int i = 2; i < ITERATIONS; i++) {
 			if (!reached1) {
-				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * exposure * params.luminance_multiplier);
+				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
 				lumaEnd1 = lumaEnd1 - lumaLocalAverage;
 			}
 			if (!reached2) {
-				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * exposure * params.luminance_multiplier);
+				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
 				lumaEnd2 = lumaEnd2 - lumaLocalAverage;
 			}
 			reached1 = abs(lumaEnd1) >= gradientScaled;
@@ -685,14 +687,14 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 		finalUv.x += finalOffset * stepLength;
 	}
 
-	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * exposure * params.luminance_multiplier;
+	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * combined_luminance_multiplier;
 	return finalColor;
 
 #else
-	float lumaUp = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaDown = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, -1)).xyz * exposure * params.luminance_multiplier);
-	float lumaLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 0)).xyz * exposure * params.luminance_multiplier);
-	float lumaRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 0)).xyz * exposure * params.luminance_multiplier);
+	float lumaUp = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, 1)).xyz * combined_luminance_multiplier);
+	float lumaDown = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, -1)).xyz * combined_luminance_multiplier);
+	float lumaLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 0)).xyz * combined_luminance_multiplier);
+	float lumaRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 0)).xyz * combined_luminance_multiplier);
 
 	float lumaCenter = rgb2luma(color);
 
@@ -705,10 +707,10 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 		return color;
 	}
 
-	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, -1)).xyz * exposure * params.luminance_multiplier);
-	float lumaUpRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaDownRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, -1)).xyz * exposure * params.luminance_multiplier);
+	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, -1)).xyz * combined_luminance_multiplier);
+	float lumaUpRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 1)).xyz * combined_luminance_multiplier);
+	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 1)).xyz * combined_luminance_multiplier);
+	float lumaDownRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, -1)).xyz * combined_luminance_multiplier);
 
 	float lumaDownUp = lumaDown + lumaUp;
 	float lumaLeftRight = lumaLeft + lumaRight;
@@ -753,8 +755,8 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	vec2 uv1 = currentUv - offset * QUALITY(0);
 	vec2 uv2 = currentUv + offset * QUALITY(0);
 
-	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * exposure * params.luminance_multiplier);
-	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * exposure * params.luminance_multiplier);
+	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
+	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
 	lumaEnd1 -= lumaLocalAverage;
 	lumaEnd2 -= lumaLocalAverage;
 
@@ -772,11 +774,11 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	if (!reachedBoth) {
 		for (int i = 2; i < ITERATIONS; i++) {
 			if (!reached1) {
-				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * exposure * params.luminance_multiplier);
+				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
 				lumaEnd1 = lumaEnd1 - lumaLocalAverage;
 			}
 			if (!reached2) {
-				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * exposure * params.luminance_multiplier);
+				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
 				lumaEnd2 = lumaEnd2 - lumaLocalAverage;
 			}
 			reached1 = abs(lumaEnd1) >= gradientScaled;
@@ -829,7 +831,7 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 		finalUv.x += finalOffset * stepLength;
 	}
 
-	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * exposure * params.luminance_multiplier;
+	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * combined_luminance_multiplier;
 	return finalColor;
 
 #endif

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap_mobile.glsl
@@ -415,11 +415,13 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	const int ITERATIONS = 12;
 	const float SUBPIXEL_QUALITY = 0.75;
 
+	float combined_luminance_multiplier = exposure * params.luminance_multiplier;
+
 #ifdef USE_MULTIVIEW
-	float lumaUp = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaDown = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, -1)).xyz * exposure * params.luminance_multiplier);
-	float lumaLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 0)).xyz * exposure * params.luminance_multiplier);
-	float lumaRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 0)).xyz * exposure * params.luminance_multiplier);
+	float lumaUp = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, 1)).xyz * combined_luminance_multiplier);
+	float lumaDown = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, -1)).xyz * combined_luminance_multiplier);
+	float lumaLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 0)).xyz * combined_luminance_multiplier);
+	float lumaRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 0)).xyz * combined_luminance_multiplier);
 
 	float lumaCenter = rgb2luma(color);
 
@@ -432,10 +434,10 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 		return color;
 	}
 
-	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, -1)).xyz * exposure * params.luminance_multiplier);
-	float lumaUpRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaDownRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, -1)).xyz * exposure * params.luminance_multiplier);
+	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, -1)).xyz * combined_luminance_multiplier);
+	float lumaUpRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, 1)).xyz * combined_luminance_multiplier);
+	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(-1, 1)).xyz * combined_luminance_multiplier);
+	float lumaDownRight = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(1, -1)).xyz * combined_luminance_multiplier);
 
 	float lumaDownUp = lumaDown + lumaUp;
 	float lumaLeftRight = lumaLeft + lumaRight;
@@ -480,8 +482,8 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	vec3 uv1 = vec3(currentUv - offset * QUALITY(0), ViewIndex);
 	vec3 uv2 = vec3(currentUv + offset * QUALITY(0), ViewIndex);
 
-	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * exposure * params.luminance_multiplier);
-	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * exposure * params.luminance_multiplier);
+	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
+	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
 	lumaEnd1 -= lumaLocalAverage;
 	lumaEnd2 -= lumaLocalAverage;
 
@@ -499,11 +501,11 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	if (!reachedBoth) {
 		for (int i = 2; i < ITERATIONS; i++) {
 			if (!reached1) {
-				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * exposure * params.luminance_multiplier);
+				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
 				lumaEnd1 = lumaEnd1 - lumaLocalAverage;
 			}
 			if (!reached2) {
-				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * exposure * params.luminance_multiplier);
+				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
 				lumaEnd2 = lumaEnd2 - lumaLocalAverage;
 			}
 			reached1 = abs(lumaEnd1) >= gradientScaled;
@@ -556,14 +558,14 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 		finalUv.x += finalOffset * stepLength;
 	}
 
-	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * exposure * params.luminance_multiplier;
+	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * combined_luminance_multiplier;
 	return finalColor;
 
 #else
-	float lumaUp = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaDown = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, -1)).xyz * exposure * params.luminance_multiplier);
-	float lumaLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 0)).xyz * exposure * params.luminance_multiplier);
-	float lumaRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 0)).xyz * exposure * params.luminance_multiplier);
+	float lumaUp = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, 1)).xyz * combined_luminance_multiplier);
+	float lumaDown = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(0, -1)).xyz * combined_luminance_multiplier);
+	float lumaLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 0)).xyz * combined_luminance_multiplier);
+	float lumaRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 0)).xyz * combined_luminance_multiplier);
 
 	float lumaCenter = rgb2luma(color);
 
@@ -576,10 +578,10 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 		return color;
 	}
 
-	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, -1)).xyz * exposure * params.luminance_multiplier);
-	float lumaUpRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 1)).xyz * exposure * params.luminance_multiplier);
-	float lumaDownRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, -1)).xyz * exposure * params.luminance_multiplier);
+	float lumaDownLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, -1)).xyz * combined_luminance_multiplier);
+	float lumaUpRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, 1)).xyz * combined_luminance_multiplier);
+	float lumaUpLeft = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(-1, 1)).xyz * combined_luminance_multiplier);
+	float lumaDownRight = rgb2luma(textureLodOffset(source_color, uv_interp, 0.0, ivec2(1, -1)).xyz * combined_luminance_multiplier);
 
 	float lumaDownUp = lumaDown + lumaUp;
 	float lumaLeftRight = lumaLeft + lumaRight;
@@ -624,8 +626,8 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	vec2 uv1 = currentUv - offset * QUALITY(0);
 	vec2 uv2 = currentUv + offset * QUALITY(0);
 
-	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * exposure * params.luminance_multiplier);
-	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * exposure * params.luminance_multiplier);
+	float lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
+	float lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
 	lumaEnd1 -= lumaLocalAverage;
 	lumaEnd2 -= lumaLocalAverage;
 
@@ -643,11 +645,11 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	if (!reachedBoth) {
 		for (int i = 2; i < ITERATIONS; i++) {
 			if (!reached1) {
-				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * exposure * params.luminance_multiplier);
+				lumaEnd1 = rgb2luma(textureLod(source_color, uv1, 0.0).xyz * combined_luminance_multiplier);
 				lumaEnd1 = lumaEnd1 - lumaLocalAverage;
 			}
 			if (!reached2) {
-				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * exposure * params.luminance_multiplier);
+				lumaEnd2 = rgb2luma(textureLod(source_color, uv2, 0.0).xyz * combined_luminance_multiplier);
 				lumaEnd2 = lumaEnd2 - lumaLocalAverage;
 			}
 			reached1 = abs(lumaEnd1) >= gradientScaled;
@@ -700,7 +702,7 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 		finalUv.x += finalOffset * stepLength;
 	}
 
-	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * exposure * params.luminance_multiplier;
+	vec3 finalColor = textureLod(source_color, finalUv, 0.0).xyz * combined_luminance_multiplier;
 	return finalColor;
 
 #endif

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1414,16 +1414,22 @@ bool RendererViewport::viewport_is_using_hdr_2d(RID p_viewport) const {
 void RendererViewport::viewport_set_screen_space_aa(RID p_viewport, RSE::ViewportScreenSpaceAA p_mode) {
 	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
 	ERR_FAIL_NULL(viewport);
+	bool fallback_to_fxaa = false;
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" && p_mode == RSE::VIEWPORT_SCREEN_SPACE_AA_SMAA) {
 #ifdef DEBUG_ENABLED
-	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" && p_mode != RSE::VIEWPORT_SCREEN_SPACE_AA_DISABLED) {
-		WARN_PRINT_ONCE_ED("Screen-space AA is only available when using the Forward+ or Mobile renderer.");
-	}
+		WARN_PRINT_ONCE_ED("SMAA screen-space antialiasing is only available when using the Forward+ or Mobile renderer. Falling back to FXAA.");
 #endif
+		fallback_to_fxaa = true;
+	}
 
 	if (viewport->screen_space_aa == p_mode) {
 		return;
 	}
-	viewport->screen_space_aa = p_mode;
+	if (fallback_to_fxaa) {
+		viewport->screen_space_aa = RSE::VIEWPORT_SCREEN_SPACE_AA_FXAA;
+	} else {
+		viewport->screen_space_aa = p_mode;
+	}
 	_configure_3d_render_buffers(viewport);
 }
 


### PR DESCRIPTION
This adds FXAA support to the Compatibility renderer, making it have parity with Godot 3.x GLES3/GLES2 on this aspect.

When attempting to use SMAA in Compatibility (which isn't currently implemented), it will now fall back to FXAA to provide an experience as close as possible.

SMAA support could be added in a future PR (OpenGL ES 3.0 and WebGL 2.0 can support it), but it's more involved.

- This closes https://github.com/godotengine/godot/issues/69463.

**Testing project:** [test_screen_space_aa.zip](https://github.com/user-attachments/files/24039744/test_screen_space_aa.zip)

## Preview

### No glow, no SSAO

*The first image has the separate tonemap pass disabled, as we don't use any effect that requires it (and `scaling_3d_scale` is `1.0`). There is a slight color shift as soon as the separate tonemap pass kicks in, but this also happens in `master` with no FXAA.*

Disabled | FXAA
-|-
<img width="1152" height="648" alt="Screenshot_20251208_195625" src="https://github.com/user-attachments/assets/b0e6476f-1562-4f9a-a793-2b8a8243c4ed" /> | <img width="1152" height="648" alt="Screenshot_20251208_195630" src="https://github.com/user-attachments/assets/2f92a6e3-ed9d-4da9-ace3-6ff0ff5e2461" />

### Glow + SSAO

Disabled | FXAA
-|-
<img width="1152" height="648" alt="Screenshot_20251208_195601" src="https://github.com/user-attachments/assets/6188e32c-cdfd-4d80-81aa-2cb6041bf1b4" /> | <img width="1152" height="648" alt="Screenshot_20251208_195606" src="https://github.com/user-attachments/assets/c0a90f7d-b847-4e6f-98d1-9c36ec9aab55" />

### Glow + SSAO + AgX tonemapping

Disabled | FXAA
-|-
<img width="1152" height="648" alt="Screenshot_20251208_195734" src="https://github.com/user-attachments/assets/5e08fe32-945c-4d74-8140-6c7399059933" /> | <img width="1152" height="648" alt="Screenshot_20251208_195739" src="https://github.com/user-attachments/assets/a6c69fb4-d94b-4c52-b3e8-2d1c845831c2" />


## TODO

- [x] Check order of operations (should FXAA be before or after tonemapping and/or glow)?
  - Currently, FXAA still works when glow is enabled, but it's less effective overall.
  - https://github.com/godotengine/godot/pull/113763#issuecomment-3628687220
- [x] Check if the luminance exposure multiplier is correctly applied. It's possible that I got it wrong, or that I'm doing the operation for no benefit.
  - https://github.com/godotengine/godot/pull/113763#issuecomment-3628687220