### PR TITLE
Fix compiling Godot for Linux failing with `profiler_sample_callstack=yes`

### DIFF
--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -60,7 +60,7 @@ if env["profiler"]:
         env_tracy = env.Clone()
         env_tracy.Append(CPPDEFINES=["TRACY_ENABLE"])
         if env["profiler_sample_callstack"]:
-            if env["platform"] not in ("windows", "linux", "android"):
+            if env["platform"] not in ("windows", "linuxbsd", "android"):
                 # Reference the feature matrix in the tracy documentation.
                 print("Tracy does not support call stack sampling on this platform. Aborting.")
                 Exit(255)


### PR DESCRIPTION
This fixes #114000.

The issue is that `/core/profiling/SCsub` checks whether the current platform is called `linux`, which will fail, because it is called `linuxbsd`.

**Important**: According to the [support chart](https://github.com/godotengine/godot/pull/104851) callstack sampling is actually not supported on BSD, unlike Linux. I don't have an installation of BSD, so I can't check whether my fix would causes issues on that platform. Although you could just not use the flag on that platform of course.