### PR TITLE
Fix TextEdit word auto wrap mode doesn't follow caret

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -8812,7 +8812,7 @@ void TextEdit::_scroll_lines_down() {
 }
 
 void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret, bool p_maximize_selection) {
-	if (get_line_wrapping_mode() != LineWrappingMode::LINE_WRAPPING_NONE) {
+	if (!h_scroll->is_visible()) {
 		first_visible_col = 0;
 		h_scroll->set_value(first_visible_col);
 		queue_redraw();


### PR DESCRIPTION
When TextEdit `autowrap_mode` is set to `Word` (not Word Smart) moving the caret sets the horizontal scroll to 0. There can be a horizontal scrollbar in this mode if there aren't any spaces / word breaks and the line is longer than the width.
The other autowrap modes wrap even there isn't any spaces in the text so there isn't a horizontal scrollbar for them.

Before:

https://github.com/user-attachments/assets/725179ed-0df2-40ab-9dc8-19d9cb5e9cfe