### PR TITLE
Rendering: Pre-allocate light vectors in scene culling

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3157,11 +3157,13 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 	cull.frustum = Frustum(planes);
 
 	Vector<RID> directional_lights;
+	directional_lights.reserve(scenario->directional_lights.size());
 	// directional lights
 	{
 		cull.shadow_count = 0;
 
 		Vector<Instance *> lights_with_shadow;
+		lights_with_shadow.reserve(scenario->directional_lights.size());
 
 		for (Instance *E : scenario->directional_lights) {
 			if (!E->visible || !(E->layer_mask & p_visible_layers)) {

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3156,21 +3156,19 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 	Vector<Plane> planes = p_camera_data->main_projection.get_projection_planes(p_camera_data->main_transform);
 	cull.frustum = Frustum(planes);
 
-	Vector<RID> directional_lights;
-	directional_lights.reserve(scenario->directional_lights.size());
+	directional_light_instances.clear();
+	lights_with_shadow.clear();
+
 	// directional lights
 	{
 		cull.shadow_count = 0;
-
-		Vector<Instance *> lights_with_shadow;
-		lights_with_shadow.reserve(scenario->directional_lights.size());
 
 		for (Instance *E : scenario->directional_lights) {
 			if (!E->visible || !(E->layer_mask & p_visible_layers)) {
 				continue;
 			}
 
-			if (directional_lights.size() >= RendererSceneRender::MAX_DIRECTIONAL_LIGHTS) {
+			if (directional_light_instances.size() >= RendererSceneRender::MAX_DIRECTIONAL_LIGHTS) {
 				break;
 			}
 
@@ -3183,7 +3181,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 					lights_with_shadow.push_back(E);
 				}
 				//add to list
-				directional_lights.push_back(light->instance);
+				directional_light_instances.push_back(light->instance);
 			}
 		}
 
@@ -3458,15 +3456,15 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		}
 
 		if (p_reflection_probe.is_null()) {
-			sdfgi_update_data.directional_lights = &directional_lights;
+			sdfgi_update_data.directional_lights = &directional_light_instances;
 			sdfgi_update_data.positional_light_instances = scenario->dynamic_lights.ptr();
 			sdfgi_update_data.positional_light_count = scenario->dynamic_lights.size();
 		}
 	}
 
 	//append the directional lights to the lights culled
-	for (int i = 0; i < directional_lights.size(); i++) {
-		scene_cull_result.light_instances.push_back(directional_lights[i]);
+	for (int i = 0; i < directional_light_instances.size(); i++) {
+		scene_cull_result.light_instances.push_back(directional_light_instances[i]);
 	}
 
 	RID camera_attributes;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1002,6 +1002,9 @@ public:
 	InstanceCullResult scene_cull_result;
 	LocalVector<InstanceCullResult> scene_cull_result_threads;
 
+	Vector<RID> directional_light_instances;
+	Vector<Instance *> lights_with_shadow;
+
 	RendererSceneRender::RenderShadowData render_shadow_data[MAX_UPDATE_SHADOWS];
 	uint32_t max_shadows_used = 0;
 


### PR DESCRIPTION
While looking through the rendering code, I noticed that `directional_lights` and `lights_with_shadow` vectors in `_render_scene` are built up with `push_back()` without reserving capacity first. Since we already know the upper bound from `scenario->directional_lights.size()`, we can avoid the reallocations.

It's a small thing, but this runs every frame during scene rendering so it adds up.

## Changes

- Added `reserve()` for `directional_lights` before the loop
- Added `reserve()` for `lights_with_shadow` inside the directional lights block

Both use `scenario->directional_lights.size()` as the capacity hint, which is the maximum number of elements either vector can have.