### PR TITLE
Node3DEditorViewport: Prevent crash while handling input.  

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2204,8 +2204,10 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						if (_edit.original_mouse_pos != _edit.mouse_pos || _edit.gizmo->get_plugin()->can_commit_handle_on_click()) {
 							_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, false);
 						}
-
-						spatial_editor->get_single_selected_node()->update_gizmos();
+						Node3D *selected_node = spatial_editor->get_single_selected_node();
+						if (selected_node) {
+							selected_node->update_gizmos();
+						}
 						_edit.gizmo = Ref<EditorNode3DGizmo>();
 						break;
 					}


### PR DESCRIPTION
 The selection might change before the user releases the mouse pointer, and this would crash the editor.

This follows the same check that is done in ::_update_gizmos

Found in Xogot's crash reports, four crashes in the last month.