### PR TITLE
Add StyleBox transition animations

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -385,6 +385,14 @@
 				Draws a rectangle on the [CanvasItem] pointed to by the [param item] [RID]. See also [method CanvasItem.draw_rect].
 			</description>
 		</method>
+		<method name="canvas_item_add_set_modulate">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="modulate" type="Color" />
+			<description>
+				Sets a [Color] that will be used to modulate subsequent canvas item commands.
+			</description>
+		</method>
 		<method name="canvas_item_add_set_transform">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />

--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -45,6 +45,27 @@
 				The [RID] value can either be the result of [method CanvasItem.get_canvas_item] called on an existing [CanvasItem]-derived node, or directly from creating a canvas item in the [RenderingServer] with [method RenderingServer.canvas_item_create].
 			</description>
 		</method>
+		<method name="get_animation_duration">
+			<return type="float" />
+			<param index="0" name="type" type="int" enum="StyleBox.AnimationPhase" />
+			<description>
+				Returns the duration of transition animations in seconds.
+			</description>
+		</method>
+		<method name="get_animation_ease">
+			<return type="int" enum="Tween.EaseType" />
+			<param index="0" name="type" type="int" enum="StyleBox.AnimationPhase" />
+			<description>
+				Returns the ease type of transition animations.
+			</description>
+		</method>
+		<method name="get_animation_transition">
+			<return type="int" enum="Tween.TransitionType" />
+			<param index="0" name="type" type="int" enum="StyleBox.AnimationPhase" />
+			<description>
+				Returns the transition type of transition animations.
+			</description>
+		</method>
 		<method name="get_content_margin" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="margin" type="int" enum="Side" />
@@ -78,6 +99,30 @@
 				Returns the "offset" of a stylebox. This helper function returns a value equivalent to [code]Vector2(style.get_margin(MARGIN_LEFT), style.get_margin(MARGIN_TOP))[/code].
 			</description>
 		</method>
+		<method name="set_animation_duration">
+			<return type="void" />
+			<param index="0" name="type" type="int" enum="StyleBox.AnimationPhase" />
+			<param index="1" name="duration" type="float" />
+			<description>
+				Sets the duration of transition animations in seconds.
+			</description>
+		</method>
+		<method name="set_animation_ease">
+			<return type="void" />
+			<param index="0" name="type" type="int" enum="StyleBox.AnimationPhase" />
+			<param index="1" name="ease" type="int" enum="Tween.EaseType" />
+			<description>
+				Sets the ease type of transition animations.
+			</description>
+		</method>
+		<method name="set_animation_transition">
+			<return type="void" />
+			<param index="0" name="type" type="int" enum="StyleBox.AnimationPhase" />
+			<param index="1" name="transition" type="int" enum="Tween.TransitionType" />
+			<description>
+				Sets the transition type of transition animations.
+			</description>
+		</method>
 		<method name="set_content_margin">
 			<return type="void" />
 			<param index="0" name="margin" type="int" enum="Side" />
@@ -103,6 +148,42 @@
 		</method>
 	</methods>
 	<members>
+		<member name="animation_animate_rect" type="bool" setter="set_animating_rect" getter="is_animating_rect" default="true">
+			Whether or not to animate changes in draw rects.
+		</member>
+		<member name="animation_duration" type="float" setter="set_animation_duration" getter="get_animation_duration" default="0.0">
+			The duration in seconds of transition animations.
+		</member>
+		<member name="animation_ease" type="int" setter="set_animation_ease" getter="get_animation_ease" enum="Tween.EaseType" default="1">
+			The ease of transition animations.
+		</member>
+		<member name="animation_exiting_duration" type="float" setter="set_animation_duration" getter="get_animation_duration" default="0.0">
+			The duration in seconds of exit animations. Exit animations occur when no styleboxes are drawn for a given animation ID. A value of [code]0[/code] will skip exit animations entirely.
+		</member>
+		<member name="animation_exiting_ease" type="int" setter="set_animation_ease" getter="get_animation_ease" enum="Tween.EaseType" default="1">
+			The ease type of exit animations.
+		</member>
+		<member name="animation_exiting_modulate" type="Color" setter="set_transform_modulate" getter="get_transform_modulate" default="Color(1, 1, 1, 1)">
+			The color the stylebox should modulate to when exiting.
+		</member>
+		<member name="animation_exiting_offset" type="Vector2" setter="set_transform_offset" getter="get_transform_offset" default="Vector2(0, 0)">
+			The offset the stylebox should transform to when exiting.
+		</member>
+		<member name="animation_exiting_pivot" type="Vector2" setter="set_transform_pivot" getter="get_transform_pivot" default="Vector2(0.5, 0.5)">
+			The pivot point for scale and rotation during exit animations. [code]Vector2(0, 0)[/code] represents the top-left of the rect, while [code]Vector2(1, 1)[/code] represents the bottom-right.
+		</member>
+		<member name="animation_exiting_rotation" type="float" setter="set_transform_rotation" getter="get_transform_rotation" default="0.0">
+			The rotation the stylebox should transform to when exiting.
+		</member>
+		<member name="animation_exiting_scale" type="Vector2" setter="set_transform_scale" getter="get_transform_scale" default="Vector2(1, 1)">
+			The scale the stylebox should transform to when exiting.
+		</member>
+		<member name="animation_exiting_transition" type="int" setter="set_animation_transition" getter="get_animation_transition" enum="Tween.TransitionType" default="1">
+			The transition type of exit animations.
+		</member>
+		<member name="animation_transition" type="int" setter="set_animation_transition" getter="get_animation_transition" enum="Tween.TransitionType" default="1">
+			The transition type of transition animations.
+		</member>
 		<member name="content_margin_bottom" type="float" setter="set_content_margin" getter="get_content_margin" default="-1.0">
 			The bottom margin for the contents of this style box. Increasing this value reduces the space available to the contents from the bottom.
 			If this value is negative, it is ignored and a child-specific margin is used instead. For example, for [StyleBoxFlat], the border thickness (if any) is used instead.
@@ -122,4 +203,12 @@
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
 	</members>
+	<constants>
+		<constant name="PHASE_NORMAL" value="0" enum="AnimationPhase">
+			Phase of transitioning between styleboxes.
+		</constant>
+		<constant name="PHASE_EXIT" value="1" enum="AnimationPhase">
+			Phase of transitioning to and from the exit state of a stylebox.
+		</constant>
+	</constants>
 </class>

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1254,6 +1254,11 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				draw_transform = transform->xform;
 			} break;
 
