### PR TITLE
Disable tool button for multiple nodes

### DIFF
--- a/editor/inspector/tool_button_editor_plugin.h
+++ b/editor/inspector/tool_button_editor_plugin.h
@@ -37,6 +37,7 @@ class EditorInspectorToolButtonPlugin : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorToolButtonPlugin, EditorInspectorPlugin);
 
 	void _call_action(const Variant &p_object, const StringName &p_property);
+	void _invoke_callable(const Callable &p_callable);
 
 public:
 	virtual bool can_handle(Object *p_object) override;


### PR DESCRIPTION
Closes #103754

<img width="454" height="120" alt="image" src="https://github.com/user-attachments/assets/5ac86a9c-548a-4165-900c-0de05b188af2" />

Note that it can't be made functional, because the Callable is bound to a specific object.