### PR TITLE
[3.x] Use approximate test when comparing properties, thoroughly

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -89,7 +89,7 @@ void Array::clear() {
 	_p->array.clear();
 }
 
-bool Array::deep_equal(const Array &p_array, int p_recursion_count) const {
+bool Array::deep_equal(const Array &p_array, int p_recursion_count, bool p_approximate) const {
 	// Cheap checks
 	ERR_FAIL_COND_V_MSG(p_recursion_count > MAX_RECURSION, true, "Max recursion reached");
 	if (_p == p_array._p) {
@@ -105,7 +105,7 @@ bool Array::deep_equal(const Array &p_array, int p_recursion_count) const {
 	// Heavy O(n) check
 	p_recursion_count++;
 	for (int i = 0; i < size; i++) {
-		if (!a1[i].deep_equal(a2[i], p_recursion_count)) {
+		if (!a1[i].deep_equal(a2[i], p_recursion_count, p_approximate)) {
 			return false;
 		}
 	}

--- a/core/array.h
+++ b/core/array.h
@@ -56,7 +56,7 @@ public:
 	bool empty() const;
 	void clear();
 
-	bool deep_equal(const Array &p_array, int p_recursion_count = 0) const;
+	bool deep_equal(const Array &p_array, int p_recursion_count = 0, bool p_approximate = false) const;
 	bool operator==(const Array &p_array) const;
 
 	uint32_t hash() const;

--- a/core/dictionary.cpp
+++ b/core/dictionary.cpp
@@ -162,7 +162,7 @@ bool Dictionary::erase(const Variant &p_key) {
 	return _p->variant_map.erase(p_key);
 }
 
-bool Dictionary::deep_equal(const Dictionary &p_dictionary, int p_recursion_count) const {
+bool Dictionary::deep_equal(const Dictionary &p_dictionary, int p_recursion_count, bool p_approximate) const {
 	// Cheap checks
 	ERR_FAIL_COND_V_MSG(p_recursion_count > MAX_RECURSION, 0, "Max recursion reached");
 	if (_p == p_dictionary._p) {
@@ -178,8 +178,8 @@ bool Dictionary::deep_equal(const Dictionary &p_dictionary, int p_recursion_coun
 	p_recursion_count++;
 	while (this_E && other_E) {
 		if (
-				!this_E.key().deep_equal(other_E.key(), p_recursion_count) ||
-				!this_E.value().deep_equal(other_E.value(), p_recursion_count)) {
+				!this_E.key().deep_equal(other_E.key(), p_recursion_count, p_approximate) ||
+				!this_E.value().deep_equal(other_E.value(), p_recursion_count, p_approximate)) {
 			return false;
 		}
 

--- a/core/dictionary.h
+++ b/core/dictionary.h
@@ -72,7 +72,7 @@ public:
 
 	bool erase(const Variant &p_key);
 
-	bool deep_equal(const Dictionary &p_dictionary, int p_recursion_count = 0) const;
+	bool deep_equal(const Dictionary &p_dictionary, int p_recursion_count = 0, bool p_approximate = false) const;
 	bool operator==(const Dictionary &p_dictionary) const;
 	bool operator!=(const Dictionary &p_dictionary) const;
 

--- a/core/variant.h
+++ b/core/variant.h
@@ -408,7 +408,7 @@ public:
 
 	//argsVariant call()
 
-	bool deep_equal(const Variant &p_variant, int p_recursion_count = 0) const;
+	bool deep_equal(const Variant &p_variant, int p_recursion_count = 0, bool p_approximate = false) const;
 	bool operator==(const Variant &p_variant) const;
 	bool operator!=(const Variant &p_variant) const;
 	bool operator<(const Variant &p_variant) const;

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -37,15 +37,11 @@
 #include "scene/resources/packed_scene.h"
 
 bool PropertyUtils::is_property_value_different(const Variant &p_a, const Variant &p_b) {
-	if (p_a.get_type() == Variant::REAL && p_b.get_type() == Variant::REAL) {
-		//this must be done because, as some scenes save as text, there might be a tiny difference in floats due to numerical error
-		return !Math::is_equal_approx((float)p_a, (float)p_b);
-	} else {
-		// For our purposes, treating null object as NIL is the right thing to do
-		const Variant &a = p_a.get_type() == Variant::OBJECT && (Object *)p_a == nullptr ? Variant() : p_a;
-		const Variant &b = p_b.get_type() == Variant::OBJECT && (Object *)p_b == nullptr ? Variant() : p_b;
-		return !a.deep_equal(b);
-	}
+	// For our purposes, treating null object as NIL is the right thing to do
+	const Variant &a = p_a.get_type() == Variant::OBJECT && (Object *)p_a == nullptr ? Variant() : p_a;
+	const Variant &b = p_b.get_type() == Variant::OBJECT && (Object *)p_b == nullptr ? Variant() : p_b;
+	// Approximation must be used because, as some scenes save as text, there might be a tiny difference in floats due to numerical error
+	return !a.deep_equal(b, 0, true);
 }
 
 Variant PropertyUtils::get_property_default_value(const Object *p_object, const StringName &p_property, bool *r_is_valid, const Vector<SceneState::PackState> *p_states_stack_cache, bool p_update_exports, const Node *p_owner, bool *r_is_class_default) {


### PR DESCRIPTION
I found the need for this when I realized derived scenes of one containing an `AnimationPlayer` were getting the blend times array duplicated on save.

Something like this: `blend_times = [ "cast", "stopped_caster", 0.3, "dodge", "stopped", 0.3, "dodge", "walk", 0.3, [...]`

Due to the `0.3` being processed differently for some reason in different places, the numeric imprecission would end up causing a comparison between something like `0.300001` and `2.999999`.

It may be good to hunt down the exact cause for the difference. However, since we are already applying loose comparison for cases like these, I've just extended the approximate comparison framework to work exhaustively.

It would be great to forward-port this to 4.x, but the codebase differs too much and it would require separate study.

---
This PR is proudly donated by [Pedrocorp](http://pedrocorp.net).