### PR TITLE
Add 'Copy All' button to Errors tab in debugger

### DIFF
--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -96,6 +96,7 @@ private:
 	Tree *error_tree = nullptr;
 	Button *expand_all_button = nullptr;
 	Button *collapse_all_button = nullptr;
+	Button *copy_all_button = nullptr;
 	Button *clear_button = nullptr;
 	PopupMenu *item_menu = nullptr;
 
@@ -265,6 +266,7 @@ private:
 
 	void _expand_errors_list();
 	void _collapse_errors_list();
+	void _copy_all_errors();
 
 	void _vmem_item_activated();
 


### PR DESCRIPTION
Adds a "Copy All" button to the Errors tab in the debugger panel, allowing users to copy all error messages to the clipboard at once.

Why:

- Makes it easier to share errors when asking for help (forums, Discord, bug reports)
- Useful for pasting into external tools or documentation
- Saves time compared to manually selecting/copying each error individually

<img width="478" height="160" alt="{C60B8EA9-767C-4AF1-B026-34683497FB4C}" src="https://github.com/user-attachments/assets/58ffb252-9500-40b8-867d-79b5f6402e5b" />

Result from pressing it:
```
E 0:00:02:408   main_menu.gd:133 @ _ready(): First error
  <C++ Source>  core\variant\variant_utility.cpp:1024 @ push_error()
  <Stack Trace> main_menu.gd:133 @ _ready()
                main_menu_with_animations.gd:55 @ _ready()
E 0:00:02:408   main_menu.gd:134 @ _ready(): Second error
  <C++ Source>  core\variant\variant_utility.cpp:1024 @ push_error()
  <Stack Trace> main_menu.gd:134 @ _ready()
                main_menu_with_animations.gd:55 @ _ready()
W 0:00:02:408   main_menu.gd:135 @ _ready(): A warning
  <C++ Source>  core\variant\variant_utility.cpp:1034 @ push_warning()
  <Stack Trace> main_menu.gd:135 @ _ready()
                main_menu_with_animations.gd:55 @ _ready()
```