### PR TITLE
Fix build errors and warnings with LLVM-21

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -95,7 +95,7 @@ using namespace godot;
 // Thirdparty headers.
 
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wshadow")
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) || __clang_major__ >= 21
 GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunnecessary-virtual-specifier")
 #endif
 
@@ -113,7 +113,7 @@ GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunnecessary-virtual-specifier")
 #include <unicode/utypes.h>
 
 GODOT_GCC_WARNING_POP
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) || __clang_major__ >= 21
 GODOT_CLANG_WARNING_POP
 #endif
 

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -132,6 +132,7 @@ Files extracted from upstream source:
 Patches:
 
 - `0001-disable-exceptions.patch` (GH-80796)
+- `0002-llvm-21-header.patch` (GH-113850)
 
 
 ## cvtt

--- a/thirdparty/clipper2/include/clipper2/clipper.core.h
+++ b/thirdparty/clipper2/include/clipper2/clipper.core.h
@@ -13,6 +13,7 @@
 #include "clipper2/clipper.version.h"
 #include <cstdint>
 #include <vector>
+#include <iterator>
 #include <string>
 #include <iostream>
 #include <algorithm>

--- a/thirdparty/clipper2/patches/0002-llvm-21-header.patch
+++ b/thirdparty/clipper2/patches/0002-llvm-21-header.patch
@@ -1,0 +1,12 @@
+diff --git a/thirdparty/clipper2/include/clipper2/clipper.core.h b/thirdparty/clipper2/include/clipper2/clipper.core.h
+index 5a698e96f4..a68e87225e 100644
+--- a/thirdparty/clipper2/include/clipper2/clipper.core.h
++++ b/thirdparty/clipper2/include/clipper2/clipper.core.h
+@@ -13,6 +13,7 @@
+ #include "clipper2/clipper.version.h"
+ #include <cstdint>
+ #include <vector>
++#include <iterator>
+ #include <string>
+ #include <iostream>
+ #include <algorithm>


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113850 as well as a bunch of warnings in ICU include.