### PR TITLE
Fix FileDialog relative paths

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1580,6 +1580,9 @@ void FileDialog::_select_drive(int p_idx) {
 }
 
 void FileDialog::_change_dir(const String &p_new_dir) {
+	if (p_new_dir.is_relative_path()) {
+		dir_access->change_dir(OS::get_singleton()->get_resource_dir());
+	}
 	if (root_prefix.is_empty()) {
 		dir_access->change_dir(p_new_dir);
 	} else {


### PR DESCRIPTION
Fixes #114055

Reference:
https://github.com/godotengine/godot/blob/77318d2acdada6089e5a8a23ed5d4a169c842105/editor/gui/editor_file_dialog.cpp#L1371-L1375