### PR TITLE
SceneTreeDock: Remove unused parameter

### DIFF
--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -304,7 +304,7 @@ class SceneTreeDock : public EditorDock {
 	void _check_object_properties_recursive(Node *p_root_node, Object *p_obj, HashMap<Node *, NodePath> *p_renames, bool p_inside_resource = false) const;
 	bool _check_node_path_recursive(Node *p_root_node, Variant &r_variant, HashMap<Node *, NodePath> *p_renames, bool p_inside_resource = false) const;
 	bool _check_node_recursive(Variant &r_variant, Node *p_node, Node *p_by_node, const String type_hint, String &r_warn_message);
-	void _replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties = true, bool p_remove_old = true);
+	void _replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties = true);
 
 private:
 	static SceneTreeDock *singleton;


### PR DESCRIPTION
It was added in #28349, but doesn't seem used anymore. It's always `false`.