### PR TITLE
Add `has_connection` to `GraphEdit`

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -242,6 +242,7 @@
 							result.push_back(dict)
 					return result
 				[/codeblock]
+				See also [method has_connection].
 			</description>
 		</method>
 		<method name="get_connections_intersecting_with_rect" qualifiers="const">
@@ -273,6 +274,23 @@
 			<description>
 				Gets the [HBoxContainer] that contains the zooming and grid snap controls in the top left of the graph. You can use this method to reposition the toolbar or to add your own custom controls to it.
 				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
+			</description>
+		</method>
+		<method name="has_connection" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="node" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the [param node] [GraphNode] has at least one connection. Otherwise, returns [code]false[/code].
+				[b]Example:[/b] Safely disconnect all paths from a specific node:
+				[codeblock]
+				func disconnect_all_from_node(node):
+					if has_connection(node):
+						var connections = get_connection_list_from_node(node)
+						for c in connections:
+							disconnect_node(c["from_node"], c["from_port"], c["to_node"], c["to_port"])
+					else:
+						print("Node ", node, " has no connections to clear.")
+				[/codeblock]
 			</description>
 		</method>
 		<method name="is_node_connected">

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2596,7 +2596,9 @@ TypedArray<Dictionary> GraphEdit::_get_connections_intersecting_with_rect(const 
 }
 
 TypedArray<Dictionary> GraphEdit::_get_connection_list_from_node(const StringName &p_node) const {
-	ERR_FAIL_COND_V(!connection_map.has(p_node), TypedArray<Dictionary>());
+	if (!connection_map.has(p_node)) {
+		return TypedArray<Dictionary>();
+	}
 
 	List<Ref<GraphEdit::Connection>> connections_from_node = connection_map.get(p_node);
 	TypedArray<Dictionary> connections_from_node_dict;
@@ -2611,6 +2613,10 @@ TypedArray<Dictionary> GraphEdit::_get_connection_list_from_node(const StringNam
 		connections_from_node_dict.push_back(d);
 	}
 	return connections_from_node_dict;
+}
+
+bool GraphEdit::_has_connection(const StringName &p_node) const {
+	return connection_map.has(p_node) && connection_map[p_node].size() > 0;
 }
 
 void GraphEdit::_zoom_minus() {
@@ -2974,6 +2980,7 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_connection_count", "from_node", "from_port"), &GraphEdit::get_connection_count);
 	ClassDB::bind_method(D_METHOD("get_closest_connection_at_point", "point", "max_distance"), &GraphEdit::_get_closest_connection_at_point, DEFVAL(4.0));
 	ClassDB::bind_method(D_METHOD("get_connection_list_from_node", "node"), &GraphEdit::_get_connection_list_from_node);
+	ClassDB::bind_method(D_METHOD("has_connection", "node"), &GraphEdit::_has_connection);
 	ClassDB::bind_method(D_METHOD("get_connections_intersecting_with_rect", "rect"), &GraphEdit::_get_connections_intersecting_with_rect);
 	ClassDB::bind_method(D_METHOD("clear_connections"), &GraphEdit::clear_connections);
 	ClassDB::bind_method(D_METHOD("force_connection_drag_end"), &GraphEdit::force_connection_drag_end);

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -356,6 +356,7 @@ private:
 	Dictionary _get_closest_connection_at_point(const Vector2 &p_point, float p_max_distance = 4.0) const;
 	TypedArray<Dictionary> _get_connections_intersecting_with_rect(const Rect2 &p_rect) const;
 	TypedArray<Dictionary> _get_connection_list_from_node(const StringName &p_node) const;
+	bool _has_connection(const StringName &p_node) const;
 
 	Rect2 _compute_shrinked_frame_rect(const GraphFrame *p_frame);
 	void _set_drag_frame_attached_nodes(GraphFrame *p_frame, bool p_drag);


### PR DESCRIPTION
Regarding issue #113682:
I removed the error message, you directly get an empty `TypedArray<Dictionary>`. 
To mitigate this potential unwanted behaviour in your GDScript, I added a `has_connection` function to the `GraphEdit` node to check for connections beforehand.