### PR TITLE
Finalize colors of modern theme

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -986,7 +986,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	effects->set_allow_rmb_select(true);
 	effects->set_focus_mode(FOCUS_CLICK);
 	effects->set_allow_reselect(true);
-	effects->set_theme_type_variation("TreeSecondary");
+	effects->set_theme_type_variation("EditorAudioBusEffectsTree");
 	effects->connect(SceneStringName(gui_input), callable_mp(this, &EditorAudioBus::_effects_gui_input));
 
 	send = memnew(OptionButton);

--- a/editor/gui/progress_dialog.cpp
+++ b/editor/gui/progress_dialog.cpp
@@ -48,6 +48,7 @@ void BackgroundProgress::_add_task(const String &p_task, const String &p_label, 
 	l->set_text(p_label + " ");
 	t.hb->add_child(l);
 	t.progress = memnew(ProgressBar);
+	t.progress->set_theme_type_variation("PopupProgressBar");
 	t.progress->set_max(p_steps);
 	t.progress->set_value(p_steps);
 	Control *ec = memnew(Control);
@@ -198,6 +199,7 @@ void ProgressDialog::add_task(const String &p_task, const String &p_label, int p
 	VBoxContainer *vb2 = memnew(VBoxContainer);
 	t.vb->add_margin_child(p_label, vb2);
 	t.progress = memnew(ProgressBar);
+	t.progress->set_theme_type_variation("PopupProgressBar");
 	t.progress->set_max(p_steps);
 	t.progress->set_value(p_steps);
 	vb2->add_child(t.progress);

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -62,10 +62,10 @@ void ProjectListItemControl::_notification(int p_what) {
 			project_title->begin_bulk_theme_override();
 			project_title->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("title"), EditorStringName(EditorFonts)));
 			project_title->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size(SNAME("title_size"), EditorStringName(EditorFonts)));
-			project_title->add_theme_color_override(SceneStringName(font_color), get_theme_color(SceneStringName(font_color), SNAME("Tree")));
+			project_title->add_theme_color_override(SceneStringName(font_color), get_theme_color(SceneStringName(font_color), SNAME("ProjectList")));
 			project_title->end_bulk_theme_override();
 
-			project_path->add_theme_color_override(SceneStringName(font_color), get_theme_color(SceneStringName(font_color), SNAME("Tree")));
+			project_path->add_theme_color_override(SceneStringName(font_color), get_theme_color(SceneStringName(font_color), SNAME("ProjectList")));
 			project_unsupported_features->set_texture(get_editor_theme_icon(SNAME("NodeWarning")));
 
 			favorite_focus_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
@@ -136,18 +136,19 @@ void ProjectListItemControl::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			if (is_selected) {
-				draw_style_box(get_theme_stylebox(SNAME("selected"), SNAME("Tree")), Rect2(Point2(), get_size()));
-			}
-			if (is_hovering) {
-				draw_style_box(get_theme_stylebox(SNAME("hovered"), SNAME("Tree")), Rect2(Point2(), get_size()));
+			if (is_selected && is_hovering) {
+				draw_style_box(get_theme_stylebox(SNAME("hover_pressed"), SNAME("ProjectList")), Rect2(Point2(), get_size()));
+			} else if (is_selected) {
+				draw_style_box(get_theme_stylebox(SNAME("selected"), SNAME("ProjectList")), Rect2(Point2(), get_size()));
+			} else if (is_hovering) {
+				draw_style_box(get_theme_stylebox(SNAME("hovered"), SNAME("ProjectList")), Rect2(Point2(), get_size()));
 			}
 			// Due to how this control works, we can't rely on the built-in way of checking for focus visibility.
 			if (has_focus() && !is_focus_hidden) {
-				draw_style_box(get_theme_stylebox(SNAME("focus"), SNAME("Tree")), Rect2(Point2(), get_size()));
+				draw_style_box(get_theme_stylebox(SNAME("focus"), SNAME("ProjectList")), Rect2(Point2(), get_size()));
 			}
 
-			draw_line(Point2(0, get_size().y + 1), Point2(get_size().x, get_size().y + 1), get_theme_color(SNAME("guide_color"), SNAME("Tree")));
+			draw_line(Point2(0, get_size().y + 1), Point2(get_size().x, get_size().y + 1), get_theme_color(SNAME("guide_color"), SNAME("ProjectList")));
 		} break;
 	}
 }

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -318,7 +318,7 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 			float preset_icon_saturation = config.default_icon_saturation;
 
 			// A negative contrast rate looks better for light themes, since it better follows the natural order of UI "elevation".
