### PR TITLE
Allow immediately updating kinematic body transforms in the physics server

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1009,9 +1009,16 @@ Error ProjectSettings::_load_settings_text_or_binary(const String &p_text_path, 
 				int major_version = feat.get_slicec('.', 0).to_int();
 				int minor_version = feat.get_slicec('.', 1).to_int();
 				// Major version is irrelevant, but the extra check ensures that the feature is in fact a version string.
-				if (major_version == 4 && minor_version < 6) {
-					// Enable MeshInstance3D compat for projects created before 4.6.
-					set_setting("animation/compatibility/default_parent_skeleton_in_mesh_instance_3d", true);
+				if (major_version == 4) {
+					if (minor_version < 6) {
+						// Enable MeshInstance3D compat for projects created before 4.6.
+						set_setting("animation/compatibility/default_parent_skeleton_in_mesh_instance_3d", true);
+					}
+					if (minor_version < 7) {
+						// Use old kinematic body behavior for GodotPhysics2D and GodotPhysics3D for projects created before 4.7.
+						set_setting("physics/2d/kinematic_body_initial_teleport", true);
+						set_setting("physics/3d/kinematic_body_initial_teleport", true);
+					}
 				}
 				break;
 			}
@@ -1740,6 +1747,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("animation/warnings/check_angle_interpolation_type_conflicting", true);
 #ifndef DISABLE_DEPRECATED
 	GLOBAL_DEF_RST("animation/compatibility/default_parent_skeleton_in_mesh_instance_3d", false);
+	GLOBAL_DEF_RST("physics/2d/kinematic_body_initial_teleport", false);
+	GLOBAL_DEF_RST("physics/3d/kinematic_body_initial_teleport", false);
 #endif
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "audio/buses/default_bus_layout", PROPERTY_HINT_FILE, "*.tres"), "res://default_bus_layout.tres");

--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -18,6 +18,13 @@
 				Adds a body to the list of bodies that this body can't collide with.
 			</description>
 		</method>
+		<method name="flush_kinematic_transform">
+			<return type="void" />
+			<description>
+				Updates the transform of a kinematic body in the server to the pending transform immediately without modifying velocities.
+				[b]Note:[/b] This method will not do anything if the new transform has not already been sent to the server. Call [method CanvasItem.force_update_transform] to send the transform to the server.
+			</description>
+		</method>
 		<method name="get_collision_exceptions">
 			<return type="PhysicsBody2D[]" />
 			<description>

--- a/doc/classes/PhysicsBody3D.xml
+++ b/doc/classes/PhysicsBody3D.xml
@@ -19,6 +19,13 @@
 				Adds a body to the list of bodies that this body can't collide with.
 			</description>
 		</method>
+		<method name="flush_kinematic_transform">
+			<return type="void" />
+			<description>
+				Updates the transform of a kinematic body in the server to the pending transform immediately without modifying velocities.
+				[b]Note:[/b] This method will not do anything if the new transform has not already been sent to the server. Call [method Node3D.force_update_transform] to send the transform to the server.
+			</description>
+		</method>
 		<method name="get_axis_lock" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -374,6 +374,13 @@
 				Use [method body_add_shape] to add shapes to it, use [method body_set_state] to set its transform, and use [method body_set_space] to add the body to a space.
 			</description>
 		</method>
+		<method name="body_flush_kinematic_transform">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Updates the transform of a kinematic body to the pending transform immediately without modifying velocities or colliding with other bodies.
+			</description>
+		</method>
 		<method name="body_get_canvas_instance_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
@@ -1103,6 +1110,7 @@
 		</constant>
 		<constant name="BODY_MODE_KINEMATIC" value="1" enum="BodyMode">
 			Constant for kinematic bodies. In this mode, a body can be only moved by user code and collides with other bodies along its path.
