### PR TITLE
Fix typos in VectorNi docs (float division examples)

### DIFF
--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -292,7 +292,7 @@
 			<description>
 				Divides each component of the [Vector2i] by the given [float]. Returns a [Vector2].
 				[codeblock]
-				print(Vector2i(10, 20) / 2.9) # Prints (5.0, 10.0)
+				print(Vector2i(1, 2) / 2.5) # Prints (0.4, 0.8)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -299,7 +299,7 @@
 			<description>
 				Divides each component of the [Vector3i] by the given [float]. Returns a [Vector3].
 				[codeblock]
-				print(Vector3i(10, 20, 30) / 2.9) # Prints (5.0, 10.0, 15.0)
+				print(Vector3i(1, 2, 3) / 2.5) # Prints (0.4, 0.8, 1.2)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -287,7 +287,7 @@
 				Divides each component of the [Vector4i] by the given [float].
 				Returns a Vector4 value due to floating-point operations.
 				[codeblock]
-				print(Vector4i(10, 20, 30, 40) / 2) # Prints (5.0, 10.0, 15.0, 20.0)
+				print(Vector4i(1, 2, 3, 4) / 2.5) # Prints (0.4, 0.8, 1.2, 1.6)
 				[/codeblock]
 			</description>
 		</operator>


### PR DESCRIPTION
While reading the docs for `Vector2i`, I noticed that the example for float division incorrectly claims that it prints `(5.0, 10.0)`.  Accordingly, I have updated it to be correct, i.e. `(3.448276, 6.896552)`.