### PR TITLE
Renderer: Add nested label support

### DIFF
--- a/drivers/gles3/storage/utilities.h
+++ b/drivers/gles3/storage/utilities.h
@@ -56,6 +56,10 @@ private:
 
 	mutable RID_Owner<VisibilityNotifier> visibility_notifier_owner;
 
+	/* DEBUG */
+
+	[[nodiscard]] DebugLabel draw_command_label(const Span<char>, const Color &) const final { return DebugLabel(); }
+
 	/* MISC */
 
 	struct ResourceAllocation {

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -75,6 +75,10 @@ public:
 	virtual uint64_t get_captured_timestamp_cpu_time(uint32_t p_index) const override { return 0; }
 	virtual String get_captured_timestamp_name(uint32_t p_index) const override { return String(); }
 
+	/* DEBUG */
+
+	[[nodiscard]] DebugLabel draw_command_label(const Span<char>, const Color &) const final { return DebugLabel(); }
+
 	/* MISC */
 
 	virtual void update_dirty_resources() override {}

--- a/servers/rendering/renderer_rd/cluster_builder_rd.cpp
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.cpp
@@ -305,12 +305,15 @@ void ClusterBuilderRD::setup(Size2i p_screen_size, uint32_t p_max_elements, RID 
 	cluster_render_buffer_size = cluster_screen_size.x * cluster_screen_size.y * (element_tag_bits_size + element_tag_depth_bits_size) * 4; // Tag bits (element was used) and tag depth (depth range in which it was used).
 
 	cluster_render_buffer = RD::get_singleton()->storage_buffer_create(cluster_render_buffer_size);
+	RD::get_singleton()->set_resource_name(cluster_render_buffer, "Cluster Render");
 	cluster_buffer = RD::get_singleton()->storage_buffer_create(cluster_buffer_size);
+	RD::get_singleton()->set_resource_name(cluster_buffer, "Cluster");
 
 	render_elements = static_cast<RenderElementData *>(memalloc(sizeof(RenderElementData) * render_element_max));
 	render_element_count = 0;
 
 	element_buffer = RD::get_singleton()->storage_buffer_create(sizeof(RenderElementData) * render_element_max);
+	RD::get_singleton()->set_resource_name(element_buffer, "Element");
 
 	uint32_t div_value = 1 << divisor;
 	if (use_msaa) {
@@ -438,7 +441,7 @@ void ClusterBuilderRD::begin(const Transform3D &p_view_transform, const Projecti
 void ClusterBuilderRD::bake_cluster() {
 	RENDER_TIMESTAMP("> Bake 3D Cluster");
 
-	RD::get_singleton()->draw_command_begin_label("Bake Light Cluster");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Bake Light Cluster");
 
 	// Clear cluster buffer.
 	RD::get_singleton()->buffer_clear(cluster_buffer, 0, cluster_buffer_size);
@@ -542,7 +545,6 @@ void ClusterBuilderRD::bake_cluster() {
 		}
 	}
 	RENDER_TIMESTAMP("< Bake 3D Cluster");
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void ClusterBuilderRD::debug(ElementType p_element) {
@@ -588,6 +590,7 @@ void ClusterBuilderRD::set_shared(ClusterBuilderSharedDataRD *p_shared) {
 
 ClusterBuilderRD::ClusterBuilderRD() {
 	state_uniform = RD::get_singleton()->uniform_buffer_create(sizeof(StateUniform));
+	RD::get_singleton()->set_resource_name(state_uniform, "Cluster Builder State");
 }
 
 ClusterBuilderRD::~ClusterBuilderRD() {

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -1446,7 +1446,7 @@ void CopyEffects::merge_specular(RID p_dest_framebuffer, RID p_specular, RID p_b
 
 	RID default_sampler = material_storage->sampler_rd_get_default(RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
-	RD::get_singleton()->draw_command_begin_label("Merge Specular");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Merge Specular");
 
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_dest_framebuffer);
 
@@ -1487,6 +1487,4 @@ void CopyEffects::merge_specular(RID p_dest_framebuffer, RID p_specular, RID p_b
 
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
 	RD::get_singleton()->draw_list_end();
-
-	RD::get_singleton()->draw_command_end_label();
 }

--- a/servers/rendering/renderer_rd/effects/motion_vectors_store.cpp
+++ b/servers/rendering/renderer_rd/effects/motion_vectors_store.cpp
@@ -73,7 +73,7 @@ void MotionVectorsStore::process(Ref<RenderSceneBuffersRD> p_render_buffers,
 
 	RID default_sampler = material_storage->sampler_rd_get_default(RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST, RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
-	RD::get_singleton()->draw_command_begin_label("Motion Vector Store");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Motion Vector Store");
 
 	RID shader = motion_shader.version_get_shader(shader_version, 0);
 	ERR_FAIL_COND(shader.is_null());
@@ -94,8 +94,6 @@ void MotionVectorsStore::process(Ref<RenderSceneBuffersRD> p_render_buffers,
 	}
 
 	RD::get_singleton()->compute_list_end();
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 } //namespace RendererRD

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -547,7 +547,7 @@ void SSEffects::downsample_depth(Ref<RenderSceneBuffersRD> p_render_buffers, uin
 	RID shader = ss_effects.downsample_shader.version_get_shader(ss_effects.downsample_shader_version, downsample_mode);
 	int depth_index = use_half_size ? 1 : 0;
 
-	RD::get_singleton()->draw_command_begin_label("Downsample Depth");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Downsample Depth");
 
 	RID downsample_uniform_set;
 	if (use_mips) {
@@ -615,7 +615,6 @@ void SSEffects::downsample_depth(Ref<RenderSceneBuffersRD> p_render_buffers, uin
 	}
 
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, size.x, size.y, 1);
-	RD::get_singleton()->draw_command_end_label();
 	RD::get_singleton()->compute_list_end();
 
 	ss_effects.used_full_mips_last_frame = use_full_mips;
@@ -724,7 +723,7 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	ERR_FAIL_NULL(material_storage);
 
-	RD::get_singleton()->draw_command_begin_label("Process Screen-Space Indirect Lighting");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Process Screen-Space Indirect Lighting");
 
 	// Obtain our (cached) buffer slices for the view we are rendering.
 	RID last_frame = p_render_buffers->get_texture_slice(RB_SCOPE_SSLF, RB_LAST_FRAME, p_view, 0, 1, 6);
@@ -757,7 +756,7 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	{
-		RD::get_singleton()->draw_command_begin_label("Gather Samples");
+		RD::DrawCommandLabel label_gather = RD::get_singleton()->draw_command_label("Gather Samples");
 		ssil.gather_push_constant.screen_size[0] = p_settings.full_screen_size.x;
 		ssil.gather_push_constant.screen_size[1] = p_settings.full_screen_size.y;
 
@@ -868,7 +867,7 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 		}
 
 		if (ssil_quality == RSE::ENV_SSIL_QUALITY_ULTRA) {
-			RD::get_singleton()->draw_command_begin_label("Generate Importance Map");
+			RD::DrawCommandLabel label_importance_map = RD::get_singleton()->draw_command_label("Generate Importance Map");
 			ssil.importance_map_push_constant.half_screen_pixel_size[0] = 1.0 / p_ssil_buffers.buffer_width;
 			ssil.importance_map_push_constant.half_screen_pixel_size[1] = 1.0 / p_ssil_buffers.buffer_height;
 			ssil.importance_map_push_constant.intensity = p_settings.intensity * Math::PI;
@@ -913,19 +912,16 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 			RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_ssil_buffers.half_buffer_width, p_ssil_buffers.half_buffer_height, 1);
 			RD::get_singleton()->compute_list_add_barrier(compute_list);
 
-			RD::get_singleton()->draw_command_end_label(); // Importance Map
-
 			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssil.pipelines[SSIL_GATHER_ADAPTIVE].get_rid());
 		} else {
 			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssil.pipelines[SSIL_GATHER].get_rid());
 		}
 
 		gather_ssil(compute_list, deinterleaved_slices, edges_slices, p_settings, false, gather_uniform_set, importance_map_uniform_set, projection_uniform_set);
-		RD::get_singleton()->draw_command_end_label(); //Gather
 	}
 
 	{
-		RD::get_singleton()->draw_command_begin_label("Edge Aware Blur");
+		RD::DrawCommandLabel label_blur = RD::get_singleton()->draw_command_label("Edge Aware Blur");
 		ssil.blur_push_constant.edge_sharpness = 1.0 - p_settings.sharpness;
 		ssil.blur_push_constant.half_screen_pixel_size[0] = 1.0 / p_ssil_buffers.buffer_width;
 		ssil.blur_push_constant.half_screen_pixel_size[1] = 1.0 / p_ssil_buffers.buffer_height;
@@ -989,12 +985,10 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 
 			RD::get_singleton()->compute_list_add_barrier(compute_list);
 		}
-
-		RD::get_singleton()->draw_command_end_label(); // Blur
 	}
 
 	{
-		RD::get_singleton()->draw_command_begin_label("Interleave Buffers");
+		RD::DrawCommandLabel label_interleave = RD::get_singleton()->draw_command_label("Interleave Buffers");
 		ssil.interleave_push_constant.inv_sharpness = 1.0 - p_settings.sharpness;
 		ssil.interleave_push_constant.pixel_size[0] = 1.0 / p_settings.full_screen_size.x;
 		ssil.interleave_push_constant.pixel_size[1] = 1.0 / p_settings.full_screen_size.y;
@@ -1029,10 +1023,7 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 		RD::get_singleton()->compute_list_set_push_constant(compute_list, &ssil.interleave_push_constant, sizeof(SSILInterleavePushConstant));
 
 		RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_settings.full_screen_size.x, p_settings.full_screen_size.y, 1);
-		RD::get_singleton()->draw_command_end_label(); // Interleave
 	}
-
-	RD::get_singleton()->draw_command_end_label(); // SSIL
 
 	RD::get_singleton()->compute_list_end();
 
@@ -1151,11 +1142,11 @@ void SSEffects::generate_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, SSAORe
 	RID shader = ssao.gather_shader.version_get_shader(ssao.gather_shader_version, SSAO_GATHER);
 	RID default_sampler = material_storage->sampler_rd_get_default(RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
-	RD::get_singleton()->draw_command_begin_label("Process Screen-Space Ambient Occlusion");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Process Screen-Space Ambient Occlusion");
 	/* SECOND PASS */
 	// Sample SSAO
 	{
-		RD::get_singleton()->draw_command_begin_label("Gather Samples");
+		RD::DrawCommandLabel label_gather = RD::get_singleton()->draw_command_label("Gather Samples");
 		ssao.gather_push_constant.screen_size[0] = p_settings.full_screen_size.x;
 		ssao.gather_push_constant.screen_size[1] = p_settings.full_screen_size.y;
 
@@ -1250,7 +1241,7 @@ void SSEffects::generate_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, SSAORe
 		}
 
 		if (ssao_quality == RSE::ENV_SSAO_QUALITY_ULTRA) {
-			RD::get_singleton()->draw_command_begin_label("Generate Importance Map");
+			RD::DrawCommandLabel label_importance_map = RD::get_singleton()->draw_command_label("Generate Importance Map");
 			ssao.importance_map_push_constant.half_screen_pixel_size[0] = 1.0 / p_ssao_buffers.buffer_width;
 			ssao.importance_map_push_constant.half_screen_pixel_size[1] = 1.0 / p_ssao_buffers.buffer_height;
 			ssao.importance_map_push_constant.intensity = p_settings.intensity;
@@ -1302,20 +1293,19 @@ void SSEffects::generate_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, SSAORe
 			RD::get_singleton()->compute_list_add_barrier(compute_list);
 
 			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssao.pipelines[SSAO_GATHER_ADAPTIVE].get_rid());
-			RD::get_singleton()->draw_command_end_label(); // Importance Map
+			label_importance_map.end();
 		} else {
 			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssao.pipelines[SSAO_GATHER].get_rid());
 		}
 
 		gather_ssao(compute_list, ao_deinterleaved_slices, p_settings, false, gather_uniform_set, importance_map_uniform_set);
-		RD::get_singleton()->draw_command_end_label(); // Gather SSAO
 	}
 
 	//	/* THIRD PASS */
 	//	// Blur
 	//
 	{
-		RD::get_singleton()->draw_command_begin_label("Edge-Aware Blur");
+		RD::DrawCommandLabel label_blur = RD::get_singleton()->draw_command_label("Edge-Aware Blur");
 		ssao.blur_push_constant.edge_sharpness = 1.0 - p_settings.sharpness;
 		ssao.blur_push_constant.half_screen_pixel_size[0] = 1.0 / p_ssao_buffers.buffer_width;
 		ssao.blur_push_constant.half_screen_pixel_size[1] = 1.0 / p_ssao_buffers.buffer_height;
@@ -1371,14 +1361,13 @@ void SSEffects::generate_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, SSAORe
 
 			RD::get_singleton()->compute_list_add_barrier(compute_list);
 		}
-		RD::get_singleton()->draw_command_end_label(); // Blur
 	}
 
 	/* FOURTH PASS */
 	// Interleave buffers
 	// back to full size
 	{
-		RD::get_singleton()->draw_command_begin_label("Interleave Buffers");
+		RD::DrawCommandLabel label_interleave = RD::get_singleton()->draw_command_label("Interleave Buffers");
 		ssao.interleave_push_constant.inv_sharpness = 1.0 - p_settings.sharpness;
 		ssao.interleave_push_constant.pixel_size[0] = 1.0 / p_settings.full_screen_size.x;
 		ssao.interleave_push_constant.pixel_size[1] = 1.0 / p_settings.full_screen_size.y;
@@ -1410,9 +1399,8 @@ void SSEffects::generate_ssao(Ref<RenderSceneBuffersRD> p_render_buffers, SSAORe
 		RD::get_singleton()->compute_list_set_push_constant(compute_list, &ssao.interleave_push_constant, sizeof(SSAOInterleavePushConstant));
 
 		RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_settings.full_screen_size.x, p_settings.full_screen_size.y, 1);
-		RD::get_singleton()->draw_command_end_label(); // Interleave
 	}
-	RD::get_singleton()->draw_command_end_label(); //SSAO
+
 	RD::get_singleton()->compute_list_end();
 
 	int zero[1] = { 0 };
@@ -1501,7 +1489,7 @@ void SSEffects::screen_space_reflection(Ref<RenderSceneBuffersRD> p_render_buffe
 	RID nearest_sampler = material_storage->sampler_rd_get_default(RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS, RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	if (ssr_half_size) {
-		RD::get_singleton()->draw_command_begin_label("SSR Downsample");
+		RD::DrawCommandLabel label_downsample = RD::get_singleton()->draw_command_label("SSR Downsample");
 
 		for (uint32_t v = 0; v < view_count; v++) {
 			ScreenSpaceReflectionDownsamplePushConstant push_constant;
@@ -1543,150 +1531,146 @@ void SSEffects::screen_space_reflection(Ref<RenderSceneBuffersRD> p_render_buffe
 
 			RD::get_singleton()->compute_list_end();
 		}
-
-		RD::get_singleton()->draw_command_end_label();
 	} else {
-		RD::get_singleton()->draw_command_begin_label("SSR Copy Depth");
+		RD::DrawCommandLabel label_copy_depth = RD::get_singleton()->draw_command_label("SSR Copy Depth");
 
 		for (uint32_t v = 0; v < view_count; v++) {
 			RID src_texture = p_render_buffers->get_depth_texture(v);
 			RID dest_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_HIZ, v, 0);
 			p_copy_effects.copy_depth_to_rect(src_texture, dest_texture, Rect2i(Vector2i(), p_ssr_buffers.size));
 		}
-
-		RD::get_singleton()->draw_command_end_label();
 	}
 
-	RD::get_singleton()->draw_command_begin_label("SSR HI-Z");
+	{
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("SSR HI-Z");
 
-	for (uint32_t v = 0; v < view_count; v++) {
-		for (uint32_t m = 1; m < p_ssr_buffers.mipmaps; m++) {
-			ScreenSpaceReflectionHizPushConstant push_constant;
-			push_constant.screen_size[0] = MAX(1, p_ssr_buffers.size.width >> m);
-			push_constant.screen_size[1] = MAX(1, p_ssr_buffers.size.height >> m);
+		for (uint32_t v = 0; v < view_count; v++) {
+			for (uint32_t m = 1; m < p_ssr_buffers.mipmaps; m++) {
+				ScreenSpaceReflectionHizPushConstant push_constant;
+				push_constant.screen_size[0] = MAX(1, p_ssr_buffers.size.width >> m);
+				push_constant.screen_size[1] = MAX(1, p_ssr_buffers.size.height >> m);
 
-			RID source;
+				RID source;
 
-			if (!ssr_half_size && m == 1) { // Reuse the depth texture to not create a dependency on the previous depth copy pass.
-				source = p_render_buffers->get_depth_texture(v);
-			} else {
-				source = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_HIZ, v, m - 1);
+				if (!ssr_half_size && m == 1) { // Reuse the depth texture to not create a dependency on the previous depth copy pass.
+					source = p_render_buffers->get_depth_texture(v);
+				} else {
+					source = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_HIZ, v, m - 1);
+				}
+
+				RID dest = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_HIZ, v, m);
+
+				Size2i parent_size = RD::get_singleton()->texture_size(source);
+				bool is_width_odd = (parent_size.width % 2) != 0;
+				bool is_height_odd = (parent_size.height % 2) != 0;
+
+				int32_t hiz_mode;
+				if (is_width_odd && is_height_odd) {
+					hiz_mode = SCREEN_SPACE_REFLECTION_HIZ_ODD_WIDTH_AND_HEIGHT;
+				} else if (is_width_odd) {
+					hiz_mode = SCREEN_SPACE_REFLECTION_HIZ_ODD_WIDTH;
+				} else if (is_height_odd) {
+					hiz_mode = SCREEN_SPACE_REFLECTION_HIZ_ODD_HEIGHT;
+				} else {
+					hiz_mode = SCREEN_SPACE_REFLECTION_HIZ_DEFAULT;
+				}
+
+				RID hiz_shader = ssr.hiz_shader.version_get_shader(ssr.hiz_shader_version, hiz_mode);
+
+				RD::Uniform u_source(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>{ nearest_sampler, source });
+				RD::Uniform u_dest(RD::UNIFORM_TYPE_IMAGE, 1, dest);
+
+				RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssr.hiz_pipelines[hiz_mode].get_rid());
+				RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(hiz_shader, 0, u_source, u_dest), 0);
+				RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(push_constant));
+				RD::get_singleton()->compute_list_dispatch_threads(compute_list, push_constant.screen_size[0], push_constant.screen_size[1], 1);
+
+				RD::get_singleton()->compute_list_end();
 			}
+		}
+	}
 
