### PR TITLE
Fix incorrect error message placement in TileMap Dock

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -4420,7 +4420,7 @@ void TileMapLayerEditor::update_layout(DockLayout p_layout) {
 	tile_map_toolbar->set_h_size_flags(is_vertical ? SIZE_SHRINK_BEGIN : SIZE_EXPAND_FILL);
 	tile_map_toolbar->set_v_size_flags(is_vertical ? SIZE_EXPAND_FILL : SIZE_SHRINK_BEGIN);
 
-	main_box_container->move_child(padding_control, is_vertical ? 0 : 3);
+	main_box_container->move_child(padding_control, is_vertical ? 0 : 2);
 
 	if (is_vertical) {
 		tile_map_wide_toolbar->add_child(tabs_bar);


### PR DESCRIPTION
Extracted from #113594
Fixes #114235

| Before | After |
| - | - |
| <img width="824" height="250" src="https://github.com/user-attachments/assets/77863b57-52ee-48ae-902a-3fbf98275ef6" /> | <img width="923" height="250" src="https://github.com/user-attachments/assets/e25b7ab6-c7af-4543-ba46-2ac8dffd6e1c" /> |

