### PR TITLE
Fix editor crash attempting to generate preview for invalid BitMap

### DIFF
--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -231,6 +231,9 @@ bool EditorBitmapPreviewPlugin::handles(const String &p_type) const {
 
 Ref<Texture2D> EditorBitmapPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const {
 	Ref<BitMap> bm = p_from;
+	if (bm.is_null()) {
+		return Ref<Texture2D>();
+	}
 
 	if (bm->get_size() == Size2()) {
 		return Ref<Texture2D>();


### PR DESCRIPTION
Follow the same idiom of other types in this class to prevent a crash.

- Fix #114246