### PR TITLE
[DRAFT] Disable subpasses on Samsung Galaxy XR to avoid issue with MSAA and eye-tracked foveated rendering

### DIFF
--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -884,6 +884,34 @@ void RenderingContextDriverVulkan::_check_driver_workarounds(const VkPhysicalDev
 			p_device_properties.deviceID >= 0x6000000 && // Adreno 6xx
 			p_device_properties.driverVersion < VK_MAKE_VERSION(512, 503, 0) &&
 			r_device.name.find("Turnip") < 0;
+
+	// Workaround for the ARM Mali-G52 family of devices. (GH-112530)
+	//TODO
+	//crash with driverVersion: 0.24.2.8, 0.25.1.0, 0.34.0.0
+	r_device.workarounds.avoid_subpass_post_process =
+			r_device.vendor == Vendor::VENDOR_ARM &&
+			p_device_properties.deviceID == 0x74021000; // Mali-G52
+
+	uint32_t driver_variant = VK_API_VERSION_VARIANT(p_device_properties.driverVersion);
+	uint32_t driver_major = VK_VERSION_MAJOR(p_device_properties.driverVersion);
+	uint32_t driver_minor = VK_VERSION_MINOR(p_device_properties.driverVersion);
+	uint32_t driver_patch = VK_VERSION_PATCH(p_device_properties.driverVersion);
+
+	print_line("==========================");
+	print_line("_check_driver_workarounds");
+	print_line("==========================");
+	print_line("r_device.vendor:", vformat("0x%08X", r_device.vendor));
+	print_line("r_device.type:", r_device.type);
+	print_line("r_device.name:", r_device.name);
+	print_line("------------------------------------");
+	print_line("deviceName:", p_device_properties.deviceName);
+	print_line("deviceID:", vformat("0x%08X", p_device_properties.deviceID));
+	print_line("driverVersion:", vformat("%d.%d.%d.%d", driver_variant, driver_major, driver_minor, driver_patch), vformat("(0x%08X)", p_device_properties.driverVersion));
+	print_line("apiVersion:", vformat("(0x%08X)", p_device_properties.apiVersion));
+	print_line("------------------------------------");
+	print_line("avoid_compute_after_draw:", r_device.workarounds.avoid_compute_after_draw);
+	print_line("avoid_subpass_post_process:", r_device.workarounds.avoid_subpass_post_process);
+	print_line("------------------------------------");
 }
 
 bool RenderingContextDriverVulkan::_use_validation_layers() const {

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -888,9 +888,13 @@ void RenderingContextDriverVulkan::_check_driver_workarounds(const VkPhysicalDev
 	// Workaround for the ARM Mali-G52 family of devices. (GH-112530)
 	//TODO
 	//crash with driverVersion: 0.24.2.8, 0.25.1.0, 0.34.0.0
-	r_device.workarounds.avoid_subpass_post_process =
-			r_device.vendor == Vendor::VENDOR_ARM &&
-			p_device_properties.deviceID == 0x74021000; // Mali-G52
+	if (r_device.vendor == Vendor::VENDOR_ARM && p_device_properties.deviceID == 0x74021000) {
+		r_device.workarounds.avoid_subpass_post_process = true;
+	}
+	// Workaround issue on Qualcomm XR2+ Gen2 with subpasses when MSAA and eye-tracked foveated rendering are enabled.
+	if (r_device.vendor == Vendor::VENDOR_QUALCOMM && p_device_properties.deviceID == 0x43050B00 && p_device_properties.driverVersion == 0x80335006) {
+		r_device.workarounds.avoid_subpass_post_process = true;
+	}
 
 	uint32_t driver_variant = VK_API_VERSION_VARIANT(p_device_properties.driverVersion);
 	uint32_t driver_major = VK_VERSION_MAJOR(p_device_properties.driverVersion);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -847,7 +847,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	RID framebuffer;
 	bool reverse_cull = p_render_data->scene_data->cam_transform.basis.determinant() < 0;
 	bool merge_transparent_pass = true; // If true: we can do our transparent pass in the same pass as our opaque pass.
-	bool using_subpass_post_process = true; // If true: we can do our post processing in a subpass
+	bool using_subpass_post_process = !avoid_subpass_post_process; // If true: we can do our post processing in a subpass
 	RendererRD::MaterialStorage::Samplers samplers;
 	bool hdr_render_target = false;
 
@@ -3453,6 +3453,14 @@ RenderForwardMobile::RenderForwardMobile() {
 	const bool root_hdr_render_target = GLOBAL_GET("rendering/viewport/hdr_2d");
 	global_pipeline_data_required.use_hdr_render_target = root_hdr_render_target;
 	global_pipeline_data_required.use_ldr_render_target = !root_hdr_render_target;
+
+	// GH-112530 avoid post processing in a subpass
+	RenderingServer *rendering_server = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+	RenderingDevice *rendering_device = rendering_server->get_rendering_device();
+	ERR_FAIL_NULL(rendering_device);
+
+	avoid_subpass_post_process = rendering_device->get_device_workarounds().avoid_subpass_post_process;
 }
 
 RenderForwardMobile::~RenderForwardMobile() {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -410,6 +410,8 @@ private:
 
 	RenderList render_list[RENDER_LIST_MAX];
 
+	bool avoid_subpass_post_process = false;
+
 protected:
 	/* setup */
 	virtual void _update_shader_quality_settings() override;

--- a/servers/rendering/rendering_context_driver.h
+++ b/servers/rendering/rendering_context_driver.h
@@ -77,6 +77,7 @@ public:
 
 	struct Workarounds {
 		bool avoid_compute_after_draw = false;
+		bool avoid_subpass_post_process = false;
 	};
 
 	struct Device {

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1005,6 +1005,7 @@ public:
 	RenderingContextDriver *get_context_driver() const { return context; }
 
 	const RDD::Capabilities &get_device_capabilities() const { return driver->get_capabilities(); }
+	const RenderingContextDriver::Workarounds &get_device_workarounds() const { return device.workarounds; }
 
 	bool has_feature(const Features p_feature) const;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113778

I'm not sure this is a good idea. Theoretically, using subpasses is important for mobile rendering so disabling them on Samsung Galaxy XR may be bad for performance (although, according to Clay, it might not be in practice, depending on the circumstances).

It's also not ideal that this'll disable them always, rather than just in the combination of features that show the problem (that being MSAA + eye-tracked foveated rendering), however, in any serious app for this headset you would almost certainly have both those features enabled.

I'm also not sure if only this particular driver version is affected, but we have to target the driver version, because this problem does NOT occur on Meta Quest 3 (which has the same device ID), even if I force the Vulkan FDM offset extension to be enabled and give a fake offset. (Note: this wouldn't normally happen on the Quest 3 because it doesn't support eye-tracked foveated rendering, only fixed foveated rendering.)

So, marking as a DRAFT because:

- I'm not 100% sure this is a good idea, and
- It depends on https://github.com/godotengine/godot/pull/113823