### PR TITLE
Limit built-in syntax highlighters to highlighting lines <10,000 characters

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -97,6 +97,12 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 	const String &str = text_edit->get_line_with_ime(p_line);
 	const int line_length = str.length();
+
+	// Don't highlight lines longer than ten thousand characters, otherwise TextEdit starts to struggle.
+	if (line_length > 10000) {
+		return Dictionary();
+	}
+
 	Color prev_color;
 
 	if (in_region != -1 && line_length == 0) {

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -146,6 +146,12 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 
 	const String &str = text_edit->get_line_with_ime(p_line);
 	const int line_length = str.length();
+
+	// Don't highlight lines longer than ten thousand characters, otherwise TextEdit starts to struggle.
+	if (line_length > 10000) {
+		return Dictionary();
+	}
+
 	Color prev_color;
 
 	if (in_region != -1 && str.length() == 0) {


### PR DESCRIPTION
For some reason TextEdit doesn't like really long lines with thousands of characters (the file I was testing was a JSON file all on one 150k character-long line), and text navigation and scrolling become very slow. This imposes a hard 10,000 character limit on highlighted lines for the internal highlighters for that not to happen.

Before:

[Screencast_20251219_014756.webm](https://github.com/user-attachments/assets/a3f15d2c-b936-4172-8328-34632cbaa951)

After:

[Screencast_20251219_014449.webm](https://github.com/user-attachments/assets/04bbb956-3dea-40e4-8910-dd2613e5e72c)

Partially fixes #114101, I don't think highlighting the file adds too much cost at load time.