### PR TITLE
Fix content margins of the editor runbar in modern theme

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1790,6 +1790,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Launch Pad and Play buttons.
 		Ref<StyleBoxFlat> style_launch_pad_movie = p_config.base_style->duplicate();
+		style_launch_pad_movie->set_content_margin_all(p_config.base_margin * EDSCALE);
 		style_launch_pad_movie->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.2));
 		style_launch_pad_movie->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.8));
 		style_launch_pad_movie->set_border_width_all(Math::round(2 * EDSCALE));


### PR DESCRIPTION
Addresses somebody's bluesky comment, runbar buttons became smaller during the port which made them a littler harder to click, this brings them back to their original size

| Master | PR |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/910b2887-65e8-4a53-a5c3-702a56886c28) | ![2](https://github.com/user-attachments/assets/0e1017ad-29f0-4e1a-b070-a6891968d2b3) |