### PR TITLE
Fix IKModifier/JointLimitation gizmo on root bone and dirty handling

### DIFF
--- a/editor/scene/3d/gizmos/chain_ik_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/chain_ik_3d_gizmo_plugin.h
@@ -46,7 +46,7 @@ class ChainIK3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	static SelectionMaterials selection_materials;
 
 public:
-	static Ref<ArrayMesh> get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_ik, bool p_is_selected);
+	static void get_joints_mesh(Skeleton3D *p_skeleton, ChainIK3D *p_ik, bool p_is_selected, Ref<ArrayMesh> &r_skinned_mesh, Ref<ArrayMesh> &r_mesh);
 	static void draw_line(Ref<SurfaceTool> &p_surface_tool, const Vector3 &p_begin_pos, const Vector3 &p_end_pos, const Color &p_color);
 
 	bool has_gizmo(Node3D *p_spatial) override;

--- a/scene/3d/ik_modifier_3d.h
+++ b/scene/3d/ik_modifier_3d.h
@@ -76,6 +76,7 @@ protected:
 
 	virtual void _validate_bone_names() override;
 
+	void _rest_updated();
 	virtual void _make_all_joints_dirty();
 	virtual void _init_joints(Skeleton3D *p_skeleton, int p_index);
 	virtual void _update_joints(int p_index);


### PR DESCRIPTION
For parentless bones, the limitation gizmo was unintentionally bound to that bone. Limitations should not be affected by pose, so they should not be bound. However, since ArrayMesh cannot mix cases where BoneWeight is used and cases where it is not, we will add a dedicated ArrayMesh for parentless bones.

Before:

https://github.com/user-attachments/assets/0bff0b22-c009-42ba-b4e0-2f128edf9f9d

After Fix:

https://github.com/user-attachments/assets/9c2c3e82-d6a4-4318-87dc-850d21d72dae

---

The handling of the dirty flag when changing the rest position was incorrect. This caused issues with handling the direction for FromParent, potentially causing the ExtendedEndBone's Limitation to temporarily point in an unintended direction. This has been fixed.

For FromParent, IK calculates the virtual rest position based on those locations. Therefore, even if the rest position of the extended bone is updated, the virtual rest orientation should not change unless the position itself changes. By the way, there is no change to the behavior when specifying axes.

Before (unintended change in limitation dir, after save and reopen, it fixed):

https://github.com/user-attachments/assets/8a5601ad-21cb-44b5-8a20-92833a02f736

After Fix:

https://github.com/user-attachments/assets/687a61ed-2b34-4bee-a6c7-4c8c916a536a

[gzmik.zip](https://github.com/user-attachments/files/24375413/gzmik.zip)

*Bugsquad edit:*
- Fixes #114666.