### PR TITLE
Fix opening errors from built-in scripts

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -162,6 +162,10 @@ void EditorDebuggerNode::_stack_frame_selected(int p_debugger) {
 }
 
 void EditorDebuggerNode::_error_selected(const String &p_file, int p_line, int p_debugger) {
+	if (!p_file.is_resource_file() && !ResourceCache::has(p_file)) {
+		// If it's a built-in script, make sure the scene is opened first.
+		EditorNode::get_singleton()->load_scene(p_file.get_slice("::", 0));
+	}
 	Ref<Script> s = ResourceLoader::load(p_file);
 	emit_signal(SNAME("goto_script_line"), s, p_line - 1);
 }


### PR DESCRIPTION
When clicking an error in the Debugger which comes from a built-in script, if the script's scene is not loaded in the editor, the editor will fail to open the script.