### PR TITLE
Add and adjust more scroll hints in the editor

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1321,6 +1321,22 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 	open_layout(p_string);
 }
 
+void EditorAudioBuses::update_layout(EditorDock::DockLayout p_layout) {
+	bool new_floating = (p_layout == EditorDock::DOCK_LAYOUT_FLOATING);
+	if (floating == new_floating) {
+		return;
+	}
+	floating = new_floating;
+
+	if (floating) {
+		bus_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		bus_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);
+	} else {
+		bus_mc->set_theme_type_variation("NoBorderBottomPanel");
+		bus_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
+	}
+}
+
 void EditorAudioBuses::_bind_methods() {
 	ClassDB::bind_method("_update_bus", &EditorAudioBuses::_update_bus);
 	ClassDB::bind_method("_update_sends", &EditorAudioBuses::_update_sends);
@@ -1387,15 +1403,15 @@ EditorAudioBuses::EditorAudioBuses() {
 	top_hb->add_child(_new);
 	_new->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBuses::_new_layout));
 
-	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontal");
-	mc->set_v_size_flags(SIZE_EXPAND_FILL);
-	main_vb->add_child(mc);
+	bus_mc = memnew(MarginContainer);
+	bus_mc->set_theme_type_variation("NoBorderBottomPanel");
+	bus_mc->set_v_size_flags(SIZE_EXPAND_FILL);
+	main_vb->add_child(bus_mc);
 
 	bus_scroll = memnew(ScrollContainer);
 	bus_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
 	bus_scroll->set_custom_minimum_size(Size2(0, 40 * EDSCALE));
-	mc->add_child(bus_scroll);
+	bus_mc->add_child(bus_scroll);
 
 	bus_hb = memnew(HBoxContainer);
 	bus_hb->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -42,7 +42,6 @@
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/texture_progress_bar.h"
-#include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 
 class EditorAudioBuses;
@@ -154,6 +153,7 @@ class EditorAudioBuses : public EditorDock {
 
 	HBoxContainer *top_hb = nullptr;
 
+	MarginContainer *bus_mc = nullptr;
 	ScrollContainer *bus_scroll = nullptr;
 	HBoxContainer *bus_hb = nullptr;
 
@@ -169,6 +169,8 @@ class EditorAudioBuses : public EditorDock {
 
 	Timer *save_timer = nullptr;
 	String edited_path;
+
+	bool floating = false;
 
 	void _update_file_label_size();
 
@@ -200,6 +202,8 @@ class EditorAudioBuses : public EditorDock {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+
+	virtual void update_layout(EditorDock::DockLayout p_layout) override;
 
 public:
 	void open_layout(const String &p_path);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2353,7 +2353,7 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		vmem_export->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_video_mem_export));
 
 		MarginContainer *mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderHorizontalWindow");
+		mc->set_theme_type_variation("NoBorderBottomPanel");
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		vmem_vb->add_child(mc);
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -107,7 +107,7 @@ private:
 		SAVE_MONITORS_CSV,
 		SAVE_VRAM_CSV,
 	};
-	FileDialogPurpose file_dialog_purpose;
+	FileDialogPurpose file_dialog_purpose = SAVE_MONITORS_CSV;
 
 	int error_count;
 	int warning_count;

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -488,13 +488,17 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 				button_toggle_display_mode->set_button_icon(get_editor_theme_icon(SNAME("Panels1")));
 				tree->show();
 				tree->set_v_size_flags(SIZE_EXPAND_FILL);
-				tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 				tree->set_theme_type_variation("");
-				tree_mc->set_theme_type_variation("NoBorderHorizontalBottom");
 				if (horizontal) {
 					toolbar2_hbc->hide();
+
+					tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
+					tree_mc->set_theme_type_variation("NoBorderBottomPanel");
 				} else {
 					toolbar2_hbc->show();
+
+					tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
+					tree_mc->set_theme_type_variation("NoBorderHorizontalBottom");
 				}
 				button_file_list_display_mode->hide();
 
@@ -517,11 +521,19 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 				if (is_vertical) {
 					tree->set_theme_type_variation("");
 					tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
-					tree_mc->set_theme_type_variation("NoBorderHorizontal");
+					tree_mc->set_theme_type_variation("NoBorderBottomPanel");
+
+					files->set_theme_type_variation("");
+					files->set_scroll_hint_mode(horizontal ? ItemList::SCROLL_HINT_MODE_BOTH : ItemList::SCROLL_HINT_MODE_TOP);
+					files_mc->set_theme_type_variation(horizontal ? "NoBorderBottomPanel" : "NoBorderHorizontalBottom");
 				} else {
 					tree->set_theme_type_variation("TreeSecondary");
 					tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);
 					tree_mc->set_theme_type_variation("");
+
+					files->set_theme_type_variation("ItemListSecondary");
+					files->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_DISABLED);
+					files_mc->set_theme_type_variation("");
 				}
 				tree->ensure_cursor_is_visible();
 
@@ -4394,11 +4406,15 @@ FileSystemDock::FileSystemDock() {
 	button_file_list_display_mode->set_theme_type_variation("FlatMenuButton");
 	path_hb->add_child(button_file_list_display_mode);
 
+	files_mc = memnew(MarginContainer);
+	file_list_vb->add_child(files_mc);
+	files_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	files_mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
 	files = memnew(FileSystemList);
-	files->set_v_size_flags(SIZE_EXPAND_FILL);
 	files->set_accessibility_name(TTRC("Files"));
 	files->set_select_mode(ItemList::SELECT_MULTI);
-	files->set_theme_type_variation("ItemListSecondary");
+	files->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_TOP);
 	SET_DRAG_FORWARDING_GCD(files, FileSystemDock);
 	files->connect("item_clicked", callable_mp(this, &FileSystemDock::_file_list_item_clicked));
 	files->connect(SceneStringName(gui_input), callable_mp(this, &FileSystemDock::_file_list_gui_input));
