### PR TITLE
Add highlight support to Language Server for external editors

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -557,6 +557,7 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 	SET_DOCUMENT_METHOD(didSave);
 
 	SET_DOCUMENT_METHOD(documentSymbol);
+	SET_DOCUMENT_METHOD(documentHighlight);
 	SET_DOCUMENT_METHOD(completion);
 	SET_DOCUMENT_METHOD(rename);
 	SET_DOCUMENT_METHOD(prepareRename);

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -165,6 +165,25 @@ Array GDScriptTextDocument::documentSymbol(const Dictionary &p_params) {
 	return arr;
 }
 
+Array GDScriptTextDocument::documentHighlight(const Dictionary &p_params) {
+	Array arr;
+	LSP::TextDocumentPositionParams params;
+	params.load(p_params);
+
+	const LSP::DocumentSymbol *symbol = GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_symbol(params);
+	if (symbol) {
+		String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(params.textDocument.uri);
+		Vector<LSP::Location> usages = GDScriptLanguageProtocol::get_singleton()->get_workspace()->find_usages_in_file(*symbol, path);
+
+		for (const LSP::Location &usage : usages) {
+			LSP::DocumentHighlight highlight;
+			highlight.range = usage.range;
+			arr.push_back(highlight.to_json());
+		}
+	}
+	return arr;
+}
+
 Array GDScriptTextDocument::completion(const Dictionary &p_params) {
 	Array arr;
 

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -62,6 +62,7 @@ public:
 
 	Variant nativeSymbol(const Dictionary &p_params);
 	Array documentSymbol(const Dictionary &p_params);
+	Array documentHighlight(const Dictionary &p_params);
 	Array completion(const Dictionary &p_params);
 	Dictionary resolve(const Dictionary &p_params);
 	Dictionary rename(const Dictionary &p_params);

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1761,7 +1761,7 @@ struct ServerCapabilities {
 	/**
 	 * The server provides document highlight support.
 	 */
-	bool documentHighlightProvider = false;
+	bool documentHighlightProvider = true;
 
 	/**
 	 * The server provides document symbol support.
@@ -2118,4 +2118,26 @@ static String marked_documentation(const String &p_bbcode) {
 	}
 	return markdown;
 }
+
+/**
+ * A document highlight is a range inside a text document which deserves
+ * special attention. Usually a document highlight is visualized by changing
+ * the background color of its range.
+ */
+struct DocumentHighlight {
+	/**
+	 * The range this highlight applies to.
+	 */
+	Range range;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["range"] = range.to_json();
+		return dict;
+	}
+
+	_FORCE_INLINE_ void load(const Dictionary &p_params) {
+		range.load(p_params["range"]);
+	}
+};
 } // namespace LSP


### PR DESCRIPTION
Whilst working on #114185 I noticed that there wasn't highlighting support yet. What this addition does is highlight all variables of the one your cursor is on like in this example:
<img width="441" height="129" alt="image" src="https://github.com/user-attachments/assets/df127365-e7a6-4849-aa0a-ea96f37ce96c" />

For people who want to test this in NeoVim and haven't highlighting enabled:
`:lua vim.api.nvim_create_autocmd({"CursorHold","CursorHoldI"},{buffer=0,callback=vim.lsp.buf.document_highlight}); vim.api.nvim_create_autocmd("CursorMoved",{buffer=0,callback=vim.lsp.buf.clear_references}); vim.opt.updatetime=200`

It's another small addition to the language server, but one which some people might want as it could be useful in certain situations.