### PR TITLE
Change TabContainer's popup button into real Button

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -137,8 +137,11 @@ EditorDock *EditorDockManager::_get_dock_tab_dragged() {
 		if (!source_tab_bar) {
 			return nullptr;
 		}
-
-		DockTabContainer *source_tab_container = Object::cast_to<DockTabContainer>(source_tab_bar->get_parent());
+		HBoxContainer *parent = Object::cast_to<HBoxContainer>(source_tab_bar->get_parent()); // The internal container.
+		if (!parent) {
+			return nullptr;
+		}
+		DockTabContainer *source_tab_container = Object::cast_to<DockTabContainer>(parent->get_parent());
 		if (!source_tab_container) {
 			return nullptr;
 		}

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -67,20 +67,6 @@ void EditorBottomPanel::_on_tab_changed(int p_idx) {
 }
 
 void EditorBottomPanel::_theme_changed() {
-	int icon_width = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
-	int margin = bottom_hbox->get_minimum_size().width;
-	if (get_popup()) {
-		margin -= icon_width;
-	}
-
-	// Add margin to make space for the right side popup button.
-	icon_spacer->set_custom_minimum_size(Vector2(icon_width, 0));
-
-	// Need to get stylebox from EditorNode to update theme correctly.
-	Ref<StyleBox> bottom_tabbar_style = EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SNAME("tabbar_background"), SNAME("BottomPanel"))->duplicate();
-	bottom_tabbar_style->set_content_margin(is_layout_rtl() ? SIDE_LEFT : SIDE_RIGHT, margin + bottom_tabbar_style->get_content_margin(is_layout_rtl() ? SIDE_RIGHT : SIDE_LEFT));
-	add_theme_style_override("tabbar_background", bottom_tabbar_style);
-
 	if (get_current_tab() == -1) {
 		// Hide panel when not showing anything.
 		remove_theme_style_override(SceneStringName(panel));
@@ -292,12 +278,7 @@ EditorBottomPanel::EditorBottomPanel() :
 
 	bottom_hbox = memnew(HBoxContainer);
 	bottom_hbox->set_mouse_filter(MOUSE_FILTER_IGNORE);
-	bottom_hbox->set_anchors_and_offsets_preset(Control::PRESET_RIGHT_WIDE);
-	get_tab_bar()->add_child(bottom_hbox);
-
-	icon_spacer = memnew(Control);
-	icon_spacer->set_mouse_filter(MOUSE_FILTER_IGNORE);
-	bottom_hbox->add_child(icon_spacer);
+	get_internal_container()->add_child(bottom_hbox);
 
 	bottom_hbox->add_child(memnew(VSeparator));
 

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -42,7 +42,6 @@ class EditorBottomPanel : public DockTabContainer {
 	GDCLASS(EditorBottomPanel, DockTabContainer);
 
 	HBoxContainer *bottom_hbox = nullptr;
-	Control *icon_spacer = nullptr;
 	EditorToaster *editor_toaster = nullptr;
 	Button *pin_button = nullptr;
 	Button *expand_button = nullptr;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -30,17 +30,10 @@
 
 #include "tab_container.h"
 
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/popup.h"
 #include "scene/theme/theme_db.h"
-
-Rect2 TabContainer::_get_tab_rect() const {
-	Rect2 rect;
-	if (tabs_visible && get_tab_count() > 0) {
-		rect = Rect2(theme_cache.tabbar_style->get_offset(), tab_bar->get_size());
-		rect.position.x += is_layout_rtl() ? theme_cache.menu_icon->get_width() : theme_cache.side_margin;
-	}
-
-	return rect;
-}
 
 TabContainer::CachedTab &TabContainer::get_pending_tab(int p_idx) const {
 	if (p_idx >= pending_tabs.size()) {
@@ -56,88 +49,6 @@ int TabContainer::_get_tab_height() const {
 	}
 
 	return height;
-}
-
-void TabContainer::gui_input(const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND(p_event.is_null());
-
-	Ref<InputEventMouseButton> mb = p_event;
-
-	Popup *popup = get_popup();
-
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
-		Point2 pos = mb->get_position();
-		real_t content_height = get_size().height - _get_tab_height();
-
-		Rect2 popup_rect = _get_tab_rect();
-		popup_rect.position.x += is_layout_rtl() ? -theme_cache.menu_icon->get_width() : popup_rect.size.x;
-		popup_rect.position.y += tabs_position == POSITION_BOTTOM ? content_height : 0;
-		popup_rect.size.x = theme_cache.menu_icon->get_width();
-
-		// Click must be on tabs in the tab header area.
-		if (!tabs_visible || pos.y < popup_rect.position.y || pos.y >= popup_rect.position.y + popup_rect.size.y) {
-			return;
-		}
-
-		// Handle menu button.
-		if (popup) {
-			if (popup_rect.has_point(pos)) {
-				emit_signal(SNAME("pre_popup_pressed"));
-
-				Vector2 popup_pos = get_screen_position();
-				popup_pos.x += popup_rect.position.x + (is_layout_rtl() ? 0 : popup_rect.size.x - popup->get_size().width);
-				popup_pos.y += popup_rect.position.y + popup_rect.size.y / 2.0;
-				if (tabs_position == POSITION_BOTTOM) {
-					popup_pos.y -= popup->get_size().height;
-					popup_pos.y -= theme_cache.menu_icon->get_height() / 2.0;
-				} else {
-					popup_pos.y += theme_cache.menu_icon->get_height() / 2.0;
-				}
-
-				popup->set_position(popup_pos);
-				popup->popup();
-				return;
-			}
-		}
-	}
-
-	Ref<InputEventMouseMotion> mm = p_event;
-
-	if (mm.is_valid()) {
-		Point2 pos = mm->get_position();
-		real_t content_height = get_size().height - _get_tab_height();
-
-		Rect2 popup_rect = _get_tab_rect();
-		popup_rect.position.x += is_layout_rtl() ? -theme_cache.menu_icon->get_width() : popup_rect.size.x;
-		popup_rect.position.y += tabs_position == POSITION_BOTTOM ? content_height : 0;
-		popup_rect.size.x = theme_cache.menu_icon->get_width();
-
-		// Mouse must be on tabs in the tab header area.
-		if (!tabs_visible || pos.y < popup_rect.position.y || pos.y >= popup_rect.position.y + popup_rect.size.y) {
-			if (menu_hovered) {
-				menu_hovered = false;
-				queue_redraw();
-			}
-			return;
-		}
-
-		if (popup) {
-			if (popup_rect.has_point(pos)) {
-				if (!menu_hovered) {
-					menu_hovered = true;
-					queue_redraw();
-					return;
-				}
-			} else if (menu_hovered) {
-				menu_hovered = false;
-				queue_redraw();
-			}
-
-			if (menu_hovered) {
-				return;
-			}
-		}
-	}
 }
 
 void TabContainer::_get_property_list(List<PropertyInfo> *p_list) const {
@@ -193,7 +104,7 @@ void TabContainer::_notification(int p_what) {
 					continue;
 				}
 				Control *control = as_sortable_control(child_node, SortableVisibilityMode::IGNORE);
-				if (!control || control == tab_bar || children_removing.has(control)) {
+				if (!control || control == internal_container || children_removing.has(control)) {
 					DisplayServer::get_singleton()->accessibility_update_add_child(ae, child_node->get_accessibility_element());
 				} else {
 					if (!tab_panels.has(child_node)) {
@@ -246,14 +157,12 @@ void TabContainer::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 			RID canvas = get_canvas_item();
 			Size2 size = get_size();
-			Rect2 tabbar_rect = _get_tab_rect();
 
 			// Draw only the tab area if the header is hidden.
 			if (!tabs_visible) {
 				theme_cache.panel_style->draw(canvas, Rect2(0, 0, size.width, size.height));
 				return;
 			}
-
 			int header_height = _get_tab_height();
 			int header_voffset = int(tabs_position == POSITION_BOTTOM) * (size.height - header_height);
 
@@ -261,18 +170,6 @@ void TabContainer::_notification(int p_what) {
 			theme_cache.tabbar_style->draw(canvas, Rect2(0, header_voffset, size.width, header_height));
 			// Draw the background for the tab's content.
 			theme_cache.panel_style->draw(canvas, Rect2(0, int(tabs_position == POSITION_TOP) * header_height, size.width, size.height - header_height));
-
-			// Draw the popup menu.
-			if (get_popup()) {
-				int x = is_layout_rtl() ? tabbar_rect.position.x - theme_cache.menu_icon->get_width() : tabbar_rect.position.x + tabbar_rect.size.x;
-				header_voffset += tabbar_rect.position.y;
-
-				if (menu_hovered) {
-					theme_cache.menu_hl_icon->draw(get_canvas_item(), Point2(x, header_voffset + (tabbar_rect.size.y - theme_cache.menu_hl_icon->get_height()) / 2));
-				} else {
-					theme_cache.menu_icon->draw(get_canvas_item(), Point2(x, header_voffset + (tabbar_rect.size.y - theme_cache.menu_icon->get_height()) / 2));
-				}
-			}
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -295,7 +192,14 @@ void TabContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED:
-		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
+			if (popup_button) {
+				popup_button->set_button_icon(theme_cache.menu_icon);
+				internal_container->move_child(popup_button, is_layout_rtl() ? 0 : 1);
+			}
+			_update_margins();
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			theme_changing = true;
 			callable_mp(this, &TabContainer::_on_theme_changed).call_deferred(); // Wait until all changed theme.
@@ -365,11 +269,11 @@ void TabContainer::_repaint() {
 	// Move the TabBar to the top or bottom.
 	// Don't change the left and right offsets since the TabBar will resize and may change tab offset.
 	if (tabs_position == POSITION_BOTTOM) {
-		tab_bar->set_anchor_and_offset(SIDE_BOTTOM, 1.0, -bottom_margin);
-		tab_bar->set_anchor_and_offset(SIDE_TOP, 1.0, top_margin - _get_tab_height());
+		internal_container->set_anchor_and_offset(SIDE_BOTTOM, 1.0, -bottom_margin);
+		internal_container->set_anchor_and_offset(SIDE_TOP, 1.0, top_margin - _get_tab_height());
 	} else {
-		tab_bar->set_anchor_and_offset(SIDE_TOP, 0.0, top_margin);
-		tab_bar->set_anchor_and_offset(SIDE_BOTTOM, 0.0, _get_tab_height() - bottom_margin);
+		internal_container->set_anchor_and_offset(SIDE_TOP, 0.0, top_margin);
+		internal_container->set_anchor_and_offset(SIDE_BOTTOM, 0.0, _get_tab_height() - bottom_margin);
 	}
 
 	updating_visibility = true;
@@ -412,32 +316,28 @@ void TabContainer::_update_margins() {
 		SWAP(left_margin, right_margin);
 	}
 
-	if (has_popup) {
-		right_margin += theme_cache.menu_icon->get_width();
-	}
-
 	if (get_tab_count() == 0) {
-		tab_bar->set_offset(SIDE_LEFT, left_margin);
-		tab_bar->set_offset(SIDE_RIGHT, -right_margin);
+		internal_container->set_offset(SIDE_LEFT, left_margin);
+		internal_container->set_offset(SIDE_RIGHT, -right_margin);
 		return;
 	}
 
 	switch (get_tab_alignment()) {
 		case TabBar::ALIGNMENT_LEFT: {
-			tab_bar->set_offset(SIDE_LEFT, left_margin + theme_cache.side_margin);
-			tab_bar->set_offset(SIDE_RIGHT, -right_margin);
+			internal_container->set_offset(SIDE_LEFT, left_margin + theme_cache.side_margin);
+			internal_container->set_offset(SIDE_RIGHT, -right_margin);
 		} break;
 
 		case TabBar::ALIGNMENT_CENTER: {
-			tab_bar->set_offset(SIDE_LEFT, left_margin);
-			tab_bar->set_offset(SIDE_RIGHT, -right_margin);
+			internal_container->set_offset(SIDE_LEFT, left_margin);
+			internal_container->set_offset(SIDE_RIGHT, -right_margin);
 		} break;
 
 		case TabBar::ALIGNMENT_RIGHT: {
-			tab_bar->set_offset(SIDE_LEFT, left_margin);
+			internal_container->set_offset(SIDE_LEFT, left_margin);
 
 			if (has_popup) {
-				tab_bar->set_offset(SIDE_RIGHT, -right_margin);
+				internal_container->set_offset(SIDE_RIGHT, -right_margin);
 				return;
 			}
 
@@ -447,9 +347,9 @@ void TabContainer::_update_margins() {
 
 			// Calculate if all the tabs would still fit if the margin was present.
 			if (get_clip_tabs() && (tab_bar->get_offset_buttons_visible() || (get_tab_count() > 1 && (total_tabs_width + theme_cache.side_margin) > get_size().width))) {
-				tab_bar->set_offset(SIDE_RIGHT, -right_margin);
+				internal_container->set_offset(SIDE_RIGHT, -right_margin);
 			} else {
-				tab_bar->set_offset(SIDE_RIGHT, -right_margin - theme_cache.side_margin);
+				internal_container->set_offset(SIDE_RIGHT, -right_margin - theme_cache.side_margin);
 			}
 		} break;
 
@@ -458,18 +358,11 @@ void TabContainer::_update_margins() {
 	}
 }
 
-void TabContainer::_on_mouse_exited() {
-	if (menu_hovered) {
-		menu_hovered = false;
-		queue_redraw();
-	}
-}
-
 Vector<Control *> TabContainer::_get_tab_controls() const {
 	Vector<Control *> controls;
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *control = as_sortable_control(get_child(i), SortableVisibilityMode::IGNORE);
-		if (!control || control == tab_bar || children_removing.has(control)) {
+		if (!control || control == internal_container || children_removing.has(control)) {
 			continue;
 		}
 
@@ -505,15 +398,42 @@ void TabContainer::_drag_move_tab(int p_from_index, int p_to_index) {
 }
 
 void TabContainer::_drag_move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_index) {
-	Node *parent = p_from_tabbar->get_parent();
+	HBoxContainer *parent = Object::cast_to<HBoxContainer>(p_from_tabbar->get_parent()); // The internal container.
 	if (!parent) {
 		return;
 	}
-	TabContainer *from_tab_container = Object::cast_to<TabContainer>(parent);
+	TabContainer *from_tab_container = Object::cast_to<TabContainer>(parent->get_parent());
 	if (!from_tab_container) {
 		return;
 	}
 	move_tab_from_tab_container(from_tab_container, p_from_index, p_to_index);
+}
+
+void TabContainer::_popup_button_hovered(bool p_hover) {
+	if (p_hover) {
+		popup_button->set_button_icon(theme_cache.menu_hl_icon);
+	} else {
+		popup_button->set_button_icon(theme_cache.menu_icon);
+	}
+}
+
+void TabContainer::_popup_button_pressed() {
+	Popup *popup = get_popup();
+	ERR_FAIL_NULL(popup);
+
+	emit_signal(SNAME("pre_popup_pressed"));
+
+	Vector2 popup_pos = popup_button->get_screen_position();
+	popup_pos.x += (is_layout_rtl() ? 0 : popup_button->get_size().x - popup->get_size().width);
+	if (tabs_position == POSITION_BOTTOM) {
+		popup_pos.y -= popup->get_size().height;
+	} else {
+		popup_pos.y += popup_button->get_size().y;
+	}
+
+	popup->set_position(popup_pos);
+	popup->popup();
+	return;
 }
 
 void TabContainer::move_tab_from_tab_container(TabContainer *p_from, int p_from_index, int p_to_index) {
@@ -640,7 +560,7 @@ void TabContainer::_refresh_tab_names() {
 void TabContainer::add_child_notify(Node *p_child) {
 	Container::add_child_notify(p_child);
 
-	if (p_child == tab_bar) {
+	if (p_child == internal_container) {
 		return;
 	}
 
@@ -672,7 +592,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 void TabContainer::move_child_notify(Node *p_child) {
 	Container::move_child_notify(p_child);
 
-	if (p_child == tab_bar) {
+	if (p_child == internal_container) {
 		return;
 	}
 
@@ -694,7 +614,7 @@ void TabContainer::remove_child_notify(Node *p_child) {
 		tab_panels.erase(p_child);
 	}
 
-	if (p_child == tab_bar) {
+	if (p_child == internal_container) {
 		return;
 	}
 
@@ -1033,7 +953,7 @@ Size2 TabContainer::get_minimum_size() const {
 		ms.height += theme_cache.tabbar_style->get_margin(SIDE_TOP) + theme_cache.tabbar_style->get_margin(SIDE_BOTTOM);
 
 		if (get_popup()) {
-			ms.width += theme_cache.menu_icon->get_width();
+			ms.width += popup_button->get_minimum_size().x;
 		}
 
 		if (theme_cache.side_margin > 0 && get_tab_alignment() != TabBar::ALIGNMENT_CENTER &&
@@ -1074,8 +994,26 @@ void TabContainer::set_popup(Node *p_popup) {
 	}
 	popup_obj_id = popup_id;
 
+	if (!popup_button) {
+		popup_button = memnew(Button);
+		popup_button->set_action_mode(BaseButton::ACTION_MODE_BUTTON_PRESS);
+		popup_button->set_flat(true);
+		if (is_inside_tree()) {
+			popup_button->set_button_icon(theme_cache.menu_icon);
+		}
+		popup_button->add_theme_color_override("icon_pressed_color", Color(1, 1, 1));
+		popup_button->add_theme_color_override("icon_hover_pressed_color", Color(1, 1, 1));
+
+		internal_container->add_child(popup_button);
+		internal_container->move_child(popup_button, is_layout_rtl() ? 0 : 1);
+
+		popup_button->connect(SceneStringName(mouse_entered), callable_mp(this, &TabContainer::_popup_button_hovered).bind(true));
+		popup_button->connect(SceneStringName(mouse_exited), callable_mp(this, &TabContainer::_popup_button_hovered).bind(false));
+		popup_button->connect(SceneStringName(pressed), callable_mp(this, &TabContainer::_popup_button_pressed));
+	}
+
 	if (had_popup != bool(popup)) {
-		queue_redraw();
+		popup_button->set_visible(popup != nullptr);
 		_update_margins();
 		update_minimum_size();
 	}
@@ -1219,6 +1157,7 @@ void TabContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_enabled"), "set_deselect_enabled", "get_deselect_enabled");
 
 	ADD_CLASS_DEPENDENCY("TabBar");
+	ADD_CLASS_DEPENDENCY("Button");
 
 	BIND_ENUM_CONSTANT(POSITION_TOP);
 	BIND_ENUM_CONSTANT(POSITION_BOTTOM);
@@ -1277,18 +1216,24 @@ void TabContainer::_bind_methods() {
 }
 
 TabContainer::TabContainer() {
+	internal_container = memnew(HBoxContainer);
+	internal_container->add_theme_constant_override(SNAME("separation"), 0);
+	internal_container->set_anchors_and_offsets_preset(Control::PRESET_TOP_WIDE);
+	internal_container->set_use_parent_material(true);
+	add_child(internal_container, false, INTERNAL_MODE_FRONT);
+
 	tab_bar = memnew(TabBar);
 	SET_DRAG_FORWARDING_GCDU(tab_bar, TabContainer);
-	add_child(tab_bar, false, INTERNAL_MODE_FRONT);
 	tab_bar->set_use_parent_material(true);
-	tab_bar->set_anchors_and_offsets_preset(Control::PRESET_TOP_WIDE);
+
+	tab_bar->set_h_size_flags(SIZE_EXPAND_FILL);
+	internal_container->add_child(tab_bar);
 	tab_bar->connect("tab_changed", callable_mp(this, &TabContainer::_on_tab_changed));
 	tab_bar->connect("tab_clicked", callable_mp(this, &TabContainer::_on_tab_clicked));
 	tab_bar->connect("tab_hovered", callable_mp(this, &TabContainer::_on_tab_hovered));
 	tab_bar->connect("tab_selected", callable_mp(this, &TabContainer::_on_tab_selected));
 	tab_bar->connect("tab_button_pressed", callable_mp(this, &TabContainer::_on_tab_button_pressed));
 	tab_bar->connect("active_tab_rearranged", callable_mp(this, &TabContainer::_on_active_tab_rearranged));
-	connect(SceneStringName(mouse_exited), callable_mp(this, &TabContainer::_on_mouse_exited));
 
 	property_helper.setup_for_instance(base_property_helper, this);
 	property_helper.enable_out_of_bounds_assign();

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -31,9 +31,12 @@
 #pragma once
 
 #include "scene/gui/container.h"
-#include "scene/gui/popup.h"
 #include "scene/gui/tab_bar.h"
 #include "scene/property_list_helper.h"
+
+class Button;
+class HBoxContainer;
+class Popup;
 
 class TabContainer : public Container {
 	GDCLASS(TabContainer, Container);
@@ -46,11 +49,13 @@ public:
 	};
 
 private:
+	HBoxContainer *internal_container = nullptr;
 	TabBar *tab_bar = nullptr;
+	Button *popup_button = nullptr;
+
 	bool tabs_visible = true;
 	bool all_tabs_in_front = false;
 	TabPosition tabs_position = POSITION_TOP;
-	bool menu_hovered = false;
 	mutable ObjectID popup_obj_id;
 	bool use_hidden_tabs_for_min_size = false;
 	bool theme_changing = false;
@@ -118,7 +123,6 @@ private:
 
 	HashMap<Node *, RID> tab_panels;
 
-	Rect2 _get_tab_rect() const;
 	int _get_tab_height() const;
 	Vector<Control *> _get_tab_controls() const;
 	void _on_theme_changed();
@@ -126,7 +130,6 @@ private:
 	void _refresh_tab_indices();
 	void _refresh_tab_names();
 	void _update_margins();
-	void _on_mouse_exited();
 	void _on_tab_changed(int p_tab);
 	void _on_tab_clicked(int p_tab);
 	void _on_tab_hovered(int p_tab);
@@ -141,9 +144,10 @@ private:
 	void _drag_move_tab(int p_from_index, int p_to_index);
 	void _drag_move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_index);
 
-protected:
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	void _popup_button_hovered(bool p_hover);
+	void _popup_button_pressed();
 
+protected:
 	bool _set(const StringName &p_name, const Variant &p_value) { return property_helper.property_set_value(p_name, p_value); }
 	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }
 	void _get_property_list(List<PropertyInfo> *p_list) const;
@@ -159,6 +163,7 @@ protected:
 public:
 	virtual bool accessibility_override_tree_hierarchy() const override { return true; }
 
+	HBoxContainer *get_internal_container() { return internal_container; }
 	TabBar *get_tab_bar() const;
 
 	int get_tab_idx_at_point(const Point2 &p_point) const;

--- a/tests/scene/test_tab_container.h
+++ b/tests/scene/test_tab_container.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "scene/gui/box_container.h"
 #include "scene/gui/tab_container.h"
 
 #include "tests/test_macros.h"
@@ -542,6 +543,7 @@ TEST_CASE("[SceneTree][TabContainer] layout and offset") {
 	Size2 all_tabs_size = tab_container->get_size();
 	const float side_margin = tab_container->get_theme_constant("side_margin");
 
+	HBoxContainer *internal_container = tab_container->get_internal_container();
 	TabBar *tab_bar = tab_container->get_tab_bar();
 
 	Vector<Rect2> tab_rects = {
@@ -580,14 +582,14 @@ TEST_CASE("[SceneTree][TabContainer] layout and offset") {
 
 		// Initial position, same as top position.
 		// Tab bar is at the top.
-		CHECK(tab_bar->get_anchor(SIDE_TOP) == 0);
-		CHECK(tab_bar->get_anchor(SIDE_BOTTOM) == 0);
-		CHECK(tab_bar->get_anchor(SIDE_LEFT) == 0);
-		CHECK(tab_bar->get_anchor(SIDE_RIGHT) == 1);
-		CHECK(tab_bar->get_offset(SIDE_TOP) == 0);
-		CHECK(tab_bar->get_offset(SIDE_BOTTOM) == tab_height);
-		CHECK(tab_bar->get_offset(SIDE_LEFT) == side_margin);
-		CHECK(tab_bar->get_offset(SIDE_RIGHT) == 0);
+		CHECK(internal_container->get_anchor(SIDE_TOP) == 0);
+		CHECK(internal_container->get_anchor(SIDE_BOTTOM) == 0);
+		CHECK(internal_container->get_anchor(SIDE_LEFT) == 0);
+		CHECK(internal_container->get_anchor(SIDE_RIGHT) == 1);
+		CHECK(internal_container->get_offset(SIDE_TOP) == 0);
+		CHECK(internal_container->get_offset(SIDE_BOTTOM) == tab_height);
+		CHECK(internal_container->get_offset(SIDE_LEFT) == side_margin);
+		CHECK(internal_container->get_offset(SIDE_RIGHT) == 0);
 
 		// Child is expanded and below the tab bar.
 		CHECK(tab0->get_anchor(SIDE_TOP) == 0);
@@ -605,14 +607,14 @@ TEST_CASE("[SceneTree][TabContainer] layout and offset") {
 		MessageQueue::get_singleton()->flush();
 
 		// Tab bar is at the bottom.
-		CHECK(tab_bar->get_anchor(SIDE_TOP) == 1);
-		CHECK(tab_bar->get_anchor(SIDE_BOTTOM) == 1);
-		CHECK(tab_bar->get_anchor(SIDE_LEFT) == 0);
-		CHECK(tab_bar->get_anchor(SIDE_RIGHT) == 1);
-		CHECK(tab_bar->get_offset(SIDE_TOP) == -tab_height);
-		CHECK(tab_bar->get_offset(SIDE_BOTTOM) == 0);
-		CHECK(tab_bar->get_offset(SIDE_LEFT) == side_margin);
-		CHECK(tab_bar->get_offset(SIDE_RIGHT) == 0);
+		CHECK(internal_container->get_anchor(SIDE_TOP) == 1);
+		CHECK(internal_container->get_anchor(SIDE_BOTTOM) == 1);
+		CHECK(internal_container->get_anchor(SIDE_LEFT) == 0);
+		CHECK(internal_container->get_anchor(SIDE_RIGHT) == 1);
+		CHECK(internal_container->get_offset(SIDE_TOP) == -tab_height);
+		CHECK(internal_container->get_offset(SIDE_BOTTOM) == 0);
+		CHECK(internal_container->get_offset(SIDE_LEFT) == side_margin);
+		CHECK(internal_container->get_offset(SIDE_RIGHT) == 0);
 
 		// Child is expanded and above the tab bar.
 		CHECK(tab0->get_anchor(SIDE_TOP) == 0);
@@ -630,14 +632,14 @@ TEST_CASE("[SceneTree][TabContainer] layout and offset") {
 		MessageQueue::get_singleton()->flush();
 
 		// Tab bar is at the top.
-		CHECK(tab_bar->get_anchor(SIDE_TOP) == 0);
-		CHECK(tab_bar->get_anchor(SIDE_BOTTOM) == 0);
-		CHECK(tab_bar->get_anchor(SIDE_LEFT) == 0);
-		CHECK(tab_bar->get_anchor(SIDE_RIGHT) == 1);
-		CHECK(tab_bar->get_offset(SIDE_TOP) == 0);
-		CHECK(tab_bar->get_offset(SIDE_BOTTOM) == tab_height);
-		CHECK(tab_bar->get_offset(SIDE_LEFT) == side_margin);
-		CHECK(tab_bar->get_offset(SIDE_RIGHT) == 0);
+		CHECK(internal_container->get_anchor(SIDE_TOP) == 0);
+		CHECK(internal_container->get_anchor(SIDE_BOTTOM) == 0);
+		CHECK(internal_container->get_anchor(SIDE_LEFT) == 0);
+		CHECK(internal_container->get_anchor(SIDE_RIGHT) == 1);
+		CHECK(internal_container->get_offset(SIDE_TOP) == 0);
+		CHECK(internal_container->get_offset(SIDE_BOTTOM) == tab_height);
+		CHECK(internal_container->get_offset(SIDE_LEFT) == side_margin);
+		CHECK(internal_container->get_offset(SIDE_RIGHT) == 0);
 
 		// Child is expanded and below the tab bar.
 		CHECK(tab0->get_anchor(SIDE_TOP) == 0);


### PR DESCRIPTION
This PR reorganizes TabContainer's internals. The popup button, which used to be drawn manually, is now a real button and is placed inside a new internal HBoxContainer, next to the TabBar. This allowed to simplify the logic and remove some hacks. The functionality/appearance should be more or less the same.

Needed for #113051