### PR TITLE
[TextServer] Do not skip non-color font if system fallback is disabled.

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -705,15 +705,17 @@ class TextServerAdvanced : public TextServerExtension {
 		uint32_t font_count = 0;
 		const String *language;
 		const String *script_code;
+		bool color = false;
 		LocalVector<Pair<RID, int>> unprocessed_fonts;
 		LocalVector<RID> fonts;
 		const TextServerAdvanced *text_server;
 
-		FontPriorityList(const TextServerAdvanced *p_text_server, const Array &p_fonts, const String &p_language, const String &p_script_code) {
+		FontPriorityList(const TextServerAdvanced *p_text_server, const Array &p_fonts, const String &p_language, const String &p_script_code, bool p_color) {
 			text_server = p_text_server;
 			language = &p_language;
 			script_code = &p_script_code;
 			font_count = p_fonts.size();
+			color = p_color;
 
 			unprocessed_fonts.reserve(font_count);
 			for (uint32_t i = 0; i < font_count; i++) {
@@ -733,6 +735,9 @@ class TextServerAdvanced : public TextServerExtension {
 		}
 
 		_FORCE_INLINE_ int _get_priority(const RID &p_font) {
+			if (color && text_server->_font_is_color(p_font)) {
+				return 0;
+			}
 			return text_server->_font_is_script_supported(p_font, *script_code) ? (text_server->_font_is_language_supported(p_font, *language) ? 0 : 1) : 2;
 		}
 
@@ -794,6 +799,7 @@ class TextServerAdvanced : public TextServerExtension {
 	static hb_font_t *_bmp_font_create(TextServerAdvanced::FontForSizeAdvanced *p_face, hb_destroy_func_t p_destroy);
 
 	hb_font_t *_font_get_hb_handle(const RID &p_font, int64_t p_font_size, bool &r_is_color) const;
+	bool _font_is_color(const RID &p_font) const;
 
 	struct GlyphCompare { // For line breaking reordering.
 		_FORCE_INLINE_ bool operator()(const Glyph &l, const Glyph &r) const {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113941

Instead of always skipping non-color fonts for emoji runs, sort color font with higher priority and skip only if system fallback is enabled.