### PR TITLE
Translate error names when displayed in dialogs

### DIFF
--- a/core/error/error_list.cpp
+++ b/core/error/error_list.cpp
@@ -30,58 +30,59 @@
 
 #include "error_list.h"
 
+#include "core/string/ustring.h"
 #include "core/typedefs.h"
 
 const char *error_names[] = {
-	"OK", // OK
-	"Failed", // FAILED
-	"Unavailable", // ERR_UNAVAILABLE
-	"Unconfigured", // ERR_UNCONFIGURED
-	"Unauthorized", // ERR_UNAUTHORIZED
-	"Parameter out of range", // ERR_PARAMETER_RANGE_ERROR
-	"Out of memory", // ERR_OUT_OF_MEMORY
-	"File not found", // ERR_FILE_NOT_FOUND
-	"File: Bad drive", // ERR_FILE_BAD_DRIVE
-	"File: Bad path", // ERR_FILE_BAD_PATH
-	"File: Permission denied", // ERR_FILE_NO_PERMISSION
-	"File already in use", // ERR_FILE_ALREADY_IN_USE
-	"Can't open file", // ERR_FILE_CANT_OPEN
-	"Can't write file", // ERR_FILE_CANT_WRITE
-	"Can't read file", // ERR_FILE_CANT_READ
-	"File unrecognized", // ERR_FILE_UNRECOGNIZED
-	"File corrupt", // ERR_FILE_CORRUPT
-	"Missing dependencies for file", // ERR_FILE_MISSING_DEPENDENCIES
-	"End of file", // ERR_FILE_EOF
-	"Can't open", // ERR_CANT_OPEN
-	"Can't create", // ERR_CANT_CREATE
-	"Query failed", // ERR_QUERY_FAILED
-	"Already in use", // ERR_ALREADY_IN_USE
-	"Locked", // ERR_LOCKED
-	"Timeout", // ERR_TIMEOUT
-	"Can't connect", // ERR_CANT_CONNECT
-	"Can't resolve", // ERR_CANT_RESOLVE
-	"Connection error", // ERR_CONNECTION_ERROR
-	"Can't acquire resource", // ERR_CANT_ACQUIRE_RESOURCE
-	"Can't fork", // ERR_CANT_FORK
-	"Invalid data", // ERR_INVALID_DATA
-	"Invalid parameter", // ERR_INVALID_PARAMETER
-	"Already exists", // ERR_ALREADY_EXISTS
-	"Does not exist", // ERR_DOES_NOT_EXIST
-	"Can't read database", // ERR_DATABASE_CANT_READ
-	"Can't write database", // ERR_DATABASE_CANT_WRITE
-	"Compilation failed", // ERR_COMPILATION_FAILED
-	"Method not found", // ERR_METHOD_NOT_FOUND
-	"Link failed", // ERR_LINK_FAILED
-	"Script failed", // ERR_SCRIPT_FAILED
-	"Cyclic link detected", // ERR_CYCLIC_LINK
-	"Invalid declaration", // ERR_INVALID_DECLARATION
-	"Duplicate symbol", // ERR_DUPLICATE_SYMBOL
-	"Parse error", // ERR_PARSE_ERROR
-	"Busy", // ERR_BUSY
-	"Skip", // ERR_SKIP
-	"Help", // ERR_HELP
-	"Bug", // ERR_BUG
-	"Printer on fire", // ERR_PRINTER_ON_FIRE
+	TTRC("OK"), // OK
+	TTRC("Failed"), // FAILED
+	TTRC("Unavailable"), // ERR_UNAVAILABLE
+	TTRC("Unconfigured"), // ERR_UNCONFIGURED
+	TTRC("Unauthorized"), // ERR_UNAUTHORIZED
+	TTRC("Parameter out of range"), // ERR_PARAMETER_RANGE_ERROR
+	TTRC("Out of memory"), // ERR_OUT_OF_MEMORY
+	TTRC("File not found"), // ERR_FILE_NOT_FOUND
+	TTRC("File: Bad drive"), // ERR_FILE_BAD_DRIVE
+	TTRC("File: Bad path"), // ERR_FILE_BAD_PATH
+	TTRC("File: Permission denied"), // ERR_FILE_NO_PERMISSION
+	TTRC("File already in use"), // ERR_FILE_ALREADY_IN_USE
+	TTRC("Can't open file"), // ERR_FILE_CANT_OPEN
+	TTRC("Can't write file"), // ERR_FILE_CANT_WRITE
+	TTRC("Can't read file"), // ERR_FILE_CANT_READ
+	TTRC("File unrecognized"), // ERR_FILE_UNRECOGNIZED
+	TTRC("File corrupt"), // ERR_FILE_CORRUPT
+	TTRC("Missing dependencies for file"), // ERR_FILE_MISSING_DEPENDENCIES
+	TTRC("End of file"), // ERR_FILE_EOF
+	TTRC("Can't open"), // ERR_CANT_OPEN
+	TTRC("Can't create"), // ERR_CANT_CREATE
+	TTRC("Query failed"), // ERR_QUERY_FAILED
+	TTRC("Already in use"), // ERR_ALREADY_IN_USE
+	TTRC("Locked"), // ERR_LOCKED
+	TTRC("Timeout"), // ERR_TIMEOUT
+	TTRC("Can't connect"), // ERR_CANT_CONNECT
+	TTRC("Can't resolve"), // ERR_CANT_RESOLVE
+	TTRC("Connection error"), // ERR_CONNECTION_ERROR
+	TTRC("Can't acquire resource"), // ERR_CANT_ACQUIRE_RESOURCE
+	TTRC("Can't fork"), // ERR_CANT_FORK
+	TTRC("Invalid data"), // ERR_INVALID_DATA
+	TTRC("Invalid parameter"), // ERR_INVALID_PARAMETER
+	TTRC("Already exists"), // ERR_ALREADY_EXISTS
+	TTRC("Does not exist"), // ERR_DOES_NOT_EXIST
+	TTRC("Can't read database"), // ERR_DATABASE_CANT_READ
+	TTRC("Can't write database"), // ERR_DATABASE_CANT_WRITE
+	TTRC("Compilation failed"), // ERR_COMPILATION_FAILED
+	TTRC("Method not found"), // ERR_METHOD_NOT_FOUND
+	TTRC("Link failed"), // ERR_LINK_FAILED
+	TTRC("Script failed"), // ERR_SCRIPT_FAILED
+	TTRC("Cyclic link detected"), // ERR_CYCLIC_LINK
+	TTRC("Invalid declaration"), // ERR_INVALID_DECLARATION
+	TTRC("Duplicate symbol"), // ERR_DUPLICATE_SYMBOL
+	TTRC("Parse error"), // ERR_PARSE_ERROR
+	TTRC("Busy"), // ERR_BUSY
+	TTRC("Skip"), // ERR_SKIP
+	TTRC("Help"), // ERR_HELP
+	TTRC("Bug"), // ERR_BUG
+	TTRC("Printer on fire"), // ERR_PRINTER_ON_FIRE
 };
 
 static_assert(std_size(error_names) == ERR_MAX);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1576,12 +1576,12 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 
 		Error err = EditorFileSystem::get_singleton()->copy_file(old_path, new_path);
 		if (err != OK) {
-			EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + U" → " + new_path + ": " + error_names[err] + "\n");
+			EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + U" → " + new_path + ": " + TTR(error_names[err]) + "\n");
 		}
 	} else {
 		Error err = EditorFileSystem::get_singleton()->copy_directory(old_path, new_path);
 		if (err != OK) {
-			EditorNode::get_singleton()->add_io_error(TTR("Error duplicating directory:") + "\n" + old_path + U" → " + new_path + ": " + error_names[err] + "\n");
+			EditorNode::get_singleton()->add_io_error(TTR("Error duplicating directory:") + "\n" + old_path + U" → " + new_path + ": " + TTR(error_names[err]) + "\n");
 		}
 	}
 }
