### PR TITLE
Fix error when break scriptless scene

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -408,12 +408,10 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	}
 
 	ScriptLanguage *script_lang = script_debugger->get_break_language();
-	ERR_FAIL_NULL(script_lang);
-
 	Array msg = {
 		p_can_continue,
-		script_lang->debug_get_error(),
-		script_lang->debug_get_stack_level_count() > 0,
+		script_lang ? script_lang->debug_get_error() : String(),
+		script_lang && (script_lang->debug_get_stack_level_count() > 0),
 		Thread::get_caller_id()
 	};
 	if (allow_focus_steal_fn) {
@@ -469,19 +467,24 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 			} else if (command == "get_stack_dump") {
 				DebuggerMarshalls::ScriptStackDump dump;
-				int slc = script_lang->debug_get_stack_level_count();
-				for (int i = 0; i < slc; i++) {
-					ScriptLanguage::StackInfo frame;
-					frame.file = script_lang->debug_get_stack_level_source(i);
-					frame.line = script_lang->debug_get_stack_level_line(i);
-					frame.func = script_lang->debug_get_stack_level_function(i);
-					dump.frames.push_back(frame);
+				if (script_lang) {
+					int slc = script_lang->debug_get_stack_level_count();
+					for (int i = 0; i < slc; i++) {
+						ScriptLanguage::StackInfo frame;
+						frame.file = script_lang->debug_get_stack_level_source(i);
+						frame.line = script_lang->debug_get_stack_level_line(i);
+						frame.func = script_lang->debug_get_stack_level_function(i);
+						dump.frames.push_back(frame);
+					}
 				}
 				send_message("stack_dump", dump.serialize());
 
 			} else if (command == "get_stack_frame_vars") {
 				ERR_FAIL_COND(data.size() != 1);
-				ERR_FAIL_NULL(script_lang);
+				if (!script_lang) {
+					send_message("stack_frame_vars", Array{ 0 });
+					continue;
+				}
 				int lv = data[0];
 
 				List<String> members;


### PR DESCRIPTION
Fixes #113621

When running a scene without a script and breaking or using the ObjectDB Profiler you get following error and crash:
<img width="848" height="80" alt="image" src="https://github.com/user-attachments/assets/baead5b1-01ff-416b-a63d-a1a3a53062e3" />

This PR checks if the scene is scriptless, removes the error, and allows for correctly pausing and breaking so the scene can be inspected. It's just a couple of extra if statements so let me know if anything else needs to change, from my testing I get a working empty project without errors and scene inspection working.
