### PR TITLE
Fix D3D12 device not getting created with Agility SDK.

### DIFF
--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -66,7 +66,6 @@ using Microsoft::WRL::ComPtr;
 
 // Note: symbols are not available in MinGW and old MSVC import libraries.
 // GUID values from https://github.com/microsoft/DirectX-Headers/blob/7a9f4d06911d30eecb56a4956dab29dcca2709ed/include/directx/d3d12.idl#L5877-L5881
-const GUID CLSID_D3D12DeviceFactoryGodot = { 0x114863bf, 0xc386, 0x4aee, { 0xb3, 0x9d, 0x8f, 0x0b, 0xbb, 0x06, 0x29, 0x55 } };
 const GUID CLSID_D3D12DebugGodot = { 0xf2352aeb, 0xdd84, 0x49fe, { 0xb9, 0x7b, 0xa9, 0xdc, 0xfd, 0xcc, 0x1b, 0x4f } };
 const GUID CLSID_D3D12SDKConfigurationGodot = { 0x7cda6aca, 0xa03e, 0x49c8, { 0x94, 0x58, 0x03, 0x34, 0xd2, 0x0e, 0x07, 0xce } };
 
@@ -123,18 +122,14 @@ Error RenderingContextDriverD3D12::_init_device_factory() {
 		return OK; // Fallback to the system loader.
 	}
 
-	ID3D12SDKConfiguration *sdk_config = nullptr;
-	if (SUCCEEDED(d3d_D3D12GetInterface(CLSID_D3D12SDKConfigurationGodot, IID_PPV_ARGS(&sdk_config)))) {
-		ID3D12SDKConfiguration1 *sdk_config1 = nullptr;
-		if (SUCCEEDED(sdk_config->QueryInterface(&sdk_config1))) {
-			if (SUCCEEDED(sdk_config1->CreateDeviceFactory(agility_sdk_version, agility_sdk_path.ascii().get_data(), IID_PPV_ARGS(device_factory.GetAddressOf())))) {
-				d3d_D3D12GetInterface(CLSID_D3D12DeviceFactoryGodot, IID_PPV_ARGS(device_factory.GetAddressOf()));
-			} else if (SUCCEEDED(sdk_config1->CreateDeviceFactory(agility_sdk_version, ".\\", IID_PPV_ARGS(device_factory.GetAddressOf())))) {
-				d3d_D3D12GetInterface(CLSID_D3D12DeviceFactoryGodot, IID_PPV_ARGS(device_factory.GetAddressOf()));
-			}
-			sdk_config1->Release();
+	ComPtr<ID3D12SDKConfiguration1> sdk_config;
+	HRESULT hr = d3d_D3D12GetInterface(CLSID_D3D12SDKConfigurationGodot, IID_PPV_ARGS(sdk_config.GetAddressOf()));
+	if (SUCCEEDED(hr)) {
+		hr = sdk_config->CreateDeviceFactory(agility_sdk_version, agility_sdk_path.ascii().get_data(), IID_PPV_ARGS(device_factory.GetAddressOf()));
+		if (FAILED(hr)) {
+			sdk_config->CreateDeviceFactory(agility_sdk_version, ".\\", IID_PPV_ARGS(device_factory.GetAddressOf()));
 		}
-		sdk_config->Release();
+		// If both calls failed, device factory is going to be nullptr, and D3D12CreateDevice is going to be used as fallback.
 	}
 	return OK;
 }


### PR DESCRIPTION
Agility SDK was getting loaded, but on successful device factory creation, it was immediately getting overridden by the OS device factory. This was causing two `D3D12Core.dll` modules to exist in memory while creating the device only through the OS one.