### PR TITLE
Remove unused variable in `editor_properties.cpp`

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -4105,7 +4105,6 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		} break;
 		case Variant::BASIS: {
 			EditorPropertyBasis *editor = memnew(EditorPropertyBasis);
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step));
 			return editor;
 		} break;


### PR DESCRIPTION
After #108065 there is no need to declare the `hint` variable here.
https://github.com/godotengine/godot/blob/1559ab34c645abf14f8b8cf61e1a6f0eddaf6285/editor/inspector/editor_properties.cpp#L4106-L4111
