### PR TITLE
Debugger show error timestamp in tooltip

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -745,7 +745,6 @@ void ScriptEditorDebugger::_msg_error(uint64_t p_thread_id, const Array &p_data)
 		stack_trace->set_text(1, frame_txt);
 	}
 
-	error->set_tooltip_text(0, tooltip);
 	error->set_tooltip_text(1, tooltip);
 
 	if (warning_count == 0 && error_count == 0) {


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/113412

Shows the timestamp of an error in its hover tooltip

<img width="1154" height="126" alt="image" src="https://github.com/user-attachments/assets/32643424-7ebd-42a9-bccd-1c9bd6c6064c" />
