### PR TITLE
Make indirectly inherited `EditorScript`s appear in the command palette

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -460,6 +460,15 @@ void ScriptServer::get_inheriters_list(const StringName &p_base_type, List<Strin
 	}
 }
 
+void ScriptServer::get_indirect_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes) {
+	List<StringName> direct_inheritors;
+	get_inheriters_list(p_base_type, &direct_inheritors);
+	for (const StringName &inheritor : direct_inheritors) {
+		r_classes->push_back(inheritor);
+		get_indirect_inheriters_list(inheritor, r_classes);
+	}
+}
+
 void ScriptServer::remove_global_class_by_path(const String &p_path) {
 	for (const KeyValue<StringName, GlobalScriptClass> &kv : global_classes) {
 		if (kv.value.path == p_path) {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -100,6 +100,7 @@ public:
 	static bool is_global_class_tool(const String &p_class);
 	static void get_global_class_list(LocalVector<StringName> &r_global_classes);
 	static void get_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes);
+	static void get_indirect_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes);
 	static void save_global_classes();
 
 	static Vector<Ref<ScriptBacktrace>> capture_script_backtraces(bool p_include_variables = false);

--- a/editor/script/editor_script_plugin.cpp
+++ b/editor/script/editor_script_plugin.cpp
@@ -53,7 +53,7 @@ void EditorScriptPlugin::command_palette_about_to_popup() {
 		EditorInterface::get_singleton()->get_command_palette()->remove_command("editor_scripts/" + command);
 	}
 	commands.clear();
-	ScriptServer::get_inheriters_list(SNAME("EditorScript"), &commands);
+	ScriptServer::get_indirect_inheriters_list(SNAME("EditorScript"), &commands);
 	for (const StringName &command : commands) {
 		EditorInterface::get_singleton()->get_command_palette()->add_command(String(command).capitalize(), "editor_scripts/" + command, callable_mp(this, &EditorScriptPlugin::run_command), varray(command), nullptr);
 	}


### PR DESCRIPTION
I added a new `ScriptServer::get_indirect_inheriters_list` function that recursively walks the inheritance tree from `ScriptServer::get_inheriters_list`. From the MRP of the attached issue, both `EditorScript`s show up now:

<img width="730" height="598" alt="Screenshot_20251208_132153" src="https://github.com/user-attachments/assets/4df4accd-78ab-4ce4-81e2-f9831733508e" />

I think it's possible to rewrite it without the second List allocation like this:
```cpp
size_t classes_start_size = r_classes->size();
get_inheriters_list(p_base_type, r_classes);
size_t classes_end_size = r_classes->size();
for (int i = classes_start_size; i < classes_end_size; i++) {
	const StringName &inheritor = r_classes[i];
	r_classes->push_back(inheritor);
	get_indirect_inheriters_list(inheritor, r_classes);
}
```
but I'm not sure if that'd work in all cases and it's more complicated.

Fixes #113749