### PR TITLE
Add missing `cstdlib` include for `EXIT_SUCCESS` and `free`

### DIFF
--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -34,6 +34,7 @@
 #include "core/math/math_funcs.h"
 
 #include <zlib.h> // Should come before including tinyexr.
+#include <cstdlib>
 
 #include "thirdparty/tinyexr/tinyexr.h"
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -36,6 +36,8 @@
 #include "core/templates/self_list.h"
 #include "scene/main/scene_tree_fti.h"
 
+#include <cstdlib>
+
 #undef Window
 
 class ArrayMesh;


### PR DESCRIPTION
`EXIT_SUCCESS` and `free` require `cstdlib` to be included when compiling with clang 21.1.7.
