### PR TITLE
Make local static `HashMap` initializations thread-safe

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -409,19 +409,22 @@ Color Color::named(const String &p_name, const Color &p_default) {
 	return named_colors[idx].color;
 }
 
+static HashMap<String, int> _init_named_colors_map() {
+	HashMap<String, int> named_colors_hashmap;
+	const int named_color_count = Color::get_named_color_count();
+	for (int i = 0; i < named_color_count; i++) {
+		named_colors_hashmap[String(named_colors[i].name).remove_char('_')] = i;
+	}
+	return named_colors_hashmap;
+}
+
 int Color::find_named_color(const String &p_name) {
 	String name = p_name;
 	// Normalize name.
 	name = name.remove_chars(" -_'.");
 	name = name.to_upper();
 
-	static HashMap<String, int> named_colors_hashmap;
-	if (unlikely(named_colors_hashmap.is_empty())) {
-		const int named_color_count = get_named_color_count();
-		for (int i = 0; i < named_color_count; i++) {
-			named_colors_hashmap[String(named_colors[i].name).remove_char('_')] = i;
-		}
-	}
+	static const HashMap<String, int> named_colors_hashmap = _init_named_colors_map();
 
 	const HashMap<String, int>::ConstIterator E = named_colors_hashmap.find(name);
 	if (E) {

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1199,20 +1199,14 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				return ERR_PARSE_ERROR;
 			}
 
-			static HashMap<StringName, Variant::Type> builtin_types;
-			if (builtin_types.is_empty()) {
-				for (int i = 1; i < Variant::VARIANT_MAX; i++) {
-					builtin_types[Variant::get_type_name((Variant::Type)i)] = (Variant::Type)i;
-				}
-			}
-
 			Dictionary dict;
 			Variant::Type key_type = Variant::NIL;
 			StringName key_class_name;
 			Variant key_script;
 			bool got_comma_token = false;
-			if (builtin_types.has(token.value)) {
-				key_type = builtin_types.get(token.value);
+			Variant::Type key_builtin_type = Variant::get_type_by_name(token.value);
+			if (key_builtin_type != Variant::NIL && key_builtin_type != Variant::VARIANT_MAX) {
+				key_type = key_builtin_type;
 			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
@@ -1257,8 +1251,9 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			StringName value_class_name;
 			Variant value_script;
 			bool got_bracket_token = false;
-			if (builtin_types.has(token.value)) {
-				value_type = builtin_types.get(token.value);
+			Variant::Type value_builtin_type = Variant::get_type_by_name(token.value);
+			if (value_builtin_type != Variant::NIL && value_builtin_type != Variant::VARIANT_MAX) {
+				value_type = value_builtin_type;
 			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
@@ -1339,17 +1334,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				return ERR_PARSE_ERROR;
 			}
 
-			static HashMap<String, Variant::Type> builtin_types;
-			if (builtin_types.is_empty()) {
-				for (int i = 1; i < Variant::VARIANT_MAX; i++) {
-					builtin_types[Variant::get_type_name((Variant::Type)i)] = (Variant::Type)i;
-				}
-			}
-
 			Array array = Array();
 			bool got_bracket_token = false;
-			if (builtin_types.has(token.value)) {
-				array.set_typed(builtin_types.get(token.value), StringName(), Variant());
+			Variant::Type builtin_type = Variant::get_type_by_name(token.value);
+			if (builtin_type != Variant::NIL && builtin_type != Variant::VARIANT_MAX) {
+				array.set_typed(builtin_type, StringName(), Variant());
 			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);

--- a/editor/project_manager/engine_update_label.cpp
+++ b/editor/project_manager/engine_update_label.cpp
@@ -210,14 +210,13 @@ EngineUpdateLabel::VersionType EngineUpdateLabel::_get_version_type(const String
 	VersionType type = VersionType::UNKNOWN;
 	String index_string;
 
-	static HashMap<String, VersionType> type_map;
-	if (type_map.is_empty()) {
-		type_map["stable"] = VersionType::STABLE;
-		type_map["rc"] = VersionType::RC;
-		type_map["beta"] = VersionType::BETA;
-		type_map["alpha"] = VersionType::ALPHA;
-		type_map["dev"] = VersionType::DEV;
-	}
+	static const HashMap<String, VersionType> type_map = {
+		{ "stable", VersionType::STABLE },
+		{ "rc", VersionType::RC },
+		{ "beta", VersionType::BETA },
+		{ "alpha", VersionType::ALPHA },
+		{ "dev", VersionType::DEV },
+	};
 
 	for (const KeyValue<String, VersionType> &kv : type_map) {
 		if (p_string.begins_with(kv.key)) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -910,6 +910,12 @@ static void _get_directory_contents(EditorFileSystemDirectory *p_dir, HashMap<St
 	}
 }
 
+static HashMap<StringName, int64_t> _init_enum_values_map(StringName p_name) {
+	HashMap<StringName, int64_t> map;
+	CoreConstants::get_enum_values(p_name, &map);
+	return map;
+}
+
 static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_annotation, int p_argument, const String p_quote_style, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_result, String &r_arghint) {
 	ERR_FAIL_NULL(p_annotation);
 
@@ -984,20 +990,14 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 	} else if (p_annotation->name == SNAME("@export_custom")) {
 		switch (p_argument) {
 			case 0: {
-				static HashMap<StringName, int64_t> items;
-				if (unlikely(items.is_empty())) {
-					CoreConstants::get_enum_values(SNAME("PropertyHint"), &items);
-				}
+				static const HashMap<StringName, int64_t> items = _init_enum_values_map("PropertyHint");
 				for (const KeyValue<StringName, int64_t> &item : items) {
 					ScriptLanguage::CodeCompletionOption option(item.key, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
 					r_result.insert(option.display, option);
 				}
 			} break;
 			case 2: {
-				static HashMap<StringName, int64_t> items;
-				if (unlikely(items.is_empty())) {
-					CoreConstants::get_enum_values(SNAME("PropertyUsageFlags"), &items);
-				}
+				static const HashMap<StringName, int64_t> items = _init_enum_values_map("PropertyUsageFlags");
 				for (const KeyValue<StringName, int64_t> &item : items) {
 					ScriptLanguage::CodeCompletionOption option(item.key, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
 					r_result.insert(option.display, option);


### PR DESCRIPTION
Updated static `HashMap` usage in several functions to be thread-safe

Fixes #113865

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
