### PR TITLE
[macOS] Disable window embedding code in export templates.

### DIFF
--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -11,10 +11,7 @@ files = [
     "godot_application_delegate.mm",
     "crash_handler_macos.mm",
     "display_server_macos_base.mm",
-    "display_server_embedded.mm",
     "display_server_macos.mm",
-    "embedded_debugger.mm",
-    "embedded_gl_manager.mm",
     "godot_button_view.mm",
     "godot_content_view.mm",
     "godot_core_cursor.mm",
@@ -35,6 +32,9 @@ files = [
 
 if env.editor_build:
     files += [
+        "display_server_embedded.mm",
+        "embedded_debugger.mm",
+        "embedded_gl_manager.mm",
         "editor/embedded_game_view_plugin.mm",
         "editor/embedded_process_macos.mm",
     ]

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -64,14 +64,18 @@
 @class GodotContentView;
 @class GodotWindowDelegate;
 @class GodotButtonView;
+#ifdef TOOLS_ENABLED
 @class GodotEmbeddedView;
 @class CALayerHost;
+#endif
 
 #undef BitMap
 #undef CursorShape
 #undef FontVariation
 
+#ifdef TOOLS_ENABLED
 class EmbeddedProcessMacOS;
+#endif
 
 class DisplayServerMacOS : public DisplayServerMacOSBase {
 	GDSOFTCLASS(DisplayServerMacOS, DisplayServerMacOSBase);
@@ -239,12 +243,14 @@ private:
 
 	Error _file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, WindowID p_window_id);
 
+#ifdef TOOLS_ENABLED
 	struct EmbeddedProcessData {
-		EmbeddedProcessMacOS *process;
+		EmbeddedProcessMacOS *process = nullptr;
 		WindowData *wd = nullptr;
 		CALayer *layer_host = nil;
 	};
 	HashMap<OS::ProcessID, EmbeddedProcessData> embedded_processes;
+#endif
 	void _window_update_display_id(WindowData *p_wd);
 
 public:
@@ -440,9 +446,9 @@ public:
 	virtual void enable_for_stealing_focus(OS::ProcessID pid) override;
 #ifdef TOOLS_ENABLED
 	Error embed_process_update(WindowID p_window, EmbeddedProcessMacOS *p_process);
-#endif
 	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;
 	virtual Error remove_embedded_process(OS::ProcessID p_pid) override;
+#endif
 
 	void _process_events(bool p_pump);
 	virtual void process_events() override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -42,8 +42,11 @@
 #import "godot_window.h"
 #import "godot_window_delegate.h"
 #import "key_mapping_macos.h"
-#import "macos_quartz_core_spi.h"
 #import "os_macos.h"
+
+#ifdef TOOLS_ENABLED
+#import "macos_quartz_core_spi.h"
+#endif
 
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
@@ -3226,8 +3229,6 @@ Error DisplayServerMacOS::embed_process_update(WindowID p_window, EmbeddedProces
 	return OK;
 }
 
-#endif
-
 Error DisplayServerMacOS::request_close_embedded_process(OS::ProcessID p_pid) {
 	return OK;
 }
@@ -3242,6 +3243,8 @@ Error DisplayServerMacOS::remove_embedded_process(OS::ProcessID p_pid) {
 
 	return OK;
 }
+
+#endif
 
 void DisplayServerMacOS::process_events() {
 	_process_events(true);

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
 
 	OS_MacOS *os = nullptr;
 	if (is_embedded) {
-#ifdef DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 		os = memnew(OS_MacOS_Embedded(args[0], remaining_args, remaining_args > 0 ? &args[1] : nullptr));
 #else
 		WARN_PRINT("Embedded mode is not supported in release builds.");

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -196,7 +196,7 @@ public:
 	OS_MacOS_Headless(const char *p_execpath, int p_argc, char **p_argv);
 };
 
-#ifdef DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 
 class OS_MacOS_Embedded : public OS_MacOS {
 public:

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -31,7 +31,7 @@
 #import "os_macos.h"
 
 #import "dir_access_macos.h"
-#ifdef DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 #import "display_server_embedded.h"
 #endif
 #import "display_server_macos.h"
@@ -1256,7 +1256,7 @@ OS_MacOS_Headless::OS_MacOS_Headless(const char *p_execpath, int p_argc, char **
 
 // MARK: - OS_MacOS_Embedded
 
-#ifdef DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 
 void OS_MacOS_Embedded::run() {
 	CFRunLoopGetCurrent();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113953