### PR TITLE
Remove underscore from parameter name in `FileAccess::set_extended_attribute_string`

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -1122,7 +1122,7 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_extended_attribute", "file", "attribute_name"), &FileAccess::get_extended_attribute);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_extended_attribute_string", "file", "attribute_name"), &FileAccess::get_extended_attribute_string);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("set_extended_attribute", "file", "attribute_name", "data"), &FileAccess::set_extended_attribute);
-	ClassDB::bind_static_method("FileAccess", D_METHOD("set_extended_attribute_string", "file", "attribute_name", "_data"), &FileAccess::set_extended_attribute_string);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("set_extended_attribute_string", "file", "attribute_name", "data"), &FileAccess::set_extended_attribute_string);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("remove_extended_attribute", "file", "attribute_name"), &FileAccess::remove_extended_attribute);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_extended_attributes_list", "file"), &FileAccess::get_extended_attributes_list);
 

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -445,7 +445,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="file" type="String" />
 			<param index="1" name="attribute_name" type="String" />
-			<param index="2" name="_data" type="String" />
+			<param index="2" name="data" type="String" />
 			<description>
 				Writes file extended attribute with name [param attribute_name] as a UTF-8 encoded string.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.


### PR DESCRIPTION
No other parameter is prefixed by an underscore in any Godot APIs, so this must be a typo.

- Follow-up to https://github.com/godotengine/godot/pull/102232.