### PR TITLE
Remove clamping from LinearToSRGB visual shader node.

### DIFF
--- a/doc/classes/VisualShaderNodeColorFunc.xml
+++ b/doc/classes/VisualShaderNodeColorFunc.xml
@@ -43,11 +43,10 @@
 		<constant name="FUNC_LINEAR_TO_SRGB" value="4" enum="Function">
 			Converts color from linear encoding to nonlinear sRGB encoding using the following formula:
 			[codeblock]
-			vec3 c = clamp(c, vec3(0.0), vec3(1.0));
 			const vec3 a = vec3(0.055f);
 			return mix((vec3(1.0f) + a) * pow(c.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * c.rgb, lessThan(c.rgb, vec3(0.0031308f)));
 			[/codeblock]
-			The Compatibility renderer uses a simpler formula:
+			The Compatibility renderer uses a simpler formula that may produce undefined behavior with negative input values:
 			[codeblock]
 			vec3 c = input;
 			return max(vec3(1.055) * pow(c, vec3(0.416666667)) - vec3(0.055), vec3(0.0));
@@ -59,7 +58,7 @@
 			vec3 c = input;
 			return mix(pow((c.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), c.rgb * (1.0 / 12.92), lessThan(c.rgb, vec3(0.04045)));
 			[/codeblock]
-			The Compatibility renderer uses a simpler formula:
+			The Compatibility renderer uses a simpler formula that behaves poorly with negative input values:
 			[codeblock]
 			vec3 c = input;
 			return c * (c * (c * 0.305306011 + 0.682171111) + 0.012522878);

--- a/drivers/gles3/shaders/effects/copy.glsl
+++ b/drivers/gles3/shaders/effects/copy.glsl
@@ -106,13 +106,13 @@ uniform float aspect_ratio;
 
 layout(location = 0) out vec4 frag_color;
 
-// This expects 0-1 range input, outside that range it behaves poorly.
+// This approximation expects non-negative input; negative input behaves poorly.
 vec3 srgb_to_linear(vec3 color) {
 	// Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
 	return color * (color * (color * 0.305306011 + 0.682171111) + 0.012522878);
 }
 
-// This expects 0-1 range input.
+// This approximation expects non-negative input; negative input is undefined behavior.
 vec3 linear_to_srgb(vec3 color) {
 	// Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
 	return max(vec3(1.055) * pow(color, vec3(0.416666667)) - vec3(0.055), vec3(0.0));

--- a/drivers/gles3/shaders/effects/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/effects/cubemap_filter.glsl
@@ -43,10 +43,12 @@ layout(location = 0) out vec4 frag_color;
 #define M_PI 3.14159265359
 
 // Don't include tonemap_inc.glsl because all we want is these functions, we don't want the uniforms
+// This approximation expects non-negative input; negative input is undefined behavior.
 vec3 linear_to_srgb(vec3 color) {
 	return max(vec3(1.055) * pow(color, vec3(0.416666667)) - vec3(0.055), vec3(0.0));
 }
 
+// This approximation expects non-negative input; negative input behaves poorly.
 vec3 srgb_to_linear(vec3 color) {
 	return color * (color * (color * 0.305306011 + 0.682171111) + 0.012522878);
 }

--- a/drivers/gles3/shaders/tonemap_inc.glsl
+++ b/drivers/gles3/shaders/tonemap_inc.glsl
@@ -10,16 +10,15 @@ layout(std140) uniform TonemapData { //ubo:0
 	int pad3;
 };
 
-// This expects 0-1 range input.
+// This approximation expects non-negative input; negative input is undefined behavior.
 vec3 linear_to_srgb(vec3 color) {
-	//color = clamp(color, vec3(0.0), vec3(1.0));
 	//const vec3 a = vec3(0.055f);
 	//return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
 	// Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
 	return max(vec3(1.055) * pow(color, vec3(0.416666667)) - vec3(0.055), vec3(0.0));
 }
 
-// This expects 0-1 range input, outside that range it behaves poorly.
+// This approximation expects non-negative input; negative input behaves poorly.
 vec3 srgb_to_linear(vec3 color) {
 	// Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
 	return color * (color * (color * 0.305306011 + 0.682171111) + 0.012522878);

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -3260,7 +3260,7 @@ String VisualShaderNodeColorFunc::generate_code(Shader::Mode p_mode, VisualShade
 				code += "		vec3 c = " + p_input_vars[0] + ";\n";
 				code += "		" + p_output_vars[0] + " = max(vec3(1.055) * pow(c, vec3(0.416666667)) - vec3(0.055), vec3(0.0));\n";
 			} else {
-				code += "		vec3 c = clamp(" + p_input_vars[0] + ", vec3(0.0), vec3(1.0));\n";
+				code += "		vec3 c = " + p_input_vars[0] + ";\n";
 				code += "		const vec3 a = vec3(0.055f);\n";
 				code += "		" + p_output_vars[0] + " = mix((vec3(1.0f) + a) * pow(c.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * c.rgb, lessThan(c.rgb, vec3(0.0031308f)));\n";
 			}

--- a/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
@@ -106,8 +106,6 @@ layout(set = 1, binding = 0) uniform sampler2D source_color2;
 layout(location = 0) out vec4 frag_color;
 
 vec3 linear_to_srgb(vec3 color) {
-	//if going to srgb, clamp from 0 to 1.
-	color = clamp(color, vec3(0.0), vec3(1.0));
 	const vec3 a = vec3(0.055f);
 	return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
 }
@@ -179,6 +177,7 @@ void main() {
 	}
 	if (bool(params.flags & FLAG_SRGB)) {
 		color.rgb = linear_to_srgb(color.rgb);
+		color.rgb = clamp(color.rgb, vec3(0.0), vec3(1.0));
 	}
 	if (bool(params.flags & FLAG_ALPHA_TO_ONE)) {
 		color.a = 1.0;

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_debug.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_debug.glsl
@@ -50,8 +50,6 @@ layout(push_constant, std430) uniform Params {
 params;
 
 vec3 linear_to_srgb(vec3 color) {
-	//if going to srgb, clamp from 0 to 1.
-	color = clamp(color, vec3(0.0), vec3(1.0));
 	const vec3 a = vec3(0.055f);
 	return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
 }
@@ -181,5 +179,5 @@ void main() {
 
 #endif
 
-	imageStore(screen_buffer, screen_pos, vec4(linear_to_srgb(light), 1.0));
+	imageStore(screen_buffer, screen_pos, vec4(clamp(linear_to_srgb(light), vec3(0.0), vec3(1.0)), 1.0));
 }


### PR DESCRIPTION
- Closes #113952

I've also updated related docs and moved clamping outside of other `linear_to_srgb` functions to stop the spread of unnecessary clamping to other parts of the code and prevent this sort of issue from happening again in the future.

This PR may affect existing projects that depend on this clamping. To achieve the existing behaviour after this PR is merged, simply use the existing `Clamp` visual shader node to clamp to the range of [0, 1].

| Before PR: background clouds are clipped | After PR: background clouds remain overbright for good tonemapping
--|--
<img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/3d76c0d5-e45f-4e26-8bd2-3195d6ddac5a" /> | <img width="1152" height="648" alt="Image" src="https://github.com/user-attachments/assets/b1a8632d-14e4-4cbe-9499-b8d73f7eaadc" />

Note: the [HDR output PR](https://github.com/godotengine/godot/pull/94496) will remove clamping from the SMAA shader, but since this change is only needed by the HDR output PR, I'm leaving the behaviour as-is in this PR.