### PR TITLE
Support tiling `AtlasTexture` in `TextureRect`

### DIFF
--- a/doc/classes/TextureRect.xml
+++ b/doc/classes/TextureRect.xml
@@ -51,6 +51,7 @@
 		</constant>
 		<constant name="STRETCH_TILE" value="1" enum="StretchMode">
 			Tile inside the node's bounding rectangle.
+			[b]Note:[/b] [constant STRETCH_TILE] mode is not supported for [member texture] set to an [AtlasTexture] with non-zero [member AtlasTexture.margin].
 		</constant>
 		<constant name="STRETCH_KEEP" value="2" enum="StretchMode">
 			The texture keeps its original size and stays in the bounding rectangle's top-left corner.

--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -88,6 +88,8 @@ public:
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
 
+	PackedStringArray get_configuration_warnings() const override;
+
 	TextureRect();
 	~TextureRect();
 };


### PR DESCRIPTION
Fixes #113691.

Adds support for tiling an AtlasTexture assigned to a TextureRect by drawing it as a nine patch, which already supports tiling a texture region.

Before<br>v4.6.dev6.official [dec5a373d]|After<br>this PR
-|-
<img width="1053" height="986" alt="vTNIzuJt0w" src="https://github.com/user-attachments/assets/15f968ce-f2b6-47c6-99a5-c0f7d09747dc" />|<img width="1053" height="986" alt="godot windows editor dev x86_64_7Ufqyqdyz7" src="https://github.com/user-attachments/assets/dc96abd6-e825-4e3c-8ab5-cbe73f342520" />
