### PR TITLE
Fix building with Perfetto profiler

### DIFF
--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -98,6 +98,8 @@ void godot_cleanup_profiler();
 
 #include <perfetto.h>
 
+#include "core/typedefs.h"
+
 PERFETTO_DEFINE_CATEGORIES(
 		perfetto::Category("godot")
 				.SetDescription("All Godot Events"), );


### PR DESCRIPTION
Currently, in `master`, attempting to build with Perfetto support will hit compiler errors!

This is due to two things:

- ~~The trailing `\\` on `GodotProfileZoneGroupedFirstScript`. I assume the other kind of slashes were intended?~~
- `_FORCE_INLINE_` is defined in `"core/typedefs.h"` but it wasn't included

This PR aims to fix those :-)