### PR TITLE
Add ability for Area3D to detect/influence SoftBody3D with Jolt Physics

### DIFF
--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -25,8 +25,9 @@
 		<method name="get_overlapping_bodies" qualifiers="const">
 			<return type="Node3D[]" />
 			<description>
-				Returns a list of intersecting [PhysicsBody3D]s and [GridMap]s. The overlapping body's [member CollisionObject3D.collision_layer] must be part of this area's [member CollisionObject3D.collision_mask] in order to be detected.
+				Returns a list of intersecting [PhysicsBody3D]s, [SoftBody3D]s, and [GridMap]s. The overlapping body's [member CollisionObject3D.collision_layer] must be part of this area's [member CollisionObject3D.collision_mask] in order to be detected.
 				For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
+				[b]Note:[/b] Godot Physics does not support reporting overlaps with [SoftBody3D], so will not return any such bodies.
 			</description>
 		</method>
 		<method name="has_overlapping_areas" qualifiers="const">
@@ -39,8 +40,9 @@
 		<method name="has_overlapping_bodies" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if intersecting any [PhysicsBody3D]s or [GridMap]s, otherwise returns [code]false[/code]. The overlapping body's [member CollisionObject3D.collision_layer] must be part of this area's [member CollisionObject3D.collision_mask] in order to be detected.
+				Returns [code]true[/code] if intersecting any [PhysicsBody3D]s, [SoftBody3D]s, or [GridMap]s, otherwise returns [code]false[/code]. The overlapping body's [member CollisionObject3D.collision_layer] must be part of this area's [member CollisionObject3D.collision_mask] in order to be detected.
 				For performance reasons (collisions are all processed at the same time) the list of overlapping bodies is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
+				[b]Note:[/b] Godot Physics does not support reporting overlaps with [SoftBody3D], so will not consider such bodies.
 			</description>
 		</method>
 		<method name="overlaps_area" qualifiers="const">
@@ -56,8 +58,9 @@
 			<param index="0" name="body" type="Node" />
 			<description>
 				Returns [code]true[/code] if the given physics body intersects or overlaps this [Area3D], [code]false[/code] otherwise.
+				[param body] argument can either be a [PhysicsBody3D], [SoftBody3D], or a [GridMap] instance. While GridMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body.
 				[b]Note:[/b] The result of this test is not immediate after moving objects. For performance, list of overlaps is updated once per frame and before the physics step. Consider using signals instead.
-				The [param body] argument can either be a [PhysicsBody3D] or a [GridMap] instance. While GridMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body.
+				[b]Note:[/b] Godot Physics does not support reporting overlaps with [SoftBody3D], so will return [code]false[/code] in such cases.
 			</description>
 		</method>
 	</methods>
@@ -181,13 +184,15 @@
 		<signal name="body_entered">
 			<param index="0" name="body" type="Node3D" />
 			<description>
