### PR TITLE
Add initial minimum/maximum viewport size to the project settings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1710,6 +1710,12 @@ ProjectSettings::ProjectSettings() {
 	// - Be displayable correctly in windowed mode on a 1366×768 display (tested on Windows 10 with default settings).
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/viewport_width", PROPERTY_HINT_RANGE, "1,7680,1,or_greater"), 1152); // 8K resolution
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/viewport_height", PROPERTY_HINT_RANGE, "1,4320,1,or_greater"), 648); // 8K resolution
+	// Default to a very small minimum window size to prevent bugs such as GH-37242.
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/minimum_window_width", PROPERTY_HINT_RANGE, "1,7680,1,or_greater"), 64);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/minimum_window_height", PROPERTY_HINT_RANGE, "1,4320,1,or_greater"), 64);
+
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/maximum_window_width", PROPERTY_HINT_RANGE, "1,7680,1,or_greater"), 32768);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/maximum_window_height", PROPERTY_HINT_RANGE, "1,4320,1,or_greater"), 32768);
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/mode", PROPERTY_HINT_ENUM, "Windowed,Minimized,Maximized,Fullscreen,Exclusive Fullscreen"), 0);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1021,8 +1021,30 @@
 		<member name="display/window/size/maximize_disabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the main window's maximize button is disabled.
 		</member>
+		<member name="display/window/size/maximum_window_height" type="int" setter="" getter="" default="32768">
+			Sets the initial maximum height for the main viewport.
+			[b]Note:[/b] This value is only set on the main window initially, if you wish to change this value dynamically (or on other windows), see [member Window.max_size].
+			[b]Note:[/b] Maximum size does not apply while the game window is embedded, both inside the editor and while floating. Disable embedding if you wish to view these changes.
+		</member>
+		<member name="display/window/size/maximum_window_width" type="int" setter="" getter="" default="32768">
+			Sets the initial maximum width for the main viewport.
+			[b]Note:[/b] This value is only set on the main window initially, if you wish to change this value dynamically (or on other windows), see [member Window.max_size].
+			[b]Note:[/b] Maximum size does not apply while the game window is embedded, both inside the editor and while floating. Disable embedding if you wish to view these changes.
+		</member>
 		<member name="display/window/size/minimize_disabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the main window's minimize button is disabled.
+		</member>
+		<member name="display/window/size/minimum_window_height" type="int" setter="" getter="" default="64">
+			Sets the initial minimum height for the main viewport.
+			[b]Note:[/b] This value is only set on the main window initially, if you wish to change this value dynamically (or on other windows), see [member Window.min_size].
+			[b]Note:[/b] Minimum size does not apply while the game window is embedded, both inside the editor and while floating. Disable embedding if you wish to view these changes.
+			[b]Warning:[/b] Setting this value below the default is not recommended, potential issues may arise when doing so.
+		</member>
+		<member name="display/window/size/minimum_window_width" type="int" setter="" getter="" default="64">
+			Sets the initial minimum width for the main viewport.
+			[b]Note:[/b] This value is only set on the main window initially, if you wish to change this value dynamically (or on other windows), see [member Window.min_size].
+			[b]Note:[/b] Minimum size does not apply while the game window is embedded, both inside the editor and while floating. Disable embedding if you wish to view these changes.
+			[b]Warning:[/b] Setting this value below the default is not recommended, potential issues may arise when doing so.
 		</member>
 		<member name="display/window/size/mode" type="int" setter="" getter="" default="0" keywords="windowed, fullscreen, borderless, exclusive">
 			Main window mode. See [enum DisplayServer.WindowMode] for possible values and how each mode behaves.
@@ -1048,10 +1070,14 @@
 			[b]Note:[/b] This setting has no effect on Android as transparency is controlled only via [member display/window/per_pixel_transparency/allowed].
 		</member>
 		<member name="display/window/size/viewport_height" type="int" setter="" getter="" default="648">
