### PR TITLE
Use Time API to show file modification date in editor tooltips

### DIFF
--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_resource_tooltip_plugins.h"
 
+#include "core/os/time.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/file_system/editor_file_system.h"
@@ -72,6 +73,14 @@ VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p
 		if (f.is_valid()) {
 			Label *label = memnew(Label(vformat(TTR("Size: %s"), String::humanize_size(f->get_length()))));
 			vb->add_child(label);
+
+			uint64_t mtime = FileAccess::get_modified_time(p_resource_path);
+			if (mtime > 0) {
+				String formatted = Time::get_singleton()->get_datetime_string_from_unix_time(mtime, true);
+
+				Label *mtime_label = memnew(Label(vformat(TTR("Modified: %s"), formatted)));
+				vb->add_child(mtime_label);
+			}
 		} else {
 			Label *label = memnew(Label(TTR("Invalid file or broken link.")));
 			label->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));


### PR DESCRIPTION
This PR improves resource tooltips in the editor by now displaying the file's last modification date.
I added this because, given that files can be sorted by modification date, I thought it made sense for the date to be visible.
Use of the Time API to convert the Unix timestamp to a readable string.