### PR TITLE
Apply tonemapping in post of Compatibility when using canvas BG

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -802,7 +802,7 @@ void RasterizerSceneGLES3::_setup_sky(const RenderDataGLES3 *p_render_data, cons
 	}
 }
 
-void RasterizerSceneGLES3::_draw_sky(RID p_env, const Projection &p_projection, const Transform3D &p_transform, float p_sky_energy_multiplier, float p_luminance_multiplier, bool p_use_multiview, bool p_flip_y, bool p_apply_color_adjustments_in_post) {
+void RasterizerSceneGLES3::_draw_sky(RID p_env, const Projection &p_projection, const Transform3D &p_transform, float p_sky_energy_multiplier, float p_luminance_multiplier, bool p_use_multiview, bool p_flip_y, bool p_apply_environment_effects_in_post) {
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 	ERR_FAIL_COND(p_env.is_null());
 
@@ -815,7 +815,7 @@ void RasterizerSceneGLES3::_draw_sky(RID p_env, const Projection &p_projection, 
 	if (p_flip_y) {
 		spec_constants |= SkyShaderGLES3::USE_INVERTED_Y;
 	}
-	if (!p_apply_color_adjustments_in_post) {
+	if (!p_apply_environment_effects_in_post) {
 		spec_constants |= SkyShaderGLES3::APPLY_TONEMAPPING;
 	}
 
@@ -2271,7 +2271,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	GLES3::Config *config = GLES3::Config::get_singleton();
 	RENDER_TIMESTAMP("Setup 3D Scene");
 
-	bool apply_color_adjustments_in_post = false;
+	bool apply_environment_effects_in_post = false;
 	bool is_reflection_probe = p_reflection_probe.is_valid();
 
 	Ref<RenderSceneBuffersGLES3> rb = p_render_buffers;
@@ -2279,7 +2279,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 
 	if (rb->get_scaling_3d_mode() != RSE::VIEWPORT_SCALING_3D_MODE_OFF) {
 		// If we're scaling, we apply tonemapping etc. in post, so disable it during rendering
-		apply_color_adjustments_in_post = true;
+		apply_environment_effects_in_post = true;
 	}
 
 	GLES3::RenderTarget *rt = nullptr; // No render target for reflection probe
@@ -2289,20 +2289,17 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	}
 
 	bool glow_enabled = false;
-	if (p_environment.is_valid()) {
-		glow_enabled = environment_get_glow_enabled(p_environment);
-		if (glow_enabled) {
-			// If glow is enabled, we apply tonemapping etc. in post, so disable it during rendering
-			apply_color_adjustments_in_post = true;
-		}
-	}
-
 	bool ssao_enabled = false;
+	bool use_bcs = false;
 	if (p_environment.is_valid()) {
+		// We apply tonemapping, etc. in post when any of these are true. In this
+		// case, set apply_environment_effects_in_post to true to skip tonemapping during rendering.
+		glow_enabled = environment_get_glow_enabled(p_environment);
 		ssao_enabled = environment_get_ssao_enabled(p_environment);
-		if (ssao_enabled) {
-			// If SSAO is enabled, we apply tonemapping etc. in post, so disable it during rendering
-			apply_color_adjustments_in_post = true;
+		use_bcs = environment_get_adjustments_enabled(p_environment);
+		bool canvas_tonemapping = environment_get_background(p_environment) == RSE::ENV_BG_CANVAS && environment_get_tone_mapper(p_environment) != RSE::ENV_TONE_MAPPER_LINEAR;
+		if (glow_enabled || ssao_enabled || use_bcs || canvas_tonemapping) {
+			apply_environment_effects_in_post = true;
 		}
 	}
 
@@ -2394,11 +2391,6 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 
 	SceneState::TonemapUBO tonemap_ubo;
 	if (render_data.environment.is_valid()) {
-		bool use_bcs = environment_get_adjustments_enabled(render_data.environment);
-		if (use_bcs) {
-			apply_color_adjustments_in_post = true;
-		}
-
 		tonemap_ubo.exposure = environment_get_exposure(render_data.environment);
 		tonemap_ubo.tonemapper = int32_t(environment_get_tone_mapper(render_data.environment));
 		RendererEnvironmentStorage::TonemapParameters params = environment_get_tonemap_parameters(render_data.environment, false, 1.0f);
@@ -2580,7 +2572,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	if (is_reflection_probe && GLES3::LightStorage::get_singleton()->reflection_probe_has_atlas_index(render_data.reflection_probe)) {
 		fbo = GLES3::LightStorage::get_singleton()->reflection_probe_instance_get_framebuffer(render_data.reflection_probe, render_data.reflection_probe_pass);
 	} else {
-		rb->set_apply_color_adjustments_in_post(apply_color_adjustments_in_post);
+		rb->set_apply_environment_effects_in_post(apply_environment_effects_in_post);
 		fbo = rb->get_render_fbo();
 	}
 
@@ -2711,7 +2703,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 			spec_constant_base_flags |= SceneShaderGLES3::USE_DEPTH_FOG;
 		}
 
-		if (!apply_color_adjustments_in_post) {
+		if (!apply_environment_effects_in_post) {
 			spec_constant_base_flags |= SceneShaderGLES3::APPLY_TONEMAPPING;
 		}
 	}
@@ -2757,7 +2749,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		Transform3D transform = render_data.cam_transform;
 		Projection projection = render_data.cam_projection;
 
-		_draw_sky(render_data.environment, projection, transform, sky_energy_multiplier, render_data.luminance_multiplier, p_camera_data->view_count > 1, flip_y, apply_color_adjustments_in_post);
+		_draw_sky(render_data.environment, projection, transform, sky_energy_multiplier, render_data.luminance_multiplier, p_camera_data->view_count > 1, flip_y, apply_environment_effects_in_post);
 	}
 
 	if (scene_state.used_screen_texture || scene_state.used_depth_texture) {

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -189,7 +189,7 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 
 	ERR_FAIL_COND(view_count == 0);
 
-	bool use_internal_buffer = scaling_3d_mode != RSE::VIEWPORT_SCALING_3D_MODE_OFF || apply_color_adjustments_in_post;
+	bool use_internal_buffer = scaling_3d_mode != RSE::VIEWPORT_SCALING_3D_MODE_OFF || apply_environment_effects_in_post;
 	GLenum depth_format = GL_DEPTH24_STENCIL8;
 	uint32_t depth_format_size = 4;
 	bool use_multiview = view_count > 1;
@@ -559,8 +559,8 @@ void RenderSceneBuffersGLES3::_clear_back_buffers() {
 	}
 }
 
-void RenderSceneBuffersGLES3::set_apply_color_adjustments_in_post(bool p_apply_in_post) {
-	apply_color_adjustments_in_post = p_apply_in_post;
+void RenderSceneBuffersGLES3::set_apply_environment_effects_in_post(bool p_apply_in_post) {
+	apply_environment_effects_in_post = p_apply_in_post;
 }
 
 void RenderSceneBuffersGLES3::check_glow_buffers() {

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -49,7 +49,7 @@ public:
 	//bool use_taa = false;
 	//bool use_debanding = false;
 	uint32_t view_count = 1;
-	bool apply_color_adjustments_in_post = false;
+	bool apply_environment_effects_in_post = false;
 
 	RID render_target;
 
@@ -106,7 +106,7 @@ public:
 	virtual void set_fsr_sharpness(float p_fsr_sharpness) override {}
 	virtual void set_texture_mipmap_bias(float p_texture_mipmap_bias) override {}
 	virtual void set_use_debanding(bool p_use_debanding) override {}
-	void set_apply_color_adjustments_in_post(bool p_apply_in_post);
+	void set_apply_environment_effects_in_post(bool p_apply_environment_effects_in_post);
 
 	void free_render_buffer_data();
 


### PR DESCRIPTION
## Issue description

1. Create a 2D scene with the Compatibility renderer
2. Add a WorldEnvironment node with an Environment
3. Change Background mode to Canvas
4. Change the tonemapper to one that is not Linear
5. Note that the tonemapper is not applied
6. Enable Glow
7. Note that the tonemapper is now applied

## This PR

- Fixes (partially) #110902 (half of this issue)

This PR fixes the above problem by applying tonemapping the same way that Glow is applied when using a Canvas background mode with the Compatibility renderer.

I also renamed a variable to keep the code clean, which makes this PR appear larger than it absolutely needs to be.

## Outstanding issues

There is another outstanding issue relating to how Tonemap Exposure should be applied when background mode is Canvas, but I think this is best left to a separate PR, as the fix is quite a bit more complex and nuanced...

Update: My solution to this issue with exposure is here: https://github.com/godotengine/godot/pull/113863