-			Sets the game's main viewport height. On desktop platforms, this is also the initial window height, represented by an indigo-colored rectangle in the 2D editor. Stretch mode settings also use this as a reference when using the [code]canvas_items[/code] or [code]viewport[/code] stretch modes. See also [member display/window/size/viewport_width], [member display/window/size/window_width_override] and [member display/window/size/window_height_override].
+			Sets the game's main viewport height. On desktop platforms, this is also the initial window height, represented by an indigo-colored rectangle in the 2D editor.
+			Stretch mode settings also use this as a reference when using the [code]canvas_items[/code] or [code]viewport[/code] stretch modes.
+			See also [member display/window/size/viewport_width], [member display/window/size/window_width_override], and [member display/window/size/window_height_override].
 		</member>
 		<member name="display/window/size/viewport_width" type="int" setter="" getter="" default="1152">
-			Sets the game's main viewport width. On desktop platforms, this is also the initial window width, represented by an indigo-colored rectangle in the 2D editor. Stretch mode settings also use this as a reference when using the [code]canvas_items[/code] or [code]viewport[/code] stretch modes. See also [member display/window/size/viewport_height], [member display/window/size/window_width_override] and [member display/window/size/window_height_override].
+			Sets the game's main viewport width. On desktop platforms, this is also the initial window width, represented by an indigo-colored rectangle in the 2D editor.
+			Stretch mode settings also use this as a reference when using the [code]canvas_items[/code] or [code]viewport[/code] stretch modes.
+			See also [member display/window/size/viewport_height], [member display/window/size/window_width_override], and [member display/window/size/window_height_override].
 		</member>
 		<member name="display/window/size/window_height_override" type="int" setter="" getter="" default="0">
 			On desktop platforms, overrides the game's initial window height. See also [member display/window/size/window_width_override], [member display/window/size/viewport_width] and [member display/window/size/viewport_height].

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2040,7 +2040,12 @@ SceneTree::SceneTree() {
 	// Create with mainloop.
 
 	root = memnew(Window);
-	root->set_min_size(Size2i(64, 64)); // Define a very small minimum window size to prevent bugs such as GH-37242.
+	Size2i initial_min_size = Size2i(GLOBAL_GET("display/window/size/minimum_window_width"),
+			GLOBAL_GET("display/window/size/minimum_window_height"));
+	root->set_min_size(initial_min_size);
+	Size2i initial_max_size = Size2i(GLOBAL_GET("display/window/size/maximum_window_width"),
+			GLOBAL_GET("display/window/size/maximum_window_height"));
+	root->set_max_size(initial_max_size);
 	root->set_process_mode(Node::PROCESS_MODE_PAUSABLE);
 	root->set_name("root");
 


### PR DESCRIPTION
This PR supersedes https://github.com/godotengine/godot/pull/87168 and closes https://github.com/godotengine/godot-proposals/issues/7586.

Adds Minimum/Maximum Window Size to the project settings. 
Setting these values will cause the window that is created with the main loop (the initial game window) to the specified minimum/maximum size.

To say I'm a fan of how this looks in the project settings would be a lie. 
<img width="974" height="270" alt="image" src="https://github.com/user-attachments/assets/a113c599-5086-41c9-b5ea-835239d995f6" />


I do not particularly care for 4 separate options (these should all be Vector2i's), however seeing as the precedent of both of the size options (Viewport Height/Width, Window Height/Width Override) being separate integer settings, it would be peculiar for these options to be Vector2i's (despite my annoyance). 

This PR is intentionally rather light on the logic side, it's not doing anything too complicated, just providing a way to overwrite variables that were already there. The only new logic is the set_max_size which was not previously there, but from my testing seems to do okay? 

I was considering making the default the recommended max of an 8K resolution, but given the prior default was the 16 bit integer limit + 1(?) I was unsure if setting it to anything else would cause incompatibilities, I hope you future kids with your 16k monitors are happy. 