-			const float light_contrast = config.style == "Modern" ? -0.4 : -0.06;
+			const float light_contrast = -0.06;
 
 			// Please use alphabetical order if you're adding a new color preset here.
 			if (config.preset == "Black (OLED)") {
@@ -356,7 +356,7 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 				preset_contrast = light_contrast;
 			} else { // Default
 				preset_accent_color = Color(0.337, 0.62, 1.0);
-				preset_base_color = Color(0.153, 0.153, 0.153);
+				preset_base_color = Color(0.161, 0.161, 0.161);
 			}
 
 			config.accent_color = preset_accent_color;

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -84,7 +84,7 @@ public:
 		// Make sure to keep those in sync with the definitions in the editor settings.
 		const float default_icon_saturation = 2.0;
 		const int default_relationship_lines = RELATIONSHIP_SELECTED_ONLY;
-		const float default_contrast = 0.35;
+		const float default_contrast = 0.3;
 		const int default_corner_radius = 4;
 
 		// Generated properties.
@@ -140,6 +140,7 @@ public:
 		Color icon_pressed_color;
 		Color icon_disabled_color;
 
+		Color surface_popup_color;
 		Color surface_lowest_color;
 		Color surface_lower_color;
 		Color surface_low_color;

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -717,6 +717,25 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_stylebox("title_button_pressed", "Tree", style_tree_title);
 		}
 
+		// ProjectList.
+		{
+			Ref<StyleBoxFlat> style_project_list_hover = p_config.base_style->duplicate();
+			style_project_list_hover->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 0.4));
+			style_project_list_hover->set_border_width_all(0);
+
+			Ref<StyleBoxFlat> style_project_list_hover_pressed = p_config.base_style->duplicate();
+			style_project_list_hover_pressed->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 1.2));
+			style_project_list_hover_pressed->set_border_width_all(0);
+
+			p_theme->set_stylebox("hovered", "ProjectList", style_project_list_hover);
+			p_theme->set_stylebox("hover_pressed", "ProjectList", style_project_list_hover_pressed);
+			p_theme->set_stylebox("selected", "ProjectList", style_tree_selected);
+			p_theme->set_stylebox("focus", "ProjectList", p_config.button_style_focus);
+
+			p_theme->set_color(SceneStringName(font_color), "ProjectList", p_config.font_color);
+			p_theme->set_color("guide_color", "ProjectList", guide_color);
+		}
+
 		// ItemList.
 		{
 			Ref<StyleBoxFlat> style_itemlist_bg = p_config.base_style->duplicate();

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -42,12 +42,10 @@
 #include "scene/resources/style_box_line.h"
 
 // Helper.
-static Color _get_base_color(EditorThemeManager::ThemeConfiguration &p_config, float p_brightness_ofs = 0.0, float p_saturation_mult = 1.0) {
-	const bool is_dark = p_brightness_ofs >= 0.0 ? p_config.dark_theme : !p_config.dark_theme;
+static Color _get_base_color(EditorThemeManager::ThemeConfiguration &p_config, float p_dimness_ofs = 0.0, float p_saturation_mult = 1.0) {
 	Color color = p_config.base_color;
-	color.set_v(CLAMP(Math::lerp(color.get_v(), is_dark ? 1 : 0, Math::abs(p_config.contrast * p_brightness_ofs)), 0, 1));
+	color.set_v(CLAMP(Math::lerp(color.get_v(), 0, p_config.contrast * p_dimness_ofs), 0, 1));
 	color.set_s(color.get_s() * p_saturation_mult);
-
 	return color;
 }
 
@@ -66,12 +64,12 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Ensure base colors are in the 0..1 luminance range to avoid 8-bit integer overflow or text rendering issues.
 		// Some places in the editor use 8-bit integer colors.
-		p_config.dark_color_1 = p_config.base_color.lerp(Color(0, 0, 0, 1), p_config.contrast).clamp();
+		p_config.dark_color_1 = p_config.base_color.lerp(Color(0, 0, 0, 1), p_config.contrast * 1.15).clamp();
 		p_config.dark_color_2 = p_config.dark_theme ? Color(0, 0, 0, 0.3) : Color(1, 1, 1, 0.3);
-		p_config.dark_color_3 = _get_base_color(p_config, p_config.dark_theme ? -0.95 : -1.8, 0.9);
+		p_config.dark_color_3 = _get_base_color(p_config, 0.8, 0.9);
 
-		p_config.contrast_color_1 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast, p_config.default_contrast));
-		p_config.contrast_color_2 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast * 1.5, p_config.default_contrast * 1.5));
+		p_config.contrast_color_1 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast * 1.15, p_config.default_contrast * 1.15));
+		p_config.contrast_color_2 = p_config.base_color.lerp(p_config.mono_color, MAX(p_config.contrast * 1.725, p_config.default_contrast * 1.725));
 
 		p_config.highlight_color = Color(p_config.accent_color.r, p_config.accent_color.g, p_config.accent_color.b, 0.275);
 		p_config.highlight_disabled_color = p_config.highlight_color.lerp(p_config.dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.5);
