### PR TITLE
Add missing method reference in `ShaderMaterial.set_shader_parameter` documentation

### DIFF
--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -26,7 +26,7 @@
 			<description>
 				Changes the value set for this material of a uniform in the shader.
 				[b]Note:[/b] [param param] is case-sensitive and must match the name of the uniform in the code exactly (not the capitalized name in the inspector).
-				[b]Note:[/b] Changes to the shader uniform will be effective on all instances using this [ShaderMaterial]. To prevent this, use per-instance uniforms with [method GeometryInstance3D.set_instance_shader_parameter] or duplicate the [ShaderMaterial] resource using [method Resource.duplicate]. Per-instance uniforms allow for better shader reuse and are therefore faster, so they should be preferred over duplicating the [ShaderMaterial] when possible.
+				[b]Note:[/b] Changes to the shader uniform will be effective on all instances using this [ShaderMaterial]. To prevent this, use per-instance uniforms with [method CanvasItem.set_instance_shader_parameter], [method GeometryInstance3D.set_instance_shader_parameter] or duplicate the [ShaderMaterial] resource using [method Resource.duplicate]. Per-instance uniforms allow for better shader reuse and are therefore faster, so they should be preferred over duplicating the [ShaderMaterial] when possible.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Reference:

https://github.com/godotengine/godot/blob/3b48b0110e04e84db54788ccda4f8f5f7fa1fcf4/doc/classes/CanvasItem.xml#L619

https://github.com/godotengine/godot/blob/3b48b0110e04e84db54788ccda4f8f5f7fa1fcf4/doc/classes/GeometryInstance3D.xml#L25


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
