### PR TITLE
Shader Blend Attachments

### DIFF
--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -52,10 +52,17 @@ struct ShaderData {
 	String path;
 	HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
 	HashMap<StringName, HashMap<int, RID>> default_texture_params;
+	GLenum color_blend_op;
+	GLenum dst_alpha_blend_factor;
+	GLenum dst_color_blend_factor;
+	GLenum src_alpha_blend_factor;
+	GLenum src_color_blend_factor;
+	bool uses_color_pass_blend_attachment = false;
 
 	virtual void set_path_hint(const String &p_hint);
 	virtual void set_default_texture_parameter(const StringName &p_name, RID p_texture, int p_index);
 	virtual Variant get_default_parameter(const StringName &p_parameter) const;
+	virtual void set_color_pass_blend_state(const Ref<RDPipelineColorBlendState> &p_value);
 	virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 	virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 	virtual bool is_parameter_texture(const StringName &p_param) const;
@@ -78,6 +85,7 @@ struct Shader {
 	String path_hint;
 	RS::ShaderMode mode;
 	HashMap<StringName, HashMap<int, RID>> default_texture_parameter;
+	Ref<RDPipelineColorBlendState> color_pass_blend_state;
 	HashSet<Material *> owners;
 };
 
@@ -609,6 +617,9 @@ public:
 	virtual void shader_set_default_texture_parameter(RID p_shader, const StringName &p_name, RID p_texture, int p_index) override;
 	virtual RID shader_get_default_texture_parameter(RID p_shader, const StringName &p_name, int p_index) const override;
 	virtual Variant shader_get_parameter_default(RID p_shader, const StringName &p_name) const override;
+
+	virtual void shader_set_color_pass_blend_state(RID p_shader, const Ref<RDPipelineColorBlendState> &p_value) override;
+	virtual Ref<RDPipelineColorBlendState> shader_get_color_pass_blend_state(RID p_shader) const override;
 
 	virtual RS::ShaderNativeSourceCode shader_get_native_source_code(RID p_shader) const override;
 	virtual void shader_embedded_set_lock() override {}

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -101,6 +101,9 @@ public:
 	virtual RID shader_get_default_texture_parameter(RID p_shader, const StringName &p_name, int p_index) const override { return RID(); }
 	virtual Variant shader_get_parameter_default(RID p_material, const StringName &p_param) const override { return Variant(); }
 
+	virtual void shader_set_color_pass_blend_state(RID p_shader, const Ref<RDPipelineColorBlendState> &p_value) override {}
+	virtual Ref<RDPipelineColorBlendState> shader_get_color_pass_blend_state(RID p_shader) const override { return nullptr; }
+
 	virtual RS::ShaderNativeSourceCode shader_get_native_source_code(RID p_shader) const override { return RS::ShaderNativeSourceCode(); }
 	virtual void shader_embedded_set_lock() override {}
 	virtual const HashSet<RID> &shader_embedded_set_get() const override { return dummy_embedded_set; }

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -453,6 +453,9 @@ void SceneShaderForwardClustered::ShaderData::_create_pipeline(PipelineKey p_pip
 				depth_stencil_state.enable_depth_write = false;
 			}
 		}
