### PR TITLE
`Find and Replace` on unsaved changes (non-built-in GDScript and GDShader code) 

### DIFF
--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -38,7 +38,10 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_command_palette.h"
+#include "editor/shader/shader_editor_plugin.h"
+#include "editor/shader/text_shader_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -281,23 +284,49 @@ void FindInFilesSearch::_scan_dir(const String &p_path, PackedStringArray &r_out
 	}
 }
 
+CodeTextEditor *get_code_edit(const String &p_fpath) {
+	Ref<Resource> res = ResourceCache::get_ref(p_fpath);
+	if (res.is_null()) {
+		return nullptr;
+	}
+
+	ShaderEditorPlugin *shader_editor_plugin = ShaderEditorPlugin::get_singleton();
+	ScriptEditorPlugin *script_editor_plugin = ScriptEditorPlugin::get_singleton();
+
+	if (shader_editor_plugin && shader_editor_plugin->handles(res.ptr())) {
+		TextShaderEditor *tse = Object::cast_to<TextShaderEditor>(shader_editor_plugin->get_shader_editor(res));
+		if (tse) {
+			return tse->get_code_editor();
+		}
+	} else if (script_editor_plugin && script_editor_plugin->handles(res.ptr())) {
+		ScriptEditor *script_editor = ScriptEditor::get_singleton();
+		TextEditorBase *teb = Object::cast_to<TextEditorBase>(script_editor->get_script_editor(res));
+		if (teb) {
+			return teb->get_code_editor();
+		}
+	}
+	return nullptr;
+}
+
 void FindInFilesSearch::_scan_file(const String &p_fpath) {
-	Ref<FileAccess> f = FileAccess::open(p_fpath, FileAccess::READ);
-	if (f.is_null()) {
-		print_verbose("Cannot open file " + p_fpath);
-		return;
+	Vector<String> lines;
+
+	CodeTextEditor *code_text_editor = get_code_edit(p_fpath);
+	if (code_text_editor) {
+		lines = code_text_editor->get_text_editor()->get_text().split("\n");
+	} else {
+		Ref<FileAccess> f = FileAccess::open(p_fpath, FileAccess::READ);
+		ERR_FAIL_COND_MSG(f.is_null(), "Cannot open file from path '" + p_fpath + "'.");
+		lines = f->get_as_text().split("\n");
 	}
 
 	int line_number = 0;
 
-	while (!f->eof_reached()) {
+	for (const String &line : lines) {
 		// Line number starts at 1.
 		++line_number;
-
 		int begin = 0;
 		int end = 0;
-
-		String line = f->get_line();
 
 		while (find_next(line, pattern, end, match_case, whole_words, begin, end)) {
 			emit_signal(SNAME("result_found"), p_fpath, line_number, begin, end, line);
@@ -1046,94 +1075,57 @@ void FindInFilesPanel::_on_button_clicked(TreeItem *p_item, int p_column, int p_
 	_update_matches_text();
 }
 
-// Same as get_line, but preserves line ending characters.
-class ConservativeGetLine {
-public:
-	String get_line(Ref<FileAccess> p_file) {
-		_line_buffer.clear();
-
-		char32_t c = p_file->get_8();
-
-		while (!p_file->eof_reached()) {
-			if (c == '\n') {
-				_line_buffer.push_back(c);
-				_line_buffer.push_back(0);
-				return String::utf8(_line_buffer.ptr());
-
-			} else if (c == '\0') {
-				_line_buffer.push_back(c);
-				return String::utf8(_line_buffer.ptr());
-
-			} else if (c != '\r') {
-				_line_buffer.push_back(c);
-			}
-
-			c = p_file->get_8();
-		}
-
-		_line_buffer.push_back(0);
-		return String::utf8(_line_buffer.ptr());
-	}
-
-private:
-	Vector<char> _line_buffer;
-};
-
 void FindInFilesPanel::_apply_replaces_in_file(const String &p_fpath, const Vector<Result> &p_locations, const String &p_new_text) {
-	// If the file is already open, I assume the editor will reload it.
-	// If there are unsaved changes, the user will be asked on focus,
-	// however that means either losing changes or losing replaces.
+	CodeTextEditor *code_text_editor = get_code_edit(p_fpath);
+	CodeEdit *code_edit = nullptr;
+	if (code_text_editor) {
+		code_edit = code_text_editor->get_text_editor();
+	}
+	Ref<FileAccess> f;
+	Vector<String> lines;
 
-	Ref<FileAccess> f = FileAccess::open(p_fpath, FileAccess::READ);
-	ERR_FAIL_COND_MSG(f.is_null(), "Cannot open file from path '" + p_fpath + "'.");
+	if (code_edit) {
+		lines = code_edit->get_text().split("\n");
+	} else {
+		f = FileAccess::open(p_fpath, FileAccess::READ);
+		ERR_FAIL_COND_MSG(f.is_null(), "Cannot open file from path '" + p_fpath + "'.");
+		lines = f->get_as_text().split("\n");
+	}
 
-	String buffer;
-	int current_line = 1;
-
-	ConservativeGetLine conservative;
-
-	String line = conservative.get_line(f);
 	String search_text = finder->get_search_text();
+	int placeholder;
+	int repl_line_number = 0;
 
-	int offset = 0;
+	// Iterate backwards so changes don't affect the location of the next change in the same line.
+	for (int i = p_locations.size() - 1; i >= 0; i--) {
+		const Result &location = p_locations[i];
+		repl_line_number = location.line_number - 1;
 
-	for (int i = 0; i < p_locations.size(); ++i) {
-		int repl_line_number = p_locations[i].line_number;
-
-		while (current_line < repl_line_number) {
-			buffer += line;
-			line = conservative.get_line(f);
-			++current_line;
-			offset = 0;
+		if (repl_line_number >= 0 && repl_line_number < lines.size()) {
+			String &line = lines.write[repl_line_number];
+			if (find_next(line, search_text, location.begin, finder->is_match_case(), finder->is_whole_words(), placeholder, placeholder)) {
+				line = line.left(location.begin) + p_new_text + line.substr(location.end);
+			} else {
+				print_verbose(vformat(R"(Occurrence no longer matches, replace will be ignored in "%s": line %d, col %d.)", p_fpath, repl_line_number, location.begin));
+			}
 		}
-
-		int repl_begin = p_locations[i].begin + offset;
-		int repl_end = p_locations[i].end + offset;
-
-		int _;
-		if (!find_next(line, search_text, repl_begin, finder->is_match_case(), finder->is_whole_words(), _, _)) {
-			// Make sure the replace is still valid in case the file was tampered with.
-			print_verbose(vformat(R"(Occurrence no longer matches, replace will be ignored in "%s": line %d, col %d.)", p_fpath, repl_line_number, repl_begin));
-			continue;
-		}
-
-		line = line.left(repl_begin) + p_new_text + line.substr(repl_end);
-		// Keep an offset in case there are successive replaces in the same line.
-		offset += p_new_text.length() - (repl_end - repl_begin);
 	}
 
-	buffer += line;
+	String final_text = String("\n").join(lines);
 
-	while (!f->eof_reached()) {
-		buffer += conservative.get_line(f);
+	if (code_edit) {
+		code_edit->begin_complex_operation();
+		Variant nav_state = code_text_editor->get_navigation_state();
+		code_edit->set_text(final_text);
+		code_edit->emit_signal(SceneStringName(text_changed));
+		code_text_editor->set_edit_state(nav_state);
+		code_edit->end_complex_operation();
+	} else {
+		// Now the modified contents are in the buffer, rewrite the file with our changes.
+		Error err = f->reopen(p_fpath, FileAccess::WRITE);
+		ERR_FAIL_COND_MSG(err != OK, "Cannot create file in path '" + p_fpath + "'.");
+		f->store_string(final_text);
 	}
-
-	// Now the modified contents are in the buffer, rewrite the file with our changes.
-
-	Error err = f->reopen(p_fpath, FileAccess::WRITE);
-	ERR_FAIL_COND_MSG(err != OK, "Cannot create file in path '" + p_fpath + "'.");
-
-	f->store_string(buffer);
 }
 
 String FindInFilesPanel::_get_replace_text() {

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3661,6 +3661,16 @@ Vector<Ref<Script>> ScriptEditor::get_open_scripts() const {
 	return out_scripts;
 }
 
+ScriptEditorBase *ScriptEditor::get_script_editor(Ref<Resource> p_script) const {
+	for (int i = 0; i < tab_container->get_tab_count(); i++) {
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
+		if (se && se->get_edited_resource() == p_script) {
+			return se;
+		}
+	}
+	return nullptr;
+}
+
 TypedArray<ScriptEditorBase> ScriptEditor::_get_open_script_editors() const {
 	TypedArray<ScriptEditorBase> script_editors;
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -4489,6 +4499,8 @@ void ScriptEditorPlugin::edited_scene_changed() {
 }
 
 ScriptEditorPlugin::ScriptEditorPlugin() {
+	script_editor_plugin = this;
+
 	ED_SHORTCUT("script_editor/reopen_closed_script", TTRC("Reopen Closed Script"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::T);
 	ED_SHORTCUT("script_editor/clear_recent", TTRC("Clear Recent Scripts"));
 	ED_SHORTCUT("script_editor/replace_in_files", TTRC("Replace in Files..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::R);

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -446,6 +446,7 @@ public:
 
 	void set_scene_root_script(Ref<Script> p_script);
 	Vector<Ref<Script>> get_open_scripts() const;
+	ScriptEditorBase *get_script_editor(Ref<Resource> p_script) const;
 
 	ScriptEditorBase *get_current_editor() const { return _get_current_editor(); }
 
@@ -489,10 +490,14 @@ class ScriptEditorPlugin : public EditorPlugin {
 	void _save_last_editor(const String &p_editor);
 	void _window_visibility_changed(bool p_visible);
 
+	static inline ScriptEditorPlugin *script_editor_plugin = nullptr;
+
 protected:
 	void _notification(int p_what);
 
 public:
+	static ScriptEditorPlugin *get_singleton() { return script_editor_plugin; }
+
 	static bool open_in_external_editor(const String &p_path, int p_line, int p_col, bool p_ignore_project = false);
 
 	virtual String get_plugin_name() const override { return TTRC("Script"); }

--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -854,6 +854,8 @@ void ShaderEditorPlugin::shortcut_input(const Ref<InputEvent> &p_event) {
 }
 
 ShaderEditorPlugin::ShaderEditorPlugin() {
+	shader_editor_plugin = this;
+
 	ED_SHORTCUT("shader_editor/new", TTRC("New Shader..."), KeyModifierMask::CMD_OR_CTRL | Key::N);
 	ED_SHORTCUT("shader_editor/new_include", TTRC("New Shader Include..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::N);
 	ED_SHORTCUT("shader_editor/open", TTRC("Load Shader File..."), KeyModifierMask::CMD_OR_CTRL | Key::O);

--- a/editor/shader/shader_editor_plugin.h
+++ b/editor/shader/shader_editor_plugin.h
@@ -123,12 +123,16 @@ class ShaderEditorPlugin : public EditorPlugin {
 
 	void _switch_to_editor(ShaderEditor *p_editor);
 
+	static inline ShaderEditorPlugin *shader_editor_plugin = nullptr;
+
 protected:
 	void _notification(int p_what);
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 public:
+	static ShaderEditorPlugin *get_singleton() { return shader_editor_plugin; }
+
 	virtual String get_plugin_name() const override { return "Shader"; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;


### PR DESCRIPTION
- Resolves https://github.com/godotengine/godot-proposals/issues/9654
- Resolves #109467
- Resolves https://github.com/godotengine/godot/issues/91406

This PR changes `Find and Replace` to edit `CodeEdit` text for open `gd` and `gdshader` files directly, enabling the modification of unsaved changes.

Something I am unsure about is the `get_code_edit` function which I think does not fit in the class it is currently defined in, but it's the best I could think of.

(Didn't happen when I was resolving conflicts recently) Also sometimes after making changes on open files and saving I get this error `The current scene has no root node, but 1 modified external resource(s) and/or plugin data were saved anyway.` which I couldn't find the reason for yet.