### PR TITLE
Fix EditorSetting presets cannot be set from code

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9665,7 +9665,7 @@ EditorNode::EditorNode() {
 	ResourceLoader::set_load_callback(_resource_loaded);
 
 	// Apply setting presets in case the editor_settings file is missing values.
-	EditorSettingsDialog::update_3d_navigation_preset();
+	Node3DEditor::get_singleton()->update_navigation_preset();
 
 	screenshot_timer = memnew(Timer);
 	screenshot_timer->set_one_shot(true);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2414,6 +2414,160 @@ void Node3DEditor::_update_theme() {
 	context_toolbar_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("ContextualToolbar"), EditorStringName(EditorStyles)));
 }
 
+static bool _update_shortcut_input(const String &p_name, Ref<InputEventKey> &p_event, bool p_set) {
+	Array sc_events;
+	if (p_event->get_keycode() != Key::NONE) {
+		sc_events.push_back((Variant)p_event);
+	}
+
+	Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(p_name);
+	Array cur_events = sc->get_events();
+	bool different = cur_events.size() != sc_events.size() || cur_events.size() > 1;
+	if (!different && cur_events.size() == 1) {
+		const Ref<InputEventKey> cur_event = cur_events[0];
+		ERR_FAIL_COND_V(cur_event.is_null(), false);
+		different = !p_event->is_match(cur_event, true);
+	}
+	if (p_set && different) {
+		sc->set_events(sc_events);
+	}
+	return different;
+}
+
+static bool _update_navigation_preset(bool p_set) {
+	View3DController::NavigationScheme nav_scheme = (View3DController::NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
+	View3DController::NavigationMouseButton set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
+	View3DController::NavigationMouseButton set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
+	View3DController::NavigationMouseButton set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
+	bool set_3_button_mouse = false;
+	Ref<InputEventKey> orbit_mod_key_1;
+	Ref<InputEventKey> orbit_mod_key_2;
+	Ref<InputEventKey> pan_mod_key_1;
+	Ref<InputEventKey> pan_mod_key_2;
+	Ref<InputEventKey> zoom_mod_key_1;
+	Ref<InputEventKey> zoom_mod_key_2;
+	Ref<InputEventKey> orbit_snap_mod_key_1;
+	Ref<InputEventKey> orbit_snap_mod_key_2;
+	bool set_preset = false;
+
+	if (nav_scheme == View3DController::NAV_SCHEME_GODOT) {
+		set_preset = true;
+		set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
+		set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
+		set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
+		set_3_button_mouse = false;
+		orbit_mod_key_1 = InputEventKey::create_reference(Key::NONE);
+		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
+		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		zoom_mod_key_1 = InputEventKey::create_reference(Key::CTRL);
+		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		orbit_snap_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		orbit_snap_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+	} else if (nav_scheme == View3DController::NAV_SCHEME_MAYA) {
+		set_preset = true;
+		set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
+		set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
+		set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_RIGHT;
+		set_3_button_mouse = false;
+		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_1 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		zoom_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		orbit_snap_mod_key_1 = InputEventKey::create_reference(Key::NONE);
+		orbit_snap_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+	} else if (nav_scheme == View3DController::NAV_SCHEME_MODO) {
+		set_preset = true;
+		set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
+		set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
+		set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
+		set_3_button_mouse = false;
+		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
+		pan_mod_key_2 = InputEventKey::create_reference(Key::ALT);
+		zoom_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		zoom_mod_key_2 = InputEventKey::create_reference(Key::CTRL);
+		orbit_snap_mod_key_1 = InputEventKey::create_reference(Key::NONE);
+		orbit_snap_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+	} else if (nav_scheme == View3DController::NAV_SCHEME_TABLET) {
+		set_preset = true;
+		set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
+		set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
+		set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
+		set_3_button_mouse = true;
+		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
+		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		zoom_mod_key_1 = InputEventKey::create_reference(Key::CTRL);
+		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		orbit_snap_mod_key_1 = InputEventKey::create_reference(Key::NONE);
+		orbit_snap_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+	}
+
+	if (p_set && set_preset) {
+		// Set settings to the desired preset values.
+		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/orbit_mouse_button", (int)set_orbit_mouse_button);
+		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/pan_mouse_button", (int)set_pan_mouse_button);
+		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/zoom_mouse_button", (int)set_zoom_mouse_button);
+		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/emulate_3_button_mouse", set_3_button_mouse);
+		bool updated = false;
+		updated |= _update_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_pan_modifier_2", pan_mod_key_2, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_zoom_modifier_1", zoom_mod_key_1, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_zoom_modifier_2", zoom_mod_key_2, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_1", orbit_snap_mod_key_1, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_2", orbit_snap_mod_key_2, true);
+		if (updated) {
+			EditorSettings::get_singleton()->mark_setting_changed("shortcuts");
+		}
+	} else if (!p_set) {
+		if (!set_preset) {
+			// Custom mode can have any shortcuts.
+			return false;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_pan_modifier_2", pan_mod_key_2, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_zoom_modifier_1", zoom_mod_key_1, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_zoom_modifier_2", zoom_mod_key_2, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_1", orbit_snap_mod_key_1, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_2", orbit_snap_mod_key_2, false)) {
+			return true;
+		}
+		return false;
+	}
+	return true;
+}
+
+void Node3DEditor::update_navigation_preset() {
+	_update_navigation_preset(true);
+}
+
+static bool _navigation_preset_changed() {
+	return _update_navigation_preset(false);
+}
+
 void Node3DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -2466,7 +2620,8 @@ void Node3DEditor::_notification(int p_what) {
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d")) {
+			EditorSettings *editor_settings = EditorSettings::get_singleton();
+			if (editor_settings->check_changed_settings_in_group("editors/3d")) {
 				const Color selection_box_color = EDITOR_GET("editors/3d/selection_box_color");
 				const Color active_selection_box_color = EDITOR_GET("editors/3d/active_selection_box_color");
 
@@ -2491,11 +2646,20 @@ void Node3DEditor::_notification(int p_what) {
 				}
 				update_gizmo_opacity();
 			}
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d_gizmos/gizmo_settings")) {
+			if (editor_settings->check_changed_settings_in_group("editors/3d_gizmos/gizmo_settings")) {
 				CollisionShape3DGizmoPlugin::set_show_only_when_selected(EDITOR_GET("editors/3d_gizmos/gizmo_settings/show_collision_shapes_only_when_selected"));
 				update_all_gizmos();
 			}
 			_update_vertex_snap_tooltips();
+			if (editor_settings->check_changed_settings_in_group("shortcuts")) {
+				// Set to custom navigation scheme if modifier shortcuts were changed.
+				if (_navigation_preset_changed()) {
+					editor_settings->set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
+				}
+			}
+			if (editor_settings->check_changed_settings_in_group("editors/3d/navigation/navigation_scheme")) {
+				update_navigation_preset();
+			}
 		} break;
 
 		case NOTIFICATION_PHYSICS_PROCESS: {

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -398,6 +398,8 @@ public:
 
 	static Size2i get_camera_viewport_size(Camera3D *p_camera);
 
+	static void update_navigation_preset();
+
 	Vector3 snap_point(Vector3 p_target, Vector3 p_start = Vector3(0, 0, 0)) const;
 
 	float get_znear() const;

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -55,6 +55,7 @@
 #include "editor/themes/editor_theme_manager.h"
 #include "editor/translations/editor_translation.h"
 #include "main/main.h"
+#include "scene/debugger/view_3d_controller.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/file_dialog.h"
 #include "scene/main/node.h"
@@ -83,13 +84,7 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 	bool changed = _set_only(p_name, p_value);
 	if (changed && initialized) {
 		changed_settings.insert(p_name);
-		if (p_name == SNAME("text_editor/external/exec_path")) {
-			const StringName exec_args_name = "text_editor/external/exec_flags";
-			const String exec_args_value = _guess_exec_args_for_extenal_editor(p_value);
-			if (!exec_args_value.is_empty() && _set_only(exec_args_name, exec_args_value)) {
-				changed_settings.insert(exec_args_name);
-			}
-		}
+		_update_linked_settings(p_name, p_value);
 		emit_signal(SNAME("settings_changed"));
 	}
 	return true;
@@ -1288,6 +1283,31 @@ String EditorSettings::_guess_exec_args_for_extenal_editor(const String &p_path)
 	}
 
 	return new_exec_flags;
+}
+
+void EditorSettings::_update_linked_settings(const StringName &p_name, const Variant &p_value) {
+	const String &name_string = p_name;
+	if (p_name == SNAME("text_editor/external/exec_path")) {
+		const StringName exec_args_name = "text_editor/external/exec_flags";
+		const String exec_args_value = _guess_exec_args_for_extenal_editor(p_value);
+		if (!exec_args_value.is_empty() && _set_only(exec_args_name, exec_args_value)) {
+			changed_settings.insert(exec_args_name);
+		}
+	} else if (p_name == "interface/theme/accent_color" || p_name == "interface/theme/base_color" || p_name == "interface/theme/contrast" || p_name == "interface/theme/draw_extra_borders" || p_name == "interface/theme/icon_saturation" || p_name == "interface/theme/draw_relationship_lines" || p_name == "interface/theme/corner_radius") {
+		// Set theme presets to Custom when controlled settings change.
+		set_manually("interface/theme/color_preset", "Custom");
+	} else if (p_name == "interface/theme/base_spacing" || p_name == "interface/theme/additional_spacing") {
+		set_manually("interface/theme/spacing_preset", "Custom");
+	} else if (name_string.begins_with("text_editor/theme/highlighting")) {
+		set_manually("text_editor/theme/color_theme", "Custom");
+	} else if (name_string.begins_with("editors/visual_editors/connection_colors") || name_string.begins_with("editors/visual_editors/category_colors")) {
+		set_manually("editors/visual_editors/color_theme", "Custom");
+	} else if (p_name == "editors/3d/navigation/orbit_mouse_button" || p_name == "editors/3d/navigation/pan_mouse_button" || p_name == "editors/3d/navigation/zoom_mouse_button" || p_name == "editors/3d/navigation/emulate_3_button_mouse") {
+		set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
+	} else if (p_name == "interface/editor/appearance/custom_display_scale") {
+		// The "Custom" display scale is index 7 in the setting's enum hint.
+		set_manually("interface/editor/appearance/display_scale", 7);
+	}
 }
 
 const String EditorSettings::_get_project_metadata_path() const {

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -122,6 +122,7 @@ private:
 	void _set_initialized();
 	void _load_defaults(Ref<ConfigFile> p_extra_config = Ref<ConfigFile>());
 	void _load_default_visual_shader_editor_theme();
+	void _update_linked_settings(const StringName &p_name, const Variant &p_value);
 	static String _guess_exec_args_for_extenal_editor(const String &p_value);
 	const String _get_project_metadata_path() const;
 #ifndef DISABLE_DEPRECATED

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -51,7 +51,6 @@
 #include "editor/settings/project_settings_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
-#include "scene/debugger/view_3d_controller.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/tab_container.h"
@@ -68,135 +67,6 @@ void EditorSettingsDialog::ok_pressed() {
 
 void EditorSettingsDialog::_settings_changed() {
 	timer->start();
-}
-
-void EditorSettingsDialog::_settings_property_edited() {
-	Vector<String> changed = EditorSettings::get_singleton()->get_changed_settings();
-	if (changed.is_empty()) {
-		return;
-	}
-
-	const String full_name = changed[changed.size() - 1];
-
-	// Set theme presets to Custom when controlled settings change.
-
-	if (full_name == "interface/theme/accent_color" || full_name == "interface/theme/base_color" || full_name == "interface/theme/contrast" || full_name == "interface/theme/draw_extra_borders" || full_name == "interface/theme/icon_saturation" || full_name == "interface/theme/draw_relationship_lines" || full_name == "interface/theme/corner_radius") {
-		EditorSettings::get_singleton()->set_manually("interface/theme/color_preset", "Custom");
-	} else if (full_name == "interface/theme/base_spacing" || full_name == "interface/theme/additional_spacing") {
-		EditorSettings::get_singleton()->set_manually("interface/theme/spacing_preset", "Custom");
-	} else if (full_name.begins_with("text_editor/theme/highlighting")) {
-		EditorSettings::get_singleton()->set_manually("text_editor/theme/color_theme", "Custom");
-	} else if (full_name.begins_with("editors/visual_editors/connection_colors") || full_name.begins_with("editors/visual_editors/category_colors")) {
-		EditorSettings::get_singleton()->set_manually("editors/visual_editors/color_theme", "Custom");
-	} else if (full_name == "editors/3d/navigation/orbit_mouse_button" || full_name == "editors/3d/navigation/pan_mouse_button" || full_name == "editors/3d/navigation/zoom_mouse_button" || full_name == "editors/3d/navigation/emulate_3_button_mouse") {
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
-	} else if (full_name == "editors/3d/navigation/navigation_scheme") {
-		update_3d_navigation_preset();
-		_update_shortcuts();
-	} else if (full_name == "interface/editor/appearance/custom_display_scale") {
-		// The "Custom" display scale is index 7 in the setting's enum hint.
-		EditorSettings::get_singleton()->set_manually("interface/editor/appearance/display_scale", 7);
-	}
-}
-
-void EditorSettingsDialog::update_3d_navigation_preset() {
-	View3DController::NavigationScheme nav_scheme = (View3DController::NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
-	View3DController::NavigationMouseButton set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
-	View3DController::NavigationMouseButton set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
-	View3DController::NavigationMouseButton set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
-	bool set_3_button_mouse = false;
-	Ref<InputEventKey> orbit_mod_key_1;
-	Ref<InputEventKey> orbit_mod_key_2;
-	Ref<InputEventKey> pan_mod_key_1;
-	Ref<InputEventKey> pan_mod_key_2;
-	Ref<InputEventKey> zoom_mod_key_1;
-	Ref<InputEventKey> zoom_mod_key_2;
-	Ref<InputEventKey> orbit_snap_mod_key_1;
-	Ref<InputEventKey> orbit_snap_mod_key_2;
-	bool set_preset = false;
-
-	if (nav_scheme == View3DController::NAV_SCHEME_GODOT) {
-		set_preset = true;
-		set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
-		set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
-		set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
-		set_3_button_mouse = false;
-		orbit_mod_key_1 = InputEventKey::create_reference(Key::NONE);
-		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
-		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		zoom_mod_key_1 = InputEventKey::create_reference(Key::CTRL);
-		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		orbit_snap_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		orbit_snap_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-	} else if (nav_scheme == View3DController::NAV_SCHEME_MAYA) {
-		set_preset = true;
-		set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
-		set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
-		set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_RIGHT;
-		set_3_button_mouse = false;
-		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_1 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		zoom_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		orbit_snap_mod_key_1 = InputEventKey::create_reference(Key::NONE);
-		orbit_snap_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-	} else if (nav_scheme == View3DController::NAV_SCHEME_MODO) {
-		set_preset = true;
-		set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
-		set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
-		set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_LEFT;
-		set_3_button_mouse = false;
-		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
-		pan_mod_key_2 = InputEventKey::create_reference(Key::ALT);
-		zoom_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		zoom_mod_key_2 = InputEventKey::create_reference(Key::CTRL);
-		orbit_snap_mod_key_1 = InputEventKey::create_reference(Key::NONE);
-		orbit_snap_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-	} else if (nav_scheme == View3DController::NAV_SCHEME_TABLET) {
-		set_preset = true;
-		set_orbit_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
-		set_pan_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
-		set_zoom_mouse_button = View3DController::NAV_MOUSE_BUTTON_MIDDLE;
-		set_3_button_mouse = true;
-		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
-		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		zoom_mod_key_1 = InputEventKey::create_reference(Key::CTRL);
-		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		orbit_snap_mod_key_1 = InputEventKey::create_reference(Key::NONE);
-		orbit_snap_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-	}
-	// Set settings to the desired preset values.
-	if (set_preset) {
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/orbit_mouse_button", (int)set_orbit_mouse_button);
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/pan_mouse_button", (int)set_pan_mouse_button);
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/zoom_mouse_button", (int)set_zoom_mouse_button);
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/emulate_3_button_mouse", set_3_button_mouse);
-		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2);
-		_set_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_pan_modifier_2", pan_mod_key_2);
-		_set_shortcut_input("spatial_editor/viewport_zoom_modifier_1", zoom_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_zoom_modifier_2", zoom_mod_key_2);
-		_set_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_1", orbit_snap_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_2", orbit_snap_mod_key_2);
-	}
-}
-
-void EditorSettingsDialog::_set_shortcut_input(const String &p_name, Ref<InputEventKey> &p_event) {
-	Array sc_events;
-	if (p_event->get_keycode() != Key::NONE) {
-		sc_events.push_back((Variant)p_event);
-	}
-
-	Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(p_name);
-	sc->set_events(sc_events);
 }
 
 void EditorSettingsDialog::_settings_save() {
@@ -456,13 +326,6 @@ void EditorSettingsDialog::_update_shortcut_events(const String &p_path, const A
 		undo_redo->add_do_method(this, "_settings_changed");
 		undo_redo->add_undo_method(this, "_settings_changed");
 		undo_redo->commit_action();
-	}
-
-	bool path_is_orbit_mod = p_path == "spatial_editor/viewport_orbit_modifier_1" || p_path == "spatial_editor/viewport_orbit_modifier_2";
-	bool path_is_pan_mod = p_path == "spatial_editor/viewport_pan_modifier_1" || p_path == "spatial_editor/viewport_pan_modifier_2";
-	bool path_is_zoom_mod = p_path == "spatial_editor/viewport_zoom_modifier_1" || p_path == "spatial_editor/viewport_zoom_modifier_2";
-	if (path_is_orbit_mod || path_is_pan_mod || path_is_zoom_mod) {
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
 	}
 }
 
@@ -1065,9 +928,6 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	restart_close_button->connect(SceneStringName(pressed), callable_mp(this, &EditorSettingsDialog::_editor_restart_close));
 	restart_hb->add_child(restart_close_button);
 	restart_container->hide();
-
-	// Needs to be done via the signal instead of the notification, otherwise it happens too late.
-	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorSettingsDialog::_settings_property_edited));
 
 	// Shortcuts Tab
 

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -81,7 +81,6 @@ class EditorSettingsDialog : public AcceptDialog {
 	virtual void ok_pressed() override;
 
 	void _settings_changed();
-	void _settings_property_edited();
 	void _settings_save();
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
@@ -114,7 +113,6 @@ class EditorSettingsDialog : public AcceptDialog {
 	void _update_shortcuts();
 	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button = MouseButton::LEFT);
 	void _shortcut_cell_double_clicked();
-	static void _set_shortcut_input(const String &p_name, Ref<InputEventKey> &p_event);
 
 	static void _undo_redo_callback(void *p_self, const String &p_name);
 
@@ -135,7 +133,6 @@ protected:
 
 public:
 	void popup_edit_settings();
-	static void update_3d_navigation_preset();
 	void set_current_section(const String &p_section);
 	void set_advanced_mode_enabled(bool p_enabled);
 	static EditorSettingsDialog *get_singleton() { return singleton; }


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/113440

Some EditorSettings don't update correctly from code.
All settings that are part of presets don't work correctly since they don't set the preset to `Custom`, and the value gets updated by the preset.

This is mainly theme settings, it includes `interface/theme`, `text_editor/theme`, `editors/visual_editors/color_theme`, and `editors/3d/navigation/navigation_scheme`.
Setting the presets themselves works, except for `navigation_scheme`.
For example, setting `"interface/theme/accent_color"` in an EditorScript will not change the color (Unless the `interface/theme` is already set to `Custom`).

Now the presets are updated in EditorSettings instead of just in the dialog.
Also moved navigation preset code to the node3d editor.

I plan to do more fixes with the presets in another PR (https://github.com/godotengine/godot/pull/114090)

Update:
- Also fixes https://github.com/godotengine/godot/issues/99215
The settings controlled by the navigation preset now update after the usual delay that the notification uses, so the modifier is updated at the same time as the button.
- Fixes https://github.com/godotengine/godot/issues/121861