### PR TITLE
`CONNECT_APPEND_SOURCE_OBJECT` on signal emission

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -1051,7 +1051,17 @@
 			Reference-counted connections can be assigned to the same [Callable] multiple times. Each disconnection decreases the internal counter. The signal fully disconnects only when the counter reaches 0.
 		</constant>
 		<constant name="CONNECT_APPEND_SOURCE_OBJECT" value="16" enum="ConnectFlags">
-			The source object is automatically bound when a [PackedScene] is instantiated. If this flag bit is enabled, the source object will be appended right after the original arguments of the signal.
+			On signal emission, the source object is automatically appended after the original arguments of the signal, regardless of the connected [Callable]'s unbinds which affect only the original arguments of the signal (see [method Callable.unbind], [method Callable.get_unbound_arguments_count]).
+			[codeblock]
+			extends Object
+
+			signal test_signal
+
+			func test():
+				print(self) # Prints e.g. &lt;Object#35332818393&gt;
+				test_signal.connect(prints.unbind(1), CONNECT_APPEND_SOURCE_OBJECT)
+				test_signal.emit("emit_arg_1", "emit_arg_2") # Prints emit_arg_1 &lt;Object#35332818393&gt;
+			[/codeblock]
 		</constant>
 	</constants>
 </class>

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1668,11 +1668,12 @@ void ConnectionsDock::update_tree() {
 				if (cd.flags & CONNECT_ONE_SHOT) {
 					path += " (one-shot)";
 				}
-				if (cd.flags & CONNECT_APPEND_SOURCE_OBJECT) {
-					path += " (source)";
-				}
 				if (cd.unbinds > 0) {
 					path += " unbinds(" + itos(cd.unbinds) + ")";
+				}
+				// CONNECT_APPEND_SOURCE_OBJECT is not affected by unbinds, list it between unbinds/binds to better indicate the final order.
+				if (cd.flags & CONNECT_APPEND_SOURCE_OBJECT) {
+					path += " (source)";
 				}
 				if (!cd.binds.is_empty()) {
 					path += " binds(";

--- a/editor/scene/connections_dialog.h
+++ b/editor/scene/connections_dialog.h
@@ -84,11 +84,6 @@ public:
 					unbinds = ccu->get_unbinds();
 					base_callable = ccu->get_callable();
 				}
-
-				// The source object may already be bound, ignore it to prevent display of the source object.
-				if ((flags & CONNECT_APPEND_SOURCE_OBJECT) && (source == binds[0])) {
-					binds.remove_at(0);
-				}
 			} else {
 				base_callable = p_connection.callable;
 			}

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -664,9 +664,6 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 		Callable callable(cto, snames[c.method]);
 
 		Array binds;
-		if (c.flags & CONNECT_APPEND_SOURCE_OBJECT) {
-			binds.push_back(cfrom);
-		}
 
 		for (int bind : c.binds) {
 			binds.push_back(props[bind]);
@@ -1192,11 +1189,6 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 					ccu->get_bound_arguments(binds);
 					unbinds = ccu->get_unbinds();
 					base_callable = ccu->get_callable();
-				}
-
-				// The source object may already be bound, ignore it to avoid saving the source object.
-				if ((c.flags & CONNECT_APPEND_SOURCE_OBJECT) && (p_node == binds[0])) {
-					binds.remove_at(0);
 				}
 			} else {
 				base_callable = c.callable;

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -316,6 +316,29 @@ TEST_CASE("[Object] Absent name getter") {
 			"The returned value should equal nil variant.");
 }
 
