### PR TITLE
Add floating dock slots

### DIFF
--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -161,10 +161,10 @@ protected:
 	void _update_debug_options();
 
 protected:
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
+
 	void _notification(int p_what);
 	static void _bind_methods();
-
-	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 public:
 	static EditorDebuggerNode *get_singleton() { return singleton; }

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -313,6 +313,8 @@ public:
 		EMBED_NEXT_FRAME,
 	};
 
+	TabContainer *get_tabs() { return tabs; }
+
 	void request_remote_objects(const TypedArray<uint64_t> &p_obj_ids, bool p_update_selection = true);
 	void update_remote_object(ObjectID p_obj_id, const String &p_prop, const Variant &p_value, const String &p_field = "");
 

--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -210,6 +210,7 @@ EditorDockDragHint::EditorDockDragHint() {
 }
 
 void DockTabContainer::_pre_popup(const Size2i &p_size) {
+	dock_context_popup->reparent(get_window());
 	dock_context_popup->set_dock(get_dock(get_current_tab()));
 }
 
@@ -220,6 +221,7 @@ void DockTabContainer::_tab_rmb_clicked(int p_tab_idx) {
 	}
 
 	// Right click context menu.
+	dock_context_popup->reparent(get_window());
 	dock_context_popup->set_dock(hovered_dock);
 	dock_context_popup->set_position(get_tab_bar()->get_screen_position() + get_tab_bar()->get_local_mouse_position());
 	dock_context_popup->popup();
@@ -230,6 +232,10 @@ void DockTabContainer::_notification(int p_what) {
 		connect("pre_popup_pressed", callable_mp(this, &DockTabContainer::_pre_popup).bind(Size2i()));
 		connect("child_order_changed", callable_mp(this, &DockTabContainer::update_visibility));
 	}
