### PR TITLE
Fix different separations across different code editors

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1702,9 +1702,9 @@ void CodeTextEditor::_notification(int p_what) {
 			update_toggle_files_button();
 
 			zoom_button->set_tooltip_text(
-					TTR("Zoom factor") + "\n" +
+					TTR("Zoom Factor") + "\n" +
 					// TRANSLATORS: The placeholders are keyboard shortcuts. The first one is in the form of "Ctrl+"/"Cmd+".
-					vformat(TTR("%s+Mouse wheel, %s/%s: Finetune\n%s: Reset"), keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL), ED_GET_SHORTCUT("script_editor/zoom_in")->get_as_text(), ED_GET_SHORTCUT("script_editor/zoom_out")->get_as_text(), ED_GET_SHORTCUT("script_editor/reset_zoom")->get_as_text()));
+					vformat(TTR("%s+Mouse Wheel, %s/%s: Finetune\n%s: Reset"), keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL), ED_GET_SHORTCUT("script_editor/zoom_in")->get_as_text(), ED_GET_SHORTCUT("script_editor/zoom_out")->get_as_text(), ED_GET_SHORTCUT("script_editor/reset_zoom")->get_as_text()));
 
 			[[fallthrough]];
 		}
@@ -2015,6 +2015,4 @@ CodeTextEditor::CodeTextEditor() {
 	idle->connect("timeout", callable_mp(this, &CodeTextEditor::_text_changed_idle_timeout));
 
 	code_complete_timer->connect("timeout", callable_mp(this, &CodeTextEditor::_code_complete_timer_timeout));
-
-	add_theme_constant_override("separation", 4 * EDSCALE);
 }

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -51,7 +51,6 @@
 #include "scene/gui/grid_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/rich_text_label.h"
-#include "scene/gui/slider.h"
 #include "scene/gui/split_container.h"
 
 void ConnectionInfoDialog::ok_pressed() {
@@ -3010,7 +3009,6 @@ void ScriptTextEditor::_enable_code_editor() {
 ScriptTextEditor::ScriptTextEditor() {
 	code_editor = memnew(CodeTextEditor);
 	code_editor->set_toggle_list_control(ScriptEditor::get_singleton()->get_left_list_split());
-	code_editor->add_theme_constant_override("separation", 2);
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	code_editor->set_code_complete_func(_code_complete_scripts, this);
 	code_editor->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/script/text_editor.cpp
+++ b/editor/script/text_editor.cpp
@@ -34,7 +34,6 @@
 #include "editor/editor_node.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/gui/menu_button.h"
-#include "scene/gui/split_container.h"
 
 void TextEditor::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());
@@ -606,7 +605,6 @@ void TextEditor::update_toggle_files_button() {
 TextEditor::TextEditor() {
 	code_editor = memnew(CodeTextEditor);
 	add_child(code_editor);
-	code_editor->add_theme_constant_override("separation", 0);
 	code_editor->connect("load_theme_settings", callable_mp(this, &TextEditor::_load_theme_settings));
 	code_editor->connect("validate_script", callable_mp(this, &TextEditor::_validate_script));
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -38,7 +38,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
-#include "scene/gui/separator.h"
 #include "scene/gui/split_container.h"
 #include "servers/rendering/shader_preprocessor.h"
 #include "servers/rendering/shader_types.h"
@@ -1185,7 +1184,6 @@ TextShaderEditor::TextShaderEditor() {
 	code_editor->connect("script_validated", callable_mp(this, &TextShaderEditor::_script_validated));
 
 	code_editor->set_v_size_flags(SIZE_EXPAND_FILL);
-	code_editor->add_theme_constant_override("separation", 0);
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 
 	code_editor->connect("show_warnings_panel", callable_mp(this, &TextShaderEditor::_show_warnings_panel));

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -174,8 +174,8 @@ class TextShaderEditor : public ShaderEditor {
 
 	uint32_t dependencies_version = 0xFFFFFFFF;
 
-	bool trim_trailing_whitespace_on_save;
-	bool trim_final_newlines_on_save;
+	bool trim_trailing_whitespace_on_save = false;
+	bool trim_final_newlines_on_save = false;
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
For whatever reason, the script, text, and shader editors all set different separation values. This PR removes those overrides, leaving them to use the default one instead.

Fixes #112809.