### PR TITLE
Fix ENetPacketPeer not freeing ENetPacket memory on disconnect

### DIFF
--- a/modules/enet/enet_packet_peer.cpp
+++ b/modules/enet/enet_packet_peer.cpp
@@ -181,10 +181,22 @@ int ENetPacketPeer::get_packet_flags() const {
 }
 
 void ENetPacketPeer::_on_disconnect() {
+	free_packet();
 	if (peer) {
 		peer->data = nullptr;
 	}
 	peer = nullptr;
+}
+
+void ENetPacketPeer::free_packet() {
+	for (ENetPacket *p : packet_queue) {
+		enet_packet_destroy(p);
+	}
+	packet_queue.clear();
+	if (last_packet) {
+		enet_packet_destroy(last_packet);
+		last_packet = nullptr;
+	}
 }
 
 void ENetPacketPeer::_queue_packet(ENetPacket *p_packet) {

--- a/modules/enet/enet_packet_peer.h
+++ b/modules/enet/enet_packet_peer.h
@@ -98,6 +98,7 @@ public:
 	int get_available_packet_count() const override;
 	Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
 	Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
+	void free_packet();
 
 	void peer_disconnect(int p_data = 0);
 	void peer_disconnect_later(int p_data = 0);


### PR DESCRIPTION
This PR introduces a partial fix for #98358 by adding cleanup logic in `ENetPacketPeer::_on_disconnect()` to manually destroy any unprocessed ENetPacket objects stored in `packet_queue` and `last_packet`.

A new `free_packet()` helper is added, which:

- destroys all packets in `packet_queue`,
- destroys `last_packet` if present,
- resets internal state.

This does not fully resolve all aspects of #98358, but it provides a clear and explicit manual memory release path for `ENetPacketPeer` and addresses one known source of memory retention when peers disconnect (especially abruptly).
