### PR TITLE
Fix bad handling of buffer over and underruns in `AudioStreamPlaybackMicrophone`

### DIFF
--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -94,7 +94,8 @@ double AudioDriver::get_time_to_next_mix() {
 
 void AudioDriver::input_buffer_init(int driver_buffer_frames) {
 	const int input_buffer_channels = 2;
-	input_buffer.resize(driver_buffer_frames * input_buffer_channels * 4);
+	// We want at least a delay of padding around input_position so mul by 4 (to keep pow of 2) again
+	input_buffer.resize(driver_buffer_frames * input_buffer_channels * 4 * 4);
 	input_position = 0;
 	input_size = 0;
 }

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -388,9 +388,8 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 	unsigned int input_size = AudioDriver::get_singleton()->get_input_size();
 	int mix_rate = AudioDriver::get_singleton()->get_input_mix_rate();
 	unsigned int playback_delay = MIN(((50 * mix_rate) / 1000) * 2, buf.size() >> 1);
-#ifdef DEBUG_ENABLED
+	unsigned int playback_half_delay = playback_delay >> 1;
 	unsigned int input_position = AudioDriver::get_singleton()->get_input_position();
-#endif
 
 	int mixed_frames = p_frames;
 
@@ -401,7 +400,32 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 		input_ofs = 0;
 	} else {
 		for (int i = 0; i < p_frames; i++) {
-			if (input_size > input_ofs && (int)input_ofs < buf.size()) {
+			int input_position_delta = (int)input_position - (int)input_ofs;
+			// Maintain playback delay barrier around current input_pos to easily minimize stutter
+			if (abs(input_position_delta) < playback_half_delay) {
+				if (input_position_delta > 0) {
+					// buffer underrun correction
+					#ifdef DEBUG_ENABLED
+							print_verbose(String(get_class_name()) + " buffer underrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
+					#endif
+					if (input_ofs < playback_delay) {
+						// Modulo wraparound bottom
+						input_ofs += (unsigned int)buf.size();
+					}
+					input_ofs -= playback_delay;
+				} else {
+					// buffer overrun correction
+					#ifdef DEBUG_ENABLED
+							print_verbose(String(get_class_name()) + " buffer overrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
+					#endif
+					input_ofs += playback_delay;
+					if ((int)input_ofs >= buf.size()) {
+						// Modulo wraparound
+						input_ofs -= (unsigned int)buf.size();
+					}
+				}
+			}
+			if ((int)input_ofs < buf.size()) {
 				float l = (buf[input_ofs++] >> 16) / 32768.f;
 				if ((int)input_ofs >= buf.size()) {
 					input_ofs = 0;
@@ -414,6 +438,7 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 				p_buffer[i] = AudioFrame(l, r);
 			} else {
 				p_buffer[i] = AudioFrame(0.0f, 0.0f);
+				input_ofs = 0;
 			}
 		}
 	}

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -402,7 +402,7 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 		for (int i = 0; i < p_frames; i++) {
 			int input_position_delta = (int)input_position - (int)input_ofs;
 			// Maintain playback delay barrier around current input_pos to easily minimize stutter
-			if (Math::abs(input_position_delta) < playback_half_delay) {
+			if ((unsigned int)Math::abs(input_position_delta) < playback_half_delay) {
 				if (input_position_delta > 0) {
 					// buffer underrun correction
 #ifdef DEBUG_ENABLED

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -402,7 +402,7 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 		for (int i = 0; i < p_frames; i++) {
 			int input_position_delta = (int)input_position - (int)input_ofs;
 			// Maintain playback delay barrier around current input_pos to easily minimize stutter
-			if (abs(input_position_delta) < playback_half_delay) {
+			if (Math::abs(input_position_delta) < playback_half_delay) {
 				if (input_position_delta > 0) {
 					// buffer underrun correction
 #ifdef DEBUG_ENABLED

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -405,9 +405,9 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 			if (abs(input_position_delta) < playback_half_delay) {
 				if (input_position_delta > 0) {
 					// buffer underrun correction
-					#ifdef DEBUG_ENABLED
-							print_verbose(String(get_class_name()) + " buffer underrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
-					#endif
+#ifdef DEBUG_ENABLED
+					print_verbose(String(get_class_name()) + " buffer underrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
+#endif
 					if (input_ofs < playback_delay) {
 						// Modulo wraparound bottom
 						input_ofs += (unsigned int)buf.size();
@@ -415,9 +415,9 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 					input_ofs -= playback_delay;
 				} else {
 					// buffer overrun correction
-					#ifdef DEBUG_ENABLED
-							print_verbose(String(get_class_name()) + " buffer overrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
-					#endif
+#ifdef DEBUG_ENABLED
+					print_verbose(String(get_class_name()) + " buffer overrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
+#endif
 					input_ofs += playback_delay;
 					if ((int)input_ofs >= buf.size()) {
 						// Modulo wraparound


### PR DESCRIPTION
Microphone input can drift in how many samples are available at any one time, losing synchronization with the output bus. When this happens, the current code starts looping a distorted mess as the playback crosses the threshold for where new samples are placed in the buffer. This fix effectively guarantees that despite this drift, decent audio will be returned. It handles these two use cases:

1. buffer underrun (microphone audio is played back quicker than is available) this jumps the current playback position in the buffer back by the input delay. 
2. buffer overrun (microphone audio is played back slower than is available) this jumps the current playback position in the buffer forward by the input delay. 

Assuming constant drift it should average out to the expected input delay.