### PR TITLE
ProjectDialog: Fix invalid button state when selecting renderer with invalid project path

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -51,7 +51,12 @@
 
 void ProjectDialog::_set_message(const String &p_msg, MessageType p_type, InputType p_input_type) {
 	msg->set_text(p_msg);
-	get_ok_button()->set_disabled(p_type == MESSAGE_ERROR);
+	if (p_type == MESSAGE_ERROR) {
+		invalid_flags.set_flag(ValidationFlags::INVALID_PATH_INPUT);
+	} else {
+		invalid_flags.clear_flag(ValidationFlags::INVALID_PATH_INPUT);
+	}
+	get_ok_button()->set_disabled(!invalid_flags.is_empty());
 
 	Ref<Texture2D> new_icon;
 	switch (p_type) {
@@ -510,11 +515,14 @@ void ProjectDialog::_renderer_selected() {
 	}
 
 	rd_not_supported->set_visible(rd_error);
-	get_ok_button()->set_disabled(rd_error);
 	if (rd_error) {
 		// Needs to be set here since theme colors aren't available at startup.
 		rd_not_supported->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		invalid_flags.set_flag(ValidationFlags::INVALID_RENDERER_SELECT);
+	} else {
+		invalid_flags.clear_flag(ValidationFlags::INVALID_RENDERER_SELECT);
 	}
+	get_ok_button()->set_disabled(!invalid_flags.is_empty());
 }
 
 void ProjectDialog::_nonempty_confirmation_ok_pressed() {

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -64,6 +64,11 @@ private:
 		INSTALL_PATH,
 	};
 
+	enum ValidationFlags {
+		INVALID_PATH_INPUT = 1,
+		INVALID_RENDERER_SELECT = 2
+	};
+
 	Mode mode = MODE_NEW;
 	bool is_folder_empty = true;
 	ConfirmationDialog *nonempty_confirmation = nullptr;
@@ -103,6 +108,8 @@ private:
 
 	String original_project_path;
 	bool duplicate_can_edit = false;
+
+	BitField<ValidationFlags> invalid_flags;
 
 	void _set_message(const String &p_msg, MessageType p_type, InputType input_type = PROJECT_PATH);
 	void _validate_path();


### PR DESCRIPTION
To avoid that (Next button is clickable, while Project Path is wrong):
<img width="1121" height="893" alt="图片" src="https://github.com/user-attachments/assets/99dbe0e9-bfd5-4d6a-8c3c-16c3344ce495" />
