### PR TITLE
Add `scroll_past_end_of_line` to TextEdit

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1462,6 +1462,9 @@
 		<member name="text_editor/behavior/navigation/scroll_past_end_of_file" type="bool" setter="" getter="">
 			If [code]true[/code], allows scrolling past the end of the file.
 		</member>
+		<member name="text_editor/behavior/navigation/scroll_past_end_of_line" type="bool" setter="" getter="">
+			If [code]true[/code], allows scrolling past the last character on a line.
+		</member>
 		<member name="text_editor/behavior/navigation/smooth_scrolling" type="bool" setter="" getter="">
 			If [code]true[/code], enables a smooth scrolling animation when using the mouse wheel to scroll. See [member text_editor/behavior/navigation/v_scroll_speed] for the speed of this animation.
 			[b]Note:[/b] [member text_editor/behavior/navigation/smooth_scrolling] currently behaves poorly in projects where [member ProjectSettings.physics/common/physics_ticks_per_second] has been increased significantly from its default value ([code]60[/code]). In this case, it is recommended to disable this setting.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1378,6 +1378,9 @@
 		<member name="scroll_past_end_of_file" type="bool" setter="set_scroll_past_end_of_file_enabled" getter="is_scroll_past_end_of_file_enabled" default="false">
 			Allow scrolling past the last line into "virtual" space.
 		</member>
