### PR TITLE
Fix completion popup contrast in Modern light theme

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1569,6 +1569,7 @@ void CodeTextEditor::goto_error() {
 
 void CodeTextEditor::_update_text_editor_theme() {
 	emit_signal(SNAME("load_theme_settings"));
+	update_editor_settings();
 
 	const Ref<Font> status_bar_font = get_theme_font(SNAME("status_source"), EditorStringName(EditorFonts));
 	const int status_bar_font_size = get_theme_font_size(SNAME("status_source_size"), EditorStringName(EditorFonts));

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -509,9 +509,9 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 
 			// Use the brightest background color on a light theme (which generally uses a negative contrast rate).
 			colors["text_editor/theme/highlighting/background_color"] = p_config.dark_icon_and_font ? p_config.dark_color_2 : p_config.dark_color_3;
-			colors["text_editor/theme/highlighting/completion_background_color"] = p_config.dark_icon_and_font ? p_config.base_color : p_config.dark_color_2;
-			colors["text_editor/theme/highlighting/completion_selected_color"] = alpha1;
-			colors["text_editor/theme/highlighting/completion_existing_color"] = alpha2;
+			colors["text_editor/theme/highlighting/completion_background_color"] = p_config.dark_icon_and_font ? p_config.base_color : p_config.mono_color_inv.lerp(p_config.mono_color, 0.05);
+			colors["text_editor/theme/highlighting/completion_selected_color"] = p_config.dark_icon_and_font ? alpha1 : p_config.mono_color_inv.lerp(p_config.mono_color, 0.12);
+			colors["text_editor/theme/highlighting/completion_existing_color"] = p_config.dark_icon_and_font ? alpha2 : p_config.mono_color_inv.lerp(p_config.mono_color, 0.35);
 			// Same opacity as the scroll grabber editor icon.
 			colors["text_editor/theme/highlighting/completion_scroll_color"] = Color(mono_value, mono_value, mono_value, 0.29);
 			colors["text_editor/theme/highlighting/completion_scroll_hovered_color"] = Color(mono_value, mono_value, mono_value, 0.4);


### PR DESCRIPTION
## Description

When using a modern theme with a light color preset, the auto-completion has very low contrast and transparency, which makes it unreadable.

Before:

<img width="676" height="225" alt="2025-12-12_13-52-07" src="https://github.com/user-attachments/assets/66b0bcff-ce0d-49c4-99a3-7c98045be446" />

After:

<img width="642" height="215" alt="image" src="https://github.com/user-attachments/assets/db02e299-04c1-4318-b803-6e2dc559fc8d" />


## Problem

The background of the autocomplete does not have sufficient contrast

## Related Issues

Fixes #113907 
