### PR TITLE
Add Mesa version check.

### DIFF
--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -2,9 +2,17 @@
 from misc.utility.scons_hints import *
 
 import os
+import re
+import sys
 from pathlib import Path
 
 import methods
+from methods import print_error
+
+# Sync with `misc/scripts/install_d3d12_sdk_windows.py` when updating Mesa.
+# Check for latest version: https://github.com/godotengine/godot-nir-static/releases/latest
+req_version_major = 25
+req_version_minor = 3
 
 Import("env")
 env_d3d12_rdd = env.Clone()
@@ -103,6 +111,18 @@ extra_defines = [
 mesa_ver = Path(mesa_absdir + "/VERSION.info")
 if not mesa_ver.is_file():
     mesa_ver = Path(mesa_absdir + "/VERSION")
+
+match = re.match(r"([0-9]*).([0-9]*).([0-9]*)-?([0-9.+]*)", mesa_ver.read_text().strip())
+if (
+    match is None
+    or int(match.group(1)) != req_version_major
+    or (int(match.group(1)) == req_version_major and int(match.group(2)) < req_version_minor)
+):
+    print_error(
+        "The Direct3D 12 rendering driver dependencies are outdated or missing.\n"
+        "You can re-install them by running `python misc\\scripts\\install_d3d12_sdk_windows.py`.\n"
+    )
+    sys.exit(255)
 
 # These defines are inspired by the Meson build scripts in the original repo.
 extra_defines += [

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -31,8 +31,9 @@ else:
     deps_folder = os.path.join("bin", "build_deps")
 
 # Mesa NIR
+# Sync with `drivers/d3d12/SCsub` when updating Mesa.
 # Check for latest version: https://github.com/godotengine/godot-nir-static/releases/latest
-mesa_version = "25.3.1"
+mesa_version = "25.3.1-1"
 # WinPixEventRuntime
 # Check for latest version: https://www.nuget.org/api/v2/package/WinPixEventRuntime (check downloaded filename)
 pix_version = "1.0.240308001"


### PR DESCRIPTION
- Adds version check and readable error in case it's outdated.
- Updates install script to use latest release.

See https://github.com/godotengine/godot/issues/114136 and multiple similar cases in the dev chat.