### PR TITLE
Use float for TextEdit horizontal margins

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -352,7 +352,7 @@
 		</method>
 		<method name="get_line_column_at_pos" qualifiers="const">
 			<return type="Vector2i" />
-			<param index="0" name="position" type="Vector2i" />
+			<param index="0" name="position" type="Vector2" />
 			<param index="1" name="clamp_line" type="bool" default="true" />
 			<param index="2" name="clamp_column" type="bool" default="true" />
 			<description>
@@ -1372,7 +1372,7 @@
 		<member name="scroll_fit_content_width" type="bool" setter="set_fit_content_width_enabled" getter="is_fit_content_width_enabled" default="false">
 			If [code]true[/code], [TextEdit] will disable horizontal scroll and fit minimum width to the widest line in the text. When both this property and [member scroll_fit_content_height] are [code]true[/code], no scrollbars will be displayed.
 		</member>
-		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
+		<member name="scroll_horizontal" type="float" setter="set_h_scroll" getter="get_h_scroll" default="0.0">
 			If there is a horizontal scrollbar, this determines the current horizontal scroll value in pixels.
 		</member>
 		<member name="scroll_past_end_of_file" type="bool" setter="set_scroll_past_end_of_file_enabled" getter="is_scroll_past_end_of_file_enabled" default="false">

