### PR TITLE
Support types from `EditorPlugin::add_custom_type()` to work as expected in the callback of `EditorInterface.popup_create_dialog()`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -336,7 +336,7 @@
 			<param index="4" name="type_blocklist" type="StringName[]" default="[]" />
 			<description>
 				Pops up an editor dialog for creating an object.
-				The [param callback] must take a single argument of type [String], which will contain the type name of the selected object (or the script path of the type, if the type is created from a script), or be an empty string if no item is selected.
+				The [param callback] must take a single argument of type [String], which will contain the type name of the selected object (or the script path of the type, if the type is created from a script or registered by [method EditorPlugin.add_custom_type]), or be an empty string if no item is selected.
 				The [param base_type] specifies the base type of objects to display. For example, if you set this to "Resource", all types derived from [Resource] will display in the create dialog.
 				The [param current_type] will be passed in the search box of the create dialog, and the specified type can be immediately selected when the dialog pops up. If the [param current_type] is not derived from [param base_type], there will be no result of the type in the dialog.
 				The [param dialog_title] allows you to define a custom title for the dialog. This is useful if you want to accurately hint the usage of the dialog. If the [param dialog_title] is an empty string, the dialog will use "Create New 'Base Type'" as the default title.

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -633,7 +633,18 @@ void EditorInterface::_create_dialog_item_selected(bool p_is_canceled, const Cal
 	const Callable callback = callable_mp(this, &EditorInterface::_create_dialog_item_selected);
 	create_dialog->disconnect(SNAME("create"), callback);
 	create_dialog->disconnect(SNAME("canceled"), callback);
-	_call_dialog_callback(p_callback, p_is_canceled ? "" : create_dialog->get_selected_type(), "create dialog");
+
+	String result = create_dialog->get_selected_type();
+
+	// Custom types added via EditorPlugin::add_custom_type() returns the class name, so we need to get the script path.
+	if (!ClassDB::class_exists(result)) {
+		const EditorData::CustomType *addon_custom_type = EditorNode::get_editor_data().get_custom_type_by_name(result);
+		if (addon_custom_type) {
+			result = addon_custom_type->script->get_path();
+		}
+	}
+
+	_call_dialog_callback(p_callback, p_is_canceled ? "" : result, "create dialog");
 }
 
 void EditorInterface::_call_dialog_callback(const Callable &p_callback, const Variant &p_selected, const String &p_context) {


### PR DESCRIPTION
Solidifies fixing #114349
Continuation of #114364 

Now, from this pr on, the callback of `EditorInterface.popup_create_dialog` will return the path of the custom type, either registered by `class_name` in GDScript or by `EditorPlugin.add_custom_type()`.