### PR TITLE
Add `EditorInterface::reload_all_scenes()`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -449,7 +449,7 @@
 		<method name="reload_all_scenes">
 			<return type="void" />
 			<description>
-				Reloads all open scenes in the editor.
+				Reloads all scenes currently open in the editor.
 			</description>
 		</method>
 		<method name="reload_scene_from_path">

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -446,6 +446,12 @@
 				Pops up an editor dialog for quick selecting a resource file. The [param callback] must take a single argument of type [String] which will contain the path of the selected resource or be empty if the dialog is canceled. If [param base_types] is provided, the dialog will only show resources that match these types. Only types deriving from [Resource] are supported.
 			</description>
 		</method>
+		<method name="reload_all_scenes">
+			<return type="void" />
+			<description>
+				Reloads all open scenes in the editor.
+			</description>
+		</method>
 		<method name="reload_scene_from_path">
 			<return type="void" />
 			<param index="0" name="scene_filepath" type="String" />

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -715,6 +715,21 @@ bool EditorInterface::is_object_edited(Object *p_object) const {
 	return p_object->is_edited();
 }
 
+void EditorInterface::reload_all_scenes() {
+	auto current_scene = get_edited_scene_root();
+
+	for (const EditorData::EditedScene &edited_scene : EditorNode::get_editor_data().get_edited_scenes()) {
+		if (edited_scene.root == nullptr || edited_scene.root == current_scene) {
+			continue;
+		}
+		EditorNode::get_singleton()->reload_scene(edited_scene.root->get_scene_file_path());
+	}
+	// Current scene gets reloaded last so it will be switched to last.
+	if (current_scene) {
+		EditorNode::get_singleton()->reload_scene(current_scene->get_scene_file_path());
+	}
+}
+
 Node *EditorInterface::get_edited_scene_root() const {
 	return EditorNode::get_singleton()->get_edited_scene();
 }
@@ -913,6 +928,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("edit_script", "script", "line", "column", "grab_focus"), &EditorInterface::edit_script, DEFVAL(-1), DEFVAL(0), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath", "set_inherited"), &EditorInterface::open_scene_from_path, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
+	ClassDB::bind_method(D_METHOD("reload_all_scenes"), &EditorInterface::reload_all_scenes);
 
 	ClassDB::bind_method(D_METHOD("set_object_edited", "object", "edited"), &EditorInterface::set_object_edited);
 	ClassDB::bind_method(D_METHOD("is_object_edited", "object"), &EditorInterface::is_object_edited);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -174,6 +174,7 @@ public:
 	void edit_script(const Ref<Script> &p_script, int p_line = -1, int p_col = 0, bool p_grab_focus = true);
 	void open_scene_from_path(const String &scene_path, bool p_set_inherited = false);
 	void reload_scene_from_path(const String &scene_path);
+	void reload_all_scenes();
 
 	void set_object_edited(Object *p_object, bool p_edited);
 	bool is_object_edited(Object *p_object) const;


### PR DESCRIPTION
This PR adds `EditorInterface::reload_all_scenes()`, which allows users to batch reload all scenes, after they have made changes on disk.

Closes: https://github.com/godotengine/godot-proposals/issues/13816

This is necessary because `reload_scene_from_path` can only be run once per frame.

Note: Since there's no way to reload a scene without switching to it, we always update the currently-editing scene *last.*