### PR TITLE
Fix Spectrum Analyzer effect returning jittered values

### DIFF
--- a/doc/classes/AudioEffectSpectrumAnalyzer.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzer.xml
@@ -18,8 +18,6 @@
 		<member name="fft_size" type="int" setter="set_fft_size" getter="get_fft_size" enum="AudioEffectSpectrumAnalyzer.FFTSize" default="2">
 			The size of the [url=https://en.wikipedia.org/wiki/Fast_Fourier_transform]Fast Fourier transform[/url] buffer. Higher values smooth out the spectrum analysis over time, but have greater latency. The effects of this higher latency are especially noticeable with sudden amplitude changes.
 		</member>
-		<member name="tap_back_pos" type="float" setter="set_tap_back_pos" getter="get_tap_back_pos" default="0.01">
-		</member>
 	</members>
 	<constants>
 		<constant name="FFT_SIZE_256" value="0" enum="FFTSize">

--- a/misc/extension_api_validation/4.6-stable/GH-114355.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-114355.txt
@@ -1,0 +1,8 @@
+GH-114355
+---------
+Validate extension JSON: API was removed: classes/AudioEffectSpectrumAnalyzer/methods/set_tap_back_pos
+Validate extension JSON: API was removed: classes/AudioEffectSpectrumAnalyzer/methods/get_tap_back_pos
+Validate extension JSON: API was removed: classes/AudioEffectSpectrumAnalyzer/properties/tap_back_pos
+
+Removed this property because it caused buggy behavior for no discernible benefit.
+Compatibility methods registered.

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.compat.inc
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  audio_effect_spectrum_analyzer.h                                      */
+/*  audio_effect_spectrum_analyzer.compat.inc                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,79 +28,20 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
-
-#include "servers/audio/audio_effect.h"
-
-class AudioEffectSpectrumAnalyzer;
-
-class AudioEffectSpectrumAnalyzerInstance : public AudioEffectInstance {
-	GDCLASS(AudioEffectSpectrumAnalyzerInstance, AudioEffectInstance);
-
-public:
-	enum MagnitudeMode {
-		MAGNITUDE_AVERAGE,
-		MAGNITUDE_MAX,
-	};
-
-private:
-	friend class AudioEffectSpectrumAnalyzer;
-	Ref<AudioEffectSpectrumAnalyzer> base;
-
-	Vector<Vector<AudioFrame>> fft_history;
-	Vector<float> temporal_fft;
-	int temporal_fft_pos;
-	int fft_size;
-	int fft_count;
-	int fft_pos;
-	float mix_rate;
-
-protected:
-	static void _bind_methods();
-
-public:
-	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
-	Vector2 get_magnitude_for_frequency_range(float p_begin, float p_end, MagnitudeMode p_mode = MAGNITUDE_MAX) const;
-};
-
-VARIANT_ENUM_CAST(AudioEffectSpectrumAnalyzerInstance::MagnitudeMode)
-
-class AudioEffectSpectrumAnalyzer : public AudioEffect {
-	GDCLASS(AudioEffectSpectrumAnalyzer, AudioEffect);
-
-public:
-	enum FFTSize {
-		FFT_SIZE_256,
-		FFT_SIZE_512,
-		FFT_SIZE_1024,
-		FFT_SIZE_2048,
-		FFT_SIZE_4096,
-		FFT_SIZE_MAX
-	};
-
-public:
-	friend class AudioEffectSpectrumAnalyzerInstance;
-	float buffer_length;
-	FFTSize fft_size;
-
-protected:
-	static void _bind_methods();
-
 #ifndef DISABLE_DEPRECATED
-	void _set_tap_back_pos_bind_compat_114355(float p_seconds);
-	float _get_tap_back_pos_bind_compat_114355();
-	static void _bind_compatibility_methods();
-#endif
 
-public:
-	Ref<AudioEffectInstance> instantiate() override;
-	void set_buffer_length(float p_seconds);
-	float get_buffer_length() const;
+void AudioEffectSpectrumAnalyzer::_set_tap_back_pos_bind_compat_114355(float p_seconds) {
+	WARN_PRINT_ONCE("AudioEffectSpectrumAnalyzer.set_tap_back_pos() is deprecated and the value will be discarded.");
+}
 
-	void set_fft_size(FFTSize);
-	FFTSize get_fft_size() const;
+float AudioEffectSpectrumAnalyzer::_get_tap_back_pos_bind_compat_114355() {
+	WARN_PRINT_ONCE("AudioEffectSpectrumAnalyzer.get_tap_back_pos() is deprecated and will only return the original default value.");
+	return 0.01;
+}
 
-	AudioEffectSpectrumAnalyzer();
-};
+void AudioEffectSpectrumAnalyzer::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_tap_back_pos", "seconds"), &AudioEffectSpectrumAnalyzer::_set_tap_back_pos_bind_compat_114355);
+	ClassDB::bind_compatibility_method(D_METHOD("get_tap_back_pos"), &AudioEffectSpectrumAnalyzer::_get_tap_back_pos_bind_compat_114355);
+}
 
-VARIANT_ENUM_CAST(AudioEffectSpectrumAnalyzer::FFTSize);
+#endif // DISABLE_DEPRECATED

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "audio_effect_spectrum_analyzer.h"
+#include "audio_effect_spectrum_analyzer.compat.inc"
 #include "servers/audio/audio_server.h"
 
 static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
@@ -99,8 +100,6 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 }
 
 void AudioEffectSpectrumAnalyzerInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
-	uint64_t time = OS::get_singleton()->get_ticks_usec();
-
 	//copy everything over first, since this only really does capture
 	for (int i = 0; i < p_frame_count; i++) {
 		p_dst_frames[i] = p_src_frames[i];
@@ -143,10 +142,6 @@ void AudioEffectSpectrumAnalyzerInstance::process(const AudioFrame *p_src_frames
 			temporal_fft_pos = 0;
 		}
 	}
-
-	//determine time of capture
-	double remainder_sec = (temporal_fft_pos / mix_rate); //subtract remainder from mix time
-	last_fft_time = time - uint64_t(remainder_sec * 1000000.0);
 }
 
 void AudioEffectSpectrumAnalyzerInstance::_bind_methods() {
@@ -156,23 +151,7 @@ void AudioEffectSpectrumAnalyzerInstance::_bind_methods() {
 }
 
 Vector2 AudioEffectSpectrumAnalyzerInstance::get_magnitude_for_frequency_range(float p_begin, float p_end, MagnitudeMode p_mode) const {
-	if (last_fft_time == 0) {
-		return Vector2();
-	}
-	uint64_t time = OS::get_singleton()->get_ticks_usec();
-	float diff = double(time - last_fft_time) / 1000000.0 + base->get_tap_back_pos();
-	diff -= AudioServer::get_singleton()->get_output_latency();
-	float fft_time_size = float(fft_size) / mix_rate;
-
 	int fft_index = fft_pos;
-
-	while (diff > fft_time_size) {
-		diff -= fft_time_size;
-		fft_index -= 1;
-		if (fft_index < 0) {
-			fft_index = fft_count - 1;
-		}
-	}
 
 	int begin_pos = p_begin * fft_size / (mix_rate * 0.5);
 	int end_pos = p_end * fft_size / (mix_rate * 0.5);
@@ -216,7 +195,6 @@ Ref<AudioEffectInstance> AudioEffectSpectrumAnalyzer::instantiate() {
 	ins->mix_rate = AudioServer::get_singleton()->get_mix_rate();
 	ins->fft_count = (buffer_length / (float(ins->fft_size) / ins->mix_rate)) + 1;
 	ins->fft_pos = 0;
-	ins->last_fft_time = 0;
 	ins->fft_history.resize(ins->fft_count);
 	ins->temporal_fft.resize(ins->fft_size * 8); //x2 stereo, x2 amount of samples for freqs, x2 for input
 	ins->temporal_fft_pos = 0;
@@ -237,14 +215,6 @@ float AudioEffectSpectrumAnalyzer::get_buffer_length() const {
 	return buffer_length;
 }
 
-void AudioEffectSpectrumAnalyzer::set_tap_back_pos(float p_seconds) {
-	tapback_pos = p_seconds;
-}
-
-float AudioEffectSpectrumAnalyzer::get_tap_back_pos() const {
-	return tapback_pos;
-}
-
 void AudioEffectSpectrumAnalyzer::set_fft_size(FFTSize p_fft_size) {
 	ERR_FAIL_INDEX(p_fft_size, FFT_SIZE_MAX);
 	fft_size = p_fft_size;
@@ -258,14 +228,10 @@ void AudioEffectSpectrumAnalyzer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_buffer_length", "seconds"), &AudioEffectSpectrumAnalyzer::set_buffer_length);
 	ClassDB::bind_method(D_METHOD("get_buffer_length"), &AudioEffectSpectrumAnalyzer::get_buffer_length);
 
-	ClassDB::bind_method(D_METHOD("set_tap_back_pos", "seconds"), &AudioEffectSpectrumAnalyzer::set_tap_back_pos);
-	ClassDB::bind_method(D_METHOD("get_tap_back_pos"), &AudioEffectSpectrumAnalyzer::get_tap_back_pos);
-
 	ClassDB::bind_method(D_METHOD("set_fft_size", "size"), &AudioEffectSpectrumAnalyzer::set_fft_size);
 	ClassDB::bind_method(D_METHOD("get_fft_size"), &AudioEffectSpectrumAnalyzer::get_fft_size);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "buffer_length", PROPERTY_HINT_RANGE, "0.1,4,0.1,suffix:s"), "set_buffer_length", "get_buffer_length");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tap_back_pos", PROPERTY_HINT_RANGE, "0.1,4,0.1"), "set_tap_back_pos", "get_tap_back_pos");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fft_size", PROPERTY_HINT_ENUM, "256,512,1024,2048,4096"), "set_fft_size", "get_fft_size");
 
 	BIND_ENUM_CONSTANT(FFT_SIZE_256);
@@ -278,6 +244,5 @@ void AudioEffectSpectrumAnalyzer::_bind_methods() {
 
 AudioEffectSpectrumAnalyzer::AudioEffectSpectrumAnalyzer() {
 	buffer_length = 2;
-	tapback_pos = 0.01;
 	fft_size = FFT_SIZE_1024;
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes #67650

### Please read the edit below. The original description is a little outdated/inaccurate since I've gotten a better understanding of this issue.

Removes the problematic undocumented variable `tap_back_pos`, and also removes lines of code related to times FFT is performed and attempts to compensate for that.

The original code records the time FFT was performed, to account for latency, I assume. The only thing it did with that data was going back to a previous FFT result (index) if a long time has passed since the last FFT calculation (hence why jittered values are more apparent on higher FFT sizes). During that process, it also made use of `tap_back_pos`, an undocumented variable. Changing the variable, only made the problem worse, as it'd make an original variable `diff` higher, and easier to go back to previous FFT indeces. Because of that, I have removed `tap_back_pos`, and set/get functions related to it.
I believe those pieces of code were performing as expected, but I see no reason to go back to previous FFT indeces. We have no author notes, so much of the work is based on assumptions.

Note: this is my first time trying to contribute. I may have gotten things wrong, so please, let me know if anything is wrong.

**EDIT:** considering that it's hard for audio PRs to be merged, and how sort of niche this issue is, I'll do my best to follow the [PR template](https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html), to properly explain the issue, this PR, and help reviewers:

- **Summary of changes:** This PR mainly removes a code block ([this loop](https://github.com/godotengine/godot/blob/ebbdef7830e9dd0a2c293ef2f951a7a2d3ada14e/servers/audio/effects/audio_effect_spectrum_analyzer.cpp#L169)) that makes `get_magnitude_for_frequency_range()` return magnitudes for older FFT results, after some time since the last time FFT was performed, by subtracting from `fft_index`, used in `fft_history`.
_In case the link is broken, the block is the `while` loop on L169 in `audio_effect_spectrum_analyzer.cpp`, inside `get_magnitude_for_frequency_range()`._

- **Motivation:** I have an audio visualizer made in Godot, and from the beginning, I wanted to have an audio spectrum mode. However, the jittered values made the spectrum behave really badly, even with time smoothing of magnitudes. It does not present the Fourier Transform of the signal in a faithful way.

- **Technical overview:** Because of the behavior described in Summary of changes, the results from `get_magnitude_for_frequency_range()` would appear jittered. Removing that code block makes the return values of that function APPEAR to update slower, but the frequency of FFT calls and execution of that function is the same as before, except that it's not "filling the gaps" with magnitudes from older FFT results that we don't need anymore. That code block depended on two other things: another code block to capture times of FFT calculations, and an undocumented variable (`tap_back_pos`), which would start at a low value, and if increased, would make the issue worse. Those two things have also been removed, since they no longer served a purpose, but because `tap_back_pos` was exposed, I had to create compatibility methods for it.
Notes: we have no author comments for the original code, so some of the work is based on assumptions, especially regarding `tap_back_pos`, a parameter I haven't seen anywhere else, like DAWs and VSTs that work with FFT.
When FFT is performed, the time for that call is captured, which is later compared to the time `get_magnitude_for_frequency_range()` is called. If the difference between both is too large, a condition for a `while` loop, which uses that `diff`, becomes true. In it, `fft_index` is subtracted by 1, and some value is subtracted from `diff`. When `diff` becomes short enough, the condition for the `while` loop becomes false. `tap_back_pos` adds to `diff` before the `while` loop, which is why increasing this value would worsen the problem.

- **Testing:** This PR was tested with the demo project linked by the original poster of the issue this PR fixes, and with an old prototype of my audio visualizer, which has an audio spectrum mode. Both worked correctly, and the spectrum works even better with time smoothing added to magnitude values (this is done in GDScript, not source code). Both projects are in GDScript, and I believe nothing would change in C#, since no matter how often `get_magnitude_for_frequency_range()` is called, FFT calls would have the same frequency, as it's an internal behavior. Also, WASAPI was used.

- **Discussion:** The original code made use of `AudioServer::get_singleton()->get_output_latency()`. To be fair, I still don't know the exact purpose of those blocks, and neither did others. Perhaps a way to compensate for delay? But from what I have seen, everything worked as it was supposed to with that code. I just don't know why it modified `fft_index`. Either way, testing this PR at different latencies, audio drivers and OS should paint a better picture for how this PR affects existing projects. The only things I can say for sure: magnitudes will update less frequently. That can be mitigated by smoothing results over time, for example, decaying magnitude at a fixed rate, until a new magnitude value is higher than the current value post-decay. And also, `set_tap_back_pos` no longer has effect, and getting its value will always return the value `tap_back_pos` was originally initialized at (in C++ code, not in engine, which sets it to 0.1, the minimum allowed).

- **Additional work:** I believe the code works well. However, as I said, it could use further testing in different audio APIs, just to make sure removing `AudioServer::get_singleton()->get_output_latency()` didn't break the method for some users, but I doubt that's the case. Testing this issue in C# could be useful, but I don't think it'd make a difference either. If anything, I think it'd just allow faster FFT calls, if that is dependent on user script. But even with high FPS in GDScript, FFT calls seem to happen in the same frequency.

**Here are demonstrations of the issue, and the result of this pull request:**

**Reference (both with a bit of time smoothing, and bottom one at 2048 FFT size and average mode, which is the same size and mode as the videos underneath):**

https://github.com/user-attachments/assets/a4d35e26-7155-4802-b1c7-e6a6eb5cec5d

**Before (4.6 RC 2, `tap_back_pos = 0.1`, lowest in engine - CW: FLASHING LIGHTS):**

https://github.com/user-attachments/assets/1271dc69-7529-4f90-aaed-15fab3c388a7

**Before (smoothing enabled):**

https://github.com/user-attachments/assets/951a4a08-7f32-43a1-b944-d7c3119a73ec

**After (this PR):**

https://github.com/user-attachments/assets/31da3930-9c3d-418a-88fd-254480265066

**After (smoothing enabled):**

https://github.com/user-attachments/assets/01dfb14c-ceb6-4e1a-8ea0-9addcc8b2b4a

_(Don't mind the quality changes, I had to compress some of the videos)_