### PR TITLE
Skip over non-CanvasItem parents when selecting texture filter properties.

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1622,13 +1622,25 @@ bool CanvasItem::get_visibility_layer_bit(uint32_t p_visibility_layer) const {
 	return (visibility_layer & (1 << p_visibility_layer));
 }
 
+CanvasItem *CanvasItem::_get_parent_item_deep() const {
+	Node *parent = get_parent();
+	while (parent) {
+		CanvasItem *ci = Object::cast_to<CanvasItem>(parent);
+		if (ci) {
+			return ci;
+		}
+		parent = parent->get_parent();
+	}
+	return nullptr;
+}
+
 void CanvasItem::_refresh_texture_filter_cache() const {
 	if (!is_inside_tree()) {
 		return;
 	}
 
 	if (texture_filter == TEXTURE_FILTER_PARENT_NODE) {
-		CanvasItem *parent_item = get_parent_item();
+		CanvasItem *parent_item = _get_parent_item_deep();
 		if (parent_item) {
 			texture_filter_cache = parent_item->texture_filter_cache;
 		} else {
@@ -1684,7 +1696,7 @@ void CanvasItem::_refresh_texture_repeat_cache() const {
 	}
 
 	if (texture_repeat == TEXTURE_REPEAT_PARENT_NODE) {
-		CanvasItem *parent_item = get_parent_item();
+		CanvasItem *parent_item = _get_parent_item_deep();
 		if (parent_item) {
 			texture_repeat_cache = parent_item->texture_repeat_cache;
 		} else {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -141,6 +141,8 @@ private:
 	virtual void _top_level_changed();
 	virtual void _top_level_changed_on_parent();
 
+	CanvasItem *_get_parent_item_deep() const;
+
 	void _redraw_callback();
 
 	void _enter_canvas();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113872

Instead of checking only direct parent, look deeper for the first encountered grandparent `CanvasItem` when selecting inherited texture filter/repeat, so it will over for subwindows and nodes inside non-CanvasItem parents.