### PR TITLE
Fix distraction-free mode changing split offsets

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -923,7 +923,9 @@ void EditorDockManager::set_docks_visible(bool p_show) {
 	}
 	docks_visible = p_show;
 	for (int i = 0; i < DockConstants::DOCK_SLOT_BOTTOM; i++) {
-		dock_slots[i].container->set_visible(docks_visible && dock_slots[i].container->get_tab_count() > 0);
+		// Show and hide in reverse order due to the SplitContainer prioritizing the last split offset.
+		TabContainer *container = dock_slots[docks_visible ? i : DockConstants::DOCK_SLOT_BOTTOM - i - 1].container;
+		container->set_visible(docks_visible && container->get_tab_count() > 0);
 	}
 	_update_layout();
 }

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -993,7 +993,7 @@ void SplitContainer::_remove_valid_child(Control *p_control) {
 	}
 	// Only use desired sizes to change the split offset after the first time a child is removed.
 	// This allows adding children to not affect the split offsets when creating.
-	can_use_desired_sizes = valid_children.size() > 1u;
+	can_use_desired_sizes = true;
 
 	_update_default_dragger_positions();
 	queue_sort();


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/113783

The `can_use_desired_sizes` is to make sure adding children doesn't affect the split offset when setting up the SplitContainer, so it should be fine to keep it as true.

The order that children are added and removed is important when trying to keep their sizes the same.