### PR TITLE
Switch mobile renderer to use fixed PCF kernel.

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1136,10 +1136,12 @@ void RendererSceneRenderRD::positional_soft_shadow_filter_set_quality(RS::Shadow
 	if (shadows_quality != p_quality) {
 		shadows_quality = p_quality;
 
+		// Mobile renderer uses different fixed count kernels. Only specific sample counts will work. Check the scene shader implementation for details.
+		bool fixed_pcf_kernel = !_render_buffers_can_be_storage();
 		switch (shadows_quality) {
 			case RS::SHADOW_QUALITY_HARD: {
 				penumbra_shadow_samples = 4;
-				soft_shadow_samples = 0;
+				soft_shadow_samples = fixed_pcf_kernel ? 1 : 0;
 				shadows_quality_radius = 1.0;
 			} break;
 			case RS::SHADOW_QUALITY_SOFT_VERY_LOW: {
@@ -1154,7 +1156,7 @@ void RendererSceneRenderRD::positional_soft_shadow_filter_set_quality(RS::Shadow
 			} break;
 			case RS::SHADOW_QUALITY_SOFT_MEDIUM: {
 				penumbra_shadow_samples = 12;
-				soft_shadow_samples = 8;
+				soft_shadow_samples = fixed_pcf_kernel ? 9 : 8;
 				shadows_quality_radius = 2.0;
 			} break;
 			case RS::SHADOW_QUALITY_SOFT_HIGH: {
@@ -1164,7 +1166,7 @@ void RendererSceneRenderRD::positional_soft_shadow_filter_set_quality(RS::Shadow
 			} break;
 			case RS::SHADOW_QUALITY_SOFT_ULTRA: {
 				penumbra_shadow_samples = 32;
-				soft_shadow_samples = 32;
+				soft_shadow_samples = fixed_pcf_kernel ? 16 : 32;
 				shadows_quality_radius = 4.0;
 			} break;
 			case RS::SHADOW_QUALITY_MAX:
@@ -1183,10 +1185,12 @@ void RendererSceneRenderRD::directional_soft_shadow_filter_set_quality(RS::Shado
 	if (directional_shadow_quality != p_quality) {
 		directional_shadow_quality = p_quality;
 
+		// Mobile renderer uses different fixed count kernels. Only specific sample counts will work. Check the scene shader implementation for details.
+		bool fixed_pcf_kernel = !_render_buffers_can_be_storage();
 		switch (directional_shadow_quality) {
 			case RS::SHADOW_QUALITY_HARD: {
 				directional_penumbra_shadow_samples = 4;
-				directional_soft_shadow_samples = 0;
+				directional_soft_shadow_samples = fixed_pcf_kernel ? 1 : 0;
 				directional_shadow_quality_radius = 1.0;
 			} break;
 			case RS::SHADOW_QUALITY_SOFT_VERY_LOW: {
@@ -1201,7 +1205,7 @@ void RendererSceneRenderRD::directional_soft_shadow_filter_set_quality(RS::Shado
 			} break;
 			case RS::SHADOW_QUALITY_SOFT_MEDIUM: {
 				directional_penumbra_shadow_samples = 12;
-				directional_soft_shadow_samples = 8;
+				directional_soft_shadow_samples = fixed_pcf_kernel ? 9 : 8;
 				directional_shadow_quality_radius = 2.0;
 			} break;
 			case RS::SHADOW_QUALITY_SOFT_HIGH: {
@@ -1211,7 +1215,7 @@ void RendererSceneRenderRD::directional_soft_shadow_filter_set_quality(RS::Shado
 			} break;
 			case RS::SHADOW_QUALITY_SOFT_ULTRA: {
 				directional_penumbra_shadow_samples = 32;
-				directional_soft_shadow_samples = 32;
+				directional_soft_shadow_samples = fixed_pcf_kernel ? 16 : 32;
 				directional_shadow_quality_radius = 4.0;
 			} break;
 			case RS::SHADOW_QUALITY_MAX:

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1023,6 +1023,9 @@ layout(location = 0) out vec4 frag_color;
 #define SPECULAR_SCHLICK_GGX
 #endif
 
+// Mobile renderer uses a fixed kernel for the PCF shadows instead of more expensive disk sampling.
+#define PCF_FIXED_KERNEL
+
 #include "../scene_forward_lights_inc.glsl"
 
 #endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && !defined(USE_VERTEX_LIGHTING)
@@ -1970,7 +1973,7 @@ void main() {
 
 					bool blend_split = sc_directional_light_blend_split(i);
 					float blend_split_weight = blend_split ? 1.0f : 0.0f;
-					shadow = half(sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor + (1.0 - blur_factor) * blend_split_weight), pssm_coord, scene_data.taa_frame_count));
+					shadow = half(sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size, pssm_coord, scene_data.taa_frame_count));
 
 					if (blend_split) {
 						half pssm_blend;
@@ -2004,7 +2007,7 @@ void main() {
 
 						pssm_coord /= pssm_coord.w;
 
-						half shadow2 = half(sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale * (blur_factor2 + (1.0 - blur_factor2) * blend_split_weight), pssm_coord, scene_data.taa_frame_count));
+						half shadow2 = half(sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size, pssm_coord, scene_data.taa_frame_count));
 						shadow = mix(shadow, shadow2, pssm_blend);
 					}
 


### PR DESCRIPTION
This PR changes the mobile renderer to use fixed kernels for shadow sampling, which can provide some pretty massive performance boosts on mobile devices when opting to use soft shadows. However, it currently breaks features such as soft shadow scaling, as the algorithm in use is not compatible with the concept of scaling as it is implemented.

As measured by @clayjohn on an Adreno 640...
```
Low Quality
Before: 20 mspf
After: 13 mspf

High Quality
Before: 44 mspf
After: 23 mspf
```
It is pretty clear that the use of a simpler kernel that doesn't rely on disk sampling can provide a pretty significant performance difference on lower end devices. However, since this PR breaks the aforementioned feature and changes the visual quality result, it is left as a draft until it is decided if the engine wants to take this approach going forward. Regardless, the PR can prove to be useful to developers who wish to use a simpler and more performant technique.

To my understanding, it was originally the intention for the mobile renderer to use techniques like these as the quality trade off is less visible on these platforms, but the implementation ended up being shared with Forward+ due to the code's structure, resulting in using a technique that might be a bit overkill depending on the developer's needs.

- *Bugsquad edit: This closes https://github.com/godotengine/godot/issues/55882
(as PCSS won't be available anymore in Mobile for any light type, rather than being in a half-working state currently).*