### PR TITLE
Fix missing null pointers checks to prevent later crashes

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -241,6 +241,7 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 	ERR_FAIL_NULL_MSG(EditorNode::get_singleton(), "EditorNode doesn't exist.");
 
 	SubViewport *sub_viewport_node = memnew(SubViewport);
+	ERR_FAIL_NULL(sub_viewport_node);
 	AABB scene_aabb;
 	scene_aabb = _calculate_aabb_for_scene(p_scene, scene_aabb);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1550,6 +1550,8 @@ void EditorNode::_viewport_resized() {
 }
 
 void EditorNode::_titlebar_resized() {
+	ERR_FAIL_NULL(DisplayServer::get_singleton());
+	ERR_FAIL_NULL(title_bar);
 	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServer::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1191,6 +1191,7 @@ void ProjectExportDialog::_check_propagated_to_item(Object *p_obj, int column) {
 		return;
 	}
 	TreeItem *item = Object::cast_to<TreeItem>(p_obj);
+	ERR_FAIL_NULL(item);
 	String path = item->get_metadata(0);
 	if (item && !path.ends_with("/")) {
 		bool added = item->is_checked(0);

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1295,6 +1295,8 @@ void ProjectManager::_files_dropped(PackedStringArray p_files) {
 }
 
 void ProjectManager::_titlebar_resized() {
+	ERR_FAIL_NULL(DisplayServer::get_singleton());
+	ERR_FAIL_NULL(title_bar);
 	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServer::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -613,7 +613,9 @@ void TileSetAtlasSourceEditor::_update_tile_inspector() {
 
 void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	String previously_selected;
-	if (tile_data_editors_tree && tile_data_editors_tree->get_selected()) {
+	ERR_FAIL_NULL(tile_data_editors_tree);
+
+	if (tile_data_editors_tree->get_selected()) {
 		previously_selected = tile_data_editors_tree->get_selected()->get_metadata(0);
 	}
 

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4921,7 +4921,9 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 
 	HashSet<RID> rids;
 
-	if (preview_node && preview_node->get_child_count() > 0) {
+	ERR_FAIL_NULL_V(preview_node, Vector3());
+
+	if (preview_node->get_child_count() > 0) {
 		_insert_rid_recursive(preview_node, rids);
 	} else if (!preview_node->is_inside_tree() && !ruler->is_inside_tree()) {
 		const List<Node *> &selection = editor_selection->get_top_selected_node_list();

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -200,6 +200,7 @@ void GridMapEditor::_menu_option(int p_option) {
 }
 
 void GridMapEditor::_update_cursor_transform() {
+	ERR_FAIL_NULL(node);
 	cursor_transform = Transform3D();
 	cursor_transform.origin = cursor_origin;
 	cursor_transform.basis *= node->get_cell_scale();

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1116,6 +1116,9 @@ void godotsharp_array_make_read_only(Array *p_self) {
 }
 
 void godotsharp_array_set_typed(Array *p_self, uint32_t p_elem_type, const StringName *p_elem_class_name, const Ref<CSharpScript> *p_elem_script) {
+	ERR_FAIL_NULL(p_elem_class_name);
+	ERR_FAIL_NULL(p_elem_script);
+	ERR_FAIL_NULL(p_self);
 	Variant elem_script_variant;
 	StringName elem_class_name = *p_elem_class_name;
 	if (p_elem_script && p_elem_script->is_valid()) {
@@ -1280,6 +1283,10 @@ void godotsharp_dictionary_make_read_only(Dictionary *p_self) {
 }
 
 void godotsharp_dictionary_set_typed(Dictionary *p_self, uint32_t p_key_type, const StringName *p_key_class_name, const Ref<CSharpScript> *p_key_script, uint32_t p_value_type, const StringName *p_value_class_name, const Ref<CSharpScript> *p_value_script) {
+	ERR_FAIL_NULL(p_key_class_name);
+	ERR_FAIL_NULL(p_key_script);
+	ERR_FAIL_NULL(p_value_script);
+	ERR_FAIL_NULL(p_value_class_name);
 	Variant key_script_variant;
 	StringName key_class_name = *p_key_class_name;
 	if (p_key_script && p_key_script->is_valid()) {

--- a/scene/3d/ik_modifier_3d.cpp
+++ b/scene/3d/ik_modifier_3d.cpp
@@ -160,6 +160,7 @@ Quaternion IKModifier3D::get_local_pose_rotation(Skeleton3D *p_skeleton, int p_b
 }
 
 Vector3 IKModifier3D::get_bone_axis(Skeleton3D *p_skeleton, int p_end_bone, BoneDirection p_direction, bool p_mutable_bone_axes) {
+	ERR_FAIL_NULL_V(p_skeleton, Vector3());
 	if (!p_skeleton->is_inside_tree()) {
 		return Vector3();
 	}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1241,6 +1241,7 @@ void RenderForwardClustered::_setup_lightmaps(const RenderDataRD *p_render_data,
 /* SDFGI */
 
 void RenderForwardClustered::_update_sdfgi(RenderDataRD *p_render_data) {
+	ERR_FAIL_NULL(p_render_data);
 	if (p_render_data->sdfgi_update_data == nullptr) {
 		return;
 	}

--- a/thirdparty/basis_universal/encoder/basisu_comp.cpp
+++ b/thirdparty/basis_universal/encoder/basisu_comp.cpp
@@ -4071,7 +4071,7 @@ namespace basisu
 				comp_params.m_source_mipmap_images_hdr.resize(1);
 				comp_params.m_source_mipmap_images_hdr[0].resize(pSource_images_hdr->size() - 1);
 
-				for (uint32_t i = 1; i < pSource_images->size(); i++)
+				for (uint32_t i = 1; i < pSource_images_hdr->size(); i++)
 					comp_params.m_source_mipmap_images_hdr[0][i - 1] = (*pSource_images_hdr)[i];
 			}
 		}


### PR DESCRIPTION
issue reference [https://github.com/godotengine/godot/issues/114433]

- adding a ERR_FAIL_NULL() guard on several pointers to avoid accessing later a null pointer
- fixing a typo in basisu_comp.cpp where it calls "pSource_images" instead of pSource_images_hdr in a code section where we know that pSource_images is null and will cause a crash for sure

