### PR TITLE
[3.x] Fix editor potentially having multiple instances of the same subresource

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -336,6 +336,10 @@ void ResourceLoader::_remove_from_loading_map_and_thread(const String &p_path, T
 }
 
 RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p_no_cache, Error *r_error) {
+	return load(p_path, p_type_hint, p_no_cache, false, r_error);
+}
+
+RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p_no_cache, bool p_no_subresources_cache, Error *r_error) {
 	if (r_error) {
 		*r_error = ERR_CANT_OPEN;
 	}
@@ -386,7 +390,7 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p
 	}
 
 	print_verbose("Loading resource: " + path);
-	RES res = _load(path, local_path, p_type_hint, p_no_cache, r_error);
+	RES res = _load(path, local_path, p_type_hint, p_no_subresources_cache, r_error);
 
 	if (res.is_null()) {
 		if (!p_no_cache) {
@@ -453,6 +457,10 @@ bool ResourceLoader::exists(const String &p_path, const String &p_type_hint) {
 }
 
 Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String &p_path, const String &p_type_hint, bool p_no_cache, Error *r_error) {
+	return load_interactive(p_path, p_type_hint, p_no_cache, p_no_cache, r_error);
+}
+
+Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String &p_path, const String &p_type_hint, bool p_no_cache, bool p_no_subresources_cache, Error *r_error) {
 	if (r_error) {
 		*r_error = ERR_CANT_OPEN;
 	}
@@ -497,7 +505,7 @@ Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String &p_
 			continue;
 		}
 		found = true;
-		Ref<ResourceInteractiveLoader> ril = loader[i]->load_interactive(path, local_path, r_error, p_no_cache);
+		Ref<ResourceInteractiveLoader> ril = loader[i]->load_interactive(path, local_path, r_error, p_no_subresources_cache);
 		if (ril.is_null()) {
 			continue;
 		}

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -143,7 +143,9 @@ class ResourceLoader {
 
 public:
 	static Ref<ResourceInteractiveLoader> load_interactive(const String &p_path, const String &p_type_hint = "", bool p_no_cache = false, Error *r_error = nullptr);
+	static Ref<ResourceInteractiveLoader> load_interactive(const String &p_path, const String &p_type_hint, bool p_no_cache, bool p_no_subresources_cache, Error *r_error = nullptr);
 	static RES load(const String &p_path, const String &p_type_hint = "", bool p_no_cache = false, Error *r_error = nullptr);
+	static RES load(const String &p_path, const String &p_type_hint, bool p_no_cache, bool p_no_subresources_cache, Error *r_error = nullptr);
 	static bool exists(const String &p_path, const String &p_type_hint = "");
 
 	static void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1002,7 +1002,7 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 	dependency_errors.clear();
 
 	Error err;
-	RES res = ResourceLoader::load(p_resource, "", false, &err);
+	RES res = ResourceLoader::load(p_resource, "", false, false, &err);
 	ERR_FAIL_COND_V(!res.is_valid(), ERR_CANT_OPEN);
 
 	if (!p_ignore_broken_deps && dependency_errors.has(p_resource)) {
@@ -3686,7 +3686,10 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	dependency_errors.clear();
 
 	Error err;
-	Ref<PackedScene> sdata = ResourceLoader::load(lpath, "", true, &err);
+	// Subresources must use cache since they may already be referenced by other scenes.
+	// Otherwise, main and inherited scenes would contain different instances of the same
+	// resource, leading to superfluously saved subresources in derived scenes.
+	Ref<PackedScene> sdata = ResourceLoader::load(lpath, "", true, false, &err);
 	if (!sdata.is_valid()) {
 		_dialog_display_load_error(lpath, err);
 		opening_prev = false;


### PR DESCRIPTION
This fixes a nasty bug I've been having.

The issue can be reproduced as follows:
1. Create the scene inheritance chain A -> B -> C.
2. Put some kind of node in A with a subresource in a property. Save.
3. Open C.
4. Close A. Re-open A.
5. Save C.

You'll see that C now contains a copy of the subresource in A.

The editor loads scenes ignoring the cache, but subresources must still use it, because otherwise loading a higher-level scene will cause new instances of its subresources to be created, while deeply derived scenes will keep pointing to the ones before the load of the top scene.

This PR adds separate cache control for subresources and leverages it in the code where the editor loads a scene.

I've tested and will keep testing, but of course this is slippery ground, so let's be careful. 😀

---
This PR is proudly donated by [Pedrocorp](http://pedrocorp.net).