### PR TITLE
Add `noperspective` back into glslang and add Affine texture mapping to BaseMaterial3D

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -424,6 +424,9 @@
 		<member name="subsurf_scatter_transmittance_texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The texture to use for multiplying the intensity of the subsurface scattering transmittance intensity. See also [member subsurf_scatter_texture]. Ignored if [member subsurf_scatter_skin_mode] is [code]true[/code].
 		</member>
+		<member name="texture_affine_mapping" type="bool" setter="set_affine_mapping_enabled" getter="is_affine_mapping_enabled" default="false">
+			If [code]true[/code] use affine texture mapping instead of perspective texture mapping. Only effective if [member uv1_triplanar] is [code]false[/code]
+		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="BaseMaterial3D.TextureFilter" default="3">
 			Filter flags for the texture.
 			[b]Note:[/b] [member heightmap_texture] is always sampled with linear filtering, even if nearest-neighbor filtering is selected here. This is to ensure the heightmap effect looks as intended. If you need sharper height transitions between pixels, resize the heightmap texture in an image editor with nearest-neighbor filtering.

--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -425,7 +425,7 @@
 			The texture to use for multiplying the intensity of the subsurface scattering transmittance intensity. See also [member subsurf_scatter_texture]. Ignored if [member subsurf_scatter_skin_mode] is [code]true[/code].
 		</member>
 		<member name="texture_affine_mapping" type="bool" setter="set_affine_mapping_enabled" getter="is_affine_mapping_enabled" default="false">
-			If [code]true[/code] use affine texture mapping instead of perspective texture mapping. Only effective if [member uv1_triplanar] is [code]false[/code]
+			If [code]true[/code], use affine texture mapping instead of perspective texture mapping. Only effective if [member uv1_triplanar] is [code]false[/code].
 		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="BaseMaterial3D.TextureFilter" default="3">
 			Filter flags for the texture.

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1214,7 +1214,7 @@ uniform vec3 uv2_offset;
 	}
 
 	if (affine) {
-		code += "varying vec3 uv_affine;\n";
+		code += "varying noperspective vec2 uv_affine;\n";
 	}
 
 	// Generate vertex shader.
@@ -1479,8 +1479,9 @@ void vertex() {)";
 	}
 
 	if (affine) {
-		code += "vec4 pos = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);";
-		code += "uv_affine = vec3(UV * pos.w, pos.w);";
+		code += R"(
+	uv_affine = UV;
+)";
 	}
 
 	// End of the vertex shader function.
@@ -1513,7 +1514,7 @@ void fragment() {)";
 	if (!flags[FLAG_UV1_USE_TRIPLANAR]) {
 		if (affine) {
 			code += R"(
-	vec2 base_uv = uv_affine.xy / uv_affine.z;
+	vec2 base_uv = uv_affine;
 )";
 		} else {
 			code += R"(
@@ -4133,7 +4134,7 @@ bool StandardMaterial3D::_set(const StringName &p_name, const Variant &p_value) 
 			{ "depth_texture", "heightmap_texture" },
 
 			{ "emission_energy", "emission_energy_multiplier" },
-			{ "affine", "affine" },
+			{ "texture_affine_mapping", "texture_affine_mapping" },
 
 			{ nullptr, nullptr },
 		};

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1480,7 +1480,7 @@ void vertex() {)";
 
 	if (affine) {
 		code += "vec4 pos = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);";
-		code += "uv_affine = vec3(UV*pos.w, pos.w);";
+		code += "uv_affine = vec3(UV * pos.w, pos.w);";
 	}
 
 	// End of the vertex shader function.

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1512,7 +1512,7 @@ void fragment() {)";
 
 	if (!flags[FLAG_UV1_USE_TRIPLANAR]) {
 		if (affine) {
-		code += R"(
+			code += R"(
 	vec2 base_uv = uv_affine.xy / uv_affine.z;
 )";
 		} else {

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -662,6 +662,8 @@ void BaseMaterial3D::init_shaders() {
 	shader_names->texture_names[TEXTURE_DETAIL_NORMAL] = "texture_detail_normal";
 	shader_names->texture_names[TEXTURE_ORM] = "texture_orm";
 
+	shader_names->affine_mapping = "affine_mapping";
+
 	shader_names->alpha_scissor_threshold = "alpha_scissor_threshold";
 	shader_names->alpha_hash_scale = "alpha_hash_scale";
 
@@ -1211,6 +1213,10 @@ uniform vec3 uv2_offset;
 		code += "uniform float fov_override : hint_range(1.0, 179.0, 0.1);\n";
 	}
 
+	if (affine) {
+		code += "varying vec3 uv_affine;\n";
+	}
+
 	// Generate vertex shader.
 	code += R"(
 void vertex() {)";
@@ -1472,6 +1478,11 @@ void vertex() {)";
 )";
 	}
 
+	if (affine) {
+		code += "vec4 pos = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);";
+		code += "uv_affine = vec3(UV*pos.w, pos.w);";
+	}
+
 	// End of the vertex shader function.
 	code += "}\n";
 
