### PR TITLE
Fix buttons overflowing in the bottom panel (reverted)

### DIFF
--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -127,6 +127,12 @@ void EditorBottomPanel::_repaint() {
 	}
 }
 
+Size2 EditorBottomPanel::get_minimum_size() const {
+	Size2 min_size = TabContainer::get_minimum_size();
+	min_size.x += bottom_hbox->get_combined_minimum_size().x;
+	return min_size;
+}
+
 void EditorBottomPanel::save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const {
 	Dictionary offsets;
 	for (const KeyValue<String, int> &E : dock_offsets) {

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -67,6 +67,8 @@ protected:
 	void _notification(int p_what);
 
 public:
+	virtual Size2 get_minimum_size() const override;
+
 	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;
 	void load_layout_from_config(Ref<ConfigFile> p_config_file, const String &p_section);
 


### PR DESCRIPTION
Fully fixes #113376.

My previous PR touching the bottom panel uncovered a bug that let the buttons overflow it if it was too full and certain editors were opened. This PR fixes that.