### PR TITLE
Fix `PhysicalBone2D` abnormally restoring `body_mode` in `_ready`

### DIFF
--- a/scene/2d/physics/physical_bone_2d.cpp
+++ b/scene/2d/physics/physical_bone_2d.cpp
@@ -178,7 +178,7 @@ void PhysicalBone2D::_stop_physics_simulation() {
 		PhysicsServer2D::get_singleton()->body_set_collision_layer(get_rid(), 0);
 		PhysicsServer2D::get_singleton()->body_set_collision_mask(get_rid(), 0);
 		PhysicsServer2D::get_singleton()->body_set_collision_priority(get_rid(), 1.0);
-		PhysicsServer2D::get_singleton()->body_set_mode(get_rid(), PhysicsServer2D::BodyMode::BODY_MODE_STATIC);
+		set_body_mode(PhysicsServer2D::BODY_MODE_STATIC);
 	}
 }
 
@@ -290,7 +290,7 @@ PhysicalBone2D::PhysicalBone2D() {
 	// Stop the RigidBody from executing its force integration.
 	PhysicsServer2D::get_singleton()->body_set_collision_layer(get_rid(), 0);
 	PhysicsServer2D::get_singleton()->body_set_collision_mask(get_rid(), 0);
-	PhysicsServer2D::get_singleton()->body_set_mode(get_rid(), PhysicsServer2D::BodyMode::BODY_MODE_STATIC);
+	set_body_mode(PhysicsServer2D::BODY_MODE_STATIC);
 
 	child_joint = nullptr;
 }


### PR DESCRIPTION
We found that during the constructor phase of the physical skeleton, the following method is used to deactivate the rigid body.
`
PhysicsServer2D::get_singleton()->body_set_mode(get_rid(), PhysicsServer2D::BodyMode::BODY_MODE_STATIC);
`
https://github.com/godotengine/godot/blob/ef34c3d534a16b140aef0643ed2fa36f8e9d1612/scene/2d/physics/physical_bone_2d.cpp#L289-L296

But this approach has serious flaws. 
**This behavior will cause the 2D physics skeleton to completely fail.**

Because this method modifies the physics mode of the rigid body through PhysicsServer2D, bypassing the set_body_mode method of CollisionObject2D.

Subsequently, PhysicalBone2D attempts to restore physics mode during the Ready phase : 
https://github.com/godotengine/godot/blob/ef34c3d534a16b140aef0643ed2fa36f8e9d1612/scene/2d/physics/physical_bone_2d.cpp#L49-L66


https://github.com/godotengine/godot/blob/ef34c3d534a16b140aef0643ed2fa36f8e9d1612/scene/2d/physics/physical_bone_2d.cpp#L150-L168

https://github.com/godotengine/godot/blob/40cf5a0f50b4ddbd1d6990c7e7b92226665d7053/scene/2d/physics/rigid_body_2d.cpp#L261-L276

https://github.com/godotengine/godot/blob/40cf5a0f50b4ddbd1d6990c7e7b92226665d7053/scene/2d/physics/collision_object_2d.cpp#L552-L566

The key point is: we modify the physics mode through PhysicsServer, while the CollisionBody2D property `body_mode` still defaults to `BODY_MODE_RIGID`, which causes `body_mode == p_mode` to be true, preventing PhysicalBone2D from correctly restoring its initial rigid body state.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/78367*