### PR TITLE
gitignore: Ignore GNU `patch` .orig and .rej backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,10 @@ cppcheck-cppcheck-build-dir/
 *.geany
 .geanyprj
 
+# GNU patch
+*.orig
+*.rej
+
 # Gprof
 gmon.out
 


### PR DESCRIPTION
Extracted from #114075, just a convenience for those of us who maintain thirdparty libs and have to apply/rediff patches using GNU `patch`.