### PR TITLE
Fix incorrect duplicated child node names

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1538,29 +1538,42 @@ void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
 
 		if (!unique) {
 			ERR_FAIL_COND(!node_hrcr_count.ref());
-			// Optimized version of the code below:
-			// String name = "@" + String(p_child->get_name()) + "@" + itos(node_hrcr_count.get());
-			uint32_t c = node_hrcr_count.get();
-			String cn = p_child->get_class_name().operator String();
-			const char32_t *cn_ptr = cn.ptr();
-			uint32_t cn_length = cn.length();
-			uint32_t c_chars = String::num_characters(c);
-			uint32_t len = 2 + cn_length + c_chars;
-			char32_t *str = (char32_t *)alloca(sizeof(char32_t) * (len + 1));
-			uint32_t idx = 0;
-			str[idx++] = '@';
-			for (uint32_t i = 0; i < cn_length; i++) {
-				str[idx++] = cn_ptr[i];
+			uint32_t node_id = node_hrcr_count.get();
+			String unique_name;
+
+			while (!unique) {
+				// Optimized version of the code below:
+				// String name = "@" + String(p_child->get_name()) + "@" + itos(node_hrcr_count.get());
+
+				uint32_t c = node_id;
+				String cn = p_child->get_class_name().operator String();
+				const char32_t *cn_ptr = cn.ptr();
+				uint32_t cn_length = cn.length();
+				uint32_t c_chars = String::num_characters(c);
+				uint32_t len = 2 + cn_length + c_chars;
+				char32_t *str = (char32_t *)alloca(sizeof(char32_t) * (len + 1));
+				uint32_t idx = 0;
+				str[idx++] = '@';
+				for (uint32_t i = 0; i < cn_length; i++) {
+					str[idx++] = cn_ptr[i];
+				}
+				str[idx++] = '@';
+				idx += c_chars;
+				ERR_FAIL_COND(idx != len);
+				str[idx] = 0;
+				while (c) {
+					str[--idx] = '0' + (c % 10);
+					c /= 10;
+				}
+
+				unique_name = String(str);
+				node_id += 1;
+
+				const Node *const *existing = data.children.getptr(unique_name);
+				unique = !existing || *existing == p_child;
 			}
-			str[idx++] = '@';
-			idx += c_chars;
-			ERR_FAIL_COND(idx != len);
-			str[idx] = 0;
-			while (c) {
-				str[--idx] = '0' + (c % 10);
-				c /= 10;
-			}
-			p_child->data.name = String(str);
+
+			p_child->data.name = unique_name;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Issue: #113040

### Details
Generated new names for duplicated name nodes depends on _SafeRefCount node_hrcr_count_
When node_hrcr_count.get() returns value, function generated not unique name that is causing a new node with this name to be wrong arranged in the list.

### Minimal reproduction project (MRP)

[test-5.zip](https://github.com/user-attachments/files/24372261/test-5.zip)

