### PR TITLE
Expose vertices of physics polygons for TileSet tiles to editor

### DIFF
--- a/modules/tilemap/editor/tile_set_atlas_source_editor.cpp
+++ b/modules/tilemap/editor/tile_set_atlas_source_editor.cpp
@@ -2865,7 +2865,10 @@ void EditorPropertyTilePolygon::update_property() {
 			// Multiple array of vertices.
 			generic_tile_polygon_editor->clear_polygons();
 			for (int i = 0; i < count; i++) {
-				generic_tile_polygon_editor->add_polygon(get_edited_object()->get(vformat(element_pattern, i)));
+				const PackedVector2Array &polygon = get_edited_object()->get(vformat(element_pattern, i));
+				if (polygon.size() >= 3) {
+					generic_tile_polygon_editor->add_polygon(polygon);
+				}
 			}
 		} else if (base_type == "OccluderPolygon2D") {
 			// Multiple OccluderPolygon2D.
@@ -2954,12 +2957,6 @@ bool EditorInspectorPluginTileData::parse_property(Object *p_object, const Varia
 			}
 			add_property_editor_for_multiple_properties("Polygons", properties, ep);
 			return true;
-		} else if (components.size() == 3 && components[1].begins_with("polygon_") && components[1].trim_prefix("polygon_").is_valid_int()) {
-			int polygon_index = components[1].trim_prefix("polygon_").to_int();
-			ERR_FAIL_COND_V(polygon_index < 0, false);
-			if (components[2] == "points") {
-				return true;
-			}
 		}
 	} else if (components.size() == 2 && components[0].begins_with("navigation_layer_") && components[0].trim_prefix("navigation_layer_").is_valid_int()) {
 		// Navigation layers.

--- a/modules/tilemap/tile_map_layer.cpp
+++ b/modules/tilemap/tile_map_layer.cpp
@@ -3585,7 +3585,7 @@ void TileMapLayer::navmesh_parse_source_geometry(const Ref<NavigationPolygon> &p
 					(tile_set->get_physics_layer_collision_layer(physics_layer) & parsed_collision_mask)) {
 				for (int collision_polygon_index = 0; collision_polygon_index < tile_data->get_collision_polygons_count(physics_layer); collision_polygon_index++) {
 					PackedVector2Array collision_polygon_points = tile_data->get_collision_polygon_points(physics_layer, collision_polygon_index);
-					if (collision_polygon_points.is_empty()) {
+					if (collision_polygon_points.size() < 3) {
 						continue;
 					}
 

--- a/modules/tilemap/tile_set.cpp
+++ b/modules/tilemap/tile_set.cpp
@@ -6412,12 +6412,19 @@ void TileData::remove_collision_polygon(int p_layer_id, int p_polygon_index) {
 void TileData::set_collision_polygon_points(int p_layer_id, int p_polygon_index, Vector<Vector2> p_polygon) {
 	ERR_FAIL_INDEX(p_layer_id, physics.size());
 	ERR_FAIL_INDEX(p_polygon_index, physics[p_layer_id].polygons.size());
-	ERR_FAIL_COND_MSG(p_polygon.size() != 0 && p_polygon.size() < 3, "Invalid polygon. Needs either 0 or at least 3 points.");
 
 	TileData::PhysicsLayerTileData::PolygonShapeTileData &polygon_shape_tile_data = physics.write[p_layer_id].polygons.write[p_polygon_index];
 
-	if (p_polygon.is_empty()) {
-		polygon_shape_tile_data.shapes.clear();
+	if (p_polygon.size() < 3) {
+		// Keep a single shape for this polygon.
+		// NOTE: This might cause errors somewhere down the line where a shape
+		// is expected to have 3 or more points; I'm not sure if that should be
+		// considered the expected behavior at that point?
+		polygon_shape_tile_data.shapes.resize(1);
+		Ref<ConvexPolygonShape2D> shape;
+		shape.instantiate();
+		shape->set_points(p_polygon);
+		polygon_shape_tile_data.shapes[0] = shape;
 	} else {
 		// Decompose into convex shapes.
 		Vector<Vector<Vector2>> decomp = Geometry2D::decompose_polygon_in_convex(p_polygon);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13895 .

This PR makes the array of collision points for a TileSet's tiles visible and editable in the inspector, so that the exact coordinates can be modified in addition to dragging the points with the visual editor:

https://github.com/user-attachments/assets/cfb4b137-02d6-4e96-9387-85138760f4dd

This was done by copying some code that was already written below for custom data layers, and modifying the last line of it to work better for the known property name.