### PR TITLE
Prevent tooltips from showing in empty space of FileSystem Dock

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -77,7 +77,7 @@ Control *FileSystemTree::make_custom_tooltip(const String &p_text) const {
 }
 
 Control *FileSystemList::make_custom_tooltip(const String &p_text) const {
-	int idx = get_item_at_position(get_local_mouse_position());
+	int idx = get_item_at_position(get_local_mouse_position(), true);
 	if (idx == -1) {
 		return nullptr;
 	}


### PR DESCRIPTION
## Description

Tooltips in the FileSystem Dock were appearing when hovering anywhere in the dock, including over empty space.

## Problem

`ItemList::set_item_tooltip()` stores tooltip text directly on items. `ItemList::get_item_at_position(p_pos, true)` can return an item index even when hovering over empty space in the last column (for better click targets). The tooltip system would then display the stored tooltip text for that item even when not actually hovering over it.

## Related Issues

Fixes #114260