### PR TITLE
Fix setting mesh blend shape properties in dummy mesh storage

### DIFF
--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -69,7 +69,11 @@ public:
 	virtual void mesh_initialize(RID p_rid) override;
 	virtual void mesh_free(RID p_rid) override;
 
-	virtual void mesh_set_blend_shape_count(RID p_mesh, int p_blend_shape_count) override {}
+	virtual void mesh_set_blend_shape_count(RID p_mesh, int p_blend_shape_count) override {
+		DummyMesh *m = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_NULL(m);
+		m->blend_shape_count = p_blend_shape_count;
+	}
 	virtual bool mesh_needs_instance(RID p_mesh, bool p_has_skeleton) override { return false; }
 
 	virtual void mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface) override {
@@ -95,10 +99,23 @@ public:
 		m->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MESH);
 	}
 
-	virtual int mesh_get_blend_shape_count(RID p_mesh) const override { return 0; }
+	virtual int mesh_get_blend_shape_count(RID p_mesh) const override {
+		DummyMesh *m = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_NULL_V(m, 0);
+		return m->blend_shape_count;
+	}
 
-	virtual void mesh_set_blend_shape_mode(RID p_mesh, RS::BlendShapeMode p_mode) override {}
-	virtual RS::BlendShapeMode mesh_get_blend_shape_mode(RID p_mesh) const override { return RS::BLEND_SHAPE_MODE_NORMALIZED; }
+	virtual void mesh_set_blend_shape_mode(RID p_mesh, RS::BlendShapeMode p_mode) override {
+		DummyMesh *m = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_NULL(m);
+		m->blend_shape_mode = p_mode;
+	}
+
+	virtual RS::BlendShapeMode mesh_get_blend_shape_mode(RID p_mesh) const override {
+		DummyMesh *m = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_NULL_V(m, RS::BLEND_SHAPE_MODE_NORMALIZED);
+		return m->blend_shape_mode;
+	}
 
 	virtual void mesh_surface_update_vertex_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override {}
 	virtual void mesh_surface_update_attribute_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override {}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

When using the dummy rendering server, `ImporterMesh::add_surface()` fails if the mesh has blend shapes:

```
ERROR: Condition "blend_shape_count != (uint32_t)mesh_get_blend_shape_count(p_mesh)" is true. Returning: Array()
	at: mesh_surface_get_blend_shape_arrays (servers/rendering_server.cpp:1774)
ERROR: Condition "p_blend_shapes.size() != blend_shapes.size()" is true.
	at: add_surface (scene/resources/3d/importer_mesh.cpp:68)
```

This causes various things, like the scene importers, to produce inaccurate scenes when running headless.

This is caused by the dummy mesh storage not actually setting and getting the blend_shape_count/blend_shape_mode. Implementing those fixes the issue.