+			case Item::Command::TYPE_MODULATE: {
+				const Item::CommandModulate *modulate = static_cast<const Item::CommandModulate *>(c);
+				base_color = p_item->final_modulate * modulate->modulate;
+			} break;
+
 			case Item::Command::TYPE_CLIP_IGNORE: {
 				const Item::CommandClipIgnore *ci = static_cast<const Item::CommandClipIgnore *>(c);
 				if (current_clip) {
@@ -1537,6 +1542,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index, Ren
 
 		} break;
 		case Item::Command::TYPE_TRANSFORM:
+		case Item::Command::TYPE_MODULATE:
 		case Item::Command::TYPE_CLIP_IGNORE:
 		case Item::Command::TYPE_ANIMATION_SLICE: {
 			// Can ignore these as they only impact batch creation.

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -220,14 +220,19 @@ void Button::_notification(int p_what) {
 			const Size2 size = get_size();
 
 			Ref<StyleBox> style = _get_current_stylebox();
+			StringName anim_id = SNAME("button");
 			// Draws the stylebox in the current state.
+			StyleBox::begin_animation_group(anim_id);
 			if (!flat) {
 				style->draw(ci, Rect2(Point2(), size));
 			}
+			StyleBox::end_animation_group(anim_id);
 
+			StyleBox::begin_animation_group(SNAME("focus"));
 			if (has_focus(true)) {
 				theme_cache.focus->draw(ci, Rect2(Point2(), size));
 			}
+			StyleBox::end_animation_group(SNAME("focus"));
 
 			Ref<Texture2D> _icon = icon;
 			if (_icon.is_null() && has_theme_icon(SNAME("icon"))) {
@@ -336,6 +341,8 @@ void Button::_notification(int p_what) {
 
 				} break;
 			}
+			font_color = StyleBox::get_animated_value(SceneStringName(font_color), font_color, anim_id);
+			icon_modulate_color = StyleBox::get_animated_value(SNAME("icon_color"), icon_modulate_color, anim_id);
 
 			const bool is_clipped = clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING || autowrap_mode != TextServer::AUTOWRAP_OFF;
 			const Size2 custom_element_size = drawable_size_remained;
@@ -465,6 +472,7 @@ void Button::_notification(int p_what) {
 
 				Color font_outline_color = theme_cache.font_outline_color;
 				int outline_size = theme_cache.outline_size;
+				text_ofs = StyleBox::get_animated_value(SNAME("text_ofs"), text_ofs, anim_id);
 				if (outline_size > 0 && font_outline_color.a > 0.0f) {
 					text_buf->draw_outline(ci, text_ofs, outline_size, font_outline_color);
 				}

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -502,6 +502,8 @@ public:
 		NOTIFICATION_MOUSE_EXIT_SELF = 61,
 	};
 
+	bool is_stylebox_animator_connected = false;
+
 	// Editor plugin interoperability.
 
 	// TODO: Decouple controls from their editor plugin and get rid of this.

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1572,9 +1572,19 @@ void ItemList::_notification(int p_what) {
 					}
 				}
 
+				StringName anim_id = StringName("item:" + itos(i));
+				StyleBox::begin_animation_group(anim_id);
 				if (style.is_valid()) {
 					draw_style_box(style, r);
 				}
+				StyleBox::end_animation_group(anim_id);
+
+				Vector2 margin_ofs = Vector2();
+				if (style.is_valid()) {
+					margin_ofs.x += style->get_margin(SIDE_LEFT) - style->get_margin(SIDE_RIGHT);
+					margin_ofs.y += style->get_margin(SIDE_TOP) - style->get_margin(SIDE_BOTTOM);
+				}
+				margin_ofs = StyleBox::get_animated_value(SNAME("margin_ofs"), margin_ofs, anim_id);
 
 				Vector2 text_ofs;
 				Size2 icon_size;
@@ -1585,7 +1595,7 @@ void ItemList::_notification(int p_what) {
 						icon_size = items[i].get_icon_size() * icon_scale;
 					}
 
-					Point2 pos = items[i].rect_cache.position + base_ofs;
+					Point2 pos = items[i].rect_cache.position + base_ofs + margin_ofs;
 
 					if (icon_mode == ICON_MODE_TOP) {
 						pos.y += MAX(theme_cache.v_separation, 0) / 2;
@@ -1613,6 +1623,7 @@ void ItemList::_notification(int p_what) {
 					if (items[i].disabled) {
 						icon_modulate.a *= 0.5;
 					}
+					icon_modulate = StyleBox::get_animated_value(SNAME("icon_modulate"), icon_modulate, anim_id);
 
 					// If the icon is transposed, we have to switch the size so that it is drawn correctly
 					if (items[i].icon_transposed) {
@@ -1637,7 +1648,7 @@ void ItemList::_notification(int p_what) {
 						tag_icon_size = items[i].tag_icon->get_size();
 					}
 
-					Point2 draw_pos = items[i].rect_cache.position + base_ofs;
+					Point2 draw_pos = items[i].rect_cache.position + base_ofs + margin_ofs;
 					draw_pos.x += MAX(theme_cache.h_separation, 0) / 2;
 					draw_pos.y += MAX(theme_cache.v_separation, 0) / 2;
 					if (rtl) {
@@ -1681,7 +1692,7 @@ void ItemList::_notification(int p_what) {
 						}
 						items.write[i].text_buf->set_width(text_w);
 
-						text_ofs += base_ofs;
+						text_ofs += base_ofs + margin_ofs;
 						text_ofs += items[i].rect_cache.position;
 
 						if (rtl) {
@@ -1699,7 +1710,7 @@ void ItemList::_notification(int p_what) {
 
 						real_t text_width_ofs = text_ofs.x;
 
-						text_ofs += base_ofs;
+						text_ofs += base_ofs + margin_ofs;
 						text_ofs += items[i].rect_cache.position;
 
 						float text_w = items[i].rect_cache.size.width - text_width_ofs;
@@ -1743,6 +1754,7 @@ void ItemList::_notification(int p_what) {
 				}
 			}
 
+			StyleBox::begin_animation_group("cursor");
 			if (cursor_rcache.size != Size2()) { // Draw cursor last, so border isn't cut off.
 				cursor_rcache.position += base_ofs;
 
@@ -1752,6 +1764,7 @@ void ItemList::_notification(int p_what) {
 
 				draw_style_box(cursor, cursor_rcache);
 			}
+			StyleBox::end_animation_group("cursor");
 
 			if (scroll_hint_mode != SCROLL_HINT_MODE_DISABLED) {
 				Size2 control_size = get_size();
@@ -1768,12 +1781,14 @@ void ItemList::_notification(int p_what) {
 				}
 			}
 
+			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
+			StyleBox::begin_animation_group("list_focus");
 			if (has_focus(true)) {
-				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
 				size.x -= (scroll_bar_h->get_max() - scroll_bar_h->get_page());
 				draw_style_box(theme_cache.focus_style, Rect2(Point2(), size));
-				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), false);
 			}
+			StyleBox::end_animation_group("list_focus");
+			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), false);
 		} break;
 	}
 }

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -453,6 +453,7 @@ void MenuBar::_draw_menu_item(int p_index) {
 	Ref<StyleBox> style;
 	Rect2 item_rect = _get_menu_item_rect(p_index);
 
+	StyleBox::begin_animation_group(StringName(itos(p_index)));
 	if (menu_cache[p_index].disabled) {
 		if (rtl && has_theme_stylebox(SNAME("disabled_mirrored"))) {
 			style = theme_cache.disabled_mirrored;
@@ -515,6 +516,7 @@ void MenuBar::_draw_menu_item(int p_index) {
 			color = theme_cache.font_color;
 		}
 	}
+	StyleBox::end_animation_group();
 
 	Point2 text_ofs = item_rect.position + Point2(style->get_margin(SIDE_LEFT), style->get_margin(SIDE_TOP));
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -940,11 +940,19 @@ void PopupMenu::_draw_items() {
 		_shape_item(i);
 
 		Point2 item_ofs = ofs;
+		Size2 style_margin = Size2();
 		Size2 icon_size = _get_item_icon_size(i);
 		float h = _get_item_height(i);
+
+		StringName anim_id = itos(i);
+		StyleBox::begin_animation_group(anim_id);
 		if ((active_submenu_index == -1 && i == mouse_over) || i == active_submenu_index) {
 			theme_cache.hover_style->draw(ci, Rect2(item_ofs + Point2(0, -theme_cache.v_separation / 2), Size2(display_width, h + theme_cache.v_separation)));
+			style_margin.x = theme_cache.hover_style->get_margin(SIDE_LEFT) - theme_cache.hover_style->get_margin(SIDE_RIGHT);
+			style_margin.y = theme_cache.hover_style->get_margin(SIDE_TOP) - theme_cache.hover_style->get_margin(SIDE_BOTTOM);
 		}
+		StyleBox::end_animation_group(anim_id);
+		item_ofs += StyleBox::get_animated_value(SNAME("style_margin"), style_margin, anim_id);
 
 		String text = items[i].xl_text;
 
@@ -1064,13 +1072,15 @@ void PopupMenu::_draw_items() {
 				if (theme_cache.font_outline_size > 0 && theme_cache.font_outline_color.a > 0) {
 					items[i].text_buf->draw_outline(ci, text_pos, theme_cache.font_outline_size, theme_cache.font_outline_color);
 				}
-				items[i].text_buf->draw(ci, text_pos, items[i].disabled ? theme_cache.font_disabled_color : (((active_submenu_index == -1 && i == mouse_over) || i == active_submenu_index) ? theme_cache.font_hover_color : theme_cache.font_color));
+				Color font_color = items[i].disabled ? theme_cache.font_disabled_color : (((active_submenu_index == -1 && i == mouse_over) || i == active_submenu_index) ? theme_cache.font_hover_color : theme_cache.font_color);
+				items[i].text_buf->draw(ci, text_pos, font_color);
 			} else {
 				Vector2 text_pos = item_ofs + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
 				if (theme_cache.font_outline_size > 0 && theme_cache.font_outline_color.a > 0) {
 					items[i].text_buf->draw_outline(ci, text_pos, theme_cache.font_outline_size, theme_cache.font_outline_color);
 				}
-				items[i].text_buf->draw(ci, text_pos, items[i].disabled ? theme_cache.font_disabled_color : (((active_submenu_index == -1 && i == mouse_over) || i == active_submenu_index) ? theme_cache.font_hover_color : theme_cache.font_color));
+				Color font_color = items[i].disabled ? theme_cache.font_disabled_color : (((active_submenu_index == -1 && i == mouse_over) || i == active_submenu_index) ? theme_cache.font_hover_color : theme_cache.font_color);
+				items[i].text_buf->draw(ci, text_pos, font_color);
 			}
 		}
 

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -314,11 +314,13 @@ void ScrollBar::_notification(int p_what) {
 				area.height -= incr->get_height() + decr->get_height();
 			}
 
+			StyleBox::begin_animation_group("scroll_bg");
 			if (has_focus(true)) {
 				theme_cache.scroll_focus_style->draw(ci, Rect2(ofs, area));
 			} else {
 				theme_cache.scroll_style->draw(ci, Rect2(ofs, area));
 			}
+			StyleBox::end_animation_group();
 
 			if (orientation == HORIZONTAL) {
 				ofs.width += area.width;
@@ -345,7 +347,9 @@ void ScrollBar::_notification(int p_what) {
 				grabber_rect.position.x = padding_left;
 			}
 
+			StyleBox::begin_animation_group(SNAME("grabber"));
 			grabber->draw(ci, grabber_rect);
+			StyleBox::end_animation_group();
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -302,8 +302,13 @@ void Slider::_notification(int p_what) {
 				int widget_width = style->get_minimum_size().width;
 				double areasize = size.height - (theme_cache.center_grabber ? 0 : grabber->get_height());
 				int grabber_shift = theme_cache.center_grabber ? grabber->get_height() / 2 : 0;
+				StyleBox::begin_animation_group("bg");
 				style->draw(ci, Rect2i(Point2i(size.width / 2 - widget_width / 2, 0), Size2i(widget_width, size.height)));
+				StyleBox::end_animation_group();
+
+				StyleBox::begin_animation_group("grabber");
 				grabber_area->draw(ci, Rect2i(Point2i((size.width - widget_width) / 2, Math::round(size.height - areasize * ratio - grabber->get_height() / 2 + grabber_shift)), Size2i(widget_width, Math::round(areasize * ratio + grabber->get_height() / 2 - grabber_shift))));
+				StyleBox::end_animation_group();
 
 				if (ticks > 1) {
 					int grabber_offset = (grabber->get_height() / 2 - tick->get_height() / 2);
@@ -334,13 +339,18 @@ void Slider::_notification(int p_what) {
 				int grabber_shift = theme_cache.center_grabber ? -grabber->get_width() / 2 : 0;
 				bool rtl = is_layout_rtl();
 
+				StyleBox::begin_animation_group("bg");
 				style->draw(ci, Rect2i(Point2i(0, (size.height - widget_height) / 2), Size2i(size.width, widget_height)));
+				StyleBox::end_animation_group();
+
+				StyleBox::begin_animation_group("grabber");
 				int p = areasize * (rtl ? 1 - ratio : ratio) + grabber->get_width() / 2 + grabber_shift;
 				if (rtl) {
 					grabber_area->draw(ci, Rect2i(Point2i(p, (size.height - widget_height) / 2), Size2i(size.width - p, widget_height)));
 				} else {
 					grabber_area->draw(ci, Rect2i(Point2i(0, (size.height - widget_height) / 2), Size2i(p, widget_height)));
 				}
+				StyleBox::end_animation_group();
 
 				if (ticks > 1) {
 					int grabber_offset = (grabber->get_width() / 2 - tick->get_width() / 2);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -493,8 +493,13 @@ void SpinBox::_notification(int p_what) {
 			draw_style_box(theme_cache.field_and_buttons_separator, Rect2(sizing_cache.field_and_buttons_separator_left, 0, sizing_cache.field_and_buttons_separator_width, size.height));
 
 			// Draw buttons.
+			StyleBox::begin_animation_group(SNAME("up"));
 			draw_style_box(up_stylebox, Rect2(sizing_cache.buttons_left, 0, sizing_cache.buttons_width, sizing_cache.button_up_height));
+			StyleBox::end_animation_group();
+
+			StyleBox::begin_animation_group(SNAME("down"));
 			draw_style_box(down_stylebox, Rect2(sizing_cache.buttons_left, sizing_cache.second_button_top, sizing_cache.buttons_width, sizing_cache.button_down_height));
+			StyleBox::end_animation_group();
 
 #ifndef DISABLE_DEPRECATED
 			if (theme_cache.is_updown_assigned) {

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -585,6 +585,8 @@ void TabBar::_notification(int p_what) {
 
 				_draw_tab(sb, col, theme_cache.icon_selected_color, current, rtl ? (size.width - tabs[current].ofs_cache - tabs[current].size_cache) : tabs[current].ofs_cache, has_focus(true));
 			}
+			StyleBox::end_animation_group("tab_focus");
+			draw_set_transform_matrix(Transform2D());
 
 			if (buttons_visible) {
 				int vofs = (size.height - theme_cache.increment_icon->get_size().height) / 2;
@@ -673,12 +675,19 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 	if (tab_style_v_flip) {
 		draw_set_transform(Point2(0.0, p_tab_style->get_draw_rect(sb_rect).size.y), 0.0, Size2(1.0, -1.0));
 	}
+
+	StringName group_id = "tab:" + itos(p_index);
+	StyleBox::begin_animation_group(group_id);
 	p_tab_style->draw(ci, sb_rect);
+	StyleBox::end_animation_group(group_id);
+
 	if (tab_style_v_flip) {
 		draw_set_transform(Point2(), 0.0, Size2(1.0, 1.0));
 	}
+
 	if (p_focus) {
 		Ref<StyleBox> focus_style = theme_cache.tab_focus_style;
+		StyleBox::begin_animation_group("tab_focus");
 		focus_style->draw(ci, sb_rect);
 	}
 
@@ -700,11 +709,13 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 	if (!tabs[p_index].text.is_empty()) {
 		Point2i text_pos = Point2i(rtl ? p_x - tabs[p_index].size_text : p_x,
 				p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - tabs[p_index].text_buf->get_size().y) / 2);
+		text_pos = StyleBox::get_animated_value("text_position", text_pos, group_id);
+		Color font_color_animated = StyleBox::get_animated_value(SceneStringName(font_color), p_font_color, group_id);
 
 		if (theme_cache.outline_size > 0 && theme_cache.font_outline_color.a > 0) {
 			tabs[p_index].text_buf->draw_outline(ci, text_pos, theme_cache.outline_size, theme_cache.font_outline_color);
 		}
-		tabs[p_index].text_buf->draw(ci, text_pos, p_font_color);
+		tabs[p_index].text_buf->draw(ci, text_pos, font_color_animated);
 
 		p_x = rtl ? p_x - tabs[p_index].size_text - theme_cache.h_separation : p_x + tabs[p_index].size_text + theme_cache.h_separation;
 	}
@@ -721,6 +732,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 
 		tabs.write[p_index].rb_rect = rb_rect;
 
+		StyleBox::begin_animation_group("button_" + itos(p_index));
 		if (rb_hover == p_index) {
 			if (rb_pressing) {
 				theme_cache.button_pressed_style->draw(ci, rb_rect);
@@ -728,6 +740,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 				style->draw(ci, rb_rect);
 			}
 		}
+		StyleBox::end_animation_group();
 
 		rb->draw(ci, Point2i(rb_rect.position.x + style->get_margin(SIDE_LEFT), rb_rect.position.y + style->get_margin(SIDE_TOP)));
 
@@ -748,6 +761,8 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 
 		tabs.write[p_index].cb_rect = cb_rect;
 
+		StringName sub_id = "close_" + itos(p_index);
+		StyleBox::begin_animation_group(sub_id);
 		if (!tabs[p_index].disabled && cb_hover == p_index) {
 			if (cb_pressing) {
 				theme_cache.button_pressed_style->draw(ci, cb_rect);
@@ -755,7 +770,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 				style->draw(ci, cb_rect);
 			}
 		}
-
+		StyleBox::end_animation_group(sub_id);
 		cb->draw(ci, Point2i(cb_rect.position.x + style->get_margin(SIDE_LEFT), cb_rect.position.y + style->get_margin(SIDE_TOP)));
 	} else {
 		tabs.write[p_index].cb_rect = Rect2();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2451,6 +2451,8 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				cell_rect.size.x += theme_cache.h_separation;
 			}
 
+			StringName anim_id = itos(p_item->get_instance_id());
+			StyleBox::begin_animation_group(anim_id);
 			if (should_draw_row_rect) {
 				if (p_item->cells[0].selected || is_row_hovered) {
 					const Rect2 content_rect = _get_content_rect();
@@ -2520,6 +2522,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					p_item->cells.write[i].focus_rect = Rect2(r.position, r.size);
 				}
 			}
+			StyleBox::end_animation_group();
 
 			if (theme_cache.draw_guides) {
 				Rect2 r = convert_rtl_rect(cell_rect);
@@ -2561,6 +2564,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				bool draw_as_hover_dim = draw_as_hover && is_cell_button_hovered;
 				cell_color = p_item->cells[i].selected && draw_as_hover ? theme_cache.font_hovered_selected_color : (p_item->cells[i].selected ? theme_cache.font_selected_color : (draw_as_hover_dim ? theme_cache.font_hovered_dimmed_color : (draw_as_hover ? theme_cache.font_hovered_color : theme_cache.font_color)));
 			}
+			cell_color = StyleBox::get_animated_value(SNAME("cell_color"), cell_color, anim_id);
 
 			Color font_outline_color = theme_cache.font_outline_color;
 			int outline_size = theme_cache.font_outline_size;
@@ -2768,6 +2772,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				ofs += item_width + buttons_width;
 			}
 
+			StyleBox::begin_animation_group("cursor");
 			if (select_mode == SELECT_MULTI && selected_item == p_item && selected_col == i) {
 				cell_rect = convert_rtl_rect(cell_rect);
 				if (has_focus(true)) {
@@ -5388,6 +5393,7 @@ void Tree::_notification(int p_what) {
 			if (root && get_size().x > 0 && get_size().y > 0) {
 				int self_height = 0; // Just to pass a reference, we don't need the root's `self_height`.
 				draw_item(Point2(), draw_ofs, draw_size, root, self_height, content_ci);
+				StyleBox::end_animation_group("cursor");
 
 				// Draw drop indicator.
 				if (drop_mode_flags && drop_mode_over) {

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -30,8 +30,14 @@
 
 #include "style_box.h"
 
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "scene/gui/control.h"
 #include "scene/main/canvas_item.h"
+#include "scene/main/scene_tree.h"
+#include "scene/resources/animation.h"
+#include "servers/rendering/rendering_server.h"
 
 Size2 StyleBox::get_minimum_size() const {
 	Size2 min_size = Size2(get_margin(SIDE_LEFT) + get_margin(SIDE_RIGHT), get_margin(SIDE_TOP) + get_margin(SIDE_BOTTOM));
@@ -90,6 +96,273 @@ Point2 StyleBox::get_offset() const {
 	return Point2(get_margin(SIDE_LEFT), get_margin(SIDE_TOP));
 }
 
+void StyleBox::begin_animation_group(StringName p_id) {
+	animation_id = p_id;
+	cached_state = nullptr;
+}
+
+void StyleBox::end_animation_group(StringName p_id) {
+	Control *node = Object::cast_to<Control>(CanvasItem::get_current_item_drawn());
+	if (!node) {
+		return;
+	}
+
+	if (!p_id.is_empty()) {
+		animation_id = p_id;
+	}
+	ObjectID nid = node->get_instance_id();
+	AnimKey key = AnimKey(nid, animation_id);
+
+	if (transition_groups.has(key)) {
+		AnimationState &current_state = transition_groups[key];
+		uint64_t current_time = OS::get_singleton()->get_ticks_usec();
+		current_state.current_time = current_time;
+		StyleBox *sb = ObjectDB::get_instance<StyleBox>(current_state.box_id);
+		if (sb && !current_state.has_drawn_box) {
+			bool exit_finished = current_state.is_exiting && current_state.current_time >= current_state.end_time;
+			bool exitable = sb->exit_info.duration > 0;
+
+			// If it's the first frame of the exit animation,
+			// increase the end time by exit duration to trigger the animation.
+			if (!current_state.is_exiting) {
+				current_state.end_time = current_time + sb->exit_info.duration;
+				current_state.is_exiting = true;
+			}
+
+			if (!exit_finished && exitable) {
+				// This flag is required to skip any draw logic that interferes with detecting exit animations.
+				is_drawing_exit = true;
+				sb->draw(node->get_canvas_item(), current_state.rect);
+				is_drawing_exit = false;
+			}
+		}
+	}
+
+	animation_id = "";
+	cached_state = nullptr;
+}
+
+void StyleBox::begin_draw(RID p_canvas_item, const Rect2 &p_rect) const {
+	current_draw_rect = p_rect;
+
+	if (animation_id.is_empty()) {
+		return;
+	}
+
+	Control *node = Object::cast_to<Control>(get_current_item_drawn());
+	if (!node) {
+		return;
+	}
+
+	AnimKey key = AnimKey(node->get_instance_id(), animation_id);
+	AnimationState &current_state = transition_groups[key];
+	cached_state = &current_state;
+	current_state.current_time = OS::get_singleton()->get_ticks_usec();
+
+	// Only set up for normally drawn stylboxes, not boxes drawn during an exit animation,
+	// since the exit state depends on these.
+	if (!is_drawing_exit) {
+		current_state.box_id = get_instance_id();
+		current_state.rect = current_draw_rect;
+		current_state.has_drawn_box = true;
+
+		// If any stylebox draws to this group, it's no longer exitng.
+		if (current_state.is_exiting) {
+			current_state.end_time = current_state.current_time + normal_info.duration;
+			current_state.is_exiting = false;
+		}
+	}
+
+	// Skip styleboxes with no animation duration
+	if (current_state.is_exiting && exit_info.duration <= 0) {
+		return;
+	}
+	if (!current_state.is_exiting && normal_info.duration <= 0) {
+		return;
+	}
+
+	// Detect if it's the first time this animation group is being drawn.
+	if (exit_info.duration > 0 && cached_state->values[SNAME("transform_offset")].to == Variant()) {
+		// Provide the starting points for the enter animation.
+		get_animated_value("transform_offset", exit_transform.offset);
+		get_animated_value("transform_scale", exit_transform.scale);
+		get_animated_value("transform_rotation", exit_transform.rotation);
+		get_animated_value("transform_modulate", exit_transform.modulate);
+	}
+
+	// Use default transform for normal state.
+	DrawTransform dt;
+	if (is_drawing_exit) {
+		dt = exit_transform;
+	}
+
+	// Animate Transform2D parts individually to avoid weird interpolation.
+	dt.offset = get_animated_value("transform_offset", dt.offset);
+	dt.scale = get_animated_value("transform_scale", dt.scale);
+	dt.rotation = get_animated_value("transform_rotation", dt.rotation);
+	dt.pivot = p_rect.position + exit_transform.pivot * p_rect.size;
+
+	Transform2D tf = Transform2D().translated(-dt.pivot).scaled(dt.scale).rotated(dt.rotation).translated(dt.pivot).translated(dt.offset);
+	Color md = get_animated_value("transform_modulate", dt.modulate);
+
+	RenderingServer *vs = RenderingServer::get_singleton();
+	if (tf != Transform2D()) {
+		vs->canvas_item_add_set_transform(p_canvas_item, tf);
+	}
+	if (md != Color(1, 1, 1, 1)) {
+		vs->canvas_item_add_set_modulate(p_canvas_item, md);
+	}
+}
+
+void StyleBox::end_draw(RID p_canvas_item, const Rect2 &p_rect) const {
+	// Reset any draw transforms or modulates used during an exit or entrance animation.
+	if (cached_state) {
+		if (cached_state->is_exiting && exit_info.duration <= 0) {
+			return;
+		}
+		if (!cached_state->is_exiting && normal_info.duration <= 0) {
+			return;
+		}
+		RenderingServer *vs = RenderingServer::get_singleton();
+		vs->canvas_item_add_set_modulate(p_canvas_item, Color(1, 1, 1, 1));
+		vs->canvas_item_add_set_transform(p_canvas_item, Transform2D());
+	}
+}
+
+Variant StyleBox::get_animated_value(StringName p_name, Variant p_target_value, StringName p_group) {
+	Control *node = Object::cast_to<Control>(CanvasItem::get_current_item_drawn());
+	if (!node) {
+		return p_target_value;
+	}
+
+	AnimationState *current_state = cached_state;
+
+	// For external animated values, like font color
+	if (!p_group.is_empty()) {
+		AnimKey key = AnimKey(node->get_instance_id(), p_group);
+		current_state = &transition_groups[key];
+	}
+
+	if (current_state == nullptr) {
+		return p_target_value;
+	}
+
+	AnimationValues &values = current_state->values[p_name];
+	current_state->has_drawn_group = true;
+
+	if (p_target_value == Variant()) {
+		return values.current;
+	}
+
+	// If it's the first time, skip interpolation.
+	StyleBox *sb = ObjectDB::get_instance<StyleBox>(current_state->box_id);
+	if (!sb || values.to == Variant()) {
+		values.from = p_target_value;
+		values.to = p_target_value;
+		values.current = p_target_value;
+		return p_target_value;
+	}
+
+	// For disabling animted rects.
+	// This is desirable for nodes that scroll,
+	// so styleboxes don't just slide around as you scroll.
+	if (!sb->should_animate_rect && p_name == SNAME("rect")) {
+		values.to = p_target_value;
+		values.current = p_target_value;
+		return p_target_value;
+	}
+
+	// Skip interpolation if there is no duration.
+	AnimationInfo info = current_state->is_exiting ? sb->exit_info : sb->normal_info;
+	if (info.duration <= 0) {
+		values.to = p_target_value;
+		values.current = p_target_value;
+		return p_target_value;
+	}
+
+	uint64_t current_time = current_state->current_time;
+
+	// Animations are only triggered when the target value has changed.
+	if (values.to != p_target_value) {
+		values.from = values.current;
+		values.to = p_target_value;
+		values.start_time = current_time;
+		current_state->end_time = MAX(current_state->end_time, current_time + info.duration * 1000000);
+		// One time connection to process_frame,
+		// so queue_redraw() can be triggered on nodes that can animate.
+		if (!redrawer_connected) {
+			node->get_tree()->connect("process_frame", callable_mp_static(StyleBox::redraw_animating_nodes));
+			redrawer_connected = true;
+		}
+		// One time connection per node,
+		// for setting up and resetting variables each draw frame.
+		if (!node->is_stylebox_animator_connected) {
+			node->connect(SceneStringName(draw), callable_mp_static(StyleBox::setup_animation_frame).bind(node));
+			node->is_stylebox_animator_connected = true;
+		}
+	}
+	if (values.from == Variant()) {
+		values.from = p_target_value;
+	}
+	if (values.current == Variant()) {
+		values.current = p_target_value;
+	}
+
+	double elapsed = (current_time - values.start_time) / 1000000.0;
+	if (elapsed < info.duration) {
+		Variant result = Animation::interpolate_variant(values.from, values.to, Tween::run_equation(info.transition, info.ease, elapsed, 0.0, 1.0, info.duration));
+		values.current = result;
+		return result;
+	} else {
+		values.current = values.to;
+		values.from = values.to;
+	}
+
+	return p_target_value;
+}
+
+void StyleBox::redraw_animating_nodes() {
+	for (HashMap<AnimKey, AnimationState>::Iterator it = transition_groups.begin(); it;) {
+		Control *node = ObjectDB::get_instance<Control>(it->key.first);
+		if (node) {
+			if (it->value.current_time < it->value.end_time) {
+				node->queue_redraw();
+			} else if (it->value.end_time > 0) {
+				// Draw one extra frame for finished exit animations.
+				// Ensures the final state does not draw the final frame of the stylebox at all.
+				if (it->value.is_exiting) {
+					transition_groups.erase(it->key);
+					node->queue_redraw();
+				}
+			} else {
+				// Just a way to detect if an animation JUST finished or any frame after.
+				it->value.end_time = 0;
+			}
+		} else {
+			transition_groups.erase(it->key);
+		}
+		++it;
+	}
+}
+
+void StyleBox::setup_animation_frame(Control *p_node) {
+	for (HashMap<AnimKey, AnimationState>::Iterator it = transition_groups.begin(); it;) {
+		Control *node = ObjectDB::get_instance<Control>(it->key.first);
+		if (node == p_node) {
+			// Erase transition groups if they were entirely skipped this frame.
+			// It happens when get_animated_value is not called at all for a given animation id.
+			// It's for clean up in nodes like ItemList or TabBar, which may delete or scroll visible items.
+			if (!it->value.has_drawn_group) {
+				transition_groups.erase(it->key);
+			} else {
+				it->value.has_drawn_box = false;
+				it->value.has_drawn_group = false;
+			}
+		}
+		++it;
+	}
+}
+
 void StyleBox::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	GDVIRTUAL_CALL(_draw, p_canvas_item, p_rect);
 }
@@ -112,6 +385,114 @@ bool StyleBox::test_mask(const Point2 &p_point, const Rect2 &p_rect) const {
 	return ret;
 }
 
+void StyleBox::set_transform_pivot(const Point2 &p_pivot) {
+	exit_transform.pivot = p_pivot;
+	emit_changed();
+}
+
+Point2 StyleBox::get_transform_pivot() const {
+	return exit_transform.pivot;
+}
+
+void StyleBox::set_transform_offset(const Point2 &p_value) {
+	exit_transform.offset = p_value;
+	emit_changed();
+}
+
+Point2 StyleBox::get_transform_offset() const {
+	return exit_transform.offset;
+}
+
+void StyleBox::set_transform_scale(const Size2 &p_value) {
+	exit_transform.scale = p_value;
+	emit_changed();
+}
+
+Size2 StyleBox::get_transform_scale() const {
+	return exit_transform.scale;
+}
+
+void StyleBox::set_transform_rotation(real_t p_value) {
+	exit_transform.rotation = p_value;
+	emit_changed();
+}
+
+real_t StyleBox::get_transform_rotation() const {
+	return exit_transform.rotation;
+}
+
+void StyleBox::set_transform_modulate(const Color &p_value) {
+	exit_transform.modulate = p_value;
+	emit_changed();
+}
+
+Color StyleBox::get_transform_modulate() const {
+	return exit_transform.modulate;
+}
+
+void StyleBox::set_animating_rect(bool p_value) {
+	if (should_animate_rect == p_value) {
+		return;
+	}
+	should_animate_rect = p_value;
+	emit_changed();
+}
+
+bool StyleBox::is_animating_rect() const {
+	return should_animate_rect;
+}
+
+void StyleBox::set_animation_duration(AnimationPhase p_phase, real_t p_value) {
+	if (p_phase == PHASE_EXIT) {
+		exit_info.duration = p_value;
+	} else {
+		normal_info.duration = p_value;
+	}
+	emit_changed();
+}
+
+real_t StyleBox::get_animation_duration(AnimationPhase p_phase) {
+	if (p_phase == PHASE_EXIT) {
+		return exit_info.duration;
+	} else {
+		return normal_info.duration;
+	}
+}
+
+void StyleBox::set_animation_ease(AnimationPhase p_phase, Tween::EaseType p_value) {
+	if (p_phase == PHASE_EXIT) {
+		exit_info.ease = p_value;
+	} else {
+		normal_info.ease = p_value;
+	}
+	emit_changed();
+}
+
+Tween::EaseType StyleBox::get_animation_ease(AnimationPhase p_phase) {
+	if (p_phase == PHASE_EXIT) {
+		return exit_info.ease;
+	} else {
+		return normal_info.ease;
+	}
+}
+
+void StyleBox::set_animation_transition(AnimationPhase p_phase, Tween::TransitionType p_value) {
+	if (p_phase == PHASE_EXIT) {
+		exit_info.transition = p_value;
+	} else {
+		normal_info.transition = p_value;
+	}
+	emit_changed();
+}
+
+Tween::TransitionType StyleBox::get_animation_transition(AnimationPhase p_phase) {
+	if (p_phase == PHASE_EXIT) {
+		return exit_info.transition;
+	} else {
+		return normal_info.transition;
+	}
+}
+
 void StyleBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_minimum_size"), &StyleBox::get_minimum_size);
 
@@ -122,16 +503,63 @@ void StyleBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_margin", "margin"), &StyleBox::get_margin);
 	ClassDB::bind_method(D_METHOD("get_offset"), &StyleBox::get_offset);
 
+	ClassDB::bind_method(D_METHOD("set_transform_pivot", "pivot"), &StyleBox::set_transform_pivot);
+	ClassDB::bind_method(D_METHOD("get_transform_pivot"), &StyleBox::get_transform_pivot);
+
+	ClassDB::bind_method(D_METHOD("set_transform_offset", "offset"), &StyleBox::set_transform_offset);
+	ClassDB::bind_method(D_METHOD("get_transform_offset"), &StyleBox::get_transform_offset);
+
+	ClassDB::bind_method(D_METHOD("set_transform_scale", "scale"), &StyleBox::set_transform_scale);
+	ClassDB::bind_method(D_METHOD("get_transform_scale"), &StyleBox::get_transform_scale);
+
+	ClassDB::bind_method(D_METHOD("set_transform_rotation", "rotation"), &StyleBox::set_transform_rotation);
+	ClassDB::bind_method(D_METHOD("get_transform_rotation"), &StyleBox::get_transform_rotation);
+
+	ClassDB::bind_method(D_METHOD("set_transform_modulate", "modulate"), &StyleBox::set_transform_modulate);
+	ClassDB::bind_method(D_METHOD("get_transform_modulate"), &StyleBox::get_transform_modulate);
+
+	ClassDB::bind_method(D_METHOD("set_animating_rect", "enabled"), &StyleBox::set_animating_rect);
+	ClassDB::bind_method(D_METHOD("is_animating_rect"), &StyleBox::is_animating_rect);
+
+	ClassDB::bind_method(D_METHOD("set_animation_duration", "type", "duration"), &StyleBox::set_animation_duration);
+	ClassDB::bind_method(D_METHOD("get_animation_duration", "type"), &StyleBox::get_animation_duration);
+
+	ClassDB::bind_method(D_METHOD("set_animation_ease", "type", "ease"), &StyleBox::set_animation_ease);
+	ClassDB::bind_method(D_METHOD("get_animation_ease", "type"), &StyleBox::get_animation_ease);
+
+	ClassDB::bind_method(D_METHOD("set_animation_transition", "type", "transition"), &StyleBox::set_animation_transition);
+	ClassDB::bind_method(D_METHOD("get_animation_transition", "type"), &StyleBox::get_animation_transition);
+
 	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "rect"), &StyleBox::draw);
 	ClassDB::bind_method(D_METHOD("get_current_item_drawn"), &StyleBox::get_current_item_drawn);
 
 	ClassDB::bind_method(D_METHOD("test_mask", "point", "rect"), &StyleBox::test_mask);
+
+	BIND_ENUM_CONSTANT(PHASE_NORMAL);
+	BIND_ENUM_CONSTANT(PHASE_EXIT);
 
 	ADD_GROUP("Content Margins", "content_margin_");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_left", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_content_margin", "get_content_margin", SIDE_LEFT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_top", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_content_margin", "get_content_margin", SIDE_TOP);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_right", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_content_margin", "get_content_margin", SIDE_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_bottom", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_content_margin", "get_content_margin", SIDE_BOTTOM);
+
+	ADD_GROUP("Animation", "animation_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "animation_duration", PROPERTY_HINT_RANGE, "0,1,0.001,or_less,or_greater"), "set_animation_duration", "get_animation_duration", PHASE_NORMAL);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "animation_ease", PROPERTY_HINT_ENUM, "In,Out,InOut,OutIn"), "set_animation_ease", "get_animation_ease", PHASE_NORMAL);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "animation_transition", PROPERTY_HINT_ENUM, "Linear,Sine,Quint,Quart,Quad,Exponential,Elastic,Cubic,Circ,Bounce,Back,Spring"), "set_animation_transition", "get_animation_transition", PHASE_NORMAL);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "animation_animate_rect"), "set_animating_rect", "is_animating_rect");
+
+	ADD_SUBGROUP("Exiting", "animation_exiting_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "animation_exiting_duration", PROPERTY_HINT_RANGE, "0,1,0.001,or_less,or_greater"), "set_animation_duration", "get_animation_duration", PHASE_EXIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "animation_exiting_ease", PROPERTY_HINT_ENUM, "In,Out,InOut,OutIn"), "set_animation_ease", "get_animation_ease", PHASE_EXIT);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "animation_exiting_transition", PROPERTY_HINT_ENUM, "Linear,Sine,Quint,Quart,Quad,Exponential,Elastic,Cubic,Circ,Bounce,Back,Spring"), "set_animation_transition", "get_animation_transition", PHASE_EXIT);
+
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "animation_exiting_modulate"), "set_transform_modulate", "get_transform_modulate");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "animation_exiting_offset", PROPERTY_HINT_NONE, "px"), "set_transform_offset", "get_transform_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "animation_exiting_scale", PROPERTY_HINT_NONE), "set_transform_scale", "get_transform_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "animation_exiting_rotation", PROPERTY_HINT_RANGE, "-180,180,1,radians_as_degrees"), "set_transform_rotation", "get_transform_rotation");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "animation_exiting_pivot", PROPERTY_HINT_NONE), "set_transform_pivot", "get_transform_pivot");
 
 	GDVIRTUAL_BIND(_draw, "to_canvas_item", "rect")
 	GDVIRTUAL_BIND(_get_draw_rect, "rect")
@@ -142,5 +570,12 @@ void StyleBox::_bind_methods() {
 StyleBox::StyleBox() {
 	for (int i = 0; i < 4; i++) {
 		content_margin[i] = -1;
+	}
+}
+
+void StyleBoxEmpty::_validate_property(PropertyInfo &p_property) const {
+	// StyleBoxEmpty can't animate so there's no reason to show animation properties.
+	if (p_property.name.begins_with("animation_")) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -32,8 +32,10 @@
 
 #include "core/io/resource.h"
 #include "core/object/gdvirtual.gen.h"
+#include "scene/animation/tween.h"
 
 class CanvasItem;
+class Control;
 
 class StyleBox : public Resource {
 	GDCLASS(StyleBox, Resource);
@@ -42,9 +44,64 @@ class StyleBox : public Resource {
 
 	float content_margin[4];
 
+	using AnimKey = Pair<ObjectID, StringName>;
+
+	struct AnimationInfo {
+		double duration = 0;
+		Tween::EaseType ease = Tween::EASE_OUT;
+		Tween::TransitionType transition = Tween::TRANS_SINE;
+	};
+
+	struct DrawTransform {
+		Point2 pivot = Point2(.5, .5);
+		Point2 offset = Point2();
+		Size2 scale = Size2(1, 1);
+		real_t rotation = 0.0;
+		Color modulate = Color(1, 1, 1, 1);
+	};
+
+	struct AnimationValues {
+		Variant from;
+		Variant to;
+		Variant current;
+		real_t start_time = 0;
+	};
+
+	struct AnimationState {
+		ObjectID box_id;
+		Rect2 rect;
+		DrawTransform draw_transform;
+		bool has_drawn_group = false;
+		bool has_drawn_box = false;
+		bool is_exiting = false;
+
+		uint64_t end_time = 0;
+		uint64_t current_time = 0;
+
+		HashMap<StringName, AnimationValues> values;
+	};
+
+	inline static HashMap<AnimKey, AnimationState> transition_groups;
+	inline static StringName animation_id;
+	inline static Rect2 current_draw_rect;
+	inline static bool redrawer_connected = false;
+	inline static AnimationState *cached_state = nullptr;
+	inline static bool is_drawing_exit = false;
+
+	AnimationInfo normal_info;
+	AnimationInfo exit_info;
+	DrawTransform exit_transform;
+	bool should_animate_rect = true;
+
+	static void redraw_animating_nodes();
+	static void setup_animation_frame(Control *p_node);
+
 protected:
 	static void _bind_methods();
 	virtual float get_style_margin(Side p_side) const { return 0; }
+
+	void begin_draw(RID p_canvas_item, const Rect2 &p_rect) const;
+	void end_draw(RID p_canvas_item, const Rect2 &p_rect) const;
 
 	GDVIRTUAL2C_REQUIRED(_draw, RID, Rect2)
 	GDVIRTUAL1RC(Rect2, _get_draw_rect, Rect2)
@@ -52,6 +109,43 @@ protected:
 	GDVIRTUAL2RC(bool, _test_mask, Point2, Rect2)
 
 public:
+	enum AnimationPhase {
+		PHASE_NORMAL,
+		PHASE_EXIT,
+		PHASE_MAX
+	};
+
+	static void begin_animation_group(StringName p_id);
+	static void end_animation_group(StringName p_id = StringName());
+	static Variant get_animated_value(StringName p_name, Variant p_target_value, StringName p_group = StringName());
+
+	void set_transform_pivot(const Point2 &p_value);
+	Point2 get_transform_pivot() const;
+
+	void set_transform_offset(const Point2 &p_value);
+	Point2 get_transform_offset() const;
+
+	void set_transform_scale(const Size2 &p_value);
+	Size2 get_transform_scale() const;
+
+	void set_transform_rotation(real_t p_value);
+	real_t get_transform_rotation() const;
+
+	void set_transform_modulate(const Color &p_value);
+	Color get_transform_modulate() const;
+
+	void set_animation_duration(AnimationPhase p_type, real_t p_value);
+	real_t get_animation_duration(AnimationPhase p_type);
+
+	void set_animation_ease(AnimationPhase p_type, Tween::EaseType p_value);
+	Tween::EaseType get_animation_ease(AnimationPhase p_type);
+
+	void set_animation_transition(AnimationPhase p_type, Tween::TransitionType p_value);
+	Tween::TransitionType get_animation_transition(AnimationPhase p_type);
+
+	void set_animating_rect(bool p_value);
+	bool is_animating_rect() const;
+
 	virtual Size2 get_minimum_size() const;
 
 	void set_content_margin(Side p_side, float p_value);
@@ -78,4 +172,7 @@ class StyleBoxEmpty : public StyleBox {
 
 public:
 	virtual void draw(RID p_canvas_item, const Rect2 &p_rect) const override {}
+	void _validate_property(PropertyInfo &p_property) const;
 };
+
+VARIANT_ENUM_CAST(StyleBox::AnimationPhase);

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -457,27 +457,60 @@ Rect2 StyleBoxFlat::get_draw_rect(const Rect2 &p_rect) const {
 }
 
 void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
-	bool draw_border = (border_width[0] > 0) || (border_width[1] > 0) || (border_width[2] > 0) || (border_width[3] > 0);
-	bool draw_shadow = (shadow_size > 0);
+	begin_draw(p_canvas_item, p_rect);
+
+	Rect2 rect_animated = get_animated_value(SNAME("rect"), p_rect);
+
+	Color bg_color_animated = get_animated_value(SNAME("bg_color"), bg_color);
+	Color border_color_animated = get_animated_value(SNAME("border/color"), border_color);
+
+	real_t expand_margin_animated[4] = {
+		get_animated_value(SNAME("expand/margin_left"), expand_margin[SIDE_LEFT]),
+		get_animated_value(SNAME("expand/margin_top"), expand_margin[SIDE_TOP]),
+		get_animated_value(SNAME("expand/margin_right"), expand_margin[SIDE_RIGHT]),
+		get_animated_value(SNAME("expand/margin_bottom"), expand_margin[SIDE_BOTTOM])
+	};
+
+	real_t border_width_animated[4] = {
+		get_animated_value(SNAME("border/width_left"), border_width[SIDE_LEFT]),
+		get_animated_value(SNAME("border/width_top"), border_width[SIDE_TOP]),
+		get_animated_value(SNAME("border/width_right"), border_width[SIDE_RIGHT]),
+		get_animated_value(SNAME("border/width_bottom"), border_width[SIDE_BOTTOM]),
+	};
+	for (int i = 0; i < 4; i++) {
+		border_width_animated[i] = MAX(0, border_width_animated[i]);
+	}
+	real_t corner_radius_animated[4];
+	corner_radius_animated[0] = MAX(0.0, (real_t)get_animated_value(SNAME("corner_radius/top_left"), corner_radius[CORNER_TOP_LEFT]));
+	corner_radius_animated[1] = MAX(0.0, (real_t)get_animated_value(SNAME("corner_radius/top_right"), corner_radius[CORNER_TOP_RIGHT]));
+	corner_radius_animated[2] = MAX(0.0, (real_t)get_animated_value(SNAME("corner_radius/bottom_right"), corner_radius[CORNER_BOTTOM_RIGHT]));
+	corner_radius_animated[3] = MAX(0.0, (real_t)get_animated_value(SNAME("corner_radius/bottom_left"), corner_radius[CORNER_BOTTOM_LEFT]));
+
+	real_t shadow_size_animated = get_animated_value(SNAME("shadow/size"), shadow_size);
+	Vector2 shadow_offset_animated = get_animated_value(SNAME("shadow/offset"), shadow_offset);
+	Color shadow_color_animated = get_animated_value(SNAME("shadow/color"), shadow_color);
+
+	bool draw_border = (border_width_animated[0] > 0) || (border_width_animated[1] > 0) || (border_width_animated[2] > 0) || (border_width_animated[3] > 0);
+	bool draw_shadow = (shadow_size_animated > 0);
 	if (!draw_border && !draw_center && !draw_shadow) {
 		return;
 	}
 
-	Rect2 style_rect = p_rect.grow_individual(expand_margin[SIDE_LEFT], expand_margin[SIDE_TOP], expand_margin[SIDE_RIGHT], expand_margin[SIDE_BOTTOM]);
+	Rect2 style_rect = rect_animated.grow_individual(expand_margin_animated[SIDE_LEFT], expand_margin_animated[SIDE_TOP], expand_margin_animated[SIDE_RIGHT], expand_margin_animated[SIDE_BOTTOM]);
 	if (Math::is_zero_approx(style_rect.size.width) || Math::is_zero_approx(style_rect.size.height)) {
 		return;
 	}
 
-	const bool rounded_corners = (corner_radius[0] > 0) || (corner_radius[1] > 0) || (corner_radius[2] > 0) || (corner_radius[3] > 0);
+	const bool rounded_corners = (corner_radius_animated[0] > 0) || (corner_radius_animated[1] > 0) || (corner_radius_animated[2] > 0) || (corner_radius_animated[3] > 0);
 	// Only enable antialiasing if it is actually needed. This improves performance
 	// and maximizes sharpness for non-skewed StyleBoxes with sharp corners.
 	const bool aa_on = (rounded_corners || !skew.is_zero_approx()) && anti_aliased;
 
 	const bool blend_on = blend_border && draw_border;
 
-	Color border_color_alpha = Color(border_color.r, border_color.g, border_color.b, 0);
-	Color border_color_blend = (draw_center ? bg_color : border_color_alpha);
-	Color border_color_inner = blend_on ? border_color_blend : border_color;
+	Color border_color_alpha = Color(border_color_animated, 0.0f);
+	Color border_color_blend = (draw_center ? bg_color_animated : border_color_alpha);
+	Color border_color_inner = blend_on ? border_color_blend : border_color_animated;
 
 	real_t aa_size_scaled = 1.0f;
 	if (aa_on) {
@@ -498,15 +531,15 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	real_t width = MAX(style_rect.size.width - aa_shrink, 0);
 	real_t height = MAX(style_rect.size.height - aa_shrink, 0);
 	real_t adapted_border[4] = { 1000000.0, 1000000.0, 1000000.0, 1000000.0 };
-	adapt_values(SIDE_TOP, SIDE_BOTTOM, adapted_border, border_width, height, height, height);
-	adapt_values(SIDE_LEFT, SIDE_RIGHT, adapted_border, border_width, width, width, width);
+	adapt_values(SIDE_TOP, SIDE_BOTTOM, adapted_border, border_width_animated, height, height, height);
+	adapt_values(SIDE_LEFT, SIDE_RIGHT, adapted_border, border_width_animated, width, width, width);
 
 	// Adapt corners (prevent weird overlapping/glitchy drawings).
 	real_t adapted_corner[4] = { 1000000.0, 1000000.0, 1000000.0, 1000000.0 };
-	adapt_values(CORNER_TOP_RIGHT, CORNER_BOTTOM_RIGHT, adapted_corner, corner_radius, height, height - adapted_border[SIDE_BOTTOM], height - adapted_border[SIDE_TOP]);
-	adapt_values(CORNER_TOP_LEFT, CORNER_BOTTOM_LEFT, adapted_corner, corner_radius, height, height - adapted_border[SIDE_BOTTOM], height - adapted_border[SIDE_TOP]);
-	adapt_values(CORNER_TOP_LEFT, CORNER_TOP_RIGHT, adapted_corner, corner_radius, width, width - adapted_border[SIDE_RIGHT], width - adapted_border[SIDE_LEFT]);
-	adapt_values(CORNER_BOTTOM_LEFT, CORNER_BOTTOM_RIGHT, adapted_corner, corner_radius, width, width - adapted_border[SIDE_RIGHT], width - adapted_border[SIDE_LEFT]);
+	adapt_values(CORNER_TOP_RIGHT, CORNER_BOTTOM_RIGHT, adapted_corner, corner_radius_animated, height, height - adapted_border[SIDE_BOTTOM], height - adapted_border[SIDE_TOP]);
+	adapt_values(CORNER_TOP_LEFT, CORNER_BOTTOM_LEFT, adapted_corner, corner_radius_animated, height, height - adapted_border[SIDE_BOTTOM], height - adapted_border[SIDE_TOP]);
+	adapt_values(CORNER_TOP_LEFT, CORNER_TOP_RIGHT, adapted_corner, corner_radius_animated, width, width - adapted_border[SIDE_RIGHT], width - adapted_border[SIDE_LEFT]);
+	adapt_values(CORNER_BOTTOM_LEFT, CORNER_BOTTOM_RIGHT, adapted_corner, corner_radius_animated, width, width - adapted_border[SIDE_RIGHT], width - adapted_border[SIDE_LEFT]);
 
 	Rect2 infill_rect = style_rect.grow_individual(-adapted_border[SIDE_LEFT], -adapted_border[SIDE_TOP], -adapted_border[SIDE_RIGHT], -adapted_border[SIDE_BOTTOM]);
 
@@ -514,7 +547,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 	if (aa_on) {
 		for (int i = 0; i < 4; i++) {
-			if (border_width[i] > 0) {
+			if (border_width_animated[i] > 0) {
 				border_style_rect = border_style_rect.grow_side((Side)i, -aa_size_scaled);
 			}
 		}
@@ -528,32 +561,32 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	// Create shadow.
 	if (draw_shadow) {
 		Rect2 shadow_inner_rect = style_rect;
-		shadow_inner_rect.position += shadow_offset;
+		shadow_inner_rect.position += shadow_offset_animated;
 
-		Rect2 shadow_rect = style_rect.grow(shadow_size);
-		shadow_rect.position += shadow_offset;
+		Rect2 shadow_rect = style_rect.grow(shadow_size_animated);
+		shadow_rect.position += shadow_offset_animated;
 
-		Color shadow_color_transparent = Color(shadow_color.r, shadow_color.g, shadow_color.b, 0);
+		Color shadow_color_transparent = Color(shadow_color_animated, 0.0f);
 
 		draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,
-				shadow_rect, shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew);
+				shadow_rect, shadow_inner_rect, shadow_color_animated, shadow_color_transparent, corner_detail, skew);
 
 		if (draw_center) {
 			draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,
-					shadow_inner_rect, shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true);
+					shadow_inner_rect, shadow_inner_rect, shadow_color_animated, shadow_color_animated, corner_detail, skew, true);
 		}
 	}
 
 	// Create border (no AA).
 	if (draw_border && !aa_on) {
 		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-				border_style_rect, infill_rect, border_color_inner, border_color, corner_detail, skew);
+				border_style_rect, infill_rect, border_color_inner, border_color_animated, corner_detail, skew);
 	}
 
 	// Create infill (no AA).
 	if (draw_center && (!aa_on || blend_on)) {
 		draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-				infill_rect, infill_rect, bg_color, bg_color, corner_detail, skew, true);
+				infill_rect, infill_rect, bg_color_animated, bg_color_animated, corner_detail, skew, true);
 	}
 
 	if (aa_on) {
@@ -564,7 +597,7 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 		if (draw_border) {
 			for (int i = 0; i < 4; i++) {
-				if (border_width[i] > 0) {
+				if (border_width_animated[i] > 0) {
 					aa_border_width[i] = aa_size_scaled;
 					aa_border_width_half[i] = aa_size_scaled * 0.5;
 					aa_fill_width[i] = 0;
@@ -595,13 +628,13 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 			if (!blend_on) {
 				// Create center fill, not antialiased yet
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						infill_rect_aa_colored, infill_rect_aa_colored, bg_color, bg_color, corner_detail, skew, true);
+						infill_rect_aa_colored, infill_rect_aa_colored, bg_color_animated, bg_color_animated, corner_detail, skew, true);
 			}
 			if (!blend_on || !draw_border) {
-				Color alpha_bg = Color(bg_color.r, bg_color.g, bg_color.b, 0);
+				Color alpha_bg = Color(bg_color_animated, 0.0f);
 				// Add antialiasing on the center fill
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						infill_rect_aa_transparent, infill_rect_aa_colored, bg_color, alpha_bg, corner_detail, skew);
+						infill_rect_aa_transparent, infill_rect_aa_colored, bg_color_animated, alpha_bg, corner_detail, skew);
 			}
 		}
 
@@ -621,15 +654,15 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 			// Create border ring, not antialiased yet
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-					outer_rect_aa_colored, ((blend_on) ? infill_rect : inner_rect_aa_colored), border_color_inner, border_color, corner_detail, skew);
+					outer_rect_aa_colored, ((blend_on) ? infill_rect : inner_rect_aa_colored), border_color_inner, border_color_animated, corner_detail, skew);
 			if (!blend_on) {
 				// Add antialiasing on the ring inner border
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						inner_rect_aa_colored, inner_rect_aa_transparent, border_color_blend, border_color, corner_detail, skew);
+						inner_rect_aa_colored, inner_rect_aa_transparent, border_color_blend, border_color_animated, corner_detail, skew);
 			}
 			// Add antialiasing on the ring outer border
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-					outer_rect_aa_transparent, outer_rect_aa_colored, border_color, border_color_alpha, corner_detail, skew);
+					outer_rect_aa_transparent, outer_rect_aa_colored, border_color_animated, border_color_alpha, corner_detail, skew);
 		}
 	}
 
