### PR TITLE
Fix potential DAP crash at startup

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -145,6 +145,7 @@ Error DebugAdapterProtocol::on_client_connected() {
 	ERR_FAIL_COND_V_MSG(clients.size() >= DAP_MAX_CLIENTS, FAILED, "Max client limits reached");
 
 	Ref<StreamPeerTCP> tcp_peer = server->take_connection();
+	ERR_FAIL_COND_V_MSG(tcp_peer.is_null(), FAILED, "Failed to take incoming DAP connection.");
 	tcp_peer->set_no_delay(true);
 	Ref<DAPeer> peer = memnew(DAPeer);
 	peer->connection = tcp_peer;


### PR DESCRIPTION
This also appeared on our crash telemetry, I have not been able to reproduce, but I suspect it is a timing issue when the client has gone away before the server connects.