@@ -119,11 +117,11 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Font colors.
 
-		p_config.font_color = p_config.mono_color_font * Color(1, 1, 1, 0.7);
-		p_config.font_secondary_color = p_config.mono_color_font * Color(1, 1, 1, 0.45);
+		p_config.font_color = p_config.mono_color_font * Color(1, 1, 1, 0.75);
+		p_config.font_secondary_color = p_config.mono_color_font * Color(1, 1, 1, 0.55);
 		p_config.font_focus_color = p_config.mono_color_font;
-		p_config.font_hover_color = p_config.mono_color_font;
-		p_config.font_pressed_color = p_config.mono_color_font;
+		p_config.font_hover_color = p_config.mono_color_font * Color(1, 1, 1, 0.85);
+		p_config.font_pressed_color = p_config.mono_color_font * Color(1, 1, 1, 0.85);
 		p_config.font_hover_pressed_color = p_config.mono_color_font;
 		p_config.font_disabled_color = p_config.mono_color_font * Color(1, 1, 1, p_config.dark_icon_and_font ? 0.35 : 0.5);
 		p_config.font_readonly_color = Color(p_config.mono_color_font.r, p_config.mono_color_font.g, p_config.mono_color_font.b, 0.65);
@@ -171,8 +169,8 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Icon colors.
 
-		p_config.icon_normal_color = Color(1, 1, 1, p_config.dark_icon_and_font ? 0.7 : 0.95);
-		p_config.icon_secondary_color = Color(1, 1, 1, p_config.dark_icon_and_font ? 0.45 : 0.6);
+		p_config.icon_normal_color = Color(1, 1, 1, p_config.dark_icon_and_font ? 0.85 : 0.95);
+		p_config.icon_secondary_color = Color(1, 1, 1, p_config.dark_icon_and_font ? 0.6 : 0.75);
 		p_config.icon_focus_color = Color(1, 1, 1);
 		p_config.icon_hover_color = Color(1, 1, 1);
 		p_config.icon_pressed_color = p_config.accent_color * (p_config.dark_icon_and_font ? 1.15 : 3.5);
@@ -187,21 +185,22 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Additional GUI colors.
 
