### PR TITLE
[3.x] Make physics interpolation compatible with separate-thread rendering

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2352,6 +2352,8 @@ bool Main::iteration() {
 	double step = advance.idle_step;
 	double scaled_step = step * time_scale;
 
+	VisualServer::get_singleton()->sync_and_halt();
+
 	Engine::get_singleton()->_frame_step = step;
 	Engine::get_singleton()->_physics_interpolation_fraction = advance.interpolation_fraction;
 
@@ -2386,9 +2388,11 @@ bool Main::iteration() {
 		// may be the same, and no interpolation takes place.
 		OS::get_singleton()->get_main_loop()->iteration_prepare();
 
-		PhysicsServer::get_singleton()->flush_queries();
-
 		Physics2DServer::get_singleton()->sync();
+
+		VisualServer::get_singleton()->thaw();
+
+		PhysicsServer::get_singleton()->flush_queries();
 		Physics2DServer::get_singleton()->flush_queries();
 
 		if (OS::get_singleton()->get_main_loop()->iteration(frame_slice * time_scale)) {
@@ -2399,6 +2403,8 @@ bool Main::iteration() {
 
 		NavigationServer::get_singleton_mut()->process(frame_slice * time_scale);
 		message_queue->flush();
+
+		VisualServer::get_singleton()->sync_and_halt();
 
 		PhysicsServer::get_singleton()->step(frame_slice * time_scale);
 
@@ -2414,6 +2420,8 @@ bool Main::iteration() {
 
 		Engine::get_singleton()->_in_physics = false;
 	}
+
+	VisualServer::get_singleton()->thaw();
 
 	if (InputDefault::get_singleton()->is_using_input_buffering() && agile_input_event_flushing) {
 		InputDefault::get_singleton()->flush_buffered_events();

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -133,7 +133,14 @@ void VisualServerRaster::draw(bool p_swap_buffers, double frame_step) {
 	}
 	VS::get_singleton()->emit_signal("frame_post_draw");
 }
+
 void VisualServerRaster::sync() {
+}
+
+void VisualServerRaster::sync_and_halt() {
+}
+
+void VisualServerRaster::thaw() {
 }
 
 void VisualServerRaster::set_physics_interpolation_enabled(bool p_enabled) {

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -803,6 +803,8 @@ public:
 	virtual void pre_draw(bool p_will_draw);
 	virtual void draw(bool p_swap_buffers, double frame_step);
 	virtual void sync();
+	virtual void sync_and_halt();
+	virtual void thaw();
 	virtual bool has_changed(ChangedPriority p_priority = CHANGED_PRIORITY_ANY) const;
 	virtual void init();
 	virtual void finish();

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -54,6 +54,9 @@ class VisualServerWrapMT : public VisualServer {
 	void thread_draw(bool p_swap_buffers, double frame_step);
 	void thread_flush();
 
+	Semaphore thread_halt_semaphore;
+	void thread_halt();
+
 	void thread_exit();
 
 	Mutex alloc_mutex;
@@ -709,6 +712,8 @@ public:
 	virtual void pre_draw(bool p_will_draw);
 	virtual void draw(bool p_swap_buffers, double frame_step);
 	virtual void sync();
+	virtual void sync_and_halt();
+	virtual void thaw();
 	FUNC1RC(bool, has_changed, ChangedPriority)
 	virtual void set_physics_interpolation_enabled(bool p_enabled);
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1189,6 +1189,8 @@ public:
 
 	virtual void draw(bool p_swap_buffers = true, double frame_step = 0.0) = 0;
 	virtual void sync() = 0;
+	virtual void sync_and_halt() = 0;
+	virtual void thaw() = 0;
 	virtual bool has_changed(ChangedPriority p_priority = CHANGED_PRIORITY_ANY) const = 0;
 	virtual void init() = 0;
 	virtual void finish() = 0;


### PR DESCRIPTION
This makes the `VisualServer` working in separate thread ("multi-threaded") mode halt and sync at the key moments that let it play nicely with physics interpolation.

I've tested and will keep testing, but seems fine so far.

---
This PR is proudly donated by [Pedrocorp](http://pedrocorp.net).