### PR TITLE
[Wayland] Implement `keyboard_get_label_from_physical`

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1665,6 +1665,12 @@ Key DisplayServerWayland::keyboard_get_keycode_from_physical(Key p_keycode) cons
 	return key;
 }
 
+Key DisplayServerWayland::keyboard_get_label_from_physical(Key p_keycode) const {
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	return wayland_thread.keyboard_get_label_from_physical(p_keycode);
+}
+
 bool DisplayServerWayland::color_picker(const Callable &p_callback) {
 #ifdef DBUS_ENABLED
 	if (!portal_desktop) {

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -339,6 +339,7 @@ public:
 	virtual String keyboard_get_layout_language(int p_index) const override;
 	virtual String keyboard_get_layout_name(int p_index) const override;
 	virtual Key keyboard_get_keycode_from_physical(Key p_keycode) const override;
+	virtual Key keyboard_get_label_from_physical(Key p_keycode) const override;
 
 	virtual bool color_picker(const Callable &p_callback) override;
 

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -1148,6 +1148,7 @@ public:
 	String keyboard_get_layout_name(int p_index) const;
 
 	Key keyboard_get_key_from_physical(Key p_key) const;
+	Key keyboard_get_label_from_physical(Key p_key) const;
 
 	void keyboard_echo_keys();
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113819

Also makes `:keyboard_get_key_from_physical` more consistent with other platforms.