### PR TITLE
Add a `doppler_scale` setting to 3d camera, listener, and audio player

### DIFF
--- a/doc/classes/AudioListener3D.xml
+++ b/doc/classes/AudioListener3D.xml
@@ -36,6 +36,10 @@
 		</method>
 	</methods>
 	<members>
+		<member name="doppler_scale" type="float" setter="set_doppler_scale" getter="get_doppler_scale" default="1.0">
+			Scale of the Doppler effect. Negative values will have an "inverted" effect, where approaching sounds have a higher pitch and departing sounds have a lower pitch.
+			The final scale is determined by multiplying this with [member AudioStreamPlayer3D.doppler_scale].
+		</member>
 		<member name="doppler_tracking" type="int" setter="set_doppler_tracking" getter="get_doppler_tracking" enum="AudioListener3D.DopplerTracking" default="0">
 			If not [constant DOPPLER_TRACKING_DISABLED], this listener will simulate the [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] for objects changed in particular [code]_process[/code] methods.
 			[b]Note:[/b] The Doppler effect will only be heard on [AudioStreamPlayer3D]s if [member AudioStreamPlayer3D.doppler_tracking] is not set to [constant AudioStreamPlayer3D.DOPPLER_TRACKING_DISABLED].

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -72,6 +72,10 @@
 			The bus on which this audio is playing.
 			[b]Note:[/b] When setting this property, keep in mind that no validation is performed to see if the given name matches an existing bus. This is because audio bus layouts might be loaded after this property is set. If this given name can't be resolved at runtime, it will fall back to [code]"Master"[/code].
 		</member>
+		<member name="doppler_scale" type="float" setter="set_doppler_scale" getter="get_doppler_scale" default="1.0">
+			Scale of the Doppler effect. Negative values will have an "inverted" effect, where approaching sounds have a higher pitch and departing sounds have a lower pitch.
+			The final scale is determined by multiplying this with [member AudioStreamPlayer3D.doppler_scale].
+		</member>
 		<member name="doppler_tracking" type="int" setter="set_doppler_tracking" getter="get_doppler_tracking" enum="AudioStreamPlayer3D.DopplerTracking" default="0">
 			Decides in which step the Doppler effect should be calculated.
 			[b]Note:[/b] If [member doppler_tracking] is not [constant DOPPLER_TRACKING_DISABLED] but the current [Camera3D]/[AudioListener3D] has doppler tracking disabled, the Doppler effect will be heard but will not take the movement of the current listener into account. If accurate Doppler effect is desired, doppler tracking should be enabled on both the [AudioStreamPlayer3D] and the current [Camera3D]/[AudioListener3D].

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -173,6 +173,10 @@
 			If [code]true[/code], the ancestor [Viewport] is currently using this camera.
 			If multiple cameras are in the scene, one will always be made current. For example, if two [Camera3D] nodes are present in the scene and only one is current, setting one camera's [member current] to [code]false[/code] will cause the other camera to be made current.
 		</member>
+		<member name="doppler_scale" type="float" setter="set_doppler_scale" getter="get_doppler_scale" default="1.0">
+			Scale of the Doppler effect. Negative values will have an "inverted" effect, where approaching sounds have a higher pitch and departing sounds have a lower pitch.
+			The final scale is determined by multiplying this with [member AudioStreamPlayer3D.doppler_scale].
+		</member>
 		<member name="doppler_tracking" type="int" setter="set_doppler_tracking" getter="get_doppler_tracking" enum="Camera3D.DopplerTracking" default="0">
 			If not [constant DOPPLER_TRACKING_DISABLED], this camera will simulate the [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] for objects changed in particular [code]_process[/code] methods.
 			[b]Note:[/b] The Doppler effect will only be heard on [AudioStreamPlayer3D]s if [member AudioStreamPlayer3D.doppler_tracking] is not set to [constant AudioStreamPlayer3D.DOPPLER_TRACKING_DISABLED].

--- a/scene/3d/audio_listener_3d.cpp
+++ b/scene/3d/audio_listener_3d.cpp
@@ -162,6 +162,14 @@ AudioListener3D::DopplerTracking AudioListener3D::get_doppler_tracking() const {
 	return doppler_tracking;
 }
 
+void AudioListener3D::set_doppler_scale(float p_scale) {
+	doppler_scale = p_scale;
+}
+
+float AudioListener3D::get_doppler_scale() const {
+	return doppler_scale;
+}
+
 void AudioListener3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("make_current"), &AudioListener3D::make_current);
 	ClassDB::bind_method(D_METHOD("clear_current"), &AudioListener3D::clear_current);
