### PR TITLE
VisualShader: Fix new node spawning position with display scaling

### DIFF
--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -3847,6 +3847,7 @@ void VisualShaderEditor::_add_node(int p_idx, const Vector<Variant> &p_ops, cons
 		position /= EDSCALE;
 	}
 	position /= graph->get_zoom();
+	position /= cached_theme_base_scale;
 	saved_node_pos_dirty = false;
 
 	int id_to_use = visual_shader->get_valid_node_id(type);


### PR DESCRIPTION
Fixes issue #113625 where nodes in the visual shader editor were spawned in the wrong place when the editor scale is set to 200%.

- Fix https://github.com/godotengine/godot/issues/113625

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
