### PR TITLE
Add optional names to tweens for debugging purposes

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -137,6 +137,13 @@
 				Returns the number of remaining loops for this [Tween] (see [method set_loops]). A return value of [code]-1[/code] indicates an infinitely looping [Tween], and a return value of [code]0[/code] indicates that the [Tween] has already finished.
 			</description>
 		</method>
+		<method name="get_name" qualifiers="const">
+			<return type="StringName" />
+			<description>
+				Returns the name set using [method set_name] for this [Tween], or an empty StringName if none was set.
+				[b]Warning:[/b] Note that a [Tween]'s name is not guaranteed to uniquely identify it.
+			</description>
+		</method>
 		<method name="get_total_elapsed_time" qualifiers="const">
 			<return type="float" />
 			<description>
@@ -256,6 +263,26 @@
 				Sets the number of times the tweening sequence will be repeated, i.e. [code]set_loops(2)[/code] will run the animation twice.
 				Calling this method without arguments will make the [Tween] run infinitely, until either it is killed with [method kill], the [Tween]'s bound node is freed, or all the animated objects have been freed (which makes further animation impossible).
 				[b]Warning:[/b] Make sure to always add some duration/delay when using infinite loops. To prevent the game freezing, 0-duration looped animations (e.g. a single [CallbackTweener] with no delay) are stopped after a small number of loops, which may produce unexpected results. If a [Tween]'s lifetime depends on some node, always use [method bind_node].
+			</description>
+		</method>
+		<method name="set_name">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Sets a name for this [Tween] to use in error statements and when displayed as a string. This is useful for determining exactly which [Tween] is raising errors when many [Tween]s are being used at the same time.
+				[codeblock]
+				var unnamed_tween = create_tween()
+				unnamed_tween.tween_callback(func(): print("This tween is looping forever"))
+				unnamed_tween.set_loops(-1)
+				# ERROR: Infinite loop detected. Check set_loops() description for more info.
+
+				var named_tween = create_tween()
+				named_tween.set_name("SlideDown")
+				named_tween.tween_callback(func(): print("This tween is looping forever"))
+				named_tween.set_loops(-1)
+				# ERROR: Infinite loop detected in Tween "SlideDown". Check set_loops() description for more info.
+				[/codeblock]
+				See also [method get_name].
 			</description>
 		</method>
 		<method name="set_parallel">

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -37,8 +37,13 @@
 #include "scene/resources/animation.h"
 
 #define CHECK_VALID() \