-			RID dest = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_HIZ, v, m);
+	{
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("SSR Main");
 
-			Size2i parent_size = RD::get_singleton()->texture_size(source);
-			bool is_width_odd = (parent_size.width % 2) != 0;
-			bool is_height_odd = (parent_size.height % 2) != 0;
+		RID ssr_shader = ssr.ssr_shader.version_get_shader(ssr.ssr_shader_version, 0);
 
-			int32_t hiz_mode;
-			if (is_width_odd && is_height_odd) {
-				hiz_mode = SCREEN_SPACE_REFLECTION_HIZ_ODD_WIDTH_AND_HEIGHT;
-			} else if (is_width_odd) {
-				hiz_mode = SCREEN_SPACE_REFLECTION_HIZ_ODD_WIDTH;
-			} else if (is_height_odd) {
-				hiz_mode = SCREEN_SPACE_REFLECTION_HIZ_ODD_HEIGHT;
-			} else {
-				hiz_mode = SCREEN_SPACE_REFLECTION_HIZ_DEFAULT;
-			}
-
-			RID hiz_shader = ssr.hiz_shader.version_get_shader(ssr.hiz_shader_version, hiz_mode);
-
-			RD::Uniform u_source(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>{ nearest_sampler, source });
-			RD::Uniform u_dest(RD::UNIFORM_TYPE_IMAGE, 1, dest);
-
+		for (uint32_t v = 0; v < view_count; v++) {
 			RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 
-			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssr.hiz_pipelines[hiz_mode].get_rid());
-			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(hiz_shader, 0, u_source, u_dest), 0);
+			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssr.ssr_pipeline.get_rid());
+
+			ScreenSpaceReflectionPushConstant push_constant;
+			push_constant.screen_size[0] = p_ssr_buffers.size.width;
+			push_constant.screen_size[1] = p_ssr_buffers.size.height;
+			push_constant.mipmaps = p_ssr_buffers.mipmaps;
+			push_constant.num_steps = p_max_steps;
+			push_constant.curve_fade_in = p_fade_in;
+			push_constant.distance_fade = p_fade_out;
+			push_constant.depth_tolerance = p_tolerance;
+			push_constant.orthogonal = p_projections[v].is_orthogonal();
+			push_constant.view_index = v;
+
+			RID last_frame_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSLF, RB_LAST_FRAME, v, 0);
+			if (ssr_half_size && RD::get_singleton()->texture_size(last_frame_texture) != p_ssr_buffers.size) {
+				// SSIL is likely also enabled. The texture we need is in the second mipmap in this case.
+				last_frame_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSLF, RB_LAST_FRAME, v, 1);
+			}
+
+			RID hiz_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_HIZ, v, 0, 1, p_ssr_buffers.mipmaps);
+			RID normal_roughness_texture = ssr_half_size ? p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_NORMAL_ROUGHNESS, v, 0) : p_normal_roughness_slices[v];
+			RID ssr_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_SSR, v, 0);
+			RID mip_level_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_MIP_LEVEL, v, 0);
+
+			RD::Uniform u_last_frame(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>{ linear_sampler, last_frame_texture });
+			RD::Uniform u_hiz(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 1, Vector<RID>{ nearest_sampler, hiz_texture });
+			RD::Uniform u_normal_roughness(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 2, Vector<RID>{ nearest_sampler, normal_roughness_texture });
+			RD::Uniform u_ssr(RD::UNIFORM_TYPE_IMAGE, 3, ssr_texture);
+			RD::Uniform u_mip_level(RD::UNIFORM_TYPE_IMAGE, 4, mip_level_texture);
+			RD::Uniform u_scene_data(RD::UNIFORM_TYPE_UNIFORM_BUFFER, 5, ssr.ubo);
+			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(ssr_shader, 0, u_last_frame, u_hiz, u_normal_roughness, u_ssr, u_mip_level, u_scene_data), 0);
+
 			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(push_constant));
-			RD::get_singleton()->compute_list_dispatch_threads(compute_list, push_constant.screen_size[0], push_constant.screen_size[1], 1);
+			RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_ssr_buffers.size.width, p_ssr_buffers.size.height, 1);
 
 			RD::get_singleton()->compute_list_end();
 		}
 	}
 
-	RD::get_singleton()->draw_command_end_label();
+	{
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("SSR Roughness Filter");
 
-	RD::get_singleton()->draw_command_begin_label("SSR Main");
+		RID filter_shader = ssr.filter_shader.version_get_shader(ssr.filter_shader_version, 0);
 
-	RID ssr_shader = ssr.ssr_shader.version_get_shader(ssr.ssr_shader_version, 0);
+		for (uint32_t v = 0; v < view_count; v++) {
+			for (uint32_t m = 1; m < p_ssr_buffers.mipmaps; m++) {
+				ScreenSpaceReflectionFilterPushConstant push_constant;
+				push_constant.screen_size[0] = MAX(1, p_ssr_buffers.size.width >> m);
+				push_constant.screen_size[1] = MAX(1, p_ssr_buffers.size.height >> m);
+				push_constant.mip_level = m;
 
-	for (uint32_t v = 0; v < view_count; v++) {
-		RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+				RID source = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_SSR, v, m - 1);
+				RID dest = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_SSR, v, m);
 
-		RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssr.ssr_pipeline.get_rid());
+				RD::Uniform u_source(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>{ linear_sampler, source });
+				RD::Uniform u_dest(RD::UNIFORM_TYPE_IMAGE, 1, dest);
 
-		ScreenSpaceReflectionPushConstant push_constant;
-		push_constant.screen_size[0] = p_ssr_buffers.size.width;
-		push_constant.screen_size[1] = p_ssr_buffers.size.height;
-		push_constant.mipmaps = p_ssr_buffers.mipmaps;
-		push_constant.num_steps = p_max_steps;
-		push_constant.curve_fade_in = p_fade_in;
-		push_constant.distance_fade = p_fade_out;
-		push_constant.depth_tolerance = p_tolerance;
-		push_constant.orthogonal = p_projections[v].is_orthogonal();
-		push_constant.view_index = v;
+				RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 
-		RID last_frame_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSLF, RB_LAST_FRAME, v, 0);
-		if (ssr_half_size && RD::get_singleton()->texture_size(last_frame_texture) != p_ssr_buffers.size) {
-			// SSIL is likely also enabled. The texture we need is in the second mipmap in this case.
-			last_frame_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSLF, RB_LAST_FRAME, v, 1);
-		}
+				RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssr.filter_pipeline.get_rid());
+				RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(filter_shader, 0, u_source, u_dest), 0);
+				RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(push_constant));
+				RD::get_singleton()->compute_list_dispatch_threads(compute_list, push_constant.screen_size[0], push_constant.screen_size[1], 1);
 
-		RID hiz_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_HIZ, v, 0, 1, p_ssr_buffers.mipmaps);
-		RID normal_roughness_texture = ssr_half_size ? p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_NORMAL_ROUGHNESS, v, 0) : p_normal_roughness_slices[v];
-		RID ssr_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_SSR, v, 0);
-		RID mip_level_texture = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_MIP_LEVEL, v, 0);
-
-		RD::Uniform u_last_frame(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>{ linear_sampler, last_frame_texture });
-		RD::Uniform u_hiz(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 1, Vector<RID>{ nearest_sampler, hiz_texture });
-		RD::Uniform u_normal_roughness(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 2, Vector<RID>{ nearest_sampler, normal_roughness_texture });
-		RD::Uniform u_ssr(RD::UNIFORM_TYPE_IMAGE, 3, ssr_texture);
-		RD::Uniform u_mip_level(RD::UNIFORM_TYPE_IMAGE, 4, mip_level_texture);
-		RD::Uniform u_scene_data(RD::UNIFORM_TYPE_UNIFORM_BUFFER, 5, ssr.ubo);
-		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(ssr_shader, 0, u_last_frame, u_hiz, u_normal_roughness, u_ssr, u_mip_level, u_scene_data), 0);
-
-		RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(push_constant));
-		RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_ssr_buffers.size.width, p_ssr_buffers.size.height, 1);
-
-		RD::get_singleton()->compute_list_end();
-	}
-
-	RD::get_singleton()->draw_command_end_label();
-
-	RD::get_singleton()->draw_command_begin_label("SSR Roughness Filter");
-
-	RID filter_shader = ssr.filter_shader.version_get_shader(ssr.filter_shader_version, 0);
-
-	for (uint32_t v = 0; v < view_count; v++) {
-		for (uint32_t m = 1; m < p_ssr_buffers.mipmaps; m++) {
-			ScreenSpaceReflectionFilterPushConstant push_constant;
-			push_constant.screen_size[0] = MAX(1, p_ssr_buffers.size.width >> m);
-			push_constant.screen_size[1] = MAX(1, p_ssr_buffers.size.height >> m);
-			push_constant.mip_level = m;
-
-			RID source = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_SSR, v, m - 1);
-			RID dest = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_SSR, v, m);
-
-			RD::Uniform u_source(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>{ linear_sampler, source });
-			RD::Uniform u_dest(RD::UNIFORM_TYPE_IMAGE, 1, dest);
-
-			RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
-
-			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, ssr.filter_pipeline.get_rid());
-			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(filter_shader, 0, u_source, u_dest), 0);
-			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(push_constant));
-			RD::get_singleton()->compute_list_dispatch_threads(compute_list, push_constant.screen_size[0], push_constant.screen_size[1], 1);
-
-			RD::get_singleton()->compute_list_end();
+				RD::get_singleton()->compute_list_end();
+			}
 		}
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 
 	if (ssr_half_size) {
-		RD::get_singleton()->draw_command_begin_label("SSR Resolve");
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("SSR Resolve");
 
 		RID resolve_shader = ssr.resolve_shader.version_get_shader(ssr.resolve_shader_version, 0);
 
@@ -1722,8 +1706,6 @@ void SSEffects::screen_space_reflection(Ref<RenderSceneBuffersRD> p_render_buffe
 
 			RD::get_singleton()->compute_list_end();
 		}
-
-		RD::get_singleton()->draw_command_end_label();
 	}
 }
 

--- a/servers/rendering/renderer_rd/effects/taa.cpp
+++ b/servers/rendering/renderer_rd/effects/taa.cpp
@@ -106,7 +106,7 @@ void TAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_f
 		just_allocated = true;
 	}
 
-	RD::get_singleton()->draw_command_begin_label("TAA");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("TAA");
 
 	for (uint32_t v = 0; v < view_count; v++) {
 		// Get our (cached) slices
@@ -125,6 +125,4 @@ void TAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_f
 		copy_effects->copy_to_rect(internal_texture, taa_history, Rect2(0, 0, internal_size.x, internal_size.y));
 		copy_effects->copy_to_rect(velocity_buffer, taa_prev_velocity, Rect2(0, 0, target_size.x, target_size.y));
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }

--- a/servers/rendering/renderer_rd/effects/vrs.cpp
+++ b/servers/rendering/renderer_rd/effects/vrs.cpp
@@ -119,7 +119,7 @@ void VRS::update_vrs_texture(RID p_vrs_fb, RID p_render_target) {
 	RSE::ViewportVRSUpdateMode vrs_update_mode = texture_storage->render_target_get_vrs_update_mode(p_render_target);
 
 	if (vrs_mode != RSE::VIEWPORT_VRS_DISABLED && vrs_update_mode != RSE::VIEWPORT_VRS_UPDATE_DISABLED) {
-		RD::get_singleton()->draw_command_begin_label("VRS Setup");
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("VRS Setup");
 
 		if (vrs_mode == RSE::VIEWPORT_VRS_TEXTURE) {
 			RID vrs_texture = texture_storage->render_target_get_vrs_texture(p_render_target);
@@ -152,7 +152,5 @@ void VRS::update_vrs_texture(RID p_vrs_fb, RID p_render_target) {
 		if (vrs_update_mode == RSE::VIEWPORT_VRS_UPDATE_ONCE) {
 			texture_storage->render_target_set_vrs_update_mode(p_render_target, RSE::VIEWPORT_VRS_UPDATE_DISABLED);
 		}
-
-		RD::get_singleton()->draw_command_end_label();
 	}
 }

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -568,14 +568,15 @@ Vector3i Fog::_point_get_position_in_froxel_volume(const Vector3 &p_point, float
 void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes) {
 	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+	RenderingDevice *rd = RD::get_singleton();
 
 	RENDER_TIMESTAMP("> Volumetric Fog");
-	RD::get_singleton()->draw_command_begin_label("Volumetric Fog");
+	RD::DrawCommandLabel label_volumetric_fog = rd->draw_command_label("Volumetric Fog");
 
 	Ref<VolumetricFog> fog = p_settings.vfog;
 
 	if (p_fog_volumes.size() > 0) {
-		RD::get_singleton()->draw_command_begin_label("Render Volumetric Fog Volumes");
+		RD::DrawCommandLabel label_fog_volumes = rd->draw_command_label("Render Volumetric Fog Volumes");
 
 		RENDER_TIMESTAMP("Render FogVolumes");
 
@@ -619,9 +620,9 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 		RendererRD::MaterialStorage::store_transform(to_prev_cam_view, params.to_prev_view);
 		RendererRD::MaterialStorage::store_transform(p_cam_transform, params.transform);
 
-		RD::get_singleton()->buffer_update(volumetric_fog.volume_ubo, 0, sizeof(VolumetricFogShader::VolumeUBO), &params);
+		rd->buffer_update(volumetric_fog.volume_ubo, 0, sizeof(VolumetricFogShader::VolumeUBO), &params);
 
-		if (fog->fog_uniform_set.is_null() || !RD::get_singleton()->uniform_set_is_valid(fog->fog_uniform_set)) {
+		if (fog->fog_uniform_set.is_null() || !rd->uniform_set_is_valid(fog->fog_uniform_set)) {
 			Vector<RD::Uniform> uniforms;
 
 			{
@@ -656,10 +657,10 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 				uniforms.push_back(u);
 			}
 
-			fog->fog_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, volumetric_fog.default_shader_rd, VolumetricFogShader::FogSet::FOG_SET_UNIFORMS);
+			fog->fog_uniform_set = rd->uniform_set_create(uniforms, volumetric_fog.default_shader_rd, VolumetricFogShader::FogSet::FOG_SET_UNIFORMS);
 		}
 
-		RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+		RD::ComputeListID compute_list = rd->compute_list_begin();
 		bool any_uses_time = false;
 		Vector3 cam_position = p_cam_transform.get_origin();
 
@@ -774,29 +775,27 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 			push_constant.shape = uint32_t(RendererRD::Fog::get_singleton()->fog_volume_get_shape(fog_volume));
 			RendererRD::MaterialStorage::store_transform(fog_volume_instance->transform.affine_inverse(), push_constant.transform);
 
-			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, shader_data->pipeline.get_rid());
+			rd->compute_list_bind_compute_pipeline(compute_list, shader_data->pipeline.get_rid());
 
-			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, fog->fog_uniform_set, VolumetricFogShader::FogSet::FOG_SET_UNIFORMS);
-			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(VolumetricFogShader::FogPushConstant));
-			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, volumetric_fog.base_uniform_set, VolumetricFogShader::FogSet::FOG_SET_BASE);
-			if (material->uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(material->uniform_set)) { // Material may not have a uniform set.
-				RD::get_singleton()->compute_list_bind_uniform_set(compute_list, material->uniform_set, VolumetricFogShader::FogSet::FOG_SET_MATERIAL);
+			rd->compute_list_bind_uniform_set(compute_list, fog->fog_uniform_set, VolumetricFogShader::FogSet::FOG_SET_UNIFORMS);
+			rd->compute_list_set_push_constant(compute_list, &push_constant, sizeof(VolumetricFogShader::FogPushConstant));
+			rd->compute_list_bind_uniform_set(compute_list, volumetric_fog.base_uniform_set, VolumetricFogShader::FogSet::FOG_SET_BASE);
+			if (material->uniform_set.is_valid() && rd->uniform_set_is_valid(material->uniform_set)) { // Material may not have a uniform set.
+				rd->compute_list_bind_uniform_set(compute_list, material->uniform_set, VolumetricFogShader::FogSet::FOG_SET_MATERIAL);
 				material->set_as_used();
 			}
 
-			RD::get_singleton()->compute_list_dispatch_threads(compute_list, kernel_size.x, kernel_size.y, kernel_size.z);
+			rd->compute_list_dispatch_threads(compute_list, kernel_size.x, kernel_size.y, kernel_size.z);
 		}
 		if (any_uses_time || RendererSceneRenderRD::get_singleton()->environment_get_volumetric_fog_temporal_reprojection(p_settings.env)) {
 			RenderingServerDefault::redraw_request();
 		}
 
-		RD::get_singleton()->draw_command_end_label();
-
-		RD::get_singleton()->compute_list_end();
+		rd->compute_list_end();
 	}
 
 	bool gi_dependent_sets_valid = fog->sync_gi_dependent_sets_validity();
