### PR TITLE
Hide properties on XRCamera3D that are managed by XRInterface

### DIFF
--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -36,6 +36,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+void XRCamera3D::_validate_property(PropertyInfo &p_property) const {
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+	// Hide properties that are managed by XRInterface or otherwise not applicable for XRCamera3D.
+	if (p_property.name == "fov" || p_property.name == "projection" || p_property.name == "size" || p_property.name == "frustum_offset" || p_property.name == "keep_aspect") {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+}
+
 void XRCamera3D::_bind_tracker() {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);

--- a/scene/3d/xr/xr_nodes.h
+++ b/scene/3d/xr/xr_nodes.h
@@ -47,6 +47,8 @@ protected:
 	StringName pose_name = SceneStringName(default_);
 	Ref<XRPositionalTracker> tracker;
 
+	void _validate_property(PropertyInfo &p_property) const;
+
 	void _bind_tracker();
 	void _unbind_tracker();
 	void _changed_tracker(const StringName &p_tracker_name, int p_tracker_type);


### PR DESCRIPTION
Since the introduction of XR, the XRInterface provides stereo projection matrices directly to the rendering pipeline. This means that various camera properties are simply being ignored.

Back when we introduced this, we didn't have a means to hide those properties. We've had that ability for many years, but it was overlooked to apply this on the XRCamera3D.

Finally got poked enough to do something about that :P

*Bugsquad edit:*
- Supersedes part of #113979.