### PR TITLE
LSP: Remove unread `native_member_completions` member

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -238,7 +238,6 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 
 	if (!_initialized) {
 		workspace->initialize();
-		text_document->initialize();
 		_initialized = true;
 	}
 

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -122,21 +122,6 @@ void GDScriptTextDocument::notify_client_show_symbol(const LSP::DocumentSymbol *
 	GDScriptLanguageProtocol::get_singleton()->notify_client("gdscript/show_native_symbol", symbol->to_json(true));
 }
 
-void GDScriptTextDocument::initialize() {
-	if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
-		for (const KeyValue<StringName, ClassMembers> &E : GDScriptLanguageProtocol::get_singleton()->get_workspace()->native_members) {
-			const ClassMembers &members = E.value;
-
-			for (const KeyValue<String, const LSP::DocumentSymbol *> &F : members) {
-				const LSP::DocumentSymbol *symbol = members.get(F.key);
-				LSP::CompletionItem item = symbol->make_completion_item();
-				item.data = JOIN_SYMBOLS(String(E.key), F.key);
-				native_member_completions.push_back(item.to_json());
-			}
-		}
-	}
-}
-
 Variant GDScriptTextDocument::nativeSymbol(const Dictionary &p_params) {
 	Variant ret;
 

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -44,8 +44,6 @@ protected:
 
 	Ref<FileAccess> file_checker;
 
-	Array native_member_completions;
-
 private:
 	Array find_symbols(const LSP::TextDocumentPositionParams &p_location, List<const LSP::DocumentSymbol *> &r_list);
 	void notify_client_show_symbol(const LSP::DocumentSymbol *symbol);
@@ -75,8 +73,6 @@ public:
 	Array definition(const Dictionary &p_params);
 	Variant declaration(const Dictionary &p_params);
 	Variant signatureHelp(const Dictionary &p_params);
-
-	void initialize();
 
 	GDScriptTextDocument();
 };


### PR DESCRIPTION
`native_member_completions` is never read from (Usage was removed by myself in https://github.com/godotengine/godot/pull/96684, kinda missed that it was the only usage). This PR removes it and the associated initialization code.