### PR TITLE
Tweak Quick Settings dialog to ensure labels and dropdowns are aligned

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1287,7 +1287,7 @@
 			The renderer type that will be checked off by default when creating a new project. Accepted strings are "forward_plus", "mobile" or "gl_compatibility".
 		</member>
 		<member name="project_manager/directory_naming_convention" type="int" setter="" getter="">
-			Directory naming convention for the project manager. Options are "No convention" (project name is directory name), "kebab-case" (default), "snake_case", "camelCase", "PascalCase", or "Title Case".
+			Directory naming convention for the project manager. Options are "No Convention" (project name is directory name), "kebab-case" (default), "snake_case", "camelCase", "PascalCase", or "Title Case".
 		</member>
 		<member name="project_manager/sorting_order" type="int" setter="" getter="">
 			The sorting order to use in the project manager. When changing the sorting order in the project manager, this setting is set permanently in the editor settings.

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -305,7 +305,7 @@ void ProjectDialog::_update_target_auto_dir() {
 	}
 	int naming_convention = (int)EDITOR_GET("project_manager/directory_naming_convention");
 	switch (naming_convention) {
-		case 0: // No convention
+		case 0: // No Convention
 			break;
 		case 1: // kebab-case
 			new_auto_dir = new_auto_dir.to_kebab_case();

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -175,7 +175,6 @@ void QuickSettingsDialog::_add_setting_control(const String &p_text, Control *p_
 	container->add_child(label);
 
 	p_control->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	p_control->set_stretch_ratio(2.0);
 	container->add_child(p_control);
 }
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1123,7 +1123,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// TRANSLATORS: Project Manager here refers to the tool used to create/manage Godot projects.
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Last Edited,Name,Path")
-	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/directory_naming_convention", 1, "No convention,kebab-case,snake_case,camelCase,PascalCase,Title Case")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/directory_naming_convention", 1, "No Convention,kebab-case,snake_case,camelCase,PascalCase,Title Case")
 
 #if defined(WEB_ENABLED)
 	// Web platform only supports `gl_compatibility`.


### PR DESCRIPTION
Previously, there was a slight misalignment between all other quick settings and Directory Naming Convention due to its long name.

~~While not technically required, this renames the editor setting so that it can be found easily with a search.
I can add compatibility code to migrate existing settings if needed. Do we have a mechanism in place for this currently?~~

This also renames the **No Convention** value to use Title Case like other dropdown options in the editor.

## Preview

<img width="631" height="319" alt="Image" src="https://github.com/user-attachments/assets/81362a39-2b77-49ef-a935-3339f8131272" />

<details>
<summary>Old version</summary>

Before | After
-|-
<img width="630" height="270" alt="Screenshot_20251212_012146" src="https://github.com/user-attachments/assets/ae8adf55-7e97-437c-a5f3-afa102733975" /> | <img width="630" height="270" alt="Screenshot_20251212_014159" src="https://github.com/user-attachments/assets/3bc5ac07-c2fe-4fe0-95b9-06db93923961" />
</details>