### PR TITLE
Add `EditorInterface::get_unsaved_scenes()`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -242,6 +242,12 @@
 				Returns the editor's [EditorSelection] instance.
 			</description>
 		</method>
+		<method name="get_unsaved_scenes" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns an array of file paths of currently unsaved scenes.
+			</description>
+		</method>
 		<method name="inspect_object">
 			<return type="void" />
 			<param index="0" name="object" type="Object" />

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -724,10 +724,19 @@ PackedStringArray EditorInterface::get_open_scenes() const {
 	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
 
 	for (EditorData::EditedScene &edited_scene : scenes) {
-		if (edited_scene.root == nullptr) {
-			continue;
+		ret.push_back(edited_scene.path);
+	}
+	return ret;
+}
+
+PackedStringArray EditorInterface::get_unsaved_scenes() const {
+	PackedStringArray ret;
+	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
+
+	for (int i = 0; i < scenes.size(); i++) {
+		if (EditorNode::get_singleton()->is_scene_unsaved(i)) {
+			ret.push_back(scenes[i].path);
 		}
-		ret.push_back(edited_scene.root->get_scene_file_path());
 	}
 	return ret;
 }
@@ -909,6 +918,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_object_edited", "object"), &EditorInterface::is_object_edited);
 
 	ClassDB::bind_method(D_METHOD("get_open_scenes"), &EditorInterface::get_open_scenes);
+	ClassDB::bind_method(D_METHOD("get_unsaved_scenes"), &EditorInterface::get_unsaved_scenes);
 	ClassDB::bind_method(D_METHOD("get_open_scene_roots"), &EditorInterface::get_open_scene_roots);
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -179,6 +179,8 @@ public:
 	bool is_object_edited(Object *p_object) const;
 
 	PackedStringArray get_open_scenes() const;
+	PackedStringArray get_unsaved_scenes() const;
+
 	TypedArray<Node> get_open_scene_roots() const;
 	Node *get_edited_scene_root() const;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2575,7 +2575,7 @@ void EditorNode::restart_editor(bool p_goto_project_manager) {
 void EditorNode::_save_all_scenes() {
 	scenes_to_save_as.clear(); // In case saving was canceled before.
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
-		if (!_is_scene_unsaved(i)) {
+		if (!is_scene_unsaved(i)) {
 			continue;
 		}
 
@@ -2619,7 +2619,7 @@ void EditorNode::_mark_unsaved_scenes() {
 	scene_tabs->update_scene_tabs();
 }
 
-bool EditorNode::_is_scene_unsaved(int p_idx) {
+bool EditorNode::is_scene_unsaved(int p_idx) {
 	const Node *scene = editor_data.get_edited_scene_root(p_idx);
 	if (!scene) {
 		return false;
@@ -4153,7 +4153,7 @@ void EditorNode::_discard_changes(const String &p_str) {
 void EditorNode::_update_file_menu_opened() {
 	bool has_unsaved = false;
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
-		if (_is_scene_unsaved(i)) {
+		if (is_scene_unsaved(i)) {
 			has_unsaved = true;
 			break;
 		}

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -641,7 +641,6 @@ private:
 	bool _find_and_save_edited_subresources(Object *obj, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
 	void _save_edited_subresources(Node *scene, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
 	void _mark_unsaved_scenes();
-	bool _is_scene_unsaved(int p_idx);
 
 	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);
 	void _save_scene_with_preview(String p_file, int p_idx = -1);
@@ -1045,6 +1044,7 @@ public:
 	bool ensure_main_scene(bool p_from_native);
 	bool validate_custom_directory();
 	void run_editor_script(const Ref<Script> &p_script);
+	bool is_scene_unsaved(int p_idx);
 };
 
 struct EditorProgressBG {


### PR DESCRIPTION
This PR creates a new method, `EditorInterface::get_unsaved_scenes()`, and exposes it to the public API.

The method:

- Iterates through `EditorNode::get_editor_data().get_edited_scenes()`
- Checks undo-redo history to determine if the scene is saved
- Returns a list of scene paths

Full description in the proposal: https://github.com/godotengine/godot-proposals/issues/13813