### PR TITLE
Prevent locked and child nodes of selection groups from being selected in the Game view

### DIFF
--- a/editor/run/game_view_plugin.h
+++ b/editor/run/game_view_plugin.h
@@ -55,6 +55,9 @@ private:
 	bool mute_audio = false;
 	EditorDebuggerNode::CameraOverride camera_override_mode = EditorDebuggerNode::OVERRIDE_INGAME;
 
+	bool selection_avoid_locked = false;
+	bool selection_prefer_group = false;
+
 	void _session_started(Ref<EditorDebuggerSession> p_session);
 	void _session_stopped();
 
@@ -90,6 +93,9 @@ public:
 
 	void set_selection_visible(bool p_visible);
 
+	void set_selection_avoid_locked(bool p_enabled);
+	void set_selection_prefer_group(bool p_enabled);
+
 	void set_debug_mute_audio(bool p_enabled);
 
 	void set_camera_override(bool p_enabled);
@@ -113,6 +119,8 @@ class GameView : public VBoxContainer {
 		CAMERA_MODE_EDITORS,
 		EMBED_RUN_GAME_EMBEDDED,
 		EMBED_MAKE_FLOATING_ON_PLAY,
+		SELECTION_AVOID_LOCKED,
+		SELECTION_PREFER_GROUP,
 	};
 
 	enum EmbedSizeMode {
@@ -153,6 +161,9 @@ class GameView : public VBoxContainer {
 
 	bool debug_mute_audio = false;
 
+	bool selection_avoid_locked = false;
+	bool selection_prefer_group = false;
+
 	Button *suspend_button = nullptr;
 	Button *next_frame_button = nullptr;
 
@@ -160,6 +171,7 @@ class GameView : public VBoxContainer {
 	Button *select_mode_button[RuntimeNodeSelect::SELECT_MODE_MAX];
 
 	Button *hide_selection = nullptr;
+	MenuButton *selection_options_menu = nullptr;
 
 	Button *debug_mute_audio_button = nullptr;
 
@@ -191,6 +203,7 @@ class GameView : public VBoxContainer {
 
 	void _node_type_pressed(int p_option);
 	void _select_mode_pressed(int p_option);
+	void _selection_options_menu_id_pressed(int p_id);
 	void _embed_options_menu_menu_id_pressed(int p_id);
 
 	void _reset_time_scales();

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -415,6 +415,20 @@ Error SceneDebugger::_msg_runtime_node_select_set_visible(const Array &p_args) {
 	return OK;
 }
 
+Error SceneDebugger::_msg_runtime_node_select_set_avoid_locked(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
+	bool avoid_locked = p_args[0];
+	RuntimeNodeSelect::get_singleton()->_set_avoid_locked(avoid_locked);
+	return OK;
+}
+
+Error SceneDebugger::_msg_runtime_node_select_set_prefer_group(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
+	bool prefer_group = p_args[0];
+	RuntimeNodeSelect::get_singleton()->_set_prefer_group(prefer_group);
+	return OK;
+}
+
 Error SceneDebugger::_msg_runtime_node_select_reset_camera_2d(const Array &p_args) {
 	RuntimeNodeSelect::get_singleton()->_reset_camera_2d();
 	return OK;
@@ -567,6 +581,8 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["runtime_node_select_set_type"] = _msg_runtime_node_select_set_type;
 	message_handlers["runtime_node_select_set_mode"] = _msg_runtime_node_select_set_mode;
 	message_handlers["runtime_node_select_set_visible"] = _msg_runtime_node_select_set_visible;
+	message_handlers["runtime_node_select_set_avoid_locked"] = _msg_runtime_node_select_set_avoid_locked;
+	message_handlers["runtime_node_select_set_prefer_group"] = _msg_runtime_node_select_set_prefer_group;
 	message_handlers["runtime_node_select_reset_camera_2d"] = _msg_runtime_node_select_reset_camera_2d;
 #ifndef _3D_DISABLED
 	message_handlers["runtime_node_select_reset_camera_3d"] = _msg_runtime_node_select_reset_camera_3d;
@@ -1859,18 +1875,6 @@ void RuntimeNodeSelect::_physics_frame() {
 			}
 		}
 
-		// Remove possible duplicates.
-		for (int i = 0; i < items.size(); i++) {
-			Node *item = items[i].item;
-			for (int j = 0; j < i; j++) {
-				if (items[j].item == item) {
-					items.remove_at(i);
-					i--;
-
-					break;
-				}
-			}
-		}
 #ifndef _3D_DISABLED
 	} else if (node_select_type == NODE_TYPE_3D) {
 		if (selection_drag_valid) {
@@ -1879,6 +1883,57 @@ void RuntimeNodeSelect::_physics_frame() {
 			_find_3d_items_at_pos(selection_position, items);
 		}
 #endif // _3D_DISABLED
+	}
+
+	if ((prefer_group_selection || avoid_locked_nodes) && !list_shortcut_pressed && node_select_mode == SELECT_MODE_SINGLE) {
+		for (int i = 0; i < items.size(); i++) {
+			Node *node = items[i].item;
+			Node *final_node = node;
+			real_t order = items[i].order;
+
+			// Replace the node by the group if grouped.
+			if (prefer_group_selection) {
+				while (node && node != root) {
+					if (node->has_meta("_edit_group_")) {
+						final_node = node;
+
+						if (Object::cast_to<CanvasItem>(final_node)) {
+							CanvasItem *ci_tmp = Object::cast_to<CanvasItem>(final_node);
+							order = ci_tmp->get_effective_z_index() + ci_tmp->get_canvas_layer();
+						} else if (Object::cast_to<Node3D>(final_node)) {
+							Node3D *node3d_tmp = Object::cast_to<Node3D>(final_node);
+							Camera3D *camera = root->get_camera_3d();
+							Vector3 pos = camera->project_ray_origin(selection_position);
+							order = -pos.distance_to(node3d_tmp->get_global_transform().origin);
+						}
+					}
+					node = node->get_parent();
+				}
+			}
+
+			// Filter out locked nodes.
+			if (avoid_locked_nodes && final_node->get_meta("_edit_lock_", false)) {
+				items.remove_at(i);
+				i--;
+				continue;
+			}
+
+			items.write[i].item = final_node;
+			items.write[i].order = order;
+		}
+	}
+
+	// Remove possible duplicates.
+	for (int i = 0; i < items.size(); i++) {
+		Node *item = items[i].item;
+		for (int j = 0; j < i; j++) {
+			if (items[j].item == item) {
+				items.remove_at(i);
+				i--;
+
+				break;
+			}
+		}
 	}
 
 	items.sort();
@@ -2334,7 +2389,29 @@ void RuntimeNodeSelect::_open_selection_list(const Vector<SelectResult> &p_items
 	root->add_child(selection_list);
 
 	for (const SelectResult &I : p_items) {
-		selection_list->add_item(I.item->get_name());
+		int locked = 0;
+		if (I.item->get_meta("_edit_lock_", false)) {
+			locked = 1;
+		} else {
+			Node *scene = SceneTree::get_singleton()->get_root();
+			Node *node = I.item;
+
+			while (node && node != scene->get_parent()) {
+				if (node->has_meta("_edit_group_")) {
+					locked = 2;
+				}
+				node = node->get_parent();
+			}
+		}
+
+		String suffix;
+		if (locked == 1) {
+			suffix = " (" + RTR("Locked") + ")";
+		} else if (locked == 2) {
+			suffix = " (" + RTR("Grouped") + ")";
+		}
+
+		selection_list->add_item((String)I.item->get_name() + suffix);
 		selection_list->set_item_metadata(-1, I.item);
 	}
 
@@ -2356,6 +2433,14 @@ void RuntimeNodeSelect::_set_selection_visible(bool p_visible) {
 	if (has_selection) {
 		_update_selection();
 	}
+}
+
+void RuntimeNodeSelect::_set_avoid_locked(bool p_enabled) {
+	avoid_locked_nodes = p_enabled;
+}
+
+void RuntimeNodeSelect::_set_prefer_group(bool p_enabled) {
+	prefer_group_selection = p_enabled;
 }
 
 // Copied and trimmed from the CanvasItemEditor implementation.

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -115,6 +115,8 @@ private:
 	static Error _msg_runtime_node_select_set_type(const Array &p_args);
 	static Error _msg_runtime_node_select_set_mode(const Array &p_args);
 	static Error _msg_runtime_node_select_set_visible(const Array &p_args);
+	static Error _msg_runtime_node_select_set_avoid_locked(const Array &p_args);
+	static Error _msg_runtime_node_select_set_prefer_group(const Array &p_args);
 	static Error _msg_rq_screenshot(const Array &p_args);
 
 	static Error _msg_runtime_node_select_reset_camera_2d(const Array &p_args);
@@ -280,6 +282,9 @@ private:
 	bool selection_visible = true;
 	bool selection_update_queued = false;
 
+	bool avoid_locked_nodes = false;
+	bool prefer_group_selection = false;
+
 	bool multi_shortcut_pressed = false;
 	bool list_shortcut_pressed = false;
 	RID draw_canvas;
@@ -396,6 +401,8 @@ private:
 	void _clear_selection();
 	void _update_selection_drag(const Point2 &p_end_pos = Point2());
 	void _set_selection_visible(bool p_visible);
+	void _set_avoid_locked(bool p_enabled);
+	void _set_prefer_group(bool p_enabled);
 
 	void _open_selection_list(const Vector<SelectResult> &p_items, const Point2 &p_pos);
 	void _close_selection_list();


### PR DESCRIPTION
- Fix https://github.com/godotengine/godot/issues/113892

This makes selection in the Game view work like in the 2D/3D view, where regular selection skips locked nodes or selects the parent when it's the child of a selection group. Also, like in the main views, these nodes are still included when in list mode with a suffix "(Locked)" or "(Grouped)".