+class SignalReceiver : public Object {
+	GDCLASS(SignalReceiver, Object);
+
+public:
+	Vector<Variant> received_args;
+
+	void callback0() {
+		received_args = Vector<Variant>{};
+	}
+
+	void callback1(Variant p_arg1) {
+		received_args = Vector<Variant>{ p_arg1 };
+	}
+
+	void callback2(Variant p_arg1, Variant p_arg2) {
+		received_args = Vector<Variant>{ p_arg1, p_arg2 };
+	}
+
+	void callback3(Variant p_arg1, Variant p_arg2, Variant p_arg3) {
+		received_args = Vector<Variant>{ p_arg1, p_arg2, p_arg3 };
+	}
+};
+
 TEST_CASE("[Object] Signals") {
 	Object object;
 
@@ -454,6 +477,51 @@ TEST_CASE("[Object] Signals") {
 		signal_connections.clear();
 		object.get_all_signal_connections(&signal_connections);
 		CHECK(signal_connections.size() == 0);
+	}
+
+	SUBCASE("Connecting with CONNECT_APPEND_SOURCE_OBJECT flag") {
+		SignalReceiver target;
+
+		object.connect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback1), Object::CONNECT_APPEND_SOURCE_OBJECT);
+		object.emit_signal("my_custom_signal");
+		CHECK_EQ(target.received_args, Vector<Variant>{ &object });
+		object.disconnect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback1));
+
+		object.connect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback2), Object::CONNECT_APPEND_SOURCE_OBJECT);
+		object.emit_signal("my_custom_signal", "emit_arg");
+		CHECK_EQ(target.received_args, Vector<Variant>{ "emit_arg", &object });
+		object.disconnect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback2));
+
+		object.connect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback2).bind("bind_arg"), Object::CONNECT_APPEND_SOURCE_OBJECT);
+		object.emit_signal("my_custom_signal");
+		CHECK_EQ(target.received_args, Vector<Variant>{ &object, "bind_arg" });
+		object.disconnect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback2));
+
+		object.connect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback3).bind("bind_arg"), Object::CONNECT_APPEND_SOURCE_OBJECT);
+		object.emit_signal("my_custom_signal", "emit_arg");
+		CHECK_EQ(target.received_args, Vector<Variant>{ "emit_arg", &object, "bind_arg" });
+		object.disconnect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback3));
+
+		object.connect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback3).bind(&object), Object::CONNECT_APPEND_SOURCE_OBJECT);
+		object.emit_signal("my_custom_signal", &object);
+		CHECK_EQ(target.received_args, Vector<Variant>{ &object, &object, &object });
+		object.disconnect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback3));
+
+		// Source should be appended regardless of unbinding.
+		object.connect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback1).unbind(1), Object::CONNECT_APPEND_SOURCE_OBJECT);
+		object.emit_signal("my_custom_signal", "emit_arg");
+		CHECK_EQ(target.received_args, Vector<Variant>{ &object });
+		object.disconnect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback1));
+
+		object.connect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback2).bind("bind_arg").unbind(1), Object::CONNECT_APPEND_SOURCE_OBJECT);
+		object.emit_signal("my_custom_signal", "emit_arg");
+		CHECK_EQ(target.received_args, Vector<Variant>{ &object, "bind_arg" });
+		object.disconnect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback2));
+
+		object.connect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback2).unbind(1).bind("bind_arg"), Object::CONNECT_APPEND_SOURCE_OBJECT);
+		object.emit_signal("my_custom_signal", "emit_arg");
+		CHECK_EQ(target.received_args, Vector<Variant>{ "emit_arg", &object });
+		object.disconnect("my_custom_signal", callable_mp(&target, &SignalReceiver::callback2));
 	}
 }
 


### PR DESCRIPTION
Fixes #114326.
Fixes #114660.

Resolves https://github.com/godotengine/godot-proposals/issues/13974.

Changes `CONNECT_APPEND_SOURCE_OBJECT` to append the source object on signal emission. Previously it was done only on PackedScene instantiation, which led to bugs/inconsistencies.

- `CONNECT_APPEND_SOURCE_OBJECT` did not work on runtime connections.
- On runtime, duplicating a Node with the source object/Node binded during the scene instantiation would not replace the binded source object with the newly duplicated one.
- The source object/Node binded during the scene instantiation might be tried to be saved in the scene file.
- etc.

---

`CONNECT_APPEND_SOURCE_OBJECT` originally was added/needed specifically only for the editor's signal connection dialog (#60143), was never implemented for using on runtime. Was added as `Object`'s connection flag for ease of storage. AFAICT it would make more sense back then to implement it internally in the connections dialog, and store as some kind of meta data for connections. 🤔 But since it was added to Object as an exposed connection flag, I think it should work consistently, even on runtime. This PR aims to make it work consistently, so no special handling is needed on scene instantiation, node duplication, etc. As long as the flag is stored/duplicated things should work as expected.

The implementation is inspired by pre-#63595 state, when binds from `Object.connect` were appended on signal emission as well.

---

Modified MRP from #114326 with the examples below: [duplicate-signal-extra-arg_v2.zip](https://github.com/user-attachments/files/24346447/duplicate-signal-extra-arg_v2.zip)

