### PR TITLE
GDScript: Fix `PROPERTY_USAGE_SCRIPT_VARIABLE` is not set for placeholder instance properties

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -4892,7 +4892,16 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 
 	for (const PropertyInfo &E : pinfo) {
 		if (E.name == leftover_path[leftover_path.size() - 1]) {
-			return E;
+			PropertyInfo pi = E;
+
+			// See `PropertySelector::_update_search()`. `PropertySelector` makes an exception for script variables,
+			// displaying them even if `PROPERTY_USAGE_EDITOR` is not set. So, we need to compensate for this here
+			// to ensure the property is visible in the Inspector.
+			if (pi.usage & PROPERTY_USAGE_SCRIPT_VARIABLE) {
+				pi.usage |= PROPERTY_USAGE_EDITOR;
+			}
+
+			return pi;
 		}
 	}
 


### PR DESCRIPTION
* Fixes #108068.

Test script:

```gdscript
#@tool
extends Node

@export_storage var t: float:
    set(v):
        t = v
        print(t)

@export var t2: float

var t3: float
```

A user emailed me with a bug: properties exported using `@export_storage` don't work correctly in animation tracks. I examined the code and discovered two issues:

1\. For placeholder instance properties, the `PROPERTY_USAGE_SCRIPT_VARIABLE` flag isn't set. This differs from runtime and tool scripts. This means that unexported properties or those exported without `PROPERTY_USAGE_EDITOR` aren't displayed in the Property Selector without `@tool`, but are displayed with `@tool`:

<img width="314" height="194" alt="" src="https://github.com/user-attachments/assets/a1fba9d0-1c8c-451a-975e-1f55eb4709f5" />

https://github.com/godotengine/godot/blob/63227bbc8ae5300319f14f8253c8158b846f355b/modules/gdscript/gdscript_compiler.cpp#L2877-L2878

2\. The Property Selector makes an exception for script variables and displays them even if `PROPERTY_USAGE_EDITOR` is not set. This results in such properties being displayed in the animation editor without the Value field (for tool scripts or if you create an animation track for another property and then manually edit the node path).

<img width="588" height="252" alt="" src="https://github.com/user-attachments/assets/e70a44c8-d889-4b53-886b-fb52e1c7450d" />

https://github.com/godotengine/godot/blob/63227bbc8ae5300319f14f8253c8158b846f355b/editor/inspector/property_selector.cpp#L134-L136