### PR TITLE
Fix `get_scene_tile_display_placeholder` erroring for transformed scene tiles

### DIFF
--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -5850,6 +5850,7 @@ void TileSetScenesCollectionSource::set_scene_tile_display_placeholder(int p_id,
 }
 
 bool TileSetScenesCollectionSource::get_scene_tile_display_placeholder(int p_id) const {
+	p_id = TileSetAtlasSource::alternative_no_transform(p_id);
 	ERR_FAIL_COND_V(!scenes.has(p_id), false);
 	return scenes[p_id].display_placeholder;
 }


### PR DESCRIPTION
Makes `TileSetScenesCollectionSource::get_scene_tile_display_placeholder` ignore transform bits encoded within the passed alternative id, just like it's done in `TileSetScenesCollectionSource::get_scene_tile_scene`:

https://github.com/godotengine/godot/blob/d743736f84fb668bcdfb5bf86258e483f35c6fec/scene/resources/2d/tile_set.cpp#L5852-L5855
https://github.com/godotengine/godot/blob/d743736f84fb668bcdfb5bf86258e483f35c6fec/scene/resources/2d/tile_set.cpp#L5838-L5842

It was making e.g. placing transformed scene tiles spam errors.

Before (v4.6.dev6.official [dec5a373d]):

https://github.com/user-attachments/assets/73fd16f5-8d1d-44df-9eb8-5a6a818c69c0

After (this PR):

https://github.com/user-attachments/assets/efb476d1-bb96-495a-81cf-928e1b9a3bfd


