### PR TITLE
ArrayMesh: Add 3.x compatibility mapping for `blend_shape/names` and `blend_shape/mode`

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1346,6 +1346,16 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 
 #ifndef DISABLE_DEPRECATED
 	// Kept for compatibility from 3.x to 4.0.
+	if (p_name == "blend_shape/names") {
+		_set_blend_shape_names(p_value);
+		return true;
+	}
+
+	if (p_name == "blend_shape/mode") {
+		set_blend_shape_mode(BlendShapeMode(int(p_value)));
+		return true;
+	}
+
 	if (!sname.begins_with("surfaces")) {
 		return false;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

The properties for `blend_shape_names` and `blend_shape_mode` were named "blend_shape/names" and "blend_shape/mode" in 3.x, respectively; however, unlike with the old surface format, there was no compatibility mapping when setting these properties from an old resource. This adds that.