### PR TITLE
Fix OpenGL motion vector regression

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2411,8 +2411,8 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 
 	scene_state.data.emissive_exposure_normalization = -1.0; // Use default exposure normalization.
 
-	bool enough_vertex_attribs_for_motion_blue = GLES3::Config::get_singleton()->max_vertex_attribs >= 22;
-	if (rt && rt->overridden.velocity_fbo != 0 && enough_vertex_attribs_for_motion_blue) {
+	bool enough_vertex_attribs_for_motion_vectors = GLES3::Config::get_singleton()->max_vertex_attribs >= 22;
+	if (rt && rt->overridden.velocity_fbo != 0 && enough_vertex_attribs_for_motion_vectors) {
 		// First frame we render motion vectors? Use our current data!
 		if (scene_state.prev_data_state == 0) {
 			scene_state.prev_data_state = 1;
@@ -2534,7 +2534,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	scene_state.reset_gl_state();
 
 	GLuint motion_vectors_fbo = rt ? rt->overridden.velocity_fbo : 0;
-	if (motion_vectors_fbo != 0 && enough_vertex_attribs_for_motion_blue) {
+	if (motion_vectors_fbo != 0 && enough_vertex_attribs_for_motion_vectors) {
 		RENDER_TIMESTAMP("Motion Vectors Pass");
 		glBindFramebuffer(GL_FRAMEBUFFER, motion_vectors_fbo);
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -231,7 +231,10 @@ layout(std140) uniform SceneDataBlock { // ubo:2
 scene_data_block;
 
 #ifdef RENDER_MOTION_VECTORS
-layout(std140) uniform SceneData prev_scene_data; // ubo:12
+layout(std140) uniform PrevSceneDataBlock { // ubo:12
+	SceneData data;
+}
+prev_scene_data_block;
 #endif
 
 #ifndef RENDER_MOTION_VECTORS
@@ -464,7 +467,10 @@ layout(std140) uniform MultiviewDataBlock { // ubo:8
 multiview_data_block;
 
 #ifdef RENDER_MOTION_VECTORS
-layout(std140) uniform MultiviewData prev_multiview_data; // ubo:13
+layout(std140) uniform PrevMultiviewDataBlock { // ubo:13
+	MultiviewData data;
+}
+prev_multiview_data_block;
 #endif // RENDER_MOTION_VECTORS
 
 #endif // USE_MULTIVIEW
@@ -909,7 +915,7 @@ void main() {
 			compressed_aabb_position,
 			prev_world_transform,
 			model_flags,
-			prev_scene_data.data,
+			prev_scene_data_block.data,
 #ifdef USE_INSTANCING
 			input_instance_xform0, input_instance_xform1, input_instance_xform2,
 			input_instance_color_custom_data,
@@ -927,9 +933,9 @@ void main() {
 			uv2_attrib,
 #endif
 #ifdef USE_MULTIVIEW
-			prev_multiview_data.projection_matrix_view[ViewIndex],
-			prev_multiview_data.inv_projection_matrix_view[ViewIndex],
-			prev_multiview_data.eye_offset[ViewIndex].xyz,
+			prev_multiview_data_block.data.projection_matrix_view[ViewIndex],
+			prev_multiview_data_block.data.inv_projection_matrix_view[ViewIndex],
+			prev_multiview_data_block.data.eye_offset[ViewIndex].xyz,
 #endif
 			uv_scale,
 			prev_clip_position);


### PR DESCRIPTION
Turns out the `layout(std140) uniform SceneData prev_scene_data; // ubo:12` notation doesn't actually work, so splitting the UBO into two to work around the memory alignment issue only partially worked.

We'll need to investigate at some point in time whether this notation can be made to work, but for now I fixed the regression by going to the older notation that we seem to be using throughout the compatibility renderer.

Fixes #114203