### PR TITLE
Add EditorDock's own DockSlot enum

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -88,7 +88,7 @@
 		<member name="closable" type="bool" setter="set_closable" getter="is_closable" default="false">
 			If [code]true[/code], the dock can be closed with the Close button in the context popup. Docks with [member global] enabled are always closable.
 		</member>
-		<member name="default_slot" type="int" setter="set_default_slot" getter="get_default_slot" enum="EditorPlugin.DockSlot" default="-1">
+		<member name="default_slot" type="int" setter="set_default_slot" getter="get_default_slot" enum="EditorDock.DockSlot" default="-1">
 			The default dock slot used when adding the dock with [method EditorPlugin.add_dock].
 			After the dock is added, it can be moved to a different slot and the editor will automatically remember its position between sessions. If you remove and re-add the dock, it will be reset to default.
 		</member>
@@ -139,6 +139,39 @@
 		</constant>
 		<constant name="DOCK_LAYOUT_ALL" value="7" enum="DockLayout" is_bitfield="true">
 			Allows placing the dock in all available slots.
+		</constant>
+		<constant name="DOCK_SLOT_NONE" value="-1" enum="DockSlot">
+			The dock is closed.
+		</constant>
+		<constant name="DOCK_SLOT_LEFT_UL" value="0" enum="DockSlot">
+			Dock slot, left side, upper-left (empty in default layout).
+		</constant>
+		<constant name="DOCK_SLOT_LEFT_BL" value="1" enum="DockSlot">
+			Dock slot, left side, bottom-left (empty in default layout).
+		</constant>
+		<constant name="DOCK_SLOT_LEFT_UR" value="2" enum="DockSlot">
+			Dock slot, left side, upper-right (in default layout includes Scene and Import docks).
+		</constant>
+		<constant name="DOCK_SLOT_LEFT_BR" value="3" enum="DockSlot">
+			Dock slot, left side, bottom-right (in default layout includes FileSystem and History docks).
+		</constant>
+		<constant name="DOCK_SLOT_RIGHT_UL" value="4" enum="DockSlot">
+			Dock slot, right side, upper-left (in default layout includes Inspector, Signal, and Group docks).
+		</constant>
+		<constant name="DOCK_SLOT_RIGHT_BL" value="5" enum="DockSlot">
+			Dock slot, right side, bottom-left (empty in default layout).
+		</constant>
+		<constant name="DOCK_SLOT_RIGHT_UR" value="6" enum="DockSlot">
+			Dock slot, right side, upper-right (empty in default layout).
+		</constant>
+		<constant name="DOCK_SLOT_RIGHT_BR" value="7" enum="DockSlot">
+			Dock slot, right side, bottom-right (empty in default layout).
+		</constant>
+		<constant name="DOCK_SLOT_BOTTOM" value="8" enum="DockSlot">
+			Bottom panel.
+		</constant>
+		<constant name="DOCK_SLOT_MAX" value="9" enum="DockSlot">
+			Represents the size of the [enum DockSlot] enum.
 		</constant>
 	</constants>
 </class>

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -2057,7 +2057,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	set_name(TTRC("Animation"));
 	set_icon_name("Animation");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_animation_bottom_panel", TTRC("Toggle Animation Dock"), KeyModifierMask::ALT | Key::N));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 
 	set_focus_mode(FOCUS_ALL);

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "animation_blend_space_2d_editor.h"
 #include "animation_blend_tree_editor_plugin.h"
 #include "animation_state_machine_editor.h"
+#include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/settings/editor_command_palette.h"
@@ -264,7 +265,7 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	set_name(TTRC("AnimationTree"));
 	set_icon_name("AnimationTreeDock");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_animation_tree_bottom_panel", TTRC("Toggle AnimationTree Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 	set_global(false);
 	set_transient(true);

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1373,7 +1373,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	set_name(TTRC("Audio"));
 	set_icon_name("AudioStreamPlayer");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_audio_bottom_panel", TTRC("Toggle Audio Dock"), KeyModifierMask::ALT | Key::A));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);

--- a/editor/debugger/debugger_editor_plugin.cpp
+++ b/editor/debugger/debugger_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/editor_debugger_server.h"
 #include "editor/debugger/editor_file_server.h"
+#include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
 #include "editor/run/run_instances_dialog.h"
 #include "editor/script/script_editor_plugin.h"

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -34,6 +34,7 @@
 #include "editor/debugger/editor_debugger_plugin.h"
 #include "editor/debugger/editor_debugger_tree.h"
 #include "editor/debugger/script_editor_debugger.h"
