### PR TITLE
Add a panel background to CreateDialog's Tree in the modern theme

### DIFF
--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -924,6 +924,7 @@ CreateDialog::CreateDialog() {
 	vbc->add_margin_child(TTR("Search:"), search_hb);
 
 	search_options = memnew(Tree);
+	search_options->set_theme_type_variation(SNAME("CreateDialogTree"));
 	search_options->set_accessibility_name(TTRC("Matches:"));
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	search_options->connect("item_activated", callable_mp(this, &CreateDialog::_confirmed));

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2425,4 +2425,10 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 	Ref<StyleBoxFlat> tile_expand_style = p_config.base_style->duplicate();
 	tile_expand_style->set_corner_radius_all(0);
 	p_theme->set_stylebox("expand_panel", "TileSetEditor", tile_expand_style);
+
+	// CreateDialog.
+	{
+		p_theme->set_type_variation("CreateDialogTree", "Tree");
+		p_theme->set_stylebox(SceneStringName(panel), "CreateDialogTree", EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 4, 4, 4, 4, p_config.corner_radius));
+	}
 }


### PR DESCRIPTION
This adds back a background to just the Tree in CreateDialog to delineate it from its surroundings:

<img width="1030" height="858" alt="Screenshot_20251209_023008" src="https://github.com/user-attachments/assets/4f01f2d3-b7d9-4cb0-ad4c-6a506f78c35e" />

This is more of a preference thing, but it seems to affect some people as indicated by #113707.

cc @passivestar 

Closes #113707 