+			[b]Note:[/b] Kinematic bodies do not immediately move to their new transform when set using [method body_set_state]. If you intend to teleport a kinematic body, set its transform and then call [method body_flush_kinematic_transform].
 		</constant>
 		<constant name="BODY_MODE_RIGID" value="2" enum="BodyMode">
 			Constant for rigid bodies. In this mode, a body can be pushed by other bodies and has forces applied.

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -368,6 +368,13 @@
 				Overridable version of [method PhysicsServer2D.body_create].
 			</description>
 		</method>
+		<method name="_body_flush_kinematic_transform" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Overridable version of [method PhysicsServer2D.body_flush_kinematic_transform].
+			</description>
+		</method>
 		<method name="_body_get_canvas_instance_id" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -356,6 +356,13 @@
 				Use [method body_add_shape] to add shapes to it, use [method body_set_state] to set its transform, and use [method body_set_space] to add the body to a space.
 			</description>
 		</method>
+		<method name="body_flush_kinematic_transform">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Updates the transform of a kinematic body to the pending transform immediately without modifying velocities or colliding with other bodies.
+			</description>
+		</method>
 		<method name="body_get_collision_layer" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
@@ -1763,6 +1770,7 @@
 		</constant>
 		<constant name="BODY_MODE_KINEMATIC" value="1" enum="BodyMode">
 			Constant for kinematic bodies. In this mode, a body can be only moved by user code and collides with other bodies along its path.
+			[b]Note:[/b] Kinematic bodies do not immediately move to their new transform when set using [method body_set_state]. If you intend to teleport a kinematic body, set its transform and then call [method body_flush_kinematic_transform].
 		</constant>
 		<constant name="BODY_MODE_RIGID" value="2" enum="BodyMode">
 			Constant for rigid bodies. In this mode, a body can be pushed by other bodies and has forces applied.

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -289,6 +289,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_flush_kinematic_transform" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Overridable version of [method PhysicsServer3D.body_flush_kinematic_transform].
+			</description>
+		</method>
 		<method name="_body_get_collision_exceptions" qualifiers="virtual required const">
 			<return type="RID[]" />
 			<param index="0" name="body" type="RID" />

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2530,6 +2530,10 @@
 			During each physics tick, Godot will multiply the linear velocity of RigidBodies by [code]1.0 - combined_damp / physics_ticks_per_second[/code], where [code]combined_damp[/code] is the sum of the linear damp of the body and this value, or the area's value the body is in, assuming the body defaults to combine damp values. See [enum RigidBody2D.DampMode].
 			[b]Warning:[/b] Godot's damping calculations are simulation tick rate dependent. Changing [member physics/common/physics_ticks_per_second] may significantly change the outcomes and feel of your simulation. This is true for the entire range of damping values greater than 0. To get back to a similar feel, you also need to change your damp values. This needed change is not proportional and differs from case to case.
 		</member>
+		<member name="physics/2d/kinematic_body_initial_teleport" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the first time the transform is set on a 2D physics body after the body's mode is set to [constant PhysicsServer2D.BODY_MODE_KINEMATIC] it will teleport to the new transform, keeping its velocity and ignoring other bodies in its path. This is the default behavior for Godot versions before 4.6.
+			[b]Note:[/b] This property only takes effect when using GodotPhysics2D as the 2D physics engine.
+		</member>
 		<member name="physics/2d/physics_engine" type="String" setter="" getter="" default="&quot;DEFAULT&quot;" keywords="godotphysics">
 			Sets which physics engine to use for 2D physics.
 			[b]DEFAULT[/b] is currently equivalent to [b]GodotPhysics2D[/b], but may change in future releases. Select an explicit implementation if you want to ensure that your project stays on the same engine.
