### PR TITLE
Fix Animation Editor erroring when animating SpriteAnimation3D `frame` but not `animation`.

### DIFF
--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -416,12 +416,20 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 			String animation_path = String(get_animation()->track_get_path(get_track()));
 			animation_path = animation_path.replace(":frame", ":animation");
 			int animation_track = get_animation()->find_track(animation_path, get_animation()->track_get_type(get_track()));
-			float track_time = get_animation()->track_get_key_time(get_track(), p_index);
-			int animation_index = get_animation()->track_find_key(animation_track, track_time);
-			animation_name = get_animation()->track_get_key_value(animation_track, animation_index);
+
+			if (animation_track != -1) {
+				float track_time = get_animation()->track_get_key_time(get_track(), p_index);
+				int animation_index = get_animation()->track_find_key(animation_track, track_time);
+				if (animation_index != -1) {
+					animation_name = get_animation()->track_get_key_value(animation_track, animation_index);
+				}
+			}
 		}
 
-		Ref<Texture2D> texture = sf->get_frame_texture(animation_name, frame);
+		Ref<Texture2D> texture;
+		if (!animation_name.is_empty()) {
+			texture = sf->get_frame_texture(animation_name, frame);
+		}
 		if (texture.is_null()) {
 			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
 		}
@@ -508,12 +516,20 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 			String animation_path = String(get_animation()->track_get_path(get_track()));
 			animation_path = animation_path.replace(":frame", ":animation");
 			int animation_track = get_animation()->find_track(animation_path, get_animation()->track_get_type(get_track()));
-			float track_time = get_animation()->track_get_key_time(get_track(), p_index);
-			int animation_index = get_animation()->track_find_key(animation_track, track_time);
-			animation_name = get_animation()->track_get_key_value(animation_track, animation_index);
+
+			if (animation_track != -1) {
+				float track_time = get_animation()->track_get_key_time(get_track(), p_index);
+				int animation_index = get_animation()->track_find_key(animation_track, track_time);
+				if (animation_index != -1) {
+					animation_name = get_animation()->track_get_key_value(animation_track, animation_index);
+				}
+			}
 		}
 
-		texture = sf->get_frame_texture(animation_name, frame);
+		if (!animation_name.is_empty()) {
+			texture = sf->get_frame_texture(animation_name, frame);
+		}
+
 		if (texture.is_null()) {
 			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
 			return;


### PR DESCRIPTION
Fixes [113715](https://github.com/godotengine/godot/issues/113715)

The animation editor no longer directly accesses the 'animation' track for AnimatedSprite2D&3D and instead checks if it first exists and if any key value was found. 
Previously this would generate errors in the editor.

With the changes the editor remains responsive in the following two cases, when previously it would generate errors.
1. Without an animation track each frame-key displays a diamond. 
<img width="436" height="161" alt="image" src="https://github.com/user-attachments/assets/3578a8aa-461e-4d49-86a9-e62578db1942" />

2. With an animation track, each frame-key displays the frame from the animation.  If no animation key has been set yet (first diamond) or frame index does not exist in the animation (second diamond) a diamond is rendered. 
<img width="419" height="158" alt="image" src="https://github.com/user-attachments/assets/8ed41297-1b78-4543-b048-d617d4c7eb1d" />

[[TokageItLab comment]](https://github.com/godotengine/godot/issues/113715#issuecomment-3622571817) recommended two items. 
- If animation track is not accessible, do not try to find the sprite's current animation.  This has been followed.
- Add a warning.  On this I'd like a second opinion on if we should emit a warning when a SpriteAnimation2D&3D do not have an animation track set or a value is not available from it.

Finally this is my first merge request here - learning along the way :) 