### PR TITLE
Wayland: Implement touch support

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -2689,7 +2689,7 @@
 			Display server supports multiple windows that can be moved outside of the main window. [b]Windows, macOS, Linux (X11)[/b]
 		</constant>
 		<constant name="FEATURE_TOUCHSCREEN" value="2" enum="Feature">
-			Display server supports touchscreen input. [b]Windows, Linux (X11), Android, iOS, Web[/b]
+			Display server supports touchscreen input. [b]Windows, Linux (X11/Wayland), Android, iOS, Web[/b]
 		</constant>
 		<constant name="FEATURE_MOUSE" value="3" enum="Feature">
 			Display server supports mouse input. [b]Windows, macOS, Linux (X11/Wayland), Android, Web[/b]

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -255,6 +255,7 @@ bool DisplayServerWayland::has_feature(DisplayServerEnums::Feature p_feature) co
 			return (native_menu && native_menu->has_feature(NativeMenu::FEATURE_GLOBAL_MENU));
 		} break;
 #endif
+		case DisplayServerEnums::FEATURE_TOUCHSCREEN:
 		case DisplayServerEnums::FEATURE_MOUSE:
 		case DisplayServerEnums::FEATURE_MOUSE_WARP:
 		case DisplayServerEnums::FEATURE_CLIPBOARD:
