### PR TITLE
Fix Mali-G52 GPU crash by introducing `avoid_subpass_post_process` workaround flag.

### DIFF
--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -884,6 +884,34 @@ void RenderingContextDriverVulkan::_check_driver_workarounds(const VkPhysicalDev
 			p_device_properties.deviceID >= 0x6000000 && // Adreno 6xx
 			p_device_properties.driverVersion < VK_MAKE_VERSION(512, 503, 0) &&
 			r_device.name.find("Turnip") < 0;
+
+	// Workaround for the ARM Mali-G52 family of devices. (GH-112530)
+	//TODO
+	//crash with driverVersion: 0.24.2.8, 0.25.1.0, 0.34.0.0
+	r_device.workarounds.avoid_subpass_post_process =
+			r_device.vendor == Vendor::VENDOR_ARM &&
+			p_device_properties.deviceID == 0x74021000; // Mali-G52
+
+	uint32_t driver_variant = VK_API_VERSION_VARIANT(p_device_properties.driverVersion);
+	uint32_t driver_major = VK_VERSION_MAJOR(p_device_properties.driverVersion);
+	uint32_t driver_minor = VK_VERSION_MINOR(p_device_properties.driverVersion);
+	uint32_t driver_patch = VK_VERSION_PATCH(p_device_properties.driverVersion);
+
+	print_line("==========================");
+	print_line("_check_driver_workarounds");
+	print_line("==========================");
+	print_line("r_device.vendor:", vformat("0x%08X", r_device.vendor));
+	print_line("r_device.type:", r_device.type);
+	print_line("r_device.name:", r_device.name);
+	print_line("------------------------------------");
+	print_line("deviceName:", p_device_properties.deviceName);
+	print_line("deviceID:", vformat("0x%08X", p_device_properties.deviceID));
+	print_line("driverVersion:", vformat("%d.%d.%d.%d", driver_variant, driver_major, driver_minor, driver_patch), vformat("(0x%08X)", p_device_properties.driverVersion));
+	print_line("apiVersion:", vformat("(0x%08X)", p_device_properties.apiVersion));
+	print_line("------------------------------------");
+	print_line("avoid_compute_after_draw:", r_device.workarounds.avoid_compute_after_draw);
+	print_line("avoid_subpass_post_process:", r_device.workarounds.avoid_subpass_post_process);
+	print_line("------------------------------------");
 }
 
 bool RenderingContextDriverVulkan::_use_validation_layers() const {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -847,7 +847,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	RID framebuffer;
 	bool reverse_cull = p_render_data->scene_data->cam_transform.basis.determinant() < 0;
 	bool merge_transparent_pass = true; // If true: we can do our transparent pass in the same pass as our opaque pass.
-	bool using_subpass_post_process = true; // If true: we can do our post processing in a subpass
+	bool using_subpass_post_process = !avoid_subpass_post_process; // If true: we can do our post processing in a subpass
 	RendererRD::MaterialStorage::Samplers samplers;
 	bool hdr_render_target = false;
 
@@ -3453,6 +3453,14 @@ RenderForwardMobile::RenderForwardMobile() {
 	const bool root_hdr_render_target = GLOBAL_GET("rendering/viewport/hdr_2d");
 	global_pipeline_data_required.use_hdr_render_target = root_hdr_render_target;
 	global_pipeline_data_required.use_ldr_render_target = !root_hdr_render_target;
+
+	// GH-112530 avoid post processing in a subpass
+	RenderingServer *rendering_server = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+	RenderingDevice *rendering_device = rendering_server->get_rendering_device();
+	ERR_FAIL_NULL(rendering_device);
+
+	avoid_subpass_post_process = rendering_device->get_device_workarounds().avoid_subpass_post_process;
 }
 
 RenderForwardMobile::~RenderForwardMobile() {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -410,6 +410,8 @@ private:
 
 	RenderList render_list[RENDER_LIST_MAX];
 
+	bool avoid_subpass_post_process = false;
+
 protected:
 	/* setup */
 	virtual void _update_shader_quality_settings() override;

--- a/servers/rendering/rendering_context_driver.h
+++ b/servers/rendering/rendering_context_driver.h
@@ -77,6 +77,7 @@ public:
 
 	struct Workarounds {
 		bool avoid_compute_after_draw = false;
+		bool avoid_subpass_post_process = false;
 	};
 
 	struct Device {

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1005,6 +1005,7 @@ public:
 	RenderingContextDriver *get_context_driver() const { return context; }
 
 	const RDD::Capabilities &get_device_capabilities() const { return driver->get_capabilities(); }
+	const RenderingContextDriver::Workarounds &get_device_workarounds() const { return device.workarounds; }
 
 	bool has_feature(const Features p_feature) const;
 


### PR DESCRIPTION
Fixes #112530

---------------


### Tests on Firebase Test Lab:

<details><summary>Galaxy Tab A8 - API Level 34, no crash, but it freezes, Mali-G52, driverVersion: 0.34.0.0</summary>

```
12-09 16:41:22.610 31360 31536 I godot : Godot Engine v4.6.dev.custom_build.639b7cefa (2025-12-09 16:18:18 UTC) - https://godotengine.org
12-09 16:41:23.020 31360 31536 I godot : ==========================
12-09 16:41:23.020 31360 31536 I godot : _check_driver_workarounds
12-09 16:41:23.020 31360 31536 I godot : ==========================
12-09 16:41:23.020 31360 31536 I godot : r_device.vendor: 0x000013B5
12-09 16:41:23.020 31360 31536 I godot : r_device.type: 1
12-09 16:41:23.020 31360 31536 I godot : r_device.name: Mali-G52
12-09 16:41:23.020 31360 31536 I godot : ------------------------------------
12-09 16:41:23.021 31360 31536 I godot : deviceName: Mali-G52
12-09 16:41:23.021 31360 31536 I godot : deviceID: 0x74021000
12-09 16:41:23.021 31360 31536 I godot : driverVersion: 0.34.0.0 (0x08800000)
12-09 16:41:23.021 31360 31536 I godot : apiVersion: (0x004010BF)
12-09 16:41:23.021 31360 31536 I godot : ------------------------------------
12-09 16:41:23.021 31360 31536 I godot : avoid_compute_after_draw: false
12-09 16:41:23.021 31360 31536 I godot : avoid_subpass_post_process: false
12-09 16:41:23.021 31360 31536 I godot : ------------------------------------
12-09 16:41:23.212 31360 31536 I godot : Vulkan 1.1.191 - Forward Mobile - Using Device #0: ARM - Mali-G52
```


https://github.com/user-attachments/assets/f8541522-6a79-4599-9981-ac230a89ba35


</details>



<details><summary>Motorola G20, API Level 30, crash, Mali-G52, driverVersion: 0.25.1.0</summary>

```
12-09 16:40:54.636 26680 26680 I GodotPluginRegistry: Registering runtime plugin AndroidRuntime
12-09 16:40:54.854 26680 26760 I godot : Godot Engine v4.6.dev.custom_build.639b7cefa (2025-12-09 16:18:18 UTC) - https://godotengine.org
12-09 16:40:54.943 26680 26760 I godot : ==========================
12-09 16:40:54.943 26680 26760 I godot : _check_driver_workarounds
12-09 16:40:54.943 26680 26760 I godot : ==========================
12-09 16:40:54.943 26680 26760 I godot : r_device.vendor: 0x000013B5
12-09 16:40:54.943 26680 26760 I godot : r_device.type: 1
12-09 16:40:54.943 26680 26760 I godot : r_device.name: Mali-G52
12-09 16:40:54.943 26680 26760 I godot : ------------------------------------
12-09 16:40:54.943 26680 26760 I godot : deviceName: Mali-G52
12-09 16:40:54.943 26680 26760 I godot : deviceID: 0x74021000
12-09 16:40:54.943 26680 26760 I godot : driverVersion: 0.25.1.0 (0x06401000)
12-09 16:40:54.943 26680 26760 I godot : apiVersion: (0x00401083)
12-09 16:40:54.943 26680 26760 I godot : ------------------------------------
12-09 16:40:54.943 26680 26760 I godot : avoid_compute_after_draw: false
12-09 16:40:54.943 26680 26760 I godot : avoid_subpass_post_process: false
12-09 16:40:54.943 26680 26760 I godot : ------------------------------------
12-09 16:40:54.972 26680 26760 I godot : Vulkan 1.1.131 - Forward Mobile - Using Device #0: ARM - Mali-G52
12-09 16:40:58.588 26680 26760 I godot :
12-09 16:41:04.172 26680 26760 I godot : set_msaa_3d

----------

     *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
Native Crash TIME: 6844957
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
Build fingerprint: 'motorola/java_retail/java:11/RTAS31.68-66-3/66-3:user/release-keys'
Revision: '0'
ABI: 'arm64'
Timestamp: 2025-12-09 16:41:04-0800
pid: 26680, tid: 26760, name: VkThread  >>> com.example.testsubviewport <<<
uid: 10264
signal 5 (SIGTRAP), code 1 (TRAP_BRKPT), fault addr 0x7be8c70890


```

</details>








<details><summary>Galaxy XCover Pro, API Level 33, crash, Mali-G72, driverVersion: 0.38.1.0</summary>

```
12-10 07:04:02.374 20828 20828 I GodotPluginRegistry: Registering runtime plugin AndroidRuntime
12-10 07:04:03.046 20828 20970 I godot : Godot Engine v4.6.dev.custom_build.639b7cefa (2025-12-09 16:18:18 UTC) - https://godotengine.org
12-10 07:04:03.296 20828 20970 I godot : ==========================
12-10 07:04:03.296 20828 20970 I godot : _check_driver_workarounds
12-10 07:04:03.296 20828 20970 I godot : ==========================
12-10 07:04:03.296 20828 20970 I godot : r_device.vendor: 0x000013B5
12-10 07:04:03.296 20828 20970 I godot : r_device.type: 1
12-10 07:04:03.296 20828 20970 I godot : r_device.name: Mali-G72
12-10 07:04:03.296 20828 20970 I godot : ------------------------------------
12-10 07:04:03.296 20828 20970 I godot : deviceName: Mali-G72
12-10 07:04:03.296 20828 20970 I godot : deviceID: 0x62210010
12-10 07:04:03.296 20828 20970 I godot : driverVersion: 0.38.1.0 (0x09801000)
12-10 07:04:03.297 20828 20970 I godot : apiVersion: (0x004010D5)
12-10 07:04:03.297 20828 20970 I godot : ------------------------------------
12-10 07:04:03.297 20828 20970 I godot : avoid_compute_after_draw: false
12-10 07:04:03.297 20828 20970 I godot : avoid_subpass_post_process: false
12-10 07:04:03.297 20828 20970 I godot : ------------------------------------
12-10 07:04:03.364 20828 20970 I godot : Vulkan 1.1.213 - Forward Mobile - Using Device #0: ARM - Mali-G72
12-10 07:04:08.505 20828 20970 I godot :
12-10 07:04:14.259 20828 20970 I godot : set_msaa_3d
----------

     *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
Build fingerprint: 'samsung/xcoverproeea/xcoverpro:13/TP1A.220624.014/G715FNXXUBFWC4:user/release-keys'
Revision: '5'
ABI: 'arm64'
Processor: '6'
Timestamp: 2025-12-10 07:04:14.971812596-0800
Process uptime: 14s
Cmdline: com.example.testsubviewport
pid: 20828, tid: 20970, name: VkThread  >>> com.example.testsubviewport <<<
uid: 10309
signal 5 (SIGTRAP), code 1 (TRAP_BRKPT), fault addr 0x00000077108d1890

```

</details>



-----------

**No crash:**

- Galaxy A10, API Level 29, Mali-G71, driverVersion: 0.19.0.0
- Pixel 6, API Level 31, Mali-G78, driverVersion: 0.32.1.0
- Galaxy A54 5G, API Level 34, Mali-G68, driverVersion: 0.38.1.0
- Galaxy S9, API Level 29, Mali-G72, driverVersion: 0.19.0.0
- no crash on all Mali-G57 devices (Level 34; 33) and other Mali-G6* / Mali-G7* devices




