### PR TITLE
Write to animation import settings only when needed to prevent bloating the .import file

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -344,11 +344,12 @@ void SceneImportSettingsDialog::_fill_animation(Tree *p_tree, const Ref<Animatio
 		ad.animation = p_anim;
 
 		_load_default_subresource_settings(ad.settings, "animations", p_name, ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION);
-		if (!ad.settings.has("settings/loop_mode")) {
+		Animation::LoopMode loop_mode = p_anim->get_loop_mode();
+		if (!ad.settings.has("settings/loop_mode") && loop_mode != Animation::LoopMode::LOOP_NONE) {
 			// Update the loop mode to match detected mode (from import hints).
 			// This is necessary on the first import of a scene, otherwise the
 			// default (0/NONE) is set when filling out defaults.
-			ad.settings["settings/loop_mode"] = p_anim->get_loop_mode();
+			ad.settings["settings/loop_mode"] = loop_mode;
 		}
 
 		animation_map[p_name] = ad;


### PR DESCRIPTION
Fix #114008

This preserves the logic of the previous PR that writes to import settings to preserve changes by import hints, but does it only if such a change exists to prevent file size bloat if both import settings and hints are not used.