-	if (!fog->copy_uniform_set.is_null() && !RD::get_singleton()->uniform_set_is_valid(fog->copy_uniform_set)) {
+	if (!fog->copy_uniform_set.is_null() && !rd->uniform_set_is_valid(fog->copy_uniform_set)) {
 		fog->copy_uniform_set = RID();
 	}
 	if (!gi_dependent_sets_valid || fog->copy_uniform_set.is_null()) {
@@ -1006,13 +1005,13 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 			copy_uniforms.push_back(u);
 		}
 
-		if (fog->copy_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(fog->copy_uniform_set)) {
-			RD::get_singleton()->free_rid(fog->copy_uniform_set);
+		if (fog->copy_uniform_set.is_valid() && rd->uniform_set_is_valid(fog->copy_uniform_set)) {
+			rd->free_rid(fog->copy_uniform_set);
 		}
-		fog->copy_uniform_set = RD::get_singleton()->uniform_set_create(copy_uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_COPY)), 0);
+		fog->copy_uniform_set = rd->uniform_set_create(copy_uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_COPY)), 0);
 
 		if (!gi_dependent_sets_valid) {
-			fog->gi_dependent_sets.process_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FOG)), 0);
+			fog->gi_dependent_sets.process_uniform_set = rd->uniform_set_create(uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FOG)), 0);
 
 			RID aux8 = uniforms.write[8].get_id(0);
 			RID aux9 = uniforms.write[9].get_id(0);
@@ -1020,18 +1019,18 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 			uniforms.write[8].set_id(0, aux9);
 			uniforms.write[9].set_id(0, aux8);
 
-			fog->gi_dependent_sets.process_uniform_set2 = RD::get_singleton()->uniform_set_create(uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FOG)), 0);
+			fog->gi_dependent_sets.process_uniform_set2 = rd->uniform_set_create(uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FOG)), 0);
 
 			uniforms.remove_at(9);
 			uniforms.write[8].set_id(0, aux8);
-			fog->gi_dependent_sets.process_uniform_set_density = RD::get_singleton()->uniform_set_create(uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_DENSITY)), 0);
+			fog->gi_dependent_sets.process_uniform_set_density = rd->uniform_set_create(uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_DENSITY)), 0);
 		}
 	}
 
 	bool using_sdfgi = RendererSceneRenderRD::get_singleton()->environment_get_volumetric_fog_gi_inject(p_settings.env) > 0.0001 && RendererSceneRenderRD::get_singleton()->environment_get_sdfgi_enabled(p_settings.env) && (p_settings.sdfgi.is_valid());
 
 	if (using_sdfgi) {
-		if (fog->sdfgi_uniform_set.is_null() || !RD::get_singleton()->uniform_set_is_valid(fog->sdfgi_uniform_set)) {
+		if (fog->sdfgi_uniform_set.is_null() || !rd->uniform_set_is_valid(fog->sdfgi_uniform_set)) {
 			Vector<RD::Uniform> uniforms;
 
 			{
@@ -1058,7 +1057,7 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 				uniforms.push_back(u);
 			}
 
-			fog->sdfgi_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_DENSITY_WITH_SDFGI)), 1);
+			fog->sdfgi_uniform_set = rd->uniform_set_create(uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_DENSITY_WITH_SDFGI)), 1);
 		}
 	}
 
@@ -1166,66 +1165,66 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 	sky_transform = sky_transform.inverse() * p_cam_transform.basis;
 	RendererRD::MaterialStorage::store_transform_3x3(sky_transform, params.radiance_inverse_xform);
 
-	RD::get_singleton()->draw_command_begin_label("Render Volumetric Fog");
+	RD::ComputeListID compute_list;
 
-	RENDER_TIMESTAMP("Render Fog");
-	RD::get_singleton()->buffer_update(volumetric_fog.params_ubo, 0, sizeof(VolumetricFogShader::ParamsUBO), &params);
+	{
+		RD::DrawCommandLabel label_render_fog = rd->draw_command_label("Render Volumetric Fog");
 
-	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
+		RENDER_TIMESTAMP("Render Fog");
+		rd->buffer_update(volumetric_fog.params_ubo, 0, sizeof(VolumetricFogShader::ParamsUBO), &params);
 
-	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[using_sdfgi ? VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_DENSITY_WITH_SDFGI : VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_DENSITY].get_rid());
+		compute_list = rd->compute_list_begin();
 
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, fog->gi_dependent_sets.process_uniform_set_density, 0);
+		rd->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[using_sdfgi ? VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_DENSITY_WITH_SDFGI : VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_DENSITY].get_rid());
 
-	if (using_sdfgi) {
-		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, fog->sdfgi_uniform_set, 1);
+		rd->compute_list_bind_uniform_set(compute_list, fog->gi_dependent_sets.process_uniform_set_density, 0);
+
+		if (using_sdfgi) {
+			rd->compute_list_bind_uniform_set(compute_list, fog->sdfgi_uniform_set, 1);
+		}
+		rd->compute_list_dispatch_threads(compute_list, fog->width, fog->height, fog->depth);
+		rd->compute_list_add_barrier(compute_list);
+
+		// Copy fog to history buffer
+		if (RendererSceneRenderRD::get_singleton()->environment_get_volumetric_fog_temporal_reprojection(p_settings.env)) {
+			rd->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_COPY].get_rid());
+			rd->compute_list_bind_uniform_set(compute_list, fog->copy_uniform_set, 0);
+			rd->compute_list_dispatch_threads(compute_list, fog->width, fog->height, fog->depth);
+			rd->compute_list_add_barrier(compute_list);
+		}
 	}
-	RD::get_singleton()->compute_list_dispatch_threads(compute_list, fog->width, fog->height, fog->depth);
-	RD::get_singleton()->compute_list_add_barrier(compute_list);
-
-	// Copy fog to history buffer
-	if (RendererSceneRenderRD::get_singleton()->environment_get_volumetric_fog_temporal_reprojection(p_settings.env)) {
-		RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_COPY].get_rid());
-		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, fog->copy_uniform_set, 0);
-		RD::get_singleton()->compute_list_dispatch_threads(compute_list, fog->width, fog->height, fog->depth);
-		RD::get_singleton()->compute_list_add_barrier(compute_list);
-	}
-	RD::get_singleton()->draw_command_end_label();
 
 	if (p_settings.volumetric_fog_filter_active) {
-		RD::get_singleton()->draw_command_begin_label("Filter Fog");
+		RD::DrawCommandLabel label_filter_fog = rd->draw_command_label("Filter Fog");
 
 		RENDER_TIMESTAMP("Filter Fog");
 
-		RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FILTER].get_rid());
-		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, fog->gi_dependent_sets.process_uniform_set, 0);
-		RD::get_singleton()->compute_list_dispatch_threads(compute_list, fog->width, fog->height, fog->depth);
+		rd->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FILTER].get_rid());
+		rd->compute_list_bind_uniform_set(compute_list, fog->gi_dependent_sets.process_uniform_set, 0);
+		rd->compute_list_dispatch_threads(compute_list, fog->width, fog->height, fog->depth);
 
-		RD::get_singleton()->compute_list_end();
+		rd->compute_list_end();
 		//need restart for buffer update
 
 		params.filter_axis = 1;
-		RD::get_singleton()->buffer_update(volumetric_fog.params_ubo, 0, sizeof(VolumetricFogShader::ParamsUBO), &params);
+		rd->buffer_update(volumetric_fog.params_ubo, 0, sizeof(VolumetricFogShader::ParamsUBO), &params);
 
-		compute_list = RD::get_singleton()->compute_list_begin();
-		RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FILTER].get_rid());
-		RD::get_singleton()->compute_list_bind_uniform_set(compute_list, fog->gi_dependent_sets.process_uniform_set2, 0);
-		RD::get_singleton()->compute_list_dispatch_threads(compute_list, fog->width, fog->height, fog->depth);
+		compute_list = rd->compute_list_begin();
+		rd->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FILTER].get_rid());
+		rd->compute_list_bind_uniform_set(compute_list, fog->gi_dependent_sets.process_uniform_set2, 0);
+		rd->compute_list_dispatch_threads(compute_list, fog->width, fog->height, fog->depth);
 
-		RD::get_singleton()->compute_list_add_barrier(compute_list);
-		RD::get_singleton()->draw_command_end_label();
+		rd->compute_list_add_barrier(compute_list);
 	}
 
 	RENDER_TIMESTAMP("Integrate Fog");
-	RD::get_singleton()->draw_command_begin_label("Integrate Fog");
+	RD::DrawCommandLabel label_integrate_fog = rd->draw_command_label("Integrate Fog");
 
-	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FOG].get_rid());
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, fog->gi_dependent_sets.process_uniform_set, 0);
-	RD::get_singleton()->compute_list_dispatch_threads(compute_list, fog->width, fog->height, 1);
+	rd->compute_list_bind_compute_pipeline(compute_list, volumetric_fog.process_pipelines[VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_FOG].get_rid());
+	rd->compute_list_bind_uniform_set(compute_list, fog->gi_dependent_sets.process_uniform_set, 0);
+	rd->compute_list_dispatch_threads(compute_list, fog->width, fog->height, 1);
 
-	RD::get_singleton()->compute_list_end();
+	rd->compute_list_end();
 
 	RENDER_TIMESTAMP("< Volumetric Fog");