@@ -645,6 +678,8 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	// Draw stylebox.
 	RenderingServer *vs = RenderingServer::get_singleton();
 	vs->canvas_item_add_triangle_array(p_canvas_item, indices, verts, colors, uvs);
+
+	end_draw(p_canvas_item, p_rect);
 }
 
 void StyleBoxFlat::_bind_methods() {

--- a/scene/resources/style_box_line.cpp
+++ b/scene/resources/style_box_line.cpp
@@ -93,20 +93,27 @@ float StyleBoxLine::get_grow_begin() const {
 }
 
 void StyleBoxLine::draw(RID p_canvas_item, const Rect2 &p_rect) const {
+	begin_draw(p_canvas_item, p_rect);
 	RenderingServer *vs = RenderingServer::get_singleton();
-	Rect2i r = p_rect;
+	Rect2i r = get_animated_value(SNAME("rect"), p_rect);
+
+	float grow_begin_animated = get_animated_value(SNAME("grow_begin"), grow_begin);
+	float grow_end_animated = get_animated_value(SNAME("grow_end"), grow_end);
+	real_t thickness_animated = get_animated_value(SNAME("thickness"), thickness);
+	Color color_animated = get_animated_value(SNAME("color"), color);
 
 	if (vertical) {
-		r.position.y -= grow_begin;
-		r.size.y += (grow_begin + grow_end);
-		r.size.x = thickness;
+		r.position.y -= grow_begin_animated;
+		r.size.y += (grow_begin_animated + grow_end_animated);
+		r.size.x = thickness_animated;
 	} else {
-		r.position.x -= grow_begin;
-		r.size.x += (grow_begin + grow_end);
-		r.size.y = thickness;
+		r.position.x -= grow_begin_animated;
+		r.size.x += (grow_begin_animated + grow_end_animated);
+		r.size.y = thickness_animated;
 	}
 
-	vs->canvas_item_add_rect(p_canvas_item, r, color);
+	vs->canvas_item_add_rect(p_canvas_item, r, color_animated);
+	end_draw(p_canvas_item, p_rect);
 }
 
 void StyleBoxLine::_bind_methods() {

--- a/scene/resources/style_box_texture.cpp
+++ b/scene/resources/style_box_texture.cpp
@@ -164,24 +164,41 @@ Rect2 StyleBoxTexture::get_draw_rect(const Rect2 &p_rect) const {
 }
 
 void StyleBoxTexture::draw(RID p_canvas_item, const Rect2 &p_rect) const {
+	begin_draw(p_canvas_item, p_rect);
+	float texture_margin_animated[4] = {
+		get_animated_value(SNAME("texture_margin/left"), texture_margin[SIDE_LEFT]),
+		get_animated_value(SNAME("texture_margin/top"), texture_margin[SIDE_TOP]),
+		get_animated_value(SNAME("texture_margin/right"), texture_margin[SIDE_RIGHT]),
+		get_animated_value(SNAME("texture_margin/bottom"), texture_margin[SIDE_BOTTOM]),
+	};
+	float expand_margin_animated[4] = {
+		get_animated_value(SNAME("expand_margin/left"), expand_margin[SIDE_LEFT]),
+		get_animated_value(SNAME("expand_margin/top"), expand_margin[SIDE_TOP]),
+		get_animated_value(SNAME("expand_margin/right"), expand_margin[SIDE_RIGHT]),
+		get_animated_value(SNAME("expand_margin/bottom"), expand_margin[SIDE_BOTTOM]),
+	};
+	Rect2 region_rect_animated = get_animated_value(SNAME("region_rect"), region_rect);
+	Color modulate_animated = get_animated_value(SNAME("modulate_color"), modulate);
+
 	if (texture.is_null()) {
 		return;
 	}
 
-	Rect2 rect = p_rect;
-	Rect2 src_rect = region_rect;
+	Rect2 rect = get_animated_value(SNAME("rect"), p_rect);
+	Rect2 src_rect = region_rect_animated;
 
 	texture->get_rect_region(rect, src_rect, rect, src_rect);
 
-	rect.position.x -= expand_margin[SIDE_LEFT];
-	rect.position.y -= expand_margin[SIDE_TOP];
-	rect.size.x += expand_margin[SIDE_LEFT] + expand_margin[SIDE_RIGHT];
-	rect.size.y += expand_margin[SIDE_TOP] + expand_margin[SIDE_BOTTOM];
+	rect.position.x -= expand_margin_animated[SIDE_LEFT];
+	rect.position.y -= expand_margin_animated[SIDE_TOP];
+	rect.size.x += expand_margin_animated[SIDE_LEFT] + expand_margin_animated[SIDE_RIGHT];
+	rect.size.y += expand_margin_animated[SIDE_TOP] + expand_margin_animated[SIDE_BOTTOM];
 
-	Vector2 start_offset = Vector2(texture_margin[SIDE_LEFT], texture_margin[SIDE_TOP]);
-	Vector2 end_offset = Vector2(texture_margin[SIDE_RIGHT], texture_margin[SIDE_BOTTOM]);
+	Vector2 start_offset = Vector2(texture_margin_animated[SIDE_LEFT], texture_margin_animated[SIDE_TOP]);
+	Vector2 end_offset = Vector2(texture_margin_animated[SIDE_RIGHT], texture_margin_animated[SIDE_BOTTOM]);
 
-	RenderingServer::get_singleton()->canvas_item_add_nine_patch(p_canvas_item, rect, src_rect, texture->get_scaled_rid(), start_offset, end_offset, RSE::NinePatchAxisMode(axis_h), RSE::NinePatchAxisMode(axis_v), draw_center, modulate);
+	RenderingServer::get_singleton()->canvas_item_add_nine_patch(p_canvas_item, rect, src_rect, texture->get_scaled_rid(), start_offset, end_offset, RSE::NinePatchAxisMode(axis_h), RSE::NinePatchAxisMode(axis_v), draw_center, modulate_animated);
+	end_draw(p_canvas_item, p_rect);
 }
 
 void StyleBoxTexture::_bind_methods() {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1806,6 +1806,15 @@ void RendererCanvasCull::canvas_item_add_set_transform(RID p_item, const Transfo
 	tr->xform = p_transform;
 }
 
+void RendererCanvasCull::canvas_item_add_set_modulate(RID p_item, const Color &p_modulate) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	Item::CommandModulate *mod = canvas_item->alloc_command<Item::CommandModulate>();
+	ERR_FAIL_NULL(mod);
+	mod->modulate = p_modulate;
+}
+
 void RendererCanvasCull::canvas_item_add_mesh(RID p_item, const RID &p_mesh, const Transform2D &p_transform, const Color &p_modulate, RID p_texture) {
 	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_NULL(canvas_item);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -277,6 +277,7 @@ public:
 	void canvas_item_add_multimesh(RID p_item, RID p_mesh, RID p_texture = RID());
 	void canvas_item_add_particles(RID p_item, RID p_particles, RID p_texture);
 	void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform);
+	void canvas_item_add_set_modulate(RID p_item, const Color &p_modulate);
 	void canvas_item_add_clip_ignore(RID p_item, bool p_ignore);
 	void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset);
 

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -190,6 +190,7 @@ public:
 				TYPE_TRANSFORM,
 				TYPE_CLIP_IGNORE,
 				TYPE_ANIMATION_SLICE,
+				TYPE_MODULATE,
 			};
 
 			Command *next = nullptr;
