### PR TITLE
Tree: Add per-cell `autowrap_trim_flags` to TreeItem

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -94,6 +94,13 @@
 				Returns the text autowrap mode in the given [param column]. By default it is [constant TextServer.AUTOWRAP_OFF].
 			</description>
 		</method>
+		<method name="get_autowrap_trim_flags" qualifiers="const">
+			<return type="int" enum="TextServer.LineBreakFlag" is_bitfield="true" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns the autowrap trim flags for the given [param column]. By default, both [constant TextServer.BREAK_TRIM_START_EDGE_SPACES] and [constant TextServer.BREAK_TRIM_END_EDGE_SPACES] are enabled.
+			</description>
+		</method>
 		<method name="get_button" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="column" type="int" />
@@ -536,6 +543,14 @@
 			<param index="1" name="autowrap_mode" type="int" enum="TextServer.AutowrapMode" />
 			<description>
 				Sets the autowrap mode in the given [param column]. If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the cell's bounding rectangle.
+			</description>
+		</method>
+		<method name="set_autowrap_trim_flags">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="flags" type="int" enum="TextServer.LineBreakFlag" is_bitfield="true" />
+			<description>
+				Sets the autowrap trim flags for the given [param column]. These flags control whether leading and trailing spaces are trimmed on wrapped lines. Set to [code]0[/code] to disable all trimming.
 			</description>
 		</method>
 		<method name="set_button">

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -678,6 +678,7 @@ void ScriptEditorDebugger::_msg_error(uint64_t p_thread_id, const Array &p_data)
 	error_title += oe.error_descr.is_empty() ? oe.error : oe.error_descr;
 	error->set_text(1, error_title);
 	error->set_autowrap_mode(1, TextServer::AUTOWRAP_WORD_SMART);
+	error->set_autowrap_trim_flags(1, 0);
 	tooltip += " " + error_title + "\n";
 
 	// Find the language of the error's source file.
@@ -1116,6 +1117,13 @@ void ScriptEditorDebugger::_notification(int p_what) {
 
 			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 			reason->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("normal"), SNAME("Label"))); // Empty stylebox.
+
+			const Ref<Font> source_font = get_theme_font(SNAME("output_source"), EditorStringName(EditorFonts));
+			if (source_font.is_valid()) {
+				error_tree->add_theme_font_override("font", source_font);
+			}
+			const int font_size = get_theme_font_size(SNAME("output_source_size"), EditorStringName(EditorFonts));
+			error_tree->add_theme_font_size_override("font_size", font_size);
 
 			TreeItem *error_root = error_tree->get_root();
 			if (error_root) {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -78,6 +78,7 @@ private:
 		Array st_args;
 		Control::TextDirection text_direction = Control::TEXT_DIRECTION_INHERITED;
 		TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
+		BitField<TextServer::LineBreakFlag> autowrap_trim_flags = TextServer::BREAK_TRIM_START_EDGE_SPACES | TextServer::BREAK_TRIM_END_EDGE_SPACES;
 		bool dirty = true;
 		double min = 0.0;
 		double max = 100.0;
@@ -283,6 +284,9 @@ public:
 
 	void set_autowrap_mode(int p_column, TextServer::AutowrapMode p_mode);
 	TextServer::AutowrapMode get_autowrap_mode(int p_column) const;
+
+	void set_autowrap_trim_flags(int p_column, BitField<TextServer::LineBreakFlag> p_flags);
+	BitField<TextServer::LineBreakFlag> get_autowrap_trim_flags(int p_column) const;
 
 	void set_text_overrun_behavior(int p_column, TextServer::OverrunBehavior p_behavior);
 	TextServer::OverrunBehavior get_text_overrun_behavior(int p_column) const;


### PR DESCRIPTION
Implements godotengine/godot-proposals#13898

## Summary

The Debugger Errors tab displays ASCII art diagnostic output (like Rust/Elm-style error messages) incorrectly because:

1. The Tree widget hardcodes `BREAK_TRIM_START_EDGE_SPACES` and `BREAK_TRIM_END_EDGE_SPACES`, trimming leading spaces on wrapped lines and breaking alignment
2. The error tree uses a proportional font instead of monospace

This PR:
- Adds a per-cell `autowrap_trim_flags` property to `TreeItem`, following the pattern used by `Label` and `RichTextLabel`
- Uses the same monospace font (`output_source`) in the Errors tab as the Output panel
- Disables space trimming for error message cells

### Before
<img width="1036" height="356" alt="image" src="https://github.com/user-attachments/assets/384e11bb-5048-4d2c-bea1-514dd7fe2eea" />

### After
<img width="1098" height="215" alt="image" src="https://github.com/user-attachments/assets/20a8f70b-18c0-4d6b-9301-01d96fcdaa01" />