### PR TITLE
Document Android joypad vibration being unsupported

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -700,7 +700,7 @@
 				[param duration] is the duration of the effect in seconds (a duration of [code]0.0[/code] will try to play the vibration as long as possible, which is about 65 seconds).
 				The vibration can be stopped early by calling [method stop_joy_vibration].
 				See also [method get_joy_vibration_strength] and [method get_joy_vibration_duration].
-				[b]Note:[/b] For macOS, vibration is only supported in macOS 11 and later. When connected via USB, vibration is only supported for major brand controllers (except Xbox One and Xbox Series X/S controllers) due to macOS limitations.
+				[b]Note:[/b] For Android, joypad vibration is not supported due to Android limitations. For macOS, vibration is only supported in macOS 11 and later. When connected via USB, vibration is only supported for major brand controllers (except Xbox One and Xbox Series X/S controllers) due to macOS limitations.
 			</description>
 		</method>
 		<method name="stop_joy_motion_sensors_calibration" experimental="">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/73446

Apparently, controller vibration on Android is very finicky. After some Google searches, some people say it works over Bluetooth, some people say it only works on wired controllers, someone says [vibration over wired connection only works for Xbox controllers](https://www.reddit.com/r/MoonlightStreaming/comments/1kajh45/comment/mpn6uhn/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) and apparently, it's [not supported in Unity either](https://discussions.unity.com/t/inputsystem-controller-vibration-through-android/842815), so I think it should be mentioned in the docs that Godot doesn't support joypad vibration on Android.
I/We can try to make it work only for wired controllers (if Android does allow it), but I'm not entirely sure if it's worth it since (I believe) most of the time controllers on Android are connected wirelessly via Bluetooth.
TODO:
- [ ] `has_joy_vibration()`