### PR TITLE
Debugger: Rather than looping infinitely on data read errors, drop the connection.

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -129,6 +129,7 @@ void RemoteDebuggerPeerTCP::_write_out() {
 void RemoteDebuggerPeerTCP::_read_in() {
 	while (tcp_client->get_status() == StreamPeerTCP::STATUS_CONNECTED && tcp_client->wait(NetSocket::POLL_TYPE_IN) == OK) {
 		uint8_t *buf = in_buf.ptrw();
+		Error err = OK;
 		if (in_left <= 0) {
 			if (in_queue.size() > max_queued_messages) {
 				break; // Too many messages already in queue.
@@ -138,18 +139,29 @@ void RemoteDebuggerPeerTCP::_read_in() {
 			}
 			uint32_t size = 0;
 			int read = 0;
-			Error err = tcp_client->get_partial_data((uint8_t *)&size, 4, read);
-			ERR_CONTINUE(read != 4 || err != OK || size > (uint32_t)in_buf.size());
+			err = tcp_client->get_partial_data((uint8_t *)&size, 4, read);
+			if (err != OK || read != 4) {
+				_disconnect_with_error("Remote debugger: Connection lost while reading packet size.");
+				return;
+			}
+			if (size > (uint32_t)in_buf.size()) {
+				_disconnect_with_error(vformat("Remote debugger: Packet too large (%s > %s bytes). Disconnecting.", String::num_uint64(size), String::num_int64(in_buf.size())));
+				return;
+			}
 			in_left = size;
 			in_pos = 0;
 		}
 		int read = 0;
-		tcp_client->get_partial_data(buf + in_pos, in_left, read);
+		err = tcp_client->get_partial_data(buf + in_pos, in_left, read);
+		if (err != OK || read == 0) {
+			_disconnect_with_error("Remote debugger: Connection lost while reading packet payload.");
+			return;
+		}
 		in_left -= read;
 		in_pos += read;
 		if (in_left == 0) {
 			Variant var;
-			Error err = decode_variant(var, buf, in_pos, &read);
+			err = decode_variant(var, buf, in_pos, &read);
 			ERR_CONTINUE(read != in_pos || err != OK);
 			ERR_CONTINUE_MSG(var.get_type() != Variant::ARRAY, "Malformed packet received, not an Array.");
 			MutexLock lock(mutex);
@@ -251,4 +263,9 @@ Ref<RemoteDebuggerPeer> RemoteDebuggerPeerTCP::create_unix(const String &p_uri) 
 
 RemoteDebuggerPeer::RemoteDebuggerPeer() {
 	max_queued_messages = (int)GLOBAL_GET("network/limits/debugger/max_queued_messages");
+}
+
+void RemoteDebuggerPeerTCP::_disconnect_with_error(const String &p_reason) {
+	ERR_PRINT(p_reason);
+	tcp_client->disconnect_from_host();
 }

--- a/core/debugger/remote_debugger_peer.h
+++ b/core/debugger/remote_debugger_peer.h
@@ -79,6 +79,7 @@ private:
 	void _poll();
 	void _write_out();
 	void _read_in();
+	void _disconnect_with_error(const String &p_reason);
 	static Error _try_connect(Ref<StreamPeerSocket> p_stream);
 
 public:


### PR DESCRIPTION
Another one of those bugs that are showing up in the Xogot telemetry in the wild.

There are various bug reports on here and on reddit for cases where the debugger fails to decode a message, and in som cases, it can crash the editor:

https://github.com/godotengine/godot/issues/102387

https://github.com/godotengine/godot/issues/94212

https://www.reddit.com/r/godot/comments/1kjy80s/remote_debugger_breaking_in_my_projects_after/

This patch would stop the debugger on its tracks, and at least prevent the editor from crashing, but someone that knows better how the debugger works should probably review this.