### PR TITLE
Allow theme settings to be overridden

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9165,7 +9165,7 @@ EditorNode::EditorNode() {
 	ResourceLoader::set_load_callback(_resource_loaded);
 
 	// Apply setting presets in case the editor_settings file is missing values.
-	EditorSettingsDialog::update_navigation_preset();
+	Node3DEditor::get_singleton()->update_navigation_preset();
 
 	screenshot_timer = memnew(Timer);
 	screenshot_timer->set_one_shot(true);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -8895,6 +8895,142 @@ void Node3DEditor::_update_theme() {
 	context_toolbar_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("ContextualToolbar"), EditorStringName(EditorStyles)));
 }
 
+static bool _update_shortcut_input(const String &p_name, Ref<InputEventKey> &p_event, bool p_set) {
+	Array sc_events;
+	if (p_event->get_keycode() != Key::NONE) {
+		sc_events.push_back((Variant)p_event);
+	}
+
+	Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(p_name);
+	Array cur_events = sc->get_events();
+	bool different = cur_events.size() != sc_events.size() || cur_events.size() > 1;
+	if (!different && cur_events.size() == 1) {
+		const Ref<InputEventKey> cur_event = Object::cast_to<InputEventKey>(cur_events[0].get_validated_object());
+		ERR_FAIL_COND_V(cur_event.is_null(), false);
+		different = !p_event->is_match(cur_event, true);
+	}
+	if (p_set && different) {
+		sc->set_events(sc_events);
+	}
+	return different;
+}
+
+static bool _update_navigation_preset(bool p_set) {
+	Node3DEditorViewport::NavigationScheme nav_scheme = (Node3DEditorViewport::NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
+	Node3DEditorViewport::ViewportNavMouseButton set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
+	Node3DEditorViewport::ViewportNavMouseButton set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
+	Node3DEditorViewport::ViewportNavMouseButton set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
+	bool set_3_button_mouse = false;
+	Ref<InputEventKey> orbit_mod_key_1;
+	Ref<InputEventKey> orbit_mod_key_2;
+	Ref<InputEventKey> pan_mod_key_1;
+	Ref<InputEventKey> pan_mod_key_2;
+	Ref<InputEventKey> zoom_mod_key_1;
+	Ref<InputEventKey> zoom_mod_key_2;
+	bool set_preset = false;
+
+	if (nav_scheme == Node3DEditorViewport::NAVIGATION_GODOT) {
+		set_preset = true;
+		set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
+		set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
+		set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
+		set_3_button_mouse = false;
+		orbit_mod_key_1 = InputEventKey::create_reference(Key::NONE);
+		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
+		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		zoom_mod_key_1 = InputEventKey::create_reference(Key::CTRL);
+		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+	} else if (nav_scheme == Node3DEditorViewport::NAVIGATION_MAYA) {
+		set_preset = true;
+		set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
+		set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
+		set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_RIGHT_MOUSE;
+		set_3_button_mouse = false;
+		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_1 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		zoom_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+	} else if (nav_scheme == Node3DEditorViewport::NAVIGATION_MODO) {
+		set_preset = true;
+		set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
+		set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
+		set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
+		set_3_button_mouse = false;
+		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
+		pan_mod_key_2 = InputEventKey::create_reference(Key::ALT);
+		zoom_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		zoom_mod_key_2 = InputEventKey::create_reference(Key::CTRL);
+	} else if (nav_scheme == Node3DEditorViewport::NAVIGATION_TABLET) {
+		set_preset = true;
+		set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
+		set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
+		set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
+		set_3_button_mouse = true;
+		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
+		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
+		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		zoom_mod_key_1 = InputEventKey::create_reference(Key::CTRL);
+		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+	}
+
+	if (p_set && set_preset) {
+		// Set settings to the desired preset values.
+		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/orbit_mouse_button", (int)set_orbit_mouse_button);
+		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/pan_mouse_button", (int)set_pan_mouse_button);
+		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/zoom_mouse_button", (int)set_zoom_mouse_button);
+		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/emulate_3_button_mouse", set_3_button_mouse);
+		bool updated = false;
+		updated |= _update_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_pan_modifier_2", pan_mod_key_2, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_zoom_modifier_1", zoom_mod_key_1, true);
+		updated |= _update_shortcut_input("spatial_editor/viewport_zoom_modifier_2", zoom_mod_key_2, true);
+		if (updated) {
+			EditorSettings::get_singleton()->mark_setting_changed("shortcuts");
+		}
+	} else if (!p_set) {
+		if (!set_preset) {
+			// Custom mode can have any shortcuts.
+			return false;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_pan_modifier_2", pan_mod_key_2, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_zoom_modifier_1", zoom_mod_key_1, false)) {
+			return true;
+		}
+		if (_update_shortcut_input("spatial_editor/viewport_zoom_modifier_2", zoom_mod_key_2, false)) {
+			return true;
+		}
+		return false;
+	}
+	return true;
+}
+
+void Node3DEditor::update_navigation_preset() {
+	_update_navigation_preset(true);
+}
+
+static bool _navigation_preset_changed() {
+	return _update_navigation_preset(false);
+}
+
 void Node3DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -8952,7 +9088,8 @@ void Node3DEditor::_notification(int p_what) {
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d")) {
+			EditorSettings *editor_settings = EditorSettings::get_singleton();
+			if (editor_settings->check_changed_settings_in_group("editors/3d")) {
 				const Color selection_box_color = EDITOR_GET("editors/3d/selection_box_color");
 				const Color active_selection_box_color = EDITOR_GET("editors/3d/active_selection_box_color");
 
@@ -8974,6 +9111,15 @@ void Node3DEditor::_notification(int p_what) {
 					viewports[i]->update_transform_gizmo_view();
 				}
 				update_gizmo_opacity();
+			}
+			if (editor_settings->check_changed_settings_in_group("shortcuts")) {
+				// Set to custom navigation scheme if modifier shortcuts were changed.
+				if (_navigation_preset_changed()) {
+					editor_settings->set_manually("editors/3d/navigation/navigation_scheme", (int)Node3DEditorViewport::NAVIGATION_CUSTOM);
+				}
+			}
+			if (editor_settings->check_changed_settings_in_group("editors/3d/navigation/navigation_scheme")) {
+				update_navigation_preset();
 			}
 		} break;
 

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -969,6 +969,8 @@ public:
 
 	static Size2i get_camera_viewport_size(Camera3D *p_camera);
 
