### PR TITLE
Fix setter for readonly bone name in the joint array and add null check in IKModifier3D

### DIFF
--- a/scene/3d/bone_twist_disperser_3d.cpp
+++ b/scene/3d/bone_twist_disperser_3d.cpp
@@ -65,11 +65,7 @@ bool BoneTwistDisperser3D::_set(const StringName &p_path, const Variant &p_value
 		} else if (what == "joints") {
 			int idx = path.get_slicec('/', 3).to_int();
 			String prop = path.get_slicec('/', 4);
-			if (prop == "bone_name") {
-				set_joint_bone_name(which, idx, p_value);
-			} else if (prop == "bone") {
-				set_joint_bone(which, idx, p_value);
-			} else if (prop == "twist_amount") {
+			if (prop == "twist_amount") {
 				set_joint_twist_amount(which, idx, p_value);
 			} else {
 				return false;
@@ -163,7 +159,7 @@ void BoneTwistDisperser3D::_get_property_list(List<PropertyInfo> *p_list) const 
 		for (uint32_t j = 0; j < settings[i]->joints.size(); j++) {
 			String joint_path = path + "joints/" + itos(j) + "/";
 			props.push_back(PropertyInfo(Variant::STRING, joint_path + "bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint, PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
-			props.push_back(PropertyInfo(Variant::INT, joint_path + "bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_READ_ONLY));
+			props.push_back(PropertyInfo(Variant::INT, joint_path + "bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_READ_ONLY));
 			props.push_back(PropertyInfo(Variant::FLOAT, joint_path + "twist_amount", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,or_less"));
 		}
 	}
@@ -456,18 +452,6 @@ Ref<Curve> BoneTwistDisperser3D::get_damping_curve(int p_index) const {
 
 // Individual joints.
 
-void BoneTwistDisperser3D::set_joint_bone_name(int p_index, int p_joint, const String &p_bone_name) {
-	// Exists only for indicate bone name on the inspector, no needs to make dirty joint array.
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<DisperseJointSetting> &joints = settings[p_index]->joints;
-	ERR_FAIL_INDEX(p_joint, (int)joints.size());
-	joints[p_joint].joint.name = p_bone_name;
-	Skeleton3D *sk = get_skeleton();
-	if (sk) {
-		set_joint_bone(p_index, p_joint, sk->find_bone(joints[p_joint].joint.name));
-	}
-}
-
 String BoneTwistDisperser3D::get_joint_bone_name(int p_index, int p_joint) const {
 	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), String());
 	const LocalVector<DisperseJointSetting> &joints = settings[p_index]->joints;
@@ -475,7 +459,7 @@ String BoneTwistDisperser3D::get_joint_bone_name(int p_index, int p_joint) const
 	return joints[p_joint].joint.name;
 }
 
-void BoneTwistDisperser3D::set_joint_bone(int p_index, int p_joint, int p_bone) {
+void BoneTwistDisperser3D::_set_joint_bone(int p_index, int p_joint, int p_bone) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	LocalVector<DisperseJointSetting> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
@@ -651,7 +635,7 @@ void BoneTwistDisperser3D::_update_joints(int p_index) {
 
 	set_joint_count(p_index, new_joints.size());
 	for (uint32_t i = 0; i < new_joints.size(); i++) {
-		set_joint_bone(p_index, i, new_joints[i]);
+		_set_joint_bone(p_index, i, new_joints[i]);
 	}
 
 	_update_reference_bone(p_index);

--- a/scene/3d/bone_twist_disperser_3d.h
+++ b/scene/3d/bone_twist_disperser_3d.h
@@ -101,6 +101,8 @@ protected:
 
 	void _make_joints_dirty(int p_index);
 	void _update_joints(int p_index);
+	void _set_joint_bone(int p_index, int p_joint, int p_bone);
+
 	void _update_reference_bone(int p_index);
 	void _update_curve(int p_index);
 
@@ -146,9 +148,7 @@ public:
 	Ref<Curve> get_damping_curve(int p_index) const;
 
 	// Individual joints.
-	void set_joint_bone_name(int p_index, int p_joint, const String &p_bone_name);
 	String get_joint_bone_name(int p_index, int p_joint) const;
-	void set_joint_bone(int p_index, int p_joint, int p_bone);
 	int get_joint_bone(int p_index, int p_joint) const;
 
 	void set_joint_twist_amount(int p_index, int p_joint, float p_amount);

--- a/scene/3d/chain_ik_3d.cpp
+++ b/scene/3d/chain_ik_3d.cpp
@@ -59,16 +59,6 @@ bool ChainIK3D::_set(const StringName &p_path, const Variant &p_value) {
 			set_extend_end_bone(which, p_value);
 		} else if (what == "joint_count") {
 			set_joint_count(which, p_value);
-		} else if (what == "joints") {
-			int idx = path.get_slicec('/', 3).to_int();
-			String prop = path.get_slicec('/', 4);
-			if (prop == "bone_name") {
-				set_joint_bone_name(which, idx, p_value);
-			} else if (prop == "bone") {
-				set_joint_bone(which, idx, p_value);
-			} else {
-				return false;
-			}
 		} else {
 			return false;
 		}
@@ -144,7 +134,7 @@ void ChainIK3D::get_property_list(List<PropertyInfo> *p_list) const {
 		for (uint32_t j = 0; j < chain_settings[i]->joints.size(); j++) {
 			String joint_path = path + "joints/" + itos(j) + "/";
 			props.push_back(PropertyInfo(Variant::STRING, joint_path + "bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint, PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
-			props.push_back(PropertyInfo(Variant::INT, joint_path + "bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_READ_ONLY));
+			props.push_back(PropertyInfo(Variant::INT, joint_path + "bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_READ_ONLY));
 		}
 	}
 
@@ -308,18 +298,6 @@ float ChainIK3D::get_end_bone_length(int p_index) const {
 
 // Individual joints.
 
-void ChainIK3D::set_joint_bone_name(int p_index, int p_joint, const String &p_bone_name) {
-	// Exists only for indicate bone name on the inspector, no needs to make dirty joint array.
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	LocalVector<BoneJoint> &joints = chain_settings[p_index]->joints;
-	ERR_FAIL_INDEX(p_joint, (int)joints.size());
-	joints[p_joint].name = p_bone_name;
-	Skeleton3D *sk = get_skeleton();
-	if (sk) {
-		set_joint_bone(p_index, p_joint, sk->find_bone(joints[p_joint].name));
-	}
-}
-
 String ChainIK3D::get_joint_bone_name(int p_index, int p_joint) const {
 	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), String());
 	const LocalVector<BoneJoint> &joints = chain_settings[p_index]->joints;
@@ -327,7 +305,7 @@ String ChainIK3D::get_joint_bone_name(int p_index, int p_joint) const {
 	return joints[p_joint].name;
 }
 
-void ChainIK3D::set_joint_bone(int p_index, int p_joint, int p_bone) {
+void ChainIK3D::_set_joint_bone(int p_index, int p_joint, int p_bone) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	LocalVector<BoneJoint> &joints = chain_settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
@@ -471,7 +449,7 @@ void ChainIK3D::_update_joints(int p_index) {
 
 	set_joint_count(p_index, new_joints.size());
 	for (uint32_t i = 0; i < new_joints.size(); i++) {
-		set_joint_bone(p_index, i, new_joints[i]);
+		_set_joint_bone(p_index, i, new_joints[i]);
 	}
 
 	if (sk) {

--- a/scene/3d/chain_ik_3d.h
+++ b/scene/3d/chain_ik_3d.h
@@ -216,6 +216,7 @@ protected:
 
 	virtual void _make_all_joints_dirty() override;
 	virtual void _update_joints(int p_index) override;
+	void _set_joint_bone(int p_index, int p_joint, int p_bone);
 
 	virtual void _process_ik(Skeleton3D *p_skeleton, double p_delta) override;
 
@@ -250,9 +251,7 @@ public:
 	float get_end_bone_length(int p_index) const;
 
 	// Individual joints.
-	void set_joint_bone_name(int p_index, int p_joint, const String &p_bone_name);
 	String get_joint_bone_name(int p_index, int p_joint) const;
-	void set_joint_bone(int p_index, int p_joint, int p_bone);
 	int get_joint_bone(int p_index, int p_joint) const;
 
 	void set_joint_count(int p_index, int p_count);

--- a/scene/3d/ik_modifier_3d.cpp
+++ b/scene/3d/ik_modifier_3d.cpp
@@ -160,7 +160,7 @@ Quaternion IKModifier3D::get_local_pose_rotation(Skeleton3D *p_skeleton, int p_b
 }
 
 Vector3 IKModifier3D::get_bone_axis(Skeleton3D *p_skeleton, int p_end_bone, BoneDirection p_direction, bool p_mutable_bone_axes) {
-	if (!p_skeleton->is_inside_tree()) {
+	if (!p_skeleton || !p_skeleton->is_inside_tree()) {
 		return Vector3();
 	}
 	Vector3 axis;

--- a/scene/3d/limit_angular_velocity_modifier_3d.h
+++ b/scene/3d/limit_angular_velocity_modifier_3d.h
@@ -53,7 +53,7 @@ private:
 	double max_angular_velocity = Math::TAU;
 
 	LocalVector<Chain> chains;
-	RBMap<int, StringName> joints;
+	LocalVector<BoneJoint> joints;
 	LocalVector<BoneRot> bones;
 
 	bool joints_dirty = false;
@@ -76,9 +76,9 @@ protected:
 
 	void _make_joints_dirty();
 	void _update_joints();
+	bool _is_joint_contained(int p_bone);
 
 	// For editor.
-	String _get_joint_bone_name(int p_bone) const;
 	int _get_joint_count() const;
 
 	virtual void _process_modification(double p_delta) override;
@@ -93,6 +93,9 @@ public:
 	String get_end_bone_name(int p_index) const;
 	void set_end_bone(int p_index, int p_bone);
 	int get_end_bone(int p_index) const;
+
+	String get_joint_bone_name(int p_index) const;
+	int get_joint_bone(int p_index) const;
 
 	void set_chain_count(int p_count);
 	int get_chain_count() const;

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -121,11 +121,7 @@ bool SpringBoneSimulator3D::_set(const StringName &p_path, const Variant &p_valu
 		} else if (what == "joints") {
 			int idx = path.get_slicec('/', 3).to_int();
 			String prop = path.get_slicec('/', 4);
-			if (prop == "bone_name") {
-				set_joint_bone_name(which, idx, p_value);
-			} else if (prop == "bone") {
-				set_joint_bone(which, idx, p_value);
-			} else if (prop == "rotation_axis") {
+			if (prop == "rotation_axis") {
 				set_joint_rotation_axis(which, idx, static_cast<RotationAxis>((int)p_value));
 			} else if (prop == "rotation_axis_vector") {
 				set_joint_rotation_axis_vector(which, idx, p_value);
@@ -321,7 +317,7 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 		for (uint32_t j = 0; j < settings[i]->joints.size(); j++) {
 			String joint_path = path + "joints/" + itos(j) + "/";
 			props.push_back(PropertyInfo(Variant::STRING, joint_path + "bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint, PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
-			props.push_back(PropertyInfo(Variant::INT, joint_path + "bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_READ_ONLY));
+			props.push_back(PropertyInfo(Variant::INT, joint_path + "bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_READ_ONLY));
 			props.push_back(PropertyInfo(Variant::INT, joint_path + "rotation_axis", PROPERTY_HINT_ENUM, SkeletonModifier3D::get_hint_rotation_axis()));
 			props.push_back(PropertyInfo(Variant::VECTOR3, joint_path + "rotation_axis_vector"));
 			props.push_back(PropertyInfo(Variant::FLOAT, joint_path + "radius", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,suffix:m"));
@@ -883,18 +879,6 @@ bool SpringBoneSimulator3D::is_config_individual(int p_index) const {
 	return settings[p_index]->individual_config;
 }
 
-void SpringBoneSimulator3D::set_joint_bone_name(int p_index, int p_joint, const String &p_bone_name) {
-	// Exists only for indicate bone name on the inspector, no needs to make dirty joint array.
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
-	ERR_FAIL_INDEX(p_joint, (int)joints.size());
-	joints[p_joint]->bone_name = p_bone_name;
-	Skeleton3D *sk = get_skeleton();
-	if (sk) {
-		set_joint_bone(p_index, p_joint, sk->find_bone(joints[p_joint]->bone_name));
-	}
-}
-
 String SpringBoneSimulator3D::get_joint_bone_name(int p_index, int p_joint) const {
 	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), String());
 	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
@@ -902,7 +886,7 @@ String SpringBoneSimulator3D::get_joint_bone_name(int p_index, int p_joint) cons
 	return joints[p_joint]->bone_name;
 }
 
-void SpringBoneSimulator3D::set_joint_bone(int p_index, int p_joint, int p_bone) {
+void SpringBoneSimulator3D::_set_joint_bone(int p_index, int p_joint, int p_bone) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
@@ -1570,7 +1554,7 @@ void SpringBoneSimulator3D::_update_joint_array(int p_index) {
 
 	set_joint_count(p_index, new_joints.size());
 	for (uint32_t i = 0; i < new_joints.size(); i++) {
-		set_joint_bone(p_index, i, new_joints[i]);
+		_set_joint_bone(p_index, i, new_joints[i]);
 	}
 }
 

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -180,6 +180,7 @@ protected:
 
 	void _update_joint_array(int p_index);
 	void _update_joints(bool p_reset);
+	void _set_joint_bone(int p_index, int p_joint, int p_bone);
 
 	void _update_bone_axis(Skeleton3D *p_skeleton, SpringBone3DSetting *p_setting);
 
@@ -267,9 +268,7 @@ public:
 	void set_individual_config(int p_index, bool p_enabled);
 	bool is_config_individual(int p_index) const;
 
-	void set_joint_bone_name(int p_index, int p_joint, const String &p_bone_name);
 	String get_joint_bone_name(int p_index, int p_joint) const;
-	void set_joint_bone(int p_index, int p_joint, int p_bone);
 	int get_joint_bone(int p_index, int p_joint) const;
 
 	void set_joint_rotation_axis(int p_index, int p_joint, RotationAxis p_axis);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/113972

This is not a fundamental fix, but I am committing it because I determined there are no side effects.

These properties should not be serialized in the first place. Although I haven't marked them as STORAGE in Usage, they are somehow being serialized to tscn. Therefore, I believe this is fundamentally a serialization bug.

However, these properties are already read-only and only allow access from within the C++ core. So, removing the function calls from the setters resolves the issue.

Additionally, make the joint array API for LimitAngularModifier consistent with other SkeletonModifiers. The indexing was broken, but this fixes it.

Before:

<img width="557" height="391" alt="image" src="https://github.com/user-attachments/assets/4944148e-5441-461b-803d-f02917bf3811" /><img width="570" height="281" alt="image" src="https://github.com/user-attachments/assets/ee67cc29-1d57-4480-82ba-2b00beaf9249" />

After fix:

<img width="558" height="328" alt="image" src="https://github.com/user-attachments/assets/89f6d72d-16d8-4688-9343-78d8a8db62b2" />

FYI, since joint array elements are dynamically generated, changing their paths will not cause compatibility breaks.