### PR TITLE
OpenXR: Only obtain `xrCreateSwapchainAndroidSurfaceKHR` extension if available

### DIFF
--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -72,7 +72,9 @@ HashMap<String, bool *> OpenXRCompositionLayerExtension::get_requested_extension
 void OpenXRCompositionLayerExtension::on_instance_created(const XrInstance p_instance) {
 #ifdef ANDROID_ENABLED
 	EXT_INIT_XR_FUNC(xrDestroySwapchain);
-	EXT_INIT_XR_FUNC(xrCreateSwapchainAndroidSurfaceKHR);
+	if (android_surface_ext_available) {
+		EXT_INIT_XR_FUNC(xrCreateSwapchainAndroidSurfaceKHR);
+	}
 #endif
 }
 


### PR DESCRIPTION
The code in our composition layers was always obtaining the pointer for the `xrCreateSwapchainAndroidSurfaceKHR` function even if the extension was not available. 

Fixes:
<img width="1171" height="112" alt="image" src="https://github.com/user-attachments/assets/a3535caa-dab0-4f64-860a-d7b7f0a3469b" />
