### PR TITLE
Add margins in the Project Manager to keep visual balance

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1510,6 +1510,7 @@ ProjectManager::ProjectManager() {
 	{
 		local_projects_vb = memnew(VBoxContainer);
 		local_projects_vb->set_name("LocalProjectsTab");
+		local_projects_vb->add_theme_constant_override("separation", 6 * EDSCALE);
 		_add_main_view(MAIN_VIEW_PROJECTS, TTRC("Projects"), Ref<Texture2D>(), local_projects_vb);
 
 		// Project list's top bar.
@@ -1573,6 +1574,7 @@ ProjectManager::ProjectManager() {
 		// Project list and its sidebar.
 		{
 			HBoxContainer *project_list_hbox = memnew(HBoxContainer);
+			project_list_hbox->add_theme_constant_override("separation", 6 * EDSCALE);
 			local_projects_vb->add_child(project_list_hbox);
 			project_list_hbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 


### PR DESCRIPTION
Project Manager is the first screen a user sees, so it's important to make a positive first impression. I've been annoyed for a long time that some margins are missing here.

Before:
<img width="720" height="450" alt="2025-12-28_03-25-56_Godot Engine - Project Manager" src="https://github.com/user-attachments/assets/275b28df-aba5-49a9-99f4-538adfca7349" />

After:
<img width="720" height="450" alt="2025-12-28_03-27-19_Godot Engine - Project Manager" src="https://github.com/user-attachments/assets/d3044a85-61c7-402d-bb07-6aa99eb641ae" />