### PR TITLE
Fix export preset not duplicating selected files

### DIFF
--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -259,6 +259,14 @@ Vector<String> EditorExportPreset::get_files_to_export() const {
 	return files;
 }
 
+HashSet<String> EditorExportPreset::get_selected_files() const {
+	return selected_files;
+}
+
+void EditorExportPreset::set_selected_files(const HashSet<String> &p_files) {
+	selected_files = p_files;
+}
+
 Dictionary EditorExportPreset::get_customized_files() const {
 	Dictionary files;
 	for (const KeyValue<String, FileExportMode> &E : customized_files) {

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -123,6 +123,8 @@ public:
 	void update_value_overrides();
 
 	Vector<String> get_files_to_export() const;
+	HashSet<String> get_selected_files() const;
+	void set_selected_files(const HashSet<String> &p_files);
 	Dictionary get_customized_files() const;
 	int get_customized_files_count() const;
 	void set_customized_files(const Dictionary &p_files);

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -756,6 +756,8 @@ void ProjectExportDialog::_duplicate_preset() {
 	preset->set_export_filter(current->get_export_filter());
 	preset->set_include_filter(current->get_include_filter());
 	preset->set_exclude_filter(current->get_exclude_filter());
+	preset->set_customized_files(current->get_customized_files());
+	preset->set_selected_files(current->get_selected_files());
 	preset->set_patches(current->get_patches());
 	preset->set_patch_delta_encoding_enabled(current->is_patch_delta_encoding_enabled());
 	preset->set_patch_delta_zstd_level(current->get_patch_delta_zstd_level());


### PR DESCRIPTION
Previously, export presets did not duplicate selected files for excluding / including specific files in the export. This commit fixes it by duplicating the selected files.

Closes https://github.com/godotengine/godot/issues/114150



https://github.com/user-attachments/assets/c2eeed9e-acb5-4bac-aa53-ee6d70ea3129

