### PR TITLE
a11y: Constrain tab focus and wrap at boundaries

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -840,8 +840,17 @@ int TabBar::get_hovered_tab() const {
 int TabBar::get_previous_available(int p_idx) const {
 	ERR_FAIL_COND_V(p_idx < -1 || p_idx > get_tab_count(), -1);
 	const int idx = p_idx == -1 ? get_current_tab() : p_idx;
-	const int offset_end = idx + 1;
-	for (int i = 1; i < offset_end; i++) {
+	if (idx == -1) {
+		// No tab selected - search all tabs starting from the last.
+		for (int i = get_tab_count() - 1; i >= 0; i--) {
+			if (!is_tab_disabled(i) && !is_tab_hidden(i)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+	// Search all tabs except current, wrapping at boundaries per ARIA tab pattern.
+	for (int i = 1; i < get_tab_count(); i++) {
 		int target_tab = idx - i;
 		if (target_tab < 0) {
 			target_tab += get_tab_count();
@@ -856,8 +865,17 @@ int TabBar::get_previous_available(int p_idx) const {
 int TabBar::get_next_available(int p_idx) const {
 	ERR_FAIL_COND_V(p_idx < -1 || p_idx > get_tab_count(), -1);
 	const int idx = p_idx == -1 ? get_current_tab() : p_idx;
-	const int offset_end = get_tab_count() - idx;
-	for (int i = 1; i < offset_end; i++) {
+	if (idx == -1) {
+		// No tab selected - search all tabs starting from 0.
+		for (int i = 0; i < get_tab_count(); i++) {
+			if (!is_tab_disabled(i) && !is_tab_hidden(i)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+	// Search all tabs except current, wrapping at boundaries per ARIA tab pattern.
+	for (int i = 1; i < get_tab_count(); i++) {
 		int target_tab = (idx + i) % get_tab_count();
 		if (!is_tab_disabled(target_tab) && !is_tab_hidden(target_tab)) {
 			return target_tab;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -607,9 +607,9 @@ void TabContainer::_on_tab_visibility_changed(Control *p_child) {
 			p_child->show();
 		} else {
 			// Set a different tab to be the current tab.
-			bool selected = select_next_available();
+			bool selected = select_previous_available();
 			if (!selected) {
-				selected = select_previous_available();
+				selected = select_next_available();
 			}
 			if (!selected) {
 				// No available tabs, deselect.

--- a/tests/scene/test_tab_bar.h
+++ b/tests/scene/test_tab_bar.h
@@ -490,37 +490,37 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		SIGNAL_CHECK("tab_selected", { { 4 } });
 		SIGNAL_CHECK("tab_changed", { { 4 } });
 
-		// Does not wrap around.
-		CHECK_FALSE(tab_bar->select_next_available());
-		CHECK(tab_bar->get_current_tab() == 4);
-		CHECK(tab_bar->get_previous_tab() == 1);
-		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK_FALSE("tab_changed");
+		// Wraps around to the first available tab.
+		CHECK(tab_bar->select_next_available());
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 4);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { { 0 } });
 
 		// Fails if there is only one valid tab.
 		tab_bar->remove_tab(0);
 		tab_bar->remove_tab(3);
 		CHECK(tab_bar->get_current_tab() == 0);
-		CHECK(tab_bar->get_previous_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 2);
 		SIGNAL_DISCARD("tab_selected");
 		SIGNAL_DISCARD("tab_changed");
 
 		CHECK_FALSE(tab_bar->select_next_available());
 		CHECK(tab_bar->get_current_tab() == 0);
-		CHECK(tab_bar->get_previous_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 2);
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
 
 		// Fails if there are no valid tabs.
 		tab_bar->remove_tab(0);
 		CHECK(tab_bar->get_current_tab() == -1);
-		CHECK(tab_bar->get_previous_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 1);
 		SIGNAL_DISCARD("tab_selected");
 		SIGNAL_DISCARD("tab_changed");
 
 		CHECK_FALSE(tab_bar->select_next_available());
 		CHECK(tab_bar->get_current_tab() == -1);
-		CHECK(tab_bar->get_previous_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 1);
 		SIGNAL_CHECK_FALSE("tab_selected");
 		SIGNAL_CHECK_FALSE("tab_changed");
 
@@ -566,14 +566,18 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		SIGNAL_CHECK("tab_selected", { { 0 } });
 		SIGNAL_CHECK("tab_changed", { { 0 } });
 
-		// Does not wrap around.
-		CHECK_FALSE(tab_bar->select_previous_available());
-		CHECK(tab_bar->get_current_tab() == 0);
-		CHECK(tab_bar->get_previous_tab() == 3);
-		SIGNAL_CHECK_FALSE("tab_selected");
-		SIGNAL_CHECK_FALSE("tab_changed");
+		// Wraps around to the last available tab.
+		CHECK(tab_bar->select_previous_available());
+		CHECK(tab_bar->get_current_tab() == 4);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", { { 4 } });
+		SIGNAL_CHECK("tab_changed", { { 4 } });
 
 		// Fails if there is only one valid tab.
+		tab_bar->set_current_tab(0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
 		tab_bar->remove_tab(4);
 		tab_bar->remove_tab(3);
 		CHECK(tab_bar->get_current_tab() == 0);

--- a/tests/scene/test_tab_container.h
+++ b/tests/scene/test_tab_container.h
@@ -260,10 +260,21 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		CHECK(tab1->is_visible());
 		CHECK_FALSE(tab2->is_visible());
 
-		// Hide the visible child to select the next tab.
+		// Hide the visible child to select the previous tab.
 		tab1->hide();
-		CHECK(tab_container->get_current_tab() == 2);
+		CHECK(tab_container->get_current_tab() == 0);
 		CHECK(tab_container->get_previous_tab() == 1);
+		SIGNAL_CHECK("tab_selected", { { 0 } });
+		SIGNAL_CHECK("tab_changed", { { 0 } });
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab0->is_visible());
+		CHECK_FALSE(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+
+		// Hide the visible child to select the next tab (no previous available).
+		tab0->hide();
+		CHECK(tab_container->get_current_tab() == 2);
+		CHECK(tab_container->get_previous_tab() == 0);
 		SIGNAL_CHECK("tab_selected", { { 2 } });
 		SIGNAL_CHECK("tab_changed", { { 2 } });
 		MessageQueue::get_singleton()->flush();
@@ -271,7 +282,7 @@ TEST_CASE("[SceneTree][TabContainer] tab operations") {
 		CHECK_FALSE(tab1->is_visible());
 		CHECK(tab2->is_visible());
 
-		// Hide the visible child to select the previous tab if there is no next.
+		// Hide the last tab to select the previous tab (the new last).
 		tab2->hide();
 		CHECK(tab_container->get_current_tab() == 1);
 		CHECK(tab_container->get_previous_tab() == 2);


### PR DESCRIPTION
As an Orca user (and presumably as *any* screen reader user) I find Godot's tabs very difficult to use. Tabs don't normally indicate their index (I.e. "Scene: 1 of 2".) As such, you'll use left/right arrows to switch tabs, then because of Godot's directional focus model, you land on some oddball control in some random location when you had no way of expecting it. Further, because you've moved focus directionally rather than by tab, finding your way *back* to the tab bar is a challenge. Rinse and repeat for essentially every tab navigation whose tab bar you aren't explicitly familiar with.

This constrains directional focus by wrapping at tab boundaries, as per the [ARIA tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/). While implementing this pattern exactly may not fit with Godot (E.g. not sure if we want Home for moving to the first tab and End for the last), I find these as good references for exhaustive descriptions of expected keyboard behavior.