### PR TITLE
Don't navigate to source when clicking on `FindInFilesResultsPanel` replace checkboxes

### DIFF
--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -1052,7 +1052,7 @@ void FindInFilesResultsPanel::_on_result_selected() {
 	TreeItem *item = results_display->get_selected();
 	HashMap<TreeItem *, Result>::Iterator E = result_items.find(item);
 
-	if (!E) {
+	if (!E || (results_display->get_selected_column() == 0 && with_replace)) {
 		return;
 	}
 	Result r = E->value;

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -220,6 +220,7 @@ private:
 	};
 
 	void apply_replaces_in_file(const String &fpath, const Vector<Result> &locations, const String &new_text);
+	void remove_result(TreeItem *p_item);
 	void update_replace_buttons();
 	void update_matches_text();
 	String get_replace_text();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3022,7 +3022,7 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 		switched = true;
 	}
 
-	bool emitted_row = false;
+	bool emitted_row = true;
 
 	for (int i = 0; i < columns.size(); i++) {
 		TreeItem::Cell &c = p_current->cells.write[i];
@@ -3032,6 +3032,10 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 		}
 
 		if (select_mode == SELECT_ROW) {
+			if (&selected_cell == &c) {
+				selected_col = i;
+				emitted_row = false;
+			}
 			if (p_selected == p_current && (!c.selected || allow_reselect)) {
 				c.selected = true;
 				selected_item = p_selected;
@@ -3044,9 +3048,6 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 					// Deselect other rows.
 					c.selected = false;
 				}
-			}
-			if (&selected_cell == &c) {
-				selected_col = i;
 			}
 		} else if (select_mode == SELECT_SINGLE || select_mode == SELECT_MULTI) {
 			if (!r_in_range && &selected_cell == &c) {


### PR DESCRIPTION
- Includes https://github.com/godotengine/godot/pull/114368
  - Resolves https://github.com/godotengine/godot/issues/116318

This PR changes the `FindInFilesResultsPanel` behavior so we don't navigate to a result when the `CheckBox` whether a result should be replaced is clicked. This is very annoying when trying to un-/check shader results which will open the shader editor each time, though this currently does not work (see https://github.com/godotengine/godot/issues/122434).