### PR TITLE
OpenXR: Remove version hack to workaround Meta aim pose issue that is now fixed

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -659,16 +659,12 @@ XrResult OpenXRAPI::attempt_create_instance(XrVersion p_version) {
 bool OpenXRAPI::create_instance() {
 	// Create our OpenXR instance, this will query any registered extension wrappers for extensions we need to enable.
 
-	// We explicitly set the version to 1.x.48 in order to workaround a bug (see #108850) in Meta's runtime.
-	// Once that is fixed, restore this to using XR_API_VERSION_1_x, which is the version associated with the
-	// OpenXR headers that we're using.
-
-	XrResult result = attempt_create_instance(XR_MAKE_VERSION(1, 1, 48)); // Replace with XR_API_VERSION_1_1
+	XrResult result = attempt_create_instance(XR_API_VERSION_1_1);
 	if (result == XR_ERROR_API_VERSION_UNSUPPORTED) {
 		// Couldn't initialize OpenXR 1.1, try 1.0
 		print_verbose("OpenXR: Falling back to OpenXR 1.0");
 
-		result = attempt_create_instance(XR_MAKE_VERSION(1, 0, 48)); // Replace with XR_API_VERSION_1_0
+		result = attempt_create_instance(XR_API_VERSION_1_0);
 	}
 	ERR_FAIL_COND_V_MSG(XR_FAILED(result), false, "Failed to create XR instance [" + get_error_string(result) + "].");
 


### PR DESCRIPTION
In https://github.com/godotengine/godot/pull/108869, we added a hack where we would report that we are using an older OpenXR version than we really are, in order to workaround an issue with the aim pose on Meta Quest headsets.

This PR removes that version hack

I just tested on one of my Meta Quest 3's (the one that I think isn't on the test channel), and it seems to work fine without the hack now!

However, it would be great if other folks with Meta headsets could give this a try. My headset reports version v83.1034 (build 5156385.14650.520).