### PR TITLE
Fix "make unique" on non-scene resources

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1926,7 +1926,7 @@ int EditorNode::get_resource_count(Ref<Resource> p_res) {
 	return L ? L->size() : 0;
 }
 
-List<Node *> EditorNode::get_resource_node_list(Ref<Resource> p_res) {
+List<Node *> EditorNode::get_resource_count_list(Ref<Resource> p_res) {
 	List<Node *> *L = resource_count.getptr(p_res);
 	return L == nullptr ? List<Node *>() : *L;
 }

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -831,7 +831,7 @@ public:
 	void update_node_reference(const Variant &p_value, Node *p_node, bool p_remove = false);
 	void clear_node_reference(Ref<Resource> p_res);
 	int get_resource_count(Ref<Resource> p_res);
-	List<Node *> get_resource_node_list(Ref<Resource> p_res);
+	List<Node *> get_resource_count_list(Ref<Resource> p_res);
 
 	void show_about() { _menu_option_confirm(HELP_ABOUT, false); }
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5271,7 +5271,7 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 
 		if (r) {
 			//Setting a Subresource. Since there's possibly multiple Nodes referencing 'r', we need to link them to the Subresource.
-			List<Node *> shared_nodes = EditorNode::get_singleton()->get_resource_node_list(r);
+			List<Node *> shared_nodes = EditorNode::get_singleton()->get_resource_count_list(r);
 			for (Node *N : shared_nodes) {
 				if ((type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && value != p_value) {
 					undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", value, N, true);

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -141,7 +141,7 @@ void EditorResourcePicker::_update_resource() {
 		}
 
 		bool is_internal = EditorNode::get_singleton()->is_resource_internal_to_scene(edited_resource);
-		Ref<Script> edited_resource_script = Object::cast_to<Script>(edited_resource.ptr());
+		Ref<Script> edited_resource_script = edited_resource;
 		if (is_internal) {
 			Ref<Resource> parent_res = _get_parent_resource();
 			bool unique_enable = _is_uniqueness_enabled();

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -81,11 +81,13 @@ static bool _has_sub_resources(const Ref<Resource> &p_res) {
 
 void EditorResourcePicker::_update_resource() {
 	String resource_path;
-	if (edited_resource.is_valid() && edited_resource->get_path().is_resource_file()) {
-		resource_path = edited_resource->get_path() + "\n";
-	}
 	String class_name = _get_resource_type(edited_resource);
 
+	if (edited_resource.is_valid()) {
+		resource_path = edited_resource->get_path();
+	}
+
+	// Assign button.
 	if (preview_rect) {
 		preview_rect->set_texture(Ref<Texture2D>());
 
@@ -106,32 +108,24 @@ void EditorResourcePicker::_update_resource() {
 			}
 
 			if (edited_resource->get_path().is_resource_file()) {
-				resource_path = edited_resource->get_path() + "\n";
+				resource_path = edited_resource->get_path();
 			}
-			assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + class_name);
+			assign_button->set_tooltip_text(resource_path + "\n" + TTR("Type:") + " " + class_name);
 
 			// Preview will override the above, so called at the end.
 			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(edited_resource, callable_mp(this, &EditorResourcePicker::_update_resource_preview).bind(edited_resource->get_instance_id()));
 		}
 	} else if (edited_resource.is_valid()) {
-		assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + edited_resource->get_class());
+		assign_button->set_tooltip_text(resource_path + "\n" + TTR("Type:") + " " + edited_resource->get_class());
 	}
 
+	// Make unique button.
 	if (edited_resource.is_null()) {
 		make_unique_button->set_visible(false);
 	} else {
-		Ref<Resource> parent_res = _has_parent_resource();
-		bool unique_enable = _is_uniqueness_enabled();
-		bool unique_recursive_enabled = _is_uniqueness_enabled(true);
-		bool is_internal = EditorNode::get_singleton()->is_resource_internal_to_scene(edited_resource);
-		int num_of_copies = EditorNode::get_singleton()->get_resource_count(edited_resource);
-		make_unique_button->set_button_icon(get_editor_theme_icon(SNAME("Instance")));
-		make_unique_button->set_visible((num_of_copies > 1 || !is_internal) && !Object::cast_to<Script>(edited_resource.ptr()));
-		make_unique_button->set_disabled((!unique_enable && !unique_recursive_enabled) || !editable);
-
 		String tooltip;
-
 		String resource_name = "resource";
+
 		if (edited_resource.is_valid()) {
 			resource_name = edited_resource->get_class();
 
@@ -146,28 +140,43 @@ void EditorResourcePicker::_update_resource() {
 			}
 		}
 
-		if (num_of_copies > 1) {
-			tooltip = vformat(TTRN("This %s is used in %d place.", "This %s is used in %d places.", num_of_copies), resource_name, num_of_copies);
-		} else if (!is_internal) {
+		bool is_internal = EditorNode::get_singleton()->is_resource_internal_to_scene(edited_resource);
+		Ref<Script> edited_resource_script = Object::cast_to<Script>(edited_resource.ptr());
+		if (is_internal) {
+			Ref<Resource> parent_res = _get_parent_resource();
+			bool unique_enable = _is_uniqueness_enabled();
+			bool unique_recursive_enabled = _is_uniqueness_enabled(true);
+			int num_of_copies = EditorNode::get_singleton()->get_resource_count(edited_resource);
+			make_unique_button->set_visible(num_of_copies > 1 && edited_resource_script.is_null());
+			make_unique_button->set_disabled((!unique_enable && !unique_recursive_enabled) || !editable);
+
+			if (num_of_copies > 1) {
+				tooltip = vformat(TTRN("This %s is used in %d place.", "This %s is used in %d places.", num_of_copies), resource_name, num_of_copies);
+			}
+
+			if (!editable) {
+				tooltip += "\n" + vformat(TTR("The %s cannot be edited in the inspector and can't be made unique directly."), resource_name) + "\n";
+			} else {
+				if (unique_enable) {
+					tooltip += "\n" + TTR("Left-click to make it unique.") + "\n";
+				}
+
+				if (unique_recursive_enabled) {
+					tooltip += TTR("It is possible to make its subresources unique.") + "\n" + TTR("Right-click to make them unique.");
+				}
+
+				if (!unique_enable && EditorNode::get_singleton()->get_editor_selection()->get_full_selected_node_list().size() == 1) {
+					tooltip += TTR("In order to duplicate it, make its parent Resource unique.") + "\n";
+				}
+			}
+		} else {
+			make_unique_button->set_visible(edited_resource_script.is_null());
+			make_unique_button->set_disabled(true);
+
 			tooltip = vformat(TTR("This %s is external to scene."), resource_name);
 		}
 
-		if (!editable) {
-			tooltip += "\n" + vformat(TTR("The %s cannot be edited in the inspector and can't be made unique directly."), resource_name) + "\n";
-		} else {
-			if (unique_enable) {
-				tooltip += "\n" + TTR("Left-click to make it unique.") + "\n";
-			}
-
-			if (unique_recursive_enabled) {
-				tooltip += TTR("It is possible to make its subresources unique.") + "\n" + TTR("Right-click to make them unique.");
-			}
-
-			if (!unique_enable && EditorNode::get_singleton()->get_editor_selection()->get_full_selected_node_list().size() == 1) {
-				tooltip += TTR("In order to duplicate it, make its parent Resource unique.") + "\n";
-			}
-		}
-
+		make_unique_button->set_button_icon(get_editor_theme_icon(SNAME("Instance")));
 		make_unique_button->set_tooltip_text(tooltip);
 	}
 
@@ -336,7 +345,7 @@ void EditorResourcePicker::_update_menu_items() {
 			if (!unique_enabled) {
 				if (EditorNode::get_singleton()->is_resource_internal_to_scene(edited_resource) && EditorNode::get_singleton()->get_resource_count(edited_resource) == 1) {
 					edit_menu->set_item_tooltip(-1, String(TTRC("This Resource is already unique.")) + "\n" + drag_and_drop_text);
-				} else if (_has_parent_resource().is_valid()) {
+				} else if (_get_parent_resource().is_valid()) {
 					edit_menu->set_item_tooltip(-1, String(TTRC("In order to duplicate it, make its parent Resource unique.")) + "\n" + drag_and_drop_text);
 				}
 			} else {
@@ -348,7 +357,7 @@ void EditorResourcePicker::_update_menu_items() {
 				edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Duplicate")), TTR("Make Unique (Recursive)"), OBJ_MENU_MAKE_UNIQUE_RECURSIVE);
 				edit_menu->set_item_disabled(-1, !unique_enabled);
 				if (!unique_enabled) {
-					Ref<Resource> parent_res = _has_parent_resource();
+					Ref<Resource> parent_res = _get_parent_resource();
 					if (EditorNode::get_singleton()->get_editor_selection()->get_full_selected_node_list().size() == 1) {
 						edit_menu->set_item_tooltip(-1, (parent_res.is_valid() && EditorNode::get_singleton()->get_resource_count(parent_res) > 1) ? TTRC("In order to duplicate recursively, make its parent Resource unique.") : TTRC("Subresources have already been made unique."));
 					}
@@ -1403,54 +1412,70 @@ void EditorResourcePicker::_duplicate_selected_resources() {
 }
 
 bool EditorResourcePicker::_is_uniqueness_enabled(bool p_check_recursive) {
+	if (edited_resource.is_null()) {
+		return false;
+	}
+
 	if (force_allow_unique) {
 		return true;
 	}
-	Ref<Resource> parent_resource = _has_parent_resource();
-	EditorNode *en = EditorNode::get_singleton();
-	bool internal_to_scene = en->is_resource_internal_to_scene(edited_resource);
-	List<Node *> node_list = en->get_editor_selection()->get_full_selected_node_list();
 
-	// Todo: Implement a more elegant solution for multiple selected Nodes. This should suffice for the time being.
-	if (node_list.size() > 1 && !p_check_recursive) {
-		return node_list.size() != EditorNode::get_singleton()->get_resource_count(edited_resource) || !internal_to_scene;
+	Ref<Resource> parent_resource = _get_parent_resource();
+	EditorNode *editor_node = EditorNode::get_singleton();
+	bool internal_to_scene = editor_node->is_resource_internal_to_scene(edited_resource);
+	List<Node *> node_list = editor_node->get_editor_selection()->get_full_selected_node_list();
+
+	if (node_list.size() > 1) {
+		// Setting a value while in multi node edit mode sets the same value for all nodes,
+		// making the set value _not_ unique.
+		return false;
 	}
 
 	if (!internal_to_scene) {
-		if (parent_resource.is_valid() && (!EditorNode::get_singleton()->is_resource_internal_to_scene(parent_resource) || en->get_resource_count(parent_resource) > 1)) {
-			return false;
+		if (parent_resource.is_valid() && (!editor_node->is_resource_internal_to_scene(parent_resource) || editor_node->get_resource_count(parent_resource) > 1)) {
+			return true;
 		} else if (!p_check_recursive) {
 			return true;
 		}
 	}
 
-	int parent_counter = en->get_resource_count(parent_resource);
-	bool above_threshold = parent_resource.is_valid() ? (en->get_resource_count(parent_resource) <= 1 && en->get_resource_count(edited_resource) > 1) : en->get_resource_count(edited_resource) > 1;
+	int parent_counter = editor_node->get_resource_count(parent_resource);
+	bool above_threshold = parent_resource.is_valid()
+			? (editor_node->get_resource_count(parent_resource) <= 1 && editor_node->get_resource_count(edited_resource) > 1)
+			: editor_node->get_resource_count(edited_resource) > 1;
 	if (!p_check_recursive) {
 		return above_threshold;
 	}
 
-	if (p_check_recursive && parent_counter <= 1) {
-		List<Ref<Resource>> nested_resources;
-		en->gather_resources(edited_resource, nested_resources, true, true);
-
-		for (Ref<Resource> R : nested_resources) {
-			// Take into account Nested External Resources.
-			if (en->get_resource_count(R) > 1 || !EditorNode::get_singleton()->is_resource_internal_to_scene(R)) {
-				return true;
-			}
-		}
+	if (!p_check_recursive) {
 		return false;
+	}
+
+	if (parent_counter > 1) {
+		return false;
+	}
+
+	List<Ref<Resource>> nested_resources;
+	editor_node->gather_resources(edited_resource, nested_resources, true, true);
+
+	for (Ref<Resource> R : nested_resources) {
+		// Take into account Nested External Resources.
+		if (editor_node->get_resource_count(R) > 1 || !editor_node->is_resource_internal_to_scene(R)) {
+			return true;
+		}
 	}
 	return false;
 }
 
-Ref<Resource> EditorResourcePicker::_has_parent_resource() {
+Ref<Resource> EditorResourcePicker::_get_parent_resource() {
 	Node *current_node = this->get_parent();
 	while (current_node != nullptr) {
-		EditorProperty *ep = Object::cast_to<EditorProperty>(current_node);
-		if (ep && Object::cast_to<Resource>(ep->get_edited_object())) {
-			return Object::cast_to<Resource>(ep->get_edited_object());
+		EditorProperty *editor_property = Object::cast_to<EditorProperty>(current_node);
+		if (editor_property != nullptr) {
+			Ref<Resource> edited_object = Object::cast_to<Resource>(editor_property->get_edited_object());
+			if (edited_object.is_valid()) {
+				return edited_object;
+			}
 		}
 		current_node = current_node->get_parent();
 	}

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -167,6 +167,7 @@ void EditorResourcePicker::_update_resource() {
 
 				if (!unique_enable && EditorNode::get_singleton()->get_editor_selection()->get_full_selected_node_list().size() == 1) {
 					tooltip += TTR("In order to duplicate it, make its parent Resource unique.") + "\n";
+					tooltip += "\n" + TTR("In order to duplicate it, make its parent Resource unique.") + "\n";
 				}
 			}
 		} else {

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1434,7 +1434,7 @@ bool EditorResourcePicker::_is_uniqueness_enabled(bool p_check_recursive) {
 
 	if (!internal_to_scene) {
 		if (parent_resource.is_valid() && (!editor_node->is_resource_internal_to_scene(parent_resource) || editor_node->get_resource_count(parent_resource) > 1)) {
-			return true;
+			return false;
 		} else if (!p_check_recursive) {
 			return true;
 		}

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -121,7 +121,7 @@ class EditorResourcePicker : public HBoxContainer {
 	void _gather_resources_to_duplicate(const Ref<Resource> p_resource, TreeItem *p_item, const String &p_property_name = "") const;
 	void _duplicate_selected_resources();
 	bool _is_uniqueness_enabled(bool p_check_recursive = false);
-	Ref<Resource> _has_parent_resource();
+	Ref<Resource> _get_parent_resource();
 
 protected:
 	virtual void _update_resource();

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -104,7 +104,7 @@ class EditorResourcePicker : public HBoxContainer {
 
 	void _button_draw();
 	void _button_input(const Ref<InputEvent> &p_event);
-	void _on_unique_button_pressed();
+	void _on_make_unique_button_pressed();
 
 	String _get_owner_path() const;
 	String _get_resource_type(const Ref<Resource> &p_resource) const;
@@ -120,7 +120,7 @@ class EditorResourcePicker : public HBoxContainer {
 	void _ensure_resource_menu();
 	void _gather_resources_to_duplicate(const Ref<Resource> p_resource, TreeItem *p_item, const String &p_property_name = "") const;
 	void _duplicate_selected_resources();
-	bool _is_uniqueness_enabled(bool p_check_recursive = false);
+	bool _is_make_unique_enabled(bool p_check_recursive = false);
 	Ref<Resource> _get_parent_resource();
 
 protected:


### PR DESCRIPTION
Fixes #113414 (at least, based on my preliminary tests)

Makes the logic of #109458 to only apply if the edited resource is a subresource of the edited scene. That follows how the feature was developed, which is to track the resources used in the current scene.

That reinstates the previous logic (were we can make unique external subresources) for the other resources.