@@ -169,8 +177,11 @@ void AudioListener3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_listener_transform"), &AudioListener3D::get_listener_transform);
 	ClassDB::bind_method(D_METHOD("set_doppler_tracking", "mode"), &AudioListener3D::set_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_doppler_tracking"), &AudioListener3D::get_doppler_tracking);
+	ClassDB::bind_method(D_METHOD("set_doppler_scale", "mode"), &AudioListener3D::set_doppler_scale);
+	ClassDB::bind_method(D_METHOD("get_doppler_scale"), &AudioListener3D::get_doppler_scale);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "doppler_tracking", PROPERTY_HINT_ENUM, "Disabled,Idle,Physics"), "set_doppler_tracking", "get_doppler_tracking");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "doppler_scale", PROPERTY_HINT_RANGE, "-4.0,4.0,or_less,or_greater"), "set_doppler_scale", "get_doppler_scale");
 
 	BIND_ENUM_CONSTANT(DOPPLER_TRACKING_DISABLED);
 	BIND_ENUM_CONSTANT(DOPPLER_TRACKING_IDLE_STEP);

--- a/scene/3d/audio_listener_3d.h
+++ b/scene/3d/audio_listener_3d.h
@@ -43,6 +43,8 @@ public:
 		DOPPLER_TRACKING_PHYSICS_STEP,
 	};
 
+	float doppler_scale = 1.0;
+
 	void make_current();
 	void clear_current();
 	bool is_current() const;
@@ -51,6 +53,9 @@ public:
 
 	void set_doppler_tracking(DopplerTracking p_tracking);
 	DopplerTracking get_doppler_tracking() const;
+
+	void set_doppler_scale(float p_scale);
+	float get_doppler_scale() const;
 
 	Vector3 get_doppler_tracked_velocity() const;
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -519,11 +519,14 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 
 		if (doppler_tracking != DOPPLER_TRACKING_DISABLED) {
 			Vector3 listener_velocity;
+			float doppler_scale_final = doppler_scale;
 
 			if (listener) {
 				listener_velocity = listener->get_doppler_tracked_velocity();
+				doppler_scale_final *= listener->get_doppler_scale();
 			} else {
 				listener_velocity = camera->get_doppler_tracked_velocity();
+				doppler_scale_final *= camera->get_doppler_scale();
 			}
 
 			const Vector3 local_velocity = listener_node->get_global_transform().orthonormalized().basis.xform_inv(linear_velocity - listener_velocity);
@@ -533,9 +536,12 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 				static constexpr float speed_of_sound = 343.0F;
 
 				float doppler_pitch_scale = internal->pitch_scale * speed_of_sound / (speed_of_sound + velocity * approaching);
+				doppler_pitch_scale = Math::pow(doppler_pitch_scale, doppler_scale_final);
 
 				// limit the pitch scale, so we do not get execeedingly extreme pitch effects in edge cases
 				doppler_pitch_scale = CLAMP(doppler_pitch_scale, (1.0F / 8.0F), 8.0F);
+
+				doppler_pitch_scale *= internal->pitch_scale;
 
 				// just use the maximum volume of the current volume vector as weight
 				// so the pitch effect fades out with lower volumes
@@ -804,6 +810,14 @@ AudioStreamPlayer3D::DopplerTracking AudioStreamPlayer3D::get_doppler_tracking()
 	return doppler_tracking;
 }
 
+void AudioStreamPlayer3D::set_doppler_scale(float p_scale) {
+	doppler_scale = p_scale;
+}
+
+float AudioStreamPlayer3D::get_doppler_scale() const {
+	return doppler_scale;
+}
+
 void AudioStreamPlayer3D::set_stream_paused(bool p_pause) {
 	internal->set_stream_paused(p_pause);
 }
@@ -918,6 +932,9 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_doppler_tracking", "mode"), &AudioStreamPlayer3D::set_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_doppler_tracking"), &AudioStreamPlayer3D::get_doppler_tracking);
 
+	ClassDB::bind_method(D_METHOD("set_doppler_scale", "mode"), &AudioStreamPlayer3D::set_doppler_scale);
+	ClassDB::bind_method(D_METHOD("get_doppler_scale"), &AudioStreamPlayer3D::get_doppler_scale);
+
 	ClassDB::bind_method(D_METHOD("set_stream_paused", "pause"), &AudioStreamPlayer3D::set_stream_paused);
 	ClassDB::bind_method(D_METHOD("get_stream_paused"), &AudioStreamPlayer3D::get_stream_paused);
 
