### PR TITLE
Fix `CreateDialog::get_selected_typed()` ignoring the custom types created from `EditorPlugin::add_custom_type()`

### DIFF
--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -620,7 +620,16 @@ String CreateDialog::get_selected_type() {
 	}
 
 	String type = selected->get_text(0).get_slicec(' ', 0);
-	return ClassDB::class_exists(type) ? type : String(selected->get_meta("_script_path", ""));
+	if (ClassDB::class_exists(type)) {
+		return type; // CPP type - from the core or GDExtensions
+	}
+
+	const EditorData::CustomType *custom_type = EditorNode::get_editor_data().get_custom_type_by_name(type);
+	if (custom_type != nullptr) {
+		return custom_type->script->get_path(); // Types via EditorPlugin::add_custom_type()
+	}
+
+	return String(selected->get_meta("_script_path", "")); // Script types
 }
 
 void CreateDialog::set_base_type(const String &p_base) {


### PR DESCRIPTION
Fixes #114349 

Added a middle check for types created from `EditorPlugin.add_custom_type()`, and a continuation optimization will be there soon in a tiny pr for `EditorInterface.popup_create_dialog()` for 4.7.
