### PR TITLE
Add leftover scroll hints, and panels for scrollables without hints

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2373,7 +2373,7 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		vmem_tree->set_column_title(3, TTRC("Usage"));
 		vmem_tree->set_column_custom_minimum_width(3, 80 * EDSCALE);
 		vmem_tree->set_hide_root(true);
-		vmem_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
+		vmem_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
 		mc->add_child(vmem_tree);
 		vmem_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_vmem_item_activated));
 

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -45,6 +45,7 @@
 #include "scene/gui/file_dialog.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/link_button.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/separator.h"
@@ -1142,12 +1143,18 @@ ExportTemplateManager::ExportTemplateManager() {
 	installed_label->set_text(TTR("Other Installed Versions:"));
 	installed_versions_hb->add_child(installed_label);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_vb->add_child(mc);
+
 	installed_table = memnew(Tree);
 	installed_table->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	installed_table->set_hide_root(true);
+	installed_table->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	installed_table->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
 	installed_table->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	main_vb->add_child(installed_table);
+	mc->add_child(installed_table);
 	installed_table->connect("button_clicked", callable_mp(this, &ExportTemplateManager::_installed_table_button_cbk));
 
 	// Dialogs.

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -413,14 +413,19 @@ DependencyEditorOwners::DependencyEditorOwners() {
 	add_child(file_options);
 	file_options->connect(SceneStringName(id_pressed), callable_mp(this, &DependencyEditorOwners::_file_option));
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	add_child(mc);
+
 	owners = memnew(ItemList);
 	owners->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	owners->set_select_mode(ItemList::SELECT_MULTI);
+	owners->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTTOM);
 	owners->connect("item_clicked", callable_mp(this, &DependencyEditorOwners::_list_rmb_clicked));
 	owners->connect("item_activated", callable_mp(this, &DependencyEditorOwners::_select_file));
 	owners->connect("empty_clicked", callable_mp(this, &DependencyEditorOwners::_empty_clicked));
 	owners->set_allow_rmb_select(true);
-	add_child(owners);
+	mc->add_child(owners);
 }
 
 ///////////////////////
@@ -702,12 +707,16 @@ DependencyRemoveDialog::DependencyRemoveDialog() {
 	files_to_delete_label->set_text(TTR("Files to be deleted:"));
 	vb->add_child(files_to_delete_label);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	vb->add_child(mc);
+
 	files_to_delete_list = memnew(ItemList);
-	files_to_delete_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	files_to_delete_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	files_to_delete_list->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTH);
 	files_to_delete_list->set_custom_minimum_size(Size2(0, 94) * EDSCALE);
 	files_to_delete_list->set_accessibility_name(TTRC("Files to be deleted:"));