+		<member name="scroll_past_end_of_line" type="bool" setter="set_scroll_past_end_of_line_enabled" getter="is_scroll_past_end_of_line_enabled" default="false">
+			Allow scrolling past the last character into "horizontal" space.
+		</member>
 		<member name="scroll_smooth" type="bool" setter="set_smooth_scroll_enabled" getter="is_smooth_scroll_enabled" default="false">
 			Scroll smoothly over the text rather than jumping to the next location.
 		</member>

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1140,6 +1140,7 @@ void CodeTextEditor::update_editor_settings() {
 
 	// Behavior: Navigation
 	text_editor->set_scroll_past_end_of_file_enabled(EDITOR_GET("text_editor/behavior/navigation/scroll_past_end_of_file"));
+	text_editor->set_scroll_past_end_of_line_enabled(EDITOR_GET("text_editor/behavior/navigation/scroll_past_end_of_line"));
 	text_editor->set_smooth_scroll_enabled(EDITOR_GET("text_editor/behavior/navigation/smooth_scrolling"));
 	text_editor->set_v_scroll_speed(EDITOR_GET("text_editor/behavior/navigation/v_scroll_speed"));
 	text_editor->set_drag_and_drop_selection_enabled(EDITOR_GET("text_editor/behavior/navigation/drag_and_drop_selection"));

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -795,6 +795,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Behavior: Navigation
 	_initial_set("text_editor/behavior/navigation/move_caret_on_right_click", true, true);
 	_initial_set("text_editor/behavior/navigation/scroll_past_end_of_file", false, true);
+	_initial_set("text_editor/behavior/navigation/scroll_past_end_of_line", false, true);
 	_initial_set("text_editor/behavior/navigation/smooth_scrolling", true, true);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/navigation/v_scroll_speed", 80, "1,10000,1")
 	_initial_set("text_editor/behavior/navigation/drag_and_drop_selection", true, true);

--- a/editor/shader/editor_native_shader_source_visualizer.cpp
+++ b/editor/shader/editor_native_shader_source_visualizer.cpp
@@ -128,6 +128,7 @@ void EditorNativeShaderSourceVisualizer::_inspect_shader(RID p_shader) {
 
 			// Behavior: Navigation
 			code_edit->set_scroll_past_end_of_file_enabled(EDITOR_GET("text_editor/behavior/navigation/scroll_past_end_of_file"));
+			code_edit->set_scroll_past_end_of_line_enabled(EDITOR_GET("text_editor/behavior/navigation/scroll_past_end_of_line"));
 			code_edit->set_smooth_scroll_enabled(EDITOR_GET("text_editor/behavior/navigation/smooth_scrolling"));
 			code_edit->set_v_scroll_speed(EDITOR_GET("text_editor/behavior/navigation/v_scroll_speed"));
 			code_edit->set_drag_and_drop_selection_enabled(EDITOR_GET("text_editor/behavior/navigation/drag_and_drop_selection"));

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6445,6 +6445,18 @@ bool TextEdit::is_scroll_past_end_of_file_enabled() const {
 	return scroll_past_end_of_file_enabled;
 }
 
+void TextEdit::set_scroll_past_end_of_line_enabled(bool p_enabled) {
+	if (scroll_past_end_of_line_enabled == p_enabled) {
+		return;
+	}
+	scroll_past_end_of_line_enabled = p_enabled;
+	queue_redraw();
+}
+
+bool TextEdit::is_scroll_past_end_of_line_enabled() const {
+	return scroll_past_end_of_line_enabled;
+}
+
 RID TextEdit::get_text_canvas_item() const {
 	return text_ci;
 }
@@ -7423,6 +7435,9 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_scroll_past_end_of_file_enabled", "enable"), &TextEdit::set_scroll_past_end_of_file_enabled);
 	ClassDB::bind_method(D_METHOD("is_scroll_past_end_of_file_enabled"), &TextEdit::is_scroll_past_end_of_file_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_scroll_past_end_of_line_enabled", "enable"), &TextEdit::set_scroll_past_end_of_line_enabled);
+	ClassDB::bind_method(D_METHOD("is_scroll_past_end_of_line_enabled"), &TextEdit::is_scroll_past_end_of_line_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_v_scroll_speed", "speed"), &TextEdit::set_v_scroll_speed);
 	ClassDB::bind_method(D_METHOD("get_v_scroll_speed"), &TextEdit::get_v_scroll_speed);
 
@@ -7560,6 +7575,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_smooth"), "set_smooth_scroll_enabled", "is_smooth_scroll_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_v_scroll_speed", PROPERTY_HINT_NONE, "suffix:lines/s"), "set_v_scroll_speed", "get_v_scroll_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_past_end_of_file"), "set_scroll_past_end_of_file_enabled", "is_scroll_past_end_of_file_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_past_end_of_line"), "set_scroll_past_end_of_line_enabled", "is_scroll_past_end_of_line_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_vertical", PROPERTY_HINT_NONE, "suffix:lines"), "set_v_scroll", "get_v_scroll");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_horizontal", PROPERTY_HINT_NONE, "suffix:px"), "set_h_scroll", "get_h_scroll");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_fit_content_height"), "set_fit_content_height_enabled", "is_fit_content_height_enabled");
@@ -8600,6 +8616,10 @@ void TextEdit::_update_scrollbars() {
 
 	int visible_width = size.width - style->get_minimum_size().width;
 	int total_width = (draw_placeholder ? placeholder_max_width : text.get_max_width()) + gutters_width + gutter_padding;
+
+	if (scroll_past_end_of_line_enabled && !fit_content_width) {
+		total_width += visible_width;
+	}
 
 	if (draw_minimap) {
 		total_width += minimap_width;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -538,6 +538,7 @@ private:
 	bool fit_content_height = false;
 	bool fit_content_width = false;
 	bool scroll_past_end_of_file_enabled = false;
+	bool scroll_past_end_of_line_enabled = false;
 
 	// Smooth scrolling.
 	bool smooth_scroll_enabled = false;
@@ -1056,6 +1057,9 @@ public:
 
 	void set_scroll_past_end_of_file_enabled(bool p_enabled);
 	bool is_scroll_past_end_of_file_enabled() const;
+
+	void set_scroll_past_end_of_line_enabled(bool p_enabled);
+	bool is_scroll_past_end_of_line_enabled() const;
 
 	VScrollBar *get_v_scroll_bar() const;
 	HScrollBar *get_h_scroll_bar() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13871

https://github.com/user-attachments/assets/124cfcb4-50d9-4ffc-a33c-256a87a30b94

