### PR TITLE
Fix changing directory in FileDialog

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1284,6 +1284,9 @@ String FileDialog::get_current_path() const {
 }
 
 void FileDialog::set_current_dir(const String &p_dir) {
+	if (p_dir.is_relative_path()) {
+		dir_access->change_dir(OS::get_singleton()->get_resource_dir());
+	}
 	_change_dir(p_dir);
 
 	_push_history();
@@ -1587,9 +1590,6 @@ void FileDialog::_select_drive(int p_idx) {
 }
 
 void FileDialog::_change_dir(const String &p_new_dir) {
-	if (p_new_dir.is_relative_path()) {
-		dir_access->change_dir(OS::get_singleton()->get_resource_dir());
-	}
 	if (root_prefix.is_empty()) {
 		dir_access->change_dir(p_new_dir);
 	} else {


### PR DESCRIPTION
Who would've though that navigating to root directory on every directory traverse would cause problems 🙃
It worked in EditorFileDialog, because it was using `DirAccess->change_dir()` directly everywhere, instead of always going through the helper method.

Fixes #114174