### PR TITLE
Make memory profiling optional

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -215,6 +215,14 @@ opts.Add(
         False,
     )
 )
+opts.Add(
+    BoolVariable(
+        "profiler_track_memory",
+        "Profile memory allocations, if the profiler supports it.",
+        False,
+    )
+)
+
 
 # Advanced options
 opts.Add(

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -46,8 +46,10 @@ def find_tracy_path(path: pathlib.Path) -> pathlib.Path:
 
 if env["profiler"]:
     if env["profiler"] == "instruments":
-        # Nothing else to do for Instruments.
-        pass
+        if env["profiler_sample_callstack"]:
+            print("profiler_sample_callstack ignored. Please configure callstack sampling in Instruments instead.")
+        if env["profiler_track_memory"]:
+            print("profiler_track_memory ignored. Please configure memory tracking in Instruments instead.")
     elif env["profiler"] == "tracy":
         if not env["profiler_path"]:
             print("profiler_path must be set when using the tracy profiler. Aborting.")
@@ -65,6 +67,8 @@ if env["profiler"]:
 
             # 62 is the maximum supported callstack depth reported by the tracy docs.
             env_tracy.Append(CPPDEFINES=[("TRACY_CALLSTACK", 62)])
+        if env["profiler_track_memory"]:
+            env_tracy.Append(CPPDEFINES=["GODOT_PROFILER_TRACK_MEMORY"])
         env_tracy.disable_warnings()
         env_tracy.add_source_files(env.core_sources, str((profiler_path / "TracyClient.cpp").absolute()))
     elif env["profiler"] == "perfetto":
@@ -78,6 +82,9 @@ if env["profiler"]:
         if env["profiler_sample_callstack"]:
             print("Perfetto does not support call stack sampling. Aborting.")
             Exit(255)
+        if env["profiler_track_memory"]:
+            print("Perfetto does not support memory tracking. Aborting.")
+            Exit(255)
         env_perfetto.disable_warnings()
         env_perfetto.Prepend(CPPPATH=[str(profiler_path.absolute())])
         env_perfetto.add_source_files(env.core_sources, str((profiler_path / "perfetto.cc").absolute()))
@@ -85,4 +92,8 @@ elif env["profiler_path"]:
     print("profiler is required if profiler_path is set. Aborting.")
     Exit(255)
 
-env.CommandNoCache("profiling.gen.h", [env.Value(env["profiler"])], env.Run(profiling_builders.profiler_gen_builder))
+env.CommandNoCache(
+    "profiling.gen.h",
+    [env.Value(env["profiler"]), env.Value(env["profiler_sample_callstack"]), env.Value(env["profiler_track_memory"])],
+    env.Run(profiling_builders.profiler_gen_builder),
+)

--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -76,8 +76,16 @@ const tracy::SourceLocationData *intern_source_location(const void *p_function_p
 	tracy::ScopedZone __godot_tracy_zone_##m_group_name(TracyInternal::intern_source_location(m_ptr, m_file, m_function, m_line))
 
 // Memory allocation
-#define GodotProfileAlloc(m_ptr, m_size) TracyAlloc(m_ptr, m_size)
+#ifdef GODOT_PROFILER_TRACK_MEMORY
+#define GodotProfileAlloc(m_ptr, m_size)                       \
+	GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wmaybe-uninitialized") \
+	TracyAlloc(m_ptr, m_size);                                 \
+	GODOT_GCC_WARNING_POP
 #define GodotProfileFree(m_ptr) TracyFree(m_ptr)
+#else
+#define GodotProfileAlloc(m_ptr, m_size)
+#define GodotProfileFree(m_ptr)
+#endif
 
 void godot_init_profiler();
 void godot_cleanup_profiler();

--- a/core/profiling/profiling_builders.py
+++ b/core/profiling/profiling_builders.py
@@ -9,6 +9,8 @@ def profiler_gen_builder(target, source, env):
             file.write("#define GODOT_USE_TRACY\n")
             if env["profiler_sample_callstack"]:
                 file.write("#define TRACY_CALLSTACK 62\n")
+            if env["profiler_track_memory"]:
+                file.write("#define GODOT_PROFILER_TRACK_MEMORY\n")
         if env["profiler"] == "perfetto":
             file.write("#define GODOT_USE_PERFETTO\n")
         if env["profiler"] == "instruments":


### PR DESCRIPTION
Relates to (but does not necessarily fix) #113805.

This introduces a new `profiler_track_memory` build option, which lets you disable (no-op) the `GodotProfileAlloc` and `GodotProfileFree` macros, in order to omit whatever overhead those macros bring with them.

This is mostly meant to be a stop-gap solution, to allow people to mitigate the rampant memory allocations that seem to be happening when using Tracy at the moment.

~~If this actually makes it to release somehow, we should probably have this new option be `False` by default, but I've left it as `True` so that people actually do run into this bug and can maybe provide more information and/or an MRP, assuming it isn't in fact unique to the project I'm working with for some odd reason.~~

Note that this also fixes a build correctness issue with the generated `profiling.gen.h`, where it wasn't being re-generated if you changed the value of `profiler_sample_callstack`, due to its value not being passed in to `CommandNoCache`.