### PR TITLE
Add Domain and Value labels to Curve Resource and Curve Editor

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3312,6 +3312,47 @@ void EditorPropertyResource::_set_read_only(bool p_read_only) {
 	resource_picker->set_editable(!p_read_only);
 }
 
+String EditorPropertyResource::_get_clean_class_type_and_cache_meta(const String &p_hint_text_raw) {
+	type_metadata_map.clear();
+	String clean_class_name_hint = "";
+
+	PackedStringArray raw_types = p_hint_text_raw.split(",");
+
+	for (int i = 0; i < raw_types.size(); i++) {
+		String segment = raw_types[i].strip_edges();
+		String class_name = segment;
+
+		int open_pos = segment.find("[");
+		int close_pos = segment.find("]");
+
+		if (open_pos != -1 && close_pos != -1 && close_pos > open_pos) {
+			class_name = segment.substr(0, open_pos).strip_edges();
+			type_metadata_map[class_name] = segment.substr(open_pos + 1, close_pos - open_pos - 1);
+		}
+
+		if (i > 0) {
+			clean_class_name_hint += ",";
+		}
+		clean_class_name_hint += class_name;
+	}
+
+	return clean_class_name_hint;
+}
+
+void EditorPropertyResource::_apply_metadata_to_resource(const Ref<Resource> &p_res) {
+	if (p_res.is_null()) {
+		return;
+	}
+
+	String res_class = p_res->get_class();
+
+	if (type_metadata_map.has(res_class)) {
+		String meta_content = type_metadata_map[res_class];
+		// Force update metadata every time to ensure hint_string, if changed, is updated
+		p_res->set_meta("_custom_resource_hint_string", meta_content);
+	}
+}
+
 void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource, bool p_inspect) {
 	if (p_resource->is_built_in() && !p_resource->get_path().is_empty()) {
 		String parent = p_resource->get_path().get_slice("::", 0);
@@ -3559,23 +3600,26 @@ void EditorPropertyResource::setup(Object *p_object, const String &p_path, const
 		resource_picker = nullptr;
 	}
 
-	if (p_path == "script" && p_base_type == "Script" && Object::cast_to<Node>(p_object)) {
+	raw_hint_string = p_base_type;
+	String base_type = _get_clean_class_type_and_cache_meta(raw_hint_string);
+
+	if (p_path == "script" && base_type == "Script" && Object::cast_to<Node>(p_object)) {
 		EditorScriptPicker *script_picker = memnew(EditorScriptPicker);
 		script_picker->set_script_owner(Object::cast_to<Node>(p_object));
 		resource_picker = script_picker;
-	} else if (p_path == "shader" && p_base_type == "Shader" && Object::cast_to<ShaderMaterial>(p_object)) {
+	} else if (p_path == "shader" && base_type == "Shader" && Object::cast_to<ShaderMaterial>(p_object)) {
 		EditorShaderPicker *shader_picker = memnew(EditorShaderPicker);
 		shader_picker->set_edited_material(Object::cast_to<ShaderMaterial>(p_object));
 		resource_picker = shader_picker;
 		connect(SceneStringName(ready), callable_mp(this, &EditorPropertyResource::_update_preferred_shader));
-	} else if (ClassDB::is_parent_class(p_base_type, "AudioStream")) {
+	} else if (ClassDB::is_parent_class(base_type, "AudioStream")) {
 		EditorAudioStreamPicker *astream_picker = memnew(EditorAudioStreamPicker);
 		resource_picker = astream_picker;
 	} else {
 		resource_picker = memnew(EditorResourcePicker);
 	}
 
-	resource_picker->set_base_type(p_base_type);
+	resource_picker->set_base_type(base_type);
 	resource_picker->set_resource_owner(p_object);
 	resource_picker->set_property_path(p_path);
 	resource_picker->set_editable(true);
@@ -3595,6 +3639,34 @@ void EditorPropertyResource::setup(Object *p_object, const String &p_path, const
 
 void EditorPropertyResource::update_property() {
 	Ref<Resource> res = get_edited_property_display_value();
+
+	// Apply the metadata anytime the update_property is triggered
+	// This ensures if the Hint was updated recently and setup was triggered, the updated hint_string is available
+	_apply_metadata_to_resource(res);
+
+	// Check for hint_string update
+	if (get_edited_object()) {
+		List<PropertyInfo> p_list;
+		get_edited_object()->get_property_list(&p_list);
+
+		for (const PropertyInfo &p_info : p_list) {
+			if (p_info.name == get_edited_property()) {
+				if (p_info.hint_string != raw_hint_string) {
+					raw_hint_string = p_info.hint_string;
+
+					// Cache the new hint_string against type
+					// ideally base_type should not change here.
+					String base_type = _get_clean_class_type_and_cache_meta(raw_hint_string);
+					if (resource_picker) {
+						resource_picker->set_base_type(base_type);
+					}
+
+					_apply_metadata_to_resource(res);
+				}
+				break;
+			}
+		}
+	}
 
 	if (use_sub_inspector) {
 		if (res.is_valid() != resource_picker->is_toggle_mode()) {

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -479,7 +479,6 @@ class EditorPropertyEasing : public EditorProperty {
 		EASING_IN_OUT,
 		EASING_OUT_IN,
 		EASING_MAX
-
 	};
 
 	void _drag_easing(const Ref<InputEvent> &p_ev);
@@ -742,6 +741,11 @@ class EditorPropertyResource : public EditorProperty {
 	EditorInspector *sub_inspector = nullptr;
 	bool opened_editor = false;
 	bool use_filter = false;
+	String raw_hint_string = "";
+	HashMap<String, String> type_metadata_map;
+
+	String _get_clean_class_type_and_cache_meta(const String &p_hint_text_raw);
+	void _apply_metadata_to_resource(const Ref<Resource> &p_res);
 
 	void _resource_selected(const Ref<Resource> &p_resource, bool p_inspect);
 	void _resource_changed(const Ref<Resource> &p_resource);

--- a/editor/scene/curve_editor_plugin.cpp
+++ b/editor/scene/curve_editor_plugin.cpp
@@ -73,6 +73,8 @@ void CurveEdit::set_curve(Ref<Curve> p_curve) {
 		curve->connect_changed(callable_mp(this, &CurveEdit::_curve_changed));
 		curve->connect(Curve::SIGNAL_RANGE_CHANGED, callable_mp(this, &CurveEdit::_curve_changed));
 		curve->connect(Curve::SIGNAL_DOMAIN_CHANGED, callable_mp(this, &CurveEdit::_curve_changed));
+
+		update_curve_labels();
 	}
 
 	// Note: if you edit a curve, then set another, and try to undo,
@@ -423,6 +425,21 @@ void CurveEdit::_curve_changed() {
 	}
 }
 
+void CurveEdit::update_curve_labels() {
+	if (curve.is_valid() && curve->has_meta("_custom_resource_hint_string")) {
+		const String curve_hint_string = curve->get_meta("_custom_resource_hint_string");
+		PackedStringArray parts = curve_hint_string.split(";");
+		if (parts.size() == 2) {
+			domain_label = parts[0];
+			value_label = parts[1];
+		} else {
+			WARN_PRINT_ED("Curve label hints are invalid. Using default values!");
+			domain_label = "Domain";
+			value_label = "Value";
+		}
+	}
+}
+
 int CurveEdit::get_point_at(const Vector2 &p_pos) const {
 	if (curve.is_null()) {
 		return -1;
@@ -674,17 +691,20 @@ void CurveEdit::update_view_transform() {
 	float min_y = curve.is_valid() ? curve->get_min_value() : 0.0;
 	float max_y = curve.is_valid() ? curve->get_max_value() : 1.0;
 
+	const Vector2 full_size = get_rect().size;
+	const Vector2 layout_size(full_size.x - margin, full_size.y - margin);
+
+	Rect2 view_rect(Vector2(margin, 0.0), layout_size);
+	view_rect = view_rect.grow(-margin);
 	const Rect2 world_rect = Rect2(min_x, min_y, max_x - min_x, max_y - min_y);
-	const Size2 view_margin(margin, margin);
-	const Size2 view_size = get_size() - view_margin * 2;
-	const Vector2 scale = view_size / world_rect.size;
+	const Vector2 scale = view_rect.size / world_rect.size;
 
 	Transform2D world_trans;
 	world_trans.translate_local(-world_rect.position - Vector2(0, world_rect.size.y));
 	world_trans.scale(Vector2(scale.x, -scale.y));
 
 	Transform2D view_trans;
-	view_trans.translate_local(view_margin);
+	view_trans.translate_local(view_rect.position);
 
 	_world_to_view = view_trans * world_trans;
 }
@@ -779,16 +799,29 @@ void CurveEdit::_redraw() {
 
 	update_view_transform();
 
-	// Draw background.
-
 	Vector2 view_size = get_rect().size;
+
+	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+	float font_height = font->get_height(font_size);
+	Color text_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor));
+
+	int pad = Math::round(2 * EDSCALE);
+
+	const real_t axis_margin_bottom = font_height + pad;
+	const real_t axis_margin_left = font_height + pad;
+
+	// Curve drawing rect (content area)
+	Rect2 content_rect(Vector2(axis_margin_left, 0), Vector2(view_size.x - axis_margin_left, view_size.y - axis_margin_bottom));
+
+	// Draw background.
 	draw_style_box(get_theme_stylebox(SceneStringName(panel), SNAME("Tree")), Rect2(Point2(), view_size));
 
 	// Draw primary grid.
 	draw_set_transform_matrix(_world_to_view);
 
-	Vector2 min_edge = get_world_pos(Vector2(0, view_size.y));
-	Vector2 max_edge = get_world_pos(Vector2(view_size.x, 0));
+	Vector2 min_edge = get_world_pos(Vector2(0, content_rect.size.y));
+	Vector2 max_edge = get_world_pos(Vector2(content_rect.size.x, 0));
 
 	const Color grid_color_primary = get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.25);
 	const Color grid_color = get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.1);
@@ -814,12 +847,22 @@ void CurveEdit::_redraw() {
 	// Draw number markings.
 	draw_set_transform_matrix(Transform2D());
 
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	float font_height = font->get_height(font_size);
-	Color text_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor));
+	// Draw Axis Labels
+	{
+		Vector2 label_size = font->get_string_size(domain_label, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
+		Vector2 pos(content_rect.position.x + (content_rect.size.x - label_size.x) * 0.5f, content_rect.position.y + content_rect.size.y + axis_margin_bottom);
 
-	int pad = Math::round(2 * EDSCALE);
+		draw_string(font, pos, domain_label, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, text_color);
+	}
+
+	{
+		Vector2 label_size = font->get_string_size(value_label, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
+		Vector2 center(content_rect.position.x - axis_margin_left * 0.5f, content_rect.position.y + content_rect.size.y * 0.5f);
+
+		draw_set_transform(center, -Math::PI / 2.0f, Vector2(1, 1));
+		draw_string(font, Vector2(-label_size.x * 0.5f, label_size.y), value_label, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, text_color);
+		draw_set_transform(Vector2(), 0);
+	}
 
 	for (int i = 0; i <= grid_steps.x; ++i) {
 		real_t x = curve->get_min_domain() + i * step_size.x;
@@ -906,20 +949,20 @@ void CurveEdit::_redraw() {
 	// Draw help text.
 
 	if (selected_index > 0 && selected_index < curve->get_point_count() - 1 && selected_tangent_index == TANGENT_NONE && hovered_tangent_index != TANGENT_NONE && !shift_pressed) {
-		float width = view_size.x - 50 * EDSCALE;
+		float width = content_rect.size.x - 50 * EDSCALE;
 		text_color.a *= 0.4;
 
 		draw_multiline_string(font, Vector2(25 * EDSCALE, font_height - Math::round(2 * EDSCALE)), TTR("Hold Shift to edit tangents individually"), HORIZONTAL_ALIGNMENT_CENTER, width, font_size, -1, text_color);
 
 	} else if (selected_index != -1 && selected_tangent_index == TANGENT_NONE) {
 		const Vector2 point_pos = curve->get_point_position(selected_index);
-		float width = view_size.x - 50 * EDSCALE;
+		float width = content_rect.size.x - 50 * EDSCALE;
 		text_color.a *= 0.8;
 
 		draw_string(font, Vector2(25 * EDSCALE, font_height - Math::round(2 * EDSCALE)), vformat("(%.2f, %.2f)", point_pos.x, point_pos.y), HORIZONTAL_ALIGNMENT_CENTER, width, font_size, text_color);
 
 	} else if (selected_index != -1 && selected_tangent_index != TANGENT_NONE) {
-		float width = view_size.x - 50 * EDSCALE;
+		float width = content_rect.size.x - 50 * EDSCALE;
 		text_color.a *= 0.8;
 		real_t theta = Math::rad_to_deg(Math::atan(selected_tangent_index == TANGENT_LEFT ? -1 * curve->get_point_left_tangent(selected_index) : curve->get_point_right_tangent(selected_index)));
 

--- a/editor/scene/curve_editor_plugin.h
+++ b/editor/scene/curve_editor_plugin.h
@@ -77,6 +77,8 @@ private:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _curve_changed();
 
+	void update_curve_labels();
+
 	int get_point_at(const Vector2 &p_pos) const;
 	TangentIndex get_tangent_at(const Vector2 &p_pos) const;
 
@@ -143,6 +145,8 @@ private:
 
 	bool snap_enabled = false;
 	int snap_count = 10;
+	String domain_label = "Domain";
+	String value_label = "Value";
 };
 
 // CurveEdit + toolbar


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13915

This PR adds the properties `domain_label` and `value_label` to the Curve Resource. This is mostly a quality of life feature.

Preview of the Curve Resource editor changes in the PR:
<img width="733" height="733" alt="image0" src="https://github.com/user-attachments/assets/82f63cf3-aad9-48bc-9c83-07c5a5ff7621" />

Approach : Added `_labels` in a way similar to how `_limits` is being handled for Curve. It does get serialized in the `.tscn` file (SS below)
<img width="505" height="178" alt="image1" src="https://github.com/user-attachments/assets/dc0ee4bc-180a-4fab-ac8c-c949c1168ae3" />


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