@@ -2610,6 +2614,10 @@
 			[b]Note:[/b] Godot damping calculations are velocity-dependent, meaning bodies moving faster will take a longer time to come to rest. They do not simulate inertia, friction, or air resistance. Therefore heavier or larger bodies will lose speed at the same proportional rate as lighter or smaller bodies.
 			During each physics tick, Godot will multiply the linear velocity of RigidBodies by [code]1.0 - combined_damp / physics_ticks_per_second[/code]. By default, bodies combine damp factors: [code]combined_damp[/code] is the sum of the damp value of the body and this value or the area's value the body is in. See [enum RigidBody3D.DampMode].
 			[b]Warning:[/b] Godot's damping calculations are simulation tick rate dependent. Changing [member physics/common/physics_ticks_per_second] may significantly change the outcomes and feel of your simulation. This is true for the entire range of damping values greater than 0. To get back to a similar feel, you also need to change your damp values. This needed change is not proportional and differs from case to case.
+		</member>
+		<member name="physics/3d/kinematic_body_initial_teleport" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the first time the transform is set on a 3D physics body after the body's mode is set to [constant PhysicsServer3D.BODY_MODE_KINEMATIC] it will teleport to the new transform, keeping its velocity and ignoring other bodies in its path. This is the default behavior for Godot versions before 4.6.
+			[b]Note:[/b] This property only takes effect when using GodotPhysics3D as the 3D physics engine.
 		</member>
 		<member name="physics/3d/physics_engine" type="String" setter="" getter="" default="&quot;DEFAULT&quot;" keywords="godotphysics, jolt">
 			Sets which physics engine to use for 3D physics.

--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -100,7 +100,9 @@ class GodotBody2D : public GodotCollisionObject2D {
 	bool omit_force_integration = false;
 	bool active = true;
 	bool can_sleep = true;
+#ifndef DISABLE_DEPRECATED
 	bool first_time_kinematic = false;
+#endif
 	void _mass_properties_changed();
 	virtual void _shapes_changed() override;
 	Transform2D new_transform;
@@ -156,6 +158,10 @@ class GodotBody2D : public GodotCollisionObject2D {
 	friend class GodotPhysicsDirectBodyState2D; // i give up, too many functions to expose
 
 public:
+#ifndef DISABLE_DEPRECATED
+	static inline bool kinematic_body_initial_teleport = false;
+#endif
+
 	void set_state_sync_callback(const Callable &p_callable);
 	void set_force_integration_callback(const Callable &p_callable, const Variant &p_udata = Variant());
 
@@ -299,6 +305,8 @@ public:
 
 	void set_state(PhysicsServer2D::BodyState p_state, const Variant &p_variant);
 	Variant get_state(PhysicsServer2D::BodyState p_state) const;
+
+	void flush_kinematic_transform();
 
 	_FORCE_INLINE_ void set_continuous_collision_detection_mode(PhysicsServer2D::CCDMode p_mode) { continuous_cd_mode = p_mode; }
 	_FORCE_INLINE_ PhysicsServer2D::CCDMode get_continuous_collision_detection_mode() const { return continuous_cd_mode; }

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -781,6 +781,13 @@ Variant GodotPhysicsServer2D::body_get_state(RID p_body, BodyState p_state) cons
 	return body->get_state(p_state);
 }
 
+void GodotPhysicsServer2D::body_flush_kinematic_transform(RID p_body) {
+	GodotBody2D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->flush_kinematic_transform();
+}
+
 void GodotPhysicsServer2D::body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -213,6 +213,8 @@ public:
 	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) override;
 	virtual Variant body_get_state(RID p_body, BodyState p_state) const override;
 
