### PR TITLE
Add tilde symbol (~) to the FileDialog

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -362,6 +362,10 @@ String OS::get_system_dir(SystemDir p_dir, bool p_shared_storage) const {
 	return ".";
 }
 
+String OS::expand_path(const String &p_path) const {
+	return p_path;
+}
+
 void OS::create_lock_file() {
 	if (Engine::get_singleton()->is_recovery_mode_hint()) {
 		return;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -336,6 +336,8 @@ public:
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const;
 
+	virtual String expand_path(const String &p_path) const;
+
 	virtual Error move_to_trash(const String &p_path) { return FAILED; }
 
 	void create_lock_file();

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1208,6 +1208,19 @@ String OS_Unix::get_executable_path() const {
 #endif
 }
 
+String OS_Unix::expand_path(const String &p_path) const {
+	String path = p_path;
+
+	if (path.begins_with("~/") || path == "~") {
+		String home = get_environment("HOME");
+		if (!home.is_empty()) {
+			path = home + path.substr(1);
+		}
+	}
+
+	return path;
+}
+
 void UnixTerminalLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces) {
 	if (!should_log(true)) {
 		return;

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -141,6 +141,8 @@ public:
 
 	virtual String get_executable_path() const override;
 	virtual String get_user_data_dir(const String &p_user_dir) const override;
+
+	virtual String expand_path(const String &p_path) const override;
 };
 
 class UnixTerminalLogger : public StdLogger {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2510,6 +2510,19 @@ String OS_Windows::get_user_data_dir(const String &p_user_dir) const {
 	return get_data_path().path_join(p_user_dir).replace_char('\\', '/');
 }
 
+String OS_Windows::expand_path(const String &p_path) const {
+	String path = p_path;
+
+	if (path.begins_with("~/") || path.begins_with("~\\") || path == "~") {
+		String home = get_environment("USERPROFILE");
+		if (!home.is_empty()) {
+			path = home + path.substr(1);
+		}
+	}
+
+	return path;
+}
+
 String OS_Windows::get_unique_id() const {
 	HW_PROFILE_INFOA HwProfInfo;
 	ERR_FAIL_COND_V(!GetCurrentHwProfileA(&HwProfInfo), "");

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -246,6 +246,8 @@ public:
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
 	virtual String get_user_data_dir(const String &p_user_dir) const override;
 
+	virtual String expand_path(const String &p_path) const override;
+
 	virtual String get_unique_id() const override;
 
 	virtual Error shell_open(const String &p_uri) override;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -385,7 +385,7 @@ void FileDialog::update_dir() {
 }
 
 void FileDialog::_dir_submitted(String p_dir) {
-	String new_dir = p_dir;
+	String new_dir = OS::get_singleton()->expand_path(p_dir);
 #ifdef WINDOWS_ENABLED
 	if (root_prefix.is_empty() && drives->is_visible() && !new_dir.is_network_share_path() && new_dir.is_absolute_path() && new_dir.find(":/") == -1 && new_dir.find(":\\") == -1) {
 		// Non network path without X:/ prefix on Windows, add drive letter.
@@ -454,6 +454,9 @@ void FileDialog::_action_pressed() {
 	}
 
 	String file_text = filename_edit->get_text();
+
+	file_text = OS::get_singleton()->expand_path(file_text);
+
 	String f = file_text.is_absolute_path() ? file_text : dir_access->get_current_dir().path_join(file_text);
 
 	if ((mode == FILE_MODE_OPEN_ANY || mode == FILE_MODE_OPEN_FILE) && (dir_access->file_exists(f) || dir_access->is_bundle(f))) {
@@ -1318,12 +1321,15 @@ void FileDialog::set_current_path(const String &p_path) {
 	if (!p_path.size()) {
 		return;
 	}
-	int pos = MAX(p_path.rfind_char('/'), p_path.rfind_char('\\'));
+
+	String path = OS::get_singleton()->expand_path(p_path);
+
+	int pos = MAX(path.rfind_char('/'), path.rfind_char('\\'));
 	if (pos == -1) {
-		set_current_file(p_path);
+		set_current_file(path);
 	} else {
-		String path_dir = p_path.substr(0, pos);
-		String path_file = p_path.substr(pos + 1);
+		String path_dir = path.substr(0, pos);
+		String path_file = path.substr(pos + 1);
 		set_current_dir(path_dir);
 		set_current_file(path_file);
 	}


### PR DESCRIPTION
TL;DR
- Closes https://github.com/godotengine/godot-proposals/issues/13823 (partially, no logic for environment vars yet)
- Adds the tilde symbol in FileDialog

This PR adds the tilde symbol (which is used in UNIX based OS). It checks for your platform & expands the tilde symbol to your home dir (which is `USERPROFILE` on Windows & `HOME` on Linux).

This is a recording of the PR in work:

[PR Showcase.webm](https://github.com/user-attachments/assets/313d89a1-ebae-4a4b-9b1d-64f10eb31522)

(Specs: Godot v4.6.beta (94d3def65) - Zorin OS 18 on Wayland - X11 display driver, Multi-window, 1 monitor - Vulkan (Forward+) - integrated Intel(R) HD Graphics 5500 (BDW GT2) - Intel(R) Core(TM) i3-5005U CPU @ 2.00GHz (4 threads) - 7.67 GiB memory)


> [!NOTE]
> Contributed by 2LazyDevs.