### PR TITLE
Fix bottom panel focus not showing

### DIFF
--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1720,7 +1720,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_stylebox("tabbar_background", "BottomPanel", style_bottom_panel_tabbar);
 		p_theme->set_stylebox("tab_selected", "BottomPanel", style_bottom_tab_selected);
 		p_theme->set_stylebox("tab_hovered", "BottomPanel", style_bottom_tab_hover);
-		p_theme->set_stylebox("tab_focus", "BottomPanel", menu_transparent_style);
+		p_theme->set_stylebox("tab_focus", "BottomPanel", p_config.button_style_focus);
 		p_theme->set_stylebox("tab_unselected", "BottomPanel", style_bottom_tab);
 		p_theme->set_color("font_unselected_color", "BottomPanel", p_config.font_color);
 		p_theme->set_color("font_hovered_color", "BottomPanel", p_config.font_hover_color);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1689,7 +1689,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_stylebox("tabbar_background", "BottomPanel", style_bottom_panel_tabbar);
 		p_theme->set_stylebox("tab_selected", "BottomPanel", bottom_panel_button_hover);
 		p_theme->set_stylebox("tab_hovered", "BottomPanel", bottom_panel_button_hover);
-		p_theme->set_stylebox("tab_focus", "BottomPanel", p_config.base_empty_style);
+		p_theme->set_stylebox("tab_focus", "BottomPanel", p_config.focus_style);
 		p_theme->set_stylebox("tab_unselected", "BottomPanel", style_bottom_tab);
 		p_theme->set_color("font_unselected_color", "BottomPanel", p_config.font_color);
 		p_theme->set_color("font_hovered_color", "BottomPanel", p_config.font_hover_color);


### PR DESCRIPTION
Fixes #113898

There are no hints for focus on the bottom panel (the focus stylebox is invisible) so it is hard to tell when the bottom panel has focus. This PR adds the focus hint to both themes mirroring the TabContainer's focus hint.

| Classic | Modern |
| - | - |
| <img width="470" height="124" src="https://github.com/user-attachments/assets/af48a294-9b80-43b6-864c-f02733d08d4c" /> | <img width="361" height="120" src="https://github.com/user-attachments/assets/2a7ab702-c0a5-4047-8df2-78b440056780" /> |