-		p_config.surface_lowest_color = _get_base_color(p_config, p_config.dark_theme ? -1.3 : -2.2, 0.9);
-		p_config.surface_lower_color = p_config.dark_color_3;
-		p_config.surface_low_color = _get_base_color(p_config, p_config.dark_theme ? -0.6 : -0.9);
-		p_config.surface_base_color = _get_base_color(p_config, -0.2);
-		p_config.surface_high_color = _get_base_color(p_config, 0.2, 0.8);
-		p_config.surface_higher_color = _get_base_color(p_config, 0.35, 0.8);
-		p_config.surface_highest_color = _get_base_color(p_config, 0.55, 0.6);
+		p_config.surface_popup_color = _get_base_color(p_config, 1.9, 0.9);
+		p_config.surface_lowest_color = _get_base_color(p_config, 1.7, 0.9);
+		p_config.surface_lower_color = _get_base_color(p_config, 1.1, 0.9);
+		p_config.surface_low_color = _get_base_color(p_config, 0.8);
+		p_config.surface_base_color = _get_base_color(p_config);
+		p_config.surface_high_color = _get_base_color(p_config, -1.3, 0.8);
+		p_config.surface_higher_color = _get_base_color(p_config, -1.5, 0.8);
+		p_config.surface_highest_color = _get_base_color(p_config, -2.2, 0.6);
 
-		p_config.button_normal_color = _get_base_color(p_config, 0.35, 0.85);
-		p_config.button_hover_color = _get_base_color(p_config, 0.55, 0.75);
-		p_config.button_pressed_color = _get_base_color(p_config, 0.75, 0.75);
-		p_config.button_disabled_color = _get_base_color(p_config, 0.2, 0.75);
-		p_config.button_border_normal_color = _get_base_color(p_config, 0.45, 0.75);
-		p_config.button_border_hover_color = _get_base_color(p_config, 0.65, 0.75);
-		p_config.button_border_pressed_color = _get_base_color(p_config, 0.85, 0.75);
+		p_config.button_normal_color = _get_base_color(p_config, -2.0, 0.85);
+		p_config.button_hover_color = _get_base_color(p_config, -2.9, 0.75);
+		p_config.button_pressed_color = _get_base_color(p_config, -3.2, 0.75);
+		p_config.button_disabled_color = _get_base_color(p_config, -1.5, 0.75);
+		p_config.button_border_normal_color = _get_base_color(p_config, -2.5, 0.75);
+		p_config.button_border_hover_color = _get_base_color(p_config, -3.4, 0.75);
+		p_config.button_border_pressed_color = _get_base_color(p_config, -3.7, 0.75);
 
 		p_config.shadow_color = Color(0, 0, 0, p_config.dark_theme ? 0.3 : 0.1);
 		p_config.selection_color = p_config.accent_color * Color(1, 1, 1, 0.4);
@@ -325,7 +324,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 			}
 
 			p_config.flat_button_pressed = p_config.flat_button_hover->duplicate();
-			p_config.flat_button_pressed->set_bg_color(p_config.button_hover_color);
+			p_config.flat_button_pressed->set_bg_color(_get_base_color(p_config, -2.4, 0.75));
 			if (p_config.draw_extra_borders) {
 				p_config.flat_button_pressed->set_border_color(p_config.extra_border_color_1);
 			}
