### PR TITLE
Implement workaround for GPU driver crash on Adreno 5XX.

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -511,6 +511,8 @@ private:
 		TightLocalVector<BufferInfo const *, uint32_t> dynamic_buffers;
 	};
 
+	bool adreno_5xx_empty_descriptor_set_layout_workaround = false;
+
 public:
 	virtual UniformSetID uniform_set_create(VectorView<BoundUniform> p_uniforms, ShaderID p_shader, uint32_t p_set_index, int p_linear_pool_index) override final;
 	virtual void linear_uniform_set_pools_reset(int p_linear_pool_index) override final;


### PR DESCRIPTION
Should fix #112158.

From my understanding, the driver skips over empty descriptor set layouts, which breaks the set order when they are placed between non-empty ones. By providing a placeholder binding that the shader doesn't actually use, the issue seems to be resolved. It works on my phone, at least.

_bugsquad edit Fixes: https://github.com/godotengine/godot/issues/79760, Fixes: https://github.com/godotengine/godot/issues/82602, Fixes:  https://github.com/godotengine/godot/issues/85097, Fixes: https://github.com/godotengine/godot/issues/86037, Fixes: https://github.com/godotengine/godot/issues/112158, Fixes: https://github.com/godotengine/godot/issues/94741_