+	virtual void body_flush_kinematic_transform(RID p_body) override;
+
 	virtual void body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) override;
 	virtual void body_apply_torque_impulse(RID p_body, real_t p_torque) override;
 	virtual void body_apply_impulse(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override;

--- a/modules/godot_physics_2d/register_types.cpp
+++ b/modules/godot_physics_2d/register_types.cpp
@@ -41,6 +41,9 @@ static PhysicsServer2D *_createGodotPhysics2DCallback() {
 #else
 	bool using_threads = false;
 #endif
+#ifndef DISABLE_DEPRECATED
+	GodotBody2D::kinematic_body_initial_teleport = GLOBAL_GET("physics/2d/kinematic_body_initial_teleport");
+#endif
 
 	PhysicsServer2D *physics_server_2d = memnew(GodotPhysicsServer2D(using_threads));
 

--- a/modules/godot_physics_3d/godot_body_3d.h
+++ b/modules/godot_physics_3d/godot_body_3d.h
@@ -105,7 +105,9 @@ class GodotBody3D : public GodotCollisionObject3D {
 
 	bool continuous_cd = false;
 	bool can_sleep = true;
+#ifndef DISABLE_DEPRECATED
 	bool first_time_kinematic = false;
+#endif
 
 	void _mass_properties_changed();
 	virtual void _shapes_changed() override;
@@ -150,6 +152,10 @@ class GodotBody3D : public GodotCollisionObject3D {
 	friend class GodotPhysicsDirectBodyState3D; // i give up, too many functions to expose
 
 public:
+#ifndef DISABLE_DEPRECATED
+	static inline bool kinematic_body_initial_teleport = false;
+#endif
+
 	void set_state_sync_callback(const Callable &p_callable);
 	void set_force_integration_callback(const Callable &p_callable, const Variant &p_udata = Variant());
 
@@ -298,6 +304,8 @@ public:
 
 	void set_state(PhysicsServer3D::BodyState p_state, const Variant &p_variant);
 	Variant get_state(PhysicsServer3D::BodyState p_state) const;
+
+	void flush_kinematic_transform();
 
 	_FORCE_INLINE_ void set_continuous_collision_detection(bool p_enable) { continuous_cd = p_enable; }
 	_FORCE_INLINE_ bool is_continuous_collision_detection_enabled() const { return continuous_cd; }

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -691,6 +691,13 @@ Variant GodotPhysicsServer3D::body_get_state(RID p_body, BodyState p_state) cons
 	return body->get_state(p_state);
 }
 
+void GodotPhysicsServer3D::body_flush_kinematic_transform(RID p_body) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->flush_kinematic_transform();
+}
+
 void GodotPhysicsServer3D::body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -208,6 +208,8 @@ public:
 	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) override;
 	virtual Variant body_get_state(RID p_body, BodyState p_state) const override;
 
+	virtual void body_flush_kinematic_transform(RID p_body) override;
+
 	virtual void body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) override;
 	virtual void body_apply_impulse(RID p_body, const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) override;
 	virtual void body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) override;

--- a/modules/godot_physics_3d/register_types.cpp
+++ b/modules/godot_physics_3d/register_types.cpp
@@ -40,6 +40,9 @@ static PhysicsServer3D *_createGodotPhysics3DCallback() {
 #else
 	bool using_threads = false;
 #endif
+#ifndef DISABLE_DEPRECATED
+	GodotBody3D::kinematic_body_initial_teleport = GLOBAL_GET("physics/3d/kinematic_body_initial_teleport");
+#endif
 
 	PhysicsServer3D *physics_server_3d = memnew(GodotPhysicsServer3D(using_threads));
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -763,6 +763,13 @@ Variant JoltPhysicsServer3D::body_get_state(RID p_body, BodyState p_state) const
 	return body->get_state(p_state);
 }
 
+void JoltPhysicsServer3D::body_flush_kinematic_transform(RID p_body) {
+	JoltBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->flush_kinematic_transform();
+}
+
 void JoltPhysicsServer3D::body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) {
 	JoltBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -253,6 +253,8 @@ public:
 	virtual void body_set_state(RID p_body, PhysicsServer3D::BodyState p_state, const Variant &p_value) override;
 	virtual Variant body_get_state(RID p_body, PhysicsServer3D::BodyState p_state) const override;
 
+	virtual void body_flush_kinematic_transform(RID p_body) override;
+
 	virtual void body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) override;
 	virtual void body_apply_impulse(RID p_body, const Vector3 &p_impulse, const Vector3 &p_position) override;
 	virtual void body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) override;

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -532,6 +532,19 @@ void JoltBody3D::set_transform(Transform3D p_transform) {
 	_transform_changed();
 }
 
