### PR TITLE
Fix Android fingerprint scanners being recognized as joypads

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
@@ -70,6 +70,16 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	private static final int ROTARY_INPUT_VERTICAL_AXIS = 1;
 	private static final int ROTARY_INPUT_HORIZONTAL_AXIS = 0;
 
+	private static final String[] JOYPAD_IGNORE_LIST = new String[] {
+		// Ignore fingerprint scanners.
+		"uinput-fpc",
+		"uinput-goodix",
+		"uinput-synaptics",
+		"uinput-elan",
+		"uinput-vfs",
+		"uinput-atrus",
+	};
+
 	private final SparseIntArray mJoystickIds = new SparseIntArray(4);
 	private final SparseArray<Joystick> mJoysticksDevices = new SparseArray<>(4);
 	private final HashSet<Integer> mHardwareKeyboardIds = new HashSet<>();
@@ -357,6 +367,13 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 		if (!device.supportsSource(InputDevice.SOURCE_GAMEPAD) &&
 				!device.supportsSource(InputDevice.SOURCE_JOYSTICK)) {
 			return;
+		}
+
+		for (String name : JOYPAD_IGNORE_LIST) {
+			if (device.getName().equals(name)) {
+				Log.i(TAG, "=== Input Device ignored: " + device.getName());
+				return;
+			}
 		}
 
 		// Assign first available number. Reuse numbers where possible.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/47656
This PR makes the Android code ignore the fingerprint scanners when they get recognized as joysticks.

<details>
<summary>Tested with a DualShock 4 controller</summary>

![Screenshot_2025-12-25-18-17-15-579_org godotengine editor v4 debug](https://github.com/user-attachments/assets/6af143e6-5a40-4a63-b921-37ca221c2386)
</details>