-				Emitted when the received [param body] enters this area. [param body] can be a [PhysicsBody3D] or a [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when the received [param body] enters this area. [param body] can be a [PhysicsBody3D], [SoftBody3D] or [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				[b]Note:[/b] Godot Physics does not support reporting overlaps with [SoftBody3D], so will not emit this signal in such cases.
 			</description>
 		</signal>
 		<signal name="body_exited">
 			<param index="0" name="body" type="Node3D" />
 			<description>
-				Emitted when the received [param body] exits this area. [param body] can be a [PhysicsBody3D] or a [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when the received [param body] exits this area. [param body] can be a [PhysicsBody3D], [SoftBody3D] or [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				[b]Note:[/b] Godot Physics does not support reporting overlaps with [SoftBody3D], so will not emit this signal in such cases.
 			</description>
 		</signal>
 		<signal name="body_shape_entered">
@@ -196,8 +201,9 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape3D] of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody3D] or a [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a [Shape3D] of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody3D], [SoftBody3D] or [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param body_shape_index] contain indices of the interacting shapes from this area and the interacting body, respectively. [param body_rid] contains the [RID] of the body. These values can be used with the [PhysicsServer3D].
+				[b]Note:[/b] Godot Physics does not support reporting overlaps with [SoftBody3D], so will not emit this signal in such cases.
 				[b]Example:[/b] Get the [CollisionShape3D] node from the shape index:
 				[codeblocks]
 				[gdscript]
@@ -216,8 +222,9 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape3D] of the received [param body] exits a shape of this area. [param body] can be a [PhysicsBody3D] or a [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a [Shape3D] of the received [param body] exits a shape of this area. [param body] can be a [PhysicsBody3D], [SoftBody3D] or [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				See also [signal body_shape_entered].
+				[b]Note:[/b] Godot Physics does not support reporting overlaps with [SoftBody3D], so will not emit this signal in such cases.
 			</description>
 		</signal>
 	</signals>

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -92,7 +92,6 @@ private:
 	float angular_damp = 0.0f;
 	float total_linear_damp = 0.0f;
 	float total_angular_damp = 0.0f;
-	float gravity_scale = 1.0f;
 	float collision_priority = 1.0f;
 
 	int contact_count = 0;
@@ -276,7 +275,7 @@ public:
 	float get_friction() const;
 	void set_friction(float p_friction);
 
-	float get_gravity_scale() const { return gravity_scale; }
+	float get_gravity_scale() const;
 	void set_gravity_scale(float p_scale);
 
 	Vector3 get_gravity() const { return gravity; }

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
@@ -195,7 +195,6 @@ JoltShapedObject3D::JoltShapedObject3D(ObjectType p_object_type) :
 	jolt_settings->mRestitution = 0.0f;
 	jolt_settings->mLinearDamping = 0.0f;
 	jolt_settings->mAngularDamping = 0.0f;
-	jolt_settings->mGravityFactor = 0.0f;
 }
 
 JoltShapedObject3D::~JoltShapedObject3D() {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -228,6 +228,87 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 	return settings;
 }
 
+void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt_body) {
+	// Get approximation of the center of the soft body.
+	Vector3 com_position = to_godot(p_jolt_body.GetCenterOfMassPosition());
+
+	// Calculate gravity and which areas affect the soft body through wind.
+	bool gravity_done = false;
+	Vector3 gravity;
+	LocalVector<JoltArea3D *> wind_areas;
+	for (JoltArea3D *area : areas) {
+		if (!gravity_done) {
+			gravity_done = JoltArea3D::apply_override(gravity, area->get_gravity_mode(), [&]() {
+				return area->compute_gravity(com_position);
+			});
+		}
+
+		if (area->get_wind_pressure() > CMP_EPSILON) {
+			wind_areas.push_back(area);
+		}
+	}
+
+	// Add default gravity.
+	if (!gravity_done) {
+		gravity += space->get_default_area()->compute_gravity(com_position);
+	}
+
+	// Apply gravity to soft body. Note that this only works so long as vertices have uniform mass (excluding pinned vertices).
+	p_jolt_body.AddForce(to_jolt(gravity) * mass);
+
+	if (!wind_areas.is_empty()) {
+		JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*p_jolt_body.GetMotionPropertiesUnchecked());
+		JPH::Array<JPH::SoftBodyVertex> &physics_vertices = motion_properties.GetVertices();
+
+		for (const JPH::SoftBodySharedSettings::Face &physics_face : motion_properties.GetFaces()) {
+			JPH::SoftBodyVertex &physics_vertex0 = physics_vertices[physics_face.mVertex[0]];
+			JPH::SoftBodyVertex &physics_vertex1 = physics_vertices[physics_face.mVertex[1]];
+			JPH::SoftBodyVertex &physics_vertex2 = physics_vertices[physics_face.mVertex[2]];
+
+			// Calculate the triangle centroid.
+			Vector3 v0 = to_godot(physics_vertex0.mPosition);
+			Vector3 v1 = to_godot(physics_vertex1.mPosition);
+			Vector3 v2 = to_godot(physics_vertex2.mPosition);
+			Vector3 centroid = com_position + (v0 + v1 + v2) * real_t(1.0 / 3.0);
+
+			// Calculate the triangle normal.
+			Vector3 normal = (v2 - v0).cross(v1 - v0);
+			real_t normal_length = normal.length();
+			if (normal_length > real_t(1.0e-6)) { // If the normal is near zero, the area is near zero so we can skip this triangle.
+				normal /= normal_length;
+
+				// Area is half the length of the cross product of two sides.
+				real_t triangle_area = real_t(0.5) * normal_length;
+
+				// Accumulate wind forces from all wind areas.
+				Vector3 wind_force;
+				for (const JoltArea3D *area : wind_areas) {
+					const Vector3 &wind_direction = area->get_wind_direction();
+					const Vector3 &wind_source = area->get_wind_source();
+
+					// Calculate attenuation factor based on distance from wind source to triangle centroid.
+					// We do not allow a projection below 1 to ensure that we never amplify and to avoid NaNs when the value would be negative.
+					real_t projection_toward_centroid = MAX((centroid - wind_source).dot(wind_direction), real_t(1.0));
+					real_t attenuation_over_distance = Math::pow(projection_toward_centroid, -real_t(area->get_wind_attenuation_factor()));
+
+					// Calculate force magnitude.
+					real_t force_magnitude = area->get_wind_pressure() * triangle_area;
+
+					// Calculate the resulting wind force on the triangle by projecting wind direction onto triangle normal.
+					// Divide by 3 to distribute force equally over each vertex.
+					wind_force += (force_magnitude * attenuation_over_distance * real_t(1.0 / 3.0) * normal.dot(wind_direction)) * normal;
+				}
+
+				// Apply the force as an impulse over the timestep.
+				JPH::Vec3 impulse = to_jolt(wind_force * p_step);
+				physics_vertex0.mVelocity += impulse * physics_vertex0.mInvMass;
+				physics_vertex1.mVelocity += impulse * physics_vertex1.mInvMass;
+				physics_vertex2.mVelocity += impulse * physics_vertex2.mInvMass;
+			}
+		}
+	}
+}
+
 void JoltSoftBody3D::_update_mass() {
 	if (!in_space()) {
 		return;
@@ -331,6 +412,14 @@ void JoltSoftBody3D::_motion_changed() {
 	wake_up();
 }
 
+void JoltSoftBody3D::_transform_changed() {
+	wake_up();
+}
+
+void JoltSoftBody3D::_areas_changed() {
+	wake_up();
+}
+
 JoltSoftBody3D::JoltSoftBody3D() :
 		JoltObject3D(OBJECT_TYPE_SOFT_BODY) {
 	jolt_settings->mRestitution = 0.0f;
@@ -362,6 +451,25 @@ bool JoltSoftBody3D::has_collision_exception(const RID &p_excepted_body) const {
 	return exceptions.find(p_excepted_body) >= 0;
 }
 
+void JoltSoftBody3D::add_area(JoltArea3D *p_area) {
+	int i = 0;
+	for (; i < (int)areas.size(); i++) {
+		if (p_area->get_priority() > areas[i]->get_priority()) {
+			break;
+		}
+	}
+
+	areas.insert(i, p_area);
+
+	_areas_changed();
+}
+
+void JoltSoftBody3D::remove_area(JoltArea3D *p_area) {
+	areas.erase(p_area);
+
+	_areas_changed();
+}
+
 bool JoltSoftBody3D::can_interact_with(const JoltBody3D &p_other) const {
 	return (can_collide_with(p_other) || p_other.can_collide_with(*this)) && !has_collision_exception(p_other.get_rid()) && !p_other.has_collision_exception(rid);
 }
@@ -376,6 +484,10 @@ bool JoltSoftBody3D::can_interact_with(const JoltArea3D &p_other) const {
 
 Vector3 JoltSoftBody3D::get_velocity_at_position(const Vector3 &p_position) const {
 	return Vector3();
+}
+
+void JoltSoftBody3D::pre_step(float p_step, JPH::Body &p_jolt_body) {
+	_apply_environmental_forces(p_step, p_jolt_body);
 }
 
 void JoltSoftBody3D::set_mesh(const RID &p_mesh) {
@@ -608,7 +720,8 @@ void JoltSoftBody3D::set_transform(const Transform3D &p_transform) {
 		vertex.mPosition = vertex.mPreviousPosition = relative_transform.Multiply3x3(vertex.mPosition);
 		vertex.mVelocity = JPH::Vec3::sZero();
 	}
-	wake_up();
+
+	_transform_changed();
 }
 
 AABB JoltSoftBody3D::get_bounds() const {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -39,15 +39,18 @@
 #include "Jolt/Physics/SoftBody/SoftBodyCreationSettings.h"
 #include "Jolt/Physics/SoftBody/SoftBodySharedSettings.h"
 
+class JoltArea3D;
 class JoltSpace3D;
 
 class JoltSoftBody3D final : public JoltObject3D {
 	HashSet<int> pinned_vertices;
-	LocalVector<RID> exceptions;
+
+	LocalVector<int> mesh_to_physics;
+	LocalVector<JoltArea3D *> areas;
 	LocalVector<Vector3> normals;
+	LocalVector<RID> exceptions;
 
 	RID mesh;
-	LocalVector<int> mesh_to_physics;
 
 	JPH::SoftBodyCreationSettings *jolt_settings = new JPH::SoftBodyCreationSettings();
 
@@ -69,6 +72,8 @@ class JoltSoftBody3D final : public JoltObject3D {
 
 	JPH::SoftBodySharedSettings *_create_shared_settings();
 
+	void _apply_environmental_forces(float p_step, JPH::Body &p_jolt_body);
+
 	void _update_mass();
 	void _update_pressure();
 	void _update_damping();
@@ -86,6 +91,8 @@ class JoltSoftBody3D final : public JoltObject3D {
 	void _vertices_changed();
 	void _exceptions_changed();
 	void _motion_changed();
+	void _transform_changed();
+	void _areas_changed();
 
 public:
 	JoltSoftBody3D();
@@ -97,6 +104,9 @@ public:
 
 	const LocalVector<RID> &get_collision_exceptions() const { return exceptions; }
 
+	void add_area(JoltArea3D *p_area);
+	void remove_area(JoltArea3D *p_area);
+
 	virtual bool can_interact_with(const JoltBody3D &p_other) const override;
 	virtual bool can_interact_with(const JoltSoftBody3D &p_other) const override;
 	virtual bool can_interact_with(const JoltArea3D &p_other) const override;
@@ -104,6 +114,8 @@ public:
 	virtual bool reports_contacts() const override { return false; }
 
 	virtual Vector3 get_velocity_at_position(const Vector3 &p_position) const override;
+
+	virtual void pre_step(float p_step, JPH::Body &p_jolt_body) override;
 
 	void set_mesh(const RID &p_mesh);
 

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
@@ -44,7 +44,7 @@ void JoltContactListener3D::OnContactAdded(const JPH::Body &p_body1, const JPH::
 	_try_override_collision_response(p_body1, p_body2, p_settings);
 	_try_apply_surface_velocities(p_body1, p_body2, p_settings);
 	_try_add_contacts(p_body1, p_body2, p_manifold, p_settings);
-	_try_evaluate_area_overlap(p_body1, p_body2, p_manifold);
+	_try_evaluate_area_overlap(p_body1, p_body2, p_manifold.mSubShapeID1, p_manifold.mSubShapeID2);
 
 #ifdef DEBUG_ENABLED
 	_try_add_debug_contacts(p_body1, p_body2, p_manifold);
@@ -55,7 +55,7 @@ void JoltContactListener3D::OnContactPersisted(const JPH::Body &p_body1, const J
 	_try_override_collision_response(p_body1, p_body2, p_settings);
 	_try_apply_surface_velocities(p_body1, p_body2, p_settings);
 	_try_add_contacts(p_body1, p_body2, p_manifold, p_settings);
-	_try_evaluate_area_overlap(p_body1, p_body2, p_manifold);
+	_try_evaluate_area_overlap(p_body1, p_body2, p_manifold.mSubShapeID1, p_manifold.mSubShapeID2);
 
 #ifdef DEBUG_ENABLED
 	_try_add_debug_contacts(p_body1, p_body2, p_manifold);
@@ -74,17 +74,20 @@ void JoltContactListener3D::OnContactRemoved(const JPH::SubShapeIDPair &p_shape_
 
 JPH::SoftBodyValidateResult JoltContactListener3D::OnSoftBodyContactValidate(const JPH::Body &p_soft_body, const JPH::Body &p_other_body, JPH::SoftBodyContactSettings &p_settings) {
 	_try_override_collision_response(p_soft_body, p_other_body, p_settings);
-
 	return JPH::SoftBodyValidateResult::AcceptContact;
 }
 
-#ifdef DEBUG_ENABLED
-
 void JoltContactListener3D::OnSoftBodyContactAdded(const JPH::Body &p_soft_body, const JPH::SoftBodyManifold &p_manifold) {
-	_try_add_debug_contacts(p_soft_body, p_manifold);
-}
+	for (JPH::uint i = 0; i < p_manifold.GetNumSensorContacts(); i++) {
+		if (JPH::Body *other_jolt_body = space->try_get_jolt_body(p_manifold.GetSensorContactBodyID(i))) {
+			_try_evaluate_area_overlap(p_soft_body, *other_jolt_body, JPH::SubShapeID(), JPH::SubShapeID());
+		}
+	}
 
+#ifdef DEBUG_ENABLED
+	_try_add_debug_contacts(p_soft_body, p_manifold);
 #endif
+}
 
 bool JoltContactListener3D::_try_override_collision_response(const JPH::Body &p_jolt_body1, const JPH::Body &p_jolt_body2, JPH::ContactSettings &p_settings) {
 	if (p_jolt_body1.IsSensor() || p_jolt_body2.IsSensor()) {
@@ -247,37 +250,13 @@ bool JoltContactListener3D::_try_add_contacts(const JPH::Body &p_jolt_body1, con
 	return true;
 }
 
-bool JoltContactListener3D::_try_evaluate_area_overlap(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold) {
+bool JoltContactListener3D::_try_evaluate_area_overlap(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::SubShapeID &p_shape_id1, const JPH::SubShapeID &p_shape_id2) {
 	if (!p_body1.IsSensor() && !p_body2.IsSensor()) {
 		return false;
 	}
 
-	auto has_shifted = [](const JoltShapedObject3D &p_object, const JPH::SubShapeID &p_sub_shape_id) {
-		return p_object.get_previous_jolt_shape() != nullptr && p_object.get_jolt_shape()->GetSubShapeUserData(p_sub_shape_id) != p_object.get_previous_jolt_shape()->GetSubShapeUserData(p_sub_shape_id);
-	};
-
-	auto evaluate = [&](const JoltArea3D &p_area, const auto &p_object, const JPH::SubShapeIDPair &p_shape_pair) {
-		const MutexLock write_lock(write_mutex);
-
-		if (p_area.can_monitor(p_object)) {
-			if (!area_overlaps.has(p_shape_pair)) {
-				area_overlaps.insert(p_shape_pair);
-				area_enters.insert(p_shape_pair);
-			} else if (has_shifted(p_area, p_shape_pair.GetSubShapeID1()) || has_shifted(p_object, p_shape_pair.GetSubShapeID2())) {
-				// A shape has taken on the `JPH::SubShapeID` value of another shape, likely because of the other shape having been replaced or moved
-				// in some way, so we force the area to refresh its internal mappings by exiting and entering this shape pair.
-				area_exits.insert(p_shape_pair);
-				area_enters.insert(p_shape_pair);
-			}
-		} else {
-			if (area_overlaps.erase(p_shape_pair)) {
-				area_exits.insert(p_shape_pair);
-			}
-		}
-	};
-
-	const JPH::SubShapeIDPair shape_pair1(p_body1.GetID(), p_manifold.mSubShapeID1, p_body2.GetID(), p_manifold.mSubShapeID2);
-	const JPH::SubShapeIDPair shape_pair2(p_body2.GetID(), p_manifold.mSubShapeID2, p_body1.GetID(), p_manifold.mSubShapeID1);
+	const JPH::SubShapeIDPair shape_pair1(p_body1.GetID(), p_shape_id1, p_body2.GetID(), p_shape_id2);
+	const JPH::SubShapeIDPair shape_pair2(p_body2.GetID(), p_shape_id2, p_body1.GetID(), p_shape_id1);
 
 	const JoltObject3D *object1 = reinterpret_cast<JoltObject3D *>(p_body1.GetUserData());
 	const JoltObject3D *object2 = reinterpret_cast<JoltObject3D *>(p_body2.GetUserData());
@@ -288,13 +267,20 @@ bool JoltContactListener3D::_try_evaluate_area_overlap(const JPH::Body &p_body1,
 	const JoltBody3D *body1 = object1->as_body();
 	const JoltBody3D *body2 = object2->as_body();
 
+	const JoltSoftBody3D *soft_body1 = object1->as_soft_body();
+	const JoltSoftBody3D *soft_body2 = object2->as_soft_body();
+
 	if (area1 != nullptr && area2 != nullptr) {
-		evaluate(*area1, *area2, shape_pair1);
-		evaluate(*area2, *area1, shape_pair2);
+		_evaluate_area_overlap(*area1, *area2, shape_pair1);
+		_evaluate_area_overlap(*area2, *area1, shape_pair2);
 	} else if (area1 != nullptr && body2 != nullptr) {
-		evaluate(*area1, *body2, shape_pair1);
+		_evaluate_area_overlap(*area1, *body2, shape_pair1);
 	} else if (area2 != nullptr && body1 != nullptr) {
-		evaluate(*area2, *body1, shape_pair2);
+		_evaluate_area_overlap(*area2, *body1, shape_pair2);
+	} else if (area1 != nullptr && soft_body2 != nullptr) {
+		_evaluate_area_overlap(*area1, *soft_body2, shape_pair1);
+	} else if (area2 != nullptr && soft_body1 != nullptr) {
+		_evaluate_area_overlap(*area2, *soft_body1, shape_pair2);
 	}
 
 	return true;
@@ -302,7 +288,6 @@ bool JoltContactListener3D::_try_evaluate_area_overlap(const JPH::Body &p_body1,
 
 bool JoltContactListener3D::_try_remove_contacts(const JPH::SubShapeIDPair &p_shape_pair) {
 	const MutexLock write_lock(write_mutex);
-
 	return manifolds_by_shape_pair.erase(p_shape_pair);
 }
 
@@ -414,6 +399,61 @@ bool JoltContactListener3D::_try_add_debug_contacts(const JPH::Body &p_soft_body
 
 #endif
 
+bool JoltContactListener3D::_has_shape_shifted(const JoltShapedObject3D &p_object, const JPH::SubShapeID &p_sub_shape_id) {
+	return p_object.get_previous_jolt_shape() != nullptr && p_object.get_jolt_shape()->GetSubShapeUserData(p_sub_shape_id) != p_object.get_previous_jolt_shape()->GetSubShapeUserData(p_sub_shape_id);
+}
+
+void JoltContactListener3D::_evaluate_area_overlap(const JoltArea3D &p_area, const JoltArea3D &p_other_area, const JPH::SubShapeIDPair &p_shape_pair) {
+	const MutexLock write_lock(write_mutex);
+
+	if (p_area.can_monitor(p_other_area)) {
+		if (!area_overlaps.has(p_shape_pair)) {
+			area_overlaps.insert(p_shape_pair);
+			area_enters.insert(p_shape_pair);
+		} else if (_has_shape_shifted(p_area, p_shape_pair.GetSubShapeID1()) || _has_shape_shifted(p_other_area, p_shape_pair.GetSubShapeID2())) {
+			// A shape has taken on the `JPH::SubShapeID` value of another shape, likely because of the other shape having been replaced or moved
+			// in some way, so we force the area to refresh its internal mappings by exiting and entering this shape pair.
+			area_exits.insert(p_shape_pair);
+			area_enters.insert(p_shape_pair);
+		}
+	} else {
+		if (area_overlaps.erase(p_shape_pair)) {
+			area_exits.insert(p_shape_pair);
+		}
+	}
+}
+
+void JoltContactListener3D::_evaluate_area_overlap(const JoltArea3D &p_area, const JoltBody3D &p_body, const JPH::SubShapeIDPair &p_shape_pair) {
+	const MutexLock write_lock(write_mutex);
+
+	if (p_area.can_monitor(p_body)) {
+		if (!area_overlaps.has(p_shape_pair)) {
+			area_overlaps.insert(p_shape_pair);
+			area_enters.insert(p_shape_pair);
+		} else if (_has_shape_shifted(p_area, p_shape_pair.GetSubShapeID1()) || _has_shape_shifted(p_body, p_shape_pair.GetSubShapeID2())) {
+			// A shape has taken on the `JPH::SubShapeID` value of another shape, likely because of the other shape having been replaced or moved
+			// in some way, so we force the area to refresh its internal mappings by exiting and entering this shape pair.
+			area_exits.insert(p_shape_pair);
+			area_enters.insert(p_shape_pair);
+		}
+	} else {
+		if (area_overlaps.erase(p_shape_pair)) {
+			area_exits.insert(p_shape_pair);
+		}
+	}
+}
+
+void JoltContactListener3D::_evaluate_area_overlap(const JoltArea3D &p_area, const JoltSoftBody3D &p_body, const JPH::SubShapeIDPair &p_shape_pair) {
+	const MutexLock write_lock(write_mutex);
+
+	if (p_area.can_monitor(p_body)) {
+		area_soft_body_overlaps.insert(p_shape_pair);
+		if (!area_exits.erase(p_shape_pair)) {
+			area_enters.insert(p_shape_pair);
+		}
+	}
+}
+
 void JoltContactListener3D::_flush_contacts() {
 	for (KeyValue<JPH::SubShapeIDPair, Manifold> &E : manifolds_by_shape_pair) {
 		const JPH::SubShapeIDPair &shape_pair = E.key;
@@ -504,7 +544,18 @@ void JoltContactListener3D::_flush_area_exits() {
 	area_exits.clear();
 }
 
+void JoltContactListener3D::_clear_area_soft_body_overlaps() {
+	area_exits.reserve(area_soft_body_overlaps.size());
+	for (const JPH::SubShapeIDPair &shape_pair : area_soft_body_overlaps) {
+		area_exits.insert(shape_pair);
+	}
+
+	area_soft_body_overlaps.clear();
+}
+
 void JoltContactListener3D::pre_step() {
+	_clear_area_soft_body_overlaps();
+
 #ifdef DEBUG_ENABLED
 	debug_contact_count = 0;
 #endif

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -127,7 +127,7 @@ public:
 	JoltPhysicsDirectSpaceState3D *get_direct_state();
 
 	JoltArea3D *get_default_area() const { return default_area; }
-	void set_default_area(JoltArea3D *p_area);
+	void set_default_area(JoltArea3D *p_area) { default_area = p_area; }
 
 	float get_last_step() const { return last_step; }
 


### PR DESCRIPTION
Fixes #111993.

This adds support for interactions between `Area3D` and `SoftBody3D` when using Jolt Physics as the 3D physics engine.

This PR also makes it so that the area's overlap signals are emitted whenever a soft body enters/exit its shapes, which is not something Godot Physics supports. As such, this is considered a breaking change, as the signal will now be emitted at times when they previously weren't, and for node types that previously were never passed to it.

To work around this breaking change you simply need to configure your collision layers/masks in such a way that the interactions between the relevant `Area3D` and `SoftBody3D` are ignored.