### PR TITLE
Expose `ScriptEditor::save_all_scripts()`

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -99,6 +99,12 @@
 				[b]Note:[/b] Does not apply to scripts that are already opened.
 			</description>
 		</method>
+		<method name="save_all_scripts">
+			<return type="void" />
+			<description>
+				Saves all open scripts.
+			</description>
+		</method>
 		<method name="unregister_syntax_highlighter">
 			<return type="void" />
 			<param index="0" name="syntax_highlighter" type="EditorSyntaxHighlighter" />

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -4158,6 +4158,8 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("update_docs_from_script", "script"), &ScriptEditor::update_docs_from_script);
 	ClassDB::bind_method(D_METHOD("clear_docs_from_script", "script"), &ScriptEditor::clear_docs_from_script);
 
+	ClassDB::bind_method(D_METHOD("save_all_scripts"), &ScriptEditor::save_all_scripts);
+
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 }


### PR DESCRIPTION
This PR simply binds `ScriptEditor::save_all_scripts` to GDScript.

Feature description in the proposal: https://github.com/godotengine/godot-proposals/issues/13812

This is similar to the already-public `EditorInterface::save_all_scenes()`

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/13812*