@@ -337,7 +336,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 		// Windows and popups.
 		{
 			p_config.popup_panel_style = p_config.base_style->duplicate();
-			p_config.popup_panel_style->set_bg_color(_get_base_color(p_config, -0.8, 0.9));
+			p_config.popup_panel_style->set_bg_color(p_config.surface_popup_color);
 			p_config.popup_panel_style->set_shadow_color(Color(0, 0, 0, 0.3));
 			p_config.popup_panel_style->set_shadow_size(p_config.base_margin * 0.75 * EDSCALE);
 			p_config.popup_panel_style->set_content_margin_all(p_config.popup_margin * EDSCALE);
@@ -357,7 +356,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_config.window_style->set_corner_radius_all(0);
 
 			p_config.window_complex_style = p_config.window_style->duplicate();
-			p_config.window_complex_style->set_bg_color(p_config.surface_lowest_color);
+			p_config.window_complex_style->set_bg_color(p_config.surface_popup_color);
 
 			p_config.dialog_style = p_config.base_style->duplicate();
 			p_config.dialog_style->set_content_margin_all(p_config.popup_margin);
@@ -424,7 +423,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_color("font_shadow_color", "TooltipLabel", Color(1, 1, 1, 0));
 
 			Ref<StyleBoxFlat> tooltip_style = p_config.base_style->duplicate();
-			tooltip_style->set_bg_color(p_config.surface_lower_color);
+			tooltip_style->set_bg_color(p_config.surface_popup_color);
 			tooltip_style->set_content_margin_all(0);
 			tooltip_style->set_corner_radius_all(0);
 			if (p_config.draw_extra_borders) {
@@ -436,7 +435,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 		// PopupPanel
 		Ref<StyleBoxFlat> popup_panel_style = p_config.base_style->duplicate();
-		popup_panel_style->set_bg_color(p_config.surface_lower_color);
+		popup_panel_style->set_bg_color(p_config.surface_popup_color);
 		popup_panel_style->set_shadow_color(Color(0, 0, 0, 0.3));
 		popup_panel_style->set_shadow_size(p_config.base_margin * 0.75 * EDSCALE);
 		popup_panel_style->set_content_margin_all(p_config.popup_margin);
@@ -620,8 +619,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_color(SceneStringName(font_color), "Tree", p_config.font_color);
 			p_theme->set_color("font_hovered_color", "Tree", p_config.font_hover_color);
 			p_theme->set_color("font_hovered_dimmed_color", "Tree", p_config.font_hover_color);
-			p_theme->set_color("font_hovered_selected_color", "Tree", p_config.font_hover_color);
-			p_theme->set_color("font_selected_color", "Tree", p_config.font_pressed_color);
+			p_theme->set_color("font_hovered_selected_color", "Tree", p_config.mono_color_font);
+			p_theme->set_color("font_selected_color", "Tree", p_config.mono_color_font);
 			p_theme->set_color("font_disabled_color", "Tree", p_config.font_disabled_color);
 			p_theme->set_color("font_outline_color", "Tree", p_config.font_outline_color);
 			p_theme->set_color("title_button_color", "Tree", p_config.font_color);
@@ -695,9 +694,9 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			style_tree_cursor->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.04));
 
 			Ref<StyleBoxFlat> style_tree_title = p_config.base_style->duplicate();
-			style_tree_title->set_bg_color(p_config.surface_lowest_color);
+			style_tree_title->set_bg_color(p_config.surface_lower_color);
 			// Use a transparent border to separate rounded column titles.
-			style_tree_title->set_border_color(Color(p_config.surface_lowest_color, 0));
+			style_tree_title->set_border_color(Color(p_config.surface_lower_color, 0));
 			style_tree_title->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
 			style_tree_title->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
 
@@ -706,6 +705,27 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_stylebox("title_button_normal", "Tree", style_tree_title);
 			p_theme->set_stylebox("title_button_hover", "Tree", style_tree_title);
 			p_theme->set_stylebox("title_button_pressed", "Tree", style_tree_title);
+		}
+
+		// ProjectList.
+		{
+			Ref<StyleBoxFlat> style_project_list_hover = p_config.flat_button_hover->duplicate();
+			style_project_list_hover->set_bg_color(_get_base_color(p_config, -0.5, 0.75));
+			style_project_list_hover->set_content_margin_all(0);
+
+			Ref<StyleBoxFlat> style_project_list_selected = style_project_list_hover->duplicate();
+			style_project_list_selected->set_bg_color(_get_base_color(p_config, -1.0, 0.75));
+
+			Ref<StyleBoxFlat> style_project_list_hover_pressed = style_project_list_selected->duplicate();
+			style_project_list_hover_pressed->set_bg_color(_get_base_color(p_config, -1.2, 0.75));
+
+			p_theme->set_stylebox("hovered", "ProjectList", style_project_list_hover);
+			p_theme->set_stylebox("selected", "ProjectList", style_project_list_selected);
+			p_theme->set_stylebox("hover_pressed", "ProjectList", style_project_list_hover_pressed);
+			p_theme->set_stylebox("focus", "ProjectList", p_config.focus_style);
+
+			p_theme->set_color(SceneStringName(font_color), "ProjectList", p_config.font_color);
+			p_theme->set_color("guide_color", "ProjectList", Color(1, 1, 1, 0));
 		}
 
 		// ItemList.
@@ -753,7 +773,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		style_tab_unselected->set_border_width_all(0);
 
 		Ref<StyleBoxFlat> style_tab_hovered = style_tab_unselected->duplicate();
