### PR TITLE
Fix `Texture*RD` appears completely white forever after assigning an empty RID once.

### DIFF
--- a/scene/resources/texture_rd.cpp
+++ b/scene/resources/texture_rd.cpp
@@ -52,8 +52,12 @@ int Texture2DRD::get_height() const {
 
 RID Texture2DRD::get_rid() const {
 	if (texture_rid.is_null()) {
-		// We are in trouble, create something temporary.
-		texture_rid = RenderingServer::get_singleton()->texture_2d_placeholder_create();
+		// Initialize the resource RID if we have not to.
+		// The RID should not change again until resource destruction,
+		// because Material is not able to detect RID changes.
+		// This also applies to the same lazy initialization in `set_texture_rd_rid()`
+		// and `_set_texture_rd_rid()`.
+		texture_rid = RS::get_singleton()->texture_2d_placeholder_create();
 	}
 
 	return texture_rid;
@@ -77,11 +81,11 @@ void Texture2DRD::set_texture_rd_rid(RID p_texture_rd_rid) {
 
 	if (p_texture_rd_rid.is_valid()) {
 		RS::get_singleton()->call_on_render_thread(callable_mp(this, &Texture2DRD::_set_texture_rd_rid).bind(p_texture_rd_rid));
-	} else if (texture_rid.is_valid()) {
-		RS::get_singleton()->free_rid(texture_rid);
-		texture_rid = RID();
+	} else if (texture_rid.is_valid() && texture_rd_rid.is_valid()) {
+		RID new_texture_rid = RS::get_singleton()->texture_2d_placeholder_create();
+		RS::get_singleton()->texture_replace(texture_rid, new_texture_rid);
 		size = Size2i();
-
+		texture_rd_rid = RID();
 		notify_property_list_changed();
 		emit_changed();
 	}
@@ -163,8 +167,12 @@ bool TextureLayeredRD::has_mipmaps() const {
 
 RID TextureLayeredRD::get_rid() const {
 	if (texture_rid.is_null()) {
-		// We are in trouble, create something temporary.
-		texture_rid = RenderingServer::get_singleton()->texture_2d_placeholder_create();
+		// Initialize the resource RID if we have not to.
+		// The RID should not change again until resource destruction,
+		// because Material is not able to detect RID changes.
+		// This also applies to the same lazy initialization in `set_texture_rd_rid()`
+		// and `_set_texture_rd_rid()`.
+		texture_rid = RS::get_singleton()->texture_2d_placeholder_create();
 	}
 
 	return texture_rid;
@@ -180,14 +188,14 @@ void TextureLayeredRD::set_texture_rd_rid(RID p_texture_rd_rid) {
 
 	if (p_texture_rd_rid.is_valid()) {
 		RS::get_singleton()->call_on_render_thread(callable_mp(this, &TextureLayeredRD::_set_texture_rd_rid).bind(p_texture_rd_rid));
-	} else if (texture_rid.is_valid()) {
-		RS::get_singleton()->free_rid(texture_rid);
-		texture_rid = RID();
+	} else if (texture_rid.is_valid() && texture_rd_rid.is_valid()) {
+		RID new_texture_rid = RS::get_singleton()->texture_2d_placeholder_create();
+		RS::get_singleton()->texture_replace(texture_rid, new_texture_rid);
 		image_format = Image::FORMAT_MAX;
 		size = Size2i();
 		layers = 0;
 		mipmaps = 0;
-
+		texture_rd_rid = RID();
 		notify_property_list_changed();
 		emit_changed();
 	}
@@ -290,8 +298,12 @@ bool Texture3DRD::has_mipmaps() const {
 
 RID Texture3DRD::get_rid() const {
 	if (texture_rid.is_null()) {
-		// We are in trouble, create something temporary.
-		texture_rid = RenderingServer::get_singleton()->texture_2d_placeholder_create();
+		// Initialize the resource RID if we have not to.
+		// The RID should not change again until resource destruction,
+		// because Material is not able to detect RID changes.
+		// This also applies to the same lazy initialization in `set_texture_rd_rid()`
+		// and `_set_texture_rd_rid()`.
+		texture_rid = RS::get_singleton()->texture_2d_placeholder_create();
 	}
 
 	return texture_rid;
@@ -302,13 +314,13 @@ void Texture3DRD::set_texture_rd_rid(RID p_texture_rd_rid) {
 
 	if (p_texture_rd_rid.is_valid()) {
 		RS::get_singleton()->call_on_render_thread(callable_mp(this, &Texture3DRD::_set_texture_rd_rid).bind(p_texture_rd_rid));
-	} else if (texture_rid.is_valid()) {
-		RS::get_singleton()->free_rid(texture_rid);
-		texture_rid = RID();
+	} else if (texture_rid.is_valid() && texture_rd_rid.is_valid()) {
+		RID new_texture_rid = RS::get_singleton()->texture_2d_placeholder_create();
+		RS::get_singleton()->texture_replace(texture_rid, new_texture_rid);
 		image_format = Image::FORMAT_MAX;
 		size = Vector3i();
 		mipmaps = 0;
-
+		texture_rd_rid = RID();
 		notify_property_list_changed();
 		emit_changed();
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95273, probably https://github.com/godotengine/godot/issues/85989 too though I don't get the essence of that issue.

There is already a PR on it https://github.com/godotengine/godot/pull/103126. However it didn't pass the CI and has not been updated for a while. So I made a new one. The idea is similar.

Issue summary:
Assume we have a `Texture2DRD` assigned to a material, either empty or not. If we for some reasons assign an empty `RID` to its `texture_rd_rid`, the texture in the material appears completely white (not the default purple-black placeholder texture). The serious problem is, after that even assigning a valid texture RID cannot change the white appearance as if the texture is fovever freezed.

```
var texture_rid: RID = create_texture_from_rd()
var scene_texture: Texture2DRD = get_it_from_scene()
scene_texture.texture_rd_rid = RID() # texture becomes white
scene_texture.texture_rd_rid = texture_rid # texture remains white
```

The reason behind is that on getting an empty texture, `Texture*RD` changes its resource rid. Normally, when giving it a different texture,  `Texture*RD` preserves the resource rid by using `texture_replace`, but it is not the case whe ngiving an empty texture. `Texture*RD` frees its resource rid. A new resource rid will be created if later a valid texture is given. However, `BaseMaterial3D` and `ShaderMaterial` is not able to know it. AFAIK, `Resource` changing its own `RID` is not expected in the first place, which should be fixed.

With this PR, `Texture*RD` creates a placehoder texture and preserves the resource rid when it receives an empty texture. The state afterwards is the same as the default one (the state after the first `get_rid()` call initializes it).

Test project:
[texture_rd_bug.zip](https://github.com/user-attachments/files/24180767/texture_rd_bug.zip)

Before fix:
![Screenshot_20251216_114301](https://github.com/user-attachments/assets/39e359a3-b7f4-4e7f-9b0c-0ceedadaadef)
In the prints we can see resource rids change after an empty texture is assigned.
(1: initial, 2: after an empty RID is assigned, 3: after a real texture is assigned)
```text
texture_2d rid 1: RID(689230581861081)
texture_2d rid 2: RID(690106755189465)
texture_2d rid 3: RID(690106755189465)
texture_layered_2d rid 1: RID(689466805062362)
texture_layered_2d rid 2: RID(690184064600794)
texture_layered_2d rid 3: RID(690184064600794)
texture_3d rid 1: RID(689703028263643)
texture_3d rid 2: RID(690261374012123)
texture_3d rid 3: RID(690261374012123)
```

After fix:
![Screenshot_20251216_114325](https://github.com/user-attachments/assets/bf2cb17d-41f8-44a9-a471-6ee5cb907405)
In the prints we can see resource rids are persistent.
```text
texture_2d rid 1: RID(869958510709465)
texture_2d rid 2: RID(869958510709465)
texture_2d rid 3: RID(869958510709465)
texture_layered_2d rid 1: RID(869971395611354)
texture_layered_2d rid 2: RID(869971395611354)
texture_layered_2d rid 3: RID(869971395611354)
texture_3d rid 1: RID(869984280513243)
texture_3d rid 2: RID(869984280513243)
texture_3d rid 3: RID(869984280513243)
```

Sprite3D is not affected by this bug because it responds to the `changed` signal. But for what I understand this signal is mainly for content change and `Material` should not care about it.


One question in mind. I saw `Texture3DRD` and `Texture2DLayered` both used `texture_2d_placeholder_create` in `get_rid()` so I did the same, and seems that it is not considered as an error by the engine. Should we use  `texture_2d_layered_placeholder_create` and `texture_3d_placeholder_create` instead? It can be made in a different PR though as it is not directly related to this issue.
