### PR TITLE
Fix icon resizing for `NodePath` properties not working

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3200,6 +3200,9 @@ void EditorPropertyNodePath::_notification(int p_what) {
 			menu->get_popup()->set_item_icon(ACTION_COPY, get_editor_theme_icon(SNAME("ActionCopy")));
 			menu->get_popup()->set_item_icon(ACTION_EDIT, get_editor_theme_icon(SNAME("Edit")));
 			menu->get_popup()->set_item_icon(ACTION_SELECT, get_editor_theme_icon(SNAME("ExternalLink")));
+
+			// Use a constant width for the icon to avoid sizing issues or blurry icons.
+			assign->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN: {
@@ -3260,8 +3263,6 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
 	assign->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	// Use a constant width for the icon to avoid sizing issues or blurry icons.
-	assign->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 	assign->set_expand_icon(true);
 	assign->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyNodePath::_node_assign));
 	assign->connect(SceneStringName(draw), callable_mp(this, &EditorPropertyNodePath::_assign_draw));


### PR DESCRIPTION
This makes so that #108882 actually works, and fixes a regression caused by it that causes an error when a `NodePath` property appears:
```
WARNING: Attempting to access theme items too early in EditorPropertyNodePath; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED
```