### PR TITLE
Add `ScriptEditor::close_file()`

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -18,6 +18,14 @@
 				[b]Note:[/b] This should be called whenever the script is changed to keep the open documentation state up to date.
 			</description>
 		</method>
+		<method name="close_file">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Closes the file at the given [param path], discarding any unsaved changes.
+				Returns [constant OK] on success or [constant ERR_FILE_NOT_FOUND] if the file is not found.
+			</description>
+		</method>
 		<method name="get_breakpoints">
 			<return type="PackedStringArray" />
 			<description>

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2611,6 +2611,20 @@ Ref<Resource> ScriptEditor::open_file(const String &p_file) {
 	return Ref<Resource>();
 }
 
+Error ScriptEditor::close_file(const String &p_file) {
+	for (int i = 0; i < tab_container->get_tab_count(); i++) {
+		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
+		if (seb && seb->get_edited_resource()->get_path() == p_file) {
+			if (seb->is_unsaved()) {
+				seb->get_edited_resource()->reload_from_file();
+			}
+			_close_tab(i, false, _get_current_editor() == seb);
+			return OK;
+		}
+	}
+	return ERR_FILE_NOT_FOUND;
+}
+
 void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const PackedStringArray &p_args) {
 	ERR_FAIL_NULL(p_obj);
 	Ref<Script> scr = p_obj->get_script();
@@ -3776,6 +3790,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_docs_from_script", "script"), &ScriptEditor::clear_docs_from_script);
 
 	ClassDB::bind_method(D_METHOD("save_all_scripts"), &ScriptEditor::save_all_scripts);
+	ClassDB::bind_method(D_METHOD("close_file", "path"), &ScriptEditor::close_file);
 
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, Script::get_class_static())));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, Script::get_class_static())));

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/error/error_list.h"
 #include "core/object/script_language.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/script/script_editor_base.h"
@@ -412,6 +413,7 @@ public:
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);
 	void open_text_file_create_dialog(const String &p_base_path, const String &p_base_name = "");
 	Ref<Resource> open_file(const String &p_file);
+	Error close_file(const String &p_file);
 
 	void ensure_select_current();
 


### PR DESCRIPTION
This PR adds `ScriptEditor::close_file(path)`, which closes a script at a given path. 

This is similar to `EditorInterface::close_scene()`, but for script files.

Closes: https://github.com/godotengine/godot-proposals/issues/13815