### PR TITLE
Check for unprefixed compilers when building on Windows.

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -24,6 +24,8 @@ def try_cmd(test, prefix, arch, check_clang=False):
     archs = ["x86_64", "x86_32", "arm64", "arm32"]
     if arch:
         archs = [arch]
+    if os.name == "nt":
+        archs += [""]
 
     for a in archs:
         try:


### PR DESCRIPTION
Partially fixes - https://github.com/godotengine/godot/issues/113798 (MinGW detection).

While `get_detected` can select both prefixed (`x86_64-w64-mingw32-gcc`) and unprefixed (`gcc`) compiler, check for valid compilers (`try_cmd`) was checking for prefixed only. This reasonable when cross-building, but for native Windows build it should be safe to assume unprefixed compiler if for current Windows platform.