+		if (uses_color_pass_blend_state) {
+			blend_state = color_pass_blend_state;
+		}
 	} else {
 		switch (p_pipeline_key.version) {
 			case PIPELINE_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS:

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -393,7 +393,7 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 		}
 
 		if (p_pipeline_key.version == SHADER_VERSION_COLOR_PASS || p_pipeline_key.version == SHADER_VERSION_COLOR_PASS_MULTIVIEW || p_pipeline_key.version == SHADER_VERSION_LIGHTMAP_COLOR_PASS || p_pipeline_key.version == SHADER_VERSION_LIGHTMAP_COLOR_PASS_MULTIVIEW || p_pipeline_key.version == SHADER_VERSION_MOTION_VECTORS_MULTIVIEW) {
-			blend_state = blend_state_blend;
+			blend_state = (uses_color_pass_blend_state) ? color_pass_blend_state : blend_state_blend;
 			if (depth_draw == DEPTH_DRAW_OPAQUE && !uses_alpha_clip) {
 				// Alpha does not write to depth.
 				depth_stencil_state.enable_depth_write = false;
@@ -408,7 +408,7 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 		}
 	} else {
 		if (p_pipeline_key.version == SHADER_VERSION_COLOR_PASS || p_pipeline_key.version == SHADER_VERSION_COLOR_PASS_MULTIVIEW || p_pipeline_key.version == SHADER_VERSION_LIGHTMAP_COLOR_PASS || p_pipeline_key.version == SHADER_VERSION_LIGHTMAP_COLOR_PASS_MULTIVIEW || p_pipeline_key.version == SHADER_VERSION_MOTION_VECTORS_MULTIVIEW) {
-			blend_state = blend_state_opaque;
+			blend_state = (uses_color_pass_blend_state) ? color_pass_blend_state : blend_state_opaque;
 		} else if (p_pipeline_key.version == SHADER_VERSION_SHADOW_PASS || p_pipeline_key.version == SHADER_VERSION_SHADOW_PASS_MULTIVIEW || p_pipeline_key.version == SHADER_VERSION_SHADOW_PASS_DP) {
 			// Contains nothing.
 		} else if (p_pipeline_key.version == SHADER_VERSION_DEPTH_PASS_WITH_MATERIAL) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1499,24 +1499,28 @@ void RendererCanvasRenderRD::CanvasShaderData::_create_pipeline(PipelineKey p_pi
 			"LCD:", p_pipeline_key.lcd_blend);
 #endif
 
-	RendererRD::MaterialStorage::ShaderData::BlendMode blend_mode_rd = RendererRD::MaterialStorage::ShaderData::BlendMode(blend_mode);
 	RD::PipelineColorBlendState blend_state;
-	RD::PipelineColorBlendState::Attachment attachment;
 	uint32_t dynamic_state_flags = 0;
-	if (p_pipeline_key.lcd_blend) {
-		attachment.enable_blend = true;
-		attachment.alpha_blend_op = RD::BLEND_OP_ADD;
-		attachment.color_blend_op = RD::BLEND_OP_ADD;
-		attachment.src_color_blend_factor = RD::BLEND_FACTOR_CONSTANT_COLOR;
-		attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_COLOR;
-		attachment.src_alpha_blend_factor = RD::BLEND_FACTOR_ONE;
-		attachment.dst_alpha_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-		dynamic_state_flags = RD::DYNAMIC_STATE_BLEND_CONSTANTS;
+	if (uses_color_pass_blend_state) {
+		blend_state = color_pass_blend_state;
 	} else {
-		attachment = RendererRD::MaterialStorage::ShaderData::blend_mode_to_blend_attachment(blend_mode_rd);
-	}
+		RendererRD::MaterialStorage::ShaderData::BlendMode blend_mode_rd = RendererRD::MaterialStorage::ShaderData::BlendMode(blend_mode);
+		RD::PipelineColorBlendState::Attachment attachment;
+		if (p_pipeline_key.lcd_blend) {
+			attachment.enable_blend = true;
+			attachment.alpha_blend_op = RD::BLEND_OP_ADD;
+			attachment.color_blend_op = RD::BLEND_OP_ADD;
+			attachment.src_color_blend_factor = RD::BLEND_FACTOR_CONSTANT_COLOR;
+			attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_COLOR;
+			attachment.src_alpha_blend_factor = RD::BLEND_FACTOR_ONE;
+			attachment.dst_alpha_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+			dynamic_state_flags = RD::DYNAMIC_STATE_BLEND_CONSTANTS;
+		} else {
+			attachment = RendererRD::MaterialStorage::ShaderData::blend_mode_to_blend_attachment(blend_mode_rd);
+		}
 
-	blend_state.attachments.push_back(attachment);
+		blend_state.attachments.push_back(attachment);
+	}
 
 	RD::PipelineMultisampleState multisample_state;
 	multisample_state.sample_count = RD::get_singleton()->framebuffer_format_get_texture_samples(p_pipeline_key.framebuffer_format_id, 0);

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -587,6 +587,13 @@ Variant MaterialStorage::ShaderData::get_default_parameter(const StringName &p_p
 	return Variant();
 }
 
+void MaterialStorage::ShaderData::set_color_pass_blend_state(const Ref<RDPipelineColorBlendState> &p_value) {
+	uses_color_pass_blend_state = p_value.is_valid();
+	if (uses_color_pass_blend_state) {
+		color_pass_blend_state = p_value->get_base();
+	}
+}
+
 void MaterialStorage::ShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	SortArray<Pair<StringName, int>, ShaderLanguage::UniformOrderComparator> sorter;
 	LocalVector<Pair<StringName, int>> filtered_uniforms;
@@ -2077,6 +2084,7 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 					shader->data->set_default_texture_parameter(E.key, E2.value, E2.key);
 				}
 			}
