### PR TITLE
Fix crash after calling `EditorUndoRedoManager.clear_history()` and then interacting with history dock entries

### DIFF
--- a/doc/classes/EditorUndoRedoManager.xml
+++ b/doc/classes/EditorUndoRedoManager.xml
@@ -73,7 +73,7 @@
 			<param index="0" name="id" type="int" default="-99" />
 			<param index="1" name="increase_version" type="bool" default="true" />
 			<description>
-				Clears the given undo history. You can clear history for a specific scene, global history, or for all scenes at once if [param id] is [constant INVALID_HISTORY].
+				Clears the given undo history. You can clear history for a specific scene, global history, or for all histories at once (except [constant REMOTE_HISTORY]) if [param id] is [constant INVALID_HISTORY].
 				If [param increase_version] is [code]true[/code], the undo history version will be increased, marking it as unsaved. Useful for operations that modify the scene, but don't support undo.
 				[codeblock]
 				var scene_root = EditorInterface.get_edited_scene_root()

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -447,8 +447,13 @@ void EditorUndoRedoManager::clear_history(int p_idx, bool p_increase_version) {
 		return;
 	}
 
-	for (const KeyValue<int, History> &E : history_map) {
+	for (KeyValue<int, History> &E : history_map) {
+		if (E.key == REMOTE_HISTORY) {
+			continue;
+		}
 		E.value.undo_redo->clear_history(p_increase_version);
+		E.value.undo_stack.clear();
+		E.value.redo_stack.clear();
 		set_history_as_saved(E.key);
 	}
 	emit_signal(SNAME("history_changed"));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes: https://github.com/godotengine/godot/issues/114429

This makes the `clear_history()` method actually perform the function per the documentation, although it originally tries to clear all history. I think the documented approach makes more sense though. 

>Clears the given undo history. You can clear history for a specific scene, global history, or for all scenes at once if id is INVALID_HISTORY.

Either way the undo/redo stack needs to be cleared to prevent the crash.