+void JoltBody3D::flush_kinematic_transform() {
+	ERR_FAIL_COND_MSG(!is_kinematic(), "Attempted to flush kinematic transform of non-kinematic body.");
+
+	if (!in_space()) {
+		jolt_settings->mPosition = to_jolt_r(kinematic_transform.origin);
+		jolt_settings->mRotation = to_jolt(kinematic_transform.basis);
+	} else {
+		space->get_body_iface().SetPositionAndRotation(jolt_body->GetID(), to_jolt_r(kinematic_transform.origin), to_jolt(kinematic_transform.basis), JPH::EActivation::DontActivate);
+	}
+
+	_transform_changed();
+}
+
 Variant JoltBody3D::get_state(PhysicsServer3D::BodyState p_state) const {
 	switch (p_state) {
 		case PhysicsServer3D::BODY_STATE_TRANSFORM: {

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -156,6 +156,8 @@ public:
 
 	void set_transform(Transform3D p_transform);
 
+	void flush_kinematic_transform();
+
 	Variant get_state(PhysicsServer3D::BodyState p_state) const;
 	void set_state(PhysicsServer3D::BodyState p_state, const Variant &p_value);
 

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -33,6 +33,7 @@
 void PhysicsBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision"), &PhysicsBody2D::_move, DEFVAL(false), DEFVAL(0.08), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("test_move", "from", "motion", "collision", "safe_margin", "recovery_as_collision"), &PhysicsBody2D::test_move, DEFVAL(Variant()), DEFVAL(0.08), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("flush_kinematic_transform"), &PhysicsBody2D::flush_kinematic_transform);
 	ClassDB::bind_method(D_METHOD("get_gravity"), &PhysicsBody2D::get_gravity);
 
 	ClassDB::bind_method(D_METHOD("get_collision_exceptions"), &PhysicsBody2D::get_collision_exceptions);
@@ -135,6 +136,10 @@ bool PhysicsBody2D::test_move(const Transform2D &p_from, const Vector2 &p_motion
 	parameters.recovery_as_collision = p_recovery_as_collision;
 
 	return PhysicsServer2D::get_singleton()->body_test_motion(get_rid(), parameters, r);
+}
+
+void PhysicsBody2D::flush_kinematic_transform() {
+	PhysicsServer2D::get_singleton()->body_flush_kinematic_transform(get_rid());
 }
 
 Vector2 PhysicsBody2D::get_gravity() const {

--- a/scene/2d/physics/physics_body_2d.h
+++ b/scene/2d/physics/physics_body_2d.h
@@ -51,6 +51,7 @@ public:
 
 	bool move_and_collide(const PhysicsServer2D::MotionParameters &p_parameters, PhysicsServer2D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);
 	bool test_move(const Transform2D &p_from, const Vector2 &p_motion, const Ref<KinematicCollision2D> &r_collision = Ref<KinematicCollision2D>(), real_t p_margin = 0.08, bool p_recovery_as_collision = false);
+	void flush_kinematic_transform();
 	Vector2 get_gravity() const;
 
 	TypedArray<PhysicsBody2D> get_collision_exceptions();

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -33,6 +33,7 @@
 void PhysicsBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision", "max_collisions"), &PhysicsBody3D::_move, DEFVAL(false), DEFVAL(0.001), DEFVAL(false), DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("test_move", "from", "motion", "collision", "safe_margin", "recovery_as_collision", "max_collisions"), &PhysicsBody3D::test_move, DEFVAL(Variant()), DEFVAL(0.001), DEFVAL(false), DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("flush_kinematic_transform"), &PhysicsBody3D::flush_kinematic_transform);
 	ClassDB::bind_method(D_METHOD("get_gravity"), &PhysicsBody3D::get_gravity);
 
 	ClassDB::bind_method(D_METHOD("set_axis_lock", "axis", "lock"), &PhysicsBody3D::set_axis_lock);
@@ -178,6 +179,10 @@ bool PhysicsBody3D::test_move(const Transform3D &p_from, const Vector3 &p_motion
 	parameters.max_collisions = p_max_collisions;
 
 	return PhysicsServer3D::get_singleton()->body_test_motion(get_rid(), parameters, r);
+}
+
+void PhysicsBody3D::flush_kinematic_transform() {
+	PhysicsServer3D::get_singleton()->body_flush_kinematic_transform(get_rid());
 }
 
 Vector3 PhysicsBody3D::get_gravity() const {

--- a/scene/3d/physics/physics_body_3d.h
+++ b/scene/3d/physics/physics_body_3d.h
@@ -55,6 +55,7 @@ public:
 
 	bool move_and_collide(const PhysicsServer3D::MotionParameters &p_parameters, PhysicsServer3D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);
 	bool test_move(const Transform3D &p_from, const Vector3 &p_motion, const Ref<KinematicCollision3D> &r_collision = Ref<KinematicCollision3D>(), real_t p_margin = 0.001, bool p_recovery_as_collision = false, int p_max_collisions = 1);
+	void flush_kinematic_transform();
 	Vector3 get_gravity() const;
 
 	void set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock);

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -733,6 +733,8 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_state", "body", "state", "value"), &PhysicsServer2D::body_set_state);
 	ClassDB::bind_method(D_METHOD("body_get_state", "body", "state"), &PhysicsServer2D::body_get_state);
 
+	ClassDB::bind_method(D_METHOD("body_flush_kinematic_transform", "body"), &PhysicsServer2D::body_flush_kinematic_transform);
+
 	ClassDB::bind_method(D_METHOD("body_apply_central_impulse", "body", "impulse"), &PhysicsServer2D::body_apply_central_impulse);
 	ClassDB::bind_method(D_METHOD("body_apply_torque_impulse", "body", "impulse"), &PhysicsServer2D::body_apply_torque_impulse);
 	ClassDB::bind_method(D_METHOD("body_apply_impulse", "body", "impulse", "position"), &PhysicsServer2D::body_apply_impulse, Vector2());
@@ -912,6 +914,9 @@ PhysicsServer2D::PhysicsServer2D() {
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/sleep_threshold_linear", PROPERTY_HINT_RANGE, "0,10,0.001,or_greater"), 2.0);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/sleep_threshold_angular", PROPERTY_HINT_RANGE, "0,90,0.1,radians_as_degrees"), Math::deg_to_rad(8.0));
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater,suffix:s"), 0.5);
+#ifndef DISABLE_DEPRECATED
+	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "physics/2d/kinematic_body_initial_teleport"), false);
+#endif
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/2d/solver/solver_iterations", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), 16);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/contact_recycle_radius", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), 1.0);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/contact_max_separation", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), 1.5);

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -451,6 +451,8 @@ public:
 	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) = 0;
 	virtual Variant body_get_state(RID p_body, BodyState p_state) const = 0;
 
