### PR TITLE
Improve the visibility of the selection of Color value keys

### DIFF
--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -182,6 +182,9 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 	if (p_selected) {
 		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 		draw_rect_clipped(rect, accent, false);
+		if (color.get_luminance() > 0.3) {
+			draw_rect_clipped(rect.grow(-1), Color(0.0, 0.0, 0.0, 0.5), false);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/114154

This adds a dark outline rect inside the selection rect when the color is bright, so it's easier to see that it's selected.

https://github.com/user-attachments/assets/c0f4e103-bca5-4fa8-a1c3-f616a1bb751d