+#include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/docks/scene_tree_dock.h"
 #include "editor/editor_log.h"
@@ -65,7 +66,7 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	set_icon_name("Debug");
 	set_layout_key("Debugger");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_debugger_bottom_panel", TTRC("Toggle Debugger Dock"), KeyModifierMask::ALT | Key::D));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL);
 	set_global(false);
 	set_transient(true);

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -34,9 +34,9 @@
 #include "core/io/config_file.h"
 #include "editor/docks/editor_dock_manager.h"
 
-void EditorDock::_set_default_slot_bind(EditorPlugin::DockSlot p_slot) {
-	ERR_FAIL_COND(p_slot < EditorPlugin::DOCK_SLOT_NONE || p_slot >= EditorPlugin::DOCK_SLOT_MAX);
-	default_slot = (DockConstants::DockSlot)p_slot;
+void EditorDock::_set_default_slot_bind(DockSlot p_slot) {
+	ERR_FAIL_COND(p_slot < DOCK_SLOT_NONE || p_slot >= DOCK_SLOT_MAX);
+	default_slot = p_slot;
 }
 
 void EditorDock::_emit_changed() {
@@ -103,6 +103,18 @@ void EditorDock::_bind_methods() {
 	BIND_BITFIELD_FLAG(DOCK_LAYOUT_HORIZONTAL);
 	BIND_BITFIELD_FLAG(DOCK_LAYOUT_FLOATING);
 	BIND_BITFIELD_FLAG(DOCK_LAYOUT_ALL);
+
+	BIND_ENUM_CONSTANT(DOCK_SLOT_NONE);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_UL);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_BL);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_UR);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_LEFT_BR);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_UL);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_BL);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_UR);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_BR);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_BOTTOM);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_MAX);
 
 	GDVIRTUAL_BIND(_update_layout, "layout");
 	GDVIRTUAL_BIND(_save_layout_to_config, "config", "section");
@@ -191,8 +203,8 @@ void EditorDock::set_dock_shortcut(const Ref<Shortcut> &p_shortcut) {
 	_emit_changed();
 }
 
-void EditorDock::set_default_slot(DockConstants::DockSlot p_slot) {
-	ERR_FAIL_INDEX(p_slot, DockConstants::DOCK_SLOT_MAX);
+void EditorDock::set_default_slot(DockSlot p_slot) {
+	ERR_FAIL_INDEX(p_slot, DOCK_SLOT_MAX);
 	default_slot = p_slot;
 }
 

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -30,11 +30,10 @@
 
 #pragma once
 
-#include "editor/docks/editor_dock_manager.h"
-#include "editor/plugins/editor_plugin.h"
+#include "core/io/config_file.h"
+#include "editor/docks/dock_constants.h"
 #include "scene/gui/margin_container.h"
 
-class ConfigFile;
 class Shortcut;
 class WindowWrapper;
 
@@ -49,6 +48,20 @@ public:
 		DOCK_LAYOUT_ALL = DOCK_LAYOUT_VERTICAL | DOCK_LAYOUT_HORIZONTAL | DOCK_LAYOUT_FLOATING,
 	};
 
+	enum DockSlot {
+		DOCK_SLOT_NONE = DockConstants::DOCK_SLOT_NONE,
+		DOCK_SLOT_LEFT_UL = DockConstants::DOCK_SLOT_LEFT_UL,
+		DOCK_SLOT_LEFT_BL = DockConstants::DOCK_SLOT_LEFT_BL,
+		DOCK_SLOT_LEFT_UR = DockConstants::DOCK_SLOT_LEFT_UR,
+		DOCK_SLOT_LEFT_BR = DockConstants::DOCK_SLOT_LEFT_BR,
+		DOCK_SLOT_RIGHT_UL = DockConstants::DOCK_SLOT_RIGHT_UL,
+		DOCK_SLOT_RIGHT_BL = DockConstants::DOCK_SLOT_RIGHT_BL,
+		DOCK_SLOT_RIGHT_UR = DockConstants::DOCK_SLOT_RIGHT_UR,
+		DOCK_SLOT_RIGHT_BR = DockConstants::DOCK_SLOT_RIGHT_BR,
+		DOCK_SLOT_BOTTOM = DockConstants::DOCK_SLOT_BOTTOM,
+		DOCK_SLOT_MAX = DockConstants::DOCK_SLOT_MAX
+	};
+
 private:
 	friend class EditorDockManager;
 	friend class DockContextPopup;
