### PR TITLE
Fix error in CodeEdit when deleting certain lines

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -939,7 +939,7 @@
 			<param index="1" name="move_carets_down" type="bool" default="true" />
 			<description>
 				Removes the line of text at [param line]. Carets on this line will attempt to match their previous visual x position.
-				If [param move_carets_down] is [code]true[/code] carets will move to the next line down, otherwise carets will move up.
+				If [param move_carets_down] is [code]true[/code], carets on the line will prefer to move down to the next line, otherwise they will prefer move up to the previous line.
 			</description>
 		</method>
 		<method name="remove_secondary_carets">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -947,7 +947,7 @@
 			<param index="1" name="move_carets_down" type="bool" default="true" />
 			<description>
 				Removes the line of text at [param line]. Carets on this line will attempt to match their previous visual x position.
-				If [param move_carets_down] is [code]true[/code] carets will move to the next line down, otherwise carets will move up.
+				If [param move_carets_down] is [code]true[/code], carets on the line will prefer to move down to the next line, otherwise they will prefer move up to the previous line.
 			</description>
 		</method>
 		<method name="remove_secondary_carets">

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2683,12 +2683,8 @@ void CodeEdit::delete_lines() {
 	Vector<Point2i> line_ranges = get_line_ranges_from_carets();
 	int line_offset = 0;
 	for (Point2i line_range : line_ranges) {
-		// Remove last line of range separately to preserve carets.
 		unfold_line(line_range.y + line_offset);
-		remove_line_at(line_range.y + line_offset);
-		if (line_range.x != line_range.y) {
-			remove_text(line_range.x + line_offset, 0, line_range.y + line_offset, 0);
-		}
+		remove_lines(line_range.x + line_offset, line_range.y + line_offset);
 		line_offset += line_range.x - line_range.y - 1;
 	}
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2908,12 +2908,8 @@ void CodeEdit::delete_lines() {
 	Vector<Point2i> line_ranges = get_line_ranges_from_carets();
 	int line_offset = 0;
 	for (Point2i line_range : line_ranges) {
-		// Remove last line of range separately to preserve carets.
 		unfold_line(line_range.y + line_offset);
-		remove_line_at(line_range.y + line_offset);
-		if (line_range.x != line_range.y) {
-			remove_text(line_range.x + line_offset, 0, line_range.y + line_offset, 0);
-		}
+		remove_lines(line_range.x + line_offset, line_range.y + line_offset);
 		line_offset += line_range.x - line_range.y - 1;
 	}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4228,61 +4228,67 @@ void TextEdit::insert_line_at(int p_line, const String &p_text) {
 
 void TextEdit::remove_line_at(int p_line, bool p_move_carets_down) {
 	ERR_FAIL_INDEX(p_line, text.size());
+	remove_lines(p_line, p_line, p_move_carets_down);
+}
 
-	if (get_line_count() == 1) {
-		// Only one line, just remove contents.
+void TextEdit::remove_lines(int p_from_line, int p_to_line, bool p_move_carets_down) {
+	// Remove entire line range, inclusive.
+	ERR_FAIL_INDEX(p_from_line, text.size());
+	ERR_FAIL_INDEX(p_to_line, text.size());
+
+	if (p_from_line > p_to_line) {
+		SWAP(p_from_line, p_to_line);
+	}
+
+	if (p_from_line == 0 && p_to_line == get_line_count() - 1) {
+		// Remove all lines.
 		begin_complex_operation();
-		int line_length = get_line(p_line).length();
-		_remove_text(p_line, 0, p_line, line_length);
-		collapse_carets(p_line, 0, p_line, line_length, true);
+		remove_secondary_carets();
+		int line_length = get_line(p_to_line).length();
+		_remove_text(p_from_line, 0, p_to_line, line_length);
+		collapse_carets(p_from_line, 0, p_to_line, line_length, true);
 		end_complex_operation();
 		return;
 	}
 
 	begin_complex_operation();
 
-	bool is_last_line = p_line == get_line_count() - 1;
-	int from_line = is_last_line ? p_line - 1 : p_line;
-	int next_line = is_last_line ? p_line : p_line + 1;
-	int from_column = is_last_line ? get_line(from_line).length() : 0;
-	int next_column = is_last_line ? get_line(next_line).length() : 0;
+	bool is_last_line = p_to_line == get_line_count() - 1;
+	int remove_from_line = is_last_line ? p_from_line - 1 : p_from_line;
+	int remove_to_line = is_last_line ? p_to_line : p_to_line + 1;
+	int remove_from_column = is_last_line ? get_line(remove_from_line).length() : 0;
+	int remove_to_column = is_last_line ? get_line(remove_to_line).length() : 0;
 
-	if ((!is_last_line && p_move_carets_down) || (p_line != 0 && !p_move_carets_down)) {
-		// Set the carets column to update their last offset x.
-		for (int i = 0; i < get_caret_count(); i++) {
-			if (get_caret_line(i) == p_line) {
-				set_caret_column(get_caret_column(i), false, i);
-			}
-			if (has_selection(i) && get_selection_origin_line(i) == p_line) {
-				set_selection_origin_column(get_selection_origin_column(i), i);
-			}
+	// Set the carets column to update their last offset x.
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (get_caret_line(i) >= p_from_line && get_caret_line(i) <= p_to_line) {
+			set_caret_column(get_caret_column(i), false, i);
+		}
+		if (has_selection(i) && get_selection_origin_line(i) >= p_from_line && get_selection_origin_line(i) <= p_to_line) {
+			set_selection_origin_column(get_selection_origin_column(i), i);
 		}
 	}
 
-	// Remove line.
-	_remove_text(from_line, from_column, next_line, next_column);
+	// Remove the lines.
+	_remove_text(remove_from_line, remove_from_column, remove_to_line, remove_to_column);
 
 	begin_multicaret_edit();
-	if ((is_last_line && p_move_carets_down) || (p_line == 0 && !p_move_carets_down)) {
-		// Collapse carets.
-		collapse_carets(from_line, from_column, next_line, next_column, true);
-	} else {
-		// Move carets to visually line up.
-		int target_line = p_move_carets_down ? p_line : p_line - 1;
-		for (int i = 0; i < get_caret_count(); i++) {
-			bool selected = has_selection(i);
-			if (get_caret_line(i) == p_line) {
-				set_caret_line(target_line, i == 0, true, 0, i);
-			}
-			if (selected && get_selection_origin_line(i) == p_line) {
-				set_selection_origin_line(target_line, true, 0, i);
-				select(get_selection_origin_line(i), get_selection_origin_column(i), get_caret_line(i), get_caret_column(i), i);
-			}
+	// Move carets to visually line up.
+	int target_line = ((p_move_carets_down && !is_last_line) || p_from_line == 0) ? p_from_line : p_from_line - 1;
+	for (int i = 0; i < get_caret_count(); i++) {
+		bool selected = has_selection(i);
+		if (get_caret_line(i) >= p_from_line && get_caret_line(i) <= p_to_line) {
+			set_caret_line(target_line, i == 0, true, 0, i);
 		}
-
-		merge_overlapping_carets();
+		if (selected && get_selection_origin_line(i) >= p_from_line && get_selection_origin_line(i) <= p_to_line) {
+			set_selection_origin_line(target_line, true, 0, i);
+			select(get_selection_origin_line(i), get_selection_origin_column(i), get_caret_line(i), get_caret_column(i), i);
+		}
 	}
-	_offset_carets_after(next_line, next_column, from_line, from_column);
+	merge_overlapping_carets();
+
+	_offset_carets_after(remove_to_line, remove_to_column, remove_from_line, remove_from_column);
+	_unhide_carets();
 	end_multicaret_edit();
 	end_complex_operation();
 
@@ -7858,11 +7864,7 @@ void TextEdit::_cut_internal(int p_caret) {
 	}
 	int line_offset = 0;
 	for (Point2i line_range : line_ranges) {
-		// Preserve carets on the last line.
-		remove_line_at(line_range.y + line_offset);
-		if (line_range.x != line_range.y) {
-			remove_text(line_range.x + line_offset, 0, line_range.y + line_offset, 0);
-		}
+		remove_lines(line_range.x + line_offset, line_range.y + line_offset);
 		line_offset += line_range.x - line_range.y - 1;
 	}
 	end_multicaret_edit();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4819,62 +4819,68 @@ void TextEdit::insert_line_at(int p_line, const String &p_text) {
 
 void TextEdit::remove_line_at(int p_line, bool p_move_carets_down) {
 	ERR_FAIL_INDEX(p_line, text.size());
+	remove_lines(p_line, p_line, p_move_carets_down);
+}
 
-	if (get_line_count() == 1) {
-		// Only one line, just remove contents.
+void TextEdit::remove_lines(int p_from_line, int p_to_line, bool p_move_carets_down) {
+	// Remove entire line range, inclusive.
+	ERR_FAIL_INDEX(p_from_line, text.size());
+	ERR_FAIL_INDEX(p_to_line, text.size());
+
+	if (p_from_line > p_to_line) {
+		SWAP(p_from_line, p_to_line);
+	}
+
+	if (p_from_line == 0 && p_to_line == get_line_count() - 1) {
+		// Remove all lines.
 		begin_complex_operation();
-		int line_length = get_line(p_line).length();
-		_remove_text(p_line, 0, p_line, line_length);
-		collapse_carets(p_line, 0, p_line, line_length, true);
+		remove_secondary_carets();
+		int line_length = get_line(p_to_line).length();
+		_remove_text(p_from_line, 0, p_to_line, line_length);
+		collapse_carets(p_from_line, 0, p_to_line, line_length, true);
 		end_complex_operation();
 		return;
 	}
 
 	begin_complex_operation();
 
-	bool is_last_line = p_line == get_line_count() - 1;
-	int from_line = is_last_line ? p_line - 1 : p_line;
-	int next_line = is_last_line ? p_line : p_line + 1;
-	int from_column = is_last_line ? get_line(from_line).length() : 0;
-	int next_column = is_last_line ? get_line(next_line).length() : 0;
+	bool is_last_line = p_to_line == get_line_count() - 1;
+	int remove_from_line = is_last_line ? p_from_line - 1 : p_from_line;
+	int remove_to_line = is_last_line ? p_to_line : p_to_line + 1;
+	int remove_from_column = is_last_line ? get_line(remove_from_line).length() : 0;
+	int remove_to_column = is_last_line ? get_line(remove_to_line).length() : 0;
 
-	if ((!is_last_line && p_move_carets_down) || (p_line != 0 && !p_move_carets_down)) {
-		// Set the carets column to update their last offset x.
-		for (int i = 0; i < get_caret_count(); i++) {
-			if (get_caret_line(i) == p_line) {
-				set_caret_column(get_caret_column(i), false, i);
-			}
-			if (has_selection(i) && get_selection_origin_line(i) == p_line) {
-				set_selection_origin_column(get_selection_origin_column(i), i);
-			}
+	// Set the carets column to update their last offset x.
+	for (int i = 0; i < get_caret_count(); i++) {
+		if (get_caret_line(i) >= p_from_line && get_caret_line(i) <= p_to_line) {
+			set_caret_column(get_caret_column(i), false, i);
+		}
+		if (has_selection(i) && get_selection_origin_line(i) >= p_from_line && get_selection_origin_line(i) <= p_to_line) {
+			set_selection_origin_column(get_selection_origin_column(i), i);
 		}
 	}
 
-	// Remove line.
-	_remove_text(from_line, from_column, next_line, next_column);
+	// Remove the lines.
+	_remove_text(remove_from_line, remove_from_column, remove_to_line, remove_to_column);
 
 	begin_multicaret_edit();
-	if ((is_last_line && p_move_carets_down) || (p_line == 0 && !p_move_carets_down)) {
-		// Collapse carets.
-		collapse_carets(from_line, from_column, next_line, next_column, true);
-	} else {
-		// Move carets to visually line up.
-		int target_line = p_move_carets_down ? p_line : p_line - 1;
-		for (int i = 0; i < get_caret_count(); i++) {
-			bool selected = has_selection(i);
-			if (get_caret_line(i) == p_line) {
-				set_caret_line(target_line, i == 0, true, 0, i);
-			}
-			if (selected && get_selection_origin_line(i) == p_line) {
-				set_selection_origin_line(target_line, true, 0, i);
-				select(get_selection_origin_line(i), get_selection_origin_column(i), get_caret_line(i), get_caret_column(i), i);
-			}
+	// Move carets to visually line up.
+	int target_line = ((p_move_carets_down && !is_last_line) || p_from_line == 0) ? p_from_line : p_from_line - 1;
+	for (int i = 0; i < get_caret_count(); i++) {
+		bool selected = has_selection(i);
+		if (get_caret_line(i) >= p_from_line && get_caret_line(i) <= p_to_line) {
+			set_caret_line(target_line, i == 0, true, 0, i);
 		}
-
-		merge_overlapping_carets();
+		if (selected && get_selection_origin_line(i) >= p_from_line && get_selection_origin_line(i) <= p_to_line) {
+			set_selection_origin_line(target_line, true, 0, i);
+			select(get_selection_origin_line(i), get_selection_origin_column(i), get_caret_line(i), get_caret_column(i), i);
+		}
 	}
-	_offset_carets_after(next_line, next_column, from_line, from_column);
-	_offset_underlines_after(next_line, next_column, from_line, from_column);
+	merge_overlapping_carets();
+
+	_offset_carets_after(remove_to_line, remove_to_column, remove_from_line, remove_from_column);
+	_offset_underlines_after(remove_to_line, remove_to_column, remove_from_line, remove_from_column);
+	_unhide_carets();
 	end_multicaret_edit();
 	end_complex_operation();
 
@@ -8485,11 +8491,7 @@ void TextEdit::_cut_internal(int p_caret) {
 	}
 	int line_offset = 0;
 	for (Point2i line_range : line_ranges) {
-		// Preserve carets on the last line.
-		remove_line_at(line_range.y + line_offset);
-		if (line_range.x != line_range.y) {
-			remove_text(line_range.x + line_offset, 0, line_range.y + line_offset, 0);
-		}
+		remove_lines(line_range.x + line_offset, line_range.y + line_offset);
 		line_offset += line_range.x - line_range.y - 1;
 	}
 	end_multicaret_edit();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -876,6 +876,7 @@ public:
 
 	void insert_line_at(int p_line, const String &p_text);
 	void remove_line_at(int p_line, bool p_move_carets_down = true);
+	void remove_lines(int p_from_line, int p_to_line, bool p_move_carets_down = true);
 
 	void insert_text_at_caret(const String &p_text, int p_caret = -1);
 	void insert_text(const String &p_text, int p_line, int p_column, bool p_before_selection_begin = true, bool p_before_selection_end = false);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -944,6 +944,7 @@ public:
 
 	void insert_line_at(int p_line, const String &p_text);
 	void remove_line_at(int p_line, bool p_move_carets_down = true);
+	void remove_lines(int p_from_line, int p_to_line, bool p_move_carets_down = true);
 
 	void insert_text_at_caret(const String &p_text, int p_caret = -1);
 	void insert_text(const String &p_text, int p_line, int p_column, bool p_before_selection_begin = true, bool p_before_selection_end = false);

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -4756,7 +4756,7 @@ TEST_CASE("[SceneTree][CodeEdit] text manipulation") {
 		CHECK(code_edit->get_caret_column(1) == 3); // In the default font, this is the same position.
 		CHECK_FALSE(code_edit->has_selection(2));
 		CHECK(code_edit->get_caret_line(2) == 0);
-		CHECK(code_edit->get_caret_column(2) == 4);
+		CHECK(code_edit->get_caret_column(2) == 0);
 		code_edit->remove_secondary_carets();
 
 		// Cut on the only line removes the contents.
@@ -5357,7 +5357,7 @@ TEST_CASE("[SceneTree][CodeEdit] text manipulation") {
 		// Delete multiple lines with multiple carets.
 		code_edit->set_text("test\nlines\nto\n\ndelete");
 		code_edit->set_caret_line(0);
-		code_edit->set_caret_column(2);
+		code_edit->set_caret_column(0);
 		code_edit->add_caret(1, 0);
 		code_edit->add_caret(4, 5);
 		code_edit->delete_lines();
@@ -5388,6 +5388,16 @@ TEST_CASE("[SceneTree][CodeEdit] text manipulation") {
 		code_edit->set_text("test");
 		code_edit->set_caret_line(0);
 		code_edit->set_caret_column(4);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "");
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Delete all lines with selection.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test\nlines\nto\n\ndelete");
+		code_edit->select(0, 1, 4, 1);
 		code_edit->delete_lines();
 		CHECK(code_edit->get_text() == "");
 		CHECK_FALSE(code_edit->has_selection());

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -4757,7 +4757,7 @@ TEST_CASE("[SceneTree][CodeEdit] text manipulation") {
 		CHECK(code_edit->get_caret_column(1) == 3); // In the default font, this is the same position.
 		CHECK_FALSE(code_edit->has_selection(2));
 		CHECK(code_edit->get_caret_line(2) == 0);
-		CHECK(code_edit->get_caret_column(2) == 4);
+		CHECK(code_edit->get_caret_column(2) == 0);
 		code_edit->remove_secondary_carets();
 
 		// Cut on the only line removes the contents.
@@ -5358,7 +5358,7 @@ TEST_CASE("[SceneTree][CodeEdit] text manipulation") {
 		// Delete multiple lines with multiple carets.
 		code_edit->set_text("test\nlines\nto\n\ndelete");
 		code_edit->set_caret_line(0);
-		code_edit->set_caret_column(2);
+		code_edit->set_caret_column(0);
 		code_edit->add_caret(1, 0);
 		code_edit->add_caret(4, 5);
 		code_edit->delete_lines();
@@ -5389,6 +5389,16 @@ TEST_CASE("[SceneTree][CodeEdit] text manipulation") {
 		code_edit->set_text("test");
 		code_edit->set_caret_line(0);
 		code_edit->set_caret_column(4);
+		code_edit->delete_lines();
+		CHECK(code_edit->get_text() == "");
+		CHECK_FALSE(code_edit->has_selection());
+		CHECK(code_edit->get_caret_line() == 0);
+		CHECK(code_edit->get_caret_column() == 0);
+
+		// Delete all lines with selection.
+		code_edit->remove_secondary_carets();
+		code_edit->set_text("test\nlines\nto\n\ndelete");
+		code_edit->select(0, 1, 4, 1);
 		code_edit->delete_lines();
 		CHECK(code_edit->get_text() == "");
 		CHECK_FALSE(code_edit->has_selection());

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -982,7 +982,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_text() == "remove line at\nlines\n\ntest");
 			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->get_caret_line(0) == 0);
-			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 3); // In the default font, this is the same position.
 			CHECK(text_edit->get_caret_line(1) == 3);
 			CHECK(text_edit->get_caret_column(1) == 4);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1019,7 +1019,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "remove line at\nlines");
 			CHECK(text_edit->get_caret_line(0) == 1);
-			CHECK(text_edit->get_caret_column(0) == 5);
+			CHECK(text_edit->get_caret_column(0) == 3); // In the default font, this is the same position.
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -3093,7 +3093,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_column(1) == 3); // In the default font, this is the same position.
 			CHECK_FALSE(text_edit->has_selection(2));
 			CHECK(text_edit->get_caret_line(2) == 0);
-			CHECK(text_edit->get_caret_column(2) == 4);
+			CHECK(text_edit->get_caret_column(2) == 0);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -3140,7 +3140,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 }, { 3, 2 }, { 2, 1 } };
+			lines_edited_args = { { 1, 0 }, { 3, 1 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -983,7 +983,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_text() == "remove line at\nlines\n\ntest");
 			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->get_caret_line(0) == 0);
-			CHECK(text_edit->get_caret_column(0) == 0);
+			CHECK(text_edit->get_caret_column(0) == 3); // In the default font, this is the same position.
 			CHECK(text_edit->get_caret_line(1) == 3);
 			CHECK(text_edit->get_caret_column(1) == 4);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1020,7 +1020,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "remove line at\nlines");
 			CHECK(text_edit->get_caret_line(0) == 1);
-			CHECK(text_edit->get_caret_column(0) == 5);
+			CHECK(text_edit->get_caret_column(0) == 3); // In the default font, this is the same position.
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -3092,7 +3092,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_column(1) == 3); // In the default font, this is the same position.
 			CHECK_FALSE(text_edit->has_selection(2));
 			CHECK(text_edit->get_caret_line(2) == 0);
-			CHECK(text_edit->get_caret_column(2) == 4);
+			CHECK(text_edit->get_caret_column(2) == 0);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -3139,7 +3139,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("text_changed");
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
-			lines_edited_args = { { 1, 0 }, { 3, 2 }, { 2, 1 } };
+			lines_edited_args = { { 1, 0 }, { 3, 1 } };
 
 			text_edit->cut();
 			MessageQueue::get_singleton()->flush();


### PR DESCRIPTION
- Fixes using delete lines on the last two lines causing an error (when the last line has content).
- Fixes caret position after deleting lines when selecting lines bottom from top.
- Fixes deleting the line below a folded section when it is the last line causing the caret to become hidden.

This applies when using the delete lines script editor shortcut (`ctrl+shift+k`), and when using cut with multiple carets but no selection in TextEdit/CodeEdit.

Error example: `ERROR: Index p_to_line = 56 is out of bounds (text.size() = 56).`

The tests have been adjusted. Some columns checks needed to be changed since the caret now moves straight up or down even if it cannot move in the specified `p_move_carets_down` direction, instead of just to the start/end of that line. And in one test the `lines_edited_from` args changed since there is now one less remove operation, but it is equivalent.