@@ -958,6 +975,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "attenuation_filter_db", PROPERTY_HINT_RANGE, "-80,0,0.1,suffix:dB"), "set_attenuation_filter_db", "get_attenuation_filter_db");
 	ADD_GROUP("Doppler", "doppler_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "doppler_tracking", PROPERTY_HINT_ENUM, "Disabled,Idle,Physics"), "set_doppler_tracking", "get_doppler_tracking");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "doppler_scale", PROPERTY_HINT_RANGE, "-4.0,4.0,or_less,or_greater"), "set_doppler_scale", "get_doppler_scale");
 
 	BIND_ENUM_CONSTANT(ATTENUATION_INVERSE_DISTANCE);
 	BIND_ENUM_CONSTANT(ATTENUATION_INVERSE_SQUARE_DISTANCE);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -77,6 +77,7 @@ private:
 	AttenuationModel attenuation_model = ATTENUATION_INVERSE_DISTANCE;
 	float unit_size = 10.0;
 	float max_db = 3.0;
+	float doppler_scale = 1.0;
 	// Internally used to take doppler tracking into account.
 	float actual_pitch_scale = 1.0;
 
@@ -202,6 +203,9 @@ public:
 
 	void set_doppler_tracking(DopplerTracking p_tracking);
 	DopplerTracking get_doppler_tracking() const;
+
+	void set_doppler_scale(float p_scale);
+	float get_doppler_scale() const;
 
 	void set_stream_paused(bool p_pause);
 	bool get_stream_paused() const;

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -626,6 +626,14 @@ Camera3D::DopplerTracking Camera3D::get_doppler_tracking() const {
 	return doppler_tracking;
 }
 
+void Camera3D::set_doppler_scale(float p_scale) {
+	doppler_scale = p_scale;
+}
+
+float Camera3D::get_doppler_scale() const {
+	return doppler_scale;
+}
+
 void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("project_ray_normal", "screen_point"), &Camera3D::project_ray_normal);
 	ClassDB::bind_method(D_METHOD("project_local_ray_normal", "screen_point"), &Camera3D::project_local_ray_normal);
@@ -670,6 +678,8 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_keep_aspect_mode"), &Camera3D::get_keep_aspect_mode);
 	ClassDB::bind_method(D_METHOD("set_doppler_tracking", "mode"), &Camera3D::set_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_doppler_tracking"), &Camera3D::get_doppler_tracking);
+	ClassDB::bind_method(D_METHOD("set_doppler_scale", "mode"), &Camera3D::set_doppler_scale);
+	ClassDB::bind_method(D_METHOD("get_doppler_scale"), &Camera3D::get_doppler_scale);
 	ClassDB::bind_method(D_METHOD("get_frustum"), &Camera3D::_get_frustum);
 	ClassDB::bind_method(D_METHOD("is_position_in_frustum", "world_point"), &Camera3D::is_position_in_frustum);
 	ClassDB::bind_method(D_METHOD("get_camera_rid"), &Camera3D::get_camera);
@@ -690,6 +700,7 @@ void Camera3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "h_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_h_offset", "get_h_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "v_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_v_offset", "get_v_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "doppler_tracking", PROPERTY_HINT_ENUM, "Disabled,Idle,Physics"), "set_doppler_tracking", "get_doppler_tracking");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "doppler_scale", PROPERTY_HINT_RANGE, "-4.0,4.0,or_less,or_greater"), "set_doppler_scale", "get_doppler_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "projection", PROPERTY_HINT_ENUM, "Perspective,Orthogonal,Frustum"), "set_projection", "get_projection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "current"), "set_current", "is_current");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fov", PROPERTY_HINT_RANGE, "1,179,0.1,degrees"), "set_fov", "get_fov");

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -93,6 +93,7 @@ private:
 	TypedArray<Plane> _get_frustum() const;
 
 	DopplerTracking doppler_tracking = DOPPLER_TRACKING_DISABLED;
+	float doppler_scale = 1.0;
 	Ref<VelocityTracker3D> velocity_tracker;
 
 #ifndef PHYSICS_3D_DISABLED
@@ -203,6 +204,9 @@ public:
 
 	void set_doppler_tracking(DopplerTracking p_tracking);
 	DopplerTracking get_doppler_tracking() const;
+
+	void set_doppler_scale(float p_scale);
+	float get_doppler_scale() const;
 
 	Vector3 get_doppler_tracked_velocity() const;
 


### PR DESCRIPTION
This adds a `doppler_scale` setting to `AudioStreamPlayer3D`, `AudioListener3D`, and `Camera3D` (all classes that use Doppler), which can be used to scale how intense the doppler effect is, per sound/listener.

`doppler_scale` can be negative to create an inverted Doppler effect, where approaching sounds are low-pitched while departing sounds are high-pitched.

Here is a video of it in action:

https://github.com/user-attachments/assets/9946fd9f-ae51-4c75-b58e-ab588c1606a3

And a demo project (used in the above video):
[doppler_scale_showcase_project.zip](https://github.com/user-attachments/files/24220375/doppler_scale_showcase_project.zip)

Addresses one of the topics in https://github.com/godotengine/godot-proposals/issues/7955 (Compliments https://github.com/godotengine/godot/pull/114124 which addresses the same topic in a similar way)

This also fixes and closes https://github.com/godotengine/godot/issues/114119 . This required rewriting one of the two lines that caused this bug, and it didn't make sense to me to consciously re-introduce the bug. Not sure if this goes against the whole "one PR per issue" thing. Will correct if it does.
