### PR TITLE
Wayland: Remove `GODOT_DEBUG_EMBEDDER_SINGLE_INSTANCE` debug option

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -4651,12 +4651,6 @@ Error WaylandThread::init() {
 		ERR_FAIL_COND_V_MSG(embedder_socket_path.is_empty(), ERR_CANT_CREATE, "Wayland embedder returned invalid path.");
 
 		OS::get_singleton()->set_environment("GODOT_WAYLAND_DISPLAY", embedder_socket_path);
-
-		// Debug
-		if (OS::get_singleton()->get_environment("GODOT_DEBUG_EMBEDDER_SINGLE_INSTANCE") == "1") {
-			print_line("Pausing as per GODOT_DEBUG_EMBEDDER_SINGLE_INSTANCE.");
-			pause();
-		}
 	}
 #endif // TOOLS_ENABLED
 


### PR DESCRIPTION
This is _extremely_ specific, and was meant to be removed after a review in the game embedder PR. No idea how it found its way back in.

---

See also https://github.com/godotengine/godot/pull/107435#discussion_r2539053160

(looks like I never pushed it? My bad :sweat_smile:)