-	RD::get_singleton()->draw_command_end_label();
-	RD::get_singleton()->draw_command_end_label();
 }

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -1247,7 +1247,7 @@ void GI::SDFGI::update(RID p_env, const Vector3 &p_world_position) {
 }
 
 void GI::SDFGI::update_light() {
-	RD::get_singleton()->draw_command_begin_label("SDFGI Update Dynamic Light");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("SDFGI Update Dynamic Light");
 
 	for (uint32_t i = 0; i < cascades.size(); i++) {
 		RD::get_singleton()->buffer_copy(cascades[i].solid_cell_dispatch_buffer_storage, cascades[i].solid_cell_dispatch_buffer_call, 0, 0, sizeof(uint32_t) * 4);
@@ -1305,11 +1305,10 @@ void GI::SDFGI::update_light() {
 		RD::get_singleton()->compute_list_dispatch_indirect(compute_list, cascade.solid_cell_dispatch_buffer_call, 0);
 	}
 	RD::get_singleton()->compute_list_end();
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void GI::SDFGI::update_probes(RID p_env, SkyRD::Sky *p_sky) {
-	RD::get_singleton()->draw_command_begin_label("SDFGI Update Probes");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("SDFGI Update Probes");
 
 	SDFGIShader::IntegratePushConstant push_constant;
 	push_constant.grid_size[1] = cascade_size;
@@ -1408,11 +1407,10 @@ void GI::SDFGI::update_probes(RID p_env, SkyRD::Sky *p_sky) {
 	}
 
 	RD::get_singleton()->compute_list_end();
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void GI::SDFGI::store_probes() {
-	RD::get_singleton()->draw_command_begin_label("SDFGI Store Probes");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("SDFGI Store Probes");
 
 	SDFGIShader::IntegratePushConstant push_constant;
 	push_constant.grid_size[1] = cascade_size;
@@ -1451,8 +1449,6 @@ void GI::SDFGI::store_probes() {
 	}
 
 	RD::get_singleton()->compute_list_end();
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 int GI::SDFGI::get_pending_region_data(int p_region, Vector3i &r_local_offset, Vector3i &r_local_size, AABB &r_bounds) const {
@@ -1755,7 +1751,7 @@ void GI::SDFGI::debug_probes(RID p_framebuffer, const uint32_t p_view_count, con
 	SDFGIShader::ProbeDebugMode mode = p_view_count > 1 ? SDFGIShader::PROBE_DEBUG_PROBES_MULTIVIEW : SDFGIShader::PROBE_DEBUG_PROBES;
 
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_framebuffer);
-	RD::get_singleton()->draw_command_begin_label("Debug SDFGI");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Debug SDFGI");
 
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, gi->sdfgi_shader.debug_probes_pipeline[mode].get_render_pipeline(RD::INVALID_FORMAT_ID, RD::get_singleton()->framebuffer_get_format(p_framebuffer)));
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, debug_probes_uniform_set, 0);
@@ -1799,9 +1795,11 @@ void GI::SDFGI::debug_probes(RID p_framebuffer, const uint32_t p_view_count, con
 		Vector3i probe_from = cascades[cascade].position / probe_cells;
 		Vector3i ofs = gi->sdfgi_debug_probe_index - probe_from;
 		if (ofs.x < 0 || ofs.y < 0 || ofs.z < 0) {
+			RD::get_singleton()->draw_list_end();
 			return;
 		}
 		if (ofs.x > SDFGI::PROBE_DIVISOR || ofs.y > SDFGI::PROBE_DIVISOR || ofs.z > SDFGI::PROBE_DIVISOR) {
+			RD::get_singleton()->draw_list_end();
 			return;
 		}
 
@@ -1817,8 +1815,6 @@ void GI::SDFGI::debug_probes(RID p_framebuffer, const uint32_t p_view_count, con
 		RD::get_singleton()->draw_list_set_push_constant(draw_list, &push_constant, sizeof(SDFGIShader::DebugProbesPushConstant));
 		RD::get_singleton()->draw_list_draw(draw_list, false, cell_count, total_points);
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 	RD::get_singleton()->draw_list_end();
 }
 
@@ -2082,7 +2078,7 @@ void GI::SDFGI::render_region(Ref<RenderSceneBuffersRD> p_render_buffers, int p_
 	RendererSceneRenderRD::get_singleton()->_render_sdfgi(p_render_buffers, from, size, bounds, p_instances, render_albedo, render_emission, render_emission_aniso, render_geom_facing, p_exposure_normalization);
 
 	if (cascade_next != cascade) {
-		RD::get_singleton()->draw_command_begin_label("SDFGI Pre-Process Cascade");
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("SDFGI Pre-Process Cascade");
 
 		RENDER_TIMESTAMP("> SDFGI Update SDF");
 		//done rendering! must update SDF
@@ -2415,7 +2411,6 @@ void GI::SDFGI::render_region(Ref<RenderSceneBuffersRD> p_render_buffers, int p_
 #endif
 
 		RENDER_TIMESTAMP("< SDFGI Update SDF");
-		RD::get_singleton()->draw_command_end_label();
 	}
 }
 
@@ -2425,7 +2420,7 @@ void GI::SDFGI::render_static_lights(RenderDataRD *p_render_data, Ref<RenderScen
 	RendererRD::LightStorage *light_storage = RendererRD::LightStorage::get_singleton();
 	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
 
-	RD::get_singleton()->draw_command_begin_label("SDFGI Render Static Lights");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("SDFGI Render Static Lights");
 
 	update_cascades();
 
@@ -2605,8 +2600,6 @@ void GI::SDFGI::render_static_lights(RenderDataRD *p_render_data, Ref<RenderScen
 	}
 
 	RD::get_singleton()->compute_list_end();
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3931,11 +3924,9 @@ void GI::setup_voxel_gi_instances(RenderDataRD *p_render_data, Ref<RenderSceneBu
 	}
 
 	if (p_voxel_gi_instances.size() > 0) {
-		RD::get_singleton()->draw_command_begin_label("VoxelGIs Setup");
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("VoxelGIs Setup");
 
 		RD::get_singleton()->buffer_update(voxel_gi_buffer, 0, sizeof(VoxelGIData) * MIN((uint64_t)MAX_VOXEL_GI_INSTANCES, p_voxel_gi_instances.size()), voxel_gi_data);
-
-		RD::get_singleton()->draw_command_end_label();
 	}
 }
 
@@ -3971,7 +3962,7 @@ void GI::process_gi(Ref<RenderSceneBuffersRD> p_render_buffers, const RID *p_nor
 
 	ERR_FAIL_COND_MSG(p_view_count > 2, "Maximum of 2 views supported for Processing GI.");
 
-	RD::get_singleton()->draw_command_begin_label("GI Render");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("GI Render");
 
 	ERR_FAIL_COND(p_render_buffers.is_null());
 
@@ -4271,7 +4262,6 @@ void GI::process_gi(Ref<RenderSceneBuffersRD> p_render_buffers, const RID *p_nor
 	}
 
 	RD::get_singleton()->compute_list_end();
-	RD::get_singleton()->draw_command_end_label();
 }
 
 RID GI::voxel_gi_instance_create(RID p_base) {

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -379,34 +379,35 @@ void SkyRD::ReflectionData::create_reflection_fast_filter(bool p_use_arrays) {
 	bool use_raster_effect = copy_effects->get_raster_effects().has_flag(RendererRD::CopyEffects::RASTER_EFFECT_OCTMAP);
 
 	if (use_raster_effect) {
-		RD::get_singleton()->draw_command_begin_label("Downsample Radiance Map");
-		copy_effects->octmap_downsample_raster(radiance_base_octmap, downsampled_layer.mipmaps[0].framebuffer, downsampled_layer.mipmaps[0].size, uv_border_size);
+		{
+			RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Downsample Radiance Map");
+			copy_effects->octmap_downsample_raster(radiance_base_octmap, downsampled_layer.mipmaps[0].framebuffer, downsampled_layer.mipmaps[0].size, uv_border_size);
 
-		for (uint32_t i = 1; i < downsampled_layer.mipmaps.size(); i++) {
-			copy_effects->octmap_downsample_raster(downsampled_layer.mipmaps[i - 1].view, downsampled_layer.mipmaps[i].framebuffer, downsampled_layer.mipmaps[i].size, uv_border_size);
+			for (uint32_t i = 1; i < downsampled_layer.mipmaps.size(); i++) {
+				copy_effects->octmap_downsample_raster(downsampled_layer.mipmaps[i - 1].view, downsampled_layer.mipmaps[i].framebuffer, downsampled_layer.mipmaps[i].size, uv_border_size);
+			}
 		}
-		RD::get_singleton()->draw_command_end_label(); // Downsample Radiance
 
 		if (p_use_arrays) {
-			RD::get_singleton()->draw_command_begin_label("Filter Radiance Map into Array Heads");
+			RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Filter Radiance Map into Array Heads");
 			for (uint32_t i = 0; i < layers.size(); i++) {
 				copy_effects->octmap_filter_raster(downsampled_radiance_octmap, layers[i].mipmaps[0].framebuffer, i, uv_border_size);
 			}
 		} else {
-			RD::get_singleton()->draw_command_begin_label("Filter Radiance Map into Mipmaps Directly");
+			RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Filter Radiance Map into Mipmaps Directly");
 			for (uint32_t j = 0; j < layers[0].mipmaps.size(); j++) {
 				copy_effects->octmap_filter_raster(downsampled_radiance_octmap, layers[0].mipmaps[j].framebuffer, j, uv_border_size);
 			}
 		}
-		RD::get_singleton()->draw_command_end_label(); // Filter radiance
 	} else {
-		RD::get_singleton()->draw_command_begin_label("Downsample Radiance Map");
-		copy_effects->octmap_downsample(radiance_base_octmap, downsampled_layer.mipmaps[0].view, downsampled_layer.mipmaps[0].size, uv_border_size);
+		{
+			RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Downsample Radiance Map");
+			copy_effects->octmap_downsample(radiance_base_octmap, downsampled_layer.mipmaps[0].view, downsampled_layer.mipmaps[0].size, uv_border_size);
 
-		for (uint32_t i = 1; i < downsampled_layer.mipmaps.size(); i++) {
-			copy_effects->octmap_downsample(downsampled_layer.mipmaps[i - 1].view, downsampled_layer.mipmaps[i].view, downsampled_layer.mipmaps[i].size, uv_border_size);
+			for (uint32_t i = 1; i < downsampled_layer.mipmaps.size(); i++) {
+				copy_effects->octmap_downsample(downsampled_layer.mipmaps[i - 1].view, downsampled_layer.mipmaps[i].view, downsampled_layer.mipmaps[i].size, uv_border_size);
+			}
 		}
-		RD::get_singleton()->draw_command_end_label(); // Downsample Radiance
 		Vector<RID> views;
 		if (p_use_arrays) {
 			for (uint32_t i = 1; i < layers.size(); i++) {
@@ -417,9 +418,8 @@ void SkyRD::ReflectionData::create_reflection_fast_filter(bool p_use_arrays) {
 				views.push_back(layers[0].mipmaps[i].view);
 			}
 		}
-		RD::get_singleton()->draw_command_begin_label("Fast Filter Radiance");
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Fast Filter Radiance");
 		copy_effects->octmap_filter(downsampled_radiance_octmap, views, p_use_arrays, uv_border_size);
-		RD::get_singleton()->draw_command_end_label(); // Filter radiance
 	}
 }
 
@@ -430,16 +430,15 @@ void SkyRD::ReflectionData::create_reflection_importance_sample(bool p_use_array
 
 	if (use_raster_effect) {
 		if (p_base_layer == 1) {
-			RD::get_singleton()->draw_command_begin_label("Downsample Radiance Map");
+			RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Downsample Radiance Map");
 			copy_effects->octmap_downsample_raster(radiance_base_octmap, downsampled_layer.mipmaps[0].framebuffer, downsampled_layer.mipmaps[0].size, uv_border_size);
 
 			for (uint32_t i = 1; i < downsampled_layer.mipmaps.size(); i++) {
 				copy_effects->octmap_downsample_raster(downsampled_layer.mipmaps[i - 1].view, downsampled_layer.mipmaps[i].framebuffer, downsampled_layer.mipmaps[i].size, uv_border_size);
 			}
-			RD::get_singleton()->draw_command_end_label(); // Downsample Radiance
 		}
 
-		RD::get_singleton()->draw_command_begin_label("High Quality Filter Radiance");
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("High Quality Filter Radiance");
 		if (p_use_arrays) {
 			copy_effects->octmap_roughness_raster(
 					downsampled_radiance_octmap,
@@ -461,23 +460,21 @@ void SkyRD::ReflectionData::create_reflection_importance_sample(bool p_use_array
 		}
 	} else {
 		if (p_base_layer == 1) {
-			RD::get_singleton()->draw_command_begin_label("Downsample Radiance Map");
+			RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Downsample Radiance Map");
 			copy_effects->octmap_downsample(radiance_base_octmap, downsampled_layer.mipmaps[0].view, downsampled_layer.mipmaps[0].size, uv_border_size);
 
 			for (uint32_t i = 1; i < downsampled_layer.mipmaps.size(); i++) {
 				copy_effects->octmap_downsample(downsampled_layer.mipmaps[i - 1].view, downsampled_layer.mipmaps[i].view, downsampled_layer.mipmaps[i].size, uv_border_size);
 			}
-			RD::get_singleton()->draw_command_end_label(); // Downsample Radiance
 		}
 
-		RD::get_singleton()->draw_command_begin_label("High Quality Filter Radiance");
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("High Quality Filter Radiance");
 		if (p_use_arrays) {
 			copy_effects->octmap_roughness(downsampled_radiance_octmap, layers[p_base_layer].mipmaps[0].view, p_sky_ggx_samples_quality, float(p_base_layer) / (layers.size() - 1.0), downsampled_layer.mipmaps[0].size.x, layers[p_base_layer].mipmaps[0].size.x, uv_border_size);
 		} else {
 			copy_effects->octmap_roughness(downsampled_radiance_octmap, layers[0].mipmaps[p_base_layer].view, p_sky_ggx_samples_quality, float(p_base_layer) / (layers[0].mipmaps.size() - 1.0), downsampled_layer.mipmaps[0].size.x, layers[0].mipmaps[p_base_layer].size.x, uv_border_size);
 		}
 	}
-	RD::get_singleton()->draw_command_end_label(); // Filter radiance
 }
 
 void SkyRD::ReflectionData::update_reflection_mipmaps(int p_start, int p_end) {
@@ -485,7 +482,7 @@ void SkyRD::ReflectionData::update_reflection_mipmaps(int p_start, int p_end) {
 	ERR_FAIL_NULL_MSG(copy_effects, "Effects haven't been initialized");
 	bool use_raster_effect = copy_effects->get_raster_effects().has_flag(RendererRD::CopyEffects::RASTER_EFFECT_OCTMAP);
 
-	RD::get_singleton()->draw_command_begin_label("Update Radiance Octmap Array Mipmaps");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Update Radiance Octmap Array Mipmaps");
 	for (int i = p_start; i < p_end; i++) {
 		for (uint32_t j = 0; j < layers[i].mipmaps.size() - 1; j++) {
 			RID view = layers[i].mipmaps[j].view;
@@ -499,7 +496,6 @@ void SkyRD::ReflectionData::update_reflection_mipmaps(int p_start, int p_end) {
 			}
 		}
 	}
-	RD::get_singleton()->draw_command_end_label();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1283,7 +1279,7 @@ void SkyRD::update_radiance_buffers(Ref<RenderSceneBuffersRD> p_render_buffers, 
 		// Note, we ignore environment_get_sky_orientation here as this is applied when we do our lookup in our scene shader.
 
 		if (shader_data->uses_quarter_res && roughness_layers >= 3) {
-			RD::get_singleton()->draw_command_begin_label("Render Sky to Quarter-Resolution Cubemap");
+			RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render Sky to Quarter-Resolution Cubemap");
 			PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_OCTMAP_QUARTER_RES];
 
 			Vector<Color> clear_colors;
@@ -1295,14 +1291,12 @@ void SkyRD::update_radiance_buffers(Ref<RenderSceneBuffersRD> p_render_buffers, 
 			octmap_draw_list = RD::get_singleton()->draw_list_begin(sky->reflection.layers[0].mipmaps[2].framebuffer, RD::DRAW_IGNORE_COLOR_ALL);
 			_render_sky(octmap_draw_list, p_time, sky->reflection.layers[0].mipmaps[2].framebuffer, pipeline, material->uniform_set, texture_uniform_set, cm, Basis(), p_global_pos, p_luminance_multiplier, p_brightness_multiplier, sky->uv_border_size);
 			RD::get_singleton()->draw_list_end();
-
-			RD::get_singleton()->draw_command_end_label();
 		} else if (shader_data->uses_quarter_res && roughness_layers < 3) {
 			ERR_PRINT_ED("Cannot use quarter res buffer in sky shader when roughness layers is less than 3. Please increase rendering/reflections/sky_reflections/roughness_layers.");
 		}
 
 		if (shader_data->uses_half_res && roughness_layers >= 2) {
-			RD::get_singleton()->draw_command_begin_label("Render Sky to Half-Resolution Cubemap");
+			RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render Sky to Half-Resolution Cubemap");
 			PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_OCTMAP_HALF_RES];
 
 			Vector<Color> clear_colors;
@@ -1314,24 +1308,21 @@ void SkyRD::update_radiance_buffers(Ref<RenderSceneBuffersRD> p_render_buffers, 
 			octmap_draw_list = RD::get_singleton()->draw_list_begin(sky->reflection.layers[0].mipmaps[1].framebuffer, RD::DRAW_IGNORE_COLOR_ALL);
 			_render_sky(octmap_draw_list, p_time, sky->reflection.layers[0].mipmaps[1].framebuffer, pipeline, material->uniform_set, texture_uniform_set, cm, Basis(), p_global_pos, p_luminance_multiplier, p_brightness_multiplier, sky->uv_border_size);
 			RD::get_singleton()->draw_list_end();
-
-			RD::get_singleton()->draw_command_end_label();
 		} else if (shader_data->uses_half_res && roughness_layers < 2) {
 			ERR_PRINT_ED("Cannot use half res buffer in sky shader when roughness layers is less than 2. Please increase rendering/reflections/sky_reflections/roughness_layers.");
 		}
 
-		RD::DrawListID octmap_draw_list;
-		PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_OCTMAP];
+		{
+			RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render Sky Octmap");
+			RD::DrawListID octmap_draw_list;
+			PipelineCacheRD *pipeline = &shader_data->pipelines[SKY_VERSION_OCTMAP];
 
-		RD::get_singleton()->draw_command_begin_label("Render Sky Octmap");
+			RID texture_uniform_set = sky->get_textures(SKY_TEXTURE_SET_OCTMAP, sky_shader.default_shader_rd, p_render_buffers);
 
-		RID texture_uniform_set = sky->get_textures(SKY_TEXTURE_SET_OCTMAP, sky_shader.default_shader_rd, p_render_buffers);
-
-		octmap_draw_list = RD::get_singleton()->draw_list_begin(sky->reflection.layers[0].mipmaps[0].framebuffer, RD::DRAW_IGNORE_COLOR_ALL, Vector<Color>(), 1.0f, 0, Rect2(), RDD::BreadcrumbMarker::SKY_PASS);
-		_render_sky(octmap_draw_list, p_time, sky->reflection.layers[0].mipmaps[0].framebuffer, pipeline, material->uniform_set, texture_uniform_set, cm, Basis(), p_global_pos, p_luminance_multiplier, p_brightness_multiplier, sky->uv_border_size);
-		RD::get_singleton()->draw_list_end();
-
-		RD::get_singleton()->draw_command_end_label();
+			octmap_draw_list = RD::get_singleton()->draw_list_begin(sky->reflection.layers[0].mipmaps[0].framebuffer, RD::DRAW_IGNORE_COLOR_ALL, Vector<Color>(), 1.0f, 0, Rect2(), RDD::BreadcrumbMarker::SKY_PASS);
+			_render_sky(octmap_draw_list, p_time, sky->reflection.layers[0].mipmaps[0].framebuffer, pipeline, material->uniform_set, texture_uniform_set, cm, Basis(), p_global_pos, p_luminance_multiplier, p_brightness_multiplier, sky->uv_border_size);
+			RD::get_singleton()->draw_list_end();
+		}
 
 		if (sky_mode == RSE::SKY_MODE_REALTIME) {
 			sky->reflection.create_reflection_fast_filter(sky_use_octmap_array);
@@ -1416,7 +1407,7 @@ void SkyRD::update_res_buffers(Ref<RenderSceneBuffersRD> p_render_buffers, RID p
 	material->set_as_used();
 
 	RENDER_TIMESTAMP("Setup Sky Resolution Buffers");
-	RD::get_singleton()->draw_command_begin_label("Setup Sky Resolution Buffers");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Setup Sky Resolution Buffers");
 
 	Basis sky_transform = RendererSceneRenderRD::get_singleton()->environment_get_sky_orientation(p_env);
 	sky_transform.invert();
@@ -1457,8 +1448,6 @@ void SkyRD::update_res_buffers(Ref<RenderSceneBuffersRD> p_render_buffers, RID p
 		_render_sky(draw_list, p_time, framebuffer, pipeline, material->uniform_set, texture_uniform_set, projection, sky_transform, sky_scene_state.cam_transform.origin, p_luminance_multiplier, p_brightness_multiplier, sky->uv_border_size);
 		RD::get_singleton()->draw_list_end();
 	}
-
-	RD::get_singleton()->draw_command_end_label(); // Setup Sky resolution buffers
 }
 
 void SkyRD::draw_sky(RD::DrawListID p_draw_list, Ref<RenderSceneBuffersRD> p_render_buffers, RID p_env, RID p_fb, double p_time, float p_luminance_multiplier, float p_brightness_multiplier) {

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -704,6 +704,9 @@ uint32_t RenderForwardClustered::_setup_environment(const RenderDataRD *p_render
 		scene_state.uniform_buffers.resize(uniform_buffer_index + 1);
 		for (uint32_t i = from; i < scene_state.uniform_buffers.size(); i++) {
 			scene_state.uniform_buffers[i] = p_render_data->scene_data->create_uniform_buffer();
+#ifdef DEV_ENABLED
+			RD::get_singleton()->set_resource_name(scene_state.uniform_buffers[i], vformat("Scene State UBO (%d)", i));
+#endif
 		}
 	}
 
@@ -779,6 +782,9 @@ uint32_t RenderForwardClustered::_setup_environment(const RenderDataRD *p_render
 		scene_state.implementation_uniform_buffers.resize(uniform_buffer_index + 1);
 		for (uint32_t i = from; i < scene_state.implementation_uniform_buffers.size(); i++) {
 			scene_state.implementation_uniform_buffers[i] = RD::get_singleton()->uniform_buffer_create(sizeof(SceneState::UBO));
+#ifdef DEV_ENABLED
+			RD::get_singleton()->set_resource_name(scene_state.implementation_uniform_buffers[i], vformat("Scene State Implementation UBO (%d)", i));
+#endif
 		}
 	}
 
@@ -1900,27 +1906,28 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 	}
 
 	p_render_data->scene_data->emissive_exposure_normalization = -1.0;
+	uint32_t depth_prepass_uniform_buffer_index = 0;
 
-	RD::get_singleton()->draw_command_begin_label("Render Setup");
+	{
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render Setup");
 
-	_setup_lightmaps(p_render_data, *p_render_data->lightmaps, p_render_data->scene_data->cam_transform);
-	_setup_voxelgis(*p_render_data->voxel_gi_instances);
-	uint32_t depth_prepass_uniform_buffer_index = _setup_environment(p_render_data, is_reflection_probe, screen_size, screen_size, p_default_bg_color, false);
+		_setup_lightmaps(p_render_data, *p_render_data->lightmaps, p_render_data->scene_data->cam_transform);
+		_setup_voxelgis(*p_render_data->voxel_gi_instances);
+		depth_prepass_uniform_buffer_index = _setup_environment(p_render_data, is_reflection_probe, screen_size, screen_size, p_default_bg_color, false);
 
-	// May have changed due to the above (light buffer enlarged, as an example).
-	_update_render_base_uniform_set();
+		// May have changed due to the above (light buffer enlarged, as an example).
+		_update_render_base_uniform_set();
 
-	_fill_render_list(RENDER_LIST_OPAQUE, p_render_data, PASS_MODE_COLOR, using_sdfgi, using_sdfgi || using_voxelgi, using_motion_pass);
-	render_list[RENDER_LIST_OPAQUE].sort_by_key();
-	render_list[RENDER_LIST_MOTION].sort_by_key();
-	render_list[RENDER_LIST_ALPHA].sort_by_reverse_depth_and_priority();
+		_fill_render_list(RENDER_LIST_OPAQUE, p_render_data, PASS_MODE_COLOR, using_sdfgi, using_sdfgi || using_voxelgi, using_motion_pass);
+		render_list[RENDER_LIST_OPAQUE].sort_by_key();
+		render_list[RENDER_LIST_MOTION].sort_by_key();
+		render_list[RENDER_LIST_ALPHA].sort_by_reverse_depth_and_priority();
 
-	int *render_info = p_render_data->render_info ? p_render_data->render_info->info[RSE::VIEWPORT_RENDER_INFO_TYPE_VISIBLE] : (int *)nullptr;
-	_fill_instance_data(RENDER_LIST_OPAQUE, render_info);
-	_fill_instance_data(RENDER_LIST_MOTION, render_info);
-	_fill_instance_data(RENDER_LIST_ALPHA, render_info);
-
-	RD::get_singleton()->draw_command_end_label();
+		int *render_info = p_render_data->render_info ? p_render_data->render_info->info[RSE::VIEWPORT_RENDER_INFO_TYPE_VISIBLE] : (int *)nullptr;
+		_fill_instance_data(RENDER_LIST_OPAQUE, render_info);
+		_fill_instance_data(RENDER_LIST_MOTION, render_info);
+		_fill_instance_data(RENDER_LIST_ALPHA, render_info);
+	}
 
 	if (!is_reflection_probe) {
 		if (using_voxelgi) {
@@ -2063,7 +2070,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		// setup sky if used for ambient, reflections, or background
 		if (draw_sky || draw_sky_fog_only || (reflection_source == RSE::ENV_REFLECTION_SOURCE_BG && bg_mode == RSE::ENV_BG_SKY) || reflection_source == RSE::ENV_REFLECTION_SOURCE_SKY || environment_get_ambient_source(p_render_data->environment) == RSE::ENV_AMBIENT_SOURCE_SKY) {
 			RENDER_TIMESTAMP("Setup Sky");
-			RD::get_singleton()->draw_command_begin_label("Setup Sky");
+			RD::DrawCommandLabel setup_sky_label = RD::get_singleton()->draw_command_label("Setup Sky");
 
 			// Setup our sky render information for this frame/viewport
 			sky.setup_sky(p_render_data, screen_size);
@@ -2083,8 +2090,6 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 				// update sky half/quarter res buffers (if required)
 				sky.update_res_buffers(rb, p_render_data->environment, time, sky_luminance_multiplier, sky_brightness_multiplier);
 			}
-
-			RD::get_singleton()->draw_command_end_label();
 		}
 
 		if (bg_mode != RSE::ENV_BG_CLEAR_COLOR && bg_mode != RSE::ENV_BG_COLOR) {
@@ -2132,19 +2137,18 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 			_post_prepass_render(p_render_data, using_sdfgi || using_voxelgi);
 		}
 
-		RD::get_singleton()->draw_command_begin_label("Render Depth Pre-Pass");
-
-		RID rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_OPAQUE, nullptr, RID(), samplers, depth_prepass_uniform_buffer_index);
-
 		bool finish_depth = using_ssao || using_ssil || using_sdfgi || using_voxelgi || ce_pre_opaque_resolved_depth || ce_post_opaque_resolved_depth;
-		RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, depth_pass_mode, 0, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
-		_render_list_with_draw_list(&render_list_params, depth_framebuffer, RD::DrawFlags(needs_pre_resolve ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_ALL), depth_pass_clear, 0.0f, 0u, p_render_data->render_region);
+		{
+			RD::DrawCommandLabel depth_prepass_label = RD::get_singleton()->draw_command_label("Render Depth Pre-Pass");
 
-		RD::get_singleton()->draw_command_end_label();
+			RID rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_OPAQUE, nullptr, RID(), samplers, depth_prepass_uniform_buffer_index);
 
+			RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, depth_pass_mode, 0, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+			_render_list_with_draw_list(&render_list_params, depth_framebuffer, RD::DrawFlags(needs_pre_resolve ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_ALL), depth_pass_clear, 0.0f, 0u, p_render_data->render_region);
+		}
 		if (use_msaa) {
 			RENDER_TIMESTAMP("Resolve Depth Pre-Pass (MSAA)");
-			RD::get_singleton()->draw_command_begin_label("Resolve Depth Pre-Pass (MSAA)");
+			RD::DrawCommandLabel resolve_depth_msaa_label = RD::get_singleton()->draw_command_label("Resolve Depth Pre-Pass (MSAA)");
 			if (depth_pass_mode == PASS_MODE_DEPTH_NORMAL_ROUGHNESS || depth_pass_mode == PASS_MODE_DEPTH_NORMAL_ROUGHNESS_VOXEL_GI) {
 				for (uint32_t v = 0; v < rb->get_view_count(); v++) {
 					resolve_effects->resolve_gi(rb->get_depth_msaa(v), rb_data->get_normal_roughness_msaa(v), using_voxelgi ? rb_data->get_voxelgi_msaa(v) : RID(), rb->get_depth_texture(v), rb_data->get_normal_roughness(v), using_voxelgi ? rb_data->get_voxelgi(v) : RID(), rb->get_internal_size(), texture_multisamples[msaa]);
@@ -2154,7 +2158,6 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 					resolve_effects->resolve_depth(rb->get_depth_msaa(v), rb->get_depth_texture(v), rb->get_internal_size(), texture_multisamples[msaa]);
 				}
 			}
-			RD::get_singleton()->draw_command_end_label();
 		}
 	}
 
@@ -2187,8 +2190,6 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 	RENDER_TIMESTAMP("Render Opaque Pass");
 
-	RD::get_singleton()->draw_command_begin_label("Render Opaque Pass");
-
 	p_render_data->scene_data->directional_light_count = p_render_data->directional_light_count;
 	p_render_data->scene_data->opaque_prepass_threshold = 0.0f;
 
@@ -2203,6 +2204,8 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		bool render_motion_pass = !render_list[RENDER_LIST_MOTION].elements.is_empty();
 
 		{
+			RD::DrawCommandLabel opaque_pass_label = RD::get_singleton()->draw_command_label("Render Opaque Pass");
+
 			Vector<Color> c;
 			if (!load_color) {
 				if (using_separate_specular || rb_data.is_valid()) {
@@ -2223,8 +2226,6 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 			_render_list_with_draw_list(&render_list_params, opaque_framebuffer, RD::DrawFlags(load_color ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_COLOR_ALL) | (depth_pre_pass ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_DEPTH), c, 0.0f, 0u, p_render_data->render_region);
 		}
 
-		RD::get_singleton()->draw_command_end_label();
-
 		if (using_motion_pass) {
 			if (scale_type == SCALE_MFX) {
 				motion_vectors_store->process(rb,
@@ -2239,7 +2240,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		}
 
 		if (render_motion_pass) {
-			RD::get_singleton()->draw_command_begin_label("Render Motion Pass");
+			RD::DrawCommandLabel motion_pass_label = RD::get_singleton()->draw_command_label("Render Motion Pass");
 
 			RENDER_TIMESTAMP("Render Motion Pass");
 
@@ -2247,8 +2248,6 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 			RenderListParameters render_list_params(render_list[RENDER_LIST_MOTION].elements.ptr(), render_list[RENDER_LIST_MOTION].element_info.ptr(), render_list[RENDER_LIST_MOTION].elements.size(), reverse_cull, PASS_MODE_COLOR, color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
 			_render_list_with_draw_list(&render_list_params, color_framebuffer);
-
-			RD::get_singleton()->draw_command_end_label();
 		}
 	}
 
@@ -2274,11 +2273,12 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		dc.set_depth_correction(true);
 		Projection cm = (dc * p_render_data->scene_data->cam_projection) * Projection(p_render_data->scene_data->cam_transform.affine_inverse());
 		RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(color_only_framebuffer);
-		RD::get_singleton()->draw_command_begin_label("Debug VoxelGIs");
-		for (int i = 0; i < (int)p_render_data->voxel_gi_instances->size(); i++) {
-			gi.debug_voxel_gi((*p_render_data->voxel_gi_instances)[i], draw_list, color_only_framebuffer, cm, get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_VOXEL_GI_LIGHTING, get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_VOXEL_GI_EMISSION, 1.0);
+		{
+			RD::DrawCommandLabel debug_voxelgi_label = RD::get_singleton()->draw_command_label("Debug VoxelGIs");
+			for (int i = 0; i < (int)p_render_data->voxel_gi_instances->size(); i++) {
+				gi.debug_voxel_gi((*p_render_data->voxel_gi_instances)[i], draw_list, color_only_framebuffer, cm, get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_VOXEL_GI_LIGHTING, get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_VOXEL_GI_EMISSION, 1.0);
+			}
 		}
-		RD::get_singleton()->draw_command_end_label();
 		RD::get_singleton()->draw_list_end();
 	}
 
@@ -2295,13 +2295,12 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 	if (draw_sky || draw_sky_fog_only) {
 		RENDER_TIMESTAMP("Render Sky");
 
-		RD::get_singleton()->draw_command_begin_label("Draw Sky");
+		RD::DrawCommandLabel draw_sky_label = RD::get_singleton()->draw_command_label("Draw Sky");
 		RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(color_only_framebuffer, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 1.0f, 0u, p_render_data->render_region);
 
 		sky.draw_sky(draw_list, rb, p_render_data->environment, color_only_framebuffer, time, sky_luminance_multiplier, sky_brightness_multiplier);
 
 		RD::get_singleton()->draw_list_end();
-		RD::get_singleton()->draw_command_end_label();
 	}
 
 	if (use_msaa) {
@@ -2334,9 +2333,8 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 	if (using_separate_specular) {
 		if (using_sss) {
 			RENDER_TIMESTAMP("Sub-Surface Scattering");
-			RD::get_singleton()->draw_command_begin_label("Process Sub-Surface Scattering");
+			RD::DrawCommandLabel sss_label = RD::get_singleton()->draw_command_label("Process Sub-Surface Scattering");
 			_process_sss(rb, p_render_data->scene_data->cam_projection);
-			RD::get_singleton()->draw_command_end_label();
 		}
 
 		{
@@ -2407,50 +2405,51 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		_process_compositor_effects(RSE::COMPOSITOR_EFFECT_CALLBACK_TYPE_PRE_TRANSPARENT, p_render_data);
 	}
 
-	RENDER_TIMESTAMP("Render 3D Transparent Pass");
-
-	RD::get_singleton()->draw_command_begin_label("Render 3D Transparent Pass");
-
-	uint32_t transparent_pass_uniform_buffer_index = _setup_environment(p_render_data, is_reflection_probe, screen_size, screen_size, p_default_bg_color, false);
-
-	rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_ALPHA, p_render_data, radiance_texture, samplers, transparent_pass_uniform_buffer_index, true);
-
 	{
-		uint32_t transparent_color_pass_flags = (color_pass_flags | uint32_t(COLOR_PASS_FLAG_TRANSPARENT)) & ~uint32_t(COLOR_PASS_FLAG_SEPARATE_SPECULAR);
-		// Motion vectors should not be overwritten by transparent objects.
-		transparent_color_pass_flags &= ~uint32_t(COLOR_PASS_FLAG_MOTION_VECTORS);
+		RENDER_TIMESTAMP("Render 3D Transparent Pass");
 
-		RID alpha_framebuffer = rb_data.is_valid() ? rb_data->get_color_pass_fb(transparent_color_pass_flags) : color_only_framebuffer;
-		RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].element_info.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR, transparent_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
-		_render_list_with_draw_list(&render_list_params, alpha_framebuffer, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 0.0f, 0u, p_render_data->render_region);
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render 3D Transparent Pass");
+
+		uint32_t transparent_pass_uniform_buffer_index = _setup_environment(p_render_data, is_reflection_probe, screen_size, screen_size, p_default_bg_color, false);
+
+		rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_ALPHA, p_render_data, radiance_texture, samplers, transparent_pass_uniform_buffer_index, true);
+
+		{
+			uint32_t transparent_color_pass_flags = (color_pass_flags | uint32_t(COLOR_PASS_FLAG_TRANSPARENT)) & ~uint32_t(COLOR_PASS_FLAG_SEPARATE_SPECULAR);
+			// Motion vectors should not be overwritten by transparent objects.
+			transparent_color_pass_flags &= ~uint32_t(COLOR_PASS_FLAG_MOTION_VECTORS);
+
+			RID alpha_framebuffer = rb_data.is_valid() ? rb_data->get_color_pass_fb(transparent_color_pass_flags) : color_only_framebuffer;
+			RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].element_info.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR, transparent_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+			_render_list_with_draw_list(&render_list_params, alpha_framebuffer, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 0.0f, 0u, p_render_data->render_region);
+		}
 	}
 
-	RD::get_singleton()->draw_command_end_label();
+	{
+		RENDER_TIMESTAMP("Resolve");
 
-	RENDER_TIMESTAMP("Resolve");
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Resolve");
 
-	RD::get_singleton()->draw_command_begin_label("Resolve");
+		if (rb_data.is_valid() && use_msaa) {
+			bool resolve_velocity_buffer = (using_taa || using_upscaling || ce_needs_motion_vectors) && rb->has_velocity_buffer(true);
+			for (uint32_t v = 0; v < rb->get_view_count(); v++) {
+				RD::get_singleton()->texture_resolve_multisample(rb->get_color_msaa(v), rb->get_internal_texture(v));
+				resolve_effects->resolve_depth(rb->get_depth_msaa(v), rb->get_depth_texture(v), rb->get_internal_size(), texture_multisamples[msaa]);
 
-	if (rb_data.is_valid() && use_msaa) {
-		bool resolve_velocity_buffer = (using_taa || using_upscaling || ce_needs_motion_vectors) && rb->has_velocity_buffer(true);
-		for (uint32_t v = 0; v < rb->get_view_count(); v++) {
-			RD::get_singleton()->texture_resolve_multisample(rb->get_color_msaa(v), rb->get_internal_texture(v));
-			resolve_effects->resolve_depth(rb->get_depth_msaa(v), rb->get_depth_texture(v), rb->get_internal_size(), texture_multisamples[msaa]);
-
-			if (resolve_velocity_buffer) {
-				RD::get_singleton()->texture_resolve_multisample(rb->get_velocity_buffer(true, v), rb->get_velocity_buffer(false, v));
+				if (resolve_velocity_buffer) {
+					RD::get_singleton()->texture_resolve_multisample(rb->get_velocity_buffer(true, v), rb->get_velocity_buffer(false, v));
+				}
 			}
 		}
 	}
 
-	RD::get_singleton()->draw_command_end_label();
-
-	RD::get_singleton()->draw_command_begin_label("Copy Framebuffer for SSIL/SSR");
-	if (using_ssil || using_ssr) {
-		RENDER_TIMESTAMP("Copy Final Framebuffer (SSIL/SSR)");
-		_copy_framebuffer_to_ss_effects(rb, using_ssil, using_ssr);
+	{
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Copy Framebuffer for SSIL/SSR");
+		if (using_ssil || using_ssr) {
+			RENDER_TIMESTAMP("Copy Final Framebuffer (SSIL/SSR)");
+			_copy_framebuffer_to_ss_effects(rb, using_ssil, using_ssr);
+		}
 	}
-	RD::get_singleton()->draw_command_end_label();
 
 	{
 		RENDER_TIMESTAMP("Process Post Transparent Compositor Effects");
@@ -2466,7 +2465,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 				exposure = luminance->get_current_luminance_buffer(rb);
 			}
 
-			RD::get_singleton()->draw_command_begin_label("FSR2");
+			RD::DrawCommandLabel fsr2_label = RD::get_singleton()->draw_command_label("FSR2");
 			RENDER_TIMESTAMP("FSR2");
 
 			for (uint32_t v = 0; v < rb->get_view_count(); v++) {
@@ -2502,8 +2501,6 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 				fsr2_effect->upscale(params);
 			}
-
-			RD::get_singleton()->draw_command_end_label();
 		} else if (scale_type == SCALE_MFX) {
 #ifdef METAL_MFXTEMPORAL_ENABLED
 			bool reset = rb_data->ensure_mfx_temporal(mfx_temporal_effect);
@@ -2513,7 +2510,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 				exposure = luminance->get_current_luminance_buffer(rb);
 			}
 
-			RD::get_singleton()->draw_command_begin_label("MetalFX Temporal");
+			RD::DrawCommandLabel mfx_temporal_label = RD::get_singleton()->draw_command_label("MetalFX Temporal");
 			// Scale to ±0.5.
 			Vector2 jitter = p_render_data->scene_data->taa_jitter * 0.5f;
 			jitter *= Vector2(1.0, -1.0); // Flip y-axis as bottom left is origin.
@@ -2530,14 +2527,11 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 				mfx_temporal_effect->process(rb_data->get_mfx_temporal_context(), params);
 			}
-
-			RD::get_singleton()->draw_command_end_label();
 #endif
 		} else if (using_taa) {
-			RD::get_singleton()->draw_command_begin_label("TAA");
+			RD::DrawCommandLabel taa_label = RD::get_singleton()->draw_command_label("TAA");
 			RENDER_TIMESTAMP("TAA");
 			taa->process(rb, rb->get_base_data_format(), p_render_data->scene_data->z_near, p_render_data->scene_data->z_far);
-			RD::get_singleton()->draw_command_end_label();
 		}
 	}
 
@@ -2794,7 +2788,7 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 
 void RenderForwardClustered::_render_shadow_begin() {
 	scene_state.shadow_passes.clear();
-	RD::get_singleton()->draw_command_begin_label("Shadow Setup");
+	scene_state.shadow_setup_label = RD::get_singleton()->draw_command_label("Shadow Setup");
 	_update_render_base_uniform_set();
 
 	render_list[RENDER_LIST_SECONDARY].clear();
@@ -2892,23 +2886,21 @@ void RenderForwardClustered::_render_shadow_process() {
 		shadow_pass.rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_SECONDARY, nullptr, RID(), RendererRD::MaterialStorage::get_singleton()->samplers_rd_get_default(), shadow_pass.uniform_buffer_index, false);
 	}
 
-	RD::get_singleton()->draw_command_end_label();
+	scene_state.shadow_setup_label.end();
 }
 void RenderForwardClustered::_render_shadow_end() {
-	RD::get_singleton()->draw_command_begin_label("Shadow Render");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Shadow Render");
 
 	for (SceneState::ShadowPass &shadow_pass : scene_state.shadow_passes) {
 		RenderListParameters render_list_parameters(render_list[RENDER_LIST_SECONDARY].elements.ptr() + shadow_pass.element_from, render_list[RENDER_LIST_SECONDARY].element_info.ptr() + shadow_pass.element_from, shadow_pass.element_count, shadow_pass.flip_cull, shadow_pass.pass_mode, 0, true, false, shadow_pass.rp_uniform_set, false, Vector2(), shadow_pass.lod_distance_multiplier, shadow_pass.screen_mesh_lod_threshold, 1, shadow_pass.element_from);
 		_render_list_with_draw_list(&render_list_parameters, shadow_pass.framebuffer, shadow_pass.clear_depth ? RD::DRAW_CLEAR_DEPTH : RD::DRAW_DEFAULT_ALL, Vector<Color>(), 0.0f, 0, shadow_pass.rect);
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RenderForwardClustered::_render_particle_collider_heightfield(RID p_fb, const Transform3D &p_cam_transform, const Projection &p_cam_projection, const PagedArray<RenderGeometryInstance *> &p_instances) {
 	RENDER_TIMESTAMP("Setup GPUParticlesCollisionHeightField3D");
 
-	RD::get_singleton()->draw_command_begin_label("Render Collider Heightfield");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render Collider Heightfield");
 
 	RenderSceneDataRD scene_data;
 	scene_data.flip_y = true;
@@ -2950,13 +2942,12 @@ void RenderForwardClustered::_render_particle_collider_heightfield(RID p_fb, con
 		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, pass_mode, 0, true, false, rp_uniform_set);
 		_render_list_with_draw_list(&render_list_params, p_fb, RD::DRAW_CLEAR_ALL);
 	}
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RenderForwardClustered::_render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) {
 	RENDER_TIMESTAMP("Setup Rendering 3D Material");
 
-	RD::get_singleton()->draw_command_begin_label("Render 3D Material");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render 3D Material");
 
 	RenderSceneDataRD scene_data;
 	scene_data.cam_projection = p_cam_projection;
@@ -3011,14 +3002,12 @@ void RenderForwardClustered::_render_material(const Transform3D &p_cam_transform
 		_render_list(draw_list, RD::get_singleton()->framebuffer_get_format(p_framebuffer), &render_list_params, 0, render_list_params.element_count);
 		RD::get_singleton()->draw_list_end();
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RenderForwardClustered::_render_uv2(const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) {
 	RENDER_TIMESTAMP("Setup Rendering UV2");
 
-	RD::get_singleton()->draw_command_begin_label("Render UV2");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render UV2");
 
 	RenderSceneDataRD scene_data;
 	scene_data.dual_paraboloid_side = 0;
@@ -3091,14 +3080,12 @@ void RenderForwardClustered::_render_uv2(const PagedArray<RenderGeometryInstance
 
 		RD::get_singleton()->draw_list_end();
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RenderForwardClustered::_render_sdfgi(Ref<RenderSceneBuffersRD> p_render_buffers, const Vector3i &p_from, const Vector3i &p_size, const AABB &p_bounds, const PagedArray<RenderGeometryInstance *> &p_instances, const RID &p_albedo_texture, const RID &p_emission_texture, const RID &p_emission_aniso_texture, const RID &p_geom_facing_texture, float p_exposure_normalization) {
 	RENDER_TIMESTAMP("Render SDFGI");
 
-	RD::get_singleton()->draw_command_begin_label("Render SDFGI Voxel");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render SDFGI Voxel");
 
 	RenderSceneDataRD scene_data;
 
@@ -3173,8 +3160,6 @@ void RenderForwardClustered::_render_sdfgi(Ref<RenderSceneBuffersRD> p_render_bu
 		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set, false);
 		_render_list_with_draw_list(&render_list_params, E->value);
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RenderForwardClustered::base_uniforms_changed() {
@@ -5130,12 +5115,18 @@ RenderForwardClustered::RenderForwardClustered() {
 			defines += "\n#define MAX_LIGHTMAPS " + itos(scene_state.max_lightmaps) + "\n";
 
 			scene_state.lightmap_buffer = RD::get_singleton()->storage_buffer_create(sizeof(LightmapData) * scene_state.max_lightmaps);
+#ifdef DEV_ENABLED
+			RD::get_singleton()->set_resource_name(scene_state.lightmap_buffer, "Lightmap");
+#endif
 		}
 		{
 			//captures
 			scene_state.max_lightmap_captures = 2048;
 			scene_state.lightmap_captures = memnew_arr(LightmapCaptureData, scene_state.max_lightmap_captures);
 			scene_state.lightmap_capture_buffer = RD::get_singleton()->storage_buffer_create(sizeof(LightmapCaptureData) * scene_state.max_lightmap_captures);
+#ifdef DEV_ENABLED
+			RD::get_singleton()->set_resource_name(scene_state.lightmap_capture_buffer, "Lightmap Capture");
+#endif
 		}
 		{
 			defines += "\n#define MATERIAL_UNIFORM_SET " + itos(MATERIAL_UNIFORM_SET) + "\n";

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -441,6 +441,7 @@ private:
 		};
 
 		LocalVector<ShadowPass> shadow_passes;
+		RD::DrawCommandLabel shadow_setup_label;
 
 		void grow_instance_buffer(RenderListType p_render_list, uint32_t p_req_element_count, bool p_append);
 	} scene_state;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1045,14 +1045,14 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 
 	p_render_data->scene_data->emissive_exposure_normalization = -1.0;
 
-	RD::get_singleton()->draw_command_begin_label("Render Setup");
+	{
+		RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render Setup");
 
-	_setup_environment(p_render_data, is_reflection_probe, screen_size, screen_size, p_default_bg_color, false);
+		_setup_environment(p_render_data, is_reflection_probe, screen_size, screen_size, p_default_bg_color, false);
 
-	// May have changed due to the above (light buffer enlarged, as an example).
-	_update_render_base_uniform_set();
-
-	RD::get_singleton()->draw_command_end_label(); // Render Setup
+		// May have changed due to the above (light buffer enlarged, as an example).
+		_update_render_base_uniform_set();
+	}
 
 	// setup environment
 	RID radiance_texture;
@@ -1119,7 +1119,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		// setup sky if used for ambient, reflections, or background
 		if (draw_sky || draw_sky_fog_only || (reflection_source == RSE::ENV_REFLECTION_SOURCE_BG && bg_mode == RSE::ENV_BG_SKY) || reflection_source == RSE::ENV_REFLECTION_SOURCE_SKY || ambient_source == RSE::ENV_AMBIENT_SOURCE_SKY) {
 			RENDER_TIMESTAMP("Setup Sky");
-			RD::get_singleton()->draw_command_begin_label("Setup Sky");
+			RD::DrawCommandLabel setup_sky_label = RD::get_singleton()->draw_command_label("Setup Sky");
 
 			sky.setup_sky(p_render_data, screen_size);
 
@@ -1138,7 +1138,6 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 				// update sky half/quarter res buffers (if required)
 				sky.update_res_buffers(rb, p_render_data->environment, time, sky_luminance_multiplier, sky_brightness_multiplier);
 			}
-			RD::get_singleton()->draw_command_end_label(); // Setup Sky
 		}
 
 		if (bg_mode != RSE::ENV_BG_CLEAR_COLOR && bg_mode != RSE::ENV_BG_COLOR) {
@@ -1183,12 +1182,13 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	}
 
 	{
+		RD::DrawCommandLabel render_pass_label;
 		RDD::BreadcrumbMarker breadcrumb;
 		if (rb_data.is_valid()) {
-			RD::get_singleton()->draw_command_begin_label("Render 3D Pass");
+			render_pass_label = RD::get_singleton()->draw_command_label("Render 3D Pass");
 			breadcrumb = RDD::BreadcrumbMarker::OPAQUE_PASS;
 		} else {
-			RD::get_singleton()->draw_command_begin_label("Render Reflection Probe Pass");
+			render_pass_label = RD::get_singleton()->draw_command_label("Render Reflection Probe Pass");
 			breadcrumb = RDD::BreadcrumbMarker::REFLECTION_PROBES;
 		}
 
@@ -1201,18 +1201,16 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 				Vector<Color> mv_pass_clear;
 				mv_pass_clear.push_back(Color(0, 0, 0, 0));
 
-				RD::get_singleton()->draw_command_begin_label("Render Motion Vectors");
+				RD::DrawCommandLabel motion_vectors_label = RD::get_singleton()->draw_command_label("Render Motion Vectors");
 
 				RID rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_OPAQUE, nullptr, RID(), samplers);
 				RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, PASS_MODE_MOTION_VECTORS, rp_uniform_set, base_specialization);
 				_render_list_with_draw_list(&render_list_params, mv_fb, RD::DRAW_CLEAR_ALL, mv_pass_clear);
-
-				RD::get_singleton()->draw_command_end_label();
 			}
 		}
 
 		// opaque pass
-		RD::get_singleton()->draw_command_begin_label("Render Opaque");
+		RD::DrawCommandLabel render_opaque_label = RD::get_singleton()->draw_command_label("Render Opaque");
 
 		p_render_data->scene_data->directional_light_count = p_render_data->directional_light_count;
 
@@ -1271,24 +1269,20 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 
 			_render_list(draw_list, fb_format, &render_list_params, 0, render_list_params.element_count);
 		}
-
-		RD::get_singleton()->draw_command_end_label(); //Render Opaque
+		render_opaque_label.end();
 
 		if (draw_sky || draw_sky_fog_only) {
-			RD::get_singleton()->draw_command_begin_label("Draw Sky");
+			RD::DrawCommandLabel draw_sky_label = RD::get_singleton()->draw_command_label("Draw Sky");
 
 			// Note, sky.setup should have been called up above and setup stuff we need.
 
 			sky.draw_sky(draw_list, rb, p_render_data->environment, framebuffer, time, inverse_luminance_multiplier, sky_brightness_multiplier);
-
-			RD::get_singleton()->draw_command_end_label(); // Draw Sky
 		}
 
 		if (merge_transparent_pass) {
 			if (render_list[RENDER_LIST_ALPHA].element_info.size() > 0) {
 				// transparent pass
-
-				RD::get_singleton()->draw_command_begin_label("Render Transparent");
+				RD::DrawCommandLabel render_transparent_label = RD::get_singleton()->draw_command_label("Render Transparent");
 
 				rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_ALPHA, p_render_data, radiance_texture, samplers, true);
 
@@ -1297,16 +1291,12 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 				render_list_params.subpass = RD::get_singleton()->draw_list_get_current_pass(); // Should now always be 0.
 
 				_render_list(draw_list, fb_format, &render_list_params, 0, render_list_params.element_count);
-
-				RD::get_singleton()->draw_command_end_label(); // Render Transparent Subpass
 			}
 
 			// blit to tonemap
 			if (rb_data.is_valid() && using_subpass_post_process) {
 				_post_process_subpass(p_render_data->render_buffers->get_internal_texture(), framebuffer, p_render_data);
 			}
-
-			RD::get_singleton()->draw_command_end_label(); // Render 3D Pass / Render Reflection Probe Pass
 
 			RD::get_singleton()->draw_list_end();
 
@@ -1322,7 +1312,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 
 			RD::get_singleton()->draw_list_end();
 
-			RD::get_singleton()->draw_command_end_label(); // Render 3D Pass / Render Reflection Probe Pass
+			render_pass_label.end();
 
 			// rendering effects
 			if (ce_has_pre_transparent) {
@@ -1353,7 +1343,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 			}
 
 			if (render_list[RENDER_LIST_ALPHA].element_info.size() > 0) {
-				RD::get_singleton()->draw_command_begin_label("Render Transparent Pass");
+				RD::DrawCommandLabel transparent_pass_label = RD::get_singleton()->draw_command_label("Render Transparent Pass");
 				RENDER_TIMESTAMP("Render Transparent");
 
 				rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_ALPHA, p_render_data, radiance_texture, samplers, true);
@@ -1368,14 +1358,12 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 				draw_list = RD::get_singleton()->draw_list_begin(framebuffer, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 1.0f, 0, p_render_data->render_region, breadcrumb);
 				_render_list(draw_list, fb_format, &render_list_params, 0, render_list_params.element_count);
 				RD::get_singleton()->draw_list_end();
-
-				RD::get_singleton()->draw_command_end_label(); // Render Transparent Pass
 			}
 		}
 	}
 
 	if (rb_data.is_valid() && !using_subpass_post_process) {
-		RD::get_singleton()->draw_command_begin_label("Post Process Pass");
+		RD::DrawCommandLabel post_process_label = RD::get_singleton()->draw_command_label("Post Process Pass");
 
 		if (ce_has_post_transparent) {
 			_process_compositor_effects(RSE::COMPOSITOR_EFFECT_CALLBACK_TYPE_POST_TRANSPARENT, p_render_data);
@@ -1385,8 +1373,6 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		RENDER_TIMESTAMP("Tonemap");
 
 		_render_buffers_post_process_and_tonemap(p_render_data, use_msaa);
-
-		RD::get_singleton()->draw_command_end_label(); // Post process pass
 	}
 
 	if (rb_data.is_valid()) {
@@ -1587,7 +1573,7 @@ void RenderForwardMobile::_render_shadow_pass(RID p_light, RID p_shadow_atlas, i
 
 void RenderForwardMobile::_render_shadow_begin() {
 	scene_state.shadow_passes.clear();
-	RD::get_singleton()->draw_command_begin_label("Shadow Setup");
+	scene_state.shadow_setup_label = RD::get_singleton()->draw_command_label("Shadow Setup");
 	_update_render_base_uniform_set();
 
 	render_list[RENDER_LIST_SECONDARY].clear();
@@ -1679,18 +1665,16 @@ void RenderForwardMobile::_render_shadow_process() {
 		shadow_pass.rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_SECONDARY, nullptr, RID(), RendererRD::MaterialStorage::get_singleton()->samplers_rd_get_default(), false, scene_state.shadow_passes.size() - 1u - i);
 	}
 
-	RD::get_singleton()->draw_command_end_label();
+	scene_state.shadow_setup_label = RD::DrawCommandLabel(); // End shadow setup label
 }
 
 void RenderForwardMobile::_render_shadow_end() {
-	RD::get_singleton()->draw_command_begin_label("Shadow Render");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Shadow Render");
 
 	for (SceneState::ShadowPass &shadow_pass : scene_state.shadow_passes) {
 		RenderListParameters render_list_parameters(render_list[RENDER_LIST_SECONDARY].elements.ptr() + shadow_pass.element_from, render_list[RENDER_LIST_SECONDARY].element_info.ptr() + shadow_pass.element_from, shadow_pass.element_count, shadow_pass.flip_cull, shadow_pass.pass_mode, shadow_pass.rp_uniform_set, scene_shader.default_specialization, false, Vector2(), shadow_pass.lod_distance_multiplier, shadow_pass.screen_mesh_lod_threshold, 1, shadow_pass.element_from);
 		_render_list_with_draw_list(&render_list_parameters, shadow_pass.framebuffer, shadow_pass.clear_depth ? RD::DRAW_CLEAR_DEPTH : RD::DRAW_DEFAULT_ALL, Vector<Color>(), 0.0f, 0, shadow_pass.rect);
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 /* */
@@ -1698,7 +1682,7 @@ void RenderForwardMobile::_render_shadow_end() {
 void RenderForwardMobile::_render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) {
 	RENDER_TIMESTAMP("Setup Rendering 3D Material");
 
-	RD::get_singleton()->draw_command_begin_label("Render 3D Material");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render 3D Material");
 
 	_update_render_base_uniform_set();
 
@@ -1748,14 +1732,12 @@ void RenderForwardMobile::_render_material(const Transform3D &p_cam_transform, c
 		_render_list(draw_list, RD::get_singleton()->framebuffer_get_format(p_framebuffer), &render_list_params, 0, render_list_params.element_count);
 		RD::get_singleton()->draw_list_end();
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RenderForwardMobile::_render_uv2(const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) {
 	RENDER_TIMESTAMP("Setup Rendering UV2");
 
-	RD::get_singleton()->draw_command_begin_label("Render UV2");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render UV2");
 
 	_update_render_base_uniform_set();
 
@@ -1823,8 +1805,6 @@ void RenderForwardMobile::_render_uv2(const PagedArray<RenderGeometryInstance *>
 
 		RD::get_singleton()->draw_list_end();
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RenderForwardMobile::_render_sdfgi(Ref<RenderSceneBuffersRD> p_render_buffers, const Vector3i &p_from, const Vector3i &p_size, const AABB &p_bounds, const PagedArray<RenderGeometryInstance *> &p_instances, const RID &p_albedo_texture, const RID &p_emission_texture, const RID &p_emission_aniso_texture, const RID &p_geom_facing_texture, float p_exposure_normalization) {
@@ -1834,7 +1814,7 @@ void RenderForwardMobile::_render_sdfgi(Ref<RenderSceneBuffersRD> p_render_buffe
 void RenderForwardMobile::_render_particle_collider_heightfield(RID p_fb, const Transform3D &p_cam_transform, const Projection &p_cam_projection, const PagedArray<RenderGeometryInstance *> &p_instances) {
 	RENDER_TIMESTAMP("Setup GPUParticlesCollisionHeightField3D");
 
-	RD::get_singleton()->draw_command_begin_label("Render Collider Heightfield");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Render Collider Heightfield");
 
 	_update_render_base_uniform_set();
 
@@ -1873,7 +1853,6 @@ void RenderForwardMobile::_render_particle_collider_heightfield(RID p_fb, const 
 		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, pass_mode, rp_uniform_set, scene_shader.default_specialization);
 		_render_list_with_draw_list(&render_list_params, p_fb);
 	}
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RenderForwardMobile::base_uniforms_changed() {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -318,6 +318,7 @@ private:
 		};
 
 		LocalVector<ShadowPass> shadow_passes;
+		RD::DrawCommandLabel shadow_setup_label;
 
 		void grow_instance_buffer(RenderListType p_render_list, uint32_t p_req_element_count, bool p_append);
 	} scene_state;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -356,7 +356,7 @@ void RendererSceneRenderRD::_render_buffers_copy_screen_texture(const RenderData
 		return;
 	}
 
-	RD::get_singleton()->draw_command_begin_label("Copy Screen Texture");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Copy Screen Texture");
 
 	StringName texture_name;
 	bool can_use_storage = _render_buffers_can_be_storage();
@@ -397,8 +397,6 @@ void RendererSceneRenderRD::_render_buffers_copy_screen_texture(const RenderData
 			}
 		}
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RendererSceneRenderRD::_render_buffers_ensure_depth_texture(const RenderDataRD *p_render_data) {
@@ -427,7 +425,7 @@ void RendererSceneRenderRD::_render_buffers_copy_depth_texture(const RenderDataR
 		return;
 	}
 
-	RD::get_singleton()->draw_command_begin_label("Copy Depth Texture");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Copy Depth Texture");
 
 	bool can_use_storage = _render_buffers_can_be_storage();
 	Size2i size = rb->get_internal_size();
@@ -448,8 +446,6 @@ void RendererSceneRenderRD::_render_buffers_copy_depth_texture(const RenderDataR
 			}
 		}
 	}
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const RenderDataRD *p_render_data, bool p_use_msaa) {
@@ -502,7 +498,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 	if (can_use_effects && using_dof) {
 		RENDER_TIMESTAMP("Depth of Field");
-		RD::get_singleton()->draw_command_begin_label("DOF");
+		RD::DrawCommandLabel dof_label = RD::get_singleton()->draw_command_label("DOF");
 
 		rb->allocate_blur_textures();
 
@@ -548,15 +544,13 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 				bokeh_dof->bokeh_dof_raster(buffers, p_render_data->camera_attributes, z_near, z_far, p_render_data->scene_data->cam_orthogonal);
 			}
 		}
-		RD::get_singleton()->draw_command_end_label();
 	}
 
 	float auto_exposure_scale = 1.0;
 
 	if (can_use_effects && RSG::camera_attributes->camera_attributes_uses_auto_exposure(p_render_data->camera_attributes)) {
 		RENDER_TIMESTAMP("Auto exposure");
-
-		RD::get_singleton()->draw_command_begin_label("Auto Exposure");
+		RD::DrawCommandLabel ae_label = RD::get_singleton()->draw_command_label("Auto Exposure");
 
 		Ref<RendererRD::Luminance::LuminanceBuffers> luminance_buffers = luminance->get_luminance_buffers(rb);
 
@@ -574,7 +568,6 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 		auto_exposure_scale = RSG::camera_attributes->camera_attributes_get_auto_exposure_scale(p_render_data->camera_attributes);
 
 		RenderingServerDefault::redraw_request(); // Redraw all the time if auto exposure rendering is on.
-		RD::get_singleton()->draw_command_end_label();
 	}
 
 	if (can_use_effects && p_render_data->environment.is_valid() && environment_get_glow_enabled(p_render_data->environment)) {
@@ -599,7 +592,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 		float luminance_multiplier = rb->get_luminance_multiplier();
 		if (can_use_storage) {
-			RD::get_singleton()->draw_command_begin_label("Gaussian Glow");
+			RD::DrawCommandLabel glow_label = RD::get_singleton()->draw_command_label("Gaussian Glow");
 			RID luminance_texture;
 			if (RSG::camera_attributes->camera_attributes_uses_auto_exposure(p_render_data->camera_attributes)) {
 				luminance_texture = luminance->get_current_luminance_buffer(rb); // this will return and empty RID if we don't have an auto exposure buffer
@@ -617,7 +610,6 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 					copy_effects->gaussian_glow(source, dest, vp_size, environment_get_glow_strength(p_render_data->environment));
 				}
 			}
-			RD::get_singleton()->draw_command_end_label();
 		} else {
 			// For the mobile renderer we blur down and up the mip chain. Which works out to (2*level-1) passes. This
 			// allows us to gather our levels at low resolutions and ultimately save a lot of texture read bandwidth.
@@ -627,54 +619,59 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 			RID dest;
 
 			for (uint32_t l = 0; l < rb->get_view_count(); l++) {
-				RD::get_singleton()->draw_command_begin_label("Gaussian Glow downsample");
-
-				Size2i source_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_COLOR, 0);
-
-				source = rb->get_internal_texture(l);
-				dest = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, l, 1); // Level 1 is quarter res.
-
-				copy_effects->gaussian_glow_downsample_raster(source, dest, luminance_multiplier, source_size, environment_get_glow_strength(p_render_data->environment), true, environment_get_glow_hdr_luminance_cap(p_render_data->environment), environment_get_exposure(p_render_data->environment), environment_get_glow_bloom(p_render_data->environment), environment_get_glow_hdr_bleed_threshold(p_render_data->environment), environment_get_glow_hdr_bleed_scale(p_render_data->environment));
-
+				Size2i source_size;
 				Size2i vp_size;
-				for (int i = 1; i < (max_glow_index + 1); i++) {
-					source = dest;
-					vp_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, i);
-					dest = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, l, i + 1);
 
-					copy_effects->gaussian_glow_downsample_raster(source, dest, luminance_multiplier, vp_size, environment_get_glow_strength(p_render_data->environment));
+				{
+					RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Gaussian Glow downsample");
+
+					source_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_COLOR, 0);
+
+					source = rb->get_internal_texture(l);
+					dest = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, l, 1); // Level 1 is quarter res.
+
+					copy_effects->gaussian_glow_downsample_raster(source, dest, luminance_multiplier, source_size, environment_get_glow_strength(p_render_data->environment), true, environment_get_glow_hdr_luminance_cap(p_render_data->environment), environment_get_exposure(p_render_data->environment), environment_get_glow_bloom(p_render_data->environment), environment_get_glow_hdr_bleed_threshold(p_render_data->environment), environment_get_glow_hdr_bleed_scale(p_render_data->environment));
+
+					for (int i = 1; i < (max_glow_index + 1); i++) {
+						source = dest;
+						vp_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, i);
+						dest = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, l, i + 1);
+
+						copy_effects->gaussian_glow_downsample_raster(source, dest, luminance_multiplier, vp_size, environment_get_glow_strength(p_render_data->environment));
+					}
 				}
-				RD::get_singleton()->draw_command_end_label();
-				RD::get_singleton()->draw_command_begin_label("Gaussian Glow upsample");
 
-				if (max_glow_index <= 0) {
-					// Only layer 1 is visible, just copy over.
-					source = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK); // Technically a waste, but oh well. I'm not optimizing for the case of only level 1.
-					vp_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, 2); // RB_TEX_BLUR_0 is double the size of RB_TEX_BLUR_1, so go up a mip level.
-					dest = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, l, 2);
-					RID blend_tex = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, l, 1);
-					source_size = vp_size;
+				{
+					RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Gaussian Glow upsample");
 
-					copy_effects->gaussian_glow_upsample_raster(source, dest, blend_tex, luminance_multiplier, source_size, vp_size, glow_levels[0], 0.0, use_debanding);
+					if (max_glow_index <= 0) {
+						// Only layer 1 is visible, just copy over.
+						source = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK); // Technically a waste, but oh well. I'm not optimizing for the case of only level 1.
+						vp_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, 2); // RB_TEX_BLUR_0 is double the size of RB_TEX_BLUR_1, so go up a mip level.
+						dest = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, l, 2);
+						RID blend_tex = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, l, 1);
+						source_size = vp_size;
+
+						copy_effects->gaussian_glow_upsample_raster(source, dest, blend_tex, luminance_multiplier, source_size, vp_size, glow_levels[0], 0.0, use_debanding);
+					}
+
+					for (int i = max_glow_index - 1; i >= 0; i--) {
+						source = dest;
+						source_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, i + 3);
+						vp_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, i + 2); // RB_TEX_BLUR_0 is double the size of RB_TEX_BLUR_1, so go up a mip level.
+						dest = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, l, i + 2);
+						RID blend_tex = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, l, i + 1);
+
+						copy_effects->gaussian_glow_upsample_raster(source, dest, blend_tex, luminance_multiplier, source_size, vp_size, glow_levels[i], i == (max_glow_index - 1) ? glow_levels[i + 1] : 1.0, use_debanding);
+					}
 				}
