### PR TITLE
Material: fix deprecated parameter setting

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -216,7 +216,7 @@ bool ShaderMaterial::_set(const StringName &p_name, const Variant &p_value) {
 			return false; // Not a shader parameter.
 		}
 
-		WARN_PRINT("This material (containing shader with path: '" + shader->get_path() + "') uses an old deprecated parameter names. Consider re-saving this resource (or scene which contains it) in order for it to continue working in future versions.");
+		WARN_DEPRECATED_MSG("This material (containing shader with path: '" + shader->get_path() + "') uses an old deprecated parameter names. Consider re-saving this resource (or scene which contains it) in order for it to continue working in future versions.");
 		String param = s.replace_first("shader_parameter/", "");
 		remap_cache[s] = param;
 		set_shader_parameter(param, p_value);
@@ -4123,7 +4123,7 @@ bool StandardMaterial3D::_set(const StringName &p_name, const Variant &p_value) 
 		}
 
 		WARN_PRINT("Godot 3.x SpatialMaterial remapped parameter not found: " + String(p_name));
-		return true;
+		return false;
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

`StandardMaterial3D::_set()` did not return `false` when a deprecated shader parameter was not found in the remap and thus was not set. 

Additionally, `ShaderMaterial::_set()` used `WARN_PRINT` instead of `WARN_DEPRECATED_MSG` when setting a deprecated shader parameter; this results in a huge amount of logspam when loading a deprecated material. 