+			shader->data->set_color_pass_blend_state(shader->color_pass_blend_state);
 		}
 	}
 
@@ -2160,6 +2168,21 @@ Variant MaterialStorage::shader_get_parameter_default(RID p_shader, const String
 		return shader->data->get_default_parameter(p_param);
 	}
 	return Variant();
+}
+
+void MaterialStorage::shader_set_color_pass_blend_state(RID p_shader, const Ref<RDPipelineColorBlendState> &p_value) {
+	Shader *shader = shader_owner.get_or_null(p_shader);
+	ERR_FAIL_NULL(shader);
+	shader->color_pass_blend_state = p_value;
+	if (shader->data) {
+		shader->data->set_color_pass_blend_state(p_value);
+	}
+}
+
+Ref<RDPipelineColorBlendState> MaterialStorage::shader_get_color_pass_blend_state(RID p_shader) const {
+	Shader *shader = shader_owner.get_or_null(p_shader);
+	ERR_FAIL_NULL_V(shader, nullptr);
+	return shader->color_pass_blend_state;
 }
 
 void MaterialStorage::shader_set_data_request_function(ShaderType p_shader_type, ShaderDataRequestFunction p_function) {

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -68,10 +68,13 @@ public:
 		String path;
 		HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
 		HashMap<StringName, HashMap<int, RID>> default_texture_params;
+		RD::PipelineColorBlendState color_pass_blend_state;
+		bool uses_color_pass_blend_state = false;
 
 		virtual void set_path_hint(const String &p_hint);
 		virtual void set_default_texture_parameter(const StringName &p_name, RID p_texture, int p_index);
 		virtual Variant get_default_parameter(const StringName &p_parameter) const;
+		virtual void set_color_pass_blend_state(const Ref<RDPipelineColorBlendState> &p_value);
 		virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 		virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 		virtual bool is_parameter_texture(const StringName &p_param) const;
@@ -220,6 +223,7 @@ private:
 		String path_hint;
 		ShaderType type;
 		HashMap<StringName, HashMap<int, RID>> default_texture_parameter;
+		Ref<RDPipelineColorBlendState> color_pass_blend_state;
 		HashSet<Material *> owners;
 		bool embedded = false;
 	};
@@ -423,6 +427,9 @@ public:
 	virtual Variant shader_get_parameter_default(RID p_shader, const StringName &p_param) const override;
 	void shader_set_data_request_function(ShaderType p_shader_type, ShaderDataRequestFunction p_function);
 	ShaderData *shader_get_data(RID p_shader) const;
