### PR TITLE
Core: Add `BIND` macro for strongly typed enums

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -551,7 +551,7 @@ public:
 };
 
 #define BIND_ENUM_CONSTANT(m_constant) \
-	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant), #m_constant, m_constant);
+	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant), #m_constant, static_cast<int64_t>(m_constant));
 
 #define BIND_BITFIELD_FLAG(m_constant) \
 	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_bitfield_name(m_constant), #m_constant, m_constant, true);


### PR DESCRIPTION
Currently, the existing BIND_ENUM_CONSTANT macro relies on implicit
conversion to integers. This works for standard C-style enums but
fails to compile with C++11 scoped enums (enum class), which require
explicit casting.

This commit adds a static_cast to int64_t, enabling support for 
modern, strictly typed C++ enums.
You want to use the modern C++11 enums to enable strict typing and 
conform memory layouts.

NOTE: This change must be implemented in core/object/class_db.h as it
modifies the base binding macros. It cannot be implemented as an addon
or GDExtension.

--- Example ---
```cpp
enum MyState { IDLE, RUN, WALK };
BIND_ENUM_CONSTANT(IDLE); // Works

enum class MyStateClass : uint8_t { IDLE, RUN, WALK };
BIND_ENUM_CONSTANT(MyStateClass::IDLE); // Now Works!
```