### PR TITLE
Android editor: Fix AAB file not copied to export path

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -282,7 +282,7 @@ task copyAndRenameBinary(type: Copy) {
         filenameSuffix = isAab ? "${exportEdition}-${exportBuildType}" : "${exportEdition}${exportBuildTypeCapitalized}"
     }
 
-    String sourceFilename = isAab ? "build-${filenameSuffix}.aab" : "android_${filenameSuffix}.apk"
+    String sourceFilename = isAab ? "${project.name}-${filenameSuffix}.aab" : "android_${filenameSuffix}.apk"
     String sourceFilepath = isAab ? "$buildDir/outputs/bundle/${exportEdition}${exportBuildTypeCapitalized}/$sourceFilename" : "$buildDir/outputs/apk/$exportEdition/$exportBuildType/$sourceFilename"
 
     from sourceFilepath


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/114379

It was previously hardcoded to look for something like `build-standard-debug.aab`, but the archive generated by GABE is named `project-standard-debug.aab`.
This PR updates the logic to use `project.name` instead of a hardcoded `build` prefix.