+	virtual void body_flush_kinematic_transform(RID p_body) = 0;
+
 	virtual void body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) = 0;
 	virtual void body_apply_torque_impulse(RID p_body, real_t p_torque) = 0;
 	virtual void body_apply_impulse(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) = 0;

--- a/servers/physics_2d/physics_server_2d_dummy.h
+++ b/servers/physics_2d/physics_server_2d_dummy.h
@@ -258,6 +258,8 @@ public:
 	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) override {}
 	virtual Variant body_get_state(RID p_body, BodyState p_state) const override { return Variant(); }
 
+	virtual void body_flush_kinematic_transform(RID p_body) override {}
+
 	virtual void body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) override {}
 	virtual void body_apply_torque_impulse(RID p_body, real_t p_torque) override {}
 	virtual void body_apply_impulse(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override {}

--- a/servers/physics_2d/physics_server_2d_extension.cpp
+++ b/servers/physics_2d/physics_server_2d_extension.cpp
@@ -263,6 +263,8 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_body_set_state, "body", "state", "value");
 	GDVIRTUAL_BIND(_body_get_state, "body", "state");
 
+	GDVIRTUAL_BIND(_body_flush_kinematic_transform, "body");
+
 	GDVIRTUAL_BIND(_body_apply_central_impulse, "body", "impulse");
 	GDVIRTUAL_BIND(_body_apply_torque_impulse, "body", "impulse");
 	GDVIRTUAL_BIND(_body_apply_impulse, "body", "impulse", "position");

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -340,6 +340,8 @@ public:
 	EXBIND3(body_set_state, RID, BodyState, const Variant &)
 	EXBIND2RC(Variant, body_get_state, RID, BodyState)
 