@@ -305,6 +306,11 @@ public:
 			CommandAnimationSlice() {
 				type = TYPE_ANIMATION_SLICE;
 			}
+		};
+
+		struct CommandModulate : public Command {
+			Color modulate;
+			CommandModulate() { type = TYPE_MODULATE; }
 		};
 
 		struct ViewportRender {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2862,6 +2862,11 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				_update_transform_2d_to_mat2x3(base_transform * transform->xform, template_instance.world);
 			} break;
 
+			case Item::Command::TYPE_MODULATE: {
+				const Item::CommandModulate *modulate = static_cast<const Item::CommandModulate *>(c);
+				base_color = p_item->final_modulate * modulate->modulate;
+			} break;
+
 			case Item::Command::TYPE_CLIP_IGNORE: {
 				const Item::CommandClipIgnore *ci = static_cast<const Item::CommandClipIgnore *>(c);
 				if (r_current_clip) {
@@ -3221,6 +3226,7 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 			}
 		} break;
 		case Item::Command::TYPE_TRANSFORM:
+		case Item::Command::TYPE_MODULATE:
 		case Item::Command::TYPE_CLIP_IGNORE:
 		case Item::Command::TYPE_ANIMATION_SLICE: {
 			// Can ignore these as they only impact batch creation.

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3357,6 +3357,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_add_multimesh", "item", "mesh", "texture"), &RenderingServer::canvas_item_add_multimesh, DEFVAL(RID()));
 	ClassDB::bind_method(D_METHOD("canvas_item_add_particles", "item", "particles", "texture"), &RenderingServer::canvas_item_add_particles);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_set_transform", "item", "transform"), &RenderingServer::canvas_item_add_set_transform);
+	ClassDB::bind_method(D_METHOD("canvas_item_add_set_modulate", "item", "modulate"), &RenderingServer::canvas_item_add_set_modulate);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_clip_ignore", "item", "ignore"), &RenderingServer::canvas_item_add_clip_ignore);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_animation_slice", "item", "animation_length", "slice_begin", "slice_end", "offset"), &RenderingServer::canvas_item_add_animation_slice, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_y", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_y);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -841,6 +841,7 @@ public:
 	virtual void canvas_item_add_multimesh(RID p_item, RID p_mesh, RID p_texture = RID()) = 0;
 	virtual void canvas_item_add_particles(RID p_item, RID p_particles, RID p_texture) = 0;
 	virtual void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform) = 0;
