### PR TITLE
Handle `RGB10_A2` storage format in octmap shaders.

### DIFF
--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -256,9 +256,11 @@ private:
 	};
 
 	enum OctmapDownsamplerMode {
-		DOWNSAMPLER_MODE_LOW_QUALITY,
-		DOWNSAMPLER_MODE_HIGH_QUALITY,
-		DOWNSAMPLER_MODE_MAX
+		DOWNSAMPLER_MODE_FLAG_HIGH_QUALITY = (1 << 0),
+		DOWNSAMPLER_MODE_FLAG_RGB10_A2 = (1 << 1),
+
+		DOWNSAMPLER_MODE_COMPUTE_MAX = ((DOWNSAMPLER_MODE_FLAG_HIGH_QUALITY | DOWNSAMPLER_MODE_FLAG_RGB10_A2) + 1),
+		DOWNSAMPLER_MODE_RASTER_MAX = (DOWNSAMPLER_MODE_FLAG_HIGH_QUALITY + 1),
 	};
 
 	struct OctmapDownsampler {
@@ -266,16 +268,17 @@ private:
 		OctmapDownsamplerShaderRD compute_shader;
 		OctmapDownsamplerRasterShaderRD raster_shader;
 		RID shader_version;
-		PipelineDeferredRD compute_pipelines[DOWNSAMPLER_MODE_MAX];
-		PipelineCacheRD raster_pipelines[DOWNSAMPLER_MODE_MAX];
+		PipelineDeferredRD compute_pipelines[DOWNSAMPLER_MODE_COMPUTE_MAX];
+		PipelineCacheRD raster_pipelines[DOWNSAMPLER_MODE_RASTER_MAX];
 	} octmap_downsampler;
 
 	enum OctmapFilterMode {
-		FILTER_MODE_HIGH_QUALITY,
-		FILTER_MODE_LOW_QUALITY,
-		FILTER_MODE_HIGH_QUALITY_ARRAY,
-		FILTER_MODE_LOW_QUALITY_ARRAY,
-		FILTER_MODE_MAX,
+		FILTER_MODE_FLAG_HIGH_QUALITY = (1 << 0),
+		FILTER_MODE_FLAG_ARRAY = (1 << 1),
+		FILTER_MODE_FLAG_RGB10_A2 = (1 << 2),
+
+		FILTER_MODE_COMPUTE_MAX = ((FILTER_MODE_FLAG_HIGH_QUALITY | FILTER_MODE_FLAG_ARRAY | FILTER_MODE_FLAG_RGB10_A2) + 1),
+		FILTER_MODE_RASTER_MAX = (FILTER_MODE_FLAG_HIGH_QUALITY + 1),
 	};
 
 	struct OctmapFilterPushConstant {
@@ -294,8 +297,8 @@ private:
 		OctmapFilterShaderRD compute_shader;
 		OctmapFilterRasterShaderRD raster_shader;
 		RID shader_version;
-		PipelineDeferredRD compute_pipelines[FILTER_MODE_MAX];
-		PipelineCacheRD raster_pipelines[FILTER_MODE_MAX];
+		PipelineDeferredRD compute_pipelines[FILTER_MODE_COMPUTE_MAX];
+		PipelineCacheRD raster_pipelines[FILTER_MODE_RASTER_MAX];
 
 		RID uniform_set;
 		RID image_uniform_set;
@@ -303,6 +306,12 @@ private:
 		bool use_high_quality;
 
 	} filter;
+
+	enum OctmapRoughnessMode {
+		ROUGHNESS_MODE_RGBA16F,
+		ROUGHNESS_MODE_RGB10_A2,
+		ROUGHNESS_MODE_MAX,
+	};
 
 	struct OctmapRoughnessPushConstant {
 		uint32_t sample_count;
@@ -320,7 +329,7 @@ private:
 		OctmapRoughnessShaderRD compute_shader;
 		OctmapRoughnessRasterShaderRD raster_shader;
 		RID shader_version;
-		PipelineDeferredRD compute_pipeline;
+		PipelineDeferredRD compute_pipelines[ROUGHNESS_MODE_MAX];
 		PipelineCacheRD raster_pipeline;
 	} roughness;
 

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_downsampler.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_downsampler.glsl
@@ -32,7 +32,7 @@ layout(local_size_x = BLOCK_SIZE, local_size_y = BLOCK_SIZE, local_size_z = 1) i
 
 layout(set = 0, binding = 0) uniform sampler2D source_octmap;
 
-layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly image2D dest_octmap;
+layout(OCTMAP_FORMAT, set = 1, binding = 0) uniform restrict writeonly image2D dest_octmap;
 
 layout(push_constant, std430) uniform Params {
 	float border_size;

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_filter.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_filter.glsl
@@ -31,12 +31,12 @@
 layout(local_size_x = GROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 layout(set = 0, binding = 0) uniform sampler2D source_octmap;
-layout(rgba16f, set = 2, binding = 0) uniform restrict writeonly image2D dest_octmap0;
-layout(rgba16f, set = 2, binding = 1) uniform restrict writeonly image2D dest_octmap1;
-layout(rgba16f, set = 2, binding = 2) uniform restrict writeonly image2D dest_octmap2;
-layout(rgba16f, set = 2, binding = 3) uniform restrict writeonly image2D dest_octmap3;
-layout(rgba16f, set = 2, binding = 4) uniform restrict writeonly image2D dest_octmap4;
-layout(rgba16f, set = 2, binding = 5) uniform restrict writeonly image2D dest_octmap5;
+layout(OCTMAP_FORMAT, set = 2, binding = 0) uniform restrict writeonly image2D dest_octmap0;
+layout(OCTMAP_FORMAT, set = 2, binding = 1) uniform restrict writeonly image2D dest_octmap1;
+layout(OCTMAP_FORMAT, set = 2, binding = 2) uniform restrict writeonly image2D dest_octmap2;
+layout(OCTMAP_FORMAT, set = 2, binding = 3) uniform restrict writeonly image2D dest_octmap3;
+layout(OCTMAP_FORMAT, set = 2, binding = 4) uniform restrict writeonly image2D dest_octmap4;
+layout(OCTMAP_FORMAT, set = 2, binding = 5) uniform restrict writeonly image2D dest_octmap5;
 
 #ifdef USE_HIGH_QUALITY
 #define NUM_TAPS 32

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_roughness.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_roughness.glsl
@@ -10,7 +10,7 @@ layout(local_size_x = GROUP_SIZE, local_size_y = GROUP_SIZE, local_size_z = 1) i
 
 layout(set = 0, binding = 0) uniform sampler2D source_oct;
 
-layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly image2D dest_octmap;
+layout(OCTMAP_FORMAT, set = 1, binding = 0) uniform restrict writeonly image2D dest_octmap;
 
 #include "../oct_inc.glsl"
 #include "octmap_roughness_inc.glsl"


### PR DESCRIPTION
Fixes #113909.
Fixes corrupted pixels on PowerVR GE8320.