--- a/misc/extension_api_validation/4.6-stable/GH-114221.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-114221.txt
@@ -1,0 +1,10 @@
+GH-114221
+--------
+Validate extension JSON: Error: Field 'classes/TextEdit/methods/get_line_column_at_pos/arguments/0': type changed value in new API, from "Vector2i" to "Vector2".
+Validate extension JSON: Error: Field 'classes/TextEdit/methods/set_h_scroll/arguments/0': type changed value in new API, from "int" to "float".
+Validate extension JSON: Error: Field 'classes/TextEdit/methods/set_h_scroll/arguments/0': meta changed value in new API, from "int32" to "double".
+Validate extension JSON: Error: Field 'classes/TextEdit/methods/get_h_scroll/return_value': type changed value in new API, from "int" to "float".
+Validate extension JSON: Error: Field 'classes/TextEdit/methods/get_h_scroll/return_value': meta changed value in new API, from "int32" to "double".
+Validate extension JSON: Error: Field 'classes/TextEdit/properties/scroll_horizontal': type changed value in new API, from "int" to "float".
+
+Changed `get_line_column_at_pos` to use `Vector2` to be more accurate. Changed horizontal scroll from `int` to `double` to match the vertical scroll. Compatibility methods registered.

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -296,12 +296,11 @@ void CodeEdit::_draw_guidelines() {
 	const bool rtl = is_layout_rtl();
 
 	Ref<StyleBox> style = is_editable() ? theme_cache.style_normal : theme_cache.style_readonly;
-	const int xmargin_beg = style->get_margin(SIDE_LEFT) + get_total_gutter_width();
-	const int xmargin_end = size.width - style->get_margin(SIDE_RIGHT) - (is_drawing_minimap() ? get_minimap_width() : 0);
-
+	const float xmargin_beg = style->get_margin(SIDE_LEFT) + get_total_gutter_width();
+	const float xmargin_end = size.width - style->get_margin(SIDE_RIGHT) - (is_drawing_minimap() ? get_minimap_width() : 0);
 	for (int i = 0; i < line_length_guideline_columns.size(); i++) {
-		const int column_pos = theme_cache.font->get_string_size(String("0").repeat((int)line_length_guideline_columns[i]), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
-		const int xoffset = xmargin_beg + column_pos - get_h_scroll();
+		const float column_pos = theme_cache.font->get_string_size(String("0").repeat((int)line_length_guideline_columns[i]), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
+		const float xoffset = xmargin_beg + column_pos - get_h_scroll();
 		if (xoffset > xmargin_beg && xoffset < xmargin_end) {
 			Color guideline_color = (i == 0) ? theme_cache.line_length_guideline_color : theme_cache.line_length_guideline_color * Color(1, 1, 1, 0.5);
 			if (rtl) {
@@ -423,7 +422,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		set_code_hint("");
 
 		if (mb->is_pressed()) {
-			Vector2i mpos = mb->get_position();
+			Vector2 mpos = mb->get_position();
 			if (is_layout_rtl()) {
 				mpos.x = get_size().x - mpos.x;
 			}
@@ -448,7 +447,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		} else {
 			if (mb->get_button_index() == MouseButton::LEFT) {
 				if (mb->is_command_or_control_pressed() && !symbol_lookup_word.is_empty()) {
-					Vector2i mpos = mb->get_position();
+					Vector2 mpos = mb->get_position();
 					if (is_layout_rtl()) {
 						mpos.x = get_size().x - mpos.x;
 					}
@@ -468,7 +467,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 	Ref<InputEventMouseMotion> mm = p_gui_input;
 	if (mm.is_valid()) {
-		Vector2i mpos = mm->get_position();
+		Vector2 mpos = mm->get_position();
 		if (is_layout_rtl()) {
 			mpos.x = get_size().x - mpos.x;
 		}
@@ -2517,8 +2516,7 @@ bool CodeEdit::is_symbol_lookup_on_click_enabled() const {
 }
 
 String CodeEdit::get_text_for_symbol_lookup() const {
-	Point2i mp = get_local_mouse_pos();
-	Point2i pos = get_line_column_at_pos(mp, false, false);
+	Point2i pos = get_line_column_at_pos(get_local_mouse_pos(), false, false);
 	int line = pos.y;
 	int col = pos.x;
 

--- a/scene/gui/text_edit.compat.inc
+++ b/scene/gui/text_edit.compat.inc
@@ -38,9 +38,24 @@ Point2i TextEdit::_get_line_column_at_pos_bind_compat_100913(const Point2i &p_po
 	return get_line_column_at_pos(p_pos, p_allow_out_of_bounds, true);
 }
 
+Point2i TextEdit::get_line_column_at_pos_bind_compat_114221(const Point2i &p_pos, bool p_clamp_line, bool p_clamp_column) const {
+	return get_line_column_at_pos(p_pos, p_clamp_line, p_clamp_column);
+}
+
+void TextEdit::set_h_scroll_bind_compat_114221(int p_scroll) {
+	set_h_scroll(p_scroll);
+}
+
+int TextEdit::get_h_scroll_bind_compat_114221() const {
+	return get_h_scroll();
+}
+
 void TextEdit::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("set_selection_mode", "mode", "line", "column", "caret_index"), &TextEdit::_set_selection_mode_compat_86978, DEFVAL(-1), DEFVAL(-1), DEFVAL(0));
 	ClassDB::bind_compatibility_method(D_METHOD("get_line_column_at_pos", "position", "allow_out_of_bounds"), &TextEdit::_get_line_column_at_pos_bind_compat_100913, DEFVAL(true));
+	ClassDB::bind_compatibility_method(D_METHOD("get_line_column_at_pos", "position", "clamp_line", "clamp_column"), &TextEdit::get_line_column_at_pos_bind_compat_114221, DEFVAL(true), DEFVAL(true));
+	ClassDB::bind_compatibility_method(D_METHOD("set_h_scroll", "value"), &TextEdit::set_h_scroll_bind_compat_114221);
+	ClassDB::bind_compatibility_method(D_METHOD("get_h_scroll"), &TextEdit::get_h_scroll_bind_compat_114221);
 }
 
 #endif

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -767,7 +767,7 @@ void TextEdit::_notification(int p_what) {
 			int first_vis_line = get_first_visible_line();
 			int row_height = get_line_height();
 			Ref<StyleBox> style = _get_current_stylebox();
-			int xmargin_beg = Math::ceil(style->get_margin(SIDE_LEFT)) + gutters_width + gutter_padding;
+			float xmargin_beg = style->get_margin(SIDE_LEFT) + gutters_width + gutter_padding;
 			Size2 size = get_size();
 			bool rtl = is_layout_rtl();
 			int lines_drawn = 0;
@@ -790,7 +790,7 @@ void TextEdit::_notification(int p_what) {
 					text_off_y -= _get_v_scroll_offset() * row_height;
 
 					float wrap_indent = j > first_indent_line ? indent_ofs : 0.0;
-					int char_margin = xmargin_beg - first_visible_col;
+					float char_margin = xmargin_beg - first_visible_col;
 					if (rtl) {
 						char_margin = size.width - char_margin - ac_buf->get_line_width(j) - wrap_indent;
 					} else {
@@ -935,10 +935,10 @@ void TextEdit::_notification(int p_what) {
 			RS::get_singleton()->canvas_item_set_visibility_layer(text_ci, get_visibility_layer());
 			RS::get_singleton()->canvas_item_set_default_texture_filter(text_ci, RS::CanvasItemTextureFilter(get_texture_filter_in_tree()));
 
-			int left_margin = Math::ceil(style->get_margin(SIDE_LEFT));
-			int xmargin_beg = left_margin + gutters_width + gutter_padding;
+			float left_margin = style->get_margin(SIDE_LEFT);
+			float xmargin_beg = left_margin + gutters_width + gutter_padding;
 
-			int xmargin_end = size.width - Math::ceil(style->get_margin(SIDE_RIGHT));
+			float xmargin_end = size.width - style->get_margin(SIDE_RIGHT);
 			if (draw_minimap) {
 				xmargin_end -= minimap_width;
 			}
@@ -1239,7 +1239,7 @@ void TextEdit::_notification(int p_what) {
 						Color next_color = current_color;
 						int characters = 0;
 						int tab_alignment = 0;
-						int xpos = xmargin_end + 2 + indent_px;
+						float xpos = xmargin_end + 2 + indent_px;
 						for (int j = 0; j < str.length(); j++) {
 							bool next_is_whitespace = false;
 							bool next_is_tab = false;
@@ -1371,9 +1371,9 @@ void TextEdit::_notification(int p_what) {
 					}
 
 					const String &str = wrap_rows[line_wrap_index];
-					int char_margin = xmargin_beg - first_visible_col;
+					float char_margin = xmargin_beg - first_visible_col;
 
-					int ofs_y = style->get_margin(SIDE_TOP);
+					int ofs_y = top_limit_y;
 
 					ofs_y += i * row_height + theme_cache.line_spacing / 2;
 					ofs_y -= first_visible_line_wrap_ofs * row_height;
@@ -1414,7 +1414,7 @@ void TextEdit::_notification(int p_what) {
 
 						cache_entry.y_offset = ofs_y;
 
-						int gutter_offset = left_margin;
+						float gutter_offset = left_margin;
 						for (int g = 0; g < gutters.size(); g++) {
 							const GutterInfo &gutter = gutters[g];
 
@@ -1714,7 +1714,7 @@ void TextEdit::_notification(int p_what) {
 								theme_cache.tab_icon->draw(text_ci, Point2(char_pos, ofs_y + yofs), gl_color);
 							} else if (draw_spaces && ((glyphs[j].flags & TextServer::GRAPHEME_IS_SPACE) == TextServer::GRAPHEME_IS_SPACE) && ((glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL)) {
 								int yofs = (text_height - theme_cache.space_icon->get_height()) / 2 - ldata->get_line_ascent(line_wrap_index);
-								int xofs = (glyphs[j].advance * glyphs[j].repeat - theme_cache.space_icon->get_width()) / 2;
+								float xofs = (glyphs[j].advance * glyphs[j].repeat - theme_cache.space_icon->get_width()) / 2;
 								theme_cache.space_icon->draw(text_ci, Point2(char_pos + xofs, ofs_y + yofs), gl_color);
 							}
 						}
@@ -1752,7 +1752,7 @@ void TextEdit::_notification(int p_what) {
 
 					// is_line_folded
 					if (line_wrap_index == line_wrap_amount && line < text.size() - 1 && _is_line_hidden(line + 1)) {
-						int xofs = char_ofs + char_margin + (_get_folded_eol_icon()->get_width() / 2);
+						float xofs = char_ofs + char_margin + (_get_folded_eol_icon()->get_width() / 2);
 						if (xofs >= xmargin_beg && xofs < xmargin_end) {
 							int yofs = (text_height - _get_folded_eol_icon()->get_height()) / 2 - ldata->get_line_ascent(line_wrap_index);
 							Color eol_color = _get_code_folding_color();
@@ -2237,7 +2237,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	Ref<InputEventMouseButton> mb = p_gui_input;
 
 	if (mb.is_valid()) {
-		Vector2i mpos = mb->get_position();
+		Vector2 mpos = mb->get_position();
 		if (is_layout_rtl()) {
 			mpos.x = get_size().x - mpos.x;
 		}
@@ -2295,7 +2295,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					emit_signal(SNAME("gutter_clicked"), hovered_gutter.y, hovered_gutter.x);
 					return;
 				}
-				int left_margin = Math::ceil(_get_current_stylebox()->get_margin(SIDE_LEFT));
+				float left_margin = _get_current_stylebox()->get_margin(SIDE_LEFT);
 				if (mpos.x < left_margin + gutters_width + gutter_padding) {
 					return;
 				}
@@ -2396,7 +2396,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				// Click inline objects.
 				if (inline_object_click_handler.is_valid()) {
-					int xmargin_beg = left_margin + gutters_width + gutter_padding;
+					float xmargin_beg = left_margin + gutters_width + gutter_padding;
 					int wrap_i = get_line_wrap_index_at_column(pos.y, pos.x);
 					const float wrap_indent = _get_wrap_indent_offset(pos.y, wrap_i, is_layout_rtl());
 
@@ -2512,7 +2512,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	Ref<InputEventMouseMotion> mm = p_gui_input;
 
 	if (mm.is_valid()) {
-		Vector2i mpos = mm->get_position();
+		Vector2 mpos = mm->get_position();
 		if (is_layout_rtl()) {
 			mpos.x = get_size().x - mpos.x;
 		}
@@ -3601,20 +3601,20 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 		}
 	}
 	Ref<StyleBox> style = _get_current_stylebox();
-	int left_margin = Math::ceil(style->get_margin(SIDE_LEFT));
+	float left_margin = style->get_margin(SIDE_LEFT);
 	if (p_pos.x < left_margin + gutters_width + gutter_padding) {
 		return CURSOR_ARROW;
 	}
 
-	int xmargin_end = get_size().width - Math::ceil(style->get_margin(SIDE_RIGHT));
-	if (draw_minimap && p_pos.x > xmargin_end - minimap_width && p_pos.x <= xmargin_end) {
+	float xmargin_end = get_size().width - style->get_margin(SIDE_RIGHT);
+	if (draw_minimap && p_pos.x >= xmargin_end - minimap_width && p_pos.x <= xmargin_end) {
 		return CURSOR_ARROW;
 	}
 
 	// Hover inline objects.
 	if (inline_object_click_handler.is_valid()) {
 		Point2i pos = get_line_column_at_pos(p_pos);
-		int xmargin_beg = left_margin + gutters_width + gutter_padding;
+		float xmargin_beg = left_margin + gutters_width + gutter_padding;
 		int wrap_i = get_line_wrap_index_at_column(pos.y, pos.x);
 		const float wrap_indent = _get_wrap_indent_offset(pos.y, wrap_i, is_layout_rtl());
 
@@ -4995,7 +4995,7 @@ String TextEdit::get_word(int p_line, int p_column) const {
 	return String();
 }
 
-Point2i TextEdit::get_line_column_at_pos(const Point2i &p_pos, bool p_clamp_line, bool p_clamp_column) const {
+Point2i TextEdit::get_line_column_at_pos(const Point2 &p_pos, bool p_clamp_line, bool p_clamp_column) const {
 	Ref<StyleBox> style = _get_current_stylebox();
 	float rows = p_pos.y - (style->get_margin(SIDE_TOP) + (theme_cache.line_spacing / 2));
 	rows /= get_line_height();
@@ -5024,7 +5024,7 @@ Point2i TextEdit::get_line_column_at_pos(const Point2i &p_pos, bool p_clamp_line
 		}
 		return Point2i(-1, -1);
 	}
-	int colx = p_pos.x - (Math::ceil(style->get_margin(SIDE_LEFT)) + gutters_width + gutter_padding);
+	float colx = p_pos.x - (style->get_margin(SIDE_LEFT) + gutters_width + gutter_padding);
 	colx += first_visible_col;
 
 	RID text_rid = text.get_line_data(row)->get_line_rid(wrap_index);
@@ -5089,9 +5089,9 @@ Rect2i TextEdit::get_rect_at_line_column(int p_line, int p_column) const {
 
 	const float wrap_indent = _get_wrap_indent_offset(p_line, wrap_index, is_layout_rtl());
 
-	Point2i pos, size;
+	Point2 pos, size;
 	pos.y = cache_entry.y_offset + get_line_height() * wrap_index;
-	pos.x = get_total_gutter_width() + Math::ceil(_get_current_stylebox()->get_margin(SIDE_LEFT)) + wrap_indent - get_h_scroll();
+	pos.x = get_total_gutter_width() + _get_current_stylebox()->get_margin(SIDE_LEFT) + wrap_indent - get_h_scroll();
 
 	RID text_rid = text.get_line_data(p_line)->get_line_rid(wrap_index);
 	Vector2 col_bounds = TS->shaped_text_get_grapheme_bounds(text_rid, p_column);
@@ -6481,7 +6481,7 @@ double TextEdit::get_v_scroll() const {
 	return v_scroll->get_value();
 }
 
-void TextEdit::set_h_scroll(int p_scroll) {
+void TextEdit::set_h_scroll(double p_scroll) {
 	if (p_scroll < 0) {
 		p_scroll = 0;
 	}
@@ -6489,7 +6489,7 @@ void TextEdit::set_h_scroll(int p_scroll) {
 	queue_accessibility_update();
 }
 
-int TextEdit::get_h_scroll() const {
+double TextEdit::get_h_scroll() const {
 	return h_scroll->get_value();
 }
 
@@ -7577,7 +7577,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_v_scroll_speed", PROPERTY_HINT_NONE, "suffix:lines/s"), "set_v_scroll_speed", "get_v_scroll_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_past_end_of_file"), "set_scroll_past_end_of_file_enabled", "is_scroll_past_end_of_file_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_vertical", PROPERTY_HINT_NONE, "suffix:lines"), "set_v_scroll", "get_v_scroll");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_horizontal", PROPERTY_HINT_NONE, "suffix:px"), "set_h_scroll", "get_h_scroll");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_horizontal", PROPERTY_HINT_NONE, "suffix:px"), "set_h_scroll", "get_h_scroll");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_fit_content_height"), "set_fit_content_height_enabled", "is_fit_content_height_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_fit_content_width"), "set_fit_content_width_enabled", "is_fit_content_width_enabled");
 
@@ -8278,7 +8278,7 @@ void TextEdit::_toggle_draw_caret() {
 	}
 }
 
-int TextEdit::_get_column_x_offset_for_line(int p_char, int p_line, int p_column) const {
+float TextEdit::_get_column_x_offset_for_line(int p_char, int p_line, int p_column) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), 0);
 
 	int wrap_index = 0;
@@ -8542,7 +8542,7 @@ bool TextEdit::_selection_contains(int p_caret, int p_line, int p_column, bool p
 
 /* Line Wrapping */
 void TextEdit::_update_wrap_at_column(bool p_force) {
-	int new_wrap_at = get_size().width - _get_current_stylebox()->get_minimum_size().width - gutters_width - gutter_padding;
+	float new_wrap_at = get_size().width - _get_current_stylebox()->get_minimum_size().width - gutters_width - gutter_padding;
 	if (draw_minimap) {
 		new_wrap_at -= minimap_width;
 	}
@@ -8612,7 +8612,7 @@ void TextEdit::_update_scrollbars() {
 		total_rows += visible_rows - 1;
 	}
 
-	int visible_width = size.width - style->get_minimum_size().width;
+	float visible_width = size.width - style->get_minimum_size().width;
 	int total_width = (draw_placeholder ? placeholder_max_width : text.get_max_width()) + gutters_width + gutter_padding;
 
 	if (draw_minimap) {
@@ -8646,10 +8646,10 @@ void TextEdit::_update_scrollbars() {
 		h_scroll->show();
 		h_scroll->set_max(total_width);
 		h_scroll->set_page(visible_width);
-		if (first_visible_col > (total_width - visible_width)) {
-			first_visible_col = (total_width - visible_width);
+		if (first_visible_col > total_width - visible_width) {
+			first_visible_col = total_width - visible_width;
 		}
-		if (std::fabs(h_scroll->get_value() - (double)first_visible_col) >= 1) {
+		if (Math::abs(h_scroll->get_value() - (double)first_visible_col) >= 1) {
 			h_scroll->set_value(first_visible_col);
 		}
 
@@ -8833,7 +8833,7 @@ void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret, bool p_maximi
 		return;
 	}
 
-	int visible_width = get_size().width - _get_current_stylebox()->get_minimum_size().width - gutters_width - gutter_padding;
+	float visible_width = get_size().width - _get_current_stylebox()->get_minimum_size().width - gutters_width - gutter_padding;
 	if (draw_minimap) {
 		visible_width -= minimap_width;
 	}
@@ -8847,8 +8847,8 @@ void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret, bool p_maximi
 		return;
 	}
 
-	int caret_start_pos;
-	int caret_end_pos;
+	float caret_start_pos;
+	float caret_end_pos;
 	bool prioritize_end = true;
 
 	// Get start and end position of the caret.
@@ -8895,9 +8895,9 @@ void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret, bool p_maximi
 
 void TextEdit::_update_minimap_hover() {
 	const Point2 mp = get_local_mouse_pos();
-	const int xmargin_end = get_size().width - Math::ceil(_get_current_stylebox()->get_margin(SIDE_RIGHT));
+	const float xmargin_end = get_size().width - _get_current_stylebox()->get_margin(SIDE_RIGHT);
 
-	bool hovering_sidebar = mp.x > xmargin_end - minimap_width && mp.x < xmargin_end;
+	bool hovering_sidebar = mp.x >= xmargin_end - minimap_width && mp.x <= xmargin_end;
 	if (!hovering_sidebar) {
 		if (hovering_minimap) {
 			// Only redraw if the hovering status changed.
@@ -8922,7 +8922,7 @@ void TextEdit::_update_minimap_hover() {
 void TextEdit::_update_minimap_click() {
 	Point2 mp = get_local_mouse_pos();
 
-	int xmargin_end = get_size().width - Math::ceil(_get_current_stylebox()->get_margin(SIDE_RIGHT));
+	float xmargin_end = get_size().width - _get_current_stylebox()->get_margin(SIDE_RIGHT);
 	if (!dragging_minimap && (mp.x < xmargin_end - minimap_width || mp.x > xmargin_end)) {
 		minimap_clicked = false;
 		return;
@@ -8985,7 +8985,7 @@ void TextEdit::_update_gutter_width() {
 }
 
 Vector2i TextEdit::_get_hovered_gutter(const Point2 &p_mouse_pos) const {
-	int left_margin = Math::ceil(_get_current_stylebox()->get_margin(SIDE_LEFT));
+	float left_margin = _get_current_stylebox()->get_margin(SIDE_LEFT);
 	if (p_mouse_pos.x > left_margin + gutters_width + gutter_padding) {
 		return Vector2i(-1, -1);
 	}

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -486,7 +486,7 @@ private:
 	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();
 
-	int _get_column_x_offset_for_line(int p_char, int p_line, int p_column) const;
+	float _get_column_x_offset_for_line(int p_char, int p_line, int p_column) const;
 	bool _is_line_col_in_range(int p_line, int p_column, int p_from_line, int p_from_column, int p_to_line, int p_to_column, bool p_include_edges = true) const;
 
 	void _offset_carets_after(int p_old_line, int p_old_column, int p_new_line, int p_new_column, bool p_include_selection_begin = true, bool p_include_selection_end = true);
@@ -547,7 +547,7 @@ private:
 	// Scrolling.
 	int first_visible_line = 0;
 	int first_visible_line_wrap_ofs = 0;
-	int first_visible_col = 0;
+	float first_visible_col = 0;
 
 	bool scrolling = false;
 	bool updating_scrolls = false;
@@ -701,6 +701,9 @@ protected:
 #ifndef DISABLE_DEPRECATED
 	void _set_selection_mode_compat_86978(SelectionMode p_mode, int p_line = -1, int p_column = -1, int p_caret = 0);
 	Point2i _get_line_column_at_pos_bind_compat_100913(const Point2i &p_pos, bool p_allow_out_of_bounds = true) const;
+	Point2i get_line_column_at_pos_bind_compat_114221(const Point2i &p_pos, bool p_clamp_line = true, bool p_clamp_column = true) const;
+	void set_h_scroll_bind_compat_114221(int p_scroll);
+	int get_h_scroll_bind_compat_114221() const;
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 
@@ -934,7 +937,7 @@ public:
 	String get_word_at_pos(const Vector2 &p_pos) const;
 	String get_word(int p_line, int p_column) const;
 
-	Point2i get_line_column_at_pos(const Point2i &p_pos, bool p_clamp_line = true, bool p_clamp_column = true) const;
+	Point2i get_line_column_at_pos(const Point2 &p_pos, bool p_clamp_line = true, bool p_clamp_column = true) const;
 	Point2i get_pos_at_line_column(int p_line, int p_column) const;
 	Rect2i get_rect_at_line_column(int p_line, int p_column) const;
 
@@ -1064,8 +1067,8 @@ public:
 	void set_v_scroll(double p_scroll);
 	double get_v_scroll() const;
 
-	void set_h_scroll(int p_scroll);
-	int get_h_scroll() const;
+	void set_h_scroll(double p_scroll);
+	double get_h_scroll() const;
 
 	void set_v_scroll_speed(float p_speed);
 	float get_v_scroll_speed() const;

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -6690,21 +6690,21 @@ TEST_CASE("[SceneTree][TextEdit] mouse") {
 	Point2i start_pos = text_edit->get_pos_at_line_column(0, 0);
 	Point2i end_pos = text_edit->get_pos_at_line_column(0, 104);
 
-	CHECK(text_edit->get_line_column_at_pos(Point2i(start_pos.x, start_pos.y)) == Point2i(0, 0));
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x, end_pos.y)) == Point2i(103, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(start_pos.x, start_pos.y)) == Point2i(0, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x, end_pos.y)) == Point2i(103, 0));
 
 	// Should this return Point2i(-1, -1) if its also < 0 not just > vis_lines.
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x - 100, end_pos.y), false) == Point2i(88, 0));
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x, end_pos.y + 100), false) == Point2i(-1, -1));
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x - 100, end_pos.y + 100), false) == Point2i(-1, -1));
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x, end_pos.y - 100), false) == Point2i(103, 0));
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x - 100, end_pos.y - 100), false) == Point2i(88, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x - 100, end_pos.y), false) == Point2i(88, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x, end_pos.y + 100), false) == Point2i(-1, -1));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x - 100, end_pos.y + 100), false) == Point2i(-1, -1));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x, end_pos.y - 100), false) == Point2i(103, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x - 100, end_pos.y - 100), false) == Point2i(88, 0));
 
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x - 100, end_pos.y)) == Point2i(88, 0));
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x, end_pos.y + 100)) == Point2i(140, 0));
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x - 100, end_pos.y + 100)) == Point2i(140, 0));
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x, end_pos.y - 100)) == Point2i(103, 0));
-	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x - 100, end_pos.y - 100)) == Point2i(88, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x - 100, end_pos.y)) == Point2i(88, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x, end_pos.y + 100)) == Point2i(140, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x - 100, end_pos.y + 100)) == Point2i(140, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x, end_pos.y - 100)) == Point2i(103, 0));
+	CHECK(text_edit->get_line_column_at_pos(Point2(end_pos.x - 100, end_pos.y - 100)) == Point2i(88, 0));
 
 	memdelete(text_edit);
 }


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/108520
- Fixes https://github.com/godotengine/godot/issues/110577 (same)
- Reverts https://github.com/godotengine/godot/pull/105870
- Alternate fix for https://github.com/godotengine/godot/issues/105827
- Alternate to https://github.com/godotengine/godot/pull/110791

This makes TextEdit (and CodeEdit) use floats for left and right content margins.
This doesn't affect the top and bottom ones since there isn't an issue with them currently and other controls that draw text seem to snap text to integers vertically anyway.
Changes `get_line_column_at_pos` to accept Vector2 instead of Vector2i since it is used with the mouse position which is a Vector2.
The `h_scroll` functions now uses double to pass to the scrollbar, like the `v_scroll` ones.
Also changed some of the minimap horizontal mouse checks to be consistent so the hover and click detection matches the cursor.

Note that TextEdit still has lots of issues in rtl layout mode, but the specific case in #105827 where the stylebox left and right margins were equal and ended with .5 or greater is fine.
This is easier to test with https://github.com/godotengine/godot/pull/114217