### PR TITLE
Add a "Speed of Sound" setting to the project settings for Doppler

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -389,6 +389,10 @@
 		<member name="playback_speed_scale" type="float" setter="set_playback_speed_scale" getter="get_playback_speed_scale" default="1.0">
 			Scales the rate at which audio is played (i.e. setting it to [code]0.5[/code] will make the audio be played at half its speed). See also [member Engine.time_scale] to affect the general simulation speed, which is independent from [member AudioServer.playback_speed_scale].
 		</member>
+		<member name="speed_of_sound" type="float" setter="set_speed_of_sound" getter="get_speed_of_sound" default="343.0">
+			The speed of sound, in meters per second. Used for Doppler calculation in [AudioStreamPlayer3D]. On initialization, this is set to [member ProjectSettings.audio/general/speed_of_sound]. This must be set to a value greater than [code]0.0[/code].
+			[b]Note:[/b] The engine currently does not simulate audio delay based on the distance between the [AudioStreamPlayer3D] node and the listener.
+		</member>
 	</members>
 	<signals>
 		<signal name="bus_layout_changed">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -493,6 +493,11 @@
 		<member name="audio/general/ios/session_category" type="int" setter="" getter="" default="0" keywords="ambient, play, record, solo">
 			Sets the [url=https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory]AVAudioSessionCategory[/url] on iOS. Use the [code]Playback[/code] category to get sound output, even if the phone is in silent mode.
 		</member>
+		<member name="audio/general/speed_of_sound" type="float" setter="" getter="" default="343.0">
+			The speed of sound, in meters per second. Used for Doppler effect calculation in [AudioStreamPlayer3D].
+			This can be changed at runtime by changing [member AudioServer.speed_of_sound].
+			[b]Note:[/b] The engine currently does not simulate audio delay based on the distance between the [AudioStreamPlayer3D] node and the listener.
+		</member>
 		<member name="audio/general/text_to_speech" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], text-to-speech support is enabled on startup, otherwise it is enabled the first time any TTS method is used. See also [method DisplayServer.tts_get_voices] and [method DisplayServer.tts_speak].
 			[b]Note:[/b] Enabling TTS can cause additional idle CPU usage and interfere with the sleep mode, so consider disabling it if TTS is not used.

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -389,10 +389,12 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 	}
 
 	Vector3 linear_velocity;
+	float speed_of_sound = 343.0;
 
-	//compute linear velocity for doppler
 	if (doppler_tracking != DOPPLER_TRACKING_DISABLED) {
+		//compute linear velocity for doppler
 		linear_velocity = velocity_tracker->get_tracked_linear_velocity();
+		speed_of_sound = AudioServer::get_singleton()->get_speed_of_sound();
 	}
 
 	Vector3 global_pos = get_global_transform().origin;
@@ -530,7 +532,6 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 			if (local_velocity != Vector3()) {
 				const float approaching = local_pos.normalized().dot(local_velocity.normalized());
 				const float velocity = local_velocity.length();
-				static constexpr float speed_of_sound = 343.0F;
 
 				float doppler_pitch_scale = internal->pitch_scale * speed_of_sound / (speed_of_sound + velocity * approaching);
 

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1526,6 +1526,7 @@ void AudioServer::init_channels_and_buffers() {
 void AudioServer::init() {
 	channel_disable_threshold_db = GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_threshold_db", PROPERTY_HINT_RANGE, "-80,0,0.1,suffix:dB"), -60.0);
 	channel_disable_frames = float(GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/buses/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 2.0)) * get_mix_rate();
+	speed_of_sound = GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/speed_of_sound", PROPERTY_HINT_RANGE, "0.01,1000,or_greater,suffix:m/s"), 343.0);
 	// TODO: Buffer size is hardcoded for now. This would be really nice to have as a project setting because currently it limits audio latency to an absolute minimum of 11ms with default mix rate, but there's some additional work required to make that happen. See TODOs in `_mix_step_for_channel`.
 	// When this becomes a project setting, it should be specified in milliseconds rather than raw sample count, because 512 samples at 192khz is shorter than it is at 48khz, for example.
 	buffer_size = 512;
@@ -2031,6 +2032,16 @@ void AudioServer::update_sample_playback_pitch_scale(const Ref<AudioSamplePlayba
 	return AudioDriver::get_singleton()->update_sample_playback_pitch_scale(p_playback, p_pitch_scale);
 }
 
+void AudioServer::set_speed_of_sound(float p_speed) {
+	ERR_FAIL_COND(p_speed <= 0);
+
+	speed_of_sound = p_speed;
+}
+
+float AudioServer::get_speed_of_sound() const {
+	return speed_of_sound;
+}
+
 void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bus_count", "amount"), &AudioServer::set_bus_count);
 	ClassDB::bind_method(D_METHOD("get_bus_count"), &AudioServer::get_bus_count);
@@ -2080,6 +2091,9 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_playback_speed_scale", "scale"), &AudioServer::set_playback_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_playback_speed_scale"), &AudioServer::get_playback_speed_scale);
 
+	ClassDB::bind_method(D_METHOD("set_speed_of_sound", "speed"), &AudioServer::set_speed_of_sound);
+	ClassDB::bind_method(D_METHOD("get_speed_of_sound"), &AudioServer::get_speed_of_sound);
+
 	ClassDB::bind_method(D_METHOD("lock"), &AudioServer::lock);
 	ClassDB::bind_method(D_METHOD("unlock"), &AudioServer::unlock);
 
@@ -2120,6 +2134,7 @@ void AudioServer::_bind_methods() {
 	// Override for class reference generation purposes.
 	ADD_PROPERTY_DEFAULT("input_device", "Default");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_speed_scale"), "set_playback_speed_scale", "get_playback_speed_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_of_sound"), "set_speed_of_sound", "get_speed_of_sound");
 
 	ADD_SIGNAL(MethodInfo("bus_layout_changed"));
 	ADD_SIGNAL(MethodInfo("bus_renamed", PropertyInfo(Variant::INT, "bus_index"), PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -349,6 +349,8 @@ private:
 
 	LocalVector<Ref<AudioSamplePlayback>> sample_playback_list;
 
+	float speed_of_sound = 343.0;
+
 protected:
 	static void _bind_methods();
 
@@ -519,6 +521,9 @@ public:
 	bool is_sample_playback_active(const Ref<AudioSamplePlayback> &p_playback);
 	double get_sample_playback_position(const Ref<AudioSamplePlayback> &p_playback);
 	void update_sample_playback_pitch_scale(const Ref<AudioSamplePlayback> &p_playback, float p_pitch_scale = 0.0f);
+
+	void set_speed_of_sound(float p_speed);
+	float get_speed_of_sound() const;
 
 	AudioServer();
 	virtual ~AudioServer();


### PR DESCRIPTION
Adds a `speed_of_sound` setting to project settings, which is (currently) only used for doppler calculation.

Can be set/get with `AudioServer.speed_of_sound`

Addresses one of the topics in https://github.com/godotengine/godot-proposals/issues/7955