+	virtual void canvas_item_add_set_modulate(RID p_item, const Color &p_modulate) = 0;
 	virtual void canvas_item_add_clip_ignore(RID p_item, bool p_ignore) = 0;
 	virtual void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset) = 0;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1047,6 +1047,7 @@ public:
 	FUNC3(canvas_item_add_multimesh, RID, RID, RID)
 	FUNC3(canvas_item_add_particles, RID, RID, RID)
 	FUNC2(canvas_item_add_set_transform, RID, const Transform2D &)
+	FUNC2(canvas_item_add_set_modulate, RID, const Color &)
 	FUNC2(canvas_item_add_clip_ignore, RID, bool)
 	FUNC5(canvas_item_add_animation_slice, RID, double, double, double, double)
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/8992
Also partially related to https://github.com/godotengine/godot-proposals/issues/13269

This is an implementation for Stylebox animations, but they work for theme_color and rect changes too. It's opt-in and should not affect anything unless a duration is provided. Video demo:

https://github.com/user-attachments/assets/6561b2c6-bb1d-4704-9fb1-aae91220b0f5


## Usage in Control Nodes
For a `Control` node to support stylebox animations, it must provide an animation group id, in which 1 stylebox is drawn at a time. Whenever that stylebox or its properties change, a transition animation is triggered. This is done via the `begin_animation_group` and `end_animation_group` methods. It typically looks something like this:
```c++
begin_animation_group("item:0");
if (hover) {
  hover->draw(ci, rect);
}
else if (pressed) {
  pressed->draw(ci, rect);
}
else {
  normal->draw(ci, rect);
}
end_animation_group("item:1");
```
The reason for these 2 functions is to minimize code/logic changes by just wrapping any existing chunks of code that would draw 1 stylebox.