Before (v4.6.beta2.official [551ce8d47])|After (this PR)
-|-
<img width="1531" height="439" alt="Godot_v4 6-beta2_win64_wQKInKJUeV" src="https://github.com/user-attachments/assets/ba4b9a91-2ec2-4ba6-98cc-cee371d08d05" />|<img width="1531" height="439" alt="Sw5Z8VevPJ" src="https://github.com/user-attachments/assets/a304e71b-41d2-4756-b17f-45a5dc28e719" />
<img width="1920" height="438" alt="Godot_v4 6-beta2_win64_DhLwm8jbzi" src="https://github.com/user-attachments/assets/576e621e-892a-41a6-bec1-3f4612cf8159" />|<img width="1920" height="438" alt="2cM7n4ITyY" src="https://github.com/user-attachments/assets/a6a2cb1f-4aca-4239-a078-bf7a3717b92f" />
<img width="1920" height="464" alt="Godot_v4 6-beta2_win64_XJHynYXQjd" src="https://github.com/user-attachments/assets/e5a24c8a-d6b6-433b-8f19-4b167c42cdd0" /><br><img width="1920" height="464" alt="gB2eqbazlf" src="https://github.com/user-attachments/assets/5c1eb552-e8d2-4fa7-b7ba-c0e8d2bc9daa" />|<img width="1920" height="464" alt="MeJntvXswE" src="https://github.com/user-attachments/assets/69847967-d3ce-49be-8a57-bcf291286b34" /><br><img width="1920" height="464" alt="NczvKU27Bc" src="https://github.com/user-attachments/assets/5f1543b4-6af6-41f8-b257-198ae678fbb7" />


Relevant part of `control.tscn` from #114326 MRP:

- Before (v4.6.beta2.official [551ce8d47]):
```
[connection signal="resized" from="Parent/Child" to="Parent" method="_on_child_resized" flags=18]
[connection signal="resized" from="Parent2/Child" to="Parent2" method="_on_child_resized" flags=18 binds= [Object(Control,"unique_name_in_owner":false,"process_mode":0,"process_priority":0,"process_physics_priority":0,"process_thread_group":0,"physics_interpolation_mode":2,"auto_translate_mode":0,"editor_description":"","visible":true,"modulate":Color(1, 1, 1, 1),"self_modulate":Color(1, 1, 1, 1),"show_behind_parent":false,"top_level":false,"clip_children":0,"light_mask":1,"visibility_layer":1,"z_index":0,"z_as_relative":true,"y_sort_enabled":false,"texture_filter":0,"texture_repeat":0,"material":null,"use_parent_material":false,"clip_contents":false,"custom_minimum_size":Vector2(0, 0),"layout_direction":0,"layout_mode":0,"anchors_preset":0,"anchor_left":0.0,"anchor_top":0.0,"anchor_right":0.0,"anchor_bottom":0.0,"offset_left":0.0,"offset_top":0.0,"offset_right":40.0,"offset_bottom":40.0,"grow_horizontal":1,"grow_vertical":1,"rotation":0.0,"scale":Vector2(1, 1),"pivot_offset":Vector2(0, 0),"pivot_offset_ratio":Vector2(0, 0),"size_flags_horizontal":1,"size_flags_vertical":1,"size_flags_stretch_ratio":1.0,"localize_numeral_system":true,"tooltip_text":"","tooltip_auto_translate_mode":0,"focus_neighbor_left":NodePath(""),"focus_neighbor_top":NodePath(""),"focus_neighbor_right":NodePath(""),"focus_neighbor_bottom":NodePath(""),"focus_next":NodePath(""),"focus_previous":NodePath(""),"focus_mode":0,"focus_behavior_recursive":0,"mouse_filter":0,"mouse_behavior_recursive":0,"mouse_force_pass_scroll_events":true,"mouse_default_cursor_shape":0,"shortcut_context":null,"accessibility_name":"","accessibility_description":"","accessibility_live":0,"accessibility_controls_nodes":Array[NodePath]([]),"accessibility_described_by_nodes":Array[NodePath]([]),"accessibility_labeled_by_nodes":Array[NodePath]([]),"accessibility_flow_to_nodes":Array[NodePath]([]),"theme":null,"theme_type_variation":&"","script":null)
]]
```
- After (this PR):
```
[connection signal="resized" from="Parent/Child" to="Parent" method="_on_child_resized" flags=18]
[connection signal="resized" from="Parent2/Child" to="Parent2" method="_on_child_resized" flags=18]
```

