### PR TITLE
Fix `Input.is_action_just_pressed_by_event` / `Input.is_action_just_released_by_event` not working for `InputEventMouseButton`

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -432,7 +432,7 @@ bool Input::is_action_just_pressed_by_event(const StringName &p_action, Required
 		return false;
 	}
 
-	if (E->value.pressed_event_id != p_event->get_instance_id()) {
+	if (E->value.pressed_event_id != p_event->get_source_id()) {
 		return false;
 	}
 
@@ -489,7 +489,7 @@ bool Input::is_action_just_released_by_event(const StringName &p_action, Require
 		return false;
 	}
 
-	if (E->value.released_event_id != p_event->get_instance_id()) {
+	if (E->value.released_event_id != p_event->get_source_id()) {
 		return false;
 	}
 
@@ -797,6 +797,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			touch_event->set_double_tap(mb->is_double_click());
 			touch_event->set_window_id(mb->get_window_id());
 			touch_event->set_device(InputEvent::DEVICE_ID_EMULATION);
+			touch_event->set_source_id(mb->get_source_id());
 			_THREAD_SAFE_UNLOCK_
 			event_dispatch_function(touch_event);
 			_THREAD_SAFE_LOCK_
@@ -827,6 +828,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			drag_event->set_velocity(get_last_mouse_velocity());
 			drag_event->set_screen_velocity(get_last_mouse_screen_velocity());
 			drag_event->set_device(InputEvent::DEVICE_ID_EMULATION);
+			drag_event->set_source_id(mm->get_source_id());
 
 			_THREAD_SAFE_UNLOCK_
 			event_dispatch_function(drag_event);
@@ -872,6 +874,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 				button_event->set_button_index(MouseButton::LEFT);
 				button_event->set_double_click(st->is_double_tap());
 				button_event->set_window_id(st->get_window_id());
+				button_event->set_source_id(st->get_source_id());
 
 				BitField<MouseButtonMask> ev_bm = mouse_button_mask;
 				if (st->is_pressed()) {
@@ -910,6 +913,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			motion_event->set_screen_velocity(sd->get_screen_velocity());
 			motion_event->set_button_mask(mouse_button_mask);
 			motion_event->set_window_id(sd->get_window_id());
+			motion_event->set_source_id(sd->get_source_id());
 
 			_parse_input_event_impl(motion_event, true);
 		}
@@ -971,12 +975,12 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 		_update_action_cache(E.key, action_state);
 		// As input may come in part way through a physics tick, the earliest we can react to it is the next physics tick.
 		if (action_state.cache.pressed && !was_pressed) {
-			action_state.pressed_event_id = p_event->get_instance_id();
+			action_state.pressed_event_id = p_event->get_source_id();
 			action_state.pressed_physics_frame = Engine::get_singleton()->get_physics_frames() + 1;
 			action_state.pressed_process_frame = Engine::get_singleton()->get_process_frames();
 		}
 		if (!action_state.cache.pressed && was_pressed) {
-			action_state.released_event_id = p_event->get_instance_id();
+			action_state.released_event_id = p_event->get_source_id();
 			action_state.released_physics_frame = Engine::get_singleton()->get_physics_frames() + 1;
 			action_state.released_process_frame = Engine::get_singleton()->get_process_frames();
 		}

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -129,6 +129,7 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("xformed_by", "xform", "local_ofs"), &InputEvent::xformed_by, DEFVAL(Vector2()));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "device"), "set_device", "get_device");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "source_id"), "set_source_id", "get_source_id");
 
 	BIND_CONSTANT(DEVICE_ID_EMULATION);
 }
