### PR TITLE
Android: Fix ANRs when shutting down the engine due to the render thread

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -108,6 +108,8 @@ class Godot private constructor(val context: Context) {
 			}
 		}
 
+		private const val EXIT_RENDERER_TIMEOUT_IN_MS = 1500L
+
 		// Supported build flavors
 		private const val EDITOR_FLAVOR = "editor"
 		private const val TEMPLATE_FLAVOR = "template"
@@ -748,7 +750,12 @@ class Godot private constructor(val context: Context) {
 			plugin.onMainDestroy()
 		}
 
-		renderView?.onActivityDestroyed()
+		if (renderView?.blockingExitRenderer(EXIT_RENDERER_TIMEOUT_IN_MS) != true) {
+			Log.w(TAG, "Unable to exit the renderer within $EXIT_RENDERER_TIMEOUT_IN_MS ms... Force quitting the process.")
+			onGodotTerminating()
+			forceQuit(0)
+		}
+
 		this.primaryHost = null
 	}
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
@@ -132,8 +132,8 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 	}
 
 	@Override
-	public void onActivityDestroyed() {
-		requestRenderThreadExitAndWait();
+	public boolean blockingExitRenderer(long blockingTimeInMs) {
+		return requestRenderThreadExitAndWait(blockingTimeInMs);
 	}
 
 	@Override

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotRenderView.java
@@ -55,7 +55,7 @@ public interface GodotRenderView {
 
 	void onActivityStarted();
 
-	void onActivityDestroyed();
+	boolean blockingExitRenderer(long blockingTimeInMs);
 
 	GodotInputHandler getInputHandler();
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
@@ -117,8 +117,8 @@ class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderView {
 	}
 
 	@Override
-	public void onActivityDestroyed() {
-		requestRenderThreadExitAndWait();
+	public boolean blockingExitRenderer(long blockingTimeInMs) {
+		return requestRenderThreadExitAndWait(blockingTimeInMs);
 	}
 
 	@Override

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/gl/GLSurfaceView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/gl/GLSurfaceView.java
@@ -604,6 +604,18 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 			mGLThread.requestExitAndWait();
 		}
 	}
+
+	/**
+	 * Requests the render thread to exit and block up to the given timeInMs until it's done.
+	 *
+	 * @return true if the thread exited, false otherwise.
+	 */
+	protected final boolean requestRenderThreadExitAndWait(long timeInMs) {
+		if (mGLThread != null) {
+			return mGLThread.requestExitAndWait(timeInMs);
+		}
+		return false;
+	}
 	// -- GODOT end --
 
 	/**
@@ -1793,6 +1805,23 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 						Thread.currentThread().interrupt();
 					}
 				}
+			}
+		}
+
+		public boolean requestExitAndWait(long timeInMs) {
+			// Don't call this from GLThread thread or it is a guaranteed deadlock!
+			synchronized(sGLThreadManager) {
+				mShouldExit = true;
+				sGLThreadManager.notifyAll();
+				if (!mExited) {
+					try {
+						sGLThreadManager.wait(timeInMs);
+					} catch (InterruptedException ex) {
+						Thread.currentThread().interrupt();
+					}
+				}
+
+				return mExited;
 			}
 		}
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkSurfaceView.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkSurfaceView.kt
@@ -119,6 +119,15 @@ open internal class VkSurfaceView(context: Context) : SurfaceView(context), Surf
 		vkThread.requestExitAndWait()
 	}
 
+	/**
+	 * Requests the render thread to exit and block up to the given [timeInMs] until it's done.
+	 *
+	 * @return true if the thread exited, false otherwise.
+	 */
+	fun requestRenderThreadExitAndWait(timeInMs: Long): Boolean {
+		return vkThread.requestExitAndWait(timeInMs)
+	}
+
 	override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
 		vkThread.onSurfaceChanged(width, height)
 	}


### PR DESCRIPTION
This addresses the ANRs (Application Not Responding) reports from the Google Play and Horizon stores:
- Google Play store ANR report: https://play.google.com/console/u/0/developers/5310120689138741555/app/4972363226496209566/vitals/crashes/7e8d9c5b349a9251fd0c06401189a907/details?days=28&isUserPerceived=true
- Horizon store ANR report: https://developers.meta.com/horizon/manage/applications/7713660705416473/analytics/crash/?start=2025-11-19&end=2025-12-18&crashID=e887666e58e42180f65d8ae9a4086a59

