### PR TITLE
Fix `ScrollBar` not accepting `InputEventPanGesture`

### DIFF
--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -46,6 +46,37 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> b = p_event;
 
+	Ref<InputEventPanGesture> pg = p_event;
+
+	if (pg.is_valid()) {
+		accept_event();
+
+		if (orientation == HORIZONTAL) {
+			if (pg->get_delta().x != 0) {
+				if (pg->get_delta().x < 0) {
+					scroll(-MAX(fabsf(pg->get_delta().x), get_step()));
+				}
+				if (pg->get_delta().x > 0) {
+					scroll(MAX(pg->get_delta().x, get_step()));
+				}
+			} else if (pg->get_delta().y != 0) {
+				if (pg->get_delta().y < 0) {
+					scroll(-MAX(fabsf(pg->get_delta().y), get_step()));
+				}
+				if (pg->get_delta().y > 0) {
+					scroll(MAX(pg->get_delta().y, get_step()));
+				}
+			}
+		} else {
+			if (pg->get_delta().y < 0) {
+				scroll(-MAX(fabsf(pg->get_delta().y), get_step()));
+			}
+			if (pg->get_delta().y > 0) {
+				scroll(MAX(pg->get_delta().y, get_step()));
+			}
+		}
+	}
+
 	if (b.is_valid()) {
 		accept_event();
 


### PR DESCRIPTION
Related: https://github.com/godotengine/godot/issues/113646 (but instead for `TabBar`)

Fixes Wayland/MacOS(?) not scrolling the `ScrollBar` node when using trackpad gestures.

Video showing behavior while running on Wayland with this PR (sensitivity being very high is caused by #49873):

https://github.com/user-attachments/assets/a73edc55-03c2-46df-b70d-2db2413cceb3

Physically scrolling up/down moving the scrollbar horizontally is standard behavior in the applications I've tested that implement this behavior (firefox, chromium, vscode) so we should follow suit. This should not be the case for vertical (as shown at end of video).