### PR TITLE
Fix `sorting_offset` property flags for `Decal`

### DIFF
--- a/doc/classes/VisualInstance3D.xml
+++ b/doc/classes/VisualInstance3D.xml
@@ -63,7 +63,7 @@
 			To adjust [member layers] more easily using a script, use [method get_layer_mask_value] and [method set_layer_mask_value].
 			[b]Note:[/b] [VoxelGI], SDFGI and [LightmapGI] will always take all layers into account to determine what contributes to global illumination. If this is an issue, set [member GeometryInstance3D.gi_mode] to [constant GeometryInstance3D.GI_MODE_DISABLED] for meshes and [member Light3D.light_bake_mode] to [constant Light3D.BAKE_DISABLED] for lights to exclude them from global illumination.
 		</member>
-		<member name="sorting_offset" type="float" setter="set_sorting_offset" getter="get_sorting_offset">
+		<member name="sorting_offset" type="float" setter="set_sorting_offset" getter="get_sorting_offset" default="0.0">
 			The amount by which the depth of this [VisualInstance3D] will be adjusted when sorting by depth. Uses the same units as the engine (which are typically meters). Adjusting it to a higher value will make the [VisualInstance3D] reliably draw on top of other [VisualInstance3D]s that are otherwise positioned at the same spot. To ensure it always draws on top of other objects around it (not positioned at the same spot), set the value to be greater than the distance between this [VisualInstance3D] and the other nearby [VisualInstance3D]s.
 		</member>
 		<member name="sorting_use_aabb_center" type="bool" setter="set_sorting_use_aabb_center" getter="is_sorting_use_aabb_center">

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -166,6 +166,12 @@ AABB Decal::get_aabb() const {
 	return aabb;
 }
 
+void Decal::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "sorting_offset") {
+		p_property.usage = PROPERTY_USAGE_DEFAULT;
+	}
+}
+
 PackedStringArray Decal::get_configuration_warnings() const {
 	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
 

--- a/scene/3d/decal.h
+++ b/scene/3d/decal.h
@@ -61,6 +61,7 @@ private:
 
 protected:
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_property) const;


### PR DESCRIPTION
Fixes #114333.

Regression from #108254, which made `VisualInstance3D::sorting_offset` for `Decal` both:
- not being shown in the editor,
- not being stored.