### PR TITLE
Fix ar version detection for wider set of Binutils authors.

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -535,7 +535,7 @@ def get_ar_version(env):
         print_warning("Couldn't check version of `ar`.")
         return ret
 
-    match = re.search(r"GNU ar(?: \(GNU Binutils\)| version) (\d+)\.(\d+)(?:\.(\d+))?", output)
+    match = re.search(r"GNU ar(?: \((?:GNU )?Binutils[^\)]*\)| version) (\d+)\.(\d+)(?:\.(\d+))?", output)
     if match:
         ret["major"] = int(match[1])
         ret["minor"] = int(match[2])


### PR DESCRIPTION
This PR updates the regex used to extract the version string from the `ar` binutil to be more forgiving of content.

Some authors are more verbose than others in what they put in here (such as their name, or my recent usecase of  `GNU ar (Binutils for MinGW-W64 x86_64)` from the WinLibs tool chain. This will correctly catch the arbitrary string inside the author bracket whilst preserving the version extraction.

This will stop the `Couldn't parse version of 'ar'.` warnings and the resulting loss of detection for "thin mode" support, since it relies on the previous check.