+	static void update_navigation_preset();
+
 	Vector3 snap_point(Vector3 p_target, Vector3 p_start = Vector3(0, 0, 0)) const;
 
 	float get_znear() const { return settings_znear->get_value(); }

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -121,6 +121,7 @@ private:
 	void _set_initialized();
 	void _load_defaults(Ref<ConfigFile> p_extra_config = Ref<ConfigFile>());
 	void _load_default_visual_shader_editor_theme();
+	void _update_linked_settings(const StringName &p_name, const Variant &p_value);
 	static String _guess_exec_args_for_extenal_editor(const String &p_value);
 	const String _get_project_metadata_path() const;
 #ifndef DISABLE_DEPRECATED

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -105,6 +105,8 @@ private:
 	HashMap<String, PackedStringArray> favorite_properties;
 	Vector<String> recent_dirs;
 
+	Vector<Pair<String, PackedStringArray>> preset_settings;
+
 	bool save_changed_setting = true;
 	bool optimize_save = true; //do not save stuff that came from config but was not set from engine
 	bool initialized = false;
@@ -187,6 +189,9 @@ public:
 	void set_recent_dirs_bind(const Vector<String> &p_recent_dirs);
 	Vector<String> get_recent_dirs() const;
 	void load_favorites_and_recent_dirs();
+
+	Vector<Pair<String, PackedStringArray>> get_preset_settings() const;
+	Variant get_preset_custom_value(const String &p_property_name) const;
 
 	static HashMap<StringName, Color> get_godot2_text_editor_theme();
 	static bool is_default_text_editor_theme(const String &p_theme_name);

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -65,114 +65,6 @@ void EditorSettingsDialog::_settings_changed() {
 	timer->start();
 }
 
