### PR TITLE
RenderingDevice: Add null checks when retrieving uniform sets

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -4996,12 +4996,13 @@ void RenderingDevice::draw_list_draw(DrawListID p_list, bool p_use_indices, uint
 
 		if (draw_list.state.sets[i].pipeline_expected_format != draw_list.state.sets[i].uniform_set_format) {
 			if (draw_list.state.sets[i].uniform_set_format == 0) {
-				ERR_FAIL_MSG("Uniforms were never supplied for set (" + itos(i) + ") at the time of drawing, which are required by the pipeline.");
+				ERR_FAIL_MSG(vformat("Uniforms were never supplied for set (%d) at the time of drawing, which are required by the pipeline.", i));
 			} else if (uniform_set_owner.owns(draw_list.state.sets[i].uniform_set)) {
 				UniformSet *us = uniform_set_owner.get_or_null(draw_list.state.sets[i].uniform_set);
-				ERR_FAIL_MSG("Uniforms supplied for set (" + itos(i) + "):\n" + _shader_uniform_debug(us->shader_id, us->shader_set) + "\nare not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n" + _shader_uniform_debug(draw_list.state.pipeline_shader));
+				const String us_info = us ? vformat("(%d):\n%s\n", i, _shader_uniform_debug(us->shader_id, us->shader_set)) : vformat("(%d, which was just freed) ", i);
+				ERR_FAIL_MSG(vformat("Uniforms supplied for set %sare not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n%s", us_info, _shader_uniform_debug(draw_list.state.pipeline_shader)));
 			} else {
-				ERR_FAIL_MSG("Uniforms supplied for set (" + itos(i) + ", which was just freed) are not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n" + _shader_uniform_debug(draw_list.state.pipeline_shader));
+				ERR_FAIL_MSG(vformat("Uniforms supplied for set (%d, which was just freed) are not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n%s", i, _shader_uniform_debug(draw_list.state.pipeline_shader)));
 			}
 		}
 	}
@@ -5053,6 +5054,7 @@ void RenderingDevice::draw_list_draw(DrawListID p_list, bool p_use_indices, uint
 				}
 
 				UniformSet *uniform_set = uniform_set_owner.get_or_null(draw_list.state.sets[i].uniform_set);
+				ERR_FAIL_NULL(uniform_set);
 				_uniform_set_update_shared(uniform_set);
 				_uniform_set_update_clears(uniform_set);
 
@@ -5161,9 +5163,10 @@ void RenderingDevice::draw_list_draw_indirect(DrawListID p_list, bool p_use_indi
 				ERR_FAIL_MSG(vformat("Uniforms were never supplied for set (%d) at the time of drawing, which are required by the pipeline.", i));
 			} else if (uniform_set_owner.owns(draw_list.state.sets[i].uniform_set)) {
 				UniformSet *us = uniform_set_owner.get_or_null(draw_list.state.sets[i].uniform_set);
-				ERR_FAIL_MSG(vformat("Uniforms supplied for set (%d):\n%s\nare not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n%s", i, _shader_uniform_debug(us->shader_id, us->shader_set), _shader_uniform_debug(draw_list.state.pipeline_shader)));
+				const String us_info = us ? vformat("(%d):\n%s\n", i, _shader_uniform_debug(us->shader_id, us->shader_set)) : vformat("(%d, which was just freed) ", i);
+				ERR_FAIL_MSG(vformat("Uniforms supplied for set %sare not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n%s", us_info, _shader_uniform_debug(draw_list.state.pipeline_shader)));
 			} else {
-				ERR_FAIL_MSG(vformat("Uniforms supplied for set (%s, which was just freed) are not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n%s", i, _shader_uniform_debug(draw_list.state.pipeline_shader)));
+				ERR_FAIL_MSG(vformat("Uniforms supplied for set (%d, which was just freed) are not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n%s", i, _shader_uniform_debug(draw_list.state.pipeline_shader)));
 			}
 		}
 	}
