### PR TITLE
Expose method and signal for debug Mute Game state

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -118,6 +118,13 @@
 				[b]Note:[/b] The returned value is equivalent to the result of [method @GlobalScope.db_to_linear] on the result of [method get_bus_volume_db].
 			</description>
 		</method>
+		<method name="get_debug_mute" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the editor's Mute Game button is enabled, or if the game has debugging enabled and is started with the [code]--debug-mute-audio[/code] flag.
+				[b]Note:[/b] If debugging is not enabled, this will always return [code]false[/code].
+			</description>
+		</method>
 		<method name="get_driver_name" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -402,6 +409,13 @@
 			<param index="2" name="new_name" type="StringName" />
 			<description>
 				Emitted when the audio bus at [param bus_index] is renamed from [param old_name] to [param new_name].
+			</description>
+		</signal>
+		<signal name="debug_mute_toggled">
+			<param index="0" name="debug_mute_enabled" type="bool" />
+			<description>
+				Emitted when the editor's Mute Game button is toggled, with the new state as [param debug_mute_enabled].
+				[b]Note:[/b] If debugging is not enabled, this will never be emitted.
 			</description>
 		</signal>
 	</signals>

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -562,13 +562,21 @@ int AudioServer::thread_find_bus_index(const StringName &p_name) {
 
 #ifdef DEBUG_ENABLED
 void AudioServer::set_debug_mute(bool p_mute) {
+	bool old_debug_mute = debug_mute;
 	debug_mute = p_mute;
-}
-
-bool AudioServer::get_debug_mute() const {
-	return debug_mute;
+	if (old_debug_mute != p_mute) {
+		emit_signal(SNAME("debug_mute_toggled"), p_mute);
+	}
 }
 #endif // DEBUG_ENABLED
+
+bool AudioServer::get_debug_mute() const {
+#ifdef DEBUG_ENABLED
+	return debug_mute;
+#else
+	return false;
+#endif // DEBUG_ENABLED
+}
 
 void AudioServer::set_bus_count(int p_count) {
 	ERR_FAIL_COND(p_count < 1);
@@ -1892,6 +1900,8 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_stream_registered_as_sample", "stream"), &AudioServer::is_stream_registered_as_sample);
 	ClassDB::bind_method(D_METHOD("register_stream_as_sample", "stream"), &AudioServer::register_stream_as_sample);
 
+	ClassDB::bind_method(D_METHOD("get_debug_mute"), &AudioServer::get_debug_mute);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bus_count"), "set_bus_count", "get_bus_count");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "output_device"), "set_output_device", "get_output_device");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "input_device"), "set_input_device", "get_input_device");
@@ -1902,6 +1912,8 @@ void AudioServer::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("bus_layout_changed"));
 	ADD_SIGNAL(MethodInfo("bus_renamed", PropertyInfo(Variant::INT, "bus_index"), PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));
+
+	ADD_SIGNAL(MethodInfo("debug_mute_toggled", PropertyInfo(Variant::BOOL, "debug_mute_enabled")));
 
 	BIND_ENUM_CONSTANT(AuSE::SPEAKER_MODE_STEREO);
 	BIND_ENUM_CONSTANT(AuSE::SPEAKER_SURROUND_31);

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -587,13 +587,21 @@ int AudioServer::thread_find_bus_index(const StringName &p_name) {
 
 #ifdef DEBUG_ENABLED
 void AudioServer::set_debug_mute(bool p_mute) {
+	bool old_debug_mute = debug_mute;
 	debug_mute = p_mute;
-}
-
-bool AudioServer::get_debug_mute() const {
-	return debug_mute;
+	if (old_debug_mute != p_mute) {
+		emit_signal(SNAME("debug_mute_toggled"), p_mute);
+	}
 }
 #endif // DEBUG_ENABLED
+
+bool AudioServer::get_debug_mute() const {
+#ifdef DEBUG_ENABLED
+	return debug_mute;
+#else
+	return false;
+#endif // DEBUG_ENABLED
+}
 
 void AudioServer::set_bus_count(int p_count) {
 	ERR_FAIL_COND(p_count < 1);
@@ -1934,6 +1942,8 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_stream_registered_as_sample", "stream"), &AudioServer::is_stream_registered_as_sample);
 	ClassDB::bind_method(D_METHOD("register_stream_as_sample", "stream"), &AudioServer::register_stream_as_sample);
 
+	ClassDB::bind_method(D_METHOD("get_debug_mute"), &AudioServer::get_debug_mute);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bus_count"), "set_bus_count", "get_bus_count");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "output_device"), "set_output_device", "get_output_device");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "input_device"), "set_input_device", "get_input_device");
@@ -1944,6 +1954,8 @@ void AudioServer::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("bus_layout_changed"));
 	ADD_SIGNAL(MethodInfo("bus_renamed", PropertyInfo(Variant::INT, "bus_index"), PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));
+
+	ADD_SIGNAL(MethodInfo("debug_mute_toggled", PropertyInfo(Variant::BOOL, "debug_mute_enabled")));
 
 	BIND_ENUM_CONSTANT(AuSE::SPEAKER_MODE_STEREO);
 	BIND_ENUM_CONSTANT(AuSE::SPEAKER_SURROUND_31);

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -222,8 +222,9 @@ public:
 
 #ifdef DEBUG_ENABLED
 	void set_debug_mute(bool p_mute);
-	bool get_debug_mute() const;
 #endif // DEBUG_ENABLED
+	// Getter function is always included, but returns false for non-debug builds.
+	bool get_debug_mute() const;
 
 	void set_bus_count(int p_count);
 	int get_bus_count() const;

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -230,8 +230,9 @@ public:
 
 #ifdef DEBUG_ENABLED
 	void set_debug_mute(bool p_mute);
-	bool get_debug_mute() const;
 #endif // DEBUG_ENABLED
+	// Getter function is always included, but returns false for non-debug builds.
+	bool get_debug_mute() const;
 
 	void set_bus_count(int p_count);
 	int get_bus_count() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13832 .

This PR exposes `AudioServer.get_debug_mute()` and provides a new signal `AudioServer.debug_mute_toggled` for determining whether the user has enabled the Mute Game toggle in the editor. When run in an exported build, the method will always return `false` and the signal will never be emitted. This makes it feasible for third-party audio addons to respect the Mute Game button's state, in addition to Godot's built-in audio system.