### PR TITLE
Fix Marker Name covered by AnimationPlayer track backgrounds

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -8109,6 +8109,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	marker_edit->set_timeline(timeline);
 	marker_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	marker_edit->set_anchors_and_offsets_preset(Control::LayoutPreset::PRESET_FULL_RECT);
+	marker_edit->set_z_index(1); // Ensure marker appears over the animation track editor.
 	marker_edit->connect(SceneStringName(draw), callable_mp(this, &AnimationTrackEditor::_redraw_groups));
 	marker_edit->connect(SceneStringName(draw), callable_mp(this, &AnimationTrackEditor::_redraw_tracks));
 	marker_edit->connect(SceneStringName(draw), callable_mp((CanvasItem *)bezier_edit, &CanvasItem::queue_redraw));


### PR DESCRIPTION
Fixes #113943

Old:

https://github.com/user-attachments/assets/3eb8b5d9-a237-4353-b5a2-d09278d06c5a

New:

https://github.com/user-attachments/assets/0935518d-5a58-4fd3-a4a0-3a31b7d6b6d4