### PR TITLE
Fix `TabContainer`'s minimum size ignoring the popup button

### DIFF
--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -64,7 +64,7 @@ void EditorBottomPanel::_on_tab_changed(int p_idx) {
 
 void EditorBottomPanel::_theme_changed() {
 	int icon_width = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
-	int margin = bottom_hbox->get_minimum_size().x;
+	int margin = bottom_hbox->get_minimum_size().width;
 	if (get_popup()) {
 		margin -= icon_width;
 	}
@@ -126,12 +126,6 @@ void EditorBottomPanel::_repaint() {
 	} else {
 		_theme_changed();
 	}
-}
-
-Size2 EditorBottomPanel::get_minimum_size() const {
-	Size2 min_size = TabContainer::get_minimum_size();
-	min_size.x += bottom_hbox->get_combined_minimum_size().x;
-	return min_size;
 }
 
 void EditorBottomPanel::save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const {

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -67,8 +67,6 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual Size2 get_minimum_size() const override;
-
 	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;
 	void load_layout_from_config(Ref<ConfigFile> p_config_file, const String &p_section);
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1031,15 +1031,13 @@ Size2 TabContainer::get_minimum_size() const {
 		ms.width += theme_cache.tabbar_style->get_margin(SIDE_LEFT) + theme_cache.tabbar_style->get_margin(SIDE_RIGHT);
 		ms.height += theme_cache.tabbar_style->get_margin(SIDE_TOP) + theme_cache.tabbar_style->get_margin(SIDE_BOTTOM);
 
-		if (!get_clip_tabs()) {
-			if (get_popup()) {
-				ms.width += theme_cache.menu_icon->get_width();
-			}
+		if (get_popup()) {
+			ms.width += theme_cache.menu_icon->get_width();
+		}
 
-			if (theme_cache.side_margin > 0 && get_tab_alignment() != TabBar::ALIGNMENT_CENTER &&
-					(get_tab_alignment() != TabBar::ALIGNMENT_RIGHT || !get_popup())) {
-				ms.width += theme_cache.side_margin;
-			}
+		if (theme_cache.side_margin > 0 && get_tab_alignment() != TabBar::ALIGNMENT_CENTER &&
+				(get_tab_alignment() != TabBar::ALIGNMENT_RIGHT || !get_popup())) {
+			ms.width += theme_cache.side_margin;
 		}
 	}
 
@@ -1078,9 +1076,7 @@ void TabContainer::set_popup(Node *p_popup) {
 	if (had_popup != bool(popup)) {
 		queue_redraw();
 		_update_margins();
-		if (!get_clip_tabs()) {
-			update_minimum_size();
-		}
+		update_minimum_size();
 	}
 }
 


### PR DESCRIPTION
Fixes #114111.
Reverts #113938.