### PR TITLE
Optimize `Geometry2D::make_atlas` by reserving result vector

### DIFF
--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -160,6 +160,7 @@ void Geometry2D::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_re
 	int widest = wrects[0].s.width;
 
 	Vector<_AtlasWorkRectResult> results;
+	results.reserve(13);
 
 	for (int i = 0; i <= 12; i++) {
 		int w = 1 << i;


### PR DESCRIPTION
This change improves `Geometry2D::make_atlas` performance with pre-allocating result vector.