### PR TITLE
[MacOS] Fix non-deterministic framework linking order on macOS for incremental builds

### DIFF
--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -291,5 +291,5 @@ def configure(env: "SConsEnvironment"):
                 sys.exit(255)
 
     if len(extra_frameworks) > 0:
-        frameworks = [item for key in extra_frameworks for item in ["-framework", key]]
+        frameworks = [item for key in sorted(extra_frameworks) for item in ["-framework", key]]
         env.Append(LINKFLAGS=frameworks)


### PR DESCRIPTION
## Issue
On macOS, the order of `-framework` flags in LINKFLAGS can vary between builds due to the use of unordered data structures for `extra_frameworks`. This causes the flags string generated from the SCons environment to change on every build invocation, even when there are no actual configuration changes.

For module developers using external build systems (like Rake) that consume these flags, this results in:
- Unnecessary regeneration of external build configuration files
- Loss of incremental build capabilities for the external system

<img width="1456" height="946" alt="图片" src="https://github.com/user-attachments/assets/5623f092-554f-4ba9-881b-a6bf2eb4324f" />
<img width="1664" height="228" alt="图片" src="https://github.com/user-attachments/assets/75f29463-b532-4941-b4f6-02632717ee07" />

## Solution
Sort the `extra_frameworks` list before generating the framework linker flags to ensure a deterministic order.

```python
# Before
frameworks = [item for key in extra_frameworks for item in ["-framework", key]]

# After
frameworks = [item for key in sorted(extra_frameworks) for item in ["-framework", key]]