+}
+
+void DockTabContainer::dock_focused(EditorDock *p_dock, bool p_was_visible) {
+	get_tab_bar()->grab_focus();
 }
 
 void DockTabContainer::update_visibility() {
@@ -262,7 +268,16 @@ int DockTabContainer::get_margin_drop_slot(int p_margin) const {
 	return -1;
 }
 
-void DockTabContainer::save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) {
+bool DockTabContainer::can_dock_float(EditorDock *p_dock, String &r_float_info) {
+	if (p_dock->get_available_layouts() & EditorDock::DOCK_LAYOUT_FLOATING) {
+		r_float_info = TTRC("Detach this dock to a new window.");
+		return true;
+	}
+	r_float_info = TTRC("This dock does not support floating.");
+	return false;
+}
+
+void DockTabContainer::save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) const {
 	PackedStringArray names;
 	names.reserve_exact(get_tab_count());
 	for (int i = 0; i < get_tab_count(); i++) {
@@ -320,7 +335,7 @@ void DockTabContainer::show_drag_hint() {
 	if (!is_visible_in_tree()) {
 		return;
 	}
-	drag_hint->set_rect(get_global_rect());
+	drag_hint->set_rect(get_drag_hint_rect());
 	drag_hint->show();
 }
 
@@ -333,7 +348,9 @@ Rect2 DockTabContainer::get_default_floating_dock_rect(EditorDock *p_dock) {
 }
 
 DockTabContainer::DockTabContainer(int p_slot) {
-	ERR_FAIL_INDEX(p_slot, EditorDock::DOCK_SLOT_MAX);
+	if (p_slot < EditorDock::DOCK_SLOT_BASE_FLOATING) {
+		ERR_FAIL_INDEX(p_slot, EditorDock::DOCK_SLOT_MAX);
+	}
 	dock_slot = p_slot;
 
 	set_drag_to_rearrange_enabled(true);

--- a/editor/docks/dock_tab_container.h
+++ b/editor/docks/dock_tab_container.h
@@ -76,8 +76,6 @@ public:
 class DockTabContainer : public TabContainer {
 	GDCLASS(DockTabContainer, TabContainer);
 
-	EditorDockDragHint *drag_hint = nullptr;
-
 	HashMap<int, int> valid_drop_margins;
 
 	void _pre_popup(const Size2i &p_size);
@@ -85,6 +83,7 @@ class DockTabContainer : public TabContainer {
 
 protected:
 	DockContextPopup *dock_context_popup = nullptr;
+	EditorDockDragHint *drag_hint = nullptr;
 
 	void _notification(int p_what);
 
@@ -101,18 +100,23 @@ public:
 
 	static String get_config_key(int p_idx) { return "dock_" + itos(p_idx + 1); }
 
+	virtual void dock_added(EditorDock *p_dock) {}
+	virtual void dock_removed(EditorDock *p_dock) {}
 	virtual void dock_closed(EditorDock *p_dock) {}
-	virtual void dock_focused(EditorDock *p_dock, bool p_was_visible) {}
+	virtual void dock_focused(EditorDock *p_dock, bool p_was_visible);
 	virtual void update_visibility();
 	virtual TabStyle get_tab_style() const;
 	virtual bool can_switch_dock() const;
 	virtual Rect2 get_floating_dock_rect(EditorDock *p_dock) { return DockTabContainer::get_default_floating_dock_rect(p_dock); }
+	virtual Rect2 get_drag_hint_rect() const { return get_global_rect(); }
+
+	virtual bool can_dock_float(EditorDock *p_dock, String &r_float_info);
 
 	void add_margin_valid_drop(int p_margin, int p_target_dock_slot);
 	int get_margin_drop_slot(int p_margin) const;
 
 	// There is no equivalent load method, because loading needs to handle floating and closing.
-	void save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section);
+	void save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
 	virtual void load_selected_tab(int p_idx);
 
 	// This method should only be called by EditorDock.

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -278,9 +278,6 @@ void EditorDock::update_tab_style() {
 	if (!enabled || !is_open) {
 		return; // Disabled by feature profile or manually closed by user.
 	}
-	if (dock_window) {
-		return; // Floating.
-	}
 
 	ERR_FAIL_NULL(parent_dock_container);
 

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -61,7 +61,9 @@ public:
 		DOCK_SLOT_BOTTOM,
 		DOCK_SLOT_BOTTOM_L,
 		DOCK_SLOT_BOTTOM_R,
-		DOCK_SLOT_MAX
+		DOCK_SLOT_MAX,
+
+		DOCK_SLOT_BASE_FLOATING = 1000,
 	};
 
 private:
@@ -88,7 +90,6 @@ private:
 	bool is_open = false;
 	bool enabled = true;
 	int previous_tab_index = -1;
-	WindowWrapper *dock_window = nullptr;
 	DockTabContainer *parent_dock_container = nullptr;
 	int dock_slot_index = DOCK_SLOT_NONE;
 

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -33,9 +33,9 @@
 #include "core/object/callable_mp.h"
 #include "editor/docks/dock_tab_container.h"
 #include "editor/docks/editor_dock.h"
+#include "editor/docks/floating_dock_container.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
-#include "editor/gui/window_wrapper.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
@@ -172,6 +172,9 @@ EditorDock *EditorDockManager::_get_dock_tab_dragged() {
 		for (int i = 0; i < EditorDock::DOCK_SLOT_MAX; i++) {
 			dock_slots[i]->show_drag_hint();
 		}
+		for (KeyValue<int, FloatingDockContainer *> &slot : floating_slots) {
+			slot.value->show_drag_hint();
+		}
 
 		return dock_tab_dragged;
 	}
@@ -252,32 +255,75 @@ void EditorDockManager::_docks_menu_option(int p_id) {
 	focus_dock(dock);
 }
 
-void EditorDockManager::_window_close_request(WindowWrapper *p_wrapper) {
-	// Give the dock back to the original owner.
-	EditorDock *dock = _close_window(p_wrapper);
-	ERR_FAIL_COND(!all_docks.has(dock));
-
-	if (dock->dock_slot_index != EditorDock::DOCK_SLOT_NONE) {
-		dock->is_open = false;
-		focus_dock(dock);
-	} else {
-		close_dock(dock);
+void EditorDockManager::_load_docks_in_slot(int p_slot, Ref<ConfigFile> p_layout, const String &p_section, bool p_first_load, const HashMap<String, EditorDock *> &p_dock_map, const Array &p_closed_docks) {
+	const String key = DockTabContainer::get_config_key(p_slot);
+	if (!p_layout->has_section_key(p_section, key)) {
+		return;
 	}
+
+	DockTabContainer *dock_container = _get_dock_slot(p_slot);
+	ERR_FAIL_NULL(dock_container);
+
+	const Vector<String> names = String(p_layout->get_value(p_section, key)).split(",");
+	for (int i = names.size() - 1; i >= 0; i--) {
+		const String &name = names[i];
+		const String section_name = p_section + "/" + name;
+
+		if (!p_dock_map.has(name)) {
+			continue;
+		}
+		EditorDock *dock = p_dock_map[name];
+
+		if (!dock->enabled) {
+			// Don't open disabled docks.
+			dock->load_layout_from_config(p_layout, section_name);
+			continue;
+		}
+
+		if (p_slot >= 0 && !(dock->transient && !dock->is_open)) {
+			// Safe to include transient open docks here because they won't be in the closed dock dump.
+			if (p_closed_docks.has(name)) {
+				dock->is_open = false;
+				dock->hide();
+				_move_dock(dock, closed_dock_parent);
+			} else {
+				dock->is_open = true;
+				_move_dock(dock, dock_container, 0, false);
+			}
+		}
+		dock->load_layout_from_config(p_layout, section_name);
+
+		dock->dock_slot_index = p_slot;
+		dock->previous_tab_index = p_slot >= 0 ? i : 0;
+	}
+	int selected_tab_idx = p_layout->get_value(p_section, key + "_selected_tab_idx", -1);
+	dock_container->load_selected_tab(selected_tab_idx);
 }
 
-EditorDock *EditorDockManager::_close_window(WindowWrapper *p_wrapper) {
-	p_wrapper->set_block_signals(true);
-	EditorDock *dock = Object::cast_to<EditorDock>(p_wrapper->release_wrapped_control());
-	p_wrapper->set_block_signals(false);
-	ERR_FAIL_COND_V(!all_docks.has(dock), nullptr);
-
-	dock->dock_window = nullptr;
-	dock_windows.erase(p_wrapper);
-	p_wrapper->queue_free();
-	return dock;
+FloatingDockContainer *EditorDockManager::_create_floating_dock_slot(const Vector2i &p_position, const Vector2i &p_size, int p_idx) {
+	if (p_idx == -1) {
+		bool added = false;
+		for (int i = EditorDock::DOCK_SLOT_BASE_FLOATING; i < EditorDock::DOCK_SLOT_BASE_FLOATING + 1000; i++) {
+			if (!floating_slots.has(i)) {
+				p_idx = i;
+				added = true;
+				break;
+			}
+		}
+		ERR_FAIL_COND_V_MSG(!added, nullptr, "No space found for floating dock slot.");
+	}
+	FloatingDockContainer *floating_container = memnew(FloatingDockContainer(p_idx));
+	floating_container->window->set_position(p_position);
+	floating_container->window->set_size(p_size);
+	if (EDITOR_GET("interface/multi_window/maximize_window").operator bool()) {
+		floating_container->window->set_mode(Window::MODE_MAXIMIZED);
+	}
+	_register_floating_dock_slot(floating_container);
+	floating_container->show();
+	return floating_container;
 }
 
-void EditorDockManager::_open_dock_in_window(EditorDock *p_dock, bool p_show_window, bool p_reset_size) {
+void EditorDockManager::_open_dock_in_window(EditorDock *p_dock) {
 	ERR_FAIL_NULL(p_dock);
 
 	DockTabContainer *parent_container = p_dock->get_parent_container();
@@ -287,46 +333,21 @@ void EditorDockManager::_open_dock_in_window(EditorDock *p_dock, bool p_show_win
 	Size2 dock_size = floating_rect.size;
 	Point2 dock_screen_pos = floating_rect.position;
 
-	WindowWrapper *wrapper = memnew(WindowWrapper);
-	wrapper->set_window_title(vformat(TTR("%s - Godot Engine"), TTR(p_dock->get_display_title())));
-	wrapper->set_margins_enabled(true);
+	Window *current_window = p_dock->get_window();
+	FloatingDockContainer *floating_container;
+	if (current_window != EditorNode::get_singleton()->get_window()) {
+		// The dock is already floating, so copy the current window's rect.
+		floating_container = _create_floating_dock_slot(current_window->get_position(), current_window->get_size());
+	} else {
+		floating_container = _create_floating_dock_slot(dock_screen_pos, dock_size);
+	}
+	_move_dock(p_dock, floating_container);
 
-	EditorNode::get_singleton()->get_gui_base()->add_child(wrapper);
-
-	_move_dock(p_dock, nullptr);
-	p_dock->update_layout(EditorDock::DOCK_LAYOUT_FLOATING, EditorDock::DOCK_SLOT_NONE);
-	p_dock->current_layout = EditorDock::DOCK_LAYOUT_FLOATING;
-	wrapper->set_wrapped_control(p_dock);
-
-	p_dock->dock_window = wrapper;
 	p_dock->is_open = true;
 	p_dock->show();
 
-	wrapper->connect("window_close_requested", callable_mp(this, &EditorDockManager::_window_close_request).bind(wrapper));
-	dock_windows.push_back(wrapper);
-
-	if (p_show_window) {
-		wrapper->restore_window(Rect2i(dock_screen_pos, dock_size), EditorNode::get_singleton()->get_gui_base()->get_window()->get_current_screen());
-		_update_layout();
-		if (p_reset_size) {
-			// Use a default size of one third the current window size.
-			Size2i popup_size = EditorNode::get_singleton()->get_window()->get_size() / 3.0;
-			p_dock->get_window()->set_size(popup_size);
-			p_dock->get_window()->move_to_center();
-		}
-		p_dock->get_window()->grab_focus();
-	}
-}
-
-void EditorDockManager::_restore_dock_to_saved_window(EditorDock *p_dock, const Dictionary &p_window_dump) {
-	if (!p_dock->dock_window) {
-		_open_dock_in_window(p_dock, false);
-	}
-
-	p_dock->dock_window->restore_window_from_saved_position(
-			p_window_dump.get("window_rect", Rect2i()),
-			p_window_dump.get("window_screen", -1),
-			p_window_dump.get("window_screen_rect", Rect2i()));
+	_update_layout();
+	p_dock->get_window()->grab_focus();
 }
 
 void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_tab_index, bool p_set_current) {
@@ -342,25 +363,32 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 		return;
 	}
 
+	DockTabContainer *dock_tab_container = Object::cast_to<DockTabContainer>(p_target);
+
 	// Remove dock from its existing parent.
 	if (parent) {
-		if (p_dock->dock_window) {
-			_close_window(p_dock->dock_window);
-		} else {
-			DockTabContainer *parent_tabs = Object::cast_to<DockTabContainer>(parent);
-			if (parent_tabs) {
-				p_dock->previous_tab_index = parent_tabs->get_tab_idx_from_control(p_dock);
+		DockTabContainer *parent_tabs = Object::cast_to<DockTabContainer>(parent);
+		if (parent_tabs) {
+			p_dock->previous_tab_index = parent_tabs->get_tab_idx_from_control(p_dock);
 
-				// Swap to previous tab when closing current tab.
-				if (parent_tabs->get_current_tab() == p_dock->previous_tab_index && parent_tabs->get_previous_tab() != -1) {
-					parent_tabs->set_current_tab(parent_tabs->get_previous_tab());
-				}
+			// Swap to previous tab when closing current tab.
+			if (parent_tabs->get_current_tab() == p_dock->previous_tab_index && parent_tabs->get_previous_tab() != -1) {
+				parent_tabs->set_current_tab(parent_tabs->get_previous_tab());
 			}
-			parent->set_block_signals(true);
-			parent->remove_child(p_dock);
-			parent->set_block_signals(false);
-			if (parent_tabs) {
-				parent_tabs->update_visibility();
+		}
+		parent->set_block_signals(true);
+		parent->remove_child(p_dock);
+		parent->set_block_signals(false);
+		if (parent_tabs) {
+			parent_tabs->update_visibility();
+			if (p_target != closed_dock_parent) {
+				parent_tabs->dock_removed(p_dock);
+			}
+		} else if (p_target != closed_dock_parent && p_dock->dock_slot_index > -1) {
+			parent_tabs = _get_dock_slot(p_dock->dock_slot_index);
+			if (parent_tabs && (!dock_tab_container || parent_tabs != dock_tab_container)) {
+				// Closed dock moved to another dock (likely result of layout change). Notify previous owner.
+				parent_tabs->dock_removed(p_dock);
 			}
 		}
 	}
@@ -373,7 +401,6 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 	// Prevent extra visibility signals from firing.
 	p_dock->hide();
 
-	DockTabContainer *dock_tab_container = Object::cast_to<DockTabContainer>(p_target);
 	if (p_target != closed_dock_parent && (dock_tab_container->layout != p_dock->current_layout || dock_tab_container->dock_slot != p_dock->dock_slot_index)) {
 		p_dock->update_layout(dock_tab_container->layout, dock_tab_container->dock_slot);
 		p_dock->current_layout = dock_tab_container->layout;
@@ -386,6 +413,7 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 	p_target->set_block_signals(false);
 
 	if (dock_tab_container) {
+		dock_tab_container->dock_added(p_dock);
 		if (dock_tab_container->is_inside_tree()) {
 			p_dock->update_tab_style();
 		}
@@ -394,6 +422,16 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 		}
 		dock_tab_container->update_visibility();
 	}
+}
+
+DockTabContainer *EditorDockManager::_get_dock_slot(int p_idx) {
+	if (p_idx >= EditorDock::DOCK_SLOT_BASE_FLOATING) {
+		FloatingDockContainer **floatainer = floating_slots.getptr(p_idx);
+		ERR_FAIL_NULL_V_MSG(floatainer, nullptr, vformat("No floating dock slot with index %d.", p_idx));
+		return *floatainer;
+	}
+	ERR_FAIL_INDEX_V(p_idx, EditorDock::DOCK_SLOT_MAX, nullptr);
+	return dock_slots[p_idx];
 }
 
 void EditorDockManager::_queue_update_tab_style(EditorDock *p_dock) {
@@ -416,49 +454,46 @@ void EditorDockManager::_update_dirty_dock_tabs() {
 	}
 }
 
+void EditorDockManager::_register_floating_dock_slot(FloatingDockContainer *p_tab_container) {
+	ERR_FAIL_NULL(p_tab_container);
+	floating_slots[p_tab_container->dock_slot] = p_tab_container;
+	EditorNode::get_singleton()->get_gui_base()->add_child(p_tab_container->window);
+
+	p_tab_container->set_dock_context_popup(dock_context_popup);
+	p_tab_container->connect("tab_changed", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
+	p_tab_container->connect("active_tab_rearranged", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
+	p_tab_container->window->connect("close_requested", callable_mp(this, &EditorDockManager::_close_floating_dock_slot).bind(p_tab_container));
+}
+
+void EditorDockManager::_close_floating_dock_slot(FloatingDockContainer *p_tab_container) {
+	int dock_count = p_tab_container->get_tab_count();
+	for (int i = dock_count - 1; i >= 0; i--) {
+		EditorDock *dock = p_tab_container->get_dock(i);
+		if (dock->global || dock->closable || dock->default_slot == EditorDock::DOCK_SLOT_NONE) {
+			close_dock(dock);
+		} else {
+			_move_dock(dock, dock_slots[dock->default_slot]);
+		}
+	}
+}
+
 void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) const {
+	// Get rid of potentially invalid data.
+	p_layout->erase_section(p_section);
+
 	// Save docks by dock slot.
 	for (int i = 0; i < EditorDock::DOCK_SLOT_MAX; i++) {
 		dock_slots[i]->save_docks_to_config(p_layout, p_section);
 	}
-
-	// Clear the special dock slot for docks without default slots (index -1 = dock_0).
-	// This prevents closed docks from being infinitely appended to the config on each save.
-	const String no_slot_config_key = "dock_0";
-	if (p_layout->has_section_key(p_section, no_slot_config_key)) {
-		p_layout->erase_section_key(p_section, no_slot_config_key);
+	for (const KeyValue<int, FloatingDockContainer *> &slot : floating_slots) {
+		slot.value->save_docks_to_config(p_layout, p_section);
 	}
 
-	// Save docks in windows.
-	Dictionary floating_docks_dump;
-	for (WindowWrapper *wrapper : dock_windows) {
-		EditorDock *dock = Object::cast_to<EditorDock>(wrapper->get_wrapped_control());
-
-		Dictionary window_dump;
-		window_dump["window_rect"] = wrapper->get_window_rect();
-
-		int screen = wrapper->get_window_screen();
-		window_dump["window_screen"] = wrapper->get_window_screen();
-		window_dump["window_screen_rect"] = DisplayServer::get_singleton()->screen_get_usable_rect(screen);
-
-		String name = dock->get_effective_layout_key();
-		if (!dock->transient) {
-			floating_docks_dump[name] = window_dump;
-		}
-
-		// Append to regular dock section so we know where to restore it to.
-		int dock_slot_id = dock->dock_slot_index;
-		String config_key = DockTabContainer::get_config_key(dock_slot_id);
-
-		String names = p_layout->get_value(p_section, config_key, "");
-		if (names.is_empty()) {
-			names = name;
-		} else {
-			names += "," + name;
-		}
-		p_layout->set_value(p_section, config_key, names);
+	// Save floating dock containers.
+	for (const KeyValue<int, FloatingDockContainer *> slot : floating_slots) {
+		const String config_key = "floating_" + DockTabContainer::get_config_key(slot.key);
+		p_layout->set_value(p_section, config_key, slot.value->get_window_layout());
 	}
-	p_layout->set_value(p_section, "dock_floating", floating_docks_dump);
 
 	Array closed_docks_dump;
 	for (const EditorDock *dock : all_docks) {
@@ -526,10 +561,20 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 }
 
 void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section, bool p_first_load) {
-	Dictionary floating_docks_dump = p_layout->get_value(p_section, "dock_floating", Dictionary());
 	Array closed_docks = p_layout->get_value(p_section, "dock_closed", Array());
 
 	bool allow_floating_docks = EditorNode::get_singleton()->is_multi_window_enabled() && (!p_first_load || EDITOR_GET("interface/multi_window/restore_windows_on_load"));
+	if (allow_floating_docks) {
+		const PackedStringArray keys = p_layout->get_section_keys(p_section);
+		for (const String &key : keys) {
+			if (!key.begins_with("floating_dock")) {
+				continue;
+			}
+			int idx = key.trim_prefix("floating_dock_").to_int() - 1; // Slots stored in layout have index + 1.
+			const Rect2i window_rect = FloatingDockContainer::get_window_rect_from_layout(p_layout->get_value(p_section, key));
+			_create_floating_dock_slot(window_rect.position, window_rect.size, idx);
+		}
+	}
 
 	// Store the docks by name for easy lookup.
 	HashMap<String, EditorDock *> dock_map;
@@ -539,51 +584,10 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 
 	// Load docks by slot. Index -1 is for docks that have no slot.
 	for (int i = -1; i < EditorDock::DOCK_SLOT_MAX; i++) {
-		const String key = DockTabContainer::get_config_key(i);
-		if (!p_layout->has_section_key(p_section, key)) {
-			continue;
-		}
-
-		Vector<String> names = String(p_layout->get_value(p_section, key)).split(",");
-		for (int j = names.size() - 1; j >= 0; j--) {
-			const String &name = names[j];
-			const String section_name = p_section + "/" + name;
-
-			if (!dock_map.has(name)) {
-				continue;
-			}
-			EditorDock *dock = dock_map[name];
-
-			if (!dock->enabled) {
-				// Don't open disabled docks.
-				dock->load_layout_from_config(p_layout, section_name);
-				continue;
-			}
-
-			if (allow_floating_docks && floating_docks_dump.has(name)) {
-				_restore_dock_to_saved_window(dock, floating_docks_dump[name]);
-			} else if (i >= 0 && !(dock->transient && !dock->is_open)) {
-				// Safe to include transient open docks here because they won't be in the closed dock dump.
-				if (closed_docks.has(name)) {
-					dock->is_open = false;
-					dock->hide();
-					_move_dock(dock, closed_dock_parent);
-				} else {
-					dock->is_open = true;
-					_move_dock(dock, dock_slots[i], 0, false);
-				}
-			}
-			dock->load_layout_from_config(p_layout, section_name);
-
-			dock->dock_slot_index = i;
-			dock->previous_tab_index = i >= 0 ? j : 0;
-		}
+		_load_docks_in_slot(i, p_layout, p_section, p_first_load, dock_map, closed_docks);
 	}
-
-	// Set the selected tabs.
-	for (int i = 0; i < EditorDock::DOCK_SLOT_MAX; i++) {
-		int selected_tab_idx = p_layout->get_value(p_section, DockTabContainer::get_config_key(i) + "_selected_tab_idx", -1);
-		dock_slots[i]->load_selected_tab(selected_tab_idx);
+	for (const KeyValue<int, FloatingDockContainer *> slot : floating_slots) {
+		_load_docks_in_slot(slot.key, p_layout, p_section, p_first_load, dock_map, closed_docks);
 	}
 
 	// Load SplitContainer offsets.
@@ -681,7 +685,7 @@ void EditorDockManager::open_dock(EditorDock *p_dock, bool p_set_current) {
 
 	// Open dock to its previous location.
 	if (p_dock->dock_slot_index != EditorDock::DOCK_SLOT_NONE) {
-		DockTabContainer *slot = dock_slots[p_dock->dock_slot_index];
+		DockTabContainer *slot = _get_dock_slot(p_dock->dock_slot_index);
 		int tab_index = p_dock->previous_tab_index;
 		if (tab_index < 0) {
 			tab_index = slot->get_tab_count();
@@ -689,7 +693,7 @@ void EditorDockManager::open_dock(EditorDock *p_dock, bool p_set_current) {
 
 		_move_dock(p_dock, slot, tab_index, p_set_current && slot->can_switch_dock());
 	} else {
-		_open_dock_in_window(p_dock, true, true);
+		_open_dock_in_window(p_dock);
 		return;
 	}
 
@@ -700,26 +704,13 @@ void EditorDockManager::make_dock_floating(EditorDock *p_dock) {
 	ERR_FAIL_NULL(p_dock);
 	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot make unknown dock '%s' floating.", p_dock->get_display_title()));
 
-	if (!p_dock->dock_window) {
-		_open_dock_in_window(p_dock);
-	}
+	_open_dock_in_window(p_dock);
 }
 
 void EditorDockManager::_make_dock_visible(EditorDock *p_dock, bool p_grab_focus) {
-	if (p_dock->dock_window) {
-		if (p_grab_focus) {
-			p_dock->get_window()->grab_focus();
-		}
-		return;
-	}
-
 	DockTabContainer *tab_container = p_dock->get_parent_container();
 	if (!tab_container || !tab_container->can_switch_dock()) {
 		return;
-	}
-
-	if (p_grab_focus) {
-		tab_container->get_tab_bar()->grab_focus();
 	}
 
 	if (!p_dock->is_visible_in_tree()) {
@@ -736,12 +727,17 @@ void EditorDockManager::focus_dock(EditorDock *p_dock) {
 		return;
 	}
 
+	bool was_visible = p_dock->is_visible();
 	if (!p_dock->is_open) {
 		p_dock->emit_signal("opened");
 		open_dock(p_dock, false);
 	}
 
 	_make_dock_visible(p_dock, true);
+
+	DockTabContainer *tab_container = p_dock->get_parent_container();
+	ERR_FAIL_NULL(tab_container);
+	tab_container->dock_focused(p_dock, was_visible);
 }
 
 void EditorDockManager::add_dock(EditorDock *p_dock) {
@@ -819,6 +815,16 @@ void EditorDockManager::register_dock_slot(DockTabContainer *p_tab_container) {
 	p_tab_container->set_dock_context_popup(dock_context_popup);
 	p_tab_container->connect("tab_changed", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
 	p_tab_container->connect("active_tab_rearranged", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
+}
+
+void EditorDockManager::destroy_floating_slot(FloatingDockContainer *p_tab_container) {
+	if (p_tab_container->window->is_ancestor_of(dock_context_popup)) {
+		dock_context_popup->reparent(EditorNode::get_singleton()->get_window());
+	}
+	_close_floating_dock_slot(p_tab_container);
+	floating_slots.erase(p_tab_container->dock_slot);
+	p_tab_container->window->queue_free();
+	EditorNode::get_singleton()->save_editor_layout_delayed();
 }
 
 int EditorDockManager::get_vsplit_count() const {
@@ -924,13 +930,9 @@ void DockContextPopup::_update_buttons() {
 		close_button->set_disabled(true);
 	}
 	if (EditorNode::get_singleton()->is_multi_window_enabled()) {
-		if (!(context_dock->available_layouts & EditorDock::DOCK_LAYOUT_FLOATING)) {
-			make_float_button->set_tooltip_text(TTRC("This dock does not support floating."));
-			make_float_button->set_disabled(true);
-		} else {
-			make_float_button->set_tooltip_text(TTRC("Make this dock floating."));
-			make_float_button->set_disabled(false);
-		}
+		String tooltip;
+		make_float_button->set_disabled(!context_dock->get_parent_container()->can_dock_float(context_dock, tooltip));
+		make_float_button->set_tooltip_text(tooltip);
 	}
 
 	// Update tab move buttons.
@@ -996,7 +998,7 @@ DockContextPopup::DockContextPopup() {
 	dock_select_popup_vb->add_child(separator);
 
 	make_float_button = memnew(Button);
-	make_float_button->set_text(TTRC("Make Floating"));
+	make_float_button->set_text(TTRC("Detach Window"));
 	if (!EditorNode::get_singleton()->is_multi_window_enabled()) {
 		make_float_button->set_disabled(true);
 		make_float_button->set_tooltip_text(EditorNode::get_singleton()->get_multiwindow_support_tooltip_text());
@@ -1022,13 +1024,8 @@ void DockShortcutHandler::shortcut_input(const Ref<InputEvent> &p_event) {
 	for (EditorDock *dock : EditorDockManager::get_singleton()->all_docks) {
 		const Ref<Shortcut> &dock_shortcut = dock->get_dock_shortcut();
 		if (dock_shortcut.is_valid() && dock_shortcut->matches_event(p_event)) {
-			bool was_visible = dock->is_visible();
 			if (!dock->transient || dock->is_open) {
 				EditorDockManager::get_singleton()->focus_dock(dock);
-			}
-			DockTabContainer *dock_container = dock->get_parent_container();
-			if (dock_container) {
-				dock_container->dock_focused(dock, was_visible);
 			}
 			get_viewport()->set_input_as_handled();
 			break;

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -38,11 +38,11 @@ class Button;
 class ConfigFile;
 class Control;
 class EditorDock;
+class FloatingDockContainer;
 class PopupMenu;
 class TabBar;
 class TabContainer;
 class VBoxContainer;
-class WindowWrapper;
 class StyleBoxFlat;
 
 class DockSplitContainer : public SplitContainer {
@@ -96,7 +96,7 @@ private:
 	DockSplitContainer *bottom_hsplit = nullptr;
 
 	DockTabContainer *dock_slots[EditorDock::DOCK_SLOT_MAX];
-	Vector<WindowWrapper *> dock_windows;
+	HashMap<int, FloatingDockContainer *> floating_slots;
 	LocalVector<EditorDock *> all_docks;
 	HashSet<EditorDock *> dirty_docks;
 
@@ -115,18 +115,20 @@ private:
 
 	void _docks_menu_option(int p_id);
 
-	void _window_close_request(WindowWrapper *p_wrapper);
-	EditorDock *_close_window(WindowWrapper *p_wrapper);
-	void _open_dock_in_window(EditorDock *p_dock, bool p_show_window = true, bool p_reset_size = false);
-	void _restore_dock_to_saved_window(EditorDock *p_dock, const Dictionary &p_window_dump);
+	void _load_docks_in_slot(int p_slot, Ref<ConfigFile> p_layout, const String &p_section, bool p_first_load, const HashMap<String, EditorDock *> &p_dock_map, const Array &p_closed_docks);
+	FloatingDockContainer *_create_floating_dock_slot(const Vector2i &p_position, const Vector2i &p_size, int p_idx = -1);
+	void _open_dock_in_window(EditorDock *p_dock);
 
 	void _make_dock_visible(EditorDock *p_dock, bool p_grab_focus);
 	void _move_dock(EditorDock *p_dock, Control *p_target, int p_tab_index = -1, bool p_set_current = true);
+	DockTabContainer *_get_dock_slot(int p_idx);
 
 	void _queue_update_tab_style(EditorDock *p_dock);
 	void _update_dirty_dock_tabs();
 
 	void _register_split(DockSplitContainer **p_var, DockSplitContainer *p_split);
+	void _register_floating_dock_slot(FloatingDockContainer *p_tab_container);
+	void _close_floating_dock_slot(FloatingDockContainer *p_tab_container);
 
 public:
 	static EditorDockManager *get_singleton() { return singleton; }
@@ -142,6 +144,7 @@ public:
 	void set_main_hsplit(DockSplitContainer *p_split) { _register_split(&main_hsplit, p_split); }
 	void set_bottom_hsplit(DockSplitContainer *p_split) { _register_split(&bottom_hsplit, p_split); }
 	void register_dock_slot(DockTabContainer *p_tab_container);
+	void destroy_floating_slot(FloatingDockContainer *p_tab_container);
 	int get_vsplit_count() const;
 	PopupMenu *get_docks_menu();
 

--- a/editor/docks/floating_dock_container.cpp
+++ b/editor/docks/floating_dock_container.cpp
@@ -1,0 +1,154 @@
+/**************************************************************************/
+/*  floating_dock_container.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "floating_dock_container.h"
+
+#include "core/object/callable_mp.h"
+#include "editor/docks/editor_dock_manager.h"
+#include "editor/editor_node.h"
+#include "editor/themes/editor_scale.h"
+#include "servers/display/display_server.h"
+
+void FloatingDockContainer::_update_window_title() {
+	EditorDock *current_dock = get_dock(get_current_tab());
+	if (current_dock) {
+		window->set_title(vformat(TTR("%s - Godot Engine"), TTR(current_dock->get_display_title())));
+	}
+}
+
+void FloatingDockContainer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+			window->add_child(this);
+			drag_hint->reparent(window);
+			connect("tab_changed", callable_mp(this, &FloatingDockContainer::_update_window_title).unbind(1));
+		} break;
+
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			_update_window_title();
+		} break;
+	}
+}
+
+void FloatingDockContainer::dock_added(EditorDock *p_dock) {
+	owned_docks.insert(p_dock);
+	if (owned_docks.size() == 1) {
+		_update_window_title();
+	}
+}
+
+void FloatingDockContainer::dock_removed(EditorDock *p_dock) {
+	owned_docks.erase(p_dock);
+	if (owned_docks.is_empty()) {
+		EditorDockManager::get_singleton()->destroy_floating_slot(this);
+	}
+}
+
+void FloatingDockContainer::dock_focused(EditorDock *p_dock, bool p_was_visible) {
+	get_window()->grab_focus();
+	get_tab_bar()->grab_focus();
+}
+
+void FloatingDockContainer::update_visibility() {
+	window->set_visible(get_tab_count() > 0);
+}
+
+Rect2 FloatingDockContainer::get_drag_hint_rect() const {
+	return DockTabContainer::get_drag_hint_rect().grow(-2 * EDSCALE);
+}
+
+bool FloatingDockContainer::can_dock_float(EditorDock *p_dock, String &r_float_info) {
+	if (owned_docks.size() == 1) {
+		r_float_info = TTRC("Can't detach a single floating dock.");
+		return false;
+	}
+	return DockTabContainer::can_dock_float(p_dock, r_float_info);
+}
+
+void FloatingDockContainer::add_child_notify(Node *p_child) {
+	DockTabContainer::add_child_notify(p_child);
+	callable_mp(this, &FloatingDockContainer::_update_window_title).call_deferred();
+}
+
+Dictionary FloatingDockContainer::get_window_layout() const {
+	Dictionary window_layout;
+	window_layout["window_rect"] = Rect2i(window->get_position(), window->get_size());
+	window_layout["screen_idx"] = window->get_current_screen();
+	window_layout["screen_rect"] = DisplayServer::get_singleton()->screen_get_usable_rect(window->get_current_screen());
+	return window_layout;
+}
+
+Rect2i FloatingDockContainer::get_window_rect_from_layout(const Dictionary &p_layout) {
+	Rect2i window_rect = p_layout.get("window_rect", Rect2i());
+	int screen = p_layout.get("screen_idx", -1);
+	Rect2i restored_screen_rect = p_layout.get("screen_rect", Rect2i());
+
+	if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_SELF_FITTING_WINDOWS)) {
+		window_rect = Rect2i();
+		restored_screen_rect = Rect2i();
+	}
+
+	if (screen < 0 || screen >= DisplayServer::get_singleton()->get_screen_count()) {
+		// Fallback to the main window screen if the saved screen is not available.
+		screen = EditorNode::get_singleton()->get_window()->get_current_screen();
+	}
+
+	Rect2i real_screen_rect = DisplayServer::get_singleton()->screen_get_usable_rect(screen);
+	if (restored_screen_rect == Rect2i()) {
+		// Fallback to the target screen rect.
+		restored_screen_rect = real_screen_rect;
+	}
+
+	if (window_rect == Rect2i()) {
+		// Fallback to a standard rect.
+		window_rect = Rect2i(restored_screen_rect.position + restored_screen_rect.size / 4, restored_screen_rect.size / 2);
+	}
+
+	// Adjust the window rect size in case the resolution changes.
+	Vector2 screen_ratio = Vector2(real_screen_rect.size) / Vector2(restored_screen_rect.size);
+
+	// The screen positioning may change, so remove the original screen position.
+	window_rect.position -= restored_screen_rect.position;
+	window_rect = Rect2i(window_rect.position * screen_ratio, window_rect.size * screen_ratio);
+	window_rect.position += real_screen_rect.position;
+
+	return Rect2i(window_rect.position, window_rect.size);
+}
+
+FloatingDockContainer::FloatingDockContainer(int p_slot) :
+		DockTabContainer(p_slot) {
+	layout = EditorDock::DOCK_LAYOUT_FLOATING;
+
+	window = memnew(Window);
+	window->set_wrap_controls(true);
+	window->set_propagate_shortcuts_to_parent(true);
+	window->hide();
+}

--- a/editor/docks/floating_dock_container.h
+++ b/editor/docks/floating_dock_container.h
@@ -1,0 +1,63 @@
+/**************************************************************************/
+/*  floating_dock_container.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/docks/dock_tab_container.h"
+
+class FloatingDockContainer : public DockTabContainer {
+	GDCLASS(FloatingDockContainer, DockTabContainer);
+
+	friend class EditorDockManager;
+
+	Window *window = nullptr;
+	HashSet<EditorDock *> owned_docks;
+
+	void _update_window_title();
+
+protected:
+	void _notification(int p_what);
+
+	virtual void dock_added(EditorDock *p_dock) override;
+	virtual void dock_removed(EditorDock *p_dock) override;
+	virtual void dock_focused(EditorDock *p_dock, bool p_was_visible) override;
+	virtual void update_visibility() override;
+	virtual Rect2 get_drag_hint_rect() const override;
+
+	virtual bool can_dock_float(EditorDock *p_dock, String &r_float_info) override;
+
+	virtual void add_child_notify(Node *p_child) override;
+
+public:
+	Dictionary get_window_layout() const;
+	static Rect2i get_window_rect_from_layout(const Dictionary &p_layout);
+
+	FloatingDockContainer(int p_slot);
+};

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -128,6 +128,8 @@ void EditorBottomPanel::dock_closed(EditorDock *p_dock) {
 void EditorBottomPanel::dock_focused(EditorDock *p_dock, bool p_was_visible) {
 	if (p_was_visible && p_dock->is_visible()) {
 		hide_bottom_panel();
+	} else {
+		get_tab_bar()->grab_focus();
 	}
 }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/b7045ee8-d7a9-4c6c-80eb-0162fbd6cd8c

This PR reworks the floating docks. The concept of "floating dock" is removed, instead making a dock floating will create a floating dock slot. You can move docks in and out of floating slots, just like with side docks and bottom panel. When closing a floating dock slot, instead of restoring docks to the previous position, it will close the docks instead. Re-opening the docks will re-open them in window. To fully get rid of a floating dock slot, all docks have to be moved to another slot.

Closes https://github.com/godotengine/godot-proposals/issues/1984
Also fixes #113259 and supersedes #113579