### PR TITLE
Fix visible empty panel in scene dock

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1757,10 +1757,10 @@ void SceneTreeDock::_notification(int p_what) {
 			if (show_create_root != create_root_dialog->is_visible_in_tree() && !remote_tree->is_visible()) {
 				if (show_create_root) {
 					create_root_dialog->show();
-					scene_tree->hide();
+					main_mc->hide();
 				} else {
 					create_root_dialog->hide();
-					scene_tree->show();
+					main_mc->show();
 				}
 			}
 		} break;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/113884


[Screencast_20251211_130714.webm](https://github.com/user-attachments/assets/267b1c08-7fb3-46d6-a73f-bf713815d96b)
