### PR TITLE
Add mechanism to restore previously selected tab when transient tabs are lost/closed

### DIFF
--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -92,6 +92,7 @@ private:
 		TabContainer *container = nullptr;
 		EditorDockDragHint *drag_hint = nullptr;
 		DockConstants::DockLayout layout = DockConstants::DOCK_LAYOUT_VERTICAL;
+		int previous_non_transient_tab = -1;
 	};
 
 	DockSlot dock_slots[DockConstants::DOCK_SLOT_MAX];
@@ -127,6 +128,8 @@ private:
 	void _queue_update_tab_style(EditorDock *p_dock);
 	void _update_dirty_dock_tabs();
 	void _update_tab_style(EditorDock *p_dock);
+
+	void _restore_first_non_transient_tab(TabContainer *p_tab_container);
 
 public:
 	static EditorDockManager *get_singleton() { return singleton; }


### PR DESCRIPTION
The PR addresses issue #114352 

Before: the default behaviour was to select the last (in the stack) available tab.

This PR implements proper tab restoration for transient docks by tracking the previously active non-transient tab per dock slot, and restoring it when a transient dock closes.
NOTE: this fix applies to all transient docks, not just `TileMap` editor. The solution mirrors the existing `previous_tab` pattern used successfully in `EditorBottomPanel`.

https://github.com/user-attachments/assets/d852558a-0808-4322-9a55-7e68c29bf133

Implementation details:
  1. When focusing a transient dock, the current non-transient tab index is saved in the dock slot
  2. When closing a transient dock, the saved tab is restored (with validation)
  3. If the saved tab is no longer valid, falls back to the first non-transient tab in the slot
  4. Bottom panel explicitly excluded as it has its own tab management

Tested the following scenarios:
  - Select `TileMap` node → deselect → Inspector tab restored
  - Reorder tabs → deselect transient dock → correct tab restored (not dependent on tab order)
  - Multiple transient docks → closes restore previous state in LIFO order
  - Manual dock close via context menu → tab restored
  - Only transient dock in slot → no crash, graceful handling
