### PR TITLE
Keep `ScriptEditor` history when closing tabs

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -742,16 +742,18 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save) {
 	// Roll back to previous tab instead of just previous history state
 	_roll_back_to_pre_tab();
 
-	// Remove all history states related to the closed tab.
+	// Update all history states related to the closed tab.
 	for (int i = 0; i < history.size(); i++) {
 		if (history[i].control == tselected) {
-			history.remove_at(i);
-			i--;
-			history_pos--;
+			if (ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tselected)) {
+				history.write[i].source = seb->edited_file_data.path;
+			}
+			if (EditorHelp *eh = Object::cast_to<EditorHelp>(tselected)) {
+				history.write[i].source = eh->get_class();
+			}
+			history.write[i].control = nullptr;
 		}
 	}
-
-	_compress_history_patterns(false);
 
 	int idx = tab_container->get_current_tab();
 	if (TextEditorBase *current = Object::cast_to<TextEditorBase>(tselected)) {
@@ -764,7 +766,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save) {
 			idx = tab_container->get_tab_count() - 1;
 		}
 		if (idx >= 0) {
-			if (history_pos >= 0) {
+			if (history_pos >= 0 && history[history_pos].control != nullptr) {
 				idx = tab_container->get_tab_idx_from_control(history[history_pos].control);
 			}
 			_go_to_tab(idx, true);
@@ -3572,11 +3574,59 @@ void ScriptEditor::_update_selected_editor_menu() {
 }
 
 void ScriptEditor::_update_history_pos(int p_new_pos) {
-	Node *n = tab_container->get_current_tab_control();
+	Control *n = tab_container->get_current_tab_control();
+	bool new_pos_is_larger = p_new_pos > history_pos;
 	history_pos = p_new_pos;
-	tab_container->set_current_tab(tab_container->get_tab_idx_from_control(history[history_pos].control));
 
 	n = history[history_pos].control;
+	if (n == nullptr) {
+		bool adjusted_history_pos = false;
+		// Remove all tabs with a deleted source from the history.
+		for (int i = history.size() - 1; i >= 0; i--) {
+			String source = history[i].source;
+			if (history[i].control || EditorHelp::has_doc(source) || ResourceLoader::exists(source)) {
+				continue;
+			}
+			history.remove_at(i);
+			if (i == history_pos) {
+				adjusted_history_pos = true;
+			}
+			if (i <= history_pos) {
+				history_pos--;
+			}
+		}
+		_compress_history_patterns(false);
+
+		// In case the history_pos was increased and the entry at the new history_pos was deleted
+		// we need to increase the history_pos to be on the next valid entry.
+		if (new_pos_is_larger && adjusted_history_pos && history_pos < history.size() - 1) {
+			history_pos = history_pos + 1;
+		}
+		if (history_pos < 0) {
+			_update_script_names();
+			_update_history_arrows();
+			_update_selected_editor_menu();
+			return;
+		}
+		n = history[history_pos].control;
+	}
+
+	// Handle closed tabs with existing source.
+	if (n == nullptr) {
+		String source = history[history_pos].source;
+		if (EditorHelp::has_doc(source)) {
+			_help_class_open(source);
+		} else {
+			edit(ResourceLoader::load(source));
+		}
+		n = tab_container->get_current_tab_control();
+		for (ScriptHistory &sh : history) {
+			if (sh.source == source) {
+				sh.control = n;
+			}
+		}
+	}
+	tab_container->set_current_tab(tab_container->get_tab_idx_from_control(n));
 
 	ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(n);
 	if (seb) {
@@ -3639,7 +3689,6 @@ void ScriptEditor::_roll_back_to_pre_tab() {
 		history.clear();
 	} else {
 		_update_history_pos(pos);
-		history.resize(history_pos + 1);
 	}
 }
 

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -235,6 +235,7 @@ class ScriptEditor : public PanelContainer {
 	struct ScriptHistory {
 		Control *control = nullptr;
 		Dictionary state;
+		String source;
 	};
 
 	Vector<ScriptHistory> history;


### PR DESCRIPTION
When closing a tab while not at the end of the history all entries after the current idx are deleted. This PRs goal is to ensure that the rest of the history is kept and working. Files are reopened if needed when the history idx changes to them, files which are deleted from the system are removed from the history.

~Note: There currently is an issue with the history when working with script files (see https://github.com/godotengine/godot/pull/113619). So I only used files from the internal documentation for testing this~

## Example

```
------- history -----
0 :  AABB
1 :  float <--- this is closed
2 :  ClassDB
3 :  bool
curr idx:  1
```
## Closing `1: float`

### Without PR
```
------- history -----
0 :  AABB
curr idx:  0
```

### With PR
```
------- history -----
0 :  AABB
1 :  float <--- tab is closed and will reopen when moving to its index in the history or be removed when the source no longer exists
1 :  ClassDB
2 :  bool
curr idx:  0
```