### PR TITLE
Fix `ScrollContainer`'s bottom scroll hint ignoring margins

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -606,7 +606,7 @@ void ScrollContainer::_update_scrollbars() {
 void ScrollContainer::_update_scroll_hints() {
 	Size2 size = get_size();
 	Rect2 margins = _get_margins();
-	Size2 scroll_size = size - margins.position + margins.size;
+	Size2 scroll_size = size - margins.position - margins.size;
 
 	float v_scroll_value = v_scroll->get_value();
 	bool v_scroll_below_max = v_scroll_value < (largest_child_min_size.height - scroll_size.height - 1);


### PR DESCRIPTION
You can see the issue in action on the bus editor.

|Before|After|
|-|-|
|<img width="687" height="210" alt="Screenshot_20251216_110037" src="https://github.com/user-attachments/assets/b778486e-6f2e-4354-aad9-d7103a512ac9" />|<img width="687" height="210" alt="image" src="https://github.com/user-attachments/assets/3748e5f7-026c-46fb-b70c-501ebf741bac" />|