@@ -1894,7 +1894,7 @@ void FileSystemDock::_duplicate_operation_confirm(const String &p_path) {
 	if (!DirAccess::dir_exists_absolute(base_dir)) {
 		Error err = EditorFileSystem::get_singleton()->make_dir_recursive(base_dir);
 		if (err != OK) {
-			EditorNode::get_singleton()->show_warning(vformat(TTR("Could not create base directory: %s"), error_names[err]));
+			EditorNode::get_singleton()->show_warning(vformat(TTR("Could not create base directory: %s"), TTR(error_names[err])));
 			return;
 		}
 	}
@@ -2894,7 +2894,7 @@ void FileSystemDock::create_directory(const String &p_path, const String &p_base
 	}
 	Error err = EditorFileSystem::get_singleton()->make_dir_recursive(trimmed_path, p_base_dir);
 	if (err != OK) {
-		EditorNode::get_singleton()->show_warning(vformat(TTR("Could not create folder: %s"), error_names[err]));
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Could not create folder: %s"), TTR(error_names[err])));
 	}
 }
 

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -279,7 +279,7 @@ void OpenXRActionMapEditor::_load_action_map(const String &p_path, bool p_create
 	if (da->file_exists(p_path)) {
 		action_map = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
 		if (err != OK) {
-			EditorNode::get_singleton()->show_warning(vformat(TTR("Error loading %s: %s."), edited_path, error_names[err]));
+			EditorNode::get_singleton()->show_warning(vformat(TTR("Error loading %s: %s."), edited_path, TTR(error_names[err])));
 
 			edited_path = "";
 			header_label->set_text("");
@@ -293,7 +293,7 @@ void OpenXRActionMapEditor::_load_action_map(const String &p_path, bool p_create
 		err = ResourceSaver::save(action_map, p_path);
 		if (err != OK) {
 			// Show warning but continue.
-			EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file %s: %s"), p_path, error_names[err]));
+			EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file %s: %s"), p_path, TTR(error_names[err])));
 		}
 	}
 
@@ -304,7 +304,7 @@ void OpenXRActionMapEditor::_load_action_map(const String &p_path, bool p_create
 void OpenXRActionMapEditor::_on_save_action_map() {
 	Error err = ResourceSaver::save(action_map, edited_path);
 	if (err != OK) {
-		EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file %s: %s"), edited_path, error_names[err]));
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file %s: %s"), edited_path, TTR(error_names[err])));
 		return;
 	}
 


### PR DESCRIPTION
I noticed there is a list of error names in the engine. While normally errors are not translated, these names are human-readable and may be displayed in the UI, which results in language mix:
<img width="962" height="579" alt="image" src="https://github.com/user-attachments/assets/a4f93a62-0f7f-444f-afe8-2cac15a6f55f" />

I made them translated, but only when they appear in dialogs (as opposed to being printed):
<img width="962" height="579" alt="image" src="https://github.com/user-attachments/assets/4e06c787-99b0-465e-8d49-234bbae6c699" />