@@ -736,6 +737,12 @@ float DisplayServerWayland::screen_get_refresh_rate(int p_screen) const {
 	ERR_FAIL_INDEX_V(p_screen, screen_count, SCREEN_REFRESH_RATE_FALLBACK);
 
 	return wayland_thread.screen_get_data(p_screen).refresh_rate;
+}
+
+bool DisplayServerWayland::is_touchscreen_available() const {
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	return wayland_thread.input_has_touch() || (Input::get_singleton() && Input::get_singleton()->is_emulating_touch_from_mouse());
 }
 
 void DisplayServerWayland::screen_set_keep_on(bool p_enable) {
@@ -1926,42 +1933,59 @@ void DisplayServerWayland::process_events() {
 
 		Ref<WaylandThread::InputEventMessage> inputev_msg = msg;
 		if (inputev_msg.is_valid()) {
+			bool process_popups = false;
+			Point2 position;
+			DisplayServerEnums::WindowID window_id = DisplayServerEnums::INVALID_WINDOW_ID;
+
 			Ref<InputEventMouseButton> mb = inputev_msg->event;
+			if (mb.is_valid()) {
+				process_popups = (mb->is_pressed() && mb->get_button_mask() != last_mouse_monitor_mask);
+				position = mb->get_position();
+				window_id = mb->get_window_id();
+
+				last_mouse_monitor_mask = mb->get_button_mask();
+			}
+
+			Ref<InputEventScreenTouch> st = inputev_msg->event;
+			if (st.is_valid()) {
+				process_popups = st->is_pressed() && (st->is_pressed() != last_touch_monitor_pressed);
+				position = st->get_position();
+				window_id = st->get_window_id();
+
+				last_touch_monitor_pressed = st->is_pressed();
+			}
 
 			bool handled = false;
-			if (mb.is_valid()) {
-				BitField<MouseButtonMask> mouse_mask = mb->get_button_mask();
-				if (!popup_menu_list.is_empty() && mb->is_pressed() && mouse_mask != last_mouse_monitor_mask) {
-					// Popup menu handling.
-					List<DisplayServerEnums::WindowID>::Element *E = popup_menu_list.back();
-					List<DisplayServerEnums::WindowID>::Element *C = nullptr;
 
-					// Looking for the oldest popup to close.
-					while (E) {
-						WindowData &wd = windows[E->get()];
-						Point2 global_pos = mb->get_position() + window_get_position(mb->get_window_id());
-						if (wd.rect.has_point(global_pos)) {
-							break;
-						} else if (wd.safe_rect.has_point(global_pos)) {
-							break;
-						}
+			if (!popup_menu_list.is_empty() && process_popups) {
+				List<DisplayServerEnums::WindowID>::Element *E = popup_menu_list.back();
+				List<DisplayServerEnums::WindowID>::Element *C = nullptr;
 
-						C = E;
-						E = E->prev();
+				Point2 global_pos = position + window_get_position(window_id);
+
+				// Looking for the oldest popup to close.
+				while (E) {
+					WindowData &wd = windows[E->get()];
+					if (wd.rect.has_point(global_pos)) {
+						break;
+					} else if (wd.safe_rect.has_point(global_pos)) {
+						break;
 					}
 
-					if (C) {
-						handled = true;
-						_send_window_event(DisplayServerEnums::WINDOW_EVENT_CLOSE_REQUEST, C->get());
-					}
+					C = E;
+					E = E->prev();
 				}
 
-				last_mouse_monitor_mask = mouse_mask;
+				if (C) {
+					handled = true;
+					_send_window_event(DisplayServerEnums::WINDOW_EVENT_CLOSE_REQUEST, C->get());
+				}
 			}
 
 			if (!handled) {
 				Input::get_singleton()->parse_input_event(inputev_msg->event);
 			}
+
 			continue;
 		}
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -144,6 +144,7 @@ class DisplayServerWayland : public DisplayServer {
 	// track of all the generic floating window concept.
 	List<DisplayServerEnums::WindowID> popup_menu_list;
 	BitField<MouseButtonMask> last_mouse_monitor_mask = MouseButtonMask::NONE;
+	bool last_touch_monitor_pressed = false;
 
 	String ime_text;
 	Vector2i ime_selection;
@@ -242,6 +243,8 @@ public:
 	virtual int screen_get_dpi(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_scale(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_refresh_rate(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+
+	virtual bool is_touchscreen_available() const override;
 
 	virtual void screen_set_keep_on(bool p_enable) override;
 	virtual bool screen_is_kept_on() const override;

--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -91,6 +91,14 @@
 #define WL_POINTER_LEAVE 1
 #define WL_POINTER_BUTTON 3
 
+#define WL_TOUCH_DOWN 0
+#define WL_TOUCH_UP 1
+#define WL_TOUCH_MOTION 2
+#define WL_TOUCH_FRAME 3
+#define WL_TOUCH_CANCEL 4
+#define WL_TOUCH_SHAPE 5
+#define WL_TOUCH_ORIENTATION 6
+
 #define WL_SHM_FORMAT 0
 
 #define WL_DRM_DEVICE 0
@@ -1437,7 +1445,7 @@ WaylandEmbedder::MessageStatus WaylandEmbedder::handle_request(LocalObjectHandle
 
 		if (p_opcode == WL_SEAT_GET_KEYBOARD) {
 			ERR_FAIL_COND_V(global_id == INVALID_ID, MessageStatus::ERROR);
-			// [Request] wl_seat::get_pointer(n);
+			// [Request] wl_seat::get_keyboard(n);
 			uint32_t new_local_id = body[0];
 
 			WaylandKeyboardData *new_data = memnew(WaylandKeyboardData);
@@ -1447,6 +1455,24 @@ WaylandEmbedder::MessageStatus WaylandEmbedder::handle_request(LocalObjectHandle
 			ERR_FAIL_COND_V(new_global_id == INVALID_ID, MessageStatus::HANDLED);
 
 			instance_data->wl_keyboard_id = new_global_id;
+
+			send_wayland_message(compositor_socket, global_id, p_opcode, { new_global_id });
+
+			return MessageStatus::HANDLED;
+		}
+
+		if (p_opcode == WL_SEAT_GET_TOUCH) {
+			ERR_FAIL_COND_V(global_id == INVALID_ID, MessageStatus::ERROR);
+			// [Request] wl_seat::get_touch(n);
+			uint32_t new_local_id = body[0];
+
+			WaylandTouchData *new_data = memnew(WaylandTouchData);
+			new_data->wl_seat_id = global_id;
+
+			uint32_t new_global_id = client->new_object(new_local_id, &wl_touch_interface, object->version, new_data);
+			ERR_FAIL_COND_V(new_global_id == INVALID_ID, MessageStatus::HANDLED);
+
+			instance_data->wl_touch_id = new_global_id;
 
 			send_wayland_message(compositor_socket, global_id, p_opcode, { new_global_id });
 
@@ -2274,6 +2300,63 @@ WaylandEmbedder::MessageStatus WaylandEmbedder::handle_event(uint32_t p_global_i
 				DEBUG_LOG_WAYLAND_EMBED(vformat("Pointer (g0x%x seat g0x%x): g0x%x -> g0x%x", p_global_id, data->wl_seat_id, global_seat_data->pointed_surface_id, INVALID_ID));
 				global_seat_data->pointed_surface_id = INVALID_ID;
 			}
+		}
+
+		return MessageStatus::UNHANDLED;
+	}
+
+	if (object->interface == &wl_touch_interface) {
+		WaylandTouchData *data = (WaylandTouchData *)object->data;
+		ERR_FAIL_NULL_V(data, MessageStatus::ERROR);
+
+		uint32_t global_seat_name = registry_globals_names[data->wl_seat_id];
+		RegistryGlobalInfo &global_seat_info = registry_globals[global_seat_name];
+		WaylandSeatGlobalData *global_seat_data = (WaylandSeatGlobalData *)global_seat_info.data;
+		ERR_FAIL_NULL_V(global_seat_data, MessageStatus::ERROR);
+
+		WaylandSeatInstanceData *seat_data = (WaylandSeatInstanceData *)object->data;
+		ERR_FAIL_NULL_V(seat_data, MessageStatus::ERROR);
+
+		if (p_opcode == WL_TOUCH_DOWN) {
+			// uint32_t serial = body[0];
+			// uint32_t time = body[1];
+			uint32_t surface = body[2];
+			// uint32_t id = body[3];
+			// uint32_t x = body[4];
+			// uint32_t y = body[5];
+
+			++data->touch_point_count;
+
+			if (data->touch_point_count == 1) {
+				if (global_seat_data->focused_surface_id == surface) {
+					return MessageStatus::UNHANDLED;
+				}
+
+				if (!global_surface_is_window(surface)) {
+					return MessageStatus::UNHANDLED;
+				}
+
+				if (global_seat_data->focused_surface_id != INVALID_ID) {
+					seat_name_leave_surface(global_seat_name, global_seat_data->focused_surface_id);
+				}
+
+				global_seat_data->focused_surface_id = surface;
+				seat_name_enter_surface(global_seat_name, surface);
+			}
+
+			return MessageStatus::UNHANDLED;
+		}
+
+		if (p_opcode == WL_TOUCH_UP) {
+			--data->touch_point_count;
+
+			return MessageStatus::UNHANDLED;
+		}
+
+		if (p_opcode == WL_TOUCH_CANCEL) {
+			data->touch_point_count = 0;
+
+			return MessageStatus::UNHANDLED;
 		}
 
 		return MessageStatus::UNHANDLED;

--- a/platform/linuxbsd/wayland/wayland_embedder.h
+++ b/platform/linuxbsd/wayland/wayland_embedder.h
@@ -223,6 +223,7 @@ class WaylandEmbedder {
 	struct WaylandSeatInstanceData : WaylandObjectData {
 		uint32_t wl_keyboard_id = INVALID_ID;
 		uint32_t wl_pointer_id = INVALID_ID;
+		uint32_t wl_touch_id = INVALID_ID;
 	};
 
 	struct WaylandSeatGlobalData : WaylandObjectData {
@@ -238,6 +239,11 @@ class WaylandEmbedder {
 
 	struct WaylandPointerData : WaylandObjectData {
 		uint32_t wl_seat_id = INVALID_ID;
+	};
+
+	struct WaylandTouchData : WaylandObjectData {
+		uint32_t wl_seat_id = INVALID_ID;
+		int touch_point_count = 0;
 	};
 
 	struct WaylandSurfaceData : WaylandObjectData {
@@ -323,7 +329,7 @@ class WaylandEmbedder {
 		&wl_subcompositor_interface,
 		&wl_subsurface_interface,
 		&wl_surface_interface,
-		//&wl_touch_interface, // Unused (at the moment).
+		&wl_touch_interface,
 
 		// xdg-shell
 		&xdg_wm_base_interface,

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1752,10 +1752,10 @@ void WaylandThread::libdecor_frame_on_dismiss_popup(struct libdecor_frame *frame
 
 void WaylandThread::_wl_seat_on_capabilities(void *data, struct wl_seat *wl_seat, uint32_t capabilities) {
 	SeatState *ss = (SeatState *)data;
-
 	ERR_FAIL_NULL(ss);
 
-	// TODO: Handle touch.
+	WaylandThread *wayland_thread = ss->wayland_thread;
+	ERR_FAIL_NULL(wayland_thread);
 
 	// Pointer handling.
 	if (capabilities & WL_SEAT_CAPABILITY_POINTER) {
@@ -1860,6 +1860,31 @@ void WaylandThread::_wl_seat_on_capabilities(void *data, struct wl_seat *wl_seat
 		if (ss->wl_keyboard) {
 			wl_keyboard_destroy(ss->wl_keyboard);
 			ss->wl_keyboard = nullptr;
+		}
+	}
+
+	if (capabilities & WL_SEAT_CAPABILITY_TOUCH) {
+		if (!ss->wl_touch) {
+			ss->wl_touch = wl_seat_get_touch(wl_seat);
+			wl_touch_add_listener(ss->wl_touch, &wl_touch_listener, ss);
+		}
+
+		wayland_thread->has_touch = true;
+	} else {
+		if (ss->wl_touch) {
+			wl_touch_destroy(ss->wl_touch);
+			ss->wl_touch = nullptr;
+		}
+
+		wayland_thread->has_touch = false;
+		for (struct wl_seat *i : wayland_thread->registry.wl_seats) {
+			SeatState *i_ss = wl_seat_get_seat_state(i);
+			ERR_CONTINUE(i_ss == nullptr);
+
+			if (i_ss->wl_touch != nullptr) {
+				wayland_thread->has_touch = true;
+				break;
+			}
 		}
 	}
 }
@@ -2488,6 +2513,225 @@ void WaylandThread::_wl_keyboard_on_repeat_info(void *data, struct wl_keyboard *
 
 	ss->repeat_key_delay_msec = rate ? 1000 / rate : 0;
 	ss->repeat_start_delay_msec = delay;
+}
+
+void WaylandThread::_wl_touch_on_down(void *data, struct wl_touch *wl_touch, uint32_t serial, uint32_t time, struct wl_surface *surface, int32_t id, wl_fixed_t x, wl_fixed_t y) {
+	WindowState *ws = wl_surface_get_window_state(surface);
+	if (!ws) {
+		return;
+	}
+
+	SeatState *ss = (SeatState *)data;
+	ERR_FAIL_NULL(ss);
+
+	ss->last_touch_id = id;
+
+	TouchPoint &tp = ss->touch_points_buffer[id];
+
+	tp.down_time = time;
+
+	tp.touched_id = ws->id;
+
+	tp.position.x = wl_fixed_to_double(x);
+	tp.position.y = wl_fixed_to_double(y);
+}
+
+void WaylandThread::_wl_touch_on_up(void *data, struct wl_touch *wl_touch, uint32_t serial, uint32_t time, int32_t id) {
+	SeatState *ss = (SeatState *)data;
+	ERR_FAIL_NULL(ss);
+
+	if (!ss->touch_points_buffer.has(id)) {
+		return;
+	}
+
+	TouchPoint &tp = ss->touch_points_buffer[id];
+
+	tp.touched_id = DisplayServerEnums::INVALID_WINDOW_ID;
+	ss->touch_points_buffer.erase(id);
+
+	// Some compositors (e.g. mutter) do not send a frame event after "up" events.
+	// AFAICT, this is an acceptable interpretation of the protocol ("No further
+	// events will be sent for this touch point[...]"). Let's just emulate it here.
+	_wl_touch_on_frame(data, wl_touch);
+}
+
+void WaylandThread::_wl_touch_on_motion(void *data, struct wl_touch *wl_touch, uint32_t time, int32_t id, wl_fixed_t x, wl_fixed_t y) {
+	SeatState *ss = (SeatState *)data;
+	ERR_FAIL_NULL(ss);
+
+	ss->last_touch_id = id;
+
+	TouchPoint &tp = ss->touch_points_buffer[id];
+
+	tp.motion_time = time;
+
+	tp.position.x = wl_fixed_to_double(x);
+	tp.position.y = wl_fixed_to_double(y);
+}
+
+void WaylandThread::_wl_touch_on_frame(void *data, struct wl_touch *wl_touch) {
+	SeatState *ss = (SeatState *)data;
+	ERR_FAIL_NULL(ss);
+
+	WaylandThread *wayland_thread = ss->wayland_thread;
+	ERR_FAIL_NULL(wayland_thread);
+
+	// Release handling.
+	for (KeyValue<int32_t, TouchPoint> &pair : ss->touch_points) {
+		int32_t id = pair.key;
+		TouchPoint &tp = pair.value;
+
+		WindowState *ws = wayland_thread->window_get_state(tp.touched_id);
+		if (tp.touched_id == DisplayServerEnums::INVALID_WINDOW_ID || ws == nullptr) {
+			continue;
+		}
+
+		double scale = window_state_get_scale_factor(ws);
+
+		if (!ss->touch_points_buffer.has(id)) {
+			Ref<InputEventScreenTouch> st;
+			st.instantiate();
+			st->set_index(id);
+			st->set_position(tp.position * scale);
+			st->set_window_id(tp.touched_id);
+			st->set_pressed(false);
+
+			Ref<InputEventMessage> iev_msg;
+			iev_msg.instantiate();
+			iev_msg->event = st;
+
+			wayland_thread->push_message(iev_msg);
+
+			// TODO: Handle "mouse enter" events globally, independently of input method.
+			if (tp.touched_id != DisplayServerEnums::INVALID_WINDOW_ID) {
+				Ref<WindowEventMessage> msg;
+				msg.instantiate();
+				msg->id = tp.touched_id;
+				msg->event = DisplayServerEnums::WINDOW_EVENT_MOUSE_EXIT;
+
+				wayland_thread->push_message(msg);
+			}
+		}
+	}
+
+	for (KeyValue<int32_t, TouchPoint> &pair : ss->touch_points_buffer) {
+		int32_t id = pair.key;
+		TouchPoint &tp = pair.value;
+
+		WindowState *ws = wayland_thread->window_get_state(tp.touched_id);
+		if (tp.touched_id == DisplayServerEnums::INVALID_WINDOW_ID || ws == nullptr) {
+			continue;
+		}
+
+		double scale = window_state_get_scale_factor(ws);
+
+		// Press handling.
+		if (!ss->touch_points.has(id)) {
+			Ref<InputEventScreenTouch> st;
+			st.instantiate();
+			st->set_index(id);
+			st->set_position(tp.position * scale);
+			st->set_window_id(tp.touched_id);
+			st->set_pressed(true);
+
+			Ref<InputEventMessage> iev_msg;
+			iev_msg.instantiate();
+			iev_msg->event = st;
+
+			wayland_thread->push_message(iev_msg);
+
+			// TODO: Handle "mouse enter" events globally, independently of input method.
+			if (tp.touched_id != DisplayServerEnums::INVALID_WINDOW_ID) {
+				Ref<WindowEventMessage> msg;
+				msg.instantiate();
+				msg->id = tp.touched_id;
+				msg->event = DisplayServerEnums::WINDOW_EVENT_MOUSE_ENTER;
+
+				wayland_thread->push_message(msg);
+			}
+
+			continue;
+		}
+
+		TouchPoint &tp_old = ss->touch_points[id];
+
+		if (tp.touched_id == DisplayServerEnums::INVALID_WINDOW_ID) {
+			ws = wayland_thread->window_get_state(tp.touched_id);
+		}
+
+		if (wayland_thread->window_get_state(tp.touched_id) == nullptr) {
+			continue;
+		}
+
+		if (tp.position != tp_old.position) {
+			Ref<InputEventScreenDrag> sd;
+			sd.instantiate();
+			sd->set_index(id);
+			sd->set_window_id(tp.touched_id);
+			sd->set_position(tp.position * scale);
+			sd->set_relative((tp.position - tp_old.position) * scale);
+			sd->set_relative_screen_position(sd->get_relative());
+
+			Ref<InputEventMessage> iev_msg;
+			iev_msg.instantiate();
+			iev_msg->event = sd;
+
+			wayland_thread->push_message(iev_msg);
+		}
+	}
+
+	ss->touch_points = ss->touch_points_buffer;
+}
+
+// NOTE: Per the spec, a frame event is not required after this event, so let's
+// assume that it's not going to happen.
+void WaylandThread::_wl_touch_on_cancel(void *data, struct wl_touch *wl_touch) {
+	SeatState *ss = (SeatState *)data;
+	ERR_FAIL_NULL(ss);
+
+	WaylandThread *wayland_thread = ss->wayland_thread;
+	ERR_FAIL_NULL(wayland_thread);
+
+	for (KeyValue<int32_t, TouchPoint> &pair : ss->touch_points_buffer) {
+		int32_t id = pair.key;
+		TouchPoint &tp = pair.value;
+
+		WindowState *ws = wayland_thread->window_get_state(tp.touched_id);
+		double scale = window_state_get_scale_factor(ws);
+
+		Ref<InputEventScreenTouch> st;
+		st.instantiate();
+		st->set_index(id);
+		st->set_position(tp.position * scale);
+		st->set_window_id(tp.touched_id);
+		st->set_pressed(false);
+		st->set_canceled(true);
+
+		Ref<InputEventMessage> cancel_msg;
+		cancel_msg.instantiate();
+		cancel_msg->event = st;
+
+		wayland_thread->push_message(cancel_msg);
+
+		// TODO: Handle "mouse enter" events globally, independently of input method.
+		if (tp.touched_id != DisplayServerEnums::INVALID_WINDOW_ID) {
+			Ref<WindowEventMessage> msg;
+			msg.instantiate();
+			msg->id = tp.touched_id;
+			msg->event = DisplayServerEnums::WINDOW_EVENT_MOUSE_EXIT;
+
+			wayland_thread->push_message(msg);
+		}
+	}
+
+	ss->touch_points_buffer.clear();
+	ss->touch_points.clear();
+}
+
+void WaylandThread::_wl_touch_on_shape(void *data, struct wl_touch *wl_touch, int32_t id, wl_fixed_t major, wl_fixed_t minor) {
+}
+
+void WaylandThread::_wl_touch_on_orientation(void *data, struct wl_touch *wl_touch, int32_t id, wl_fixed_t orientation) {
 }
 
 // NOTE: Don't forget to `memfree` the offer's state.
@@ -4931,10 +5175,16 @@ int WaylandThread::get_screen_count() const {
 	return registry.wl_outputs.size();
 }
 
+bool WaylandThread::input_has_touch() const {
+	return has_touch;
+}
+
 DisplayServerEnums::WindowID WaylandThread::pointer_get_pointed_window_id() const {
 	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
 
 	if (ss) {
+		TouchPoint *tp = ss->touch_points.getptr(ss->last_touch_id);
+
 		// Let's determine the most recently used tablet tool.
 		TabletToolState *max_ts = nullptr;
 		for (struct zwp_tablet_tool_v2 *tool : ss->tablet_tools) {
@@ -4955,18 +5205,38 @@ DisplayServerEnums::WindowID WaylandThread::pointer_get_pointed_window_id() cons
 
 		const PointerData &pd = ss->pointer_data;
 
+		Pair<uint32_t, DisplayServerEnums::WindowID> best;
+		best.first = MAX(pd.button_time, pd.motion_time);
+		best.second = pd.pointed_id;
+
 		if (max_ts) {
 			TabletToolData &td = max_ts->data;
-			if (MAX(td.button_time, td.motion_time) > MAX(pd.button_time, pd.motion_time)) {
-				return td.proximal_id;
+
+			Pair<uint32_t, DisplayServerEnums::WindowID> cur;
+			cur.first = MAX(td.button_time, td.motion_time);
+			cur.second = td.proximal_id;
+
+			if (cur.first > best.first) {
+				best = cur;
 			}
 		}
 
-		return ss->pointer_data.pointed_id;
+		if (tp) {
+			Pair<uint32_t, DisplayServerEnums::WindowID> cur;
+			cur.first = MAX(tp->down_time, tp->motion_time);
+			cur.second = tp->touched_id;
+
+			if (cur.first > best.first) {
+				best = cur;
+			}
+		}
+
+		return best.second;
 	}
 
 	return DisplayServerEnums::INVALID_WINDOW_ID;
 }
+
 DisplayServerEnums::WindowID WaylandThread::pointer_get_last_pointed_window_id() const {
 	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
 

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -472,6 +472,13 @@ public:
 		HashSet<String> mime_types;
 	};
 
+	struct TouchPoint {
+		DisplayServerEnums::WindowID touched_id = DisplayServerEnums::INVALID_WINDOW_ID;
+		Point2 position;
+		uint32_t down_time = 0;
+		uint32_t motion_time = 0;
+	};
+
 	struct SeatState {
 		RegistryState *registry = nullptr;
 
@@ -555,6 +562,12 @@ public:
 		uint32_t last_key_pressed_serial = 0;
 
 		struct wl_data_device *wl_data_device = nullptr;
+
+		// Touch.
+		struct wl_touch *wl_touch = nullptr;
+		AHashMap<int32_t, TouchPoint> touch_points_buffer;
+		AHashMap<int32_t, TouchPoint> touch_points;
+		int32_t last_touch_id = -1;
 
 		// Drag and drop.
 		DisplayServerEnums::WindowID dnd_id = DisplayServerEnums::INVALID_WINDOW_ID;
@@ -692,6 +705,7 @@ private:
 	struct wl_registry *wl_registry = nullptr;
 
 	struct wl_seat *wl_seat_current = nullptr;
+	bool has_touch = false;
 
 	bool frame = true;
 
@@ -751,6 +765,14 @@ private:
 	static void _wl_keyboard_on_key(void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
 	static void _wl_keyboard_on_modifiers(void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group);
 	static void _wl_keyboard_on_repeat_info(void *data, struct wl_keyboard *wl_keyboard, int32_t rate, int32_t delay);
+
+	static void _wl_touch_on_down(void *data, struct wl_touch *wl_touch, uint32_t serial, uint32_t time, struct wl_surface *surface, int32_t id, wl_fixed_t x, wl_fixed_t y);
+	static void _wl_touch_on_up(void *data, struct wl_touch *wl_touch, uint32_t serial, uint32_t time, int32_t id);
+	static void _wl_touch_on_motion(void *data, struct wl_touch *wl_touch, uint32_t time, int32_t id, wl_fixed_t x, wl_fixed_t y);
+	static void _wl_touch_on_frame(void *data, struct wl_touch *wl_touch);
+	static void _wl_touch_on_cancel(void *data, struct wl_touch *wl_touch);
+	static void _wl_touch_on_shape(void *data, struct wl_touch *wl_touch, int32_t id, wl_fixed_t major, wl_fixed_t minor);
+	static void _wl_touch_on_orientation(void *data, struct wl_touch *wl_touch, int32_t id, wl_fixed_t orientation);
 
 	static void _wl_data_device_on_data_offer(void *data, struct wl_data_device *wl_data_device, struct wl_data_offer *id);
 	static void _wl_data_device_on_enter(void *data, struct wl_data_device *wl_data_device, uint32_t serial, struct wl_surface *surface, wl_fixed_t x, wl_fixed_t y, struct wl_data_offer *id);
@@ -929,6 +951,16 @@ private:
 		.key = _wl_keyboard_on_key,
 		.modifiers = _wl_keyboard_on_modifiers,
 		.repeat_info = _wl_keyboard_on_repeat_info,
+	};
+
+	static constexpr struct wl_touch_listener wl_touch_listener = {
+		.down = _wl_touch_on_down,
+		.up = _wl_touch_on_up,
+		.motion = _wl_touch_on_motion,
+		.frame = _wl_touch_on_frame,
+		.cancel = _wl_touch_on_cancel,
+		.shape = _wl_touch_on_shape,
+		.orientation = _wl_touch_on_orientation,
 	};
 
 	static constexpr struct wl_data_device_listener wl_data_device_listener = {
@@ -1257,6 +1289,8 @@ public:
 
 	ScreenData screen_get_data(int p_screen) const;
 	int get_screen_count() const;
+
+	bool input_has_touch() const;
 
 	void pointer_set_constraint(PointerConstraint p_constraint);
 	void pointer_set_hint(const Point2i &p_hint);


### PR DESCRIPTION
Fixes #95256.
Supersedes #113705.

~~Needs some testing with input cancellation (system gesture), as I can't seem trigger it on sway.~~ Tested on Fedora 43.

This went really smoothly but, as we need to implement embedded game focus and popup menu tracking (along other things), it's already quite chunky.

Because of this I won't be looking _yet_ to add simple gesture recognition, but it looks ~~surprisingly simple~~ doable in our case (we'll see in another PR). We also need to implement generic alternatives to the `input_devices/pointing/android/enable_pan_and_scale_gestures` and `input_devices/pointing/android/enable_long_press_as_right_click` project settings (the editor is already covered).

That said, unlike other desktop DSes, I implemented the `is_touchscreen_available` method, which tells supported controls to turn on touch awareness (like touch drag scrolling on `Tree`), and various touch aids (like the 3d navigation gizmos at startup).

This offsets a lot the fact that we don't implement gesture support yet and should make the experience on mobile touch devices a lot better, akin to the android editor in some ways.

Lastly, it looks like this exacerbated the "this should not happen" DS warning issue, and I finally figured out why: we need to track when we send window mouse enter/leave events in a single place, instead of sending them out from each individual pointing device handling logic. Since this issue is deeper rooted, I'll look into this in another PR.