### PR TITLE
Enable scroll hints and background panel in the AssetLib

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -702,8 +702,8 @@ void EditorAssetLibrary::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			error_tr->set_texture(get_editor_theme_icon(SNAME("Error")));
 			filter->set_right_icon(get_editor_theme_icon(SNAME("Search")));
-			library_scroll_bg->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			downloads_scroll->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
+			library_scroll->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
+			downloads_scroll->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("downloads"), SNAME("AssetLib")));
 			error_label->add_theme_color_override("color", get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 		} break;
 
@@ -735,6 +735,9 @@ void EditorAssetLibrary::_notification(int p_what) {
 			const bool no_downloads = downloads_hb->get_child_count() == 0;
 			if (no_downloads == downloads_scroll->is_visible()) {
 				downloads_scroll->set_visible(!no_downloads);
+
+				library_mc->set_theme_type_variation(no_downloads ? "NoBorderHorizontalBottom" : "NoBorderHorizontal");
+				library_scroll->set_scroll_hint_mode(no_downloads ? ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT : ScrollContainer::SCROLL_HINT_MODE_ALL);
 			}
 
 		} break;
@@ -1731,14 +1734,15 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	/////////
 
-	library_scroll_bg = memnew(PanelContainer);
-	library_main->add_child(library_scroll_bg);
-	library_scroll_bg->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	library_mc = memnew(MarginContainer);
+	library_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	library_mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	library_main->add_child(library_mc);
 
 	library_scroll = memnew(ScrollContainer);
+	library_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);
 	library_scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
-
-	library_scroll_bg->add_child(library_scroll);
+	library_mc->add_child(library_scroll);
 
 	Ref<StyleBoxEmpty> border2;
 	border2.instantiate();
@@ -1806,6 +1810,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	downloads_scroll = memnew(ScrollContainer);
 	downloads_scroll->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	downloads_scroll->set_theme_type_variation("ScrollContainerSecondary");
 	library_main->add_child(downloads_scroll);
 	downloads_hb = memnew(HBoxContainer);
 	downloads_scroll->add_child(downloads_hb);

--- a/editor/asset_library/asset_library_editor_plugin.h
+++ b/editor/asset_library/asset_library_editor_plugin.h
@@ -194,7 +194,7 @@ class EditorAssetLibrary : public PanelContainer {
 	void _asset_file_selected(const String &p_file);
 	void _update_repository_options();
 
-	PanelContainer *library_scroll_bg = nullptr;
+	MarginContainer *library_mc = nullptr;
 	ScrollContainer *library_scroll = nullptr;
 	VBoxContainer *library_vb = nullptr;
 	VBoxContainer *library_message_box = nullptr;

--- a/editor/asset_library/editor_asset_installer.cpp
+++ b/editor/asset_library/editor_asset_installer.cpp
@@ -43,6 +43,7 @@
 #include "scene/gui/check_box.h"
 #include "scene/gui/label.h"
 #include "scene/gui/link_button.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/split_container.h"
 
@@ -412,8 +413,14 @@ void EditorAssetInstaller::_toggle_source_tree(bool p_visible, bool p_scroll_to_
 
 	if (p_visible) {
 		show_source_files_button->set_button_icon(get_editor_theme_icon(SNAME("Back")));
+		destination_tree_mc->set_theme_type_variation("");
+		destination_tree->set_theme_type_variation("TreeSecondary");
+		destination_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);
 	} else {
 		show_source_files_button->set_button_icon(get_editor_theme_icon(SNAME("Forward")));
+		destination_tree_mc->set_theme_type_variation("NoBorderHorizontalWindow");
+		destination_tree->set_theme_type_variation("");
+		destination_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	}
 
 	if (p_visible && p_scroll_to_error && first_file_conflict) {
@@ -750,12 +757,17 @@ EditorAssetInstaller::EditorAssetInstaller() {
 	destination_tree_label->set_theme_type_variation("HeaderSmall");
 	destination_tree_vb->add_child(destination_tree_label);
 
+	destination_tree_mc = memnew(MarginContainer);
+	destination_tree_mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	destination_tree_mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	destination_tree_vb->add_child(destination_tree_mc);
+
 	destination_tree = memnew(Tree);
 	destination_tree->set_accessibility_name(TTRC("Destination Files"));
 	destination_tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	destination_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	destination_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	destination_tree->connect("item_edited", callable_mp(this, &EditorAssetInstaller::_item_checked_cbk));
-	destination_tree_vb->add_child(destination_tree);
+	destination_tree_mc->add_child(destination_tree);
 
 	// Dialog configuration.
 

--- a/editor/asset_library/editor_asset_installer.h
+++ b/editor/asset_library/editor_asset_installer.h
@@ -43,6 +43,7 @@ class EditorAssetInstaller : public ConfirmationDialog {
 
 	VBoxContainer *source_tree_vb = nullptr;
 	Tree *source_tree = nullptr;
+	MarginContainer *destination_tree_mc = nullptr;
 	Tree *destination_tree = nullptr;
 	Label *asset_title_label = nullptr;
 	Label *asset_conflicts_label = nullptr;

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -2316,6 +2316,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 	// Asset Library.
 	p_theme->set_stylebox("bg", "AssetLib", p_config.base_empty_style);
 	p_theme->set_stylebox(SceneStringName(panel), "AssetLib", p_config.content_panel_style);
+	p_theme->set_stylebox("downloads", "AssetLib", p_theme->get_stylebox(SceneStringName(panel), SNAME("Tree")));
 	p_theme->set_color("status_color", "AssetLib", Color(0.5, 0.5, 0.5)); // FIXME: Use a defined color instead.
 	p_theme->set_icon("dismiss", "AssetLib", p_theme->get_icon(SNAME("Close"), EditorStringName(EditorIcons)));
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2362,12 +2362,9 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 	}
 
 	// Asset Library.
-	Ref<StyleBoxFlat> assetlib_panel_style = p_config.base_style->duplicate();
-	assetlib_panel_style->set_bg_color(p_config.surface_low_color);
-	assetlib_panel_style->set_content_margin_all(p_config.base_margin * 2 * EDSCALE);
-
 	p_theme->set_stylebox("bg", "AssetLib", EditorThemeManager::make_empty_stylebox(p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
-	p_theme->set_stylebox(SceneStringName(panel), "AssetLib", assetlib_panel_style);
+	p_theme->set_stylebox(SceneStringName(panel), "AssetLib", p_config.foreground_panel);
+	p_theme->set_stylebox("downloads", "AssetLib", p_theme->get_stylebox(SceneStringName(panel), SNAME("ScrollContainerSecondary")));
 	p_theme->set_color("status_color", "AssetLib", Color(0.5, 0.5, 0.5)); // FIXME: Use a defined color instead.
 	p_theme->set_icon("dismiss", "AssetLib", p_theme->get_icon(SNAME("Close"), EditorStringName(EditorIcons)));
 


### PR DESCRIPTION
The fact that people noticed those missing for obscure dialogs but not for the AssetLib speaks volumes. :melting_face: