### PR TITLE
Implement Resizable Scroll Bar for Animation Player (Revival)

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -1287,61 +1287,63 @@ void AnimationMultiTrackKeyEdit::set_use_fps(bool p_enable) {
 }
 
 void AnimationTimelineEdit::_zoom_changed(double) {
-	double zoom_pivot = 0; // Point on timeline to stay fixed.
-	double zoom_pivot_delta = 0; // Delta seconds from left-most point on timeline to zoom pivot.
+	if (!scroll_zoom_change) {
+		double zoom_pivot = 0; // Point on timeline to stay fixed.
+		double zoom_pivot_delta = 0; // Delta seconds from left-most point on timeline to zoom pivot.
 
-	int timeline_width_pixels = get_size().width - get_buttons_width() - get_name_limit();
-	double timeline_width_seconds = timeline_width_pixels / last_zoom_scale; // Length (in seconds) of visible part of timeline before zoom.
-	double updated_timeline_width_seconds = timeline_width_pixels / get_zoom_scale(); // Length after zoom.
-	double updated_timeline_half_width = updated_timeline_width_seconds / 2.0;
-	bool zooming = updated_timeline_width_seconds < timeline_width_seconds;
+		int timeline_width_pixels = get_size().width - get_buttons_width() - get_name_limit();
+		double timeline_width_seconds = timeline_width_pixels / last_zoom_scale; // Length (in seconds) of visible part of timeline before zoom.
+		double updated_timeline_width_seconds = timeline_width_pixels / get_zoom_scale(); // Length after zoom.
+		double updated_timeline_half_width = updated_timeline_width_seconds / 2.0;
+		bool zooming = updated_timeline_width_seconds < timeline_width_seconds;
 
-	double timeline_left = get_value();
-	double timeline_right = timeline_left + timeline_width_seconds;
-	double timeline_center = timeline_left + timeline_width_seconds / 2.0;
+		double timeline_left = get_value();
+		double timeline_right = timeline_left + timeline_width_seconds;
+		double timeline_center = timeline_left + timeline_width_seconds / 2.0;
 
-	if (zoom_callback_occurred) { // Zooming with scroll wheel will focus on the position of the mouse.
-		double zoom_scroll_origin_norm = (zoom_scroll_origin.x - get_name_limit()) / timeline_width_pixels;
-		zoom_scroll_origin_norm = MAX(zoom_scroll_origin_norm, 0);
-		zoom_pivot = timeline_left + timeline_width_seconds * zoom_scroll_origin_norm;
-		zoom_pivot_delta = updated_timeline_width_seconds * zoom_scroll_origin_norm;
-		zoom_callback_occurred = false;
-	} else { // Zooming with slider will depend on the current play position.
-		// If the play position is not in range, or exactly in the center, zoom in on the center.
-		if (get_play_position() < timeline_left || get_play_position() > timeline_left + timeline_width_seconds || get_play_position() == timeline_center) {
-			zoom_pivot = timeline_center;
-			zoom_pivot_delta = updated_timeline_half_width;
+		if (zoom_callback_occurred) { // Zooming with scroll wheel will focus on the position of the mouse.
+			double zoom_scroll_origin_norm = (zoom_scroll_origin.x - get_name_limit()) / timeline_width_pixels;
+			zoom_scroll_origin_norm = MAX(zoom_scroll_origin_norm, 0);
+			zoom_pivot = timeline_left + timeline_width_seconds * zoom_scroll_origin_norm;
+			zoom_pivot_delta = updated_timeline_width_seconds * zoom_scroll_origin_norm;
+			zoom_callback_occurred = false;
+		} else { // Zooming with slider will depend on the current play position.
+			// If the play position is not in range, or exactly in the center, zoom in on the center.
+			if (get_play_position() < timeline_left || get_play_position() > timeline_left + timeline_width_seconds || get_play_position() == timeline_center) {
+				zoom_pivot = timeline_center;
+				zoom_pivot_delta = updated_timeline_half_width;
+			}
+			// Zoom from right if play position is right of center,
+			// and shrink from right if play position is left of center.
+			else if ((get_play_position() > timeline_center) == zooming) {
+				// If play position crosses to other side of center, center it.
+				bool center_passed = (get_play_position() < timeline_right - updated_timeline_half_width) == zooming;
+				zoom_pivot = center_passed ? get_play_position() : timeline_right;
+				double center_offset = CMP_EPSILON * (zooming ? 1 : -1); // Small offset to prevent crossover.
+				zoom_pivot_delta = center_passed ? updated_timeline_half_width + center_offset : updated_timeline_width_seconds;
+			}
+			// Zoom from left if play position is left of center,
+			// and shrink from left if play position is right of center.
+			else if ((get_play_position() <= timeline_center) == zooming) {
+				// If play position crosses to other side of center, center it.
+				bool center_passed = (get_play_position() > timeline_left + updated_timeline_half_width) == zooming;
+				zoom_pivot = center_passed ? get_play_position() : timeline_left;
+				double center_offset = CMP_EPSILON * (zooming ? -1 : 1); // Small offset to prevent crossover.
+				zoom_pivot_delta = center_passed ? updated_timeline_half_width + center_offset : 0;
+			}
 		}
-		// Zoom from right if play position is right of center,
-		// and shrink from right if play position is left of center.
-		else if ((get_play_position() > timeline_center) == zooming) {
-			// If play position crosses to other side of center, center it.
-			bool center_passed = (get_play_position() < timeline_right - updated_timeline_half_width) == zooming;
-			zoom_pivot = center_passed ? get_play_position() : timeline_right;
-			double center_offset = CMP_EPSILON * (zooming ? 1 : -1); // Small offset to prevent crossover.
-			zoom_pivot_delta = center_passed ? updated_timeline_half_width + center_offset : updated_timeline_width_seconds;
-		}
-		// Zoom from left if play position is left of center,
-		// and shrink from left if play position is right of center.
-		else if ((get_play_position() <= timeline_center) == zooming) {
-			// If play position crosses to other side of center, center it.
-			bool center_passed = (get_play_position() > timeline_left + updated_timeline_half_width) == zooming;
-			zoom_pivot = center_passed ? get_play_position() : timeline_left;
-			double center_offset = CMP_EPSILON * (zooming ? -1 : 1); // Small offset to prevent crossover.
-			zoom_pivot_delta = center_passed ? updated_timeline_half_width + center_offset : 0;
-		}
+
+		double hscroll_pos = zoom_pivot - zoom_pivot_delta;
+		hscroll_pos = CLAMP(hscroll_pos, hscroll->get_min(), hscroll->get_max());
+
+		hscroll->set_value(hscroll_pos);
+		hscroll_on_zoom_buffer = hscroll_pos; // In case of page update.
+		last_zoom_scale = get_zoom_scale();
+
+		queue_redraw();
+		play_position->queue_redraw();
+		emit_signal(SNAME("zoom_changed"));
 	}
-
-	double hscroll_pos = zoom_pivot - zoom_pivot_delta;
-	hscroll_pos = CLAMP(hscroll_pos, hscroll->get_min(), hscroll->get_max());
-
-	hscroll->set_value(hscroll_pos);
-	hscroll_on_zoom_buffer = hscroll_pos; // In case of page update.
-	last_zoom_scale = get_zoom_scale();
-
-	queue_redraw();
-	play_position->queue_redraw();
-	emit_signal(SNAME("zoom_changed"));
 }
 
 float AnimationTimelineEdit::get_zoom_scale() const {
@@ -1562,21 +1564,25 @@ void AnimationTimelineEdit::_notification(int p_what) {
 					}
 				}
 
-				float extra = (zoomw / scale) * 0.5;
+				float extra = animation->get_length() * 0.2;
 
 				time_max += extra;
 				set_min(time_min);
 				set_max(time_max);
-
-				if (zoomw / scale < (time_max - time_min)) {
-					hscroll->show();
-
-				} else {
-					hscroll->hide();
-				}
 			}
 
 			set_page(zoomw / scale);
+
+			if (scroll_zoom_change) {
+				if (hscroll->is_min_handle_being_dragged()) {
+					hscroll->set_value(hscroll->get_start_page_at_drag());
+				} else if (hscroll->is_max_handle_being_dragged()) {
+					hscroll->set_value(hscroll->get_start_page());
+				}
+				hscroll->set_min(get_min());
+				hscroll->set_max(get_max());
+				scroll_zoom_change = false;
+			}
 
 			if (hscroll->is_visible() && hscroll_on_zoom_buffer >= 0) {
 				hscroll->set_value(hscroll_on_zoom_buffer);
@@ -2032,8 +2038,45 @@ bool AnimationTimelineEdit::is_using_fps() const {
 	return use_fps;
 }
 
-void AnimationTimelineEdit::set_hscroll(HScrollBar *p_hscroll) {
+void AnimationTimelineEdit::set_hscroll(HResizableScrollBar *p_hscroll) {
 	hscroll = p_hscroll;
+	hscroll->connect(SNAME("change_zoom"), callable_mp(this, &AnimationTimelineEdit::_zoom_changed_scroll));
+}
+
+void AnimationTimelineEdit::_zoom_changed_scroll() {
+	double page;
+	// calculate new page size
+	if (hscroll->is_min_handle_being_dragged()) {
+		page = hscroll->get_end_page() - hscroll->get_start_page_at_drag();
+	} else {
+		page = hscroll->get_end_page_at_drag() - hscroll->get_start_page();
+	}
+	// calculate zoom value to change in the slider
+	if (page > 0) {
+		int key_range = get_size().width - get_buttons_width() - get_name_limit();
+		double scale = key_range / page;
+		double zoom_value;
+		if (scale > _get_zoom_scale(zoom->get_max())) {
+			zoom_value = zoom->get_max();
+		} else {
+			zoom_value = _scale_to_zoom(scale);
+			scroll_zoom_change = true;
+			zoom->set_value(zoom_value);
+		}
+
+		queue_redraw();
+		play_position->queue_redraw();
+		emit_signal(SNAME("zoom_changed"));
+	}
+}
+
+double AnimationTimelineEdit::_scale_to_zoom(double scale) {
+	float val = scale / 100.0f;
+	if (val >= 1.0f) {
+		return pow(val, 1.0f / 8.0f);
+	} else {
+		return 2.0f - pow(1.0f / val, 1.0f / 8.0f);
+	}
 }
 
 void AnimationTimelineEdit::_track_added(int p_track) {
@@ -8216,7 +8259,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	timeline_vbox->set_custom_minimum_size(Size2(0, 150) * EDSCALE);
 
-	hscroll = memnew(HScrollBar);
+	hscroll = memnew(HResizableScrollBar);
 	hscroll->share(timeline);
 	hscroll->hide();
 	hscroll->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_update_scroll));
@@ -8385,7 +8428,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	zoom_icon->set_v_size_flags(SIZE_SHRINK_CENTER);
 	zoom_hb->add_child(zoom_icon);
 	zoom = memnew(HSlider);
-	zoom->set_step(0.01);
+	zoom->set_step(0.000001);
 	zoom->set_min(0.0);
 	zoom->set_max(2.0);
 	zoom->set_value(1.0);

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -32,12 +32,12 @@
 
 #include "core/templates/rb_map.h"
 #include "editor/editor_data.h"
+#include "editor/gui/resizable_scroll_bar.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/inspector/property_selector.h"
 #include "scene/3d/node_3d.h"
 #include "scene/gui/control.h"
 #include "scene/gui/menu_button.h"
-#include "scene/gui/scroll_bar.h"
 #include "scene/gui/tree.h"
 #include "scene/resources/animation.h"
 
@@ -214,9 +214,13 @@ class AnimationTimelineEdit : public Range {
 	MenuButton *add_track = nullptr;
 	LineEdit *filter_track = nullptr;
 	Control *play_position = nullptr; //separate control used to draw so updates for only position changed are much faster
-	HScrollBar *hscroll = nullptr;
+	HResizableScrollBar *hscroll = nullptr;
+
+	bool scroll_zoom_change = false;
 
 	void _zoom_changed(double);
+	void _zoom_changed_scroll();
+	double _scale_to_zoom(double scale);
 	void _anim_length_changed(double p_new_len);
 	void _anim_loop_pressed();
 
@@ -280,7 +284,7 @@ public:
 	void set_use_fps(bool p_use_fps);
 	bool is_using_fps() const;
 
-	void set_hscroll(HScrollBar *p_hscroll);
+	void set_hscroll(HResizableScrollBar *p_hscroll);
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
@@ -618,7 +622,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	MenuButton *edit = nullptr;
 
 	PanelContainer *main_panel = nullptr;
-	HScrollBar *hscroll = nullptr;
+	HResizableScrollBar *hscroll = nullptr;
 	ScrollContainer *scroll = nullptr;
 	VBoxContainer *track_vbox = nullptr;
 	MarginContainer *bezier_mc = nullptr;

--- a/editor/gui/resizable_scroll_bar.cpp
+++ b/editor/gui/resizable_scroll_bar.cpp
@@ -1,0 +1,416 @@
+/**************************************************************************/
+/*  resizable_scroll_bar.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resizable_scroll_bar.h"
+
+#include "scene/theme/theme_db.h"
+
+void ResizableScrollBar::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventMouseMotion> m = p_event;
+
+	Ref<InputEventMouseButton> b = p_event;
+
+	if (b.is_valid()) {
+		accept_event();
+
+		if (b->get_button_index() == MouseButton::WHEEL_DOWN && b->is_pressed()) {
+			double change = ((get_page() != 0.0) ? get_page() / PAGE_DIVISOR : (get_max() - get_min()) / 16.0) * b->get_factor();
+			scroll(MAX(change, get_step()));
+			accept_event();
+		}
+
+		if (b->get_button_index() == MouseButton::WHEEL_UP && b->is_pressed()) {
+			double change = ((get_page() != 0.0) ? get_page() / PAGE_DIVISOR : (get_max() - get_min()) / 16.0) * b->get_factor();
+			scroll(-MAX(change, get_step()));
+			accept_event();
+		}
+
+		if (b->get_button_index() != MouseButton::LEFT) {
+			return;
+		}
+
+		if (b->is_pressed()) {
+			double ofs = orientation == VERTICAL ? b->get_position().y : b->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+			Ref<Texture2D> incr = theme_cache.increment_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
+			double grabber_ofs = get_grabber_offset();
+			double grabber_size = get_grabber_size();
+			double total = orientation == VERTICAL ? get_size().height : get_size().width;
+
+			if (ofs < decr_size) {
+				decr_active = true;
+				scroll(-(custom_step >= 0 ? custom_step : get_step()));
+				queue_redraw();
+				return;
+			}
+
+			if (ofs > total - incr_size) {
+				incr_active = true;
+				scroll(custom_step >= 0 ? custom_step : get_step());
+				queue_redraw();
+				return;
+			}
+
+			ofs -= decr_size + theme_cache.scroll_style->get_margin(orientation == VERTICAL ? SIDE_TOP : SIDE_LEFT);
+
+			if (ofs < grabber_ofs) {
+				if (scrolling) {
+					target_scroll = CLAMP(target_scroll - get_page(), get_min(), get_max() - get_page());
+				} else {
+					double change = get_page() != 0.0 ? get_page() : (get_max() - get_min()) / 16.0;
+					target_scroll = CLAMP(get_value() - change, get_min(), get_max() - get_page());
+				}
+
+				if (smooth_scroll_enabled) {
+					scrolling = true;
+					set_process_internal(true);
+				} else {
+					scroll_to(target_scroll);
+				}
+				return;
+			}
+
+			ofs -= grabber_ofs;
+			if (get_grabber_size() >= get_handle_min_size()) {
+				if (ofs < get_handle_size()) {
+					resizable_drag.min_handle_being_dragged = true;
+					drag.pos_at_click = grabber_ofs + ofs;
+					drag.value_at_click = get_as_ratio();
+					resizable_drag.start_page_at_click = get_value();
+					resizable_drag.end_page_at_click = get_value() + get_page();
+					resizable_drag.handle_offset = ofs;
+					queue_redraw();
+				} else if (ofs > get_handle_size() && ofs < grabber_size - get_handle_size()) {
+					drag.active = true;
+					drag.pos_at_click = grabber_ofs + ofs;
+					drag.value_at_click = get_as_ratio();
+					queue_redraw();
+				} else if (ofs > grabber_size - get_handle_size() && ofs < grabber_size) {
+					resizable_drag.max_handle_being_dragged = true;
+					drag.pos_at_click = grabber_ofs + ofs;
+					drag.value_at_click = get_as_ratio();
+					resizable_drag.start_page_at_click = get_value();
+					resizable_drag.end_page_at_click = get_value() + get_page();
+					resizable_drag.handle_offset = grabber_size - ofs;
+					queue_redraw();
+				} else {
+					if (scrolling) {
+						target_scroll = CLAMP(target_scroll + get_page(), get_min(), get_max() - get_page());
+					} else {
+						double change = get_page() != 0.0 ? get_page() : (get_max() - get_min()) / 16.0;
+						target_scroll = CLAMP(get_value() + change, get_min(), get_max() - get_page());
+					}
+
+					if (smooth_scroll_enabled) {
+						scrolling = true;
+						set_process_internal(true);
+					} else {
+						scroll_to(target_scroll);
+					}
+				}
+			} else {
+				if (ofs < grabber_size) {
+					drag.active = true;
+					drag.pos_at_click = grabber_ofs + ofs;
+					drag.value_at_click = get_as_ratio();
+					queue_redraw();
+				} else {
+					if (scrolling) {
+						target_scroll = CLAMP(target_scroll + get_page(), get_min(), get_max() - get_page());
+					} else {
+						double change = get_page() != 0.0 ? get_page() : (get_max() - get_min()) / 16.0;
+						target_scroll = CLAMP(get_value() + change, get_min(), get_max() - get_page());
+					}
+
+					if (smooth_scroll_enabled) {
+						scrolling = true;
+						set_process_internal(true);
+					} else {
+						scroll_to(target_scroll);
+					}
+				}
+			}
+		} else {
+			incr_active = false;
+			decr_active = false;
+			drag.active = false;
+			resizable_drag.min_handle_being_dragged = false;
+			resizable_drag.max_handle_being_dragged = false;
+			queue_redraw();
+		}
+	}
+
+	if (m.is_valid()) {
+		accept_event();
+
+		if (drag.active) {
+			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			ofs -= decr_size + theme_cache.scroll_style->get_margin(orientation == VERTICAL ? SIDE_TOP : SIDE_LEFT);
+
+			double diff = (ofs - drag.pos_at_click) / get_area_size();
+
+			double prev_scroll = get_value();
+
+			set_as_ratio(drag.value_at_click + diff);
+
+			if (!Math::is_equal_approx(prev_scroll, get_value())) {
+				emit_signal(SNAME("scrolling"));
+			}
+		} else if (resizable_drag.min_handle_being_dragged) {
+			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			ofs -= decr_size + theme_cache.scroll_style->get_margin(orientation == VERTICAL ? SIDE_TOP : SIDE_LEFT);
+
+			if (get_max() < resizable_drag.end_page_at_click) {
+				resizable_drag.end_page_at_click = get_max();
+			}
+
+			double min_value = get_min();
+			double max_value = resizable_drag.end_page_at_click - ratio_to_value((get_handle_min_size()) / get_area_size());
+
+			resizable_drag.start_page_at_drag = CLAMP(ratio_to_value((ofs - resizable_drag.handle_offset) / get_area_size()), min_value, max_value);
+
+			emit_signal(SNAME("change_zoom"));
+		} else if (resizable_drag.max_handle_being_dragged) {
+			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			ofs -= decr_size + theme_cache.scroll_style->get_margin(orientation == VERTICAL ? SIDE_TOP : SIDE_LEFT);
+
+			double min_value = resizable_drag.start_page_at_click + ratio_to_value((get_handle_min_size()) / get_area_size());
+			double max_value = get_max();
+
+			resizable_drag.end_page_at_drag = CLAMP(ratio_to_value((ofs + resizable_drag.handle_offset - get_grabber_min_size()) / get_area_size()), min_value, max_value);
+
+			emit_signal(SNAME("change_zoom"));
+		} else {
+			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+			Ref<Texture2D> incr = theme_cache.increment_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
+			double total = orientation == VERTICAL ? get_size().height : get_size().width;
+			double grabber_ofs = get_grabber_offset();
+			double grabber_size = get_grabber_size();
+
+			int new_hilite;
+
+			if (ofs < decr_size) {
+				new_hilite = HIGHLIGHT_DECR;
+
+			} else if (ofs > grabber_ofs && ofs < grabber_ofs + get_handle_size()) {
+				new_hilite = HIGHLIGHT_MIN_HANDLE;
+
+			} else if (ofs > grabber_ofs + grabber_size - get_handle_size() && ofs < grabber_ofs + grabber_size) {
+				new_hilite = HIGHLIGHT_MAX_HANDLE;
+
+			} else if (ofs > total - incr_size) {
+				new_hilite = HIGHLIGHT_INCR;
+
+			} else {
+				new_hilite = HIGHLIGHT_RANGE;
+			}
+
+			if (new_hilite != highlight) {
+				highlight = new_hilite;
+				queue_redraw();
+			}
+		}
+	}
+
+	if (p_event->is_pressed()) {
+		if (p_event->is_action("ui_left", true)) {
+			if (orientation != HORIZONTAL) {
+				return;
+			}
+			scroll(-(custom_step >= 0 ? custom_step : get_step()));
+
+		} else if (p_event->is_action("ui_right", true)) {
+			if (orientation != HORIZONTAL) {
+				return;
+			}
+			scroll(custom_step >= 0 ? custom_step : get_step());
+
+		} else if (p_event->is_action("ui_up", true)) {
+			if (orientation != VERTICAL) {
+				return;
+			}
+
+			scroll(-(custom_step >= 0 ? custom_step : get_step()));
+
+		} else if (p_event->is_action("ui_down", true)) {
+			if (orientation != VERTICAL) {
+				return;
+			}
+			scroll(custom_step >= 0 ? custom_step : get_step());
+
+		} else if (p_event->is_action("ui_home", true)) {
+			scroll_to(get_min());
+
+		} else if (p_event->is_action("ui_end", true)) {
+			scroll_to(get_max());
+		}
+	}
+}
+
+void ResizableScrollBar::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			RID ci = get_canvas_item();
+
+			Ref<Texture2D> decr, incr;
+
+			if (decr_active) {
+				decr = theme_cache.decrement_pressed_icon;
+			} else if (highlight == HIGHLIGHT_DECR) {
+				decr = theme_cache.decrement_hl_icon;
+			} else {
+				decr = theme_cache.decrement_icon;
+			}
+
+			if (incr_active) {
+				incr = theme_cache.increment_pressed_icon;
+			} else if (highlight == HIGHLIGHT_INCR) {
+				incr = theme_cache.increment_hl_icon;
+			} else {
+				incr = theme_cache.increment_icon;
+			}
+
+			Ref<StyleBox> min_handle, max_handle;
+			if (resizable_drag.min_handle_being_dragged) {
+				min_handle = theme_cache.grabber_pressed_style;
+			} else if (highlight == HIGHLIGHT_MIN_HANDLE) {
+				min_handle = theme_cache.grabber_hl_style;
+			} else {
+				min_handle = theme_cache.grabber_style;
+			}
+
+			if (resizable_drag.max_handle_being_dragged) {
+				max_handle = theme_cache.grabber_pressed_style;
+			} else if (highlight == HIGHLIGHT_MAX_HANDLE) {
+				max_handle = theme_cache.grabber_hl_style;
+			} else {
+				max_handle = theme_cache.grabber_style;
+			}
+
+			Rect2 min_handle_rect, max_handle_rect;
+
+			// Only valid for HORIZONTAL.
+			// If/when you add a vertical version, make sure the widths and heights
+			// here get switched appropriately!
+			min_handle_rect.size.width = get_size().height; //get_handle_size();
+			min_handle_rect.size.height = get_size().height;
+			min_handle_rect.position.y = 0;
+			min_handle_rect.position.x = get_grabber_offset() + decr->get_width() + theme_cache.scroll_style->get_margin(SIDE_LEFT);
+
+			max_handle_rect.size.width = get_size().height; //get_handle_size();
+			max_handle_rect.size.height = get_size().height;
+			max_handle_rect.position.y = 0;
+			max_handle_rect.position.x = get_grabber_offset() + decr->get_width() + theme_cache.scroll_style->get_margin(SIDE_LEFT) + get_grabber_size() - get_size().height; //get_handle_size();
+
+			if (get_grabber_size() >= get_handle_min_size()) {
+				min_handle->draw(ci, min_handle_rect);
+				max_handle->draw(ci, max_handle_rect);
+			}
+		} break;
+
+		case NOTIFICATION_ACCESSIBILITY_UPDATE:
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_EXIT_TREE:
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			ScrollBar::_notification(p_what);
+		} break;
+		case NOTIFICATION_MOUSE_EXIT: {
+			highlight = HIGHLIGHT_NONE;
+			queue_redraw();
+		} break;
+	}
+}
+
+bool ResizableScrollBar::is_min_handle_being_dragged() {
+	return resizable_drag.min_handle_being_dragged;
+}
+
+bool ResizableScrollBar::is_max_handle_being_dragged() {
+	return resizable_drag.max_handle_being_dragged;
+}
+
+double ResizableScrollBar::get_end_page() {
+	return resizable_drag.end_page_at_click;
+}
+
+double ResizableScrollBar::get_start_page() {
+	return resizable_drag.start_page_at_click;
+}
+
+double ResizableScrollBar::get_end_page_at_drag() {
+	return resizable_drag.end_page_at_drag;
+}
+
+double ResizableScrollBar::get_start_page_at_drag() {
+	return resizable_drag.start_page_at_drag;
+}
+
+double ResizableScrollBar::get_handle_size() {
+	return get_size().height;
+}
+
+double ResizableScrollBar::get_handle_min_size() {
+	return 2.0 * get_size().height;
+}
+
+double ResizableScrollBar::ratio_to_value(double p_value) {
+	double v;
+	double percent = (get_max() - get_min()) * p_value;
+	v = percent + get_min();
+	v = CLAMP(v, get_min(), get_max());
+	return v;
+}
+
+void ResizableScrollBar::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("change_zoom"));
+}
+
+ResizableScrollBar::ResizableScrollBar(Orientation p_orientation) :
+		ScrollBar(p_orientation) {}
+
+ResizableScrollBar::~ResizableScrollBar() {}

--- a/editor/gui/resizable_scroll_bar.h
+++ b/editor/gui/resizable_scroll_bar.h
@@ -1,0 +1,84 @@
+/**************************************************************************/
+/*  resizable_scroll_bar.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/scroll_bar.h"
+
+class ResizableScrollBar : public ScrollBar {
+	GDCLASS(ResizableScrollBar, ScrollBar);
+
+	enum HighlightStatus {
+		HIGHLIGHT_MIN_HANDLE = ScrollBar::HighlightStatus::BASE_ENUM_COUNT,
+		HIGHLIGHT_MAX_HANDLE,
+	};
+
+	Orientation orientation;
+
+	struct ResizableDrag {
+		bool min_handle_being_dragged = false;
+		bool max_handle_being_dragged = false;
+		float end_page_at_click = 0.0;
+		float start_page_at_click = 0.0;
+		float start_page_at_drag = 0.0;
+		float end_page_at_drag = 0.0;
+		float handle_offset = 0.0;
+	} resizable_drag;
+
+	double ratio_to_value(double p_value);
+	double get_handle_size();
+
+protected:
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	double get_end_page();
+	double get_start_page();
+	double get_end_page_at_drag();
+	double get_start_page_at_drag();
+
+	double get_handle_min_size();
+
+	bool is_min_handle_being_dragged();
+	bool is_max_handle_being_dragged();
+
+	ResizableScrollBar(Orientation p_orientation = HORIZONTAL);
+	~ResizableScrollBar();
+};
+
+class HResizableScrollBar : public ResizableScrollBar {
+	GDCLASS(HResizableScrollBar, ResizableScrollBar);
+
+public:
+	HResizableScrollBar() :
+			ResizableScrollBar(HORIZONTAL) { set_v_size_flags(0); }
+};

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1159,11 +1159,13 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 		// HScrollBar.
 
+		Ref<StyleBox> h_scroll_style;
 		if (p_config.enable_touch_optimizations) {
-			p_theme->set_stylebox("scroll", "HScrollBar", EditorThemeManager::make_line_stylebox(p_config.separator_color, 50));
+			h_scroll_style = EditorThemeManager::make_line_stylebox(p_config.separator_color, 50);
 		} else {
-			p_theme->set_stylebox("scroll", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, -5, 1, -5, 1));
+			h_scroll_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, -5, 1, -5, 1);
 		}
+		p_theme->set_stylebox("scroll", "HScrollBar", h_scroll_style);
 		p_theme->set_stylebox("scroll_focus", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
 		p_theme->set_stylebox("grabber", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabber"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
 		p_theme->set_stylebox("grabber_highlight", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberHl"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
@@ -1175,6 +1177,40 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_icon("decrement", "HScrollBar", empty_icon);
 		p_theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
 		p_theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
+
+		// HResizableScrollBar.
+		Ref<StyleBoxTexture> resizable_h_scroll_style = h_scroll_style->duplicate();
+		resizable_h_scroll_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_h_scroll_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		Ref<StyleBoxTexture> resizable_h_scroll_focus_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1);
+		resizable_h_scroll_focus_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_h_scroll_focus_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		Ref<StyleBoxTexture> resizable_grabber_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabber"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1);
+		resizable_grabber_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_grabber_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		Ref<StyleBoxTexture> resizable_grabber_hl_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberHl"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1);
+		resizable_grabber_hl_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_grabber_hl_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		Ref<StyleBoxTexture> resizable_grabber_pr_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberPressed"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1);
+		resizable_grabber_pr_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_grabber_pr_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		p_theme->set_stylebox("scroll", "HResizableScrollBar", resizable_h_scroll_style);
+		p_theme->set_stylebox("scroll_focus", "HResizableScrollBar", resizable_h_scroll_focus_style);
+		p_theme->set_stylebox("grabber", "HResizableScrollBar", resizable_grabber_style);
+		p_theme->set_stylebox("grabber_highlight", "HResizableScrollBar", resizable_grabber_hl_style);
+		p_theme->set_stylebox("grabber_pressed", "HResizableScrollBar", resizable_grabber_pr_style);
+
+		p_theme->set_icon("increment", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("increment_highlight", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("increment_pressed", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement_highlight", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement_pressed", "HResizableScrollBar", empty_icon);
 
 		// VScrollBar.
 

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1161,11 +1161,13 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 		// HScrollBar.
 
+		Ref<StyleBox> h_scroll_style;
 		if (p_config.enable_touch_optimizations) {
-			p_theme->set_stylebox("scroll", "HScrollBar", EditorThemeManager::make_line_stylebox(p_config.separator_color, 50));
+			h_scroll_style = EditorThemeManager::make_line_stylebox(p_config.separator_color, 50);
 		} else {
-			p_theme->set_stylebox("scroll", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, -5, 1, -5, 1));
+			h_scroll_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, -5, 1, -5, 1);
 		}
+		p_theme->set_stylebox("scroll", "HScrollBar", h_scroll_style);
 		p_theme->set_stylebox("scroll_focus", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
 		p_theme->set_stylebox("grabber", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabber"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1));
 		p_theme->set_stylebox("grabber_highlight", "HScrollBar", EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberHl"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1));
@@ -1177,6 +1179,40 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_icon("decrement", "HScrollBar", empty_icon);
 		p_theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
 		p_theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
+
+		// HResizableScrollBar.
+		Ref<StyleBoxTexture> resizable_h_scroll_style = h_scroll_style->duplicate();
+		resizable_h_scroll_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_h_scroll_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		Ref<StyleBoxTexture> resizable_h_scroll_focus_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollBg"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1);
+		resizable_h_scroll_focus_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_h_scroll_focus_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		Ref<StyleBoxTexture> resizable_grabber_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabber"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1);
+		resizable_grabber_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_grabber_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		Ref<StyleBoxTexture> resizable_grabber_hl_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberHl"), EditorStringName(EditorIcons)), 5, 5, 5, 5, 1, 1, 1, 1);
+		resizable_grabber_hl_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_grabber_hl_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		Ref<StyleBoxTexture> resizable_grabber_pr_style = EditorThemeManager::make_stylebox(p_theme->get_icon(SNAME("GuiScrollGrabberPressed"), EditorStringName(EditorIcons)), 6, 6, 6, 6, 1, 1, 1, 1);
+		resizable_grabber_pr_style->set_expand_margin(SIDE_TOP, 10);
+		resizable_grabber_pr_style->set_expand_margin(SIDE_BOTTOM, 10);
+
+		p_theme->set_stylebox("scroll", "HResizableScrollBar", resizable_h_scroll_style);
+		p_theme->set_stylebox("scroll_focus", "HResizableScrollBar", resizable_h_scroll_focus_style);
+		p_theme->set_stylebox("grabber", "HResizableScrollBar", resizable_grabber_style);
+		p_theme->set_stylebox("grabber_highlight", "HResizableScrollBar", resizable_grabber_hl_style);
+		p_theme->set_stylebox("grabber_pressed", "HResizableScrollBar", resizable_grabber_pr_style);
+
+		p_theme->set_icon("increment", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("increment_highlight", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("increment_pressed", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement_highlight", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement_pressed", "HResizableScrollBar", empty_icon);
 
 		// VScrollBar.
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1182,6 +1182,20 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_constant("padding_left", "VScrollBar", EDSCALE_RND(p_config.base_margin));
 		p_theme->set_constant("padding_right", "VScrollBar", EDSCALE_RND(p_config.base_margin));
 
+		// HResizableScrollBar.
+		p_theme->set_stylebox("scroll", "HResizableScrollBar", h_scroll_style);
+		p_theme->set_stylebox("scroll_focus", "HResizableScrollBar", p_config.focus_style);
+		p_theme->set_stylebox("grabber", "HResizableScrollBar", grabber_style);
+		p_theme->set_stylebox("grabber_highlight", "HResizableScrollBar", grabber_hl_style);
+		p_theme->set_stylebox("grabber_pressed", "HResizableScrollBar", grabber_hl_style);
+
+		p_theme->set_icon("increment", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("increment_highlight", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("increment_pressed", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement_highlight", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement_pressed", "HResizableScrollBar", empty_icon);
+
 		// Slider
 		const int background_margin = MAX(2, p_config.base_margin / 2);
 
@@ -1209,6 +1223,19 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_stylebox("grabber_area_highlight", "VSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, background_margin, 0, background_margin, 0));
 		p_theme->set_constant("center_grabber", "VSlider", 0);
 		p_theme->set_constant("grabber_offset", "VSlider", 0);
+
+		// Resizable scroll bars.
+		int resizable_scroll_thickness = 8 * EDSCALE;
+
+		// HResizableScrollBar.
+		Ref<StyleBoxEmpty> h_resizable_scroll_style = p_config.base_empty_style->duplicate();
+		h_resizable_scroll_style->set_content_margin_individual(0, resizable_scroll_thickness, 0, resizable_scroll_thickness);
+		p_theme->set_stylebox("scroll", "HResizableScrollBar", h_resizable_scroll_style);
+
+		// VResizableScrollBar.
+		Ref<StyleBoxEmpty> v_resizable_scroll_style = p_config.base_empty_style->duplicate();
+		v_resizable_scroll_style->set_content_margin_individual(resizable_scroll_thickness, 0, resizable_scroll_thickness, 0);
+		p_theme->set_stylebox("scroll", "VResizableScrollBar", v_resizable_scroll_style);
 	}
 
 	// Labels.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1184,6 +1184,20 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_constant("padding_left", "VScrollBar", EDSCALE_RND(p_config.base_margin));
 		p_theme->set_constant("padding_right", "VScrollBar", EDSCALE_RND(p_config.base_margin));
 
+		// HResizableScrollBar.
+		p_theme->set_stylebox("scroll", "HResizableScrollBar", h_scroll_style);
+		p_theme->set_stylebox("scroll_focus", "HResizableScrollBar", p_config.focus_style);
+		p_theme->set_stylebox("grabber", "HResizableScrollBar", grabber_style);
+		p_theme->set_stylebox("grabber_highlight", "HResizableScrollBar", grabber_hl_style);
+		p_theme->set_stylebox("grabber_pressed", "HResizableScrollBar", grabber_hl_style);
+
+		p_theme->set_icon("increment", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("increment_highlight", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("increment_pressed", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement_highlight", "HResizableScrollBar", empty_icon);
+		p_theme->set_icon("decrement_pressed", "HResizableScrollBar", empty_icon);
+
 		// Slider
 		const int background_margin = MAX(2, p_config.base_margin / 2);
 
@@ -1211,6 +1225,19 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_stylebox("grabber_area_highlight", "VSlider", EditorThemeManager::make_flat_stylebox(p_config.contrast_color_1, background_margin, 0, background_margin, 0));
 		p_theme->set_constant("center_grabber", "VSlider", 0);
 		p_theme->set_constant("grabber_offset", "VSlider", 0);
+
+		// Resizable scroll bars.
+		int resizable_scroll_thickness = 8 * EDSCALE;
+
+		// HResizableScrollBar.
+		Ref<StyleBoxEmpty> h_resizable_scroll_style = p_config.base_empty_style->duplicate();
+		h_resizable_scroll_style->set_content_margin_individual(0, resizable_scroll_thickness, 0, resizable_scroll_thickness);
+		p_theme->set_stylebox("scroll", "HResizableScrollBar", h_resizable_scroll_style);
+
+		// VResizableScrollBar.
+		Ref<StyleBoxEmpty> v_resizable_scroll_style = p_config.base_empty_style->duplicate();
+		v_resizable_scroll_style->set_content_margin_individual(resizable_scroll_thickness, 0, resizable_scroll_thickness, 0);
+		p_theme->set_stylebox("scroll", "VResizableScrollBar", v_resizable_scroll_style);
 	}
 
 	// Labels.

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -35,34 +35,10 @@
 class ScrollBar : public Range {
 	GDCLASS(ScrollBar, Range);
 
-	enum HighlightStatus {
-		HIGHLIGHT_NONE,
-		HIGHLIGHT_DECR,
-		HIGHLIGHT_RANGE,
-		HIGHLIGHT_INCR,
-	};
-
 	static bool focus_by_default;
 
 	Orientation orientation;
 	Size2 size;
-	float custom_step = -1.0;
-
-	HighlightStatus highlight = HIGHLIGHT_NONE;
-
-	bool incr_active = false;
-	bool decr_active = false;
-
-	struct Drag {
-		bool active = false;
-		float pos_at_click = 0.0;
-		float value_at_click = 0.0;
-	} drag;
-
-	double get_grabber_size() const;
-	double get_grabber_min_size() const;
-	double get_area_size() const;
-	double get_grabber_offset() const;
 
 	static void set_can_focus_by_default(bool p_can_focus);
 
@@ -77,6 +53,29 @@ class ScrollBar : public Range {
 	float time_since_motion = 0.0;
 	bool drag_node_touching = false;
 	bool drag_node_touching_deaccel = false;
+	bool click_handled = false;
+
+protected:
+	struct Drag {
+		bool active = false;
+		float pos_at_click = 0.0;
+		float value_at_click = 0.0;
+	} drag;
+
+	enum HighlightStatus {
+		HIGHLIGHT_NONE,
+		HIGHLIGHT_DECR,
+		HIGHLIGHT_RANGE,
+		HIGHLIGHT_INCR,
+		BASE_ENUM_COUNT,
+	};
+
+	int highlight = HIGHLIGHT_NONE;
+
+	bool incr_active = false;
+	bool decr_active = false;
+
+	float custom_step = -1.0;
 
 	bool scrolling = false;
 	double target_scroll = 0.0;
@@ -84,8 +83,6 @@ class ScrollBar : public Range {
 
 	void _drag_node_exit();
 	void _drag_node_input(const Ref<InputEvent> &p_input);
-
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 protected:
 	struct ThemeCache {
@@ -109,6 +106,12 @@ protected:
 		int padding_bottom = 0;
 	} theme_cache;
 
+	double get_grabber_size() const;
+	double get_grabber_min_size() const;
+	double get_area_size() const;
+	double get_grabber_offset() const;
+
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
 	static void _bind_methods();
 


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/107242 . Closes https://github.com/godotengine/godot-proposals/issues/11546 .

https://github.com/user-attachments/assets/315a451a-be84-4841-a956-935a018f0363

This updates @Chenyang341 and @migboy1 's PR to work with the latest code in Godot, and also addresses the previously-brought-up issue of the far edge of the scroll bar moving when a near edge is dragged. In addition, I renamed a few members of ResizableScrollBar to be (at least in my opinion) a bit more readable and quickly understandable. This is more than 99% not my own work, I just wanted to ensure it was ready to be merged as soon as we leave feature freeze 😄 

Note to the original authors: If you see this and would like to continue with your version of the PR, let me know in the thread here and I can close this 🙂 