@@ -61,7 +74,7 @@ private:
 	bool force_show_icon = false;
 	Color title_color = Color(0, 0, 0, 0);
 	Ref<Shortcut> shortcut;
-	DockConstants::DockSlot default_slot = DockConstants::DOCK_SLOT_NONE;
+	DockSlot default_slot = DOCK_SLOT_NONE;
 	bool global = true;
 	bool transient = false;
 	bool closable = false;
@@ -74,8 +87,8 @@ private:
 	WindowWrapper *dock_window = nullptr;
 	int dock_slot_index = DockConstants::DOCK_SLOT_NONE;
 
-	void _set_default_slot_bind(EditorPlugin::DockSlot p_slot);
-	EditorPlugin::DockSlot _get_default_slot_bind() const { return (EditorPlugin::DockSlot)default_slot; }
+	void _set_default_slot_bind(DockSlot p_slot);
+	DockSlot _get_default_slot_bind() const { return default_slot; }
 
 	void _emit_changed();
 
@@ -121,8 +134,8 @@ public:
 	void set_dock_shortcut(const Ref<Shortcut> &p_shortcut);
 	Ref<Shortcut> get_dock_shortcut() const { return shortcut; }
 
-	void set_default_slot(DockConstants::DockSlot p_slot);
-	DockConstants::DockSlot get_default_slot() const { return default_slot; }
+	void set_default_slot(DockSlot p_slot);
+	DockSlot get_default_slot() const { return default_slot; }
 
 	void set_available_layouts(BitField<DockLayout> p_layouts) { available_layouts = p_layouts; }
 	BitField<DockLayout> get_available_layouts() const { return available_layouts; }
@@ -136,3 +149,4 @@ public:
 };
 
 VARIANT_BITFIELD_CAST(EditorDock::DockLayout);
