### PR TITLE
Instantly stop `AudioStreamRandomizer` if it tries to play without any streams

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -789,6 +789,12 @@ AudioStreamRandomizer::AudioStreamRandomizer() {
 }
 
 void AudioStreamPlaybackRandomizer::start(double p_from_pos) {
+	if (active) {
+		return;
+	}
+
+	active = true;
+
 	playing = playback;
 	{
 		// GH-10238 : Pitch_scale is multiplicative, so picking a random number for it without log
@@ -813,6 +819,10 @@ void AudioStreamPlaybackRandomizer::start(double p_from_pos) {
 }
 
 void AudioStreamPlaybackRandomizer::stop() {
+	if (!active) {
+		return;
+	}
+
 	if (playing.is_valid()) {
 		playing->stop();
 	}
@@ -857,6 +867,10 @@ void AudioStreamPlaybackRandomizer::tag_used_streams() {
 }
 
 int AudioStreamPlaybackRandomizer::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
+	if (!active) {
+		return 0;
+	}
+
 	if (playing.is_valid()) {
 		int mixed_samples = playing->mix(p_buffer, p_rate_scale * pitch_scale, p_frames);
 		for (int samp = 0; samp < mixed_samples; samp++) {
@@ -864,6 +878,7 @@ int AudioStreamPlaybackRandomizer::mix(AudioFrame *p_buffer, float p_rate_scale,
 		}
 		return mixed_samples;
 	} else {
+		active = false;
 		for (int i = 0; i < p_frames; i++) {
 			p_buffer[i] = AudioFrame(0, 0);
 		}

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -359,6 +359,8 @@ class AudioStreamPlaybackRandomizer : public AudioStreamPlayback {
 	float pitch_scale;
 	float volume_scale;
 
+	bool active = false;
+
 public:
 	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot-proposals/issues/13270

I didn't add an error as suggested in the proposal. `AudioStreamPlaylist`, `AudioStreamInteractive`, and `AudioStreamSynchronized` will instantly stop if they don't have child streams, however they don't throw warnings/errors. This keeps `AudioStreamRandomizer` consistent with those.