Diving into the report from the Google Play store shows that the ANRs tend to occur on application exit when the main thread is waiting for the render thread to clean up and shutdown the engine.
```
"main" tid=1 Waiting
  at java.lang.Object.wait (Native method)
  at java.lang.Object.wait (Object.java:405)
  at java.lang.Object.wait (Object.java:543)
  at org.godotengine.godot.gl.GLSurfaceView$GLThread.requestExitAndWait (GLSurfaceView.java:1791)
  at org.godotengine.godot.gl.GLSurfaceView.requestRenderThreadExitAndWait (GLSurfaceView.java:604)
  at org.godotengine.godot.GodotGLRenderView.onActivityDestroyed (GodotGLRenderView.java:134)
  at org.godotengine.godot.Godot.onDestroy (Godot.kt:739)
  at org.godotengine.godot.Godot.destroyAndKillProcess$lambda$25 (Godot.kt:1072)
  at org.godotengine.godot.Godot.$r8$lambda$0Jotn_vpQ3wRkZHjwwa4O3QZtLs (unavailable)
  at org.godotengine.godot.Godot$$ExternalSyntheticLambda5.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:201)
  at android.os.Looper.loop (Looper.java:288)
  at android.app.ActivityThread.main (ActivityThread.java:7941)
  at java.lang.reflect.Method.invoke (Native method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:553)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1003)
```

In certain conditions however, the render thread ends up itself being blocked waiting on internal threads to complete their cleanup. For example, in the logs below, the render thread is blocked by the destruction of the `IP` object which is blocked on [`resolver->thread.wait_to_finish();`](https://github.com/godotengine/godot/blob/551ce8d47feda9c81c870314745366b24957624b/core/io/ip.cpp#L350).
```
"GLThread 1367" tid=15 Native
  #00  pc 0x000000000004c01c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28)
  #01  pc 0x00000000000b1cc8  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_join+244)
  #02  pc 0x00000000000dc040  /data/app/~~uaMD97Az4XPyvygrw4DQJw==/org.godotengine.editor.v4-k33iNo7R0XF9MVzrt8iUhA==/split_config.arm64_v8a.apk (std::__ndk1::thread::join()+191) (BuildId: 725db191d65be59dc18ddb3238f9e749442844a4)
  #03  pc 0x000000000813b5ec  /data/app/~~uaMD97Az4XPyvygrw4DQJw==/org.godotengine.editor.v4-k33iNo7R0XF9MVzrt8iUhA==/split_config.arm64_v8a.apk (Thread::wait_to_finish()+86) (BuildId: 149dd1732e747a99)
  #04  pc 0x0000000008295a60  /data/app/~~uaMD97Az4XPyvygrw4DQJw==/org.godotengine.editor.v4-k33iNo7R0XF9MVzrt8iUhA==/split_config.arm64_v8a.apk (IP::~IP()+350) (BuildId: 149dd1732e747a99)
  #05  pc 0x000000000807d424  /data/app/~~uaMD97Az4XPyvygrw4DQJw==/org.godotengine.editor.v4-k33iNo7R0XF9MVzrt8iUhA==/split_config.arm64_v8a.apk (unregister_core_types()+139) (BuildId: 149dd1732e747a99)
  #06  pc 0x00000000039f8784  /data/app/~~uaMD97Az4XPyvygrw4DQJw==/org.godotengine.editor.v4-k33iNo7R0XF9MVzrt8iUhA==/split_config.arm64_v8a.apk (Main::cleanup(bool)+5121) (BuildId: 149dd1732e747a99)
  #07  pc 0x000000000399b54c  /data/app/~~uaMD97Az4XPyvygrw4DQJw==/org.godotengine.editor.v4-k33iNo7R0XF9MVzrt8iUhA==/split_config.arm64_v8a.apk (_terminate(_JNIEnv*, bool)+109) (BuildId: 149dd1732e747a99)
  #08  pc 0x000000000399bbf0  /data/app/~~uaMD97Az4XPyvygrw4DQJw==/org.godotengine.editor.v4-k33iNo7R0XF9MVzrt8iUhA==/split_config.arm64_v8a.apk (Java_org_godotengine_godot_GodotLib_step+313) (BuildId: 149dd1732e747a99)
  at org.godotengine.godot.GodotLib.step (Native method)
  at org.godotengine.godot.gl.GodotRenderer.onDrawFrame (GodotRenderer.java:61)
  at org.godotengine.godot.gl.GLSurfaceView$GLThread.guardedRun (GLSurfaceView.java:1592)
  at org.godotengine.godot.gl.GLSurfaceView$GLThread.run (GLSurfaceView.java:1294)
```

This PR fixes the issue by adding a timeout for how long the main thread should wait for the render thread. On expiry of the timeout, the main thread gives up on waiting on the render thread and force kill the process.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
