### PR TITLE
Avoid singularity during sky filtering

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/octmap_roughness.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_roughness.glsl
@@ -29,7 +29,8 @@ void main() {
 			float solid_angle_texel = 4.0 * M_PI / float(params.dest_size * params.dest_size);
 			float roughness2 = params.roughness * params.roughness;
 			float roughness4 = roughness2 * roughness2;
-			vec3 UpVector = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+
+			vec3 UpVector = abs(N.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(0.0, 0.0, 1.0);
 			mat3 T;
 			T[0] = normalize(cross(UpVector, N));
 			T[1] = cross(N, T[0]);

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_roughness_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_roughness_raster.glsl
@@ -43,7 +43,8 @@ void main() {
 		float solid_angle_texel = 4.0 * M_PI / (params.size * params.size);
 		float roughness2 = params.roughness * params.roughness;
 		float roughness4 = roughness2 * roughness2;
-		vec3 UpVector = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+
+		vec3 UpVector = abs(N.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(0.0, 0.0, 1.0);
 		mat3 T;
 		T[0] = normalize(cross(UpVector, N));
 		T[1] = cross(N, T[0]);


### PR DESCRIPTION
Fixes part of: https://github.com/godotengine/godot/issues/113676

This switches the singularity to be on the y axis instead of the z. 

Previously the singularity wasn't a big deal since only one or fewer pixels would have a z value of exactly 0 since the poles were in the center of the cubemap faces where there is the least distortion. But since octahedral mapping warps space different the z-axis poles are directly on seams, which lead to a huge increase in the amount of distortion

This PR switches to using the y-axis because it isn't on a seam and has a low amount of distortion. This removes the obvious stretching artifacts as well as the little circle. 

However, it does not fully close the PR since there are other quality differences resulting from using octahedral coordinates. Importantly, I notice a difference in the contrast for fully rough materials. (Actually, that may not be a regression. The difference may actually be more correct see https://github.com/godotengine/godot/issues/108273)