### PR TITLE
Fix incorrect sky luminance multiplier for Mobile HDR 2D.

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1026,7 +1026,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	bool draw_sky_fog_only = false;
 	// We invert luminance_multiplier for sky so that we can combine it with exposure value.
 	float inverse_luminance_multiplier = 1.0 / rb->get_luminance_multiplier();
-	float sky_luminance_multiplier = 1.0 / 2.0; // Hardcoded since sky always uses LDR in the mobile renderer
+	float sky_luminance_multiplier = inverse_luminance_multiplier;
 	float sky_brightness_multiplier = 1.0;
 
 	Color clear_color = p_default_bg_color;


### PR DESCRIPTION
- Fixes #113597

## Notes to reviewers

This PR reverts a small part of #109971.

I don't understand this code: it seems the `inverse_luminance_multiplier` and `sky_luminance_multiplier` need to be identical, even though the sky buffer should be always using a RGB10A2 buffer? I'm not familiar with the sky codebase, so I'm not sure if further cleaning up is needed here... but this change at least fixes the bug.