### PR TITLE
LSP: Fix infinite recursion in symbol calculation

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -389,12 +389,15 @@ ExtendGDScriptParser *GDScriptLanguageProtocol::LSPeer::parse_script(const Strin
 	}
 
 	ExtendGDScriptParser *parser = memnew(ExtendGDScriptParser);
+	parse_results[p_path] = parser;
+
 	parser->parse(content, p_path);
 
 	if (document != nullptr) {
-		parse_results[p_path] = parser;
 		GDScriptLanguageProtocol::get_singleton()->get_workspace()->publish_diagnostics(p_path);
 	} else {
+		// Don't keep cached for further requests since we can't invalidate the cache properly.
+		parse_results.erase(p_path);
 		stale_parsers[p_path] = parser;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/114305

Regression from https://github.com/godotengine/godot/pull/105236

Apparently `GDScriptExtendParser::parse` has recursive properties. This makes it necessary to have all scripts properly in cache before calling it. We invalidate the cache for files that are not managed by the client afterwards. Because we have no monitoring capabilities for them.
