### PR TITLE
Return at invalid skeleton in ChainIK3D before updating mutable info

### DIFF
--- a/scene/3d/chain_ik_3d.cpp
+++ b/scene/3d/chain_ik_3d.cpp
@@ -497,6 +497,7 @@ void ChainIK3D::_update_mutable_info() {
 		for (uint32_t i = 0; i < settings.size(); i++) {
 			chain_settings[i]->root_global_rest = Transform3D();
 		}
+		return;
 	}
 	bool changed = false;
 	for (uint32_t i = 0; i < settings.size(); i++) {


### PR DESCRIPTION
pretty self explanatory i hope.. in my testing it fixes the segfault reported in https://github.com/godotengine/godot/issues/114059 when moving a ChainIK3D derived node from its parent skeleton in the editor's scene tree

edit:

been trying to find an alternative way of doing this and couldn't really find one that was a solid fix, it seems like for some reason the function that caused the segfault gets called a few times once its gone from the skeleton's hierarchy.

either way it's probably a good idea to return when the skeleton is invalid because right after the skeleton check it's getting referenced 

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/114059*