-		style_tab_hovered->set_bg_color(p_config.surface_base_color * Color(1, 1, 1, 0.8));
+		style_tab_hovered->set_bg_color(p_config.surface_base_color * Color(1, 1, 1, 0.6));
 
 		Color drop_mark_color = p_config.dark_color_2.lerp(p_config.accent_color, 0.75);
 
@@ -1018,7 +1038,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		// PopupMenu.
 		{
 			Ref<StyleBoxFlat> style_popup_menu = p_config.base_style->duplicate();
-			style_popup_menu->set_bg_color(p_config.surface_lower_color);
+			style_popup_menu->set_bg_color(p_config.surface_popup_color);
 			style_popup_menu->set_content_margin_all(p_config.popup_margin);
 			style_popup_menu->set_corner_radius_all(0);
 			if (p_config.draw_extra_borders) {
@@ -1027,7 +1047,10 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			}
 			p_theme->set_stylebox(SceneStringName(panel), "PopupMenu", style_popup_menu);
 
-			p_theme->set_stylebox(SceneStringName(hover), "PopupMenu", p_config.flat_button_hover);
+			Ref<StyleBoxFlat> style_popup_hover = p_config.flat_button_hover->duplicate();
+			style_popup_hover->set_bg_color(_get_base_color(p_config, -0.5, 0.75));
+
+			p_theme->set_stylebox(SceneStringName(hover), "PopupMenu", style_popup_hover);
 
 			Ref<StyleBoxLine> style_popup_separator = EditorThemeManager::make_line_stylebox(p_config.mono_color * Color(1, 1, 1, p_config.dark_theme ? 0.075 : 0.125), Math::round(2 * EDSCALE), p_config.base_margin * -2 * EDSCALE, p_config.base_margin * -2 * EDSCALE);
 
@@ -1251,6 +1274,22 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 	p_theme->set_color("font_outline_color", "ProgressBar", p_config.font_outline_color);
 	p_theme->set_constant("outline_size", "ProgressBar", 0);
 
+	// PopupProgressBar
+
+	p_theme->set_type_variation("PopupProgressBar", "ProgressBar");
+
+	Ref<StyleBoxFlat> popup_progress_bar_style = progress_bar_style->duplicate();
+	popup_progress_bar_style->set_bg_color(_get_base_color(p_config, 0.4, 0.9));
+
+	Ref<StyleBoxFlat> popup_progress_fill_style = progress_fill_style->duplicate();
+	popup_progress_fill_style->set_bg_color(_get_base_color(p_config, -1.6, 0.9));
+	if (p_config.draw_extra_borders) {
+		popup_progress_fill_style->set_border_color(p_config.extra_border_color_1);
+	}
+
+	p_theme->set_stylebox("background", "PopupProgressBar", popup_progress_bar_style);
+	p_theme->set_stylebox("fill", "PopupProgressBar", popup_progress_fill_style);
+
 	// GraphEdit and related nodes.
 	{
 		// GraphEdit.
@@ -1332,7 +1371,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			const int gn_corner_radius = 3;
 
 			const Color gn_bg_color = p_config.dark_theme ? p_config.dark_color_3 : p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
-			const Color gn_frame_bg = _get_base_color(p_config, p_config.dark_theme ? -1.8 : -0.5, 0.9);
+			const Color gn_frame_bg = _get_base_color(p_config, 2.4, 0.9);
 
 			const bool high_contrast_borders = p_config.draw_extra_borders && p_config.dark_theme;
 
@@ -1529,7 +1568,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_type_variation("ProjectTagButton", "Button");
 
 			Ref<StyleBoxFlat> tag = p_config.button_style->duplicate();
-			tag->set_bg_color(p_config.dark_theme ? tag->get_bg_color().lightened(0.2) : tag->get_bg_color().darkened(0.2));
+			tag->set_border_width_all(0);
 			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
 			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
 			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
@@ -1537,6 +1576,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox(CoreStringName(normal), "ProjectTagButton", tag);
 
 			tag = p_config.button_style_hover->duplicate();
+			tag->set_border_width_all(0);
 			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
 			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
 			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
@@ -1544,6 +1584,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox(SceneStringName(hover), "ProjectTagButton", tag);
 
 			tag = p_config.button_style_pressed->duplicate();
+			tag->set_border_width_all(0);
 			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
 			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
 			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
@@ -1555,7 +1596,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 	// Editor and main screen.
 	{
 		// Editor background.
-		Color background_color = p_config.surface_lowest_color; //_get_base_color(p_config, -1.5);
+		Color background_color = p_config.surface_lowest_color;
 		p_theme->set_color("background", EditorStringName(Editor), background_color);
 		Ref<StyleBoxFlat> style_bg = p_config.base_style->duplicate();
 		style_bg->set_bg_color(background_color);
@@ -1636,6 +1677,8 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_stylebox("hover_mirrored", "MainScreenButton", p_config.base_empty_wide_style);
 		p_theme->set_stylebox("hover_pressed", "MainScreenButton", p_config.base_empty_wide_style);
 		p_theme->set_stylebox("hover_pressed_mirrored", "MainScreenButton", p_config.base_empty_wide_style);
+
+		p_theme->set_color("font_pressed_color", "MainScreenButton", p_config.mono_color_font);
 
 		p_theme->set_type_variation("MainMenuBar", "FlatMenuButton");
 		p_theme->set_stylebox(CoreStringName(normal), "MainMenuBar", p_config.flat_button);
@@ -1957,6 +2000,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_type_variation("ScrollContainerSecondary", "ScrollContainer");
 			p_theme->set_type_variation("TreeSecondary", "Tree");
 			p_theme->set_type_variation("ItemListSecondary", "ItemList");
+			p_theme->set_type_variation("EditorAudioBusEffectsTree", "Tree");
 
 			Ref<StyleBoxFlat> style_sidebar = p_config.base_style->duplicate();
 			style_sidebar->set_bg_color(p_config.surface_low_color);
@@ -1971,6 +2015,27 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			// Use it for EditorDebuggerInspector in StackTrace to keep the default 3-column layout,
 			// as the debugger inspector is too small to be considered a main area.
 			p_theme->set_stylebox(SceneStringName(panel), "EditorDebuggerInspector", style_sidebar);
+
+			// TreeSecondary title headers
+			Ref<StyleBoxFlat> style_tree_title_secondary = p_config.base_style->duplicate();
+			Color secondary_title_color = _get_base_color(p_config, 1.6, 0.9);
+			style_tree_title_secondary->set_bg_color(secondary_title_color);
+			style_tree_title_secondary->set_border_color(Color(secondary_title_color, 0));
+			style_tree_title_secondary->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_tree_title_secondary->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+
+			p_theme->set_stylebox("title_button_normal", "TreeSecondary", style_tree_title_secondary);
+			p_theme->set_stylebox("title_button_hover", "TreeSecondary", style_tree_title_secondary);
+			p_theme->set_stylebox("title_button_pressed", "TreeSecondary", style_tree_title_secondary);
+
+			// EditorAudioBusEffectsTree
+			Ref<StyleBoxFlat> style_audio_bus_effect_tree = p_config.base_style->duplicate();
+			style_audio_bus_effect_tree->set_bg_color(_get_base_color(p_config, 0.3));
+			if (p_config.draw_extra_borders) {
+				style_audio_bus_effect_tree->set_border_width_all(1 * EDSCALE);
+				style_audio_bus_effect_tree->set_border_color(p_config.extra_border_color_2);
+			}
+			p_theme->set_stylebox(SceneStringName(panel), "EditorAudioBusEffectsTree", style_audio_bus_effect_tree);
 		}
 
 		// ForegroundPanel.
@@ -2003,7 +2068,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		style_property_bg->set_border_width_all(0);
 
 		Ref<StyleBoxFlat> style_property_bg_selected = p_config.base_style->duplicate();
-		style_property_bg_selected->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.03));
+		style_property_bg_selected->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.05));
 
 		Ref<StyleBoxFlat> style_property_child_bg = p_config.base_style->duplicate();
 		style_property_child_bg->set_bg_color(p_config.surface_lower_color);
