### PR TITLE
Don't allow changing extension when duplicating

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2565,11 +2565,11 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			if (to_duplicate.is_file) {
 				String name = to_duplicate.path.get_file();
 				make_dir_dialog->config(to_duplicate.path.get_base_dir(), callable_mp(this, &FileSystemDock::_duplicate_operation_confirm),
-						DirectoryCreateDialog::MODE_FILE, TTR("Duplicating file:") + " " + name, name);
+						DirectoryCreateDialog::MODE_DUPLICATE_FILE, TTR("Duplicating file:") + " " + name, name);
 			} else {
 				String name = to_duplicate.path.trim_suffix("/").get_file();
 				make_dir_dialog->config(to_duplicate.path.trim_suffix("/").get_base_dir(), callable_mp(this, &FileSystemDock::_duplicate_operation_confirm),
-						DirectoryCreateDialog::MODE_DIRECTORY, TTR("Duplicating folder:") + " " + name, name);
+						DirectoryCreateDialog::MODE_CREATE_DIRECTORY, TTR("Duplicating folder:") + " " + name, name);
 			}
 			make_dir_dialog->popup_centered();
 		} break;
@@ -2584,7 +2584,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				directory = directory.get_base_dir();
 			}
 			make_dir_dialog->config(directory, callable_mp(this, &FileSystemDock::create_directory).bind(directory),
-					DirectoryCreateDialog::MODE_DIRECTORY, TTR("Create Folder"), "new folder");
+					DirectoryCreateDialog::MODE_CREATE_DIRECTORY, TTR("Create Folder"), "new folder");
 			make_dir_dialog->popup_centered();
 		} break;
 

--- a/editor/gui/directory_create_dialog.h
+++ b/editor/gui/directory_create_dialog.h
@@ -41,21 +41,22 @@ class DirectoryCreateDialog : public ConfirmationDialog {
 
 public:
 	enum Mode {
-		MODE_FILE,
-		MODE_DIRECTORY,
+		MODE_DUPLICATE_FILE,
+		MODE_CREATE_DIRECTORY,
 	};
 
 private:
 	String base_dir;
+	String base_name;
 	Callable accept_callback;
-	int mode = MODE_FILE;
+	int mode = MODE_DUPLICATE_FILE;
 
 	Label *base_path_label = nullptr;
 	LineEdit *dir_path = nullptr;
 	EditorValidationPanel *validation_panel = nullptr;
 
 	String _sanitize_input(const String &p_input) const;
-	String _validate_path(const String &p_path) const;
+	String _validate_path(const String &p_path, bool *p_warning) const;
 	void _on_dir_path_changed();
 
 protected:

--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -176,7 +176,7 @@ void EditorDirDialog::_make_dir() {
 	TreeItem *ti = tree->get_selected();
 	ERR_FAIL_NULL(ti);
 	const String &directory = ti->get_metadata(0);
-	makedialog->config(directory, callable_mp(this, &EditorDirDialog::_make_dir_confirm).bind(directory), DirectoryCreateDialog::MODE_DIRECTORY, "new folder");
+	makedialog->config(directory, callable_mp(this, &EditorDirDialog::_make_dir_confirm).bind(directory), DirectoryCreateDialog::MODE_CREATE_DIRECTORY, "new folder");
 	makedialog->popup_centered();
 }
 


### PR DESCRIPTION
Makes the duplication dialog disallow changing file extension:

https://github.com/user-attachments/assets/4fb12acf-7d44-4546-9222-c74ce0fac883

At first I made it check if the extension matches resource type, but then realized that changing extension to a valid one will make the file unusable anyway, because the content stays the same when duplicating.

I also renamed mode enums to be more explicit.

Technically closes #113700
