### PR TITLE
[SplitContainer] Fix custom touch dragger theme icon not updating

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -207,6 +207,7 @@ void SplitContainerDragger::_notification(int p_what) {
 				SplitContainer *sc = Object::cast_to<SplitContainer>(get_parent());
 				touch_dragger->set_modulate(sc->theme_cache.touch_dragger_color);
 				touch_dragger->set_texture(sc->_get_touch_dragger_icon());
+				touch_dragger->set_anchors_and_offsets_preset(Control::PRESET_CENTER);
 			}
 		} break;
 


### PR DESCRIPTION
Fixes the issue where a custom touch dragger icon is not updated unless `touch_dragger_enabled` is toggled. Also fixes the issue where the anchors for the touch dragger for the first pair of children is not properly set.

This is a WIP: prior to #90411, this code also toggled the touch dragger icon in the editor when the theme changed. Can someone weigh-in on where that needs to happen with the latest version? If `SplitContainer::_notification` gets the theme change notification, would it work to queue a resort, and add a `queue_redraw` inside `update_draggers`?

This is before PR:

https://github.com/user-attachments/assets/ecd46706-3fb9-4d53-9bda-c9dd00d7ddf1


