### PR TITLE
Fix gdscript's "as" (type cast) keyword when casting to the same type of PackedArray.

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1629,15 +1629,21 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				}
 #endif
 
-				Callable::CallError err;
-				Variant::construct(to_type, *dst, (const Variant **)&src, 1, err);
+				// Assume all PackedArray type enums are greater than or equal to Variant::PACKED_BYTE_ARRAY.
+				if (to_type >= Variant::PACKED_BYTE_ARRAY && src->get_type() == to_type) {
+					// Avoid making a copy when casting to the same type of PackedArray.
+					*dst = *src;
+				} else {
+					Callable::CallError err;
+					Variant::construct(to_type, *dst, (const Variant **)&src, 1, err);
 
 #ifdef DEBUG_ENABLED
-				if (err.error != Callable::CallError::CALL_OK) {
-					err_text = "Invalid cast: could not convert value to '" + Variant::get_type_name(to_type) + "'.";
-					OPCODE_BREAK;
-				}
+					if (err.error != Callable::CallError::CALL_OK) {
+						err_text = "Invalid cast: could not convert value to '" + Variant::get_type_name(to_type) + "'.";
+						OPCODE_BREAK;
+					}
 #endif
+				}
 
 				ip += 4;
 			}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Close [#114118](https://github.com/godotengine/godot/issues/114118).
