### PR TITLE
Improve GDScript Parser error messages

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1346,8 +1346,14 @@ GDScriptParser::VariableNode *GDScriptParser::parse_property(VariableNode *p_var
 				getter_used = true;
 			}
 		} else {
-			// TODO: Update message to only have the missing one if it's the case.
-			push_error(R"(Expected "get" or "set" for property declaration.)");
+			if (getter_used && !setter_used) {
+				push_error(R"(Expected "set" after "get" in property declaration.)", function);
+			} else if (setter_used && !getter_used) {
+				push_error(R"(Expected "get" after "set" in property declaration.)", function);
+			} else {
+				push_error(R"(Expected "get" or "set" for property declaration.)", function);
+			}
+			break;
 		}
 
 		if (i == 0 && p_variable->property == VariableNode::PROP_SETGET) {
@@ -2234,11 +2240,32 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 #ifdef DEBUG_ENABLED
 	if (unreachable && result != nullptr) {
 		current_suite->has_unreachable_code = true;
+		String context;
+
 		if (current_function) {
-			push_warning(result, GDScriptWarning::UNREACHABLE_CODE, current_function->identifier ? current_function->identifier->name : "<anonymous lambda>");
+			if (current_function->identifier) {
+				String name = current_function->identifier->name;
+				if (name.begins_with("@")) {
+					if (name.ends_with("_getter")) {
+						context = vformat("the getter of property \"%s\"", name.trim_prefix("@").trim_suffix("_getter"));
+					} else if (name.ends_with("_setter")) {
+						context = vformat("the setter of property \"%s\"", name.trim_prefix("@").trim_suffix("_setter"));
+					} else {
+						context = vformat("internal function \"%s\"", name);
+					}
+				} else {
+					context = vformat("function \"%s()\"", name);
+				}
+			} else {
+				context = "an anonymous lambda";
+			}
+		} else if (current_class && current_class->identifier) {
+			context = vformat("the initializer of class \"%s\"", current_class->identifier->name);
 		} else {
-			// TODO: Properties setters and getters with unreachable code are not being warned
+			context = "the script initializer";
 		}
+
+		push_warning(result, GDScriptWarning::UNREACHABLE_CODE, context);
 	}
 #endif
 

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -74,7 +74,7 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"(The %s "%s" has the same name as a %s.)", symbols[0], symbols[1], symbols[2]);
 		case UNREACHABLE_CODE:
 			CHECK_SYMBOLS(1);
-			return vformat(R"*(Unreachable code (statement after return) in function "%s()".)*", symbols[0]);
+			return vformat(R"*(Unreachable code (statement after return) in %s.)*", symbols[0]);
 		case UNREACHABLE_PATTERN:
 			return "Unreachable pattern (pattern after wildcard or bind).";
 		case STANDALONE_EXPRESSION:

--- a/modules/gdscript/tests/scripts/parser/errors/property_expected_token.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/property_expected_token.gd
@@ -1,0 +1,6 @@
+var x:
+	get: return 1
+	invalid_keyword: pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/property_expected_token.out
+++ b/modules/gdscript/tests/scripts/parser/errors/property_expected_token.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected "set" after "get" in property declaration.

--- a/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_property.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_property.gd
@@ -1,0 +1,12 @@
+var test_property: int:
+	get:
+		return 0
+		print("unreachable")
+	set(value):
+		test_property = value
+		return
+		print("unreachable")
+
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_property.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_property.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+~~ WARNING at line 4: (UNREACHABLE_CODE) Unreachable code (statement after return) in the getter of property "test_property".
+~~ WARNING at line 8: (UNREACHABLE_CODE) Unreachable code (statement after return) in the setter of property "test_property".


### PR DESCRIPTION
Fixed/improved following TODO's inside of gdscript_parser.cpp
* Line 1246: // TODO: Update message to only have the missing one if it's the case.
* Line 2131: // TODO: Properties setters and getters with unreachable code are not being warned
* ~~Line 3421: // TODO: The analyzer can see if this is actually a Callable and give better error message.~~

Let me know if some need better wording or more information.

## The set/get message:
<img width="465" height="221" alt="image" src="https://github.com/user-attachments/assets/59243694-e04b-476d-ac20-72082b8ff4df" />
Results in:
`SCRIPT ERROR: Parse Error: Expected "get" after "set" in property declaration.` and `SCRIPT ERROR: Parse Error: Expected "set" after "get" in property declaration.`

<img width="388" height="57" alt="image" src="https://github.com/user-attachments/assets/6c9b1ebb-c8bc-4321-bb33-2a0ce8d29e74" />
SCRIPT ERROR: Parse Error: Expected "get" after "set" in property declaration.

## Unreachable code of property setters and getters
<img width="556" height="255" alt="image" src="https://github.com/user-attachments/assets/c6dc14ad-b49c-4ae0-abf9-b4c8e72dd4c1" />
<img width="653" height="107" alt="image" src="https://github.com/user-attachments/assets/ec4730dc-e37f-4173-914c-6a2b9fb3e720" />
<img width="661" height="147" alt="image" src="https://github.com/user-attachments/assets/56ba6b70-4a94-449c-8e99-cf58f887ff34" />
<img width="660" height="43" alt="image" src="https://github.com/user-attachments/assets/9feca23e-35de-4699-b601-0ac2b3238a90" />