+VARIANT_ENUM_CAST(EditorDock::DockSlot);

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -934,7 +934,7 @@ void EditorDockManager::add_dock(EditorDock *p_dock) {
 	p_dock->connect("_tab_style_changed", callable_mp(this, &EditorDockManager::_queue_update_tab_style).bind(p_dock));
 	p_dock->connect("renamed", callable_mp(this, &EditorDockManager::_queue_update_tab_style).bind(p_dock));
 
-	if (p_dock->default_slot != DockConstants::DOCK_SLOT_NONE) {
+	if (p_dock->default_slot != EditorDock::DOCK_SLOT_NONE) {
 		open_dock(p_dock, false);
 	} else {
 		closed_dock_parent->add_child(p_dock);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -4243,7 +4243,7 @@ FileSystemDock::FileSystemDock() {
 	set_name(TTRC("FileSystem"));
 	set_icon_name("Folder");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_filesystem", TTRC("Open FileSystem Dock"), KeyModifierMask::ALT | Key::F));
-	set_default_slot(DockConstants::DOCK_SLOT_LEFT_BR);
+	set_default_slot(EditorDock::DOCK_SLOT_LEFT_BR);
 	set_available_layouts(DOCK_LAYOUT_ALL);
 
 	ProjectSettings::get_singleton()->add_hidden_prefix("file_customization/");

--- a/editor/docks/groups_dock.cpp
+++ b/editor/docks/groups_dock.cpp
@@ -41,7 +41,7 @@ GroupsDock::GroupsDock() {
 	set_name(TTRC("Groups"));
 	set_icon_name("Groups");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_groups", TTRC("Open Groups Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_RIGHT_UL);
+	set_default_slot(EditorDock::DOCK_SLOT_RIGHT_UL);
 
 	groups = memnew(GroupsEditor);
 	groups->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/docks/history_dock.cpp
+++ b/editor/docks/history_dock.cpp
@@ -239,7 +239,7 @@ HistoryDock::HistoryDock() {
 	set_name(TTRC("History"));
 	set_icon_name("History");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_history", TTRC("Open History Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_LEFT_BR);
+	set_default_slot(EditorDock::DOCK_SLOT_LEFT_BR);
 
 	ur_manager = EditorUndoRedoManager::get_singleton();
 	ur_manager->connect("history_changed", callable_mp(this, &HistoryDock::on_history_changed));

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -747,7 +747,7 @@ ImportDock::ImportDock() {
 	set_name(TTRC("Import"));
 	set_icon_name("FileAccess");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_import", TTRC("Open Import Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_LEFT_UR);
+	set_default_slot(EditorDock::DOCK_SLOT_LEFT_UR);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -719,7 +719,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	set_name(TTRC("Inspector"));
 	set_icon_name("AnimationTrackList");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_inspector", TTRC("Open Inspector Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_RIGHT_UL);
+	set_default_slot(EditorDock::DOCK_SLOT_RIGHT_UL);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4777,7 +4777,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	set_name(TTRC("Scene"));
 	set_icon_name("PackedScene");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_scene", TTRC("Open Scene Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_LEFT_UR);
+	set_default_slot(EditorDock::DOCK_SLOT_LEFT_UR);
 
 	singleton = this;
 	editor_data = &p_editor_data;

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -42,7 +42,9 @@ class HBoxContainer;
 class MenuButton;
 class RenameDialog;
 class ReparentDialog;
+class Shader;
 class ShaderCreateDialog;
+class ShaderMaterial;
 class TextureRect;
 class VBoxContainer;
 

--- a/editor/docks/signals_dock.cpp
+++ b/editor/docks/signals_dock.cpp
@@ -46,7 +46,7 @@ SignalsDock::SignalsDock() {
 	set_name(TTRC("Signals"));
 	set_icon_name("Signals");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_signals", TTRC("Open Signals Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_RIGHT_UL);
+	set_default_slot(EditorDock::DOCK_SLOT_RIGHT_UL);
 
 	connections = memnew(ConnectionsDock);
 	connections->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -490,7 +490,7 @@ EditorLog::EditorLog() {
 	set_name(TTRC("Output"));
 	set_icon_name("Output");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_output_bottom_panel", TTRC("Toggle Output Dock"), KeyModifierMask::ALT | Key::O));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 
 	save_state_timer = memnew(Timer);

--- a/editor/gui/credits_roll.cpp
+++ b/editor/gui/credits_roll.cpp
@@ -42,6 +42,7 @@
 #include "scene/gui/color_rect.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
+#include "scene/main/window.h"
 
 Label *CreditsRoll::_create_label(const String &p_with_text, LabelSize p_size) {
 	Label *label = memnew(Label);

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -207,7 +207,7 @@ Button *EditorBottomPanel::add_item(String p_text, Control *p_item, const Ref<Sh
 	dock->set_dock_shortcut(p_shortcut);
 	dock->set_global(false);
 	dock->set_transient(true);
-	dock->set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	dock->set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	dock->set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL);
 	EditorDockManager::get_singleton()->add_dock(dock);
 	bottom_docks.push_back(dock);

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -94,7 +94,7 @@ void EditorPlugin::add_control_to_dock(DockSlot p_slot, Control *p_control, cons
 	EditorDock *dock = memnew(EditorDock);
 	dock->set_title(p_control->get_name());
 	dock->set_dock_shortcut(p_shortcut);
-	dock->set_default_slot((DockConstants::DockSlot)p_slot);
+	dock->set_default_slot((EditorDock::DockSlot)p_slot);
 	dock->add_child(p_control);
 	legacy_docks[p_control] = dock;
 

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/config_file.h"
-#include "editor/docks/editor_dock_manager.h"
+#include "editor/docks/dock_constants.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/gui/control.h"

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -1339,7 +1339,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	polygon_edit->set_name(TTRC("Polygon"));
 	polygon_edit->set_icon_name("PolygonDock");
 	polygon_edit->set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_polygon_2d_bottom_panel", TTRC("Toggle Polygon Dock")));
-	polygon_edit->set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	polygon_edit->set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	polygon_edit->set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 	polygon_edit->set_global(false);
 	polygon_edit->set_transient(true);

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -4449,7 +4449,7 @@ TileMapLayerEditor::TileMapLayerEditor() {
 	set_name(TTRC("TileMap"));
 	set_icon_name("TileMapDock");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_tile_map_bottom_panel", TTRC("Open TileMap Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_ALL);
 	set_global(false);
 	set_transient(true);

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -811,7 +811,7 @@ TileSetEditor::TileSetEditor() {
 	set_name(TTRC("TileSet"));
 	set_icon_name("TileSet");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_tile_set_bottom_panel", TTRC("Open TileSet Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 	set_global(false);
 	set_transient(true);

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -34,6 +34,7 @@
 
 #include "core/os/mutex.h"
 
+#include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -3958,7 +3958,7 @@ ThemeEditor::ThemeEditor() {
 	set_name(TTRC("Theme"));
 	set_icon_name("ThemeDock");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_theme_bottom_panel", TTRC("Toggle Theme Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 	set_global(false);
 	set_transient(true);

--- a/editor/scene/resource_preloader_editor_plugin.cpp
+++ b/editor/scene/resource_preloader_editor_plugin.cpp
@@ -364,7 +364,7 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	set_name(TTRC("ResourcePreloader"));
 	set_icon_name("ResourcePreloader");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_resource_preloader_bottom_panel", TTRC("Toggle ResourcePreloader Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_ALL);
 	set_global(false);
 	set_transient(true);

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -33,6 +33,7 @@
 #include "core/io/resource_loader.h"
 #include "core/os/keyboard.h"
 #include "core/string/translation_server.h"
+#include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/scene_tree_dock.h"
 #include "editor/editor_node.h"
@@ -2121,7 +2122,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	set_name(TTRC("SpriteFrames"));
 	set_icon_name("SpriteFrames");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_sprite_frames_bottom_panel", TTRC("Open SpriteFrames Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 	set_global(false);
 	set_transient(true);

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -1322,7 +1322,7 @@ FindInFilesContainer::FindInFilesContainer() {
 	set_name(TTRC("Search Results"));
 	set_icon_name("Search");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_search_results_bottom_panel", TTRC("Toggle Search Results Bottom Panel")));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 	set_global(false);
 	set_transient(true);

--- a/editor/script/text_editor.cpp
+++ b/editor/script/text_editor.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_node.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/split_container.h"
 
 void TextEditor::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());

--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -860,7 +860,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	shader_dock->set_name(TTRC("Shader Editor"));
 	shader_dock->set_icon_name("ShaderDock");
 	shader_dock->set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_shader_editor_bottom_panel", TTRC("Toggle Shader Editor Dock"), KeyModifierMask::ALT | Key::S));
-	shader_dock->set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	shader_dock->set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	shader_dock->set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 	shader_dock->set_custom_minimum_size(Size2(460, 300) * EDSCALE);
 	EditorDockManager::get_singleton()->add_dock(shader_dock);

--- a/editor/shader/shader_file_editor_plugin.cpp
+++ b/editor/shader/shader_file_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_file_editor_plugin.h"
 
+#include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/settings/editor_command_palette.h"
@@ -248,7 +249,7 @@ ShaderFileEditor::ShaderFileEditor() {
 	set_name(TTRC("ShaderFile"));
 	set_icon_name("RDShaderFile");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_shader_file_bottom_panel", TTRC("Toggle ShaderFile Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_ALL);
 	set_global(false);
 	set_transient(true);

--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -1151,7 +1151,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	version_commit_dock->set_layout_key("VersionCommit");
 	version_commit_dock->set_icon_name("VcsBranches");
 	version_commit_dock->set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_version_control", TTRC("Open Version Control Dock")));
-	version_commit_dock->set_default_slot(DockConstants::DOCK_SLOT_RIGHT_UL);
+	version_commit_dock->set_default_slot(EditorDock::DOCK_SLOT_RIGHT_UL);
 
 	VBoxContainer *dock_vb = memnew(VBoxContainer);
 	version_commit_dock->add_child(dock_vb);

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -204,7 +204,7 @@ namespace GodotTools.Build
         {
             Name = "MSBuild".TTR();
             IconName = "BuildCSharp";
-            DefaultSlot = EditorPlugin.DockSlot.Bottom;
+            DefaultSlot = EditorDock.DockSlot.Bottom;
             AvailableLayouts = DockLayout.Horizontal | DockLayout.Floating;
             Global = false;
             Transient = true;

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -437,7 +437,7 @@ OpenXRActionMapEditor::OpenXRActionMapEditor() {
 	set_name(TTRC("OpenXR Action Map"));
 	set_icon_name("OpenXRActionMap");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_openxr_action_map_bottom_panel", TTRC("Toggle OpenXR Action Map Dock")));
-	set_default_slot(DockConstants::DOCK_SLOT_BOTTOM);
+	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 	set_custom_minimum_size(Size2(0.0, 300.0 * EDSCALE));
 


### PR DESCRIPTION
When EditorDock was added, it was using DockSlot from EditorPlugin. It was done for legacy reasons and to avoid duplicating that enum. However it doesn't really make sense for EditorDock to use enum from EditorPlugin, the old one should just get deprecated.

This PR introduces DockSlot in EditorDock. The `default_slot` property was changed to use this enum (it's a new API in 4.6, so only affects plugins that have upgraded to the new system). Hopefully C++20 will allow to make the enums less duplicated (there is some new enum feature that might make it possible).

I'm also thinking about removing DockConstants. They were added to avoid some cross-includes (I think?), but no such thing exists anymore so it's somewhat redundant.

EDIT:
The PR also has some include-related changes. EditorDock no longer needs to include EditorPlugin, and I also removed EditorDockManager includes from some headers.