## Usage in StyleBox classes
Now for a `StyleBox` type to support animations, like `StyleBoxFlat`, `StyleBoxLine`, or `StyleBoxTexture`, it just has to call 2 other wrapper functions at the beginning and end of the draw call, `begin_draw` and `end_draw`. Then for any animatable property, use `get_animated_value` like this:
```c++
begin_draw();
Color animated_bg_color = get_animated_value("bg_color", bg_color);
// For the rest of the draw code use animated_bg_color instead of bg_color
end_draw();
```
The `get_animated_value` method can be used outside of styleboxes too, allowing text, icons and other content to animate in sync with the stylebox. Like so:
```c++
StringName anim_id = "item:0";
begin_animation_group(anim_id);
// Draw the StyleBox
end_animation_group();

// Draw the text or icon in fron
Color font_color = hovered ? hovered_color : normal_color; // Or whatever logic to get the current theme color
font_color = StyleBox::get_animated_value("font_color", font_color, anim_id);
text_buff->draw(ci, pos, font_color);
```

## Exit Animations (Appearing / Disappearing Styleboxes)
Exit animations are another part to this PR. Some nodes like ItemList, Tree, and PopupMenu don't always draw a stylebox, particularly for the normal/unhovered state. So those nodes can't just "transition" to a style. Focus styleboxes are another example, where a stylebox is either shown or not shown, there is no other stylebox to transition to.

To still support animations for those cases, exit animations have you provide a transform & modulate, so that box can animate appearing and disappearing. For example scaling to 0 or fading to transparent. `end_animation_group` acts like an "else" block. It detects whether a stylebox was drawn or not, and if not, draws the last used stylebox but transforming to its exit state.

## Custom Animation Id
If there is a node that does not yet support animations via providing an animation_id, a stylebox itself can define one via custom_id. This value is also for Styleboxes that should animate independently of the Control's internally provided ID. This enables the tab-pill animation in the video, because the `pressed` stylebox uses a separate custom_id which overrides the internally provided `tab:0`, `tab:1` etc. So the pressed stylebox animates its change in rect, rather than transitioning back to the hovered or normal style.