### PR TITLE
Fix crash on quit when `settings_changed` signal is emitted during exit

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -507,6 +507,10 @@ void GameView::_embedded_process_focused() {
 }
 
 void GameView::_editor_or_project_settings_changed() {
+	if (!is_inside_tree()) {
+		return;
+	}
+
 	// Update the window size and aspect ratio.
 	_update_embed_window_size();
 


### PR DESCRIPTION
Add `is_inside_tree()` guard to `GameView::_editor_or_project_settings_changed()` to prevent accessing invalid state when the signal is emitted during editor shutdown.

Fixes #113829
