### PR TITLE
Add null verification to avoid background theme error in texture shader properties

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -468,7 +468,7 @@ void EditorProperty::_notification(int p_what) {
 			// Only draw the label if it's not empty.
 			if (label.is_empty()) {
 				size.height = 0;
-			} else if (sub_inspector_color_level >= 0) {
+			} else if (sub_inspector_color_level >= 0 && theme_cache.sub_inspector_background[sub_inspector_color_level].is_valid()) {
 				draw_style_box(theme_cache.sub_inspector_background[sub_inspector_color_level], Rect2(Vector2(), size));
 			} else {
 				draw_style_box(selected ? theme_cache.background_selected : theme_cache.background, Rect2(Vector2(), size));


### PR DESCRIPTION
Fixes: #113797

## Technical details
Only inspector should sub_inspector_background filled.

editor_inspector.cpp
```
if (p_control == parent_inspector) {
  // Only initialize for the inspector, as stand-alone properties won't need it.
  for (int i = 0; i <= 16; i++) {
	  p_cache.sub_inspector_background[i] = p_control->get_theme_stylebox("sub_inspector_property_bg" + itos(i), EditorStringName(EditorStyles));
  }
}
```
But in EditorProperty::_update_property_bg() function _sub_inspector_color_level_ parametr sets to 1 that causes theme_cache.sub_inspector_background[sub_inspector_color_level] reference to null

Code example from EditorProperty::_notification(int)
```
// Only draw the label if it's not empty.
if (label.is_empty()) {
   size.height = 0;
} else if (sub_inspector_color_level >= 0) {
   draw_style_box(theme_cache.sub_inspector_background[sub_inspector_color_level], Rect2(Vector2(), size));
} else {
   draw_style_box(selected ? theme_cache.background_selected : theme_cache.background, Rect2(Vector2(), size));
}
```

