### PR TITLE
Improve editor inspector main container spacing in modern theme

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3823,7 +3823,7 @@ void EditorInspector::_add_section_in_tree(EditorInspectorSection *p_section, VB
 	}
 	if (!container) {
 		container = memnew(VBoxContainer);
-		container->set_theme_type_variation(SNAME("EditorInspectorContainer"));
+		container->set_theme_type_variation(SNAME("EditorSectionContainer"));
 		p_current_vbox->add_child(container);
 	}
 	container->add_child(p_section);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -2014,6 +2014,10 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_type_variation("EditorInspectorContainer", "VBoxContainer");
 		p_theme->set_constant("separation", "EditorInspectorContainer", 0);
 
+		// Vertical separation between inspector sections.
+		p_theme->set_type_variation("EditorSectionContainer", "VBoxContainer");
+		p_theme->set_constant("separation", "EditorSectionContainer", 0);
+
 		// Vertical separation between inspector properties.
 		p_theme->set_type_variation("EditorPropertyContainer", "VBoxContainer");
 		p_theme->set_constant("separation", "EditorPropertyContainer", p_config.increased_margin * EDSCALE);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1990,7 +1990,11 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Vertical separation between inspector areas.
 		p_theme->set_type_variation("EditorInspectorContainer", "VBoxContainer");
-		p_theme->set_constant("separation", "EditorInspectorContainer", Math::ceil(p_config.base_margin * 0.5 * EDSCALE));
+		p_theme->set_constant("separation", "EditorInspectorContainer", Math::ceil(p_config.base_margin * EDSCALE));
+
+		// Vertical separation between inspector sections.
+		p_theme->set_type_variation("EditorSectionContainer", "VBoxContainer");
+		p_theme->set_constant("separation", "EditorSectionContainer", p_config.base_margin * 0.5 * EDSCALE);
 
 		// Vertical separation between inspector properties.
 		p_theme->set_type_variation("EditorPropertyContainer", "VBoxContainer");


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/112366

Adds a bit of extra space around inspector categories (class names) to separate them from their properties while keeping all of the internal category spacing intact

| Master | PR |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/bc4fe6fc-2653-4a49-a341-58d1a9fdb736) | ![2](https://github.com/user-attachments/assets/0f76519c-7b8a-49b1-8cc5-c211c69c4974) |