### PR TITLE
Fix outdated comment in `CanvasItem.draw_string()` code sample

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -376,20 +376,10 @@
 				[b]Example:[/b] Draw "Hello world", using the project's default font:
 				[codeblocks]
 				[gdscript]
-				# If using this method in a script that redraws constantly, move the
-				# `default_font` declaration to a member variable assigned in `_ready()`
-				# so the Control is only created once.
-				var default_font = ThemeDB.fallback_font
-				var default_font_size = ThemeDB.fallback_font_size
-				draw_string(default_font, Vector2(64, 64), "Hello world", HORIZONTAL_ALIGNMENT_LEFT, -1, default_font_size)
+				draw_string(ThemeDB.fallback_font, Vector2(64, 64), "Hello world", HORIZONTAL_ALIGNMENT_LEFT, -1, ThemeDB.fallback_font_size)
 				[/gdscript]
 				[csharp]
-				// If using this method in a script that redraws constantly, move the
-				// `default_font` declaration to a member variable assigned in `_Ready()`
-				// so the Control is only created once.
-				Font defaultFont = ThemeDB.FallbackFont;
-				int defaultFontSize = ThemeDB.FallbackFontSize;
-				DrawString(defaultFont, new Vector2(64, 64), "Hello world", HORIZONTAL_ALIGNMENT_LEFT, -1, defaultFontSize);
+				DrawString(ThemeDB.FallbackFont, new Vector2(64, 64), "Hello world", HorizontalAlignment.Left, -1, ThemeDB.FallbackFontSize);
 				[/csharp]
 				[/codeblocks]
 				See also [method Font.draw_string].


### PR DESCRIPTION
For context, this is what the comment was originally referring to: https://github.com/godotengine/godot/commit/0c7735be5b3404b87a1801d7494dd2ac42e6571b

- Simplify the code sample by removing obsolete caching mechanism (there is no more need to create a Control node to get the defaul font and its size).