+	EXBIND1(body_flush_kinematic_transform, RID)
+
 	EXBIND2(body_apply_central_impulse, RID, const Vector2 &)
 	EXBIND2(body_apply_torque_impulse, RID, real_t)
 	EXBIND3(body_apply_impulse, RID, const Vector2 &, const Vector2 &)

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -222,6 +222,8 @@ public:
 	FUNC3(body_set_state, RID, BodyState, const Variant &);
 	FUNC2RC(Variant, body_get_state, RID, BodyState);
 
+	FUNC1(body_flush_kinematic_transform, RID);
+
 	FUNC2(body_apply_central_impulse, RID, const Vector2 &);
 	FUNC2(body_apply_torque_impulse, RID, real_t);
 	FUNC3(body_apply_impulse, RID, const Vector2 &, const Vector2 &);

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -802,6 +802,8 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_state", "body", "state", "value"), &PhysicsServer3D::body_set_state);
 	ClassDB::bind_method(D_METHOD("body_get_state", "body", "state"), &PhysicsServer3D::body_get_state);
 
+	ClassDB::bind_method(D_METHOD("body_flush_kinematic_transform", "body"), &PhysicsServer3D::body_flush_kinematic_transform);
+
 	ClassDB::bind_method(D_METHOD("body_apply_central_impulse", "body", "impulse"), &PhysicsServer3D::body_apply_central_impulse);
 	ClassDB::bind_method(D_METHOD("body_apply_impulse", "body", "impulse", "position"), &PhysicsServer3D::body_apply_impulse, Vector3());
 	ClassDB::bind_method(D_METHOD("body_apply_torque_impulse", "body", "impulse"), &PhysicsServer3D::body_apply_torque_impulse);
@@ -1147,6 +1149,9 @@ PhysicsServer3D::PhysicsServer3D() {
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/sleep_threshold_linear", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater"), 0.1);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/sleep_threshold_angular", PROPERTY_HINT_RANGE, "0,90,0.1,radians_as_degrees"), Math::deg_to_rad(8.0));
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 0.5);
+#ifndef DISABLE_DEPRECATED
+	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "physics/3d/kinematic_body_initial_teleport"), false);
+#endif
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/3d/solver/solver_iterations", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), 16);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/solver/contact_recycle_radius", PROPERTY_HINT_RANGE, "0,0.1,0.001,or_greater"), 0.01);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/solver/contact_max_separation", PROPERTY_HINT_RANGE, "0,0.1,0.001,or_greater"), 0.05);

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -469,6 +469,8 @@ public:
 	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) = 0;
 	virtual Variant body_get_state(RID p_body, BodyState p_state) const = 0;
 
+	virtual void body_flush_kinematic_transform(RID p_body) = 0;
+
 	virtual void body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) = 0;
 	virtual void body_apply_impulse(RID p_body, const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) = 0;
 	virtual void body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) = 0;

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -263,6 +263,8 @@ public:
 	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) override {}
 	virtual Variant body_get_state(RID p_body, BodyState p_state) const override { return Variant(); }
 
