### PR TITLE
Reset caret blink timer in some `CodeEdit` `gui_input` cases

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -640,12 +640,14 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	/* Indentation */
 	if (k->is_action("ui_text_indent", true)) {
 		do_indent();
+		_reset_caret_blink_timer();
 		accept_event();
 		return;
 	}
 
 	if (k->is_action("ui_text_dedent", true)) {
 		unindent_lines();
+		_reset_caret_blink_timer();
 		accept_event();
 		return;
 	}
@@ -1138,6 +1140,7 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 	if (!is_editable()) {
 		return;
 	}
+	_reset_caret_blink_timer();
 
 	begin_complex_operation();
 	begin_multicaret_edit();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -483,7 +483,6 @@ private:
 	void _emit_caret_changed();
 
 	void _show_virtual_keyboard();
-	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();
 
 	int _get_column_x_offset_for_line(int p_char, int p_line, int p_column) const;
@@ -695,6 +694,7 @@ private:
 	bool _clear_carets_and_selection();
 
 protected:
+	void _reset_caret_blink_timer();
 	void _notification(int p_what);
 	static void _bind_methods();
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/114402

Resets the `CodeEdit` caret blink timer when:
- indenting
- unindenting
- adding new lines