+
+	virtual void shader_set_color_pass_blend_state(RID p_shader, const Ref<RDPipelineColorBlendState> &p_value) override;
+	virtual Ref<RDPipelineColorBlendState> shader_get_color_pass_blend_state(RID p_shader) const override;
 
 	virtual RS::ShaderNativeSourceCode shader_get_native_source_code(RID p_shader) const override;
 	virtual void shader_embedded_set_lock() override;

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -655,6 +655,7 @@ protected:
 class RDPipelineColorBlendStateAttachment : public RefCounted {
 	GDCLASS(RDPipelineColorBlendStateAttachment, RefCounted)
 	friend class RenderingDevice;
+	friend class RDPipelineColorBlendState;
 	RD::PipelineColorBlendState::Attachment base;
 
 public:
@@ -708,6 +709,18 @@ public:
 	RD_SETGET(bool, enable_logic_op)
 	RD_SETGET(RD::LogicOperation, logic_op)
 	RD_SETGET(Color, blend_constant)
+
+	RD::PipelineColorBlendState get_base() const {
+		RD::PipelineColorBlendState result = base;
+		result.attachments.clear();
+		for (int i = 0; i < attachments.size(); i++) {
+			Ref<RDPipelineColorBlendStateAttachment> attachment = attachments[i];
+			if (attachment.is_valid()) {
+				result.attachments.push_back(attachment->base);
+			}
+		}
+		return result;
+	}
 
 	void set_attachments(const TypedArray<RDPipelineColorBlendStateAttachment> &p_attachments) {
 		attachments = p_attachments;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -30,6 +30,7 @@
 
 #include "rendering_server.h"
 #include "rendering_server.compat.inc"
+#include "rendering_device_binds.h"
 
 #include "core/config/project_settings.h"
 #include "core/variant/typed_array.h"
@@ -2380,6 +2381,9 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("shader_set_default_texture_parameter", "shader", "name", "texture", "index"), &RenderingServer::shader_set_default_texture_parameter, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("shader_get_default_texture_parameter", "shader", "name", "index"), &RenderingServer::shader_get_default_texture_parameter, DEFVAL(0));
+
+	ClassDB::bind_method(D_METHOD("shader_set_color_pass_blend_state", "shader", "value"), &RenderingServer::shader_set_color_pass_blend_state);
+	ClassDB::bind_method(D_METHOD("shader_get_color_pass_blend_state", "shader"), &RenderingServer::shader_get_color_pass_blend_state);
 
 	BIND_ENUM_CONSTANT(SHADER_SPATIAL);
 	BIND_ENUM_CONSTANT(SHADER_CANVAS_ITEM);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -236,6 +236,9 @@ public:
 	virtual void get_shader_parameter_list(RID p_shader, List<PropertyInfo> *p_param_list) const = 0;
 	virtual Variant shader_get_parameter_default(RID p_shader, const StringName &p_param) const = 0;
 
+	virtual void shader_set_color_pass_blend_state(RID p_shader, const Ref<RDPipelineColorBlendState> &p_value) = 0;
+	virtual Ref<RDPipelineColorBlendState> shader_get_color_pass_blend_state(RID p_shader) const = 0;
+
 	virtual void shader_set_default_texture_parameter(RID p_shader, const StringName &p_name, RID p_texture, int p_index = 0) = 0;
 	virtual RID shader_get_default_texture_parameter(RID p_shader, const StringName &p_name, int p_index = 0) const = 0;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -284,6 +284,9 @@ public:
 	FUNC3RC(RID, shader_get_default_texture_parameter, RID, const StringName &, int)
 	FUNC2RC(Variant, shader_get_parameter_default, RID, const StringName &)
 
+	FUNC2(shader_set_color_pass_blend_state, RID, const Ref<RDPipelineColorBlendState> &)
+	FUNC1RC(Ref<RDPipelineColorBlendState>, shader_get_color_pass_blend_state, RID)
+
 	FUNC1RC(ShaderNativeSourceCode, shader_get_native_source_code, RID)
 
 	/* COMMON MATERIAL API */

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "servers/rendering/rendering_server.h"
+#include "servers/rendering/rendering_device_binds.h"
 #include "utilities.h"
 
 class RendererMaterialStorage {
@@ -67,6 +68,9 @@ public:
 	virtual void shader_set_default_texture_parameter(RID p_shader, const StringName &p_name, RID p_texture, int p_index) = 0;
 	virtual RID shader_get_default_texture_parameter(RID p_shader, const StringName &p_name, int p_index) const = 0;
 	virtual Variant shader_get_parameter_default(RID p_material, const StringName &p_param) const = 0;
+
+	virtual void shader_set_color_pass_blend_state(RID p_shader, const Ref<RDPipelineColorBlendState> &p_value) = 0;
+	virtual Ref<RDPipelineColorBlendState> shader_get_color_pass_blend_state(RID p_shader) const = 0;
 
 	virtual RS::ShaderNativeSourceCode shader_get_native_source_code(RID p_shader) const = 0;
 	virtual void shader_embedded_set_lock() = 0;


### PR DESCRIPTION
This PR implements the necessary APIs to allow users to attach an `RDPipelineColorBlendState` to a shader. This permits users to control how surfaces rendered with the shader get blended into the scene.

This is an alternative implementation approach to what PR #102366 proposed, for enhancing user blending flexibility -- see that PR for discussion of why this is important, usecases, etc. It is intended for advanced users, and requires direct interaction with `RenderingServer` to use. Specifically, the new method `shader_set_color_blend_state()`.


