### PR TITLE
Allow for setting rest pose skin onto imported meshes with skeletons

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -53,6 +53,9 @@
 #include "scene/2d/gpu_particles_2d.h"
 #include "scene/3d/fog_volume.h"
 #include "scene/3d/gpu_particles_3d.h"
+#include "scene/3d/importer_mesh_instance_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/skeleton_3d.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/text_edit.h"
@@ -3567,7 +3570,22 @@ void EditorPropertyResource::setup(Object *p_object, const String &p_path, const
 	} else if (ClassDB::is_parent_class(p_base_type, "AudioStream")) {
 		EditorAudioStreamPicker *astream_picker = memnew(EditorAudioStreamPicker);
 		resource_picker = astream_picker;
-	} else {
+	} else if (p_path == "skin" && p_base_type == "Skin") {
+		Skeleton3D *s = nullptr;
+		if (Object::cast_to<MeshInstance3D>(p_object)) {
+			MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(p_object);
+			s = Object::cast_to<Skeleton3D>(mi->get_node_or_null(mi->get_skeleton_path()));
+		} else if (Object::cast_to<ImporterMeshInstance3D>(p_object)) {
+			ImporterMeshInstance3D *imi = Object::cast_to<ImporterMeshInstance3D>(p_object);
+			s = Object::cast_to<Skeleton3D>(imi->get_node_or_null(imi->get_skeleton_path()));
+		}
+		if (s != nullptr) {
+			EditorSkinPicker *skin_picker = memnew(EditorSkinPicker);
+			skin_picker->set_rest_skin(s->create_skin_from_rest_transforms());
+			resource_picker = skin_picker;
+		}
+	}
+	if (resource_picker == nullptr) {
 		resource_picker = memnew(EditorResourcePicker);
 	}
 

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -49,6 +49,7 @@
 #include "scene/gui/button.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/property_utils.h"
+#include "scene/resources/3d/skin.h"
 #include "scene/resources/gradient_texture.h"
 #include "scene/resources/image_texture.h"
 

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1615,7 +1615,7 @@ void EditorSkinPicker::set_create_options(Object *p_menu_node) {
 }
 
 bool EditorSkinPicker::handle_menu_selected(int p_which) {
-	Ref<Skin> skin = Ref<Skin>(get_rest_skin());
+	Ref<Skin> skin = get_rest_skin();
 
 	switch (p_which) {
 		case OBJ_MENU_REST_SKIN: {

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -44,6 +44,8 @@
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/3d/importer_mesh_instance_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/button.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/property_utils.h"
@@ -1212,6 +1214,10 @@ void EditorResourcePicker::set_resource_owner(Object *p_object) {
 	resource_owner = p_object;
 }
 
+Object *EditorResourcePicker::get_resource_owner() const {
+	return resource_owner;
+}
+
 void EditorResourcePicker::set_editable(bool p_editable) {
 	editable = p_editable;
 	assign_button->set_disabled(!editable && edited_resource.is_null());
@@ -1593,6 +1599,50 @@ ShaderMaterial *EditorShaderPicker::get_edited_material() const {
 
 void EditorShaderPicker::set_preferred_mode(int p_mode) {
 	preferred_mode = p_mode;
+}
+
+// EditorSkinPicker
+
+void EditorSkinPicker::set_create_options(Object *p_menu_node) {
+	PopupMenu *menu_node = Object::cast_to<PopupMenu>(p_menu_node);
+	if (!menu_node) {
+		return;
+	}
+
+	menu_node->add_icon_item(get_editor_theme_icon(SNAME("Skin")), TTR("Rest Skin"), OBJ_MENU_REST_SKIN);
+	menu_node->add_separator();
+}
+
+bool EditorSkinPicker::handle_menu_selected(int p_which) {
+	Ref<Skin> skin = Ref<Skin>(get_rest_skin());
+
+	switch (p_which) {
+		case OBJ_MENU_REST_SKIN: {
+			if (rest_skin.is_valid()) {
+				if (Object::cast_to<MeshInstance3D>(get_resource_owner())) {
+					MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(get_resource_owner());
+					mi->set_skin(skin);
+				} else if (Object::cast_to<ImporterMeshInstance3D>(get_resource_owner())) {
+					ImporterMeshInstance3D *imi = Object::cast_to<ImporterMeshInstance3D>(get_resource_owner());
+					imi->set_skin(skin);
+				} else {
+					return false;
+				}
+				return true;
+			}
+		} break;
+		default:
+			break;
+	}
+	return false;
+}
+
+void EditorSkinPicker::set_rest_skin(Ref<Skin> p_rest_skin) {
+	rest_skin = p_rest_skin;
+}
+
+Ref<Skin> EditorSkinPicker::get_rest_skin() const {
+	return rest_skin;
 }
 
 //////////////

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -32,6 +32,7 @@
 
 #include "scene/gui/box_container.h"
 #include "scene/resources/material.h"
+#include "scene/resources/3d/skin.h"
 
 class Button;
 class ConfirmationDialog;
@@ -151,6 +152,7 @@ public:
 	bool is_toggle_pressed() const;
 
 	void set_resource_owner(Object *p_object);
+	Object *get_resource_owner() const;
 	void set_property_path(const StringName &p_path) { property_path = p_path; }
 
 	void set_editable(bool p_editable);
@@ -200,6 +202,23 @@ public:
 	void set_edited_material(ShaderMaterial *p_material);
 	ShaderMaterial *get_edited_material() const;
 	void set_preferred_mode(int p_preferred_mode);
+};
+
+class EditorSkinPicker : public EditorResourcePicker {
+	GDCLASS(EditorSkinPicker, EditorResourcePicker);
+
+	enum ExtraMenuOption {
+		OBJ_MENU_REST_SKIN = 50,
+	};
+
+	Ref<Skin> rest_skin = nullptr;
+
+public:
+	virtual void set_create_options(Object *p_menu_node) override;
+	virtual bool handle_menu_selected(int p_which) override;
+
+	void set_rest_skin(Ref<Skin> p_reset_skin);
+	Ref<Skin> get_rest_skin() const;
 };
 
 class EditorAudioStreamPicker : public EditorResourcePicker {

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -211,7 +211,7 @@ class EditorSkinPicker : public EditorResourcePicker {
 		OBJ_MENU_REST_SKIN = 50,
 	};
 
-	Ref<Skin> rest_skin = nullptr;
+	Ref<Skin> rest_skin;
 
 public:
 	virtual void set_create_options(Object *p_menu_node) override;

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -31,8 +31,8 @@
 #pragma once
 
 #include "scene/gui/box_container.h"
-#include "scene/resources/material.h"
 #include "scene/resources/3d/skin.h"
+#include "scene/resources/material.h"
 
 class Button;
 class ConfirmationDialog;

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -31,13 +31,13 @@
 #pragma once
 
 #include "scene/gui/box_container.h"
-#include "scene/resources/3d/skin.h"
 #include "scene/resources/material.h"
 
 class Button;
 class ConfirmationDialog;
 class EditorFileDialog;
 class PopupMenu;
+class Skin;
 class TextureRect;
 class Tree;
 class TreeItem;


### PR DESCRIPTION
This change allows an imported mesh to have its skin property overwritten with a generated skin reference from the rest poses of an attached skeleton.