@@ -2321,7 +2386,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_color("link_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color_font, 0.8));
 		p_theme->set_color("code_color", "EditorHelp", p_config.accent_color.lerp(p_config.mono_color_font, 0.6));
 		p_theme->set_color("kbd_color", "EditorHelp", p_config.accent_color.lerp(kbd_color, 0.6));
-		p_theme->set_color("code_bg_color", "EditorHelp", p_config.dark_color_3);
+		p_theme->set_color("code_bg_color", "EditorHelp", _get_base_color(p_config, 1.6, 0.8));
 		p_theme->set_color("kbd_bg_color", "EditorHelp", p_config.dark_color_1);
 		p_theme->set_color("param_bg_color", "EditorHelp", p_config.dark_color_1);
 		p_theme->set_constant(SceneStringName(line_separation), "EditorHelp", Math::round(6 * EDSCALE));
@@ -2334,7 +2399,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 	// EditorHelpBitTitle.
 	{
 		Ref<StyleBoxFlat> editor_help_title_style = p_config.base_style->duplicate();
-		editor_help_title_style->set_bg_color(_get_base_color(p_config, p_config.dark_theme ? -0.55 : -0.9));
+		editor_help_title_style->set_bg_color(_get_base_color(p_config, 1.25, 0.75));
 		editor_help_title_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE);
 		editor_help_title_style->set_corner_radius_individual(p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE, 0, 0);
 		if (p_config.draw_extra_borders) {


### PR DESCRIPTION
Addresses most of remaining contrast-related feedback and simplifies logic of `_get_base_color()`. Doing it all in one PR because a lot of these changes are interdependent

Closes https://github.com/godotengine/godot/issues/112230
Closes https://github.com/godotengine/godot/issues/112385
Closes https://github.com/godotengine/godot/issues/114031
Supersedes https://github.com/godotengine/godot/pull/112558

| Master | PR |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/ea1621eb-a2a9-4631-93f6-844569462208) | ![2](https://github.com/user-attachments/assets/1601ed44-fd4d-42e8-9023-766e5a6ca3f4) |

<details><summary>Full list of changes:</summary>
<p>

1. Moves the contrast multiplier from the editor setting to the theme, restoring `0.3` as the default value.

2. Simplifies the logic of `_get_base_color()` and adds support for negative contrast. Since we're now lerping the same amount regardless of whether the dimness offset is positive or negative we have simpler calls to `_get_base_color()` and more predictable values in light themes. It now works similar to how it did in classic theme. Because of that the light theme now also uses the same contrast of `-0.06` for the light theme as the classic theme.

3. Changes base color from `#272727` to `#292929` to make panels and tabs easier to distinguish.

4. Slightly increases the default font and icon brightness (0.7 -> 0.75, 0.7 -> 0.8) to improve readability.

5. Increases brightness of inactive tab font and icon (they became too dim when support for themable tab icon colors was introduced, which is especially noticeable in scene tabs).

6. Makes popup menus darker to make them blend less with inspector properties. This isn't perfect and is more of a mitigation than a fix for now because there's not a lot of range to work with there. When popup menus are reworked to support shadows (https://github.com/godotengine/godot/pull/106324) it will be more feasible to make them elevated (i.e see https://github.com/godotengine/godot/pull/91333#issuecomment-2091005682)

7. More subtle hover indication in popup menus.

8. Reduces brightness of backgrounds of pressed flat buttons (i.e in toolbars) to make their icons more readable.

9. Makes the selected editor property brighter to make it easier to see it.

10. Progressbars in dark popups have different colors now to account for new dark popup background.

11. Project list items now use their own colors instead of Tree colors to make the hover indication more fitting for their background

12. Audio bus effect list has a more fitting background color now, the secondary tree one was too contrasty for the audio bus background.

13. Fixes overbrightened font color on checkboxes.

14. Headers of sidebar trees now have their own colors that look better on sidebar backgrounds, while regular tree headers are less contrasty and more fitting for regular backgrounds.

15. Fixes overbrightened project tags.

16. Adds missing hover-pressed state to project list.

17. Fixes code blocks blending with help background.

</p>
</details> 