@@ -4407,7 +4423,7 @@ FileSystemDock::FileSystemDock() {
 	files->connect("item_edited", callable_mp(this, &FileSystemDock::_rename_operation_confirm));
 	files->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
 	files->set_allow_rmb_select(true);
-	file_list_vb->add_child(files);
+	files_mc->add_child(files);
 
 	scanning_vb = memnew(VBoxContainer);
 	scanning_vb->hide();

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -154,6 +154,7 @@ private:
 	ProgressBar *scanning_progress = nullptr;
 	SplitContainer *split_box = nullptr;
 	MarginContainer *tree_mc = nullptr;
+	MarginContainer *files_mc = nullptr;
 	VBoxContainer *file_list_vb = nullptr;
 
 	int split_box_offset_h = 0;

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -2407,6 +2407,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	frame_list->set_icon_mode(ItemList::ICON_MODE_TOP);
 	frame_list->set_texture_filter(TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
 	frame_list->set_select_mode(ItemList::SELECT_MULTI);
+	frame_list->set_theme_type_variation("ItemListSecondary");
 
 	frame_list->set_max_columns(0);
 	frame_list->set_max_text_lines(2);

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -187,6 +187,8 @@ public:
 	void start_search();
 	void stop_search();
 
+	void update_layout(EditorDock::DockLayout p_layout);
+
 protected:
 	static void _bind_methods();
 
@@ -244,6 +246,9 @@ private:
 	HBoxContainer *_replace_container = nullptr;
 	LineEdit *_replace_line_edit = nullptr;
 	Button *_replace_all_button = nullptr;
+
+	bool _floating = false;
+	MarginContainer *_results_mc = nullptr;
 };
 
 class PopupMenu;
@@ -284,6 +289,8 @@ protected:
 	void _on_find_in_files_result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end);
 	void _on_find_in_files_modified_files(const PackedStringArray &p_paths);
 	void _on_find_in_files_close_button_clicked(FindInFilesPanel *p_panel);
+
+	virtual void update_layout(EditorDock::DockLayout p_layout) override;
 
 public:
 	FindInFilesContainer();

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1868,7 +1868,8 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// MarginContainers with negative margins, to negate borders. Used with scroll hints.
 		{
-			int margin = -p_theme->get_stylebox(SceneStringName(panel), SNAME("PanelContainer"))->get_content_margin(SIDE_LEFT);
+			int panel_margin = p_theme->get_stylebox(SceneStringName(panel), SNAME("PanelContainer"))->get_content_margin(SIDE_LEFT);
+			int margin = -panel_margin;
 
 			p_theme->set_type_variation("NoBorderHorizontal", "MarginContainer");
 			p_theme->set_constant("margin_left", "NoBorderHorizontal", margin);
@@ -1879,7 +1880,15 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_constant("margin_right", "NoBorderHorizontalBottom", margin);
 			p_theme->set_constant("margin_bottom", "NoBorderHorizontalBottom", margin);
 
-			margin = margin - p_theme->get_stylebox(SNAME("BottomPanel"), EditorStringName(EditorStyles))->get_content_margin(SIDE_LEFT);
+			int bottom_margin = p_theme->get_stylebox(SNAME("BottomPanel"), EditorStringName(EditorStyles))->get_content_margin(SIDE_LEFT);
+			margin = -bottom_margin;
+
+			// Used in editors residing in the bottom panel.
+			p_theme->set_type_variation("NoBorderBottomPanel", "MarginContainer");
+			p_theme->set_constant("margin_left", "NoBorderBottomPanel", margin);
+			p_theme->set_constant("margin_right", "NoBorderBottomPanel", margin);
+
+			margin = -panel_margin - bottom_margin;
 
 			// Used in the animation track editor.
 			p_theme->set_type_variation("NoBorderAnimation", "MarginContainer");

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -817,6 +817,11 @@ LocalizationEditor::LocalizationEditor() {
 		translation_res_option_add_button = addtr;
 		thb->add_child(addtr);
 
+		mc = memnew(MarginContainer);
+		mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		mc->set_v_size_flags(SIZE_EXPAND_FILL);
+		tvb->add_child(mc);
+
 		translation_remap_options = memnew(Tree);
 		translation_remap_options->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		translation_remap_options->set_columns(2);

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -45,6 +45,7 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/label.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/separator.h"
 #include "scene/main/window.h"
@@ -1637,10 +1638,15 @@ GridMapEditor::GridMapEditor() {
 
 	toolbar->add_child(options);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_theme_type_variation("NoBorderBottomPanel");
+	mc->set_v_size_flags(SIZE_EXPAND_FILL);
+	add_child(mc);
+
 	mesh_library_palette = memnew(ItemList);
 	mesh_library_palette->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	add_child(mesh_library_palette);
-	mesh_library_palette->set_v_size_flags(SIZE_EXPAND_FILL);
+	mesh_library_palette->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTH);
+	mc->add_child(mesh_library_palette);
 	mesh_library_palette->connect(SceneStringName(gui_input), callable_mp(this, &GridMapEditor::_mesh_library_palette_input));
 	mesh_library_palette->connect(SceneStringName(item_selected), callable_mp(this, &GridMapEditor::_item_selected_cbk));
 


### PR DESCRIPTION
- Add scroll hints to the "Find in Files" and `GridMap` editors.
- Add a panel background to the `SpriteFrames` editor.
- Fix a missing `MarginContainer` in the Localization/Remaps tab (fixes #114106).
- Fix hints spilling out of borders on some editors.
- Use proper hints when editors are floating.