-
-				for (int i = max_glow_index - 1; i >= 0; i--) {
-					source = dest;
-					source_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, i + 3);
-					vp_size = rb->get_texture_slice_size(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, i + 2); // RB_TEX_BLUR_0 is double the size of RB_TEX_BLUR_1, so go up a mip level.
-					dest = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0, l, i + 2);
-					RID blend_tex = rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1, l, i + 1);
-
-					copy_effects->gaussian_glow_upsample_raster(source, dest, blend_tex, luminance_multiplier, source_size, vp_size, glow_levels[i], i == (max_glow_index - 1) ? glow_levels[i + 1] : 1.0, use_debanding);
-				}
-				RD::get_singleton()->draw_command_end_label();
 			}
 		}
 	}
 
 	{
 		RENDER_TIMESTAMP("Tonemap");
-		RD::get_singleton()->draw_command_begin_label("Tonemap");
+		RD::DrawCommandLabel tonemap_label = RD::get_singleton()->draw_command_label("Tonemap");
 
 		RendererRD::ToneMapper::TonemapSettings tonemap;
 
@@ -812,13 +809,11 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 		} else {
 			tone_mapper->tonemapper_mobile(color_texture, dest_fb, tonemap);
 		}
-
-		RD::get_singleton()->draw_command_end_label();
 	}
 
 	if (use_smaa) {
 		RENDER_TIMESTAMP("SMAA");
-		RD::get_singleton()->draw_command_begin_label("SMAA");
+		RD::DrawCommandLabel smaa_label = RD::get_singleton()->draw_command_label("SMAA");
 
 		bool using_hdr = texture_storage->render_target_is_using_hdr(render_target);
 
@@ -857,12 +852,10 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 			smaa->process(rb, source_texture, dest_fb, rb->get_use_debanding() && !using_hdr);
 		}
