### PR TITLE
Allow searching for editor shortcuts by section

### DIFF
--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -107,7 +107,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	PropertyInfo _create_mouse_shortcut_property_info(const String &p_property_name, const String &p_shortcut_1_name, const String &p_shortcut_2_name);
 	String _get_shortcut_button_string(const String &p_shortcut_name);
 
-	bool _should_display_shortcut(const String &p_name, const Array &p_events, bool p_match_localized_name) const;
+	bool _should_display_shortcut(const String &p_section, const String &p_section_tr, const String &p_name, const Array &p_events, bool p_match_localized_name) const;
 
 	void _update_shortcuts();
 	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button = MouseButton::LEFT);


### PR DESCRIPTION
This PR allows searching for editor shortcuts by section, and every shortcut under that section is shown. Previously when searching for shortcuts I found it really annoying to search for shortcuts related to search for shortcuts that only work in a specific context, in the TileMap dock for example. This PR allows for searching based on section names in addition to shortcut names.

| Before | After |
| - | - |
| <img width="901" height="731" src="https://github.com/user-attachments/assets/b53aa8c6-10f2-4f39-ad48-6288b601311e" /> | <img width="1048" height="793" src="https://github.com/user-attachments/assets/470fac71-b1e8-4e57-bf6e-300581894710" /> |

Note how before, none of the shortcuts I was actually searching for appeared, but after all of them did.