### PR TITLE
Make sure `ScriptLanguage` is initialized even after `init_languages` call

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -253,6 +253,13 @@ Error ScriptServer::register_language(ScriptLanguage *p_language) {
 		ERR_FAIL_COND_V_MSG(other_language->get_type() == p_language->get_type(), ERR_ALREADY_EXISTS, vformat("A script language with type '%s' is already registered.", p_language->get_type()));
 	}
 	_languages[_language_count++] = p_language;
+
+	// Make sure the new language is initialized in case languages have already been initialized before
+	// This happens when importing the GDExtension for the first time in the editor
+	if (languages_ready) {
+		p_language->init();
+	}
+
 	return OK;
 }
 


### PR DESCRIPTION
Make sure `ScriptLanguage`s are initialized even if `init_languages` has already been called, which is the case when first importing a GDExtension that registers a `ScriptLanguageExtension`.

Fixes #114130.

I'm not sure if I should let the mutex be unlocked before calling `p_language->init()`, let me know if you think it's needed and I'll update it accordingly.