### PR TITLE
Remove superfluous space from translation

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -800,7 +800,7 @@ void QuickOpenResultContainer::_select_item(int p_index) {
 
 	result_items[selection_index]->highlight_item(true);
 	bool in_history = history_set.has(candidates[selection_index].file_path);
-	file_details_path->set_text(get_selected() + (in_history ? TTR(" (recently opened)") : ""));
+	file_details_path->set_text(get_selected() + (in_history ? vformat(" %s", TTR("(recently opened)")) : ""));
 
 	emit_signal(SNAME("selection_changed"));
 

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -116,7 +116,7 @@ void EditorResourcePicker::_update_resource() {
 			if (!editable) {
 				tooltip += "\n" + TTR("The Resource cannot be edited in the inspector and can't be made unique directly.") + "\n";
 			} else {
-				tooltip += unique_enable ? TTR(" Left-click to make it unique.") + "\n" : "\n";
+				tooltip += unique_enable ? vformat(" %s\n", TTR("Left-click to make it unique.")) : "\n";
 
 				if (unique_recursive_enabled) {
 					tooltip += TTR("It is possible to make its subresources unique. Right-click to make them unique.") + "\n";


### PR DESCRIPTION
Comes from #109458

Translations shouldn't start with spaces, IMHO.