-void EditorSettingsDialog::_settings_property_edited(const String &p_name) {
-	String full_name = inspector->get_full_item_path(p_name);
-
-	// Set theme presets to Custom when controlled settings change.
-
-	if (full_name == "interface/theme/accent_color" || full_name == "interface/theme/base_color" || full_name == "interface/theme/contrast" || full_name == "interface/theme/draw_extra_borders" || full_name == "interface/theme/icon_saturation" || full_name == "interface/theme/draw_relationship_lines" || full_name == "interface/theme/corner_radius") {
-		EditorSettings::get_singleton()->set_manually("interface/theme/color_preset", "Custom");
-	} else if (full_name == "interface/theme/base_spacing" || full_name == "interface/theme/additional_spacing") {
-		EditorSettings::get_singleton()->set_manually("interface/theme/spacing_preset", "Custom");
-	} else if (full_name.begins_with("text_editor/theme/highlighting")) {
-		EditorSettings::get_singleton()->set_manually("text_editor/theme/color_theme", "Custom");
-	} else if (full_name.begins_with("editors/visual_editors/connection_colors") || full_name.begins_with("editors/visual_editors/category_colors")) {
-		EditorSettings::get_singleton()->set_manually("editors/visual_editors/color_theme", "Custom");
-	} else if (full_name == "editors/3d/navigation/orbit_mouse_button" || full_name == "editors/3d/navigation/pan_mouse_button" || full_name == "editors/3d/navigation/zoom_mouse_button" || full_name == "editors/3d/navigation/emulate_3_button_mouse") {
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/navigation_scheme", (int)Node3DEditorViewport::NAVIGATION_CUSTOM);
-	} else if (full_name == "editors/3d/navigation/navigation_scheme") {
-		update_navigation_preset();
-	}
-}
-
-void EditorSettingsDialog::update_navigation_preset() {
-	Node3DEditorViewport::NavigationScheme nav_scheme = (Node3DEditorViewport::NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
-	Node3DEditorViewport::ViewportNavMouseButton set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
-	Node3DEditorViewport::ViewportNavMouseButton set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
-	Node3DEditorViewport::ViewportNavMouseButton set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
-	bool set_3_button_mouse = false;
-	Ref<InputEventKey> orbit_mod_key_1;
-	Ref<InputEventKey> orbit_mod_key_2;
-	Ref<InputEventKey> pan_mod_key_1;
-	Ref<InputEventKey> pan_mod_key_2;
-	Ref<InputEventKey> zoom_mod_key_1;
-	Ref<InputEventKey> zoom_mod_key_2;
-	bool set_preset = false;
-
-	if (nav_scheme == Node3DEditorViewport::NAVIGATION_GODOT) {
-		set_preset = true;
-		set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
-		set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
-		set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
-		set_3_button_mouse = false;
-		orbit_mod_key_1 = InputEventKey::create_reference(Key::NONE);
-		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
-		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		zoom_mod_key_1 = InputEventKey::create_reference(Key::CTRL);
-		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-	} else if (nav_scheme == Node3DEditorViewport::NAVIGATION_MAYA) {
-		set_preset = true;
-		set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
-		set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
-		set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_RIGHT_MOUSE;
-		set_3_button_mouse = false;
-		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_1 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		zoom_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-	} else if (nav_scheme == Node3DEditorViewport::NAVIGATION_MODO) {
-		set_preset = true;
-		set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
-		set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
-		set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
-		set_3_button_mouse = false;
-		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
-		pan_mod_key_2 = InputEventKey::create_reference(Key::ALT);
-		zoom_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		zoom_mod_key_2 = InputEventKey::create_reference(Key::CTRL);
-	} else if (nav_scheme == Node3DEditorViewport::NAVIGATION_TABLET) {
-		set_preset = true;
-		set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
-		set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
-		set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_MIDDLE_MOUSE;
-		set_3_button_mouse = true;
-		orbit_mod_key_1 = InputEventKey::create_reference(Key::ALT);
-		orbit_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		pan_mod_key_1 = InputEventKey::create_reference(Key::SHIFT);
-		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-		zoom_mod_key_1 = InputEventKey::create_reference(Key::CTRL);
-		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
-	}
-	// Set settings to the desired preset values.
-	if (set_preset) {
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/orbit_mouse_button", (int)set_orbit_mouse_button);
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/pan_mouse_button", (int)set_pan_mouse_button);
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/zoom_mouse_button", (int)set_zoom_mouse_button);
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/emulate_3_button_mouse", set_3_button_mouse);
-		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2);
-		_set_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_pan_modifier_2", pan_mod_key_2);
-		_set_shortcut_input("spatial_editor/viewport_zoom_modifier_1", zoom_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_zoom_modifier_2", zoom_mod_key_2);
-	}
-}
-
-void EditorSettingsDialog::_set_shortcut_input(const String &p_name, Ref<InputEventKey> &p_event) {
-	Array sc_events;
-	if (p_event->get_keycode() != Key::NONE) {
-		sc_events.push_back((Variant)p_event);
-	}
-
-	Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(p_name);
-	sc->set_events(sc_events);
-}
-
 void EditorSettingsDialog::_settings_save() {
 	if (!timer->is_stopped()) {
 		timer->stop();
@@ -394,13 +286,6 @@ void EditorSettingsDialog::_update_shortcut_events(const String &p_path, const A
 		undo_redo->add_do_method(this, "_settings_changed");
 		undo_redo->add_undo_method(this, "_settings_changed");
 		undo_redo->commit_action();
-	}
-
-	bool path_is_orbit_mod = p_path == "spatial_editor/viewport_orbit_modifier_1" || p_path == "spatial_editor/viewport_orbit_modifier_2";
-	bool path_is_pan_mod = p_path == "spatial_editor/viewport_pan_modifier_1" || p_path == "spatial_editor/viewport_pan_modifier_2";
-	bool path_is_zoom_mod = p_path == "spatial_editor/viewport_zoom_modifier_1" || p_path == "spatial_editor/viewport_zoom_modifier_2";
-	if (path_is_orbit_mod || path_is_pan_mod || path_is_zoom_mod) {
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/navigation_scheme", (int)Node3DEditorViewport::NAVIGATION_CUSTOM);
 	}
 }
 
@@ -963,7 +848,6 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	inspector->register_advanced_toggle(advanced_switch);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_general->add_child(inspector);
-	inspector->get_inspector()->connect("property_edited", callable_mp(this, &EditorSettingsDialog::_settings_property_edited));
 	inspector->get_inspector()->connect("restart_requested", callable_mp(this, &EditorSettingsDialog::_editor_restart_request));
 
 	if (EDITOR_GET("interface/touchscreen/enable_touch_optimizations")) {

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -79,7 +79,6 @@ class EditorSettingsDialog : public AcceptDialog {
 	virtual void ok_pressed() override;
 
 	void _settings_changed();
-	void _settings_property_edited(const String &p_name);
 	void _settings_save();
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
@@ -112,7 +111,6 @@ class EditorSettingsDialog : public AcceptDialog {
 	void _update_shortcuts();
 	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button = MouseButton::LEFT);
 	void _shortcut_cell_double_clicked();
-	static void _set_shortcut_input(const String &p_name, Ref<InputEventKey> &p_event);
 
 	static void _undo_redo_callback(void *p_self, const String &p_name);
 
@@ -130,7 +128,6 @@ protected:
 
 public:
 	void popup_edit_settings();
-	static void update_navigation_preset();
 
 	EditorSettingsDialog();
 };

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -139,6 +139,7 @@ class EditorSettingsPropertyWrapper : public EditorProperty {
 	PropertyHint hint;
 	String hint_text;
 	uint32_t usage;
+	String preset_property;
 
 	EditorProperty *editor_property = nullptr;
 
@@ -147,6 +148,7 @@ class EditorSettingsPropertyWrapper : public EditorProperty {
 	EditorProperty *override_editor_property = nullptr;
 	Button *goto_button = nullptr;
 	Button *remove_button = nullptr;
+	Label *preset_override_label = nullptr;
 
 	void _setup_override_info();
 	void _update_override();


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/13839
- Built on https://github.com/godotengine/godot/pull/114005

Allow theme settings to be overridden.

Also fixes a case when the default theme is changed to custom and the editor is restarted, the colors had their initial value to a slightly different color.

Changed `set_initial_value` when updating current to not send the signal. This lets it not need `set_manually` to be called after it anymore.

Added an indicator in the EditorSettingsDialog for settings when a preset that controls them is overridden. These are also made read-only, since they would just be immediately reverted. These can still be overriden. These are not made read-only when the preset's override is set to `Custom`, since it will still use the EditorSettings values in that case.

For the theme, moved `EDITOR_GET` after the presets updated their values, so it can work with overrides. 
When it is set to `Custom`, it now sets the initial value to the default to keep it consistent.
Also made sure that the presets are not set here, this means `follow_system_theme` and `use_system_accent_color` no longer set the theme to Custom. It seems to still work fine, they act like modifiers to the preset.

For `editors/visual_editors/color_theme`, it needed to set the initial value for `Custom`, and it was not using `EDITOR_GET`.

<img width="834" height="580" alt="image" src="https://github.com/user-attachments/assets/6ba861f0-bee0-4881-b179-c72652c9290e" />
