### PR TITLE
Fix builds on FreeBSD, OpenBSD, and NetBSD

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -384,7 +384,6 @@ if not env["platform"]:
     # Missing `platform` argument, try to detect platform automatically
     if (
         sys.platform.startswith("linux")
-        or sys.platform.startswith("dragonfly")
         or sys.platform.startswith("freebsd")
         or sys.platform.startswith("netbsd")
         or sys.platform.startswith("openbsd")

--- a/drivers/sdl/SCsub
+++ b/drivers/sdl/SCsub
@@ -3,6 +3,8 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
+import sys
+
 env_sdl = env.Clone()
 
 # Thirdparty source files
@@ -119,8 +121,18 @@ if env["builtin_sdl"]:
     # Platform specific sources.
 
     if env["platform"] == "linuxbsd":
-        # TODO: Check support for BSD systems.
-        env_sdl.Append(CPPDEFINES=["SDL_PLATFORM_LINUX"])
+        if sys.platform.startswith("linux"):
+            env_sdl.Append(CPPDEFINES=["SDL_PLATFORM_LINUX"])
+
+        elif sys.platform.startswith("freebsd"):
+            env_sdl.Append(CPPDEFINES=["SDL_PLATFORM_FREEBSD"])
+
+        elif sys.platform.startswith("openbsd"):
+            env_sdl.Append(CPPDEFINES=["SDL_PLATFORM_OPENBSD"])
+
+        elif sys.platform.startswith("netbsd"):
+            env_sdl.Append(CPPDEFINES=["SDL_PLATFORM_NETBSD"])
+
         thirdparty_sources += [
             "core/linux/SDL_dbus.c",
             "core/linux/SDL_evdev.c",
@@ -132,6 +144,7 @@ if env["builtin_sdl"]:
             "core/unix/SDL_poll.c",
             "haptic/linux/SDL_syshaptic.c",
             "joystick/linux/SDL_sysjoystick.c",
+            "joystick/bsd/SDL_bsdjoystick.c",
             "loadso/dlopen/SDL_sysloadso.c",
             "thread/pthread/SDL_syscond.c",
             "thread/pthread/SDL_sysmutex.c",

--- a/drivers/sdl/SDL_build_config_private.h
+++ b/drivers/sdl/SDL_build_config_private.h
@@ -74,26 +74,14 @@
 #define SDL_TIMER_WINDOWS 1
 #define SDL_SENSOR_WINDOWS 1
 
-// Linux defines
-#elif defined(SDL_PLATFORM_LINUX)
+// Linux / BSD defines
+#elif defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_FREEBSD) || defined(SDL_PLATFORM_OPENBSD) || defined(SDL_PLATFORM_NETBSD)
 
-#define SDL_PLATFORM_PRIVATE_NAME "Linux"
 #define SDL_PLATFORM_UNIX 1
 
 #define HAVE_STDIO_H 1
 #define HAVE_LIBC 1
-#define HAVE_LINUX_INPUT_H 1
 #define HAVE_POLL 1
-
-#ifdef __linux__
-#define HAVE_INOTIFY 1
-#define HAVE_INOTIFY_INIT1 1
-// Don't add these defines, for some reason they mess with C#'s ability
-// to use environment variables (see GH-109024)
-//#define HAVE_GETENV 1
-//#define HAVE_SETENV 1
-//#define HAVE_UNSETENV 1
-#endif
 
 #ifdef DBUS_ENABLED
 #define HAVE_DBUS_DBUS_H 1
@@ -110,12 +98,57 @@
 #endif
 
 #define SDL_LOADSO_DLOPEN 1
-#define SDL_HAPTIC_LINUX 1
 #define SDL_TIMER_UNIX 1
-#define SDL_JOYSTICK_LINUX 1
 #define SDL_JOYSTICK_HIDAPI 1
-#define SDL_INPUT_LINUXEV 1
 #define SDL_THREAD_PTHREAD 1
+
+// Linux defines
+#ifdef SDL_PLATFORM_LINUX
+
+#define SDL_PLATFORM_PRIVATE_NAME "Linux"
+
+#define HAVE_LINUX_INPUT_H 1
+
+#define SDL_HAPTIC_LINUX 1
+#define SDL_JOYSTICK_LINUX 1
+#define SDL_INPUT_LINUXEV 1
+
+#define HAVE_INOTIFY 1
+#define HAVE_INOTIFY_INIT1 1
+
+// Don't add these defines, for some reason they mess with C#'s ability
+// to use environment variables (see GH-109024)
+//#define HAVE_GETENV 1
+//#define HAVE_SETENV 1
+//#define HAVE_UNSETENV 1
+
+// *BSD defines
+#else
+
+#ifdef SDL_PLATFORM_FREEBSD
+
+#define SDL_PLATFORM_PRIVATE_NAME "FreeBSD"
+
+#elif defined(SDL_PLATFORM_OPENBSD)
+
+#define SDL_PLATFORM_PRIVATE_NAME "OpenBSD"
+#define USBHID_NEW 1
+#define USBHID_UCR_DATA 1
+
+#elif defined(SDL_PLATFORM_NETBSD)
+
+#define SDL_PLATFORM_PRIVATE_NAME "NetBSD"
+#define USBHID_NEW 1
+#define USBHID_UCR_DATA 1
+
+#endif
+
+#define HAVE_USBHID_H 1
+
+#define SDL_HAPTIC_DISABLED 1
+#define SDL_JOYSTICK_USBHID 1
+
+#endif
 
 // macOS defines
 #elif defined(SDL_PLATFORM_MACOS)

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -438,7 +438,7 @@ Error FileAccessUnix::_set_unix_permissions(const String &p_file, BitField<FileA
 }
 
 bool FileAccessUnix::_get_hidden_attribute(const String &p_file) {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 	String file = fix_path(p_file);
 
 	struct stat st = {};
@@ -452,7 +452,7 @@ bool FileAccessUnix::_get_hidden_attribute(const String &p_file) {
 }
 
 Error FileAccessUnix::_set_hidden_attribute(const String &p_file, bool p_hidden) {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 	String file = fix_path(p_file);
 
 	struct stat st = {};

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -504,7 +504,7 @@ Dictionary OS_Unix::get_memory_info() const {
 	uint64_t sused = 0;
 	int count = swapctl(SWAP_NSWAP, 0, 0);
 	if (count > 0) {
-		swapent swap_info[count];
+		swapent *swap_info = (swapent *)memalloc(count * sizeof(swapent));
 		count = swapctl(SWAP_STATS, swap_info, count);
 
 		for (int i = 0; i < count; i++) {
@@ -513,6 +513,7 @@ Dictionary OS_Unix::get_memory_info() const {
 				stotal += swap_info[i].se_nblks;
 			}
 		}
+		memfree(swap_info);
 	}
 
 	if (uvmexp_info.npages * pagesize != 0) {

--- a/methods.py
+++ b/methods.py
@@ -812,7 +812,10 @@ def using_gcc(env):
 
 
 def using_clang(env):
-    return "clang" in os.path.basename(env["CC"])
+    return "clang" in os.path.basename(env["CC"]) or (
+        (sys.platform.startswith("freebsd") or sys.platform.startswith("openbsd"))
+        and os.path.basename(env["CC"]) == "cc"
+    )
 
 
 def using_emcc(env):
@@ -1099,7 +1102,6 @@ def generate_vs_project(env, original_args, project_name="godot"):
     host_platform = "windows"
     if (
         sys.platform.startswith("linux")
-        or sys.platform.startswith("dragonfly")
         or sys.platform.startswith("freebsd")
         or sys.platform.startswith("netbsd")
         or sys.platform.startswith("openbsd")

--- a/misc/scripts/install_angle.py
+++ b/misc/scripts/install_angle.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import platform
 import shutil
 import sys
 import urllib.request
@@ -36,12 +35,12 @@ archs = [
     "x86_64-gcc",
     "x86_64-llvm",
 ]
-if platform.system() == "Windows":
+if sys.platform == "win32":
     # Only download MSVC libraries if we can build using it.
     archs.append("arm64-msvc")
     archs.append("x86_32-msvc")
     archs.append("x86_64-msvc")
-elif platform.system() == "Darwin":
+elif sys.platform == "darwin":
     # Only download macOS/iOS libraries if we can build for these platforms.
     archs.append("arm64-ios")
     archs.append("arm64-ios-sim")

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -37,7 +37,11 @@
 #include "servers/rendering/rendering_server.h"
 
 GODOT_GCC_WARNING_PUSH
+#if defined(__GNUC__) && defined(__GNUC_PREREQ)
+#if __GNUC_PREREQ(11, 0)
 GODOT_GCC_WARNING_IGNORE("-Wenum-conversion")
+#endif // __GNUC_PREREQ(11, 0)
+#endif // defined(__GNUC__) && defined(__GNUC_PREREQ)
 GODOT_GCC_WARNING_IGNORE("-Wshadow")
 GODOT_GCC_WARNING_IGNORE("-Wunused-value")
 

--- a/modules/camera/config.py
+++ b/modules/camera/config.py
@@ -1,12 +1,10 @@
 def can_build(env, platform):
     import sys
 
-    if sys.platform.startswith("freebsd") or sys.platform.startswith("openbsd"):
-        return False
     return (
         platform == "macos"
         or platform == "windows"
-        or platform == "linuxbsd"
+        or (platform == "linuxbsd" and sys.platform.startswith("linux"))
         or platform == "android"
         or platform == "ios"
         or platform == "visionos"

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -28,8 +28,8 @@ elif env["platform"] == "linuxbsd":
         env_openxr.AppendUnique(CPPDEFINES=["XR_USE_PLATFORM_EGL", "XRDEPENDENCIES_USE_GLAD"])
         env_openxr.Prepend(CPPPATH=["#thirdparty/glad"])
 
-    # FreeBSD uses non-standard getenv functions.
-    if not sys.platform.startswith("freebsd"):
+    # BSDs use non-standard getenv functions.
+    if sys.platform.startswith("linux"):
         env_openxr.AppendUnique(CPPDEFINES=["HAVE_SECURE_GETENV"])
 elif env["platform"] == "windows":
     env_openxr.AppendUnique(CPPDEFINES=["XR_OS_WINDOWS", "NOMINMAX", "XR_USE_PLATFORM_WIN32"])

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -3,7 +3,7 @@ import platform
 import sys
 from typing import TYPE_CHECKING
 
-from methods import get_compiler_version, print_error, print_info, print_warning, using_gcc
+from methods import get_compiler_version, print_error, print_info, print_warning, using_clang, using_gcc
 from platform_methods import detect_arch, validate_arch
 
 if TYPE_CHECKING:
@@ -117,8 +117,8 @@ def configure(env: "SConsEnvironment"):
 
     ## Compiler configuration
 
-    if "CXX" in env and "clang" in os.path.basename(env["CXX"]):
-        # Convenience check to enforce the use_llvm overrides when CXX is clang(++)
+    if using_clang(env):
+        # Convenience check to enforce the use_llvm overrides when using clang.
         env["use_llvm"] = True
 
     if env["use_llvm"]:
@@ -407,7 +407,7 @@ def configure(env: "SConsEnvironment"):
     else:
         env.Append(CPPDEFINES=["XKB_ENABLED"])
 
-    if platform.system() == "Linux":
+    if sys.platform.startswith("linux"):
         if env["udev"]:
             if not env["use_sowrap"]:
                 if os.system("pkg-config --exists libudev") == 0:  # 0 means found
@@ -424,9 +424,13 @@ def configure(env: "SConsEnvironment"):
     if env["sdl"]:
         if env["builtin_sdl"]:
             env.Append(CPPDEFINES=["SDL_ENABLED"])
+            if not sys.platform.startswith("linux"):  # BSD
+                env.Append(LIBS=["usbhid"])
         elif os.system("pkg-config --exists sdl3") == 0:  # 0 means found
             env.ParseConfig("pkg-config sdl3 --cflags --libs")
             env.Append(CPPDEFINES=["SDL_ENABLED"])
+            if not sys.platform.startswith("linux"):  # BSD
+                env.Append(LIBS=["usbhid"])
         else:
             print_warning(
                 "SDL3 development libraries not found, and `builtin_sdl` was explicitly disabled. Disabling SDL input driver support."
@@ -509,7 +513,10 @@ def configure(env: "SConsEnvironment"):
             env.Append(CPPDEFINES=["LIBDECOR_ENABLED"])
 
         env.Append(CPPDEFINES=["WAYLAND_ENABLED"])
-        env.Append(LIBS=["rt"])  # Needed by glibc, used by _allocate_shm_file
+
+        # FreeBSD and OpenBSD keep rt functionality in libc
+        if sys.platform.startswith("linux") or sys.platform.startswith("netbsd"):
+            env.Append(LIBS=["rt"])  # Needed by glibc, used by _allocate_shm_file
 
     if env["accesskit"]:
         if os.path.exists(env["accesskit_sdk_path"]):
@@ -549,7 +556,7 @@ def configure(env: "SConsEnvironment"):
 
     env.Append(LIBS=["pthread"])
 
-    if platform.system() == "Linux":
+    if sys.platform.startswith("linux"):
         env.Append(LIBS=["dl"])
 
     if platform.libc_ver()[0] != "glibc":
@@ -563,14 +570,25 @@ def configure(env: "SConsEnvironment"):
     else:
         env.Append(CPPDEFINES=["CRASH_HANDLER_ENABLED"])
 
-    if platform.system() == "FreeBSD":
+    if sys.platform.startswith("freebsd"):
         env.Append(LINKFLAGS=["-lkvm"])
 
     # Link those statically for portability
     if env["use_static_cpp"]:
-        env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
-        if env["use_llvm"] and platform.system() != "FreeBSD":
-            env["LINKCOM"] = env["LINKCOM"] + " -l:libatomic.a"
+        if env["use_llvm"] and not sys.platform.startswith("linux"):
+            if sys.platform.startswith("freebsd"):
+                env.Append(LINKFLAGS=["-nostdlib++"])
+                env["LINKCOM"] += " -l:libc++.a"
+                env["LINKCOM"] += " -l:libcxxrt.a"
+            elif sys.platform.startswith("netbsd"):
+                env.Append(LINKFLAGS=["-nostdlib++"])
+                env["LINKCOM"] += " -l:libstdc++.a"
+            # OpenBSD binaries are not portable anyways, so do nothing in that case.
+        else:
+            env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
+
+        if env["use_llvm"] and sys.platform.startswith("linux"):
+            env["LINKCOM"] += " -l:libatomic.a"
     else:
-        if env["use_llvm"] and platform.system() != "FreeBSD":
+        if env["use_llvm"] and sys.platform.startswith("linux"):
             env.Append(LIBS=["atomic"])

--- a/platform/linuxbsd/platform_config.h
+++ b/platform/linuxbsd/platform_config.h
@@ -30,18 +30,18 @@
 
 #pragma once
 
+// alloca
 #ifdef __linux__
 #include <alloca.h>
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#include <stdlib.h>
 #endif
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
-#include <cstdlib> // alloca
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 // FreeBSD and OpenBSD use pthread_set_name_np, while other platforms,
 // include NetBSD, use pthread_setname_np. NetBSD's version however requires
 // a different format, we handle this directly in thread_posix.
-#ifdef __NetBSD__
-#define PTHREAD_NETBSD_SET_NAME
-#else
 #define PTHREAD_BSD_SET_NAME
-#endif
+#elif defined(__NetBSD__)
+#define PTHREAD_NETBSD_SET_NAME
 #endif

--- a/platform/linuxbsd/wayland/detect_prime_egl.cpp
+++ b/platform/linuxbsd/wayland/detect_prime_egl.cpp
@@ -44,6 +44,11 @@
 #include <GL/glcorearb.h>
 #endif
 
+#ifdef __OpenBSD__
+// quick_exit not available
+#define quick_exit _exit
+#endif
+
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -34,13 +34,13 @@
 
 #ifdef TOOLS_ENABLED
 
+// From linux/input-event-codes.h
+#define BTN_LEFT 0x110
+
 #include <sys/stat.h>
 
 #ifdef __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#else
-// Assume Linux.
-#include <linux/input-event-codes.h>
+#include <sys/ucred.h>
 #endif
 
 #include "core/os/os.h"
@@ -692,7 +692,13 @@ Error WaylandEmbedder::send_raw_message(int p_socket, std::initializer_list<stru
 	if (!p_fds.is_empty()) {
 		size_t data_size = p_fds.size() * sizeof(int);
 
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+		msg.msg_control = Memory::alloc_aligned_static(CMSG_SPACE(data_size), _ALIGN(1));
+#elif defined(__NetBSD__)
+		msg.msg_control = Memory::alloc_aligned_static(CMSG_SPACE(data_size), __CMSG_ALIGN(1));
+#else
 		msg.msg_control = Memory::alloc_aligned_static(CMSG_SPACE(data_size), CMSG_ALIGN(1));
+#endif
 		msg.msg_controllen = CMSG_SPACE(data_size);
 
 		struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
@@ -2715,7 +2721,7 @@ Error WaylandEmbedder::handle_sock(int p_fd) {
 			ERR_FAIL_V_MSG(FAILED, vformat("Can't read message header: %s", strerror(errno)));
 		}
 
-		ERR_FAIL_COND_V_MSG(((size_t)head_rec) != vec.iov_len, ERR_CONNECTION_ERROR, vformat("Should've received %d bytes, instead got %d bytes", vec.iov_len, head_rec));
+		ERR_FAIL_COND_V_MSG(((size_t)head_rec) != vec.iov_len, ERR_CONNECTION_ERROR, vformat("Should've received %d bytes, instead got %d bytes", (uint64_t)vec.iov_len, (uint64_t)head_rec));
 
 		// Header is two 32-bit words: first is ID, second has size in most significant
 		// half and opcode in the other half.
@@ -2949,15 +2955,34 @@ void WaylandEmbedder::handle_fd(int p_fd, int p_revents) {
 		int new_fd = accept(proxy_socket, nullptr, nullptr);
 		ERR_FAIL_COND_MSG(new_fd == -1, "Failed to accept client.");
 
+		pid_t cred_pid;
+#ifdef __FreeBSD__
+		struct xucred cred = {};
+		socklen_t cred_size = sizeof cred;
+		getsockopt(new_fd, SOL_LOCAL, LOCAL_PEERCRED, &cred, &cred_size);
+		cred_pid = cred.cr_pid;
+#elif defined(__NetBSD__)
+		struct sockcred cred = {};
+		socklen_t cred_size = sizeof cred;
+		getsockopt(new_fd, SOL_LOCAL, LOCAL_PEEREID, &cred, &cred_size);
+		cred_pid = cred.sc_pid;
+#elif defined(__OpenBSD__)
+		struct sockpeercred cred = {};
+		socklen_t cred_size = sizeof cred;
+		getsockopt(new_fd, SOL_SOCKET, SO_PEERCRED, &cred, &cred_size);
+		cred_pid = cred.pid;
+#else // Linux.
 		struct ucred cred = {};
 		socklen_t cred_size = sizeof cred;
 		getsockopt(new_fd, SOL_SOCKET, SO_PEERCRED, &cred, &cred_size);
+		cred_pid = cred.pid;
+#endif //__FreeBSD__
 
 		Client &client = clients.insert_new(new_fd, {})->value;
 
 		client.embedder = this;
 		client.socket = new_fd;
-		client.pid = cred.pid;
+		client.pid = cred_pid;
 
 		client.global_ids[DISPLAY_ID] = Client::GlobalIdInfo(DISPLAY_ID, nullptr);
 		client.local_ids[DISPLAY_ID] = DISPLAY_ID;
@@ -2980,11 +3005,11 @@ void WaylandEmbedder::handle_fd(int p_fd, int p_revents) {
 				main_client->new_fake_object(new_local_id, &godot_embedded_client_interface, 1, eclient_data);
 
 				// godot_embedding_compositor::client(nu)
-				send_wayland_message(main_client->socket, local_id, 0, { new_local_id, (uint32_t)cred.pid });
+				send_wayland_message(main_client->socket, local_id, 0, { new_local_id, (uint32_t)cred_pid });
 			}
 		}
 
-		DEBUG_LOG_WAYLAND_EMBED(vformat("New client %d (pid %d) initialized.", client.socket, cred.pid));
+		DEBUG_LOG_WAYLAND_EMBED(vformat("New client %d (pid %d) initialized.", client.socket, cred_pid));
 		return;
 	}
 

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -36,12 +36,14 @@
 
 #ifdef WAYLAND_ENABLED
 
-#ifdef __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#else
-// Assume Linux.
-#include <linux/input-event-codes.h>
-#endif
+// From linux/input-event-codes.h
+#define BTN_LEFT 0x110
+#define BTN_RIGHT 0x111
+#define BTN_MIDDLE 0x112
+#define BTN_SIDE 0x113
+#define BTN_EXTRA 0x114
+#define BTN_STYLUS 0x14b
+#define BTN_STYLUS2 0x14c
 
 // For the actual polling thread.
 #include <poll.h>
@@ -97,7 +99,7 @@ Vector<uint8_t> WaylandThread::_read_fd(int fd) {
 			break;
 		}
 
-		DEBUG_LOG_WAYLAND_THREAD(vformat("Read chunk of %d bytes.", last_bytes_read));
+		DEBUG_LOG_WAYLAND_THREAD(vformat("Read chunk of %d bytes.", (uint64_t)last_bytes_read));
 
 		bytes_read += last_bytes_read;
 
@@ -1288,7 +1290,7 @@ void WaylandThread::_wl_surface_on_enter(void *data, struct wl_surface *wl_surfa
 	WindowState *ws = (WindowState *)data;
 	ERR_FAIL_NULL(ws);
 
-	DEBUG_LOG_WAYLAND_THREAD(vformat("Window entered output %x.", (size_t)wl_output));
+	DEBUG_LOG_WAYLAND_THREAD(vformat("Window entered output %x.", (uint64_t)wl_output));
 
 	ws->wl_outputs.insert(wl_output);
 
@@ -1328,7 +1330,7 @@ void WaylandThread::_wl_surface_on_leave(void *data, struct wl_surface *wl_surfa
 
 	ws->wl_outputs.erase(wl_output);
 
-	DEBUG_LOG_WAYLAND_THREAD(vformat("Window left output %x.\n", (size_t)wl_output));
+	DEBUG_LOG_WAYLAND_THREAD(vformat("Window left output %x.\n", (uint64_t)wl_output));
 }
 
 // TODO: Add support to this event.
@@ -1394,7 +1396,7 @@ void WaylandThread::_wl_output_on_done(void *data, struct wl_output *wl_output) 
 
 	ss->wayland_thread->_update_scale(ss->data.scale);
 
-	DEBUG_LOG_WAYLAND_THREAD(vformat("Output %x done.", (size_t)wl_output));
+	DEBUG_LOG_WAYLAND_THREAD(vformat("Output %x done.", (uint64_t)wl_output));
 }
 
 void WaylandThread::_wl_output_on_scale(void *data, struct wl_output *wl_output, int32_t factor) {
@@ -1403,7 +1405,7 @@ void WaylandThread::_wl_output_on_scale(void *data, struct wl_output *wl_output,
 
 	ss->pending_data.scale = factor;
 
-	DEBUG_LOG_WAYLAND_THREAD(vformat("Output %x scale %d", (size_t)wl_output, factor));
+	DEBUG_LOG_WAYLAND_THREAD(vformat("Output %x scale %d", (uint64_t)wl_output, factor));
 }
 
 void WaylandThread::_wl_output_on_name(void *data, struct wl_output *wl_output, const char *name) {

--- a/platform/linuxbsd/x11/detect_prime_x11.cpp
+++ b/platform/linuxbsd/x11/detect_prime_x11.cpp
@@ -48,6 +48,11 @@
 #include <X11/Xutil.h>
 #endif
 
+#ifdef __OpenBSD__
+// quick_exit not available
+#define quick_exit _exit
+#endif
+
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/thirdparty/basis_universal/encoder/basisu_enc.h
+++ b/thirdparty/basis_universal/encoder/basisu_enc.h
@@ -4261,7 +4261,7 @@ namespace basisu
 	// Positive, negative, or denormals. No NaN or Inf. Clamped to MAX_HALF_FLOAT.
 	inline basist::half_float fast_float_to_half_trunc_no_nan_or_inf(float f)
 	{
-		assert(!isnan(f) && !isinf(f));
+		assert(!std::isnan(f) && !std::isinf(f));
 
 		// Sutract 112 from the exponent, to change the bias from 127 to 15.
 		static const fu32 g_f_to_h{ 0x7800000 };
@@ -4275,7 +4275,7 @@ namespace basisu
 
 	inline basist::half_float fast_float_to_half_trunc_no_clamp_neg_nan_or_inf(float f)
 	{
-		assert(!isnan(f) && !isinf(f));
+		assert(!std::isnan(f) && !std::isinf(f));
 		assert((f >= 0.0f) && (f <= basist::MAX_HALF_FLOAT));
 		
 		// Sutract 112 from the exponent, to change the bias from 127 to 15.
@@ -4290,7 +4290,7 @@ namespace basisu
 		
 	inline basist::half_float fast_float_to_half_no_clamp_neg_nan_or_inf(float f)
 	{
-		assert(!isnan(f) && !isinf(f));
+		assert(!std::isnan(f) && !std::isinf(f));
 		assert((f >= 0.0f) && (f <= basist::MAX_HALF_FLOAT));
 
 		// Sutract 112 from the exponent, to change the bias from 127 to 15.

--- a/thirdparty/basis_universal/patches/0007-fix-netbsd.patch
+++ b/thirdparty/basis_universal/patches/0007-fix-netbsd.patch
@@ -1,0 +1,44 @@
+diff --git a/thirdparty/basis_universal/encoder/basisu_enc.h b/thirdparty/basis_universal/encoder/basisu_enc.h
+index 5256d34ad3..949e830f29 100644
+--- a/thirdparty/basis_universal/encoder/basisu_enc.h
++++ b/thirdparty/basis_universal/encoder/basisu_enc.h
+@@ -4261,7 +4261,7 @@ namespace basisu
+ 	// Positive, negative, or denormals. No NaN or Inf. Clamped to MAX_HALF_FLOAT.
+ 	inline basist::half_float fast_float_to_half_trunc_no_nan_or_inf(float f)
+ 	{
+-		assert(!isnan(f) && !isinf(f));
++		assert(!std::isnan(f) && !std::isinf(f));
+ 
+ 		// Sutract 112 from the exponent, to change the bias from 127 to 15.
+ 		static const fu32 g_f_to_h{ 0x7800000 };
+@@ -4275,7 +4275,7 @@ namespace basisu
+ 
+ 	inline basist::half_float fast_float_to_half_trunc_no_clamp_neg_nan_or_inf(float f)
+ 	{
+-		assert(!isnan(f) && !isinf(f));
++		assert(!std::isnan(f) && !std::isinf(f));
+ 		assert((f >= 0.0f) && (f <= basist::MAX_HALF_FLOAT));
+ 		
+ 		// Sutract 112 from the exponent, to change the bias from 127 to 15.
+@@ -4290,7 +4290,7 @@ namespace basisu
+ 		
+ 	inline basist::half_float fast_float_to_half_no_clamp_neg_nan_or_inf(float f)
+ 	{
+-		assert(!isnan(f) && !isinf(f));
++		assert(!std::isnan(f) && !std::isinf(f));
+ 		assert((f >= 0.0f) && (f <= basist::MAX_HALF_FLOAT));
+ 
+ 		// Sutract 112 from the exponent, to change the bias from 127 to 15.
+diff --git a/thirdparty/basis_universal/transcoder/basisu_transcoder.cpp b/thirdparty/basis_universal/transcoder/basisu_transcoder.cpp
+index e46d0aefb9..c3f4b10895 100644
+--- a/thirdparty/basis_universal/transcoder/basisu_transcoder.cpp
++++ b/thirdparty/basis_universal/transcoder/basisu_transcoder.cpp
+@@ -22119,7 +22119,7 @@ namespace basist
+ 
+ 		static BASISU_FORCE_INLINE basist::half_float fast_float_to_half_no_clamp_neg_nan_or_inf(float f)
+ 		{
+-			assert(!isnan(f) && !isinf(f));
++			assert(!std::isnan(f) && !std::isinf(f));
+ 			assert((f >= 0.0f) && (f <= basist::MAX_HALF_FLOAT));
+ 
+ 			// Sutract 112 from the exponent, to change the bias from 127 to 15.

--- a/thirdparty/basis_universal/transcoder/basisu_transcoder.cpp
+++ b/thirdparty/basis_universal/transcoder/basisu_transcoder.cpp
@@ -22119,7 +22119,7 @@ namespace basist
 
 		static BASISU_FORCE_INLINE basist::half_float fast_float_to_half_no_clamp_neg_nan_or_inf(float f)
 		{
-			assert(!isnan(f) && !isinf(f));
+			assert(!std::isnan(f) && !std::isinf(f));
 			assert((f >= 0.0f) && (f <= basist::MAX_HALF_FLOAT));
 
 			// Sutract 112 from the exponent, to change the bias from 127 to 15.

--- a/thirdparty/embree/common/math/emath.h
+++ b/thirdparty/embree/common/math/emath.h
@@ -253,7 +253,7 @@ namespace embree
 #if defined(__64BIT__) || defined(__EMSCRIPTEN__)
   __forceinline   size_t min(size_t   a, size_t   b) { return a<b ? a:b; }
 #endif
-#if defined(__EMSCRIPTEN__)
+#if defined(__EMSCRIPTEN__) || defined(__OPENBSD__)
   __forceinline   long   min(long     a, long     b) { return a<b ? a:b; }
 #endif
 
@@ -273,7 +273,7 @@ namespace embree
 #if defined(__64BIT__) || defined(__EMSCRIPTEN__)
   __forceinline   size_t max(size_t   a, size_t   b) { return a<b ? b:a; }
 #endif
-#if defined(__EMSCRIPTEN__)
+#if defined(__EMSCRIPTEN__) || defined(__OPENBSD__)
   __forceinline   long   max(long     a, long     b) { return a<b ? b:a; }
 #endif
 

--- a/thirdparty/embree/common/sys/platform.h
+++ b/thirdparty/embree/common/sys/platform.h
@@ -82,6 +82,26 @@
 #  endif
 #endif
 
+/* detect OpenBSD platform */
+#if defined(__OpenBSD__) || defined(__OPENBSD__)
+#  if !defined(__OPENBSD__)
+#     define __OPENBSD__
+#  endif
+#  if !defined(__UNIX__)
+#     define __UNIX__
+#  endif
+#endif
+
+/* detect NetBSD platform */
+#if defined(__NetBSD__) || defined(__NETBSD__)
+#  if !defined(__NETBSD__)
+#     define __NETBSD__
+#  endif
+#  if !defined(__UNIX__)
+#     define __UNIX__
+#  endif
+#endif
+
 /* detect Windows 95/98/NT/2000/XP/Vista/7/8/10 platform */
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)) && !defined(__CYGWIN__)
 #  if !defined(__WIN32__)

--- a/thirdparty/embree/common/sys/sysinfo.cpp
+++ b/thirdparty/embree/common/sys/sysinfo.cpp
@@ -39,6 +39,14 @@ namespace embree
     return "FreeBSD (32bit)";
 #elif defined(__FREEBSD__) && defined(__64BIT__)
     return "FreeBSD (64bit)";
+#elif defined(__OPENBSD__) && !defined(__64BIT__)
+    return "OpenBSD (32bit)";
+#elif defined(__OPENBSD__) && defined(__64BIT__)
+    return "OpenBSD (64bit)";
+#elif defined(__NETBSD__) && !defined(__64BIT__)
+    return "NetBSD (32bit)";
+#elif defined(__NETBSD__) && defined(__64BIT__)
+    return "NetBSD (64bit)";
 #elif defined(__CYGWIN__) && !defined(__64BIT__)
     return "Cygwin (32bit)";
 #elif defined(__CYGWIN__) && defined(__64BIT__)
@@ -617,6 +625,71 @@ namespace embree
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
+/// OpenBSD Platform
+////////////////////////////////////////////////////////////////////////////////
+
+#if defined (__OPENBSD__)
+
+namespace embree
+{
+  std::string getExecutableFileName()
+  {
+    // Only possible using argv[0]
+    return "";
+  }
+
+  size_t getVirtualMemoryBytes() {
+    return 0;
+  }
+
+  size_t getResidentMemoryBytes() {
+    return 0;
+  }
+}
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+/// NetBSD Platform
+////////////////////////////////////////////////////////////////////////////////
+
+#if defined (__NETBSD__)
+
+#include <stdio.h>
+#include <unistd.h>
+
+namespace embree
+{
+  std::string getExecutableFileName()
+  {
+    std::string pid = "/proc/" + toString(getpid()) + "/exe";
+    char buf[4096];
+    memset(buf,0,sizeof(buf));
+    if (readlink(pid.c_str(), buf, sizeof(buf)-1) == -1)
+      return std::string();
+    return std::string(buf);
+  }
+
+  size_t getVirtualMemoryBytes()
+  {
+    size_t virt, resident, shared;
+    std::ifstream buffer("/proc/self/statm");
+    buffer >> virt >> resident >> shared;
+    return virt*sysconf(_SC_PAGE_SIZE);
+  }
+
+  size_t getResidentMemoryBytes()
+  {
+    size_t virt, resident, shared;
+    std::ifstream buffer("/proc/self/statm");
+    buffer >> virt >> resident >> shared;
+    return resident*sysconf(_SC_PAGE_SIZE);
+  }
+}
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
 /// Mac OS X Platform
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -672,7 +745,7 @@ namespace embree
     static int nThreads = -1;
     if (nThreads != -1) return nThreads;
 
-#if defined(__MACOSX__) || defined(__ANDROID__)
+#if defined(__MACOSX__) || defined(__ANDROID__) || defined(__OPENBSD__) || defined(__NETBSD__)
     nThreads = sysconf(_SC_NPROCESSORS_ONLN); // does not work in Linux LXC container
     assert(nThreads);
 #elif defined(__EMSCRIPTEN__)

--- a/thirdparty/embree/patches/0007-fix-bsd.patch
+++ b/thirdparty/embree/patches/0007-fix-bsd.patch
@@ -1,0 +1,153 @@
+diff --git a/thirdparty/embree/common/math/emath.h b/thirdparty/embree/common/math/emath.h
+index 22a89a7669..fd99b6fa1a 100644
+--- a/thirdparty/embree/common/math/emath.h
++++ b/thirdparty/embree/common/math/emath.h
+@@ -253,7 +253,7 @@ namespace embree
+ #if defined(__64BIT__) || defined(__EMSCRIPTEN__)
+   __forceinline   size_t min(size_t   a, size_t   b) { return a<b ? a:b; }
+ #endif
+-#if defined(__EMSCRIPTEN__)
++#if defined(__EMSCRIPTEN__) || defined(__OPENBSD__)
+   __forceinline   long   min(long     a, long     b) { return a<b ? a:b; }
+ #endif
+ 
+@@ -273,7 +273,7 @@ namespace embree
+ #if defined(__64BIT__) || defined(__EMSCRIPTEN__)
+   __forceinline   size_t max(size_t   a, size_t   b) { return a<b ? b:a; }
+ #endif
+-#if defined(__EMSCRIPTEN__)
++#if defined(__EMSCRIPTEN__) || defined(__OPENBSD__)
+   __forceinline   long   max(long     a, long     b) { return a<b ? b:a; }
+ #endif
+ 
+diff --git a/thirdparty/embree/common/sys/platform.h b/thirdparty/embree/common/sys/platform.h
+index 1e5b02550e..4c8db7addd 100644
+--- a/thirdparty/embree/common/sys/platform.h
++++ b/thirdparty/embree/common/sys/platform.h
+@@ -82,6 +82,26 @@
+ #  endif
+ #endif
+ 
++/* detect OpenBSD platform */
++#if defined(__OpenBSD__) || defined(__OPENBSD__)
++#  if !defined(__OPENBSD__)
++#     define __OPENBSD__
++#  endif
++#  if !defined(__UNIX__)
++#     define __UNIX__
++#  endif
++#endif
++
++/* detect NetBSD platform */
++#if defined(__NetBSD__) || defined(__NETBSD__)
++#  if !defined(__NETBSD__)
++#     define __NETBSD__
++#  endif
++#  if !defined(__UNIX__)
++#     define __UNIX__
++#  endif
++#endif
++
+ /* detect Windows 95/98/NT/2000/XP/Vista/7/8/10 platform */
+ #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)) && !defined(__CYGWIN__)
+ #  if !defined(__WIN32__)
+diff --git a/thirdparty/embree/common/sys/sysinfo.cpp b/thirdparty/embree/common/sys/sysinfo.cpp
+index f3046d89f2..eed9275553 100644
+--- a/thirdparty/embree/common/sys/sysinfo.cpp
++++ b/thirdparty/embree/common/sys/sysinfo.cpp
+@@ -39,6 +39,14 @@ namespace embree
+     return "FreeBSD (32bit)";
+ #elif defined(__FREEBSD__) && defined(__64BIT__)
+     return "FreeBSD (64bit)";
++#elif defined(__OPENBSD__) && !defined(__64BIT__)
++    return "OpenBSD (32bit)";
++#elif defined(__OPENBSD__) && defined(__64BIT__)
++    return "OpenBSD (64bit)";
++#elif defined(__NETBSD__) && !defined(__64BIT__)
++    return "NetBSD (32bit)";
++#elif defined(__NETBSD__) && defined(__64BIT__)
++    return "NetBSD (64bit)";
+ #elif defined(__CYGWIN__) && !defined(__64BIT__)
+     return "Cygwin (32bit)";
+ #elif defined(__CYGWIN__) && defined(__64BIT__)
+@@ -616,6 +624,71 @@ namespace embree
+ 
+ #endif
+ 
++////////////////////////////////////////////////////////////////////////////////
++/// OpenBSD Platform
++////////////////////////////////////////////////////////////////////////////////
++
++#if defined (__OPENBSD__)
++
++namespace embree
++{
++  std::string getExecutableFileName()
++  {
++    // Only possible using argv[0]
++    return "";
++  }
++
++  size_t getVirtualMemoryBytes() {
++    return 0;
++  }
++
++  size_t getResidentMemoryBytes() {
++    return 0;
++  }
++}
++
++#endif
++
++////////////////////////////////////////////////////////////////////////////////
++/// NetBSD Platform
++////////////////////////////////////////////////////////////////////////////////
++
++#if defined (__NETBSD__)
++
++#include <stdio.h>
++#include <unistd.h>
++
++namespace embree
++{
++  std::string getExecutableFileName()
++  {
++    std::string pid = "/proc/" + toString(getpid()) + "/exe";
++    char buf[4096];
++    memset(buf,0,sizeof(buf));
++    if (readlink(pid.c_str(), buf, sizeof(buf)-1) == -1)
++      return std::string();
++    return std::string(buf);
++  }
++
++  size_t getVirtualMemoryBytes()
++  {
++    size_t virt, resident, shared;
++    std::ifstream buffer("/proc/self/statm");
++    buffer >> virt >> resident >> shared;
++    return virt*sysconf(_SC_PAGE_SIZE);
++  }
++
++  size_t getResidentMemoryBytes()
++  {
++    size_t virt, resident, shared;
++    std::ifstream buffer("/proc/self/statm");
++    buffer >> virt >> resident >> shared;
++    return resident*sysconf(_SC_PAGE_SIZE);
++  }
++}
++
++#endif
++
+ ////////////////////////////////////////////////////////////////////////////////
+ /// Mac OS X Platform
+ ////////////////////////////////////////////////////////////////////////////////
+@@ -672,7 +745,7 @@ namespace embree
+     static int nThreads = -1;
+     if (nThreads != -1) return nThreads;
+ 
+-#if defined(__MACOSX__) || defined(__ANDROID__)
++#if defined(__MACOSX__) || defined(__ANDROID__) || defined(__OPENBSD__) || defined(__NETBSD__)
+     nThreads = sysconf(_SC_NPROCESSORS_ONLN); // does not work in Linux LXC container
+     assert(nThreads);
+ #elif defined(__EMSCRIPTEN__)

--- a/thirdparty/sdl/hidapi/netbsd/hid.c
+++ b/thirdparty/sdl/hidapi/netbsd/hid.c
@@ -1,0 +1,1173 @@
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ James Buren
+ libusb/hidapi Team
+
+ Copyright 2023, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        https://github.com/libusb/hidapi .
+********************************************************/
+
+/* C */
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <locale.h>
+#include <ctype.h>
+#include <errno.h>
+
+/* Unix */
+#include <unistd.h>
+#include <fcntl.h>
+#include <iconv.h>
+#include <poll.h>
+
+/* NetBSD */
+#include <sys/drvctlio.h>
+#include <dev/usb/usb.h>
+#include <dev/usb/usbhid.h>
+
+#include "../hidapi/hidapi.h"
+
+#define HIDAPI_MAX_CHILD_DEVICES 256
+
+struct hid_device_ {
+	int device_handle;
+	int blocking;
+	wchar_t *last_error_str;
+	struct hid_device_info *device_info;
+	size_t poll_handles_length;
+	struct pollfd poll_handles[256];
+	int report_handles[256];
+	char path[USB_MAX_DEVNAMELEN];
+};
+
+struct hid_enumerate_data {
+	struct hid_device_info *root;
+	struct hid_device_info *end;
+	int drvctl;
+	uint16_t vendor_id;
+	uint16_t product_id;
+};
+
+typedef void (*enumerate_devices_callback) (const struct usb_device_info *, void *);
+
+static wchar_t *last_global_error_str = NULL;
+
+/* The caller must free the returned string with free(). */
+static wchar_t *utf8_to_wchar_t(const char *utf8)
+{
+	wchar_t *ret = NULL;
+
+	if (utf8) {
+		size_t wlen = mbstowcs(NULL, utf8, 0);
+		if ((size_t) -1 == wlen) {
+			return wcsdup(L"");
+		}
+		ret = (wchar_t*) calloc(wlen+1, sizeof(wchar_t));
+		if (ret == NULL) {
+			/* as much as we can do at this point */
+			return NULL;
+		}
+		mbstowcs(ret, utf8, wlen+1);
+		ret[wlen] = 0x0000;
+	}
+
+	return ret;
+}
+
+/* Makes a copy of the given error message (and decoded according to the
+ * currently locale) into the wide string pointer pointed by error_str.
+ * The last stored error string is freed.
+ * Use register_error_str(NULL) to free the error message completely. */
+static void register_error_str(wchar_t **error_str, const char *msg)
+{
+	free(*error_str);
+	*error_str = utf8_to_wchar_t(msg);
+}
+
+/* Semilar to register_error_str, but allows passing a format string with va_list args into this function. */
+static void register_error_str_vformat(wchar_t **error_str, const char *format, va_list args)
+{
+	char msg[256];
+	vsnprintf(msg, sizeof(msg), format, args);
+
+	register_error_str(error_str, msg);
+}
+
+/* Set the last global error to be reported by hid_error(NULL).
+ * The given error message will be copied (and decoded according to the
+ * currently locale, so do not pass in string constants).
+ * The last stored global error message is freed.
+ * Use register_global_error(NULL) to indicate "no error". */
+static void register_global_error(const char *msg)
+{
+	register_error_str(&last_global_error_str, msg);
+}
+
+/* Similar to register_global_error, but allows passing a format string into this function. */
+static void register_global_error_format(const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	register_error_str_vformat(&last_global_error_str, format, args);
+	va_end(args);
+}
+
+/* Set the last error for a device to be reported by hid_error(dev).
+ * The given error message will be copied (and decoded according to the
+ * currently locale, so do not pass in string constants).
+ * The last stored device error message is freed.
+ * Use register_device_error(dev, NULL) to indicate "no error". */
+static void register_device_error(hid_device *dev, const char *msg)
+{
+	register_error_str(&dev->last_error_str, msg);
+}
+
+/* Similar to register_device_error, but you can pass a format string into this function. */
+static void register_device_error_format(hid_device *dev, const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	register_error_str_vformat(&dev->last_error_str, format, args);
+	va_end(args);
+}
+
+
+/*
+ * Gets the size of the HID item at the given position
+ * Returns 1 if successful, 0 if an invalid key
+ * Sets data_len and key_size when successful
+ */
+static int get_hid_item_size(const uint8_t *report_descriptor, uint32_t size, unsigned int pos, int *data_len, int *key_size)
+{
+	int key = report_descriptor[pos];
+	int size_code;
+
+	/*
+	 * This is a Long Item. The next byte contains the
+	 * length of the data section (value) for this key.
+	 * See the HID specification, version 1.11, section
+	 * 6.2.2.3, titled "Long Items."
+	 */
+	if ((key & 0xf0) == 0xf0) {
+		if (pos + 1 < size)
+		{
+			*data_len = report_descriptor[pos + 1];
+			*key_size = 3;
+			return 1;
+		}
+		*data_len = 0; /* malformed report */
+		*key_size = 0;
+	}
+
+	/*
+	 * This is a Short Item. The bottom two bits of the
+	 * key contain the size code for the data section
+	 * (value) for this key. Refer to the HID
+	 * specification, version 1.11, section 6.2.2.2,
+	 * titled "Short Items."
+	 */
+	size_code = key & 0x3;
+	switch (size_code) {
+	case 0:
+	case 1:
+	case 2:
+		*data_len = size_code;
+		*key_size = 1;
+		return 1;
+	case 3:
+		*data_len = 4;
+		*key_size = 1;
+		return 1;
+	default:
+		/* Can't ever happen since size_code is & 0x3 */
+		*data_len = 0;
+		*key_size = 0;
+		break;
+	};
+
+	/* malformed report */
+	return 0;
+}
+
+/*
+ * Get bytes from a HID Report Descriptor.
+ * Only call with a num_bytes of 0, 1, 2, or 4.
+ */
+static uint32_t get_hid_report_bytes(const uint8_t *rpt, size_t len, size_t num_bytes, size_t cur)
+{
+	/* Return if there aren't enough bytes. */
+	if (cur + num_bytes >= len)
+		return 0;
+
+	if (num_bytes == 0)
+		return 0;
+	else if (num_bytes == 1)
+		return rpt[cur + 1];
+	else if (num_bytes == 2)
+		return (rpt[cur + 2] * 256 + rpt[cur + 1]);
+	else if (num_bytes == 4)
+		return (
+			rpt[cur + 4] * 0x01000000 +
+			rpt[cur + 3] * 0x00010000 +
+			rpt[cur + 2] * 0x00000100 +
+			rpt[cur + 1] * 0x00000001
+		);
+	else
+		return 0;
+}
+
+/*
+ * Iterates until the end of a Collection.
+ * Assumes that *pos is exactly at the beginning of a Collection.
+ * Skips all nested Collection, i.e. iterates until the end of current level Collection.
+ *
+ * The return value is non-0 when an end of current Collection is found,
+ * 0 when error is occurred (broken Descriptor, end of a Collection is found before its begin,
+ *  or no Collection is found at all).
+ */
+static int hid_iterate_over_collection(const uint8_t *report_descriptor, uint32_t size, unsigned int *pos, int *data_len, int *key_size)
+{
+	int collection_level = 0;
+
+	while (*pos < size) {
+		int key = report_descriptor[*pos];
+		int key_cmd = key & 0xfc;
+
+		/* Determine data_len and key_size */
+		if (!get_hid_item_size(report_descriptor, size, *pos, data_len, key_size))
+			return 0; /* malformed report */
+
+		switch (key_cmd) {
+		case 0xa0: /* Collection 6.2.2.4 (Main) */
+			collection_level++;
+			break;
+		case 0xc0: /* End Collection 6.2.2.4 (Main) */
+			collection_level--;
+			break;
+		}
+
+		if (collection_level < 0) {
+			/* Broken descriptor or someone is using this function wrong,
+			 * i.e. should be called exactly at the collection start */
+			return 0;
+		}
+
+		if (collection_level == 0) {
+			/* Found it!
+			 * Also possible when called not at the collection start, but should not happen if used correctly */
+			return 1;
+		}
+
+		*pos += *data_len + *key_size;
+	}
+
+	return 0; /* Did not find the end of a Collection */
+}
+
+struct hid_usage_iterator {
+	unsigned int pos;
+	int usage_page_found;
+	unsigned short usage_page;
+};
+
+/*
+ * Retrieves the device's Usage Page and Usage from the report descriptor.
+ * The algorithm returns the current Usage Page/Usage pair whenever a new
+ * Collection is found and a Usage Local Item is currently in scope.
+ * Usage Local Items are consumed by each Main Item (See. 6.2.2.8).
+ * The algorithm should give similar results as Apple's:
+ *   https://developer.apple.com/documentation/iokit/kiohiddeviceusagepairskey?language=objc
+ * Physical Collections are also matched (macOS does the same).
+ *
+ * This function can be called repeatedly until it returns non-0
+ * Usage is found. pos is the starting point (initially 0) and will be updated
+ * to the next search position.
+ *
+ * The return value is 0 when a pair is found.
+ * 1 when finished processing descriptor.
+ * -1 on a malformed report.
+ */
+static int get_next_hid_usage(const uint8_t *report_descriptor, uint32_t size, struct hid_usage_iterator *ctx, unsigned short *usage_page, unsigned short *usage)
+{
+	int data_len, key_size;
+	int initial = ctx->pos == 0; /* Used to handle case where no top-level application collection is defined */
+
+	int usage_found = 0;
+
+	while (ctx->pos < size) {
+		int key = report_descriptor[ctx->pos];
+		int key_cmd = key & 0xfc;
+
+		/* Determine data_len and key_size */
+		if (!get_hid_item_size(report_descriptor, size, ctx->pos, &data_len, &key_size))
+			return -1; /* malformed report */
+
+		switch (key_cmd) {
+		case 0x4: /* Usage Page 6.2.2.7 (Global) */
+			ctx->usage_page = get_hid_report_bytes(report_descriptor, size, data_len, ctx->pos);
+			ctx->usage_page_found = 1;
+			break;
+
+		case 0x8: /* Usage 6.2.2.8 (Local) */
+			if (data_len == 4) { /* Usages 5.5 / Usage Page 6.2.2.7 */
+				ctx->usage_page = get_hid_report_bytes(report_descriptor, size, 2, ctx->pos + 2);
+				ctx->usage_page_found = 1;
+				*usage = get_hid_report_bytes(report_descriptor, size, 2, ctx->pos);
+				usage_found = 1;
+			}
+			else {
+				*usage = get_hid_report_bytes(report_descriptor, size, data_len, ctx->pos);
+				usage_found = 1;
+			}
+			break;
+
+		case 0xa0: /* Collection 6.2.2.4 (Main) */
+			if (!hid_iterate_over_collection(report_descriptor, size, &ctx->pos, &data_len, &key_size)) {
+				return -1;
+			}
+
+			/* A pair is valid - to be reported when Collection is found */
+			if (usage_found && ctx->usage_page_found) {
+				*usage_page = ctx->usage_page;
+				return 0;
+			}
+
+			break;
+		}
+
+		/* Skip over this key and its associated data */
+		ctx->pos += data_len + key_size;
+	}
+
+	/* If no top-level application collection is found and usage page/usage pair is found, pair is valid
+	   https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/top-level-collections */
+	if (initial && usage_found && ctx->usage_page_found) {
+			*usage_page = ctx->usage_page;
+			return 0; /* success */
+	}
+
+	return 1; /* finished processing */
+}
+
+static struct hid_device_info *create_device_info(const struct usb_device_info *udi, const char *path, const struct usb_ctl_report_desc *ucrd)
+{
+	struct hid_device_info *root;
+	struct hid_device_info *end;
+
+	root = (struct hid_device_info *) calloc(1, sizeof(struct hid_device_info));
+	if (!root)
+		return NULL;
+
+	end = root;
+
+	/* Path */
+	end->path = (path) ? strdup(path) : NULL;
+
+	/* Vendor Id */
+	end->vendor_id = udi->udi_vendorNo;
+
+	/* Product Id */
+	end->product_id = udi->udi_productNo;
+
+	/* Serial Number */
+	end->serial_number = utf8_to_wchar_t(udi->udi_serial);
+
+	/* Release Number */
+	end->release_number = udi->udi_releaseNo;
+
+	/* Manufacturer String */
+	end->manufacturer_string = utf8_to_wchar_t(udi->udi_vendor);
+
+	/* Product String */
+	end->product_string = utf8_to_wchar_t(udi->udi_product);
+
+	/* Usage Page */
+	end->usage_page = 0;
+
+	/* Usage */
+	end->usage = 0;
+
+	/* Interface Number */
+	end->interface_number = -1;
+
+	/* Next Device Info */
+	end->next = NULL;
+
+	/* Bus Type */
+	end->bus_type = HID_API_BUS_USB;
+
+	if (ucrd) {
+		uint16_t page;
+		uint16_t usage;
+		struct hid_usage_iterator usage_iterator;
+
+		page = usage = 0;
+		memset(&usage_iterator, 0, sizeof(usage_iterator));
+
+		/*
+		 * Parse the first usage and usage page
+		 * out of the report descriptor.
+		 */
+		if (get_next_hid_usage(ucrd->ucrd_data, ucrd->ucrd_size, &usage_iterator, &page, &usage) == 0) {
+			end->usage_page = page;
+			end->usage = usage;
+		}
+
+		/*
+		 * Parse any additional usage and usage pages
+		 * out of the report descriptor.
+		 */
+		while (get_next_hid_usage(ucrd->ucrd_data, ucrd->ucrd_size, &usage_iterator, &page, &usage) == 0) {
+			/* Create new record for additional usage pairs */
+			struct hid_device_info *node = (struct hid_device_info *) calloc(1, sizeof(struct hid_device_info));
+
+			if (!node)
+				continue;
+
+			/* Update fields */
+			node->path = (end->path) ? strdup(end->path) : NULL;
+			node->vendor_id = end->vendor_id;
+			node->product_id = end->product_id;
+			node->serial_number = (end->serial_number) ? wcsdup(end->serial_number) : NULL;
+			node->release_number = end->release_number;
+			node->manufacturer_string = (end->manufacturer_string) ? wcsdup(end->manufacturer_string) : NULL;
+			node->product_string = (end->product_string) ? wcsdup(end->product_string) : NULL;
+			node->usage_page = page;
+			node->usage = usage;
+			node->interface_number = end->interface_number;
+			node->next = NULL;
+			node->bus_type = end->bus_type;
+
+			/* Insert node */
+			end->next = node;
+			end = node;
+		}
+	}
+
+	return root;
+}
+
+static int is_usb_controller(const char *s)
+{
+	return (!strncmp(s, "usb", 3) && isdigit((int) s[3]));
+}
+
+static int is_uhid_parent_device(const char *s)
+{
+	return (!strncmp(s, "uhidev", 6) && isdigit((int) s[6]));
+}
+
+static int is_uhid_device(const char *s)
+{
+	return (!strncmp(s, "uhid", 4) && isdigit((int) s[4]));
+}
+
+static void walk_device_tree(int drvctl, const char *dev, int depth, char arr[static HIDAPI_MAX_CHILD_DEVICES][USB_MAX_DEVNAMELEN], size_t *len, int (*cmp) (const char *))
+{
+	int res;
+	char childname[HIDAPI_MAX_CHILD_DEVICES][USB_MAX_DEVNAMELEN];
+	struct devlistargs dla;
+
+	if (depth && (!dev || !*dev))
+		return;
+
+	if (cmp(dev) && *len < HIDAPI_MAX_CHILD_DEVICES)
+		strlcpy(arr[(*len)++], dev, sizeof(*arr));
+
+	strlcpy(dla.l_devname, dev, sizeof(dla.l_devname));
+	dla.l_childname = childname;
+	dla.l_children = HIDAPI_MAX_CHILD_DEVICES;
+
+	res = ioctl(drvctl, DRVLISTDEV, &dla);
+	if (res == -1)
+		return;
+
+	/*
+	 * DO NOT CHANGE THIS. This is a fail-safe check
+	 * for the unlikely event that a parent device has
+	 * more than HIDAPI_MAX_CHILD_DEVICES child devices
+	 * to prevent iterating over uninitialized data.
+	 */
+	if (dla.l_children > HIDAPI_MAX_CHILD_DEVICES)
+		return;
+
+	for (size_t i = 0; i < dla.l_children; i++)
+		walk_device_tree(drvctl, dla.l_childname[i], depth + 1, arr, len, cmp);
+}
+
+static void enumerate_usb_devices(int bus, uint8_t addr, enumerate_devices_callback func, void *data)
+{
+	int res;
+	struct usb_device_info udi;
+
+	udi.udi_addr = addr;
+
+	res = ioctl(bus, USB_DEVICEINFO, &udi);
+	if (res == -1)
+		return;
+
+	for (int port = 0; port < udi.udi_nports; port++) {
+		addr = udi.udi_ports[port];
+		if (addr >= USB_MAX_DEVICES)
+			continue;
+
+		enumerate_usb_devices(bus, addr, func, data);
+	}
+
+	func(&udi, data);
+}
+
+static void hid_enumerate_callback(const struct usb_device_info *udi, void *data)
+{
+	struct hid_enumerate_data *hed;
+
+	hed = (struct hid_enumerate_data *) data;
+
+	if (hed->vendor_id != 0 && hed->vendor_id != udi->udi_vendorNo)
+		return;
+
+	if (hed->product_id != 0 && hed->product_id != udi->udi_productNo)
+		return;
+
+	for (size_t i = 0; i < USB_MAX_DEVNAMES; i++) {
+		const char *parent_dev;
+		char arr[HIDAPI_MAX_CHILD_DEVICES][USB_MAX_DEVNAMELEN];
+		size_t len;
+		const char *child_dev;
+		char devpath[USB_MAX_DEVNAMELEN];
+		int uhid;
+		struct usb_ctl_report_desc ucrd;
+		int use_ucrd;
+		struct hid_device_info *node;
+
+		parent_dev = udi->udi_devnames[i];
+		if (!is_uhid_parent_device(parent_dev))
+			continue;
+
+		len = 0;
+		walk_device_tree(hed->drvctl, parent_dev, 0, arr, &len, is_uhid_device);
+
+		if (len == 0)
+			continue;
+
+		child_dev = arr[0];
+		strlcpy(devpath, "/dev/", sizeof(devpath));
+		strlcat(devpath, child_dev, sizeof(devpath));
+
+		uhid = open(devpath, O_RDONLY | O_CLOEXEC);
+		if (uhid >= 0) {
+			use_ucrd = (ioctl(uhid, USB_GET_REPORT_DESC, &ucrd) != -1);
+			close(uhid);
+		} else {
+			use_ucrd = 0;
+		}
+
+		node = create_device_info(udi, parent_dev, (use_ucrd) ? &ucrd : NULL);
+		if (!node)
+			continue;
+
+		if (!hed->root) {
+			hed->root = node;
+			hed->end = node;
+		} else {
+			hed->end->next = node;
+			hed->end = node;
+		}
+
+		while (hed->end->next)
+			hed->end = hed->end->next;
+	}
+}
+
+static int set_report(hid_device *dev, const uint8_t *data, size_t length, int report)
+{
+	int res;
+	int device_handle;
+	struct usb_ctl_report ucr;
+
+	if (length < 1) {
+		register_device_error(dev, "report must be greater than 1 byte");
+		return -1;
+	}
+
+	device_handle = dev->report_handles[*data];
+	if (device_handle < 0) {
+		register_device_error_format(dev, "unsupported report id: %hhu", *data);
+		return -1;
+	}
+
+	length--;
+	data++;
+
+	if (length > sizeof(ucr.ucr_data)) {
+		register_device_error_format(dev, "report must be less than or equal to %zu bytes", sizeof(ucr.ucr_data));
+		return -1;
+	}
+
+	ucr.ucr_report = report;
+	memcpy(ucr.ucr_data, data, length);
+
+	res = ioctl(device_handle, USB_SET_REPORT, &ucr);
+	if (res == -1) {
+		register_device_error_format(dev, "ioctl (USB_SET_REPORT): %s", strerror(errno));
+		return -1;
+	}
+
+	return (int) (length + 1);
+}
+
+static int get_report(hid_device *dev, uint8_t *data, size_t length, int report)
+{
+	int res;
+	int device_handle;
+	struct usb_ctl_report ucr;
+
+	if (length < 1) {
+		register_device_error(dev, "report must be greater than 1 byte");
+		return -1;
+	}
+
+	device_handle = dev->report_handles[*data];
+	if (device_handle < 0) {
+		register_device_error_format(dev, "unsupported report id: %hhu", *data);
+		return -1;
+	}
+
+	length--;
+	data++;
+
+	if (length > sizeof(ucr.ucr_data)) {
+		length = sizeof(ucr.ucr_data);
+	}
+
+	ucr.ucr_report = report;
+
+	res = ioctl(device_handle, USB_GET_REPORT, &ucr);
+	if (res == -1) {
+		register_device_error_format(dev, "ioctl (USB_GET_REPORT): %s", strerror(errno));
+		return -1;
+	}
+
+	memcpy(data, ucr.ucr_data, length);
+
+	return (int) (length + 1);
+}
+
+int HID_API_EXPORT HID_API_CALL hid_init(void)
+{
+	/* indicate no error */
+	register_global_error(NULL);
+
+	return 0;
+}
+
+int HID_API_EXPORT HID_API_CALL hid_exit(void)
+{
+	/* Free global error message */
+	register_global_error(NULL);
+
+	return 0;
+}
+
+struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+{
+	int res;
+	int drvctl;
+	char arr[HIDAPI_MAX_CHILD_DEVICES][USB_MAX_DEVNAMELEN];
+	size_t len;
+	struct hid_enumerate_data hed;
+
+	res = hid_init();
+	if (res == -1)
+		return NULL;
+
+	drvctl = open(DRVCTLDEV, O_RDONLY | O_CLOEXEC);
+	if (drvctl == -1) {
+		register_global_error_format("failed to open drvctl: %s", strerror(errno));
+		return NULL;
+	}
+
+	len = 0;
+	walk_device_tree(drvctl, "", 0, arr, &len, is_usb_controller);
+
+	hed.root = NULL;
+	hed.end = NULL;
+	hed.drvctl = drvctl;
+	hed.vendor_id = vendor_id;
+	hed.product_id = product_id;
+
+	for (size_t i = 0; i < len; i++) {
+		char devpath[USB_MAX_DEVNAMELEN];
+		int bus;
+
+		strlcpy(devpath, "/dev/", sizeof(devpath));
+		strlcat(devpath, arr[i], sizeof(devpath));
+
+		bus = open(devpath, O_RDONLY | O_CLOEXEC);
+		if (bus == -1)
+			continue;
+
+		enumerate_usb_devices(bus, 0, hid_enumerate_callback, &hed);
+
+		close(bus);
+	}
+
+	close(drvctl);
+
+	return hed.root;
+}
+
+void HID_API_EXPORT HID_API_CALL hid_free_enumeration(struct hid_device_info *devs)
+{
+	while (devs) {
+		struct hid_device_info *next = devs->next;
+		free(devs->path);
+		free(devs->serial_number);
+		free(devs->manufacturer_string);
+		free(devs->product_string);
+		free(devs);
+		devs = next;
+	}
+}
+
+HID_API_EXPORT hid_device * HID_API_CALL hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)
+{
+	struct hid_device_info *devs;
+	struct hid_device_info *dev;
+	char path[USB_MAX_DEVNAMELEN];
+
+	devs = hid_enumerate(vendor_id, product_id);
+	if (!devs)
+		return NULL;
+
+	*path = '\0';
+
+	for (dev = devs; dev; dev = dev->next) {
+		if (dev->vendor_id != vendor_id)
+			continue;
+
+		if (dev->product_id != product_id)
+			continue;
+
+		if (serial_number && wcscmp(dev->serial_number, serial_number))
+			continue;
+
+		strlcpy(path, dev->path, sizeof(path));
+
+		break;
+	}
+
+	hid_free_enumeration(devs);
+
+	if (*path == '\0') {
+		register_global_error("Device with requested VID/PID/(SerialNumber) not found");
+		return NULL;
+	}
+
+	return hid_open_path(path);
+}
+
+HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
+{
+	int res;
+	hid_device *dev;
+	int drvctl;
+	char arr[HIDAPI_MAX_CHILD_DEVICES][USB_MAX_DEVNAMELEN];
+	size_t len;
+
+	res = hid_init();
+	if (res == -1)
+		goto err_0;
+
+	dev = (hid_device *) calloc(1, sizeof(hid_device));
+	if (!dev) {
+		register_global_error("could not allocate hid_device");
+		goto err_0;
+	}
+
+	drvctl = open(DRVCTLDEV, O_RDONLY | O_CLOEXEC);
+	if (drvctl == -1) {
+		register_global_error_format("failed to open drvctl: %s", strerror(errno));
+		goto err_1;
+	}
+
+	if (!is_uhid_parent_device(path)) {
+		register_global_error("not a uhidev device");
+		goto err_2;
+	}
+
+	len = 0;
+	walk_device_tree(drvctl, path, 0, arr, &len, is_uhid_device);
+
+	dev->poll_handles_length = 0;
+	memset(dev->poll_handles, 0x00, sizeof(dev->poll_handles));
+	memset(dev->report_handles, 0xff, sizeof(dev->report_handles));
+
+	for (size_t i = 0; i < len; i++) {
+		const char *child_dev;
+		char devpath[USB_MAX_DEVNAMELEN];
+		int uhid;
+		int rep_id;
+		struct pollfd *ph;
+
+		child_dev = arr[i];
+		strlcpy(devpath, "/dev/", sizeof(devpath));
+		strlcat(devpath, child_dev, sizeof(devpath));
+
+		uhid = open(devpath, O_RDWR | O_CLOEXEC);
+		if (uhid == -1) {
+			register_global_error_format("failed to open %s: %s", child_dev, strerror(errno));
+			goto err_3;
+		}
+
+		res = ioctl(uhid, USB_GET_REPORT_ID, &rep_id);
+		if (res == -1) {
+			close(uhid);
+			register_global_error_format("failed to get report id %s: %s", child_dev, strerror(errno));
+			goto err_3;
+		}
+
+		ph = &dev->poll_handles[dev->poll_handles_length++];
+		ph->fd = uhid;
+		ph->events = POLLIN;
+		ph->revents = 0;
+		dev->report_handles[rep_id] = uhid;
+		dev->device_handle = uhid;
+	}
+
+	dev->blocking = 1;
+	dev->last_error_str = NULL;
+	dev->device_info = NULL;
+	strlcpy(dev->path, path, sizeof(dev->path));
+
+	register_global_error(NULL);
+	return dev;
+
+err_3:
+	for (size_t i = 0; i < dev->poll_handles_length; i++)
+		close(dev->poll_handles[i].fd);
+err_2:
+	close(drvctl);
+err_1:
+	free(dev);
+err_0:
+	return NULL;
+}
+
+int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *data, size_t length)
+{
+	return set_report(dev, data, length, UHID_OUTPUT_REPORT);
+}
+
+int HID_API_EXPORT HID_API_CALL hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds)
+{
+	int res;
+	size_t i;
+	struct pollfd *ph;
+	ssize_t n;
+
+	res = poll(dev->poll_handles, dev->poll_handles_length, milliseconds);
+	if (res == -1) {
+		register_device_error_format(dev, "error while polling: %s", strerror(errno));
+		return -1;
+	}
+
+	if (res == 0)
+		return 0;
+
+	for (i = 0; i < dev->poll_handles_length; i++) {
+		ph = &dev->poll_handles[i];
+
+		if (ph->revents & (POLLERR | POLLHUP | POLLNVAL)) {
+			register_device_error(dev, "device IO error while polling");
+			return -1;
+		}
+
+		if (ph->revents & POLLIN)
+			break;
+	}
+
+	if (i == dev->poll_handles_length)
+		return 0;
+
+	n = read(ph->fd, data, length);
+	if (n == -1) {
+		if (errno == EAGAIN || errno == EINPROGRESS)
+			n = 0;
+		else
+			register_device_error_format(dev, "error while reading: %s", strerror(errno));
+	}
+
+	return n;
+}
+
+int HID_API_EXPORT HID_API_CALL hid_read(hid_device *dev, unsigned char *data, size_t length)
+{
+	return hid_read_timeout(dev, data, length, (dev->blocking) ? -1 : 0);
+}
+
+int HID_API_EXPORT HID_API_CALL hid_set_nonblocking(hid_device *dev, int nonblock)
+{
+	dev->blocking = !nonblock;
+	return 0;
+}
+
+int HID_API_EXPORT HID_API_CALL hid_send_feature_report(hid_device *dev, const unsigned char *data, size_t length)
+{
+	return set_report(dev, data, length, UHID_FEATURE_REPORT);
+}
+
+int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *dev, unsigned char *data, size_t length)
+{
+	return get_report(dev, data, length, UHID_FEATURE_REPORT);
+}
+
+int HID_API_EXPORT HID_API_CALL hid_get_input_report(hid_device *dev, unsigned char *data, size_t length)
+{
+	return get_report(dev, data, length, UHID_INPUT_REPORT);
+}
+
+void HID_API_EXPORT HID_API_CALL hid_close(hid_device *dev)
+{
+	if (!dev)
+		return;
+
+	/* Free the device error message */
+	register_device_error(dev, NULL);
+
+	hid_free_enumeration(dev->device_info);
+
+	for (size_t i = 0; i < dev->poll_handles_length; i++)
+		close(dev->poll_handles[i].fd);
+
+	free(dev);
+}
+
+int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	struct hid_device_info *hdi;
+
+	if (!string || !maxlen) {
+		register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
+	hdi = hid_get_device_info(dev);
+	if (!dev)
+		return -1;
+
+	if (hdi->manufacturer_string) {
+		wcsncpy(string, hdi->manufacturer_string, maxlen);
+		string[maxlen - 1] = L'\0';
+	} else {
+		string[0] = L'\0';
+	}
+
+	return 0;
+}
+
+int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	struct hid_device_info *hdi;
+
+	if (!string || !maxlen) {
+		register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
+	hdi = hid_get_device_info(dev);
+	if (!dev)
+		return -1;
+
+	if (hdi->product_string) {
+		wcsncpy(string, hdi->product_string, maxlen);
+		string[maxlen - 1] = L'\0';
+	} else {
+		string[0] = L'\0';
+	}
+
+	return 0;
+}
+
+int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	struct hid_device_info *hdi;
+
+	if (!string || !maxlen) {
+		register_device_error(dev, "Zero buffer/length");
+		return -1;
+	}
+
+	hdi = hid_get_device_info(dev);
+	if (!dev)
+		return -1;
+
+	if (hdi->serial_number) {
+		wcsncpy(string, hdi->serial_number, maxlen);
+		string[maxlen - 1] = L'\0';
+	} else {
+		string[0] = L'\0';
+	}
+
+	return 0;
+}
+
+struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_get_device_info(hid_device *dev)
+{
+	int res;
+	struct usb_device_info udi;
+	struct usb_ctl_report_desc ucrd;
+	int use_ucrd;
+	struct hid_device_info *hdi;
+
+	if (dev->device_info)
+		return dev->device_info;
+
+	res = ioctl(dev->device_handle, USB_GET_DEVICEINFO, &udi);
+	if (res == -1) {
+		register_device_error_format(dev, "ioctl (USB_GET_DEVICEINFO): %s", strerror(errno));
+		return NULL;
+	}
+
+	use_ucrd = (ioctl(dev->device_handle, USB_GET_REPORT_DESC, &ucrd) != -1);
+
+	hdi = create_device_info(&udi, dev->path, (use_ucrd) ? &ucrd : NULL);
+	if (!hdi) {
+		register_device_error(dev, "failed to create device info");
+		return NULL;
+	}
+
+	dev->device_info = hdi;
+
+	return hdi;
+}
+
+int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)
+{
+	int res;
+	struct usb_string_desc usd;
+	usb_string_descriptor_t *str;
+	iconv_t ic;
+	char *src;
+	size_t srcleft;
+	char *dst;
+	size_t dstleft;
+	size_t ic_res;
+
+	/* First let us get the supported language IDs. */
+	usd.usd_string_index = 0;
+	usd.usd_language_id = 0;
+
+	res = ioctl(dev->device_handle, USB_GET_STRING_DESC, &usd);
+	if (res == -1) {
+		register_device_error_format(dev, "ioctl (USB_GET_STRING_DESC): %s", strerror(errno));
+		return -1;
+	}
+
+	str = &usd.usd_desc;
+
+	if (str->bLength < 4) {
+		register_device_error(dev, "failed to get supported language IDs");
+		return -1;
+	}
+
+	/* Now we can get the requested string. */
+	usd.usd_string_index = string_index;
+	usd.usd_language_id = UGETW(str->bString[0]);
+
+	res = ioctl(dev->device_handle, USB_GET_STRING_DESC, &usd);
+	if (res == -1) {
+		register_device_error_format(dev, "ioctl (USB_GET_STRING_DESC): %s", strerror(errno));
+		return -1;
+	}
+
+	/* Now we need to convert it, using iconv. */
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	ic = iconv_open("utf-32le", "utf-16le");
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	ic = iconv_open("utf-32be", "utf-16le");
+#endif
+	if (ic == (iconv_t) -1) {
+		register_device_error_format(dev, "iconv_open failed: %s", strerror(errno));
+		return -1;
+	}
+
+	src = (char *) str->bString;
+	srcleft = str->bLength - 2;
+	dst = (char *) string;
+	dstleft = sizeof(wchar_t[maxlen]);
+
+	ic_res = iconv(ic, &src, &srcleft, &dst, &dstleft);
+	iconv_close(ic);
+	if (ic_res == (size_t) -1) {
+		register_device_error_format(dev, "iconv failed: %s", strerror(errno));
+		return -1;
+	}
+
+	/* Write the terminating NULL. */
+	string[maxlen - 1] = L'\0';
+	if (dstleft >= sizeof(wchar_t))
+		*((wchar_t *) dst) = L'\0';
+
+	return 0;
+}
+
+int HID_API_EXPORT_CALL hid_get_report_descriptor(hid_device *dev, unsigned char *buf, size_t buf_size)
+{
+	int res;
+	struct usb_ctl_report_desc ucrd;
+
+	res = ioctl(dev->device_handle, USB_GET_REPORT_DESC, &ucrd);
+	if (res == -1) {
+		register_device_error_format(dev, "ioctl (USB_GET_REPORT_DESC): %s", strerror(errno));
+		return -1;
+	}
+
+	if ((size_t) ucrd.ucrd_size < buf_size)
+		buf_size = (size_t) ucrd.ucrd_size;
+
+	memcpy(buf, ucrd.ucrd_data, buf_size);
+
+	return (int) buf_size;
+}
+
+HID_API_EXPORT const wchar_t* HID_API_CALL hid_error(hid_device *dev)
+{
+	if (dev) {
+		if (dev->last_error_str == NULL)
+			return L"Success";
+		return dev->last_error_str;
+	}
+
+	if (last_global_error_str == NULL)
+		return L"Success";
+	return last_global_error_str;
+}
+
+HID_API_EXPORT const struct hid_api_version* HID_API_CALL hid_version(void)
+{
+	static const struct hid_api_version api_version = {
+		.major = HID_API_VERSION_MAJOR,
+		.minor = HID_API_VERSION_MINOR,
+		.patch = HID_API_VERSION_PATCH
+	};
+
+	return &api_version;
+}
+
+HID_API_EXPORT const char* HID_API_CALL hid_version_str(void)
+{
+	return HID_API_VERSION_STR;
+}

--- a/thirdparty/sdl/joystick/bsd/SDL_bsdjoystick.c
+++ b/thirdparty/sdl/joystick/bsd/SDL_bsdjoystick.c
@@ -1,0 +1,868 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2025 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "SDL_internal.h"
+
+#ifdef SDL_JOYSTICK_USBHID
+
+/*
+ * Joystick driver for the uhid(4) / ujoy(4) interface found in OpenBSD,
+ * NetBSD and FreeBSD.
+ *
+ * Maintainer: <vedge at csoft.org>
+ */
+
+#include <sys/param.h>
+#include <sys/stat.h>
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#ifndef __FreeBSD_kernel_version
+#define __FreeBSD_kernel_version __FreeBSD_version
+#endif
+
+#ifdef HAVE_USB_H
+#include <usb.h>
+#endif
+#ifdef __DragonFly__
+#include <bus/u4b/usb.h>
+#include <bus/u4b/usbhid.h>
+#else
+#include <dev/usb/usb.h>
+#include <dev/usb/usbhid.h>
+#endif
+
+#ifdef HAVE_USBHID_H
+#include <usbhid.h>
+#elif defined(HAVE_LIBUSB_H)
+#include <libusb.h>
+#elif defined(HAVE_LIBUSBHID_H)
+#include <libusbhid.h>
+#endif
+
+#if defined(SDL_PLATFORM_FREEBSD)
+#include <osreldate.h>
+#if __FreeBSD_kernel_version > 800063
+#include <dev/usb/usb_ioctl.h>
+#elif defined(__DragonFly__)
+#include <bus/u4b/usb_ioctl.h>
+#endif
+#include <sys/joystick.h>
+#endif
+
+#ifdef SDL_HAVE_MACHINE_JOYSTICK_H
+#include <machine/joystick.h>
+#endif
+
+#include "../SDL_sysjoystick.h"
+#include "../SDL_joystick_c.h"
+#include "../hidapi/SDL_hidapijoystick_c.h"
+
+#if defined(SDL_PLATFORM_FREEBSD) || defined(SDL_HAVE_MACHINE_JOYSTICK_H) || defined(__FreeBSD_kernel__) || defined(__DragonFly_)
+#define SUPPORT_JOY_GAMEPORT
+#endif
+
+#define MAX_UHID_JOYS 64
+#define MAX_JOY_JOYS  2
+#define MAX_JOYS      (MAX_UHID_JOYS + MAX_JOY_JOYS)
+
+#ifdef SDL_PLATFORM_OPENBSD
+
+#define HUG_DPAD_UP    0x90
+#define HUG_DPAD_DOWN  0x91
+#define HUG_DPAD_RIGHT 0x92
+#define HUG_DPAD_LEFT  0x93
+
+#define HAT_UP        0x01
+#define HAT_RIGHT     0x02
+#define HAT_DOWN      0x04
+#define HAT_LEFT      0x08
+
+#endif
+
+struct report
+{
+#if defined(SDL_PLATFORM_FREEBSD) && (__FreeBSD_kernel_version > 900000) || \
+    defined(__DragonFly__)
+    void *buf; // Buffer
+#elif defined(SDL_PLATFORM_FREEBSD) && (__FreeBSD_kernel_version > 800063)
+    struct usb_gen_descriptor *buf; // Buffer
+#else
+    struct usb_ctl_report *buf; // Buffer
+#endif
+    size_t size; // Buffer size
+    int rid;     // Report ID
+    enum
+    {
+        SREPORT_UNINIT,
+        SREPORT_CLEAN,
+        SREPORT_DIRTY
+    } status;
+};
+
+static struct
+{
+    int uhid_report;
+    hid_kind_t kind;
+    const char *name;
+} const repinfo[] = {
+    { UHID_INPUT_REPORT, hid_input, "input" },
+    { UHID_OUTPUT_REPORT, hid_output, "output" },
+    { UHID_FEATURE_REPORT, hid_feature, "feature" }
+};
+
+enum
+{
+    REPORT_INPUT = 0,
+    REPORT_OUTPUT = 1,
+    REPORT_FEATURE = 2
+};
+
+enum
+{
+    JOYAXE_X,
+    JOYAXE_Y,
+    JOYAXE_Z,
+    JOYAXE_SLIDER,
+    JOYAXE_WHEEL,
+    JOYAXE_RX,
+    JOYAXE_RY,
+    JOYAXE_RZ,
+    JOYAXE_count
+};
+
+struct joystick_hwdata
+{
+    int fd;
+    enum
+    {
+        BSDJOY_UHID, // uhid(4)
+        BSDJOY_JOY   // joy(4)
+    } type;
+
+    int naxes;
+    int nbuttons;
+    int nhats;
+    struct report_desc *repdesc;
+    struct report inreport;
+    int axis_map[JOYAXE_count]; /* map present JOYAXE_* to 0,1,.. */
+};
+
+// A linked list of available joysticks
+typedef struct SDL_joylist_item
+{
+    SDL_JoystickID device_instance;
+    char *path; // "/dev/uhid0" or whatever
+    char *name; // "SideWinder 3D Pro" or whatever
+    SDL_GUID guid;
+    dev_t devnum;
+    struct SDL_joylist_item *next;
+} SDL_joylist_item;
+
+static SDL_joylist_item *SDL_joylist = NULL;
+static SDL_joylist_item *SDL_joylist_tail = NULL;
+static int numjoysticks = 0;
+
+static bool report_alloc(struct report *, struct report_desc *, int);
+static void report_free(struct report *);
+
+#if defined(USBHID_UCR_DATA) || (defined(__FreeBSD_kernel__) && __FreeBSD_kernel_version <= 800063)
+#define REP_BUF_DATA(rep) ((rep)->buf->ucr_data)
+#elif (defined(SDL_PLATFORM_FREEBSD) && (__FreeBSD_kernel_version > 900000)) || \
+    defined(__DragonFly__)
+#define REP_BUF_DATA(rep) ((rep)->buf)
+#elif (defined(SDL_PLATFORM_FREEBSD) && (__FreeBSD_kernel_version > 800063))
+#define REP_BUF_DATA(rep) ((rep)->buf->ugd_data)
+#else
+#define REP_BUF_DATA(rep) ((rep)->buf->data)
+#endif
+
+static int usage_to_joyaxe(int usage)
+{
+    int joyaxe;
+    switch (usage) {
+    case HUG_X:
+        joyaxe = JOYAXE_X;
+        break;
+    case HUG_Y:
+        joyaxe = JOYAXE_Y;
+        break;
+    case HUG_Z:
+        joyaxe = JOYAXE_Z;
+        break;
+    case HUG_SLIDER:
+        joyaxe = JOYAXE_SLIDER;
+        break;
+    case HUG_WHEEL:
+        joyaxe = JOYAXE_WHEEL;
+        break;
+    case HUG_RX:
+        joyaxe = JOYAXE_RX;
+        break;
+    case HUG_RY:
+        joyaxe = JOYAXE_RY;
+        break;
+    case HUG_RZ:
+        joyaxe = JOYAXE_RZ;
+        break;
+    default:
+        joyaxe = -1;
+    }
+    return joyaxe;
+}
+
+static void FreeJoylistItem(SDL_joylist_item *item)
+{
+    SDL_free(item->path);
+    SDL_free(item->name);
+    SDL_free(item);
+}
+
+static void FreeHwData(struct joystick_hwdata *hw)
+{
+    if (hw->type == BSDJOY_UHID) {
+        report_free(&hw->inreport);
+
+        if (hw->repdesc) {
+            hid_dispose_report_desc(hw->repdesc);
+        }
+    }
+    close(hw->fd);
+    SDL_free(hw);
+}
+
+static struct joystick_hwdata *CreateHwData(const char *path)
+{
+    struct joystick_hwdata *hw;
+    struct hid_item hitem;
+    struct hid_data *hdata;
+    struct report *rep = NULL;
+    int fd;
+    int i;
+
+    fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd == -1) {
+        SDL_SetError("%s: %s", path, strerror(errno));
+        return NULL;
+    }
+
+    hw = (struct joystick_hwdata *)
+        SDL_calloc(1, sizeof(struct joystick_hwdata));
+    if (!hw) {
+        close(fd);
+        return NULL;
+    }
+    hw->fd = fd;
+
+#ifdef SUPPORT_JOY_GAMEPORT
+    if (SDL_strncmp(path, "/dev/joy", 8) == 0) {
+        hw->type = BSDJOY_JOY;
+        hw->naxes = 2;
+        hw->nbuttons = 2;
+    } else
+#endif
+    {
+        hw->type = BSDJOY_UHID;
+        {
+            int ax;
+            for (ax = 0; ax < JOYAXE_count; ax++) {
+                hw->axis_map[ax] = -1;
+            }
+        }
+        hw->repdesc = hid_get_report_desc(fd);
+        if (!hw->repdesc) {
+            SDL_SetError("%s: USB_GET_REPORT_DESC: %s", path,
+                         strerror(errno));
+            goto usberr;
+        }
+        rep = &hw->inreport;
+#if defined(SDL_PLATFORM_FREEBSD) && (__FreeBSD_kernel_version > 800063) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+        rep->rid = hid_get_report_id(fd);
+        if (rep->rid < 0) {
+#else
+        if (ioctl(fd, USB_GET_REPORT_ID, &rep->rid) < 0) {
+#endif
+            rep->rid = -1; // XXX
+        }
+        if (!report_alloc(rep, hw->repdesc, REPORT_INPUT)) {
+            goto usberr;
+        }
+        if (rep->size <= 0) {
+            SDL_SetError("%s: Input report descriptor has invalid length",
+                         path);
+            goto usberr;
+        }
+#if defined(USBHID_NEW) || (defined(SDL_PLATFORM_FREEBSD) && __FreeBSD_kernel_version >= 500111) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+        hdata = hid_start_parse(hw->repdesc, 1 << hid_input, rep->rid);
+#else
+        hdata = hid_start_parse(hw->repdesc, 1 << hid_input);
+#endif
+        if (!hdata) {
+            SDL_SetError("%s: Cannot start HID parser", path);
+            goto usberr;
+        }
+        for (i = 0; i < JOYAXE_count; i++) {
+            hw->axis_map[i] = -1;
+        }
+
+        while (hid_get_item(hdata, &hitem) > 0) {
+            switch (hitem.kind) {
+            case hid_input:
+                switch (HID_PAGE(hitem.usage)) {
+                case HUP_GENERIC_DESKTOP:
+                {
+                    int usage = HID_USAGE(hitem.usage);
+                    int joyaxe = usage_to_joyaxe(usage);
+                    if (joyaxe >= 0) {
+                        hw->axis_map[joyaxe] = 1;
+                    } else if (usage == HUG_HAT_SWITCH
+#ifdef SDL_PLATFORM_OPENBSD
+                               || usage == HUG_DPAD_UP
+#endif
+                    ) {
+                        hw->nhats++;
+                    }
+                    break;
+                }
+                case HUP_BUTTON:
+                {
+                    int usage = HID_USAGE(hitem.usage);
+                    if (usage > hw->nbuttons) {
+                        hw->nbuttons = usage;
+                    }
+                } break;
+                default:
+                    break;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+        hid_end_parse(hdata);
+        for (i = 0; i < JOYAXE_count; i++) {
+            if (hw->axis_map[i] > 0) {
+                hw->axis_map[i] = hw->naxes++;
+            }
+        }
+
+        if (hw->naxes == 0 && hw->nbuttons == 0 && hw->nhats == 0) {
+            SDL_SetError("%s: Not a joystick, ignoring", path);
+            goto usberr;
+        }
+    }
+
+    // The poll blocks the event thread.
+    fcntl(fd, F_SETFL, O_NONBLOCK);
+#ifdef SDL_PLATFORM_NETBSD
+    // Flush pending events
+    if (rep) {
+        while (read(fd, REP_BUF_DATA(rep), rep->size) == rep->size)
+            ;
+    }
+#endif
+
+    return hw;
+
+usberr:
+    FreeHwData(hw);
+    return NULL;
+}
+
+static bool MaybeAddDevice(const char *path)
+{
+    struct stat sb;
+    char *name = NULL;
+    SDL_GUID guid;
+    SDL_joylist_item *item;
+    struct joystick_hwdata *hw;
+
+    if (!path) {
+        return false;
+    }
+
+    if (stat(path, &sb) == -1) {
+        return false;
+    }
+
+    // Check to make sure it's not already in list.
+    for (item = SDL_joylist; item; item = item->next) {
+        if (sb.st_rdev == item->devnum) {
+            return false; // already have this one
+        }
+    }
+
+    hw = CreateHwData(path);
+    if (!hw) {
+        return false;
+    }
+
+    if (hw->type == BSDJOY_JOY) {
+        name = SDL_strdup("Gameport joystick");
+        guid = SDL_CreateJoystickGUIDForName(name);
+    } else {
+#ifdef USB_GET_DEVICEINFO
+        struct usb_device_info di;
+        if (ioctl(hw->fd, USB_GET_DEVICEINFO, &di) != -1) {
+            name = SDL_CreateJoystickName(di.udi_vendorNo, di.udi_productNo, di.udi_vendor, di.udi_product);
+            guid = SDL_CreateJoystickGUID(SDL_HARDWARE_BUS_USB, di.udi_vendorNo, di.udi_productNo, di.udi_releaseNo, di.udi_vendor, di.udi_product, 0, 0);
+
+            if (SDL_ShouldIgnoreJoystick(di.udi_vendorNo, di.udi_productNo, di.udi_releaseNo, name) ||
+                SDL_JoystickHandledByAnotherDriver(&SDL_BSD_JoystickDriver, di.udi_vendorNo, di.udi_productNo, di.udi_releaseNo, name)) {
+                SDL_free(name);
+                FreeHwData(hw);
+                return false;
+            }
+        }
+#endif // USB_GET_DEVICEINFO
+    }
+    if (!name) {
+        name = SDL_strdup(path);
+        guid = SDL_CreateJoystickGUIDForName(name);
+    }
+    FreeHwData(hw);
+
+    item = (SDL_joylist_item *)SDL_calloc(1, sizeof(SDL_joylist_item));
+    if (!item) {
+        SDL_free(name);
+        return false;
+    }
+
+    item->devnum = sb.st_rdev;
+    item->path = SDL_strdup(path);
+    item->name = name;
+    item->guid = guid;
+
+    if ((!item->path) || (!item->name)) {
+        FreeJoylistItem(item);
+        return false;
+    }
+
+    item->device_instance = SDL_GetNextObjectID();
+    if (!SDL_joylist_tail) {
+        SDL_joylist = SDL_joylist_tail = item;
+    } else {
+        SDL_joylist_tail->next = item;
+        SDL_joylist_tail = item;
+    }
+
+    // Need to increment the joystick count before we post the event
+    ++numjoysticks;
+
+    SDL_PrivateJoystickAdded(item->device_instance);
+
+    return true;
+}
+
+static bool BSD_JoystickInit(void)
+{
+    char s[16];
+    int i;
+
+    for (i = 0; i < MAX_UHID_JOYS; i++) {
+#if defined(SDL_PLATFORM_OPENBSD) && (OpenBSD >= 202105)
+        SDL_snprintf(s, SDL_arraysize(s), "/dev/ujoy/%d", i);
+#else
+        SDL_snprintf(s, SDL_arraysize(s), "/dev/uhid%d", i);
+#endif
+        MaybeAddDevice(s);
+    }
+#ifdef SUPPORT_JOY_GAMEPORT
+    for (i = 0; i < MAX_JOY_JOYS; i++) {
+        SDL_snprintf(s, SDL_arraysize(s), "/dev/joy%d", i);
+        MaybeAddDevice(s);
+    }
+#endif // SUPPORT_JOY_GAMEPORT
+
+    // Read the default USB HID usage table.
+    hid_init(NULL);
+
+    return true;
+}
+
+static int BSD_JoystickGetCount(void)
+{
+    return numjoysticks;
+}
+
+static void BSD_JoystickDetect(void)
+{
+}
+
+static bool BSD_JoystickIsDevicePresent(Uint16 vendor_id, Uint16 product_id, Uint16 version, const char *name)
+{
+    // We don't override any other drivers
+    return false;
+}
+
+static SDL_joylist_item *GetJoystickByDevIndex(int device_index)
+{
+    SDL_joylist_item *item = SDL_joylist;
+
+    if ((device_index < 0) || (device_index >= numjoysticks)) {
+        return NULL;
+    }
+
+    while (device_index > 0) {
+        SDL_assert(item != NULL);
+        device_index--;
+        item = item->next;
+    }
+
+    return item;
+}
+
+static const char *BSD_JoystickGetDeviceName(int device_index)
+{
+    return GetJoystickByDevIndex(device_index)->name;
+}
+
+static const char *BSD_JoystickGetDevicePath(int device_index)
+{
+    return GetJoystickByDevIndex(device_index)->path;
+}
+
+static int BSD_JoystickGetDeviceSteamVirtualGamepadSlot(int device_index)
+{
+    return -1;
+}
+
+static int BSD_JoystickGetDevicePlayerIndex(int device_index)
+{
+    return -1;
+}
+
+static void BSD_JoystickSetDevicePlayerIndex(int device_index, int player_index)
+{
+}
+
+static SDL_GUID BSD_JoystickGetDeviceGUID(int device_index)
+{
+    return GetJoystickByDevIndex(device_index)->guid;
+}
+
+// Function to perform the mapping from device index to the instance id for this index
+static SDL_JoystickID BSD_JoystickGetDeviceInstanceID(int device_index)
+{
+    return GetJoystickByDevIndex(device_index)->device_instance;
+}
+
+static unsigned hatval_to_sdl(Sint32 hatval)
+{
+    static const unsigned hat_dir_map[8] = {
+        SDL_HAT_UP, SDL_HAT_RIGHTUP, SDL_HAT_RIGHT, SDL_HAT_RIGHTDOWN,
+        SDL_HAT_DOWN, SDL_HAT_LEFTDOWN, SDL_HAT_LEFT, SDL_HAT_LEFTUP
+    };
+    unsigned result;
+    if ((hatval & 7) == hatval)
+        result = hat_dir_map[hatval];
+    else
+        result = SDL_HAT_CENTERED;
+    return result;
+}
+
+static bool BSD_JoystickOpen(SDL_Joystick *joy, int device_index)
+{
+    SDL_joylist_item *item = GetJoystickByDevIndex(device_index);
+    struct joystick_hwdata *hw;
+
+    if (!item) {
+        return SDL_SetError("No such device");
+    }
+
+    hw = CreateHwData(item->path);
+    if (!hw) {
+        return false;
+    }
+
+    joy->hwdata = hw;
+    joy->naxes = hw->naxes;
+    joy->nbuttons = hw->nbuttons;
+    joy->nhats = hw->nhats;
+
+    return true;
+}
+
+static void BSD_JoystickUpdate(SDL_Joystick *joy)
+{
+    struct hid_item hitem;
+    struct hid_data *hdata;
+    struct report *rep;
+    int nbutton, naxe = -1;
+    Sint32 v;
+#ifdef SDL_PLATFORM_OPENBSD
+    Sint32 dpad[4] = { 0, 0, 0, 0 };
+#endif
+    Uint64 timestamp = SDL_GetTicksNS();
+
+#ifdef SUPPORT_JOY_GAMEPORT
+    struct joystick gameport;
+    static int x, y, xmin = 0xffff, ymin = 0xffff, xmax = 0, ymax = 0;
+
+    if (joy->hwdata->type == BSDJOY_JOY) {
+        while (read(joy->hwdata->fd, &gameport, sizeof(gameport)) == sizeof(gameport)) {
+            if (SDL_abs(x - gameport.x) > 8) {
+                x = gameport.x;
+                if (x < xmin) {
+                    xmin = x;
+                }
+                if (x > xmax) {
+                    xmax = x;
+                }
+                if (xmin == xmax) {
+                    xmin--;
+                    xmax++;
+                }
+                v = (((SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) * ((Sint32)x - xmin)) / (xmax - xmin)) + SDL_JOYSTICK_AXIS_MIN;
+                SDL_SendJoystickAxis(timestamp, joy, 0, v);
+            }
+            if (SDL_abs(y - gameport.y) > 8) {
+                y = gameport.y;
+                if (y < ymin) {
+                    ymin = y;
+                }
+                if (y > ymax) {
+                    ymax = y;
+                }
+                if (ymin == ymax) {
+                    ymin--;
+                    ymax++;
+                }
+                v = (((SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) * ((Sint32)y - ymin)) / (ymax - ymin)) + SDL_JOYSTICK_AXIS_MIN;
+                SDL_SendJoystickAxis(timestamp, joy, 1, v);
+            }
+            SDL_SendJoystickButton(timestamp, joy, 0, (gameport.b1 != 0));
+            SDL_SendJoystickButton(timestamp, joy, 1, (gameport.b2 != 0));
+        }
+        return;
+    }
+#endif // SUPPORT_JOY_GAMEPORT
+
+    rep = &joy->hwdata->inreport;
+
+    while (read(joy->hwdata->fd, REP_BUF_DATA(rep), rep->size) == rep->size) {
+#if defined(USBHID_NEW) || (defined(SDL_PLATFORM_FREEBSD) && __FreeBSD_kernel_version >= 500111) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+        hdata = hid_start_parse(joy->hwdata->repdesc, 1 << hid_input, rep->rid);
+#else
+        hdata = hid_start_parse(joy->hwdata->repdesc, 1 << hid_input);
+#endif
+        if (!hdata) {
+            // fprintf(stderr, "%s: Cannot start HID parser\n", joy->hwdata->path);
+            continue;
+        }
+
+        while (hid_get_item(hdata, &hitem) > 0) {
+            switch (hitem.kind) {
+            case hid_input:
+                switch (HID_PAGE(hitem.usage)) {
+                case HUP_GENERIC_DESKTOP:
+                {
+                    int usage = HID_USAGE(hitem.usage);
+                    int joyaxe = usage_to_joyaxe(usage);
+                    if (joyaxe >= 0) {
+                        naxe = joy->hwdata->axis_map[joyaxe];
+                        // scaleaxe
+                        v = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
+                        v = (((SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) * (v - hitem.logical_minimum)) / (hitem.logical_maximum - hitem.logical_minimum)) + SDL_JOYSTICK_AXIS_MIN;
+                        SDL_SendJoystickAxis(timestamp, joy, naxe, v);
+                    } else if (usage == HUG_HAT_SWITCH) {
+                        v = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
+                        SDL_SendJoystickHat(timestamp, joy, 0,
+                                               hatval_to_sdl(v) -
+                                                   hitem.logical_minimum);
+                    }
+#ifdef SDL_PLATFORM_OPENBSD
+                    /* here D-pad directions are reported like separate buttons.
+                     * calculate the SDL hat value from the 4 separate values.
+                     */
+                    switch (usage) {
+                    case HUG_DPAD_UP:
+                        dpad[0] = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
+                        break;
+                    case HUG_DPAD_DOWN:
+                        dpad[1] = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
+                        break;
+                    case HUG_DPAD_RIGHT:
+                        dpad[2] = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
+                        break;
+                    case HUG_DPAD_LEFT:
+                        dpad[3] = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
+                        break;
+                    //default:
+                        // no-op
+                    }
+                    SDL_SendJoystickHat(timestamp, joy, 0, (dpad[0] * HAT_UP) |
+                                                           (dpad[1] * HAT_DOWN) |
+                                                           (dpad[2] * HAT_RIGHT) |
+                                                           (dpad[3] * HAT_LEFT) );
+#endif
+                    break;
+                }
+                case HUP_BUTTON:
+                    v = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
+                    nbutton = HID_USAGE(hitem.usage) - 1; // SDL buttons are zero-based
+                    SDL_SendJoystickButton(timestamp, joy, nbutton, (v != 0));
+                    break;
+                default:
+                    continue;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+        hid_end_parse(hdata);
+    }
+}
+
+// Function to close a joystick after use
+static void BSD_JoystickClose(SDL_Joystick *joy)
+{
+    if (joy->hwdata) {
+        FreeHwData(joy->hwdata);
+        joy->hwdata = NULL;
+    }
+}
+
+static void BSD_JoystickQuit(void)
+{
+    SDL_joylist_item *item = NULL;
+    SDL_joylist_item *next = NULL;
+
+    for (item = SDL_joylist; item; item = next) {
+        next = item->next;
+        FreeJoylistItem(item);
+    }
+
+    SDL_joylist = SDL_joylist_tail = NULL;
+
+    numjoysticks = 0;
+}
+
+static bool report_alloc(struct report *r, struct report_desc *rd, int repind)
+{
+    int len;
+
+#ifdef __DragonFly__
+    len = hid_report_size(rd, repinfo[repind].kind, r->rid);
+#elif defined(SDL_PLATFORM_FREEBSD)
+#if (__FreeBSD_kernel_version >= 460000) || defined(__FreeBSD_kernel__)
+#if (__FreeBSD_kernel_version <= 500111)
+    len = hid_report_size(rd, r->rid, repinfo[repind].kind);
+#else
+    len = hid_report_size(rd, repinfo[repind].kind, r->rid);
+#endif
+#else
+    len = hid_report_size(rd, repinfo[repind].kind, &r->rid);
+#endif
+#else
+#ifdef USBHID_NEW
+    len = hid_report_size(rd, repinfo[repind].kind, r->rid);
+#else
+    len = hid_report_size(rd, repinfo[repind].kind, &r->rid);
+#endif
+#endif
+
+    if (len < 0) {
+        return SDL_SetError("Negative HID report size");
+    }
+    r->size = len;
+
+    if (r->size > 0) {
+#if defined(SDL_PLATFORM_FREEBSD) && (__FreeBSD_kernel_version > 900000) || defined(__DragonFly__)
+        r->buf = SDL_malloc(r->size);
+#else
+        r->buf = SDL_malloc(sizeof(*r->buf) - sizeof(REP_BUF_DATA(r)) +
+                            r->size);
+#endif
+        if (!r->buf) {
+            return false;
+        }
+    } else {
+        r->buf = NULL;
+    }
+
+    r->status = SREPORT_CLEAN;
+    return true;
+}
+
+static void report_free(struct report *r)
+{
+    SDL_free(r->buf);
+    r->status = SREPORT_UNINIT;
+}
+
+static bool BSD_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble)
+{
+    return SDL_Unsupported();
+}
+
+static bool BSD_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+{
+    return SDL_Unsupported();
+}
+
+static bool BSD_JoystickGetGamepadMapping(int device_index, SDL_GamepadMapping *out)
+{
+    return false;
+}
+
+static bool BSD_JoystickSetLED(SDL_Joystick *joystick, Uint8 red, Uint8 green, Uint8 blue)
+{
+    return SDL_Unsupported();
+}
+
+static bool BSD_JoystickSendEffect(SDL_Joystick *joystick, const void *data, int size)
+{
+    return SDL_Unsupported();
+}
+
+static bool BSD_JoystickSetSensorsEnabled(SDL_Joystick *joystick, bool enabled)
+{
+    return SDL_Unsupported();
+}
+
+SDL_JoystickDriver SDL_BSD_JoystickDriver = {
+    BSD_JoystickInit,
+    BSD_JoystickGetCount,
+    BSD_JoystickDetect,
+    BSD_JoystickIsDevicePresent,
+    BSD_JoystickGetDeviceName,
+    BSD_JoystickGetDevicePath,
+    BSD_JoystickGetDeviceSteamVirtualGamepadSlot,
+    BSD_JoystickGetDevicePlayerIndex,
+    BSD_JoystickSetDevicePlayerIndex,
+    BSD_JoystickGetDeviceGUID,
+    BSD_JoystickGetDeviceInstanceID,
+    BSD_JoystickOpen,
+    BSD_JoystickRumble,
+    BSD_JoystickRumbleTriggers,
+    BSD_JoystickSetLED,
+    BSD_JoystickSendEffect,
+    BSD_JoystickSetSensorsEnabled,
+    BSD_JoystickUpdate,
+    BSD_JoystickClose,
+    BSD_JoystickQuit,
+    BSD_JoystickGetGamepadMapping
+};
+
+#endif // SDL_JOYSTICK_USBHID

--- a/thirdparty/sdl/patches/0007-fix-openbsd.patch
+++ b/thirdparty/sdl/patches/0007-fix-openbsd.patch
@@ -1,0 +1,19 @@
+diff --git a/thirdparty/sdl/joystick/bsd/SDL_bsdjoystick.c b/thirdparty/sdl/joystick/bsd/SDL_bsdjoystick.c
+index b3fd3e9ca3..e4a17990f3 100644
+--- a/thirdparty/sdl/joystick/bsd/SDL_bsdjoystick.c
++++ b/thirdparty/sdl/joystick/bsd/SDL_bsdjoystick.c
+@@ -710,10 +710,10 @@ static void BSD_JoystickUpdate(SDL_Joystick *joy)
+                     //default:
+                         // no-op
+                     }
+-                    SDL_PrivateJoystickHat(joy, 0, (dpad[0] * HAT_UP) |
+-                                                   (dpad[1] * HAT_DOWN) |
+-                                                   (dpad[2] * HAT_RIGHT) |
+-                                                   (dpad[3] * HAT_LEFT) );
++                    SDL_SendJoystickHat(timestamp, joy, 0, (dpad[0] * HAT_UP) |
++                                                           (dpad[1] * HAT_DOWN) |
++                                                           (dpad[2] * HAT_RIGHT) |
++                                                           (dpad[3] * HAT_LEFT) );
+ #endif
+                     break;
+                 }

--- a/thirdparty/sdl/update-sdl.sh
+++ b/thirdparty/sdl/update-sdl.sh
@@ -55,7 +55,7 @@ mkdir $target/haptic
 cp -rv haptic/{*.{c,h},darwin,dummy,linux,windows} $target/haptic
 
 mkdir $target/joystick
-cp -rv joystick/{*.{c,h},apple,darwin,hidapi,linux,windows} $target/joystick
+cp -rv joystick/{*.{c,h},apple,bsd,darwin,hidapi,linux,windows} $target/joystick
 
 mkdir $target/loadso
 cp -rv loadso/{dlopen,dummy} $target/loadso
@@ -78,7 +78,7 @@ cp -rv timer/{*.{c,h},unix,windows} $target/timer
 
 mkdir -p $target/hidapi
 cp -v hidapi/{*.{c,h},AUTHORS.txt,LICENSE.txt,LICENSE-bsd.txt,VERSION} $target/hidapi
-for dir in hidapi linux mac windows; do
+for dir in hidapi linux netbsd mac windows; do
   mkdir $target/hidapi/$dir
   cp -v hidapi/$dir/*.{c,h} $target/hidapi/$dir
 done


### PR DESCRIPTION
I was able to compile from scratch on FreeBSD 15.0 / 13.5, OpenBSD 7.8 / 7.7, and NetBSD 10.1 without disabling anything using this pr.

I briefly ran the editor on OpenBSD, created a new project, and add a couple nodes in 3D. I currently do not have access to a FreeBSD or NetBSD machine with a display out so I have only briefly tested them in headless mode.

Basically what I've done when compiling under bsd:
- Use bsd joystick implementation in sdl.
- Disabled haptics.
- Disabled camera module.
- Dont set `HAVE_SECURE_GETENV` for openxr.
- Modify linker flags and fix clang / gcc detection.
- Directly define mouse button codes so that `input-event-codes.h` can be removed because it is not available on NetBSD.
- Replace a few system apis with their bsd counterparts.
- Fix some warnings which become errors when compiling in dev mode.
- Replace some problem instances of `size_t` with `uint64_t` in the wayland implementation instead of adding a `long` constructor to `Variant` due to OpenBSD defining `size_t` as `long`. The two wayland files are the only ones in the project with this problem so it seems overkill to change `Variant` to fix the problem.

Also the issue in https://github.com/godotengine/godot/pull/101588#issue-2790302628 where the editor would not compile is due to the process memory limit being relatively low in OpenBSD by default (1.5GB for users with the `staff` class). I also had this failure around the same part, but if you raise the limit (e.g. `ulimit -d 10000000`), then you can compile fine.

Fixes https://github.com/godotengine/godot/issues/55192
Fixes https://github.com/godotengine/godot/issues/92130
Fixes https://github.com/godotengine/godot/issues/110606
Supersedes https://github.com/godotengine/godot/issues/101588