-	ERR_FAIL_COND_V_MSG(!valid, nullptr, "Tween invalid. Either finished or created outside scene tree."); \
-	ERR_FAIL_COND_V_MSG(started, nullptr, "Can't append to a Tween that has started. Use stop() first.");
+	if (!name.is_empty()) { \
+		ERR_FAIL_COND_V_MSG(!valid, nullptr, vformat("Tween \"%s\" invalid. Either finished or created outside scene tree.", name)); \
+		ERR_FAIL_COND_V_MSG(started, nullptr, vformat("Can't append to a Tween \"%s\" that has started. Use stop() first.", name)); \
+	} else { \
+		ERR_FAIL_COND_V_MSG(!valid, nullptr, "Tween invalid. Either finished or created outside scene tree."); \
+		ERR_FAIL_COND_V_MSG(started, nullptr, "Can't append to a Tween that has started. Use stop() first."); \
+	}
 
 Tween::interpolater Tween::interpolaters[Tween::TRANS_MAX][Tween::EASE_MAX] = {
 	{ &Linear::in, &Linear::in, &Linear::in, &Linear::in }, // Linear is the same for each easing.
@@ -80,7 +85,11 @@ void Tweener::_bind_methods() {
 void Tween::_start_tweeners() {
 	if (tweeners.is_empty()) {
 		dead = true;
-		ERR_FAIL_MSG("Tween without commands, aborting.");
+		if (!name.is_empty()) {
+			ERR_FAIL_MSG(vformat("Tween \"%s\" has no commands, aborting.", name));
+		} else {
+			ERR_FAIL_MSG("Tween has no commands, aborting.");
+		}
 	}
 
 	for (Ref<Tweener> &tweener : tweeners[current_step]) {
@@ -202,8 +211,14 @@ void Tween::pause() {
 }
 
 void Tween::play() {
-	ERR_FAIL_COND_MSG(!valid, "Tween invalid. Either finished or created outside scene tree.");
-	ERR_FAIL_COND_MSG(dead, "Can't play finished Tween, use stop() first to reset its state.");
+	if (!name.is_empty()) {
+		ERR_FAIL_COND_MSG(!valid, vformat("Tween \"%s\" invalid. Either finished or created outside scene tree.", name));
+		ERR_FAIL_COND_MSG(dead, vformat("Can't play finished Tween \"%s\", use stop() first to reset its state.", name));
+	} else {
+		ERR_FAIL_COND_MSG(!valid, "Tween invalid. Either finished or created outside scene tree.");
+		ERR_FAIL_COND_MSG(dead, "Can't play finished Tween, use stop() first to reset its state.");
+	}
+
 	running = true;
 }
 
@@ -323,7 +338,11 @@ RequiredResult<Tween> Tween::chain() {
 }
 
 bool Tween::custom_step(double p_delta) {
-	ERR_FAIL_COND_V_MSG(in_step, true, "Can't call custom_step() during another Tween step.");
+	if (!name.is_empty()) {
+		ERR_FAIL_COND_V_MSG(in_step, true, vformat("Can't call custom_step() during another Tween step for Tween named \"%s\".", name));
+	} else {
+		ERR_FAIL_COND_V_MSG(in_step, true, "Can't call custom_step() during another Tween step.");
+	}
 
 	bool r = running;
 	running = true;
@@ -355,10 +374,10 @@ bool Tween::step(double p_delta) {
 
 	if (!started) {
 		if (tweeners.is_empty()) {
-			String tween_id;
+			String tween_id = name.is_empty() ? "Tween" : vformat("Tween \"%s\"", name);
 			Node *node = get_bound_node();
 			if (node) {
-				tween_id = vformat("Tween (bound to %s)", node->is_inside_tree() ? (String)node->get_path() : (String)node->get_name());
+				tween_id = vformat("%s (bound to %s)", tween_id, node->is_inside_tree() ? (String)node->get_path() : (String)node->get_name());
 			} else {
 				tween_id = to_string();
 			}
@@ -417,7 +436,11 @@ bool Tween::step(double p_delta) {
 						} else {
 							// Looped twice without using any time, this is 100% certain infinite loop.
 							in_step = false;
-							ERR_FAIL_V_MSG(false, "Infinite loop detected. Check set_loops() description for more info.");
+							if (!name.is_empty()) {
+								ERR_FAIL_V_MSG(false, vformat("Infinite loop detected in Tween \"%s\". Check set_loops() description for more info.", name));
+							} else {
+								ERR_FAIL_V_MSG(false, "Infinite loop detected. Check set_loops() description for more info.");
+							}
 						}
 					}
 #endif
@@ -476,10 +499,21 @@ Variant Tween::interpolate_variant(const Variant &p_initial_val, const Variant &
 String Tween::_to_string() {
 	String ret = Object::_to_string();
 	Node *node = get_bound_node();
+	if (!name.is_empty()) {
+		ret += vformat(" \"%s\"", name);
+	}
 	if (node) {
 		ret += vformat(" (bound to %s)", node->get_name());
 	}
 	return ret;
+}
+
+void Tween::set_name(const StringName &p_name) {
+	name = p_name;
+}
+
+StringName Tween::get_name() const {
+	return name;
 }
 
 void Tween::_bind_methods() {
@@ -514,6 +548,9 @@ void Tween::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("parallel"), &Tween::parallel);
 	ClassDB::bind_method(D_METHOD("chain"), &Tween::chain);
+
+	ClassDB::bind_method(D_METHOD("set_name", "name"), &Tween::set_name);
+	ClassDB::bind_method(D_METHOD("get_name"), &Tween::get_name);
 
 	ClassDB::bind_static_method("Tween", D_METHOD("interpolate_value", "initial_value", "delta_value", "elapsed_time", "duration", "trans_type", "ease_type"), &Tween::interpolate_variant);
 
@@ -562,10 +599,19 @@ double PropertyTweener::_get_custom_interpolated_value(const Variant &p_value) {
 	Variant result;
 	Callable::CallError ce;
 	custom_method.callp(&argptr, 1, result, ce);
+	Ref<Tween> tween = _get_tween();
 	if (ce.error != Callable::CallError::CALL_OK) {
-		ERR_FAIL_V_MSG(false, "Error calling custom method from PropertyTweener: " + Variant::get_callable_error_text(custom_method, &argptr, 1, ce) + ".");
+		if (!tween->get_name().is_empty()) {
+			ERR_FAIL_V_MSG(false, vformat("Error calling custom method from PropertyTweener in Tween \"%s\": %s.", tween->get_name(), Variant::get_callable_error_text(custom_method, &argptr, 1, ce)));
+		} else {
+			ERR_FAIL_V_MSG(false, vformat("Error calling custom method from PropertyTweener: %s.", Variant::get_callable_error_text(custom_method, &argptr, 1, ce)));
+		}
 	} else if (result.get_type() != Variant::FLOAT) {
-		ERR_FAIL_V_MSG(false, vformat("Wrong return type in PropertyTweener custom method. Expected float, got %s.", Variant::get_type_name(result.get_type())));
+		if (!tween->get_name().is_empty()) {
+			ERR_FAIL_V_MSG(false, vformat("Wrong return type in PropertyTweener custom method in Tween \"%s\". Expected float, got %s.", tween->get_name(), Variant::get_type_name(result.get_type())));
+		} else {
+			ERR_FAIL_V_MSG(false, vformat("Wrong return type in PropertyTweener custom method. Expected float, got %s.", Variant::get_type_name(result.get_type())));
+		}
 	}
 	return result;
 }
@@ -768,7 +814,12 @@ bool CallbackTweener::step(double &r_delta) {
 		Callable::CallError ce;
 		callback.callp(nullptr, 0, result, ce);
 		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(false, "Error calling method from CallbackTweener: " + Variant::get_callable_error_text(callback, nullptr, 0, ce) + ".");
+			Ref<Tween> tween = _get_tween();
+			if (!tween->get_name().is_empty()) {
+				ERR_FAIL_V_MSG(false, vformat("Error calling method from CallbackTweener in Tween \"%s\": %s.", tween->get_name(), Variant::get_callable_error_text(callback, nullptr, 0, ce)));
+			} else {
+				ERR_FAIL_V_MSG(false, vformat("Error calling method from CallbackTweener: %s.", Variant::get_callable_error_text(callback, nullptr, 0, ce)));
+			}
 		}
 
 		r_delta = elapsed_time - delay;
@@ -845,7 +896,11 @@ bool MethodTweener::step(double &r_delta) {
 	Callable::CallError ce;
 	callback.callp(argptr, 1, result, ce);
 	if (ce.error != Callable::CallError::CALL_OK) {
-		ERR_FAIL_V_MSG(false, "Error calling method from MethodTweener: " + Variant::get_callable_error_text(callback, argptr, 1, ce) + ".");
+		if (!tween->get_name().is_empty()) {
+			ERR_FAIL_V_MSG(false, vformat("Error calling method from MethodTweener in Tween \"%s\": %s.", tween->get_name(), Variant::get_callable_error_text(callback, argptr, 1, ce)));
+		} else {
+			ERR_FAIL_V_MSG(false, vformat("Error calling method from MethodTweener: %s.", Variant::get_callable_error_text(callback, argptr, 1, ce)));
+		}
 	}
 
 	if (time < duration) {

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -130,6 +130,8 @@ private:
 	bool valid = false;
 	bool default_parallel = false;
 	bool parallel_enabled = false;
+
+	StringName name;
 #ifdef DEBUG_ENABLED
 	bool is_infinite = false;
 #endif
@@ -191,6 +193,9 @@ public:
 	bool can_process(bool p_tree_paused) const;
 	Node *get_bound_node() const;
 	double get_total_time() const;
+
+	void set_name(const StringName &p_name);
+	StringName get_name() const;
 
 	Tween();
 	Tween(SceneTree *p_parent_tree);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12712 .

This PR adds the `set_name()` and `get_name()` methods to Tween. When a Tween is given a name, error messages involving that Tween will display the name. This will help users diagnose which Tween within a scene is experiencing issues, if they have a tween-heavy workflow (i.e., animating lots of things using tweens simultaneously).

Example:
```gdscript
var unnamed_tween = create_tween()
unnamed_tween.tween_callback(func(): print("This tween is looping forever"))
unnamed_tween.set_loops(-1)
# ERROR: Infinite loop detected. Check set_loops() description for more info.

var named_tween = create_tween()
named_tween.set_name("SlideDown")
named_tween.tween_callback(func(): print("This tween is looping forever"))
named_tween.set_loops(-1)
# ERROR: Infinite loop detected in Tween "SlideDown". Check set_loops() description for more info.
```