### PR TITLE
[macOS] Add editor settings to PM menu, fix Window translation.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7983,7 +7983,7 @@ void EditorNode::_update_main_menu_type() {
 		main_menu_button->set_switch_on_hover(true);
 
 		for (PopupMenu *menu : main_menu_items) {
-			if (menu != apple_menu) {
+			if (menu != apple_menu && menu != window_menu) {
 				main_menu_button->get_popup()->add_submenu_node_item(menu->get_name(), menu);
 			}
 		}
@@ -8011,7 +8011,7 @@ void EditorNode::_update_main_menu_type() {
 		main_menu_bar->set_switch_on_hover(true);
 
 		for (PopupMenu *menu : main_menu_items) {
-			if (menu != apple_menu || menu_type == MENU_TYPE_GLOBAL) {
+			if ((menu != apple_menu && menu != window_menu) || menu_type == MENU_TYPE_GLOBAL) {
 				main_menu_bar->add_child(menu);
 			}
 		}
@@ -8733,6 +8733,14 @@ EditorNode::EditorNode() {
 	settings_menu = memnew(PopupMenu);
 	settings_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorNode::_menu_option));
 	_add_to_main_menu(TTRC("Editor"), settings_menu);
+
+#ifdef MACOS_ENABLED
+	if (NativeMenu::get_singleton()->has_system_menu(NativeMenu::WINDOW_MENU_ID)) {
+		window_menu = memnew(PopupMenu);
+		window_menu->set_system_menu(NativeMenu::WINDOW_MENU_ID);
+		_add_to_main_menu(TTRC("Window"), window_menu);
+	}
+#endif
 
 	help_menu = memnew(PopupMenu);
 	help_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorNode::_menu_option));

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -341,6 +341,7 @@ private:
 	PopupMenu *project_menu = nullptr;
 	PopupMenu *debug_menu = nullptr;
 	PopupMenu *settings_menu = nullptr;
+	PopupMenu *window_menu = nullptr;
 	PopupMenu *help_menu = nullptr;
 	PopupMenu *tool_menu = nullptr;
 	PopupMenu *export_as_menu = nullptr;

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1314,6 +1314,14 @@ void ProjectManager::_open_donate_page() {
 	OS::get_singleton()->shell_open("https://fund.godotengine.org/?ref=project_manager");
 }
 
+void ProjectManager::_menu_option(int p_option) {
+	if (p_option == EDITOR_OPEN_SETTINGS) {
+		if (quick_settings_dialog) {
+			quick_settings_dialog->_show_full_settings();
+		}
+	}
+}
+
 // Object methods.
 
 ProjectManager::ProjectManager() {
@@ -1439,13 +1447,21 @@ ProjectManager::ProjectManager() {
 		left_hbox->add_child(title_bar_logo);
 		title_bar_logo->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_show_about));
 
-		bool global_menu = !bool(EDITOR_GET("interface/editor/use_embedded_menu")) && NativeMenu::get_singleton()->has_feature(NativeMenu::FEATURE_GLOBAL_MENU);
-		if (global_menu) {
+#ifdef MACOS_ENABLED
+		{
 			MenuBar *main_menu_bar = memnew(MenuBar);
 			main_menu_bar->set_start_index(0); // Main menu, add to the start of global menu.
 			main_menu_bar->set_prefer_global_menu(true);
 			left_hbox->add_child(main_menu_bar);
+			if (NativeMenu::get_singleton()->has_system_menu(NativeMenu::APPLICATION_MENU_ID)) {
+				PopupMenu *apple_menu = memnew(PopupMenu);
+				apple_menu->set_system_menu(NativeMenu::APPLICATION_MENU_ID);
+				main_menu_bar->add_child(apple_menu);
 
+				apple_menu->add_item(TTRC("Editor Settings..."), EDITOR_OPEN_SETTINGS, KeyModifierMask::META + Key::COMMA);
+				apple_menu->add_separator();
+				apple_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ProjectManager::_menu_option));
+			}
 			if (NativeMenu::get_singleton()->has_system_menu(NativeMenu::WINDOW_MENU_ID)) {
 				PopupMenu *window_menu = memnew(PopupMenu);
 				window_menu->set_system_menu(NativeMenu::WINDOW_MENU_ID);
@@ -1459,6 +1475,8 @@ ProjectManager::ProjectManager() {
 				main_menu_bar->add_child(help_menu);
 			}
 		}
+#endif
+
 		if (can_expand) {
 			// Spacer to center main toggles.
 			left_spacer = memnew(Control);

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -250,6 +250,12 @@ class ProjectManager : public Control {
 	Button *full_convert_button = nullptr;
 	Button *migration_guide_button = nullptr;
 
+	enum MenuOptions {
+		EDITOR_OPEN_SETTINGS,
+	};
+
+	void _menu_option(int p_option);
+
 	String version_convert_feature;
 	bool open_in_recovery_mode = false;
 	bool open_in_verbose_mode = false;

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -83,8 +83,6 @@ class QuickSettingsDialog : public AcceptDialog {
 	void _check_for_update_selected(int p_id);
 	void _directory_naming_convention_selected(int p_id);
 	void _set_setting_value(const String &p_setting, const Variant &p_value, bool p_restart_required = false);
-	void _show_full_settings();
-
 	Label *restart_required_label = nullptr;
 	Button *restart_required_button = nullptr;
 
@@ -95,6 +93,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	void _show_full_settings();
+
 	void update_size_limits(const Size2 &p_max_popup_size);
 
 	QuickSettingsDialog();


### PR DESCRIPTION
- Adds "Editor settings" to the project manager global menu (since it' now supported in project manager, and it is expected to be there on macOS).
- Adds "Window" menu to the editor global menu to ensure it is translated (part of https://github.com/godotengine/godot/pull/109138 lost in rebase).