### PR TITLE
Fix docks grabbing too much focus

### DIFF
--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -116,7 +116,7 @@ void EditorDock::open() {
 }
 
 void EditorDock::make_visible() {
-	EditorDockManager::get_singleton()->focus_dock(this);
+	EditorDockManager::get_singleton()->open_dock(this, true);
 }
 
 void EditorDock::close() {

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -844,6 +844,19 @@ void EditorDockManager::open_dock(EditorDock *p_dock, bool p_set_current) {
 	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot open unknown dock '%s'.", p_dock->get_display_title()));
 
 	if (p_dock->is_open) {
+		// Show the dock if it is already open.
+		if (p_set_current) {
+			if (p_dock->dock_window) {
+				p_dock->get_window()->grab_focus();
+				return;
+			}
+
+			TabContainer *dock_tab_container = get_dock_tab_container(p_dock);
+			if (dock_tab_container) {
+				int tab_index = dock_tab_container->get_tab_idx_from_control(p_dock);
+				dock_tab_container->set_current_tab(tab_index);
+			}
+		}
 		return;
 	}
 

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -373,7 +373,7 @@ void TileMapEditorPlugin::_update_tile_map() {
 		Ref<TileSet> tile_set = edited_layer->get_tile_set();
 		if (tile_set.is_valid() && tile_set_id != tile_set->get_instance_id()) {
 			tile_set_plugin_singleton->edit(tile_set.ptr());
-			tile_set_plugin_singleton->make_visible_no_focus();
+			tile_set_plugin_singleton->make_visible(true);
 			tile_set_id = tile_set->get_instance_id();
 		} else if (tile_set.is_null()) {
 			tile_set_plugin_singleton->edit(nullptr);
@@ -410,7 +410,7 @@ void TileMapEditorPlugin::_edit_tile_map_layer(TileMapLayer *p_tile_map_layer, b
 	Ref<TileSet> tile_set = p_tile_map_layer->get_tile_set();
 	if (tile_set.is_valid()) {
 		tile_set_plugin_singleton->edit(tile_set.ptr());
-		tile_set_plugin_singleton->make_visible_no_focus();
+		tile_set_plugin_singleton->make_visible(true);
 		tile_set_id = tile_set->get_instance_id();
 	} else {
 		tile_set_plugin_singleton->edit(nullptr);
@@ -537,10 +537,6 @@ void TileSetEditorPlugin::make_visible(bool p_visible) {
 	} else {
 		editor->close();
 	}
-}
-
-void TileSetEditorPlugin::make_visible_no_focus() {
-	editor->open();
 }
 
 ObjectID TileSetEditorPlugin::get_edited_tileset() const {

--- a/editor/scene/2d/tiles/tiles_editor_plugin.h
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.h
@@ -165,7 +165,6 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	void make_visible_no_focus();
 	ObjectID get_edited_tileset() const;
 
 	TileSetEditorPlugin();


### PR DESCRIPTION
Fixes #114232
Dock counterpart to #114241 for #113898
Related https://chat.godotengine.org/channel/editor?msg=7moZ6boxcxmAqha7s

This PR fixes the docks stealing focus when nodes like `TileMapLayer` and `AnimationPlayer` are selected. Note that this is a regression from 4.5 because previously the bottom docks didn't take focus when made visible.

I considered modifying the `focus_dock` method, but this was the only use case of that method that didn't make sense to me, so instead this PR introduces a fix for the `open_dock` method. The reason why `focus_dock` was chosen for `EditorDock::make_visible` was because `open_dock` wouldn't do anything with already open docks (while `focus_dock` would actively make the dock visible). This PR fixes that issue with `open_dock` by selecting the correct tab but not taking focus.