@@ -1500,9 +1511,15 @@ vec4 triplanar_texture(sampler2D p_sampler, vec3 p_weights, vec3 p_triplanar_pos
 void fragment() {)";
 
 	if (!flags[FLAG_UV1_USE_TRIPLANAR]) {
+		if (affine) {
 		code += R"(
+	vec2 base_uv = uv_affine.xy / uv_affine.z;
+)";
+		} else {
+			code += R"(
 	vec2 base_uv = UV;
 )";
+		}
 	}
 
 	if ((features[FEATURE_DETAIL] && detail_uv == DETAIL_UV_2) || (features[FEATURE_AMBIENT_OCCLUSION] && flags[FLAG_AO_ON_UV2]) || (features[FEATURE_EMISSION] && flags[FLAG_EMISSION_ON_UV2])) {
@@ -2904,6 +2921,16 @@ bool BaseMaterial3D::is_grow_enabled() const {
 	return grow_enabled;
 }
 
+void BaseMaterial3D::set_affine_mapping_enabled(bool p_enable) {
+	affine = p_enable;
+	_queue_shader_change();
+	notify_property_list_changed();
+}
+
+bool BaseMaterial3D::is_affine_mapping_enabled() const {
+	return affine;
+}
+
 void BaseMaterial3D::set_alpha_scissor_threshold(float p_threshold) {
 	alpha_scissor_threshold = p_threshold;
 	_material_set_param(shader_names->alpha_scissor_threshold, p_threshold);
@@ -3519,6 +3546,9 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_grow_enabled", "enable"), &BaseMaterial3D::set_grow_enabled);
 	ClassDB::bind_method(D_METHOD("is_grow_enabled"), &BaseMaterial3D::is_grow_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_affine_mapping_enabled", "enable"), &BaseMaterial3D::set_affine_mapping_enabled);
+	ClassDB::bind_method(D_METHOD("is_affine_mapping_enabled"), &BaseMaterial3D::is_affine_mapping_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_metallic_texture_channel", "channel"), &BaseMaterial3D::set_metallic_texture_channel);
 	ClassDB::bind_method(D_METHOD("get_metallic_texture_channel"), &BaseMaterial3D::get_metallic_texture_channel);
 
@@ -3723,6 +3753,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_GROUP("Sampling", "texture_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "texture_repeat"), "set_flag", "get_flag", FLAG_USE_TEXTURE_REPEAT);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "texture_affine_mapping"), "set_affine_mapping_enabled", "is_affine_mapping_enabled");
 
 	ADD_GROUP("Shadows", "");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "disable_receive_shadows"), "set_flag", "get_flag", FLAG_DONT_RECEIVE_SHADOWS);
@@ -3981,6 +4012,8 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 
 	set_grow(0.0);
 
+	set_affine_mapping_enabled(false);
+
 	set_msdf_pixel_range(4.0);
 	set_msdf_outline_size(0.0);
 
@@ -4100,6 +4133,7 @@ bool StandardMaterial3D::_set(const StringName &p_name, const Variant &p_value) 
 			{ "depth_texture", "heightmap_texture" },
 
 			{ "emission_energy", "emission_energy_multiplier" },
+			{ "affine_mapping", "affine_mapping" },
 
 			{ nullptr, nullptr },
 		};

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -4133,7 +4133,7 @@ bool StandardMaterial3D::_set(const StringName &p_name, const Variant &p_value) 
 			{ "depth_texture", "heightmap_texture" },
 
 			{ "emission_energy", "emission_energy_multiplier" },
-			{ "affine_mapping", "affine_mapping" },
+			{ "affine", "affine" },
 
 			{ nullptr, nullptr },
 		};

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -387,6 +387,7 @@ private:
 		uint64_t grow : 1;
 		uint64_t proximity_fade : 1;
 		uint64_t orm : 1;
+		uint64_t affine : 1;
 
 		// flag bitfield
 		uint32_t feature_mask;
@@ -441,6 +442,7 @@ private:
 		mk.emission_op = emission_op;
 		mk.alpha_antialiasing_mode = alpha_antialiasing_mode;
 		mk.orm = orm;
+		mk.affine = affine;
 
 		mk.stencil_mode = stencil_mode;
 		mk.stencil_flags = stencil_flags;
@@ -502,6 +504,7 @@ private:
 		StringName distance_fade_min;
 		StringName distance_fade_max;
 		StringName ao_light_affect;
+		StringName affine_mapping;
 
 		StringName metallic_texture_channel;
 		StringName ao_texture_channel;
@@ -569,6 +572,7 @@ private:
 	bool particles_anim_loop = false;
 	Transparency transparency = TRANSPARENCY_DISABLED;
 	ShadingMode shading_mode = SHADING_MODE_PER_PIXEL;
+	bool affine = false;
 
 	TextureFilter texture_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
 
@@ -808,6 +812,9 @@ public:
 
 	void set_grow(float p_grow);
 	float get_grow() const;
+
+	void set_affine_mapping_enabled(bool p_enable);
+	bool is_affine_mapping_enabled() const;
 
 	void set_alpha_scissor_threshold(float p_threshold);
 	float get_alpha_scissor_threshold() const;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -131,6 +131,7 @@ const char *ShaderLanguage::token_names[TK_MAX] = {
 	"TYPE_SAMPLEREXT",
 	"INTERPOLATION_FLAT",
 	"INTERPOLATION_SMOOTH",
+	"INTERPOLATION_NOPERSPECTIVE",
 	"CONST",
 	"STRUCT",
 	"PRECISION_LOW",
@@ -323,6 +324,7 @@ const ShaderLanguage::KeyWord ShaderLanguage::keyword_list[] = {
 
 	{ TK_INTERPOLATION_FLAT, "flat", CF_INTERPOLATION_QUALIFIER, {}, {} },
 	{ TK_INTERPOLATION_SMOOTH, "smooth", CF_INTERPOLATION_QUALIFIER, {}, {} },
+	{ TK_INTERPOLATION_NOPERSPECTIVE, "noperspective", CF_INTERPOLATION_QUALIFIER, {}, {} },
 
 	// precision modifiers
 
@@ -1043,12 +1045,15 @@ ShaderLanguage::DataType ShaderLanguage::get_token_datatype(TokenType p_type) {
 bool ShaderLanguage::is_token_interpolation(TokenType p_type) {
 	return (
 			p_type == TK_INTERPOLATION_FLAT ||
+			p_type == TK_INTERPOLATION_NOPERSPECTIVE ||
 			p_type == TK_INTERPOLATION_SMOOTH);
 }
 
 ShaderLanguage::DataInterpolation ShaderLanguage::get_token_interpolation(TokenType p_type) {
 	if (p_type == TK_INTERPOLATION_FLAT) {
 		return INTERPOLATION_FLAT;
+	} else if (p_type == TK_INTERPOLATION_NOPERSPECTIVE) {
+		return INTERPOLATION_NOPERSPECTIVE;
 	} else {
 		return INTERPOLATION_SMOOTH;
 	}
@@ -1098,6 +1103,8 @@ String ShaderLanguage::get_interpolation_name(DataInterpolation p_interpolation)
 			return "flat";
 		case INTERPOLATION_SMOOTH:
 			return "smooth";
+		case INTERPOLATION_NOPERSPECTIVE:
+			return "noperspective";
 		default:
 			break;
 	}

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -94,6 +94,7 @@ public:
 		TK_TYPE_SAMPLEREXT,
 		TK_INTERPOLATION_FLAT,
 		TK_INTERPOLATION_SMOOTH,
+		TK_INTERPOLATION_NOPERSPECTIVE,
 		TK_CONST,
 		TK_STRUCT,
 		TK_PRECISION_LOW,
@@ -253,6 +254,7 @@ public:
 	enum DataInterpolation {
 		INTERPOLATION_FLAT,
 		INTERPOLATION_SMOOTH,
+		INTERPOLATION_NOPERSPECTIVE,
 		INTERPOLATION_DEFAULT,
 	};
 
@@ -720,6 +722,8 @@ public:
 
 		HashMap<StringName, Constant> constants;
 		HashMap<StringName, Varying> varyings;
+		//used for low-end devices that don't support the GLSL `noperspective` keyword
+		Vector<StringName> noperspective_varyings;
 		HashMap<StringName, Uniform> uniforms;
 		HashMap<StringName, Struct> structs;
 		HashMap<StringName, Function> functions;


### PR DESCRIPTION
Adds [affine texture mapping](https://en.wikipedia.org/wiki/Texture_mapping#Affine_texture_mapping) to BaseMaterial3D and adds `noperspective` back into glslang.

This effect is useful for retro graphics, such as recreating the visual style of the original Playstation. I personally made this to prevent having to do several different StandardMaterial3D -> ShaderMaterial conversions due to code repetition, then expanded it to having the `noperspective` option in glslang due to a comment under this PR.

This is an effect with very little use case outside of PSX style games, but I see many PSX games being made in Godot so I believe it may benefit by having this option be something out of the box.

~~This effect works by reversing the perspective correction that the GPU does. This is usually done via a `noperspective` keyword in the shader language, but I could not find documentation saying that there was such keyword in glslang.~~
The reversing part is only true for `gl_compatibility`, as GLES3 doesn't support `noperspective` without extensions. The other two rendering modes use the GLSL keyword `noperspective`. The rest of the statement is outdated as of this PR.

<img width="541" height="150" alt="affine3" src="https://github.com/user-attachments/assets/0a7789ec-f201-48d2-ac8b-b37cbc696873" />
<img width="1211" height="1192" alt="affine2" src="https://github.com/user-attachments/assets/9b05349a-f5e9-4232-942c-9e9fec64fe0e" />
<img width="1247" height="765" alt="affine1" src="https://github.com/user-attachments/assets/bdac0032-6932-4503-b116-39cf2ffbbd4d" />
<img width="1279" height="766" alt="image" src="https://github.com/user-attachments/assets/3858793d-9e26-4e18-84d4-c1becb9cfaec" />