-
-		RD::get_singleton()->draw_command_end_label();
 	}
 
 	if (rb.is_valid() && using_scaling_pass) {
-		RD::get_singleton()->draw_command_begin_label(spatial_upscaler ? spatial_upscaler->get_label() : "3D Viewport Scaling");
+		RD::DrawCommandLabel upscaler_label = RD::get_singleton()->draw_command_label(spatial_upscaler ? spatial_upscaler->get_label() : "3D Viewport Scaling");
 
 		if (spatial_upscaler) {
 			spatial_upscaler->ensure_context(rb);
@@ -890,8 +883,6 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 			texture_storage->render_target_set_msaa_needs_resolve(render_target, true); // Make sure this gets resolved.
 		}
-
-		RD::get_singleton()->draw_command_end_label();
 	}
 
 	texture_storage->render_target_disable_clear_request(render_target);
@@ -899,7 +890,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 void RendererSceneRenderRD::_post_process_subpass(RID p_source_texture, RID p_framebuffer, const RenderDataRD *p_render_data) {
 	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
-	RD::get_singleton()->draw_command_begin_label("Post Process Subpass");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Post Process Subpass");
 
 	Ref<RenderSceneBuffersRD> rb = p_render_data->render_buffers;
 	ERR_FAIL_COND(rb.is_null());
@@ -984,8 +975,6 @@ void RendererSceneRenderRD::_post_process_subpass(RID p_source_texture, RID p_fr
 	}
 
 	tone_mapper->tonemapper_subpass(draw_list, p_source_texture, RD::get_singleton()->framebuffer_get_format(p_framebuffer), tonemap);
-
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void RendererSceneRenderRD::_disable_clear_request(const RenderDataRD *p_render_data) {

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1711,7 +1711,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 		atlas->render_buffers.instantiate();
 	}
 
-	RD::get_singleton()->draw_command_begin_label("Reflection Probe Render");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Reflection Probe Render");
 
 	const bool update_always = LightStorage::get_singleton()->reflection_probe_get_update_mode(rpi->probe) == RSE::REFLECTION_PROBE_UPDATE_ALWAYS;
 	if (update_always && atlas->reflection.is_valid() && atlas->size != 256) {
@@ -1821,8 +1821,6 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 	rpi->dirty = false;
 	rpi->processing_layer = 1;
 
-	RD::get_singleton()->draw_command_end_label();
-
 	return true;
 }
 
@@ -1836,9 +1834,8 @@ bool LightStorage::reflection_probe_instance_end_render(RID p_instance, RID p_re
 	ReflectionProbeInstance *rpi = reflection_probe_instance_owner.get_or_null(p_instance);
 	ERR_FAIL_NULL_V(rpi, false);
 
-	RD::get_singleton()->draw_command_begin_label("Convert reflection probe to octahedral");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Convert reflection probe to octahedral");
 	copy_effects->copy_cubemap_to_octmap(atlas->color_buffer, atlas->reflections.write[rpi->atlas_index].data.layers[0].mipmaps[0].framebuffer, atlas->uv_border_size);
-	RD::get_singleton()->draw_command_end_label();
 
 	return true;
 }

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1806,7 +1806,7 @@ void TextureStorage::texture_drawable_blit_rect(const TypedArray<RID> &p_texture
 
 	Rect2i tex_blit_rr;
 
-	RD::get_singleton()->draw_command_begin_label("Blit Rect");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Blit Rect");
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(tex_blit_fb, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 1.0f, 0u, tex_blit_rr);
 
 	RD::FramebufferFormatID fb_format = RD::get_singleton()->framebuffer_get_format(tex_blit_fb);
@@ -1833,7 +1833,6 @@ void TextureStorage::texture_drawable_blit_rect(const TypedArray<RID> &p_texture
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 6u);
 
 	RD::get_singleton()->draw_list_end();
-	RD::get_singleton()->draw_command_end_label();
 }
 
 //these two APIs can be used together or in combination with the others.
@@ -5096,7 +5095,7 @@ void TextureStorage::render_target_copy_to_back_buffer(RID p_render_target, cons
 	if (!p_gen_mipmaps) {
 		return;
 	}
-	RD::get_singleton()->draw_command_begin_label("Gaussian Blur Mipmaps");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Gaussian Blur Mipmaps");
 	//then mipmap blur
 	RID prev_texture = rt->color; //use color, not backbuffer, as bb has mipmaps.
 
@@ -5116,7 +5115,6 @@ void TextureStorage::render_target_copy_to_back_buffer(RID p_render_target, cons
 		}
 		prev_texture = mipmap;
 	}
-	RD::get_singleton()->draw_command_end_label();
 }
 
 void TextureStorage::render_target_clear_back_buffer(RID p_render_target, const Rect2i &p_region, const Color &p_color) {
@@ -5168,7 +5166,7 @@ void TextureStorage::render_target_gen_back_buffer_mipmaps(RID p_render_target, 
 			return; //nothing to do
 		}
 	}
