### PR TITLE
Add "Threaded Loading Demo" link to `ResourceLoader` tutorials

### DIFF
--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -10,6 +10,7 @@
 		[b]Note:[/b] Non-resource files such as plain text files cannot be read using [ResourceLoader]. Use [FileAccess] for those files instead, and be aware that non-resource files are not exported by default (see notes in the [FileAccess] class description for instructions on exporting them).
 	</description>
 	<tutorials>
+		<link title="Threaded Loading Demo">https://godotengine.org/asset-library/asset/2778</link>
 		<link title="Operating System Testing Demo">https://godotengine.org/asset-library/asset/2789</link>
 	</tutorials>
 	<methods>


### PR DESCRIPTION

This demo should also be listed:
https://godotengine.org/asset-library/asset/2778


It shows how to use the functions `ResourceLoader.load_threaded_request` and `ResourceLoader.load_threaded_get`.
https://github.com/godotengine/godot-demo-projects/blob/master/loading/load_threaded/load_threaded.gd
