### PR TITLE
Change `radius_range` to `angle` to indicate hole size of `JointLimitationCone3D`

### DIFF
--- a/doc/classes/JointLimitationCone3D.xml
+++ b/doc/classes/JointLimitationCone3D.xml
@@ -9,9 +9,9 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="radius_range" type="float" setter="set_radius_range" getter="get_radius_range" default="0.25">
-			The size of the hole made by the cone.
-			[code]0[/code] is no hole, [code]0.5[/code] makes a hemisphere, and [code]1.0[/code] makes a sphere (no limitation).
+		<member name="angle" type="float" setter="set_angle" getter="get_angle" default="1.5707964">
+			The radius range of the hole made by the cone.
+			[code]0[/code] degrees makes a sphere without hole, [code]180[/code] degrees makes a hemisphere, and [code]360[/code] degrees become empty (no limitation).
 		</member>
 	</members>
 </class>

--- a/scene/resources/3d/joint_limitation_cone_3d.h
+++ b/scene/resources/3d/joint_limitation_cone_3d.h
@@ -35,16 +35,19 @@
 class JointLimitationCone3D : public JointLimitation3D {
 	GDCLASS(JointLimitationCone3D, JointLimitation3D);
 
-	real_t radius_range = 0.25;
+	real_t angle = Math::TAU * 0.25;
 
 protected:
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+#endif // DISABLE_DEPRECATED
 	static void _bind_methods();
 
 	virtual Vector3 _solve(const Vector3 &p_direction) const override;
 
 public:
-	void set_radius_range(real_t p_radius_range);
-	real_t get_radius_range() const;
+	void set_angle(real_t p_angle);
+	real_t get_angle() const;
 
 #ifdef TOOLS_ENABLED
 	virtual void draw_shape(Ref<SurfaceTool> &p_surface_tool, const Transform3D &p_transform, float p_bone_length, const Color &p_color) const override;


### PR DESCRIPTION
It was `radius_range` property had a range of `0.0` - `1.0`, but for consistency with other classes (such as LookAtModifier, 6DOFJoint), I will unify it to angle.

Before:
<img width="1658" height="724" alt="image" src="https://github.com/user-attachments/assets/bcbebaec-54d5-4121-8614-846115979fa8" />

After this PR:
<img width="1236" height="311" alt="image" src="https://github.com/user-attachments/assets/7d90dfa4-a1c1-4196-aeeb-842c5c741c45" />