-	RD::get_singleton()->draw_command_begin_label("Gaussian Blur Mipmaps Pass 2");
+	RD::DrawCommandLabel label = RD::get_singleton()->draw_command_label("Gaussian Blur Mipmaps Pass 2");
 	//then mipmap blur
 	RID prev_texture = rt->backbuffer_mipmap0;
 	Size2i texture_size = rt->size;
@@ -5188,7 +5186,6 @@ void TextureStorage::render_target_gen_back_buffer_mipmaps(RID p_render_target, 
 		}
 		prev_texture = mipmap;
 	}
-	RD::get_singleton()->draw_command_end_label();
 }
 
 RID TextureStorage::render_target_get_framebuffer_uniform_set(RID p_render_target) {

--- a/servers/rendering/renderer_rd/storage_rd/utilities.h
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/templates/rid_owner.h"
+#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/storage/utilities.h"
 
 namespace RendererRD {
@@ -98,6 +99,12 @@ public:
 	virtual uint64_t get_captured_timestamp_gpu_time(uint32_t p_index) const override;
 	virtual uint64_t get_captured_timestamp_cpu_time(uint32_t p_index) const override;
 	virtual String get_captured_timestamp_name(uint32_t p_index) const override;
+
+	/* DEBUG */
+
+	[[nodiscard]] DebugLabel draw_command_label(const Span<char> p_label_name, const Color &p_color = Color(1, 1, 1, 1)) const final {
+		return DebugLabel(RD::get_singleton()->draw_command_label(p_label_name, p_color));
+	}
 
 	/* MISC */
 

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3860,11 +3860,13 @@ void RendererSceneCull::render_probes() {
 
 	SelfList<InstanceReflectionProbeData> *ref_probe = reflection_probe_render_list.first();
 	Vector<SelfList<InstanceReflectionProbeData> *> done_list;
+	RendererUtilities::DebugLabel render_probes_label = RSG::utilities->draw_command_label("Render Probes");
 
 	bool busy = false;
 
 	if (ref_probe) {
 		RENDER_TIMESTAMP("Render ReflectionProbes");
+		RendererUtilities::DebugLabel reflection_label = RSG::utilities->draw_command_label("Render ReflectionProbes");
 
 		while (ref_probe) {
 			SelfList<InstanceReflectionProbeData> *next = ref_probe->next();
@@ -3910,8 +3912,10 @@ void RendererSceneCull::render_probes() {
 
 	SelfList<InstanceVoxelGIData> *voxel_gi = voxel_gi_update_list.first();
 
+	RendererUtilities::DebugLabel voxel_gi_label;
 	if (voxel_gi) {
 		RENDER_TIMESTAMP("Render VoxelGI");
+		voxel_gi_label = RSG::utilities->draw_command_label("Render VoxelGI");
 	}
 
 	while (voxel_gi) {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -884,6 +884,9 @@ Error RenderingDevice::_insert_staging_block(StagingBuffers &p_staging_buffers) 
 
 	block.driver_id = driver->buffer_create(p_staging_buffers.block_size, p_staging_buffers.usage_bits, RDD::MEMORY_ALLOCATION_TYPE_CPU, frames_drawn);
 	ERR_FAIL_COND_V(!block.driver_id, ERR_CANT_CREATE);
+#if DEV_ENABLED
+	driver->set_object_name(RDD::OBJECT_TYPE_BUFFER, block.driver_id, "Staging");
+#endif
 
 	block.frame_used = 0;
 	block.fill_amount = 0;
@@ -7814,6 +7817,11 @@ void RenderingDevice::draw_command_begin_label(const Span<char> p_label_name, co
 	}
 
 	draw_graph.begin_label(p_label_name, p_color);
+}
+
+RenderingDevice::DrawCommandLabel RenderingDevice::draw_command_label(const Span<char> p_label_name, const Color &p_color) {
+	draw_command_begin_label(p_label_name, p_color);
+	return DrawCommandLabel(this);
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1937,10 +1937,47 @@ public:
 
 	void set_resource_name(RID p_id, const String &p_name);
 
+	class DrawCommandLabel {
+		RenderingDevice *rd = nullptr;
+
+	public:
+		DrawCommandLabel() = default;
+		explicit DrawCommandLabel(RenderingDevice *p_rd) :
+				rd(p_rd) {}
+		~DrawCommandLabel() { end(); }
+
+		DrawCommandLabel(const DrawCommandLabel &) = delete;
+		DrawCommandLabel &operator=(const DrawCommandLabel &) = delete;
+		DrawCommandLabel(DrawCommandLabel &&p_other) noexcept :
+				rd(p_other.rd) {
+			p_other.rd = nullptr;
+		}
+		DrawCommandLabel &operator=(DrawCommandLabel &&p_other) noexcept {
+			if (this != &p_other) {
+				end();
+				rd = p_other.rd;
+				p_other.rd = nullptr;
+			}
+			return *this;
+		}
+
+		void end() {
+			if (rd) {
+				rd->draw_command_end_label();
+				rd = nullptr;
+			}
+		}
+	};
+
+	[[nodiscard]] DrawCommandLabel draw_command_label(const Span<char> p_label_name, const Color &p_color = Color(1, 1, 1, 1));
+
 	void _draw_command_begin_label(String p_label_name, const Color &p_color = Color(1, 1, 1, 1));
-	void draw_command_begin_label(const Span<char> p_label_name, const Color &p_color = Color(1, 1, 1, 1));
 	void draw_command_end_label();
 
+private:
+	void draw_command_begin_label(const Span<char> p_label_name, const Color &p_color = Color(1, 1, 1, 1));
+
+public:
 	String get_device_vendor_name() const;
 	String get_device_name() const;
 	RenderingDeviceEnums::DeviceType get_device_type() const;

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -1225,105 +1225,168 @@ void RenderingDeviceGraph::_run_render_commands(int32_t p_level, const RecordedC
 	}
 }
 
+// Sentinel value indicating "Command Graph" empty label is active on the GPU stack.
+static constexpr int32_t LABEL_INDEX_EMPTY = -2;
+
 void RenderingDeviceGraph::_run_label_command_change(RDD::CommandBufferID p_command_buffer, int32_t p_new_label_index, int32_t p_new_level, bool p_ignore_previous_value, bool p_use_label_for_empty, const RecordedCommandSort *p_sorted_commands, uint32_t p_sorted_commands_count, int32_t &r_current_label_index, int32_t &r_current_label_level) {
-	if (command_label_count == 0) {
-		// Ignore any label operations if no labels were pushed.
+	if (command_label_count == 0 && !p_use_label_for_empty) {
+		// Ignore any label operations if no labels were pushed and we don't need an empty label.
 		return;
 	}
 
-	if (p_ignore_previous_value || p_new_label_index != r_current_label_index || p_new_level != r_current_label_level) {
-		if (!p_ignore_previous_value && (p_use_label_for_empty || r_current_label_index >= 0 || r_current_label_level >= 0)) {
-			// End the current label.
-			driver->command_end_label(p_command_buffer);
-		}
-
-		String label_name;
-		Color label_color;
-		if (p_new_label_index >= 0) {
-			const char *label_chars = &command_label_chars[command_label_offsets[p_new_label_index]];
-			label_name.append_utf8(label_chars);
-			label_color = command_label_colors[p_new_label_index];
-		} else if (p_use_label_for_empty) {
-			label_name = "Command Graph";
-			label_color = Color(1, 1, 1, 1);
-		} else {
-			return;
-		}
-
-		// Add the level to the name.
-		label_name += " (L" + itos(p_new_level) + ")";
-
-		if (p_sorted_commands != nullptr && p_sorted_commands_count > 0) {
-			// Analyze the commands in the level that have the same label to detect what type of operations are performed.
-			bool copy_commands = false;
-			bool compute_commands = false;
-			bool draw_commands = false;
-			bool custom_commands = false;
-			for (uint32_t i = 0; i < p_sorted_commands_count; i++) {
-				const uint32_t command_index = p_sorted_commands[i].index;
-				const uint32_t command_data_offset = command_data_offsets[command_index];
-				const RecordedCommand *command = reinterpret_cast<RecordedCommand *>(&command_data[command_data_offset]);
-				if (command->label_index != p_new_label_index) {
-					break;
-				}
-
-				switch (command->type) {
-					case RecordedCommand::TYPE_BUFFER_CLEAR:
-					case RecordedCommand::TYPE_BUFFER_COPY:
-					case RecordedCommand::TYPE_BUFFER_GET_DATA:
-					case RecordedCommand::TYPE_BUFFER_UPDATE:
-					case RecordedCommand::TYPE_TEXTURE_CLEAR_COLOR:
-					case RecordedCommand::TYPE_TEXTURE_CLEAR_DEPTH_STENCIL:
-					case RecordedCommand::TYPE_TEXTURE_COPY:
-					case RecordedCommand::TYPE_TEXTURE_GET_DATA:
-					case RecordedCommand::TYPE_TEXTURE_RESOLVE:
-					case RecordedCommand::TYPE_TEXTURE_UPDATE: {
-						copy_commands = true;
-					} break;
-					case RecordedCommand::TYPE_COMPUTE_LIST: {
-						compute_commands = true;
-					} break;
-					case RecordedCommand::TYPE_DRAW_LIST: {
-						draw_commands = true;
-					} break;
-					case RecordedCommand::TYPE_DRIVER_CALLBACK: {
-						custom_commands = true;
-					} break;
-					default: {
-						// Ignore command.
-					} break;
-				}
-
-				if (copy_commands && compute_commands && draw_commands && custom_commands) {
-					// There's no more command types to find.
-					break;
-				}
-			}
-
-			if (copy_commands || compute_commands || draw_commands || custom_commands) {
-				// Add the operations to the name.
-				bool plus_after_copy = copy_commands && (compute_commands || draw_commands || custom_commands);
-				bool plus_after_compute = compute_commands && (draw_commands || custom_commands);
-				bool plus_after_draw = draw_commands && custom_commands;
-				label_name += " (";
-				label_name += copy_commands ? "Copy" : "";
-				label_name += plus_after_copy ? "+" : "";
-				label_name += compute_commands ? "Compute" : "";
-				label_name += plus_after_compute ? "+" : "";
-				label_name += draw_commands ? "Draw" : "";
-				label_name += plus_after_draw ? "+" : "";
-				label_name += custom_commands ? "Custom" : "";
-				label_name += ")";
-			}
-		}
-
-		// Start the new label.
-		CharString label_name_utf8 = label_name.utf8();
-		driver->command_begin_label(p_command_buffer, label_name_utf8.get_data(), label_color);
-
-		r_current_label_index = p_new_label_index;
-		r_current_label_level = p_new_level;
+	// Determine target label index: use sentinel for empty label case.
+	int32_t target_label_index = p_new_label_index;
+	if (p_new_label_index < 0 && p_use_label_for_empty) {
+		target_label_index = LABEL_INDEX_EMPTY;
 	}
+
+	if (!p_ignore_previous_value && target_label_index == r_current_label_index && p_new_level == r_current_label_level) {
+		// No change needed.
+		return;
+	}
+
+	// Build path from root to current label.
+	thread_local LocalVector<int32_t> current_path;
+	thread_local LocalVector<int32_t> new_path;
+
+	current_path.clear();
+	new_path.clear();
+
+	if (!p_ignore_previous_value) {
+		// Check if "Command Graph" empty label is active.
+		if (r_current_label_index == LABEL_INDEX_EMPTY) {
+			current_path.push_back(LABEL_INDEX_EMPTY);
+		} else {
+			// Build current path (innermost to root).
+			for (int32_t idx = r_current_label_index; idx >= 0; idx = command_label_parents[idx]) {
+				current_path.push_back(idx);
+			}
+			// Reverse to get root-to-leaf order.
+			for (uint32_t i = 0; i < current_path.size() / 2; i++) {
+				SWAP(current_path[i], current_path[current_path.size() - 1 - i]);
+			}
+		}
+	}
+
+	// Build new path.
+	if (target_label_index == LABEL_INDEX_EMPTY) {
+		new_path.push_back(LABEL_INDEX_EMPTY);
+	} else if (p_new_label_index >= 0) {
+		// Build new path (innermost to root).
+		for (int32_t idx = p_new_label_index; idx >= 0; idx = command_label_parents[idx]) {
+			new_path.push_back(idx);
+		}
+		// Reverse to get root-to-leaf order.
+		for (uint32_t i = 0; i < new_path.size() / 2; i++) {
+			SWAP(new_path[i], new_path[new_path.size() - 1 - i]);
+		}
+	}
+
+	// Find common prefix length.
+	uint32_t common_len = 0;
+	while (common_len < current_path.size() && common_len < new_path.size() &&
+			current_path[common_len] == new_path[common_len]) {
+		common_len++;
+	}
+
+	// Pop labels from current down to common ancestor.
+	for (uint32_t i = current_path.size(); i > common_len; i--) {
+		driver->command_end_label(p_command_buffer);
+	}
+
+	// Push labels from common ancestor up to new label.
+	for (uint32_t i = common_len; i < new_path.size(); i++) {
+		int32_t label_idx = new_path[i];
+
+		// Handle "Command Graph" empty label.
+		if (label_idx == LABEL_INDEX_EMPTY) {
+			driver->command_begin_label(p_command_buffer, "Command Graph", Color(1, 1, 1, 1));
+			continue;
+		}
+
+		const char *label_chars = &command_label_chars[command_label_offsets[label_idx]];
+		Color label_color = command_label_colors[label_idx];
+
+		// For the innermost (leaf) label, add level and operation type annotations.
+		if (i == new_path.size() - 1) {
+			String label_name;
+			label_name.append_utf8(label_chars);
+			label_name += " (L" + itos(p_new_level) + ")";
+
+			if (p_sorted_commands != nullptr && p_sorted_commands_count > 0) {
+				// Analyze the commands in the level that have the same label to detect what type of operations are performed.
+				bool copy_commands = false;
+				bool compute_commands = false;
+				bool draw_commands = false;
+				bool custom_commands = false;
+				for (uint32_t j = 0; j < p_sorted_commands_count; j++) {
+					const uint32_t command_index = p_sorted_commands[j].index;
+					const uint32_t command_data_offset = command_data_offsets[command_index];
+					const RecordedCommand *command = reinterpret_cast<RecordedCommand *>(&command_data[command_data_offset]);
+					if (command->label_index != p_new_label_index) {
+						break;
+					}
+
+					switch (command->type) {
+						case RecordedCommand::TYPE_BUFFER_CLEAR:
+						case RecordedCommand::TYPE_BUFFER_COPY:
+						case RecordedCommand::TYPE_BUFFER_GET_DATA:
+						case RecordedCommand::TYPE_BUFFER_UPDATE:
+						case RecordedCommand::TYPE_TEXTURE_CLEAR_COLOR:
+						case RecordedCommand::TYPE_TEXTURE_CLEAR_DEPTH_STENCIL:
+						case RecordedCommand::TYPE_TEXTURE_COPY:
+						case RecordedCommand::TYPE_TEXTURE_GET_DATA:
+						case RecordedCommand::TYPE_TEXTURE_RESOLVE:
+						case RecordedCommand::TYPE_TEXTURE_UPDATE: {
+							copy_commands = true;
+						} break;
+						case RecordedCommand::TYPE_COMPUTE_LIST: {
+							compute_commands = true;
+						} break;
+						case RecordedCommand::TYPE_DRAW_LIST: {
+							draw_commands = true;
+						} break;
+						case RecordedCommand::TYPE_DRIVER_CALLBACK: {
+							custom_commands = true;
+						} break;
+						default: {
+							// Ignore command.
+						} break;
+					}
+
+					if (copy_commands && compute_commands && draw_commands && custom_commands) {
+						// There's no more command types to find.
+						break;
+					}
+				}
+
+				if (copy_commands || compute_commands || draw_commands || custom_commands) {
+					// Add the operations to the name.
+					bool plus_after_copy = copy_commands && (compute_commands || draw_commands || custom_commands);
+					bool plus_after_compute = compute_commands && (draw_commands || custom_commands);
+					bool plus_after_draw = draw_commands && custom_commands;
+					label_name += " (";
+					label_name += copy_commands ? "Copy" : "";
+					label_name += plus_after_copy ? "+" : "";
+					label_name += compute_commands ? "Compute" : "";
+					label_name += plus_after_compute ? "+" : "";
+					label_name += draw_commands ? "Draw" : "";
+					label_name += plus_after_draw ? "+" : "";
+					label_name += custom_commands ? "Custom" : "";
+					label_name += ")";
+				}
+			}
+
+			CharString label_name_utf8 = label_name.utf8();
+			driver->command_begin_label(p_command_buffer, label_name_utf8.get_data(), label_color);
+		} else {
+			// Intermediate labels: emit as-is.
+			driver->command_begin_label(p_command_buffer, label_chars, label_color);
+		}
+	}
+
+	r_current_label_index = target_label_index;
+	r_current_label_level = p_new_level;
 }
 
 void RenderingDeviceGraph::_boost_priority_for_render_commands(RecordedCommandSort *p_sorted_commands, uint32_t p_sorted_commands_count, uint32_t &r_boosted_priority) {
@@ -1764,6 +1827,7 @@ void RenderingDeviceGraph::begin() {
 	command_label_chars.clear();
 	command_label_colors.clear();
 	command_label_offsets.clear();
+	command_label_parents.clear();
 	command_list_nodes.clear();
 	read_slice_list_nodes.clear();
 	write_slice_list_nodes.clear();
@@ -2572,12 +2636,15 @@ void RenderingDeviceGraph::begin_label(const Span<char> &p_label_name, const Col
 	command_label_chars[command_label_offset + command_label_size] = '\0';
 	command_label_colors.push_back(p_color);
 	command_label_offsets.push_back(command_label_offset);
+	command_label_parents.push_back(command_label_index);
 	command_label_index = command_label_count;
 	command_label_count++;
 }
 
 void RenderingDeviceGraph::end_label() {
-	command_label_index = -1;
+	if (command_label_index >= 0) {
+		command_label_index = command_label_parents[command_label_index];
+	}
 }
 
 void RenderingDeviceGraph::end(bool p_reorder_commands, bool p_full_barriers, RDD::CommandBufferID &r_command_buffer, CommandBufferPool &r_command_buffer_pool) {

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -823,6 +823,7 @@ private:
 	LocalVector<char> command_label_chars;
 	LocalVector<Color> command_label_colors;
 	LocalVector<uint32_t> command_label_offsets;
+	LocalVector<int32_t> command_label_parents;
 	int32_t command_label_index = -1;
 	DrawInstructionList draw_instruction_list;
 	ComputeInstructionList compute_instruction_list;

--- a/servers/rendering/storage/utilities.h
+++ b/servers/rendering/storage/utilities.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/math/aabb.h"
+#include "core/math/color.h"
 #include "core/math/vector2i.h"
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
@@ -177,6 +178,54 @@ public:
 	virtual uint64_t get_captured_timestamp_gpu_time(uint32_t p_index) const = 0;
 	virtual uint64_t get_captured_timestamp_cpu_time(uint32_t p_index) const = 0;
 	virtual String get_captured_timestamp_name(uint32_t p_index) const = 0;
+
+	/* DEBUG */
+
+	class DebugLabel {
+		static constexpr size_t BufSize = 16;
+
+		alignas(std::max_align_t) char buf[BufSize];
+		void (*cleanup)(void *) = nullptr;
+
+	public:
+		template <typename T>
+		explicit DebugLabel(T &&obj) {
+			using U = std::decay_t<T>;
+			static_assert(sizeof(U) <= BufSize);
+			static_assert(alignof(U) <= alignof(std::max_align_t));
+			new (buf) U(std::move(obj));
+			cleanup = [](void *p) { static_cast<U *>(p)->~U(); };
+		}
+
+		~DebugLabel() { do_cleanup(); }
+
+		DebugLabel() = default;
+		DebugLabel(const DebugLabel &) = delete;
+		DebugLabel &operator=(const DebugLabel &) = delete;
+
+		DebugLabel(DebugLabel &&o) noexcept
+				: cleanup(o.cleanup) {
+			std::memcpy(buf, o.buf, BufSize);
+			o.cleanup = nullptr;
+		}
+
+		DebugLabel &operator=(DebugLabel &&o) noexcept {
+			do_cleanup();
+			std::memcpy(buf, o.buf, BufSize);
+			cleanup = o.cleanup;
+			o.cleanup = nullptr;
+			return *this;
+		}
+
+		void do_cleanup() {
+			if (cleanup) {
+				cleanup(buf);
+				cleanup = nullptr;
+			}
+		}
+	};
+
+	[[nodiscard]] virtual DebugLabel draw_command_label(const Span<char> p_label_name, const Color &p_color = Color(1, 1, 1, 1)) const = 0;
 
 	/* MISC */
 


### PR DESCRIPTION
## Summary

Adds nested label support to the `RenderingDeviceGraph`, so GPU debug labels (visible in tools like RenderDoc/Xcode GPU Debugger) can form a hierarchy rather than being flat.

## Changes

### Nested label tracking in `RenderingDeviceGraph`
- Added a `command_label_parents` vector to track each label's parent, forming a tree.
- `begin_label` now records the current label as the new label's parent; `end_label` walks back up to the parent instead of resetting to `-1`.
- Rewrote `_run_label_command_change` to compute the common ancestor between the current and target label paths, popping and pushing only the necessary GPU debug labels. Intermediate (non-leaf) labels are emitted as-is, while the innermost label retains the existing level and operation-type annotations (e.g. `(L0) (Copy+Compute)`).

### RAII `DrawCommandLabel` API (`RenderingDevice`)
- Added `RenderingDevice::draw_command_label()` which returns a stack-allocated `DrawCommandLabel` that calls `draw_command_end_label()` on destruction.
- `DrawCommandLabel` is move-only with an explicit `end()` method for early termination.
- The move-assignment operator ends the current label before accepting the new one.
- Made `draw_command_begin_label` private to encourage use of the RAII API.
  - Existing GDScript API is unmodified

### RAII `DebugLabel` wrapper (`RendererUtilities`)
- Added a small-buffer-optimized `DebugLabel` type-erased wrapper in `storage/utilities.h`, with a pure virtual `draw_command_label` on `RendererUtilities` so non-RD backends (GLES3, dummy) can provide their own implementations. Currently these are a no-op.

### Renderer callsite migration
- Converted all `draw_command_begin_label`/`draw_command_end_label` pairs across the RD renderer (forward clustered, forward mobile, effects, environment, scene render) to use the new RAII `DrawCommandLabel`. Introduced scoping braces where a single function uses multiple sequential labels.

### Minor additions
- Named the staging buffer (`"Staging"`) via `set_object_name` under `DEV_ENABLED`.
- Added a few buffer debug labels in `light_storage`, `texture_storage`, and `cluster_builder_rd` for easier GPU debugging.

> [!IMPORTANT]
> If you hide whitespace changes, it removes a lot of noise — many of the line changes are from the added scoping braces for RAII labels.

### Example Metal capture with nested labels

<img width="3568" height="2180" alt="CleanShot 2026-02-03 at 13 15 25@2x" src="https://github.com/user-attachments/assets/fbdf5210-88f8-4349-8f23-a16bc681b9db" />
