### PR TITLE
Return full ObjectIDs from `Node::get_orphan_node_ids()`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3447,8 +3447,8 @@ void Node::print_orphan_nodes() {
 	_print_orphan_nodes_map.clear();
 #endif
 }
-TypedArray<int> Node::get_orphan_node_ids() {
-	TypedArray<int> ret;
+TypedArray<ObjectID> Node::get_orphan_node_ids() {
+	TypedArray<ObjectID> ret;
 #ifdef DEBUG_ENABLED
 	// Make sure it's empty.
 	_print_orphan_nodes_map.clear();

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -764,7 +764,7 @@ public:
 	ProcessThreadGroup get_process_thread_group() const;
 
 	static void print_orphan_nodes();
-	static TypedArray<int> get_orphan_node_ids();
+	static TypedArray<ObjectID> get_orphan_node_ids();
 
 #ifdef TOOLS_ENABLED
 	String validate_child_name(Node *p_child);


### PR DESCRIPTION
Fixes #114242

An implementation of the fix suggested by @kleonc in the linked issue. The current form of the method added in #83757 mistakenly converts node IDs to int and truncates the values. This should fix the problem. 

This will change the binary compatibility for the C# bindings as mentioned by @raulsntos. Since the method was added relatively recently in 4.5, this may be acceptable.