### PR TITLE
Update the correct original copyright year in `main.cpp`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -518,7 +518,7 @@ void Main::print_help_option(const char *p_option, const char *p_description, CL
 void Main::print_help(const char *p_binary) {
 	print_header(true);
 	print_help_copyright("Free and open source software under the terms of the MIT license.");
-	print_help_copyright("(c) 2014-present Godot Engine contributors. (c) 2007-present Juan Linietsky, Ariel Manzur.");
+	print_help_copyright("(c) 2014-present Godot Engine contributors. (c) 2007-2014 Juan Linietsky, Ariel Manzur.");
 
 	print_help_title("Usage");
 	OS::get_singleton()->print("  %s \u001b[96m[options] [path to \"project.godot\" file]\u001b[0m\n", p_binary);


### PR DESCRIPTION
This PR simply updates the correct latest copyright year before Godot went open-source in `main.cpp`.

Absolutely cherry-pickable for older supported versions.