### PR TITLE
Wayland: Ignore IME events without a valid window

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3025,6 +3025,10 @@ void WaylandThread::_wp_text_input_on_enter(void *data, struct zwp_text_input_v3
 		return;
 	}
 
+	if (ss->ime_window_id == DisplayServer::INVALID_WINDOW_ID) {
+		return;
+	}
+
 	WindowState *ws = wl_surface_get_window_state(surface);
 	if (!ws) {
 		return;
@@ -3034,9 +3038,14 @@ void WaylandThread::_wp_text_input_on_enter(void *data, struct zwp_text_input_v3
 	ss->ime_enabled = true;
 }
 
+// NOTE: From now on, we must ignore all further events until an enter event.
 void WaylandThread::_wp_text_input_on_leave(void *data, struct zwp_text_input_v3 *wp_text_input_v3, struct wl_surface *surface) {
 	SeatState *ss = (SeatState *)data;
 	if (!ss) {
+		return;
+	}
+
+	if (ss->ime_window_id == DisplayServer::INVALID_WINDOW_ID) {
 		return;
 	}
 
@@ -3058,6 +3067,10 @@ void WaylandThread::_wp_text_input_on_leave(void *data, struct zwp_text_input_v3
 void WaylandThread::_wp_text_input_on_preedit_string(void *data, struct zwp_text_input_v3 *wp_text_input_v3, const char *text, int32_t cursor_begin, int32_t cursor_end) {
 	SeatState *ss = (SeatState *)data;
 	if (!ss) {
+		return;
+	}
+
+	if (ss->ime_window_id == DisplayServer::INVALID_WINDOW_ID) {
 		return;
 	}
 
@@ -3109,6 +3122,10 @@ void WaylandThread::_wp_text_input_on_commit_string(void *data, struct zwp_text_
 		return;
 	}
 
+	if (ss->ime_window_id == DisplayServer::INVALID_WINDOW_ID) {
+		return;
+	}
+
 	ss->ime_text_commit = String::utf8(text);
 }
 
@@ -3119,6 +3136,10 @@ void WaylandThread::_wp_text_input_on_delete_surrounding_text(void *data, struct
 void WaylandThread::_wp_text_input_on_done(void *data, struct zwp_text_input_v3 *wp_text_input_v3, uint32_t serial) {
 	SeatState *ss = (SeatState *)data;
 	if (!ss) {
+		return;
+	}
+
+	if (ss->ime_window_id == DisplayServer::INVALID_WINDOW_ID) {
 		return;
 	}
 


### PR DESCRIPTION
[The spec](https://wayland.app/protocols/text-input-unstable-v3#zwp_text_input_v3:event:leave) says:

> After leave event, compositor must ignore requests from any text input instances until next enter event.

Fixes an error on [jay](https://github.com/mahkoh/jay), which at least on 1.11.0 sends `zwp_text_input_v3::done` after `zwp_text_input_v3::leave`, which we didn't ignore, leading to a commit without a valid window id.

---

Also added a teeny tiny note next to the leave event handler, as this is _very_ easy to miss.

Cherry-pickable to 4.5.