@@ -5191,6 +5194,7 @@ void RenderingDevice::draw_list_draw_indirect(DrawListID p_list, bool p_use_indi
 			draw_graph.add_draw_list_bind_uniform_set(draw_list.state.pipeline_shader_driver_id, draw_list.state.sets[i].uniform_set_driver_id, i);
 
 			UniformSet *uniform_set = uniform_set_owner.get_or_null(draw_list.state.sets[i].uniform_set);
+			ERR_FAIL_NULL(uniform_set);
 			_uniform_set_update_shared(uniform_set);
 			_uniform_set_update_clears(uniform_set);
 


### PR DESCRIPTION
This may mitigate a crash seen in the wild in Rift Riff on Android, most likely trading it for a single-frame rendering bug (which is better than crashing on user devices).

It doesn't solve the underlying issue which seems to be a race condition where a uniform set RID gets has been freed while still being reported as owned by the RID_Owner.

Stack trace from Rift Riff:

```
backtrace:
  #00  pc 0x0000000003369f3c  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RenderingDevice::_uniform_set_update_shared(RenderingDevice::UniformSet*)+76) (BuildId: 51ca91226c11fafc)
  #01  pc 0x0000000003375458  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RenderingDevice::draw_list_draw(long, bool, unsigned int, unsigned int)+4839) (BuildId: 51ca91226c11fafc)
  #02  pc 0x000000000354e814  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RendererCanvasRenderRD::_render_batch(long, RendererCanvasRenderRD::CanvasShaderData*, long, RendererCanvasRender::Light*, RendererCanvasRenderRD::Batch const*, RenderingMethod::RenderInfo*)+3050) (BuildId: 51ca91226c11fafc)
  #03  pc 0x0000000003540b7c  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RendererCanvasRenderRD::_render_batch_items(RendererCanvasRenderRD::RenderTarget, int, Transform2D const&, RendererCanvasRender::Light*, bool&, bool, RenderingMethod::RenderInfo*)+2280) (BuildId: 51ca91226c11fafc)
  #04  pc 0x000000000353ffa4  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RendererCanvasRenderRD::canvas_render_items(RID, RendererCanvasRender::Item*, Color const&, RendererCanvasRender::Light*, RendererCanvasRender::Light*, Transform2D const&, RenderingServer::CanvasItemTextureFilter, RenderingServer::CanvasItemTextureRepeat, bool, bool&, RenderingMethod::RenderInfo*)+906) (BuildId: 51ca91226c11fafc)
  #05  pc 0x0000000003460828  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RendererCanvasCull::_render_canvas_item_tree(RID, RendererCanvasCull::Canvas::ChildItem*, int, Transform2D const&, Rect2 const&, Color const&, RendererCanvasRender::Light*, RendererCanvasRender::Light*, RenderingServer::CanvasItemTextureFilter, RenderingServer::CanvasItemTextureRepeat, bool, unsigned int, RenderingMethod::RenderInfo*)+104) (BuildId: 51ca91226c11fafc)
  #06  pc 0x00000000034623b0  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RendererCanvasCull::render_canvas(RID, RendererCanvasCull::Canvas*, Transform2D const&, RendererCanvasRender::Light*, RendererCanvasRender::Light*, Rect2 const&, RenderingServer::CanvasItemTextureFilter, RenderingServer::CanvasItemTextureRepeat, bool, bool, unsigned int, RenderingMethod::RenderInfo*)+498) (BuildId: 51ca91226c11fafc)
  #07  pc 0x000000000347d100  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RendererViewport::_draw_viewport(RendererViewport::Viewport*)+685) (BuildId: 51ca91226c11fafc)
  #08  pc 0x000000000347ddcc  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RendererViewport::draw_viewports(bool)+885) (BuildId: 51ca91226c11fafc)
  #09  pc 0x0000000003415100  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (RenderingServerDefault::_draw(bool, double)+94) (BuildId: 51ca91226c11fafc)
  #10  pc 0x000000000116abac  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (Main::iteration()+4829) (BuildId: 51ca91226c11fafc)
  #11  pc 0x0000000001105ae4  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (OS_Android::main_loop_iterate(bool*)+364) (BuildId: 51ca91226c11fafc)
  #12  pc 0x000000000111bc6c  /data/app/~~YAGMvfnvDWYPjrX_I08qyA==/com.adriaandejongh.riftriff-aS9-Onpv7Ow5TubZ2-HSxg==/split_config.arm64_v8a.apk!libgodot_android.so (Java_org_godotengine_godot_GodotLib_step+312) (BuildId: 51ca91226c11fafc)
  #13  pc 0x0000000000d9d1a8  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+104)
  #14  pc 0x0000000002002908  /memfd:jit-cache (org.godotengine.godot.vulkan.VkRenderer.onVkDrawFrame+40)
  #15  pc 0x0000000002003f3c  /memfd:jit-cache (org.godotengine.godot.vulkan.VkThread.run+860)
  #16  pc 0x0000000000317194  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612)
  #17  pc 0x0000000000302838  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+216)
  #18  pc 0x00000000004c8298  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallback(void*)+932)
  #19  pc 0x00000000004c7ee4  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallbackWithUffdGc(void*)+8)
  #20  pc 0x000000000006b1f0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+196)
  #21  pc 0x000000000005e1b4  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)
```

This was partially mentioned in #112157 but it seems conflated with other rendering related crashes which may not have the same cause there, so it's not fixing that issue per se.

Some more context on devices where this issue was reproduced in Rift Riff, mainly Mediatek, Google Tensor, Spreadtrum and Samsung s5e8835 SoCs.

<details>

<img width="1084" height="850" alt="image" src="https://github.com/user-attachments/assets/e503a1a6-055f-4e05-978e-b6861a8bb3f1" />

<img width="1084" height="662" alt="image" src="https://github.com/user-attachments/assets/e735b0f5-8bcd-421c-b5de-7b96874e4f15" />

<img width="1084" height="895" alt="image" src="https://github.com/user-attachments/assets/51948c9f-7b01-4280-9e2a-bb09e51da6c2" />

</details>