@@ -759,6 +760,7 @@ RequiredResult<InputEvent> InputEventMouseButton::xformed_by(const Transform2D &
 	mb->set_double_click(double_click);
 	mb->set_factor(factor);
 	mb->set_button_index(button_index);
+	mb->set_source_id(get_source_id());
 
 	mb->merge_meta_from(this);
 
@@ -981,6 +983,7 @@ RequiredResult<InputEvent> InputEventMouseMotion::xformed_by(const Transform2D &
 	mm->set_relative_screen_position(get_relative_screen_position());
 	mm->set_velocity(p_xform.basis_xform(get_velocity()));
 	mm->set_screen_velocity(get_screen_velocity());
+	mm->set_source_id(get_source_id());
 
 	mm->merge_meta_from(this);
 
@@ -1377,6 +1380,7 @@ RequiredResult<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &
 	st->set_pressed(pressed);
 	st->set_canceled(canceled);
 	st->set_double_tap(double_tap);
+	st->set_source_id(get_source_id());
 
 	st->merge_meta_from(this);
 
@@ -1507,6 +1511,7 @@ RequiredResult<InputEvent> InputEventScreenDrag::xformed_by(const Transform2D &p
 	sd->set_relative_screen_position(get_relative_screen_position());
 	sd->set_velocity(p_xform.basis_xform(velocity));
 	sd->set_screen_velocity(get_screen_velocity());
+	sd->set_source_id(get_source_id());
 
 	sd->merge_meta_from(this);
 
@@ -1720,6 +1725,7 @@ RequiredResult<InputEvent> InputEventMagnifyGesture::xformed_by(const Transform2
 
 	ev->set_position(p_xform.xform(get_position() + p_local_ofs));
 	ev->set_factor(get_factor());
+	ev->set_source_id(get_source_id());
 
 	ev->merge_meta_from(this);
 
@@ -1762,6 +1768,7 @@ RequiredResult<InputEvent> InputEventPanGesture::xformed_by(const Transform2D &p
 
 	ev->set_position(p_xform.xform(get_position() + p_local_ofs));
 	ev->set_delta(get_delta());
+	ev->set_source_id(get_source_id());
 
 	ev->merge_meta_from(this);
 

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -53,6 +53,7 @@ class InputEvent : public Resource {
 	GDCLASS(InputEvent, Resource);
 
 	int device = 0;
+	ObjectID source_id;
 
 protected:
 	bool canceled = false;
@@ -72,6 +73,9 @@ public:
 	bool is_action_released(const StringName &p_action, bool p_exact_match = false) const;
 	float get_action_strength(const StringName &p_action, bool p_exact_match = false) const;
 	float get_action_raw_strength(const StringName &p_action, bool p_exact_match = false) const;
+
+	void set_source_id(ObjectID p_id) { source_id = p_id; }
+	ObjectID get_source_id() const { return source_id.is_valid() ? source_id : get_instance_id(); }
 
 	bool is_canceled() const;
 	bool is_pressed() const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113472

Currently, `Input.is_action_just_pressed_by_event` and `Input.is_action_just_released_by_event` rely on comparing the event's `get_instance_id()`.

_However,_ for `InputEventMouseButton` there are a few instances where the event is modified and a new instance is created.

For example...

When `emulate_mouse_from_touch` is `true`:
https://github.com/godotengine/godot/blob/63227bbc8ae5300319f14f8253c8158b846f355b/core/input/input.cpp#L863-L885

Inside of `Input::ensure_touch_mouse_raised`:
https://github.com/godotengine/godot/blob/63227bbc8ae5300319f14f8253c8158b846f355b/core/input/input.cpp#L1166-L1187

Inside of `InputEventMouseButton::xformed_by`:
https://github.com/godotengine/godot/blob/63227bbc8ae5300319f14f8253c8158b846f355b/core/input/input_event.cpp#L742-L766

The fix I've implemented here is to store the `InputEvent` itself instead of just its instance ID and, when doing a comparison with an `InputEventMouseButton`, check if `is_match` is true.

I tried to use `is_match` for other events but that wasn't as reliable as the instance ID and resulted in some events double-firing, so I opted to only fall back on it for the mouse input events.