### PR TITLE
OpenXR: Add Valve Frame controller support

### DIFF
--- a/modules/openxr/extensions/openxr_valve_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_valve_controller_extension.cpp
@@ -1,0 +1,113 @@
+/**************************************************************************/
+/*  openxr_valve_controller_extension.cpp                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_valve_controller_extension.h"
+
+#include "../action_map/openxr_interaction_profile_metadata.h"
+
+// Not yet part of the published OpenXR spec
+#ifndef XR_VALVE_FRAME_CONTROLLER_INTERACTION_EXTENSION_NAME
+#define XR_VALVE_FRAME_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_VALVE_frame_controller_interaction"
+#endif
+
+HashMap<String, bool *> OpenXRValveControllerExtension::get_requested_extensions(XrVersion p_version) {
+	HashMap<String, bool *> request_extensions;
+
+	request_extensions[XR_VALVE_FRAME_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
+
+	return request_extensions;
+}
+
+bool OpenXRValveControllerExtension::is_available() {
+	return available;
+}
+
+void OpenXRValveControllerExtension::on_register_metadata() {
+	OpenXRInteractionProfileMetadata *openxr_metadata = OpenXRInteractionProfileMetadata::get_singleton();
+	ERR_FAIL_NULL(openxr_metadata);
+
+	{ // Valve Frame controller
+		const String profile_path = "/interaction_profiles/valve/frame_controller";
+		openxr_metadata->register_interaction_profile("Valve Frame controller", profile_path, XR_VALVE_FRAME_CONTROLLER_INTERACTION_EXTENSION_NAME);
+		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
+			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+
+			openxr_metadata->register_io_path(profile_path, "System touch", user_path, user_path + "/input/system/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "System click", user_path, user_path + "/input/system/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+			openxr_metadata->register_io_path(profile_path, "Bumper touch", user_path, user_path + "/input/bumper/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Bumper click", user_path, user_path + "/input/bumper/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+			openxr_metadata->register_io_path(profile_path, "Trigger", user_path, user_path + "/input/trigger/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+			openxr_metadata->register_io_path(profile_path, "Trigger touch", user_path, user_path + "/input/trigger/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Trigger click", user_path, user_path + "/input/trigger/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+			openxr_metadata->register_io_path(profile_path, "Squeeze", user_path, user_path + "/input/squeeze/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+			openxr_metadata->register_io_path(profile_path, "Squeeze touch", user_path, user_path + "/input/squeeze/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Squeeze click", user_path, user_path + "/input/squeeze/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+			openxr_metadata->register_io_path(profile_path, "Thumbstick", user_path, user_path + "/input/thumbstick", "", OpenXRAction::OPENXR_ACTION_VECTOR2);
+			openxr_metadata->register_io_path(profile_path, "Thumbstick click", user_path, user_path + "/input/thumbstick/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Thumbstick touch", user_path, user_path + "/input/thumbstick/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Thumbstick Dpad Up", user_path, user_path + "/input/thumbstick/dpad_up", "XR_EXT_dpad_binding", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Thumbstick Dpad Down", user_path, user_path + "/input/thumbstick/dpad_down", "XR_EXT_dpad_binding", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Thumbstick Dpad Left", user_path, user_path + "/input/thumbstick/dpad_left", "XR_EXT_dpad_binding", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Thumbstick Dpad Right", user_path, user_path + "/input/thumbstick/dpad_right", "XR_EXT_dpad_binding", OpenXRAction::OPENXR_ACTION_BOOL);
+
+			openxr_metadata->register_io_path(profile_path, "Haptic output", user_path, user_path + "/output/haptic", "", OpenXRAction::OPENXR_ACTION_HAPTIC);
+		}
+
+		openxr_metadata->register_io_path(profile_path, "Menu touch", "/user/hand/right", "/user/hand/right/input/menu/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Menu click", "/user/hand/right", "/user/hand/right/input/menu/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+		openxr_metadata->register_io_path(profile_path, "View touch", "/user/hand/left", "/user/hand/left/input/view/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "View click", "/user/hand/left", "/user/hand/left/input/view/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+		openxr_metadata->register_io_path(profile_path, "A touch", "/user/hand/right", "/user/hand/right/input/a/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "A click", "/user/hand/right", "/user/hand/right/input/a/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "B touch", "/user/hand/right", "/user/hand/right/input/b/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "B click", "/user/hand/right", "/user/hand/right/input/b/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "X touch", "/user/hand/right", "/user/hand/right/input/x/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "X click", "/user/hand/right", "/user/hand/right/input/x/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Y touch", "/user/hand/right", "/user/hand/right/input/y/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Y click", "/user/hand/right", "/user/hand/right/input/y/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+		openxr_metadata->register_io_path(profile_path, "Dpad Up touch", "/user/hand/left", "/user/hand/left/input/dpad_up/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Dpad Up click", "/user/hand/left", "/user/hand/left/input/dpad_up/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Dpad Left touch", "/user/hand/left", "/user/hand/left/input/dpad_left/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Dpad Left click", "/user/hand/left", "/user/hand/left/input/dpad_left/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Dpad Down touch", "/user/hand/left", "/user/hand/left/input/dpad_down/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Dpad Down click", "/user/hand/left", "/user/hand/left/input/dpad_down/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Dpad Right touch", "/user/hand/left", "/user/hand/left/input/dpad_right/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Dpad Right click", "/user/hand/left", "/user/hand/left/input/dpad_right/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+	}
+}

--- a/modules/openxr/extensions/openxr_valve_controller_extension.h
+++ b/modules/openxr/extensions/openxr_valve_controller_extension.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  openxr_valve_controller_extension.h                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "openxr_extension_wrapper.h"
+
+class OpenXRValveControllerExtension : public OpenXRExtensionWrapper {
+	GDCLASS(OpenXRValveControllerExtension, OpenXRExtensionWrapper);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
+
+	bool is_available();
+
+	virtual void on_register_metadata() override;
+
+private:
+	bool available = false;
+};

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -75,6 +75,7 @@
 #include "extensions/openxr_pico_controller_extension.h"
 #include "extensions/openxr_render_model_extension.h"
 #include "extensions/openxr_valve_analog_threshold_extension.h"
+#include "extensions/openxr_valve_controller_extension.h"
 #include "extensions/openxr_visibility_mask_extension.h"
 #include "extensions/openxr_wmr_controller_extension.h"
 #include "extensions/spatial_entities/openxr_spatial_entity_extension.h"
@@ -164,6 +165,7 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRMxInkExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRVisibilityMaskExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRPerformanceSettingsExtension));
+			OpenXRAPI::register_extension_wrapper(memnew(OpenXRValveControllerExtension));
 
 			// Futures extension has to be registered as a singleton so extensions can access it.
 			OpenXRFutureExtension *future_extension = memnew(OpenXRFutureExtension);


### PR DESCRIPTION
This PR adds support for the Valve Frame controller interaction profile to Godot.
This is a prerequisite to making full use of the new controllers. 

We are publishing this early with permission from Valve as this has not been added to the official OpenXR specification.
If at all possible it would be great to still merge this into 4.6 even though we are in feature freeze. The risk is zero.

The following test project has been used to test this:
https://github.com/BastiaanOlij/godot-valve-frame-controller-test