### PR TITLE
Add XROrigin3D scale warning

### DIFF
--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -681,9 +681,12 @@ PackedStringArray XROrigin3D::get_configuration_warnings() const {
 				has_camera = true;
 			}
 		}
-
 		if (!has_camera) {
 			warnings.push_back(RTR("XROrigin3D requires an XRCamera3D child node."));
+		}
+
+		if (get_scale().is_equal_approx(Vector3(1, 1, 1))) {
+			warnings.push_back(RTR("Changing the scale on the XROrigin3D node is not supported. Change the World Scale instead."));
 		}
 	}
 


### PR DESCRIPTION
Dear Godot community,

This small PR spun off https://github.com/godotengine/godot/pull/109975

It adds a warning advising against changing the scale in `XROrigin3D`. I think this warning applies to all XR platforms, and is a good addition to guide developers towards best practices.