### PR TITLE
Always stop script debugger when stopping game (reverted)

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -321,9 +321,7 @@ void EditorDebuggerNode::stop(bool p_force) {
 
 	// Also close all debugging sessions.
 	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
-		if (dbg->is_session_active()) {
-			dbg->_stop_and_notify();
-		}
+		dbg->_stop_and_notify();
 	});
 	_break_state_changed();
 	breakpoints.clear();


### PR DESCRIPTION
Fixes #114173. Possibly fixes #111175.

When restarting the game, stop the script debugger early to prevent it from stopping the new run.

Before this fix, what happens is:

1. The play button is clicked, calls `EditorRunBar::play_main_scene()`
    - Calls `EditorRunBar::stop_playing()`
      - Calls `EditorRun::stop()`
      - Calls `EditorDebuggerNode::stop()`
        And that's it - the script debugger is not running
    - Calls `EditorRunBar::_run_scene()`
      - Calls `EditorDebuggerNode::start()`.

2. `EditorDebuggerNode::_process()` is called
   Editor enters game running mode.

3. `ScriptEditorDebugger::_process()` is called
    - `!is_session_active()`, so it calls `_stop_and_notify()`
      - Calls `ScriptEditorDebugger::stop()`
      - Signals `"stopped"`
        Which calls `EditorDebuggerNode::_debugger_stopped()`
        Which calls `EditorNode::notify_all_debug_sessions_exited()`
        Which calls `EditorRunBar::stop_playing()`
        And the editor leaves game running mode.

After this fix:

1. The play button is clicked, calls `EditorRunBar::play_main_scene()`
    - Calls `EditorRunBar::stop_playing()`
      - Calls `EditorRun::stop()`
      - Calls `EditorDebuggerNode::stop()`
        No longer checks if the debugger is running, so:
        - Calls `ScriptEditorDebugger::_stop_and_notify()`
          - Calls `ScriptEditorDebugger::stop()`
          - ...ultimately calls `EditorRunBar::stop_playing()`
            Which has no effect, as `editor_run` is `STATUS_STOP`
    - Calls `EditorRunBar::_run_scene()`
      - Calls `EditorDebuggerNode::start()`
        - Calls `EditorDebuggerNode::stop()`
          No longer checks if the debugger is running, so:
          - Calls `ScriptEditorDebugger::_stop_and_notify()`
            - Calls `ScriptEditorDebugger::stop()`
            - ...ultimately calls `EditorRunBar::stop_playing()`
              Which has no effect, as `editor_run` is `STATUS_STOP`

2. `EditorDebuggerNode::_process()` is called
   Happens several times...

3. `EditorDebuggerNode::_process()` is called again
   And this time the editor re-enters game running mode.

I'm not happy with the `_run_scene()` being called so much, but I have no idea how to do it better.
Perhaps someone more familiar with Godot internals can untangle this and do a clean fix.

Also, not sure why this doesn't happen on other platforms.