+	virtual void body_flush_kinematic_transform(RID p_body) override {}
+
 	virtual void body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) override {}
 	virtual void body_apply_impulse(RID p_body, const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) override {}
 	virtual void body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) override {}

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -264,6 +264,8 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_body_set_state, "body", "state", "value");
 	GDVIRTUAL_BIND(_body_get_state, "body", "state");
 
+	GDVIRTUAL_BIND(_body_flush_kinematic_transform, "body");
+
 	GDVIRTUAL_BIND(_body_apply_central_impulse, "body", "impulse");
 	GDVIRTUAL_BIND(_body_apply_impulse, "body", "impulse", "position");
 	GDVIRTUAL_BIND(_body_apply_torque_impulse, "body", "impulse");

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -337,6 +337,8 @@ public:
 	EXBIND3(body_set_state, RID, BodyState, const Variant &)
 	EXBIND2RC(Variant, body_get_state, RID, BodyState)
 
+	EXBIND1(body_flush_kinematic_transform, RID)
+
 	EXBIND2(body_apply_central_impulse, RID, const Vector3 &)
 	EXBIND3(body_apply_impulse, RID, const Vector3 &, const Vector3 &)
 	EXBIND2(body_apply_torque_impulse, RID, const Vector3 &)

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -225,6 +225,8 @@ public:
 	FUNC3(body_set_state, RID, BodyState, const Variant &);
 	FUNC2RC(Variant, body_get_state, RID, BodyState);
 
+	FUNC1(body_flush_kinematic_transform, RID);
+
 	FUNC2(body_apply_torque_impulse, RID, const Vector3 &);
 	FUNC2(body_apply_central_impulse, RID, const Vector3 &);
 	FUNC3(body_apply_impulse, RID, const Vector3 &, const Vector3 &);


### PR DESCRIPTION
Currently there is no way to move a kinematic body (AnimatableBody3D, CharacterBody3D) in Godot within the physics simulation without both modifying the velocity, as well as waiting until at least the next physics frame for the new transform to take effect. This pr adds a new method which does this.

If you need to immediately move a kinematic body you first set the transform either through the server or via a node and calling `Node2/3D.force_update_transform()`, and now you can call `PhysicsServer2/3D.body_flush_kinematic_transform()` or `PhysicsBody2/3D.flush_kinematic_transform()`.

I've also deprecated the hack in GodotPhysics2/3D which automatically teleports a kinematic body on its first transform after being set to kinematic mode. It is now toggled by a project setting which is disabled by default, but enabled when upgrading from previous versions. Instead the body is always teleported if it is not in the physics space, similar to how Jolt already does it. This means that when using the physics server API, you need to manually call `PhysicsServer2/3D.body_flush_kinematic_transform()` in GodotPhysics2/3D if you are setting the initial transform after adding the body to the space. This makes the behaviour consistent across engines.

Closes https://github.com/godotengine/godot/issues/76256
Closes https://github.com/godotengine/godot/issues/109885
Supersedes https://github.com/godotengine/godot/pull/109086
Supersedes https://github.com/godotengine/godot/pull/113654

Supersedes? https://github.com/godotengine/godot/pull/113712
If this pr is merged I'm not sure that https://github.com/godotengine/godot/pull/113712 should be as well. Without this pr it kind of makes sense as there is no way to get the set transform but in general it makes things more confusing by returning a transform that does not actually match the physics state.

Related https://github.com/godotengine/godot/issues/53099
Related https://github.com/godotengine/godot/issues/86199
These two issues are most likely / partially due to this behaviour where the physics server does not immediately move kinematic bodies to the new transform on `body_set_state(BODY_STATE_TRANSFORM)`, although this pr does not fix them because they are using `move_and_slide()` where the velocities are intended to be updated.