### PR TITLE
[macOS] Remove duplicate profiler init call.

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -1088,8 +1088,6 @@ static void handle_interrupt(int sig) {
 }
 
 void OS_MacOS_NSApp::start_main() {
-	godot_init_profiler();
-
 	Error err;
 	@autoreleasepool {
 		err = Main::setup(execpath, argc, argv);


### PR DESCRIPTION
It's already called in `main`: https://github.com/godotengine/godot/blob/bb92a4c8e27e30cdec05ab6d540d724b9b3cfb72/platform/macos/godot_main_macos.mm#L43