### PR TITLE
Add `physics_space_override` to `TileMapLayer` for functionally-3D games

### DIFF
--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -140,6 +140,13 @@
 				Creates and returns a new [TileMapPattern] from the given array of cells. See also [method set_pattern].
 			</description>
 		</method>
+		<method name="get_physics_space" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of the [PhysicsServer2D] space used by this [TileMapLayer].
+				By default this returns the default [World2D] physics space, unless a custom space was provided using [method set_physics_space].
+			</description>
+		</method>
 		<method name="get_surrounding_cells">
 			<return type="Vector2i[]" />
 			<param index="0" name="coords" type="Vector2i" />
@@ -281,6 +288,13 @@
 			<param index="1" name="pattern" type="TileMapPattern" />
 			<description>
 				Pastes the [TileMapPattern] at the given [param position] in the tile map. See also [method get_pattern].
+			</description>
+		</method>
+		<method name="set_physics_space">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<description>
+				Sets a custom [param space] as a [PhysicsServer2D] physics space. If not set, uses the default [World2D] physics space instead.
 			</description>
 		</method>
 		<method name="update_internals">

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -42,7 +42,7 @@
 
 #ifndef PHYSICS_2D_DISABLED
 #include "servers/physics_2d/physics_server_2d.h"
-#endif // PHYSICS_3D_DISABLED
+#endif // PHYSICS_2D_DISABLED
 
 #ifndef NAVIGATION_2D_DISABLED
 #include "servers/navigation_2d/navigation_server_2d.h"
@@ -784,11 +784,11 @@ void TileMapLayer::_physics_update(bool p_force_cleanup) {
 	}
 
 	if (!forced_cleanup) {
-		RID space = get_world_2d()->get_space();
+		RID space = physics_space_override.is_valid() ? physics_space_override : get_world_2d()->get_space();
 		Transform2D gl_transform = get_global_transform();
 
 		// List all quadrants to update, recreating them if needed.
-		if (dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE] || _physics_was_cleaned_up) {
+		if (dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE] || _physics_was_cleaned_up || dirty.flags[DIRTY_FLAGS_LAYER_PHYSICS_SPACE]) {
 			// Update all cells.
 			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
 				CellData &cell_data = kv.value;
@@ -1065,7 +1065,7 @@ void TileMapLayer::_physics_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 			// Changes in the tree may cause the space to change (e.g. when reparenting to a SubViewport).
 			if (is_inside_tree()) {
-				RID space = get_world_2d()->get_space();
+				RID space = physics_space_override.is_valid() ? physics_space_override : get_world_2d()->get_space();
 
 				for (KeyValue<Vector2i, Ref<PhysicsQuadrant>> &kv : physics_quadrant_map) {
 					for (const KeyValue<PhysicsQuadrant::PhysicsBodyKey, PhysicsQuadrant::PhysicsBodyValue> &kvbody : kv.value->bodies) {
@@ -2248,6 +2248,11 @@ void TileMapLayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_quadrant_size", "size"), &TileMapLayer::set_physics_quadrant_size);
 	ClassDB::bind_method(D_METHOD("get_physics_quadrant_size"), &TileMapLayer::get_physics_quadrant_size);
 
+#ifndef PHYSICS_2D_DISABLED
+	ClassDB::bind_method(D_METHOD("set_physics_space", "space"), &TileMapLayer::set_physics_space);
+	ClassDB::bind_method(D_METHOD("get_physics_space"), &TileMapLayer::get_physics_space);
+#endif // PHYSICS_2D_DISABLED
+
 	ClassDB::bind_method(D_METHOD("set_occlusion_enabled", "enabled"), &TileMapLayer::set_occlusion_enabled);
 	ClassDB::bind_method(D_METHOD("is_occlusion_enabled"), &TileMapLayer::is_occlusion_enabled);
 
@@ -3394,6 +3399,27 @@ void TileMapLayer::set_collision_enabled(bool p_enabled) {
 bool TileMapLayer::is_collision_enabled() const {
 	return collision_enabled;
 }
+
+#ifndef PHYSICS_2D_DISABLED
+void TileMapLayer::set_physics_space(RID p_space) {
+	if (physics_space_override == p_space) {
+		return;
+	}
+	physics_space_override = p_space;
+	dirty.flags[DIRTY_FLAGS_LAYER_PHYSICS_SPACE] = true;
+	_queue_internal_update();
+	emit_signal(CoreStringName(changed));
+}
+
+RID TileMapLayer::get_physics_space() const {
+	if (physics_space_override.is_valid()) {
+		return physics_space_override;
+	} else if (is_inside_tree()) {
+		return get_world_2d()->get_space();
+	}
+	return RID();
+}
+#endif // PHYSICS_2D_DISABLED
 
 void TileMapLayer::set_use_kinematic_bodies(bool p_use_kinematic_bodies) {
 	if (use_kinematic_bodies == p_use_kinematic_bodies) {

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -361,6 +361,7 @@ public:
 		DIRTY_FLAGS_LAYER_TEXTURE_REPEAT,
 		DIRTY_FLAGS_LAYER_RENDERING_QUADRANT_SIZE,
 		DIRTY_FLAGS_LAYER_COLLISION_ENABLED,
+		DIRTY_FLAGS_LAYER_PHYSICS_SPACE,
 		DIRTY_FLAGS_LAYER_USE_KINEMATIC_BODIES,
 		DIRTY_FLAGS_LAYER_PHYSICS_QUADRANT_SIZE,
 		DIRTY_FLAGS_LAYER_COLLISION_VISIBILITY_MODE,
@@ -397,6 +398,7 @@ private:
 	int rendering_quadrant_size = 16;
 
 	bool collision_enabled = true;
+	RID physics_space_override;
 	bool use_kinematic_bodies = false;
 	int physics_quadrant_size = 16;
 	DebugVisibilityMode collision_visibility_mode = DEBUG_VISIBILITY_MODE_DEFAULT;
@@ -624,6 +626,8 @@ public:
 
 	void set_collision_enabled(bool p_enabled);
 	bool is_collision_enabled() const;
+	void set_physics_space(RID p_space);
+	RID get_physics_space() const;
 	void set_use_kinematic_bodies(bool p_use_kinematic_bodies);
 	bool is_using_kinematic_bodies() const;
 	void set_collision_visibility_mode(DebugVisibilityMode p_show_collision);


### PR DESCRIPTION
**Associated proposal:** [13837](https://github.com/godotengine/godot-proposals/issues/13837)

**Reason of this pr:**
Easily create isolated Z-levels in 2D games, [to leave collision layers for game-mechanics rather than level design.](https://www.reddit.com/r/godot/comments/1fkhvwy/is_there_any_way_to_access_the_collisionbodies_of/)

**Implementation:**
Added TileMapLayer physics_space_override RID member variable and its setter/getter functions, in the same way as already-present navigation_map_override.
When not set, as navigation_map_override, the TileMapLayer will fall back to use its world2D.space

**Usage scenarios:**
Can be used in any game requiring isolated physics contexts for different visual layers, such as multi-floor buildings or Dwarf Fortress-style games.

```GDScript
var floor1_space: RID = PhysicsServer2D.space_create()
var floor2_space: RID = PhysicsServer2D.space_create()

$Floor1TileMapLayer.set_physics_space(floor1_space)
$Floor2TileMapLayer.set_physics_space(floor2_space)
``` 

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/13837*