### PR TITLE
Update EditorDock shortcut documentation

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -96,7 +96,7 @@
 			The icon for the dock, as a texture. If specified, it will override [member icon_name].
 		</member>
 		<member name="dock_shortcut" type="Shortcut" setter="set_dock_shortcut" getter="get_dock_shortcut">
-			The shortcut used to open the dock. This property can only be set before this dock is added via [method EditorPlugin.add_dock].
+			The shortcut used to open the dock.
 		</member>
 		<member name="force_show_icon" type="bool" setter="set_force_show_icon" getter="get_force_show_icon" default="false">
 			If [code]true[/code], the dock will always display an icon, regardless of [member EditorSettings.interface/editor/dock_tab_style] or [member EditorSettings.interface/editor/bottom_dock_tab_style].

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -431,7 +431,8 @@
 			<param index="2" name="shortcut" type="Shortcut" default="null" />
 			<description>
 				Adds a control to the bottom panel (together with Output, Debug, Animation, etc.). Returns a reference to a button that is outside the scene tree. It's up to you to hide/show the button when needed. When your plugin is deactivated, make sure to remove your custom control with [method remove_control_from_bottom_panel] and free it with [method Node.queue_free].
-				Optionally, you can specify a shortcut parameter. When pressed, this shortcut will toggle the bottom panel's visibility. See the default editor bottom panel shortcuts in the Editor Settings for inspiration. Per convention, they all use [kbd]Alt[/kbd] modifier.
+				[param shortcut] is a shortcut that, when activated, will toggle the bottom panel's visibility. The shortcut object is only set when this control is added to the bottom panel.
+				[b]Note[/b] See the default editor bottom panel shortcuts in the Editor Settings for inspiration. By convention, they all use [kbd]Alt[/kbd] modifier.
 			</description>
 		</method>
 		<method name="add_control_to_container">


### PR DESCRIPTION
Closes #113810

This PR updates the documentation for EditorDocks in two places.

First, the `EditorDock::shortcut` documentation was accurate when it was written, but after #108647 and the introduction of the `DockShortcutHandler` node, shortcuts are updated instantaneously (as the shortcut handler gets the shortcut of each dock each time `shortcut_input` is called). 

Secondly, since the `EditorBottomPanel` was refactored, the button that `add_control_to_bottom_panel` returns is no longer in the scene tree (or visible even if it was), so it cannot receive shortcut input through `BaseButton::shortcut_input` and therefore its shortcut cannot be dynamically updated.