### PR TITLE
[4.3] Cherry-pick Windows build system fixes to fix command too long error

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -467,16 +467,6 @@ def use_windows_spawn_fix(self, platform=None):
     if os.name != "nt":
         return  # not needed, only for windows
 
-    # On Windows, due to the limited command line length, when creating a static library
-    # from a very high number of objects SCons will invoke "ar" once per object file;
-    # that makes object files with same names to be overwritten so the last wins and
-    # the library loses symbols defined by overwritten objects.
-    # By enabling quick append instead of the default mode (replacing), libraries will
-    # got built correctly regardless the invocation strategy.
-    # Furthermore, since SCons will rebuild the library from scratch when an object file
-    # changes, no multiple versions of the same object file will be present.
-    self.Replace(ARFLAGS="q")
-
     def mySubProcess(cmdline, env):
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
@@ -498,19 +488,17 @@ def use_windows_spawn_fix(self, platform=None):
         return rv
 
     def mySpawn(sh, escape, cmd, args, env):
+        # Used by TEMPFILE.
+        if cmd == "del":
+            os.remove(args[1])
+            return 0
+
         newargs = " ".join(args[1:])
         cmdline = cmd + " " + newargs
 
         rv = 0
         env = {str(key): str(value) for key, value in iter(env.items())}
-        if len(cmdline) > 32000 and cmd.endswith("ar"):
-            cmdline = cmd + " " + args[1] + " " + args[2] + " "
-            for i in range(3, len(args)):
-                rv = mySubProcess(cmdline + args[i], env)
-                if rv:
-                    break
-        else:
-            rv = mySubProcess(cmdline, env)
+        rv = mySubProcess(cmdline, env)
 
         return rv
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -387,8 +387,6 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
 
     ## Compile/link flags
 
-    env["MAXLINELENGTH"] = 8192  # Windows Vista and beyond, so always applicable.
-
     if env["silence_msvc"] and not env.GetOption("clean"):
         from tempfile import mkstemp
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -631,6 +631,17 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
     env.AppendUnique(LINKFLAGS=["/STACK:" + str(STACK_SIZE)])
 
 
+WINPATHSEP_RE = re.compile(r"\\([^\"'\\]|$)")
+
+
+def tempfile_arg_esc_func(arg):
+    from SCons.Subst import quote_spaces
+
+    arg = quote_spaces(arg)
+    # GCC requires double Windows slashes, let's use UNIX separator
+    return WINPATHSEP_RE.sub(r"/\1", arg)
+
+
 def configure_mingw(env: "SConsEnvironment"):
     # Workaround for MinGW. See:
     # https://www.scons.org/wiki/LongCmdLinesOnWin32
@@ -640,6 +651,8 @@ def configure_mingw(env: "SConsEnvironment"):
     env["ARCOM_ORIG"] = env["ARCOM"]
     env["ARCOM"] = "${TEMPFILE('$ARCOM_ORIG', '$ARCOMSTR')}"
     env["TEMPFILESUFFIX"] = ".rsp"
+    if os.name == "nt":
+        env["TEMPFILEARGESCFUNC"] = tempfile_arg_esc_func
 
     ## Build type
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -636,6 +636,11 @@ def configure_mingw(env: "SConsEnvironment"):
     # https://www.scons.org/wiki/LongCmdLinesOnWin32
     env.use_windows_spawn_fix()
 
+    # In case the command line to AR is too long, use a response file.
+    env["ARCOM_ORIG"] = env["ARCOM"]
+    env["ARCOM"] = "${TEMPFILE('$ARCOM_ORIG', '$ARCOMSTR')}"
+    env["TEMPFILESUFFIX"] = ".rsp"
+
     ## Build type
 
     if not env["use_llvm"] and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]):


### PR DESCRIPTION
This PR cherry-picks PR #96407, PR #97188, and PR #97458, fixing issue #99710 in the Godot 4.3 branch. In general 4.3 is considered EOL, but buildsystem fixes are still valid to backport.

I have [a large module](https://github.com/godot-dimensions/godot-4d) which supports multiple Godot versions, all the way back to Godot 4.3. However, the module is now big enough that I am getting an error "The command line is too long" when compiling on Windows (it actually doesn't trigger on my machine, but it triggers on CI and on another person's machine, and I believe it's gotta be close to the limit on my machine too).

This PR cherry-picks those 3 PRs to fix this problem. I have tested that this works, the CI successfully compiles with these fixes.

Disclaimer: I am far from an expert on this specific code. The only thing I have done is perform the cherry-picks and test that this fixes the problem. I did not test every combination of the individual PRs to see which specific ones are needed to fix the problem, I just tested all of them in one go and it worked.