### PR TITLE
Fix importing projects with PNG assets freezes Web Editor

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3756,6 +3756,8 @@ void EditorFileSystem::remove_import_format_support_query(Ref<EditorFileSystemIm
 
 EditorFileSystem::EditorFileSystem() {
 #if defined(THREADS_ENABLED) && !defined(WEB_ENABLED)
+	// On web, threaded scanning blocks the browser's event loop, causing freezes.
+	// See GH-112072 for details.
 	use_threads = true;
 #endif
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3287,6 +3287,15 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 
 #ifdef THREADS_ENABLED
 	bool use_multiple_threads = GLOBAL_GET("editor/import/use_multiple_threads");
+#ifdef WEB_ENABLED
+	// The Web platform may have threading compiled in, but with only 1 available thread (the main thread).
+	// Using threaded imports with a single thread causes a deadlock as the main thread waits in a busy-loop
+	// while the import tasks can't execute. Disable threaded imports when insufficient threads are available.
+	// See GH-112072 for details.
+	if (WorkerThreadPool::get_singleton()->get_thread_count() <= 1) {
+		use_multiple_threads = false;
+	}
+#endif
 #else
 	bool use_multiple_threads = false;
 #endif


### PR DESCRIPTION
Fixes #112072

## Root Cause

The Godot Web Editor uses busy-wait loops on the main thread for threaded file scanning and asset importing. On web platforms, blocking the main thread prevents the browser's JavaScript event loop from running, causing the page to appear frozen, even when worker threads are successfully completing their tasks.

## Fix

Disable threaded operations in `EditorFileSystem` on the Web platform, for scanning and importing. This forces all file system operations to run synchronously on the main thread, avoiding the busy-wait patterns that block the browser. Trade-off is slower scanning/importing, but the editor remains responsive.

EDIT: slowness is prominent on startup of the editor, but after it becomes responsive, again.

## Demo

Built on `macOS 15.7.1` with 1.4 GHz Quad-Core Intel Core i5 and Intel Iris Plus Graphics 645 1536 MB. On `Edge` web browser.

Also, using MRP from #112072

https://github.com/user-attachments/assets/cd619aa3-fdbe-43e0-a027-bb22fc8f26e6

> During build I get the following `warning`:
> ```
> em++: warning: -pthread + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see
> https://github.com/WebAssembly/design/issues/1271 [-Wpthreads-mem-growth]
> warning: user library symbol '$GodotWebXR' depends on internal symbol '$MainLoop'
> ```
> which can explan slowness in this and official builds.
