### PR TITLE
CommandQueueMT: Make re-entrant again + Fix multiple flushers case

### DIFF
--- a/modules/betsy/image_compress_betsy.h
+++ b/modules/betsy/image_compress_betsy.h
@@ -103,7 +103,7 @@ Error _betsy_compress_s3tc(Image *r_img, Image::UsedChannels p_channels);
 class BetsyCompressor : public Object {
 	GDSOFTCLASS(BetsyCompressor, Object);
 
-	mutable CommandQueueMT command_queue = CommandQueueMT(true);
+	mutable CommandQueueMT command_queue;
 	bool exit = false;
 	WorkerThreadPool::TaskID task_id = WorkerThreadPool::INVALID_TASK_ID;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -74,7 +74,7 @@ class RenderingServerDefault : public RenderingServer {
 	uint64_t print_frame_profile_ticks_from = 0;
 	uint32_t print_frame_profile_frame_count = 0;
 
-	mutable CommandQueueMT command_queue = CommandQueueMT(true);
+	mutable CommandQueueMT command_queue;
 
 	Thread::ID server_thread = Thread::MAIN_ID;
 	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;


### PR DESCRIPTION
Let's see if we finally get a functional and reliable `CommandQueueMT`.

In order to allow `_flush()` to be called from multiple threads, we were considering making the mutex recursive. However, even after removing the unlock allowance logic that is indeed not needed here, there's still some condition variable logic that needs the mutex to be binary.

In the end, I've simply added a thread-local variable for the current thread to know if it should attempt to lock.

Moreover, loosely related to re-entrancy, in the case of another thread requesting a flush while another thread performing one, I've added code so the former waits for the latter. Otherwise, we would be breaking the assumption that after calling a flush function all the commands added up to that point have been run.

☣ Disclaimer: untested. ☣

CC @brycehutchings

Fixes #113627.