-	vb->add_child(files_to_delete_list);
+	mc->add_child(files_to_delete_list);
 
 	vb_owners = memnew(VBoxContainer);
 	vb_owners->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -719,12 +728,18 @@ DependencyRemoveDialog::DependencyRemoveDialog() {
 	owners_label->set_text(TTR("Dependencies of files to be deleted:"));
 	vb_owners->add_child(owners_label);
 
+	mc = memnew(MarginContainer);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	vb_owners->add_child(mc);
+
 	owners = memnew(Tree);
 	owners->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	owners->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	owners->set_hide_root(true);
 	owners->set_custom_minimum_size(Size2(0, 94) * EDSCALE);
 	owners->set_accessibility_name(TTRC("Dependencies"));
-	vb_owners->add_child(owners);
+	mc->add_child(owners);
 	owners->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	List<PropertyInfo> property_list;
@@ -1040,6 +1055,10 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 	files->set_column_title(0, TTR("Resource"));
 	files->set_column_title(1, TTR("Owns"));
 	files->set_hide_root(true);
-	vbc->add_margin_child(TTR("Resources Without Explicit Ownership:"), files, true);
+	files->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
 	files->connect("button_clicked", callable_mp(this, &OrphanResourcesDialog::_button_pressed));
+
+	MarginContainer *mc = vbc->add_margin_child(TTRC("Resources Without Explicit Ownership:"), files, true);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 }

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -929,6 +929,7 @@ CreateDialog::CreateDialog() {
 	search_options->connect("item_activated", callable_mp(this, &CreateDialog::_confirmed));
 	search_options->connect("cell_selected", callable_mp(this, &CreateDialog::_item_selected));
 	search_options->connect("button_clicked", callable_mp(this, &CreateDialog::_script_button_clicked));
+	search_options->set_theme_type_variation("TreeSecondary");
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 
 	help_bit = memnew(EditorHelpBit);

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -317,11 +317,16 @@ QuickOpenResultContainer::QuickOpenResultContainer() {
 		}
 
 		{
+			MarginContainer *mc = memnew(MarginContainer);
+			mc->set_theme_type_variation("NoBorderHorizontalWindow");
+			mc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+			mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+			panel_container->add_child(mc);
+
 			// Search results
 			scroll_container = memnew(ScrollContainer);
-			scroll_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-			scroll_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 			scroll_container->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+			scroll_container->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
 			scroll_container->hide();
 			panel_container->add_child(scroll_container);
 

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1065,6 +1065,7 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	inspector_general = memnew(EditorInspector);
 	inspector_general->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_general->set_custom_minimum_size(Size2(300 * EDSCALE, 250 * EDSCALE));
+	inspector_general->set_theme_type_variation("ScrollContainerSecondary");
 	page1_hb->add_child(inspector_general);
 	inspector_general->connect("property_edited", callable_mp(this, &DynamicFontImportSettingsDialog::_main_prop_changed));
 
@@ -1114,12 +1115,14 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	vars_list->set_column_expand(1, false);
 	vars_list->set_column_custom_minimum_width(1, 50 * EDSCALE);
 	vars_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	vars_list->set_theme_type_variation("TreeSecondary");
 	page2_side_vb->add_child(vars_list);
 	vars_list->connect(SceneStringName(item_selected), callable_mp(this, &DynamicFontImportSettingsDialog::_variation_selected));
 	vars_list->connect("button_clicked", callable_mp(this, &DynamicFontImportSettingsDialog::_variation_remove));
 
 	inspector_vars = memnew(EditorInspector);
 	inspector_vars->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	inspector_vars->set_theme_type_variation("ScrollContainerSecondary");
 	page2_side_vb->add_child(inspector_vars);
 	inspector_vars->connect("property_edited", callable_mp(this, &DynamicFontImportSettingsDialog::_variation_changed));
 
@@ -1166,6 +1169,7 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	locale_tree->set_column_expand(0, true);
 	locale_tree->set_column_custom_minimum_width(0, 120 * EDSCALE);
 	locale_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	locale_tree->set_theme_type_variation("TreeSecondary");
 	page2_0_vb->add_child(locale_tree);
 	locale_tree->connect("item_activated", callable_mp(this, &DynamicFontImportSettingsDialog::_locale_edited));
 
@@ -1199,9 +1203,9 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	page2_1_vb->add_child(page2_1_hb);
 
 	inspector_text = memnew(EditorInspector);
-
 	inspector_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_text->set_custom_minimum_size(Size2(300 * EDSCALE, 250 * EDSCALE));
+	inspector_text->set_theme_type_variation("ScrollContainerSecondary");
 	page2_1_hb->add_child(inspector_text);
 	inspector_text->connect("property_edited", callable_mp(this, &DynamicFontImportSettingsDialog::_change_text_opts));
 
@@ -1252,6 +1256,7 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	glyph_table->add_theme_style_override("selected", glyph_table->get_theme_stylebox(SceneStringName(panel)));
 	glyph_table->add_theme_style_override("selected_focus", glyph_table->get_theme_stylebox(SceneStringName(panel)));
 	glyph_table->add_theme_constant_override("h_separation", 0);
+	glyph_table->set_theme_type_variation("TreeSecondary");
 	glyph_table->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	glyph_table->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	glyphs_split->add_child(glyph_table);
@@ -1266,6 +1271,7 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	glyph_tree->set_column_expand(1, true);
 	glyph_tree->set_column_custom_minimum_width(0, 120 * EDSCALE);
 	glyph_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	glyph_tree->set_theme_type_variation("TreeSecondary");
 	glyph_root = glyph_tree->create_item();
 	for (int i = 0; !unicode_ranges[i].name.is_empty(); i++) {
 		_add_glyph_range_item(unicode_ranges[i].start, unicode_ranges[i].end, unicode_ranges[i].name);

--- a/editor/inspector/editor_sectioned_inspector.cpp
+++ b/editor/inspector/editor_sectioned_inspector.cpp
@@ -378,6 +378,7 @@ SectionedInspector::SectionedInspector() :
 	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	right_vb->add_child(inspector, true);
 	inspector->set_use_doc_hints(true);
+	inspector->set_theme_type_variation("TreeSecondary");
 
 	sections->connect("cell_selected", callable_mp(this, &SectionedInspector::_section_selected));
 }

--- a/editor/run/run_instances_dialog.cpp
+++ b/editor/run/run_instances_dialog.cpp
@@ -37,6 +37,7 @@
 #include "scene/gui/grid_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/line_edit.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
@@ -370,8 +371,12 @@ RunInstancesDialog::RunInstancesDialog() {
 	enable_multiple_instances_checkbox->connect(SceneStringName(toggled), callable_mp(instance_count, &SpinBox::set_editable));
 	instance_count->set_editable(enable_multiple_instances_checkbox->is_pressed());
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_vb->add_child(mc);
+
 	instance_tree = memnew(Tree);
-	instance_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	instance_tree->set_h_scroll_enabled(false);
 	instance_tree->set_columns(4);
 	instance_tree->set_column_titles_visible(true);
@@ -383,6 +388,7 @@ RunInstancesDialog::RunInstancesDialog() {
 	instance_tree->set_column_title(COLUMN_FEATURE_TAGS, TTR("Feature Tags"));
 	instance_tree->set_hide_root(true);
 	instance_tree->set_allow_rmb_select(true);
+	instance_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
 
 	popup_menu = memnew(PopupMenu);
 	popup_menu->connect(SceneStringName(id_pressed), callable_mp(this, &RunInstancesDialog::_instance_menu_id_pressed));
@@ -390,7 +396,7 @@ RunInstancesDialog::RunInstancesDialog() {
 
 	instance_tree->connect("item_mouse_selected", callable_mp(this, &RunInstancesDialog::_instance_tree_rmb));
 	instance_tree->connect("empty_clicked", callable_mp(this, &RunInstancesDialog::_instance_tree_rmb));
-	main_vb->add_child(instance_tree);
+	mc->add_child(instance_tree);
 
 	_refresh_argument_count();
 	instance_tree->connect("item_edited", callable_mp(this, &RunInstancesDialog::_start_instance_timer));

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -884,6 +884,7 @@ ConnectDialog::ConnectDialog() {
 
 	bind_editor = memnew(EditorInspector);
 	bind_editor->set_accessibility_name(TTRC("Extra Call Arguments:"));
+	bind_editor->set_theme_type_variation("ScrollContainerSecondary");
 	bind_controls.push_back(bind_editor);
 
 	vbc_right->add_margin_child(TTR("Extra Call Arguments:"), bind_editor, true);

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -40,6 +40,7 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/line_edit.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/separator.h"
 
 #include "modules/modules_enabled.gen.h" // For mono.
@@ -1326,11 +1327,15 @@ EditorBuildProfileManager::EditorBuildProfileManager() {
 	class_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	class_list->set_hide_root(true);
 	class_list->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
+	class_list->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	class_list->connect("cell_selected", callable_mp(this, &EditorBuildProfileManager::_class_list_item_selected));
 	class_list->connect("item_edited", callable_mp(this, &EditorBuildProfileManager::_class_list_item_edited), CONNECT_DEFERRED);
 	class_list->connect("item_collapsed", callable_mp(this, &EditorBuildProfileManager::_class_list_item_collapsed));
+
 	// It will be displayed once the user creates or chooses a profile.
-	main_vbc->add_margin_child(TTR("Configure Engine Compilation Profile:"), class_list, true);
+	MarginContainer *mc = main_vbc->add_margin_child(TTRC("Configure Engine Compilation Profile:"), class_list, true);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	description_bit = memnew(EditorHelpBit);
 	description_bit->set_content_height_limits(80 * EDSCALE, 80 * EDSCALE);

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -1028,6 +1028,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	property_list->set_hide_folding(true);
 	property_list->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
 	property_list->connect("item_edited", callable_mp(this, &EditorFeatureProfileManager::_property_item_edited), CONNECT_DEFERRED);
+	property_list->set_theme_type_variation("TreeSecondary");
 	// It will be displayed once the user creates or chooses a profile.
 	property_list_vbc->hide();
 

--- a/editor/settings/editor_layouts_dialog.cpp
+++ b/editor/settings/editor_layouts_dialog.cpp
@@ -105,7 +105,7 @@ void EditorLayoutsDialog::_post_popup() {
 	if (name->is_visible()) {
 		name->grab_focus();
 	} else {
-		layout_names->grab_focus();
+		layout_names->grab_focus(true);
 	}
 }
 
@@ -115,24 +115,20 @@ EditorLayoutsDialog::EditorLayoutsDialog() {
 
 	layout_names = memnew(ItemList);
 	layout_names->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	layout_names->set_auto_height(true);
-	layout_names->set_custom_minimum_size(Size2(300 * EDSCALE, 50 * EDSCALE));
-	layout_names->set_visible(true);
-	layout_names->set_offset(SIDE_TOP, 5);
-	layout_names->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	layout_names->set_select_mode(ItemList::SELECT_MULTI);
 	layout_names->set_allow_rmb_select(true);
+	layout_names->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTH);
 	layout_names->connect("multi_selected", callable_mp(this, &EditorLayoutsDialog::_update_ok_disable_state).unbind(2));
-	MarginContainer *mc = makevb->add_margin_child(TTR("Select existing layout:"), layout_names);
+
+	MarginContainer *mc = makevb->add_margin_child(TTRC("Select Existing Layout:"), layout_names);
+	mc->set_custom_minimum_size(Size2(300 * EDSCALE, 50 * EDSCALE));
 	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
 
 	name = memnew(LineEdit);
 	makevb->add_child(name);
-	name->set_placeholder(TTR("Or enter new layout name"));
+	name->set_placeholder(TTRC("Or enter new layout name."));
 	name->set_accessibility_name(TTRC("New layout name"));
-	name->set_offset(SIDE_TOP, 5);
-	name->set_anchor_and_offset(SIDE_LEFT, Control::ANCHOR_BEGIN, 5);
-	name->set_anchor_and_offset(SIDE_RIGHT, Control::ANCHOR_END, -5);
 	name->connect(SceneStringName(gui_input), callable_mp(this, &EditorLayoutsDialog::_line_gui_input));
 	name->connect(SceneStringName(focus_entered), callable_mp(this, &EditorLayoutsDialog::_deselect_layout_names));
 	name->connect(SceneStringName(text_changed), callable_mp(this, &EditorLayoutsDialog::_update_ok_disable_state).unbind(1));

--- a/editor/settings/input_event_configuration_dialog.cpp
+++ b/editor/settings/input_event_configuration_dialog.cpp
@@ -36,6 +36,7 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/line_edit.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/tree.h"
@@ -677,12 +678,17 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	input_list_search->connect(SceneStringName(text_changed), callable_mp(this, &InputEventConfigurationDialog::_search_term_updated));
 	manual_vbox->add_child(input_list_search);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	manual_vbox->add_child(mc);
+
 	input_list_tree = memnew(Tree);
 	input_list_tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	input_list_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	input_list_tree->connect("item_activated", callable_mp(this, &InputEventConfigurationDialog::_input_list_item_activated));
 	input_list_tree->connect(SceneStringName(item_selected), callable_mp(this, &InputEventConfigurationDialog::_input_list_item_selected));
-	input_list_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	manual_vbox->add_child(input_list_tree);
+	mc->add_child(input_list_tree);
 
 	input_list_tree->set_hide_root(true);
 	input_list_tree->set_columns(1);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1938,6 +1938,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Sidebars.
 		{
+			p_theme->set_type_variation("ScrollContainerSecondary", "ScrollContainer");
 			p_theme->set_type_variation("TreeSecondary", "Tree");
 			p_theme->set_type_variation("ItemListSecondary", "ItemList");
 
@@ -1948,6 +1949,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 				style_sidebar->set_border_color(p_config.extra_border_color_2);
 			}
 
+			p_theme->set_stylebox(SceneStringName(panel), "ScrollContainerSecondary", style_sidebar);
 			p_theme->set_stylebox(SceneStringName(panel), "TreeSecondary", style_sidebar);
 			p_theme->set_stylebox(SceneStringName(panel), "ItemListSecondary", style_sidebar);
 			// Use it for EditorDebuggerInspector in StackTrace to keep the default 3-column layout,

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -402,6 +402,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	counters_display->set_column_title(2, TTRC("Outgoing RPC"));
 	counters_display->set_column_expand(2, false);
 	counters_display->set_column_clip_content(2, true);
+	counters_display->set_theme_type_variation("TreeSecondary");
 	counters_display->set_column_custom_minimum_width(2, 120 * EDSCALE);
 	sc->add_child(counters_display);
 
@@ -434,6 +435,7 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	replication_display->set_column_expand(4, false);
 	replication_display->set_column_clip_content(4, true);
 	replication_display->set_column_custom_minimum_width(4, 80 * EDSCALE);
+	replication_display->set_theme_type_variation("TreeSecondary");
 	replication_display->connect("button_clicked", callable_mp(this, &EditorNetworkProfiler::_replication_button_clicked));
 	sc->add_child(replication_display);
 

--- a/modules/objectdb_profiler/editor/objectdb_profiler_panel.cpp
+++ b/modules/objectdb_profiler/editor/objectdb_profiler_panel.cpp
@@ -381,6 +381,7 @@ ObjectDBProfilerPanel::ObjectDBProfilerPanel() {
 	snapshot_list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	snapshot_list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	snapshot_list->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
+	snapshot_list->set_theme_type_variation("TreeSecondary");
 
 	snapshot_list->set_allow_rmb_select(true);
 	snapshot_list->connect("item_mouse_selected", callable_mp(this, &ObjectDBProfilerPanel::_snapshot_rmb));

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -388,7 +388,6 @@ MarginContainer *VBoxContainer::add_margin_child(const String &p_label, Control 
 	l->set_text(p_label);
 	add_child(l);
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->add_theme_constant_override("margin_left", 0);
 	mc->add_child(p_control, true);
 	add_child(mc);
 	if (p_expand) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -2466,6 +2466,7 @@ FileDialog::FileDialog() {
 	file_list = memnew(ItemList);
 	file_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	file_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	file_list->set_theme_type_variation("ItemListSecondary");
 	file_list->set_accessibility_name(ETR("Directories & Files:"));
 	file_list->set_allow_rmb_select(true);
 	file_vbox->add_child(file_list);


### PR DESCRIPTION
- Add scroll hints to places I missed in the editor.
- Add background panels for places where scroll hints couldn't be enabled. This is a stopgap until those places can be redesigned.

Fixes #113707.
Supersedes #113796.