### PR TITLE
Fix get_point_path function in Astar when source node is disabled

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -437,6 +437,10 @@ Vector<Vector3> AStar3D::get_point_path(int64_t p_from_id, int64_t p_to_id, bool
 	Point *begin_point = a;
 	Point *end_point = b;
 
+	if (!begin_point->enabled) {
+		return Vector<Vector3>();
+	}
+	
 	bool found_route = _solve(begin_point, end_point, p_allow_partial_path);
 	if (!found_route) {
 		if (!p_allow_partial_path || last_closest_point == nullptr) {
@@ -745,6 +749,10 @@ Vector<Vector2> AStar2D::get_point_path(int64_t p_from_id, int64_t p_to_id, bool
 
 	AStar3D::Point *begin_point = a;
 	AStar3D::Point *end_point = b;
+
+	if (!begin_point->enabled) {
+		return Vector<Vector2>();
+	}
 
 	bool found_route = _solve(begin_point, end_point, p_allow_partial_path);
 	if (!found_route) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

**Issue Ticket:**
https://github.com/godotengine/godot/issues/113975

**Problem Description:**
The `get_point_path()` function returns the full path from the source to the destination even when the source node is disabled, whereas `get_id_path()` returns an empty path in this case. The expected behavior is for `get_point_path()` to also return an empty path, matching `get_id_path()`.

**What's changed:**
Added a check to handle the source node being disabled, consistent with the logic used in `get_id_path()`.