### PR TITLE
Wayland: Silence `window_get_wl_surface` on invalid window

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -826,6 +826,7 @@ void DisplayServerWayland::show_window(WindowID p_window_id) {
 #ifdef VULKAN_ENABLED
 			if (rendering_driver == "vulkan") {
 				wpd.vulkan.surface = wayland_thread.window_get_wl_surface(wd.id);
+				ERR_FAIL_NULL(wpd.vulkan.surface);
 				wpd.vulkan.display = wayland_thread.get_wl_display();
 			}
 #endif
@@ -847,6 +848,7 @@ void DisplayServerWayland::show_window(WindowID p_window_id) {
 #ifdef GLES3_ENABLED
 		if (egl_manager) {
 			struct wl_surface *wl_surface = wayland_thread.window_get_wl_surface(wd.id);
+			ERR_FAIL_NULL(wl_surface);
 			wd.wl_egl_window = wl_egl_window_create(wl_surface, wd.rect.size.width, wd.rect.size.height);
 
 			Error err = egl_manager->window_create(p_window_id, wayland_thread.get_wl_display(), wd.wl_egl_window, wd.rect.size.width, wd.rect.size.height);

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3950,10 +3950,12 @@ void WaylandThread::window_destroy(DisplayServer::WindowID p_window_id) {
 }
 
 struct wl_surface *WaylandThread::window_get_wl_surface(DisplayServer::WindowID p_window_id) const {
-	ERR_FAIL_COND_V(!windows.has(p_window_id), nullptr);
-	const WindowState &ws = windows[p_window_id];
+	const WindowState *ws = windows.getptr(p_window_id);
+	if (ws) {
+		return ws->wl_surface;
+	}
 
-	return ws.wl_surface;
+	return nullptr;
 }
 
 WaylandThread::WindowState *WaylandThread::window_get_state(DisplayServer::WindowID p_window_id) {


### PR DESCRIPTION
Makes it more consistent with the rest of the `WaylandThread` methods (so that we can silently check for the window's existence).

Fixes errors when trying to capture the pointer when no surface has been pointed yet (its logic assumed that this method was silent).

We double-check everywhere anyway but I added it in some places where we can't either guarantee that it'll check (to avoid segfaults) or that would be useful to report directly.